### PR TITLE
chore: Remove unused `warning` prop

### DIFF
--- a/ui/components/ui/qr-code-view/qr-code-view.test.tsx
+++ b/ui/components/ui/qr-code-view/qr-code-view.test.tsx
@@ -10,12 +10,10 @@ const mockBtcAddress = 'bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq';
 const render = (
   {
     Qr,
-    warning,
   }: // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  { Qr: { message: string; data: string }; warning: null | string } = {
+  { Qr: { message: string; data: string } } = {
     Qr: { data: mockEthAddress, message: '' },
-    warning: '',
   },
 ) => {
   const store = configureStore({
@@ -23,8 +21,7 @@ const render = (
       ...mockState.metamask,
     },
   });
-  // @ts-expect-error TODO: Remove once `react-redux` is upgraded to v8 and `connect` type is fixed.
-  return renderWithProvider(<QRCodeView Qr={Qr} warning={warning} />, store);
+  return renderWithProvider(<QRCodeView Qr={Qr} />, store);
 };
 
 describe('QRCodeView', () => {
@@ -60,7 +57,6 @@ describe('QRCodeView', () => {
     async ({ data, message }: { data: string; message: string }) => {
       const { container } = render({
         Qr: { data, message },
-        warning: '',
       });
       const qrCodeImage = container.querySelector(
         '[data-testid="qr-code-image"]',

--- a/ui/components/ui/qr-code-view/qr-code-view.tsx
+++ b/ui/components/ui/qr-code-view/qr-code-view.tsx
@@ -1,14 +1,12 @@
 import PropTypes from 'prop-types';
 import React, { useContext } from 'react';
 import qrCode from 'qrcode-generator';
-import { connect } from 'react-redux';
 import { isHexPrefixed } from 'ethereumjs-util';
 // TODO: Remove restricted import
 // eslint-disable-next-line import-x/no-restricted-paths
 import { normalizeSafeAddress } from '../../../../app/scripts/lib/multichain/address';
 import { Box, Icon, IconName, IconSize, Text } from '../../component-library';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
-import type { MetaMaskReduxState } from '../../../store/store';
 import {
   AlignItems,
   Display,
@@ -24,26 +22,18 @@ import {
 } from '../../../../shared/constants/metametrics';
 import { useCopyToClipboard } from '../../../hooks/useCopyToClipboard';
 
-function mapStateToProps(state: Pick<MetaMaskReduxState, 'appState'>) {
-  const { warning } = state.appState;
-  return {
-    warning,
-  };
-}
 const PREFIX_LEN = 6;
 const SUFFIX_LEN = 5;
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function QrCodeView({
   Qr,
-  warning,
   accountName,
   location = 'Account Details Modal',
 }: {
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
   Qr: { message?: string; data: string };
-  warning: string | null | undefined;
   accountName?: string;
   location?: string;
 }) {
@@ -86,7 +76,6 @@ function QrCodeView({
       ) : (
         header
       )}
-      {warning ? <span className="qr-code__error">{warning}</span> : null}
       <Box className="qr-code__wrapper" marginBottom={4}>
         <Box
           data-testid="qr-code-image"
@@ -157,7 +146,6 @@ function QrCodeView({
 }
 
 QrCodeView.propTypes = {
-  warning: PropTypes.node,
   Qr: PropTypes.shape({
     message: PropTypes.oneOfType([
       PropTypes.arrayOf(PropTypes.node),
@@ -168,4 +156,4 @@ QrCodeView.propTypes = {
   location: PropTypes.string,
 };
 
-export default connect(mapStateToProps)(QrCodeView);
+export default QrCodeView;


### PR DESCRIPTION
## **Description**

The `QrCodeView` component has been updated to remove a now-unused `warning` prop. This prop was added 10 years ago in #559 for an integration with ShapeShift, which was also removed years ago. At the time, this QR code component was shown based on the `appState` Redux slice, but that is not the case anymore.

The `appState.warning` property is deprecated as well, and this is one of the last references to it.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a deprecated UI prop and redux wiring without changing core QR generation or address-copy behavior; potential risk is losing any previously surfaced warning text in the QR code view.
> 
> **Overview**
> Removes the deprecated `warning` prop from `QrCodeView`, including deleting the `react-redux` `connect`/`mapStateToProps` usage and the conditional warning rendering.
> 
> Updates `qr-code-view.test.tsx` to stop passing `warning` and to render the component directly with only the `Qr` prop.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 631459825f5d770bf0ee645299ede44f8172730e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->