### PR TITLE
chore: fix inline doc errors related to profile metrics

### DIFF
--- a/app/scripts/messenger-client-init/messengers/profile-metrics-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/profile-metrics-controller-messenger.ts
@@ -12,7 +12,7 @@ type AllowedEvents = MessengerEvents<ProfileMetricsControllerMessenger>;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
- * accounts controller.
+ * profile metrics controller.
  *
  * @param messenger - The base messenger used to create the restricted
  * messenger.

--- a/app/scripts/messenger-client-init/messengers/profile-metrics-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/profile-metrics-service-messenger.ts
@@ -12,7 +12,7 @@ type AllowedEvents = MessengerEvents<ProfileMetricsServiceMessenger>;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
- * accounts controller.
+ * profile metrics service.
  *
  * @param messenger - The base messenger used to create the restricted
  * messenger.


### PR DESCRIPTION
## **Description**

The messenger init functions for the profile metrics controller and service erroneously stated they were for the accounts controller. These errors have been fixed.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change correcting JSDoc comments; no runtime behavior or interfaces are modified.
> 
> **Overview**
> Corrects the JSDoc in `getProfileMetricsControllerMessenger` and `getProfileMetricsServiceMessenger` to refer to the profile metrics controller/service (instead of incorrectly mentioning the accounts controller).
> 
> No functional code changes; messenger setup, delegated actions, and events remain the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cdd63efaedb949670c1058230712966226c249bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->