### PR TITLE
revert: Monad swap activity in asset details

### DIFF
--- a/shared/lib/multichain/transformations.test.ts
+++ b/shared/lib/multichain/transformations.test.ts
@@ -231,68 +231,6 @@ describe('selectTransactions', () => {
     expect(result.pages[0].data).toHaveLength(1);
   });
 
-  it('shows swaps where only valueTransfers identify the account', () => {
-    const router = '0x2222222222222222222222222222222222222222';
-    const pool = '0x3333333333333333333333333333333333333333';
-    const usdcAddress = '0x754704Bc059F8C67012fEd69BC8A327a5aafb603';
-
-    const result = selectTransactions({ address: account })(
-      createData([
-        {
-          ...baseRawTx,
-          chainId: 143,
-          from: router,
-          to: pool,
-          value: '0',
-          valueTransfers: [
-            {
-              from: account,
-              to: router,
-              amount: '30000000000000000000',
-              decimal: 18,
-              symbol: 'MON',
-              transferType: 'internal',
-            },
-            {
-              from: pool,
-              to: account,
-              amount: '866885',
-              decimal: 6,
-              symbol: 'USDC',
-              name: 'USD Coin',
-              contractAddress: usdcAddress,
-              transferType: 'erc20',
-            },
-          ],
-        },
-      ]),
-    );
-
-    const transaction = result.pages[0]?.data[0];
-    expect(transaction).toBeDefined();
-    if (!transaction) {
-      throw new Error('Expected Monad swap transaction to be included');
-    }
-    expect(transaction.amounts?.from).toStrictEqual({
-      token: {
-        address: NATIVE_TOKEN_ADDRESS,
-        symbol: 'MON',
-        decimals: 18,
-        chainId: '0x8f',
-      },
-      amount: -30000000000000000000n,
-    });
-    expect(transaction.amounts?.to).toStrictEqual({
-      token: {
-        address: usdcAddress.toLowerCase(),
-        symbol: 'USDC',
-        decimals: 6,
-        chainId: '0x8f',
-      },
-      amount: 866885n,
-    });
-  });
-
   it('blocks incoming native transfers where the account is the recipient', () => {
     const result = selectTransactions({ address: account })(
       createData([

--- a/shared/lib/multichain/transformations.ts
+++ b/shared/lib/multichain/transformations.ts
@@ -114,15 +114,9 @@ export function normalizeTransaction(
       vt.contractAddress,
   );
 
-  const hasOutgoingValueTransfer =
-    transaction.valueTransfers?.some(
-      (vt) => vt.from?.toLowerCase() === address.toLowerCase(),
-    ) ?? false;
-
   const isIncomingTokenTransfer =
     valueTransfer?.to?.toLowerCase() === address.toLowerCase() &&
-    from.toLowerCase() !== address.toLowerCase() &&
-    !hasOutgoingValueTransfer;
+    from.toLowerCase() !== address.toLowerCase();
 
   const amount = valueTransfer?.amount;
   const contractAddress = valueTransfer?.contractAddress as string;
@@ -204,6 +198,9 @@ export function selectTransactions({
         // Filter out transactions not involving the current address
         const rawFrom = raw.from?.toLowerCase();
         const rawTo = raw.to?.toLowerCase();
+        if (rawFrom !== addr && rawTo !== addr) {
+          return result;
+        }
 
         // Filter out excluded transaction hashes (e.g. internal prerequisite transactions)
         if (raw.hash && excludedTxHashes?.has(raw.hash.toLowerCase())) {


### PR DESCRIPTION
This reverts commit 75d9dfce59d303dc9ec449a7ae51d940b06b2900.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This pull request reverts #42669 as relay transactions need further API work

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes transaction inclusion logic so activity may no longer show transactions where the account only appears in `valueTransfers`, potentially hiding some swap/relay activity. Also tweaks incoming token-transfer detection, which could affect transfer classification in edge cases.
> 
> **Overview**
> Reverts the prior behavior that surfaced transactions where the account was only present in `valueTransfers` (e.g., relay/swap patterns) by filtering `selectTransactions` to include only rows whose `from` or `to` matches the current address.
> 
> Simplifies `normalizeTransaction`’s incoming token-transfer detection by removing the extra guard around outgoing `valueTransfers`, and drops the associated unit test that expected these value-transfer-only swaps to be included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 233009a32ea64d37d276da768432fa35e9785b02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->