### PR TITLE
docs: E2E Test Decision Tree

### DIFF
--- a/.github/guidelines/E2E_DECISION_TREE.md
+++ b/.github/guidelines/E2E_DECISION_TREE.md
@@ -1,0 +1,181 @@
+# E2E Test Decision Tree
+
+The following diagram shows the high-level decision flow used by Extension CI
+to determine whether E2E tests run on a given PR or push.
+
+All logic lives in
+[`get-requirements.yml`](../workflows/get-requirements.yml) and the filter
+definitions in [`filter-rules.yml`](../rules/filter-rules.yml).
+
+```mermaid
+flowchart TD
+  START[CI run starts] --> RUNEVERY{"#1: Push to main or stable?"}
+
+  RUNEVERY -->|Yes| RUN_ALL[✅ Run all E2E tests<br/><i>safety net — always full signal</i>]
+
+  RUNEVERY -->|No| SKIPALL{"#2: skip-everything?<br/><i>locales-only / version bump /<br/>merge queue up-to-date</i>"}
+
+  SKIPALL -->|Yes| NO_E2E_SKIP[⏭️ Skip E2E<br/><i>entire CI skipped</i>]
+
+  SKIPALL -->|No| FORCE{"#3: force-e2e label<br/>or #91;force-e2e#93; tag?"}
+
+  FORCE -->|Yes| RUN_FORCE[✅ Run E2E<br/><i>manual force overrides all</i>]
+
+  FORCE -->|No| MSKIP{"#4: skip-e2e label<br/>or #91;skip-e2e#93; tag?"}
+
+  MSKIP -->|Yes| NO_E2E_MANUAL[⏭️ Skip E2E<br/><i>manual override</i>]
+
+  MSKIP -->|No| MATRIX{"#5: Builds from base branch<br/>AND no test/e2e/** changed?"}
+
+  MATRIX -->|Yes| NO_E2E_MATRIX[⏭️ Skip E2E<br/><i>2×2 matrix: validated builds +<br/>no E2E file changes</i>]
+
+  MATRIX -->|No| FILTER{"#6: All files non-E2E-related<br/>AND no build-affecting CI changed?"}
+
+  FILTER -->|Yes| NO_E2E_FILTER[⏭️ Skip E2E<br/><i>docs / tests / config only</i>]
+
+  FILTER -->|No| RUN_E2E_DEFAULT[✅ Run E2E<br/><i>#7: no skip condition met</i>]
+```
+
+---
+
+## Skip rules
+
+The skip conditions below are evaluated in this order — first match wins.
+These are referenced as **rule #1** through **rule #7** throughout this
+document.
+
+| # | Condition | Result | Rationale |
+|---|-----------|--------|-----------|
+| 1 | Push to `main` or `stable` | **Always run** | Safety net; all tests must pass on run-everything branches |
+| 2 | `skip-everything` is true | **Skip all CI** | Locales-only, version-bump-only, or merge-queue-up-to-date |
+| 3 | `force-e2e` label or `[force-e2e]` commit tag | **Force run** | Overrides all skip conditions below |
+| 4 | `skip-e2e` label or `[skip-e2e]` commit tag | **Skip** | Manual escape hatch for infra issues |
+| 5 | Builds reused from base branch AND no `test/e2e/**` files changed | **Skip** | 2×2 matrix — validated builds + no test changes |
+| 6 | ALL changed files match `non_e2e_related_files` AND no build-affecting CI files changed | **Skip** | Docs, unit tests, config, CI, dev tools only |
+| 7 | None of the above | **Run** | Default — when in doubt, run E2E |
+
+---
+
+## Build reuse and the 2×2 matrix
+
+The "builds from base branch" condition (rule #5) deserves special attention:
+
+| Builds from… | E2E test files changed? | E2E runs? | Why |
+|---|---|---|---|
+| `main` or `stable` | No | **Skip** | Builds validated by full CI on base branch |
+| `main` or `stable` | Yes | **Run** | Test fixtures/specs changed — must verify |
+| Same branch | Any | **Run** | Same-branch builds may not have passed tests |
+| Other branch (e.g. `feature-parent`) | Any | **Run** | Non-run-everything branches aren't validated |
+| No reuse (fresh build) | Any | **Run** | New builds need full verification |
+
+---
+
+## Manual overrides
+
+| Mechanism | Scope | Effect |
+|---|---|---|
+| `force-e2e` label | PR | Force E2E to run, overrides all skip logic |
+| `skip-e2e` label | PR | Skip E2E (escape hatch for infra issues) |
+| `[force-e2e]` in commit message | Single push | Same as label — force run |
+| `[skip-e2e]` in commit message | Single push | Same as label — skip |
+| `force-builds` label | PR | Force fresh builds (disables build reuse) |
+| `skip-builds` label | PR | Force build reuse regardless of hash match |
+
+> **Note:** Labels carry through to merge queue runs. Commit message tags do
+> NOT (they're ignored in merge queue to prevent leakage from squash messages).
+
+> **Cross-repo PRs:** Manual overrides are ignored for PRs from forks
+> (security measure — external contributors cannot bypass E2E).
+
+---
+
+## Non-E2E-related file categories
+
+These file types, when they are the ONLY changes in a PR, allow E2E to be
+skipped via rule #6:
+
+| Category | Patterns |
+|---|---|
+| Documentation | `**/*.{md,mdx,txt}`, `docs/**`, `LICENSE` |
+| Unit/integration tests | `**/*.test.*`, `**/*.snap`, `**/*.stories.*`, `test/{jest,lib,mocks,stub,unit-global}/**` |
+| Config files | `.eslint*`, `.prettierrc*`, `codecov.yml`, `stylelint.config.js`, etc. |
+| Dev tools | `development/{attributions,fitness-functions,lint-*,ts-migration-dashboard}/**` |
+| CI/GitHub | `.github/**` (with build-affecting exception below) |
+| Editor/Agent | `.agents/**`, `.claude/**`, `.cursor/**`, `.vscode/**`, `.storybook/**` |
+
+### Exception: build-affecting CI files
+
+`.github/workflows/run-build.yml` is under `.github/` (matches `ci_files`) but
+directly affects build output. If this file changes, rule #6 is blocked even if
+all other files are non-E2E-related.
+
+---
+
+## Other test types
+
+The same 2×2 matrix pattern applies to unit/integration and storybook tests:
+
+| Test type | Skip when | Filter |
+|---|---|---|
+| Unit & integration | Builds from base branch AND no `unit_integration_test_files` changed | `**/*.test.*`, `jest.config.js`, etc. |
+| Storybook | Builds from base branch AND no `storybook_files` changed | `**/*.stories.*`, `.storybook/**`, `**/*.snap` |
+| Benchmarks | Any build reuse (same or base branch) | N/A — identical builds = identical perf |
+
+---
+
+## Release branches
+
+Release branches (`release/*`) have stricter CI behavior than feature branches.
+
+| Behavior | Reason |
+|---|---|
+| `IS_RUN_EVERYTHING_BRANCH` = false | Only `main` and `stable` are run-everything |
+| `BRANCH` starts with `release/` | Detected via `startsWith` |
+| Build reuse **disabled** | `find-reusable-builds` is skipped — too high-risk to reuse builds on release branches |
+| E2E runs (unless rule #6 fires) | Rule #5 (2×2 matrix) can't fire without build reuse; rule #6 can still skip for docs/config-only pushes |
+| `BASE_BRANCH` = `stable` | Fallback for non-PR pushes on release branches |
+
+### PRs targeting `release/*` (cherry-picks)
+
+When a PR targets a release branch (e.g. `cherry-pick-fix` → `release/12.0.0`):
+
+| Behavior | Reason |
+|---|---|
+| `BRANCH` = PR head (e.g. `cherry-pick-fix`) | Not a release branch itself |
+| `BASE_BRANCH` = `release/12.0.0` | From `github.event.pull_request.base.ref` |
+| Build reuse **can occur** | `BRANCH` doesn't start with `release/`, so `find-reusable-builds` runs |
+| But: `builds-from-base-branch` = false | `release/*` is NOT in `runEverythingBranches` (`main`/`stable` only) |
+| E2E **runs** (unless rule #4 or #6 applies) | 2×2 matrix skip is blocked because builds aren't from a validated base |
+
+**Summary for release PRs:** Builds may be reused (saving build time), but
+tests always run because `release/*` branches aren't in the run-everything set.
+The only ways to skip E2E on a release PR are:
+
+1. **Manual skip** — `skip-e2e` label or `[skip-e2e]` commit tag (rule #4)
+2. **Non-E2E files only** — all changes are docs/tests/config (rule #6)
+
+### Why release branches don't allow test skipping
+
+Release branches always build and test fresh because:
+- They don't participate in the merge queue (no batching guarantees)
+- Cherry-picks may interact with release-specific state (version numbers, changelogs)
+- The cost of a missed regression on a release is much higher than on `main`
+- Release branches have low PR volume, so the time savings would be minimal
+
+---
+
+## FAQ
+
+**Q: My PR only changes docs but E2E still runs. Why?**
+A: Check that ALL files in the diff match `non_e2e_related_files`. A single
+file outside those patterns (even `package.json`) will prevent the skip.
+
+**Q: Why does the merge queue show more files changed than my PR?**
+A: The merge queue compares the merge group head against its base. If other
+PRs merged ahead of yours, their changes are included in the diff.
+
+**Q: My cherry-pick PR to a release branch takes longer than the same PR to main. Why?**
+A: PRs to `main` can skip tests via the 2×2 matrix (builds validated on main).
+PRs to `release/*` can reuse builds but always run tests because `release/*`
+isn't a run-everything branch. This is intentional — release stability takes
+priority over CI speed.

--- a/.github/guidelines/E2E_DECISION_TREE.md
+++ b/.github/guidelines/E2E_DECISION_TREE.md
@@ -48,7 +48,7 @@ document.
 |---|-----------|--------|-----------|
 | 1 | Push to `main` or `stable` | **Always run** | Safety net; all tests must pass on run-everything branches |
 | 2 | `skip-everything` is true | **Skip all CI** | Locales-only, version-bump-only, or merge-queue-up-to-date |
-| 3 | `force-e2e` label or `[force-e2e]` commit tag | **Force run** | Overrides all skip conditions below |
+| 3 | `force-e2e` label or `[force-e2e]` commit tag | **Force run** | Overrides skip conditions #4–#6 (but not #2 — `skip-everything` gates the entire step) |
 | 4 | `skip-e2e` label or `[skip-e2e]` commit tag | **Skip** | Manual escape hatch for infra issues |
 | 5 | Builds reused from base branch AND no `test/e2e/**` files changed | **Skip** | 2×2 matrix — validated builds + no test changes |
 | 6 | ALL changed files match `non_e2e_related_files` AND no build-affecting CI files changed | **Skip** | Docs, unit tests, config, CI, dev tools only |
@@ -74,15 +74,21 @@ The "builds from base branch" condition (rule #5) deserves special attention:
 
 | Mechanism | Scope | Effect |
 |---|---|---|
-| `force-e2e` label | PR | Force E2E to run, overrides all skip logic |
+| `force-e2e` label | PR | Force E2E to run, overrides skip conditions #4–#6 |
 | `skip-e2e` label | PR | Skip E2E (escape hatch for infra issues) |
 | `[force-e2e]` in commit message | Single push | Same as label — force run |
 | `[skip-e2e]` in commit message | Single push | Same as label — skip |
 | `force-builds` label | PR | Force fresh builds (disables build reuse) |
 | `skip-builds` label | PR | Force build reuse regardless of hash match |
 
-> **Note:** Labels carry through to merge queue runs. Commit message tags do
-> NOT (they're ignored in merge queue to prevent leakage from squash messages).
+> **Note:** E2E labels (`skip-e2e`, `force-e2e`) carry through to merge queue
+> runs via API label lookup. Build labels (`skip-builds`, `force-builds`) only
+> apply on `pull_request` events — the build-overrides step is skipped in the
+> merge queue.
+
+> **`skip-builds` and merge:** When `skip-builds` is used, builds are reused
+> without hash verification. The CI status gate blocks merge in this case —
+> remove the label and push again to merge.
 
 > **Cross-repo PRs:** Manual overrides are ignored for PRs from forks
 > (security measure — external contributors cannot bypass E2E).
@@ -151,8 +157,11 @@ When a PR targets a release branch (e.g. `cherry-pick-fix` → `release/12.0.0`)
 tests always run because `release/*` branches aren't in the run-everything set.
 The only ways to skip E2E on a release PR are:
 
-1. **Manual skip** — `skip-e2e` label or `[skip-e2e]` commit tag (rule #4)
-2. **Non-E2E files only** — all changes are docs/tests/config (rule #6)
+- **Manual skip** — `skip-e2e` label or `[skip-e2e]` commit tag (rule #4)
+- **Non-E2E files only** — all changes are docs/tests/config (rule #6)
+
+Rule #2 (`skip-everything`) also applies in theory, but locales-only or
+version-bump-only cherry-picks to release branches don't happen in practice.
 
 ### Why release branches don't allow test skipping
 

--- a/.github/guidelines/LABELING_GUIDELINES.md
+++ b/.github/guidelines/LABELING_GUIDELINES.md
@@ -24,6 +24,12 @@ Any label can be manually added on demand depending on the PR's content. For ins
 Using any of these labels should be exceptional in case of CI friction and urgencies. Please use them reasonably and verify new changes and regressions manually.
 
 - **skip-e2e-quality-gate**: This label will disable the default test retries for E2E test files modified in the PR. Useful when making large refactors or when changes don't pose flakiness risk.
+- **skip-e2e**: Skip E2E tests entirely. Use only if you're sure what you're working on will not affect them.
+- **force-e2e**: Force E2E tests to run, overriding all automatic skip conditions.
+- **skip-builds**: Force build reuse regardless of hash match (skip the build step).
+- **force-builds**: Force fresh builds, disabling build reuse.
+
+For the full CI flow that these labels control, see [E2E_DECISION_TREE.md](E2E_DECISION_TREE.md).
 
 ### Block merge if any is present
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1672,6 +1672,7 @@ Performance Checks (React Components):
 - **Controller Patterns:** [.cursor/rules/controller-guidelines/RULE.md](./.cursor/rules/controller-guidelines/RULE.md)
 - **Unit Testing:** [.cursor/rules/unit-testing-guidelines/RULE.md](./.cursor/rules/unit-testing-guidelines/RULE.md)
 - **E2E Testing:** [./test/e2e/AGENTS.md](./test/e2e/AGENTS.md)
+- **E2E CI Decision Tree:** [.github/guidelines/E2E_DECISION_TREE.md](./.github/guidelines/E2E_DECISION_TREE.md)
 - **E2E Deprecated Patterns:** [./test/e2e/AGENTS.md](./test/e2e/AGENTS.md)
 - **CI Workflows:** [.github/AGENTS.md](./.github/AGENTS.md)
 - **Front-End Performance:**

--- a/test/e2e/AGENTS.md
+++ b/test/e2e/AGENTS.md
@@ -8,6 +8,7 @@ Instructions for AI coding agents working on E2E tests in the MetaMask Browser E
 
 - **Creating new E2E tests (agent skill / workflow):** [.cursor/skills/creating-e2e-tests/SKILL.md](../../.cursor/skills/creating-e2e-tests/SKILL.md) (symlinked from `.claude/skills/` and `.agents/skills/` — edit the `.cursor` copy only)
 - **E2E testing:** [.cursor/rules/e2e-testing-guidelines/RULE.md](../../.cursor/rules/e2e-testing-guidelines/RULE.md)
+- **E2E CI decision tree:** [.github/guidelines/E2E_DECISION_TREE.md](../../.github/guidelines/E2E_DECISION_TREE.md) — when E2E runs/skips, label effects, build-reuse logic
 - **E2E deprecated patterns:** [.cursor/BUGBOT.md](../../.cursor/BUGBOT.md)
 - **Testing philosophy:** [docs/testing.md](../../docs/testing.md)
 - **E2E Driver API:** [webdriver/README.md](./webdriver/README.md)


### PR DESCRIPTION
## **Description**

A small guide describing when E2E tests are forced and skipped, and links to that guide (links are primarily for AI discovery).

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds CI/E2E decision guidance and cross-links; no runtime or workflow logic is modified, so risk is low.
> 
> **Overview**
> Adds new `.github/guidelines/E2E_DECISION_TREE.md` documenting the CI decision flow for when E2E runs vs skips (including build-reuse matrix, override labels/commit tags, and release-branch nuances).
> 
> Updates `.github/guidelines/LABELING_GUIDELINES.md`, `AGENTS.md`, and `test/e2e/AGENTS.md` to document the new CI labels (`skip-e2e`, `force-e2e`, `skip-builds`, `force-builds`) and link to the decision tree for discoverability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f121e5c96e7e0335047b7b1735fac0f3193b3cb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->