### PR TITLE
fix: NFTs in Send flow overlapping

### DIFF
--- a/ui/pages/confirmations/components/UI/asset/asset.test.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.test.tsx
@@ -191,6 +191,27 @@ describe('NFTAsset', () => {
     expect(image).toHaveAttribute('src', 'https://example.com/collection.png');
   });
 
+  it('renders NFT asset image container with consistent min dimensions when no image is available', () => {
+    mockUseNftImageUrl.mockReturnValue('');
+    const assetWithNoImage = {
+      ...mockNFTERC721Asset,
+      image: undefined,
+      collection: { name: 'Test Collection', imageUrl: undefined },
+    };
+    const { getByTestId, queryByRole } = render(
+      <Asset asset={assetWithNoImage} />,
+    );
+
+    // No image element should be rendered
+    expect(queryByRole('img')).not.toBeInTheDocument();
+
+    // The left-side image container (first child of nft-asset) must keep a
+    // 32px minimum height so the absolutely-positioned network badge stays
+    // anchored within its bounds and doesn't overlap adjacent rows.
+    const nftAsset = getByTestId('nft-asset');
+    expect(nftAsset.firstElementChild).toHaveStyle('min-height: 32px');
+  });
+
   it('renders account type label when account type is provided', () => {
     const assetWithAccountType = {
       ...mockTokenAsset,

--- a/ui/pages/confirmations/components/UI/asset/asset.tsx
+++ b/ui/pages/confirmations/components/UI/asset/asset.tsx
@@ -66,19 +66,19 @@ const NftAsset = ({ asset, onClick, isSelected }: AssetProps) => {
       paddingLeft={4}
       paddingRight={4}
     >
-      <Box marginRight={4} display={Display.Flex} style={{ minWidth: 32 }}>
-        <BadgeWrapper
-          badge={
-            nftData.chainId ? (
-              <AvatarNetwork
-                size={AvatarNetworkSize.Xs}
-                name={nftData.networkName ?? ''}
-                src={nftData.networkImage}
-              />
-            ) : null
-          }
-        >
-          {image || collection?.imageUrl ? (
+      <Box marginRight={4} display={Display.Flex} style={{ minWidth: 32, minHeight: 32 }}>
+        {image || collection?.imageUrl ? (
+          <BadgeWrapper
+            badge={
+              nftData.chainId ? (
+                <AvatarNetwork
+                  size={AvatarNetworkSize.Xs}
+                  name={nftData.networkName ?? ''}
+                  src={nftData.networkImage}
+                />
+              ) : null
+            }
+          >
             <Box
               as="img"
               src={nftItemSrc || (collection?.imageUrl as string)}
@@ -90,8 +90,8 @@ const NftAsset = ({ asset, onClick, isSelected }: AssetProps) => {
                 objectFit: 'cover',
               }}
             />
-          ) : null}
-        </BadgeWrapper>
+          </BadgeWrapper>
+        ) : null}
       </Box>
       <Box
         display={Display.Flex}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Both changes look exactly right. Here is the final summary:

## **Changelog**

CHANGELOG entry: Fixed both changes look exactly right. Here is the final summary:

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/40669

## **Manual testing steps**

1. Hold at least two NFTs, with at least one missing a generated image in the NFTs tab.
2. Click Send.
3. Scroll down to the NFTs section.
4. Notice the NFTs are overlapping in the Send flow.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- AEP_VISUAL_VALIDATION_START -->
## AEP Visual Validation

- Status: Failed
- Run ID: `dc79ddfe-bd7b-47af-9ef4-5a98fb28cdcc`
- LangSmith: https://smith.langchain.com/o/09df0f02-e7c8-47f9-b00a-9e4757168f81/projects/p/metamask-aep

### What was tested
- Visual validation failed: Visual validation of PR #42738 (NFT overlap fix in Send flow) is INCOMPLETE. The sole screenshot artifact (nft-send-flow-no-overlap-1779054332872.png, 60 KB) shows the Send asset-selection page with only token rows — no `nft-asset` elements are present. The target behavior (NftAsset rows with minHeight:32, non-overlapping layout, contained BadgeWrapper) was never rendered and therefore could not be visually confirmed. The execution was blocked at the infrastructure layer: mm CLI v0.3.0 does not support `--preset`, and the HTTP-API path for `fixturePreset:withNFTs` fails because `FixtureCapability.start()` eagerly resolves `__FIXTURE_SUBSTITUTION__CONTRACTnfts` with a hardcoded error-throwing callback before Anvil can deploy the NFT contract. Source-code inspection independently confirmed the two code changes from the PR diff are present in the built extension (`minHeight: 32` added on line 69 of asset.tsx; `BadgeWrapper` now conditional on `image || collection?.imageUrl`), and the companion unit test in asset.test.tsx covers the zero-image collapse scenario. But source inspection is not a substitute for visual evidence: zero assertions from the navigation plan were satisfied by the screenshot.
- metamask-mm-visual-validation: failed. Visual validation of the NFT overlap fix (PR #42738) was blocked by a fundamental incompatibility between the `withNFTs` preset and the installed mm CLI (v0.3.0). The `--preset` flag does not exist in the installed CLI; only `--state`, `--context`, `--extension-path`, `--goal`, `--force`, and `--flow-tags` are supported. Attempts to launch via the HTTP API with `{stateMode:'custom', fixturePreset:'withNFTs'}` failed because the fixture server processes `__FIXTURE_SUBSTITUTION__CONTRACTnfts` substitutions eagerly in `FixtureCapability.start()` using a hardcoded error-throwing `getContractAddress` callback — the `nfts` contract cannot be deployed before the fixture server starts. Fallback to the default fixture state provided a running session, but the default wallet has no NFTs, so no `nft-asset` rows appeared in the Send flow asset selection page. The screenshot at `test-artifacts/screenshots/nft-send-flow-no-overlap-*.png` shows the Send asset selection page with token assets only; no NFT section is visible. Source-code inspection confirmed the PR fix is present: `asset.tsx` line 69 has `style={{ minWidth: 32, minHeight: 32 }}` (adding `minHeight:32` alongside the pre-existing `minWidth:32`) and `BadgeWrapper` is now conditional (only rendered when `image || collection?.imageUrl` is truthy), consistent with the PR diff.

### Screenshots
<details><summary>nft-send-flow-no-overlap-1779054332872.png</summary>

<img alt="nft-send-flow-no-overlap-1779054332872.png" src="http://localhost:3000/v1/runs/dc79ddfe-bd7b-47af-9ef4-5a98fb28cdcc/artifacts/nft-send-flow-no-overlap-1779054332872.png" width="420" />

[Open full-size image](http://localhost:3000/v1/runs/dc79ddfe-bd7b-47af-9ef4-5a98fb28cdcc/artifacts/nft-send-flow-no-overlap-1779054332872.png)

</details>


> Screenshot URLs point at the local control plane. They are clickable from the demo machine, but GitHub may not render them inline unless CONTROL_PLANE_PUBLIC_URL is a public tunnel URL.
<!-- AEP_VISUAL_VALIDATION_END -->
