### PR TITLE
test: add memory profiling CLI for extension flows

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "build:test:webpack:mv2": "BLOCKAID_FILE_CDN=static.cx.metamask.io/api/v1/confirmations/ppom yarn env:e2e webpack:lavamoat:build:mv2 --test",
     "build:test:flask:webpack": "yarn env:e2e webpack:lavamoat:build --test --type flask",
     "build:test:flask:webpack:mv2": "yarn env:e2e webpack:lavamoat:build:mv2 --test --type flask",
+    "llm:memory": "tsx test/e2e/playwright/llm-workflow/memory-profiler.ts",
     "test": "yarn lint && yarn test:unit",
     "dapp": "node development/static-server.js node_modules/@metamask/test-dapp/dist --port 8080",
     "dapp-multichain": "node development/static-server.js node_modules/@metamask/test-dapp-multichain/build --port 8080",

--- a/test/e2e/playwright/llm-workflow/README.md
+++ b/test/e2e/playwright/llm-workflow/README.md
@@ -129,6 +129,45 @@ mm cleanup
 - `mm knowledge-last`: Get last N step records from this session.
 - `mm knowledge-sessions`: List recent sessions with metadata.
 
+### Memory Profiling
+
+Use `yarn llm:memory` for repeatable Chrome DevTools Protocol memory samples
+against the extension page. The command launches the same MetaMask E2E
+environment as `mm launch`, unlocks the default wallet by default, runs a route
+flow, samples heap/DOM counters after forced garbage collection, and writes a
+JSON report under `test-artifacts/memory`.
+
+```bash
+# Build first if dist/chrome is not current
+yarn build:test:webpack
+
+# Route-cycle profile with a final heap snapshot
+yarn llm:memory -- --iterations 25 --flow route-cycle --snapshot final
+
+# Fail the run if used heap growth exceeds 25 MiB
+yarn llm:memory -- --iterations 50 --max-used-heap-growth 25MiB
+
+# Send-flow profile with only baseline/final samples and no Playwright DOM count
+yarn llm:memory -- --iterations 50 --flow send-open-back --sample final --probe cdp
+
+# Fail when DOM counters regress past known budgets
+yarn llm:memory -- --iterations 50 --flow send-open-back \
+  --max-dom-nodes-growth 1000 \
+  --max-js-event-listeners-growth 300
+```
+
+The report includes `Runtime.getHeapUsage`, `Performance.getMetrics`,
+`Memory.getDOMCounters`, per-run deltas, threshold results, and any
+`.heapsnapshot` artifact paths.
+
+Use `--sample final` when checking whether repeated CDP sampling is affecting
+retention; it records the baseline and final samples only. The default
+`--sample each` keeps per-iteration trend data.
+
+Use `--probe cdp` to skip the Playwright live-DOM locator count while keeping
+CDP heap and DOM counters. Use `--probe heap` to skip DOM counters too, which is
+useful when isolating app heap growth from DOM-counter observer effects.
+
 ---
 
 ## Launch Modes

--- a/test/e2e/playwright/llm-workflow/README.md
+++ b/test/e2e/playwright/llm-workflow/README.md
@@ -150,16 +150,6 @@ yarn llm:memory -- --iterations 50 --max-used-heap-growth 25MiB
 # Send-flow profile with only baseline/final samples and no Playwright DOM count
 yarn llm:memory -- --iterations 50 --flow send-open-back --sample final --probe cdp
 
-# Hosted test dapp initiated confirmation flows
-yarn llm:memory -- --iterations 25 --flow dapp-initiated-transaction
-yarn llm:memory -- --iterations 25 --flow dapp-initiated-signature
-
-# Wallet initiated send flow
-yarn llm:memory -- --iterations 25 --flow wallet-initiated-transaction
-
-# Wallet initiated signing through the internal debug/test background hook
-yarn llm:memory -- --iterations 25 --flow wallet-initiated-signature
-
 # Fail when DOM counters regress past known budgets
 yarn llm:memory -- --iterations 50 --flow send-open-back \
   --max-dom-nodes-growth 1000 \
@@ -177,11 +167,6 @@ retention; it records the baseline and final samples only. The default
 Use `--probe cdp` to skip the Playwright live-DOM locator count while keeping
 CDP heap and DOM counters. Use `--probe heap` to skip DOM counters too, which is
 useful when isolating app heap growth from DOM-counter observer effects.
-
-The dapp-initiated flows use the hosted MetaMask test dapp at
-`https://metamask.github.io/test-dapp/`. The `wallet-initiated-signature` flow
-requires an extension build with `METAMASK_DEBUG` enabled so the script can call
-the internal background signing hook from the wallet UI.
 
 ---
 

--- a/test/e2e/playwright/llm-workflow/README.md
+++ b/test/e2e/playwright/llm-workflow/README.md
@@ -150,6 +150,16 @@ yarn llm:memory -- --iterations 50 --max-used-heap-growth 25MiB
 # Send-flow profile with only baseline/final samples and no Playwright DOM count
 yarn llm:memory -- --iterations 50 --flow send-open-back --sample final --probe cdp
 
+# Hosted test dapp initiated confirmation flows
+yarn llm:memory -- --iterations 25 --flow dapp-initiated-transaction
+yarn llm:memory -- --iterations 25 --flow dapp-initiated-signature
+
+# Wallet initiated send flow
+yarn llm:memory -- --iterations 25 --flow wallet-initiated-transaction
+
+# Wallet initiated signing through the internal debug/test background hook
+yarn llm:memory -- --iterations 25 --flow wallet-initiated-signature
+
 # Fail when DOM counters regress past known budgets
 yarn llm:memory -- --iterations 50 --flow send-open-back \
   --max-dom-nodes-growth 1000 \
@@ -167,6 +177,11 @@ retention; it records the baseline and final samples only. The default
 Use `--probe cdp` to skip the Playwright live-DOM locator count while keeping
 CDP heap and DOM counters. Use `--probe heap` to skip DOM counters too, which is
 useful when isolating app heap growth from DOM-counter observer effects.
+
+The dapp-initiated flows use the hosted MetaMask test dapp at
+`https://metamask.github.io/test-dapp/`. The `wallet-initiated-signature` flow
+requires an extension build with `METAMASK_DEBUG` enabled so the script can call
+the internal background signing hook from the wallet UI.
 
 ---
 

--- a/test/e2e/playwright/llm-workflow/memory-profiler.test.ts
+++ b/test/e2e/playwright/llm-workflow/memory-profiler.test.ts
@@ -1,0 +1,258 @@
+import type { SessionLaunchResult } from '@metamask/client-mcp-core';
+import {
+  calculateDeltas,
+  createMemoryReport,
+  navigateExtensionRoute,
+  parseByteSize,
+  parseMemoryProfilerArgs,
+  type MemorySample,
+} from './memory-profiler';
+
+const baselineSample: MemorySample = {
+  label: 'baseline',
+  timestamp: '2026-05-15T00:00:00.000Z',
+  url: 'chrome-extension://extension-id/home.html#/',
+  runtimeHeap: {
+    usedSize: 100,
+    totalSize: 200,
+  },
+  performance: {
+    JSHeapUsedSize: 50,
+    JSHeapTotalSize: 75,
+  },
+  domCounters: {
+    documents: 1,
+    nodes: 10,
+    jsEventListeners: 5,
+  },
+  liveDomElementCount: 7,
+};
+
+const finalSample: MemorySample = {
+  label: 'iteration-1',
+  timestamp: '2026-05-15T00:01:00.000Z',
+  url: 'chrome-extension://extension-id/home.html#/',
+  runtimeHeap: {
+    usedSize: 120,
+    totalSize: 260,
+  },
+  performance: {
+    JSHeapUsedSize: 90,
+    JSHeapTotalSize: 150,
+  },
+  domCounters: {
+    documents: 2,
+    nodes: 18,
+    jsEventListeners: 9,
+  },
+  liveDomElementCount: 11,
+};
+
+describe('memory-profiler', () => {
+  describe('parseMemoryProfilerArgs', () => {
+    it('uses useful defaults for route leak profiling', () => {
+      const options = parseMemoryProfilerArgs([]);
+
+      expect(options.iterations).toBe(5);
+      expect(options.flow).toBe('route-cycle');
+      expect(options.stateMode).toBe('default');
+      expect(options.sampleMode).toBe('each');
+      expect(options.probeMode).toBe('full');
+      expect(options.unlock).toBe(true);
+      expect(options.collectGarbage).toBe(true);
+      expect(options.outputPath).toMatch(
+        /test-artifacts\/memory\/memory-profile-\d+\.json/u,
+      );
+    });
+
+    it('parses explicit profiling options', () => {
+      const options = parseMemoryProfilerArgs([
+        '--',
+        '--iterations',
+        '25',
+        '--flow',
+        'settings-route',
+        '--state',
+        'custom',
+        '--preset',
+        'withMultipleAccounts',
+        '--snapshot',
+        'final',
+        '--sample',
+        'final',
+        '--probe',
+        'cdp',
+        '--no-unlock',
+        '--no-gc',
+        '--wait-after-flow',
+        '100',
+        '--interval',
+        '50',
+        '--max-used-heap-growth',
+        '25MiB',
+        '--max-js-heap-growth',
+        '5mb',
+        '--max-dom-nodes-growth',
+        '100',
+        '--max-js-event-listeners-growth',
+        '20',
+        '--output',
+        '/tmp/report.json',
+      ]);
+
+      expect(options).toStrictEqual(
+        expect.objectContaining({
+          iterations: 25,
+          flow: 'settings-route',
+          stateMode: 'custom',
+          fixturePreset: 'withMultipleAccounts',
+          snapshotMode: 'final',
+          sampleMode: 'final',
+          probeMode: 'cdp',
+          unlock: false,
+          collectGarbage: false,
+          waitAfterFlowMs: 100,
+          intervalMs: 50,
+          maxUsedHeapGrowthBytes: 25 * 1024 * 1024,
+          maxJsHeapGrowthBytes: 5 * 1000 * 1000,
+          maxDomNodesGrowth: 100,
+          maxJsEventListenersGrowth: 20,
+          outputPath: '/tmp/report.json',
+        }),
+      );
+    });
+
+    it('rejects invalid sample and probe modes', () => {
+      expect(() => parseMemoryProfilerArgs(['--sample', 'always'])).toThrow(
+        '--sample must be one of: each, final',
+      );
+
+      expect(() => parseMemoryProfilerArgs(['--probe', 'dom'])).toThrow(
+        '--probe must be one of: full, cdp, heap',
+      );
+    });
+
+    it('rejects unknown options', () => {
+      expect(() => parseMemoryProfilerArgs(['--unknown'])).toThrow(
+        'Unknown option: --unknown',
+      );
+    });
+
+    it('accepts the user-like send open and back flow', () => {
+      const options = parseMemoryProfilerArgs([
+        '--flow',
+        'send-open-back',
+      ]);
+
+      expect(options.flow).toBe('send-open-back');
+    });
+  });
+
+  describe('parseByteSize', () => {
+    it('parses byte units', () => {
+      expect(parseByteSize('1024')).toBe(1024);
+      expect(parseByteSize('1kb')).toBe(1000);
+      expect(parseByteSize('1KiB')).toBe(1024);
+      expect(parseByteSize('1.5MiB')).toBe(1572864);
+    });
+  });
+
+  describe('calculateDeltas', () => {
+    it('calculates heap and DOM counter deltas', () => {
+      expect(calculateDeltas(baselineSample, finalSample)).toStrictEqual({
+        runtimeUsedSize: 20,
+        runtimeTotalSize: 60,
+        jsHeapUsedSize: 40,
+        jsHeapTotalSize: 75,
+        nodes: 8,
+        documents: 1,
+        jsEventListeners: 4,
+        liveDomElements: 4,
+      });
+    });
+  });
+
+  describe('navigateExtensionRoute', () => {
+    it('navigates to an extension hash route', async () => {
+      const page = {
+        goto: jest.fn().mockResolvedValue(undefined),
+        waitForLoadState: jest.fn().mockResolvedValue(undefined),
+      };
+
+      await navigateExtensionRoute(
+        page as never,
+        'extension-id',
+        '/send/asset',
+      );
+
+      expect(page.goto).toHaveBeenCalledWith(
+        'chrome-extension://extension-id/home.html#/send/asset',
+      );
+      expect(page.waitForLoadState).toHaveBeenCalledWith('domcontentloaded');
+    });
+  });
+
+  describe('createMemoryReport', () => {
+    it('summarizes samples and threshold results without serializing password', () => {
+      const options = parseMemoryProfilerArgs([
+        '--output',
+        '/tmp/report.json',
+        '--max-used-heap-growth',
+        '25b',
+        '--max-js-heap-growth',
+        '25b',
+        '--max-dom-nodes-growth',
+        '10',
+        '--max-js-event-listeners-growth',
+        '3',
+      ]);
+      const launchResult = {
+        sessionId: 'session-id',
+        extensionId: 'extension-id',
+        state: {},
+      } as unknown as SessionLaunchResult;
+
+      const report = createMemoryReport({
+        createdAt: '2026-05-15T00:00:00.000Z',
+        launchResult,
+        options,
+        samples: [baselineSample, finalSample],
+        snapshots: [],
+      });
+
+      expect(report.summary.deltas.runtimeUsedSize).toBe(20);
+      expect(report.summary.deltas.jsHeapUsedSize).toBe(40);
+      expect(report.summary.thresholds).toStrictEqual([
+        {
+          name: 'runtimeUsedSize',
+          limit: 25,
+          actual: 20,
+          unit: 'bytes',
+          passed: true,
+        },
+        {
+          name: 'jsHeapUsedSize',
+          limit: 25,
+          actual: 40,
+          unit: 'bytes',
+          passed: false,
+        },
+        {
+          name: 'nodes',
+          limit: 10,
+          actual: 8,
+          unit: 'count',
+          passed: true,
+        },
+        {
+          name: 'jsEventListeners',
+          limit: 3,
+          actual: 4,
+          unit: 'count',
+          passed: false,
+        },
+      ]);
+      expect(report.options).not.toHaveProperty('password');
+    });
+  });
+});

--- a/test/e2e/playwright/llm-workflow/memory-profiler.test.ts
+++ b/test/e2e/playwright/llm-workflow/memory-profiler.test.ts
@@ -146,24 +146,6 @@ describe('memory-profiler', () => {
 
       expect(options.flow).toBe('send-open-back');
     });
-
-    it('accepts dapp and wallet initiated flows', () => {
-      expect(
-        parseMemoryProfilerArgs(['--flow', 'dapp-initiated-transaction'])
-          .flow,
-      ).toBe('dapp-initiated-transaction');
-      expect(
-        parseMemoryProfilerArgs(['--flow', 'dapp-initiated-signature']).flow,
-      ).toBe('dapp-initiated-signature');
-      expect(
-        parseMemoryProfilerArgs(['--flow', 'wallet-initiated-transaction'])
-          .flow,
-      ).toBe('wallet-initiated-transaction');
-      expect(
-        parseMemoryProfilerArgs(['--flow', 'wallet-initiated-signature'])
-          .flow,
-      ).toBe('wallet-initiated-signature');
-    });
   });
 
   describe('parseByteSize', () => {

--- a/test/e2e/playwright/llm-workflow/memory-profiler.test.ts
+++ b/test/e2e/playwright/llm-workflow/memory-profiler.test.ts
@@ -146,6 +146,24 @@ describe('memory-profiler', () => {
 
       expect(options.flow).toBe('send-open-back');
     });
+
+    it('accepts dapp and wallet initiated flows', () => {
+      expect(
+        parseMemoryProfilerArgs(['--flow', 'dapp-initiated-transaction'])
+          .flow,
+      ).toBe('dapp-initiated-transaction');
+      expect(
+        parseMemoryProfilerArgs(['--flow', 'dapp-initiated-signature']).flow,
+      ).toBe('dapp-initiated-signature');
+      expect(
+        parseMemoryProfilerArgs(['--flow', 'wallet-initiated-transaction'])
+          .flow,
+      ).toBe('wallet-initiated-transaction');
+      expect(
+        parseMemoryProfilerArgs(['--flow', 'wallet-initiated-signature'])
+          .flow,
+      ).toBe('wallet-initiated-signature');
+    });
   });
 
   describe('parseByteSize', () => {

--- a/test/e2e/playwright/llm-workflow/memory-profiler.ts
+++ b/test/e2e/playwright/llm-workflow/memory-profiler.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import path from 'path';
 import { createWriteStream, promises as fs } from 'fs';
-import type { CDPSession, Page } from '@playwright/test';
+import type { CDPSession, Locator, Page } from '@playwright/test';
 import {
   allocatePort,
   KnowledgeStore,
@@ -23,6 +23,16 @@ const DEFAULT_PASSWORD = 'correct horse battery staple';
 const DEFAULT_ARTIFACT_DIR = 'test-artifacts/memory';
 const DEFAULT_ITERATIONS = 5;
 const DEFAULT_WAIT_AFTER_FLOW_MS = 500;
+const TEST_DAPP_URL = 'https://metamask.github.io/test-dapp/';
+const CONFIRMATION_WAIT_TIMEOUT_MS = 30000;
+const DEFAULT_SEND_RECIPIENT = '0x2f318C334780961FB129D2a6c30D0763d9a5C970';
+const DEFAULT_WALLET_SEND_AMOUNT = '0.000001';
+const WALLET_SIGNATURE_MESSAGE = 'MetaMask memory profiler wallet signature';
+const ETHEREUM_ADDRESS_REGEX = /0x[a-fA-F0-9]{40}/u;
+const WALLET_SIGNATURE_MESSAGE_HEX = `0x${Buffer.from(
+  WALLET_SIGNATURE_MESSAGE,
+  'utf8',
+).toString('hex')}`;
 
 export type MemoryFlow =
   | 'idle'
@@ -31,7 +41,11 @@ export type MemoryFlow =
   | 'send-open-back'
   | 'settings-route'
   | 'asset-route'
-  | 'route-cycle';
+  | 'route-cycle'
+  | 'dapp-initiated-transaction'
+  | 'dapp-initiated-signature'
+  | 'wallet-initiated-transaction'
+  | 'wallet-initiated-signature';
 
 export type HeapSnapshotMode = 'none' | 'baseline' | 'final' | 'both' | 'each';
 
@@ -145,6 +159,10 @@ const VALID_FLOWS: MemoryFlow[] = [
   'settings-route',
   'asset-route',
   'route-cycle',
+  'dapp-initiated-transaction',
+  'dapp-initiated-signature',
+  'wallet-initiated-transaction',
+  'wallet-initiated-signature',
 ];
 
 const VALID_SNAPSHOT_MODES: HeapSnapshotMode[] = [
@@ -632,6 +650,7 @@ export async function runMemoryProfiler(
 
     await runFlowIteration({
       page,
+      sessionManager,
       extensionId: launchResult.extensionId,
       flow: 'home',
       waitAfterFlowMs: options.waitAfterFlowMs,
@@ -655,6 +674,7 @@ export async function runMemoryProfiler(
     for (let iteration = 1; iteration <= options.iterations; iteration += 1) {
       await runFlowIteration({
         page,
+        sessionManager,
         extensionId: launchResult.extensionId,
         flow: options.flow,
         waitAfterFlowMs: options.waitAfterFlowMs,
@@ -737,7 +757,9 @@ Collect MetaMask extension memory telemetry through Chrome DevTools Protocol.
 
 Options:
   --iterations <n>              Number of flow iterations. Default: ${DEFAULT_ITERATIONS}
-  --flow <name>                 idle, home, send-route, send-open-back, settings-route, asset-route, route-cycle
+  --flow <name>                 idle, home, send-route, send-open-back, settings-route, asset-route, route-cycle,
+                                dapp-initiated-transaction, dapp-initiated-signature,
+                                wallet-initiated-transaction, wallet-initiated-signature
   --state <mode>                default, onboarding, custom. Default: default
   --preset <name>               Fixture preset when --state custom is used
   --extension-path <path>       Extension build path. Default: dist/chrome
@@ -763,6 +785,7 @@ Examples:
   yarn llm:memory -- --iterations 25 --flow route-cycle --snapshot final
   yarn llm:memory -- --iterations 50 --max-used-heap-growth 25MiB
   yarn llm:memory -- --iterations 50 --flow send-open-back --sample final --probe cdp
+  yarn llm:memory -- --iterations 25 --flow dapp-initiated-transaction
 `;
 }
 
@@ -1007,11 +1030,13 @@ async function unlockIfNeeded(page: Page, password: string): Promise<boolean> {
 
 async function runFlowIteration({
   page,
+  sessionManager,
   extensionId,
   flow,
   waitAfterFlowMs,
 }: {
   page: Page;
+  sessionManager: MetaMaskSessionManager;
   extensionId: string;
   flow: MemoryFlow;
   waitAfterFlowMs: number;
@@ -1044,6 +1069,18 @@ async function runFlowIteration({
       await navigateExtensionRoute(page, extensionId, `${ASSET_ROUTE}/0x539`);
       await navigateExtensionRoute(page, extensionId, DEFAULT_ROUTE);
       break;
+    case 'dapp-initiated-transaction':
+      await runDappInitiatedTransactionFlow(page, sessionManager, extensionId);
+      break;
+    case 'dapp-initiated-signature':
+      await runDappInitiatedSignatureFlow(page, sessionManager, extensionId);
+      break;
+    case 'wallet-initiated-transaction':
+      await runWalletInitiatedTransactionFlow(page, extensionId);
+      break;
+    case 'wallet-initiated-signature':
+      await runWalletInitiatedSignatureFlow(page, extensionId);
+      break;
     default:
       throw new Error('Unsupported memory flow');
   }
@@ -1064,6 +1101,261 @@ async function runSendOpenBackFlow(page: Page): Promise<void> {
   await backButton.waitFor({ state: 'visible', timeout: 30000 });
   await backButton.click();
   await sendButton.waitFor({ state: 'visible', timeout: 30000 });
+}
+
+async function runDappInitiatedTransactionFlow(
+  page: Page,
+  sessionManager: MetaMaskSessionManager,
+  extensionId: string,
+): Promise<void> {
+  const dappPage = await ensureTestDappConnected(
+    page,
+    sessionManager,
+    extensionId,
+  );
+
+  await dappPage.locator('#sendButton').waitFor({
+    state: 'visible',
+    timeout: CONFIRMATION_WAIT_TIMEOUT_MS,
+  });
+  await dappPage.locator('#sendButton').click();
+
+  const confirmationPage = await sessionManager.waitForNotificationPage(
+    CONFIRMATION_WAIT_TIMEOUT_MS,
+  );
+  await confirmCurrentApproval(confirmationPage);
+  await closeConfirmationPage(confirmationPage);
+  await navigateExtensionRoute(page, extensionId, DEFAULT_ROUTE);
+}
+
+async function runDappInitiatedSignatureFlow(
+  page: Page,
+  sessionManager: MetaMaskSessionManager,
+  extensionId: string,
+): Promise<void> {
+  const dappPage = await ensureTestDappConnected(
+    page,
+    sessionManager,
+    extensionId,
+  );
+
+  await dappPage.locator('#personalSign').waitFor({
+    state: 'visible',
+    timeout: CONFIRMATION_WAIT_TIMEOUT_MS,
+  });
+  await dappPage.locator('#personalSign').click();
+
+  const confirmationPage = await sessionManager.waitForNotificationPage(
+    CONFIRMATION_WAIT_TIMEOUT_MS,
+  );
+  await confirmCurrentApproval(confirmationPage);
+  await closeConfirmationPage(confirmationPage);
+  await navigateExtensionRoute(page, extensionId, DEFAULT_ROUTE);
+}
+
+async function runWalletInitiatedTransactionFlow(
+  page: Page,
+  extensionId: string,
+): Promise<void> {
+  await navigateExtensionRoute(page, extensionId, SEND_ROUTE);
+
+  await page
+    .locator('[data-testid="recipient-address-input"]')
+    .fill(DEFAULT_SEND_RECIPIENT);
+  await page
+    .locator('[data-testid="send-amount-input"]')
+    .fill(DEFAULT_WALLET_SEND_AMOUNT);
+  await page.locator('[data-testid="send-continue-button"]').click();
+
+  await confirmCurrentApproval(page);
+  await navigateExtensionRoute(page, extensionId, DEFAULT_ROUTE);
+}
+
+async function runWalletInitiatedSignatureFlow(
+  page: Page,
+  extensionId: string,
+): Promise<void> {
+  await navigateExtensionRoute(page, extensionId, DEFAULT_ROUTE);
+
+  const signature = await page.evaluate(async (messageHex) => {
+    type MemoryProfilerStateHooks = {
+      getCleanAppState?: () => Promise<{
+        metamask?: {
+          internalAccounts?: {
+            selectedAccount?: string;
+            accounts?: Record<string, { address?: string }>;
+          };
+        };
+      }>;
+      submitRequestToBackground?: (
+        method: string,
+        args?: unknown[],
+      ) => Promise<unknown>;
+    };
+
+    const hooks = (globalThis as typeof globalThis & {
+      stateHooks?: MemoryProfilerStateHooks;
+    }).stateHooks;
+
+    if (typeof hooks?.submitRequestToBackground !== 'function') {
+      return null;
+    }
+
+    const state = await hooks.getCleanAppState?.();
+    const selectedAccountId =
+      state?.metamask?.internalAccounts?.selectedAccount;
+    const selectedAccount =
+      selectedAccountId &&
+      state?.metamask?.internalAccounts?.accounts?.[selectedAccountId];
+    const from = selectedAccount?.address;
+
+    if (!from) {
+      throw new Error('Unable to resolve the selected wallet account');
+    }
+
+    return await hooks.submitRequestToBackground('messengerCall', [
+      'KeyringController:signPersonalMessage',
+      [
+        {
+          data: messageHex,
+          from,
+        },
+      ],
+    ]);
+  }, WALLET_SIGNATURE_MESSAGE_HEX);
+
+  if (!signature) {
+    throw new Error(
+      'wallet-initiated-signature requires a METAMASK_DEBUG build so the UI can call the internal background test hook',
+    );
+  }
+}
+
+async function ensureTestDappConnected(
+  page: Page,
+  sessionManager: MetaMaskSessionManager,
+  extensionId: string,
+): Promise<Page> {
+  const dappPage = await getOrCreateTestDappPage(page);
+  await dappPage.locator('#connectButton').waitFor({
+    state: 'visible',
+    timeout: CONFIRMATION_WAIT_TIMEOUT_MS,
+  });
+
+  if (await isTestDappConnected(dappPage)) {
+    return dappPage;
+  }
+
+  await dappPage.locator('#connectButton').click();
+
+  const confirmationPage = await sessionManager.waitForNotificationPage(
+    CONFIRMATION_WAIT_TIMEOUT_MS,
+  );
+  await confirmCurrentApproval(confirmationPage);
+  await closeConfirmationPage(confirmationPage);
+  await waitForTestDappConnection(dappPage);
+  await navigateExtensionRoute(page, extensionId, DEFAULT_ROUTE);
+
+  return dappPage;
+}
+
+async function getOrCreateTestDappPage(page: Page): Promise<Page> {
+  const existingPage = page
+    .context()
+    .pages()
+    .find((candidate) => candidate.url().startsWith(TEST_DAPP_URL));
+
+  if (existingPage && !existingPage.isClosed()) {
+    await existingPage.bringToFront();
+    await existingPage.waitForLoadState('domcontentloaded');
+    return existingPage;
+  }
+
+  const dappPage = await page.context().newPage();
+  await dappPage.goto(TEST_DAPP_URL);
+  await dappPage.waitForLoadState('domcontentloaded');
+  return dappPage;
+}
+
+async function isTestDappConnected(dappPage: Page): Promise<boolean> {
+  const accountsText = await dappPage
+    .locator('#accounts')
+    .textContent({ timeout: 1000 })
+    .catch(() => '');
+
+  return ETHEREUM_ADDRESS_REGEX.test(accountsText ?? '');
+}
+
+async function waitForTestDappConnection(dappPage: Page): Promise<void> {
+  await dappPage.waitForFunction(
+    () =>
+      /0x[a-fA-F0-9]{40}/u.test(
+        document.querySelector('#accounts')?.textContent ?? '',
+      ),
+    undefined,
+    { timeout: CONFIRMATION_WAIT_TIMEOUT_MS },
+  );
+}
+
+async function confirmCurrentApproval(page: Page): Promise<void> {
+  await clickScrollToBottomIfPresent(page);
+
+  const confirmButton = await findVisibleLocator(page, [
+    '[data-testid="confirm-footer-button"]',
+    '[data-testid="confirm-btn"]',
+    '[data-testid="confirmation-submit-button"]',
+    '[data-testid="page-container-footer-next"]',
+    'button:has-text("Connect")',
+    'button:has-text("Confirm")',
+    'button:has-text("Sign")',
+  ]);
+
+  await confirmButton.click();
+  await confirmButton.waitFor({ state: 'hidden', timeout: 10000 }).catch(() => {
+    // Some confirmation surfaces remain mounted while the background request
+    // finishes. The click is the important part for this profiler flow.
+  });
+}
+
+async function closeConfirmationPage(page: Page): Promise<void> {
+  await page.waitForTimeout(500);
+  await page.close().catch(() => undefined);
+}
+
+async function clickScrollToBottomIfPresent(page: Page): Promise<void> {
+  const scrollButton = page
+    .locator(
+      '[data-testid="confirm-scroll-to-bottom"], .confirm-scroll-to-bottom__button',
+    )
+    .first();
+  const isVisible = await scrollButton
+    .isVisible({ timeout: 1000 })
+    .catch(() => false);
+
+  if (isVisible) {
+    await scrollButton.click();
+  }
+}
+
+async function findVisibleLocator(
+  page: Page,
+  selectors: string[],
+): Promise<Locator> {
+  for (const selector of selectors) {
+    const locator = page.locator(selector).first();
+    const isVisible = await locator
+      .isVisible({ timeout: 1000 })
+      .catch(() => false);
+
+    if (isVisible) {
+      await locator.waitFor({ state: 'visible', timeout: 10000 });
+      return locator;
+    }
+  }
+
+  throw new Error(
+    `No visible confirmation action found: ${selectors.join(', ')}`,
+  );
 }
 
 export async function navigateExtensionRoute(

--- a/test/e2e/playwright/llm-workflow/memory-profiler.ts
+++ b/test/e2e/playwright/llm-workflow/memory-profiler.ts
@@ -1,0 +1,1087 @@
+#!/usr/bin/env node
+import path from 'path';
+import { createWriteStream, promises as fs } from 'fs';
+import type { CDPSession, Page } from '@playwright/test';
+import {
+  allocatePort,
+  KnowledgeStore,
+  setKnowledgeStore,
+  type SessionLaunchResult,
+  type WorkflowContext,
+} from '@metamask/client-mcp-core';
+import {
+  ASSET_ROUTE,
+  DEFAULT_ROUTE,
+  SEND_ROUTE,
+  SETTINGS_ROUTE,
+} from '../../../../ui/helpers/constants/routes';
+import { createMetaMaskE2EContext } from './capabilities/factory';
+import { MetaMaskSessionManager } from './metamask-provider';
+import { resolveRepoRoot } from './resolve-repo-root';
+
+const DEFAULT_PASSWORD = 'correct horse battery staple';
+const DEFAULT_ARTIFACT_DIR = 'test-artifacts/memory';
+const DEFAULT_ITERATIONS = 5;
+const DEFAULT_WAIT_AFTER_FLOW_MS = 500;
+
+export type MemoryFlow =
+  | 'idle'
+  | 'home'
+  | 'send-route'
+  | 'send-open-back'
+  | 'settings-route'
+  | 'asset-route'
+  | 'route-cycle';
+
+export type HeapSnapshotMode = 'none' | 'baseline' | 'final' | 'both' | 'each';
+
+export type MemorySampleMode = 'each' | 'final';
+
+export type MemoryProbeMode = 'full' | 'cdp' | 'heap';
+
+export type MemoryProfilerOptions = {
+  iterations: number;
+  flow: MemoryFlow;
+  stateMode: 'default' | 'onboarding' | 'custom';
+  fixturePreset?: string;
+  extensionPath?: string;
+  artifactDir: string;
+  outputPath: string;
+  snapshotMode: HeapSnapshotMode;
+  sampleMode: MemorySampleMode;
+  probeMode: MemoryProbeMode;
+  unlock: boolean;
+  password: string;
+  collectGarbage: boolean;
+  waitAfterFlowMs: number;
+  intervalMs: number;
+  slowMo: number;
+  maxUsedHeapGrowthBytes?: number;
+  maxJsHeapGrowthBytes?: number;
+  maxDomNodesGrowth?: number;
+  maxJsEventListenersGrowth?: number;
+  help: boolean;
+};
+
+export type RuntimeHeapUsage = {
+  usedSize: number;
+  totalSize: number;
+  embedderHeapUsedSize?: number;
+  backingStorageSize?: number;
+};
+
+export type DomCounters = {
+  documents: number;
+  nodes: number;
+  jsEventListeners: number;
+};
+
+export type MemorySample = {
+  label: string;
+  timestamp: string;
+  url: string;
+  runtimeHeap: RuntimeHeapUsage | null;
+  performance: Record<string, number>;
+  domCounters: DomCounters | null;
+  liveDomElementCount: number | null;
+};
+
+export type MemoryDeltaSummary = {
+  runtimeUsedSize: number | null;
+  runtimeTotalSize: number | null;
+  jsHeapUsedSize: number | null;
+  jsHeapTotalSize: number | null;
+  nodes: number | null;
+  documents: number | null;
+  jsEventListeners: number | null;
+  liveDomElements: number | null;
+};
+
+export type ThresholdEvaluation = {
+  name:
+    | 'runtimeUsedSize'
+    | 'jsHeapUsedSize'
+    | 'nodes'
+    | 'jsEventListeners';
+  limit: number;
+  actual: number | null;
+  unit: 'bytes' | 'count';
+  passed: boolean;
+};
+
+export type HeapSnapshotArtifact = {
+  label: string;
+  path: string;
+};
+
+export type MemoryReport = {
+  schemaVersion: 1;
+  createdAt: string;
+  options: Omit<MemoryProfilerOptions, 'help' | 'password'>;
+  session: {
+    sessionId: string;
+    extensionId: string;
+    stateMode: MemoryProfilerOptions['stateMode'];
+  };
+  samples: MemorySample[];
+  snapshots: HeapSnapshotArtifact[];
+  summary: {
+    baseline: MemorySample | null;
+    final: MemorySample | null;
+    deltas: MemoryDeltaSummary;
+    thresholds: ThresholdEvaluation[];
+  };
+};
+
+type MutableMemoryProfilerOptions = MemoryProfilerOptions;
+
+type PortAllocation = Awaited<ReturnType<typeof allocatePort>>;
+
+const VALID_FLOWS: MemoryFlow[] = [
+  'idle',
+  'home',
+  'send-route',
+  'send-open-back',
+  'settings-route',
+  'asset-route',
+  'route-cycle',
+];
+
+const VALID_SNAPSHOT_MODES: HeapSnapshotMode[] = [
+  'none',
+  'baseline',
+  'final',
+  'both',
+  'each',
+];
+
+const VALID_SAMPLE_MODES: MemorySampleMode[] = ['each', 'final'];
+
+const VALID_PROBE_MODES: MemoryProbeMode[] = ['full', 'cdp', 'heap'];
+
+export function parseMemoryProfilerArgs(
+  argv: string[],
+): MemoryProfilerOptions {
+  const options: MutableMemoryProfilerOptions = {
+    iterations: DEFAULT_ITERATIONS,
+    flow: 'route-cycle',
+    stateMode: 'default',
+    artifactDir: DEFAULT_ARTIFACT_DIR,
+    outputPath: '',
+    snapshotMode: 'none',
+    sampleMode: 'each',
+    probeMode: 'full',
+    unlock: true,
+    password: DEFAULT_PASSWORD,
+    collectGarbage: true,
+    waitAfterFlowMs: DEFAULT_WAIT_AFTER_FLOW_MS,
+    intervalMs: 0,
+    slowMo: 0,
+    help: false,
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    switch (arg) {
+      case '--':
+        break;
+      case '--help':
+      case '-h':
+        options.help = true;
+        break;
+      case '--iterations':
+        options.iterations = parsePositiveInteger(
+          readArgValue(argv, (index += 1), arg),
+          arg,
+        );
+        break;
+      case '--flow':
+        options.flow = parseChoice(
+          readArgValue(argv, (index += 1), arg),
+          VALID_FLOWS,
+          arg,
+        );
+        break;
+      case '--state':
+        options.stateMode = parseChoice(
+          readArgValue(argv, (index += 1), arg),
+          ['default', 'onboarding', 'custom'],
+          arg,
+        );
+        break;
+      case '--preset':
+        options.fixturePreset = readArgValue(argv, (index += 1), arg);
+        break;
+      case '--extension-path':
+        options.extensionPath = path.resolve(
+          readArgValue(argv, (index += 1), arg),
+        );
+        break;
+      case '--artifact-dir':
+        options.artifactDir = readArgValue(argv, (index += 1), arg);
+        break;
+      case '--output':
+        options.outputPath = readArgValue(argv, (index += 1), arg);
+        break;
+      case '--snapshot':
+        options.snapshotMode = parseChoice(
+          readArgValue(argv, (index += 1), arg),
+          VALID_SNAPSHOT_MODES,
+          arg,
+        );
+        break;
+      case '--sample':
+      case '--sample-mode':
+        options.sampleMode = parseChoice(
+          readArgValue(argv, (index += 1), arg),
+          VALID_SAMPLE_MODES,
+          arg,
+        );
+        break;
+      case '--probe':
+      case '--probe-mode':
+        options.probeMode = parseChoice(
+          readArgValue(argv, (index += 1), arg),
+          VALID_PROBE_MODES,
+          arg,
+        );
+        break;
+      case '--unlock':
+        options.unlock = true;
+        break;
+      case '--no-unlock':
+        options.unlock = false;
+        break;
+      case '--password':
+        options.password = readArgValue(argv, (index += 1), arg);
+        break;
+      case '--gc':
+        options.collectGarbage = true;
+        break;
+      case '--no-gc':
+        options.collectGarbage = false;
+        break;
+      case '--wait-after-flow':
+        options.waitAfterFlowMs = parseNonNegativeInteger(
+          readArgValue(argv, (index += 1), arg),
+          arg,
+        );
+        break;
+      case '--interval':
+        options.intervalMs = parseNonNegativeInteger(
+          readArgValue(argv, (index += 1), arg),
+          arg,
+        );
+        break;
+      case '--slow-mo':
+        options.slowMo = parseNonNegativeInteger(
+          readArgValue(argv, (index += 1), arg),
+          arg,
+        );
+        break;
+      case '--max-used-heap-growth':
+        options.maxUsedHeapGrowthBytes = parseByteSize(
+          readArgValue(argv, (index += 1), arg),
+          arg,
+        );
+        break;
+      case '--max-js-heap-growth':
+        options.maxJsHeapGrowthBytes = parseByteSize(
+          readArgValue(argv, (index += 1), arg),
+          arg,
+        );
+        break;
+      case '--max-dom-nodes-growth':
+        options.maxDomNodesGrowth = parseNonNegativeInteger(
+          readArgValue(argv, (index += 1), arg),
+          arg,
+        );
+        break;
+      case '--max-js-event-listeners-growth':
+        options.maxJsEventListenersGrowth = parseNonNegativeInteger(
+          readArgValue(argv, (index += 1), arg),
+          arg,
+        );
+        break;
+      default:
+        throw new Error(`Unknown option: ${arg}`);
+    }
+  }
+
+  options.artifactDir = resolveOutputPath(options.artifactDir);
+  options.outputPath = options.outputPath
+    ? resolveOutputPath(options.outputPath)
+    : createDefaultOutputPath(options.artifactDir);
+
+  return options;
+}
+
+export function createMemoryReport({
+  createdAt,
+  launchResult,
+  options,
+  samples,
+  snapshots,
+}: {
+  createdAt: string;
+  launchResult: SessionLaunchResult;
+  options: MemoryProfilerOptions;
+  samples: MemorySample[];
+  snapshots: HeapSnapshotArtifact[];
+}): MemoryReport {
+  const baseline = samples[0] ?? null;
+  const final = samples[samples.length - 1] ?? null;
+  const deltas = calculateDeltas(baseline, final);
+  const { help: _help, password: _password, ...serializedOptions } = options;
+
+  return {
+    schemaVersion: 1,
+    createdAt,
+    options: serializedOptions,
+    session: {
+      sessionId: launchResult.sessionId,
+      extensionId: launchResult.extensionId,
+      stateMode: options.stateMode,
+    },
+    samples,
+    snapshots,
+    summary: {
+      baseline,
+      final,
+      deltas,
+      thresholds: evaluateThresholds(options, deltas),
+    },
+  };
+}
+
+export function calculateDeltas(
+  baseline: MemorySample | null,
+  final: MemorySample | null,
+): MemoryDeltaSummary {
+  return {
+    runtimeUsedSize: delta(
+      baseline?.runtimeHeap?.usedSize,
+      final?.runtimeHeap?.usedSize,
+    ),
+    runtimeTotalSize: delta(
+      baseline?.runtimeHeap?.totalSize,
+      final?.runtimeHeap?.totalSize,
+    ),
+    jsHeapUsedSize: delta(
+      baseline?.performance.JSHeapUsedSize,
+      final?.performance.JSHeapUsedSize,
+    ),
+    jsHeapTotalSize: delta(
+      baseline?.performance.JSHeapTotalSize,
+      final?.performance.JSHeapTotalSize,
+    ),
+    nodes: delta(baseline?.domCounters?.nodes, final?.domCounters?.nodes),
+    documents: delta(
+      baseline?.domCounters?.documents,
+      final?.domCounters?.documents,
+    ),
+    jsEventListeners: delta(
+      baseline?.domCounters?.jsEventListeners,
+      final?.domCounters?.jsEventListeners,
+    ),
+    liveDomElements: delta(
+      baseline?.liveDomElementCount,
+      final?.liveDomElementCount,
+    ),
+  };
+}
+
+export function evaluateThresholds(
+  options: Pick<
+    MemoryProfilerOptions,
+    | 'maxUsedHeapGrowthBytes'
+    | 'maxJsHeapGrowthBytes'
+    | 'maxDomNodesGrowth'
+    | 'maxJsEventListenersGrowth'
+  >,
+  deltas: MemoryDeltaSummary,
+): ThresholdEvaluation[] {
+  const thresholds: ThresholdEvaluation[] = [];
+
+  if (options.maxUsedHeapGrowthBytes !== undefined) {
+    thresholds.push(
+      createThresholdEvaluation({
+        name: 'runtimeUsedSize',
+        limit: options.maxUsedHeapGrowthBytes,
+        actual: deltas.runtimeUsedSize,
+        unit: 'bytes',
+      }),
+    );
+  }
+
+  if (options.maxJsHeapGrowthBytes !== undefined) {
+    thresholds.push(
+      createThresholdEvaluation({
+        name: 'jsHeapUsedSize',
+        limit: options.maxJsHeapGrowthBytes,
+        actual: deltas.jsHeapUsedSize,
+        unit: 'bytes',
+      }),
+    );
+  }
+
+  if (options.maxDomNodesGrowth !== undefined) {
+    thresholds.push(
+      createThresholdEvaluation({
+        name: 'nodes',
+        limit: options.maxDomNodesGrowth,
+        actual: deltas.nodes,
+        unit: 'count',
+      }),
+    );
+  }
+
+  if (options.maxJsEventListenersGrowth !== undefined) {
+    thresholds.push(
+      createThresholdEvaluation({
+        name: 'jsEventListeners',
+        limit: options.maxJsEventListenersGrowth,
+        actual: deltas.jsEventListeners,
+        unit: 'count',
+      }),
+    );
+  }
+
+  return thresholds;
+}
+
+function createThresholdEvaluation({
+  name,
+  limit,
+  actual,
+  unit,
+}: Pick<ThresholdEvaluation, 'name' | 'limit' | 'actual' | 'unit'>) {
+  return {
+    name,
+    limit,
+    actual,
+    unit,
+    passed: actual !== null && actual <= limit,
+  };
+}
+
+export function parseByteSize(value: string, optionName = 'value'): number {
+  const match = value
+    .trim()
+    .match(/^(\d+(?:\.\d+)?)\s*(b|kb|kib|mb|mib|gb|gib)?$/iu);
+
+  if (!match) {
+    throw new Error(
+      `${optionName} must be a byte size such as 5000000, 25mb, or 25MiB`,
+    );
+  }
+
+  const amount = Number(match[1]);
+  const unit = match[2]?.toLowerCase() ?? 'b';
+  const multiplier =
+    {
+      b: 1,
+      kb: 1000,
+      kib: 1024,
+      mb: 1000 * 1000,
+      mib: 1024 * 1024,
+      gb: 1000 * 1000 * 1000,
+      gib: 1024 * 1024 * 1024,
+    }[unit] ?? 1;
+
+  return Math.round(amount * multiplier);
+}
+
+export async function collectMemorySample({
+  page,
+  label,
+  collectGarbage,
+  probeMode,
+}: {
+  page: Page;
+  label: string;
+  collectGarbage: boolean;
+  probeMode: MemoryProbeMode;
+}): Promise<MemorySample> {
+  return await withCdpSession(page, async (cdp) => {
+    if (collectGarbage) {
+      await cdp.send('HeapProfiler.enable');
+      await cdp.send('HeapProfiler.collectGarbage');
+    }
+
+    const [
+      runtimeHeap,
+      performanceMetrics,
+      domCounters,
+      liveDomElementCount,
+    ] = await Promise.all([
+      getRuntimeHeapUsage(cdp),
+      getPerformanceMetrics(cdp),
+      shouldCollectDomCounters(probeMode)
+        ? getDomCounters(cdp)
+        : Promise.resolve(null),
+      shouldCollectLiveDomElementCount(probeMode)
+        ? getLiveDomElementCount(page)
+        : Promise.resolve(null),
+    ]);
+
+    return {
+      label,
+      timestamp: new Date().toISOString(),
+      url: page.url(),
+      runtimeHeap,
+      performance: performanceMetrics,
+      domCounters,
+      liveDomElementCount,
+    };
+  });
+}
+
+export async function writeHeapSnapshot({
+  page,
+  snapshotPath,
+}: {
+  page: Page;
+  snapshotPath: string;
+}): Promise<void> {
+  await fs.mkdir(path.dirname(snapshotPath), { recursive: true });
+
+  await withCdpSession(page, async (cdp) => {
+    await cdp.send('HeapProfiler.enable');
+    await cdp.send('HeapProfiler.collectGarbage');
+
+    const stream = createWriteStream(snapshotPath, { encoding: 'utf8' });
+    const finished = new Promise<void>((resolve, reject) => {
+      stream.on('finish', resolve);
+      stream.on('error', reject);
+    });
+
+    cdp.on('HeapProfiler.addHeapSnapshotChunk', (event: unknown) => {
+      const { chunk } = event as { chunk?: string };
+      if (chunk) {
+        stream.write(chunk);
+      }
+    });
+
+    try {
+      await cdp.send('HeapProfiler.takeHeapSnapshot', {
+        reportProgress: false,
+      });
+    } finally {
+      stream.end();
+    }
+
+    await finished;
+  });
+}
+
+export async function runMemoryProfiler(
+  options: MemoryProfilerOptions,
+): Promise<MemoryReport> {
+  const repoRoot = resolveRepoRoot();
+  const sessionManager = new MetaMaskSessionManager();
+  const snapshots: HeapSnapshotArtifact[] = [];
+  const samples: MemorySample[] = [];
+  let launchResult: SessionLaunchResult | undefined;
+
+  setKnowledgeStore(new KnowledgeStore());
+
+  const [anvilAlloc, fixtureAlloc, mockAlloc] = await Promise.all([
+    allocatePort(),
+    allocatePort(),
+    allocatePort(),
+  ]);
+
+  await Promise.all([
+    releasePort(anvilAlloc),
+    releasePort(fixtureAlloc),
+    releasePort(mockAlloc),
+  ]);
+
+  const context = createMetaMaskE2EContext({
+    config: {
+      ports: {
+        anvil: anvilAlloc.port,
+        fixtureServer: fixtureAlloc.port,
+      },
+      artifactsDir: path.relative(repoRoot, options.artifactDir),
+    },
+    mockServer: {
+      port: mockAlloc.port,
+    },
+  });
+
+  sessionManager.setWorkflowContext(context as WorkflowContext);
+
+  try {
+    launchResult = await sessionManager.launch({
+      stateMode: options.stateMode,
+      fixturePreset: options.fixturePreset,
+      extensionPath: options.extensionPath,
+      slowMo: options.slowMo,
+      goal: 'Collect browser heap telemetry for leak investigation',
+      flowTags: ['memory', options.flow],
+    });
+
+    const page = sessionManager.getPage();
+
+    if (options.unlock) {
+      await unlockIfNeeded(page, options.password);
+    }
+
+    await runFlowIteration({
+      page,
+      extensionId: launchResult.extensionId,
+      flow: 'home',
+      waitAfterFlowMs: options.waitAfterFlowMs,
+    });
+
+    if (shouldCaptureSnapshot(options.snapshotMode, 'baseline')) {
+      const snapshotPath = createSnapshotPath(options, 'baseline');
+      await writeHeapSnapshot({ page, snapshotPath });
+      snapshots.push({ label: 'baseline', path: snapshotPath });
+    }
+
+    samples.push(
+      await collectMemorySample({
+        page,
+        label: 'baseline',
+        collectGarbage: options.collectGarbage,
+        probeMode: options.probeMode,
+      }),
+    );
+
+    for (let iteration = 1; iteration <= options.iterations; iteration += 1) {
+      await runFlowIteration({
+        page,
+        extensionId: launchResult.extensionId,
+        flow: options.flow,
+        waitAfterFlowMs: options.waitAfterFlowMs,
+      });
+
+      if (options.sampleMode === 'each') {
+        samples.push(
+          await collectMemorySample({
+            page,
+            label: `iteration-${iteration}`,
+            collectGarbage: options.collectGarbage,
+            probeMode: options.probeMode,
+          }),
+        );
+      }
+
+      if (shouldCaptureSnapshot(options.snapshotMode, 'each')) {
+        const snapshotPath = createSnapshotPath(
+          options,
+          `iteration-${iteration}`,
+        );
+        await writeHeapSnapshot({ page, snapshotPath });
+        snapshots.push({
+          label: `iteration-${iteration}`,
+          path: snapshotPath,
+        });
+      }
+
+      if (options.intervalMs > 0 && iteration < options.iterations) {
+        await page.waitForTimeout(options.intervalMs);
+      }
+    }
+
+    if (options.sampleMode === 'final') {
+      samples.push(
+        await collectMemorySample({
+          page,
+          label: 'final',
+          collectGarbage: options.collectGarbage,
+          probeMode: options.probeMode,
+        }),
+      );
+    }
+
+    if (shouldCaptureSnapshot(options.snapshotMode, 'final')) {
+      const snapshotPath = createSnapshotPath(options, 'final');
+      await writeHeapSnapshot({ page, snapshotPath });
+      snapshots.push({ label: 'final', path: snapshotPath });
+    }
+
+    const report = createMemoryReport({
+      createdAt: new Date().toISOString(),
+      launchResult,
+      options,
+      samples,
+      snapshots,
+    });
+
+    await fs.mkdir(path.dirname(options.outputPath), { recursive: true });
+    await fs.writeFile(options.outputPath, `${JSON.stringify(report, null, 2)}\n`);
+
+    return report;
+  } finally {
+    await sessionManager.cleanup();
+  }
+}
+
+export function formatBytes(value: number | null): string {
+  if (value === null) {
+    return 'n/a';
+  }
+
+  return `${(value / (1024 * 1024)).toFixed(2)} MiB`;
+}
+
+export function getHelpText(): string {
+  return `Usage: yarn llm:memory -- [options]
+
+Collect MetaMask extension memory telemetry through Chrome DevTools Protocol.
+
+Options:
+  --iterations <n>              Number of flow iterations. Default: ${DEFAULT_ITERATIONS}
+  --flow <name>                 idle, home, send-route, send-open-back, settings-route, asset-route, route-cycle
+  --state <mode>                default, onboarding, custom. Default: default
+  --preset <name>               Fixture preset when --state custom is used
+  --extension-path <path>       Extension build path. Default: dist/chrome
+  --artifact-dir <path>         Artifact directory. Default: ${DEFAULT_ARTIFACT_DIR}
+  --output <path>               JSON report path
+  --snapshot <mode>             none, baseline, final, both, each. Default: none
+  --sample <mode>               each, final. Default: each
+  --probe <mode>                full, cdp, heap. Default: full
+  --unlock / --no-unlock        Unlock the default wallet before profiling. Default: unlock
+  --password <password>         Wallet password. Default: MetaMask E2E password
+  --gc / --no-gc                Run HeapProfiler.collectGarbage before sampling. Default: gc
+  --wait-after-flow <ms>        Delay after each flow iteration. Default: ${DEFAULT_WAIT_AFTER_FLOW_MS}
+  --interval <ms>               Delay between iterations. Default: 0
+  --slow-mo <ms>                Playwright slowMo launch option. Default: 0
+  --max-used-heap-growth <size> Fail if Runtime.getHeapUsage usedSize grows above size
+  --max-js-heap-growth <size>   Fail if Performance JSHeapUsedSize grows above size
+  --max-dom-nodes-growth <n>    Fail if Memory.getDOMCounters nodes grow above count
+  --max-js-event-listeners-growth <n>
+                                Fail if Memory.getDOMCounters listeners grow above count
+  --help                        Show this help text
+
+Examples:
+  yarn llm:memory -- --iterations 25 --flow route-cycle --snapshot final
+  yarn llm:memory -- --iterations 50 --max-used-heap-growth 25MiB
+  yarn llm:memory -- --iterations 50 --flow send-open-back --sample final --probe cdp
+`;
+}
+
+async function main(): Promise<void> {
+  const options = parseMemoryProfilerArgs(process.argv.slice(2));
+
+  if (options.help) {
+    console.log(getHelpText());
+    return;
+  }
+
+  const report = await runMemoryProfiler(options);
+  const failedThresholds = report.summary.thresholds.filter(
+    (threshold) => !threshold.passed,
+  );
+
+  console.log(`Memory report: ${options.outputPath}`);
+  console.log(
+    `Runtime used heap delta: ${formatBytes(report.summary.deltas.runtimeUsedSize)}`,
+  );
+  console.log(
+    `Performance JS heap delta: ${formatBytes(report.summary.deltas.jsHeapUsedSize)}`,
+  );
+  console.log(`DOM node delta: ${report.summary.deltas.nodes ?? 'n/a'}`);
+  console.log(
+    `JS event listener delta: ${
+      report.summary.deltas.jsEventListeners ?? 'n/a'
+    }`,
+  );
+  console.log(
+    `Live DOM element delta: ${report.summary.deltas.liveDomElements ?? 'n/a'}`,
+  );
+
+  if (report.snapshots.length > 0) {
+    console.log(
+      `Heap snapshots: ${report.snapshots
+        .map((snapshot) => snapshot.path)
+        .join(', ')}`,
+    );
+  }
+
+  if (failedThresholds.length > 0) {
+    for (const threshold of failedThresholds) {
+      console.error(
+        `Memory threshold failed: ${threshold.name} grew by ${formatThresholdValue(
+          threshold,
+          threshold.actual,
+        )}, limit ${formatThresholdValue(threshold, threshold.limit)}`,
+      );
+    }
+    process.exitCode = 1;
+  }
+}
+
+function formatThresholdValue(
+  threshold: Pick<ThresholdEvaluation, 'unit'>,
+  value: number | null,
+): string {
+  if (threshold.unit === 'bytes') {
+    return formatBytes(value);
+  }
+
+  return value === null ? 'n/a' : `${value}`;
+}
+
+function readArgValue(
+  argv: string[],
+  valueIndex: number,
+  optionName: string,
+): string {
+  const value = argv[valueIndex];
+
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${optionName} requires a value`);
+  }
+
+  return value;
+}
+
+function parsePositiveInteger(value: string, optionName: string): number {
+  const parsed = parseNonNegativeInteger(value, optionName);
+
+  if (parsed < 1) {
+    throw new Error(`${optionName} must be greater than 0`);
+  }
+
+  return parsed;
+}
+
+function parseNonNegativeInteger(value: string, optionName: string): number {
+  const parsed = Number(value);
+
+  if (!Number.isInteger(parsed) || parsed < 0) {
+    throw new Error(`${optionName} must be a non-negative integer`);
+  }
+
+  return parsed;
+}
+
+function parseChoice<Choice extends string>(
+  value: string,
+  choices: readonly Choice[],
+  optionName: string,
+): Choice {
+  if (!choices.includes(value as Choice)) {
+    throw new Error(`${optionName} must be one of: ${choices.join(', ')}`);
+  }
+
+  return value as Choice;
+}
+
+function resolveOutputPath(outputPath: string): string {
+  return path.isAbsolute(outputPath)
+    ? outputPath
+    : path.join(resolveRepoRoot(), outputPath);
+}
+
+function createDefaultOutputPath(artifactDir: string): string {
+  return path.join(artifactDir, `memory-profile-${Date.now()}.json`);
+}
+
+function delta(
+  baselineValue: number | null | undefined,
+  finalValue: number | null | undefined,
+): number | null {
+  if (typeof baselineValue !== 'number' || typeof finalValue !== 'number') {
+    return null;
+  }
+
+  return finalValue - baselineValue;
+}
+
+async function getRuntimeHeapUsage(
+  cdp: CDPSession,
+): Promise<RuntimeHeapUsage | null> {
+  try {
+    return (await cdp.send('Runtime.getHeapUsage')) as RuntimeHeapUsage;
+  } catch {
+    return null;
+  }
+}
+
+async function getPerformanceMetrics(
+  cdp: CDPSession,
+): Promise<Record<string, number>> {
+  try {
+    await cdp.send('Performance.enable');
+    const result = (await cdp.send('Performance.getMetrics')) as {
+      metrics: { name: string; value: number }[];
+    };
+
+    return Object.fromEntries(
+      result.metrics.map(({ name, value }) => [name, value]),
+    );
+  } catch {
+    return {};
+  }
+}
+
+async function getDomCounters(cdp: CDPSession): Promise<DomCounters | null> {
+  try {
+    return (await cdp.send('Memory.getDOMCounters')) as DomCounters;
+  } catch {
+    return null;
+  }
+}
+
+async function getLiveDomElementCount(page: Page): Promise<number | null> {
+  try {
+    return await page.locator('body *').count();
+  } catch {
+    return null;
+  }
+}
+
+function shouldCollectDomCounters(probeMode: MemoryProbeMode): boolean {
+  return probeMode === 'full' || probeMode === 'cdp';
+}
+
+function shouldCollectLiveDomElementCount(
+  probeMode: MemoryProbeMode,
+): boolean {
+  return probeMode === 'full';
+}
+
+async function withCdpSession<Result>(
+  page: Page,
+  callback: (cdp: CDPSession) => Promise<Result>,
+): Promise<Result> {
+  const cdp = await page.context().newCDPSession(page);
+
+  try {
+    return await callback(cdp);
+  } finally {
+    await cdp.detach().catch(() => undefined);
+  }
+}
+
+function shouldCaptureSnapshot(
+  mode: HeapSnapshotMode,
+  point: 'baseline' | 'final' | 'each',
+): boolean {
+  if (mode === 'each') {
+    return true;
+  }
+
+  if (mode === 'both') {
+    return point === 'baseline' || point === 'final';
+  }
+
+  return mode === point;
+}
+
+function createSnapshotPath(
+  options: Pick<MemoryProfilerOptions, 'artifactDir'>,
+  label: string,
+): string {
+  return path.join(
+    options.artifactDir,
+    `heap-${label}-${Date.now()}.heapsnapshot`,
+  );
+}
+
+async function unlockIfNeeded(page: Page, password: string): Promise<boolean> {
+  const passwordInput = page.locator('[data-testid="unlock-password"]');
+  const isLocked = await passwordInput
+    .isVisible({ timeout: 1500 })
+    .catch(() => false);
+
+  if (!isLocked) {
+    return false;
+  }
+
+  await passwordInput.fill(password);
+  await page.locator('[data-testid="unlock-submit"]').click();
+  await page
+    .locator('[data-testid="account-menu-icon"]')
+    .waitFor({ state: 'visible', timeout: 30000 });
+
+  return true;
+}
+
+async function runFlowIteration({
+  page,
+  extensionId,
+  flow,
+  waitAfterFlowMs,
+}: {
+  page: Page;
+  extensionId: string;
+  flow: MemoryFlow;
+  waitAfterFlowMs: number;
+}): Promise<void> {
+  switch (flow) {
+    case 'idle':
+      await page.waitForTimeout(waitAfterFlowMs);
+      return;
+    case 'home':
+      await navigateExtensionRoute(page, extensionId, DEFAULT_ROUTE);
+      break;
+    case 'send-route':
+      await navigateExtensionRoute(page, extensionId, SEND_ROUTE);
+      await navigateExtensionRoute(page, extensionId, DEFAULT_ROUTE);
+      break;
+    case 'send-open-back':
+      await runSendOpenBackFlow(page);
+      break;
+    case 'settings-route':
+      await navigateExtensionRoute(page, extensionId, SETTINGS_ROUTE);
+      await navigateExtensionRoute(page, extensionId, DEFAULT_ROUTE);
+      break;
+    case 'asset-route':
+      await navigateExtensionRoute(page, extensionId, `${ASSET_ROUTE}/0x539`);
+      await navigateExtensionRoute(page, extensionId, DEFAULT_ROUTE);
+      break;
+    case 'route-cycle':
+      await navigateExtensionRoute(page, extensionId, SETTINGS_ROUTE);
+      await navigateExtensionRoute(page, extensionId, SEND_ROUTE);
+      await navigateExtensionRoute(page, extensionId, `${ASSET_ROUTE}/0x539`);
+      await navigateExtensionRoute(page, extensionId, DEFAULT_ROUTE);
+      break;
+    default:
+      throw new Error('Unsupported memory flow');
+  }
+
+  if (waitAfterFlowMs > 0) {
+    await page.waitForTimeout(waitAfterFlowMs);
+  }
+}
+
+async function runSendOpenBackFlow(page: Page): Promise<void> {
+  const sendButton = page
+    .locator('[data-testid="eth-overview-send"], [data-testid="coin-overview-send"]')
+    .first();
+  await sendButton.waitFor({ state: 'visible', timeout: 30000 });
+  await sendButton.click();
+
+  const backButton = page.locator('[aria-label="go to previous page"]').first();
+  await backButton.waitFor({ state: 'visible', timeout: 30000 });
+  await backButton.click();
+  await sendButton.waitFor({ state: 'visible', timeout: 30000 });
+}
+
+export async function navigateExtensionRoute(
+  page: Page,
+  extensionId: string,
+  route: string,
+): Promise<void> {
+  await page.goto(`chrome-extension://${extensionId}/home.html#${route}`);
+  await page.waitForLoadState('domcontentloaded');
+}
+
+function releasePort(alloc: PortAllocation): Promise<void> {
+  return new Promise<void>((resolve) => alloc.server.close(() => resolve()));
+}
+
+if (require.main === module) {
+  main().catch((error: Error) => {
+    console.error(error.message);
+    process.exit(1);
+  });
+}

--- a/test/e2e/playwright/llm-workflow/memory-profiler.ts
+++ b/test/e2e/playwright/llm-workflow/memory-profiler.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import path from 'path';
 import { createWriteStream, promises as fs } from 'fs';
-import type { CDPSession, Locator, Page } from '@playwright/test';
+import type { CDPSession, Page } from '@playwright/test';
 import {
   allocatePort,
   KnowledgeStore,
@@ -23,16 +23,6 @@ const DEFAULT_PASSWORD = 'correct horse battery staple';
 const DEFAULT_ARTIFACT_DIR = 'test-artifacts/memory';
 const DEFAULT_ITERATIONS = 5;
 const DEFAULT_WAIT_AFTER_FLOW_MS = 500;
-const TEST_DAPP_URL = 'https://metamask.github.io/test-dapp/';
-const CONFIRMATION_WAIT_TIMEOUT_MS = 30000;
-const DEFAULT_SEND_RECIPIENT = '0x2f318C334780961FB129D2a6c30D0763d9a5C970';
-const DEFAULT_WALLET_SEND_AMOUNT = '0.000001';
-const WALLET_SIGNATURE_MESSAGE = 'MetaMask memory profiler wallet signature';
-const ETHEREUM_ADDRESS_REGEX = /0x[a-fA-F0-9]{40}/u;
-const WALLET_SIGNATURE_MESSAGE_HEX = `0x${Buffer.from(
-  WALLET_SIGNATURE_MESSAGE,
-  'utf8',
-).toString('hex')}`;
 
 export type MemoryFlow =
   | 'idle'
@@ -41,11 +31,7 @@ export type MemoryFlow =
   | 'send-open-back'
   | 'settings-route'
   | 'asset-route'
-  | 'route-cycle'
-  | 'dapp-initiated-transaction'
-  | 'dapp-initiated-signature'
-  | 'wallet-initiated-transaction'
-  | 'wallet-initiated-signature';
+  | 'route-cycle';
 
 export type HeapSnapshotMode = 'none' | 'baseline' | 'final' | 'both' | 'each';
 
@@ -159,10 +145,6 @@ const VALID_FLOWS: MemoryFlow[] = [
   'settings-route',
   'asset-route',
   'route-cycle',
-  'dapp-initiated-transaction',
-  'dapp-initiated-signature',
-  'wallet-initiated-transaction',
-  'wallet-initiated-signature',
 ];
 
 const VALID_SNAPSHOT_MODES: HeapSnapshotMode[] = [
@@ -650,7 +632,6 @@ export async function runMemoryProfiler(
 
     await runFlowIteration({
       page,
-      sessionManager,
       extensionId: launchResult.extensionId,
       flow: 'home',
       waitAfterFlowMs: options.waitAfterFlowMs,
@@ -674,7 +655,6 @@ export async function runMemoryProfiler(
     for (let iteration = 1; iteration <= options.iterations; iteration += 1) {
       await runFlowIteration({
         page,
-        sessionManager,
         extensionId: launchResult.extensionId,
         flow: options.flow,
         waitAfterFlowMs: options.waitAfterFlowMs,
@@ -757,9 +737,7 @@ Collect MetaMask extension memory telemetry through Chrome DevTools Protocol.
 
 Options:
   --iterations <n>              Number of flow iterations. Default: ${DEFAULT_ITERATIONS}
-  --flow <name>                 idle, home, send-route, send-open-back, settings-route, asset-route, route-cycle,
-                                dapp-initiated-transaction, dapp-initiated-signature,
-                                wallet-initiated-transaction, wallet-initiated-signature
+  --flow <name>                 idle, home, send-route, send-open-back, settings-route, asset-route, route-cycle
   --state <mode>                default, onboarding, custom. Default: default
   --preset <name>               Fixture preset when --state custom is used
   --extension-path <path>       Extension build path. Default: dist/chrome
@@ -785,7 +763,6 @@ Examples:
   yarn llm:memory -- --iterations 25 --flow route-cycle --snapshot final
   yarn llm:memory -- --iterations 50 --max-used-heap-growth 25MiB
   yarn llm:memory -- --iterations 50 --flow send-open-back --sample final --probe cdp
-  yarn llm:memory -- --iterations 25 --flow dapp-initiated-transaction
 `;
 }
 
@@ -1030,13 +1007,11 @@ async function unlockIfNeeded(page: Page, password: string): Promise<boolean> {
 
 async function runFlowIteration({
   page,
-  sessionManager,
   extensionId,
   flow,
   waitAfterFlowMs,
 }: {
   page: Page;
-  sessionManager: MetaMaskSessionManager;
   extensionId: string;
   flow: MemoryFlow;
   waitAfterFlowMs: number;
@@ -1069,18 +1044,6 @@ async function runFlowIteration({
       await navigateExtensionRoute(page, extensionId, `${ASSET_ROUTE}/0x539`);
       await navigateExtensionRoute(page, extensionId, DEFAULT_ROUTE);
       break;
-    case 'dapp-initiated-transaction':
-      await runDappInitiatedTransactionFlow(page, sessionManager, extensionId);
-      break;
-    case 'dapp-initiated-signature':
-      await runDappInitiatedSignatureFlow(page, sessionManager, extensionId);
-      break;
-    case 'wallet-initiated-transaction':
-      await runWalletInitiatedTransactionFlow(page, extensionId);
-      break;
-    case 'wallet-initiated-signature':
-      await runWalletInitiatedSignatureFlow(page, extensionId);
-      break;
     default:
       throw new Error('Unsupported memory flow');
   }
@@ -1101,261 +1064,6 @@ async function runSendOpenBackFlow(page: Page): Promise<void> {
   await backButton.waitFor({ state: 'visible', timeout: 30000 });
   await backButton.click();
   await sendButton.waitFor({ state: 'visible', timeout: 30000 });
-}
-
-async function runDappInitiatedTransactionFlow(
-  page: Page,
-  sessionManager: MetaMaskSessionManager,
-  extensionId: string,
-): Promise<void> {
-  const dappPage = await ensureTestDappConnected(
-    page,
-    sessionManager,
-    extensionId,
-  );
-
-  await dappPage.locator('#sendButton').waitFor({
-    state: 'visible',
-    timeout: CONFIRMATION_WAIT_TIMEOUT_MS,
-  });
-  await dappPage.locator('#sendButton').click();
-
-  const confirmationPage = await sessionManager.waitForNotificationPage(
-    CONFIRMATION_WAIT_TIMEOUT_MS,
-  );
-  await confirmCurrentApproval(confirmationPage);
-  await closeConfirmationPage(confirmationPage);
-  await navigateExtensionRoute(page, extensionId, DEFAULT_ROUTE);
-}
-
-async function runDappInitiatedSignatureFlow(
-  page: Page,
-  sessionManager: MetaMaskSessionManager,
-  extensionId: string,
-): Promise<void> {
-  const dappPage = await ensureTestDappConnected(
-    page,
-    sessionManager,
-    extensionId,
-  );
-
-  await dappPage.locator('#personalSign').waitFor({
-    state: 'visible',
-    timeout: CONFIRMATION_WAIT_TIMEOUT_MS,
-  });
-  await dappPage.locator('#personalSign').click();
-
-  const confirmationPage = await sessionManager.waitForNotificationPage(
-    CONFIRMATION_WAIT_TIMEOUT_MS,
-  );
-  await confirmCurrentApproval(confirmationPage);
-  await closeConfirmationPage(confirmationPage);
-  await navigateExtensionRoute(page, extensionId, DEFAULT_ROUTE);
-}
-
-async function runWalletInitiatedTransactionFlow(
-  page: Page,
-  extensionId: string,
-): Promise<void> {
-  await navigateExtensionRoute(page, extensionId, SEND_ROUTE);
-
-  await page
-    .locator('[data-testid="recipient-address-input"]')
-    .fill(DEFAULT_SEND_RECIPIENT);
-  await page
-    .locator('[data-testid="send-amount-input"]')
-    .fill(DEFAULT_WALLET_SEND_AMOUNT);
-  await page.locator('[data-testid="send-continue-button"]').click();
-
-  await confirmCurrentApproval(page);
-  await navigateExtensionRoute(page, extensionId, DEFAULT_ROUTE);
-}
-
-async function runWalletInitiatedSignatureFlow(
-  page: Page,
-  extensionId: string,
-): Promise<void> {
-  await navigateExtensionRoute(page, extensionId, DEFAULT_ROUTE);
-
-  const signature = await page.evaluate(async (messageHex) => {
-    type MemoryProfilerStateHooks = {
-      getCleanAppState?: () => Promise<{
-        metamask?: {
-          internalAccounts?: {
-            selectedAccount?: string;
-            accounts?: Record<string, { address?: string }>;
-          };
-        };
-      }>;
-      submitRequestToBackground?: (
-        method: string,
-        args?: unknown[],
-      ) => Promise<unknown>;
-    };
-
-    const hooks = (globalThis as typeof globalThis & {
-      stateHooks?: MemoryProfilerStateHooks;
-    }).stateHooks;
-
-    if (typeof hooks?.submitRequestToBackground !== 'function') {
-      return null;
-    }
-
-    const state = await hooks.getCleanAppState?.();
-    const selectedAccountId =
-      state?.metamask?.internalAccounts?.selectedAccount;
-    const selectedAccount =
-      selectedAccountId &&
-      state?.metamask?.internalAccounts?.accounts?.[selectedAccountId];
-    const from = selectedAccount?.address;
-
-    if (!from) {
-      throw new Error('Unable to resolve the selected wallet account');
-    }
-
-    return await hooks.submitRequestToBackground('messengerCall', [
-      'KeyringController:signPersonalMessage',
-      [
-        {
-          data: messageHex,
-          from,
-        },
-      ],
-    ]);
-  }, WALLET_SIGNATURE_MESSAGE_HEX);
-
-  if (!signature) {
-    throw new Error(
-      'wallet-initiated-signature requires a METAMASK_DEBUG build so the UI can call the internal background test hook',
-    );
-  }
-}
-
-async function ensureTestDappConnected(
-  page: Page,
-  sessionManager: MetaMaskSessionManager,
-  extensionId: string,
-): Promise<Page> {
-  const dappPage = await getOrCreateTestDappPage(page);
-  await dappPage.locator('#connectButton').waitFor({
-    state: 'visible',
-    timeout: CONFIRMATION_WAIT_TIMEOUT_MS,
-  });
-
-  if (await isTestDappConnected(dappPage)) {
-    return dappPage;
-  }
-
-  await dappPage.locator('#connectButton').click();
-
-  const confirmationPage = await sessionManager.waitForNotificationPage(
-    CONFIRMATION_WAIT_TIMEOUT_MS,
-  );
-  await confirmCurrentApproval(confirmationPage);
-  await closeConfirmationPage(confirmationPage);
-  await waitForTestDappConnection(dappPage);
-  await navigateExtensionRoute(page, extensionId, DEFAULT_ROUTE);
-
-  return dappPage;
-}
-
-async function getOrCreateTestDappPage(page: Page): Promise<Page> {
-  const existingPage = page
-    .context()
-    .pages()
-    .find((candidate) => candidate.url().startsWith(TEST_DAPP_URL));
-
-  if (existingPage && !existingPage.isClosed()) {
-    await existingPage.bringToFront();
-    await existingPage.waitForLoadState('domcontentloaded');
-    return existingPage;
-  }
-
-  const dappPage = await page.context().newPage();
-  await dappPage.goto(TEST_DAPP_URL);
-  await dappPage.waitForLoadState('domcontentloaded');
-  return dappPage;
-}
-
-async function isTestDappConnected(dappPage: Page): Promise<boolean> {
-  const accountsText = await dappPage
-    .locator('#accounts')
-    .textContent({ timeout: 1000 })
-    .catch(() => '');
-
-  return ETHEREUM_ADDRESS_REGEX.test(accountsText ?? '');
-}
-
-async function waitForTestDappConnection(dappPage: Page): Promise<void> {
-  await dappPage.waitForFunction(
-    () =>
-      /0x[a-fA-F0-9]{40}/u.test(
-        document.querySelector('#accounts')?.textContent ?? '',
-      ),
-    undefined,
-    { timeout: CONFIRMATION_WAIT_TIMEOUT_MS },
-  );
-}
-
-async function confirmCurrentApproval(page: Page): Promise<void> {
-  await clickScrollToBottomIfPresent(page);
-
-  const confirmButton = await findVisibleLocator(page, [
-    '[data-testid="confirm-footer-button"]',
-    '[data-testid="confirm-btn"]',
-    '[data-testid="confirmation-submit-button"]',
-    '[data-testid="page-container-footer-next"]',
-    'button:has-text("Connect")',
-    'button:has-text("Confirm")',
-    'button:has-text("Sign")',
-  ]);
-
-  await confirmButton.click();
-  await confirmButton.waitFor({ state: 'hidden', timeout: 10000 }).catch(() => {
-    // Some confirmation surfaces remain mounted while the background request
-    // finishes. The click is the important part for this profiler flow.
-  });
-}
-
-async function closeConfirmationPage(page: Page): Promise<void> {
-  await page.waitForTimeout(500);
-  await page.close().catch(() => undefined);
-}
-
-async function clickScrollToBottomIfPresent(page: Page): Promise<void> {
-  const scrollButton = page
-    .locator(
-      '[data-testid="confirm-scroll-to-bottom"], .confirm-scroll-to-bottom__button',
-    )
-    .first();
-  const isVisible = await scrollButton
-    .isVisible({ timeout: 1000 })
-    .catch(() => false);
-
-  if (isVisible) {
-    await scrollButton.click();
-  }
-}
-
-async function findVisibleLocator(
-  page: Page,
-  selectors: string[],
-): Promise<Locator> {
-  for (const selector of selectors) {
-    const locator = page.locator(selector).first();
-    const isVisible = await locator
-      .isVisible({ timeout: 1000 })
-      .catch(() => false);
-
-    if (isVisible) {
-      await locator.waitFor({ state: 'visible', timeout: 10000 });
-      return locator;
-    }
-  }
-
-  throw new Error(
-    `No visible confirmation action found: ${selectors.join(', ')}`,
-  );
 }
 
 export async function navigateExtensionRoute(


### PR DESCRIPTION
## **Description**

Adds a repeatable Chrome DevTools Protocol memory profiler for MetaMask extension flows. The profiler launches the existing LLM/E2E extension environment, optionally unlocks the default wallet, runs configurable route/send flows repeatedly, collects forced-GC heap and DOM counter samples, can write heap snapshots, and can fail on configurable heap/listener/node growth thresholds.

This is tooling-only. It does not include the Popover or Snow memory-leak fixes found during investigation.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Build a test extension if `dist/chrome` is not current: `yarn build:test:webpack`
2. Run `yarn llm:memory -- --help`
3. Run a profiling pass such as `yarn llm:memory -- --iterations 5 --flow send-open-back --sample final --probe cdp --extension-path dist/chrome`
4. Confirm a JSON report is written under `test-artifacts/memory` and prints heap/listener/node deltas

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## Validation

- `yarn test:unit test/e2e/playwright/llm-workflow/memory-profiler.test.ts`
- `yarn lint:changed:fix`
- `yarn llm:memory -- --help`
- `yarn build:test:webpack`