### PR TITLE
chore: update empty tx state UI and create shared account list path

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -176,7 +176,10 @@
     "message": "Activity"
   },
   "activityEmptyDescription": {
-    "message": "Nothing to see yet. Swap your first token today."
+    "message": "Swap your first token today."
+  },
+  "activityEmptyNoFundsDescription": {
+    "message": "Add funds to your wallet to get started."
   },
   "add": {
     "message": "Add"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -176,7 +176,10 @@
     "message": "Activity"
   },
   "activityEmptyDescription": {
-    "message": "Nothing to see yet. Swap your first token today."
+    "message": "Swap your first token today."
+  },
+  "activityEmptyNoFundsDescription": {
+    "message": "Add funds to your wallet to get started."
   },
   "add": {
     "message": "Add"

--- a/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.test.tsx
+++ b/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.test.tsx
@@ -15,9 +15,20 @@ import {
   TransactionActivityEmptyState,
   type TransactionActivityEmptyStateProps,
 } from './transaction-activity-empty-state';
+import { selectAccountGroupBalanceForEmptyState } from '../../../selectors/assets';
 
 // Mock the useBridging hook
 jest.mock('../../../hooks/bridge/useBridging');
+
+jest.mock('../../../selectors/assets', () => ({
+  ...jest.requireActual('../../../selectors/assets'),
+  selectAccountGroupBalanceForEmptyState: jest.fn(),
+}));
+
+const mockSelectAccountGroupBalanceForEmptyState =
+  selectAccountGroupBalanceForEmptyState as jest.MockedFunction<
+    typeof selectAccountGroupBalanceForEmptyState
+  >;
 
 const createAccount = (
   overrides: Partial<InternalAccount> = {},
@@ -131,6 +142,7 @@ describe('TransactionActivityEmptyState', () => {
 
   beforeEach(() => {
     ({ mockOpenBridgeExperience } = setupMocks());
+    mockSelectAccountGroupBalanceForEmptyState.mockReturnValue(true);
   });
 
   const renderComponent = (
@@ -170,11 +182,26 @@ describe('TransactionActivityEmptyState', () => {
     expect(screen.getByTestId('activity-tab-empty-state')).toBeInTheDocument();
   });
 
-  it('renders description text', () => {
+  it('renders swap description when the account has tokens', () => {
+    mockSelectAccountGroupBalanceForEmptyState.mockReturnValue(true);
     renderComponent();
     expect(
       screen.getByText(messages.activityEmptyDescription.message),
     ).toBeInTheDocument();
+    expect(
+      screen.queryByText(messages.activityEmptyNoFundsDescription.message),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders add funds description when the account has no tokens', () => {
+    mockSelectAccountGroupBalanceForEmptyState.mockReturnValue(false);
+    renderComponent();
+    expect(
+      screen.getByText(messages.activityEmptyNoFundsDescription.message),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(messages.activityEmptyDescription.message),
+    ).not.toBeInTheDocument();
   });
 
   it('applies custom className', () => {
@@ -273,6 +300,30 @@ describe('TransactionActivityEmptyState', () => {
         'Activity Tab Empty State',
         undefined, // No specific token
       );
+    });
+  });
+
+  describe('Add funds button functionality', () => {
+    beforeEach(() => {
+      mockSelectAccountGroupBalanceForEmptyState.mockReturnValue(false);
+    });
+
+    it('renders add funds button when the account has no tokens', () => {
+      renderComponent();
+      expect(
+        screen.getByRole('button', { name: messages.addFunds.message }),
+      ).toBeInTheDocument();
+    });
+
+    it('opens funding modal when add funds button is clicked', () => {
+      renderComponent();
+      fireEvent.click(
+        screen.getByRole('button', { name: messages.addFunds.message }),
+      );
+
+      expect(
+        screen.getByTestId('activity-tab-empty-state-funding-modal'),
+      ).toBeInTheDocument();
     });
   });
 });

--- a/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.test.tsx
+++ b/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.test.tsx
@@ -11,11 +11,11 @@ import { ThemeType } from '../../../../shared/constants/preferences';
 import useBridging from '../../../hooks/bridge/useBridging';
 import { MultichainNetworks } from '../../../../shared/constants/multichain/networks';
 import * as useMultichainSelectorHook from '../../../hooks/useMultichainSelector';
+import { selectAccountGroupBalanceForEmptyState } from '../../../selectors/assets';
 import {
   TransactionActivityEmptyState,
   type TransactionActivityEmptyStateProps,
 } from './transaction-activity-empty-state';
-import { selectAccountGroupBalanceForEmptyState } from '../../../selectors/assets';
 
 // Mock the useBridging hook
 jest.mock('../../../hooks/bridge/useBridging');

--- a/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.tsx
+++ b/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.tsx
@@ -1,5 +1,6 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useContext, useState } from 'react';
 import { useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
 import { twMerge } from '@metamask/design-system-react';
 import { EthMethod } from '@metamask/keyring-api';
 import { TabEmptyState } from '../../ui/tab-empty-state';
@@ -7,13 +8,22 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useTheme } from '../../../hooks/useTheme';
 import { getUseExternalServices, getIsSwapsChain } from '../../../selectors';
 import { getCurrentChainId } from '../../../../shared/lib/selectors/networks';
-import { MetaMetricsSwapsEventSource } from '../../../../shared/constants/metametrics';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+  MetaMetricsSwapsEventSource,
+} from '../../../../shared/constants/metametrics';
 import useBridging from '../../../hooks/bridge/useBridging';
 import { ThemeType } from '../../../../shared/constants/preferences';
 import { getMultichainNetwork } from '../../../selectors/multichain';
 import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
 import { MultichainNetworks } from '../../../../shared/constants/multichain/networks';
 import { getSelectedInternalAccount } from '../../../../shared/lib/selectors/accounts';
+import { selectAccountGroupBalanceForEmptyState } from '../../../selectors/assets';
+import { getSelectedAccountGroup } from '../../../selectors/multichain-accounts/account-tree';
+import { FundingMethodModal } from '../../multichain/funding-method-modal/funding-method-modal';
+import { getMultichainAccountAddressListReceivePagePath } from '../../../pages/multichain-accounts/multichain-account-address-list-page';
+import { MetaMetricsContext } from '../../../contexts/metametrics';
 
 export type TransactionActivityEmptyStateProps = {
   /**
@@ -28,6 +38,12 @@ export const TransactionActivityEmptyState: React.FC<
   const account = useSelector(getSelectedInternalAccount);
   const t = useI18nContext();
   const theme = useTheme();
+  const navigate = useNavigate();
+  const { trackEvent } = useContext(MetaMetricsContext);
+  const hasTokens = useSelector(selectAccountGroupBalanceForEmptyState);
+  const selectedAccountGroup = useSelector(getSelectedAccountGroup);
+  const [isFundingModalOpen, setIsFundingModalOpen] = useState(false);
+
   const isSigningEnabled =
     account.methods.includes(EthMethod.SignTransaction) ||
     account.methods.includes(EthMethod.SignUserOperation);
@@ -54,24 +70,64 @@ export const TransactionActivityEmptyState: React.FC<
     );
   }, [openBridgeExperience]);
 
-  // Determine if swap button should be enabled
+  const handleAddFundsOnClick = useCallback(() => {
+    trackEvent({
+      event: MetaMetricsEventName.NavBuyButtonClicked,
+      category: MetaMetricsEventCategory.Navigation,
+      properties: {
+        location: 'Activity Tab Empty State',
+        text: 'Add funds',
+        chainId,
+      },
+    });
+
+    setIsFundingModalOpen(true);
+  }, [chainId, trackEvent]);
+
+  const handleFundingModalClose = useCallback(() => {
+    setIsFundingModalOpen(false);
+  }, []);
+
+  const handleReceiveOnClick = useCallback(() => {
+    setIsFundingModalOpen(false);
+
+    if (selectedAccountGroup) {
+      navigate(getMultichainAccountAddressListReceivePagePath(selectedAccountGroup));
+    }
+  }, [navigate, selectedAccountGroup]);
+
   const isSwapButtonEnabled =
     multichainChainId === MultichainNetworks.SOLANA ||
     (isSwapsChain && isSigningEnabled && isExternalServicesEnabled);
 
   return (
-    <TabEmptyState
-      icon={
-        <img src={activityIcon} alt={t('activity')} width={72} height={72} />
-      }
-      description={t('activityEmptyDescription')}
-      actionButtonText={t('swapTokens')}
-      actionButtonProps={{
-        isDisabled: !isSwapButtonEnabled,
-      }}
-      onAction={handleSwapOnClick}
-      data-testid="activity-tab-empty-state"
-      className={twMerge('max-w-48', className)}
-    />
+    <>
+      <TabEmptyState
+        icon={
+          <img src={activityIcon} alt={t('activity')} width={72} height={72} />
+        }
+        description={
+          hasTokens
+            ? t('activityEmptyDescription')
+            : t('activityEmptyNoFundsDescription')
+        }
+        actionButtonText={hasTokens ? t('swapTokens') : t('addFunds')}
+        actionButtonProps={
+          hasTokens ? { isDisabled: !isSwapButtonEnabled } : undefined
+        }
+        onAction={hasTokens ? handleSwapOnClick : handleAddFundsOnClick}
+        data-testid="activity-tab-empty-state"
+        className={twMerge('max-w-56', className)}
+      />
+      {!hasTokens && (
+        <FundingMethodModal
+          isOpen={isFundingModalOpen}
+          onClose={handleFundingModalClose}
+          title={t('addFunds')}
+          onClickReceive={handleReceiveOnClick}
+          data-testid="activity-tab-empty-state-funding-modal"
+        />
+      )}
+    </>
   );
 };

--- a/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.tsx
+++ b/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.tsx
@@ -92,7 +92,9 @@ export const TransactionActivityEmptyState: React.FC<
     setIsFundingModalOpen(false);
 
     if (selectedAccountGroup) {
-      navigate(getMultichainAccountAddressListReceivePagePath(selectedAccountGroup));
+      navigate(
+        getMultichainAccountAddressListReceivePagePath(selectedAccountGroup),
+      );
     }
   }, [navigate, selectedAccountGroup]);
 

--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -16,11 +16,7 @@ import { transitionForward } from '../../ui/transition';
 
 import { I18nContext } from '../../../contexts/i18n';
 
-import { MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE } from '../../../helpers/constants/routes';
-import {
-  AddressListQueryParams,
-  AddressListSource,
-} from '../../../pages/multichain-accounts/multichain-account-address-list-page';
+import { getMultichainAccountAddressListReceivePagePath } from '../../../pages/multichain-accounts/multichain-account-address-list-page';
 import {
   getUseExternalServices,
   getNetworkConfigurationIdByChainId,
@@ -331,7 +327,7 @@ const CoinButtons = ({
       // Navigate to the multichain address list page with receive source
       transitionForward(() =>
         navigate(
-          `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}?accountGroupId=${encodeURIComponent(selectedAccountGroup)}&${AddressListQueryParams.Source}=${AddressListSource.Receive}`,
+          getMultichainAccountAddressListReceivePagePath(selectedAccountGroup),
         ),
       );
     } else {

--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -16,11 +16,7 @@ import {
 } from '../../../../shared/constants/metametrics';
 
 import { I18nContext } from '../../../contexts/i18n';
-import { MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE } from '../../../helpers/constants/routes';
-import {
-  AddressListQueryParams,
-  AddressListSource,
-} from '../../../pages/multichain-accounts/multichain-account-address-list-page';
+import { getMultichainAccountAddressListReceivePagePath } from '../../../pages/multichain-accounts/multichain-account-address-list-page';
 import Tooltip from '../../ui/tooltip';
 import UserPreferencedCurrencyDisplay from '../user-preferenced-currency-display';
 import { PRIMARY, SECONDARY } from '../../../helpers/constants/common';
@@ -253,9 +249,7 @@ export const CoinOverview = ({
 
     if (selectedAccountGroup) {
       // Navigate to the multichain address list page with receive source
-      navigate(
-        `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}?accountGroupId=${encodeURIComponent(selectedAccountGroup)}&${AddressListQueryParams.Source}=${AddressListSource.Receive}`,
-      );
+      navigate(getMultichainAccountAddressListReceivePagePath(selectedAccountGroup));
     }
   }, [selectedAccountGroup, navigate, trackEvent, chainId]);
 

--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -249,7 +249,9 @@ export const CoinOverview = ({
 
     if (selectedAccountGroup) {
       // Navigate to the multichain address list page with receive source
-      navigate(getMultichainAccountAddressListReceivePagePath(selectedAccountGroup));
+      navigate(
+        getMultichainAccountAddressListReceivePagePath(selectedAccountGroup),
+      );
     }
   }, [selectedAccountGroup, navigate, trackEvent, chainId]);
 

--- a/ui/pages/multichain-accounts/multichain-account-address-list-page/index.ts
+++ b/ui/pages/multichain-accounts/multichain-account-address-list-page/index.ts
@@ -3,3 +3,7 @@ export {
   AddressListQueryParams,
   AddressListSource,
 } from './multichain-account-address-list-page.types';
+export {
+  getMultichainAccountAddressListPagePath,
+  getMultichainAccountAddressListReceivePagePath,
+} from './multichain-account-address-list-page.utils';

--- a/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.utils.test.ts
+++ b/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.utils.test.ts
@@ -10,9 +10,7 @@ describe('multichain-account-address-list-page utils', () => {
 
   describe('getMultichainAccountAddressListPagePath', () => {
     it('returns the address list route with an encoded account group id', () => {
-      expect(
-        getMultichainAccountAddressListPagePath(accountGroupId),
-      ).toBe(
+      expect(getMultichainAccountAddressListPagePath(accountGroupId)).toBe(
         `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}?accountGroupId=${encodeURIComponent(accountGroupId)}`,
       );
     });
@@ -28,7 +26,9 @@ describe('multichain-account-address-list-page utils', () => {
 
   describe('getMultichainAccountAddressListReceivePagePath', () => {
     it('returns the receive-flow address list route', () => {
-      expect(getMultichainAccountAddressListReceivePagePath(accountGroupId)).toBe(
+      expect(
+        getMultichainAccountAddressListReceivePagePath(accountGroupId),
+      ).toBe(
         `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}?accountGroupId=${encodeURIComponent(accountGroupId)}&source=receive`,
       );
     });

--- a/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.utils.test.ts
+++ b/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.utils.test.ts
@@ -1,0 +1,36 @@
+import { MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE } from '../../../helpers/constants/routes';
+import {
+  getMultichainAccountAddressListPagePath,
+  getMultichainAccountAddressListReceivePagePath,
+} from './multichain-account-address-list-page.utils';
+import { AddressListSource } from './multichain-account-address-list-page.types';
+
+describe('multichain-account-address-list-page utils', () => {
+  const accountGroupId = 'entropy:wallet1/group1';
+
+  describe('getMultichainAccountAddressListPagePath', () => {
+    it('returns the address list route with an encoded account group id', () => {
+      expect(
+        getMultichainAccountAddressListPagePath(accountGroupId),
+      ).toBe(
+        `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}?accountGroupId=${encodeURIComponent(accountGroupId)}`,
+      );
+    });
+
+    it('includes the receive source query param when provided', () => {
+      expect(
+        getMultichainAccountAddressListPagePath(accountGroupId, {
+          source: AddressListSource.Receive,
+        }),
+      ).toBe(getMultichainAccountAddressListReceivePagePath(accountGroupId));
+    });
+  });
+
+  describe('getMultichainAccountAddressListReceivePagePath', () => {
+    it('returns the receive-flow address list route', () => {
+      expect(getMultichainAccountAddressListReceivePagePath(accountGroupId)).toBe(
+        `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}?accountGroupId=${encodeURIComponent(accountGroupId)}&source=receive`,
+      );
+    });
+  });
+});

--- a/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.utils.ts
+++ b/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.utils.ts
@@ -12,7 +12,8 @@ type GetMultichainAccountAddressListPagePathOptions = {
  * Builds the path for the multichain account address list page.
  *
  * @param accountGroupId - Account group id used by the address list page.
- * @param options - Optional query params, such as receive-flow source.
+ * @param options - Optional query params.
+ * @param options.source - Address list page source.
  * @returns Route path with encoded query params.
  */
 export function getMultichainAccountAddressListPagePath(

--- a/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.utils.ts
+++ b/ui/pages/multichain-accounts/multichain-account-address-list-page/multichain-account-address-list-page.utils.ts
@@ -1,0 +1,45 @@
+import { MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE } from '../../../helpers/constants/routes';
+import {
+  AddressListQueryParams,
+  AddressListSource,
+} from './multichain-account-address-list-page.types';
+
+type GetMultichainAccountAddressListPagePathOptions = {
+  source?: AddressListSource;
+};
+
+/**
+ * Builds the path for the multichain account address list page.
+ *
+ * @param accountGroupId - Account group id used by the address list page.
+ * @param options - Optional query params, such as receive-flow source.
+ * @returns Route path with encoded query params.
+ */
+export function getMultichainAccountAddressListPagePath(
+  accountGroupId: string,
+  { source }: GetMultichainAccountAddressListPagePathOptions = {},
+): string {
+  const searchParams = new URLSearchParams({
+    accountGroupId,
+  });
+
+  if (source) {
+    searchParams.set(AddressListQueryParams.Source, source);
+  }
+
+  return `${MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE}?${searchParams.toString()}`;
+}
+
+/**
+ * Builds the receive-flow path for the multichain account address list page.
+ *
+ * @param accountGroupId - Account group id used by the address list page.
+ * @returns Route path for the receive address list view.
+ */
+export function getMultichainAccountAddressListReceivePagePath(
+  accountGroupId: string,
+): string {
+  return getMultichainAccountAddressListPagePath(accountGroupId, {
+    source: AddressListSource.Receive,
+  });
+}


### PR DESCRIPTION
## **Description**

Updates the Activity tab empty state to match the Activity redesign specs, with different messaging and CTAs depending on whether the user holds tokens.

**Context:** The Activity tab previously showed a single empty state (“Nothing to see yet. Swap your first token today.”) with a Swap CTA for all users with no transactions.

**Solution:**
- **Has tokens, no transactions:** Shows “Swap your first token today.” with a **Swap tokens** CTA (opens bridge/swap; existing behavior preserved).
- **No tokens, no transactions:** Shows “Add funds to your wallet to get started.” with an **Add funds** CTA that opens `FundingMethodModal` (same pattern as `BalanceEmptyState`).

Token detection uses `selectAccountGroupBalanceForEmptyState`, consistent with the home balance empty state.

Also extracts the repeated receive-navigation URL into shared helpers:
- `getMultichainAccountAddressListPagePath()`
- `getMultichainAccountAddressListReceivePagePath()`

Used in `coin-overview.tsx`, `coin-buttons.tsx`, and `transaction-activity-empty-state.tsx`.

**Design references:**
- [Has tokens, no transactions](https://www.figma.com/design/DIOn5ykuCcmvEjhYjTVdLi/Activity-redesign?node-id=994-16866&m=dev)
- [No tokens, no transactions](https://www.figma.com/design/DIOn5ykuCcmvEjhYjTVdLi/Activity-redesign?node-id=1145-9854&m=dev)

## **Changelog**

CHANGELOG entry: Updated Activity tab empty states to show context-specific messaging and actions when users have no transaction history.

## **Related issues**

Partly fixes: https://consensyssoftware.atlassian.net/browse/CEUX-1062

## **Manual testing steps**

2. Open the home screen and go to the **Activity** tab.
3. **Account with tokens, no transactions:**
   - Confirm copy: “Swap your first token today.”
   - Confirm CTA: **Swap tokens** (enabled when swap/bridge is available for the network).
   - Click **Swap tokens** and verify bridge/swap opens.
4. **Account with no tokens, no transactions:**
   - Confirm copy: “Add funds to your wallet to get started.”
   - Confirm CTA: **Add funds**.
   - Click **Add funds** and verify `FundingMethodModal` opens.
   - From the modal, test **Receive** navigates to the multichain address list in receive mode.
5. Toggle light/dark theme and confirm the activity empty-state illustration still renders correctly.
6. (Optional) From home **Receive** (coin overview / coin buttons), confirm receive navigation still works after the route helper refactor.

## **Screenshots/Recordings**

### **Before**


### **After**

- **With tokens:** “Swap your first token today.” + Swap tokens CTA

<img width="422" height="367" alt="image" src="https://github.com/user-attachments/assets/1e70c30b-ad86-474b-a38f-20899b1cadf3" />


- **Without tokens:** “Add funds to your wallet to get started.” + Add funds CTA
 
<img width="422" height="368" alt="image" src="https://github.com/user-attachments/assets/1b5bf89e-2725-485d-a0ea-d589a5d86fe6" />



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Activity empty-state CTA flow to conditionally open a funding modal and navigate to a receive page, plus refactors route construction; regressions could affect onboarding/funding navigation and metrics tracking.
> 
> **Overview**
> Updates the Activity tab empty state to be *token-aware*: if the selected account group has balance it keeps the Swap CTA, otherwise it shows new copy and an **Add funds** CTA that opens `FundingMethodModal` and can navigate to the multichain receive address list.
> 
> Adds a shared URL builder (`getMultichainAccountAddressListPagePath` / `getMultichainAccountAddressListReceivePagePath`) and replaces duplicated receive-route string construction in wallet overview components. Also updates en/en_GB i18n strings and expands tests to cover the new empty-state branches and funding modal behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ec4f209d21e79c38f08f5761dc32e59cd3b63ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->