### PR TITLE
fix: release settings form controls on unmount

### DIFF
--- a/ui/pages/settings/settings.test.tsx
+++ b/ui/pages/settings/settings.test.tsx
@@ -111,6 +111,42 @@ describe('Settings', () => {
       ).toBeInTheDocument();
     });
 
+    it('detaches form controls that can be retained by non-delegated React listeners on unmount', async () => {
+      mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_FULLSCREEN);
+      const storeWithDefaultAddress = configureMockStore([thunk])({
+        ...mockState,
+        metamask: {
+          ...mockState.metamask,
+          remoteFeatureFlags: {
+            ...mockState.metamask.remoteFeatureFlags,
+            extensionUxDefaultAddressVersioned: true,
+          },
+        },
+      });
+
+      const { unmount } = renderSettings(storeWithDefaultAddress);
+      const select = await screen.findByTestId(
+        'default-address-scope-dropdown',
+      );
+
+      Object.defineProperty(select, '__reactFiber$test', {
+        configurable: true,
+        enumerable: true,
+        value: {},
+      });
+      Object.defineProperty(select, '__reactProps$test', {
+        configurable: true,
+        enumerable: true,
+        value: {},
+      });
+
+      unmount();
+
+      expect(select.parentElement).toBeNull();
+      expect('__reactFiber$test' in select).toBe(false);
+      expect('__reactProps$test' in select).toBe(false);
+    });
+
     it('navigates to transaction shield from the root page', async () => {
       renderSettings(mockStore);
 

--- a/ui/pages/settings/settings.tsx
+++ b/ui/pages/settings/settings.tsx
@@ -5,6 +5,7 @@ import React, {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from 'react';
 import {
@@ -78,6 +79,16 @@ const normalizeSettingsPath = (path: string) =>
 
 const getRoutePathname = (path: string) => path.split('?')[0];
 
+const reactRetainedElementSelector = 'input, select, textarea, img';
+
+const clearReactInternalReferences = (element: Element) => {
+  for (const key of Object.keys(element)) {
+    if (key.startsWith('__reactFiber$') || key.startsWith('__reactProps$')) {
+      delete (element as unknown as Record<string, unknown>)[key];
+    }
+  }
+};
+
 /**
  * Layout for Settings: header, tab bar, and content area.
  *
@@ -104,7 +115,28 @@ const SettingsLayout = ({ children }: { children: React.ReactNode }) => {
 
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [searchValue, setSearchValue] = useState('');
+  const settingsRootRef = useRef<HTMLElement | null>(null);
   const searchResults = useSettingsSearch(searchValue);
+
+  const setSettingsRootRef = useCallback((element: HTMLElement | null) => {
+    if (element) {
+      settingsRootRef.current = element;
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      settingsRootRef.current
+        ?.querySelectorAll(reactRetainedElementSelector)
+        .forEach((element) => {
+          // React 17 leaves per-node non-delegated event listeners on these
+          // elements. If the browser retains one listener target, the target's
+          // React internals and parent links can retain the whole settings tree.
+          clearReactInternalReferences(element);
+          element.remove();
+        });
+    };
+  }, []);
 
   // --- Shield entry modal interception ---
   const hasSubscribedToShield = useSelector(getHasSubscribedToShield);
@@ -381,6 +413,7 @@ const SettingsLayout = ({ children }: { children: React.ReactNode }) => {
 
   return (
     <Box
+      ref={setSettingsRootRef}
       flexDirection={BoxFlexDirection.Column}
       backgroundColor={BoxBackgroundColor.BackgroundDefault}
       className="h-full w-full shadow-xs"


### PR DESCRIPTION
## **Description**

The `settings-route` memory profile still retained one detached Settings page per route cycle after the shared image-listener fix. Heap snapshots showed the full settings subtree retained through React 17's per-node non-delegated listener on the native select:

`V8EventListener -> native_bind -> select[data-testid="default-address-scope-dropdown"] -> parent settings DOM subtree`

React 17 attaches per-node non-delegated listeners to form controls such as `input`, `select`, and `textarea`. On Settings unmount, this change detaches those retained listener targets and clears React's private host references so a retained listener target cannot keep the entire Settings tree alive. The cleanup is scoped to Settings and covered by a unit test that verifies the retained select is detached and scrubbed on unmount.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. `source ~/.nvm/nvm.sh && nvm use && yarn build:test`
2. In the memory investigation worktree, with profiler tooling intentionally excluded from this PR and the earlier memory fixes applied: `source ~/.nvm/nvm.sh && nvm use && yarn llm:memory -- --iterations 20 --flow settings-route --sample final --probe cdp --snapshot both --output test-artifacts/memory/settings-route-detach-form-controls-probe-cdp-heap-20.json`
PR: https://github.com/MetaMask/metamask-extension/pull/42733

Profiler evidence:

- `settings-route` before this change, after the earlier Safe Chains and image-listener fixes: runtime `+10.49 MiB`, JS `+6.89 MiB`, DOM nodes `+5581`, JS listeners `+534` over 20 iterations.
- `settings-route` after this change: runtime `+5.60 MiB`, JS `+3.49 MiB`, DOM nodes `+183`, JS listeners `+55` over 20 iterations.
- Heap delta after this change no longer shows retained copies of the settings root or `default-address-scope-dropdown`; remaining retained `maskicon` image nodes are detached from the settings tree.

<!-- ## **Screenshots/Recordings** -->

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

<!-- ### **Before** -->

<!-- [screenshots/recordings] -->

<!-- ### **After** -->

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds manual DOM cleanup during Settings unmount, which could inadvertently remove or interfere with elements if the selector scope or ref wiring is wrong. Changes are localized to the Settings page and covered by a new unit test.
> 
> **Overview**
> Prevents Settings-route memory retention by adding an unmount cleanup in `SettingsLayout` that finds `input/select/textarea/img` under the settings root, deletes React 17 internal `__reactFiber$`/`__reactProps$` references, and removes those nodes from the DOM.
> 
> Adds a regression test that mounts Settings with the default-address dropdown enabled, injects fake React internals onto the `<select>`, unmounts, and asserts the element is detached and the internal keys are cleared.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e95b112ccf609759fa25b1c2478a24c1e48f837. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->