### PR TITLE
refactor: migrate AccountPicker to DS

### DIFF
--- a/ui/components/multichain/account-picker/__snapshots__/account-picker.test.js.snap
+++ b/ui/components/multichain/account-picker/__snapshots__/account-picker.test.js.snap
@@ -3,74 +3,78 @@
 exports[`AccountPicker renders properly 1`] = `
 <div>
   <div
-    class="mm-box w-full mm-box--display-flex mm-box--flex-direction-row mm-box--align-items-center"
+    class="flex flex-row items-center w-full"
   >
     <button
-      class="mm-box mm-text mm-button-base mm-button-base--size-sm mm-button-base--ellipsis multichain-account-picker mm-text--body-md-medium mm-text--ellipsis mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--gap-1 mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-transparent mm-box--rounded-lg"
+      class="inline-flex items-center justify-center px-4 font-medium text-default overflow-hidden relative h-8 transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] multichain-account-picker bg-transparent rounded-lg min-w-0 gap-1"
       data-testid="account-menu-icon"
+      role="button"
       style="height: auto;"
     >
-      <span
-        class="mm-box mm-text mm-text--inherit mm-text--ellipsis mm-box--display-flex mm-box--gap-2 mm-box--align-items-center mm-box--color-text-default"
+      <div
+        class="flex flex-row gap-2 items-center min-w-0"
       >
         <div
-          class="mm-box min-w-0 mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center"
+          class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-sm h-4 w-4"
         >
           <div
-            class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-section rounded-sm h-4 w-4"
+            class="flex [&>div]:!rounded-none"
           >
             <div
-              class="flex [&>div]:!rounded-none"
+              style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 16px; height: 16px; display: inline-block; background: rgb(250, 58, 0);"
             >
-              <div
-                style="border-radius: 50px; overflow: hidden; padding: 0px; margin: 0px; width: 16px; height: 16px; display: inline-block; background: rgb(250, 58, 0);"
+              <svg
+                height="16"
+                width="16"
+                x="0"
+                y="0"
               >
-                <svg
+                <rect
+                  fill="#18CDF2"
                   height="16"
+                  transform="translate(-0.52419675189697 -1.65214203473025) rotate(328.9 8.00000000000000 8.00000000000000)"
                   width="16"
                   x="0"
                   y="0"
-                >
-                  <rect
-                    fill="#18CDF2"
-                    height="16"
-                    transform="translate(-0.52419675189697 -1.65214203473025) rotate(328.9 8.00000000000000 8.00000000000000)"
-                    width="16"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#035E56"
-                    height="16"
-                    transform="translate(-9.14923085441602 5.29623093587430) rotate(176.2 8.00000000000000 8.00000000000000)"
-                    width="16"
-                    x="0"
-                    y="0"
-                  />
-                  <rect
-                    fill="#F26602"
-                    height="16"
-                    transform="translate(8.33392100911196 -7.10256986149854) rotate(468.9 8.00000000000000 8.00000000000000)"
-                    width="16"
-                    x="0"
-                    y="0"
-                  />
-                </svg>
-              </div>
+                />
+                <rect
+                  fill="#035E56"
+                  height="16"
+                  transform="translate(-9.14923085441602 5.29623093587430) rotate(176.2 8.00000000000000 8.00000000000000)"
+                  width="16"
+                  x="0"
+                  y="0"
+                />
+                <rect
+                  fill="#F26602"
+                  height="16"
+                  transform="translate(8.33392100911196 -7.10256986149854) rotate(468.9 8.00000000000000 8.00000000000000)"
+                  width="16"
+                  x="0"
+                  y="0"
+                />
+              </svg>
             </div>
           </div>
-          <span
-            class="mm-box mm-text multichain-account-picker__label w-full mm-text--body-md-medium mm-text--ellipsis mm-box--color-text-default"
-            style="font-weight: 500;"
-          >
-            Account 1
-          </span>
         </div>
-      </span>
-      <span
-        class="mm-box mm-icon mm-icon--size-sm mm-box--margin-inline-start-1 mm-box--display-inline-block mm-box--color-icon-default"
-        style="mask-image: url('./images/icons/arrow-down.svg');"
-      />
+        <span
+          class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default truncate multichain-account-picker__label w-full"
+          style="font-weight: 500;"
+        >
+          Account 1
+        </span>
+      </div>
+      <svg
+        aria-hidden="true"
+        class="inline-block w-4 h-4 ml-2 shrink-0 text-inherit"
+        fill="currentColor"
+        viewBox="0 0 24 24"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="m2 7.887 1.775-1.775L12 14.337l8.225-8.225L22 7.887l-10 10z"
+        />
+      </svg>
     </button>
   </div>
 </div>

--- a/ui/components/multichain/account-picker/account-picker.js
+++ b/ui/components/multichain/account-picker/account-picker.js
@@ -1,31 +1,109 @@
 import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'clsx';
-import { AvatarAccountSize } from '@metamask/design-system-react';
-import { toChecksumHexAddress } from '../../../../shared/lib/hexstring-utils';
 import {
+  AvatarAccountSize,
   Box,
+  BoxAlignItems,
+  BoxFlexDirection,
   ButtonBase,
   ButtonBaseSize,
-  IconName,
-  Text,
-} from '../../component-library';
-import {
-  AlignItems,
-  BackgroundColor,
-  BorderRadius,
-  Display,
-  FlexDirection,
+  FontWeight,
   IconColor,
-  Size,
+  IconName,
+  IconSize,
+  Text,
   TextColor,
   TextVariant,
-} from '../../../helpers/constants/design-system';
+} from '@metamask/design-system-react';
+import { toChecksumHexAddress } from '../../../../shared/lib/hexstring-utils';
 import { shortenAddress } from '../../../helpers/utils/util';
 import { trace, TraceName } from '../../../../shared/lib/trace';
 import { PreferredAvatar } from '../../app/preferred-avatar';
 
 const AccountMenuStyle = { height: 'auto' };
+
+const SPACING_CLASSES = {
+  paddingLeft: {
+    0: 'pl-0',
+    1: 'pl-1',
+    2: 'pl-2',
+    3: 'pl-3',
+    4: 'pl-4',
+    5: 'pl-5',
+    6: 'pl-6',
+    7: 'pl-7',
+    8: 'pl-8',
+    9: 'pl-9',
+    10: 'pl-10',
+    11: 'pl-11',
+    12: 'pl-12',
+  },
+  paddingRight: {
+    0: 'pr-0',
+    1: 'pr-1',
+    2: 'pr-2',
+    3: 'pr-3',
+    4: 'pr-4',
+    5: 'pr-5',
+    6: 'pr-6',
+    7: 'pr-7',
+    8: 'pr-8',
+    9: 'pr-9',
+    10: 'pr-10',
+    11: 'pr-11',
+    12: 'pr-12',
+  },
+  paddingTop: {
+    0: 'pt-0',
+    1: 'pt-1',
+    2: 'pt-2',
+    3: 'pt-3',
+    4: 'pt-4',
+    5: 'pt-5',
+    6: 'pt-6',
+    7: 'pt-7',
+    8: 'pt-8',
+    9: 'pt-9',
+    10: 'pt-10',
+    11: 'pt-11',
+    12: 'pt-12',
+  },
+  paddingBottom: {
+    0: 'pb-0',
+    1: 'pb-1',
+    2: 'pb-2',
+    3: 'pb-3',
+    4: 'pb-4',
+    5: 'pb-5',
+    6: 'pb-6',
+    7: 'pb-7',
+    8: 'pb-8',
+    9: 'pb-9',
+    10: 'pb-10',
+    11: 'pb-11',
+    12: 'pb-12',
+  },
+};
+
+const BORDER_RADIUS_CLASSES = {
+  xs: 'rounded-xs',
+  sm: 'rounded-sm',
+  md: 'rounded-md',
+  lg: 'rounded-lg',
+  xl: 'rounded-xl',
+  none: 'rounded-none',
+  pill: 'rounded-full',
+  full: 'rounded-full',
+};
+
+const BORDER_COLOR_CLASSES = {
+  'border-default': 'border border-default',
+  'border-muted': 'border border-muted',
+  transparent: 'border border-transparent',
+};
+
+const getSpacingClassName = (type, value) => SPACING_CLASSES[type]?.[value];
 
 export const AccountPicker = ({
   address,
@@ -38,6 +116,14 @@ export const AccountPicker = ({
   textProps = {},
   className = '',
   showAvatarAccount = true,
+  block = false,
+  paddingLeft,
+  paddingRight,
+  paddingTop,
+  paddingBottom,
+  borderRadius,
+  borderColor,
+  endIconProps = {},
   ...props
 }) => {
   const shortenedAddress = address
@@ -52,48 +138,63 @@ export const AccountPicker = ({
     [labelProps.style],
   );
 
+  const { className: textPropsClassName, style: textPropsStyle } = textProps;
+  const { className: addressPropsClassName } = addressProps;
+  const { className: endIconPropsClassName, marginLeft, ...restEndIconProps } =
+    endIconProps;
+  const translatedEndIconProps = {
+    color: IconColor.IconDefault,
+    size: IconSize.Sm,
+    ...restEndIconProps,
+    ...(marginLeft === 'auto'
+      ? {
+          style: {
+            ...restEndIconProps.style,
+            marginLeft,
+          },
+        }
+      : {}),
+    ...(endIconPropsClassName ? { className: endIconPropsClassName } : {}),
+  };
+
   return (
     <Box
-      display={Display.Flex}
-      flexDirection={FlexDirection.Row}
-      alignItems={AlignItems.center}
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
       className="w-full"
     >
       <ButtonBase
-        className={classnames('multichain-account-picker', className)}
+        className={classnames(
+          'multichain-account-picker bg-transparent rounded-lg min-w-0 gap-1',
+          getSpacingClassName('paddingLeft', paddingLeft),
+          getSpacingClassName('paddingRight', paddingRight),
+          getSpacingClassName('paddingTop', paddingTop),
+          getSpacingClassName('paddingBottom', paddingBottom),
+          BORDER_RADIUS_CLASSES[borderRadius],
+          BORDER_COLOR_CLASSES[borderColor],
+          className,
+        )}
         data-testid="account-menu-icon"
         onClick={() => {
           trace({ name: TraceName.AccountList });
           onClick();
         }}
-        backgroundColor={BackgroundColor.transparent}
-        borderRadius={BorderRadius.LG}
-        ellipsis
-        textProps={{
-          display: Display.Flex,
-          alignItems: AlignItems.center,
-          gap: 2,
-          ...textProps,
-        }}
         size={showAddress ? ButtonBaseSize.Lg : ButtonBaseSize.Sm}
-        disabled={disabled}
+        isDisabled={disabled}
+        isFullWidth={block}
         endIconName={IconName.ArrowDown}
-        endIconProps={{
-          color: IconColor.iconDefault,
-          size: Size.SM,
-        }}
+        endIconProps={translatedEndIconProps}
         {...props}
-        gap={1}
         style={AccountMenuStyle}
       >
         <Box
-          display={Display.Flex}
           flexDirection={
-            showAvatarAccount ? FlexDirection.Row : FlexDirection.Column
+            showAvatarAccount ? BoxFlexDirection.Row : BoxFlexDirection.Column
           }
-          alignItems={AlignItems.center}
+          alignItems={BoxAlignItems.Center}
           gap={showAvatarAccount ? 2 : 0}
-          className="min-w-0"
+          className={classnames('min-w-0', textPropsClassName)}
+          style={textPropsStyle}
         >
           {showAvatarAccount ? (
             <PreferredAvatar
@@ -102,9 +203,10 @@ export const AccountPicker = ({
             />
           ) : null}
           <Text
-            as="span"
+            asChild
             ellipsis
-            variant={TextVariant.bodyMdMedium}
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Medium}
             {...labelProps}
             className={classnames(
               'multichain-account-picker__label w-full',
@@ -112,17 +214,22 @@ export const AccountPicker = ({
             )}
             style={accountNameStyling}
           >
-            {name}
-            {showAddress ? (
-              <Text
-                color={TextColor.textAlternative}
-                variant={TextVariant.bodySmMedium}
-                ellipsis
-                {...addressProps}
-              >
-                {shortenedAddress}
-              </Text>
-            ) : null}
+            <span>
+              {name}
+              {showAddress ? (
+                <Text
+                  color={TextColor.TextAlternative}
+                  variant={TextVariant.BodySm}
+                  fontWeight={FontWeight.Medium}
+                  ellipsis
+                  {...addressProps}
+                  asChild
+                  className={classnames('block', addressPropsClassName)}
+                >
+                  <span>{shortenedAddress}</span>
+                </Text>
+              ) : null}
+            </span>
           </Text>
         </Box>
       </ButtonBase>
@@ -159,6 +266,22 @@ AccountPicker.propTypes = {
    * Represents if the AccountPicker should take full width
    */
   block: PropTypes.bool,
+  /**
+   * Legacy padding props translated to DSR Tailwind classes
+   */
+  paddingLeft: PropTypes.number,
+  paddingRight: PropTypes.number,
+  paddingTop: PropTypes.number,
+  paddingBottom: PropTypes.number,
+  /**
+   * Legacy border props translated to DSR Tailwind classes
+   */
+  borderRadius: PropTypes.string,
+  borderColor: PropTypes.string,
+  /**
+   * Props to be added to the end icon
+   */
+  endIconProps: PropTypes.object,
   /**
    * Props to be added to the label element
    */

--- a/ui/components/multichain/account-picker/account-picker.js
+++ b/ui/components/multichain/account-picker/account-picker.js
@@ -117,12 +117,12 @@ export const AccountPicker = ({
   className = '',
   showAvatarAccount = true,
   block = false,
-  paddingLeft,
-  paddingRight,
-  paddingTop,
-  paddingBottom,
-  borderRadius,
-  borderColor,
+  paddingLeft = /** @type {number | undefined} */ (undefined),
+  paddingRight = /** @type {number | undefined} */ (undefined),
+  paddingTop = /** @type {number | undefined} */ (undefined),
+  paddingBottom = /** @type {number | undefined} */ (undefined),
+  borderRadius = /** @type {string | undefined} */ (undefined),
+  borderColor = /** @type {string | undefined} */ (undefined),
   endIconProps = {},
   ...props
 }) => {
@@ -140,8 +140,11 @@ export const AccountPicker = ({
 
   const { className: textPropsClassName, style: textPropsStyle } = textProps;
   const { className: addressPropsClassName } = addressProps;
-  const { className: endIconPropsClassName, marginLeft, ...restEndIconProps } =
-    endIconProps;
+  const {
+    className: endIconPropsClassName,
+    marginLeft,
+    ...restEndIconProps
+  } = endIconProps;
   const translatedEndIconProps = {
     color: IconColor.IconDefault,
     size: IconSize.Sm,

--- a/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
+++ b/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
@@ -106,31 +106,35 @@ exports[`App Header unlocked state matches snapshot: unlocked 1`] = `
             class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--display-flex mm-box--flex-direction-column mm-box--align-items-flex-start mm-box--color-text-default"
           >
             <div
-              class="mm-box w-full mm-box--display-flex mm-box--flex-direction-row mm-box--align-items-center"
+              class="flex flex-row items-center w-full"
             >
               <button
-                class="mm-box mm-text mm-button-base mm-button-base--size-sm mm-button-base--ellipsis multichain-account-picker mm-text--body-md-medium mm-text--ellipsis mm-box--padding-0 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-inline-flex mm-box--gap-1 mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-transparent mm-box--rounded-lg"
+                class="inline-flex items-center justify-center px-4 font-medium text-default overflow-hidden relative h-8 transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] multichain-account-picker bg-transparent rounded-lg min-w-0 gap-1 pl-2 pr-2"
                 data-testid="account-menu-icon"
+                role="button"
                 style="height: auto;"
               >
-                <span
-                  class="mm-box mm-text mm-text--inherit mm-text--ellipsis mm-box--display-flex mm-box--gap-2 mm-box--align-items-center mm-box--color-text-default"
+                <div
+                  class="flex flex-col gap-0 items-center min-w-0"
                 >
-                  <div
-                    class="mm-box min-w-0 mm-box--display-flex mm-box--gap-0 mm-box--flex-direction-column mm-box--align-items-center"
+                  <span
+                    class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default truncate multichain-account-picker__label w-full"
+                    style="font-weight: 500;"
                   >
-                    <span
-                      class="mm-box mm-text multichain-account-picker__label w-full mm-text--body-md-medium mm-text--ellipsis mm-box--color-text-default"
-                      style="font-weight: 500;"
-                    >
-                      Account 1
-                    </span>
-                  </div>
-                </span>
-                <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--margin-inline-start-1 mm-box--display-inline-block mm-box--color-icon-default"
-                  style="mask-image: url('./images/icons/arrow-down.svg');"
-                />
+                    Account 1
+                  </span>
+                </div>
+                <svg
+                  aria-hidden="true"
+                  class="inline-block w-4 h-4 ml-2 shrink-0 text-inherit"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="m2 7.887 1.775-1.775L12 14.337l8.225-8.225L22 7.887l-10 10z"
+                  />
+                </svg>
               </button>
             </div>
           </div>


### PR DESCRIPTION
## **Description**

Migrates the multichain `AccountPicker` component from deprecated `ui/components/component-library` imports to `@metamask/design-system-react` equivalents.

This keeps the existing account picker behavior while translating the old utility-style props used by consumers into DSR/Tailwind classes, including button padding, full-width layout, border styling, icon props, text truncation, and avatar/name/address layout.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1671

## **Manual testing steps**

1. Import a few SRPs
2. Check that the account pickers renders 

## **Screenshots/Recordings**

<img width="300" alt="Screenshot 2026-05-19 at 10 08 41 PM" src="https://github.com/user-attachments/assets/f9922712-c332-4255-9ba1-473b59edd7b9" /> <img width="300" alt="Screenshot 2026-05-19 at 10 08 54 PM" src="https://github.com/user-attachments/assets/1391d494-0d73-4b4e-b98f-1527078184bf" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
<!-- - [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable -->
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily a UI refactor, but it changes `AccountPicker`’s prop handling and class composition (spacing/border/icon props), which could subtly affect layout and styling across consumers.
> 
> **Overview**
> Migrates the multichain `AccountPicker` from the deprecated internal `component-library`/design-system constants to `@metamask/design-system-react` components and enums.
> 
> Adds legacy-compat props (`padding*`, `borderRadius`, `borderColor`, `endIconProps`, `block`) that are translated into Tailwind/DSR classes and updated `ButtonBase`/`Text` APIs (`isDisabled`, `isFullWidth`, `asChild`, new variants).
> 
> Updates Jest snapshots for `AccountPicker` and `AppHeader` to reflect the new DOM structure/classes (including the new down-arrow SVG icon rendering).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 783fb2485ac4a9e24f93a16cc98c3c7f17fa1549. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->