### PR TITLE
fix: dapp connection control bar add tron icon

### DIFF
--- a/ui/selectors/dapp.test.ts
+++ b/ui/selectors/dapp.test.ts
@@ -93,7 +93,33 @@ describe('getDappActiveNetwork selector', () => {
     options: {},
   };
 
-  const mockMultichainNetworkConfig: NetworkConfiguration = {
+  const mockTronAccount = {
+    id: '1e535d1b-4f7c-443a-803d-c32717c48983',
+    address: 'TGJn1wnUYHJbvN88cynZbsAz2EMeZq73yx',
+    type: 'tron:eoa',
+    metadata: {
+      name: '',
+      lastSelected: Date.now(),
+    },
+    scopes: ['tron:728126428', 'tron:3448148188', 'tron:2494104990'],
+    methods: [],
+    options: {},
+  };
+
+  const mockNonCaipAccount = {
+    id: '3e79-4f99-993a-993d-c99717c47411',
+    address: '0xfoo',
+    type: 'foo:bar',
+    metadata: {
+      name: '',
+      lastSelected: Date.now(),
+    },
+    scopes: ['nonCaipInvalid'],
+    methods: [],
+    options: {},
+  };
+
+  const mockSolanaMultichainNetworkConfig: NetworkConfiguration = {
     chainId: '0x1' as `0x${string}`,
     name: 'Solana Mainnet',
     nativeCurrency: 'SOL',
@@ -107,6 +133,21 @@ describe('getDappActiveNetwork selector', () => {
       },
     ],
   };
+
+  const mockTronMultichainNetworkConfig: NetworkConfiguration = {
+    chainId: 'tron:728126428',
+    name: 'Tron',
+    nativeCurrency: 'TRX',
+    blockExplorerUrls: [],
+    defaultRpcEndpointIndex: 0,
+    rpcEndpoints: [
+      {
+        networkClientId: 'tron-mainnet',
+        type: RpcEndpointType.Custom,
+        url: '',
+      },
+    ],
+  } as unknown as NetworkConfiguration;
 
   const arrangeMocks = () => {
     mockGetOrderedConnectedAccountsForActiveTab.mockReturnValue([
@@ -145,11 +186,30 @@ describe('getDappActiveNetwork selector', () => {
       mockSolanaAccount as MockedValue,
     ]);
     mocks.mockGetMultichainNetworkConfigurationsByChainId.mockReturnValue({
-      'solana:mainnet': mockMultichainNetworkConfig,
+      'solana:mainnet': mockSolanaMultichainNetworkConfig,
     });
 
     const result = getDappActiveNetwork(mocks.mockState);
-    expect(result).toEqual({ ...mockMultichainNetworkConfig, isEvm: false });
+    expect(result).toEqual({
+      ...mockSolanaMultichainNetworkConfig,
+      isEvm: false,
+    });
+  });
+
+  it('returns correct non-EVM network configuration for Tron account', () => {
+    const mocks = arrangeMocks();
+    mocks.mockGetOrderedConnectedAccountsForActiveTab.mockReturnValue([
+      mockTronAccount as MockedValue,
+    ]);
+    mocks.mockGetMultichainNetworkConfigurationsByChainId.mockReturnValue({
+      'tron:728126428': mockTronMultichainNetworkConfig,
+    });
+
+    const result = getDappActiveNetwork(mocks.mockState);
+    expect(result).toEqual({
+      ...mockTronMultichainNetworkConfig,
+      isEvm: false,
+    });
   });
 
   it('returns null when no connected accounts', () => {
@@ -179,6 +239,17 @@ describe('getDappActiveNetwork selector', () => {
     const mocks = arrangeMocks();
     mocks.mockGetOrderedConnectedAccountsForActiveTab.mockReturnValue([
       mockSolanaAccount as MockedValue,
+    ]);
+    mocks.mockGetMultichainNetworkConfigurationsByChainId.mockReturnValue({});
+
+    const result = getDappActiveNetwork(mocks.mockState);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when a non-caip network is being used (no crash)', () => {
+    const mocks = arrangeMocks();
+    mocks.mockGetOrderedConnectedAccountsForActiveTab.mockReturnValue([
+      mockNonCaipAccount as MockedValue,
     ]);
     mocks.mockGetMultichainNetworkConfigurationsByChainId.mockReturnValue({});
 

--- a/ui/selectors/dapp.ts
+++ b/ui/selectors/dapp.ts
@@ -1,5 +1,6 @@
 import { isEvmAccountType } from '@metamask/keyring-api';
 import { KnownSessionProperties } from '@metamask/chain-agnostic-permission';
+import { isCaipChainId, parseCaipChainId } from '@metamask/utils';
 import { getNetworkConfigurationsByChainId } from '../../shared/lib/selectors/networks';
 import { createDeepEqualSelector } from '../../shared/lib/selectors/selector-creators';
 import { getCaip25CaveatValueFromPermissions } from '../pages/permissions-connect/connect-page/utils';
@@ -10,6 +11,9 @@ import {
   getAllDomains,
 } from './selectors';
 import { getMultichainNetworkConfigurationsByChainId } from './multichain';
+
+// TODO: Add support for other non-EVM networks (Bitcoin, ...) and test
+const SUPPORTED_NON_EVM_NAMESPACES = new Set(['solana', 'tron']);
 
 export const getDappActiveNetwork = createDeepEqualSelector(
   getOrderedConnectedAccountsForActiveTab,
@@ -62,9 +66,14 @@ export const getDappActiveNetwork = createDeepEqualSelector(
         }
       }
     } else {
-      // TODO: Add support for other networks (Bitcoin, Solana)
-      const nonEvmScope = selectedAccount.scopes.find((scope: string) =>
-        scope.startsWith('solana:'),
+      const nonEvmScope = selectedAccount.scopes.find(
+        (scope: `${string}:${string}`) => {
+          if (!isCaipChainId(scope)) {
+            return false;
+          }
+          const { namespace } = parseCaipChainId(scope);
+          return SUPPORTED_NON_EVM_NAMESPACES.has(namespace);
+        },
       );
 
       if (nonEvmScope) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

When connecting MetaMask on a Tron dApp through Tron network, the bottom dapp connection dapp control bar wasn't showing the Tron Network Icon. Instead it would show either no icon or a default icon (Ethereum).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: dapp connection control bar add tron icon

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/NEB-1130?atlOrigin=eyJpIjoiNjhjN2M5NDBmMzIxNDI2N2E5MGE1YjQ1ODRkN2U1Y2EiLCJwIjoiaiJ9

## **Manual testing steps**

1. Enable Tron on MetaMask with a Tron account (can be empty)
2. Connect to a major Tron dApp such as [Justlend](http://3.20.169.37:18115/homeNew) or [Sun.io](https://sun.io/).
3. When Extension is opened on the right of the screen, check the bottom right icon, next to the "settings" gear icon and disconnect button.
4. Tron Network icon should be displayed there - whereas it wasn't before.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="300" alt="image" src="https://github.com/user-attachments/assets/a4b9e9e7-3ae3-4564-950b-a80005729548" />

(also before, other env)
<img width="300" alt="image" src="https://github.com/user-attachments/assets/f637af60-5d80-4cdd-83e7-a5651831b430" />


### **After**

<!-- [screenshots/recordings] -->
<img width="300" alt="image" src="https://github.com/user-attachments/assets/c0cae5e9-f1ff-424a-89f2-9ee4bff66fcd" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small selector change with added unit tests; affects UI network display only, not signing or permissions.
> 
> **Overview**
> **Tron dapp connections** now resolve the active multichain network for the bottom connection control bar instead of falling through to a missing or default EVM icon.
> 
> `getDappActiveNetwork` no longer picks non-EVM scopes with a `solana:` prefix only. It validates scopes as CAIP chain IDs, allows namespaces in `solana` and `tron`, and looks up the matching multichain network config. Invalid or unsupported scopes return `null` without throwing.
> 
> Tests cover Tron resolution, renamed Solana fixtures, and a non-CAIP scope path that must not crash.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eda9b395ac354edb4d1c83a271ef9cc334aaa81e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->