### PR TITLE
feat: use `Box` from DSR (core team)

### DIFF
--- a/ui/components/app/snaps/copyable/copyable.js
+++ b/ui/components/app/snaps/copyable/copyable.js
@@ -2,16 +2,19 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'clsx';
 import {
-  BorderRadius,
   BackgroundColor,
   TextColor,
   Color,
-  Display,
   OverflowWrap,
   IconColor,
 } from '../../../../helpers/constants/design-system';
 import { useCopyToClipboard } from '../../../../hooks/useCopyToClipboard';
-import { Icon, IconName, Box, Text } from '../../../component-library';
+import {
+  Box,
+  BoxBackgroundColor,
+  BoxFlexDirection,
+} from '@metamask/design-system-react';
+import { Icon, IconName, Text } from '../../../component-library';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import Tooltip from '../../../ui/tooltip';
 import { ShowMore } from '../show-more';
@@ -49,21 +52,20 @@ export const Copyable = ({
 
   return (
     <Box
-      display={Display.Flex}
+      flexDirection={BoxFlexDirection.Row}
       onClick={
         sensitive && !isVisible ? handleVisibilityClick : handleCopyClick
       }
-      className={classnames('copyable', {
+      className={classnames('copyable rounded-lg', {
         sensitive,
         clicked: isClicked,
         visible: isVisible,
       })}
       backgroundColor={
         isVisible && sensitive
-          ? BackgroundColor.errorMuted
-          : BackgroundColor.primaryMuted
+          ? BoxBackgroundColor.ErrorMuted
+          : BoxBackgroundColor.PrimaryMuted
       }
-      borderRadius={BorderRadius.LG}
       padding={2}
       marginTop={marginTop}
       marginBottom={marginBottom}

--- a/ui/components/app/snaps/copyable/copyable.js
+++ b/ui/components/app/snaps/copyable/copyable.js
@@ -2,6 +2,11 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'clsx';
 import {
+  Box,
+  BoxBackgroundColor,
+  BoxFlexDirection,
+} from '@metamask/design-system-react';
+import {
   BackgroundColor,
   TextColor,
   Color,
@@ -9,11 +14,6 @@ import {
   IconColor,
 } from '../../../../helpers/constants/design-system';
 import { useCopyToClipboard } from '../../../../hooks/useCopyToClipboard';
-import {
-  Box,
-  BoxBackgroundColor,
-  BoxFlexDirection,
-} from '@metamask/design-system-react';
 import { Icon, IconName, Text } from '../../../component-library';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import Tooltip from '../../../ui/tooltip';

--- a/ui/components/app/snaps/copyable/copyable.js
+++ b/ui/components/app/snaps/copyable/copyable.js
@@ -56,7 +56,7 @@ export const Copyable = ({
       onClick={
         sensitive && !isVisible ? handleVisibilityClick : handleCopyClick
       }
-      className={classnames('copyable rounded-lg', {
+      className={classnames('flex copyable rounded-lg', {
         sensitive,
         clicked: isClicked,
         visible: isVisible,

--- a/ui/components/app/snaps/keyring-snap-removal-warning/keyring-account-list-item.tsx
+++ b/ui/components/app/snaps/keyring-snap-removal-warning/keyring-account-list-item.tsx
@@ -33,7 +33,11 @@ export const KeyringAccountListItem = ({
       data-testid="keyring-account-list-item"
     >
       <Box flexDirection={BoxFlexDirection.Column} className="flex w-10/12">
-        <Box flexDirection={BoxFlexDirection.Column} marginBottom={2} className="flex">
+        <Box
+          flexDirection={BoxFlexDirection.Column}
+          marginBottom={2}
+          className="flex"
+        >
           <Text color={TextColor.textMuted}>{t('keyringAccountName')}</Text>
           <Text>{account.name}</Text>
         </Box>

--- a/ui/components/app/snaps/keyring-snap-removal-warning/keyring-account-list-item.tsx
+++ b/ui/components/app/snaps/keyring-snap-removal-warning/keyring-account-list-item.tsx
@@ -29,15 +29,15 @@ export const KeyringAccountListItem = ({
       justifyContent={BoxJustifyContent.Between}
       borderColor={BoxBorderColor.BorderDefault}
       padding={3}
-      className="w-full rounded-md"
+      className="flex w-full rounded-md"
       data-testid="keyring-account-list-item"
     >
-      <Box flexDirection={BoxFlexDirection.Column} className="w-10/12">
-        <Box flexDirection={BoxFlexDirection.Column} marginBottom={2}>
+      <Box flexDirection={BoxFlexDirection.Column} className="flex w-10/12">
+        <Box flexDirection={BoxFlexDirection.Column} marginBottom={2} className="flex">
           <Text color={TextColor.textMuted}>{t('keyringAccountName')}</Text>
           <Text>{account.name}</Text>
         </Box>
-        <Box flexDirection={BoxFlexDirection.Column}>
+        <Box flexDirection={BoxFlexDirection.Column} className="flex">
           <Text color={TextColor.textMuted}>
             {t('keyringAccountPublicAddress')}
           </Text>
@@ -49,6 +49,7 @@ export const KeyringAccountListItem = ({
       <Box
         flexDirection={BoxFlexDirection.Column}
         justifyContent={BoxJustifyContent.Center}
+        className="flex"
       >
         <ButtonIcon
           ariaLabel="snap-url-export"

--- a/ui/components/app/snaps/keyring-snap-removal-warning/keyring-account-list-item.tsx
+++ b/ui/components/app/snaps/keyring-snap-removal-warning/keyring-account-list-item.tsx
@@ -32,10 +32,7 @@ export const KeyringAccountListItem = ({
       className="w-full rounded-md"
       data-testid="keyring-account-list-item"
     >
-      <Box
-        flexDirection={BoxFlexDirection.Column}
-        className="w-10/12"
-      >
+      <Box flexDirection={BoxFlexDirection.Column} className="w-10/12">
         <Box flexDirection={BoxFlexDirection.Column} marginBottom={2}>
           <Text color={TextColor.textMuted}>{t('keyringAccountName')}</Text>
           <Text>{account.name}</Text>

--- a/ui/components/app/snaps/keyring-snap-removal-warning/keyring-account-list-item.tsx
+++ b/ui/components/app/snaps/keyring-snap-removal-warning/keyring-account-list-item.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { ButtonIcon, IconName, Text, Box } from '../../../component-library';
 import {
-  BlockSize,
-  BorderColor,
-  BorderRadius,
-  Display,
-  FlexDirection,
+  Box,
+  BoxBorderColor,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
+import { ButtonIcon, IconName, Text } from '../../../component-library';
+import {
   IconColor,
-  JustifyContent,
   OverflowWrap,
   TextColor,
 } from '../../../../helpers/constants/design-system';
@@ -25,25 +25,22 @@ export const KeyringAccountListItem = ({
   const t = useI18nContext();
   return (
     <Box
-      display={Display.Flex}
-      flexDirection={FlexDirection.Row}
-      justifyContent={JustifyContent.spaceBetween}
-      borderRadius={BorderRadius.MD}
-      borderColor={BorderColor.borderDefault}
+      flexDirection={BoxFlexDirection.Row}
+      justifyContent={BoxJustifyContent.Between}
+      borderColor={BoxBorderColor.BorderDefault}
       padding={3}
-      width={BlockSize.Full}
+      className="w-full rounded-md"
       data-testid="keyring-account-list-item"
     >
       <Box
-        display={Display.Flex}
-        flexDirection={FlexDirection.Column}
-        width={BlockSize.TenTwelfths}
+        flexDirection={BoxFlexDirection.Column}
+        className="w-10/12"
       >
-        <Box flexDirection={FlexDirection.Column} marginBottom={2}>
+        <Box flexDirection={BoxFlexDirection.Column} marginBottom={2}>
           <Text color={TextColor.textMuted}>{t('keyringAccountName')}</Text>
           <Text>{account.name}</Text>
         </Box>
-        <Box flexDirection={FlexDirection.Column}>
+        <Box flexDirection={BoxFlexDirection.Column}>
           <Text color={TextColor.textMuted}>
             {t('keyringAccountPublicAddress')}
           </Text>
@@ -53,9 +50,8 @@ export const KeyringAccountListItem = ({
         </Box>
       </Box>
       <Box
-        display={Display.Flex}
-        flexDirection={FlexDirection.Column}
-        justifyContent={JustifyContent.center}
+        flexDirection={BoxFlexDirection.Column}
+        justifyContent={BoxJustifyContent.Center}
       >
         <ButtonIcon
           ariaLabel="snap-url-export"

--- a/ui/components/app/snaps/show-more/show-more.js
+++ b/ui/components/app/snaps/show-more/show-more.js
@@ -3,7 +3,8 @@ import PropTypes from 'prop-types';
 
 import classnames from 'clsx';
 import useIsOverflowing from '../../../../hooks/snaps/useIsOverflowing';
-import { Box, Button, ButtonVariant, Text } from '../../../component-library';
+import { Box } from '@metamask/design-system-react';
+import { Button, ButtonVariant, Text } from '../../../component-library';
 import {
   BackgroundColor,
   TextColor,

--- a/ui/components/app/snaps/show-more/show-more.js
+++ b/ui/components/app/snaps/show-more/show-more.js
@@ -2,8 +2,8 @@ import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
 import classnames from 'clsx';
-import useIsOverflowing from '../../../../hooks/snaps/useIsOverflowing';
 import { Box } from '@metamask/design-system-react';
+import useIsOverflowing from '../../../../hooks/snaps/useIsOverflowing';
 import { Button, ButtonVariant, Text } from '../../../component-library';
 import {
   BackgroundColor,

--- a/ui/components/app/snaps/snap-authorship-expanded/snap-authorship-expanded.js
+++ b/ui/components/app/snaps/snap-authorship-expanded/snap-authorship-expanded.js
@@ -85,7 +85,7 @@ const SnapAuthorshipExpanded = ({ snapId, className, snap }) => {
         paddingTop={4}
         paddingBottom={4}
         borderColor={BoxBorderColor.BorderDefault}
-        className="w-full"
+        className="flex w-full"
         style={{
           borderLeft: BorderStyle.none,
           borderRight: BorderStyle.none,
@@ -107,7 +107,7 @@ const SnapAuthorshipExpanded = ({ snapId, className, snap }) => {
             flexDirection={BoxFlexDirection.Row}
             justifyContent={BoxJustifyContent.Between}
             marginBottom={4}
-            className="w-full"
+            className="flex w-full"
           >
             <Text variant={TextVariant.bodyMd} fontWeight={FontWeight.Medium}>
               {t('snapDetailWebsite')}
@@ -116,6 +116,7 @@ const SnapAuthorshipExpanded = ({ snapId, className, snap }) => {
               paddingLeft={8}
               flexDirection={BoxFlexDirection.Column}
               alignItems={BoxAlignItems.End}
+              className="flex"
             >
               <ButtonLink
                 href={safeWebsite.toString()}
@@ -131,7 +132,7 @@ const SnapAuthorshipExpanded = ({ snapId, className, snap }) => {
           <Box
             flexDirection={BoxFlexDirection.Row}
             justifyContent={BoxJustifyContent.Between}
-            className="w-full"
+            className="flex w-full"
           >
             <Text variant={TextVariant.bodyMd} fontWeight={FontWeight.Medium}>
               {t('installOrigin')}
@@ -139,6 +140,7 @@ const SnapAuthorshipExpanded = ({ snapId, className, snap }) => {
             <Box
               flexDirection={BoxFlexDirection.Column}
               alignItems={BoxAlignItems.End}
+              className="flex"
             >
               <Text textAlign={TextAlign.End}>{installOrigin.host}</Text>
               <Text color={Color.textMuted}>
@@ -154,6 +156,7 @@ const SnapAuthorshipExpanded = ({ snapId, className, snap }) => {
           justifyContent={BoxJustifyContent.Between}
           alignItems={BoxAlignItems.Center}
           marginTop={4}
+          className="flex"
         >
           <Text variant={TextVariant.bodyMd} fontWeight={FontWeight.Medium}>
             {t('version')}

--- a/ui/components/app/snaps/snap-authorship-expanded/snap-authorship-expanded.js
+++ b/ui/components/app/snaps/snap-authorship-expanded/snap-authorship-expanded.js
@@ -4,17 +4,9 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
-  AlignItems,
-  BackgroundColor,
-  BlockSize,
-  BorderColor,
-  BorderRadius,
   BorderStyle,
   Color,
-  Display,
-  FlexDirection,
   FontWeight,
-  JustifyContent,
   OverflowWrap,
   TextAlign,
   TextVariant,
@@ -24,7 +16,15 @@ import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { useOriginMetadata } from '../../../../hooks/useOriginMetadata';
 import { getSnapRegistryData } from '../../../../selectors';
 import { disableSnap, enableSnap } from '../../../../store/actions';
-import { Box, ButtonLink, Text } from '../../../component-library';
+import {
+  Box,
+  BoxAlignItems,
+  BoxBackgroundColor,
+  BoxBorderColor,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
+import { ButtonLink, Text } from '../../../component-library';
 import ToggleButton from '../../../ui/toggle-button';
 import Tooltip from '../../../ui/tooltip/tooltip';
 import SnapExternalPill from '../snap-version/snap-external-pill';
@@ -70,22 +70,19 @@ const SnapAuthorshipExpanded = ({ snapId, className, snap }) => {
 
   return (
     <Box
-      className={classnames('snaps-authorship-expanded', className)}
-      backgroundColor={BackgroundColor.backgroundDefault}
-      borderColor={BorderColor.borderDefault}
+      className={classnames('snaps-authorship-expanded rounded-lg w-full', className)}
+      backgroundColor={BoxBackgroundColor.BackgroundDefault}
+      borderColor={BoxBorderColor.BorderDefault}
       borderWidth={1}
-      width={BlockSize.Full}
-      borderRadius={BorderRadius.LG}
     >
       <Box
-        display={Display.Flex}
-        flexDirection={FlexDirection.Row}
-        justifyContent={JustifyContent.spaceBetween}
+        flexDirection={BoxFlexDirection.Row}
+        justifyContent={BoxJustifyContent.Between}
         paddingLeft={4}
         paddingTop={4}
         paddingBottom={4}
-        borderColor={BorderColor.borderDefault}
-        width={BlockSize.Full}
+        borderColor={BoxBorderColor.BorderDefault}
+        className="w-full"
         style={{
           borderLeft: BorderStyle.none,
           borderRight: BorderStyle.none,
@@ -101,23 +98,21 @@ const SnapAuthorshipExpanded = ({ snapId, className, snap }) => {
           </Tooltip>
         </Box>
       </Box>
-      <Box padding={4} width={BlockSize.Full}>
+      <Box padding={4} className="w-full">
         {safeWebsite && (
           <Box
-            display={Display.Flex}
-            flexDirection={FlexDirection.Row}
-            justifyContent={JustifyContent.spaceBetween}
-            width={BlockSize.Full}
+            flexDirection={BoxFlexDirection.Row}
+            justifyContent={BoxJustifyContent.Between}
             marginBottom={4}
+            className="w-full"
           >
             <Text variant={TextVariant.bodyMd} fontWeight={FontWeight.Medium}>
               {t('snapDetailWebsite')}
             </Text>
             <Box
               paddingLeft={8}
-              display={Display.Flex}
-              flexDirection={FlexDirection.Column}
-              alignItems={AlignItems.flexEnd}
+              flexDirection={BoxFlexDirection.Column}
+              alignItems={BoxAlignItems.End}
             >
               <ButtonLink
                 href={safeWebsite.toString()}
@@ -131,18 +126,16 @@ const SnapAuthorshipExpanded = ({ snapId, className, snap }) => {
         )}
         {installOrigin && installInfo && (
           <Box
-            display={Display.Flex}
-            flexDirection={FlexDirection.Row}
-            justifyContent={JustifyContent.spaceBetween}
-            width={BlockSize.Full}
+            flexDirection={BoxFlexDirection.Row}
+            justifyContent={BoxJustifyContent.Between}
+            className="w-full"
           >
             <Text variant={TextVariant.bodyMd} fontWeight={FontWeight.Medium}>
               {t('installOrigin')}
             </Text>
             <Box
-              display={Display.Flex}
-              flexDirection={FlexDirection.Column}
-              alignItems={AlignItems.flexEnd}
+              flexDirection={BoxFlexDirection.Column}
+              alignItems={BoxAlignItems.End}
             >
               <Text textAlign={TextAlign.End}>{installOrigin.host}</Text>
               <Text color={Color.textMuted}>
@@ -154,10 +147,9 @@ const SnapAuthorshipExpanded = ({ snapId, className, snap }) => {
           </Box>
         )}
         <Box
-          display={Display.Flex}
-          flexDirection={FlexDirection.Row}
-          justifyContent={JustifyContent.spaceBetween}
-          alignItems={AlignItems.center}
+          flexDirection={BoxFlexDirection.Row}
+          justifyContent={BoxJustifyContent.Between}
+          alignItems={BoxAlignItems.Center}
           marginTop={4}
         >
           <Text variant={TextVariant.bodyMd} fontWeight={FontWeight.Medium}>

--- a/ui/components/app/snaps/snap-authorship-expanded/snap-authorship-expanded.js
+++ b/ui/components/app/snaps/snap-authorship-expanded/snap-authorship-expanded.js
@@ -4,6 +4,14 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
+  Box,
+  BoxAlignItems,
+  BoxBackgroundColor,
+  BoxBorderColor,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
+import {
   BorderStyle,
   Color,
   FontWeight,
@@ -16,14 +24,6 @@ import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { useOriginMetadata } from '../../../../hooks/useOriginMetadata';
 import { getSnapRegistryData } from '../../../../selectors';
 import { disableSnap, enableSnap } from '../../../../store/actions';
-import {
-  Box,
-  BoxAlignItems,
-  BoxBackgroundColor,
-  BoxBorderColor,
-  BoxFlexDirection,
-  BoxJustifyContent,
-} from '@metamask/design-system-react';
 import { ButtonLink, Text } from '../../../component-library';
 import ToggleButton from '../../../ui/toggle-button';
 import Tooltip from '../../../ui/tooltip/tooltip';

--- a/ui/components/app/snaps/snap-authorship-expanded/snap-authorship-expanded.js
+++ b/ui/components/app/snaps/snap-authorship-expanded/snap-authorship-expanded.js
@@ -70,7 +70,10 @@ const SnapAuthorshipExpanded = ({ snapId, className, snap }) => {
 
   return (
     <Box
-      className={classnames('snaps-authorship-expanded rounded-lg w-full', className)}
+      className={classnames(
+        'snaps-authorship-expanded rounded-lg w-full',
+        className,
+      )}
       backgroundColor={BoxBackgroundColor.BackgroundDefault}
       borderColor={BoxBorderColor.BorderDefault}
       borderWidth={1}

--- a/ui/components/app/snaps/snap-authorship-pill/snap-authorship-pill.tsx
+++ b/ui/components/app/snaps/snap-authorship-pill/snap-authorship-pill.tsx
@@ -28,7 +28,7 @@ const SnapAuthorshipPill: React.FC<SnapAuthorshipPillProps> = ({
 
   return (
     <Box
-      className="snap-authorship-pill rounded-full"
+      className="flex snap-authorship-pill rounded-full"
       flexDirection={BoxFlexDirection.Row}
       alignItems={BoxAlignItems.Center}
       paddingTop={1}

--- a/ui/components/app/snaps/snap-authorship-pill/snap-authorship-pill.tsx
+++ b/ui/components/app/snaps/snap-authorship-pill/snap-authorship-pill.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { Box, IconSize, Text } from '../../../component-library';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+} from '@metamask/design-system-react';
+import { IconSize, Text } from '../../../component-library';
 import { SnapIcon } from '../snap-icon';
 import { getSnapMetadata } from '../../../../selectors';
 import {
-  AlignItems,
-  BorderRadius,
-  Display,
-  FlexDirection,
   TextColor,
   TextVariant,
 } from '../../../../helpers/constants/design-system';
@@ -27,11 +28,9 @@ const SnapAuthorshipPill: React.FC<SnapAuthorshipPillProps> = ({
 
   return (
     <Box
-      className="snap-authorship-pill"
-      display={Display.Flex}
-      flexDirection={FlexDirection.Row}
-      alignItems={AlignItems.center}
-      borderRadius={BorderRadius.pill}
+      className="snap-authorship-pill rounded-full"
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
       paddingTop={1}
       paddingBottom={1}
       paddingLeft={1}

--- a/ui/components/app/snaps/snap-home-page/snap-home-renderer.js
+++ b/ui/components/app/snaps/snap-home-page/snap-home-renderer.js
@@ -2,7 +2,8 @@ import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
-import { Box, Text } from '../../../component-library';
+import { Box, BoxBackgroundColor } from '@metamask/design-system-react';
+import { Text } from '../../../component-library';
 import { SnapUIRenderer } from '../snap-ui-renderer';
 import {
   getSnapMetadata,
@@ -11,11 +12,7 @@ import {
 } from '../../../../selectors';
 import { SnapDelineator } from '../snap-delineator';
 import { DelineatorType } from '../../../../helpers/constants/snaps';
-import {
-  BackgroundColor,
-  BlockSize,
-  TextVariant,
-} from '../../../../helpers/constants/design-system';
+import { TextVariant } from '../../../../helpers/constants/design-system';
 import { Copyable } from '../copyable';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { deleteInterface } from '../../../../store/actions';
@@ -70,14 +67,13 @@ export const SnapHomeRenderer = ({ snapId }) => {
   if (error) {
     return (
       <Box
-        height={BlockSize.Full}
-        width={BlockSize.Full}
-        backgroundColor={BackgroundColor.backgroundAlternative}
+        backgroundColor={BoxBackgroundColor.BackgroundAlternative}
+        className="h-full w-full"
         style={{
           overflowY: 'auto',
         }}
       >
-        <Box height={BlockSize.Full} padding={4}>
+        <Box padding={4} className="h-full">
           <SnapDelineator snapName={snapName} type={DelineatorType.Error}>
             <Text variant={TextVariant.bodySm} marginBottom={4}>
               {t('snapsUIError', [<b key="0">{snapName}</b>])}

--- a/ui/components/app/snaps/snap-list-item/snap-list-item.js
+++ b/ui/components/app/snaps/snap-list-item/snap-list-item.js
@@ -3,15 +3,16 @@ import PropTypes from 'prop-types';
 
 import {
   Color,
-  AlignItems,
-  JustifyContent,
-  Display,
-  BlockSize,
   TextVariant,
-  BorderRadius,
-  BackgroundColor,
 } from '../../../../helpers/constants/design-system';
-import { Text, Box } from '../../../component-library';
+import {
+  Box,
+  BoxAlignItems,
+  BoxBackgroundColor,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
+import { Text } from '../../../component-library';
 import { SnapIcon } from '../snap-icon';
 
 const SnapListItem = ({
@@ -23,21 +24,19 @@ const SnapListItem = ({
 }) => {
   return (
     <Box
-      className="snap-list-item"
+      className="snap-list-item w-full"
       data-testid={snapId}
-      display={Display.Flex}
-      alignItems={AlignItems.center}
-      justifyContent={JustifyContent.spaceBetween}
-      width={BlockSize.Full}
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      justifyContent={BoxJustifyContent.Between}
       padding={4}
       onClick={onClick}
     >
       <Box
-        className="snap-list-item__inner-wrapper"
-        display={Display.Flex}
-        alignItems={AlignItems.center}
-        justifyContent={JustifyContent.flexStart}
-        width={BlockSize.Full}
+        className="snap-list-item__inner-wrapper w-full"
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Start}
       >
         <Box>
           <SnapIcon snapId={snapId} />
@@ -45,7 +44,7 @@ const SnapListItem = ({
         <Box
           paddingLeft={4}
           paddingRight={4}
-          width={BlockSize.Full}
+          className="w-full"
           style={{ overflow: 'hidden' }}
         >
           <Text
@@ -68,10 +67,9 @@ const SnapListItem = ({
       </Box>
       {showUpdateDot && (
         <Box
-          display={Display.Flex}
+          className="rounded-full"
           style={{ width: '10px', height: '10px', content: '' }}
-          borderRadius={BorderRadius.full}
-          backgroundColor={BackgroundColor.primaryDefault}
+          backgroundColor={BoxBackgroundColor.PrimaryDefault}
         />
       )}
     </Box>

--- a/ui/components/app/snaps/snap-list-item/snap-list-item.js
+++ b/ui/components/app/snaps/snap-list-item/snap-list-item.js
@@ -2,16 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 
 import {
-  Color,
-  TextVariant,
-} from '../../../../helpers/constants/design-system';
-import {
   Box,
   BoxAlignItems,
   BoxBackgroundColor,
   BoxFlexDirection,
   BoxJustifyContent,
 } from '@metamask/design-system-react';
+import {
+  Color,
+  TextVariant,
+} from '../../../../helpers/constants/design-system';
 import { Text } from '../../../component-library';
 import { SnapIcon } from '../snap-icon';
 

--- a/ui/components/app/snaps/snap-list-item/snap-list-item.js
+++ b/ui/components/app/snaps/snap-list-item/snap-list-item.js
@@ -24,7 +24,7 @@ const SnapListItem = ({
 }) => {
   return (
     <Box
-      className="snap-list-item w-full"
+      className="flex snap-list-item w-full"
       data-testid={snapId}
       flexDirection={BoxFlexDirection.Row}
       alignItems={BoxAlignItems.Center}
@@ -33,7 +33,7 @@ const SnapListItem = ({
       onClick={onClick}
     >
       <Box
-        className="snap-list-item__inner-wrapper w-full"
+        className="flex snap-list-item__inner-wrapper w-full"
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Center}
         justifyContent={BoxJustifyContent.Start}

--- a/ui/components/app/snaps/snap-permissions-list/snap-permissions-list.js
+++ b/ui/components/app/snaps/snap-permissions-list/snap-permissions-list.js
@@ -70,10 +70,7 @@ export default function SnapPermissionsList({
   };
 
   return (
-    <Box
-      flexDirection={BoxFlexDirection.Column}
-      className="w-full"
-    >
+    <Box flexDirection={BoxFlexDirection.Column} className="w-full">
       <Box className="snap-permissions-list w-full">
         <SnapPermissionAdapter
           permissions={showAll ? weightedPermissions : filteredPermissions}

--- a/ui/components/app/snaps/snap-permissions-list/snap-permissions-list.js
+++ b/ui/components/app/snaps/snap-permissions-list/snap-permissions-list.js
@@ -1,12 +1,12 @@
 import React, { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
-import { useI18nContext } from '../../../../hooks/useI18nContext';
 import {
   Box,
   BoxFlexDirection,
   BoxJustifyContent,
 } from '@metamask/design-system-react';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { ButtonLink } from '../../../component-library';
 import {
   getMultipleTargetsSubjectMetadata,

--- a/ui/components/app/snaps/snap-permissions-list/snap-permissions-list.js
+++ b/ui/components/app/snaps/snap-permissions-list/snap-permissions-list.js
@@ -2,17 +2,16 @@ import React, { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
-import { Box, ButtonLink } from '../../../component-library';
+import {
+  Box,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
+import { ButtonLink } from '../../../component-library';
 import {
   getMultipleTargetsSubjectMetadata,
   getSnapsMetadata,
 } from '../../../../selectors';
-import {
-  BlockSize,
-  Display,
-  FlexDirection,
-  JustifyContent,
-} from '../../../../helpers/constants/design-system';
 import {
   MinPermissionAbstractionDisplayCount,
   PermissionsAbstractionThreshold,
@@ -72,11 +71,10 @@ export default function SnapPermissionsList({
 
   return (
     <Box
-      display={Display.Flex}
-      flexDirection={FlexDirection.Column}
-      width={BlockSize.Full}
+      flexDirection={BoxFlexDirection.Column}
+      className="w-full"
     >
-      <Box className="snap-permissions-list" width={BlockSize.Full}>
+      <Box className="snap-permissions-list w-full">
         <SnapPermissionAdapter
           permissions={showAll ? weightedPermissions : filteredPermissions}
           snapId={snapId}
@@ -87,8 +85,8 @@ export default function SnapPermissionsList({
       </Box>
       {showAll ? null : (
         <Box
-          display={Display.Flex}
-          justifyContent={JustifyContent.center}
+          flexDirection={BoxFlexDirection.Row}
+          justifyContent={BoxJustifyContent.Center}
           paddingTop={2}
           paddingBottom={2}
         >

--- a/ui/components/app/snaps/snap-permissions-list/snap-permissions-list.js
+++ b/ui/components/app/snaps/snap-permissions-list/snap-permissions-list.js
@@ -70,7 +70,7 @@ export default function SnapPermissionsList({
   };
 
   return (
-    <Box flexDirection={BoxFlexDirection.Column} className="w-full">
+    <Box flexDirection={BoxFlexDirection.Column} className="flex w-full">
       <Box className="snap-permissions-list w-full">
         <SnapPermissionAdapter
           permissions={showAll ? weightedPermissions : filteredPermissions}
@@ -86,6 +86,7 @@ export default function SnapPermissionsList({
           justifyContent={BoxJustifyContent.Center}
           paddingTop={2}
           paddingBottom={2}
+          className="flex"
         >
           <ButtonLink onClick={onShowAllPermissionsHandler}>
             {t('seeAllPermissions')}

--- a/ui/components/app/snaps/snap-settings-page/snap-settings-renderer.tsx
+++ b/ui/components/app/snaps/snap-settings-page/snap-settings-renderer.tsx
@@ -4,10 +4,10 @@ import { useSearchParams } from 'react-router-dom';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 
 import { deleteInterface } from '../../../../store/actions';
-import { Box, Text } from '../../../component-library';
+import { Box, BoxBackgroundColor } from '@metamask/design-system-react';
+import { Text } from '../../../component-library';
 import {
   BackgroundColor,
-  BlockSize,
   TextVariant,
 } from '../../../../helpers/constants/design-system';
 import { SnapDelineator } from '../snap-delineator';
@@ -46,12 +46,11 @@ export const SnapSettingsRenderer = () => {
 
   return (
     <Box
-      height={BlockSize.Full}
-      width={BlockSize.Full}
-      backgroundColor={BackgroundColor.backgroundDefault}
+      backgroundColor={BoxBackgroundColor.BackgroundDefault}
+      className="h-full w-full"
     >
       {error && (
-        <Box height={BlockSize.Full} padding={4}>
+        <Box padding={4} className="h-full">
           <SnapDelineator snapName={snapName} type={DelineatorType.Error}>
             <Text variant={TextVariant.bodySm} marginBottom={4}>
               {t('snapsUIError', [<b key="0">{snapName}</b>])}

--- a/ui/components/app/snaps/snap-settings-page/snap-settings-renderer.tsx
+++ b/ui/components/app/snaps/snap-settings-page/snap-settings-renderer.tsx
@@ -1,10 +1,10 @@
 import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useSearchParams } from 'react-router-dom';
+import { Box, BoxBackgroundColor } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 
 import { deleteInterface } from '../../../../store/actions';
-import { Box, BoxBackgroundColor } from '@metamask/design-system-react';
 import { Text } from '../../../component-library';
 import {
   BackgroundColor,

--- a/ui/components/app/snaps/snap-ui-address/__snapshots__/snap-ui-address.test.tsx.snap
+++ b/ui/components/app/snaps/snap-ui-address/__snapshots__/snap-ui-address.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`SnapUIAddress renders Bitcoin address 1`] = `
 <div>
   <div
-    class="flex flex-row gap-2 items-center snap-ui-renderer__address"
+    class="flex-row gap-2 items-center flex snap-ui-renderer__address"
     data-testid="snap-ui-address"
   >
     <div
@@ -62,7 +62,7 @@ exports[`SnapUIAddress renders Bitcoin address 1`] = `
 exports[`SnapUIAddress renders Bitcoin address with blockie 1`] = `
 <div>
   <div
-    class="flex flex-row gap-2 items-center snap-ui-renderer__address"
+    class="flex-row gap-2 items-center flex snap-ui-renderer__address"
     data-testid="snap-ui-address"
   >
     <div
@@ -88,7 +88,7 @@ exports[`SnapUIAddress renders Bitcoin address with blockie 1`] = `
 exports[`SnapUIAddress renders Cosmos address 1`] = `
 <div>
   <div
-    class="flex flex-row gap-2 items-center snap-ui-renderer__address"
+    class="flex-row gap-2 items-center flex snap-ui-renderer__address"
     data-testid="snap-ui-address"
   >
     <div
@@ -147,7 +147,7 @@ exports[`SnapUIAddress renders Cosmos address 1`] = `
 exports[`SnapUIAddress renders Cosmos address with blockie 1`] = `
 <div>
   <div
-    class="flex flex-row gap-2 items-center snap-ui-renderer__address"
+    class="flex-row gap-2 items-center flex snap-ui-renderer__address"
     data-testid="snap-ui-address"
   >
     <div
@@ -173,7 +173,7 @@ exports[`SnapUIAddress renders Cosmos address with blockie 1`] = `
 exports[`SnapUIAddress renders Ethereum address 1`] = `
 <div>
   <div
-    class="flex flex-row gap-2 items-center snap-ui-renderer__address"
+    class="flex-row gap-2 items-center flex snap-ui-renderer__address"
     data-testid="snap-ui-address"
   >
     <div
@@ -232,7 +232,7 @@ exports[`SnapUIAddress renders Ethereum address 1`] = `
 exports[`SnapUIAddress renders Ethereum address with blockie 1`] = `
 <div>
   <div
-    class="flex flex-row gap-2 items-center snap-ui-renderer__address"
+    class="flex-row gap-2 items-center flex snap-ui-renderer__address"
     data-testid="snap-ui-address"
   >
     <div
@@ -258,7 +258,7 @@ exports[`SnapUIAddress renders Ethereum address with blockie 1`] = `
 exports[`SnapUIAddress renders Hedera address 1`] = `
 <div>
   <div
-    class="flex flex-row gap-2 items-center snap-ui-renderer__address"
+    class="flex-row gap-2 items-center flex snap-ui-renderer__address"
     data-testid="snap-ui-address"
   >
     <div
@@ -317,7 +317,7 @@ exports[`SnapUIAddress renders Hedera address 1`] = `
 exports[`SnapUIAddress renders Hedera address with blockie 1`] = `
 <div>
   <div
-    class="flex flex-row gap-2 items-center snap-ui-renderer__address"
+    class="flex-row gap-2 items-center flex snap-ui-renderer__address"
     data-testid="snap-ui-address"
   >
     <div
@@ -343,7 +343,7 @@ exports[`SnapUIAddress renders Hedera address with blockie 1`] = `
 exports[`SnapUIAddress renders Polkadot address 1`] = `
 <div>
   <div
-    class="flex flex-row gap-2 items-center snap-ui-renderer__address"
+    class="flex-row gap-2 items-center flex snap-ui-renderer__address"
     data-testid="snap-ui-address"
   >
     <div
@@ -402,7 +402,7 @@ exports[`SnapUIAddress renders Polkadot address 1`] = `
 exports[`SnapUIAddress renders Polkadot address with blockie 1`] = `
 <div>
   <div
-    class="flex flex-row gap-2 items-center snap-ui-renderer__address"
+    class="flex-row gap-2 items-center flex snap-ui-renderer__address"
     data-testid="snap-ui-address"
   >
     <div
@@ -428,7 +428,7 @@ exports[`SnapUIAddress renders Polkadot address with blockie 1`] = `
 exports[`SnapUIAddress renders Starknet address 1`] = `
 <div>
   <div
-    class="flex flex-row gap-2 items-center snap-ui-renderer__address"
+    class="flex-row gap-2 items-center flex snap-ui-renderer__address"
     data-testid="snap-ui-address"
   >
     <div
@@ -487,7 +487,7 @@ exports[`SnapUIAddress renders Starknet address 1`] = `
 exports[`SnapUIAddress renders Starknet address with blockie 1`] = `
 <div>
   <div
-    class="flex flex-row gap-2 items-center snap-ui-renderer__address"
+    class="flex-row gap-2 items-center flex snap-ui-renderer__address"
     data-testid="snap-ui-address"
   >
     <div
@@ -513,7 +513,7 @@ exports[`SnapUIAddress renders Starknet address with blockie 1`] = `
 exports[`SnapUIAddress renders legacy Ethereum address 1`] = `
 <div>
   <div
-    class="flex flex-row gap-2 items-center snap-ui-renderer__address"
+    class="flex-row gap-2 items-center flex snap-ui-renderer__address"
     data-testid="snap-ui-address"
   >
     <div

--- a/ui/components/app/snaps/snap-ui-address/__snapshots__/snap-ui-address.test.tsx.snap
+++ b/ui/components/app/snaps/snap-ui-address/__snapshots__/snap-ui-address.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`SnapUIAddress renders Bitcoin address 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__address mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+    class="flex flex-row gap-2 items-center snap-ui-renderer__address"
     data-testid="snap-ui-address"
   >
     <div
@@ -62,7 +62,7 @@ exports[`SnapUIAddress renders Bitcoin address 1`] = `
 exports[`SnapUIAddress renders Bitcoin address with blockie 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__address mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+    class="flex flex-row gap-2 items-center snap-ui-renderer__address"
     data-testid="snap-ui-address"
   >
     <div
@@ -88,7 +88,7 @@ exports[`SnapUIAddress renders Bitcoin address with blockie 1`] = `
 exports[`SnapUIAddress renders Cosmos address 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__address mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+    class="flex flex-row gap-2 items-center snap-ui-renderer__address"
     data-testid="snap-ui-address"
   >
     <div
@@ -147,7 +147,7 @@ exports[`SnapUIAddress renders Cosmos address 1`] = `
 exports[`SnapUIAddress renders Cosmos address with blockie 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__address mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+    class="flex flex-row gap-2 items-center snap-ui-renderer__address"
     data-testid="snap-ui-address"
   >
     <div
@@ -173,7 +173,7 @@ exports[`SnapUIAddress renders Cosmos address with blockie 1`] = `
 exports[`SnapUIAddress renders Ethereum address 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__address mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+    class="flex flex-row gap-2 items-center snap-ui-renderer__address"
     data-testid="snap-ui-address"
   >
     <div
@@ -232,7 +232,7 @@ exports[`SnapUIAddress renders Ethereum address 1`] = `
 exports[`SnapUIAddress renders Ethereum address with blockie 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__address mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+    class="flex flex-row gap-2 items-center snap-ui-renderer__address"
     data-testid="snap-ui-address"
   >
     <div
@@ -258,7 +258,7 @@ exports[`SnapUIAddress renders Ethereum address with blockie 1`] = `
 exports[`SnapUIAddress renders Hedera address 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__address mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+    class="flex flex-row gap-2 items-center snap-ui-renderer__address"
     data-testid="snap-ui-address"
   >
     <div
@@ -317,7 +317,7 @@ exports[`SnapUIAddress renders Hedera address 1`] = `
 exports[`SnapUIAddress renders Hedera address with blockie 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__address mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+    class="flex flex-row gap-2 items-center snap-ui-renderer__address"
     data-testid="snap-ui-address"
   >
     <div
@@ -343,7 +343,7 @@ exports[`SnapUIAddress renders Hedera address with blockie 1`] = `
 exports[`SnapUIAddress renders Polkadot address 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__address mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+    class="flex flex-row gap-2 items-center snap-ui-renderer__address"
     data-testid="snap-ui-address"
   >
     <div
@@ -402,7 +402,7 @@ exports[`SnapUIAddress renders Polkadot address 1`] = `
 exports[`SnapUIAddress renders Polkadot address with blockie 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__address mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+    class="flex flex-row gap-2 items-center snap-ui-renderer__address"
     data-testid="snap-ui-address"
   >
     <div
@@ -428,7 +428,7 @@ exports[`SnapUIAddress renders Polkadot address with blockie 1`] = `
 exports[`SnapUIAddress renders Starknet address 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__address mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+    class="flex flex-row gap-2 items-center snap-ui-renderer__address"
     data-testid="snap-ui-address"
   >
     <div
@@ -487,7 +487,7 @@ exports[`SnapUIAddress renders Starknet address 1`] = `
 exports[`SnapUIAddress renders Starknet address with blockie 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__address mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+    class="flex flex-row gap-2 items-center snap-ui-renderer__address"
     data-testid="snap-ui-address"
   >
     <div
@@ -513,7 +513,7 @@ exports[`SnapUIAddress renders Starknet address with blockie 1`] = `
 exports[`SnapUIAddress renders legacy Ethereum address 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__address mm-box--display-flex mm-box--gap-2 mm-box--align-items-center"
+    class="flex flex-row gap-2 items-center snap-ui-renderer__address"
     data-testid="snap-ui-address"
   >
     <div

--- a/ui/components/app/snaps/snap-ui-address/snap-ui-address.tsx
+++ b/ui/components/app/snaps/snap-ui-address/snap-ui-address.tsx
@@ -66,7 +66,7 @@ export const SnapUIAddress: React.FunctionComponent<SnapUIAddressProps> = ({
 
   return (
     <Box
-      className="snap-ui-renderer__address"
+      className="flex snap-ui-renderer__address"
       data-testid="snap-ui-address"
       flexDirection={BoxFlexDirection.Row}
       alignItems={BoxAlignItems.Center}

--- a/ui/components/app/snaps/snap-ui-address/snap-ui-address.tsx
+++ b/ui/components/app/snaps/snap-ui-address/snap-ui-address.tsx
@@ -4,11 +4,14 @@ import {
   isHexString,
   parseCaipAccountId,
 } from '@metamask/utils';
-import { AvatarAccountSize } from '@metamask/design-system-react';
-import { Box, Text } from '../../../component-library';
 import {
-  AlignItems,
-  Display,
+  AvatarAccountSize,
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+} from '@metamask/design-system-react';
+import { Text } from '../../../component-library';
+import {
   TextColor,
   TextVariant,
 } from '../../../../helpers/constants/design-system';
@@ -65,8 +68,8 @@ export const SnapUIAddress: React.FunctionComponent<SnapUIAddressProps> = ({
     <Box
       className="snap-ui-renderer__address"
       data-testid="snap-ui-address"
-      display={Display.Flex}
-      alignItems={AlignItems.center}
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
       gap={2}
     >
       {avatar && <SnapUIAvatar address={caipIdentifier} size={avatarSize} />}

--- a/ui/components/app/snaps/snap-ui-card/snap-ui-card.tsx
+++ b/ui/components/app/snaps/snap-ui-card/snap-ui-card.tsx
@@ -1,14 +1,15 @@
 import React, { FunctionComponent, ReactNode } from 'react';
 import {
-  Display,
-  FlexDirection,
-  JustifyContent,
-  TextAlign,
   TextColor,
   TextVariant,
-  AlignItems,
 } from '../../../../helpers/constants/design-system';
-import { Box, Text } from '../../../component-library';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
+import { Text } from '../../../component-library';
 import { SnapUIImage } from '../snap-ui-image';
 
 export type SnapUICardProps = {
@@ -29,15 +30,15 @@ export const SnapUICard: FunctionComponent<SnapUICardProps> = ({
   return (
     <Box
       className="snap-ui-renderer__card"
-      display={Display.Flex}
-      justifyContent={JustifyContent.spaceBetween}
-      alignItems={AlignItems.center}
+      flexDirection={BoxFlexDirection.Row}
+      justifyContent={BoxJustifyContent.Between}
+      alignItems={BoxAlignItems.Center}
       gap={2}
     >
       <Box
-        display={Display.Flex}
+        flexDirection={BoxFlexDirection.Row}
         gap={4}
-        alignItems={AlignItems.center}
+        alignItems={BoxAlignItems.Center}
         style={{ overflow: 'hidden' }}
       >
         {image && (
@@ -49,8 +50,7 @@ export const SnapUICard: FunctionComponent<SnapUICardProps> = ({
           />
         )}
         <Box
-          display={Display.Flex}
-          flexDirection={FlexDirection.Column}
+          flexDirection={BoxFlexDirection.Column}
           style={{ overflow: 'hidden' }}
         >
           <Text variant={TextVariant.bodyMdMedium} ellipsis>
@@ -64,9 +64,8 @@ export const SnapUICard: FunctionComponent<SnapUICardProps> = ({
         </Box>
       </Box>
       <Box
-        display={Display.Flex}
-        flexDirection={FlexDirection.Column}
-        textAlign={TextAlign.Right}
+        flexDirection={BoxFlexDirection.Column}
+        className="text-right"
         style={{ overflow: 'hidden' }}
       >
         <Text variant={TextVariant.bodyMdMedium} ellipsis>

--- a/ui/components/app/snaps/snap-ui-card/snap-ui-card.tsx
+++ b/ui/components/app/snaps/snap-ui-card/snap-ui-card.tsx
@@ -29,7 +29,7 @@ export const SnapUICard: FunctionComponent<SnapUICardProps> = ({
 }) => {
   return (
     <Box
-      className="snap-ui-renderer__card"
+      className="flex snap-ui-renderer__card"
       flexDirection={BoxFlexDirection.Row}
       justifyContent={BoxJustifyContent.Between}
       alignItems={BoxAlignItems.Center}
@@ -39,6 +39,7 @@ export const SnapUICard: FunctionComponent<SnapUICardProps> = ({
         flexDirection={BoxFlexDirection.Row}
         gap={4}
         alignItems={BoxAlignItems.Center}
+        className="flex"
         style={{ overflow: 'hidden' }}
       >
         {image && (
@@ -51,6 +52,7 @@ export const SnapUICard: FunctionComponent<SnapUICardProps> = ({
         )}
         <Box
           flexDirection={BoxFlexDirection.Column}
+          className="flex"
           style={{ overflow: 'hidden' }}
         >
           <Text variant={TextVariant.bodyMdMedium} ellipsis>
@@ -65,7 +67,7 @@ export const SnapUICard: FunctionComponent<SnapUICardProps> = ({
       </Box>
       <Box
         flexDirection={BoxFlexDirection.Column}
-        className="text-right"
+        className="flex text-right"
         style={{ overflow: 'hidden' }}
       >
         <Text variant={TextVariant.bodyMdMedium} ellipsis>

--- a/ui/components/app/snaps/snap-ui-card/snap-ui-card.tsx
+++ b/ui/components/app/snaps/snap-ui-card/snap-ui-card.tsx
@@ -1,14 +1,14 @@
 import React, { FunctionComponent, ReactNode } from 'react';
 import {
-  TextColor,
-  TextVariant,
-} from '../../../../helpers/constants/design-system';
-import {
   Box,
   BoxAlignItems,
   BoxFlexDirection,
   BoxJustifyContent,
 } from '@metamask/design-system-react';
+import {
+  TextColor,
+  TextVariant,
+} from '../../../../helpers/constants/design-system';
 import { Text } from '../../../component-library';
 import { SnapUIImage } from '../snap-ui-image';
 

--- a/ui/components/app/snaps/snap-ui-form/snap-ui-form.tsx
+++ b/ui/components/app/snaps/snap-ui-form/snap-ui-form.tsx
@@ -22,7 +22,12 @@ export const SnapUIForm: FunctionComponent<SnapUIFormProps> = ({
   };
 
   return (
-    <Box asChild flexDirection={BoxFlexDirection.Column} gap={2} className="flex">
+    <Box
+      asChild
+      flexDirection={BoxFlexDirection.Column}
+      gap={2}
+      className="flex"
+    >
       <form
         className="snap-ui-renderer__form"
         onSubmit={handleSubmit}

--- a/ui/components/app/snaps/snap-ui-form/snap-ui-form.tsx
+++ b/ui/components/app/snaps/snap-ui-form/snap-ui-form.tsx
@@ -1,11 +1,7 @@
 import React, { FormEvent, FunctionComponent } from 'react';
 import { UserInputEventType } from '@metamask/snaps-sdk';
 import { useSnapInterfaceContext } from '../../../../contexts/snaps';
-import { Box } from '../../../component-library';
-import {
-  Display,
-  FlexDirection,
-} from '../../../../helpers/constants/design-system';
+import { Box, BoxFlexDirection } from '@metamask/design-system-react';
 
 export type SnapUIFormProps = {
   name: string;
@@ -26,16 +22,14 @@ export const SnapUIForm: FunctionComponent<SnapUIFormProps> = ({
   };
 
   return (
-    <Box
-      as="form"
-      className="snap-ui-renderer__form"
-      onSubmit={handleSubmit}
-      id={name}
-      display={Display.Flex}
-      flexDirection={FlexDirection.Column}
-      gap={2}
-    >
-      {children}
+    <Box asChild flexDirection={BoxFlexDirection.Column} gap={2}>
+      <form
+        className="snap-ui-renderer__form"
+        onSubmit={handleSubmit}
+        id={name}
+      >
+        {children}
+      </form>
     </Box>
   );
 };

--- a/ui/components/app/snaps/snap-ui-form/snap-ui-form.tsx
+++ b/ui/components/app/snaps/snap-ui-form/snap-ui-form.tsx
@@ -1,7 +1,7 @@
 import React, { FormEvent, FunctionComponent } from 'react';
 import { UserInputEventType } from '@metamask/snaps-sdk';
-import { useSnapInterfaceContext } from '../../../../contexts/snaps';
 import { Box, BoxFlexDirection } from '@metamask/design-system-react';
+import { useSnapInterfaceContext } from '../../../../contexts/snaps';
 
 export type SnapUIFormProps = {
   name: string;

--- a/ui/components/app/snaps/snap-ui-form/snap-ui-form.tsx
+++ b/ui/components/app/snaps/snap-ui-form/snap-ui-form.tsx
@@ -22,7 +22,7 @@ export const SnapUIForm: FunctionComponent<SnapUIFormProps> = ({
   };
 
   return (
-    <Box asChild flexDirection={BoxFlexDirection.Column} gap={2}>
+    <Box asChild flexDirection={BoxFlexDirection.Column} gap={2} className="flex">
       <form
         className="snap-ui-renderer__form"
         onSubmit={handleSubmit}

--- a/ui/components/app/snaps/snap-ui-renderer/__snapshots__/snap-ui-renderer.test.js.snap
+++ b/ui/components/app/snaps/snap-ui-renderer/__snapshots__/snap-ui-renderer.test.js.snap
@@ -3,7 +3,7 @@
 exports[`SnapUIRenderer prefills interactive inputs with existing state 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    class="snap-ui-renderer__content h-full bg-alternative"
     style="overflow-y: auto;"
   >
     <div
@@ -41,7 +41,7 @@ exports[`SnapUIRenderer prefills interactive inputs with existing state 1`] = `
 exports[`SnapUIRenderer re-focuses input after re-render 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    class="snap-ui-renderer__content h-full bg-alternative"
     style="overflow-y: auto;"
   >
     <div
@@ -95,7 +95,7 @@ exports[`SnapUIRenderer re-focuses input after re-render 1`] = `
 exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    class="snap-ui-renderer__content h-full bg-alternative"
     style="overflow-y: auto;"
   >
     <div
@@ -149,7 +149,7 @@ exports[`SnapUIRenderer re-renders when the interface changes 1`] = `
 exports[`SnapUIRenderer re-syncs state when the interface changes 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    class="snap-ui-renderer__content h-full bg-alternative"
     style="overflow-y: auto;"
   >
     <div
@@ -203,7 +203,7 @@ exports[`SnapUIRenderer re-syncs state when the interface changes 1`] = `
 exports[`SnapUIRenderer renders basic UI 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    class="snap-ui-renderer__content h-full bg-alternative"
     style="overflow-y: auto;"
   >
     <div
@@ -230,7 +230,7 @@ exports[`SnapUIRenderer renders basic UI 1`] = `
 exports[`SnapUIRenderer renders footers 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    class="snap-ui-renderer__content h-full bg-alternative"
     style="overflow-y: auto;"
   >
     <div
@@ -278,7 +278,7 @@ exports[`SnapUIRenderer renders footers 1`] = `
 exports[`SnapUIRenderer renders loading state 1`] = `
 <div>
   <div
-    class="mm-box mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--width-full mm-box--height-full"
+    class="flex flex-row items-center justify-center h-full w-full"
   >
     <div
       class="pulse-loader"
@@ -301,7 +301,7 @@ exports[`SnapUIRenderer renders loading state 1`] = `
 exports[`SnapUIRenderer supports container backgrounds 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-default"
+    class="snap-ui-renderer__content h-full bg-default"
     style="overflow-y: auto;"
   >
     <div
@@ -349,7 +349,7 @@ exports[`SnapUIRenderer supports container backgrounds 1`] = `
 exports[`SnapUIRenderer supports interactive inputs 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    class="snap-ui-renderer__content h-full bg-alternative"
     style="overflow-y: auto;"
   >
     <div
@@ -387,7 +387,7 @@ exports[`SnapUIRenderer supports interactive inputs 1`] = `
 exports[`SnapUIRenderer supports the contentBackgroundColor prop 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-default"
+    class="snap-ui-renderer__content h-full bg-default"
     style="overflow-y: auto;"
   >
     <div
@@ -435,7 +435,7 @@ exports[`SnapUIRenderer supports the contentBackgroundColor prop 1`] = `
 exports[`SnapUIRenderer supports the onCancel prop 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    class="snap-ui-renderer__content h-full bg-alternative"
     style="overflow-y: auto;"
   >
     <div

--- a/ui/components/app/snaps/snap-ui-renderer/__snapshots__/snap-ui-renderer.test.js.snap
+++ b/ui/components/app/snaps/snap-ui-renderer/__snapshots__/snap-ui-renderer.test.js.snap
@@ -278,7 +278,7 @@ exports[`SnapUIRenderer renders footers 1`] = `
 exports[`SnapUIRenderer renders loading state 1`] = `
 <div>
   <div
-    class="flex flex-row items-center justify-center h-full w-full"
+    class="flex-row items-center justify-center flex h-full w-full"
   >
     <div
       class="pulse-loader"

--- a/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/account-selector.test.ts.snap
+++ b/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/account-selector.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`SnapUIAccountSelector renders an account selector 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    class="snap-ui-renderer__content h-full bg-alternative"
     style="overflow-y: auto;"
   >
     <div
@@ -309,7 +309,7 @@ exports[`SnapUIAccountSelector renders an account selector 1`] = `
 exports[`SnapUIAccountSelector renders inside a field 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    class="snap-ui-renderer__content h-full bg-alternative"
     style="overflow-y: auto;"
   >
     <div

--- a/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/address-input.test.ts.snap
+++ b/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/address-input.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`SnapUIAddressInput renders the matched address info in a disabled state 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    class="snap-ui-renderer__content h-full bg-alternative"
     style="overflow-y: auto;"
   >
     <div
@@ -101,7 +101,7 @@ exports[`SnapUIAddressInput renders the matched address info in a disabled state
 exports[`SnapUIAddressInput renders with an invalid CAIP Account ID 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    class="snap-ui-renderer__content h-full bg-alternative"
     style="overflow-y: auto;"
   >
     <div
@@ -143,7 +143,7 @@ exports[`SnapUIAddressInput renders with an invalid CAIP Account ID 1`] = `
 exports[`SnapUIAddressInput will not render avatar when displayAvatar is false 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    class="snap-ui-renderer__content h-full bg-alternative"
     style="overflow-y: auto;"
   >
     <div
@@ -185,7 +185,7 @@ exports[`SnapUIAddressInput will not render avatar when displayAvatar is false 1
 exports[`SnapUIAddressInput will render 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    class="snap-ui-renderer__content h-full bg-alternative"
     style="overflow-y: auto;"
   >
     <div
@@ -223,7 +223,7 @@ exports[`SnapUIAddressInput will render 1`] = `
 exports[`SnapUIAddressInput will render a matched address name 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    class="snap-ui-renderer__content h-full bg-alternative"
     style="overflow-y: auto;"
   >
     <div
@@ -321,7 +321,7 @@ exports[`SnapUIAddressInput will render a matched address name 1`] = `
 exports[`SnapUIAddressInput will render avatar when displayAvatar is true 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    class="snap-ui-renderer__content h-full bg-alternative"
     style="overflow-y: auto;"
   >
     <div

--- a/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/asset-selector.test.ts.snap
+++ b/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/asset-selector.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`SnapUIAssetSelector renders an asset selector 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    class="snap-ui-renderer__content h-full bg-alternative"
     style="overflow-y: auto;"
   >
     <div
@@ -107,7 +107,7 @@ exports[`SnapUIAssetSelector renders an asset selector 1`] = `
 exports[`SnapUIAssetSelector renders inside a field 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    class="snap-ui-renderer__content h-full bg-alternative"
     style="overflow-y: auto;"
   >
     <div

--- a/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/collapsible-section.test.ts.snap
+++ b/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/collapsible-section.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`CollapsibleSection can expand 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    class="snap-ui-renderer__content h-full bg-alternative"
     style="overflow-y: auto;"
   >
     <div

--- a/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/date-time-picker.test.ts.snap
+++ b/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/date-time-picker.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`SnapUIDateTimePicker can show an error 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    class="snap-ui-renderer__content h-full bg-alternative"
     style="overflow-y: auto;"
   >
     <div
@@ -57,7 +57,7 @@ exports[`SnapUIDateTimePicker can show an error 1`] = `
 exports[`SnapUIDateTimePicker renders a date picker 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    class="snap-ui-renderer__content h-full bg-alternative"
     style="overflow-y: auto;"
   >
     <div
@@ -100,7 +100,7 @@ exports[`SnapUIDateTimePicker renders a date picker 1`] = `
 exports[`SnapUIDateTimePicker renders a date time picker 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    class="snap-ui-renderer__content h-full bg-alternative"
     style="overflow-y: auto;"
   >
     <div
@@ -143,7 +143,7 @@ exports[`SnapUIDateTimePicker renders a date time picker 1`] = `
 exports[`SnapUIDateTimePicker renders a time picker 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    class="snap-ui-renderer__content h-full bg-alternative"
     style="overflow-y: auto;"
   >
     <div
@@ -186,7 +186,7 @@ exports[`SnapUIDateTimePicker renders a time picker 1`] = `
 exports[`SnapUIDateTimePicker renders inside a field 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    class="snap-ui-renderer__content h-full bg-alternative"
     style="overflow-y: auto;"
   >
     <div

--- a/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/file-input.test.ts.snap
+++ b/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/file-input.test.ts.snap
@@ -13,7 +13,7 @@ exports[`SnapUIFileInput renders and emits events when used 1`] = `
         class="box snap-ui-renderer__panel box--display-flex box--flex-direction-column box--justify-content-flex-start box--color-text-default"
       >
         <form
-          class="flex flex-col gap-2 snap-ui-renderer__form"
+          class="flex-col gap-2 flex snap-ui-renderer__form"
           id="form"
         >
           <div

--- a/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/file-input.test.ts.snap
+++ b/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/file-input.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`SnapUIFileInput renders and emits events when used 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    class="snap-ui-renderer__content h-full bg-alternative"
     style="overflow-y: auto;"
   >
     <div
@@ -13,7 +13,7 @@ exports[`SnapUIFileInput renders and emits events when used 1`] = `
         class="box snap-ui-renderer__panel box--display-flex box--flex-direction-column box--justify-content-flex-start box--color-text-default"
       >
         <form
-          class="mm-box snap-ui-renderer__form mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-column"
+          class="flex flex-col gap-2 snap-ui-renderer__form"
           id="form"
         >
           <div

--- a/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/form.test.ts.snap
+++ b/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/form.test.ts.snap
@@ -13,7 +13,7 @@ exports[`SnapUIForm will render 1`] = `
         class="box snap-ui-renderer__panel box--display-flex box--flex-direction-column box--justify-content-flex-start box--color-text-default"
       >
         <form
-          class="flex flex-col gap-2 snap-ui-renderer__form"
+          class="flex-col gap-2 flex snap-ui-renderer__form"
           id="form"
         >
           <div
@@ -63,7 +63,7 @@ exports[`SnapUIForm will render with fields 1`] = `
         class="box snap-ui-renderer__panel box--display-flex box--flex-direction-column box--justify-content-flex-start box--color-text-default"
       >
         <form
-          class="flex flex-col gap-2 snap-ui-renderer__form"
+          class="flex-col gap-2 flex snap-ui-renderer__form"
           id="form"
         >
           <div

--- a/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/form.test.ts.snap
+++ b/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/form.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`SnapUIForm will render 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    class="snap-ui-renderer__content h-full bg-alternative"
     style="overflow-y: auto;"
   >
     <div
@@ -13,7 +13,7 @@ exports[`SnapUIForm will render 1`] = `
         class="box snap-ui-renderer__panel box--display-flex box--flex-direction-column box--justify-content-flex-start box--color-text-default"
       >
         <form
-          class="mm-box snap-ui-renderer__form mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-column"
+          class="flex flex-col gap-2 snap-ui-renderer__form"
           id="form"
         >
           <div
@@ -53,7 +53,7 @@ exports[`SnapUIForm will render 1`] = `
 exports[`SnapUIForm will render with fields 1`] = `
 <div>
   <div
-    class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-alternative"
+    class="snap-ui-renderer__content h-full bg-alternative"
     style="overflow-y: auto;"
   >
     <div
@@ -63,7 +63,7 @@ exports[`SnapUIForm will render with fields 1`] = `
         class="box snap-ui-renderer__panel box--display-flex box--flex-direction-column box--justify-content-flex-start box--color-text-default"
       >
         <form
-          class="mm-box snap-ui-renderer__form mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-column"
+          class="flex flex-col gap-2 snap-ui-renderer__form"
           id="form"
         >
           <div

--- a/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
+++ b/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
@@ -7,14 +7,14 @@ import { isEqual } from 'lodash';
 import { MuiPickersUtilsProvider } from '@material-ui/pickers';
 import LuxonUtils from '@date-io/luxon';
 import { ThemeProvider } from '@material-ui/core/styles';
-import MetaMaskTemplateRenderer from '../../metamask-template-renderer/metamask-template-renderer';
-import { getInterface } from '../../../../selectors';
 import {
   Box,
   BoxAlignItems,
   BoxFlexDirection,
   BoxJustifyContent,
 } from '@metamask/design-system-react';
+import MetaMaskTemplateRenderer from '../../metamask-template-renderer/metamask-template-renderer';
+import { getInterface } from '../../../../selectors';
 
 import { SnapInterfaceContextProvider } from '../../../../contexts/snaps';
 import PulseLoader from '../../../ui/pulse-loader';

--- a/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
+++ b/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
@@ -28,6 +28,16 @@ import {
 } from './utils';
 import { COMPONENT_MAPPING } from './components';
 
+// Maps legacy BackgroundColor enum values used by Snaps content to the
+// Tailwind utility classes consumed by `@metamask/design-system-react` Box.
+const BACKGROUND_TO_TAILWIND = {
+  [BackgroundColor.backgroundDefault]: 'bg-default',
+  [BackgroundColor.backgroundAlternative]: 'bg-alternative',
+  [BackgroundColor.backgroundSection]: 'bg-section',
+  [BackgroundColor.backgroundSubsection]: 'bg-subsection',
+  [BackgroundColor.backgroundMuted]: 'bg-muted',
+};
+
 // Component for tracking the number of re-renders
 // DO NOT USE IN PRODUCTION
 const PerformanceTracker = () => {
@@ -147,11 +157,7 @@ const SnapUIRendererComponent = ({
       <ThemeProvider theme={muiPickerTheme}>
         <MuiPickersUtilsProvider utils={LuxonUtils} locale={locale}>
           <Box
-            className={`snap-ui-renderer__content h-full ${
-              backgroundColor === BackgroundColor.backgroundDefault
-                ? 'bg-default'
-                : 'bg-alternative'
-            }`}
+            className={`snap-ui-renderer__content h-full ${BACKGROUND_TO_TAILWIND[backgroundColor] ?? 'bg-alternative'}`}
             style={{
               overflowY: 'auto',
             }}

--- a/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
+++ b/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
@@ -139,7 +139,7 @@ const SnapUIRendererComponent = ({
         flexDirection={BoxFlexDirection.Row}
         justifyContent={BoxJustifyContent.Center}
         alignItems={BoxAlignItems.Center}
-        className="h-full w-full"
+        className="flex h-full w-full"
       >
         <PulseLoader />
       </Box>

--- a/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
+++ b/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.js
@@ -9,17 +9,16 @@ import LuxonUtils from '@date-io/luxon';
 import { ThemeProvider } from '@material-ui/core/styles';
 import MetaMaskTemplateRenderer from '../../metamask-template-renderer/metamask-template-renderer';
 import { getInterface } from '../../../../selectors';
-import { Box } from '../../../component-library';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
 
 import { SnapInterfaceContextProvider } from '../../../../contexts/snaps';
 import PulseLoader from '../../../ui/pulse-loader';
-import {
-  AlignItems,
-  BackgroundColor,
-  BlockSize,
-  Display,
-  JustifyContent,
-} from '../../../../helpers/constants/design-system';
+import { BackgroundColor } from '../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { getIntlLocale } from '../../../../ducks/locale/locale';
 import {
@@ -127,11 +126,10 @@ const SnapUIRendererComponent = ({
   if (isLoading || !content) {
     return (
       <Box
-        display={Display.Flex}
-        justifyContent={JustifyContent.center}
-        alignItems={AlignItems.center}
-        height={BlockSize.Full}
-        width={BlockSize.Full}
+        flexDirection={BoxFlexDirection.Row}
+        justifyContent={BoxJustifyContent.Center}
+        alignItems={BoxAlignItems.Center}
+        className="h-full w-full"
       >
         <PulseLoader />
       </Box>
@@ -149,9 +147,11 @@ const SnapUIRendererComponent = ({
       <ThemeProvider theme={muiPickerTheme}>
         <MuiPickersUtilsProvider utils={LuxonUtils} locale={locale}>
           <Box
-            className="snap-ui-renderer__content"
-            height={BlockSize.Full}
-            backgroundColor={backgroundColor}
+            className={`snap-ui-renderer__content h-full ${
+              backgroundColor === BackgroundColor.backgroundDefault
+                ? 'bg-default'
+                : 'bg-alternative'
+            }`}
             style={{
               overflowY: 'auto',
             }}

--- a/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.test.js
+++ b/ui/components/app/snaps/snap-ui-renderer/snap-ui-renderer.test.js
@@ -55,11 +55,7 @@ describe('SnapUIRenderer', () => {
       },
     );
 
-    expect(
-      container.getElementsByClassName(
-        'mm-box--background-color-background-default',
-      ),
-    ).toHaveLength(1);
+    expect(container.getElementsByClassName('bg-default')).toHaveLength(1);
     expect(container).toMatchSnapshot();
   });
 
@@ -78,10 +74,11 @@ describe('SnapUIRenderer', () => {
     );
 
     expect(
-      container.getElementsByClassName(
-        'mm-box snap-ui-renderer__content mm-box--background-color-background-default',
-      ),
+      container.getElementsByClassName('snap-ui-renderer__content'),
     ).toHaveLength(1);
+    expect(
+      container.querySelector('.snap-ui-renderer__content.bg-default'),
+    ).not.toBeNull();
     expect(container).toMatchSnapshot();
   });
 

--- a/ui/components/app/snaps/snap-ui-selector/snap-ui-selector.stories.tsx
+++ b/ui/components/app/snaps/snap-ui-selector/snap-ui-selector.stories.tsx
@@ -66,14 +66,15 @@ AdvancedStory.args = {
       key="account1"
       flexDirection={BoxFlexDirection.Row}
       justifyContent={BoxJustifyContent.Between}
+      className="flex"
     >
-      <Box flexDirection={BoxFlexDirection.Column}>
+      <Box flexDirection={BoxFlexDirection.Column} className="flex">
         <Text>Account 1</Text>
         <Text>
           {shortenAddress('0xc0ffee254729296a45a3885639AC7E10F9d54979')}
         </Text>
       </Box>
-      <Box flexDirection={BoxFlexDirection.Column}>
+      <Box flexDirection={BoxFlexDirection.Column} className="flex">
         <Text>3000 USD</Text>
         <Text>1 ETH</Text>
       </Box>
@@ -82,14 +83,15 @@ AdvancedStory.args = {
       key="account2"
       flexDirection={BoxFlexDirection.Row}
       justifyContent={BoxJustifyContent.Between}
+      className="flex"
     >
-      <Box flexDirection={BoxFlexDirection.Column}>
+      <Box flexDirection={BoxFlexDirection.Column} className="flex">
         <Text>Account 2</Text>
         <Text>
           {shortenAddress('0xc0ffee254729296a45a3885639AC7E10F9d54979')}
         </Text>
       </Box>
-      <Box flexDirection={BoxFlexDirection.Column}>
+      <Box flexDirection={BoxFlexDirection.Column} className="flex">
         <Text>0 USD</Text>
         <Text>0 ETH</Text>
       </Box>

--- a/ui/components/app/snaps/snap-ui-selector/snap-ui-selector.stories.tsx
+++ b/ui/components/app/snaps/snap-ui-selector/snap-ui-selector.stories.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { SnapUISelector } from './snap-ui-selector';
-import { Box, Text } from '../../../component-library';
 import {
-  Display,
-  FlexDirection,
-  JustifyContent,
-} from '../../../../helpers/constants/design-system';
+  Box,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
+import { Text } from '../../../component-library';
 import { shortenAddress } from '../../../../helpers/utils/util';
 import { SnapUICard } from '../snap-ui-card/snap-ui-card';
 import configureStore from '../../../../store/store';
@@ -64,32 +64,32 @@ AdvancedStory.args = {
   optionComponents: [
     <Box
       key="account1"
-      display={Display.Flex}
-      justifyContent={JustifyContent.spaceBetween}
+      flexDirection={BoxFlexDirection.Row}
+      justifyContent={BoxJustifyContent.Between}
     >
-      <Box display={Display.Flex} flexDirection={FlexDirection.Column}>
+      <Box flexDirection={BoxFlexDirection.Column}>
         <Text>Account 1</Text>
         <Text>
           {shortenAddress('0xc0ffee254729296a45a3885639AC7E10F9d54979')}
         </Text>
       </Box>
-      <Box display={Display.Flex} flexDirection={FlexDirection.Column}>
+      <Box flexDirection={BoxFlexDirection.Column}>
         <Text>3000 USD</Text>
         <Text>1 ETH</Text>
       </Box>
     </Box>,
     <Box
       key="account2"
-      display={Display.Flex}
-      justifyContent={JustifyContent.spaceBetween}
+      flexDirection={BoxFlexDirection.Row}
+      justifyContent={BoxJustifyContent.Between}
     >
-      <Box display={Display.Flex} flexDirection={FlexDirection.Column}>
+      <Box flexDirection={BoxFlexDirection.Column}>
         <Text>Account 2</Text>
         <Text>
           {shortenAddress('0xc0ffee254729296a45a3885639AC7E10F9d54979')}
         </Text>
       </Box>
-      <Box display={Display.Flex} flexDirection={FlexDirection.Column}>
+      <Box flexDirection={BoxFlexDirection.Column}>
         <Text>0 USD</Text>
         <Text>0 ETH</Text>
       </Box>

--- a/ui/components/app/snaps/update-snap-permission-list/update-snap-permission-list.js
+++ b/ui/components/app/snaps/update-snap-permission-list/update-snap-permission-list.js
@@ -2,18 +2,18 @@ import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
-import { Box, ButtonLink } from '../../../component-library';
+import {
+  Box,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
+import { ButtonLink } from '../../../component-library';
 import {
   getMultipleTargetsSubjectMetadata,
   getSnapMetadata,
   getSnapsMetadata,
 } from '../../../../selectors';
 import SnapPermissionAdapter from '../snap-permission-adapter';
-import {
-  BlockSize,
-  Display,
-  JustifyContent,
-} from '../../../../helpers/constants/design-system';
 import {
   MinPermissionAbstractionDisplayCount,
   PermissionWeightThreshold,
@@ -113,7 +113,7 @@ export default function UpdateSnapPermissionList({
   };
 
   return (
-    <Box width={BlockSize.Full}>
+    <Box className="w-full">
       <SnapPermissionAdapter
         permissions={newWeightedPermissions}
         snapId={snapId}
@@ -140,8 +140,8 @@ export default function UpdateSnapPermissionList({
       />
       {showAll ? null : (
         <Box
-          display={Display.Flex}
-          justifyContent={JustifyContent.center}
+          flexDirection={BoxFlexDirection.Row}
+          justifyContent={BoxJustifyContent.Center}
           paddingTop={2}
           paddingBottom={2}
         >

--- a/ui/components/app/snaps/update-snap-permission-list/update-snap-permission-list.js
+++ b/ui/components/app/snaps/update-snap-permission-list/update-snap-permission-list.js
@@ -144,6 +144,7 @@ export default function UpdateSnapPermissionList({
           justifyContent={BoxJustifyContent.Center}
           paddingTop={2}
           paddingBottom={2}
+          className="flex"
         >
           <ButtonLink onClick={() => onShowAllPermissions()}>
             {t('seeAllPermissions')}

--- a/ui/components/app/snaps/update-snap-permission-list/update-snap-permission-list.js
+++ b/ui/components/app/snaps/update-snap-permission-list/update-snap-permission-list.js
@@ -1,12 +1,12 @@
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
-import { useI18nContext } from '../../../../hooks/useI18nContext';
 import {
   Box,
   BoxFlexDirection,
   BoxJustifyContent,
 } from '@metamask/design-system-react';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { ButtonLink } from '../../../component-library';
 import {
   getMultipleTargetsSubjectMetadata,

--- a/ui/pages/confirmations/components/confirm/snaps/snaps-section/__snapshots__/snaps-section.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/snaps/snaps-section/__snapshots__/snaps-section.test.tsx.snap
@@ -39,7 +39,7 @@ exports[`SnapsSection renders section for typed sign request 1`] = `
         class="mm-box mm-box--padding-top-0 mm-box--padding-right-0 mm-box--padding-bottom-0 mm-box--padding-left-0 mm-box--flex-direction-column"
       >
         <div
-          class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-section"
+          class="snap-ui-renderer__content h-full bg-section"
           style="overflow-y: auto;"
         >
           <div
@@ -101,7 +101,7 @@ exports[`SnapsSection renders section personal sign request 1`] = `
         class="mm-box mm-box--padding-top-0 mm-box--padding-right-0 mm-box--padding-bottom-0 mm-box--padding-left-0 mm-box--flex-direction-column"
       >
         <div
-          class="mm-box snap-ui-renderer__content mm-box--height-full mm-box--background-color-background-section"
+          class="snap-ui-renderer__content h-full bg-section"
           style="overflow-y: auto;"
         >
           <div

--- a/ui/pages/permissions-connect/snaps/snaps-connect/snaps-connect.js
+++ b/ui/pages/permissions-connect/snaps/snaps-connect/snaps-connect.js
@@ -3,18 +3,19 @@ import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { isSnapId } from '@metamask/snaps-utils';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
-import { Box, IconSize, Text } from '../../../../components/component-library';
 import {
-  FlexDirection,
+  Box,
+  BoxAlignItems,
+  BoxBackgroundColor,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
+import { IconSize, Text } from '../../../../components/component-library';
+import {
   TextVariant,
-  JustifyContent,
-  AlignItems,
   TextAlign,
-  Display,
   FontWeight,
-  BlockSize,
   OverflowWrap,
-  BackgroundColor,
 } from '../../../../helpers/constants/design-system';
 import { PageContainerFooter } from '../../../../components/ui/page-container';
 import SnapConnectCell from '../../../../components/app/snaps/snap-connect-cell/snap-connect-cell';
@@ -84,12 +85,10 @@ export default function SnapsConnect({
     if (isLoading) {
       return (
         <Box
-          display={Display.Flex}
-          flexDirection={FlexDirection.Column}
-          alignItems={AlignItems.center}
-          justifyContent={JustifyContent.center}
-          width={BlockSize.Full}
-          height={BlockSize.Full}
+          flexDirection={BoxFlexDirection.Column}
+          alignItems={BoxAlignItems.Center}
+          justifyContent={BoxJustifyContent.Center}
+          className="h-full w-full"
         >
           <PulseLoader />
         </Box>
@@ -99,13 +98,13 @@ export default function SnapsConnect({
     if (snaps?.length > 1) {
       return (
         <Box
-          flexDirection={FlexDirection.Column}
-          justifyContent={JustifyContent.center}
-          alignItems={AlignItems.center}
+          flexDirection={BoxFlexDirection.Column}
+          justifyContent={BoxJustifyContent.Center}
+          alignItems={BoxAlignItems.Center}
           paddingTop={4}
-          width={BlockSize.Full}
+          className="w-full"
           style={{ overflowY: 'hidden' }}
-          backgroundColor={BackgroundColor.backgroundAlternative}
+          backgroundColor={BoxBackgroundColor.BackgroundAlternative}
         >
           <Text
             paddingBottom={2}
@@ -135,10 +134,9 @@ export default function SnapsConnect({
             ])}
           </Text>
           <Box
-            flexDirection={FlexDirection.Column}
-            display={Display.Flex}
+            flexDirection={BoxFlexDirection.Column}
             marginTop={4}
-            width={BlockSize.Full}
+            className="w-full"
             style={{ overflowY: 'auto', flex: 1 }}
           >
             {snaps.map((snap) => (
@@ -155,15 +153,13 @@ export default function SnapsConnect({
     } else if (snaps?.length === 1) {
       return (
         <Box
-          display={Display.Flex}
-          flexDirection={FlexDirection.Column}
-          justifyContent={JustifyContent.center}
-          alignItems={AlignItems.center}
-          width={BlockSize.Full}
-          height={BlockSize.Full}
+          flexDirection={BoxFlexDirection.Column}
+          justifyContent={BoxJustifyContent.Center}
+          alignItems={BoxAlignItems.Center}
           paddingLeft={4}
           paddingRight={4}
-          backgroundColor={BackgroundColor.backgroundAlternative}
+          className="h-full w-full"
+          backgroundColor={BoxBackgroundColor.BackgroundAlternative}
         >
           <Box paddingBottom={2}>
             <SnapIcon snapId={snaps[0]} avatarSize={IconSize.Xl} />
@@ -208,13 +204,10 @@ export default function SnapsConnect({
 
   return (
     <Box
-      className="snaps-connect"
-      display={Display.Flex}
-      flexDirection={FlexDirection.Column}
-      alignItems={AlignItems.center}
-      height={BlockSize.Full}
-      width={BlockSize.Full}
-      backgroundColor={BackgroundColor.backgroundAlternative}
+      className="snaps-connect h-full w-full"
+      flexDirection={BoxFlexDirection.Column}
+      alignItems={BoxAlignItems.Center}
+      backgroundColor={BoxBackgroundColor.BackgroundAlternative}
     >
       {isShowingSnapsPrivacyWarning && (
         <SnapPrivacyWarning
@@ -226,11 +219,10 @@ export default function SnapsConnect({
         />
       )}
       <Box
-        display={Display.Flex}
-        height={BlockSize.Full}
-        width={BlockSize.Full}
+        flexDirection={BoxFlexDirection.Row}
         paddingLeft={4}
         paddingRight={4}
+        className="h-full w-full"
       >
         <SnapsConnectContent />
       </Box>

--- a/ui/pages/permissions-connect/snaps/snaps-connect/snaps-connect.js
+++ b/ui/pages/permissions-connect/snaps/snaps-connect/snaps-connect.js
@@ -88,7 +88,7 @@ export default function SnapsConnect({
           flexDirection={BoxFlexDirection.Column}
           alignItems={BoxAlignItems.Center}
           justifyContent={BoxJustifyContent.Center}
-          className="h-full w-full"
+          className="flex h-full w-full"
         >
           <PulseLoader />
         </Box>
@@ -102,7 +102,7 @@ export default function SnapsConnect({
           justifyContent={BoxJustifyContent.Center}
           alignItems={BoxAlignItems.Center}
           paddingTop={4}
-          className="w-full"
+          className="flex w-full"
           style={{ overflowY: 'hidden' }}
           backgroundColor={BoxBackgroundColor.BackgroundAlternative}
         >
@@ -136,7 +136,7 @@ export default function SnapsConnect({
           <Box
             flexDirection={BoxFlexDirection.Column}
             marginTop={4}
-            className="w-full"
+            className="flex w-full"
             style={{ overflowY: 'auto', flex: 1 }}
           >
             {snaps.map((snap) => (
@@ -158,7 +158,7 @@ export default function SnapsConnect({
           alignItems={BoxAlignItems.Center}
           paddingLeft={4}
           paddingRight={4}
-          className="h-full w-full"
+          className="flex h-full w-full"
           backgroundColor={BoxBackgroundColor.BackgroundAlternative}
         >
           <Box paddingBottom={2}>
@@ -204,7 +204,7 @@ export default function SnapsConnect({
 
   return (
     <Box
-      className="snaps-connect h-full w-full"
+      className="flex snaps-connect h-full w-full"
       flexDirection={BoxFlexDirection.Column}
       alignItems={BoxAlignItems.Center}
       backgroundColor={BoxBackgroundColor.BackgroundAlternative}
@@ -222,7 +222,7 @@ export default function SnapsConnect({
         flexDirection={BoxFlexDirection.Row}
         paddingLeft={4}
         paddingRight={4}
-        className="h-full w-full"
+        className="flex h-full w-full"
       >
         <SnapsConnectContent />
       </Box>

--- a/ui/pages/permissions-connect/snaps/snaps-connect/snaps-connect.js
+++ b/ui/pages/permissions-connect/snaps/snaps-connect/snaps-connect.js
@@ -2,7 +2,6 @@ import React, { useCallback, useState } from 'react';
 import { useSelector } from 'react-redux';
 import PropTypes from 'prop-types';
 import { isSnapId } from '@metamask/snaps-utils';
-import { useI18nContext } from '../../../../hooks/useI18nContext';
 import {
   Box,
   BoxAlignItems,
@@ -10,6 +9,7 @@ import {
   BoxFlexDirection,
   BoxJustifyContent,
 } from '@metamask/design-system-react';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { IconSize, Text } from '../../../../components/component-library';
 import {
   TextVariant,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Use Box from DSR (core platform team).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-433

## **Manual testing steps**

1. Open extension
2. Check files modified in this PR

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="376" height="1114" alt="image" src="https://github.com/user-attachments/assets/e8b1c184-427c-4e83-9552-9e5fdd88b060" />

### **After**

<img width="365" height="1113" alt="image" src="https://github.com/user-attachments/assets/4327e9f4-a11d-4262-ba9d-a8a845b34be9" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a UI refactor, but it touches many Snap-related screens and changes how container background colors are mapped to CSS classes, which could cause layout/styling regressions if any enum-to-class mapping is wrong.
> 
> **Overview**
> Migrates Snap-related UI components from the internal `component-library` `Box`/legacy layout enums to `@metamask/design-system-react` `Box`, replacing `display`/`width`/`borderRadius` props with Tailwind-style `className`s and DSR-specific enums (e.g., `BoxFlexDirection`, `BoxJustifyContent`, `BoxBackgroundColor`).
> 
> Updates `SnapUIRenderer` to apply background colors via a new `BACKGROUND_TO_TAILWIND` mapping (e.g., `bg-default`, `bg-section`) and adjusts loading layout markup accordingly; associated Jest snapshots/tests are updated to match the new class output.
> 
> Adjusts `SnapUIForm` to use DSR `Box`’s `asChild` wrapper around a native `<form>` element, keeping form submission behavior while aligning with the new layout approach.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5aaea662e7d3be966028041b7227373531144255. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->