### PR TITLE
test: remove all Docker containers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -385,7 +385,7 @@ jobs:
     secrets: inherit
 
   run-benchmarks:
-    if: ${{ needs.get-requirements.outputs.needs-benchmarks == 'true' }}
+    if: ${{ !cancelled() && needs.get-requirements.outputs.needs-benchmarks == 'true' && !contains(needs.*.result, 'failure') }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -38,14 +38,9 @@ jobs:
           - userJourneyAccountManagement
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    container:
-      image: ghcr.io/metamask/metamask-extension-e2e-image:v24.13.0
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
     env:
       SELENIUM_BROWSER: ${{ matrix.browser }}
-      HEADLESS: false
+      SELENIUM_HEADLESS: true
       INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
       TEST_SRP_2: ${{ secrets.TEST_SRP_2 }}
       SENTRY_DSN_PERFORMANCE: ${{ vars.SENTRY_DSN_PERFORMANCE }}
@@ -80,20 +75,6 @@ jobs:
           name: build-test${{ matrix.browser == 'firefox' && '-mv2' || '' }}-${{ matrix.buildType }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ inputs.builds-from-run }}
-
-      - name: Configure Xvfb
-        run: Xvfb -ac :99 -screen 0 1280x1024x16 &
-        shell: bash
-
-      - name: Install AWS CLI (needed for S3 upload)
-        if: >-
-          ${{
-            vars.AWS_REGION != '' &&
-            vars.AWS_IAM_ROLE != '' &&
-            vars.AWS_S3_BUCKET != ''
-          }}
-        run: sudo apt-get update && sudo apt-get install python3-pip && sudo pip install awscli --break-system-packages
-        shell: bash
 
       - name: Run the benchmark
         run: >-

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -50,17 +50,13 @@ jobs:
     name: ${{ inputs.test-suite-name }}${{ inputs.matrix-total > 1 && format(' ({0})', inputs.matrix-index) || '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
-    container:
-      image: ghcr.io/metamask/metamask-extension-e2e-image:v24.13.0
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
     env:
+      SELENIUM_HEADLESS: true
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # This is to support tests that set manifestFlags.testing.infuraProjectId, such as power-user.spec.ts
       INFURA_PROJECT_ID: ${{ secrets.INFURA_PROJECT_ID }}
       # Disables ASSETS_UNIFIED_STATE_ENABLED
-      ASSETS_UNIFIED_STATE_ENABLED: 'false'
+      ASSETS_UNIFIED_STATE_ENABLED: false
       SENTRY_DSN_PERFORMANCE: ${{ vars.SENTRY_DSN_PERFORMANCE }}
       # Enable colors in CI for enhanced test reporter output
       FORCE_COLOR: '1'
@@ -113,9 +109,6 @@ jobs:
       # if there is a build-command and there is no build artifact, or the specified artifact does not exist, we run the build command
       - run: ${{ inputs.build-command }}
         if: ${{ inputs.build-command != '' && (inputs.build-artifact == '' || steps.download-build-artifact.outcome == 'failure') }}
-
-      - name: Configure Xvfb
-        run: Xvfb -ac :99 -screen 0 1280x1024x16 &
 
       - name: Download changed-files artifact
         if: ${{ env.BRANCH != 'main' }}

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -139,11 +139,6 @@ jobs:
     timeout-minutes: 30
     needs:
       - prepare
-    container:
-      image: ghcr.io/metamask/metamask-extension-e2e-image:v24.13.0
-      credentials:
-        username: ${{ github.actor }}
-        password: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -183,10 +178,11 @@ jobs:
 
       - name: Update E2E fixtures
         run: |
-          Xvfb -ac :99 -screen 0 1280x1024x16 &
           yarn test:e2e:single test/e2e/dist/wallet-fixture-export.spec.ts --browser chrome --retries 1
           yarn lint:json:fix
           yarn lint:format:fix
+        env:
+          SELENIUM_HEADLESS: true
 
       - name: Upload test artifacts
         if: ${{ !cancelled() }}

--- a/test/e2e/run-e2e-test.js
+++ b/test/e2e/run-e2e-test.js
@@ -183,7 +183,6 @@ async function main() {
   const allBrowsers = ['chrome', 'firefox'];
   if (browser === 'all') {
     for (const currentBrowser of allBrowsers) {
-      console.log(`Running tests on ${currentBrowser}`);
       try {
         await runTestsOnSingleBrowser(currentBrowser);
       } catch (error) {
@@ -193,7 +192,6 @@ async function main() {
       }
     }
   } else {
-    console.log(`Running tests on ${browser}`);
     try {
       await runTestsOnSingleBrowser(browser);
     } catch (error) {

--- a/test/e2e/webdriver/chrome.js
+++ b/test/e2e/webdriver/chrome.js
@@ -34,9 +34,11 @@ class ChromeDriver {
   }) {
     const args = [
       `--proxy-server=${getProxyServer(proxyPort)}`, // Set proxy in the way that doesn't interfere with Selenium Manager
-      '--disable-features=OptimizationGuideModelDownloading,OptimizationHintsFetching,OptimizationTargetPrediction,OptimizationHints,NetworkTimeServiceQuerying', // Stop chrome from calling home so much (auto-downloads of AI models; time sync)
+      '--disable-features=OptimizationGuideModelDownloading,OptimizationHintsFetching,OptimizationTargetPrediction,OptimizationHints,NetworkTimeServiceQuerying,Crashpad', // disable Crashpad to prevent orphaned crash-reporter processes
+      '--disable-crash-reporter', // Prevent chrome_crashpad_handler zombie accumulation in CI
       '--disable-component-update', // Stop chrome from calling home so much (auto-update)
       '--disable-dev-shm-usage',
+      '--no-sandbox',
     ];
 
     if (process.env.MULTIPROVIDER) {
@@ -70,8 +72,6 @@ class ChromeDriver {
         '*** Running e2e tests in headless mode is experimental and some tests are known to fail for unknown reasons',
       );
       args.push('--headless=new');
-    } else {
-      args.push('--no-sandbox');
     }
 
     const options = new chrome.Options().addArguments(args);
@@ -116,19 +116,42 @@ class ChromeDriver {
     builder.setChromeService(service);
     const driver = builder.build();
 
-    // When the manifest has a `key`, the extension ID is deterministic and can
-    // be computed locally — skipping the chrome://extensions round-trip (~880ms).
-    let extensionId = ChromeDriver._computeExtensionId('dist/chrome');
-    if (!extensionId) {
-      const chromeDriver = new ChromeDriver(driver);
-      extensionId = await chromeDriver.getExtensionIdByName('MetaMask');
-    }
+    // Ensure Chrome is cleaned up if anything below fails (extension ID
+    // lookup, etc.).  Without this, a partial failure orphans the browser.
+    try {
+      // When the manifest has a `key`, the extension ID is deterministic and can
+      // be computed locally — skipping the chrome://extensions round-trip (~880ms).
+      let extensionId = ChromeDriver._computeExtensionId('dist/chrome');
+      if (!extensionId) {
+        const chromeDriver = new ChromeDriver(driver);
+        extensionId = await chromeDriver.getExtensionIdByName('MetaMask');
+      }
 
-    return {
-      driver,
-      extensionId,
-      extensionUrl: `chrome-extension://${extensionId}`,
-    };
+      return {
+        driver,
+        extensionId,
+        extensionUrl: `chrome-extension://${extensionId}`,
+      };
+    } catch (error) {
+      // Clean up Chrome on partial build failure. Must close all windows
+      // before quit() — on Windows, quit() alone leaves Chrome running
+      // (see PR #31962).
+      try {
+        const handles = await driver.getAllWindowHandles();
+        for (const handle of handles) {
+          await driver.switchTo().window(handle);
+          await driver.close();
+        }
+      } catch {
+        // best-effort
+      }
+      try {
+        await driver.quit();
+      } catch {
+        // best-effort
+      }
+      throw error;
+    }
   }
 
   /**

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -94,24 +94,37 @@ class FirefoxDriver {
 
     builder.setFirefoxService(service);
     const driver = builder.build();
-    const fxDriver = new FirefoxDriver(driver);
 
-    // Pre-build an XPI and cache it across test runs.
-    // Without this, installAddon() zips the 348MB unpacked dir on every call,
-    // adding ~10s of overhead per test.
-    const xpiPath = await getOrBuildXpi('dist/firefox');
-    const installedExtensionId = await fxDriver.installExtension(xpiPath);
-    const internalExtensionId = await fxDriver.getInternalId();
+    // Ensure Firefox is cleaned up if anything below fails (XPI build,
+    // extension install, etc.).  Without this, a partial failure orphans
+    // the browser.
+    try {
+      const fxDriver = new FirefoxDriver(driver);
 
-    if (responsive || constrainWindowSize) {
-      await driver.manage().window().setRect({ width: 320, height: 600 });
+      // Pre-build an XPI and cache it across test runs.
+      // Without this, installAddon() zips the 348MB unpacked dir on every call,
+      // adding ~10s of overhead per test.
+      const xpiPath = await getOrBuildXpi('dist/firefox');
+      const installedExtensionId = await fxDriver.installExtension(xpiPath);
+      const internalExtensionId = await fxDriver.getInternalId();
+
+      if (responsive || constrainWindowSize) {
+        await driver.manage().window().setRect({ width: 320, height: 600 });
+      }
+
+      return {
+        driver,
+        extensionId: installedExtensionId,
+        extensionUrl: `moz-extension://${internalExtensionId}`,
+      };
+    } catch (error) {
+      try {
+        await driver.quit();
+      } catch {
+        // best-effort cleanup
+      }
+      throw error;
     }
-
-    return {
-      driver,
-      extensionId: installedExtensionId,
-      extensionUrl: `moz-extension://${internalExtensionId}`,
-    };
   }
 
   /**


### PR DESCRIPTION
## **Description**

We had memory leaks and zombie processes that must have existed for several years.  We used to run our E2E tests on CircleCI, and when we moved to GitHub Actions, we had trouble getting them to run with good stability.  So what we did was use [this Docker image](https://github.com/MetaMask/metamask-extension-e2e-image), which derives from the CircleCI docker image.

I finally spent some more time investigating the problem, and it turned out that we had massive memory leaks and zombie processes.  I put this code temporarily in run-e2e.yml to discover them:

```
- name: Check for zombie processes
  if: ${{ !cancelled() }}
  run: |
    zombies=$(ps -eo state= | awk '$1=="Z"{n++} END{print n+0}')
    procs=$(ps -eo comm= | wc -l)
    chrome=$(pgrep -c chrome || true)
    echo "zombies=$zombies total_procs=$procs chrome=$chrome"
    if [ "$zombies" -gt 20 ]; then
      echo "::warning::High zombie count ($zombies) — possible process leak"
      ps -eo pid,ppid,state,comm | awk '$3=="Z"' | head -20
    fi
```

### Solutions

#### 1. Disable Crashpad (Chrome flags)
```
--disable-features=...Crashpad
--disable-crash-reporter
```
Chrome spawns `chrome_crashpad_handler` processes for crash reporting. Without a container's process namespace isolation, these accumulate as zombies when Chrome exits but the crash handler doesn't get reaped. Disabling Crashpad entirely prevents them from spawning.

#### 2. Try/catch cleanup on partial driver build failure (Chrome & Firefox)

Both `ChromeDriver.build()` and `FirefoxDriver.build()` now wrap post-construction steps (extension ID lookup, XPI install, etc.) in a try/catch. If anything fails after `builder.build()` spawns the browser process, the catch block kills the browser before re-throwing. Without this, a partial failure orphans a running browser process that never gets cleaned up.

#### 3. Close all windows before `quit()` (Windows compatibility)

The catch block explicitly closes each window handle before calling `quit()`. On Windows, `quit()` alone can leave Chrome running (referenced from PR #31962). This ensures the process tree is fully torn down.

#### 4. Fix individual tests that had problems running in HEADLESS

Done in PR #42702

### This enabled

- Removal of all Docker containers
- Removal of Xvfb (a virtual display driver)
- HEADLESS everywhere

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Closes: MetaMask/MetaMask-planning#6129
Enabled by: #42702

<!--## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CI execution environment (no Docker/Xvfb, headless-only) and browser startup flags/cleanup logic, which could cause new CI flakiness or masking of underlying failures.
> 
> **Overview**
> CI E2E/benchmark jobs now run **fully headless on `ubuntu-latest` without Docker containers or Xvfb**, including fixture updates; benchmarks also stop early when upstream jobs fail.
> 
> Selenium WebDriver startup is hardened to reduce process leaks: Chrome disables Crashpad/crash reporting, always uses `--no-sandbox`, and both Chrome/Firefox `build()` wrap post-launch setup in try/catch to `quit()` (and for Chrome, close all windows) on partial failures. Minor E2E runner logging noise is reduced by removing redundant `console.log` lines.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86158240328861d9edfa9c359e1525309a08c69d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->