### PR TITLE
fix: improve Perps withdraw validation and activity details

### DIFF
--- a/ui/components/app/transaction-list-item/helpers.test.ts
+++ b/ui/components/app/transaction-list-item/helpers.test.ts
@@ -85,6 +85,12 @@ describe('mapTransactionTypeToCategory', () => {
     );
   });
 
+  it('returns send category for perpsWithdraw', () => {
+    expect(mapTransactionTypeToCategory(TransactionType.perpsWithdraw)).toBe(
+      TransactionGroupCategory.send,
+    );
+  });
+
   it('returns send category for contractInteraction with Merkl distributor and claim method', () => {
     const resolved = resolveTransactionType(
       TransactionType.contractInteraction,

--- a/ui/components/app/transaction-list-item/helpers.ts
+++ b/ui/components/app/transaction-list-item/helpers.ts
@@ -65,6 +65,7 @@ export function mapTransactionTypeToCategory(
     case TransactionType.musdClaim:
     case TransactionType.musdConversion:
     case TransactionType.perpsDeposit:
+    case TransactionType.perpsWithdraw:
     case TransactionType.simpleSend: {
       return GroupCategory.send;
     }

--- a/ui/pages/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.test.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.test.tsx
@@ -7,7 +7,13 @@ import { TransactionDetailsProvider } from '../transaction-details-context';
 import { TransactionDetailsAccountRow } from './transaction-details-account-row';
 
 const FROM_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678';
-const ACCOUNT_NAME = 'Test Account';
+const UNKNOWN_FROM_ADDRESS = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+const INTERNAL_ACCOUNT_NAME = 'Test Account';
+const ACCOUNT_GROUP_NAME = 'Account 1';
+const SELECTED_ACCOUNT_GROUP_NAME = 'Account 2';
+const WALLET_ID = 'entropy:wallet';
+const ACCOUNT_GROUP_ID = `${WALLET_ID}/0`;
+const SELECTED_ACCOUNT_GROUP_ID = `${WALLET_ID}/1`;
 
 const mockStore = configureMockStore([]);
 
@@ -34,29 +40,71 @@ function createMockTransactionMeta(includeMetamaskPay = false) {
   };
 }
 
-const mockState = {
-  metamask: {
-    internalAccounts: {
-      accounts: {
-        'account-1': {
-          id: 'account-1',
-          address: FROM_ADDRESS,
-          metadata: { name: ACCOUNT_NAME },
-        },
-      },
-      selectedAccount: 'account-1',
+function createAccountGroup(id: string, name: string, accounts: string[]) {
+  return {
+    id,
+    type: 'multichain-account',
+    accounts,
+    metadata: {
+      name,
+      pinned: false,
+      hidden: false,
+      lastSelected: 0,
+    },
+  };
+}
+
+function createMockState({
+  accounts = {
+    'account-1': {
+      id: 'account-1',
+      address: FROM_ADDRESS,
+      metadata: { name: INTERNAL_ACCOUNT_NAME },
     },
   },
-};
+  selectedAccount = 'account-1',
+  selectedAccountGroup = ACCOUNT_GROUP_ID,
+  groups = {
+    [ACCOUNT_GROUP_ID]: createAccountGroup(ACCOUNT_GROUP_ID, ACCOUNT_GROUP_NAME, [
+      'account-1',
+    ]),
+  },
+}: {
+  accounts?: Record<string, unknown>;
+  selectedAccount?: string;
+  selectedAccountGroup?: string;
+  groups?: Record<string, unknown>;
+} = {}) {
+  return {
+    metamask: {
+      internalAccounts: {
+        accounts,
+        selectedAccount,
+      },
+      selectedAccountGroup,
+      accountTree: {
+        wallets: {
+          [WALLET_ID]: {
+            id: WALLET_ID,
+            type: 'entropy',
+            groups,
+            metadata: { name: 'Wallet 1' },
+          },
+        },
+      },
+    },
+  };
+}
+
+const mockState = createMockState();
 
 function render(
   state: Record<string, unknown> = mockState,
   includeMetamaskPay = true,
+  transactionMeta = createMockTransactionMeta(includeMetamaskPay),
 ) {
   return renderWithProvider(
-    <TransactionDetailsProvider
-      transactionMeta={createMockTransactionMeta(includeMetamaskPay) as never}
-    >
+    <TransactionDetailsProvider transactionMeta={transactionMeta as never}>
       <TransactionDetailsAccountRow />
     </TransactionDetailsProvider>,
     mockStore(state),
@@ -70,9 +118,46 @@ describe('TransactionDetailsAccountRow', () => {
   });
 
   describe('with metamaskPay data', () => {
-    it('renders account name when available', () => {
+    it('renders account group name when available', () => {
       const { getByText } = render();
-      expect(getByText(ACCOUNT_NAME)).toBeInTheDocument();
+      expect(getByText(ACCOUNT_GROUP_NAME)).toBeInTheDocument();
+    });
+
+    it('renders selected account group name when the transaction account name is unavailable', () => {
+      const state = createMockState({
+        accounts: {
+          'selected-account': {
+            id: 'selected-account',
+            address: UNKNOWN_FROM_ADDRESS,
+            metadata: { name: INTERNAL_ACCOUNT_NAME },
+          },
+        },
+        selectedAccount: 'selected-account',
+        selectedAccountGroup: SELECTED_ACCOUNT_GROUP_ID,
+        groups: {
+          [SELECTED_ACCOUNT_GROUP_ID]: createAccountGroup(
+            SELECTED_ACCOUNT_GROUP_ID,
+            SELECTED_ACCOUNT_GROUP_NAME,
+            ['selected-account'],
+          ),
+        },
+      });
+      const transactionMeta = {
+        ...createMockTransactionMeta(true),
+        txParams: {
+          from: FROM_ADDRESS,
+          to: '0x456',
+        },
+      };
+
+      const { getByText, queryByText } = render(
+        state,
+        true,
+        transactionMeta,
+      );
+
+      expect(getByText(SELECTED_ACCOUNT_GROUP_NAME)).toBeInTheDocument();
+      expect(queryByText(FROM_ADDRESS)).not.toBeInTheDocument();
     });
 
     it('renders with correct test id', () => {
@@ -85,6 +170,57 @@ describe('TransactionDetailsAccountRow', () => {
     it('renders Account label', () => {
       const { getByText } = render();
       expect(getByText(messages.account.message)).toBeInTheDocument();
+    });
+
+    it('renders selected account group name when the account address is missing', () => {
+      const transactionMeta = {
+        ...createMockTransactionMeta(true),
+        txParams: {
+          to: '0x456',
+        },
+      };
+
+      const { getByText } = render(mockState, true, transactionMeta);
+
+      expect(getByText(ACCOUNT_GROUP_NAME)).toBeInTheDocument();
+    });
+
+    it('renders first account group name when the selected account group is unavailable', () => {
+      const state = createMockState({
+        selectedAccount: '',
+        selectedAccountGroup: '',
+      });
+      const transactionMeta = {
+        ...createMockTransactionMeta(true),
+        txParams: {
+          to: '0x456',
+        },
+      };
+
+      const { getByText } = render(state, true, transactionMeta);
+
+      expect(getByText(ACCOUNT_GROUP_NAME)).toBeInTheDocument();
+    });
+
+    it('does not render when an account name cannot be resolved', () => {
+      const state = createMockState({
+        accounts: {},
+        selectedAccount: '',
+        selectedAccountGroup: '',
+        groups: {},
+      });
+      const transactionMeta = {
+        ...createMockTransactionMeta(true),
+        txParams: {
+          to: '0x456',
+        },
+      };
+
+      const { queryByTestId } = render(state, true, transactionMeta);
+
+      expect(
+        queryByTestId('transaction-details-account-row'),
+      ).not.toBeInTheDocument();
     });
   });
 });

--- a/ui/pages/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.test.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.test.tsx
@@ -174,6 +174,7 @@ describe('TransactionDetailsAccountRow', () => {
       const transactionMeta = {
         ...createMockTransactionMeta(true),
         txParams: {
+          from: '',
           to: '0x456',
         },
       };
@@ -191,6 +192,7 @@ describe('TransactionDetailsAccountRow', () => {
       const transactionMeta = {
         ...createMockTransactionMeta(true),
         txParams: {
+          from: '',
           to: '0x456',
         },
       };
@@ -210,6 +212,7 @@ describe('TransactionDetailsAccountRow', () => {
       const transactionMeta = {
         ...createMockTransactionMeta(true),
         txParams: {
+          from: '',
           to: '0x456',
         },
       };

--- a/ui/pages/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.test.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.test.tsx
@@ -65,9 +65,11 @@ function createMockState({
   selectedAccount = 'account-1',
   selectedAccountGroup = ACCOUNT_GROUP_ID,
   groups = {
-    [ACCOUNT_GROUP_ID]: createAccountGroup(ACCOUNT_GROUP_ID, ACCOUNT_GROUP_NAME, [
-      'account-1',
-    ]),
+    [ACCOUNT_GROUP_ID]: createAccountGroup(
+      ACCOUNT_GROUP_ID,
+      ACCOUNT_GROUP_NAME,
+      ['account-1'],
+    ),
   },
 }: {
   accounts?: Record<string, unknown>;
@@ -150,11 +152,7 @@ describe('TransactionDetailsAccountRow', () => {
         },
       };
 
-      const { getByText, queryByText } = render(
-        state,
-        true,
-        transactionMeta,
-      );
+      const { getByText, queryByText } = render(state, true, transactionMeta);
 
       expect(getByText(SELECTED_ACCOUNT_GROUP_NAME)).toBeInTheDocument();
       expect(queryByText(FROM_ADDRESS)).not.toBeInTheDocument();

--- a/ui/pages/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.tsx
@@ -12,6 +12,7 @@ import {
   getSelectedAccountGroup,
   selectAccountGroupNameByAddress,
 } from '../../../../../selectors/multichain-accounts/account-tree';
+import type { MultichainAccountsState } from '../../../../../selectors/multichain-accounts/account-tree.types';
 import { TransactionDetailsRow } from '../transaction-details-row';
 import { useTransactionDetails } from '../transaction-details-context';
 
@@ -20,7 +21,9 @@ export function TransactionDetailsAccountRow() {
   const t = useI18nContext();
   const { transactionMeta } = useTransactionDetails();
   const hasPaymentDetails = Boolean(transactionMeta.metamaskPay);
-  const selectedAccountGroupId = useSelector(getSelectedAccountGroup);
+  const selectedAccountGroupId = useSelector((state) =>
+    getSelectedAccountGroup(state as MultichainAccountsState),
+  );
 
   const {
     txParams: { from },
@@ -31,13 +34,16 @@ export function TransactionDetailsAccountRow() {
   );
   const selectedAccountGroupName = useSelector(
     (state) =>
-      getMultichainAccountGroupById(state, selectedAccountGroupId)?.metadata
-        .name,
+      getMultichainAccountGroupById(
+        state as MultichainAccountsState,
+        selectedAccountGroupId,
+      )?.metadata.name,
   );
   const firstAccountGroupName = useSelector(
     (state) =>
-      getAllAccountGroups(state).find((group) => group.metadata.name)?.metadata
-        .name,
+      getAllAccountGroups(state as MultichainAccountsState).find(
+        (group) => group.metadata.name,
+      )?.metadata.name,
   );
 
   const displayName =

--- a/ui/pages/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.tsx
@@ -21,30 +21,43 @@ export function TransactionDetailsAccountRow() {
   const t = useI18nContext();
   const { transactionMeta } = useTransactionDetails();
   const hasPaymentDetails = Boolean(transactionMeta.metamaskPay);
-  const selectedAccountGroupId = useSelector((state) =>
-    getSelectedAccountGroup(state as MultichainAccountsState),
-  );
+  const selectedAccountGroupId = useSelector((state) => {
+    const multichainAccountsState = getMultichainAccountsState(state);
+    return multichainAccountsState
+      ? getSelectedAccountGroup(multichainAccountsState)
+      : undefined;
+  });
 
   const {
     txParams: { from },
   } = transactionMeta;
 
-  const accountName = useSelector((state) =>
-    selectAccountGroupNameByAddress(state, from),
-  );
-  const selectedAccountGroupName = useSelector(
-    (state) =>
-      getMultichainAccountGroupById(
-        state as MultichainAccountsState,
-        selectedAccountGroupId,
-      )?.metadata.name,
-  );
-  const firstAccountGroupName = useSelector(
-    (state) =>
-      getAllAccountGroups(state as MultichainAccountsState).find(
-        (group) => group.metadata.name,
-      )?.metadata.name,
-  );
+  const accountName = useSelector((state) => {
+    const multichainAccountsState = getMultichainAccountsState(state);
+    return multichainAccountsState
+      ? selectAccountGroupNameByAddress(multichainAccountsState, from)
+      : undefined;
+  });
+  const selectedAccountGroupName = useSelector((state) => {
+    const multichainAccountsState = getMultichainAccountsState(state);
+
+    if (!multichainAccountsState || !selectedAccountGroupId) {
+      return undefined;
+    }
+
+    return getMultichainAccountGroupById(
+      multichainAccountsState,
+      selectedAccountGroupId,
+    )?.metadata.name;
+  });
+  const firstAccountGroupName = useSelector((state) => {
+    const multichainAccountsState = getMultichainAccountsState(state);
+    return multichainAccountsState
+      ? getAllAccountGroups(multichainAccountsState).find(
+          (group) => group.metadata.name,
+        )?.metadata.name
+      : undefined;
+  });
 
   const displayName =
     accountName || selectedAccountGroupName || firstAccountGroupName;
@@ -63,4 +76,14 @@ export function TransactionDetailsAccountRow() {
       </Text>
     </TransactionDetailsRow>
   );
+}
+
+function getMultichainAccountsState(
+  state: unknown,
+): MultichainAccountsState | undefined {
+  const maybeState = state as Partial<MultichainAccountsState>;
+
+  return maybeState.metamask?.accountTree?.wallets
+    ? (state as MultichainAccountsState)
+    : undefined;
 }

--- a/ui/pages/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.tsx
@@ -6,7 +6,12 @@ import {
   TextVariant,
 } from '../../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
-import { getAccountName, getInternalAccounts } from '../../../../../selectors';
+import {
+  getAllAccountGroups,
+  getMultichainAccountGroupById,
+  getSelectedAccountGroup,
+  selectAccountGroupNameByAddress,
+} from '../../../../../selectors/multichain-accounts/account-tree';
 import { TransactionDetailsRow } from '../transaction-details-row';
 import { useTransactionDetails } from '../transaction-details-context';
 
@@ -15,17 +20,30 @@ export function TransactionDetailsAccountRow() {
   const t = useI18nContext();
   const { transactionMeta } = useTransactionDetails();
   const hasPaymentDetails = Boolean(transactionMeta.metamaskPay);
-  const internalAccounts = useSelector(getInternalAccounts);
+  const selectedAccountGroupId = useSelector(getSelectedAccountGroup);
 
   const {
     txParams: { from },
   } = transactionMeta;
 
-  const accountName = getAccountName(internalAccounts, from);
+  const accountName = useSelector((state) =>
+    selectAccountGroupNameByAddress(state, from),
+  );
+  const selectedAccountGroupName = useSelector(
+    (state) =>
+      getMultichainAccountGroupById(state, selectedAccountGroupId)?.metadata
+        .name,
+  );
+  const firstAccountGroupName = useSelector(
+    (state) =>
+      getAllAccountGroups(state).find((group) => group.metadata.name)?.metadata
+        .name,
+  );
 
-  const displayName = accountName ?? from;
+  const displayName =
+    accountName || selectedAccountGroupName || firstAccountGroupName;
 
-  if (!hasPaymentDetails) {
+  if (!hasPaymentDetails || !displayName) {
     return null;
   }
 

--- a/ui/pages/confirmations/components/activity/transaction-details/transaction-details.test.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details/transaction-details.test.tsx
@@ -14,6 +14,8 @@ jest.mock('../../../hooks/send/useSendTokens', () => ({
 
 const CHAIN_ID = '0x1';
 const TOKEN_ADDRESS = '0xtoken123';
+const FROM_ADDRESS = '0x123';
+const ACCOUNT_NAME = 'Account 1';
 
 const mockStore = configureMockStore([]);
 
@@ -22,8 +24,14 @@ function createMockState(includeToken = false) {
     metamask: {
       transactions: [],
       internalAccounts: {
-        accounts: {},
-        selectedAccount: '',
+        accounts: {
+          'account-1': {
+            id: 'account-1',
+            address: FROM_ADDRESS,
+            metadata: { name: ACCOUNT_NAME },
+          },
+        },
+        selectedAccount: 'account-1',
       },
       allTokens: includeToken
         ? {
@@ -72,7 +80,7 @@ function createMockTransactionMeta(
     time: Date.now(),
     type,
     txParams: {
-      from: '0x123',
+      from: FROM_ADDRESS,
       to: '0x456',
     },
     ...(includeMetamaskPay && {

--- a/ui/pages/confirmations/components/confirm/footer/single-action-footer.test.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/single-action-footer.test.tsx
@@ -175,6 +175,25 @@ describe('<SingleActionFooter />', () => {
     expect(button).toHaveTextContent('Insufficient funds');
   });
 
+  it('shows insufficient funds on perpsWithdraw button when amount exceeds balance', () => {
+    const { getByTestId } = render({
+      confirmation: genPerpsWithdraw(),
+      alerts: [
+        {
+          key: 'insufficient-pay-token-balance',
+          severity: Severity.Danger,
+          reason: 'Insufficient funds',
+          message: 'Amount exceeds your available Perps balance.',
+          isBlocking: true,
+        },
+      ],
+    });
+
+    const button = getByTestId('confirm-footer-button');
+    expect(button).toBeDisabled();
+    expect(button).toHaveTextContent('Insufficient funds');
+  });
+
   it('disables button when amount is zero', () => {
     jest.mocked(useTransactionPayPrimaryRequiredToken).mockReturnValue({
       amountUsd: '0',

--- a/ui/pages/confirmations/components/confirm/info/perps-withdraw-info/perps-withdraw-info.tsx
+++ b/ui/pages/confirmations/components/confirm/info/perps-withdraw-info/perps-withdraw-info.tsx
@@ -6,6 +6,7 @@ import { CustomAmountInfo } from '../../../info/custom-amount-info';
 import { PerpsWithdrawBalance } from '../../../perps-confirmations/perps-withdraw-balance';
 import { PERPS_CURRENCY, ARBITRUM_USDC } from '../../../../constants/perps';
 import { usePerpsLiveAccount } from '../../../../../../hooks/perps/stream';
+import { getTradeableBalance } from '../../../../../../hooks/perps/getTradeableBalance';
 
 export const PerpsWithdrawInfo = () => {
   useAddToken({
@@ -20,10 +21,7 @@ export const PerpsWithdrawInfo = () => {
   const preferredToken = usePerpsWithdrawDefaultToken();
 
   const { account } = usePerpsLiveAccount();
-  const balanceUsdOverride =
-    parseFloat(
-      account?.withdrawableBalance ?? account?.spendableBalance ?? '0',
-    ) || 0;
+  const balanceUsdOverride = parseFloat(getTradeableBalance(account)) || 0;
 
   return (
     // Percentage buttons (25/50/75/Max) are intentionally hidden for MVP —

--- a/ui/pages/confirmations/components/perps-confirmations/perps-withdraw-balance/perps-withdraw-balance.tsx
+++ b/ui/pages/confirmations/components/perps-confirmations/perps-withdraw-balance/perps-withdraw-balance.tsx
@@ -12,6 +12,7 @@ import {
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { useFormatters } from '../../../../../hooks/useFormatters';
 import { usePerpsLiveAccount } from '../../../../../hooks/perps/stream';
+import { getTradeableBalance } from '../../../../../hooks/perps/getTradeableBalance';
 
 export const PerpsWithdrawBalance = () => {
   const t = useI18nContext();
@@ -19,12 +20,9 @@ export const PerpsWithdrawBalance = () => {
   const { account } = usePerpsLiveAccount();
 
   const balanceFormatted = useMemo(() => {
-    const value =
-      parseFloat(
-        account?.withdrawableBalance ?? account?.spendableBalance ?? '0',
-      ) || 0;
+    const value = parseFloat(getTradeableBalance(account)) || 0;
     return formatCurrency(value, 'USD');
-  }, [account?.spendableBalance, account?.withdrawableBalance, formatCurrency]);
+  }, [account, formatCurrency]);
 
   return (
     <Box

--- a/ui/pages/confirmations/hooks/alerts/transactions/usePerpsWithdrawInsufficientBalanceAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/usePerpsWithdrawInsufficientBalanceAlert.test.ts
@@ -37,8 +37,8 @@ const EXPECTED_ALERT = {
   field: RowAlertKey.EstimatedFee,
   isBlocking: true,
   key: AlertsName.InsufficientPayTokenBalance,
-  message: 'Amount exceeds your available Perps balance.',
-  reason: 'Enter a valid amount.',
+  message: 'Insufficient funds',
+  reason: 'Insufficient funds',
   severity: Severity.Danger,
 };
 

--- a/ui/pages/confirmations/hooks/alerts/transactions/usePerpsWithdrawInsufficientBalanceAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/usePerpsWithdrawInsufficientBalanceAlert.ts
@@ -60,8 +60,8 @@ export function usePerpsWithdrawInsufficientBalanceAlert(): Alert[] {
         field: RowAlertKey.EstimatedFee,
         isBlocking: true,
         key: AlertsName.InsufficientPayTokenBalance,
-        message: t('perpsWithdrawInsufficient'),
-        reason: t('perpsWithdrawInvalidAmount'),
+        message: t('alertInsufficientPayTokenBalance'),
+        reason: t('alertInsufficientPayTokenBalance'),
         severity: Severity.Danger,
       },
     ];


### PR DESCRIPTION
## **Description**

Fixes several Perps withdraw issues in the extension:

- Uses the normalized Perps balance in the withdraw confirmation UI.
- Shows `Insufficient funds` without the extra inline balance error.
- Uses the send-style icon for Perps withdraw activity items.
- Shows the account group name, for example `Account 1`, in Perps withdraw activity details.

## **Changelog**

CHANGELOG entry: Fixed Perps withdraw validation and activity details.

## **Related issues**

Fixes:
- CONF-1393
- CONF-1394
- CONF-1396
- CONF-1397

## **Manual testing steps**

1. Open Perps withdraw and enter an amount near the available balance.
2. Verify insufficient funds uses the correct disabled button copy and no extra inline balance error appears.
3. Complete a Perps withdraw and open activity details.
4. Verify the activity icon and Account row display correctly.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed MetaMask Contributor Docs and MetaMask Extension Coding Standards.
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using JSDoc format if applicable
- [ ] I’ve applied the right labels on the PR.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR.
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates Perps withdraw balance/alert logic and transaction categorization, which can affect whether confirmations are blocked and how activity is presented. Changes are UI/validation-focused and covered by added/updated tests, but still impact a key user flow.
> 
> **Overview**
> **Perps withdraw confirmations now use a normalized “tradeable” balance** (via `getTradeableBalance`) for the displayed available balance and the `CustomAmountInfo` balance override, aligning UI with the balance used elsewhere.
> 
> **Insufficient-funds handling for Perps withdraw is simplified/standardized**: the blocking alert now uses the generic `alertInsufficientPayTokenBalance` string for both `message` and `reason`, and tests assert the confirm button shows **“Insufficient funds”** when blocked.
> 
> **Activity presentation is adjusted for Perps withdraw**: `perpsWithdraw` transactions are mapped to the **send** category, and the activity details “Account” row now resolves and displays the **account group name** (with fallbacks to selected/first group) instead of an internal account name/address, returning `null` if no name can be resolved.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2273a2421dfc35f3b9583314d05e55d1b0e72d86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->