### PR TITLE
fix: selectNetworkClientId for applyAnvilPort fixture

### DIFF
--- a/test/e2e/playwright/llm-workflow/fixture-helper.ts
+++ b/test/e2e/playwright/llm-workflow/fixture-helper.ts
@@ -38,6 +38,7 @@ function applyAnvilPort(
   anvilPort: number,
 ): FixtureBuilderV2 {
   return builder.withNetworkController({
+    selectedNetworkClientId: 'localhost',
     networkConfigurationsByChainId: {
       '0x539': {
         blockExplorerUrls: [],


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes current anvil port network fixture for mm cli. It was missing the selectedNetworkClientId, which was being set to mainnet by default. This causes issues in the actual network selected.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: N/A

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only fixture change that explicitly sets `selectedNetworkClientId` to `localhost`, affecting only Playwright E2E network selection behavior.
> 
> **Overview**
> Fixes the Anvil-port fixture override used by Playwright E2E tests by setting `selectedNetworkClientId: 'localhost'` when patching the localhost (`0x539`) network.
> 
> This prevents the fixture from implicitly selecting mainnet after applying the dynamic RPC URL update, ensuring tests actually run against the intended local Anvil network.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b7037e7e7cd38ca57b32eb3a402ea7b95ed3b128. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->