### PR TITLE
feat: update lock text in global menu

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -3932,9 +3932,6 @@
   "lockMetaMaskLoadingMessage": {
     "message": "MetaMask wird gesperrt ..."
   },
-  "logOut": {
-    "message": "Abmelden"
-  },
   "loginErrorConnectButton": {
     "message": "Erneut versuchen"
   },

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -3932,9 +3932,6 @@
   "lockMetaMaskLoadingMessage": {
     "message": "Γίνεται κλείδωμα του MetaMask..."
   },
-  "logOut": {
-    "message": "Αποσύνδεση"
-  },
   "loginErrorConnectButton": {
     "message": "Προσπαθήστε ξανά"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3944,9 +3944,6 @@
   "lockMetaMaskLoadingMessage": {
     "message": "Locking MetaMask..."
   },
-  "logOut": {
-    "message": "Log out"
-  },
   "loginErrorConnectButton": {
     "message": "Try again"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -3944,9 +3944,6 @@
   "lockMetaMaskLoadingMessage": {
     "message": "Locking MetaMask..."
   },
-  "logOut": {
-    "message": "Log out"
-  },
   "loginErrorConnectButton": {
     "message": "Try again"
   },

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -3932,9 +3932,6 @@
   "lockMetaMaskLoadingMessage": {
     "message": "Bloqueando MetaMask..."
   },
-  "logOut": {
-    "message": "Cerrar sesión"
-  },
   "loginErrorConnectButton": {
     "message": "Inténtalo de nuevo"
   },

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -3932,9 +3932,6 @@
   "lockMetaMaskLoadingMessage": {
     "message": "Verrouillage de MetaMask…"
   },
-  "logOut": {
-    "message": "Déconnexion"
-  },
   "loginErrorConnectButton": {
     "message": "Réessayer"
   },

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -3932,9 +3932,6 @@
   "lockMetaMaskLoadingMessage": {
     "message": "MetaMask लॉक हो रहा है..."
   },
-  "logOut": {
-    "message": "लॉग आउट करें"
-  },
   "loginErrorConnectButton": {
     "message": "फिर से कोशिश करें"
   },

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -3932,9 +3932,6 @@
   "lockMetaMaskLoadingMessage": {
     "message": "Mengunci MetaMask..."
   },
-  "logOut": {
-    "message": "Keluar"
-  },
   "loginErrorConnectButton": {
     "message": "Coba lagi"
   },

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -3932,9 +3932,6 @@
   "lockMetaMaskLoadingMessage": {
     "message": "MetaMaskをロックしています…"
   },
-  "logOut": {
-    "message": "ログアウト"
-  },
   "loginErrorConnectButton": {
     "message": "再試行"
   },

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -3932,9 +3932,6 @@
   "lockMetaMaskLoadingMessage": {
     "message": "MetaMask 잠그는 중..."
   },
-  "logOut": {
-    "message": "로그아웃"
-  },
   "loginErrorConnectButton": {
     "message": "다시 시도"
   },

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -3932,9 +3932,6 @@
   "lockMetaMaskLoadingMessage": {
     "message": "Trancando a MetaMask..."
   },
-  "logOut": {
-    "message": "Sair"
-  },
   "loginErrorConnectButton": {
     "message": "Tentar novamente"
   },

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -3932,9 +3932,6 @@
   "lockMetaMaskLoadingMessage": {
     "message": "Блокировка MetaMask..."
   },
-  "logOut": {
-    "message": "Выйти"
-  },
   "loginErrorConnectButton": {
     "message": "Повторить попытку"
   },

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -3932,9 +3932,6 @@
   "lockMetaMaskLoadingMessage": {
     "message": "Nila-lock ang MetaMask..."
   },
-  "logOut": {
-    "message": "Mag-log out"
-  },
   "loginErrorConnectButton": {
     "message": "Subukang muli"
   },

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -3932,9 +3932,6 @@
   "lockMetaMaskLoadingMessage": {
     "message": "MetaMask kilitleniyor..."
   },
-  "logOut": {
-    "message": "Oturumu kapat"
-  },
   "loginErrorConnectButton": {
     "message": "Tekrar deneyin"
   },

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -3932,9 +3932,6 @@
   "lockMetaMaskLoadingMessage": {
     "message": "Đang khóa MetaMask..."
   },
-  "logOut": {
-    "message": "Đăng xuất"
-  },
   "loginErrorConnectButton": {
     "message": "Thử lại"
   },

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -3932,9 +3932,6 @@
   "lockMetaMaskLoadingMessage": {
     "message": "正在锁定 MetaMask……"
   },
-  "logOut": {
-    "message": "退出登录"
-  },
   "loginErrorConnectButton": {
     "message": "重试"
   },

--- a/ui/components/multichain/global-menu-drawer/useGlobalMenuSections.tsx
+++ b/ui/components/multichain/global-menu-drawer/useGlobalMenuSections.tsx
@@ -438,7 +438,7 @@ export function useGlobalMenuSections(
           iconName: IconName.Lock,
           iconColor: IconColor.ErrorDefault,
           textColor: TextColor.ErrorDefault,
-          label: t('logOut'),
+          label: t('lock'),
           onClick: async () => {
             trackEvent({
               category: MetaMetricsEventCategory.Navigation,


### PR DESCRIPTION
This PR is to change log out to "lock"

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: text update

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to global menu
2. Check the lock text

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
NA

### **After**

<img width="1038" height="196" alt="Screenshot 2026-05-14 at 4 49 58 PM" src="https://github.com/user-attachments/assets/27e9283e-5812-4b81-bc7b-ac5b5a930ad8" />






## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk text-only change: updates i18n strings and the menu label without altering locking behavior or data/security logic.
> 
> **Overview**
> Updates the global menu drawer to label the lock action as `lock` instead of `logOut`.
> 
> Removes the `logOut` translation key from multiple locale `messages.json` files, relying on the existing `lock` key for the menu item text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dddb8350ea1e67e38b020ee4fe3cd896ed930187. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->