### PR TITLE
feat(ci): add upload-extension-to-cws workflow for CWS submission

### DIFF
--- a/.github/workflows/upload-extension-to-cws.yml
+++ b/.github/workflows/upload-extension-to-cws.yml
@@ -38,20 +38,40 @@ jobs:
       VERSION: ${{ inputs.version }}
       RELEASE_TAG: v${{ inputs.version }}
       ZIP_NAME: metamask-chrome-${{ inputs.version }}.zip
-      WIF_PROVIDER: ${{ inputs.target == 'beta' && vars.WIF_PROVIDER_BETA || vars.WIF_PROVIDER }}
-      WIF_SERVICE_ACCOUNT: ${{ inputs.target == 'beta' && vars.WIF_SERVICE_ACCOUNT_BETA || vars.WIF_SERVICE_ACCOUNT }}
-      EXTENSION_ID: ${{ inputs.target == 'beta' && vars.EXTENSION_ID_BETA || vars.EXTENSION_ID }}
-      PUBLISHER_EMAIL: ${{ inputs.target == 'beta' && vars.PUBLISHER_EMAIL_BETA || vars.PUBLISHER_EMAIL }}
     steps:
       - name: Validate inputs and configuration
+        env:
+          TARGET: ${{ inputs.target }}
+          WIF_PROVIDER_BETA: ${{ vars.WIF_PROVIDER_BETA }}
+          WIF_SERVICE_ACCOUNT_BETA: ${{ vars.WIF_SERVICE_ACCOUNT_BETA }}
+          EXTENSION_ID_BETA: ${{ vars.EXTENSION_ID_BETA }}
+          PUBLISHER_EMAIL_BETA: ${{ vars.PUBLISHER_EMAIL_BETA }}
+          WIF_PROVIDER_PROD: ${{ vars.WIF_PROVIDER }}
+          WIF_SERVICE_ACCOUNT_PROD: ${{ vars.WIF_SERVICE_ACCOUNT }}
+          EXTENSION_ID_PROD: ${{ vars.EXTENSION_ID }}
+          PUBLISHER_EMAIL_PROD: ${{ vars.PUBLISHER_EMAIL }}
         run: |
           set -euo pipefail
           if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
             echo "::error::Invalid version format: ${VERSION}"
             exit 1
           fi
-          if [[ "${{ inputs.target }}" == "production" && "${{ github.ref }}" != "refs/heads/main" ]]; then
+          if [[ "${TARGET}" == "production" && "${{ github.ref }}" != "refs/heads/main" ]]; then
             echo "::error::Production uploads must run from the main branch (current: ${{ github.ref }})"
+            exit 1
+          fi
+          if [[ "${TARGET}" == "beta" ]]; then
+            WIF_PROVIDER="${WIF_PROVIDER_BETA}"
+            WIF_SERVICE_ACCOUNT="${WIF_SERVICE_ACCOUNT_BETA}"
+            EXTENSION_ID="${EXTENSION_ID_BETA}"
+            PUBLISHER_EMAIL="${PUBLISHER_EMAIL_BETA}"
+          elif [[ "${TARGET}" == "production" ]]; then
+            WIF_PROVIDER="${WIF_PROVIDER_PROD}"
+            WIF_SERVICE_ACCOUNT="${WIF_SERVICE_ACCOUNT_PROD}"
+            EXTENSION_ID="${EXTENSION_ID_PROD}"
+            PUBLISHER_EMAIL="${PUBLISHER_EMAIL_PROD}"
+          else
+            echo "::error::Invalid target: ${TARGET}"
             exit 1
           fi
           missing=""
@@ -61,15 +81,21 @@ jobs:
             fi
           done
           if [[ -n "${missing}" ]]; then
-            echo "::error::Missing repository variables for target '${{ inputs.target }}':${missing}"
+            echo "::error::Missing repository variables for target '${TARGET}':${missing}"
             exit 1
           fi
+          {
+            echo "WIF_PROVIDER=${WIF_PROVIDER}"
+            echo "WIF_SERVICE_ACCOUNT=${WIF_SERVICE_ACCOUNT}"
+            echo "EXTENSION_ID=${EXTENSION_ID}"
+            echo "PUBLISHER_EMAIL=${PUBLISHER_EMAIL}"
+          } >> "${GITHUB_ENV}"
           {
             echo "## CWS upload"
             echo ""
             echo "| Field | Value |"
             echo "|-------|-------|"
-            echo "| Target | \`${{ inputs.target }}\` |"
+            echo "| Target | \`${TARGET}\` |"
             echo "| Version | \`${VERSION}\` |"
             echo "| Release tag | \`${RELEASE_TAG}\` |"
             echo "| Asset | \`${ZIP_NAME}\` |"
@@ -139,6 +165,17 @@ jobs:
             exit 1
           fi
 
+          UPLOAD_STATE=$(jq -r '.uploadState // empty' /tmp/response.json)
+          echo "upload_state=${UPLOAD_STATE}" >> "${GITHUB_OUTPUT}"
+          if [[ "${UPLOAD_STATE}" != "SUCCESS" ]]; then
+            echo "::error::CWS upload failed: uploadState=${UPLOAD_STATE:-<missing>}"
+            if jq -e '.itemError | length > 0' /tmp/response.json >/dev/null 2>&1; then
+              echo "::error::itemError:"
+              jq -c '.itemError[]' /tmp/response.json
+            fi
+            exit 1
+          fi
+
           echo "Package uploaded (draft/pending review). Not published to users."
 
       - name: Summary
@@ -151,6 +188,7 @@ jobs:
             echo "| Field | Value |"
             echo "|-------|-------|"
             echo "| HTTP status | \`${{ steps.cws-upload.outputs.http_code || 'n/a' }}\` |"
+            echo "| CWS uploadState | \`${{ steps.cws-upload.outputs.upload_state || 'n/a' }}\` |"
             echo "| Published to users | no (upload only) |"
             echo "| Workflow run | ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} |"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/upload-extension-to-cws.yml
+++ b/.github/workflows/upload-extension-to-cws.yml
@@ -30,6 +30,9 @@ jobs:
     name: Upload to CWS (${{ inputs.target }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.target }}
+      cancel-in-progress: false
     environment: ${{ inputs.target == 'production' && 'cws-production' || inputs.target == 'beta' && 'cws-beta' || null }}
     env:
       VERSION: ${{ inputs.version }}

--- a/.github/workflows/upload-extension-to-cws.yml
+++ b/.github/workflows/upload-extension-to-cws.yml
@@ -5,10 +5,6 @@ name: Upload extension to Chrome Web Store
 # Production: cws-production environment + prod variables (INFRA-3644).
 # CWS API v2 upload (v1.1 sunsets 2026-10-15): chromewebstore.googleapis.com/upload/v2/...
 # Runway sender verification: deferred to INFRA-3649 (RAPID runtime identity enforcement).
-#
-# TEMP (remove before merge): pull_request + label `test-cws-upload` for PR testing.
-# Requires repo variable CWS_PR_TEST_VERSION (Chrome manifest version, e.g. 13.31.0) and
-# release v{CWS_PR_TEST_VERSION} with asset metamask-chrome-{version}.zip.
 
 on:
   workflow_dispatch:
@@ -25,9 +21,6 @@ on:
         options:
           - beta
           - production
-  # TEMP — delete before merging to main
-  pull_request:
-    types: [labeled, synchronize]
 
 permissions:
   contents: read
@@ -35,28 +28,21 @@ permissions:
 
 jobs:
   upload:
-    name: Upload to CWS (${{ github.event_name == 'workflow_dispatch' && inputs.target || 'beta' }})
+    name: Upload to CWS (${{ inputs.target }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: >-
-      github.event_name == 'workflow_dispatch'
-      || (
-        github.event_name == 'pull_request'
-        && github.event.pull_request.head.repo.full_name == github.repository
-        && contains(join(github.event.pull_request.labels.*.name, ','), 'test-cws-upload')
-      )
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.target || 'beta' }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.target }}
       cancel-in-progress: false
-    environment: ${{ (github.event_name == 'workflow_dispatch' && inputs.target == 'production' && 'cws-production') || 'cws-beta' }}
+    environment: ${{ inputs.target == 'production' && 'cws-production' || inputs.target == 'beta' && 'cws-beta' || null }}
     env:
-      VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || vars.CWS_PR_TEST_VERSION }}
-      RELEASE_TAG: v${{ github.event_name == 'workflow_dispatch' && inputs.version || vars.CWS_PR_TEST_VERSION }}
-      ZIP_NAME: metamask-chrome-${{ github.event_name == 'workflow_dispatch' && inputs.version || vars.CWS_PR_TEST_VERSION }}.zip
+      VERSION: ${{ inputs.version }}
+      RELEASE_TAG: v${{ inputs.version }}
+      ZIP_NAME: metamask-chrome-${{ inputs.version }}.zip
     steps:
       - name: Validate inputs and configuration
         env:
-          TARGET: ${{ github.event_name == 'workflow_dispatch' && inputs.target || 'beta' }}
+          TARGET: ${{ inputs.target }}
           WIF_PROVIDER_BETA: ${{ vars.WIF_PROVIDER_BETA }}
           WIF_SERVICE_ACCOUNT_BETA: ${{ vars.WIF_SERVICE_ACCOUNT_BETA }}
           EXTENSION_ID_BETA: ${{ vars.EXTENSION_ID_BETA }}
@@ -69,17 +55,6 @@ jobs:
           PUBLISHER_EMAIL_PROD: ${{ vars.PUBLISHER_EMAIL }}
         run: |
           set -euo pipefail
-          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "TEMP PR test mode (label: test-cws-upload, target: beta, environment: cws-beta)"
-          fi
-          if [[ -z "${VERSION}" ]]; then
-            echo "::error::VERSION is empty. For pull_request runs set repo variable CWS_PR_TEST_VERSION."
-            exit 1
-          fi
-          if [[ "${{ github.event_name }}" == "pull_request" && "${TARGET}" != "beta" ]]; then
-            echo "::error::pull_request test runs are beta-only"
-            exit 1
-          fi
           if [[ ! "${VERSION}" =~ ^[0-9]+(\.[0-9]+){0,3}$ ]]; then
             echo "::error::Invalid version format (Chrome manifest): ${VERSION} — use 1–4 dot-separated integers (e.g. 13.0.0), not semver pre-release/build metadata"
             exit 1
@@ -126,7 +101,6 @@ jobs:
             exit 1
           fi
           {
-            echo "TARGET=${TARGET}"
             echo "WIF_PROVIDER=${WIF_PROVIDER}"
             echo "WIF_SERVICE_ACCOUNT=${WIF_SERVICE_ACCOUNT}"
             echo "EXTENSION_ID=${EXTENSION_ID}"
@@ -138,7 +112,6 @@ jobs:
             echo ""
             echo "| Field | Value |"
             echo "|-------|-------|"
-            echo "| Trigger | \`${{ github.event_name }}\` |"
             echo "| Target | \`${TARGET}\` |"
             echo "| Version | \`${VERSION}\` |"
             echo "| Release tag | \`${RELEASE_TAG}\` |"
@@ -161,7 +134,7 @@ jobs:
 
       # Beta/dev listing rejects manifest.key tied to production extension ID (POC lesson).
       - name: Strip manifest key from zip (beta only)
-        if: env.TARGET == 'beta'
+        if: inputs.target == 'beta'
         run: |
           set -euo pipefail
           mkdir -p /tmp/extension
@@ -187,7 +160,7 @@ jobs:
           ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
         run: |
           set -euo pipefail
-          echo "Target: ${TARGET}"
+          echo "Target: ${{ inputs.target }}"
           echo "Publisher ID: ${PUBLISHER_ID}"
           echo "Extension ID: ${EXTENSION_ID}"
           echo "Publisher email (dashboard): ${PUBLISHER_EMAIL}"

--- a/.github/workflows/upload-extension-to-cws.yml
+++ b/.github/workflows/upload-extension-to-cws.yml
@@ -103,7 +103,7 @@ jobs:
 
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
           workload_identity_provider: ${{ env.WIF_PROVIDER }}
           service_account: ${{ env.WIF_SERVICE_ACCOUNT }}

--- a/.github/workflows/upload-extension-to-cws.yml
+++ b/.github/workflows/upload-extension-to-cws.yml
@@ -3,6 +3,7 @@ name: Upload extension to Chrome Web Store
 # INFRA-3646 — workflow_dispatch upload to CWS via GCP WIF (no refresh tokens in GitHub Secrets).
 # Beta: cws-beta environment + *_BETA repo variables (INFRA-3645).
 # Production: cws-production environment + prod variables (INFRA-3644).
+# CWS API v2 upload (v1.1 sunsets 2026-10-15): chromewebstore.googleapis.com/upload/v2/...
 # Runway sender verification: deferred to INFRA-3649 (RAPID runtime identity enforcement).
 
 on:
@@ -45,10 +46,12 @@ jobs:
           WIF_PROVIDER_BETA: ${{ vars.WIF_PROVIDER_BETA }}
           WIF_SERVICE_ACCOUNT_BETA: ${{ vars.WIF_SERVICE_ACCOUNT_BETA }}
           EXTENSION_ID_BETA: ${{ vars.EXTENSION_ID_BETA }}
+          PUBLISHER_ID_BETA: ${{ vars.PUBLISHER_ID_BETA }}
           PUBLISHER_EMAIL_BETA: ${{ vars.PUBLISHER_EMAIL_BETA }}
           WIF_PROVIDER_PROD: ${{ vars.WIF_PROVIDER }}
           WIF_SERVICE_ACCOUNT_PROD: ${{ vars.WIF_SERVICE_ACCOUNT }}
           EXTENSION_ID_PROD: ${{ vars.EXTENSION_ID }}
+          PUBLISHER_ID_PROD: ${{ vars.PUBLISHER_ID }}
           PUBLISHER_EMAIL_PROD: ${{ vars.PUBLISHER_EMAIL }}
         run: |
           set -euo pipefail
@@ -58,7 +61,11 @@ jobs:
           fi
           IFS='.' read -r -a version_parts <<< "${VERSION}"
           for part in "${version_parts[@]}"; do
-            if (( part < 0 || part > 65535 )); then
+            if [[ ! "${part}" =~ ^(0|[1-9][0-9]*)$ ]]; then
+              echo "::error::Version segment must be a non-negative integer without leading zeros: ${part} in ${VERSION}"
+              exit 1
+            fi
+            if (( 10#${part} > 65535 )); then
               echo "::error::Version segment out of range (0–65535): ${part} in ${VERSION}"
               exit 1
             fi
@@ -71,18 +78,20 @@ jobs:
             WIF_PROVIDER="${WIF_PROVIDER_BETA}"
             WIF_SERVICE_ACCOUNT="${WIF_SERVICE_ACCOUNT_BETA}"
             EXTENSION_ID="${EXTENSION_ID_BETA}"
+            PUBLISHER_ID="${PUBLISHER_ID_BETA}"
             PUBLISHER_EMAIL="${PUBLISHER_EMAIL_BETA}"
           elif [[ "${TARGET}" == "production" ]]; then
             WIF_PROVIDER="${WIF_PROVIDER_PROD}"
             WIF_SERVICE_ACCOUNT="${WIF_SERVICE_ACCOUNT_PROD}"
             EXTENSION_ID="${EXTENSION_ID_PROD}"
+            PUBLISHER_ID="${PUBLISHER_ID_PROD}"
             PUBLISHER_EMAIL="${PUBLISHER_EMAIL_PROD}"
           else
             echo "::error::Invalid target: ${TARGET}"
             exit 1
           fi
           missing=""
-          for name in WIF_PROVIDER WIF_SERVICE_ACCOUNT EXTENSION_ID PUBLISHER_EMAIL; do
+          for name in WIF_PROVIDER WIF_SERVICE_ACCOUNT EXTENSION_ID PUBLISHER_ID PUBLISHER_EMAIL; do
             if [[ -z "${!name:-}" ]]; then
               missing="${missing} ${name}"
             fi
@@ -95,6 +104,7 @@ jobs:
             echo "WIF_PROVIDER=${WIF_PROVIDER}"
             echo "WIF_SERVICE_ACCOUNT=${WIF_SERVICE_ACCOUNT}"
             echo "EXTENSION_ID=${EXTENSION_ID}"
+            echo "PUBLISHER_ID=${PUBLISHER_ID}"
             echo "PUBLISHER_EMAIL=${PUBLISHER_EMAIL}"
           } >> "${GITHUB_ENV}"
           {
@@ -107,6 +117,7 @@ jobs:
             echo "| Release tag | \`${RELEASE_TAG}\` |"
             echo "| Asset | \`${ZIP_NAME}\` |"
             echo "| Extension ID | \`${EXTENSION_ID}\` |"
+            echo "| Publisher ID | \`${PUBLISHER_ID}\` |"
             echo "| Service account | \`${WIF_SERVICE_ACCOUNT}\` |"
           } >> "${GITHUB_STEP_SUMMARY}"
 
@@ -150,18 +161,22 @@ jobs:
         run: |
           set -euo pipefail
           echo "Target: ${{ inputs.target }}"
+          echo "Publisher ID: ${PUBLISHER_ID}"
           echo "Extension ID: ${EXTENSION_ID}"
-          echo "Publisher email: ${PUBLISHER_EMAIL}"
+          echo "Publisher email (dashboard): ${PUBLISHER_EMAIL}"
           echo "Version: ${VERSION}"
           echo "Zip size: $(stat --format=%s "${ZIP_NAME}") bytes"
           echo ""
 
-          HTTP_CODE=$(curl -s -o /tmp/response.json -w "%{http_code}" \
-            -X PUT \
+          UPLOAD_URL="https://chromewebstore.googleapis.com/upload/v2/publishers/${PUBLISHER_ID}/items/${EXTENSION_ID}:upload"
+          FETCH_STATUS_URL="https://chromewebstore.googleapis.com/v2/publishers/${PUBLISHER_ID}/items/${EXTENSION_ID}:fetchStatus"
+
+          HTTP_CODE=$(curl -sS \
+            -o /tmp/response.json -w "%{http_code}" \
+            -X POST \
             -H "Authorization: Bearer ${ACCESS_TOKEN}" \
-            -H "x-goog-api-version: 2" \
             -T "${ZIP_NAME}" \
-            "https://www.googleapis.com/upload/chromewebstore/v1.1/items/${EXTENSION_ID}?uploadType=media&publisherEmail=${PUBLISHER_EMAIL}")
+            "${UPLOAD_URL}")
 
           echo "http_code=${HTTP_CODE}" >> "${GITHUB_OUTPUT}"
           echo "HTTP Status: ${HTTP_CODE}"
@@ -171,17 +186,45 @@ jobs:
 
           if [[ "${HTTP_CODE}" != "200" ]]; then
             echo "::error::Upload failed with HTTP ${HTTP_CODE}"
+            cat /tmp/response.json
             exit 1
           fi
 
           UPLOAD_STATE=$(jq -r '.uploadState // empty' /tmp/response.json)
-          echo "upload_state=${UPLOAD_STATE}" >> "${GITHUB_OUTPUT}"
-          if [[ "${UPLOAD_STATE}" != "SUCCESS" ]]; then
-            echo "::error::CWS upload failed: uploadState=${UPLOAD_STATE:-<missing>}"
-            if jq -e '.itemError | length > 0' /tmp/response.json >/dev/null 2>&1; then
-              echo "::error::itemError:"
-              jq -c '.itemError[]' /tmp/response.json
+          if [[ "${UPLOAD_STATE}" == "IN_PROGRESS" ]]; then
+            max_polls=6
+            poll_interval_seconds=10
+            echo "Upload in progress; polling :fetchStatus (up to ${max_polls}×${poll_interval_seconds}s)..."
+            poll=0
+            while [[ "${UPLOAD_STATE}" == "IN_PROGRESS" && poll -lt ${max_polls} ]]; do
+              poll=$((poll + 1))
+              sleep "${poll_interval_seconds}"
+              FETCH_HTTP_CODE=$(curl -sS \
+                -o /tmp/fetch-status.json -w "%{http_code}" \
+                -H "Authorization: Bearer ${ACCESS_TOKEN}" \
+                "${FETCH_STATUS_URL}")
+              if [[ "${FETCH_HTTP_CODE}" != "200" ]]; then
+                echo "::error::fetchStatus failed with HTTP ${FETCH_HTTP_CODE} (poll ${poll}/${max_polls})"
+                cat /tmp/fetch-status.json
+                exit 1
+              fi
+              UPLOAD_STATE=$(jq -r '.lastAsyncUploadState // empty' /tmp/fetch-status.json)
+              echo "Poll ${poll}/${max_polls}: uploadState=${UPLOAD_STATE:-<unset>}"
+            done
+            if [[ "${UPLOAD_STATE}" == "IN_PROGRESS" ]]; then
+              echo "::error::CWS upload still IN_PROGRESS after ${max_polls} polls (${poll_interval_seconds}s apart); check CWS console or re-run"
+              cat /tmp/fetch-status.json
+              exit 1
             fi
+            if [[ -f /tmp/fetch-status.json ]]; then
+              cp /tmp/fetch-status.json /tmp/response.json
+            fi
+          fi
+
+          echo "upload_state=${UPLOAD_STATE}" >> "${GITHUB_OUTPUT}"
+          if [[ "${UPLOAD_STATE}" != "SUCCEEDED" ]]; then
+            echo "::error::CWS upload failed: uploadState=${UPLOAD_STATE:-<missing>}"
+            cat /tmp/response.json
             exit 1
           fi
 

--- a/.github/workflows/upload-extension-to-cws.yml
+++ b/.github/workflows/upload-extension-to-cws.yml
@@ -1,0 +1,153 @@
+name: Upload extension to Chrome Web Store
+
+# INFRA-3646 — workflow_dispatch upload to CWS via GCP WIF (no refresh tokens in GitHub Secrets).
+# Beta: cws-beta environment + *_BETA repo variables (INFRA-3645).
+# Production: cws-production environment + prod variables (INFRA-3644).
+# Runway sender verification: deferred to INFRA-3649 (RAPID runtime identity enforcement).
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (semver without v), e.g. 13.0.0 — must match GitHub Release tag v{version}'
+        required: true
+        type: string
+      target:
+        description: 'CWS target'
+        required: true
+        type: choice
+        default: beta
+        options:
+          - beta
+          - production
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  upload:
+    name: Upload to CWS (${{ inputs.target }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment: ${{ inputs.target == 'production' && 'cws-production' || inputs.target == 'beta' && 'cws-beta' || null }}
+    env:
+      VERSION: ${{ inputs.version }}
+      RELEASE_TAG: v${{ inputs.version }}
+      ZIP_NAME: metamask-chrome-${{ inputs.version }}.zip
+      WIF_PROVIDER: ${{ inputs.target == 'beta' && vars.WIF_PROVIDER_BETA || vars.WIF_PROVIDER }}
+      WIF_SERVICE_ACCOUNT: ${{ inputs.target == 'beta' && vars.WIF_SERVICE_ACCOUNT_BETA || vars.WIF_SERVICE_ACCOUNT }}
+      EXTENSION_ID: ${{ inputs.target == 'beta' && vars.EXTENSION_ID_BETA || vars.EXTENSION_ID }}
+      PUBLISHER_EMAIL: ${{ inputs.target == 'beta' && vars.PUBLISHER_EMAIL_BETA || vars.PUBLISHER_EMAIL }}
+    steps:
+      - name: Validate inputs and configuration
+        run: |
+          set -euo pipefail
+          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Invalid version format: ${VERSION}"
+            exit 1
+          fi
+          if [[ "${{ inputs.target }}" == "production" && "${{ github.ref }}" != "refs/heads/main" ]]; then
+            echo "::error::Production uploads must run from the main branch (current: ${{ github.ref }})"
+            exit 1
+          fi
+          missing=""
+          for name in WIF_PROVIDER WIF_SERVICE_ACCOUNT EXTENSION_ID PUBLISHER_EMAIL; do
+            if [[ -z "${!name:-}" ]]; then
+              missing="${missing} ${name}"
+            fi
+          done
+          if [[ -n "${missing}" ]]; then
+            echo "::error::Missing repository variables for target '${{ inputs.target }}':${missing}"
+            exit 1
+          fi
+          {
+            echo "## CWS upload"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Target | \`${{ inputs.target }}\` |"
+            echo "| Version | \`${VERSION}\` |"
+            echo "| Release tag | \`${RELEASE_TAG}\` |"
+            echo "| Asset | \`${ZIP_NAME}\` |"
+            echo "| Extension ID | \`${EXTENSION_ID}\` |"
+            echo "| Service account | \`${WIF_SERVICE_ACCOUNT}\` |"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+      - name: Download release asset
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          echo "Downloading ${ZIP_NAME} from release ${RELEASE_TAG}..."
+          gh release download "${RELEASE_TAG}" \
+            --repo "${{ github.repository }}" \
+            --pattern "${ZIP_NAME}"
+          ls -lh "${ZIP_NAME}"
+
+      # Beta/dev listing rejects manifest.key tied to production extension ID (POC lesson).
+      - name: Strip manifest key from zip (beta only)
+        if: inputs.target == 'beta'
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/extension
+          unzip -q "${ZIP_NAME}" -d /tmp/extension
+          jq 'del(.key) | .version = env.VERSION' /tmp/extension/manifest.json > /tmp/extension/manifest-tmp.json
+          mv /tmp/extension/manifest-tmp.json /tmp/extension/manifest.json
+          cd /tmp/extension
+          zip -r -q "${GITHUB_WORKSPACE}/${ZIP_NAME}" .
+          echo "Stripped manifest key and set version in manifest.json"
+
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: google-github-actions/auth@c200f3691d83b41bf9bbd8638997a462592937ed # v2.1.13
+        with:
+          workload_identity_provider: ${{ env.WIF_PROVIDER }}
+          service_account: ${{ env.WIF_SERVICE_ACCOUNT }}
+          token_format: access_token
+          access_token_scopes: https://www.googleapis.com/auth/chromewebstore
+
+      - name: Upload to Chrome Web Store
+        id: cws-upload
+        run: |
+          set -euo pipefail
+          echo "Target: ${{ inputs.target }}"
+          echo "Extension ID: ${EXTENSION_ID}"
+          echo "Publisher email: ${PUBLISHER_EMAIL}"
+          echo "Version: ${VERSION}"
+          echo "Zip size: $(stat --format=%s "${ZIP_NAME}") bytes"
+          echo ""
+
+          HTTP_CODE=$(curl -s -o /tmp/response.json -w "%{http_code}" \
+            -X PUT \
+            -H "Authorization: Bearer ${{ steps.auth.outputs.access_token }}" \
+            -H "x-goog-api-version: 2" \
+            -T "${ZIP_NAME}" \
+            "https://www.googleapis.com/upload/chromewebstore/v1.1/items/${EXTENSION_ID}?uploadType=media&publisherEmail=${PUBLISHER_EMAIL}")
+
+          echo "http_code=${HTTP_CODE}" >> "${GITHUB_OUTPUT}"
+          echo "HTTP Status: ${HTTP_CODE}"
+          echo ""
+          cat /tmp/response.json
+          echo ""
+
+          if [[ "${HTTP_CODE}" != "200" ]]; then
+            echo "::error::Upload failed with HTTP ${HTTP_CODE}"
+            exit 1
+          fi
+
+          echo "Package uploaded (draft/pending review). Not published to users."
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo ""
+            echo "### Result"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| HTTP status | \`${{ steps.cws-upload.outputs.http_code || 'n/a' }}\` |"
+            echo "| Published to users | no (upload only) |"
+            echo "| Workflow run | ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} |"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/upload-extension-to-cws.yml
+++ b/.github/workflows/upload-extension-to-cws.yml
@@ -9,7 +9,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version (semver without v), e.g. 13.0.0 — must match GitHub Release tag v{version}'
+        description: 'Chrome manifest version (1–4 dot-separated integers, e.g. 13.0.0) — must match GitHub Release tag v{version}'
         required: true
         type: string
       target:
@@ -52,10 +52,17 @@ jobs:
           PUBLISHER_EMAIL_PROD: ${{ vars.PUBLISHER_EMAIL }}
         run: |
           set -euo pipefail
-          if [[ ! "${VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$ ]]; then
-            echo "::error::Invalid version format: ${VERSION}"
+          if [[ ! "${VERSION}" =~ ^[0-9]+(\.[0-9]+){0,3}$ ]]; then
+            echo "::error::Invalid version format (Chrome manifest): ${VERSION} — use 1–4 dot-separated integers (e.g. 13.0.0), not semver pre-release/build metadata"
             exit 1
           fi
+          IFS='.' read -r -a version_parts <<< "${VERSION}"
+          for part in "${version_parts[@]}"; do
+            if (( part < 0 || part > 65535 )); then
+              echo "::error::Version segment out of range (0–65535): ${part} in ${VERSION}"
+              exit 1
+            fi
+          done
           if [[ "${TARGET}" == "production" && "${{ github.ref }}" != "refs/heads/main" ]]; then
             echo "::error::Production uploads must run from the main branch (current: ${{ github.ref }})"
             exit 1
@@ -138,6 +145,8 @@ jobs:
 
       - name: Upload to Chrome Web Store
         id: cws-upload
+        env:
+          ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
         run: |
           set -euo pipefail
           echo "Target: ${{ inputs.target }}"
@@ -149,7 +158,7 @@ jobs:
 
           HTTP_CODE=$(curl -s -o /tmp/response.json -w "%{http_code}" \
             -X PUT \
-            -H "Authorization: Bearer ${{ steps.auth.outputs.access_token }}" \
+            -H "Authorization: Bearer ${ACCESS_TOKEN}" \
             -H "x-goog-api-version: 2" \
             -T "${ZIP_NAME}" \
             "https://www.googleapis.com/upload/chromewebstore/v1.1/items/${EXTENSION_ID}?uploadType=media&publisherEmail=${PUBLISHER_EMAIL}")

--- a/.github/workflows/upload-extension-to-cws.yml
+++ b/.github/workflows/upload-extension-to-cws.yml
@@ -5,6 +5,10 @@ name: Upload extension to Chrome Web Store
 # Production: cws-production environment + prod variables (INFRA-3644).
 # CWS API v2 upload (v1.1 sunsets 2026-10-15): chromewebstore.googleapis.com/upload/v2/...
 # Runway sender verification: deferred to INFRA-3649 (RAPID runtime identity enforcement).
+#
+# TEMP (remove before merge): pull_request + label `test-cws-upload` for PR testing.
+# Requires repo variable CWS_PR_TEST_VERSION (Chrome manifest version, e.g. 13.31.0) and
+# release v{CWS_PR_TEST_VERSION} with asset metamask-chrome-{version}.zip.
 
 on:
   workflow_dispatch:
@@ -21,6 +25,9 @@ on:
         options:
           - beta
           - production
+  # TEMP — delete before merging to main
+  pull_request:
+    types: [labeled, synchronize]
 
 permissions:
   contents: read
@@ -28,21 +35,28 @@ permissions:
 
 jobs:
   upload:
-    name: Upload to CWS (${{ inputs.target }})
+    name: Upload to CWS (${{ github.event_name == 'workflow_dispatch' && inputs.target || 'beta' }})
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    if: >-
+      github.event_name == 'workflow_dispatch'
+      || (
+        github.event_name == 'pull_request'
+        && github.event.pull_request.head.repo.full_name == github.repository
+        && contains(join(github.event.pull_request.labels.*.name, ','), 'test-cws-upload')
+      )
     concurrency:
-      group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.target }}
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name == 'workflow_dispatch' && inputs.target || 'beta' }}
       cancel-in-progress: false
-    environment: ${{ inputs.target == 'production' && 'cws-production' || inputs.target == 'beta' && 'cws-beta' || null }}
+    environment: ${{ (github.event_name == 'workflow_dispatch' && inputs.target == 'production' && 'cws-production') || 'cws-beta' }}
     env:
-      VERSION: ${{ inputs.version }}
-      RELEASE_TAG: v${{ inputs.version }}
-      ZIP_NAME: metamask-chrome-${{ inputs.version }}.zip
+      VERSION: ${{ github.event_name == 'workflow_dispatch' && inputs.version || vars.CWS_PR_TEST_VERSION }}
+      RELEASE_TAG: v${{ github.event_name == 'workflow_dispatch' && inputs.version || vars.CWS_PR_TEST_VERSION }}
+      ZIP_NAME: metamask-chrome-${{ github.event_name == 'workflow_dispatch' && inputs.version || vars.CWS_PR_TEST_VERSION }}.zip
     steps:
       - name: Validate inputs and configuration
         env:
-          TARGET: ${{ inputs.target }}
+          TARGET: ${{ github.event_name == 'workflow_dispatch' && inputs.target || 'beta' }}
           WIF_PROVIDER_BETA: ${{ vars.WIF_PROVIDER_BETA }}
           WIF_SERVICE_ACCOUNT_BETA: ${{ vars.WIF_SERVICE_ACCOUNT_BETA }}
           EXTENSION_ID_BETA: ${{ vars.EXTENSION_ID_BETA }}
@@ -55,6 +69,17 @@ jobs:
           PUBLISHER_EMAIL_PROD: ${{ vars.PUBLISHER_EMAIL }}
         run: |
           set -euo pipefail
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "TEMP PR test mode (label: test-cws-upload, target: beta, environment: cws-beta)"
+          fi
+          if [[ -z "${VERSION}" ]]; then
+            echo "::error::VERSION is empty. For pull_request runs set repo variable CWS_PR_TEST_VERSION."
+            exit 1
+          fi
+          if [[ "${{ github.event_name }}" == "pull_request" && "${TARGET}" != "beta" ]]; then
+            echo "::error::pull_request test runs are beta-only"
+            exit 1
+          fi
           if [[ ! "${VERSION}" =~ ^[0-9]+(\.[0-9]+){0,3}$ ]]; then
             echo "::error::Invalid version format (Chrome manifest): ${VERSION} — use 1–4 dot-separated integers (e.g. 13.0.0), not semver pre-release/build metadata"
             exit 1
@@ -101,6 +126,7 @@ jobs:
             exit 1
           fi
           {
+            echo "TARGET=${TARGET}"
             echo "WIF_PROVIDER=${WIF_PROVIDER}"
             echo "WIF_SERVICE_ACCOUNT=${WIF_SERVICE_ACCOUNT}"
             echo "EXTENSION_ID=${EXTENSION_ID}"
@@ -112,6 +138,7 @@ jobs:
             echo ""
             echo "| Field | Value |"
             echo "|-------|-------|"
+            echo "| Trigger | \`${{ github.event_name }}\` |"
             echo "| Target | \`${TARGET}\` |"
             echo "| Version | \`${VERSION}\` |"
             echo "| Release tag | \`${RELEASE_TAG}\` |"
@@ -134,7 +161,7 @@ jobs:
 
       # Beta/dev listing rejects manifest.key tied to production extension ID (POC lesson).
       - name: Strip manifest key from zip (beta only)
-        if: inputs.target == 'beta'
+        if: env.TARGET == 'beta'
         run: |
           set -euo pipefail
           mkdir -p /tmp/extension
@@ -160,7 +187,7 @@ jobs:
           ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
         run: |
           set -euo pipefail
-          echo "Target: ${{ inputs.target }}"
+          echo "Target: ${TARGET}"
           echo "Publisher ID: ${PUBLISHER_ID}"
           echo "Extension ID: ${EXTENSION_ID}"
           echo "Publisher email (dashboard): ${PUBLISHER_EMAIL}"


### PR DESCRIPTION
## **Description**

Adds `upload-extension-to-cws.yml`, a `workflow_dispatch`-only GitHub Actions workflow that uploads `metamask-chrome-{version}.zip` from GitHub Releases to the Chrome Web Store using **GCP Workload Identity Federation** (no refresh tokens in GitHub Secrets).

**Why:** Replaces manual CWSS upload with an auditable, keyless pipeline ([INFRA-3646](https://consensyssoftware.atlassian.net/browse/INFRA-3646), epic [INFRA-2565](https://consensyssoftware.atlassian.net/browse/INFRA-2565)).

**How:**
- Inputs: `version` (semver) + `target` (`beta` | `production`, default `beta`)
- Resolves `*_BETA` or production repo **variables** per target
- WIF auth via pinned `google-github-actions/auth` **v3.0.0**, then `curl` PUT to CWS (update only — does not publish live)
- Beta: strips `manifest.json` `key` before upload (POC lesson for dev listing)
- Production: requires `cws-production` environment + `main` branch ref
- Concurrency group per workflow/ref/target (no cancel-in-progress)

Runway sender verification is **out of scope** for this PR ([INFRA-3649](https://consensyssoftware.atlassian.net/browse/INFRA-3649)).

**Beta E2E (validated on this branch):** [Actions run 26119853507](https://github.com/MetaMask/metamask-extension/actions/runs/26119853507) — `target=beta`, `version=13.31.0`, HTTP **200**, `uploadState: SUCCESS`, dev extension `beknelapmjpgbnafpmjnhjekjdbhbnbk` (not published to users). Validated via a temporary PR trigger that has been **removed**; merge-ready workflow is `workflow_dispatch` only.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [INFRA-3646](https://consensyssoftware.atlassian.net/browse/INFRA-3646)

Related: [INFRA-3645](https://consensyssoftware.atlassian.net/browse/INFRA-3645) (beta WIF + variables), [INFRA-3644](https://consensyssoftware.atlassian.net/browse/INFRA-3644) (production WIF + variables)

## **Manual testing steps**

**Prerequisites (repo admin):**
1. GitHub Environment **`cws-beta`** (no required reviewers for beta).
2. `*_BETA` repo variables set (INFRA-3645).
3. WIF trusts `MetaMask/metamask-extension`; SA is manager on dev CWS item `beknelapmjpgbnafpmjnhjekjdbhbnbk`.

**Beta test (completed):**
1. [Run 26119853507](https://github.com/MetaMask/metamask-extension/actions/runs/26119853507) — success on dev listing.
2. After merge: Actions → **Upload extension to Chrome Web Store** → Run workflow from `main` (or feature branch for beta).
3. `version`: must match an existing release asset `metamask-chrome-{version}.zip` on tag `v{version}`.
4. `target`: `beta` (default).
5. Expect HTTP 200; package pending in CWS dev console (upload only).

**Post-merge / follow-up:**
- Production E2E + `cws-production` environment ([INFRA-3644](https://consensyssoftware.atlassian.net/browse/INFRA-3644)).
- Optional: remove repo variable `CWS_PR_TEST_VERSION` if it was added only for PR testing.

## **Screenshots/Recordings**

N/A — CI workflow only (no UI change).

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable — N/A (workflow-only; E2E is manual dispatch)
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable — N/A
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[INFRA-3646]: https://consensyssoftware.atlassian.net/browse/INFRA-3646?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INFRA-2565]: https://consensyssoftware.atlassian.net/browse/INFRA-2565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INFRA-3649]: https://consensyssoftware.atlassian.net/browse/INFRA-3649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new privileged GitHub Actions workflow that can upload extension packages to the Chrome Web Store using OIDC/WIF; misconfiguration of repo variables/environments or misuse of manual dispatch could publish unintended builds (though it only uploads as draft).
> 
> **Overview**
> Introduces a new `workflow_dispatch` GitHub Actions workflow (`.github/workflows/upload-extension-to-cws.yml`) to **upload a release ZIP from GitHub Releases to the Chrome Web Store** using **GCP Workload Identity Federation** (OIDC), avoiding long-lived secrets.
> 
> The workflow validates `version`/`target`, selects beta vs production repository variables and environment, optionally strips `manifest.json` `key` for beta uploads, then calls the CWS API v2 upload endpoint and polls `fetchStatus` until completion, emitting a run summary (upload-only; not published to users).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce8d7cef4200f649700c5cb4a6d9032864d6b2fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->