### PR TITLE
refactor: remove usage of deprecated `warning` state from account details

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -10662,6 +10662,10 @@
   "unexpectedBehavior": {
     "message": "This behavior is unexpected and should be reported as a bug, even if your accounts are restored."
   },
+  "unexpectedError": {
+    "message": "An unexpected error occurred.",
+    "description": "This is a fallback error message used for unexpected errors."
+  },
   "unifiedSwapAllowSwappingOf": {
     "message": "Allow exact access to $1 $2 on $3 for swapping"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -10662,6 +10662,10 @@
   "unexpectedBehavior": {
     "message": "This behavior is unexpected and should be reported as a bug, even if your accounts are restored."
   },
+  "unexpectedError": {
+    "message": "An unexpected error occurred.",
+    "description": "This is a fallback error message used for unexpected errors."
+  },
   "unifiedSwapAllowSwappingOf": {
     "message": "Allow exact access to $1 $2 on $3 for swapping"
   },

--- a/ui/components/multichain/account-details/account-details-authenticate.js
+++ b/ui/components/multichain/account-details/account-details-authenticate.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { useCallback, useState } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import {
   BannerAlert,
   BannerAlertSeverity,
@@ -14,8 +14,9 @@ import {
   TextVariant,
 } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { exportAccount, hideWarning } from '../../../store/actions';
+import { exportAccount } from '../../../store/actions';
 import { FormTextField } from '../../component-library/form-text-field/deprecated';
+import { captureException } from '../../../../shared/lib/sentry';
 
 export const AccountDetailsAuthenticate = ({
   address,
@@ -27,22 +28,24 @@ export const AccountDetailsAuthenticate = ({
   const dispatch = useDispatch();
 
   const [password, setPassword] = useState('');
-
-  // Password error would result from appState
-  const warning = useSelector((state) => state.appState.warning);
+  const [warning, setWarning] = useState('');
 
   const onSubmit = useCallback(() => {
     dispatch(
       exportAccount(password, address, setPrivateKey, setShowHoldToReveal),
     )
       .then((res) => {
-        dispatch(hideWarning());
-        return res;
+        if (res.error && res.error === 'invalidPassword') {
+          setWarning(t('wrongPassword'));
+        } else if (warning !== '') {
+          setWarning('');
+        }
       })
-      .catch(() => {
-        // No need to do anything more with the caught error here, we already logged the error
+      .catch((error) => {
+        setWarning(t('unexpectedError'));
+        captureException(error);
       });
-  }, [dispatch, password, address, setPrivateKey, setShowHoldToReveal]);
+  }, [dispatch, password, address, setPrivateKey, setShowHoldToReveal, t]);
 
   const handleKeyPress = useCallback(
     (e) => {

--- a/ui/components/multichain/account-details/account-details-authenticate.js
+++ b/ui/components/multichain/account-details/account-details-authenticate.js
@@ -35,7 +35,7 @@ export const AccountDetailsAuthenticate = ({
       exportAccount(password, address, setPrivateKey, setShowHoldToReveal),
     )
       .then((res) => {
-        if (res.error && res.error === 'invalidPassword') {
+        if (res && res.error && res.error === 'invalidPassword') {
           setWarning(t('wrongPassword'));
         } else if (warning !== '') {
           setWarning('');
@@ -45,7 +45,16 @@ export const AccountDetailsAuthenticate = ({
         setWarning(t('unexpectedError'));
         captureException(error);
       });
-  }, [dispatch, password, address, setPrivateKey, setShowHoldToReveal, t]);
+  }, [
+    dispatch,
+    password,
+    address,
+    setPrivateKey,
+    setShowHoldToReveal,
+    setWarning,
+    t,
+    warning,
+  ]);
 
   const handleKeyPress = useCallback(
     (e) => {

--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -2837,20 +2837,16 @@ describe('Actions', () => {
 
     it('returns expected actions for successful action', async () => {
       const store = mockStore();
-
       const testPrivKey = 'a-test-priv-key';
-
       const verifyPasswordStub = sinon.stub().resolves();
-
       const exportAccountStub = sinon.stub().resolves(testPrivKey);
-
+      const setPrivateKeyStub = jest.fn();
+      const setShowHoldToReveal = jest.fn();
       background.getApi.returns({
         verifyPassword: verifyPasswordStub,
         exportAccount: exportAccountStub,
       });
-
       setBackgroundConnection(background.getApi());
-
       const expectedActions = [
         { type: 'SHOW_LOADING_INDICATION', payload: undefined },
         { type: 'HIDE_LOADING_INDICATION' },
@@ -2860,60 +2856,46 @@ describe('Actions', () => {
         actions.exportAccount(
           'a-test-password',
           '0xAddress',
-          jest.fn(),
-          jest.fn(),
+          setPrivateKeyStub,
+          setShowHoldToReveal,
         ),
       );
 
-      expect(verifyPasswordStub.callCount).toStrictEqual(1);
-      expect(exportAccountStub.callCount).toStrictEqual(1);
       expect(store.getActions()).toStrictEqual(expectedActions);
+      expect(setPrivateKeyStub).toHaveBeenCalledWith(testPrivKey);
+      expect(setShowHoldToReveal).toHaveBeenCalledWith(true);
     });
 
-    it('returns action errors when first func callback errors', async () => {
+    it('returns invalidPassword error when password validation failes', async () => {
       const store = mockStore();
-
       const verifyPasswordStub = sinon.stub().rejects(new Error('error'));
-
       background.getApi.returns({
         verifyPassword: verifyPasswordStub,
       });
-
       setBackgroundConnection(background.getApi());
-
       const expectedActions = [
         { type: 'SHOW_LOADING_INDICATION', payload: undefined },
         { type: 'HIDE_LOADING_INDICATION' },
-        { type: 'DISPLAY_WARNING', payload: 'Incorrect Password.' },
       ];
 
       await expect(
         store.dispatch(actions.exportAccount('a-test-password', '0xAddress')),
-      ).rejects.toThrow('error');
+      ).resolves.toStrictEqual({ error: 'invalidPassword' });
 
       expect(store.getActions()).toStrictEqual(expectedActions);
     });
 
-    it('returns action errors when second func callback errors', async () => {
+    it('throws when account export fails', async () => {
       const store = mockStore();
-
       const verifyPasswordStub = sinon.stub().resolves();
-
       const exportAccountStub = sinon.stub().rejects(new Error('error'));
-
       background.getApi.returns({
         verifyPassword: verifyPasswordStub,
         exportAccount: exportAccountStub,
       });
-
       setBackgroundConnection(background.getApi());
-
       const expectedActions = [
         { type: 'SHOW_LOADING_INDICATION', payload: undefined },
-        {
-          type: 'DISPLAY_WARNING',
-          payload: 'Had a problem exporting the account.',
-        },
         { type: 'HIDE_LOADING_INDICATION' },
       ];
 

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -4146,12 +4146,29 @@ export function hideWarning() {
   };
 }
 
+/**
+ * Export an account.
+ *
+ * The password is verified to be correct before attempting to export the account. If the password
+ * is correct, the exported private key is passed to the `setPrivateKey` callback.
+ *
+ * @param password - The vault password.
+ * @param address - The address to export.
+ * @param setPrivateKey - The callback the private key is passed to if the export is successful.
+ * @param setShowHoldToReveal - Resets the "hold to reveal" state.
+ * @returns An error constant upon validation failure, or nothing upon success.
+ */
 export function exportAccount(
   password: string,
   address: string,
   setPrivateKey: (key: string) => void,
   setShowHoldToReveal: (show: boolean) => void,
-): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
+): ThunkAction<
+  void | { error: 'invalidPassword' },
+  MetaMaskReduxState,
+  unknown,
+  AnyAction
+> {
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async function (dispatch) {
@@ -4162,10 +4179,8 @@ export function exportAccount(
       await submitRequestToBackground('verifyPassword', [password]);
     } catch (error) {
       log.error('Error in verifying password.');
-
       dispatch(hideLoadingIndication());
-      dispatch(displayWarning('Incorrect Password.'));
-      throw error;
+      return { error: 'invalidPassword' };
     }
 
     try {
@@ -4177,13 +4192,6 @@ export function exportAccount(
 
       setPrivateKey(result);
       setShowHoldToReveal(true);
-
-      return result;
-    } catch (error) {
-      logErrorWithMessage(error);
-      dispatch(displayWarning('Had a problem exporting the account.'));
-
-      throw error;
     } finally {
       dispatch(hideLoadingIndication());
     }


### PR DESCRIPTION
## **Description**

The account details authenticate component was using the deprecated `warning` state to store the error when password validation or account export failed. This was one of the last usages of this deprecated warning state.

he `exportAccount` action creator has been updated to return errors directly to the caller, and the component has been refactored to use component state for the warning message. The message is now correctly localized as well.


## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

1. Export an account, and enter an incorrect password to ensure the correct message is displayed
2. Export an account and enter the correct password to ensure that it still works as expected

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->


### **After**


https://github.com/user-attachments/assets/3399e2b0-2d5f-437b-a3e0-6fc14887c81f



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes error handling on the private-key export path; behavior is preserved for wrong password and success, but export failures now surface via promise rejection rather than global warnings.
> 
> **Overview**
> Stops routing **account export** password/export errors through the deprecated global `appState.warning` path and handles them in the authenticate UI instead.
> 
> `exportAccount` no longer dispatches `DISPLAY_WARNING` or throws on a bad password—it **returns** `{ error: 'invalidPassword' }` while still using loading indicators. Export failures after a valid password are no longer turned into a global warning; they **reject** the thunk so the component can show a localized **`unexpectedError`** and report via **Sentry**. **Account details authenticate** keeps the banner in **local state**, uses **`wrongPassword`** / **`unexpectedError`** strings, and drops **`hideWarning`**. Locale entries and **`exportAccount`** action tests were updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87d29b06dbf1cfe9de0ff1c068682d73eedd4255. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->