### PR TITLE
fix: clean up popover capture listeners

### DIFF
--- a/ui/components/component-library/popover/popover.test.tsx
+++ b/ui/components/component-library/popover/popover.test.tsx
@@ -223,6 +223,50 @@ describe('Popover', () => {
     expect(getByTestId('popover')).toHaveClass('mm-popover--reference-hidden');
   });
 
+  test('removes document listeners with the same callbacks and capture options used on add', () => {
+    const addEventListenerSpy = jest.spyOn(document, 'addEventListener');
+    const removeEventListenerSpy = jest.spyOn(document, 'removeEventListener');
+
+    try {
+      const { unmount } = render(
+        <Popover
+          isOpen={true}
+          onClickOutside={jest.fn()}
+          onPressEscKey={jest.fn()}
+        >
+          Popover
+        </Popover>,
+      );
+
+      const keydownAddCall = addEventListenerSpy.mock.calls.find(
+        ([eventType]) => eventType === 'keydown',
+      );
+      const clickAddCall = addEventListenerSpy.mock.calls.find(
+        ([eventType]) => eventType === 'click',
+      );
+
+      if (!keydownAddCall || !clickAddCall) {
+        throw new Error('Expected Popover to add document event listeners');
+      }
+
+      unmount();
+
+      expect(removeEventListenerSpy).toHaveBeenCalledWith(
+        'keydown',
+        keydownAddCall[1],
+        keydownAddCall[2],
+      );
+      expect(removeEventListenerSpy).toHaveBeenCalledWith(
+        'click',
+        clickAddCall[1],
+        clickAddCall[2],
+      );
+    } finally {
+      addEventListenerSpy.mockRestore();
+      removeEventListenerSpy.mockRestore();
+    }
+  });
+
   const EscKeyTestComponent = () => {
     const [isOpen, setIsOpen] = useState(true);
 

--- a/ui/components/component-library/popover/popover.tsx
+++ b/ui/components/component-library/popover/popover.tsx
@@ -21,6 +21,8 @@ import {
   PopoverRole,
 } from './popover.types';
 
+const CAPTURE_EVENT_LISTENER_OPTIONS = { capture: true };
+
 export const Popover: PopoverComponent = React.forwardRef(
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -87,41 +89,59 @@ export const Popover: PopoverComponent = React.forwardRef(
     };
 
     useEffect(() => {
+      if (!isOpen || (!onPressEscKey && !onClickOutside)) {
+        return undefined;
+      }
+
       // Esc key press
       const handleEscKey = (event: KeyboardEvent) => {
         if (event.key === 'Escape') {
-          // Close the popover when the "Esc" key is pressed
-          if (onPressEscKey) {
-            onPressEscKey();
-          }
+          onPressEscKey?.();
         }
       };
 
       const handleClickOutside = (event: MouseEvent) => {
         if (
-          isOpen &&
           popoverRef.current &&
           !popoverRef.current.contains(event.target as Node) &&
           !referenceElement?.contains(event.target as Node)
         ) {
-          if (onClickOutside) {
-            onClickOutside();
-          }
+          onClickOutside?.();
         }
       };
 
-      document.addEventListener('keydown', handleEscKey, { capture: true });
-      if (isOpen) {
-        document.addEventListener('click', handleClickOutside, {
-          capture: true,
-        });
-      } else {
-        document.removeEventListener('click', handleClickOutside);
+      if (onPressEscKey) {
+        document.addEventListener(
+          'keydown',
+          handleEscKey,
+          CAPTURE_EVENT_LISTENER_OPTIONS,
+        );
+      }
+
+      if (onClickOutside) {
+        document.addEventListener(
+          'click',
+          handleClickOutside,
+          CAPTURE_EVENT_LISTENER_OPTIONS,
+        );
       }
 
       return () => {
-        document.removeEventListener('keydown', handleEscKey);
-        document.removeEventListener('click', handleClickOutside);
+        if (onPressEscKey) {
+          document.removeEventListener(
+            'keydown',
+            handleEscKey,
+            CAPTURE_EVENT_LISTENER_OPTIONS,
+          );
+        }
+
+        if (onClickOutside) {
+          document.removeEventListener(
+            'click',
+            handleClickOutside,
+            CAPTURE_EVENT_LISTENER_OPTIONS,
+          );
+        }
       };
     }, [onPressEscKey, isOpen, onClickOutside, referenceElement]);
 


### PR DESCRIPTION
## **Description**

Fixes a shared Popover listener leak that retained old route trees during send/settings route churn.

Popover registered document `keydown` and `click` listeners with capture enabled, but removed them without matching capture options. Since `removeEventListener` matches on event type, callback, and capture flag, cleanup failed and leaked document listeners retained their React closure scope.

This PR keeps the change scoped to `ui/components/component-library/popover/popover.tsx` by:

- defining one shared capture listener options object
- adding document listeners only while the Popover is open and the matching callback exists
- removing those listeners with the same callback and capture options
- adding a regression test that verifies unmount cleanup uses the same listener and options captured from `addEventListener`

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Build the test extension:
   ```bash
   source ~/.nvm/nvm.sh && nvm use
   yarn build:test:webpack
   ```
2. The `yarn llm:memory` profiler is available on the separate [profiler PR](https://github.com/MetaMask/metamask-extension/pull/42733). With that tooling available and this branch's `dist/chrome` build, run:
   ```bash
   yarn llm:memory -- --iterations 50 --flow send-open-back --sample final --probe cdp --wait-after-flow 500 --extension-path dist/chrome
   yarn llm:memory -- --iterations 100 --flow settings-route --sample final --probe cdp --wait-after-flow 500 --extension-path dist/chrome
   ```
3. Expected post-fix profile from the prior investigation with the [Snow WeakMap patch](https://github.com/LavaMoat/snow/pull/170) still applied:

   | Flow | Before | After |
   |---|---:|---:|
   | settings-route 50x | +118.91 MiB | +2.22 MiB rerun, +37 listeners |
   | settings-route 100x | n/a | -0.34 MiB, +34 listeners |
   | settings-route 50x paired heap snapshots | n/a | -5.84 MiB |
   | send-open-back 50x | +111.66 MiB | +0.05 MiB, +307 listeners |

<!--
## **Screenshots/Recordings**

If applicable, add screenshots and/or recordings to visualize the before and after of your change.

### **Before**

[screenshots/recordings]

### **After**

[screenshots/recordings]
-->

## **Validation**

- `source ~/.nvm/nvm.sh && nvm use && yarn test:unit ui/components/component-library/popover/popover.test.tsx`
- `source ~/.nvm/nvm.sh && nvm use && yarn lint:changed:fix`
- `source ~/.nvm/nvm.sh && nvm use && yarn webpack:tsc`
- `source ~/.nvm/nvm.sh && nvm use && yarn build:test:webpack`

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: scoped to Popover’s document event listener lifecycle and adds a regression test; main risk is behavior change in when listeners are attached (only when open and handlers provided).
> 
> **Overview**
> Fixes a Popover document-listener leak by **reusing a shared capture options object** and ensuring `removeEventListener` is called with the *same* callback and capture options used for `addEventListener`.
> 
> Listeners for `keydown` (Esc) and `click` (outside) are now only attached when the popover is open and the corresponding handler prop is provided, and a new unit test asserts the add/remove signatures match on unmount to prevent regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ccfb58b62a6938d1656c0b92da390d8ec5c2c80. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->