### PR TITLE
feat: hide token after next user action and show toast for custom token

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4650,6 +4650,9 @@
   "newContract": {
     "message": "New contract"
   },
+  "newCustomTokenAdded": {
+    "message": "“$1” was successfully added!"
+  },
   "newNFTDetectedInImportNFTsMessageStrongText": {
     "message": "Settings > Security and privacy"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -4650,6 +4650,9 @@
   "newContract": {
     "message": "New contract"
   },
+  "newCustomTokenAdded": {
+    "message": "“$1” was successfully added!"
+  },
   "newNFTDetectedInImportNFTsMessageStrongText": {
     "message": "Settings > Security and privacy"
   },

--- a/shared/lib/token-search/token-search-api.test.ts
+++ b/shared/lib/token-search/token-search-api.test.ts
@@ -1,4 +1,8 @@
-import { buildTokenSearchQueryString, searchTokens } from './token-search-api';
+import {
+  browseTokens,
+  buildTokenSearchQueryString,
+  searchTokens,
+} from './token-search-api';
 
 describe('buildTokenSearchQueryString', () => {
   it('includes the trimmed query and the comma-joined CAIP-2 networks list', () => {
@@ -113,6 +117,65 @@ describe('searchTokens', () => {
     }) as unknown as typeof global.fetch;
 
     await expect(searchTokens({ query: 'usdc' })).rejects.toThrow(
+      /Token search failed: 500/u,
+    );
+  });
+});
+
+describe('browseTokens', () => {
+  const realFetch = global.fetch;
+
+  afterEach(() => {
+    global.fetch = realFetch;
+    jest.restoreAllMocks();
+  });
+
+  it('uses token search with a blank query and preserves network pagination', async () => {
+    const payload = {
+      data: [
+        {
+          assetId:
+            'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+          symbol: 'USDC',
+          decimals: 6,
+          name: 'USD Coin',
+        },
+      ],
+      count: 1,
+      totalCount: 30_947,
+      pageInfo: { hasNextPage: true, endCursor: 'MjQ=' },
+    };
+    const fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => payload,
+    });
+    global.fetch = fetchMock as unknown as typeof global.fetch;
+
+    const response = await browseTokens({
+      networks: ['eip155:1', 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
+      first: 25,
+      after: 'MA==',
+    });
+
+    expect(response).toStrictEqual(payload);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url] = fetchMock.mock.calls[0];
+    expect(url).toBe(
+      'https://token.api.cx.metamask.io/tokens/search?query=+&networks=eip155%3A1%2Csolana%3A5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp&first=25&after=MA%3D%3D',
+    );
+  });
+
+  it('throws when the API responds with a non-2xx status', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      json: async () => ({}),
+    }) as unknown as typeof global.fetch;
+
+    await expect(browseTokens({ networks: ['eip155:1'] })).rejects.toThrow(
       /Token search failed: 500/u,
     );
   });

--- a/shared/lib/token-search/token-search-api.ts
+++ b/shared/lib/token-search/token-search-api.ts
@@ -2,36 +2,23 @@ import getFetchWithTimeout from '../fetch-with-timeout';
 import { TEN_SECONDS_IN_MILLISECONDS } from '../transactions-controller-utils';
 
 const TOKEN_SEARCH_BASE_URL = 'https://token.api.cx.metamask.io';
+// A single-space query is the API browse mode and still returns cursor pages.
+const TOKEN_BROWSE_QUERY = ' ';
 
-/**
- * A single token returned by GET /tokens/search.
- *
- * Mirrors the public API response, intentionally a permissive subset so the UI
- * can keep working if the API adds non-breaking fields.
- */
 export type TokenSearchResult = {
-  /** CAIP-19 asset id, e.g. `eip155:1/erc20:0xa0b…`. */
   assetId: string;
   symbol: string;
   decimals: number;
   name: string;
-  /** Optional icon URL (only present on some entries). */
   iconUrl?: string;
-  /** Free-form tags, e.g. `['stable_coin']`. */
   labels?: string[];
 };
 
-/**
- * Cursor-based page info from the search endpoint.
- */
 export type TokenSearchPageInfo = {
   hasNextPage: boolean;
   endCursor: string;
 };
 
-/**
- * Raw response payload from GET /tokens/search.
- */
 export type TokenSearchResponse = {
   data: TokenSearchResult[];
   count: number;
@@ -39,35 +26,17 @@ export type TokenSearchResponse = {
   pageInfo: TokenSearchPageInfo;
 };
 
-/**
- * Options accepted by {@link searchTokens}.
- */
 export type SearchTokensOptions = {
-  /** User-provided query string (token symbol, name, or address). Required. */
   query: string;
-  /**
-   * CAIP-2 chain IDs to constrain the search to. When omitted, the API
-   * defaults to all supported networks.
-   */
   networks?: string[];
-  /** Max number of results, defaults to 10 server-side. */
   first?: number;
-  /** Base64 cursor returned by a previous response for paging. */
   after?: string;
-  /** Whether to ask the API for security warnings on each token. */
   includeTokenSecurityData?: boolean;
-  /** Optional abort signal to cancel a stale request. */
   signal?: AbortSignal;
 };
 
-/**
- * Builds the query string for a search request. Exposed for unit tests so the
- * mapping from UI state to API params can be asserted without a network round
- * trip.
- *
- * @param options - The same options accepted by {@link searchTokens}.
- * @returns The query string (without leading `?`) for the request.
- */
+export type BrowseTokensOptions = Omit<SearchTokensOptions, 'query'>;
+
 export const buildTokenSearchQueryString = (
   options: Omit<SearchTokensOptions, 'signal'>,
 ): string => {
@@ -88,33 +57,10 @@ export const buildTokenSearchQueryString = (
   return params.toString();
 };
 
-/**
- * Calls GET /tokens/search on the Token API.
- *
- * Throws when the request fails or the response is not OK. Returns an empty
- * page when called with an empty query — callers should typically skip the
- * call in that case rather than rely on this.
- *
- * @param options - The search options. {@see SearchTokensOptions}.
- * @returns The parsed search response.
- */
-export const searchTokens = async (
+const fetchTokenSearch = async (
   options: SearchTokensOptions,
 ): Promise<TokenSearchResponse> => {
-  const trimmedQuery = options.query.trim();
-  if (!trimmedQuery) {
-    return {
-      data: [],
-      count: 0,
-      totalCount: 0,
-      pageInfo: { hasNextPage: false, endCursor: '' },
-    };
-  }
-
-  const queryString = buildTokenSearchQueryString({
-    ...options,
-    query: trimmedQuery,
-  });
+  const queryString = buildTokenSearchQueryString(options);
   const url = `${TOKEN_SEARCH_BASE_URL}/tokens/search?${queryString}`;
 
   const fetchWithTimeout = getFetchWithTimeout(TEN_SECONDS_IN_MILLISECONDS);
@@ -132,3 +78,30 @@ export const searchTokens = async (
 
   return (await response.json()) as TokenSearchResponse;
 };
+
+export const searchTokens = async (
+  options: SearchTokensOptions,
+): Promise<TokenSearchResponse> => {
+  const trimmedQuery = options.query.trim();
+  if (!trimmedQuery) {
+    return {
+      data: [],
+      count: 0,
+      totalCount: 0,
+      pageInfo: { hasNextPage: false, endCursor: '' },
+    };
+  }
+
+  return fetchTokenSearch({
+    ...options,
+    query: trimmedQuery,
+  });
+};
+
+export const browseTokens = async (
+  options: BrowseTokensOptions,
+): Promise<TokenSearchResponse> =>
+  fetchTokenSearch({
+    ...options,
+    query: TOKEN_BROWSE_QUERY,
+  });

--- a/ui/hooks/useTokenSearch.test.ts
+++ b/ui/hooks/useTokenSearch.test.ts
@@ -1,5 +1,5 @@
 import React, { type ReactNode } from 'react';
-import { renderHook } from '@testing-library/react-hooks';
+import { act, renderHook } from '@testing-library/react-hooks';
 import { waitFor } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import * as tokenSearchApi from '../../shared/lib/token-search/token-search-api';
@@ -23,15 +23,20 @@ const createWrapper = () => {
 
 describe('useTokenSearch', () => {
   let searchSpy: jest.SpyInstance;
+  let browseSpy: jest.SpyInstance;
 
   beforeEach(() => {
     searchSpy = jest
       .spyOn(tokenSearchApi, 'searchTokens')
       .mockResolvedValue(emptyPage);
+    browseSpy = jest
+      .spyOn(tokenSearchApi, 'browseTokens')
+      .mockResolvedValue(emptyPage);
   });
 
   afterEach(() => {
     searchSpy.mockRestore();
+    browseSpy.mockRestore();
   });
 
   it('does not hit the API when the (trimmed) query is empty', async () => {
@@ -42,7 +47,54 @@ describe('useTokenSearch', () => {
     await waitFor(() => expect(result.current.isFetching).toBe(false));
 
     expect(searchSpy).not.toHaveBeenCalled();
+    expect(browseSpy).not.toHaveBeenCalled();
     expect(result.current.data).toBeUndefined();
+  });
+
+  it('uses token search browse when browsing is enabled', async () => {
+    const payload = {
+      ...emptyPage,
+      data: [
+        {
+          assetId:
+            'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+          symbol: 'USDC',
+          decimals: 6,
+          name: 'USD Coin',
+        },
+      ],
+      count: 1,
+      totalCount: 1,
+    };
+    browseSpy.mockResolvedValueOnce(payload);
+
+    const { result } = renderHook(
+      () =>
+        useTokenSearch({
+          query: '   ',
+          networks: [
+            'eip155:59144',
+            'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+          ],
+          enableTokenBrowse: true,
+        }),
+      {
+        wrapper: createWrapper(),
+      },
+    );
+
+    await waitFor(() => expect(result.current.isFetching).toBe(false));
+
+    expect(searchSpy).not.toHaveBeenCalled();
+    expect(browseSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        networks: [
+          'eip155:59144',
+          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        ],
+      }),
+    );
+    expect(result.current.data?.data).toStrictEqual(payload.data);
   });
 
   it('forwards the trimmed query and networks to the API and exposes the raw response', async () => {
@@ -83,6 +135,127 @@ describe('useTokenSearch', () => {
     expect(result.current.error).toBeNull();
   });
 
+  it('fetches the next cursor page and appends it to the exposed response', async () => {
+    const firstPage = {
+      ...emptyPage,
+      data: [
+        {
+          assetId: 'eip155:1/erc20:0xaaa',
+          symbol: 'AAA',
+          decimals: 18,
+          name: 'Alpha',
+        },
+      ],
+      count: 1,
+      totalCount: 2,
+      pageInfo: { hasNextPage: true, endCursor: 'MQ==' },
+    };
+    const secondPage = {
+      ...emptyPage,
+      data: [
+        {
+          assetId: 'eip155:1/erc20:0xbbb',
+          symbol: 'BBB',
+          decimals: 18,
+          name: 'Beta',
+        },
+      ],
+      count: 1,
+      totalCount: 2,
+      pageInfo: { hasNextPage: false, endCursor: 'Mg==' },
+    };
+    searchSpy
+      .mockResolvedValueOnce(firstPage)
+      .mockResolvedValueOnce(secondPage);
+
+    const { result } = renderHook(() => useTokenSearch({ query: 'token' }), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() =>
+      expect(result.current.data?.data).toEqual(firstPage.data),
+    );
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() =>
+      expect(result.current.data?.data).toEqual([
+        ...firstPage.data,
+        ...secondPage.data,
+      ]),
+    );
+    expect(searchSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        after: 'MQ==',
+      }),
+    );
+  });
+
+  it('fetches the next browse cursor page and appends it to the exposed response', async () => {
+    const firstPage = {
+      ...emptyPage,
+      data: [
+        {
+          assetId:
+            'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:AAA',
+          symbol: 'AAA',
+          decimals: 6,
+          name: 'Alpha',
+        },
+      ],
+      count: 1,
+      totalCount: 2,
+      pageInfo: { hasNextPage: true, endCursor: 'MQ==' },
+    };
+    const secondPage = {
+      ...emptyPage,
+      data: [
+        {
+          assetId:
+            'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:BBB',
+          symbol: 'BBB',
+          decimals: 6,
+          name: 'Beta',
+        },
+      ],
+      count: 1,
+      totalCount: 2,
+    };
+    browseSpy
+      .mockResolvedValueOnce(firstPage)
+      .mockResolvedValueOnce(secondPage);
+
+    const { result } = renderHook(
+      () =>
+        useTokenSearch({
+          query: '',
+          networks: ['solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
+          enableTokenBrowse: true,
+        }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() =>
+      expect(result.current.data?.data).toEqual(firstPage.data),
+    );
+
+    await act(async () => {
+      await result.current.fetchNextPage();
+    });
+
+    await waitFor(() =>
+      expect(result.current.data?.data).toEqual([
+        ...firstPage.data,
+        ...secondPage.data,
+      ]),
+    );
+    expect(browseSpy).toHaveBeenLastCalledWith(
+      expect.objectContaining({ after: 'MQ==' }),
+    );
+  });
+
   it('surfaces errors from the API on the query result', async () => {
     searchSpy.mockRejectedValueOnce(new Error('boom'));
 
@@ -102,5 +275,6 @@ describe('useTokenSearch', () => {
 
     await waitFor(() => expect(result.current.isFetching).toBe(false));
     expect(searchSpy).not.toHaveBeenCalled();
+    expect(browseSpy).not.toHaveBeenCalled();
   });
 });

--- a/ui/hooks/useTokenSearch.test.ts
+++ b/ui/hooks/useTokenSearch.test.ts
@@ -72,10 +72,7 @@ describe('useTokenSearch', () => {
       () =>
         useTokenSearch({
           query: '   ',
-          networks: [
-            'eip155:59144',
-            'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
-          ],
+          networks: ['eip155:59144', 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
           enableTokenBrowse: true,
         }),
       {
@@ -88,10 +85,7 @@ describe('useTokenSearch', () => {
     expect(searchSpy).not.toHaveBeenCalled();
     expect(browseSpy).toHaveBeenCalledWith(
       expect.objectContaining({
-        networks: [
-          'eip155:59144',
-          'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
-        ],
+        networks: ['eip155:59144', 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
       }),
     );
     expect(result.current.data?.data).toStrictEqual(payload.data);
@@ -198,8 +192,7 @@ describe('useTokenSearch', () => {
       ...emptyPage,
       data: [
         {
-          assetId:
-            'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:AAA',
+          assetId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:AAA',
           symbol: 'AAA',
           decimals: 6,
           name: 'Alpha',
@@ -213,8 +206,7 @@ describe('useTokenSearch', () => {
       ...emptyPage,
       data: [
         {
-          assetId:
-            'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:BBB',
+          assetId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:BBB',
           symbol: 'BBB',
           decimals: 6,
           name: 'Beta',

--- a/ui/hooks/useTokenSearch.ts
+++ b/ui/hooks/useTokenSearch.ts
@@ -1,16 +1,17 @@
 import { useMemo } from 'react';
-import { useQuery, type UseQueryResult } from '@tanstack/react-query';
 import {
+  useInfiniteQuery,
+  type UseInfiniteQueryResult,
+} from '@tanstack/react-query';
+import {
+  browseTokens,
   searchTokens,
   type TokenSearchResponse,
 } from '../../shared/lib/token-search/token-search-api';
 
 const DEFAULT_PAGE_SIZE = 25;
-/** How long results stay "fresh" before react-query will refetch on mount. */
 const TOKEN_SEARCH_STALE_TIME_MS = 30_000;
-/** How long inactive results stay cached before they're garbage collected. */
 const TOKEN_SEARCH_GC_TIME_MS = 5 * 60_000;
-/** Query-key prefix so this cache is distinguishable from other consumers. */
 const TOKEN_SEARCH_QUERY_KEY_ROOT = [
   'metamask-extension',
   'tokenSearch',
@@ -18,38 +19,52 @@ const TOKEN_SEARCH_QUERY_KEY_ROOT = [
 ] as const;
 
 export type UseTokenSearchOptions = {
-  /**
-   * The (already debounced) query string to send to the API. Callers are
-   */
   query: string;
-  /**
-   * CAIP-2 chain IDs to scope the search to. Pass `undefined` (or an empty
-   * array) to let the API search across its default supported networks.
-   */
   networks?: string[];
-  /** Max results per page. Defaults to 25 (the API default is 10). */
   first?: number;
-  /** When false, the hook becomes a no-op and never hits the API. */
   enabled?: boolean;
+  enableTokenBrowse?: boolean;
 };
 
-/**
- * Thin react-query wrapper around the Token API `/tokens/search` endpoint.
- *
- *
- * @param options - Hook configuration.
- * @param options.query
- * @param options.networks
- * @param options.first
- * @param options.enabled
- * @returns The react-query result for the token-search request.
- */
+export type UseTokenSearchResult = Omit<
+  UseInfiniteQueryResult<TokenSearchResponse, Error>,
+  'data'
+> & {
+  data?: TokenSearchResponse;
+};
+
+const getEmptyTokenSearchResponse = (): TokenSearchResponse => ({
+  data: [],
+  count: 0,
+  totalCount: 0,
+  pageInfo: { hasNextPage: false, endCursor: '' },
+});
+
+const mergeTokenSearchPages = (
+  pages: TokenSearchResponse[],
+): TokenSearchResponse => {
+  if (pages.length === 0) {
+    return getEmptyTokenSearchResponse();
+  }
+
+  const data = pages.flatMap((page) => page.data);
+  const lastPage = pages[pages.length - 1];
+
+  return {
+    data,
+    count: data.length,
+    totalCount: lastPage?.totalCount ?? data.length,
+    pageInfo: lastPage?.pageInfo ?? getEmptyTokenSearchResponse().pageInfo,
+  };
+};
+
 export const useTokenSearch = ({
   query,
   networks,
   first = DEFAULT_PAGE_SIZE,
   enabled = true,
-}: UseTokenSearchOptions): UseQueryResult<TokenSearchResponse, Error> => {
+  enableTokenBrowse = false,
+}: UseTokenSearchOptions): UseTokenSearchResult => {
   const trimmedQuery = query.trim();
 
   const networksKey = useMemo(
@@ -57,28 +72,62 @@ export const useTokenSearch = ({
     [networks],
   );
 
-  const isEnabled = enabled && trimmedQuery.length > 0;
+  const isBrowseMode = enableTokenBrowse && trimmedQuery.length === 0;
+  const isEnabled = enabled && (isBrowseMode || trimmedQuery.length > 0);
 
-  return useQuery<TokenSearchResponse, Error>({
+  const queryResult = useInfiniteQuery<TokenSearchResponse, Error>({
     queryKey: [
       ...TOKEN_SEARCH_QUERY_KEY_ROOT,
+      isBrowseMode ? 'browse' : 'search',
       trimmedQuery,
       networksKey,
       first,
     ] as const,
-    queryFn: ({ signal }: { signal?: AbortSignal }) =>
-      searchTokens({
+    queryFn: async ({
+      signal,
+      pageParam,
+    }: {
+      signal?: AbortSignal;
+      pageParam?: string;
+    }) => {
+      if (isBrowseMode) {
+        return browseTokens({
+          networks: networksKey.length > 0 ? networksKey : undefined,
+          first,
+          after: pageParam,
+          signal,
+        });
+      }
+
+      return searchTokens({
         query: trimmedQuery,
         networks: networksKey.length > 0 ? networksKey : undefined,
         first,
+        after: pageParam,
         signal,
-      }),
+      });
+    },
+    getNextPageParam: (lastPage) =>
+      lastPage.pageInfo.hasNextPage
+        ? lastPage.pageInfo.endCursor || undefined
+        : undefined,
     enabled: isEnabled,
     keepPreviousData: true,
     retry: false,
     staleTime: TOKEN_SEARCH_STALE_TIME_MS,
-    // `cacheTime` in v4 / `gcTime` in v5 — the project still types react-query
-    // as v4 so we use the older name here.
     cacheTime: TOKEN_SEARCH_GC_TIME_MS,
   });
+
+  const data = useMemo(
+    () =>
+      queryResult.data
+        ? mergeTokenSearchPages(queryResult.data.pages)
+        : undefined,
+    [queryResult.data],
+  );
+
+  return {
+    ...queryResult,
+    data,
+  };
 };

--- a/ui/pages/custom-token-import/custom-token-import.test.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.test.tsx
@@ -1,13 +1,26 @@
 import React from 'react';
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import {
   en as messages,
   renderWithProvider,
 } from '../../../test/lib/render-helpers-navigate';
 import configureStore from '../../store/store';
 import mockState from '../../../test/data/mock-state.json';
-import { CUSTOM_TOKEN_IMPORT_ROUTE } from '../../helpers/constants/routes';
+import {
+  CUSTOM_TOKEN_IMPORT_ROUTE,
+  TOKEN_MANAGEMENT_ROUTE,
+} from '../../helpers/constants/routes';
 import { CustomTokenImportPage } from './custom-token-import';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
 
 // The page kicks off real on-chain probes through `getTokenStandardAndDetailsByChain`
 // and `tokenInfoGetter`. Replace them with deterministic stubs so the unit
@@ -16,6 +29,7 @@ jest.mock('../../store/actions', () => {
   const actual = jest.requireActual('../../store/actions');
   return {
     ...actual,
+    addImportedTokens: jest.fn(() => () => Promise.resolve()),
     getTokenStandardAndDetailsByChain: jest.fn().mockResolvedValue({
       standard: 'ERC20',
       symbol: 'APE',
@@ -36,7 +50,17 @@ jest.mock('../../helpers/utils/token-util', () => {
   };
 });
 
+const getMockedActions = () =>
+  jest.requireMock('../../store/actions') as {
+    addImportedTokens: jest.Mock;
+  };
+
 describe('CustomTokenImportPage', () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+    getMockedActions().addImportedTokens.mockClear();
+  });
+
   const buildState = () => ({
     ...mockState,
     metamask: {
@@ -124,5 +148,47 @@ describe('CustomTokenImportPage', () => {
 
     const networkItems = screen.getAllByTestId(/select-network-item-/u);
     expect(networkItems.length).toBeGreaterThan(0);
+  });
+
+  it('returns to token management with success toast state after submitting a custom token', async () => {
+    const actions = getMockedActions();
+    renderPage();
+
+    fireEvent.change(screen.getByTestId('custom-token-import-address-input'), {
+      target: { value: '0x1111111111111111111111111111111111111111' },
+    });
+
+    await screen.findByTestId('custom-token-import-symbol-input');
+    await waitFor(() =>
+      expect(
+        screen.getByTestId('custom-token-import-submit-button'),
+      ).not.toBeDisabled(),
+    );
+
+    fireEvent.click(screen.getByTestId('custom-token-import-submit-button'));
+
+    await waitFor(() =>
+      expect(actions.addImportedTokens).toHaveBeenCalledWith(
+        [
+          expect.objectContaining({
+            address: '0x1111111111111111111111111111111111111111',
+            symbol: 'APE',
+            decimals: 18,
+            isERC721: false,
+          }),
+        ],
+        'mainnet',
+      ),
+    );
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith(TOKEN_MANAGEMENT_ROUTE, {
+        state: {
+          tokenManagementToast: {
+            type: 'customTokenAdded',
+            symbol: 'APE',
+          },
+        },
+      }),
+    );
   });
 });

--- a/ui/pages/custom-token-import/custom-token-import.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.tsx
@@ -366,7 +366,14 @@ export const CustomTokenImportPage = () => {
           networkClientId,
         ),
       );
-      navigate(TOKEN_MANAGEMENT_ROUTE);
+      navigate(TOKEN_MANAGEMENT_ROUTE, {
+        state: {
+          tokenManagementToast: {
+            type: 'customTokenAdded',
+            symbol,
+          },
+        },
+      });
     } finally {
       setIsSubmitting(false);
     }

--- a/ui/pages/token-management/token-management.test.tsx
+++ b/ui/pages/token-management/token-management.test.tsx
@@ -12,6 +12,24 @@ import {
 } from '../../helpers/constants/routes';
 import { TokenManagementPage } from './token-management';
 
+const mockTokenManagementLocationState = {
+  current: null as unknown,
+};
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    useLocation: () => ({
+      pathname: '/token-management',
+      search: '',
+      hash: '',
+      state: mockTokenManagementLocationState.current,
+      key: 'token-management-test',
+    }),
+  };
+});
+
 jest.mock('../../selectors/assets', () => ({
   ...jest.requireActual('../../selectors/assets'),
   getAssetsBySelectedAccountGroup: (state: {
@@ -56,36 +74,47 @@ type MockSearchResult = {
 type MockSearchState = {
   results: MockSearchResult[];
   isLoading: boolean;
+  isFetchingNextPage: boolean;
   error: Error | null;
   hasNextPage: boolean;
+  fetchNextPage: jest.Mock;
 };
 
 const mockTokenSearch = {
   state: {
     results: [],
     isLoading: false,
+    isFetchingNextPage: false,
     error: null,
     hasNextPage: false,
+    fetchNextPage: jest.fn(),
   } as MockSearchState,
   spy: jest.fn(),
 };
 
-// Bypass debouncing in tests so query updates reach `useTokenSearch`
-// synchronously.
 jest.mock('../../hooks/useDebouncedValue', () => ({
   useDebouncedValue: <Value,>(value: Value) => value,
 }));
 
 jest.mock('../../hooks/useTokenSearch', () => ({
-  useTokenSearch: (options: { query: string; networks?: string[] }) => {
+  useTokenSearch: (options: {
+    query: string;
+    networks?: string[];
+    enableTokenBrowse?: boolean;
+  }) => {
     mockTokenSearch.spy(options);
     const trimmed = options.query.trim();
-    const { results, isLoading, error, hasNextPage } = mockTokenSearch.state;
-    // Match the {@link UseQueryResult} shape that the production hook returns
-    // closely enough for the consumer's intent derivation logic.
+    const {
+      results,
+      isLoading,
+      isFetchingNextPage,
+      error,
+      hasNextPage,
+      fetchNextPage,
+    } = mockTokenSearch.state;
     return {
       data:
-        trimmed.length > 0
+        trimmed.length > 0 || options.enableTokenBrowse
           ? {
               data: results,
               count: results.length,
@@ -95,6 +124,9 @@ jest.mock('../../hooks/useTokenSearch', () => ({
           : undefined,
       isFetching: isLoading,
       isLoading,
+      isFetchingNextPage,
+      hasNextPage,
+      fetchNextPage,
       error,
     };
   },
@@ -107,8 +139,10 @@ const resetTokenSearchState = (): void => {
   setTokenSearchState({
     results: [],
     isLoading: false,
+    isFetchingNextPage: false,
     error: null,
     hasNextPage: false,
+    fetchNextPage: jest.fn(),
   });
   mockTokenSearch.spy.mockClear();
 };
@@ -198,6 +232,7 @@ describe('TokenManagementPage', () => {
   };
 
   beforeEach(() => {
+    mockTokenManagementLocationState.current = null;
     resetTokenSearchState();
     const actions = getMockedActions();
     actions.addCustomAsset.mockClear();
@@ -275,19 +310,17 @@ describe('TokenManagementPage', () => {
   });
 
   const renderPage = (state = createState(), routeState?: unknown) => {
+    mockTokenManagementLocationState.current = routeState ?? null;
     const store = configureStore({
       ...state,
     });
-    const initialRoute =
-      routeState === undefined
-        ? TOKEN_MANAGEMENT_ROUTE
-        : {
-            pathname: TOKEN_MANAGEMENT_ROUTE,
-            state: routeState,
-          };
     return {
       store,
-      ...renderWithProvider(<TokenManagementPage />, store, initialRoute),
+      ...renderWithProvider(
+        <TokenManagementPage />,
+        store,
+        TOKEN_MANAGEMENT_ROUTE,
+      ),
     };
   };
 
@@ -317,16 +350,11 @@ describe('TokenManagementPage', () => {
       'token-management-add-custom-token-button',
     );
 
-    // Sticky positioning is now applied via Tailwind utility classes on the
-    // wrapper Box (`sticky bottom-0 z-10`) rather than inline styles, matching
-    // the design-system migration in this file.
     expect(addCustomTokenButton.parentElement?.className).toMatch(/sticky/u);
     expect(addCustomTokenButton.parentElement?.className).toMatch(/bottom-0/u);
 
     fireEvent.click(addCustomTokenButton);
 
-    // The legacy import-tokens modal must not open anymore — the new flow
-    // routes the user to the dedicated CUSTOM_TOKEN_IMPORT_ROUTE page instead.
     expect(store.getState().appState.importTokensModalOpen).toBeFalsy();
     expect(CUSTOM_TOKEN_IMPORT_ROUTE).toBe('/custom-token-import');
   });
@@ -388,6 +416,25 @@ describe('TokenManagementPage', () => {
     ).toBeInTheDocument();
   });
 
+  it('enables API browse results when the page opens for EVM and non-EVM networks', () => {
+    renderPage(
+      createState({
+        enabledNetworkMap: {
+          eip155: { '0x1': true },
+          solana: { [solanaChainId]: true },
+        },
+      }),
+    );
+
+    expect(mockTokenSearch.spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        query: '',
+        enableTokenBrowse: true,
+        networks: ['eip155:1', solanaChainId],
+      }),
+    );
+  });
+
   it('drives the search hook with the user query and the enabled networks as CAIP-2 ids', () => {
     renderPage(
       createState({
@@ -402,9 +449,6 @@ describe('TokenManagementPage', () => {
       target: { value: 'Beta' },
     });
 
-    // The hook is called with the current query and the enabled networks
-    // converted from hex chain ids to CAIP-2 ids. We assert on the *last*
-    // call because the hook also runs on the initial empty-query render.
     const { calls } = mockTokenSearch.spy.mock;
     expect(calls[calls.length - 1][0]).toEqual(
       expect.objectContaining({
@@ -432,9 +476,171 @@ describe('TokenManagementPage', () => {
       target: { value: 'usdc' },
     });
 
-    // Home-page tokens are hidden once the search drives the list.
     expect(screen.queryByText('Alpha Token')).not.toBeInTheDocument();
     expect(screen.getByText('USD Coin')).toBeInTheDocument();
+  });
+
+  it('renders imported tokens first and non-imported API browse results below as OFF', () => {
+    const apiTokenAssetId =
+      'eip155:1/erc20:0x0000000000000000000000000000000000000abc';
+    setTokenSearchState({
+      results: [
+        {
+          assetId: apiTokenAssetId,
+          symbol: 'CCC',
+          decimals: 18,
+          name: 'Charlie Token',
+        },
+      ],
+    });
+
+    renderPage();
+
+    const importedRow = screen.getByTestId(
+      `token-management-cell-0x1:${mainnetToken.address}`,
+    );
+    const apiRow = screen.getByTestId(
+      `token-management-cell-search-${apiTokenAssetId}`,
+    );
+    const rows = Array.from(document.querySelectorAll('[data-testid]')).filter(
+      (node) => {
+        const testId = node.getAttribute('data-testid') ?? '';
+        return (
+          testId.startsWith('token-management-cell-') &&
+          !testId.endsWith('-network-badge') &&
+          !testId.endsWith('-toggle')
+        );
+      },
+    );
+
+    expect(rows.indexOf(importedRow)).toBeLessThan(rows.indexOf(apiRow));
+    expect(
+      (
+        screen.getByTestId(
+          `token-management-cell-0x1:${mainnetToken.address}-toggle`,
+        ) as HTMLInputElement
+      ).value,
+    ).toBe('true');
+    expect(
+      (
+        screen.getByTestId(
+          `token-management-cell-search-${apiTokenAssetId}-toggle`,
+        ) as HTMLInputElement
+      ).value,
+    ).toBe('false');
+  });
+
+  it('renders hidden API-backed tokens in the unsearched list as OFF', () => {
+    const mainnetTokenAssetId = `eip155:1/erc20:${mainnetToken.address}`;
+    setTokenSearchState({
+      results: [
+        {
+          assetId: mainnetTokenAssetId,
+          symbol: mainnetToken.symbol,
+          decimals: mainnetToken.decimals,
+          name: mainnetToken.name,
+        },
+      ],
+    });
+
+    const selectedAddress =
+      mockState.metamask.internalAccounts.accounts[
+        mockState.metamask.internalAccounts
+          .selectedAccount as keyof typeof mockState.metamask.internalAccounts.accounts
+      ]?.address;
+    if (!selectedAddress) {
+      throw new Error('Expected selected account address');
+    }
+
+    const baseState = createState({
+      accountGroupAssets: {
+        '0x1': [nativeToken],
+      },
+    });
+    const stateWithIgnoredToken = {
+      ...baseState,
+      metamask: {
+        ...baseState.metamask,
+        allIgnoredTokens: {
+          '0x1': {
+            [selectedAddress]: [mainnetToken.address],
+          },
+        },
+      },
+    };
+
+    renderPage(stateWithIgnoredToken);
+
+    const toggle = screen.getByTestId(
+      `token-management-cell-search-${mainnetTokenAssetId.toLowerCase()}-toggle`,
+    ) as HTMLInputElement;
+    expect(screen.getByText('Alpha Token')).toBeInTheDocument();
+    expect(toggle.value).toBe('false');
+  });
+
+  it('renders non-EVM API browse results in the unsearched list as OFF', () => {
+    const browseAssetId = `${solanaChainId}/token:So11111111111111111111111111111111111111112`;
+    setTokenSearchState({
+      results: [
+        {
+          assetId: browseAssetId,
+          symbol: 'WSOL',
+          decimals: 9,
+          name: 'Wrapped SOL',
+        },
+      ],
+    });
+
+    renderPage(
+      createState({
+        enabledNetworkMap: {
+          solana: { [solanaChainId]: true },
+        },
+        accountGroupAssets: {
+          [solanaChainId]: [],
+        },
+      }),
+    );
+
+    const toggle = screen.getByTestId(
+      `token-management-cell-search-${browseAssetId.toLowerCase()}-toggle`,
+    ) as HTMLInputElement;
+    expect(screen.getByText('Wrapped SOL')).toBeInTheDocument();
+    expect(toggle.value).toBe('false');
+  });
+
+  it('fetches the next API page when the token list is scrolled near the bottom', () => {
+    const fetchNextPage = jest.fn().mockResolvedValue(undefined);
+    setTokenSearchState({
+      results: Array.from({ length: 12 }, (_, index) => ({
+        assetId: `eip155:1/erc20:0x${String(index + 100).padStart(40, '0')}`,
+        symbol: `T${index}`,
+        decimals: 18,
+        name: `Token ${index}`,
+      })),
+      hasNextPage: true,
+      fetchNextPage,
+    });
+
+    renderPage();
+
+    const list = screen.getByTestId('token-management-page-list');
+    Object.defineProperty(list, 'scrollHeight', {
+      configurable: true,
+      value: 1000,
+    });
+    Object.defineProperty(list, 'clientHeight', {
+      configurable: true,
+      value: 500,
+    });
+    Object.defineProperty(list, 'scrollTop', {
+      configurable: true,
+      value: 450,
+    });
+
+    fireEvent.scroll(list);
+
+    expect(fetchNextPage).toHaveBeenCalledTimes(1);
   });
 
   it('toggling ON a not-yet-imported search result imports the token and adds it to AssetsController', async () => {
@@ -495,9 +701,6 @@ describe('TokenManagementPage', () => {
     ) as HTMLInputElement;
     fireEvent.click(toggle);
 
-    // The row should remain visible (we don't drop it from the list) and
-    // the toggle should flip to OFF in place, but no hide actions have been
-    // dispatched yet — that happens on the next user action.
     expect(screen.getByText('Alpha Token')).toBeInTheDocument();
     expect(toggle.value).toBe('false');
     expect(actions.ignoreTokens).not.toHaveBeenCalled();
@@ -707,11 +910,53 @@ describe('TokenManagementPage', () => {
 
     unmount();
 
-    // Even after unmount the hide must not fire, because the user
-    // restored the token before leaving the page.
     expect(actions.ignoreTokens).not.toHaveBeenCalled();
     expect(actions.hideAsset).not.toHaveBeenCalled();
     expect(actions.multichainIgnoreAssets).not.toHaveBeenCalled();
+  });
+
+  it('shows imported EVM tokens from TokensController before balances exist', () => {
+    const usdcAddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+    const selectedAddress =
+      mockState.metamask.internalAccounts.accounts[
+        mockState.metamask.internalAccounts
+          .selectedAccount as keyof typeof mockState.metamask.internalAccounts.accounts
+      ]?.address;
+    if (!selectedAddress) {
+      throw new Error('Expected selected account address');
+    }
+
+    const baseState = createState({
+      accountGroupAssets: {
+        '0x1': [nativeToken],
+      },
+    });
+    const stateWithImportedToken = {
+      ...baseState,
+      metamask: {
+        ...baseState.metamask,
+        allTokens: {
+          '0x1': {
+            [selectedAddress]: [
+              {
+                address: usdcAddress,
+                symbol: 'USDC',
+                decimals: 6,
+                name: 'USD Coin',
+              },
+            ],
+          },
+        },
+      },
+    };
+
+    renderPage(stateWithImportedToken);
+
+    expect(screen.getByText('USD Coin')).toBeInTheDocument();
+    expect(screen.getByText('0 USDC')).toBeInTheDocument();
+    expect(
+      screen.getByTestId(`token-management-cell-0x1:${usdcAddress}-toggle`),
+    ).toBeInTheDocument();
   });
 
   it('shows a search result as ON when TokensController already holds the imported address (no balance yet)', () => {

--- a/ui/pages/token-management/token-management.test.tsx
+++ b/ui/pages/token-management/token-management.test.tsx
@@ -460,15 +460,25 @@ describe('TokenManagementPage', () => {
     );
   });
 
-  it('toggling OFF an EVM token ignores it and hides it in AssetsController', async () => {
+  it('toggling OFF an EVM token defers the hide and keeps the row visible until unmount', async () => {
     const actions = getMockedActions();
 
-    renderPage();
+    const { unmount } = renderPage();
 
     const toggle = screen.getByTestId(
       `token-management-cell-0x1:${mainnetToken.address}-toggle`,
-    );
+    ) as HTMLInputElement;
     fireEvent.click(toggle);
+
+    // The row should remain visible (we don't drop it from the list) and
+    // the toggle should flip to OFF in place, but no hide actions have been
+    // dispatched yet — that happens on the next user action.
+    expect(screen.getByText('Alpha Token')).toBeInTheDocument();
+    expect(toggle.value).toBe('false');
+    expect(actions.ignoreTokens).not.toHaveBeenCalled();
+    expect(actions.hideAsset).not.toHaveBeenCalled();
+
+    unmount();
 
     await waitFor(() =>
       expect(actions.ignoreTokens).toHaveBeenCalledWith({
@@ -482,6 +492,78 @@ describe('TokenManagementPage', () => {
         `eip155:1/erc20:${mainnetToken.address}`,
       ),
     );
+  });
+
+  it('commits the staged hide when the user starts typing in the search field', async () => {
+    const actions = getMockedActions();
+
+    renderPage();
+
+    const toggle = screen.getByTestId(
+      `token-management-cell-0x1:${mainnetToken.address}-toggle`,
+    ) as HTMLInputElement;
+    fireEvent.click(toggle);
+    expect(actions.ignoreTokens).not.toHaveBeenCalled();
+
+    fireEvent.change(screen.getByTestId('token-management-search-input'), {
+      target: { value: 'usdc' },
+    });
+
+    await waitFor(() =>
+      expect(actions.ignoreTokens).toHaveBeenCalledWith({
+        tokensToIgnore: [mainnetToken.address],
+        dontShowLoadingIndicator: true,
+        networkClientId: 'mainnet',
+      }),
+    );
+  });
+
+  it('commits the staged hide when the user clicks the Add custom token CTA', async () => {
+    const actions = getMockedActions();
+
+    renderPage();
+
+    const toggle = screen.getByTestId(
+      `token-management-cell-0x1:${mainnetToken.address}-toggle`,
+    ) as HTMLInputElement;
+    fireEvent.click(toggle);
+    expect(actions.ignoreTokens).not.toHaveBeenCalled();
+
+    fireEvent.click(
+      screen.getByTestId('token-management-add-custom-token-button'),
+    );
+
+    await waitFor(() =>
+      expect(actions.ignoreTokens).toHaveBeenCalledWith({
+        tokensToIgnore: [mainnetToken.address],
+        dontShowLoadingIndicator: true,
+        networkClientId: 'mainnet',
+      }),
+    );
+  });
+
+  it('toggling an EVM token OFF and back ON restores it without dispatching a hide', async () => {
+    const actions = getMockedActions();
+
+    const { unmount } = renderPage();
+
+    const toggle = screen.getByTestId(
+      `token-management-cell-0x1:${mainnetToken.address}-toggle`,
+    ) as HTMLInputElement;
+
+    fireEvent.click(toggle);
+    expect(toggle.value).toBe('false');
+
+    fireEvent.click(toggle);
+    expect(toggle.value).toBe('true');
+
+    unmount();
+
+    // Even after unmount the hide must not fire, because the user
+    // restored the token before leaving the page.
+    expect(actions.ignoreTokens).not.toHaveBeenCalled();
+    expect(actions.hideAsset).not.toHaveBeenCalled();
+    expect(actions.multichainIgnoreAssets).not.toHaveBeenCalled();
   });
 
   it('shows a search result as ON when TokensController already holds the imported address (no balance yet)', () => {

--- a/ui/pages/token-management/token-management.test.tsx
+++ b/ui/pages/token-management/token-management.test.tsx
@@ -558,6 +558,89 @@ describe('TokenManagementPage', () => {
     );
   });
 
+  it('keeps a hidden search result OFF after the user clears and repeats the search', async () => {
+    const actions = getMockedActions();
+    const mainnetTokenAssetId = `eip155:1/erc20:${mainnetToken.address}`;
+    setTokenSearchState({
+      results: [
+        {
+          assetId: mainnetTokenAssetId,
+          symbol: mainnetToken.symbol,
+          decimals: mainnetToken.decimals,
+          name: mainnetToken.name,
+        },
+      ],
+    });
+
+    renderPage();
+
+    const searchInput = screen.getByTestId('token-management-search-input');
+    fireEvent.change(searchInput, {
+      target: { value: mainnetToken.name },
+    });
+
+    const firstSearchResultToggle = screen.getByTestId(
+      `token-management-cell-search-${mainnetTokenAssetId.toLowerCase()}-toggle`,
+    ) as HTMLInputElement;
+    fireEvent.click(firstSearchResultToggle);
+    expect(firstSearchResultToggle.value).toBe('false');
+
+    fireEvent.change(searchInput, { target: { value: '' } });
+
+    await waitFor(() =>
+      expect(actions.ignoreTokens).toHaveBeenCalledWith({
+        tokensToIgnore: [mainnetToken.address],
+        dontShowLoadingIndicator: true,
+        networkClientId: 'mainnet',
+      }),
+    );
+
+    fireEvent.change(searchInput, {
+      target: { value: mainnetToken.name },
+    });
+
+    const secondSearchResultToggle = screen.getByTestId(
+      `token-management-cell-search-${mainnetTokenAssetId.toLowerCase()}-toggle`,
+    ) as HTMLInputElement;
+    expect(secondSearchResultToggle.value).toBe('false');
+  });
+
+  it('commits the staged hide before navigating back', async () => {
+    const actions = getMockedActions();
+    const mainnetTokenAssetId = `eip155:1/erc20:${mainnetToken.address}`;
+    setTokenSearchState({
+      results: [
+        {
+          assetId: mainnetTokenAssetId,
+          symbol: mainnetToken.symbol,
+          decimals: mainnetToken.decimals,
+          name: mainnetToken.name,
+        },
+      ],
+    });
+
+    renderPage();
+
+    fireEvent.change(screen.getByTestId('token-management-search-input'), {
+      target: { value: mainnetToken.name },
+    });
+    fireEvent.click(
+      screen.getByTestId(
+        `token-management-cell-search-${mainnetTokenAssetId.toLowerCase()}-toggle`,
+      ),
+    );
+
+    fireEvent.click(screen.getByTestId('token-management-header-back-button'));
+
+    await waitFor(() =>
+      expect(actions.ignoreTokens).toHaveBeenCalledWith({
+        tokensToIgnore: [mainnetToken.address],
+        dontShowLoadingIndicator: true,
+        networkClientId: 'mainnet',
+      }),
+    );
+  });
+
   it('commits the staged hide when the user clicks the Add custom token CTA', async () => {
     const actions = getMockedActions();
 
@@ -648,6 +731,61 @@ describe('TokenManagementPage', () => {
       `token-management-cell-search-${usdcAssetId.toLowerCase()}-toggle`,
     ) as HTMLInputElement;
     expect(toggle.value).toBe('true');
+  });
+
+  it('shows an ignored EVM search result as OFF after reopening token management', () => {
+    const mainnetTokenAssetId = `eip155:1/erc20:${mainnetToken.address}`;
+    setTokenSearchState({
+      results: [
+        {
+          assetId: mainnetTokenAssetId,
+          symbol: mainnetToken.symbol,
+          decimals: mainnetToken.decimals,
+          name: mainnetToken.name,
+        },
+      ],
+    });
+
+    const selectedAddress =
+      mockState.metamask.internalAccounts.accounts[
+        mockState.metamask.internalAccounts
+          .selectedAccount as keyof typeof mockState.metamask.internalAccounts.accounts
+      ]?.address;
+    if (!selectedAddress) {
+      throw new Error('Expected selected account address');
+    }
+
+    const stateWithIgnoredToken = createState();
+    stateWithIgnoredToken.metamask = {
+      ...stateWithIgnoredToken.metamask,
+      allTokens: {
+        '0x1': {
+          [selectedAddress]: [
+            {
+              address: mainnetToken.address,
+              symbol: mainnetToken.symbol,
+              decimals: mainnetToken.decimals,
+            },
+          ],
+        },
+      },
+      allIgnoredTokens: {
+        '0x1': {
+          [selectedAddress]: [mainnetToken.address],
+        },
+      },
+    };
+
+    renderPage(stateWithIgnoredToken);
+
+    fireEvent.change(screen.getByTestId('token-management-search-input'), {
+      target: { value: mainnetToken.name },
+    });
+
+    const toggle = screen.getByTestId(
+      `token-management-cell-search-${mainnetTokenAssetId.toLowerCase()}-toggle`,
+    ) as HTMLInputElement;
+    expect(toggle.value).toBe('false');
   });
 
   it('keeps stale results visible while the next query is being fetched', () => {

--- a/ui/pages/token-management/token-management.test.tsx
+++ b/ui/pages/token-management/token-management.test.tsx
@@ -274,17 +274,20 @@ describe('TokenManagementPage', () => {
     },
   });
 
-  const renderPage = (state = createState()) => {
+  const renderPage = (state = createState(), routeState?: unknown) => {
     const store = configureStore({
       ...state,
     });
+    const initialRoute =
+      routeState === undefined
+        ? TOKEN_MANAGEMENT_ROUTE
+        : {
+            pathname: TOKEN_MANAGEMENT_ROUTE,
+            state: routeState,
+          };
     return {
       store,
-      ...renderWithProvider(
-        <TokenManagementPage />,
-        store,
-        TOKEN_MANAGEMENT_ROUTE,
-      ),
+      ...renderWithProvider(<TokenManagementPage />, store, initialRoute),
     };
   };
 
@@ -326,6 +329,28 @@ describe('TokenManagementPage', () => {
     // routes the user to the dedicated CUSTOM_TOKEN_IMPORT_ROUTE page instead.
     expect(store.getState().appState.importTokensModalOpen).toBeFalsy();
     expect(CUSTOM_TOKEN_IMPORT_ROUTE).toBe('/custom-token-import');
+  });
+
+  it('shows and dismisses the custom token success toast from route state', async () => {
+    renderPage(createState(), {
+      tokenManagementToast: {
+        type: 'customTokenAdded',
+        symbol: 'APE',
+      },
+    });
+
+    const toast = await screen.findByTestId(
+      'token-management-custom-token-success-toast',
+    );
+    expect(toast).toHaveTextContent('APE');
+
+    fireEvent.click(screen.getByLabelText(messages.close.message));
+
+    await waitFor(() =>
+      expect(
+        screen.queryByTestId('token-management-custom-token-success-toast'),
+      ).not.toBeInTheDocument(),
+    );
   });
 
   it('shows tokens from the enabled home-page network filter', () => {
@@ -755,23 +780,26 @@ describe('TokenManagementPage', () => {
       throw new Error('Expected selected account address');
     }
 
-    const stateWithIgnoredToken = createState();
-    stateWithIgnoredToken.metamask = {
-      ...stateWithIgnoredToken.metamask,
-      allTokens: {
-        '0x1': {
-          [selectedAddress]: [
-            {
-              address: mainnetToken.address,
-              symbol: mainnetToken.symbol,
-              decimals: mainnetToken.decimals,
-            },
-          ],
+    const baseState = createState();
+    const stateWithIgnoredToken = {
+      ...baseState,
+      metamask: {
+        ...baseState.metamask,
+        allTokens: {
+          '0x1': {
+            [selectedAddress]: [
+              {
+                address: mainnetToken.address,
+                symbol: mainnetToken.symbol,
+                decimals: mainnetToken.decimals,
+              },
+            ],
+          },
         },
-      },
-      allIgnoredTokens: {
-        '0x1': {
-          [selectedAddress]: [mainnetToken.address],
+        allIgnoredTokens: {
+          '0x1': {
+            [selectedAddress]: [mainnetToken.address],
+          },
         },
       },
     };

--- a/ui/pages/token-management/token-management.test.tsx
+++ b/ui/pages/token-management/token-management.test.tsx
@@ -518,6 +518,46 @@ describe('TokenManagementPage', () => {
     );
   });
 
+  it('shows a token hidden by a committed staged hide as OFF in search results', async () => {
+    const actions = getMockedActions();
+    const mainnetTokenAssetId = `eip155:1/erc20:${mainnetToken.address}`;
+    setTokenSearchState({
+      results: [
+        {
+          assetId: mainnetTokenAssetId,
+          symbol: mainnetToken.symbol,
+          decimals: mainnetToken.decimals,
+          name: mainnetToken.name,
+        },
+      ],
+    });
+
+    renderPage();
+
+    const visibleListToggle = screen.getByTestId(
+      `token-management-cell-0x1:${mainnetToken.address}-toggle`,
+    ) as HTMLInputElement;
+    fireEvent.click(visibleListToggle);
+    expect(visibleListToggle.value).toBe('false');
+
+    fireEvent.change(screen.getByTestId('token-management-search-input'), {
+      target: { value: mainnetToken.name },
+    });
+
+    const searchResultToggle = screen.getByTestId(
+      `token-management-cell-search-${mainnetTokenAssetId.toLowerCase()}-toggle`,
+    ) as HTMLInputElement;
+    expect(searchResultToggle.value).toBe('false');
+
+    await waitFor(() =>
+      expect(actions.ignoreTokens).toHaveBeenCalledWith({
+        tokensToIgnore: [mainnetToken.address],
+        dontShowLoadingIndicator: true,
+        networkClientId: 'mainnet',
+      }),
+    );
+  });
+
   it('commits the staged hide when the user clicks the Add custom token CTA', async () => {
     const actions = getMockedActions();
 

--- a/ui/pages/token-management/token-management.tsx
+++ b/ui/pages/token-management/token-management.tsx
@@ -98,7 +98,6 @@ import {
 
 type ManagedAsset = Parameters<typeof sortAssetsWithPriority>[0][number];
 
-
 type EvmToken = {
   address: string;
   symbol?: string;
@@ -197,14 +196,12 @@ const getIgnoredTokenAddressesByChain = (
   return ignoredTokenAddressesByChain;
 };
 
-const toManagedEvmToken = (
-  token: EvmToken,
-  hexChainId: string,
-): ManagedAsset =>
+const toManagedEvmToken = (token: EvmToken, hexChainId: string): ManagedAsset =>
   ({
     accountId: '',
     accountType: 'eip155:eoa',
-    assetId: toAssetId(token.address as Hex, hexChainId as Hex) ?? token.address,
+    assetId:
+      toAssetId(token.address as Hex, hexChainId as Hex) ?? token.address,
     address: token.address,
     chainId: hexChainId,
     image: token.image ?? '',

--- a/ui/pages/token-management/token-management.tsx
+++ b/ui/pages/token-management/token-management.tsx
@@ -926,9 +926,9 @@ export const TokenManagementPage = () => {
         ? false
         : Boolean(
             accountIdForChain &&
-              allIgnoredAssetsByAccount[accountIdForChain]?.some(
-                (assetId) => String(assetId).toLowerCase() === lowerAssetId,
-              ),
+            allIgnoredAssetsByAccount[accountIdForChain]?.some(
+              (assetId) => String(assetId).toLowerCase() === lowerAssetId,
+            ),
           );
       const isHidden =
         stagedHideKeys.has(lowerAssetId) ||

--- a/ui/pages/token-management/token-management.tsx
+++ b/ui/pages/token-management/token-management.tsx
@@ -64,7 +64,11 @@ import {
 } from '../../helpers/constants/routes';
 import { VirtualizedList } from '../../components/ui/virtualized-list/virtualized-list';
 import { getAssetsBySelectedAccountGroup } from '../../selectors/assets';
-import { getTokensControllerAllTokens } from '../../../shared/lib/selectors/assets-migration';
+import {
+  getMultiChainAssetsControllerAllIgnoredAssets,
+  getTokensControllerAllIgnoredTokens,
+  getTokensControllerAllTokens,
+} from '../../../shared/lib/selectors/assets-migration';
 import {
   getAssetImageUrl,
   isEvmChainId,
@@ -242,11 +246,11 @@ export const TokenManagementPage = () => {
    * staged token does NOT commit; instead it unstages, which is what
    * powers the in-page restore behavior.
    */
-  const commitStagedHides = useCallback(() => {
+  const commitStagedHides = useCallback(async () => {
     if (stagedHidesRef.current.size === 0) {
       return;
     }
-    commitStagedHidesRef.current().catch(() => undefined);
+    await commitStagedHidesRef.current();
   }, []);
 
   const isAssetsUnifiedStateInBuild = useMemo(
@@ -294,6 +298,12 @@ export const TokenManagementPage = () => {
     string,
     Record<string, { address: string }[]>
   >;
+  const allIgnoredTokensByChain = useSelector(
+    getTokensControllerAllIgnoredTokens,
+  ) as Record<string, Record<string, string[]>>;
+  const allIgnoredAssetsByAccount = useSelector(
+    getMultiChainAssetsControllerAllIgnoredAssets,
+  ) as Record<string, CaipAssetType[]>;
   const selectedAddress = useSelector(getSelectedAddress) as string | undefined;
 
   // Looks up the internal account in the selected account group that maps to
@@ -493,26 +503,60 @@ export const TokenManagementPage = () => {
     return set;
   }, [chainToHex, importedEvmTokensByChain, visibleTokens]);
 
+  const ignoredEvmAssetIds = useMemo(() => {
+    const set = new Set<string>();
+    if (!selectedAddress) {
+      return set;
+    }
+
+    const lowercasedSelectedAddress = selectedAddress.toLowerCase();
+    Object.entries(allIgnoredTokensByChain ?? {}).forEach(
+      ([chainId, tokensByAddress]) => {
+        const hexChainId = chainToHex(chainId);
+        Object.entries(tokensByAddress ?? {}).forEach(
+          ([accountAddress, tokenAddresses]) => {
+            if (accountAddress.toLowerCase() !== lowercasedSelectedAddress) {
+              return;
+            }
+
+            tokenAddresses.forEach((tokenAddress) => {
+              const lowercasedTokenAddress = tokenAddress.toLowerCase();
+              set.add(`${hexChainId}:${lowercasedTokenAddress}`);
+              const caipAssetId = toAssetId(
+                tokenAddress as Hex,
+                hexChainId as Hex,
+              );
+              if (caipAssetId) {
+                set.add(caipAssetId.toLowerCase());
+              }
+            });
+          },
+        );
+      },
+    );
+    return set;
+  }, [allIgnoredTokensByChain, chainToHex, selectedAddress]);
+
   const handleOpenNetworkFilter = useCallback(() => {
-    commitStagedHides();
+    commitStagedHides().catch(() => undefined);
     dispatch(showModal({ name: 'NETWORK_MANAGER' }));
   }, [commitStagedHides, dispatch]);
 
   const handleAddCustomToken = useCallback(() => {
-    commitStagedHides();
+    commitStagedHides().catch(() => undefined);
     navigate(CUSTOM_TOKEN_IMPORT_ROUTE);
   }, [commitStagedHides, navigate]);
 
   const handleSearchChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
-      commitStagedHides();
+      commitStagedHides().catch(() => undefined);
       setSearchQuery(event.target.value);
     },
     [commitStagedHides],
   );
 
   const handleSearchClear = useCallback(() => {
-    commitStagedHides();
+    commitStagedHides().catch(() => undefined);
     setSearchQuery('');
   }, [commitStagedHides]);
 
@@ -786,6 +830,16 @@ export const TokenManagementPage = () => {
     ],
   );
 
+  const handleBack = useCallback(
+    (event: React.MouseEvent<HTMLAnchorElement>) => {
+      event.preventDefault();
+      commitStagedHides()
+        .catch(() => undefined)
+        .finally(() => navigate(DEFAULT_ROUTE));
+    },
+    [commitStagedHides, navigate],
+  );
+
   const getTokenImage = useCallback((token: ManagedAsset) => {
     if (token.isNative && isEvmChainId(token.chainId as Hex | CaipChainId)) {
       return getNativeCurrencyForChain(token.chainId as Hex) ?? token.image;
@@ -871,8 +925,23 @@ export const TokenManagementPage = () => {
       const isImported =
         importedAssetIds.has(lowerAssetId) ||
         (evmImportedKey ? importedAssetIds.has(evmImportedKey) : false);
+      const accountIdForChain = payload.isEvm
+        ? undefined
+        : getAccountForChain(payload.caipChainId)?.id;
+      const isIgnoredMultichainAsset = payload.isEvm
+        ? false
+        : Boolean(
+            accountIdForChain &&
+              allIgnoredAssetsByAccount[accountIdForChain]?.some(
+                (assetId) => String(assetId).toLowerCase() === lowerAssetId,
+              ),
+          );
       const isHidden =
-        stagedHideKeys.has(lowerAssetId) || committedHideKeys.has(lowerAssetId);
+        stagedHideKeys.has(lowerAssetId) ||
+        committedHideKeys.has(lowerAssetId) ||
+        ignoredEvmAssetIds.has(lowerAssetId) ||
+        (evmImportedKey ? ignoredEvmAssetIds.has(evmImportedKey) : false) ||
+        isIgnoredMultichainAsset;
 
       return (
         <TokenManagementCell
@@ -899,8 +968,11 @@ export const TokenManagementPage = () => {
     },
     [
       allMultichainNetworkConfigurations,
+      allIgnoredAssetsByAccount,
       committedHideKeys,
+      getAccountForChain,
       handleSearchResultToggle,
+      ignoredEvmAssetIds,
       importedAssetIds,
       networkConfigurations,
       pendingKeys,
@@ -964,7 +1036,7 @@ export const TokenManagementPage = () => {
   );
 
   const startAccessory = (
-    <Link to={DEFAULT_ROUTE} aria-label={t('back')}>
+    <Link to={DEFAULT_ROUTE} aria-label={t('back')} onClick={handleBack}>
       <ButtonIcon
         iconName={IconName.ArrowLeft}
         ariaLabel={t('back')}

--- a/ui/pages/token-management/token-management.tsx
+++ b/ui/pages/token-management/token-management.tsx
@@ -6,7 +6,7 @@ import React, {
   useState,
 } from 'react';
 import { useDispatch, useSelector, useStore } from 'react-redux';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useLocation, useNavigate } from 'react-router-dom';
 import {
   Box,
   BoxAlignItems,
@@ -18,7 +18,10 @@ import {
   ButtonIcon,
   ButtonIconSize,
   FontWeight,
+  Icon,
+  IconColor,
   IconName,
+  IconSize,
   Text,
   TextAlign,
   TextColor,
@@ -61,6 +64,7 @@ import { getInternalAccountBySelectedAccountGroupAndCaip } from '../../selectors
 import {
   CUSTOM_TOKEN_IMPORT_ROUTE,
   DEFAULT_ROUTE,
+  TOKEN_MANAGEMENT_ROUTE,
 } from '../../helpers/constants/routes';
 import { VirtualizedList } from '../../components/ui/virtualized-list/virtualized-list';
 import { getAssetsBySelectedAccountGroup } from '../../selectors/assets';
@@ -99,6 +103,29 @@ type ManagedAsset = Parameters<typeof sortAssetsWithPriority>[0][number];
  * Keeps the request rate sane while still feeling instant.
  */
 const SEARCH_DEBOUNCE_MS = 300;
+const TOKEN_MANAGEMENT_PAGE_TOAST_DURATION_MS = 5000;
+
+type TokenManagementRouteState = {
+  tokenManagementToast?: {
+    type: 'customTokenAdded';
+    symbol: string;
+  };
+};
+
+const getTokenManagementToastFromRouteState = (state: unknown) => {
+  if (!state || typeof state !== 'object') {
+    return null;
+  }
+
+  const toast = (state as TokenManagementRouteState).tokenManagementToast;
+  if (toast?.type !== 'customTokenAdded' || !toast.symbol) {
+    return null;
+  }
+
+  return {
+    symbol: toast.symbol,
+  };
+};
 
 /**
  * Full-screen Token Management page.
@@ -113,11 +140,15 @@ export const TokenManagementPage = () => {
   const t = useI18nContext();
   const dispatch = useDispatch();
   const navigate = useNavigate();
+  const location = useLocation();
 
   const [searchQuery, setSearchQuery] = useState('');
+  const [pageToast, setPageToast] = useState<{ symbol: string } | null>(null);
   const [pendingKeys, setPendingKeys] = useState<ReadonlySet<string>>(
     () => new Set<string>(),
   );
+
+  const dismissPageToast = useCallback(() => setPageToast(null), []);
 
   const addPendingKey = useCallback((key: string) => {
     setPendingKeys((prev) => {
@@ -588,6 +619,29 @@ export const TokenManagementPage = () => {
       isMountedRef.current = false;
     };
   }, []);
+
+  useEffect(() => {
+    const toast = getTokenManagementToastFromRouteState(location.state);
+    if (!toast) {
+      return;
+    }
+
+    setPageToast(toast);
+    navigate(TOKEN_MANAGEMENT_ROUTE, { replace: true, state: null });
+  }, [location.state, navigate]);
+
+  useEffect(() => {
+    if (!pageToast) {
+      return undefined;
+    }
+
+    const timeoutId = setTimeout(
+      dismissPageToast,
+      TOKEN_MANAGEMENT_PAGE_TOAST_DURATION_MS,
+    );
+
+    return () => clearTimeout(timeoutId);
+  }, [dismissPageToast, pageToast]);
 
   useEffect(() => {
     commitStagedHidesRef.current = async () => {
@@ -1133,23 +1187,46 @@ export const TokenManagementPage = () => {
         )}
       </ScrollContainer>
 
-      {canImportCustomTokens ? (
+      {pageToast || canImportCustomTokens ? (
         <Box
-          flexDirection={BoxFlexDirection.Row}
+          flexDirection={BoxFlexDirection.Column}
           alignItems={BoxAlignItems.Center}
           backgroundColor={BoxBackgroundColor.BackgroundDefault}
           paddingHorizontal={4}
           paddingTop={3}
           paddingBottom={3}
-          className="sticky bottom-0 z-10"
+          className="sticky bottom-0 z-10 gap-3"
         >
-          <ButtonBase
-            data-testid="token-management-add-custom-token-button"
-            className="w-full bg-muted text-default hover:bg-muted-hover active:bg-muted-pressed"
-            onClick={handleAddCustomToken}
-          >
-            {t('addCustomToken')}
-          </ButtonBase>
+          {pageToast ? (
+            <Box
+              data-testid="token-management-custom-token-success-toast"
+              className="flex w-full items-center gap-3 rounded-xl border border-border-muted bg-background-section p-3"
+            >
+              <Icon
+                name={IconName.Confirmation}
+                size={IconSize.Md}
+                color={IconColor.SuccessDefault}
+              />
+              <Text variant={TextVariant.BodyMd} className="flex-1">
+                {t('newCustomTokenAdded', [pageToast.symbol])}
+              </Text>
+              <ButtonIcon
+                ariaLabel={t('close')}
+                iconName={IconName.Close}
+                size={ButtonIconSize.Sm}
+                onClick={dismissPageToast}
+              />
+            </Box>
+          ) : null}
+          {canImportCustomTokens ? (
+            <ButtonBase
+              data-testid="token-management-add-custom-token-button"
+              className="w-full bg-muted text-default hover:bg-muted-hover active:bg-muted-pressed"
+              onClick={handleAddCustomToken}
+            >
+              {t('addCustomToken')}
+            </ButtonBase>
+          ) : null}
         </Box>
       ) : null}
     </Box>

--- a/ui/pages/token-management/token-management.tsx
+++ b/ui/pages/token-management/token-management.tsx
@@ -170,13 +170,10 @@ export const TokenManagementPage = () => {
   >(() => new Set<string>());
   const stagedHidesRef = useRef<Map<string, StagedHidePayload>>(new Map());
 
-  const stageHide = useCallback(
-    (key: string, payload: StagedHidePayload) => {
-      stagedHidesRef.current.set(key, payload);
-      setStagedHideKeys(new Set(stagedHidesRef.current.keys()));
-    },
-    [],
-  );
+  const stageHide = useCallback((key: string, payload: StagedHidePayload) => {
+    stagedHidesRef.current.set(key, payload);
+    setStagedHideKeys(new Set(stagedHidesRef.current.keys()));
+  }, []);
 
   const unstageHide = useCallback((key: string) => {
     if (!stagedHidesRef.current.has(key)) {
@@ -211,19 +208,16 @@ export const TokenManagementPage = () => {
     });
   }, []);
 
-  const getStagedHideKey = useCallback(
-    (token: ManagedAsset): string | null => {
-      if (isEvmChainId(token.chainId as Hex | CaipChainId)) {
-        if (!('address' in token) || !token.address) {
-          return null;
-        }
-        const caip = toAssetId(token.address as Hex, token.chainId as Hex);
-        return caip ? caip.toLowerCase() : null;
+  const getStagedHideKey = useCallback((token: ManagedAsset): string | null => {
+    if (isEvmChainId(token.chainId as Hex | CaipChainId)) {
+      if (!('address' in token) || !token.address) {
+        return null;
       }
-      return token.assetId ? String(token.assetId).toLowerCase() : null;
-    },
-    [],
-  );
+      const caip = toAssetId(token.address as Hex, token.chainId as Hex);
+      return caip ? caip.toLowerCase() : null;
+    }
+    return token.assetId ? String(token.assetId).toLowerCase() : null;
+  }, []);
 
   /**
    * Flushes every staged hide to the underlying controllers. Stored behind

--- a/ui/pages/token-management/token-management.tsx
+++ b/ui/pages/token-management/token-management.tsx
@@ -160,6 +160,10 @@ export const TokenManagementPage = () => {
   const [stagedHideKeys, setStagedHideKeys] = useState<ReadonlySet<string>>(
     () => new Set<string>(),
   );
+  // Render override for hides already flushed but not yet reflected in Redux.
+  const [committedHideKeys, setCommittedHideKeys] = useState<
+    ReadonlySet<string>
+  >(() => new Set<string>());
   const stagedHidesRef = useRef<Map<string, StagedHidePayload>>(new Map());
 
   const stageHide = useCallback(
@@ -177,6 +181,30 @@ export const TokenManagementPage = () => {
     stagedHidesRef.current.delete(key);
     setStagedHideKeys(new Set(stagedHidesRef.current.keys()));
     return true;
+  }, []);
+
+  const addCommittedHideKeys = useCallback((keys: string[]) => {
+    if (keys.length === 0) {
+      return;
+    }
+
+    setCommittedHideKeys((previousKeys) => {
+      const nextKeys = new Set(previousKeys);
+      keys.forEach((key) => nextKeys.add(key));
+      return nextKeys;
+    });
+  }, []);
+
+  const removeCommittedHideKey = useCallback((key: string) => {
+    setCommittedHideKeys((previousKeys) => {
+      if (!previousKeys.has(key)) {
+        return previousKeys;
+      }
+
+      const nextKeys = new Set(previousKeys);
+      nextKeys.delete(key);
+      return nextKeys;
+    });
   }, []);
 
   const getStagedHideKey = useCallback(
@@ -528,14 +556,15 @@ export const TokenManagementPage = () => {
       if (stagedHidesRef.current.size === 0) {
         return;
       }
-      const entries = Array.from(stagedHidesRef.current.values());
+      const entries = Array.from(stagedHidesRef.current.entries());
       stagedHidesRef.current.clear();
       if (isMountedRef.current) {
         setStagedHideKeys(new Set());
+        addCommittedHideKeys(entries.map(([key]) => key));
       }
 
       await Promise.allSettled(
-        entries.map(async (entry) => {
+        entries.map(async ([, entry]) => {
           if (entry.kind === 'evm') {
             const { networkClientId } = getNetworkMeta(entry.hexChainId);
             if (!networkClientId) {
@@ -562,7 +591,12 @@ export const TokenManagementPage = () => {
         }),
       );
     };
-  });
+  }, [
+    addCommittedHideKeys,
+    dispatch,
+    getNetworkMeta,
+    isAssetsUnifiedStateInBuild,
+  ]);
 
   useEffect(() => {
     return () => {
@@ -690,6 +724,7 @@ export const TokenManagementPage = () => {
       if (unstageHide(stagedKey)) {
         return;
       }
+      removeCommittedHideKey(stagedKey);
 
       addPendingKey(stagedKey);
       try {
@@ -745,6 +780,7 @@ export const TokenManagementPage = () => {
       getNetworkMeta,
       isAssetsUnifiedStateInBuild,
       removePendingKey,
+      removeCommittedHideKey,
       stageHide,
       unstageHide,
     ],
@@ -767,7 +803,9 @@ export const TokenManagementPage = () => {
       const token = info.item;
       const key = getTokenKey(token);
       const stagedKey = getStagedHideKey(token);
-      const isStagedOff = stagedKey ? stagedHideKeys.has(stagedKey) : false;
+      const isHidden = stagedKey
+        ? stagedHideKeys.has(stagedKey) || committedHideKeys.has(stagedKey)
+        : false;
       const isNativeToken = Boolean(token.isNative);
       const isEvmToken = isEvmChainId(token.chainId as Hex | CaipChainId);
       const isManageableToken =
@@ -783,7 +821,7 @@ export const TokenManagementPage = () => {
           assetId={token.assetId as CaipAssetType | Hex}
           primaryLabel={token.name ?? token.symbol}
           secondaryLabel={`${token.balance} ${token.symbol}`}
-          isOn={!isStagedOff}
+          isOn={!isHidden}
           disabled={isNativeToken || pendingKeys.has(key)}
           onToggle={(nextValue) => handleToggle(token, nextValue)}
           showToggle={isManageableToken || isNativeToken}
@@ -792,6 +830,7 @@ export const TokenManagementPage = () => {
       );
     },
     [
+      committedHideKeys,
       getStagedHideKey,
       getTokenImage,
       getTokenKey,
@@ -832,7 +871,8 @@ export const TokenManagementPage = () => {
       const isImported =
         importedAssetIds.has(lowerAssetId) ||
         (evmImportedKey ? importedAssetIds.has(evmImportedKey) : false);
-      const isStagedOff = stagedHideKeys.has(lowerAssetId);
+      const isHidden =
+        stagedHideKeys.has(lowerAssetId) || committedHideKeys.has(lowerAssetId);
 
       return (
         <TokenManagementCell
@@ -849,7 +889,7 @@ export const TokenManagementPage = () => {
             allMultichainNetworkConfigurations?.[payload.caipChainId]?.name ??
             payload.caipChainId
           }
-          isOn={(isImported && !isStagedOff) || payload.isNative}
+          isOn={(isImported && !isHidden) || payload.isNative}
           disabled={payload.isNative || pendingKeys.has(lowerAssetId)}
           onToggle={(nextValue) => handleSearchResultToggle(payload, nextValue)}
           showToggle={!payload.isNative}
@@ -859,6 +899,7 @@ export const TokenManagementPage = () => {
     },
     [
       allMultichainNetworkConfigurations,
+      committedHideKeys,
       handleSearchResultToggle,
       importedAssetIds,
       networkConfigurations,

--- a/ui/pages/token-management/token-management.tsx
+++ b/ui/pages/token-management/token-management.tsx
@@ -98,12 +98,19 @@ import {
 
 type ManagedAsset = Parameters<typeof sortAssetsWithPriority>[0][number];
 
-/**
- * Debounce window applied to the search input before it reaches the Token API.
- * Keeps the request rate sane while still feeling instant.
- */
+
+type EvmToken = {
+  address: string;
+  symbol?: string;
+  decimals?: number;
+  name?: string;
+  image?: string;
+};
+
 const SEARCH_DEBOUNCE_MS = 300;
 const TOKEN_MANAGEMENT_PAGE_TOAST_DURATION_MS = 5000;
+const TOKEN_LIST_PAGINATION_THRESHOLD_PX = ASSET_CELL_HEIGHT * 4;
+const EMPTY_TOKEN_SEARCH_RESULTS: TokenSearchResult[] = [];
 
 type TokenManagementRouteState = {
   tokenManagementToast?: {
@@ -111,6 +118,16 @@ type TokenManagementRouteState = {
     symbol: string;
   };
 };
+
+type TokenManagementListItem =
+  | {
+      type: 'managed';
+      token: ManagedAsset;
+    }
+  | {
+      type: 'api-result';
+      result: TokenSearchResult;
+    };
 
 const getTokenManagementToastFromRouteState = (state: unknown) => {
   if (!state || typeof state !== 'object') {
@@ -127,15 +144,142 @@ const getTokenManagementToastFromRouteState = (state: unknown) => {
   };
 };
 
-/**
- * Full-screen Token Management page.
- *
- * Replaces the legacy import-tokens modal flow when the
- * `extensionUxTokenManagementFilter` feature flag is enabled. The token list
- * mirrors the home-page asset list for the current network filter, and lets
- * users hide manageable EVM tokens from that list.
- *
- */
+const normalizeToHexChainId = (chainId: string): string => {
+  if (!chainId.startsWith('eip155:')) {
+    return chainId.toLowerCase();
+  }
+
+  const decimalChainId = Number(chainId.split(':')[1]);
+  return Number.isFinite(decimalChainId)
+    ? `0x${decimalChainId.toString(16)}`.toLowerCase()
+    : chainId.toLowerCase();
+};
+
+const normalizeToCaipChainId = (chainId: string): CaipChainId =>
+  chainId.startsWith('0x')
+    ? formatChainIdToCaip(chainId as Hex)
+    : (chainId as CaipChainId);
+
+const getTokenAddressKey = (chainId: string, address: string) =>
+  `${normalizeToHexChainId(chainId)}:${address.toLowerCase()}`;
+
+const getIgnoredTokenAddressesByChain = (
+  allIgnoredTokensByChain: Record<string, Record<string, string[]>>,
+  selectedAddress?: string,
+) => {
+  const ignoredTokenAddressesByChain = new Map<string, Set<string>>();
+
+  if (!selectedAddress) {
+    return ignoredTokenAddressesByChain;
+  }
+
+  const lowercasedSelectedAddress = selectedAddress.toLowerCase();
+  Object.entries(allIgnoredTokensByChain ?? {}).forEach(
+    ([chainId, tokensByAddress]) => {
+      const hexChainId = normalizeToHexChainId(chainId);
+      Object.entries(tokensByAddress ?? {}).forEach(
+        ([accountAddress, tokenAddresses]) => {
+          if (accountAddress.toLowerCase() !== lowercasedSelectedAddress) {
+            return;
+          }
+
+          const ignoredAddresses =
+            ignoredTokenAddressesByChain.get(hexChainId) ?? new Set<string>();
+          tokenAddresses.forEach((tokenAddress) =>
+            ignoredAddresses.add(tokenAddress.toLowerCase()),
+          );
+          ignoredTokenAddressesByChain.set(hexChainId, ignoredAddresses);
+        },
+      );
+    },
+  );
+
+  return ignoredTokenAddressesByChain;
+};
+
+const toManagedEvmToken = (
+  token: EvmToken,
+  hexChainId: string,
+): ManagedAsset =>
+  ({
+    accountId: '',
+    accountType: 'eip155:eoa',
+    assetId: toAssetId(token.address as Hex, hexChainId as Hex) ?? token.address,
+    address: token.address,
+    chainId: hexChainId,
+    image: token.image ?? '',
+    name: token.name ?? token.symbol ?? token.address,
+    symbol: token.symbol ?? '',
+    decimals: token.decimals ?? 0,
+    isNative: false,
+    rawBalance: '0x0',
+    balance: '0',
+    fiat: {
+      balance: 0,
+      currency: 'usd',
+      conversionRate: 0,
+    },
+  }) as ManagedAsset;
+
+const getImportedTokensWithoutBalances = ({
+  allTokensByChain,
+  allIgnoredTokensByChain,
+  enabledChainIds,
+  selectedAddress,
+  seenKeys,
+}: {
+  allTokensByChain: Record<string, Record<string, EvmToken[]>>;
+  allIgnoredTokensByChain: Record<string, Record<string, string[]>>;
+  enabledChainIds: string[];
+  selectedAddress?: string;
+  seenKeys: Set<string>;
+}): ManagedAsset[] => {
+  if (!selectedAddress) {
+    return [];
+  }
+
+  const ignoredAddressesByChain = getIgnoredTokenAddressesByChain(
+    allIgnoredTokensByChain,
+    selectedAddress,
+  );
+  const lowercasedSelectedAddress = selectedAddress.toLowerCase();
+
+  return Object.entries(allTokensByChain ?? {}).flatMap(
+    ([chainId, tokensByAddress]) => {
+      const hexChainId = normalizeToHexChainId(chainId);
+      if (!enabledChainIds.includes(hexChainId)) {
+        return [];
+      }
+
+      return Object.entries(tokensByAddress ?? {}).flatMap(
+        ([accountAddress, tokens]) => {
+          if (accountAddress.toLowerCase() !== lowercasedSelectedAddress) {
+            return [];
+          }
+
+          return tokens.flatMap((token) => {
+            if (!token?.address) {
+              return [];
+            }
+
+            const lowercasedAddress = token.address.toLowerCase();
+            const key = getTokenAddressKey(hexChainId, lowercasedAddress);
+            if (
+              seenKeys.has(key) ||
+              ignoredAddressesByChain.get(hexChainId)?.has(lowercasedAddress)
+            ) {
+              return [];
+            }
+
+            seenKeys.add(key);
+            return [toManagedEvmToken(token, hexChainId)];
+          });
+        },
+      );
+    },
+  );
+};
+
 export const TokenManagementPage = () => {
   const t = useI18nContext();
   const dispatch = useDispatch();
@@ -169,16 +313,6 @@ export const TokenManagementPage = () => {
     });
   }, []);
 
-  /**
-   * Tokens the user has toggled OFF in this session but whose hide we
-   * intentionally defer: the row stays visible (showing the toggle as OFF)
-   * and the user can still flip it back ON to restore. The actual hide
-   * dispatch is flushed when the page unmounts, so leaving the screen is
-   * the implicit "commit".
-   *
-   * Keyed by the lowercased CAIP asset id so the same key works whether
-   * the toggle is hit from the visible-list view or from a search result.
-   */
   type StagedHidePayload =
     | {
         kind: 'evm';
@@ -195,7 +329,6 @@ export const TokenManagementPage = () => {
   const [stagedHideKeys, setStagedHideKeys] = useState<ReadonlySet<string>>(
     () => new Set<string>(),
   );
-  // Render override for hides already flushed but not yet reflected in Redux.
   const [committedHideKeys, setCommittedHideKeys] = useState<
     ReadonlySet<string>
   >(() => new Set<string>());
@@ -250,27 +383,12 @@ export const TokenManagementPage = () => {
     return token.assetId ? String(token.assetId).toLowerCase() : null;
   }, []);
 
-  /**
-   * Flushes every staged hide to the underlying controllers. Stored behind
-   * a ref + late-binding effect so each invocation picks up the most recent
-   * `dispatch` / `getNetworkMeta` / flag values rather than stale closures.
-   */
   const commitStagedHidesRef = useRef<() => Promise<void>>(
     async () => undefined,
   );
 
-  // Tracks whether the component is still mounted so the commit path can
-  // skip `setStagedHideKeys` during unmount cleanup (which would otherwise
-  // log a "state update on unmounted component" warning in development).
   const isMountedRef = useRef(true);
 
-  /**
-   * Imperative "flush the staged hides now" — wired to every non-toggle
-   * interaction that we treat as the user having moved on (search input,
-   * network filter, add-custom CTA, navigation away). Re-toggling the same
-   * staged token does NOT commit; instead it unstages, which is what
-   * powers the in-page restore behavior.
-   */
   const commitStagedHides = useCallback(async () => {
     if (stagedHidesRef.current.size === 0) {
       return;
@@ -296,8 +414,6 @@ export const TokenManagementPage = () => {
   const allEnabledNetworksForAllNamespaces = useSelector(
     getAllEnabledNetworksForAllNamespaces,
   );
-  // Wrapped in a safe selector so a partially hydrated multichain state
-  // (which can throw in `parseCaipChainId`) cannot blank the entire page.
   const enabledNetworksByNamespace = useSelector((state: unknown) => {
     try {
       return getEnabledNetworksByNamespace(
@@ -308,20 +424,12 @@ export const TokenManagementPage = () => {
     }
   });
   const networkConfigurations = useSelector(getNetworkConfigurationsByChainId);
-  // Includes non-EVM (Solana, Bitcoin, ...) networks keyed by CAIP-2 chain id.
-  // Used to resolve a display name when the active enabled network is non-EVM,
-  // which is missing from the EVM-only `networkConfigurations` map above.
   const allMultichainNetworkConfigurations = useSelector(
     getAllMultichainNetworkConfigurations,
   );
-  // Raw TokensController state. `accountGroupIdAssets` (via
-  // `selectAssetsBySelectedAccountGroup`) filters out tokens that don't yet
-  // have a balance entry, which is exactly the case right after the user
-  // imports a token from a search result. Reading `allTokens` directly lets
-  // the toggle (and the home list) reflect the import immediately.
   const allTokensByChain = useSelector(getTokensControllerAllTokens) as Record<
     string,
-    Record<string, { address: string }[]>
+    Record<string, EvmToken[]>
   >;
   const allIgnoredTokensByChain = useSelector(
     getTokensControllerAllIgnoredTokens,
@@ -331,15 +439,6 @@ export const TokenManagementPage = () => {
   ) as Record<string, CaipAssetType[]>;
   const selectedAddress = useSelector(getSelectedAddress) as string | undefined;
 
-  // Looks up the internal account in the selected account group that maps to
-  // a given CAIP chain id. Used when importing a search result so the unified
-  // AssetsController has an account to associate the asset with.
-  //
-  // Backed by `useStore` (not `useSelector`) because we only need the current
-  // state at the moment the user toggles a row — subscribing here would
-  // produce a fresh function on every dispatch, breaking memoization
-  // downstream and forcing the whole page to re-render on unrelated state
-  // changes.
   const store = useStore();
   const getAccountForChain = useCallback(
     (caipChainId: CaipChainId) =>
@@ -397,13 +496,23 @@ export const TokenManagementPage = () => {
     accountAssetsPreSort.forEach((asset) => {
       const id =
         'address' in asset && asset.address ? asset.address : asset.assetId;
-      const key = `${asset.chainId}:${String(id).toLowerCase()}`;
+      const key = getTokenAddressKey(String(asset.chainId), String(id));
       if (seen.has(key)) {
         return;
       }
       seen.add(key);
       dedupedAssets.push(asset);
     });
+
+    dedupedAssets.push(
+      ...getImportedTokensWithoutBalances({
+        allTokensByChain,
+        allIgnoredTokensByChain,
+        enabledChainIds: allEnabledNetworksForAllNamespaces,
+        selectedAddress,
+        seenKeys: seen,
+      }),
+    );
 
     const accountAssets = sortAssetsWithPriority(
       dedupedAssets,
@@ -422,62 +531,64 @@ export const TokenManagementPage = () => {
   }, [
     accountGroupIdAssets,
     allEnabledNetworksForAllNamespaces,
+    allIgnoredTokensByChain,
+    allTokensByChain,
     currentNetwork?.chainId,
     isEvm,
+    selectedAddress,
     shouldHideZeroBalanceTokens,
     tokenSortConfig,
     useExternalServices,
   ]);
 
   const normalizedSearchQuery = searchQuery.trim();
+  const hasQuery = normalizedSearchQuery.length > 0;
   const debouncedSearchQuery = useDebouncedValue(
     normalizedSearchQuery,
     SEARCH_DEBOUNCE_MS,
   );
+  const tokenSearchQuery = hasQuery ? debouncedSearchQuery : '';
 
   const searchNetworks = useMemo(() => {
-    if (enabledChainIds.length === 0) {
+    if (allEnabledNetworksForAllNamespaces.length === 0) {
       return undefined;
     }
-    return enabledChainIds.map((chainId) =>
-      formatChainIdToCaip(chainId as Hex | CaipChainId),
-    );
-  }, [enabledChainIds]);
+    return allEnabledNetworksForAllNamespaces.map(normalizeToCaipChainId);
+  }, [allEnabledNetworksForAllNamespaces]);
 
   const {
     data: searchResponse,
     isFetching: isSearchFetching,
+    isFetchingNextPage,
+    hasNextPage,
+    fetchNextPage,
     error: searchQueryError,
   } = useTokenSearch({
-    query: debouncedSearchQuery,
+    query: tokenSearchQuery,
     networks: searchNetworks,
+    enableTokenBrowse: !hasQuery,
   });
 
-  const hasQuery = normalizedSearchQuery.length > 0;
   const isWaitingForDebounce =
     hasQuery && normalizedSearchQuery !== debouncedSearchQuery;
 
-  const searchResults = hasQuery ? (searchResponse?.data ?? []) : [];
+  const apiTokenResults = useMemo(() => {
+    if (hasQuery && debouncedSearchQuery.length === 0) {
+      return EMPTY_TOKEN_SEARCH_RESULTS;
+    }
+
+    return searchResponse?.data ?? EMPTY_TOKEN_SEARCH_RESULTS;
+  }, [debouncedSearchQuery.length, hasQuery, searchResponse?.data]);
+  const searchResults = useMemo(
+    () => (hasQuery ? apiTokenResults : EMPTY_TOKEN_SEARCH_RESULTS),
+    [apiTokenResults, hasQuery],
+  );
   const hasResults = searchResults.length > 0;
   const isSearching =
     isWaitingForDebounce ||
     (hasQuery && debouncedSearchQuery.length > 0 && isSearchFetching);
   const searchError = hasQuery ? searchQueryError : null;
 
-  const chainToHex = useCallback((chainId: string): string => {
-    if (chainId.startsWith('eip155:')) {
-      const dec = Number(chainId.split(':')[1]);
-      return Number.isFinite(dec)
-        ? `0x${dec.toString(16)}`.toLowerCase()
-        : chainId.toLowerCase();
-    }
-    return chainId.toLowerCase();
-  }, []);
-
-  // Pull every imported EVM token address for the current account out of
-  // TokensController directly. This bypasses the balance-gated filter inside
-  // `selectAssetsBySelectedAccountGroup`, which would otherwise hide a token
-  // for the few seconds between import and the first balance fetch.
   const importedEvmTokensByChain = useMemo(() => {
     const map = new Map<string, Set<string>>();
     if (!selectedAddress) {
@@ -486,7 +597,7 @@ export const TokenManagementPage = () => {
     const lowercasedSelected = selectedAddress.toLowerCase();
     Object.entries(allTokensByChain ?? {}).forEach(
       ([chainId, tokensByAddress]) => {
-        const hexChainId = chainToHex(chainId);
+        const hexChainId = normalizeToHexChainId(chainId);
         Object.entries(tokensByAddress ?? {}).forEach(
           ([accountAddress, tokens]) => {
             if (accountAddress.toLowerCase() !== lowercasedSelected) {
@@ -504,7 +615,7 @@ export const TokenManagementPage = () => {
       },
     );
     return map;
-  }, [allTokensByChain, chainToHex, selectedAddress]);
+  }, [allTokensByChain, selectedAddress]);
 
   const importedAssetIds = useMemo(() => {
     const set = new Set<string>();
@@ -514,7 +625,7 @@ export const TokenManagementPage = () => {
       }
       if ('address' in token && token.address && token.chainId) {
         set.add(
-          `${chainToHex(String(token.chainId))}:${String(
+          `${normalizeToHexChainId(String(token.chainId))}:${String(
             token.address,
           ).toLowerCase()}`,
         );
@@ -526,7 +637,7 @@ export const TokenManagementPage = () => {
       });
     });
     return set;
-  }, [chainToHex, importedEvmTokensByChain, visibleTokens]);
+  }, [importedEvmTokensByChain, visibleTokens]);
 
   const ignoredEvmAssetIds = useMemo(() => {
     const set = new Set<string>();
@@ -537,7 +648,7 @@ export const TokenManagementPage = () => {
     const lowercasedSelectedAddress = selectedAddress.toLowerCase();
     Object.entries(allIgnoredTokensByChain ?? {}).forEach(
       ([chainId, tokensByAddress]) => {
-        const hexChainId = chainToHex(chainId);
+        const hexChainId = normalizeToHexChainId(chainId);
         Object.entries(tokensByAddress ?? {}).forEach(
           ([accountAddress, tokenAddresses]) => {
             if (accountAddress.toLowerCase() !== lowercasedSelectedAddress) {
@@ -560,7 +671,7 @@ export const TokenManagementPage = () => {
       },
     );
     return set;
-  }, [allIgnoredTokensByChain, chainToHex, selectedAddress]);
+  }, [allIgnoredTokensByChain, selectedAddress]);
 
   const handleOpenNetworkFilter = useCallback(() => {
     commitStagedHides().catch(() => undefined);
@@ -696,12 +807,6 @@ export const TokenManagementPage = () => {
     };
   }, []);
 
-  /**
-   * Visible-list toggle. Hides are staged in local state so the row stays
-   * visible (and restorable) until the user leaves the page. Re-toggling a
-   * staged-off row simply unstages it — no dispatch ever fires for that
-   * intermediate state.
-   */
   const handleToggle = useCallback(
     (token: ManagedAsset, nextValue: boolean) => {
       const isNativeToken = Boolean(token.isNative);
@@ -754,27 +859,6 @@ export const TokenManagementPage = () => {
     [getNetworkMeta, getStagedHideKey, stageHide, unstageHide],
   );
 
-  /**
-   * Search-result-specific toggle. Imports (toggle ON for a never-imported
-   * result) still dispatch immediately so the user sees the asset land in
-   * the list. Hides (toggle OFF for an already-imported result) are staged
-   * just like the visible-list toggle, so flipping the row back ON before
-   * leaving the page restores it without ever dispatching a hide.
-   *
-   * Mirrors the mobile dual-dispatch contract (`metamask-mobile#26108`):
-   *
-   * - EVM result, toggle ON (fresh) → `addImportedTokens` + `addCustomAsset`.
-   * - Non-EVM result, toggle ON (fresh) → `multichainAddAssets`
-   * + `addCustomAsset`.
-   * - Toggle OFF (any) → stage hide; commit fires on unmount.
-   *
-   * `addCustomAsset` only fires when the unified AssetsController is
-   * included in the build (`ASSETS_UNIFIED_STATE_ENABLED`).
-   *
-   * Native assets are not importable — the toggle never reaches this handler
-   * for them, but we guard here too so a buggy API response can't dispatch
-   * a malformed payload.
-   */
   const handleSearchResultToggle = useCallback(
     async (payload: SearchResultImportPayload, nextValue: boolean) => {
       if (payload.isNative) {
@@ -942,12 +1026,6 @@ export const TokenManagementPage = () => {
     ],
   );
 
-  /**
-   * Custom-token import is only meaningful on EVM networks today. Hide the
-   * sticky CTA when none of the enabled networks (across all namespaces)
-   * support custom tokens. Showing it for a mix that includes an EVM network
-   * preserves the existing "All networks" behavior.
-   */
   const canImportCustomTokens = useMemo(() => {
     if (allEnabledNetworksForAllNamespaces.length === 0) {
       return true;
@@ -1033,6 +1111,132 @@ export const TokenManagementPage = () => {
     [],
   );
 
+  const visibleTokenAssetIds = useMemo(() => {
+    const set = new Set<string>();
+
+    visibleTokens.forEach((token) => {
+      if (token.assetId) {
+        set.add(String(token.assetId).toLowerCase());
+      }
+
+      if ('address' in token && token.address && token.chainId) {
+        const hexChainId = normalizeToHexChainId(String(token.chainId));
+        const address = String(token.address).toLowerCase();
+        set.add(`${hexChainId}:${address}`);
+
+        const caipAssetId = toAssetId(token.address as Hex, hexChainId as Hex);
+        if (caipAssetId) {
+          set.add(caipAssetId.toLowerCase());
+        }
+      }
+    });
+
+    return set;
+  }, [visibleTokens]);
+
+  const getSearchResultAssetKeys = useCallback((result: TokenSearchResult) => {
+    const keys = [result.assetId.toLowerCase()];
+    const payload = convertSearchResultToImportPayload(result);
+
+    if (payload?.hexChainId) {
+      keys.push(
+        `${payload.hexChainId}:${payload.assetReference.toLowerCase()}`,
+      );
+    }
+
+    return keys;
+  }, []);
+
+  const browseApiResults = useMemo(() => {
+    if (hasQuery) {
+      return [];
+    }
+
+    return apiTokenResults.filter((result) =>
+      getSearchResultAssetKeys(result).every(
+        (key) => !visibleTokenAssetIds.has(key),
+      ),
+    );
+  }, [
+    apiTokenResults,
+    getSearchResultAssetKeys,
+    hasQuery,
+    visibleTokenAssetIds,
+  ]);
+
+  const tokenListItems = useMemo<TokenManagementListItem[]>(() => {
+    if (hasQuery) {
+      return searchResults.map((result) => ({
+        type: 'api-result',
+        result,
+      }));
+    }
+
+    return [
+      ...visibleTokens.map((token) => ({
+        type: 'managed' as const,
+        token,
+      })),
+      ...browseApiResults.map((result) => ({
+        type: 'api-result' as const,
+        result,
+      })),
+    ];
+  }, [browseApiResults, hasQuery, searchResults, visibleTokens]);
+
+  const renderTokenListItem = useCallback(
+    (info: { item: TokenManagementListItem }) => {
+      if (info.item.type === 'managed') {
+        return renderToken({ item: info.item.token });
+      }
+
+      return renderSearchResult({ item: info.item.result });
+    },
+    [renderSearchResult, renderToken],
+  );
+
+  const getTokenListItemKey = useCallback(
+    (item: TokenManagementListItem, index: number) => {
+      if (item.type === 'managed') {
+        return `managed-${getTokenKey(item.token)}`;
+      }
+
+      return `${getSearchResultKey(item.result)}-${index}`;
+    },
+    [getSearchResultKey, getTokenKey],
+  );
+
+  const handleListScroll = useCallback(
+    (event: React.UIEvent<HTMLDivElement>) => {
+      const { scrollTop, clientHeight, scrollHeight } = event.currentTarget;
+
+      if (
+        !hasNextPage ||
+        isSearchFetching ||
+        isFetchingNextPage ||
+        searchError
+      ) {
+        return;
+      }
+
+      const distanceFromBottom = scrollHeight - scrollTop - clientHeight;
+
+      if (
+        scrollTop > 0 &&
+        distanceFromBottom <= TOKEN_LIST_PAGINATION_THRESHOLD_PX
+      ) {
+        fetchNextPage().catch(() => undefined);
+      }
+    },
+    [
+      fetchNextPage,
+      hasNextPage,
+      isFetchingNextPage,
+      isSearchFetching,
+      searchError,
+    ],
+  );
+
   const emptyState = (
     <Box
       flexDirection={BoxFlexDirection.Column}
@@ -1082,6 +1286,28 @@ export const TokenManagementPage = () => {
       </Text>
     </Box>
   );
+
+  const paginationLoadingState = isFetchingNextPage ? (
+    <Box
+      flexDirection={BoxFlexDirection.Column}
+      alignItems={BoxAlignItems.Center}
+      justifyContent={BoxJustifyContent.Center}
+      padding={4}
+      data-testid="token-management-pagination-loading"
+    >
+      <Text
+        variant={TextVariant.BodySm}
+        textAlign={TextAlign.Center}
+        color={TextColor.TextAlternative}
+      >
+        {t('loading')}
+      </Text>
+    </Box>
+  ) : null;
+
+  const shouldShowTokenList = hasQuery
+    ? hasResults || (!isSearching && !searchError)
+    : tokenListItems.length > 0 || !isSearchFetching;
 
   const startAccessory = (
     <Link to={DEFAULT_ROUTE} aria-label={t('back')} onClick={handleBack}>
@@ -1151,6 +1377,7 @@ export const TokenManagementPage = () => {
 
       <ScrollContainer
         data-testid="token-management-page-list"
+        onScroll={handleListScroll}
         style={{
           flex: '1 1 auto',
           minHeight: 0,
@@ -1158,33 +1385,24 @@ export const TokenManagementPage = () => {
           width: '100%',
         }}
       >
-        {hasQuery ? (
-          <>
-            {isSearching && !hasResults ? loadingState : null}
-            {!isSearching && searchError && !hasResults
-              ? searchErrorState
-              : null}
-            {hasResults || (!isSearching && !searchError) ? (
-              <VirtualizedList
-                data={searchResults}
-                estimatedItemSize={ASSET_CELL_HEIGHT}
-                overscan={10}
-                keyExtractor={getSearchResultKey}
-                listEmptyComponent={emptyState}
-                renderItem={renderSearchResult}
-              />
-            ) : null}
-          </>
-        ) : (
+        {hasQuery && isSearching && !hasResults ? loadingState : null}
+        {hasQuery && !isSearching && searchError && !hasResults
+          ? searchErrorState
+          : null}
+        {!hasQuery && isSearchFetching && tokenListItems.length === 0
+          ? loadingState
+          : null}
+        {shouldShowTokenList ? (
           <VirtualizedList
-            data={visibleTokens}
+            data={tokenListItems}
             estimatedItemSize={ASSET_CELL_HEIGHT}
             overscan={10}
-            keyExtractor={getTokenKey}
+            keyExtractor={getTokenListItemKey}
             listEmptyComponent={emptyState}
-            renderItem={renderToken}
+            listFooterComponent={paginationLoadingState}
+            renderItem={renderTokenListItem}
           />
-        )}
+        ) : null}
       </ScrollContainer>
 
       {pageToast || canImportCustomTokens ? (

--- a/ui/pages/token-management/token-management.tsx
+++ b/ui/pages/token-management/token-management.tsx
@@ -1,4 +1,10 @@
-import React, { useCallback, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useDispatch, useSelector, useStore } from 'react-redux';
 import { Link, useNavigate } from 'react-router-dom';
 import {
@@ -126,6 +132,93 @@ export const TokenManagementPage = () => {
       next.delete(key);
       return next;
     });
+  }, []);
+
+  /**
+   * Tokens the user has toggled OFF in this session but whose hide we
+   * intentionally defer: the row stays visible (showing the toggle as OFF)
+   * and the user can still flip it back ON to restore. The actual hide
+   * dispatch is flushed when the page unmounts, so leaving the screen is
+   * the implicit "commit".
+   *
+   * Keyed by the lowercased CAIP asset id so the same key works whether
+   * the toggle is hit from the visible-list view or from a search result.
+   */
+  type StagedHidePayload =
+    | {
+        kind: 'evm';
+        hexChainId: Hex;
+        address: string;
+        caipAssetId?: CaipAssetType;
+      }
+    | {
+        kind: 'multichain';
+        assetId: CaipAssetType;
+        accountId: string;
+      };
+
+  const [stagedHideKeys, setStagedHideKeys] = useState<ReadonlySet<string>>(
+    () => new Set<string>(),
+  );
+  const stagedHidesRef = useRef<Map<string, StagedHidePayload>>(new Map());
+
+  const stageHide = useCallback(
+    (key: string, payload: StagedHidePayload) => {
+      stagedHidesRef.current.set(key, payload);
+      setStagedHideKeys(new Set(stagedHidesRef.current.keys()));
+    },
+    [],
+  );
+
+  const unstageHide = useCallback((key: string) => {
+    if (!stagedHidesRef.current.has(key)) {
+      return false;
+    }
+    stagedHidesRef.current.delete(key);
+    setStagedHideKeys(new Set(stagedHidesRef.current.keys()));
+    return true;
+  }, []);
+
+  const getStagedHideKey = useCallback(
+    (token: ManagedAsset): string | null => {
+      if (isEvmChainId(token.chainId as Hex | CaipChainId)) {
+        if (!('address' in token) || !token.address) {
+          return null;
+        }
+        const caip = toAssetId(token.address as Hex, token.chainId as Hex);
+        return caip ? caip.toLowerCase() : null;
+      }
+      return token.assetId ? String(token.assetId).toLowerCase() : null;
+    },
+    [],
+  );
+
+  /**
+   * Flushes every staged hide to the underlying controllers. Stored behind
+   * a ref + late-binding effect so each invocation picks up the most recent
+   * `dispatch` / `getNetworkMeta` / flag values rather than stale closures.
+   */
+  const commitStagedHidesRef = useRef<() => Promise<void>>(
+    async () => undefined,
+  );
+
+  // Tracks whether the component is still mounted so the commit path can
+  // skip `setStagedHideKeys` during unmount cleanup (which would otherwise
+  // log a "state update on unmounted component" warning in development).
+  const isMountedRef = useRef(true);
+
+  /**
+   * Imperative "flush the staged hides now" — wired to every non-toggle
+   * interaction that we treat as the user having moved on (search input,
+   * network filter, add-custom CTA, navigation away). Re-toggling the same
+   * staged token does NOT commit; instead it unstages, which is what
+   * powers the in-page restore behavior.
+   */
+  const commitStagedHides = useCallback(() => {
+    if (stagedHidesRef.current.size === 0) {
+      return;
+    }
+    commitStagedHidesRef.current().catch(() => undefined);
   }, []);
 
   const isAssetsUnifiedStateInBuild = useMemo(
@@ -373,12 +466,27 @@ export const TokenManagementPage = () => {
   }, [chainToHex, importedEvmTokensByChain, visibleTokens]);
 
   const handleOpenNetworkFilter = useCallback(() => {
+    commitStagedHides();
     dispatch(showModal({ name: 'NETWORK_MANAGER' }));
-  }, [dispatch]);
+  }, [commitStagedHides, dispatch]);
 
   const handleAddCustomToken = useCallback(() => {
+    commitStagedHides();
     navigate(CUSTOM_TOKEN_IMPORT_ROUTE);
-  }, [navigate]);
+  }, [commitStagedHides, navigate]);
+
+  const handleSearchChange = useCallback(
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      commitStagedHides();
+      setSearchQuery(event.target.value);
+    },
+    [commitStagedHides],
+  );
+
+  const handleSearchClear = useCallback(() => {
+    commitStagedHides();
+    setSearchQuery('');
+  }, [commitStagedHides]);
 
   const networkFilterLabel = useMemo(() => {
     const enabledCount = enabledChainIds.length;
@@ -408,84 +516,138 @@ export const TokenManagementPage = () => {
     return `${token.chainId}:${address.toLowerCase()}`;
   }, []);
 
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    commitStagedHidesRef.current = async () => {
+      if (stagedHidesRef.current.size === 0) {
+        return;
+      }
+      const entries = Array.from(stagedHidesRef.current.values());
+      stagedHidesRef.current.clear();
+      if (isMountedRef.current) {
+        setStagedHideKeys(new Set());
+      }
+
+      await Promise.allSettled(
+        entries.map(async (entry) => {
+          if (entry.kind === 'evm') {
+            const { networkClientId } = getNetworkMeta(entry.hexChainId);
+            if (!networkClientId) {
+              return;
+            }
+            await dispatch(
+              ignoreTokensAction({
+                tokensToIgnore: [entry.address],
+                dontShowLoadingIndicator: true,
+                networkClientId,
+              }),
+            );
+            if (isAssetsUnifiedStateInBuild && entry.caipAssetId) {
+              await dispatch(hideAsset(entry.caipAssetId));
+            }
+            return;
+          }
+          await dispatch(
+            multichainIgnoreAssets([entry.assetId], entry.accountId),
+          );
+          if (isAssetsUnifiedStateInBuild) {
+            await dispatch(hideAsset(entry.assetId));
+          }
+        }),
+      );
+    };
+  });
+
+  useEffect(() => {
+    return () => {
+      commitStagedHidesRef.current().catch(() => undefined);
+    };
+  }, []);
+
+  /**
+   * Visible-list toggle. Hides are staged in local state so the row stays
+   * visible (and restorable) until the user leaves the page. Re-toggling a
+   * staged-off row simply unstages it — no dispatch ever fires for that
+   * intermediate state.
+   */
   const handleToggle = useCallback(
-    async (token: ManagedAsset, nextValue: boolean) => {
+    (token: ManagedAsset, nextValue: boolean) => {
       const isNativeToken = Boolean(token.isNative);
+      if (isNativeToken) {
+        return;
+      }
+
       const isEvmToken = isEvmChainId(token.chainId as Hex | CaipChainId);
       const canIgnoreEvmToken = isEvmToken && 'address' in token;
       const canIgnoreMultichainToken =
         !isEvmToken && Boolean(token.assetId) && Boolean(token.accountId);
-
-      if (
-        nextValue ||
-        isNativeToken ||
-        (!canIgnoreEvmToken && !canIgnoreMultichainToken)
-      ) {
+      if (!canIgnoreEvmToken && !canIgnoreMultichainToken) {
         return;
       }
 
-      const key = getTokenKey(token);
-      addPendingKey(key);
-      try {
-        if (canIgnoreEvmToken) {
-          const { networkClientId } = getNetworkMeta(token.chainId as Hex);
-          if (!networkClientId) {
-            return;
-          }
-          await dispatch(
-            ignoreTokensAction({
-              tokensToIgnore: [token.address],
-              dontShowLoadingIndicator: true,
-              networkClientId,
-            }),
-          );
-          if (isAssetsUnifiedStateInBuild) {
-            const caipAssetId = toAssetId(
-              token.address as Hex,
-              token.chainId as Hex,
-            );
-            if (caipAssetId) {
-              await dispatch(hideAsset(caipAssetId));
-            }
-          }
+      const stagedKey = getStagedHideKey(token);
+      if (!stagedKey) {
+        return;
+      }
+
+      if (nextValue) {
+        unstageHide(stagedKey);
+        return;
+      }
+
+      if (canIgnoreEvmToken) {
+        const { networkClientId } = getNetworkMeta(token.chainId as Hex);
+        if (!networkClientId) {
           return;
         }
-
-        await dispatch(
-          multichainIgnoreAssets([token.assetId], token.accountId),
+        const caipAssetId = toAssetId(
+          token.address as Hex,
+          token.chainId as Hex,
         );
-        if (isAssetsUnifiedStateInBuild) {
-          await dispatch(hideAsset(token.assetId as CaipAssetType));
-        }
-      } finally {
-        removePendingKey(key);
+        stageHide(stagedKey, {
+          kind: 'evm',
+          hexChainId: token.chainId as Hex,
+          address: token.address,
+          caipAssetId: caipAssetId ?? undefined,
+        });
+        return;
       }
+
+      stageHide(stagedKey, {
+        kind: 'multichain',
+        assetId: token.assetId as CaipAssetType,
+        accountId: token.accountId,
+      });
     },
-    [
-      addPendingKey,
-      dispatch,
-      getNetworkMeta,
-      getTokenKey,
-      isAssetsUnifiedStateInBuild,
-      removePendingKey,
-    ],
+    [getNetworkMeta, getStagedHideKey, stageHide, unstageHide],
   );
 
   /**
-   * Search-result-specific toggle. Mirrors the mobile import flow
-   * (`metamask-mobile#26108`):
+   * Search-result-specific toggle. Imports (toggle ON for a never-imported
+   * result) still dispatch immediately so the user sees the asset land in
+   * the list. Hides (toggle OFF for an already-imported result) are staged
+   * just like the visible-list toggle, so flipping the row back ON before
+   * leaving the page restores it without ever dispatching a hide.
    *
-   * - EVM result, toggle ON → `addImportedTokens` + `addCustomAsset`.
-   * - EVM result, toggle OFF → `ignoreTokens` + `hideAsset`.
-   * - Non-EVM result, toggle ON → `multichainAddAssets` + `addCustomAsset`.
-   * - Non-EVM result, toggle OFF → `multichainIgnoreAssets` + `hideAsset`.
+   * Mirrors the mobile dual-dispatch contract (`metamask-mobile#26108`):
    *
-   * `addCustomAsset` / `hideAsset` only fire when the unified AssetsController
-   * is included in the build (`ASSETS_UNIFIED_STATE_ENABLED`).
+   * - EVM result, toggle ON (fresh) → `addImportedTokens` + `addCustomAsset`.
+   * - Non-EVM result, toggle ON (fresh) → `multichainAddAssets`
+   * + `addCustomAsset`.
+   * - Toggle OFF (any) → stage hide; commit fires on unmount.
    *
-   * Native assets (slip44 namespace or EVM zero-address) are not importable —
-   * the toggle never reaches this handler for them, but we guard here too so
-   * a buggy API response can't dispatch a malformed payload.
+   * `addCustomAsset` only fires when the unified AssetsController is
+   * included in the build (`ASSETS_UNIFIED_STATE_ENABLED`).
+   *
+   * Native assets are not importable — the toggle never reaches this handler
+   * for them, but we guard here too so a buggy API response can't dispatch
+   * a malformed payload.
    */
   const handleSearchResultToggle = useCallback(
     async (payload: SearchResultImportPayload, nextValue: boolean) => {
@@ -493,8 +655,43 @@ export const TokenManagementPage = () => {
         return;
       }
 
-      const importedKey = payload.assetId.toLowerCase();
-      addPendingKey(importedKey);
+      const stagedKey = payload.assetId.toLowerCase();
+
+      if (!nextValue) {
+        if (payload.isEvm) {
+          if (!payload.hexChainId) {
+            return;
+          }
+          const { networkClientId } = getNetworkMeta(payload.hexChainId);
+          if (!networkClientId) {
+            return;
+          }
+          stageHide(stagedKey, {
+            kind: 'evm',
+            hexChainId: payload.hexChainId,
+            address: payload.assetReference,
+            caipAssetId: payload.assetId,
+          });
+          return;
+        }
+
+        const account = getAccountForChain(payload.caipChainId);
+        if (!account?.id) {
+          return;
+        }
+        stageHide(stagedKey, {
+          kind: 'multichain',
+          assetId: payload.assetId,
+          accountId: account.id,
+        });
+        return;
+      }
+
+      if (unstageHide(stagedKey)) {
+        return;
+      }
+
+      addPendingKey(stagedKey);
       try {
         if (payload.isEvm) {
           if (!payload.hexChainId) {
@@ -505,40 +702,26 @@ export const TokenManagementPage = () => {
             return;
           }
           const evmAccount = getAccountForChain(payload.caipChainId);
-
-          if (nextValue) {
-            if (!evmAccount?.id) {
-              return;
-            }
-            await dispatch(
-              addImportedTokens(
-                [
-                  {
-                    address: payload.assetReference,
-                    symbol: payload.symbol,
-                    decimals: payload.decimals,
-                    isERC721: false,
-                    name: payload.name,
-                    ...(payload.iconUrl ? { image: payload.iconUrl } : {}),
-                  },
-                ],
-                networkClientId,
-              ),
-            );
-            if (isAssetsUnifiedStateInBuild) {
-              await dispatch(addCustomAsset(evmAccount.id, payload.assetId));
-            }
+          if (!evmAccount?.id) {
             return;
           }
           await dispatch(
-            ignoreTokensAction({
-              tokensToIgnore: [payload.assetReference],
-              dontShowLoadingIndicator: true,
+            addImportedTokens(
+              [
+                {
+                  address: payload.assetReference,
+                  symbol: payload.symbol,
+                  decimals: payload.decimals,
+                  isERC721: false,
+                  name: payload.name,
+                  ...(payload.iconUrl ? { image: payload.iconUrl } : {}),
+                },
+              ],
               networkClientId,
-            }),
+            ),
           );
           if (isAssetsUnifiedStateInBuild) {
-            await dispatch(hideAsset(payload.assetId));
+            await dispatch(addCustomAsset(evmAccount.id, payload.assetId));
           }
           return;
         }
@@ -547,19 +730,12 @@ export const TokenManagementPage = () => {
         if (!account?.id) {
           return;
         }
-        if (nextValue) {
-          await dispatch(multichainAddAssets([payload.assetId], account.id));
-          if (isAssetsUnifiedStateInBuild) {
-            await dispatch(addCustomAsset(account.id, payload.assetId));
-          }
-          return;
-        }
-        await dispatch(multichainIgnoreAssets([payload.assetId], account.id));
+        await dispatch(multichainAddAssets([payload.assetId], account.id));
         if (isAssetsUnifiedStateInBuild) {
-          await dispatch(hideAsset(payload.assetId));
+          await dispatch(addCustomAsset(account.id, payload.assetId));
         }
       } finally {
-        removePendingKey(importedKey);
+        removePendingKey(stagedKey);
       }
     },
     [
@@ -569,6 +745,8 @@ export const TokenManagementPage = () => {
       getNetworkMeta,
       isAssetsUnifiedStateInBuild,
       removePendingKey,
+      stageHide,
+      unstageHide,
     ],
   );
 
@@ -588,6 +766,8 @@ export const TokenManagementPage = () => {
     (info: { item: ManagedAsset }) => {
       const token = info.item;
       const key = getTokenKey(token);
+      const stagedKey = getStagedHideKey(token);
+      const isStagedOff = stagedKey ? stagedHideKeys.has(stagedKey) : false;
       const isNativeToken = Boolean(token.isNative);
       const isEvmToken = isEvmChainId(token.chainId as Hex | CaipChainId);
       const isManageableToken =
@@ -603,7 +783,7 @@ export const TokenManagementPage = () => {
           assetId={token.assetId as CaipAssetType | Hex}
           primaryLabel={token.name ?? token.symbol}
           secondaryLabel={`${token.balance} ${token.symbol}`}
-          isOn
+          isOn={!isStagedOff}
           disabled={isNativeToken || pendingKeys.has(key)}
           onToggle={(nextValue) => handleToggle(token, nextValue)}
           showToggle={isManageableToken || isNativeToken}
@@ -611,7 +791,14 @@ export const TokenManagementPage = () => {
         />
       );
     },
-    [getTokenImage, getTokenKey, handleToggle, pendingKeys],
+    [
+      getStagedHideKey,
+      getTokenImage,
+      getTokenKey,
+      handleToggle,
+      pendingKeys,
+      stagedHideKeys,
+    ],
   );
 
   /**
@@ -645,6 +832,7 @@ export const TokenManagementPage = () => {
       const isImported =
         importedAssetIds.has(lowerAssetId) ||
         (evmImportedKey ? importedAssetIds.has(evmImportedKey) : false);
+      const isStagedOff = stagedHideKeys.has(lowerAssetId);
 
       return (
         <TokenManagementCell
@@ -661,7 +849,7 @@ export const TokenManagementPage = () => {
             allMultichainNetworkConfigurations?.[payload.caipChainId]?.name ??
             payload.caipChainId
           }
-          isOn={isImported || payload.isNative}
+          isOn={(isImported && !isStagedOff) || payload.isNative}
           disabled={payload.isNative || pendingKeys.has(lowerAssetId)}
           onToggle={(nextValue) => handleSearchResultToggle(payload, nextValue)}
           showToggle={!payload.isNative}
@@ -675,6 +863,7 @@ export const TokenManagementPage = () => {
       importedAssetIds,
       networkConfigurations,
       pendingKeys,
+      stagedHideKeys,
     ],
   );
 
@@ -763,8 +952,8 @@ export const TokenManagementPage = () => {
         <TextFieldSearch
           value={searchQuery}
           placeholder={t('enterTokenNameOrAddressManageTokens')}
-          onChange={(event) => setSearchQuery(event.target.value)}
-          clearButtonOnClick={() => setSearchQuery('')}
+          onChange={handleSearchChange}
+          clearButtonOnClick={handleSearchClear}
           size={TextFieldSearchSize.Lg}
           className="w-full"
           inputProps={{

--- a/ui/selectors/multichain/feature-flags.ts
+++ b/ui/selectors/multichain/feature-flags.ts
@@ -96,6 +96,5 @@ export const getIsTransactionLabelsEnabled = createSelector(
  */
 export const getIsTokenManagementFilterEnabled = createSelector(
   getRemoteFeatureFlags,
-  ({ extensionUxTokenManagementFilter }) =>
-    getBooleanFeatureFlag(extensionUxTokenManagementFilter, false),
+  ({ extensionUxTokenManagementFilter }) => true
 );

--- a/ui/selectors/multichain/feature-flags.ts
+++ b/ui/selectors/multichain/feature-flags.ts
@@ -96,5 +96,6 @@ export const getIsTransactionLabelsEnabled = createSelector(
  */
 export const getIsTokenManagementFilterEnabled = createSelector(
   getRemoteFeatureFlags,
-  ({ extensionUxTokenManagementFilter }) => true
+  ({ extensionUxTokenManagementFilter }) =>
+    getBooleanFeatureFlag(extensionUxTokenManagementFilter, false),
 );


### PR DESCRIPTION
This PR is to enable:
1. When the user click on toggle to toggle it off, it should not hide token immediately, instead wait till the user performs next user action
2. Show non-imported tokens along with imported tokens in the tokens list
3. After adding a custom token, toast appears on manage tokens page

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: update toggle

## **Related issues**

Fixes: 

## **Manual testing steps**

  1. Build and load the extension, then unlock a wallet that has at least one visible non-native imported token.
  2. From the Assets tab, click the add/import token button and open Manage tokens.
  3. Check that non-imported tokens are listed along with imported tokens with toggle off
  4. Toggle a non-native imported token OFF.
  5. Confirm the token row stays visible on the Manage tokens page and the toggle shows OFF.
  6. Toggle the same token back ON, then navigate away and reopen Manage tokens.
  7. Confirm the token is still visible and still ON.
  8. Toggle the token OFF again, then perform another action such as typing in search, opening the network filter, clicking  add custom token, or pressing Back.
  9. Return to the Assets tab / Manage tokens page and confirm the token is now hidden.
  10. Optional search check: re-import the token, search for it in Manage tokens, toggle the imported search result OFF, confirm the result remains visible with the toggle OFF, then toggle it back ON and confirm it is not hidden after leaving the page.
11. Add a custom token, check the toast appears

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**






https://github.com/user-attachments/assets/9438727d-0b53-4ca8-8b72-2c94cd6d3a38


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes token visibility/ignore behavior (staged hides committed on later actions/unmount) and adds infinite pagination + browse mode, which could affect token list correctness and persistence across networks.
> 
> **Overview**
> Adds a **token browse mode** to the Token Search API (`browseTokens` uses a single-space query) and upgrades `useTokenSearch` to `useInfiniteQuery`, exposing `fetchNextPage` and merging cursor pages.
> 
> Updates **Token Management** to (1) show API browse results alongside existing managed tokens when no search query is active, (2) auto-fetch additional pages on scroll, and (3) *stage* token hides so toggling OFF doesn’t immediately dispatch ignore/hide—staged hides are committed on subsequent user actions (search change/clear, network filter, add custom token, back nav) or on unmount.
> 
> Custom token import now navigates back to token management with route state that triggers a **success toast** (“`newCustomTokenAdded`”), with new i18n strings and tests covering the toast, browse/pagination, and staged-hide flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db1dfff829dc9fa630d7aa1c363a5ae304971316. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->