### PR TITLE
fix: avoid react image listener retention

### DIFF
--- a/test/e2e/page-objects/pages/home/asset-list.ts
+++ b/test/e2e/page-objects/pages/home/asset-list.ts
@@ -470,12 +470,24 @@ class AssetListPage {
     console.log('Getting network icon details from sort-by-networks button');
     const iconDetails = await this.driver.executeScript(`
       const button = document.querySelector('[data-testid="sort-by-networks"]');
-      const avatarNetwork = button?.querySelector('.mm-avatar-network img');
-      return avatarNetwork ? {
-        src: avatarNetwork.src,
-        alt: avatarNetwork.alt,
-        isVisible: avatarNetwork.offsetWidth > 0 && avatarNetwork.offsetHeight > 0
-      } : null;
+      const avatarNetwork = button?.querySelector('.mm-avatar-network__network-image');
+
+      if (!avatarNetwork) {
+        return null;
+      }
+
+      const backgroundImage = getComputedStyle(avatarNetwork).backgroundImage || avatarNetwork.style.backgroundImage;
+      const backgroundImageUrl = backgroundImage.match(/^url\\(["']?(.*?)["']?\\)$/)?.[1] ?? '';
+      const isImage = avatarNetwork instanceof HTMLImageElement;
+      const rect = avatarNetwork.getBoundingClientRect();
+
+      return {
+        src: isImage ? avatarNetwork.src : backgroundImageUrl,
+        alt: isImage
+          ? avatarNetwork.alt
+          : avatarNetwork.getAttribute('aria-label') || '',
+        isVisible: rect.width > 0 && rect.height > 0,
+      };
     `);
     return iconDetails as {
       src: string;

--- a/test/e2e/page-objects/pages/home/asset-list.ts
+++ b/test/e2e/page-objects/pages/home/asset-list.ts
@@ -478,7 +478,7 @@ class AssetListPage {
 
       const backgroundImage = getComputedStyle(avatarNetwork).backgroundImage || avatarNetwork.style.backgroundImage;
       const backgroundImageUrl = backgroundImage.match(/^url\\(["']?(.*?)["']?\\)$/)?.[1] ?? '';
-      const isImage = avatarNetwork instanceof HTMLImageElement;
+      const isImage = avatarNetwork.tagName.toLowerCase() === 'img';
       const rect = avatarNetwork.getBoundingClientRect();
 
       return {

--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -42,7 +42,8 @@ class HomePage {
     css: '.mm-banner-base',
   };
 
-  private readonly bitcoinAccountIcon = 'img[src="./images/bitcoin-logo.svg"]';
+  private readonly bitcoinAccountIcon =
+    '.mm-avatar-network__network-image[style*="bitcoin-logo.svg"], .mm-avatar-token__token-image[style*="bitcoin-logo.svg"]';
 
   protected readonly bridgeButton: string =
     '[data-testid="eth-overview-bridge"]';
@@ -84,7 +85,8 @@ class HomePage {
 
   protected readonly sendButton: string = '[data-testid="eth-overview-send"]';
 
-  private readonly solanaAccountIcon = 'img[src="./images/solana-logo.svg"]';
+  private readonly solanaAccountIcon =
+    '.mm-avatar-network__network-image[style*="solana-logo.svg"], .mm-avatar-token__token-image[style*="solana-logo.svg"]';
 
   protected readonly swapButton: string = '[data-testid="eth-overview-swap"]';
 

--- a/ui/components/app/assets/defi-list/defi-list.test.tsx
+++ b/ui/components/app/assets/defi-list/defi-list.test.tsx
@@ -165,10 +165,9 @@ describe('DeFiDetailsPage', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByAltText('stETH logo')).toHaveAttribute(
-        'src',
-        'logo.png',
-      );
+      expect(screen.getByRole('img', { name: 'stETH logo' })).toHaveStyle({
+        backgroundImage: 'url(logo.png)',
+      });
       expect(screen.getByText('Lido')).toBeInTheDocument();
       expect(screen.getByText('$20,000.00')).toBeInTheDocument();
       expect(screen.getByText('stETH only')).toBeInTheDocument();
@@ -180,10 +179,9 @@ describe('DeFiDetailsPage', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByAltText('USDC logo')).toHaveAttribute(
-        'src',
-        'logo.png',
-      );
+      expect(screen.getByRole('img', { name: 'USDC logo' })).toHaveStyle({
+        backgroundImage: 'url(logo.png)',
+      });
       expect(screen.getByText('mountain-protocol')).toBeInTheDocument();
       const marketValueElement = screen.getByTestId('defi-list-market-value');
       expect(marketValueElement).toBeInTheDocument();

--- a/ui/components/app/assets/defi-list/defi-tab.test.tsx
+++ b/ui/components/app/assets/defi-list/defi-tab.test.tsx
@@ -115,17 +115,17 @@ describe('DefiList', () => {
     });
 
     await waitFor(() => {
-      const image = screen.getByAltText('stETH logo');
+      const image = screen.getByRole('img', { name: 'stETH logo' });
 
       expect(screen.getByTestId('defi-list-market-value')).toHaveTextContent(
         '$20,000.00',
       );
 
       expect(image).toBeInTheDocument();
-      expect(image).toHaveAttribute(
-        'src',
-        'https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84/logo.png',
-      );
+      expect(image).toHaveStyle({
+        backgroundImage:
+          'url(https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84/logo.png)',
+      });
 
       expect(screen.getByTestId('avatar-group')).toBeInTheDocument();
       expect(screen.getByTestId('sort-by-popover-toggle')).toBeInTheDocument();

--- a/ui/components/app/assets/token-cell/__snapshots__/token-cell.test.tsx.snap
+++ b/ui/components/app/assets/token-cell/__snapshots__/token-cell.test.tsx.snap
@@ -17,10 +17,11 @@ exports[`Token Cell should match snapshot 1`] = `
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-token mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-section mm-box--rounded-full"
         >
-          <img
-            alt="TEST logo"
+          <span
+            aria-label="TEST logo"
             class="mm-avatar-token__token-image"
-            src="./images/test_image.svg"
+            role="img"
+            style="background-image: url(./images/test_image.svg);"
           />
         </div>
         <div
@@ -29,10 +30,11 @@ exports[`Token Cell should match snapshot 1`] = `
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-section mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-2 box--border-style-solid"
           >
-            <img
-              alt="network logo"
+            <span
+              aria-label="network logo"
               class="mm-avatar-network__network-image"
-              src="./images/eth_logo.svg"
+              role="img"
+              style="background-image: url(./images/eth_logo.svg);"
             />
           </div>
         </div>

--- a/ui/components/app/assets/token-cell/token-cell.test.tsx
+++ b/ui/components/app/assets/token-cell/token-cell.test.tsx
@@ -259,16 +259,18 @@ describe('Token Cell', () => {
   });
 
   it('should render the correct token and filter by symbol and address', () => {
-    const { getByTestId, getByAltText } = renderWithProvider(
+    const { getByTestId, getByRole } = renderWithProvider(
       <TokenCell {...(props as TokenCellProps)} />,
       mockStore,
     );
 
-    const image = getByAltText('TEST logo');
+    const image = getByRole('img', { name: 'TEST logo' });
 
     expect(getByTestId('multichain-token-list-item-value')).toBeInTheDocument();
     expect(image).toBeInTheDocument();
-    expect(image).toHaveAttribute('src', './images/test_image.svg');
+    expect(image).toHaveStyle({
+      backgroundImage: 'url(./images/test_image.svg)',
+    });
   });
 
   it('should render amount with the correct format', () => {

--- a/ui/components/app/balance-empty-state/balance-empty-state.tsx
+++ b/ui/components/app/balance-empty-state/balance-empty-state.tsx
@@ -116,11 +116,18 @@ export const BalanceEmptyState: React.FC<BalanceEmptyStateProps> = ({
           flexDirection={BoxFlexDirection.Column}
           alignItems={BoxAlignItems.Center}
         >
-          <img
-            src="./images/bank-transfer.png"
-            alt={t('fundYourWallet')}
-            width="100"
-            height="100"
+          <span
+            role="img"
+            aria-label={t('fundYourWallet')}
+            style={{
+              backgroundImage: 'url("./images/bank-transfer.png")',
+              backgroundPosition: 'center',
+              backgroundRepeat: 'no-repeat',
+              backgroundSize: 'contain',
+              display: 'block',
+              height: 100,
+              width: 100,
+            }}
           />
         </Box>
         <Text

--- a/ui/components/app/import-token/network-filter-import-token/network-filter-dropdown/__snapshots__/index.test.tsx.snap
+++ b/ui/components/app/import-token/network-filter-import-token/network-filter-dropdown/__snapshots__/index.test.tsx.snap
@@ -23,10 +23,11 @@ exports[`NetworkFilterDropdown should render correctly 1`] = `
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
         >
-          <img
-            alt="mockCurrentNetworkImageUrl logo"
+          <span
+            aria-label="mockCurrentNetworkImageUrl logo"
             class="mm-avatar-network__network-image"
-            src="mockCurrentNetworkImageUrl"
+            role="img"
+            style="background-image: url(mockCurrentNetworkImageUrl);"
           />
         </div>
       </div>

--- a/ui/components/app/import-token/network-filter-import-token/network-filter-dropdown/network-filter-drop-down-item/__snapshots__/index.test.tsx.snap
+++ b/ui/components/app/import-token/network-filter-import-token/network-filter-dropdown/network-filter-drop-down-item/__snapshots__/index.test.tsx.snap
@@ -20,10 +20,11 @@ exports[`NetworkFilterDropdownItem renders current network correctly and matches
       <div
         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
       >
-        <img
-          alt="http://current-network.com logo"
+        <span
+          aria-label="http://current-network.com logo"
           class="mm-avatar-network__network-image"
-          src="http://current-network.com"
+          role="img"
+          style="background-image: url(http://current-network.com);"
         />
       </div>
     </div>

--- a/ui/components/app/multi-rpc-edit-modal/__snapshots__/multi-rpc-edit-modal.test.tsx.snap
+++ b/ui/components/app/multi-rpc-edit-modal/__snapshots__/multi-rpc-edit-modal.test.tsx.snap
@@ -65,10 +65,11 @@ exports[`MultiRpcEditModal renders correctly with required props 1`] = `
                     <div
                       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                     >
-                      <img
-                        alt="Ethereum Mainnet logo"
+                      <span
+                        aria-label="Ethereum Mainnet logo"
                         class="mm-avatar-network__network-image"
-                        src="./images/eth_logo.svg"
+                        role="img"
+                        style="background-image: url(./images/eth_logo.svg);"
                       />
                     </div>
                     <div

--- a/ui/components/app/multi-rpc-edit-modal/network-list-item/__snapshots__/network-list-item.test.tsx.snap
+++ b/ui/components/app/multi-rpc-edit-modal/network-list-item/__snapshots__/network-list-item.test.tsx.snap
@@ -11,10 +11,11 @@ exports[`NetworkListItem renders correctly with required props 1`] = `
       <div
         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
       >
-        <img
-          alt="Ethereum Mainnet logo"
+        <span
+          aria-label="Ethereum Mainnet logo"
           class="mm-avatar-network__network-image"
-          src="./images/eth_logo.svg"
+          role="img"
+          style="background-image: url(./images/eth_logo.svg);"
         />
       </div>
       <div

--- a/ui/components/app/musd/musd-buy-get-cta.test.tsx
+++ b/ui/components/app/musd/musd-buy-get-cta.test.tsx
@@ -331,7 +331,9 @@ describe('MusdBuyGetCta', () => {
       );
 
       expect(screen.getByTestId('musd-buy-get-cta-icon')).toBeInTheDocument();
-      expect(screen.getByAltText('mUSD logo')).toBeInTheDocument();
+      expect(
+        screen.getByRole('img', { name: 'mUSD logo' }),
+      ).toBeInTheDocument();
     });
 
     it('renders network badge when selectedChainId is provided', () => {
@@ -344,7 +346,9 @@ describe('MusdBuyGetCta', () => {
         store,
       );
 
-      expect(screen.getByAltText('Ethereum Mainnet logo')).toBeInTheDocument();
+      expect(
+        screen.getByRole('img', { name: 'Ethereum Mainnet logo' }),
+      ).toBeInTheDocument();
     });
 
     it('does not render network badge when selectedChainId is null', () => {
@@ -359,7 +363,7 @@ describe('MusdBuyGetCta', () => {
 
       expect(screen.getByTestId('musd-buy-get-cta-icon')).toBeInTheDocument();
       expect(
-        screen.queryByAltText('Ethereum Mainnet logo'),
+        screen.queryByRole('img', { name: 'Ethereum Mainnet logo' }),
       ).not.toBeInTheDocument();
     });
   });

--- a/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/account-selector.test.ts.snap
+++ b/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/account-selector.test.ts.snap
@@ -222,10 +222,11 @@ exports[`SnapUIAccountSelector renders an account selector 1`] = `
                                     <div
                                       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                                     >
-                                      <img
-                                        alt="Polygon logo"
+                                      <span
+                                        aria-label="Polygon logo"
                                         class="mm-avatar-network__network-image"
-                                        src="./images/pol-token.svg"
+                                        role="img"
+                                        style="background-image: url(./images/pol-token.svg);"
                                       />
                                     </div>
                                   </div>
@@ -236,10 +237,11 @@ exports[`SnapUIAccountSelector renders an account selector 1`] = `
                                     <div
                                       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                                     >
-                                      <img
-                                        alt="BNB Chain logo"
+                                      <span
+                                        aria-label="BNB Chain logo"
                                         class="mm-avatar-network__network-image"
-                                        src="./images/bnb.svg"
+                                        role="img"
+                                        style="background-image: url(./images/bnb.svg);"
                                       />
                                     </div>
                                   </div>
@@ -260,10 +262,11 @@ exports[`SnapUIAccountSelector renders an account selector 1`] = `
                                     <div
                                       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                                     >
-                                      <img
-                                        alt="Custom Mainnet RPC logo"
+                                      <span
+                                        aria-label="Custom Mainnet RPC logo"
                                         class="mm-avatar-network__network-image"
-                                        src="./images/eth_logo.svg"
+                                        role="img"
+                                        style="background-image: url(./images/eth_logo.svg);"
                                       />
                                     </div>
                                   </div>
@@ -534,10 +537,11 @@ exports[`SnapUIAccountSelector renders inside a field 1`] = `
                                     <div
                                       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                                     >
-                                      <img
-                                        alt="Polygon logo"
+                                      <span
+                                        aria-label="Polygon logo"
                                         class="mm-avatar-network__network-image"
-                                        src="./images/pol-token.svg"
+                                        role="img"
+                                        style="background-image: url(./images/pol-token.svg);"
                                       />
                                     </div>
                                   </div>
@@ -548,10 +552,11 @@ exports[`SnapUIAccountSelector renders inside a field 1`] = `
                                     <div
                                       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                                     >
-                                      <img
-                                        alt="BNB Chain logo"
+                                      <span
+                                        aria-label="BNB Chain logo"
                                         class="mm-avatar-network__network-image"
-                                        src="./images/bnb.svg"
+                                        role="img"
+                                        style="background-image: url(./images/bnb.svg);"
                                       />
                                     </div>
                                   </div>
@@ -572,10 +577,11 @@ exports[`SnapUIAccountSelector renders inside a field 1`] = `
                                     <div
                                       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                                     >
-                                      <img
-                                        alt="Custom Mainnet RPC logo"
+                                      <span
+                                        aria-label="Custom Mainnet RPC logo"
                                         class="mm-avatar-network__network-image"
-                                        src="./images/eth_logo.svg"
+                                        role="img"
+                                        style="background-image: url(./images/eth_logo.svg);"
                                       />
                                     </div>
                                   </div>

--- a/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/asset-selector.test.ts.snap
+++ b/ui/components/app/snaps/snap-ui-renderer/components/__snapshots__/asset-selector.test.ts.snap
@@ -36,10 +36,11 @@ exports[`SnapUIAssetSelector renders an asset selector 1`] = `
                     <div
                       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-token mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
                     >
-                      <img
-                        alt="SOL logo"
+                      <span
+                        aria-label="SOL logo"
                         class="mm-avatar-token__token-image"
-                        src="https://static.cx.metamask.io/api/v2/tokenIcons/assets/solana/5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44/501.png"
+                        role="img"
+                        style="background-image: url(https://static.cx.metamask.io/api/v2/tokenIcons/assets/solana/5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44/501.png);"
                       />
                     </div>
                     <div
@@ -48,10 +49,11 @@ exports[`SnapUIAssetSelector renders an asset selector 1`] = `
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-default mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                       >
-                        <img
-                          alt="Solana logo"
+                        <span
+                          aria-label="Solana logo"
                           class="mm-avatar-network__network-image"
-                          src="./images/solana-logo.svg"
+                          role="img"
+                          style="background-image: url(./images/solana-logo.svg);"
                         />
                       </div>
                     </div>
@@ -146,10 +148,11 @@ exports[`SnapUIAssetSelector renders inside a field 1`] = `
                     <div
                       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-token mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
                     >
-                      <img
-                        alt="SOL logo"
+                      <span
+                        aria-label="SOL logo"
                         class="mm-avatar-token__token-image"
-                        src="https://static.cx.metamask.io/api/v2/tokenIcons/assets/solana/5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44/501.png"
+                        role="img"
+                        style="background-image: url(https://static.cx.metamask.io/api/v2/tokenIcons/assets/solana/5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44/501.png);"
                       />
                     </div>
                     <div
@@ -158,10 +161,11 @@ exports[`SnapUIAssetSelector renders inside a field 1`] = `
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-default mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                       >
-                        <img
-                          alt="Solana logo"
+                        <span
+                          aria-label="Solana logo"
                           class="mm-avatar-network__network-image"
-                          src="./images/solana-logo.svg"
+                          role="img"
+                          style="background-image: url(./images/solana-logo.svg);"
                         />
                       </div>
                     </div>

--- a/ui/components/component-library/avatar-base/avatar-image.test-utils.ts
+++ b/ui/components/component-library/avatar-base/avatar-image.test-utils.ts
@@ -1,0 +1,38 @@
+type MockImageEvent = 'load' | 'error';
+
+type MockImage = {
+  onerror: (() => void) | null;
+  onload: (() => void) | null;
+  removeAttribute: jest.Mock;
+  src?: string;
+};
+
+export function mockImageEvent(event: MockImageEvent) {
+  const removeAttribute = jest.fn();
+
+  jest.spyOn(window, 'Image').mockImplementation(() => {
+    const image: MockImage = {
+      onerror: null,
+      onload: null,
+      removeAttribute,
+    };
+
+    let imageSrc = '';
+    Object.defineProperty(image, 'src', {
+      get() {
+        return imageSrc;
+      },
+      set(src) {
+        imageSrc = src;
+        if (event === 'load') {
+          image.onload?.();
+        } else {
+          image.onerror?.();
+        }
+      },
+    });
+
+    return image as unknown as HTMLImageElement;
+  });
+  return { removeAttribute };
+}

--- a/ui/components/component-library/avatar-base/avatar-image.tsx
+++ b/ui/components/component-library/avatar-base/avatar-image.tsx
@@ -1,0 +1,75 @@
+import React, { useEffect, useState } from 'react';
+
+export type AvatarImageProps = {
+  src: string;
+  showHalo?: boolean;
+  imageClassName: string;
+  reducedImageClassName: string;
+  blurredImageClassName: string;
+  label: string;
+};
+
+export function useImageFallback(src?: string): boolean {
+  const [showFallback, setShowFallback] = useState(!src);
+
+  useEffect(() => {
+    if (!src) {
+      setShowFallback(true);
+      return undefined;
+    }
+
+    let isMounted = true;
+    const image = new Image();
+
+    image.onload = () => {
+      if (isMounted) {
+        setShowFallback(false);
+      }
+    };
+    image.onerror = () => {
+      if (isMounted) {
+        setShowFallback(true);
+      }
+    };
+    setShowFallback(false);
+    image.src = src;
+
+    return () => {
+      isMounted = false;
+      image.onload = null;
+      image.onerror = null;
+      image.removeAttribute('src');
+    };
+  }, [src]);
+
+  return showFallback;
+}
+
+export function AvatarImage({
+  src,
+  showHalo,
+  imageClassName,
+  reducedImageClassName,
+  blurredImageClassName,
+  label,
+}: AvatarImageProps) {
+  const imageStyle = { backgroundImage: `url("${src}")` };
+
+  return (
+    <>
+      {showHalo && (
+        <span
+          style={imageStyle}
+          className={blurredImageClassName}
+          aria-hidden="true"
+        />
+      )}
+      <span
+        role="img"
+        className={showHalo ? reducedImageClassName : imageClassName}
+        style={imageStyle}
+        aria-label={label}
+      />
+    </>
+  );
+}

--- a/ui/components/component-library/avatar-network/__snapshots__/avatar-network.test.tsx.snap
+++ b/ui/components/component-library/avatar-network/__snapshots__/avatar-network.test.tsx.snap
@@ -6,10 +6,11 @@ exports[`AvatarNetwork should render correctly 1`] = `
     class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
     data-testid="avatar-network"
   >
-    <img
-      alt="ethereum logo"
+    <span
+      aria-label="ethereum logo"
       class="mm-avatar-network__network-image"
-      src="./images/eth_logo.svg"
+      role="img"
+      style="background-image: url(./images/eth_logo.svg);"
     />
   </div>
 </div>

--- a/ui/components/component-library/avatar-network/avatar-network.scss
+++ b/ui/components/component-library/avatar-network/avatar-network.scss
@@ -4,9 +4,20 @@
   }
 
   &__network-image {
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: contain;
+    display: block;
+    height: 100%;
     width: 100%;
 
     &--blurred {
+      background-position: center;
+      background-repeat: no-repeat;
+      background-size: contain;
+      display: block;
+      height: 100%;
+      width: 100%;
       filter: blur(8px);
       opacity: 0.5;
     }

--- a/ui/components/component-library/avatar-network/avatar-network.test.tsx
+++ b/ui/components/component-library/avatar-network/avatar-network.test.tsx
@@ -53,7 +53,11 @@ describe('AvatarNetwork', () => {
 
   it('should render the default image label if no name is provided', () => {
     render(
-      <AvatarNetwork data-testid="avatar-network" src="./images/eth_logo.svg" />,
+      <AvatarNetwork
+        data-testid="avatar-network"
+        name=""
+        src="./images/eth_logo.svg"
+      />,
     );
 
     expect(screen.getByRole('img', { name: 'network logo' })).toBeDefined();

--- a/ui/components/component-library/avatar-network/avatar-network.test.tsx
+++ b/ui/components/component-library/avatar-network/avatar-network.test.tsx
@@ -7,6 +7,7 @@ import {
   BorderColor,
   TextColor,
 } from '../../../helpers/constants/design-system';
+import { mockImageEvent } from '../avatar-base/avatar-image.test-utils';
 import { AvatarNetwork } from './avatar-network';
 import { AvatarNetworkSize } from './avatar-network.types';
 
@@ -37,32 +38,7 @@ describe('AvatarNetwork', () => {
   });
 
   it('should render the first letter of the name prop if the image fails to load', async () => {
-    jest.spyOn(window, 'Image').mockImplementation(() => {
-      const image: {
-        onerror: (() => void) | null;
-        onload: (() => void) | null;
-        removeAttribute: jest.Mock;
-        src?: string;
-      } = {
-        onerror: null,
-        onload: null,
-        removeAttribute: jest.fn(),
-      };
-
-      let imageSrc = '';
-      Object.defineProperty(image, 'src', {
-        get() {
-          return imageSrc;
-        },
-        set(src) {
-          imageSrc = src;
-          image.onerror?.();
-        },
-      });
-
-      return image as unknown as HTMLImageElement;
-    });
-
+    mockImageEvent('error');
     render(<AvatarNetwork data-testid="avatar-network" {...args} />);
 
     expect(await screen.findByText('e')).toBeDefined();
@@ -75,6 +51,14 @@ describe('AvatarNetwork', () => {
     expect(getByText('e')).toBeDefined();
   });
 
+  it('should render the default image label if no name is provided', () => {
+    render(
+      <AvatarNetwork data-testid="avatar-network" src="./images/eth_logo.svg" />,
+    );
+
+    expect(screen.getByRole('img', { name: 'network logo' })).toBeDefined();
+  });
+
   it('should render halo effect if showHalo is true and image url is there', () => {
     const { container } = render(
       <AvatarNetwork data-testid="avatar-network" {...args} showHalo />,
@@ -83,6 +67,9 @@ describe('AvatarNetwork', () => {
       '.mm-avatar-network__network-image--size-reduced',
     );
     expect(image).toBeDefined();
+    expect(
+      container.querySelector('.mm-avatar-network__network-image--blurred'),
+    ).toBeDefined();
   });
 
   it('should render the first letter of the name prop when showHalo is true and no image url is provided', () => {

--- a/ui/components/component-library/avatar-network/avatar-network.test.tsx
+++ b/ui/components/component-library/avatar-network/avatar-network.test.tsx
@@ -11,6 +11,10 @@ import { AvatarNetwork } from './avatar-network';
 import { AvatarNetworkSize } from './avatar-network.types';
 
 describe('AvatarNetwork', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   const args = {
     name: 'ethereum',
     src: './images/eth_logo.svg',
@@ -29,7 +33,39 @@ describe('AvatarNetwork', () => {
     render(<AvatarNetwork data-testid="avatar-network" {...args} />);
     const image = screen.getByRole('img');
     expect(image).toBeDefined();
-    expect(image).toHaveAttribute('src', args.src);
+    expect(image).toHaveStyle(`background-image: url("${args.src}")`);
+  });
+
+  it('should render the first letter of the name prop if the image fails to load', async () => {
+    jest.spyOn(window, 'Image').mockImplementation(() => {
+      const image: {
+        onerror: (() => void) | null;
+        onload: (() => void) | null;
+        removeAttribute: jest.Mock;
+        src?: string;
+      } = {
+        onerror: null,
+        onload: null,
+        removeAttribute: jest.fn(),
+      };
+
+      let imageSrc = '';
+      Object.defineProperty(image, 'src', {
+        get() {
+          return imageSrc;
+        },
+        set(src) {
+          imageSrc = src;
+          image.onerror?.();
+        },
+      });
+
+      return image as unknown as HTMLImageElement;
+    });
+
+    render(<AvatarNetwork data-testid="avatar-network" {...args} />);
+
+    expect(await screen.findByText('e')).toBeDefined();
   });
 
   it('should render the first letter of the name prop if no src is provided', () => {
@@ -40,11 +76,13 @@ describe('AvatarNetwork', () => {
   });
 
   it('should render halo effect if showHalo is true and image url is there', () => {
-    render(<AvatarNetwork data-testid="avatar-network" {...args} showHalo />);
-    const image = screen.getAllByRole('img', { hidden: true });
-    expect(image[1]).toHaveClass(
-      'mm-avatar-network__network-image--size-reduced',
+    const { container } = render(
+      <AvatarNetwork data-testid="avatar-network" {...args} showHalo />,
     );
+    const image = container.querySelector(
+      '.mm-avatar-network__network-image--size-reduced',
+    );
+    expect(image).toBeDefined();
   });
 
   it('should render the first letter of the name prop when showHalo is true and no image url is provided', () => {

--- a/ui/components/component-library/avatar-network/avatar-network.tsx
+++ b/ui/components/component-library/avatar-network/avatar-network.tsx
@@ -36,17 +36,40 @@ export const AvatarNetwork: AvatarNetworkComponent = React.forwardRef(
     }: AvatarNetworkProps<C>,
     ref?: PolymorphicRef<C>,
   ) => {
-    const [showFallback, setShowFallback] = useState(false);
+    const [showFallback, setShowFallback] = useState(!src);
 
     useEffect(() => {
-      setShowFallback(!src);
+      if (!src) {
+        setShowFallback(true);
+        return undefined;
+      }
+
+      let isMounted = true;
+      const image = new Image();
+
+      image.onload = () => {
+        if (isMounted) {
+          setShowFallback(false);
+        }
+      };
+      image.onerror = () => {
+        if (isMounted) {
+          setShowFallback(true);
+        }
+      };
+      setShowFallback(false);
+      image.src = src;
+
+      return () => {
+        isMounted = false;
+        image.onload = null;
+        image.onerror = null;
+        image.removeAttribute('src');
+      };
     }, [src]);
 
     const fallbackString = name?.[0] ?? '?';
-
-    const handleOnError = () => {
-      setShowFallback(true);
-    };
+    const networkImageStyle = { backgroundImage: `url("${src}")` };
 
     return (
       <AvatarBase
@@ -74,23 +97,23 @@ export const AvatarNetwork: AvatarNetworkComponent = React.forwardRef(
         ) : (
           <>
             {showHalo && (
-              <img
-                src={src}
+              <span
+                style={networkImageStyle}
                 className={
                   showHalo ? 'mm-avatar-network__network-image--blurred' : ''
                 }
                 aria-hidden="true"
               />
             )}
-            <img
+            <span
+              role="img"
               className={
                 showHalo
                   ? 'mm-avatar-network__network-image--size-reduced'
                   : 'mm-avatar-network__network-image'
               }
-              onError={handleOnError}
-              src={src}
-              alt={(name && `${name} logo`) || 'network logo'}
+              style={networkImageStyle}
+              aria-label={(name && `${name} logo`) || 'network logo'}
             />
           </>
         )}

--- a/ui/components/component-library/avatar-network/avatar-network.tsx
+++ b/ui/components/component-library/avatar-network/avatar-network.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import classnames from 'clsx';
 import {
   Display,
@@ -11,6 +11,7 @@ import {
 } from '../../../helpers/constants/design-system';
 import type { PolymorphicRef } from '../box';
 import { AvatarBase, AvatarBaseProps } from '../avatar-base';
+import { AvatarImage, useImageFallback } from '../avatar-base/avatar-image';
 import type { AvatarNetworkComponent } from './avatar-network.types';
 import { AvatarNetworkProps, AvatarNetworkSize } from './avatar-network.types';
 
@@ -36,40 +37,9 @@ export const AvatarNetwork: AvatarNetworkComponent = React.forwardRef(
     }: AvatarNetworkProps<C>,
     ref?: PolymorphicRef<C>,
   ) => {
-    const [showFallback, setShowFallback] = useState(!src);
-
-    useEffect(() => {
-      if (!src) {
-        setShowFallback(true);
-        return undefined;
-      }
-
-      let isMounted = true;
-      const image = new Image();
-
-      image.onload = () => {
-        if (isMounted) {
-          setShowFallback(false);
-        }
-      };
-      image.onerror = () => {
-        if (isMounted) {
-          setShowFallback(true);
-        }
-      };
-      setShowFallback(false);
-      image.src = src;
-
-      return () => {
-        isMounted = false;
-        image.onload = null;
-        image.onerror = null;
-        image.removeAttribute('src');
-      };
-    }, [src]);
+    const showFallback = useImageFallback(src);
 
     const fallbackString = name?.[0] ?? '?';
-    const networkImageStyle = { backgroundImage: `url("${src}")` };
 
     return (
       <AvatarBase
@@ -92,30 +62,17 @@ export const AvatarNetwork: AvatarNetworkComponent = React.forwardRef(
           ...(props as AvatarBaseProps<C>),
         }}
       >
-        {showFallback ? (
+        {showFallback || !src ? (
           fallbackString
         ) : (
-          <>
-            {showHalo && (
-              <span
-                style={networkImageStyle}
-                className={
-                  showHalo ? 'mm-avatar-network__network-image--blurred' : ''
-                }
-                aria-hidden="true"
-              />
-            )}
-            <span
-              role="img"
-              className={
-                showHalo
-                  ? 'mm-avatar-network__network-image--size-reduced'
-                  : 'mm-avatar-network__network-image'
-              }
-              style={networkImageStyle}
-              aria-label={(name && `${name} logo`) || 'network logo'}
-            />
-          </>
+          <AvatarImage
+            src={src}
+            showHalo={showHalo}
+            imageClassName="mm-avatar-network__network-image"
+            reducedImageClassName="mm-avatar-network__network-image--size-reduced"
+            blurredImageClassName="mm-avatar-network__network-image--blurred"
+            label={(name && `${name} logo`) || 'network logo'}
+          />
         )}
       </AvatarBase>
     );

--- a/ui/components/component-library/avatar-token/__snapshots__/avatar-token.test.tsx.snap
+++ b/ui/components/component-library/avatar-token/__snapshots__/avatar-token.test.tsx.snap
@@ -6,10 +6,11 @@ exports[`AvatarToken should render correctly 1`] = `
     class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-token mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
     data-testid="avatar-token"
   >
-    <img
-      alt="ast logo"
+    <span
+      aria-label="ast logo"
       class="mm-avatar-token__token-image"
-      src="./AST.png"
+      role="img"
+      style="background-image: url(./AST.png);"
     />
   </div>
 </div>

--- a/ui/components/component-library/avatar-token/avatar-token.scss
+++ b/ui/components/component-library/avatar-token/avatar-token.scss
@@ -4,9 +4,20 @@
   }
 
   &__token-image {
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: contain;
+    display: block;
+    height: 100%;
     width: 100%;
 
     &--blurred {
+      background-position: center;
+      background-repeat: no-repeat;
+      background-size: contain;
+      display: block;
+      height: 100%;
+      width: 100%;
       filter: blur(8px);
       opacity: 0.5;
     }

--- a/ui/components/component-library/avatar-token/avatar-token.test.tsx
+++ b/ui/components/component-library/avatar-token/avatar-token.test.tsx
@@ -10,6 +10,10 @@ import { AvatarToken } from './avatar-token';
 import { AvatarTokenSize } from './avatar-token.types';
 
 describe('AvatarToken', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
   const args = {
     name: 'ast',
     src: './AST.png',
@@ -28,7 +32,39 @@ describe('AvatarToken', () => {
     render(<AvatarToken {...args} data-testid="avatar-token" />);
     const image = screen.getByRole('img');
     expect(image).toBeDefined();
-    expect(image).toHaveAttribute('src', args.src);
+    expect(image).toHaveStyle(`background-image: url("${args.src}")`);
+  });
+
+  it('should render the first letter of the name prop if the image fails to load', async () => {
+    jest.spyOn(window, 'Image').mockImplementation(() => {
+      const image: {
+        onerror: (() => void) | null;
+        onload: (() => void) | null;
+        removeAttribute: jest.Mock;
+        src?: string;
+      } = {
+        onerror: null,
+        onload: null,
+        removeAttribute: jest.fn(),
+      };
+
+      let imageSrc = '';
+      Object.defineProperty(image, 'src', {
+        get() {
+          return imageSrc;
+        },
+        set(src) {
+          imageSrc = src;
+          image.onerror?.();
+        },
+      });
+
+      return image as unknown as HTMLImageElement;
+    });
+
+    render(<AvatarToken {...args} data-testid="avatar-token" />);
+
+    expect(await screen.findByText('a')).toBeDefined();
   });
 
   it('should render the first letter of the name prop if no src is provided', () => {
@@ -39,9 +75,13 @@ describe('AvatarToken', () => {
   });
 
   it('should render halo effect if showHalo is true and image url is there', () => {
-    render(<AvatarToken {...args} data-testid="avatar-token" showHalo />);
-    const image = screen.getAllByRole('img', { hidden: true });
-    expect(image[1]).toHaveClass('mm-avatar-token__token-image--size-reduced');
+    const { container } = render(
+      <AvatarToken {...args} data-testid="avatar-token" showHalo />,
+    );
+    const image = container.querySelector(
+      '.mm-avatar-token__token-image--size-reduced',
+    );
+    expect(image).toBeDefined();
   });
 
   it('should render the first letter of the name prop when showHalo is true and no image url is provided', () => {

--- a/ui/components/component-library/avatar-token/avatar-token.test.tsx
+++ b/ui/components/component-library/avatar-token/avatar-token.test.tsx
@@ -6,6 +6,7 @@ import {
   BorderColor,
   TextColor,
 } from '../../../helpers/constants/design-system';
+import { mockImageEvent } from '../avatar-base/avatar-image.test-utils';
 import { AvatarToken } from './avatar-token';
 import { AvatarTokenSize } from './avatar-token.types';
 
@@ -36,32 +37,7 @@ describe('AvatarToken', () => {
   });
 
   it('should render the first letter of the name prop if the image fails to load', async () => {
-    jest.spyOn(window, 'Image').mockImplementation(() => {
-      const image: {
-        onerror: (() => void) | null;
-        onload: (() => void) | null;
-        removeAttribute: jest.Mock;
-        src?: string;
-      } = {
-        onerror: null,
-        onload: null,
-        removeAttribute: jest.fn(),
-      };
-
-      let imageSrc = '';
-      Object.defineProperty(image, 'src', {
-        get() {
-          return imageSrc;
-        },
-        set(src) {
-          imageSrc = src;
-          image.onerror?.();
-        },
-      });
-
-      return image as unknown as HTMLImageElement;
-    });
-
+    mockImageEvent('error');
     render(<AvatarToken {...args} data-testid="avatar-token" />);
 
     expect(await screen.findByText('a')).toBeDefined();
@@ -74,6 +50,19 @@ describe('AvatarToken', () => {
     expect(getByText('a')).toBeDefined();
   });
 
+  it('cleans up the preloaded image on unmount', () => {
+    const { removeAttribute } = mockImageEvent('load');
+    const { unmount } = render(
+      <AvatarToken {...args} data-testid="avatar-token" />,
+    );
+
+    expect(screen.getByRole('img')).toHaveStyle(
+      `background-image: url("${args.src}")`,
+    );
+    unmount();
+    expect(removeAttribute).toHaveBeenCalledWith('src');
+  });
+
   it('should render halo effect if showHalo is true and image url is there', () => {
     const { container } = render(
       <AvatarToken {...args} data-testid="avatar-token" showHalo />,
@@ -82,6 +71,9 @@ describe('AvatarToken', () => {
       '.mm-avatar-token__token-image--size-reduced',
     );
     expect(image).toBeDefined();
+    expect(
+      container.querySelector('.mm-avatar-token__token-image--blurred'),
+    ).toBeDefined();
   });
 
   it('should render the first letter of the name prop when showHalo is true and no image url is provided', () => {

--- a/ui/components/component-library/avatar-token/avatar-token.tsx
+++ b/ui/components/component-library/avatar-token/avatar-token.tsx
@@ -34,17 +34,40 @@ export const AvatarToken: AvatarTokenComponent = React.forwardRef(
     }: AvatarTokenProps<C>,
     ref: PolymorphicRef<C>,
   ) => {
-    const [showFallback, setShowFallback] = useState(false);
+    const [showFallback, setShowFallback] = useState(!src);
 
     useEffect(() => {
-      setShowFallback(!src);
+      if (!src) {
+        setShowFallback(true);
+        return undefined;
+      }
+
+      let isMounted = true;
+      const image = new Image();
+
+      image.onload = () => {
+        if (isMounted) {
+          setShowFallback(false);
+        }
+      };
+      image.onerror = () => {
+        if (isMounted) {
+          setShowFallback(true);
+        }
+      };
+      setShowFallback(false);
+      image.src = src;
+
+      return () => {
+        isMounted = false;
+        image.onload = null;
+        image.onerror = null;
+        image.removeAttribute('src');
+      };
     }, [src]);
 
-    const handleOnError = () => {
-      setShowFallback(true);
-    };
-
     const fallbackString = name?.[0] ?? '?';
+    const tokenImageStyle = { backgroundImage: `url("${src}")` };
 
     return (
       <AvatarBase
@@ -70,23 +93,23 @@ export const AvatarToken: AvatarTokenComponent = React.forwardRef(
         ) : (
           <>
             {showHalo && (
-              <img
-                src={src}
+              <span
+                style={tokenImageStyle}
                 className={
                   showHalo ? 'mm-avatar-token__token-image--blurred' : ''
                 }
                 aria-hidden="true"
               />
             )}
-            <img
+            <span
+              role="img"
               className={
                 showHalo
                   ? 'mm-avatar-token__token-image--size-reduced'
                   : 'mm-avatar-token__token-image'
               }
-              onError={handleOnError}
-              src={src}
-              alt={`${name} logo`}
+              style={tokenImageStyle}
+              aria-label={`${name} logo`}
             />
           </>
         )}

--- a/ui/components/component-library/avatar-token/avatar-token.tsx
+++ b/ui/components/component-library/avatar-token/avatar-token.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import classnames from 'clsx';
 import { AvatarBase, AvatarBaseProps } from '../avatar-base';
 import {
@@ -8,6 +8,7 @@ import {
   TextColor,
   BackgroundColor,
 } from '../../../helpers/constants/design-system';
+import { AvatarImage, useImageFallback } from '../avatar-base/avatar-image';
 import type { PolymorphicRef } from '../box';
 import type { AvatarTokenComponent } from './avatar-token.types';
 import { AvatarTokenProps, AvatarTokenSize } from './avatar-token.types';
@@ -34,40 +35,9 @@ export const AvatarToken: AvatarTokenComponent = React.forwardRef(
     }: AvatarTokenProps<C>,
     ref: PolymorphicRef<C>,
   ) => {
-    const [showFallback, setShowFallback] = useState(!src);
-
-    useEffect(() => {
-      if (!src) {
-        setShowFallback(true);
-        return undefined;
-      }
-
-      let isMounted = true;
-      const image = new Image();
-
-      image.onload = () => {
-        if (isMounted) {
-          setShowFallback(false);
-        }
-      };
-      image.onerror = () => {
-        if (isMounted) {
-          setShowFallback(true);
-        }
-      };
-      setShowFallback(false);
-      image.src = src;
-
-      return () => {
-        isMounted = false;
-        image.onload = null;
-        image.onerror = null;
-        image.removeAttribute('src');
-      };
-    }, [src]);
+    const showFallback = useImageFallback(src);
 
     const fallbackString = name?.[0] ?? '?';
-    const tokenImageStyle = { backgroundImage: `url("${src}")` };
 
     return (
       <AvatarBase
@@ -88,30 +58,17 @@ export const AvatarToken: AvatarTokenComponent = React.forwardRef(
           ...(props as AvatarBaseProps<C>),
         }}
       >
-        {showFallback ? (
+        {showFallback || !src ? (
           fallbackString
         ) : (
-          <>
-            {showHalo && (
-              <span
-                style={tokenImageStyle}
-                className={
-                  showHalo ? 'mm-avatar-token__token-image--blurred' : ''
-                }
-                aria-hidden="true"
-              />
-            )}
-            <span
-              role="img"
-              className={
-                showHalo
-                  ? 'mm-avatar-token__token-image--size-reduced'
-                  : 'mm-avatar-token__token-image'
-              }
-              style={tokenImageStyle}
-              aria-label={`${name} logo`}
-            />
-          </>
+          <AvatarImage
+            src={src}
+            showHalo={showHalo}
+            imageClassName="mm-avatar-token__token-image"
+            reducedImageClassName="mm-avatar-token__token-image--size-reduced"
+            blurredImageClassName="mm-avatar-token__token-image--blurred"
+            label={`${name} logo`}
+          />
         )}
       </AvatarBase>
     );

--- a/ui/components/component-library/picker-network/__snapshots__/picker-network.test.tsx.snap
+++ b/ui/components/component-library/picker-network/__snapshots__/picker-network.test.tsx.snap
@@ -20,10 +20,11 @@ exports[`PickerNetwork should render multiple avatars when avatarGroupProps is p
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
           >
-            <img
-              alt="Network3 logo"
+            <span
+              aria-label="Network3 logo"
               class="mm-avatar-network__network-image"
-              src="img2"
+              role="img"
+              style="background-image: url(img2);"
             />
           </div>
         </div>
@@ -34,10 +35,11 @@ exports[`PickerNetwork should render multiple avatars when avatarGroupProps is p
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
           >
-            <img
-              alt="Network1 logo"
+            <span
+              aria-label="Network1 logo"
               class="mm-avatar-network__network-image"
-              src="img1"
+              role="img"
+              style="background-image: url(img1);"
             />
           </div>
         </div>
@@ -82,10 +84,11 @@ exports[`PickerNetwork should render multiple avatars with a stacked tag when is
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
           >
-            <img
-              alt="Network3 logo"
+            <span
+              aria-label="Network3 logo"
               class="mm-avatar-network__network-image"
-              src="img2"
+              role="img"
+              style="background-image: url(img2);"
             />
           </div>
         </div>
@@ -96,10 +99,11 @@ exports[`PickerNetwork should render multiple avatars with a stacked tag when is
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
           >
-            <img
-              alt="Network1 logo"
+            <span
+              aria-label="Network1 logo"
               class="mm-avatar-network__network-image"
-              src="img1"
+              role="img"
+              style="background-image: url(img1);"
             />
           </div>
         </div>

--- a/ui/components/component-library/picker-network/picker-network.test.tsx
+++ b/ui/components/component-library/picker-network/picker-network.test.tsx
@@ -26,7 +26,9 @@ describe('PickerNetwork', () => {
     );
     const image = screen.getByRole('img');
     expect(image).toBeDefined();
-    expect(image).toHaveAttribute('src', './images/pol-token.svg');
+    expect(image).toHaveStyle({
+      backgroundImage: 'url(./images/pol-token.svg)',
+    });
   });
   it('should render avatar network inside the PickerNetwork with custom props', () => {
     const container = (

--- a/ui/components/multichain-accounts/multichain-address-rows-triggered-list/multichain-aggregated-list-row.test.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-triggered-list/multichain-aggregated-list-row.test.tsx
@@ -233,14 +233,16 @@ describe('MultichainAggregatedAddressListRow', () => {
 
       // Verify network avatars are displayed
       // Note: Only networks with valid images will be rendered
-      const networkAvatars = screen.queryAllByAltText(ALT_TEXTS.NETWORK_LOGO);
+      const networkAvatars = screen.queryAllByRole('img', {
+        name: ALT_TEXTS.NETWORK_LOGO,
+      });
 
       expect(networkAvatars.length).toBeGreaterThanOrEqual(1);
       expect(networkAvatars.length).toBeLessThanOrEqual(chainIds.length);
 
       // Verify at least one expected image is present
-      const avatarSources = networkAvatars.map((avatar) =>
-        avatar.getAttribute('src'),
+      const avatarImageStyles = networkAvatars.map((avatar) =>
+        avatar.getAttribute('style'),
       );
       const expectedSources = [
         IMAGE_SOURCES.ETH_LOGO,
@@ -248,10 +250,8 @@ describe('MultichainAggregatedAddressListRow', () => {
         IMAGE_SOURCES.ARBITRUM,
       ];
       expect(
-        avatarSources.some(
-          (src) =>
-            src &&
-            expectedSources.includes(src as (typeof expectedSources)[number]),
+        avatarImageStyles.some((style) =>
+          expectedSources.some((src) => style?.includes(src)),
         ),
       ).toBe(true);
     });

--- a/ui/components/multichain/account-list-item/__snapshots__/account-list-item.test.js.snap
+++ b/ui/components/multichain/account-list-item/__snapshots__/account-list-item.test.js.snap
@@ -451,10 +451,11 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
                         <div
                           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                         >
-                          <img
-                            alt="Polygon logo"
+                          <span
+                            aria-label="Polygon logo"
                             class="mm-avatar-network__network-image"
-                            src="./images/pol-token.svg"
+                            role="img"
+                            style="background-image: url(./images/pol-token.svg);"
                           />
                         </div>
                       </div>
@@ -465,10 +466,11 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
                         <div
                           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                         >
-                          <img
-                            alt="BNB Chain logo"
+                          <span
+                            aria-label="BNB Chain logo"
                             class="mm-avatar-network__network-image"
-                            src="./images/bnb.svg"
+                            role="img"
+                            style="background-image: url(./images/bnb.svg);"
                           />
                         </div>
                       </div>
@@ -489,10 +491,11 @@ exports[`AccountListItem renders AccountListItem component and shows account nam
                         <div
                           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                         >
-                          <img
-                            alt="Custom Mainnet RPC logo"
+                          <span
+                            aria-label="Custom Mainnet RPC logo"
                             class="mm-avatar-network__network-image"
-                            src="./images/eth_logo.svg"
+                            role="img"
+                            style="background-image: url(./images/eth_logo.svg);"
                           />
                         </div>
                       </div>

--- a/ui/components/multichain/account-network-indicator/__snapshots__/account-network-indicator.test.tsx.snap
+++ b/ui/components/multichain/account-network-indicator/__snapshots__/account-network-indicator.test.tsx.snap
@@ -29,10 +29,11 @@ exports[`AccountNetworkIndicator renders the avatar group with network images: a
               <div
                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
               >
-                <img
-                  alt="Polygon logo"
+                <span
+                  aria-label="Polygon logo"
                   class="mm-avatar-network__network-image"
-                  src="./images/pol-token.svg"
+                  role="img"
+                  style="background-image: url(./images/pol-token.svg);"
                 />
               </div>
             </div>
@@ -43,10 +44,11 @@ exports[`AccountNetworkIndicator renders the avatar group with network images: a
               <div
                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
               >
-                <img
-                  alt="BNB Chain logo"
+                <span
+                  aria-label="BNB Chain logo"
                   class="mm-avatar-network__network-image"
-                  src="./images/bnb.svg"
+                  role="img"
+                  style="background-image: url(./images/bnb.svg);"
                 />
               </div>
             </div>
@@ -67,10 +69,11 @@ exports[`AccountNetworkIndicator renders the avatar group with network images: a
               <div
                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
               >
-                <img
-                  alt="Custom Mainnet RPC logo"
+                <span
+                  aria-label="Custom Mainnet RPC logo"
                   class="mm-avatar-network__network-image"
-                  src="./images/eth_logo.svg"
+                  role="img"
+                  style="background-image: url(./images/eth_logo.svg);"
                 />
               </div>
             </div>

--- a/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
+++ b/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
@@ -48,10 +48,10 @@ exports[`App Header locked state matches snapshot: locked 1`] = `
             fill="rgb(22,22,22)"
           />
         </svg>
-        <img
-          alt=""
+        <span
+          aria-hidden="true"
           class="app-header__metafox-logo--icon"
-          src="./images/logo/metamask-fox.svg"
+          style="background-image: url(./images/logo/metamask-fox.svg); background-position: center; background-repeat: no-repeat; background-size: contain; display: inline-block;"
         />
       </button>
     </div>
@@ -82,10 +82,10 @@ exports[`App Header unlocked state matches snapshot: unlocked 1`] = `
           fill="rgb(22,22,22)"
         />
       </svg>
-      <img
-        alt=""
+      <span
+        aria-hidden="true"
         class="app-header__metafox-logo--icon"
-        src="./images/logo/metamask-fox.svg"
+        style="background-image: url(./images/logo/metamask-fox.svg); background-position: center; background-repeat: no-repeat; background-size: contain; display: inline-block;"
       />
     </button>
   </div>
@@ -163,10 +163,11 @@ exports[`App Header unlocked state matches snapshot: unlocked 1`] = `
                         <div
                           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                         >
-                          <img
-                            alt="network logo"
+                          <span
+                            aria-label="network logo"
                             class="mm-avatar-network__network-image"
-                            src="./images/arbitrum.svg"
+                            role="img"
+                            style="background-image: url(./images/arbitrum.svg);"
                           />
                         </div>
                       </div>
@@ -177,10 +178,11 @@ exports[`App Header unlocked state matches snapshot: unlocked 1`] = `
                         <div
                           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                         >
-                          <img
-                            alt="network logo"
+                          <span
+                            aria-label="network logo"
                             class="mm-avatar-network__network-image"
-                            src="./images/pol-token.svg"
+                            role="img"
+                            style="background-image: url(./images/pol-token.svg);"
                           />
                         </div>
                       </div>
@@ -191,10 +193,11 @@ exports[`App Header unlocked state matches snapshot: unlocked 1`] = `
                         <div
                           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                         >
-                          <img
-                            alt="network logo"
+                          <span
+                            aria-label="network logo"
                             class="mm-avatar-network__network-image"
-                            src="./images/bnb.svg"
+                            role="img"
+                            style="background-image: url(./images/bnb.svg);"
                           />
                         </div>
                       </div>
@@ -205,10 +208,11 @@ exports[`App Header unlocked state matches snapshot: unlocked 1`] = `
                         <div
                           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                         >
-                          <img
-                            alt="network logo"
+                          <span
+                            aria-label="network logo"
                             class="mm-avatar-network__network-image"
-                            src="./images/eth_logo.svg"
+                            role="img"
+                            style="background-image: url(./images/eth_logo.svg);"
                           />
                         </div>
                       </div>

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/__snapshots__/asset-picker-modal-network.test.tsx.snap
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/__snapshots__/asset-picker-modal-network.test.tsx.snap
@@ -144,10 +144,11 @@ exports[`AssetPickerModalNetwork should not show selected network when network p
                 <div
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                 >
-                  <img
-                    alt="Ethereum logo"
+                  <span
+                    aria-label="Ethereum logo"
                     class="mm-avatar-network__network-image"
-                    src="./images/eth_logo.svg"
+                    role="img"
+                    style="background-image: url(./images/eth_logo.svg);"
                   />
                 </div>
                 <div
@@ -185,10 +186,11 @@ exports[`AssetPickerModalNetwork should not show selected network when network p
                 <div
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                 >
-                  <img
-                    alt="OP logo"
+                  <span
+                    aria-label="OP logo"
                     class="mm-avatar-network__network-image"
-                    src="./images/optimism.svg"
+                    role="img"
+                    style="background-image: url(./images/optimism.svg);"
                   />
                 </div>
                 <div
@@ -316,10 +318,11 @@ exports[`AssetPickerModalNetwork should use passed in network as default when ne
                 <div
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                 >
-                  <img
-                    alt="Ethereum logo"
+                  <span
+                    aria-label="Ethereum logo"
                     class="mm-avatar-network__network-image"
-                    src="./images/eth_logo.svg"
+                    role="img"
+                    style="background-image: url(./images/eth_logo.svg);"
                   />
                 </div>
                 <div
@@ -357,10 +360,11 @@ exports[`AssetPickerModalNetwork should use passed in network as default when ne
                 <div
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                 >
-                  <img
-                    alt="OP logo"
+                  <span
+                    aria-label="OP logo"
                     class="mm-avatar-network__network-image"
-                    src="./images/optimism.svg"
+                    role="img"
+                    style="background-image: url(./images/optimism.svg);"
                   />
                 </div>
                 <div

--- a/ui/components/multichain/avatar-group/__snapshots__/avatar-group.test.tsx.snap
+++ b/ui/components/multichain/avatar-group/__snapshots__/avatar-group.test.tsx.snap
@@ -16,10 +16,11 @@ exports[`AvatarGroup should render AvatarGroup component 1`] = `
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
         >
-          <img
-            alt="AVAX logo"
+          <span
+            aria-label="AVAX logo"
             class="mm-avatar-token__token-image"
-            src="./images/avax-token.svg"
+            role="img"
+            style="background-image: url(./images/avax-token.svg);"
           />
         </div>
       </div>
@@ -30,10 +31,11 @@ exports[`AvatarGroup should render AvatarGroup component 1`] = `
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
         >
-          <img
-            alt="OP logo"
+          <span
+            aria-label="OP logo"
             class="mm-avatar-token__token-image"
-            src="./images/optimism.svg"
+            role="img"
+            style="background-image: url(./images/optimism.svg);"
           />
         </div>
       </div>
@@ -44,10 +46,11 @@ exports[`AvatarGroup should render AvatarGroup component 1`] = `
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
         >
-          <img
-            alt="MATIC logo"
+          <span
+            aria-label="MATIC logo"
             class="mm-avatar-token__token-image"
-            src="./images/pol-token.svg"
+            role="img"
+            style="background-image: url(./images/pol-token.svg);"
           />
         </div>
       </div>
@@ -58,10 +61,11 @@ exports[`AvatarGroup should render AvatarGroup component 1`] = `
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
         >
-          <img
-            alt="ETH logo"
+          <span
+            aria-label="ETH logo"
             class="mm-avatar-token__token-image"
-            src="./images/eth_logo.svg"
+            role="img"
+            style="background-image: url(./images/eth_logo.svg);"
           />
         </div>
       </div>

--- a/ui/components/multichain/network-list-item/__snapshots__/network-list-item.test.js.snap
+++ b/ui/components/multichain/network-list-item/__snapshots__/network-list-item.test.js.snap
@@ -9,10 +9,11 @@ exports[`NetworkListItem renders properly 1`] = `
     <div
       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
     >
-      <img
-        alt="Polygon logo"
+      <span
+        aria-label="Polygon logo"
         class="mm-avatar-network__network-image"
-        src="./images/pol-token.svg"
+        role="img"
+        style="background-image: url(./images/pol-token.svg);"
       />
     </div>
     <div

--- a/ui/components/multichain/network-list-menu/__snapshots__/network-list-menu.test.tsx.snap
+++ b/ui/components/multichain/network-list-menu/__snapshots__/network-list-menu.test.tsx.snap
@@ -116,10 +116,11 @@ exports[`NetworkListMenu renders properly 1`] = `
                     <div
                       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                     >
-                      <img
-                        alt="Ethereum logo"
+                      <span
+                        aria-label="Ethereum logo"
                         class="mm-avatar-network__network-image"
-                        src="./images/eth_logo.svg"
+                        role="img"
+                        style="background-image: url(./images/eth_logo.svg);"
                       />
                     </div>
                     <div
@@ -179,10 +180,11 @@ exports[`NetworkListMenu renders properly 1`] = `
                     <div
                       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                     >
-                      <img
-                        alt="Linea logo"
+                      <span
+                        aria-label="Linea logo"
                         class="mm-avatar-network__network-image"
-                        src="./images/linea-logo-mainnet.svg"
+                        role="img"
+                        style="background-image: url(./images/linea-logo-mainnet.svg);"
                       />
                     </div>
                     <div
@@ -242,10 +244,11 @@ exports[`NetworkListMenu renders properly 1`] = `
                     <div
                       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                     >
-                      <img
-                        alt="BNB Chain logo"
+                      <span
+                        aria-label="BNB Chain logo"
                         class="mm-avatar-network__network-image"
-                        src="./images/bnb.svg"
+                        role="img"
+                        style="background-image: url(./images/bnb.svg);"
                       />
                     </div>
                     <div
@@ -364,10 +367,11 @@ exports[`NetworkListMenu renders properly 1`] = `
                     <div
                       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                     >
-                      <img
-                        alt="Monad logo"
+                      <span
+                        aria-label="Monad logo"
                         class="mm-avatar-network__network-image"
-                        src="./images/monad.svg"
+                        role="img"
+                        style="background-image: url(./images/monad.svg);"
                       />
                     </div>
                     <div
@@ -457,10 +461,11 @@ exports[`NetworkListMenu renders properly 1`] = `
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                       >
-                        <img
-                          alt="Arbitrum logo"
+                        <span
+                          aria-label="Arbitrum logo"
                           class="mm-avatar-network__network-image"
-                          src="./images/arbitrum.svg"
+                          role="img"
+                          style="background-image: url(./images/arbitrum.svg);"
                         />
                       </div>
                       <div
@@ -504,10 +509,11 @@ exports[`NetworkListMenu renders properly 1`] = `
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                       >
-                        <img
-                          alt="Avalanche logo"
+                        <span
+                          aria-label="Avalanche logo"
                           class="mm-avatar-network__network-image"
-                          src="./images/avax-token.svg"
+                          role="img"
+                          style="background-image: url(./images/avax-token.svg);"
                         />
                       </div>
                       <div
@@ -551,10 +557,11 @@ exports[`NetworkListMenu renders properly 1`] = `
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                       >
-                        <img
-                          alt="Base logo"
+                        <span
+                          aria-label="Base logo"
                           class="mm-avatar-network__network-image"
-                          src="./images/base.svg"
+                          role="img"
+                          style="background-image: url(./images/base.svg);"
                         />
                       </div>
                       <div
@@ -598,10 +605,11 @@ exports[`NetworkListMenu renders properly 1`] = `
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                       >
-                        <img
-                          alt="HyperEVM logo"
+                        <span
+                          aria-label="HyperEVM logo"
                           class="mm-avatar-network__network-image"
-                          src="./images/hyperevm.svg"
+                          role="img"
+                          style="background-image: url(./images/hyperevm.svg);"
                         />
                       </div>
                       <div
@@ -645,10 +653,11 @@ exports[`NetworkListMenu renders properly 1`] = `
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                       >
-                        <img
-                          alt="MegaETH logo"
+                        <span
+                          aria-label="MegaETH logo"
                           class="mm-avatar-network__network-image"
-                          src="./images/MegaETH-logo-mainnet.png"
+                          role="img"
+                          style="background-image: url(./images/MegaETH-logo-mainnet.png);"
                         />
                       </div>
                       <div
@@ -692,10 +701,11 @@ exports[`NetworkListMenu renders properly 1`] = `
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                       >
-                        <img
-                          alt="OP logo"
+                        <span
+                          aria-label="OP logo"
                           class="mm-avatar-network__network-image"
-                          src="./images/optimism.svg"
+                          role="img"
+                          style="background-image: url(./images/optimism.svg);"
                         />
                       </div>
                       <div
@@ -739,10 +749,11 @@ exports[`NetworkListMenu renders properly 1`] = `
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                       >
-                        <img
-                          alt="Polygon logo"
+                        <span
+                          aria-label="Polygon logo"
                           class="mm-avatar-network__network-image"
-                          src="./images/pol-token.svg"
+                          role="img"
+                          style="background-image: url(./images/pol-token.svg);"
                         />
                       </div>
                       <div
@@ -786,10 +797,11 @@ exports[`NetworkListMenu renders properly 1`] = `
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                       >
-                        <img
-                          alt="Sei logo"
+                        <span
+                          aria-label="Sei logo"
                           class="mm-avatar-network__network-image"
-                          src="./images/sei.svg"
+                          role="img"
+                          style="background-image: url(./images/sei.svg);"
                         />
                       </div>
                       <div
@@ -833,10 +845,11 @@ exports[`NetworkListMenu renders properly 1`] = `
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                       >
-                        <img
-                          alt="Tempo logo"
+                        <span
+                          aria-label="Tempo logo"
                           class="mm-avatar-network__network-image"
-                          src="./images/tempo.svg"
+                          role="img"
+                          style="background-image: url(./images/tempo.svg);"
                         />
                       </div>
                       <div
@@ -880,10 +893,11 @@ exports[`NetworkListMenu renders properly 1`] = `
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                       >
-                        <img
-                          alt="zkSync Era logo"
+                        <span
+                          aria-label="zkSync Era logo"
                           class="mm-avatar-network__network-image"
-                          src="./images/zk-sync.svg"
+                          role="img"
+                          style="background-image: url(./images/zk-sync.svg);"
                         />
                       </div>
                       <div
@@ -1392,10 +1406,11 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                     <div
                       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                     >
-                      <img
-                        alt="Ethereum logo"
+                      <span
+                        aria-label="Ethereum logo"
                         class="mm-avatar-network__network-image"
-                        src="./images/eth_logo.svg"
+                        role="img"
+                        style="background-image: url(./images/eth_logo.svg);"
                       />
                     </div>
                     <div
@@ -1455,10 +1470,11 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                     <div
                       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                     >
-                      <img
-                        alt="Linea logo"
+                      <span
+                        aria-label="Linea logo"
                         class="mm-avatar-network__network-image"
-                        src="./images/linea-logo-mainnet.svg"
+                        role="img"
+                        style="background-image: url(./images/linea-logo-mainnet.svg);"
                       />
                     </div>
                     <div
@@ -1518,10 +1534,11 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                     <div
                       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                     >
-                      <img
-                        alt="BNB Chain logo"
+                      <span
+                        aria-label="BNB Chain logo"
                         class="mm-avatar-network__network-image"
-                        src="./images/bnb.svg"
+                        role="img"
+                        style="background-image: url(./images/bnb.svg);"
                       />
                     </div>
                     <div
@@ -1640,10 +1657,11 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                     <div
                       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                     >
-                      <img
-                        alt="Monad logo"
+                      <span
+                        aria-label="Monad logo"
                         class="mm-avatar-network__network-image"
-                        src="./images/monad.svg"
+                        role="img"
+                        style="background-image: url(./images/monad.svg);"
                       />
                     </div>
                     <div
@@ -1733,10 +1751,11 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                       >
-                        <img
-                          alt="Arbitrum logo"
+                        <span
+                          aria-label="Arbitrum logo"
                           class="mm-avatar-network__network-image"
-                          src="./images/arbitrum.svg"
+                          role="img"
+                          style="background-image: url(./images/arbitrum.svg);"
                         />
                       </div>
                       <div
@@ -1780,10 +1799,11 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                       >
-                        <img
-                          alt="Avalanche logo"
+                        <span
+                          aria-label="Avalanche logo"
                           class="mm-avatar-network__network-image"
-                          src="./images/avax-token.svg"
+                          role="img"
+                          style="background-image: url(./images/avax-token.svg);"
                         />
                       </div>
                       <div
@@ -1827,10 +1847,11 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                       >
-                        <img
-                          alt="Base logo"
+                        <span
+                          aria-label="Base logo"
                           class="mm-avatar-network__network-image"
-                          src="./images/base.svg"
+                          role="img"
+                          style="background-image: url(./images/base.svg);"
                         />
                       </div>
                       <div
@@ -1874,10 +1895,11 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                       >
-                        <img
-                          alt="HyperEVM logo"
+                        <span
+                          aria-label="HyperEVM logo"
                           class="mm-avatar-network__network-image"
-                          src="./images/hyperevm.svg"
+                          role="img"
+                          style="background-image: url(./images/hyperevm.svg);"
                         />
                       </div>
                       <div
@@ -1921,10 +1943,11 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                       >
-                        <img
-                          alt="MegaETH logo"
+                        <span
+                          aria-label="MegaETH logo"
                           class="mm-avatar-network__network-image"
-                          src="./images/MegaETH-logo-mainnet.png"
+                          role="img"
+                          style="background-image: url(./images/MegaETH-logo-mainnet.png);"
                         />
                       </div>
                       <div
@@ -1968,10 +1991,11 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                       >
-                        <img
-                          alt="OP logo"
+                        <span
+                          aria-label="OP logo"
                           class="mm-avatar-network__network-image"
-                          src="./images/optimism.svg"
+                          role="img"
+                          style="background-image: url(./images/optimism.svg);"
                         />
                       </div>
                       <div
@@ -2015,10 +2039,11 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                       >
-                        <img
-                          alt="Polygon logo"
+                        <span
+                          aria-label="Polygon logo"
                           class="mm-avatar-network__network-image"
-                          src="./images/pol-token.svg"
+                          role="img"
+                          style="background-image: url(./images/pol-token.svg);"
                         />
                       </div>
                       <div
@@ -2062,10 +2087,11 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                       >
-                        <img
-                          alt="Sei logo"
+                        <span
+                          aria-label="Sei logo"
                           class="mm-avatar-network__network-image"
-                          src="./images/sei.svg"
+                          role="img"
+                          style="background-image: url(./images/sei.svg);"
                         />
                       </div>
                       <div
@@ -2109,10 +2135,11 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                       >
-                        <img
-                          alt="Tempo logo"
+                        <span
+                          aria-label="Tempo logo"
                           class="mm-avatar-network__network-image"
-                          src="./images/tempo.svg"
+                          role="img"
+                          style="background-image: url(./images/tempo.svg);"
                         />
                       </div>
                       <div
@@ -2156,10 +2183,11 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                       <div
                         class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                       >
-                        <img
-                          alt="zkSync Era logo"
+                        <span
+                          aria-label="zkSync Era logo"
                           class="mm-avatar-network__network-image"
-                          src="./images/zk-sync.svg"
+                          role="img"
+                          style="background-image: url(./images/zk-sync.svg);"
                         />
                       </div>
                       <div

--- a/ui/components/multichain/network-list-menu/select-rpc-url-modal/__snapshots__/select-rpc-url-modal.test.tsx.snap
+++ b/ui/components/multichain/network-list-menu/select-rpc-url-modal/__snapshots__/select-rpc-url-modal.test.tsx.snap
@@ -14,10 +14,11 @@ exports[`SelectRpcUrlModal Component renders select rpc url 1`] = `
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--margin-right-1 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
         >
-          <img
-            alt="Ethereum Mainnet logo"
+          <span
+            aria-label="Ethereum Mainnet logo"
             class="mm-avatar-network__network-image"
-            src="./images/eth_logo.svg"
+            role="img"
+            style="background-image: url(./images/eth_logo.svg);"
           />
         </div>
         <p

--- a/ui/components/multichain/network-list-menu/select-rpc-url-modal/select-rpc-url-modal.test.tsx
+++ b/ui/components/multichain/network-list-menu/select-rpc-url-modal/select-rpc-url-modal.test.tsx
@@ -92,7 +92,9 @@ describe('SelectRpcUrlModal Component', () => {
     const networkImage = getByRole('img');
 
     expect(networkImage).toBeInTheDocument();
-    expect(networkImage).toHaveAttribute('src', imageSrc);
+    expect(networkImage).toHaveStyle({
+      backgroundImage: `url(${imageSrc})`,
+    });
     expect(getByText(networkConfiguration.name)).toBeInTheDocument();
   });
 
@@ -165,13 +167,15 @@ describe('SelectRpcUrlModal Component', () => {
     );
 
     const networkImage = screen.getByRole('img');
-    expect(networkImage).toBeInTheDocument();
-    expect(networkImage).toHaveAttribute(
-      'src',
+    const imageSrc =
       CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP[
         networkConfiguration.chainId as keyof typeof CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP
-      ],
-    );
+      ];
+
+    expect(networkImage).toBeInTheDocument();
+    expect(networkImage).toHaveStyle({
+      backgroundImage: `url(${imageSrc})`,
+    });
   });
 
   it('should handle click on RPC URL and call onNetworkChange', () => {

--- a/ui/components/multichain/notification-detail-collection/notification-detail-collection.test.tsx
+++ b/ui/components/multichain/notification-detail-collection/notification-detail-collection.test.tsx
@@ -45,6 +45,8 @@ describe('NotificationDetailCollection', () => {
     const images = screen.getAllByRole('img');
     expect(images.length).toBe(2);
     expect(images[0]).toHaveAttribute('src', defaultProps.icon.src);
-    expect(images[1]).toHaveAttribute('src', defaultProps.icon.badgeSrc);
+    expect(images[1]).toHaveStyle(
+      `background-image: url("${defaultProps.icon.badgeSrc}")`,
+    );
   });
 });

--- a/ui/components/multichain/pages/gator-permissions/components/__snapshots__/permissions-cell-connection-list-item.test.tsx.snap
+++ b/ui/components/multichain/pages/gator-permissions/components/__snapshots__/permissions-cell-connection-list-item.test.tsx.snap
@@ -66,10 +66,11 @@ exports[`PermissionsCellConnectionListItem renders correctly with required props
                 <div
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
                 >
-                  <img
-                    alt="Polygon logo"
+                  <span
+                    aria-label="Polygon logo"
                     class="mm-avatar-token__token-image"
-                    src="./images/pol-token.svg"
+                    role="img"
+                    style="background-image: url(./images/pol-token.svg);"
                   />
                 </div>
               </div>
@@ -80,10 +81,11 @@ exports[`PermissionsCellConnectionListItem renders correctly with required props
                 <div
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
                 >
-                  <img
-                    alt="Ethereum Mainnet logo"
+                  <span
+                    aria-label="Ethereum Mainnet logo"
                     class="mm-avatar-token__token-image"
-                    src="./images/eth_logo.svg"
+                    role="img"
+                    style="background-image: url(./images/eth_logo.svg);"
                   />
                 </div>
               </div>

--- a/ui/components/multichain/pages/gator-permissions/components/__snapshots__/permissions-cell-tooltip.test.tsx.snap
+++ b/ui/components/multichain/pages/gator-permissions/components/__snapshots__/permissions-cell-tooltip.test.tsx.snap
@@ -23,10 +23,11 @@ exports[`PermissionsCellTooltip renders correctly with networks 1`] = `
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
           >
-            <img
-              alt="BNB Smart Chain logo"
+            <span
+              aria-label="BNB Smart Chain logo"
               class="mm-avatar-token__token-image"
-              src="./images/bnb.svg"
+              role="img"
+              style="background-image: url(./images/bnb.svg);"
             />
           </div>
         </div>
@@ -37,10 +38,11 @@ exports[`PermissionsCellTooltip renders correctly with networks 1`] = `
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
           >
-            <img
-              alt="Avalanche C-Chain logo"
+            <span
+              aria-label="Avalanche C-Chain logo"
               class="mm-avatar-token__token-image"
-              src="./images/avax-token.svg"
+              role="img"
+              style="background-image: url(./images/avax-token.svg);"
             />
           </div>
         </div>
@@ -51,10 +53,11 @@ exports[`PermissionsCellTooltip renders correctly with networks 1`] = `
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
           >
-            <img
-              alt="Polygon logo"
+            <span
+              aria-label="Polygon logo"
               class="mm-avatar-token__token-image"
-              src="./images/pol-token.svg"
+              role="img"
+              style="background-image: url(./images/pol-token.svg);"
             />
           </div>
         </div>
@@ -65,10 +68,11 @@ exports[`PermissionsCellTooltip renders correctly with networks 1`] = `
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
           >
-            <img
-              alt="Ethereum Mainnet logo"
+            <span
+              aria-label="Ethereum Mainnet logo"
               class="mm-avatar-token__token-image"
-              src="./images/eth_logo.svg"
+              role="img"
+              style="background-image: url(./images/eth_logo.svg);"
             />
           </div>
         </div>

--- a/ui/components/multichain/pages/gator-permissions/components/__snapshots__/permissions-cell.test.tsx.snap
+++ b/ui/components/multichain/pages/gator-permissions/components/__snapshots__/permissions-cell.test.tsx.snap
@@ -70,10 +70,11 @@ exports[`PermissionsCell renders correctly with required props 1`] = `
                   <div
                     class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
                   >
-                    <img
-                      alt="Polygon logo"
+                    <span
+                      aria-label="Polygon logo"
                       class="mm-avatar-token__token-image"
-                      src="./images/pol-token.svg"
+                      role="img"
+                      style="background-image: url(./images/pol-token.svg);"
                     />
                   </div>
                 </div>
@@ -84,10 +85,11 @@ exports[`PermissionsCell renders correctly with required props 1`] = `
                   <div
                     class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-token mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full"
                   >
-                    <img
-                      alt="Ethereum Mainnet logo"
+                    <span
+                      aria-label="Ethereum Mainnet logo"
                       class="mm-avatar-token__token-image"
-                      src="./images/eth_logo.svg"
+                      role="img"
+                      style="background-image: url(./images/eth_logo.svg);"
                     />
                   </div>
                 </div>

--- a/ui/components/multichain/token-list-item/__snapshots__/token-list-item.test.tsx.snap
+++ b/ui/components/multichain/token-list-item/__snapshots__/token-list-item.test.tsx.snap
@@ -26,10 +26,11 @@ exports[`TokenListItem handles clicking staking opens tab 1`] = `
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network multichain-token-list-item__badge__avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-default mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-2 box--border-style-solid"
           >
-            <img
-              alt="network logo"
+            <span
+              aria-label="network logo"
               class="mm-avatar-network__network-image"
-              src="./eth-logo.png"
+              role="img"
+              style="background-image: url(./eth-logo.png);"
             />
           </div>
         </div>
@@ -288,10 +289,11 @@ exports[`TokenListItem should render correctly 1`] = `
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network multichain-token-list-item__badge__avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-default mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-2 box--border-style-solid"
           >
-            <img
-              alt="network logo"
+            <span
+              aria-label="network logo"
               class="mm-avatar-network__network-image"
-              src="./eth-logo.png"
+              role="img"
+              style="background-image: url(./eth-logo.png);"
             />
           </div>
         </div>

--- a/ui/components/ui/metafox-logo/__snapshots__/metafox-logo.component.test.js.snap
+++ b/ui/components/ui/metafox-logo/__snapshots__/metafox-logo.component.test.js.snap
@@ -7,10 +7,10 @@ exports[`MetaFoxLogo does not set icon height and width when unsetIconHeight is 
     data-testid="app-header-logo"
   >
     <div />
-    <img
-      alt=""
+    <span
+      aria-hidden="true"
       class="app-header__metafox-logo--icon"
-      src="./images/logo/metamask-fox.svg"
+      style="background-image: url(./images/logo/metamask-fox.svg); background-position: center; background-repeat: no-repeat; background-size: contain; display: inline-block;"
     />
   </button>
 </div>
@@ -23,12 +23,10 @@ exports[`MetaFoxLogo should match snapshot with img width and height default set
     data-testid="app-header-logo"
   >
     <div />
-    <img
-      alt=""
+    <span
+      aria-hidden="true"
       class="app-header__metafox-logo--icon"
-      height="42"
-      src="./images/logo/metamask-fox.svg"
-      width="42"
+      style="background-image: url(./images/logo/metamask-fox.svg); background-position: center; background-repeat: no-repeat; background-size: contain; display: inline-block; height: 42px; width: 42px;"
     />
   </button>
 </div>

--- a/ui/components/ui/metafox-logo/metafox-logo.component.js
+++ b/ui/components/ui/metafox-logo/metafox-logo.component.js
@@ -25,9 +25,7 @@ export default class MetaFoxLogo extends PureComponent {
   render() {
     const { onClick, unsetIconHeight, isOnboarding, src, theme } = this.props;
 
-    const iconProps = unsetIconHeight ? {} : { height: 42, width: 42 };
-
-    iconProps.src = './images/logo/metamask-fox.svg';
+    const imageDimensions = unsetIconHeight ? {} : { height: 42, width: 42 };
 
     let renderHorizontalLogo = () => (
       <MetaFoxHorizontalLogo
@@ -43,14 +41,20 @@ export default class MetaFoxLogo extends PureComponent {
 
     if (src) {
       renderHorizontalLogo = () => (
-        <img
-          {...iconProps}
-          src={src}
+        <span
+          style={{
+            backgroundImage: `url("${src}")`,
+            backgroundPosition: 'center',
+            backgroundRepeat: 'no-repeat',
+            backgroundSize: 'contain',
+            display: 'inline-block',
+            ...imageDimensions,
+          }}
           className={classnames({
             'app-header__metafox-logo--horizontal': !isOnboarding,
             'onboarding-app-header__metafox-logo--horizontal': isOnboarding,
           })}
-          alt=""
+          aria-hidden="true"
         />
       );
 
@@ -71,14 +75,20 @@ export default class MetaFoxLogo extends PureComponent {
       >
         {renderHorizontalLogo()}
 
-        <img
-          {...iconProps}
-          src={imageSrc}
+        <span
+          style={{
+            backgroundImage: `url("${imageSrc}")`,
+            backgroundPosition: 'center',
+            backgroundRepeat: 'no-repeat',
+            backgroundSize: 'contain',
+            display: 'inline-block',
+            ...imageDimensions,
+          }}
           className={classnames({
             'app-header__metafox-logo--icon': !isOnboarding,
             'onboarding-app-header__metafox-logo--icon': isOnboarding,
           })}
-          alt=""
+          aria-hidden="true"
         />
       </Box>
     );

--- a/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
+++ b/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
@@ -218,10 +218,11 @@ exports[`AssetPage should render a native asset 1`] = `
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-token mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-section mm-box--rounded-full"
             >
-              <img
-                alt="static-logo"
+              <span
+                aria-label="TEST logo"
                 class="mm-avatar-token__token-image"
-                src="./images/eth_logo.svg"
+                role="img"
+                style="background-image: url(./images/eth_logo.svg);"
               />
             </div>
             <div
@@ -230,10 +231,11 @@ exports[`AssetPage should render a native asset 1`] = `
               <div
                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-section mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-2 box--border-style-solid"
               >
-                <img
-                  alt="static-logo"
+                <span
+                  aria-label="Ethereum logo"
                   class="mm-avatar-network__network-image"
-                  src="./images/eth_logo.svg"
+                  role="img"
+                  style="background-image: url(./images/eth_logo.svg);"
                 />
               </div>
             </div>
@@ -587,10 +589,11 @@ exports[`AssetPage should render an ERC20 asset without prices 1`] = `
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-token mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-section mm-box--rounded-full"
             >
-              <img
-                alt="static-logo"
+              <span
+                aria-label="TEST logo"
                 class="mm-avatar-token__token-image"
-                src="https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0x309375769e79382befdec5bdab51063aebdc4936.png"
+                role="img"
+                style="background-image: url(https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0x309375769e79382befdec5bdab51063aebdc4936.png);"
               />
             </div>
             <div
@@ -599,10 +602,11 @@ exports[`AssetPage should render an ERC20 asset without prices 1`] = `
               <div
                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-section mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-2 box--border-style-solid"
               >
-                <img
-                  alt="static-logo"
+                <span
+                  aria-label="Ethereum logo"
                   class="mm-avatar-network__network-image"
-                  src="./images/eth_logo.svg"
+                  role="img"
+                  style="background-image: url(./images/eth_logo.svg);"
                 />
               </div>
             </div>
@@ -993,10 +997,11 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
             <div
               class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-token mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-section mm-box--rounded-full"
             >
-              <img
-                alt="static-logo"
+              <span
+                aria-label="TEST logo"
                 class="mm-avatar-token__token-image"
-                src="https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0xe4246b1ac0ba6839d9efa41a8a30ae3007185f55.png"
+                role="img"
+                style="background-image: url(https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/0xe4246b1ac0ba6839d9efa41a8a30ae3007185f55.png);"
               />
             </div>
             <div
@@ -1005,10 +1010,11 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
               <div
                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-section mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-2 box--border-style-solid"
               >
-                <img
-                  alt="static-logo"
+                <span
+                  aria-label="Ethereum logo"
                   class="mm-avatar-network__network-image"
-                  src="./images/eth_logo.svg"
+                  role="img"
+                  style="background-image: url(./images/eth_logo.svg);"
                 />
               </div>
             </div>

--- a/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
+++ b/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
@@ -73,10 +73,11 @@ exports[`BridgeInputGroup should render destination networks 1`] = `
     <div
       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
     >
-      <img
-        alt="Solana logo"
+      <span
+        aria-label="Solana logo"
         class="mm-avatar-network__network-image"
-        src="./images/solana-logo.svg"
+        role="img"
+        style="background-image: url(./images/solana-logo.svg);"
       />
     </div>
     <div
@@ -114,10 +115,11 @@ exports[`BridgeInputGroup should render destination networks 1`] = `
     <div
       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
     >
-      <img
-        alt="Bitcoin logo"
+      <span
+        aria-label="Bitcoin logo"
         class="mm-avatar-network__network-image"
-        src="./images/bitcoin-logo.svg"
+        role="img"
+        style="background-image: url(./images/bitcoin-logo.svg);"
       />
     </div>
     <div
@@ -155,10 +157,11 @@ exports[`BridgeInputGroup should render destination networks 1`] = `
     <div
       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
     >
-      <img
-        alt="Ethereum logo"
+      <span
+        aria-label="Ethereum logo"
         class="mm-avatar-network__network-image"
-        src="./images/eth_logo.svg"
+        role="img"
+        style="background-image: url(./images/eth_logo.svg);"
       />
     </div>
     <div
@@ -196,10 +199,11 @@ exports[`BridgeInputGroup should render destination networks 1`] = `
     <div
       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
     >
-      <img
-        alt="OP logo"
+      <span
+        aria-label="OP logo"
         class="mm-avatar-network__network-image"
-        src="./images/optimism.svg"
+        role="img"
+        style="background-image: url(./images/optimism.svg);"
       />
     </div>
     <div
@@ -237,10 +241,11 @@ exports[`BridgeInputGroup should render destination networks 1`] = `
     <div
       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
     >
-      <img
-        alt="Polygon logo"
+      <span
+        aria-label="Polygon logo"
         class="mm-avatar-network__network-image"
-        src="./images/pol-token.svg"
+        role="img"
+        style="background-image: url(./images/pol-token.svg);"
       />
     </div>
     <div
@@ -278,10 +283,11 @@ exports[`BridgeInputGroup should render destination networks 1`] = `
     <div
       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
     >
-      <img
-        alt="BNB Chain logo"
+      <span
+        aria-label="BNB Chain logo"
         class="mm-avatar-network__network-image"
-        src="./images/bnb.svg"
+        role="img"
+        style="background-image: url(./images/bnb.svg);"
       />
     </div>
     <div
@@ -319,10 +325,11 @@ exports[`BridgeInputGroup should render destination networks 1`] = `
     <div
       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
     >
-      <img
-        alt="Tron logo"
+      <span
+        aria-label="Tron logo"
         class="mm-avatar-network__network-image"
-        src="./images/tron-logo.svg"
+        role="img"
+        style="background-image: url(./images/tron-logo.svg);"
       />
     </div>
     <div
@@ -482,10 +489,11 @@ exports[`BridgeInputGroup should render source networks 1`] = `
     <div
       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
     >
-      <img
-        alt="Solana logo"
+      <span
+        aria-label="Solana logo"
         class="mm-avatar-network__network-image"
-        src="./images/solana-logo.svg"
+        role="img"
+        style="background-image: url(./images/solana-logo.svg);"
       />
     </div>
     <div
@@ -523,10 +531,11 @@ exports[`BridgeInputGroup should render source networks 1`] = `
     <div
       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
     >
-      <img
-        alt="Bitcoin logo"
+      <span
+        aria-label="Bitcoin logo"
         class="mm-avatar-network__network-image"
-        src="./images/bitcoin-logo.svg"
+        role="img"
+        style="background-image: url(./images/bitcoin-logo.svg);"
       />
     </div>
     <div
@@ -564,10 +573,11 @@ exports[`BridgeInputGroup should render source networks 1`] = `
     <div
       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
     >
-      <img
-        alt="Ethereum logo"
+      <span
+        aria-label="Ethereum logo"
         class="mm-avatar-network__network-image"
-        src="./images/eth_logo.svg"
+        role="img"
+        style="background-image: url(./images/eth_logo.svg);"
       />
     </div>
     <div
@@ -605,10 +615,11 @@ exports[`BridgeInputGroup should render source networks 1`] = `
     <div
       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
     >
-      <img
-        alt="OP logo"
+      <span
+        aria-label="OP logo"
         class="mm-avatar-network__network-image"
-        src="./images/optimism.svg"
+        role="img"
+        style="background-image: url(./images/optimism.svg);"
       />
     </div>
     <div
@@ -646,10 +657,11 @@ exports[`BridgeInputGroup should render source networks 1`] = `
     <div
       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
     >
-      <img
-        alt="Polygon logo"
+      <span
+        aria-label="Polygon logo"
         class="mm-avatar-network__network-image"
-        src="./images/pol-token.svg"
+        role="img"
+        style="background-image: url(./images/pol-token.svg);"
       />
     </div>
     <div
@@ -687,10 +699,11 @@ exports[`BridgeInputGroup should render source networks 1`] = `
     <div
       class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
     >
-      <img
-        alt="BNB Chain logo"
+      <span
+        aria-label="BNB Chain logo"
         class="mm-avatar-network__network-image"
-        src="./images/bnb.svg"
+        role="img"
+        style="background-image: url(./images/bnb.svg);"
       />
     </div>
     <div

--- a/ui/pages/bridge/prepare/components/__snapshots__/destination-account-picker-modal.test.tsx.snap
+++ b/ui/pages/bridge/prepare/components/__snapshots__/destination-account-picker-modal.test.tsx.snap
@@ -184,10 +184,11 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
               <div
                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
               >
-                <img
-                  alt="Ethereum logo"
+                <span
+                  aria-label="Ethereum logo"
                   class="mm-avatar-network__network-image"
-                  src="./images/eth_logo.svg"
+                  role="img"
+                  style="background-image: url(./images/eth_logo.svg);"
                 />
               </div>
             </div>
@@ -284,10 +285,11 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
               <div
                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
               >
-                <img
-                  alt="Ethereum logo"
+                <span
+                  aria-label="Ethereum logo"
                   class="mm-avatar-network__network-image"
-                  src="./images/eth_logo.svg"
+                  role="img"
+                  style="background-image: url(./images/eth_logo.svg);"
                 />
               </div>
             </div>
@@ -384,10 +386,11 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
               <div
                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
               >
-                <img
-                  alt="Ethereum logo"
+                <span
+                  aria-label="Ethereum logo"
                   class="mm-avatar-network__network-image"
-                  src="./images/eth_logo.svg"
+                  role="img"
+                  style="background-image: url(./images/eth_logo.svg);"
                 />
               </div>
             </div>
@@ -576,10 +579,11 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
               <div
                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
               >
-                <img
-                  alt="Ethereum logo"
+                <span
+                  aria-label="Ethereum logo"
                   class="mm-avatar-network__network-image"
-                  src="./images/eth_logo.svg"
+                  role="img"
+                  style="background-image: url(./images/eth_logo.svg);"
                 />
               </div>
             </div>
@@ -676,10 +680,11 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
               <div
                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
               >
-                <img
-                  alt="Ethereum logo"
+                <span
+                  aria-label="Ethereum logo"
                   class="mm-avatar-network__network-image"
-                  src="./images/eth_logo.svg"
+                  role="img"
+                  style="background-image: url(./images/eth_logo.svg);"
                 />
               </div>
             </div>
@@ -776,10 +781,11 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
               <div
                 class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
               >
-                <img
-                  alt="Ethereum logo"
+                <span
+                  aria-label="Ethereum logo"
                   class="mm-avatar-network__network-image"
-                  src="./images/eth_logo.svg"
+                  role="img"
+                  style="background-image: url(./images/eth_logo.svg);"
                 />
               </div>
             </div>

--- a/ui/pages/confirmations/components/token-icon/token-icon.test.tsx
+++ b/ui/pages/confirmations/components/token-icon/token-icon.test.tsx
@@ -77,8 +77,12 @@ describe('TokenIcon', () => {
 
     const { container } = renderTokenIcon();
 
-    const avatarToken = container.querySelector('.mm-avatar-token img');
-    expect(avatarToken).toHaveAttribute('src', TOKEN_IMAGE_MOCK);
+    const avatarToken = container.querySelector(
+      '.mm-avatar-token .mm-avatar-token__token-image',
+    );
+    expect(avatarToken).toHaveStyle({
+      backgroundImage: `url(${TOKEN_IMAGE_MOCK})`,
+    });
   });
 
   it('handles missing token gracefully', () => {

--- a/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
+++ b/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
@@ -585,10 +585,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                   style="border-width: 0px;"
                 >
-                  <img
-                    alt="Goerli logo"
-                    class="mm-avatar-network__network-image"
-                  />
+                  G
                 </div>
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
@@ -1009,10 +1006,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitS
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                   style="border-width: 0px;"
                 >
-                  <img
-                    alt="Goerli logo"
-                    class="mm-avatar-network__network-image"
-                  />
+                  G
                 </div>
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-text-default"
@@ -3334,10 +3328,7 @@ exports[`Confirm should render SmartTransactionsBannerAlert for transaction type
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
                   style="border-width: 0px;"
                 >
-                  <img
-                    alt="Goerli logo"
-                    class="mm-avatar-network__network-image"
-                  />
+                  G
                 </div>
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-text-default"

--- a/ui/pages/defi/components/__snapshots__/defi-details-page.test.tsx.snap
+++ b/ui/pages/defi/components/__snapshots__/defi-details-page.test.tsx.snap
@@ -35,10 +35,11 @@ exports[`DeFiDetailsPage renders defi asset page 1`] = `
         <div
           class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-token mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-section mm-box--rounded-full"
         >
-          <img
-            alt="Lido logo"
+          <span
+            aria-label="Lido logo"
             class="mm-avatar-token__token-image"
-            src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84/logo.png"
+            role="img"
+            style="background-image: url(https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84/logo.png);"
           />
         </div>
         <div
@@ -47,10 +48,11 @@ exports[`DeFiDetailsPage renders defi asset page 1`] = `
           <div
             class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-section mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-2 box--border-style-solid"
           >
-            <img
-              alt="Custom Mainnet RPC logo"
+            <span
+              aria-label="Custom Mainnet RPC logo"
               class="mm-avatar-network__network-image"
-              src="./images/eth_logo.svg"
+              role="img"
+              style="background-image: url(./images/eth_logo.svg);"
             />
           </div>
         </div>
@@ -101,10 +103,11 @@ exports[`DeFiDetailsPage renders defi asset page 1`] = `
                 <div
                   class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-token mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-section mm-box--rounded-full"
                 >
-                  <img
-                    alt="Liquid staked Ether 2.0 logo"
+                  <span
+                    aria-label="Liquid staked Ether 2.0 logo"
                     class="mm-avatar-token__token-image"
-                    src="https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84/logo.png"
+                    role="img"
+                    style="background-image: url(https://raw.githubusercontent.com/trustwallet/assets/master/blockchains/ethereum/assets/0xae7ab96520DE3A18E5e111B5EaAb095312D7fE84/logo.png);"
                   />
                 </div>
                 <div
@@ -113,10 +116,11 @@ exports[`DeFiDetailsPage renders defi asset page 1`] = `
                   <div
                     class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-avatar-network mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-section mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-2 box--border-style-solid"
                   >
-                    <img
-                      alt="Custom Mainnet RPC logo"
+                    <span
+                      aria-label="Custom Mainnet RPC logo"
                       class="mm-avatar-network__network-image"
-                      src="./images/eth_logo.svg"
+                      role="img"
+                      style="background-image: url(./images/eth_logo.svg);"
                     />
                   </div>
                 </div>

--- a/ui/pages/onboarding-flow/onboarding-app-header/__snapshots__/onboarding-app-header.test.tsx.snap
+++ b/ui/pages/onboarding-flow/onboarding-app-header/__snapshots__/onboarding-app-header.test.tsx.snap
@@ -25,10 +25,10 @@ exports[`OnboardingAppHeader shoul match snapshot on onboarding completion page 
             fill="rgb(22,22,22)"
           />
         </svg>
-        <img
-          alt=""
+        <span
+          aria-hidden="true"
           class="onboarding-app-header__metafox-logo--icon"
-          src="./images/logo/metamask-fox.svg"
+          style="background-image: url(./images/logo/metamask-fox.svg); background-position: center; background-repeat: no-repeat; background-size: contain; display: inline-block;"
         />
       </button>
       <div
@@ -118,10 +118,10 @@ exports[`OnboardingAppHeader should match snapshot 1`] = `
             fill="rgb(22,22,22)"
           />
         </svg>
-        <img
-          alt=""
+        <span
+          aria-hidden="true"
           class="onboarding-app-header__metafox-logo--icon"
-          src="./images/logo/metamask-fox.svg"
+          style="background-image: url(./images/logo/metamask-fox.svg); background-position: center; background-repeat: no-repeat; background-size: contain; display: inline-block;"
         />
       </button>
       <div


### PR DESCRIPTION
## **Description**

React 17 attaches non-delegated `load` and `error` listeners to every React-created `img`. In the memory profiler heap snapshots, detached Home trees were retained through:

`V8EventListener -> native_bind -> img -> __reactFiber$... -> Home subtree`

This replaces the Home-path image elements in the deprecated extension avatar components, MetaFox logo, and balance empty state with background-image elements so React does not attach per-image listeners to those rendered nodes. AvatarToken and AvatarNetwork keep their existing fallback behavior by validating image URLs with an off-DOM `Image` instance that is cleaned up on unmount.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. In the memory investigation worktree, with the profiler tooling intentionally excluded from this PR: `source ~/.nvm/nvm.sh && nvm use && yarn llm:memory -- --iterations 20 --flow send-route --sample final --probe cdp --snapshot both --output test-artifacts/memory/send-route-background-image-final-cdp-heap-20.json`
2. Additional profiler spot checks in the investigation worktree: `settings-route` and `send-open-back` with 20 iterations.
3. See PR:  https://github.com/MetaMask/metamask-extension/pull/42733

Profiler evidence:

- `send-route` after Safe Chains cache fix, before this change: runtime `+16.11 MiB`, JS `+16.11 MiB`, DOM nodes `+2961`, JS listeners `+702` over 20 iterations.
- `send-route` after this change: runtime `+6.20 MiB`, JS `+2.65 MiB`, DOM nodes `+161`, JS listeners `+24` over 20 iterations.
- `send-open-back` after this change: runtime `+7.76 MiB`, JS `+7.76 MiB`, DOM nodes `+661`, JS listeners `+124` over 20 iterations.
- `settings-route` after this change: runtime `+9.60 MiB`, JS `+9.63 MiB`, DOM nodes `+5300`, JS listeners `+510` over 20 iterations. This still shows a separate settings-specific DOM/listener retention source.

<!-- ## **Screenshots/Recordings** -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

<!-- ### **Before** -->

<!-- [screenshots/recordings] -->

<!-- ### **After** -->

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
