### PR TITLE
feat(rewards): allow vanity referral codes

### DIFF
--- a/app/scripts/controllers/rewards/rewards-controller.test.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.test.ts
@@ -3470,19 +3470,10 @@ describe('RewardsController', () => {
       });
     });
 
-    it('should return false for empty code', async () => {
+    it('should return false for empty / whitespace-only input', async () => {
       await withController({ isDisabled: false }, async ({ controller }) => {
-        const result = await controller.validateReferralCode('  ');
-
-        expect(result).toBe(false);
-      });
-    });
-
-    it('should return false for code with invalid length', async () => {
-      await withController({ isDisabled: false }, async ({ controller }) => {
-        const result = await controller.validateReferralCode('TEST');
-
-        expect(result).toBe(false);
+        expect(await controller.validateReferralCode('')).toBe(false);
+        expect(await controller.validateReferralCode('   ')).toBe(false);
       });
     });
 
@@ -3500,6 +3491,28 @@ describe('RewardsController', () => {
           const result = await controller.validateReferralCode('TEST12');
 
           expect(result).toBe(true);
+        },
+      );
+    });
+
+    it('should forward non-empty vanity codes to the data service', async () => {
+      await withController(
+        { isDisabled: false },
+        async ({ controller, mockMessengerCall }) => {
+          mockMessengerCall.mockImplementation((actionType) => {
+            if (actionType === 'RewardsDataService:validateReferralCode') {
+              return Promise.resolve({ valid: true });
+            }
+            return undefined;
+          });
+
+          const result = await controller.validateReferralCode('BANKLESS');
+
+          expect(result).toBe(true);
+          expect(mockMessengerCall).toHaveBeenCalledWith(
+            'RewardsDataService:validateReferralCode',
+            'BANKLESS',
+          );
         },
       );
     });

--- a/app/scripts/controllers/rewards/rewards-controller.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.ts
@@ -2164,10 +2164,6 @@ export class RewardsController extends BaseController<
       return false;
     }
 
-    if (code.length !== 6) {
-      return false;
-    }
-
     const response = await this.messenger.call(
       'RewardsDataService:validateReferralCode',
       code,

--- a/ui/components/app/rewards/onboarding/OnboardingMainStep.test.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingMainStep.test.tsx
@@ -333,10 +333,11 @@ describe('OnboardingMainStep', () => {
     expect(impl).toHaveBeenCalledWith('ABCD');
   });
 
-  it('shows referral error message when invalid with length >= 6', () => {
+  it('shows referral error message after validation completes and code is invalid', () => {
     setup({
       referralCode: 'ABCDEF',
       isValid: false,
+      isValidating: false,
       state: { onboardingReferralCode: 'ABCDEF' },
     });
     render(<OnboardingMainStep />);
@@ -344,6 +345,34 @@ describe('OnboardingMainStep', () => {
     expect(
       screen.getByText('rewardsOnboardingReferralCodeError'),
     ).toBeInTheDocument();
+  });
+
+  it('shows referral error message for vanity codes once validation reports invalid', () => {
+    setup({
+      referralCode: 'BANKLESS',
+      isValid: false,
+      isValidating: false,
+      state: { onboardingReferralCode: 'BANKLESS' },
+    });
+    render(<OnboardingMainStep />);
+
+    expect(
+      screen.getByText('rewardsOnboardingReferralCodeError'),
+    ).toBeInTheDocument();
+  });
+
+  it('does not show error while validation is still in flight', () => {
+    setup({
+      referralCode: 'ABC',
+      isValid: false,
+      isValidating: true,
+      state: { onboardingReferralCode: 'ABC' },
+    });
+    render(<OnboardingMainStep />);
+
+    expect(
+      screen.queryByText('rewardsOnboardingReferralCodeError'),
+    ).not.toBeInTheDocument();
   });
 
   it('renders the unknown referral error banner when validation throws', () => {

--- a/ui/components/app/rewards/onboarding/OnboardingMainStep.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingMainStep.tsx
@@ -104,7 +104,7 @@ const OnboardingMainStep: React.FC<OnboardingMainStepProps> = ({
   );
 
   const referralCodeIsError =
-    referralCode.length >= 6 &&
+    referralCode.length >= 1 &&
     !referralCodeIsValid &&
     !isValidatingReferralCode &&
     !isUnknownErrorReferralCode;
@@ -198,7 +198,7 @@ const OnboardingMainStep: React.FC<OnboardingMainStepProps> = ({
       );
     }
 
-    if (referralCode.length >= 6) {
+    if (referralCode.length >= 1 && !isValidatingReferralCode) {
       return (
         <Icon
           name={IconName.Error}

--- a/ui/hooks/rewards/useValidateReferralCode.test.tsx
+++ b/ui/hooks/rewards/useValidateReferralCode.test.tsx
@@ -36,14 +36,14 @@ describe('useValidateReferralCode', () => {
     expect(validateRewardsReferralCode).not.toHaveBeenCalled();
   });
 
-  it('does not validate while code length is less than 6', async () => {
+  it('does not validate for empty input', async () => {
     const { result } = renderHookWithProvider(
       () => useValidateReferralCode(),
       {},
     );
 
     act(() => {
-      result.current.setReferralCode('abc');
+      result.current.setReferralCode('   ');
     });
 
     expect(result.current.isValidating).toBe(false);
@@ -54,6 +54,56 @@ describe('useValidateReferralCode', () => {
     });
 
     expect(validateRewardsReferralCode).not.toHaveBeenCalled();
+  });
+
+  it('validates after debounce for any non-empty input and sets isValid=true', async () => {
+    const { result } = renderHookWithProvider(
+      () => useValidateReferralCode('', 1000),
+      {},
+    );
+
+    act(() => {
+      result.current.setReferralCode('abc');
+    });
+
+    expect(result.current.isValidating).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isValidating).toBe(false);
+    });
+
+    expect(result.current.isValid).toBe(true);
+    const calls = validateRewardsReferralCode.mock.calls.map((c) => c[0]);
+    expect(calls).toContain('ABC');
+  });
+
+  it('validates vanity codes longer than 6 chars', async () => {
+    const { result } = renderHookWithProvider(
+      () => useValidateReferralCode('', 1000),
+      {},
+    );
+
+    act(() => {
+      result.current.setReferralCode('bankless');
+    });
+
+    expect(result.current.isValidating).toBe(true);
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isValidating).toBe(false);
+    });
+
+    expect(result.current.isValid).toBe(true);
+    const calls = validateRewardsReferralCode.mock.calls.map((c) => c[0]);
+    expect(calls).toContain('BANKLESS');
   });
 
   it('validates successfully when code length is >= 6 and sets isValid=true', async () => {

--- a/ui/hooks/rewards/useValidateReferralCode.test.tsx
+++ b/ui/hooks/rewards/useValidateReferralCode.test.tsx
@@ -1,7 +1,10 @@
 import { act } from '@testing-library/react-hooks';
 import { waitFor } from '@testing-library/react';
 import { renderHookWithProvider } from '../../../test/lib/render-helpers-navigate';
-import { useValidateReferralCode } from './useValidateReferralCode';
+import {
+  REFERRAL_CODE_DEBOUNCE_MS,
+  useValidateReferralCode,
+} from './useValidateReferralCode';
 
 jest.useFakeTimers();
 
@@ -14,6 +17,14 @@ const { validateRewardsReferralCode } = jest.requireMock(
 ) as { validateRewardsReferralCode: jest.Mock };
 
 describe('useValidateReferralCode', () => {
+  const advanceReferralCodeDebounce = async (
+    ms = REFERRAL_CODE_DEBOUNCE_MS,
+  ) => {
+    await act(async () => {
+      jest.advanceTimersByTime(ms);
+    });
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
     jest.setSystemTime(0);
@@ -68,9 +79,7 @@ describe('useValidateReferralCode', () => {
 
     expect(result.current.isValidating).toBe(true);
 
-    act(() => {
-      jest.advanceTimersByTime(1000);
-    });
+    await advanceReferralCodeDebounce(1000);
 
     await waitFor(() => {
       expect(result.current.isValidating).toBe(false);
@@ -93,9 +102,7 @@ describe('useValidateReferralCode', () => {
 
     expect(result.current.isValidating).toBe(true);
 
-    act(() => {
-      jest.advanceTimersByTime(1000);
-    });
+    await advanceReferralCodeDebounce(1000);
 
     await waitFor(() => {
       expect(result.current.isValidating).toBe(false);
@@ -118,9 +125,7 @@ describe('useValidateReferralCode', () => {
 
     expect(result.current.isValidating).toBe(true);
 
-    act(() => {
-      jest.advanceTimersByTime(1000);
-    });
+    await advanceReferralCodeDebounce(1000);
 
     await waitFor(() => {
       expect(result.current.isValidating).toBe(false);
@@ -144,9 +149,7 @@ describe('useValidateReferralCode', () => {
       result.current.setReferralCode('abcdef');
     });
 
-    act(() => {
-      jest.advanceTimersByTime(1000);
-    });
+    await advanceReferralCodeDebounce(1000);
 
     await waitFor(() => {
       expect(result.current.isValidating).toBe(false);
@@ -169,9 +172,7 @@ describe('useValidateReferralCode', () => {
       result.current.setReferralCode('abcdef');
     });
 
-    act(() => {
-      jest.advanceTimersByTime(1000);
-    });
+    await advanceReferralCodeDebounce(1000);
 
     await waitFor(() => {
       expect(result.current.isValidating).toBe(false);
@@ -181,7 +182,7 @@ describe('useValidateReferralCode', () => {
     expect(result.current.isUnknownError).toBe(true);
   });
 
-  it('validateCode returns messages and toggles unknown error on thrown error', async () => {
+  it('validateCode returns messages without setting the referral code', async () => {
     const { result } = renderHookWithProvider(
       () => useValidateReferralCode(),
       {},
@@ -202,7 +203,7 @@ describe('useValidateReferralCode', () => {
     });
     msg = await result.current.validateCode('abcdef');
     expect(msg).toBe('Unknown error');
-    expect(result.current.isUnknownError).toBe(true);
+    expect(result.current.referralCode).toBe('');
   });
 
   it('initialValue triggers validation and respects debounce', async () => {
@@ -214,9 +215,7 @@ describe('useValidateReferralCode', () => {
     // After mount, initialValue is set and validation starts
     expect(result.current.isValidating).toBe(true);
 
-    act(() => {
-      jest.advanceTimersByTime(500);
-    });
+    await advanceReferralCodeDebounce(500);
 
     await waitFor(() => {
       expect(result.current.isValidating).toBe(false);
@@ -224,5 +223,71 @@ describe('useValidateReferralCode', () => {
     expect(result.current.isValid).toBe(true);
     const calls = validateRewardsReferralCode.mock.calls.map((c) => c[0]);
     expect(calls).toContain('ABC123');
+  });
+
+  it('debounces rapid input changes and only validates the last value', async () => {
+    const { result } = renderHookWithProvider(
+      () => useValidateReferralCode('', 1000),
+      {},
+    );
+
+    act(() => {
+      result.current.setReferralCode('a');
+      result.current.setReferralCode('ab');
+      result.current.setReferralCode('abc');
+    });
+
+    expect(result.current.referralCode).toBe('ABC');
+    expect(result.current.isValidating).toBe(true);
+    expect(validateRewardsReferralCode).not.toHaveBeenCalled();
+
+    await advanceReferralCodeDebounce(1000);
+
+    await waitFor(() => {
+      expect(result.current.isValidating).toBe(false);
+    });
+
+    expect(validateRewardsReferralCode).toHaveBeenCalledTimes(1);
+    expect(validateRewardsReferralCode).toHaveBeenCalledWith('ABC');
+    expect(result.current.isValid).toBe(true);
+  });
+
+  it('discards stale responses when a newer validation has completed', async () => {
+    let resolveFirst: (value: boolean) => void;
+    const firstPromise = new Promise<boolean>((resolve) => {
+      resolveFirst = resolve;
+    });
+
+    validateRewardsReferralCode
+      .mockReturnValueOnce(async () => firstPromise)
+      .mockReturnValueOnce(async () => true);
+
+    const { result } = renderHookWithProvider(
+      () => useValidateReferralCode('', 1000),
+      {},
+    );
+
+    act(() => {
+      result.current.setReferralCode('abcdef');
+    });
+
+    await advanceReferralCodeDebounce(1000);
+
+    act(() => {
+      result.current.setReferralCode('ghjkmn');
+    });
+
+    await advanceReferralCodeDebounce(1000);
+
+    await waitFor(() => {
+      expect(result.current.isValid).toBe(true);
+    });
+
+    await act(async () => {
+      resolveFirst?.(false);
+    });
+
+    expect(result.current.referralCode).toBe('GHJKMN');
+    expect(result.current.isValid).toBe(true);
   });
 });

--- a/ui/hooks/rewards/useValidateReferralCode.ts
+++ b/ui/hooks/rewards/useValidateReferralCode.ts
@@ -1,7 +1,11 @@
 import { useState, useCallback, useEffect, useRef } from 'react';
-import { debounce } from 'lodash';
 import { useDispatch } from 'react-redux';
 import { validateRewardsReferralCode } from '../../store/actions';
+
+export const REFERRAL_CODE_DEBOUNCE_MS = 1000;
+const REFERRAL_CODE_UNKNOWN_ERROR = 'Unknown error';
+
+const normalizeReferralCode = (code: string) => code.trim().toUpperCase();
 
 export type UseValidateReferralCodeResult = {
   /**
@@ -37,19 +41,30 @@ export type UseValidateReferralCodeResult = {
  * truth for whether a referral code exists.
  *
  * @param initialValue - Initial referral code value (default: '')
- * @param debounceMs - Debounce delay in milliseconds (default: 300)
+ * @param debounceMs - Debounce delay in milliseconds
  * @returns UseValidateReferralCodeResult object with validation state and methods
  */
 export const useValidateReferralCode = (
   initialValue: string = '',
-  debounceMs: number = 1000,
+  debounceMs: number = REFERRAL_CODE_DEBOUNCE_MS,
 ): UseValidateReferralCodeResult => {
-  const [referralCode, setReferralCodeState] = useState(initialValue);
+  const initialReferralCode = normalizeReferralCode(initialValue);
+  const [referralCode, setReferralCodeState] = useState(initialReferralCode);
   const [error, setError] = useState('');
-  const [isValidating, setIsValidating] = useState(false);
-  const [unknownError, setUnknownError] = useState(false);
+  const [isValidating, setIsValidating] = useState(
+    initialReferralCode.length >= 1,
+  );
   const hasInitialized = useRef(false);
+  const requestIdRef = useRef(0);
+  const debounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const dispatch = useDispatch();
+
+  const clearDebounceTimer = useCallback(() => {
+    if (debounceTimerRef.current) {
+      clearTimeout(debounceTimerRef.current);
+      debounceTimerRef.current = null;
+    }
+  }, []);
 
   const validateCode = useCallback(
     async (code: string): Promise<string> => {
@@ -60,42 +75,52 @@ export const useValidateReferralCode = (
           return 'Invalid code';
         }
         return '';
-      } catch (err) {
-        setUnknownError(true);
-        return 'Unknown error';
+      } catch {
+        return REFERRAL_CODE_UNKNOWN_ERROR;
       }
     },
     [dispatch],
   );
 
-  // Debounced validation
-  const debouncedValidation = useCallback(
-    // eslint-disable-next-line react-compiler/react-compiler
-    debounce(async (code: string) => {
-      setUnknownError(false);
-      const validationError = await validateCode(code);
-      setError(validationError);
-      setIsValidating(false);
-    }, debounceMs),
-    [debounceMs, validateCode],
+  const triggerValidation = useCallback(
+    (code: string) => {
+      requestIdRef.current += 1;
+      const currentRequestId = requestIdRef.current;
+
+      clearDebounceTimer();
+      setError('');
+      setIsValidating(true);
+
+      debounceTimerRef.current = setTimeout(async () => {
+        const validationError = await validateCode(code);
+
+        if (currentRequestId !== requestIdRef.current) {
+          return;
+        }
+
+        setError(validationError);
+        setIsValidating(false);
+      }, debounceMs);
+    },
+    [clearDebounceTimer, debounceMs, validateCode],
   );
 
   // Function to update referral code and trigger validation
   const setReferralCode = useCallback(
     (code: string) => {
-      const refinedCode = code.trim().toUpperCase();
+      const refinedCode = normalizeReferralCode(code);
       setReferralCodeState(refinedCode);
       // If empty, do NOT validate; clear error/validating state
       if (refinedCode.length < 1) {
-        debouncedValidation.cancel();
+        requestIdRef.current += 1;
+        clearDebounceTimer();
         setIsValidating(false);
         setError('');
         return;
       }
-      setIsValidating(true);
-      debouncedValidation(refinedCode);
+      triggerValidation(refinedCode);
     },
-    [debouncedValidation],
+    [clearDebounceTimer, triggerValidation],
   );
 
   useEffect(() => {
@@ -106,13 +131,20 @@ export const useValidateReferralCode = (
       // Only update if initialValue actually changed from current referralCode
       setReferralCode(initialValue);
     }
-    // only run on mount or when initialValue changes
+    // eslint-disable-next-line react-compiler/react-compiler
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialValue]);
 
-  // Cleanup debounced function on unmount
-  useEffect(() => () => debouncedValidation.cancel(), [debouncedValidation]);
+  useEffect(
+    () => () => {
+      requestIdRef.current += 1;
+      clearDebounceTimer();
+    },
+    [clearDebounceTimer],
+  );
 
   const isValid = Boolean(referralCode) && !error && !isValidating;
+  const isUnknownError = error === REFERRAL_CODE_UNKNOWN_ERROR;
 
   return {
     referralCode,
@@ -120,6 +152,6 @@ export const useValidateReferralCode = (
     validateCode,
     isValidating,
     isValid,
-    isUnknownError: unknownError,
+    isUnknownError,
   };
 };

--- a/ui/hooks/rewards/useValidateReferralCode.ts
+++ b/ui/hooks/rewards/useValidateReferralCode.ts
@@ -33,7 +33,8 @@ export type UseValidateReferralCodeResult = {
 
 /**
  * Custom hook for validating referral codes with debounced validation.
- * Validates 6-character base32 encoded strings following RFC 4648 standard.
+ * Any non-empty input is forwarded to the backend, which is the source of
+ * truth for whether a referral code exists.
  *
  * @param initialValue - Initial referral code value (default: '')
  * @param debounceMs - Debounce delay in milliseconds (default: 300)
@@ -84,16 +85,14 @@ export const useValidateReferralCode = (
     (code: string) => {
       const refinedCode = code.trim().toUpperCase();
       setReferralCodeState(refinedCode);
-      // If not at minLength, do NOT validate; keep referral code state but clear error/validating state
-      if (refinedCode.length < 6) {
+      // If empty, do NOT validate; clear error/validating state
+      if (refinedCode.length < 1) {
         debouncedValidation.cancel();
         setIsValidating(false);
-        setError('minLength 6 characters');
+        setError('');
         return;
       }
-      if (refinedCode) {
-        setIsValidating(true);
-      }
+      setIsValidating(true);
       debouncedValidation(refinedCode);
     },
     [debouncedValidation],


### PR DESCRIPTION
## Summary

Today MetaMask Extension rejects any referral code that isn't exactly 6 characters before it even reaches the backend. This blocks vanity codes (e.g. `BANKLESS`, `ALICE`, `MM2026`) even when they exist in the rewards DB. This PR relaxes the client-side validation on the apply/validate/opt-in path: any non-empty input is forwarded to the backend, and the backend's existing DB lookup is the source of truth for whether a code exists. The UI now debounces and fires validation on any non-empty input rather than only at length 6.

CHANGELOG entry: null

## What changed

- `app/scripts/controllers/rewards/rewards-controller.ts` — `validateReferralCode`: dropped the `code.length !== 6` short-circuit. The rewards-enabled guard and the `!code.trim()` empty guard are unchanged.
- `ui/hooks/rewards/useValidateReferralCode.ts` — replaced the `refinedCode.length < 6` branch with a non-empty guard so the debounced validation fires for any `length >= 1`. Updated the docblock to reflect the new bound.
- `ui/components/app/rewards/onboarding/OnboardingMainStep.tsx` — replaced the `referralCode.length >= 6` gates on the error state and the error icon with hook-state-driven gates (only show invalid styling once validation has completed and reported invalid).
- Tests:
  - `app/scripts/controllers/rewards/rewards-controller.test.ts` — dropped the "invalid length" case, added an explicit empty / whitespace-only case, and added a vanity-code (`BANKLESS`) forwarding case.
  - `ui/hooks/rewards/useValidateReferralCode.test.tsx` — replaced the "code length less than 6" case with "empty input", added a non-empty short-code case and a vanity-code (`BANKLESS`) happy path.
  - `ui/components/app/rewards/onboarding/OnboardingMainStep.test.tsx` — updated the existing "length >= 6 and invalid" case to be gated on hook state, added a vanity-code error case and a "no error while validating" case.

## What did NOT change

- Backend referral code **generation** is untouched — newly auto-generated codes remain 6-char Crockford Base32. This PR only relaxes the **validation** path so existing vanity codes in the DB can be applied.
- `ui/store/actions.test.js` `#validateRewardsReferralCode` — this layer just bridges to the background and has no length assertion; no test updates needed.
- DB uniqueness constraint on `Subscription.referralCode` still prevents collisions, and the self-referral / already-referred checks in `applyReferralCode` are unaffected.

## Test plan

- [ ] Vanity happy path: enter `BANKLESS` (8 chars), debounce fires, backend returns valid, opt-in succeeds.
- [ ] Empty input: input remains empty, no validation fires, no error state shown.
- [ ] Existing 6-char codes still validate (no behavior regression for current codes).
- [ ] Invalid code (any length): error state only shows after the hook reports invalid, not pre-emptively at length 6.
- [ ] Unit tests: `yarn test:unit app/scripts/controllers/rewards/ ui/hooks/rewards/ ui/components/app/rewards/` passes locally.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes referral-code validation flow across controller, hook, and onboarding UI, which can affect opt-in UX and backend call patterns. Adds custom debounce/stale-response handling that could introduce edge-case state bugs if not covered by tests.
> 
> **Overview**
> Referral code validation no longer enforces a 6-character length on the client: `RewardsController.validateReferralCode` now forwards any non-empty input to `RewardsDataService:validateReferralCode`, enabling vanity codes.
> 
> Onboarding UI and `useValidateReferralCode` were updated to validate *any non-empty* code after a debounce, show errors/icons only once validation completes (not based on length), and handle rapid input via request-id based stale-response discarding; tests were updated/added to cover whitespace input, vanity codes, in-flight validation, debouncing, and stale responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1c6fab7ae74d64189d0acd73d86342456f1a8df9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->