### PR TITLE
fix: cache safe chains hook result

### DIFF
--- a/ui/components/multichain/networks-form/use-safe-chains.test.ts
+++ b/ui/components/multichain/networks-form/use-safe-chains.test.ts
@@ -1,6 +1,7 @@
 import * as FetchWithCacheModule from '../../../../shared/lib/fetch-with-cache';
 import { renderHookWithProviderTyped } from '../../../../test/lib/render-helpers-navigate';
 import {
+  resetSafeChainsCacheForTesting,
   rpcIdentifierUtility,
   SafeChain,
   useSafeChains,
@@ -94,6 +95,7 @@ describe('rpcIdentifierUtility', () => {
 describe('useSafeChains', () => {
   beforeEach(() => {
     jest.resetAllMocks();
+    resetSafeChainsCacheForTesting();
   });
 
   const arrange = () => {
@@ -139,6 +141,22 @@ describe('useSafeChains', () => {
 
     await waitFor(() => expect(result.current.safeChains).toHaveLength(1));
     expect(mockFetchWithCache).toHaveBeenCalled();
+  });
+
+  it('reuses cached safe chains across hook mounts', async () => {
+    const { result, mockFetchWithCache, mockState, unmount, waitFor } =
+      arrangeAct();
+
+    await waitFor(() => expect(result.current.safeChains).toHaveLength(1));
+    unmount();
+
+    const secondHook = renderHookWithProviderTyped(
+      () => useSafeChains(),
+      mockState,
+    );
+
+    expect(secondHook.result.current.safeChains).toHaveLength(1);
+    expect(mockFetchWithCache).toHaveBeenCalledTimes(1);
   });
 
   it('does not fetch safe chains when useSafeChainsListValidation is disabled', async () => {

--- a/ui/components/multichain/networks-form/use-safe-chains.ts
+++ b/ui/components/multichain/networks-form/use-safe-chains.ts
@@ -15,43 +15,89 @@ export type SafeChain = {
   rpc: string[];
 };
 
+type SafeChainsState = {
+  safeChains?: SafeChain[];
+  error?: Error;
+};
+
+let safeChainsState: SafeChainsState = { safeChains: [] };
+let safeChainsRequest: Promise<SafeChainsState> | null = null;
+let safeChainsCacheTime = 0;
+
+const safeChainsSubscribers = new Set<(state: SafeChainsState) => void>();
+
+const notifySafeChainsSubscribers = () => {
+  for (const subscriber of safeChainsSubscribers) {
+    subscriber(safeChainsState);
+  }
+};
+
+const loadSafeChains = () => {
+  if (
+    safeChainsCacheTime &&
+    Date.now() - safeChainsCacheTime < DAY &&
+    safeChainsState.safeChains
+  ) {
+    return Promise.resolve(safeChainsState);
+  }
+
+  if (!safeChainsRequest) {
+    safeChainsRequest = fetchWithCache({
+      url: CHAIN_SPEC_URL,
+      functionName: 'getSafeChainsList',
+      allowStale: true,
+      cacheOptions: { cacheRefreshTime: DAY },
+    })
+      .then((response) => ({ safeChains: response as SafeChain[] }))
+      .catch((error: Error) => ({ error }))
+      .then((nextState) => {
+        safeChainsState = nextState;
+        if (nextState.safeChains) {
+          safeChainsCacheTime = Date.now();
+        }
+        notifySafeChainsSubscribers();
+        return nextState;
+      })
+      .finally(() => {
+        safeChainsRequest = null;
+      });
+  }
+
+  return safeChainsRequest;
+};
+
 export const useSafeChains = () => {
   const useSafeChainsListValidation = useSelector(
     getUseSafeChainsListValidation,
   );
 
-  const [safeChains, setSafeChains] = useState<{
-    safeChains?: SafeChain[];
-    error?: Error;
-  }>({ safeChains: [] });
+  const [safeChains, setSafeChains] = useState<SafeChainsState>(() =>
+    useSafeChainsListValidation ? safeChainsState : { safeChains: [] },
+  );
 
   useEffect(() => {
-    let isMounted = true;
-    if (useSafeChainsListValidation) {
-      fetchWithCache({
-        url: CHAIN_SPEC_URL,
-        functionName: 'getSafeChainsList',
-        allowStale: true,
-        cacheOptions: { cacheRefreshTime: DAY },
-      })
-        .then((response) => {
-          if (isMounted) {
-            setSafeChains({ safeChains: response });
-          }
-        })
-        .catch((error) => {
-          if (isMounted) {
-            setSafeChains({ error });
-          }
-        });
+    if (!useSafeChainsListValidation) {
+      setSafeChains({ safeChains: [] });
+      return undefined;
     }
 
+    safeChainsSubscribers.add(setSafeChains);
+    setSafeChains(safeChainsState);
+    loadSafeChains().catch(() => undefined);
+
     return () => {
-      isMounted = false;
+      safeChainsSubscribers.delete(setSafeChains);
     };
   }, [useSafeChainsListValidation]);
 
   return safeChains;
+};
+
+export const resetSafeChainsCacheForTesting = () => {
+  safeChainsState = { safeChains: [] };
+  safeChainsRequest = null;
+  safeChainsCacheTime = 0;
+  safeChainsSubscribers.clear();
 };
 
 export const getSafeNativeCurrencySymbol = (

--- a/ui/components/multichain/networks-form/use-safe-chains.ts
+++ b/ui/components/multichain/networks-form/use-safe-chains.ts
@@ -48,8 +48,12 @@ const loadSafeChains = () => {
       allowStale: true,
       cacheOptions: { cacheRefreshTime: DAY },
     })
-      .then((response) => ({ safeChains: response as SafeChain[] }))
-      .catch((error: Error) => ({ error }))
+      .then(
+        (response): SafeChainsState => ({
+          safeChains: response as SafeChain[],
+        }),
+      )
+      .catch((error: Error): SafeChainsState => ({ error }))
       .then((nextState) => {
         safeChainsState = nextState;
         if (nextState.safeChains) {


### PR DESCRIPTION
## **Description**

Caches the Safe chains hook result in module memory for the same one-day refresh window used by `fetchWithCache`. Multiple mounted hook instances now share both the in-flight request and the resolved `safeChains` object, and only currently mounted hooks subscribe to updates.

This reduces route churn retaining fresh large `chains.json` arrays under AccountOverview while leaving the existing network validation behavior unchanged.

Profiler evidence from 30 iterations:

- `send-route`: +72.46 MiB before -> +28.89 MiB after
- `settings-route`: +79.15 MiB before -> +34.66 MiB after
- `send-open-back`: +83.83 MiB before -> +46.56 MiB after

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

<!--
## **Screenshots/Recordings**

If applicable, add screenshots and/or recordings to visualize the before and after of your change.

### **Before**

[screenshots/recordings]

### **After**

[screenshots/recordings]
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces module-level caching and a subscriber fan-out for `useSafeChains`, which can cause subtle staleness or state-sharing issues if cache invalidation/subscription cleanup is wrong; impact is limited to safe chain list fetching/validation UI behavior.
> 
> **Overview**
> **Caches Safe chain list data across `useSafeChains` hook instances.** The hook now keeps a module-level `{safeChains,error}` state, shares a single in-flight `fetchWithCache` request, and notifies only currently mounted hook subscribers when the request resolves.
> 
> Adds a 1-day TTL aligned with `fetchWithCache` refresh timing and exposes `resetSafeChainsCacheForTesting()` to clear the module cache; tests are updated to reset the cache between cases and to assert cached reuse across unmount/remount without additional fetches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44b3f56a38ba29360ce89649e31987c3bda8b779. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->