### PR TITLE
build: preserve lazy route chunks in webpack

### DIFF
--- a/development/webpack/webpack.config.ts
+++ b/development/webpack/webpack.config.ts
@@ -9,6 +9,7 @@ import {
   ProvidePlugin,
   type Chunk,
   type Configuration,
+  type Module,
   type WebpackPluginInstance,
   type MemoryCacheOptions,
   type FileCacheOptions,
@@ -250,6 +251,26 @@ const tsxLoader = getSwcLoader('typescript', true, safeVariables, swcConfig);
 const jsxLoader = getSwcLoader('ecmascript', true, safeVariables, swcConfig);
 const npmLoader = getSwcLoader('ecmascript', false, {}, swcConfig);
 const cjsLoader = getSwcLoader('ecmascript', false, {}, swcConfig, 'commonjs');
+const javascriptModuleExtensions = [
+  '.js',
+  '.jsx',
+  '.mjs',
+  '.ts',
+  '.tsx',
+  '.mts',
+] as const;
+const nodeModulesPathSegments = ['/node_modules/', '\\node_modules\\'] as const;
+const getModuleResource = (module: Module) => {
+  const { resource } = module as Module & { resource?: unknown };
+  return typeof resource === 'string' ? resource : module.identifier();
+};
+const isApplicationJavaScriptModule = (module: Module) => {
+  const resource = getModuleResource(module);
+  return (
+    nodeModulesPathSegments.every((segment) => !resource.includes(segment)) &&
+    javascriptModuleExtensions.some((extension) => resource.endsWith(extension))
+  );
+};
 const isChunkableInitial = (chunk: Chunk) =>
   manifestPlugin.canBeChunked(chunk) && chunk.canBeInitial();
 const isChunkableAsync = (chunk: Chunk) =>
@@ -541,7 +562,7 @@ const config = {
       cacheGroups: {
         js: {
           // only our own ts/mts/tsx/js/mjs/jsx files (NOT in node_modules)
-          test: /(?!.*\/node_modules\/).+\.(?:m?[tj]s|[tj]sx?)?$/u,
+          test: isApplicationJavaScriptModule,
           name: 'js',
           chunks: isChunkableInitial,
         },
@@ -553,7 +574,7 @@ const config = {
         },
         asyncJs: {
           // only our own ts/mts/tsx/js/mjs/jsx files (NOT in node_modules)
-          test: /(?!.*\/node_modules\/).+\.(?:m?[tj]s|[tj]sx?)?$/u,
+          test: isApplicationJavaScriptModule,
           chunks: isChunkableAsync,
           minChunks: 2,
         },

--- a/development/webpack/webpack.config.ts
+++ b/development/webpack/webpack.config.ts
@@ -541,7 +541,7 @@ const config = {
       cacheGroups: {
         js: {
           // only our own ts/mts/tsx/js/mjs/jsx files (NOT in node_modules)
-          test: /(?!.*\/node_modules\/).+\.(?:m?[tj]s|[tj]sx?)?$/u,
+          test: /^(?!.*[\\/]node_modules[\\/]).+\.(?:m?[tj]s|[tj]sx?)?$/u,
           name: 'js',
           chunks: isChunkableInitial,
         },
@@ -553,7 +553,7 @@ const config = {
         },
         asyncJs: {
           // only our own ts/mts/tsx/js/mjs/jsx files (NOT in node_modules)
-          test: /(?!.*\/node_modules\/).+\.(?:m?[tj]s|[tj]sx?)?$/u,
+          test: /^(?!.*[\\/]node_modules[\\/]).+\.(?:m?[tj]s|[tj]sx?)?$/u,
           chunks: isChunkableAsync,
           minChunks: 2,
         },

--- a/development/webpack/webpack.config.ts
+++ b/development/webpack/webpack.config.ts
@@ -557,12 +557,6 @@ const config = {
           chunks: isChunkableAsync,
           minChunks: 2,
         },
-        asyncVendor: {
-          // js/mjs files in node_modules or subdirectories of node_modules
-          test: /[\\/]node_modules[\\/].*?\.m?js$/u,
-          chunks: isChunkableAsync,
-          minChunks: 2,
-        },
       },
     },
   },

--- a/development/webpack/webpack.config.ts
+++ b/development/webpack/webpack.config.ts
@@ -9,7 +9,6 @@ import {
   ProvidePlugin,
   type Chunk,
   type Configuration,
-  type Module,
   type WebpackPluginInstance,
   type MemoryCacheOptions,
   type FileCacheOptions,
@@ -251,26 +250,6 @@ const tsxLoader = getSwcLoader('typescript', true, safeVariables, swcConfig);
 const jsxLoader = getSwcLoader('ecmascript', true, safeVariables, swcConfig);
 const npmLoader = getSwcLoader('ecmascript', false, {}, swcConfig);
 const cjsLoader = getSwcLoader('ecmascript', false, {}, swcConfig, 'commonjs');
-const javascriptModuleExtensions = [
-  '.js',
-  '.jsx',
-  '.mjs',
-  '.ts',
-  '.tsx',
-  '.mts',
-] as const;
-const nodeModulesPathSegments = ['/node_modules/', '\\node_modules\\'] as const;
-const getModuleResource = (module: Module) => {
-  const { resource } = module as Module & { resource?: unknown };
-  return typeof resource === 'string' ? resource : module.identifier();
-};
-const isApplicationJavaScriptModule = (module: Module) => {
-  const resource = getModuleResource(module);
-  return (
-    nodeModulesPathSegments.every((segment) => !resource.includes(segment)) &&
-    javascriptModuleExtensions.some((extension) => resource.endsWith(extension))
-  );
-};
 const isChunkableInitial = (chunk: Chunk) =>
   manifestPlugin.canBeChunked(chunk) && chunk.canBeInitial();
 const isChunkableAsync = (chunk: Chunk) =>
@@ -562,7 +541,7 @@ const config = {
       cacheGroups: {
         js: {
           // only our own ts/mts/tsx/js/mjs/jsx files (NOT in node_modules)
-          test: isApplicationJavaScriptModule,
+          test: /(?!.*\/node_modules\/).+\.(?:m?[tj]s|[tj]sx?)?$/u,
           name: 'js',
           chunks: isChunkableInitial,
         },
@@ -574,7 +553,7 @@ const config = {
         },
         asyncJs: {
           // only our own ts/mts/tsx/js/mjs/jsx files (NOT in node_modules)
-          test: isApplicationJavaScriptModule,
+          test: /(?!.*\/node_modules\/).+\.(?:m?[tj]s|[tj]sx?)?$/u,
           chunks: isChunkableAsync,
           minChunks: 2,
         },

--- a/development/webpack/webpack.config.ts
+++ b/development/webpack/webpack.config.ts
@@ -7,6 +7,7 @@ import { join } from 'node:path';
 import { argv, exit } from 'node:process';
 import {
   ProvidePlugin,
+  type Chunk,
   type Configuration,
   type WebpackPluginInstance,
   type MemoryCacheOptions,
@@ -249,6 +250,10 @@ const tsxLoader = getSwcLoader('typescript', true, safeVariables, swcConfig);
 const jsxLoader = getSwcLoader('ecmascript', true, safeVariables, swcConfig);
 const npmLoader = getSwcLoader('ecmascript', false, {}, swcConfig);
 const cjsLoader = getSwcLoader('ecmascript', false, {}, swcConfig, 'commonjs');
+const isChunkableInitial = (chunk: Chunk) =>
+  manifestPlugin.canBeChunked(chunk) && chunk.canBeInitial();
+const isChunkableAsync = (chunk: Chunk) =>
+  manifestPlugin.canBeChunked(chunk) && !chunk.canBeInitial();
 
 const threadLoader = getThreadLoader(args);
 const reactCompiler = getReactCompilerLoader({
@@ -538,13 +543,25 @@ const config = {
           // only our own ts/mts/tsx/js/mjs/jsx files (NOT in node_modules)
           test: /(?!.*\/node_modules\/).+\.(?:m?[tj]s|[tj]sx?)?$/u,
           name: 'js',
-          chunks: manifestPlugin.canBeChunked,
+          chunks: isChunkableInitial,
         },
         vendor: {
           // js/mjs files in node_modules or subdirectories of node_modules
           test: /[\\/]node_modules[\\/].*?\.m?js$/u,
           name: 'vendor',
-          chunks: manifestPlugin.canBeChunked,
+          chunks: isChunkableInitial,
+        },
+        asyncJs: {
+          // only our own ts/mts/tsx/js/mjs/jsx files (NOT in node_modules)
+          test: /(?!.*\/node_modules\/).+\.(?:m?[tj]s|[tj]sx?)?$/u,
+          chunks: isChunkableAsync,
+          minChunks: 2,
+        },
+        asyncVendor: {
+          // js/mjs files in node_modules or subdirectories of node_modules
+          test: /[\\/]node_modules[\\/].*?\.m?js$/u,
+          chunks: isChunkableAsync,
+          minChunks: 2,
         },
       },
     },

--- a/development/webpack/webpack.config.ts
+++ b/development/webpack/webpack.config.ts
@@ -555,7 +555,7 @@ const config = {
           // only our own ts/mts/tsx/js/mjs/jsx files (NOT in node_modules)
           test: /^(?!.*[\\/]node_modules[\\/]).+\.(?:m?[tj]s|[tj]sx?)?$/u,
           chunks: isChunkableAsync,
-          minChunks: 2,
+          minChunks: 1,
         },
       },
     },

--- a/development/webpack/webpack.config.ts
+++ b/development/webpack/webpack.config.ts
@@ -555,7 +555,9 @@ const config = {
           // only our own ts/mts/tsx/js/mjs/jsx files (NOT in node_modules)
           test: /^(?!.*[\\/]node_modules[\\/]).+\.(?:m?[tj]s|[tj]sx?)?$/u,
           chunks: isChunkableAsync,
-          minChunks: 1,
+          // Avoid minChunks: 1: it creates extra single-use async chunks
+          // without reducing the initial entrypoint payload.
+          minChunks: 2,
         },
       },
     },

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -146,9 +146,7 @@ import { NetworkHandler } from './network-handler';
 // Begin Lazy Routes
 const OnboardingFlow = mmLazy(() => import('../onboarding-flow/index.ts'));
 const Lock = mmLazy(() => import('../lock/index.ts'));
-const UnlockPage = mmLazy(
-  () => import(/* webpackMode: "eager" */ '../unlock-page/index.ts'),
-);
+const UnlockPage = mmLazy(() => import('../unlock-page/index.ts'));
 const RestoreVaultPage = mmLazy(() => import('../keychains/restore-vault.tsx'));
 const ImportSrpPage = mmLazy(() => import('../multi-srp/import-srp/index.ts'));
 const RevealSeedConfirmation = mmLazy(
@@ -214,9 +212,7 @@ const GatorPermissionsReviewPermissionsPage = mmLazy(
   () =>
     import('../../components/multichain/pages/gator-permissions/review-permissions/review-gator-permissions-page.tsx'),
 );
-const Home = mmLazy(
-  () => import(/* webpackMode: "eager" */ '../home/index.js'),
-);
+const Home = mmLazy(() => import('../home/index.js'));
 const DeepLink = mmLazy(() => import('../deep-link/deep-link.tsx'));
 const BasicFunctionalityOff = mmLazy(
   () =>

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -138,6 +138,10 @@ import { ToastListener } from '../../components/app/toast-listener/toast-listene
 import { ALLOWED_CAPABILITIES as SNAP_VIEW_ROUTE_ALLOWED_CAPABILITIES } from '../snaps/snap-view/messenger';
 import { createRouteWithMessenger } from '../../helpers/route-messenger-helpers';
 import { getIsTokenManagementFilterEnabled } from '../../selectors/multichain/feature-flags';
+import UnlockPage from '../unlock-page/index.ts';
+import Confirm from '../confirmations/confirm/confirm.tsx';
+import ConfirmationPage from '../confirmations/confirmation/index.js';
+import Home from '../home/index.js';
 import { getConnectingLabel, setTheme } from './utils';
 import { ConfirmationRouter } from './confirmation-router';
 import { Modals } from './modals';
@@ -146,7 +150,6 @@ import { NetworkHandler } from './network-handler';
 // Begin Lazy Routes
 const OnboardingFlow = mmLazy(() => import('../onboarding-flow/index.ts'));
 const Lock = mmLazy(() => import('../lock/index.ts'));
-const UnlockPage = mmLazy(() => import('../unlock-page/index.ts'));
 const RestoreVaultPage = mmLazy(() => import('../keychains/restore-vault.tsx'));
 const ImportSrpPage = mmLazy(() => import('../multi-srp/import-srp/index.ts'));
 const RevealSeedConfirmation = mmLazy(
@@ -172,7 +175,6 @@ const ConfirmEncryptionPublicKey = mmLazy(
 const ConfirmDecryptMessage = mmLazy(
   () => import('../confirm-decrypt-message/index.js'),
 );
-const Confirm = mmLazy(() => import('../confirmations/confirm/confirm.tsx'));
 const SendPage = mmLazy(() => import('../confirmations/send/index.ts'));
 const CrossChainSwap = mmLazy(() => import('../bridge/index.tsx'));
 const PermissionsConnect = mmLazy(
@@ -183,9 +185,6 @@ const ConfirmAddSuggestedTokenPage = mmLazy(
 );
 const ConfirmAddSuggestedNftPage = mmLazy(
   () => import('../confirm-add-suggested-nft/index.js'),
-);
-const ConfirmationPage = mmLazy(
-  () => import('../confirmations/confirmation/index.js'),
 );
 const CreateAccountPage = mmLazy(
   () => import('../create-account/create-account.component.js'),
@@ -212,7 +211,6 @@ const GatorPermissionsReviewPermissionsPage = mmLazy(
   () =>
     import('../../components/multichain/pages/gator-permissions/review-permissions/review-gator-permissions-page.tsx'),
 );
-const Home = mmLazy(() => import('../home/index.js'));
 const DeepLink = mmLazy(() => import('../deep-link/deep-link.tsx'));
 const BasicFunctionalityOff = mmLazy(
   () =>

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -138,10 +138,6 @@ import { ToastListener } from '../../components/app/toast-listener/toast-listene
 import { ALLOWED_CAPABILITIES as SNAP_VIEW_ROUTE_ALLOWED_CAPABILITIES } from '../snaps/snap-view/messenger';
 import { createRouteWithMessenger } from '../../helpers/route-messenger-helpers';
 import { getIsTokenManagementFilterEnabled } from '../../selectors/multichain/feature-flags';
-import UnlockPage from '../unlock-page/index.ts';
-import Confirm from '../confirmations/confirm/confirm.tsx';
-import ConfirmationPage from '../confirmations/confirmation/index.js';
-import Home from '../home/index.js';
 import { getConnectingLabel, setTheme } from './utils';
 import { ConfirmationRouter } from './confirmation-router';
 import { Modals } from './modals';
@@ -150,6 +146,9 @@ import { NetworkHandler } from './network-handler';
 // Begin Lazy Routes
 const OnboardingFlow = mmLazy(() => import('../onboarding-flow/index.ts'));
 const Lock = mmLazy(() => import('../lock/index.ts'));
+const UnlockPage = mmLazy(
+  () => import(/* webpackMode: "eager" */ '../unlock-page/index.ts'),
+);
 const RestoreVaultPage = mmLazy(() => import('../keychains/restore-vault.tsx'));
 const ImportSrpPage = mmLazy(() => import('../multi-srp/import-srp/index.ts'));
 const RevealSeedConfirmation = mmLazy(
@@ -175,6 +174,7 @@ const ConfirmEncryptionPublicKey = mmLazy(
 const ConfirmDecryptMessage = mmLazy(
   () => import('../confirm-decrypt-message/index.js'),
 );
+const Confirm = mmLazy(() => import('../confirmations/confirm/confirm.tsx'));
 const SendPage = mmLazy(() => import('../confirmations/send/index.ts'));
 const CrossChainSwap = mmLazy(() => import('../bridge/index.tsx'));
 const PermissionsConnect = mmLazy(
@@ -185,6 +185,9 @@ const ConfirmAddSuggestedTokenPage = mmLazy(
 );
 const ConfirmAddSuggestedNftPage = mmLazy(
   () => import('../confirm-add-suggested-nft/index.js'),
+);
+const ConfirmationPage = mmLazy(
+  () => import('../confirmations/confirmation/index.js'),
 );
 const CreateAccountPage = mmLazy(
   () => import('../create-account/create-account.component.js'),
@@ -211,6 +214,7 @@ const GatorPermissionsReviewPermissionsPage = mmLazy(
   () =>
     import('../../components/multichain/pages/gator-permissions/review-permissions/review-gator-permissions-page.tsx'),
 );
+const Home = mmLazy(() => import(/* webpackMode: "eager" */ '../home/index.js'));
 const DeepLink = mmLazy(() => import('../deep-link/deep-link.tsx'));
 const BasicFunctionalityOff = mmLazy(
   () =>

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -214,7 +214,9 @@ const GatorPermissionsReviewPermissionsPage = mmLazy(
   () =>
     import('../../components/multichain/pages/gator-permissions/review-permissions/review-gator-permissions-page.tsx'),
 );
-const Home = mmLazy(() => import(/* webpackMode: "eager" */ '../home/index.js'));
+const Home = mmLazy(
+  () => import(/* webpackMode: "eager" */ '../home/index.js'),
+);
 const DeepLink = mmLazy(() => import('../deep-link/deep-link.tsx'));
 const BasicFunctionalityOff = mmLazy(
   () =>


### PR DESCRIPTION
## **Description**

Update webpack `splitChunks` so the broad `js` and `vendor` cache groups only collect initial chunks. Lazy route imports created through `mmLazy` can now remain in async chunks instead of being folded back into the startup script set.

This keeps the existing shared startup buckets for initial code, while adding async-only cache groups for modules shared across multiple lazy chunks.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6547

## **Manual testing steps**

1. Run `yarn webpack`.
2. Inspect `dist/chrome/popup.html` and confirm the initial deferred script list no longer includes the large lazy route chunk buckets.
3. Confirm lazy route/page code is emitted as async numbered chunks.

<!-- ## **Screenshots/Recordings**

Not applicable; this is a webpack chunking change.
-->

### **Before**

See After.

### **After**

Before on the left, After on the right

https://github.com/user-attachments/assets/226c6cac-96de-4cfd-a02b-3d870941cd0c

(tests were run with a simulated CPU slowdown to better align with what many of our users experience)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Webpack chunk-splitting rules for initial vs async code, which can impact load order, caching, and runtime behavior of the extension if mis-grouped.
> 
> **Overview**
> Adjusts Webpack `splitChunks` so the broad `js` and `vendor` cache groups only apply to **initial** chunkable entrypoints, preventing lazy-loaded route code from being merged into the startup bundle.
> 
> Adds an async-only cache group (`asyncJs`) to dedupe modules shared across multiple async chunks (with `minChunks: 2`), and tightens the “non-`node_modules`” regex to be Windows path-safe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6b462bf3e3e81ca1e593a3fe5363fe33e286aa6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->