### PR TITLE
bump: webpack-dev-server to fix audit cp-13.32.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -812,7 +812,7 @@
     "webpack": "^5.104.1",
     "webpack-bundle-analyzer": "^5.3.0",
     "webpack-cli": "^6.0.1",
-    "webpack-dev-server": "^5.2.3",
+    "webpack-dev-server": "^5.2.4",
     "ws": "^8.17.1",
     "yaml": "^2.4.1",
     "yargs": "^17.7.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34098,7 +34098,7 @@ __metadata:
     webpack: "npm:^5.104.1"
     webpack-bundle-analyzer: "npm:^5.3.0"
     webpack-cli: "npm:^6.0.1"
-    webpack-dev-server: "npm:^5.2.3"
+    webpack-dev-server: "npm:^5.2.4"
     ws: "npm:^8.17.1"
     xml2js: "npm:^0.6.2"
     yaml: "npm:^2.4.1"
@@ -45148,9 +45148,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-dev-server@npm:^5.2.3":
-  version: 5.2.3
-  resolution: "webpack-dev-server@npm:5.2.3"
+"webpack-dev-server@npm:^5.2.4":
+  version: 5.2.4
+  resolution: "webpack-dev-server@npm:5.2.4"
   dependencies:
     "@types/bonjour": "npm:^3.5.13"
     "@types/connect-history-api-fallback": "npm:^1.5.4"
@@ -45189,7 +45189,7 @@ __metadata:
       optional: true
   bin:
     webpack-dev-server: bin/webpack-dev-server.js
-  checksum: 10/6a3d55c5d84d10b5e23a0638e0031ef85b262947fdacc86d96b7392538ad5894ac14aebef1e2b877f8d27302c71247215b7aa6713e01b1c37d31342415b1a150
+  checksum: 10/5e5382f8cc7a73e2957542de0c755769548cbca8e7c6d17ed6b526364f11af35025be74f03827afa6723ccbdcc93730b0a0a59882d332fb3c6694a6d290c41e7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Bump webpack-dev-server from 5.2.3 to 5.2.4

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Closes: #42755

<!--## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency-only update limited to the dev build server; potential impact is confined to local development workflows if the new patch changes behavior.
> 
> **Overview**
> Updates `webpack-dev-server` from `5.2.3` to `5.2.4` in `package.json` and refreshes `yarn.lock` to pull the new resolved version/checksum (audit fix).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a866774233988fa607ea027c53a3fbe1d708398f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->