### PR TITLE
test: stabilize E2E tests for container removal

### DIFF
--- a/test/e2e/dist/wallet-fixture-validation.spec.ts
+++ b/test/e2e/dist/wallet-fixture-validation.spec.ts
@@ -147,6 +147,15 @@ describe('Wallet State', function () {
         const homePage = new HomePage(driver);
         await homePage.checkPageIsLoaded();
 
+        // Headless Chrome defaults to 800×600 which is too short for the
+        // settings-v2 content pane — the native-balance toggle is below the
+        // fold and waitForSelector's visibility check times out.  Resize to
+        // a height that keeps the toggle visible without scrolling.
+        await driver.driver.manage().window().setRect({
+          width: 1280,
+          height: 960,
+        });
+
         // Set the settings to match the desired fixture state:
         // 1. enabled native balance and 2. enabled test networks
         await enableNativeTokenAsMainBalance(driver);

--- a/test/e2e/flask/multi-srp/add-accounts.spec.ts
+++ b/test/e2e/flask/multi-srp/add-accounts.spec.ts
@@ -6,9 +6,13 @@ import { login } from '../../page-objects/flows/login.flow';
 import { importAdditionalSecretRecoveryPhrase } from '../../page-objects/flows/multi-srp.flow';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import AccountListPage from '../../page-objects/pages/account-list-page';
+import HomePage from '../../page-objects/pages/home/homepage';
 import { mockActiveNetworks } from './common-multi-srp';
 
 const addAccountToSrp = async (driver: Driver, srpIndex: number) => {
+  // Dismiss any lingering toast so it cannot overlay the add-account button.
+  await new HomePage(driver).dismissSrpAddedToast();
+
   const headerNavbar = new HeaderNavbar(driver);
   await headerNavbar.openAccountMenu();
 

--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -104,7 +104,7 @@ class HomePage {
   private readonly srpAddedToast = '[data-testid="new-srp-added-toast"]';
 
   private readonly srpAddedToastCloseButton =
-    '[data-testid="new-srp-added-toast"] ~ button[aria-label="Close"]';
+    '.toast-container button[aria-label="Close"]';
 
   private readonly surveyToast = '[data-testid="survey-toast"]';
 

--- a/test/e2e/page-objects/pages/perps/perps-market-detail-page.ts
+++ b/test/e2e/page-objects/pages/perps/perps-market-detail-page.ts
@@ -351,9 +351,13 @@ export class PerpsMarketDetailPage {
 
   /**
    * Opens the margin Add/Remove popover: clicks the margin summary card, then waits for the menu.
+   *
+   * Dismisses any visible toast and scrolls the card to the viewport centre
+   * so that sticky CTA buttons at the bottom cannot intercept the click.
    */
   async clickMarginMenu(): Promise<void> {
-    await this.driver.clickElement(this.marginCard);
+    await this.dismissPerpsToastIfPresent();
+    await this.driver.findScrollToAndClickElement(this.marginCard);
     await this.driver.waitForSelector(this.marginMenu);
   }
 
@@ -424,9 +428,13 @@ export class PerpsMarketDetailPage {
   /**
    * Clicks the auto-close row to open the TP/SL update modal.
    * Works whether the position has no TP/SL yet (shows a CTA) or already has one.
+   *
+   * Dismisses any visible toast and scrolls the row to the viewport centre
+   * so that sticky CTA buttons at the bottom cannot intercept the click.
    */
   async clickAutoCloseRow(): Promise<void> {
-    await this.driver.clickElement(this.autoCloseRow);
+    await this.dismissPerpsToastIfPresent();
+    await this.driver.findScrollToAndClickElement(this.autoCloseRow);
   }
 
   /**

--- a/test/e2e/page-objects/pages/settings/privacy-settings.ts
+++ b/test/e2e/page-objects/pages/settings/privacy-settings.ts
@@ -248,7 +248,9 @@ class PrivacySettings {
       await this.driver.clickElement(this.revealSrpQuizTryAgainButton);
     }
     await this.driver.waitForSelector(this.revealSrpQuizQuestionOne);
-    await this.driver.clickElement(this.revealSrpQuizRightAnswerButton);
+    await this.driver.findScrollToAndClickElement(
+      this.revealSrpQuizRightAnswerButton,
+    );
     await this.driver.clickElement(this.revealSrpQuizContinueButton);
 
     // answer quiz question 2
@@ -261,7 +263,9 @@ class PrivacySettings {
       await this.driver.clickElement(this.revealSrpQuizTryAgainButton);
     }
     await this.driver.waitForSelector(this.revealSrpQuizQuestionTwo);
-    await this.driver.clickElement(this.revealSrpQuizRightAnswerButton);
+    await this.driver.findScrollToAndClickElement(
+      this.revealSrpQuizRightAnswerButton,
+    );
     await this.driver.clickElement(this.revealSrpQuizContinueButton);
   }
 

--- a/test/e2e/tests/identity/account-syncing/multi-srp.spec.ts
+++ b/test/e2e/tests/identity/account-syncing/multi-srp.spec.ts
@@ -111,6 +111,9 @@ describe('Account syncing - Multiple SRPs', function () {
         // Importing an SRP can be long, so we add a bit of extra time here
         await driver.delay(10000);
 
+        // Dismiss any lingering toast so it cannot overlay the add-account button.
+        await homePage.dismissSrpAddedToast();
+
         // Add a fourth account with custom name to the second SRP
         await header.openAccountMenu();
         await accountListPage.checkPageIsLoaded();

--- a/test/e2e/tests/send/send-nft-filtering.spec.ts
+++ b/test/e2e/tests/send/send-nft-filtering.spec.ts
@@ -9,7 +9,6 @@ import { withFixtures } from '../../helpers';
 import { SMART_CONTRACTS } from '../../seeder/smart-contracts';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { Driver } from '../../webdriver/driver';
-import { Anvil } from '../../seeder/anvil';
 
 import Homepage from '../../page-objects/pages/home/homepage';
 import NftListPage from '../../page-objects/pages/home/nft-list';
@@ -27,14 +26,20 @@ describe('Send NFT - Filtering', function () {
         smartContract,
         title: this.test?.fullTitle(),
       },
-      async ({
-        driver,
-        localNodes,
-      }: {
-        driver: Driver;
-        localNodes: Anvil[];
-      }) => {
-        await login(driver, { localNode: localNodes[0] });
+      async ({ driver }: { driver: Driver }) => {
+        await login(driver, {
+          // Skip balance validation — this test is about NFT filtering, and
+          // the balance check races against node RPC on slower CI runners.
+          validateBalance: false,
+        });
+
+        // At the default headless viewport (800×600), the NFT list on the
+        // send page is not fully rendered, causing selectNft to time out.
+        await driver.driver
+          .manage()
+          .window()
+          .setRect({ width: 1280, height: 960 });
+
         const homepage = new Homepage(driver);
         await homepage.goToNftTab();
         const nftListPage = new NftListPage(driver);

--- a/test/e2e/webdriver/driver.js
+++ b/test/e2e/webdriver/driver.js
@@ -750,6 +750,19 @@ class Driver {
               error.name
             }`,
           );
+
+          // When another element (e.g. a toast banner) overlaps the target,
+          // scrolling it to the viewport center usually moves it clear of the
+          // obstruction so the next attempt can succeed.
+          if (error.name === 'ElementClickInterceptedError') {
+            try {
+              const el = await this.findElement(rawLocator);
+              await this.scrollToElement(el);
+            } catch {
+              // Element may have gone stale; the next iteration will re-find it.
+            }
+          }
+
           await this.delay(1000);
         } else {
           throw error;
@@ -949,7 +962,7 @@ class Driver {
    */
   async scrollToElement(element) {
     await this.driver.executeScript(
-      'arguments[0].scrollIntoView(true)',
+      'arguments[0].scrollIntoView({block:"center"})',
       element,
     );
   }


### PR DESCRIPTION
## **Description**

I've figured out how to remove the Docker container we use for the E2E tests, but for that to work, I need to stabilize a few of the tests first.  Most of these are tests that already have a race condition or a problem, but the container is hiding the problem.

### Types of fixes

1. **Viewport resize** — We're about to move the tests to run in HEADLESS, and the default size becomes 800x600, which is too small for a few of the tests. So we add `setRect(1280, 960)` to two of the tests.
2. **Toast overlay dismissal** — Dismiss lingering toast banners before interacting with elements they cover (multi-SRP, perps).
3. **Broken CSS selector fix** — Fix the SRP toast close button selector that never matched due to react-hot-toast's DOM structure.
4. **Scroll-to-center** — Change `scrollToElement` from top-aligned to center-aligned, and use scroll-to-click in places where elements are obscured by sticky UI.
5. **Click retry improvement** — On `ElementClickInterceptedError`, scroll the target to center before retrying.
6. **Skip unnecessary validation** — Skip balance check in a test that doesn't need it to avoid a timing race.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Progresses: MetaMask/MetaMask-planning#6129

<!--## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes globally alter `Driver.scrollToElement` and click-retry behavior, which can affect many E2E interactions; however scope is limited to test code and aims to reduce flakiness from overlays/viewport differences.
> 
> **Overview**
> Improves E2E stability when running headless by explicitly resizing the browser viewport in tests where key controls render below the fold (wallet fixture validation and NFT send filtering).
> 
> Reduces UI-interaction flakes by dismissing SRP/perps toast overlays before clicking, fixing the SRP toast close-button selector, and switching several interactions to `findScrollToAndClickElement` to avoid sticky UI intercepting clicks.
> 
> Hardens the WebDriver wrapper by centering `scrollIntoView`, and by enhancing `clickElement` retries to re-scroll targets on `ElementClickInterceptedError`; the NFT filtering test also skips balance validation to avoid an unrelated timing race.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 158b08dd814846055da22a833b36ef95fdd372dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->