### PR TITLE
fix: adding alert for network RPC issue

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -9633,6 +9633,13 @@
   "unavailable": {
     "message": "Unavailable"
   },
+  "unavailableNetworkConnection": {
+    "message": "Unavailable network connection"
+  },
+  "unavailableNetworkConnectionDescription": {
+    "message": "The connection with $1 is unreliable. Update network connectivity details before continuing or try again later.",
+    "description": "Message shown when the send page detects the asset's network has an unreliable RPC. $1 is the network name."
+  },
   "unexpectedBehavior": {
     "message": "This behavior is unexpected and should be reported as a bug, even if your accounts are restored."
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -9633,6 +9633,13 @@
   "unavailable": {
     "message": "Unavailable"
   },
+  "unavailableNetworkConnection": {
+    "message": "Unavailable network connection"
+  },
+  "unavailableNetworkConnectionDescription": {
+    "message": "The connection with $1 is unreliable. Update network connectivity details before continuing or try again later.",
+    "description": "Message shown when the send page detects the asset's network has an unreliable RPC. $1 is the network name."
+  },
   "unexpectedBehavior": {
     "message": "This behavior is unexpected and should be reported as a bug, even if your accounts are restored."
   },

--- a/ui/pages/confirmations/components/send/amount-recipient/amount-recipient.test.tsx
+++ b/ui/pages/confirmations/components/send/amount-recipient/amount-recipient.test.tsx
@@ -16,6 +16,7 @@ import * as SendContext from '../../../context/send';
 import * as RecipientValidation from '../../../hooks/send/useRecipientValidation';
 import * as RecipientSelectionMetrics from '../../../hooks/send/metrics/useRecipientSelectionMetrics';
 import * as SendType from '../../../hooks/send/useSendType';
+import * as UnreliableNetworkRpcHook from '../../../hooks/send/useUnreliableNetworkRpc';
 import { AmountRecipient } from './amount-recipient';
 
 const MOCK_ADDRESS = '0xdB055877e6c13b6A6B25aBcAA29B393777dD0a73';
@@ -479,6 +480,37 @@ describe('AmountRecipient', () => {
 
       expect(mockAcknowledgeError).toHaveBeenCalled();
       expect(mockHandleSubmit).toHaveBeenCalled();
+    });
+
+    it('disables the Continue button when the asset network RPC is unreliable', async () => {
+      jest.spyOn(SendContext, 'useSendContext').mockReturnValue({
+        toResolved: MOCK_ADDRESS,
+        asset: EVM_ASSET,
+        chainId: '0x1',
+        from: 'from-address',
+        updateAsset: jest.fn(),
+        updateCurrentPage: jest.fn(),
+        updateTo: jest.fn(),
+        updateToResolved: jest.fn(),
+        updateValue: jest.fn(),
+        value: '1',
+      } as unknown as ReturnType<typeof SendContext.useSendContext>);
+      jest.spyOn(AmountValidation, 'useAmountValidation').mockReturnValue({
+        amountError: undefined,
+      } as unknown as ReturnType<typeof AmountValidation.useAmountValidation>);
+      jest
+        .spyOn(UnreliableNetworkRpcHook, 'useUnreliableNetworkRpc')
+        .mockReturnValue({
+          isUnreliable: true,
+          networkName: 'Ethereum',
+          navigateToEditNetwork: jest.fn(),
+        });
+
+      const { findByRole } = render();
+
+      expect(
+        await findByRole('button', { name: messages.continue.message }),
+      ).toBeDisabled();
     });
 
     it('does not submit when acknowledging from icon-triggered modal', async () => {

--- a/ui/pages/confirmations/components/send/amount-recipient/amount-recipient.tsx
+++ b/ui/pages/confirmations/components/send/amount-recipient/amount-recipient.tsx
@@ -17,16 +17,20 @@ import { useRecipientValidation } from '../../../hooks/send/useRecipientValidati
 import { useRecipientSelectionMetrics } from '../../../hooks/send/metrics/useRecipientSelectionMetrics';
 import { useAmountValidation } from '../../../hooks/send/useAmountValidation';
 import { useSendType } from '../../../hooks/send/useSendType';
+import { useUnreliableNetworkRpc } from '../../../hooks/send/useUnreliableNetworkRpc';
 import { SendHero } from '../../UI/send-hero';
 import { Amount } from '../amount/amount';
 import { Recipient } from '../recipient';
 import { HexData } from '../hex-data';
-import { SendAlertModal } from '../send-alert-modal';
+import { SendAlerts } from '../send-alerts';
 
 export const AmountRecipient = () => {
   const t = useI18nContext();
   const [hexDataError, setHexDataError] = useState<string>();
-  const [isAlertModalOpen, setIsAlertModalOpen] = useState(false);
+  const [isSmartContractAlertOpen, setIsSmartContractAlertOpen] =
+    useState(false);
+  const [shouldSubmitOnAcknowledge, setShouldSubmitOnAcknowledge] =
+    useState(false);
   const { asset, toResolved, nonEVMSubmitError } = useSendContext();
   const { amountError, validateNonEvmAmountAsync } = useAmountValidation();
   const { isNonEvmSendType } = useSendType();
@@ -34,6 +38,7 @@ export const AmountRecipient = () => {
   const { captureAmountSelected } = useAmountSelectionMetrics();
   const { captureRecipientSelected } = useRecipientSelectionMetrics();
   const recipientValidationResult = useRecipientValidation();
+  const { isUnreliable: isNetworkUnreliable } = useUnreliableNetworkRpc();
 
   const { recipientErrorAllowAcknowledge, acknowledgeError } =
     recipientValidationResult;
@@ -44,19 +49,8 @@ export const AmountRecipient = () => {
       !recipientErrorAllowAcknowledge) ||
     Boolean(hexDataError) ||
     Boolean(nonEVMSubmitError);
-  const isDisabled = hasBlockingError || !toResolved;
-
-  const [shouldSubmitOnAcknowledge, setShouldSubmitOnAcknowledge] =
-    useState(false);
-
-  const openAlertModal = useCallback(() => {
-    setShouldSubmitOnAcknowledge(false);
-    setIsAlertModalOpen(true);
-  }, []);
-
-  const handleAlertModalClose = useCallback(() => {
-    setIsAlertModalOpen(false);
-  }, []);
+  const isDisabled =
+    hasBlockingError || !toResolved || isNetworkUnreliable;
 
   const proceedWithSubmit = useCallback(async () => {
     if (isNonEvmSendType) {
@@ -78,8 +72,17 @@ export const AmountRecipient = () => {
     validateNonEvmAmountAsync,
   ]);
 
-  const handleAlertModalAcknowledge = useCallback(async () => {
-    setIsAlertModalOpen(false);
+  const openSmartContractAlert = useCallback(() => {
+    setShouldSubmitOnAcknowledge(false);
+    setIsSmartContractAlertOpen(true);
+  }, []);
+
+  const handleSmartContractClose = useCallback(() => {
+    setIsSmartContractAlertOpen(false);
+  }, []);
+
+  const handleSmartContractAcknowledge = useCallback(async () => {
+    setIsSmartContractAlertOpen(false);
     acknowledgeError();
     if (shouldSubmitOnAcknowledge) {
       await proceedWithSubmit();
@@ -89,7 +92,7 @@ export const AmountRecipient = () => {
   const onClick = useCallback(async () => {
     if (recipientErrorAllowAcknowledge) {
       setShouldSubmitOnAcknowledge(true);
-      setIsAlertModalOpen(true);
+      setIsSmartContractAlertOpen(true);
       return;
     }
     await proceedWithSubmit();
@@ -110,7 +113,7 @@ export const AmountRecipient = () => {
         <SendHero asset={asset as Asset} />
         <Recipient
           recipientValidationResult={recipientValidationResult}
-          onAlertIconClick={openAlertModal}
+          onAlertIconClick={openSmartContractAlert}
         />
         <Amount amountError={amountError} />
         <HexData setHexDataError={setHexDataError} />
@@ -124,12 +127,10 @@ export const AmountRecipient = () => {
       >
         {amountError ?? hexDataError ?? nonEVMSubmitError ?? t('continue')}
       </Button>
-      <SendAlertModal
-        isOpen={isAlertModalOpen}
-        title={t('smartContractAddress')}
-        errorMessage={t('smartContractAddressWarning')}
-        onAcknowledge={handleAlertModalAcknowledge}
-        onClose={handleAlertModalClose}
+      <SendAlerts
+        isSmartContractAlertOpen={isSmartContractAlertOpen}
+        onSmartContractClose={handleSmartContractClose}
+        onSmartContractAcknowledge={handleSmartContractAcknowledge}
       />
     </Box>
   );

--- a/ui/pages/confirmations/components/send/amount-recipient/amount-recipient.tsx
+++ b/ui/pages/confirmations/components/send/amount-recipient/amount-recipient.tsx
@@ -49,8 +49,7 @@ export const AmountRecipient = () => {
       !recipientErrorAllowAcknowledge) ||
     Boolean(hexDataError) ||
     Boolean(nonEVMSubmitError);
-  const isDisabled =
-    hasBlockingError || !toResolved || isNetworkUnreliable;
+  const isDisabled = hasBlockingError || !toResolved || isNetworkUnreliable;
 
   const proceedWithSubmit = useCallback(async () => {
     if (isNonEvmSendType) {

--- a/ui/pages/confirmations/components/send/send-alert-modal/send-alert-modal.test.tsx
+++ b/ui/pages/confirmations/components/send/send-alert-modal/send-alert-modal.test.tsx
@@ -97,8 +97,8 @@ describe('SendAlertModal', () => {
   it('uses the supplied acknowledgeLabel when provided', () => {
     const { getByTestId } = renderComponent({ acknowledgeLabel: 'Update' });
 
-    expect(getByTestId('send-alert-modal-acknowledge-button')).toHaveTextContent(
-      'Update',
-    );
+    expect(
+      getByTestId('send-alert-modal-acknowledge-button'),
+    ).toHaveTextContent('Update');
   });
 });

--- a/ui/pages/confirmations/components/send/send-alert-modal/send-alert-modal.test.tsx
+++ b/ui/pages/confirmations/components/send/send-alert-modal/send-alert-modal.test.tsx
@@ -85,4 +85,20 @@ describe('SendAlertModal', () => {
     const icon = document.querySelector('.mm-icon');
     expect(icon).toBeInTheDocument();
   });
+
+  it('uses the default acknowledge label when acknowledgeLabel is not provided', () => {
+    const { getByTestId } = renderComponent();
+
+    expect(
+      getByTestId('send-alert-modal-acknowledge-button'),
+    ).toHaveTextContent('IUNDERSTAND');
+  });
+
+  it('uses the supplied acknowledgeLabel when provided', () => {
+    const { getByTestId } = renderComponent({ acknowledgeLabel: 'Update' });
+
+    expect(getByTestId('send-alert-modal-acknowledge-button')).toHaveTextContent(
+      'Update',
+    );
+  });
 });

--- a/ui/pages/confirmations/components/send/send-alert-modal/send-alert-modal.tsx
+++ b/ui/pages/confirmations/components/send/send-alert-modal/send-alert-modal.tsx
@@ -30,6 +30,7 @@ export const SendAlertModal = ({
   errorMessage,
   onAcknowledge,
   onClose,
+  acknowledgeLabel,
 }: SendAlertModalProps) => {
   const t = useI18nContext();
 
@@ -76,7 +77,7 @@ export const SendAlertModal = ({
           onCancel={onClose}
           onSubmit={onAcknowledge}
           submitButtonProps={{
-            children: t('iUnderstand'),
+            children: acknowledgeLabel ?? t('iUnderstand'),
             'data-testid': 'send-alert-modal-acknowledge-button',
           }}
           cancelButtonProps={{

--- a/ui/pages/confirmations/components/send/send-alert-modal/send-alert-modal.types.ts
+++ b/ui/pages/confirmations/components/send/send-alert-modal/send-alert-modal.types.ts
@@ -4,4 +4,5 @@ export type SendAlertModalProps = {
   errorMessage: string;
   onAcknowledge: () => void;
   onClose: () => void;
+  acknowledgeLabel?: string;
 };

--- a/ui/pages/confirmations/components/send/send-alerts/index.ts
+++ b/ui/pages/confirmations/components/send/send-alerts/index.ts
@@ -1,0 +1,1 @@
+export { SendAlerts } from './send-alerts';

--- a/ui/pages/confirmations/components/send/send-alerts/send-alerts.test.tsx
+++ b/ui/pages/confirmations/components/send/send-alerts/send-alerts.test.tsx
@@ -45,10 +45,11 @@ describe('SendAlerts', () => {
     );
 
   beforeEach(() => {
-    mockUseI18nContext.mockReturnValue((key: string, substitutions?: string[]) =>
-      substitutions?.length
-        ? `${key.toUpperCase()}::${substitutions.join(',')}`
-        : key.toUpperCase(),
+    mockUseI18nContext.mockReturnValue(
+      (key: string, substitutions?: string[]) =>
+        substitutions?.length
+          ? `${key.toUpperCase()}::${substitutions.join(',')}`
+          : key.toUpperCase(),
     );
     jest.spyOn(SendContext, 'useSendContext').mockReturnValue({
       chainId: '0x1',

--- a/ui/pages/confirmations/components/send/send-alerts/send-alerts.test.tsx
+++ b/ui/pages/confirmations/components/send/send-alerts/send-alerts.test.tsx
@@ -1,0 +1,138 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+
+import mockState from '../../../../../../test/data/mock-state.json';
+import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
+import configureStore from '../../../../../store/store';
+import { useI18nContext } from '../../../../../hooks/useI18nContext';
+import * as SendContext from '../../../context/send';
+import * as UnreliableNetworkRpcHook from '../../../hooks/send/useUnreliableNetworkRpc';
+import { SendAlerts } from './send-alerts';
+
+jest.mock('../../../../../hooks/useI18nContext');
+
+describe('SendAlerts', () => {
+  const mockUseI18nContext = jest.mocked(useI18nContext);
+  const mockStore = configureStore(mockState);
+
+  const defaultProps = {
+    isSmartContractAlertOpen: false,
+    onSmartContractClose: jest.fn(),
+    onSmartContractAcknowledge: jest.fn(),
+  };
+
+  const mockNavigateToEditNetwork = jest.fn();
+
+  const mockUnreliableNetworkRpc = (
+    overrides: Partial<
+      ReturnType<typeof UnreliableNetworkRpcHook.useUnreliableNetworkRpc>
+    > = {},
+  ) => {
+    jest
+      .spyOn(UnreliableNetworkRpcHook, 'useUnreliableNetworkRpc')
+      .mockReturnValue({
+        isUnreliable: false,
+        networkName: undefined,
+        navigateToEditNetwork: mockNavigateToEditNetwork,
+        ...overrides,
+      });
+  };
+
+  const renderComponent = (propOverrides = {}) =>
+    renderWithProvider(
+      <SendAlerts {...defaultProps} {...propOverrides} />,
+      mockStore,
+    );
+
+  beforeEach(() => {
+    mockUseI18nContext.mockReturnValue((key: string, substitutions?: string[]) =>
+      substitutions?.length
+        ? `${key.toUpperCase()}::${substitutions.join(',')}`
+        : key.toUpperCase(),
+    );
+    jest.spyOn(SendContext, 'useSendContext').mockReturnValue({
+      chainId: '0x1',
+    } as unknown as SendContext.SendContextType);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders nothing when neither alert is open', () => {
+    mockUnreliableNetworkRpc();
+    const { queryByTestId } = renderComponent();
+
+    expect(queryByTestId('send-alert-modal-message')).not.toBeInTheDocument();
+  });
+
+  it('auto-opens the network alert when network is unreliable', () => {
+    mockUnreliableNetworkRpc({
+      isUnreliable: true,
+      networkName: 'Ethereum',
+    });
+    const { getByTestId } = renderComponent();
+
+    expect(getByTestId('send-alert-modal-message')).toHaveTextContent(
+      'UNAVAILABLENETWORKCONNECTIONDESCRIPTION::Ethereum',
+    );
+    expect(
+      getByTestId('send-alert-modal-acknowledge-button'),
+    ).toHaveTextContent('UPDATE');
+  });
+
+  it('closes the network alert when cancel is clicked, but does not re-open while chainId unchanged', () => {
+    mockUnreliableNetworkRpc({
+      isUnreliable: true,
+      networkName: 'Ethereum',
+    });
+    const { getByTestId, queryByTestId } = renderComponent();
+
+    fireEvent.click(getByTestId('send-alert-modal-cancel-button'));
+
+    expect(queryByTestId('send-alert-modal-message')).not.toBeInTheDocument();
+  });
+
+  it('navigates to edit network when Update is clicked', () => {
+    mockUnreliableNetworkRpc({
+      isUnreliable: true,
+      networkName: 'Ethereum',
+    });
+    const { getByTestId } = renderComponent();
+
+    fireEvent.click(getByTestId('send-alert-modal-acknowledge-button'));
+
+    expect(mockNavigateToEditNetwork).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the smart contract alert when controlled prop is true', () => {
+    mockUnreliableNetworkRpc();
+    const { getByTestId } = renderComponent({
+      isSmartContractAlertOpen: true,
+    });
+
+    expect(getByTestId('send-alert-modal-message')).toHaveTextContent(
+      'SMARTCONTRACTADDRESSWARNING',
+    );
+    expect(
+      getByTestId('send-alert-modal-acknowledge-button'),
+    ).toHaveTextContent('IUNDERSTAND');
+  });
+
+  it('forwards smart contract alert acknowledge and close callbacks', () => {
+    mockUnreliableNetworkRpc();
+    const onSmartContractAcknowledge = jest.fn();
+    const onSmartContractClose = jest.fn();
+    const { getByTestId } = renderComponent({
+      isSmartContractAlertOpen: true,
+      onSmartContractAcknowledge,
+      onSmartContractClose,
+    });
+
+    fireEvent.click(getByTestId('send-alert-modal-acknowledge-button'));
+    expect(onSmartContractAcknowledge).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(getByTestId('send-alert-modal-cancel-button'));
+    expect(onSmartContractClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/pages/confirmations/components/send/send-alerts/send-alerts.tsx
+++ b/ui/pages/confirmations/components/send/send-alerts/send-alerts.tsx
@@ -1,0 +1,72 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useI18nContext } from '../../../../../hooks/useI18nContext';
+import { useSendContext } from '../../../context/send';
+import { useUnreliableNetworkRpc } from '../../../hooks/send/useUnreliableNetworkRpc';
+import { SendAlertModal } from '../send-alert-modal';
+
+type SendAlertsProps = {
+  isSmartContractAlertOpen: boolean;
+  onSmartContractClose: () => void;
+  onSmartContractAcknowledge: () => void;
+};
+
+export const SendAlerts = ({
+  isSmartContractAlertOpen,
+  onSmartContractClose,
+  onSmartContractAcknowledge,
+}: SendAlertsProps) => {
+  const t = useI18nContext();
+  const { chainId } = useSendContext();
+  const {
+    isUnreliable: isNetworkUnreliable,
+    networkName: unreliableNetworkName,
+    navigateToEditNetwork,
+  } = useUnreliableNetworkRpc();
+
+  const [isNetworkAlertOpen, setIsNetworkAlertOpen] = useState(false);
+  const lastAutoOpenedChainIdRef = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (isNetworkUnreliable) {
+      if (lastAutoOpenedChainIdRef.current !== chainId) {
+        setIsNetworkAlertOpen(true);
+        lastAutoOpenedChainIdRef.current = chainId;
+      }
+    } else {
+      lastAutoOpenedChainIdRef.current = undefined;
+      setIsNetworkAlertOpen(false);
+    }
+  }, [chainId, isNetworkUnreliable]);
+
+  const handleNetworkClose = useCallback(() => {
+    setIsNetworkAlertOpen(false);
+  }, []);
+
+  const handleNetworkAcknowledge = useCallback(() => {
+    setIsNetworkAlertOpen(false);
+    navigateToEditNetwork();
+  }, [navigateToEditNetwork]);
+
+  return (
+    <>
+      <SendAlertModal
+        isOpen={isNetworkAlertOpen}
+        title={t('unavailableNetworkConnection')}
+        errorMessage={t('unavailableNetworkConnectionDescription', [
+          unreliableNetworkName ?? '',
+        ])}
+        acknowledgeLabel={t('update')}
+        onAcknowledge={handleNetworkAcknowledge}
+        onClose={handleNetworkClose}
+      />
+      <SendAlertModal
+        isOpen={isSmartContractAlertOpen}
+        title={t('smartContractAddress')}
+        errorMessage={t('smartContractAddressWarning')}
+        onAcknowledge={onSmartContractAcknowledge}
+        onClose={onSmartContractClose}
+      />
+    </>
+  );
+};

--- a/ui/pages/confirmations/hooks/send/useUnreliableNetworkRpc.test.ts
+++ b/ui/pages/confirmations/hooks/send/useUnreliableNetworkRpc.test.ts
@@ -1,0 +1,128 @@
+import { act } from '@testing-library/react';
+import { NetworkStatus } from '@metamask/network-controller';
+
+import mockState from '../../../../../test/data/mock-state.json';
+import { renderHookWithProvider } from '../../../../../test/lib/render-helpers-navigate';
+import { NETWORKS_ROUTE } from '../../../../helpers/constants/routes';
+import * as SendContext from '../../context/send';
+import { setEditedNetwork } from '../../../../store/actions';
+import { useUnreliableNetworkRpc } from './useUnreliableNetworkRpc';
+
+const mockNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useLocation: () => ({ pathname: '/send/asset' }),
+  useNavigate: () => mockNavigate,
+  useSearchParams: () => [{ get: () => null }],
+}));
+
+jest.mock('../../../../store/actions', () => {
+  const actual = jest.requireActual('../../../../store/actions');
+  return {
+    ...actual,
+    setEditedNetwork: jest.fn(() => ({ type: 'SET_EDITED_NETWORK_TEST' })),
+  };
+});
+
+const mockSetEditedNetwork = jest.mocked(setEditedNetwork);
+
+const mockSendContext = (chainId: string | undefined) => {
+  jest.spyOn(SendContext, 'useSendContext').mockReturnValue({
+    chainId,
+  } as unknown as SendContext.SendContextType);
+};
+
+const buildState = (overrides: {
+  status?: NetworkStatus;
+}) => ({
+  ...mockState,
+  metamask: {
+    ...mockState.metamask,
+    networksMetadata: {
+      ...mockState.metamask.networksMetadata,
+      // matches networkClientId of chainId 0x5 (Goerli) in mock-state
+      goerli: {
+        EIPS: { 1559: true },
+        status: overrides.status ?? NetworkStatus.Available,
+      },
+    },
+  },
+});
+
+describe('useUnreliableNetworkRpc', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns isUnreliable=false when chainId is not a hex (non-EVM)', () => {
+    mockSendContext('bip122:000000000019d6689c085ae165831e93');
+    const { result } = renderHookWithProvider(
+      useUnreliableNetworkRpc,
+      buildState({ status: NetworkStatus.Unknown }),
+    );
+
+    expect(result.current.isUnreliable).toBe(false);
+    expect(result.current.networkName).toBeUndefined();
+  });
+
+  it('returns isUnreliable=false when network is available', () => {
+    mockSendContext('0x5');
+    const { result } = renderHookWithProvider(
+      useUnreliableNetworkRpc,
+      buildState({ status: NetworkStatus.Available }),
+    );
+
+    expect(result.current.isUnreliable).toBe(false);
+    expect(result.current.networkName).toBe('Goerli');
+  });
+
+  it('returns isUnreliable=true when network status is not Available', () => {
+    mockSendContext('0x5');
+    const { result } = renderHookWithProvider(
+      useUnreliableNetworkRpc,
+      buildState({ status: NetworkStatus.Unavailable }),
+    );
+
+    expect(result.current.isUnreliable).toBe(true);
+    expect(result.current.networkName).toBe('Goerli');
+  });
+
+  it('returns isUnreliable=false when the chain has no network configuration', () => {
+    mockSendContext('0xdeadbeef');
+    const { result } = renderHookWithProvider(useUnreliableNetworkRpc, mockState);
+
+    expect(result.current.isUnreliable).toBe(false);
+    expect(result.current.networkName).toBeUndefined();
+  });
+
+  it('navigateToEditNetwork dispatches setEditedNetwork and navigates', () => {
+    mockSendContext('0x5');
+    const { result } = renderHookWithProvider(
+      useUnreliableNetworkRpc,
+      buildState({ status: NetworkStatus.Unavailable }),
+    );
+
+    act(() => {
+      result.current.navigateToEditNetwork();
+    });
+
+    expect(mockSetEditedNetwork).toHaveBeenCalledWith({
+      chainId: '0x5',
+      trackRpcUpdateFromBanner: true,
+    });
+    expect(mockNavigate).toHaveBeenCalledWith(NETWORKS_ROUTE);
+  });
+
+  it('navigateToEditNetwork is a no-op for non-hex chainId', () => {
+    mockSendContext('bip122:000000000019d6689c085ae165831e93');
+    const { result } = renderHookWithProvider(useUnreliableNetworkRpc, mockState);
+
+    act(() => {
+      result.current.navigateToEditNetwork();
+    });
+
+    expect(mockSetEditedNetwork).not.toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/ui/pages/confirmations/hooks/send/useUnreliableNetworkRpc.test.ts
+++ b/ui/pages/confirmations/hooks/send/useUnreliableNetworkRpc.test.ts
@@ -33,9 +33,7 @@ const mockSendContext = (chainId: string | undefined) => {
   } as unknown as SendContext.SendContextType);
 };
 
-const buildState = (overrides: {
-  status?: NetworkStatus;
-}) => ({
+const buildState = (overrides: { status?: NetworkStatus }) => ({
   ...mockState,
   metamask: {
     ...mockState.metamask,
@@ -90,7 +88,10 @@ describe('useUnreliableNetworkRpc', () => {
 
   it('returns isUnreliable=false when the chain has no network configuration', () => {
     mockSendContext('0xdeadbeef');
-    const { result } = renderHookWithProvider(useUnreliableNetworkRpc, mockState);
+    const { result } = renderHookWithProvider(
+      useUnreliableNetworkRpc,
+      mockState,
+    );
 
     expect(result.current.isUnreliable).toBe(false);
     expect(result.current.networkName).toBeUndefined();
@@ -116,7 +117,10 @@ describe('useUnreliableNetworkRpc', () => {
 
   it('navigateToEditNetwork is a no-op for non-hex chainId', () => {
     mockSendContext('bip122:000000000019d6689c085ae165831e93');
-    const { result } = renderHookWithProvider(useUnreliableNetworkRpc, mockState);
+    const { result } = renderHookWithProvider(
+      useUnreliableNetworkRpc,
+      mockState,
+    );
 
     act(() => {
       result.current.navigateToEditNetwork();

--- a/ui/pages/confirmations/hooks/send/useUnreliableNetworkRpc.ts
+++ b/ui/pages/confirmations/hooks/send/useUnreliableNetworkRpc.ts
@@ -1,0 +1,66 @@
+import { useCallback, useMemo } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
+import { isHexString } from 'ethereumjs-util';
+import { Hex } from '@metamask/utils';
+import { NetworkStatus } from '@metamask/network-controller';
+
+import {
+  getNetworkConfigurationsByChainId,
+  getNetworksMetadata,
+} from '../../../../../shared/lib/selectors/networks';
+import { setEditedNetwork } from '../../../../store/actions';
+import { NETWORKS_ROUTE } from '../../../../helpers/constants/routes';
+import { useSendContext } from '../../context/send';
+
+export const useUnreliableNetworkRpc = () => {
+  const dispatch = useDispatch();
+  const navigate = useNavigate();
+  const { chainId } = useSendContext();
+  const networkConfigurationsByChainId = useSelector(
+    getNetworkConfigurationsByChainId,
+  );
+  const networksMetadata = useSelector(getNetworksMetadata);
+
+  const { isUnreliable, networkName } = useMemo(() => {
+    if (!chainId || !isHexString(chainId)) {
+      return { isUnreliable: false, networkName: undefined };
+    }
+    const networkConfiguration =
+      networkConfigurationsByChainId[chainId as Hex];
+    if (!networkConfiguration) {
+      return { isUnreliable: false, networkName: undefined };
+    }
+    const { rpcEndpoints, defaultRpcEndpointIndex, name } =
+      networkConfiguration;
+    const rpcEndpoint = rpcEndpoints[defaultRpcEndpointIndex];
+    if (!rpcEndpoint) {
+      return { isUnreliable: false, networkName: name };
+    }
+    const status = networksMetadata[rpcEndpoint.networkClientId]?.status;
+    return {
+      isUnreliable:
+        status !== undefined && status !== NetworkStatus.Available,
+      networkName: name,
+    };
+  }, [chainId, networkConfigurationsByChainId, networksMetadata]);
+
+  const navigateToEditNetwork = useCallback(() => {
+    if (!chainId || !isHexString(chainId)) {
+      return;
+    }
+    dispatch(
+      setEditedNetwork({
+        chainId,
+        trackRpcUpdateFromBanner: true,
+      }),
+    );
+    navigate(NETWORKS_ROUTE);
+  }, [chainId, dispatch, navigate]);
+
+  return {
+    isUnreliable,
+    networkName,
+    navigateToEditNetwork,
+  };
+};

--- a/ui/pages/confirmations/hooks/send/useUnreliableNetworkRpc.ts
+++ b/ui/pages/confirmations/hooks/send/useUnreliableNetworkRpc.ts
@@ -26,8 +26,7 @@ export const useUnreliableNetworkRpc = () => {
     if (!chainId || !isHexString(chainId)) {
       return { isUnreliable: false, networkName: undefined };
     }
-    const networkConfiguration =
-      networkConfigurationsByChainId[chainId as Hex];
+    const networkConfiguration = networkConfigurationsByChainId[chainId as Hex];
     if (!networkConfiguration) {
       return { isUnreliable: false, networkName: undefined };
     }
@@ -39,8 +38,7 @@ export const useUnreliableNetworkRpc = () => {
     }
     const status = networksMetadata[rpcEndpoint.networkClientId]?.status;
     return {
-      isUnreliable:
-        status !== undefined && status !== NetworkStatus.Available,
+      isUnreliable: status !== undefined && status !== NetworkStatus.Available,
       networkName: name,
     };
   }, [chainId, networkConfigurationsByChainId, networksMetadata]);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Add alert on send page if RPC url is not correct.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1128

## **Manual testing steps**

1. Check that RPC is not working on a network
2. Trigger send and notice alert

## **Screenshots/Recordings**

https://github.com/user-attachments/assets/55d32e04-404d-411b-af5c-0ed1257c4367

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes send-flow gating by disabling submission and auto-showing a new alert based on network RPC health, which could unintentionally block sending on some networks if metadata/status mapping is wrong.
> 
> **Overview**
> Adds detection of *unreliable RPC connectivity* during the send confirmation flow via a new `useUnreliableNetworkRpc` hook (based on `networksMetadata` status for the selected chain’s default RPC) and uses it to disable the **Continue** button.
> 
> Introduces a new `SendAlerts` wrapper that auto-opens a network-connection modal (with an **Update** CTA that routes users to network settings via `setEditedNetwork`) while retaining the existing smart-contract recipient warning modal. Updates `SendAlertModal` to support a customizable acknowledge button label and adds i18n strings and tests covering the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61b9bbdbc843e5077bae04ef19b0694bc8d2e001. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->