### PR TITLE
feat: add keyring transaction adapter

### DIFF
--- a/shared/lib/activity/adapters/keyring-transaction.test.ts
+++ b/shared/lib/activity/adapters/keyring-transaction.test.ts
@@ -1,0 +1,106 @@
+import { TransactionStatus, TransactionType } from '@metamask/keyring-api';
+import { MultichainNetworks } from '../../../constants/multichain/networks';
+import { mapKeyringTransaction } from './keyring-transaction';
+
+describe('mapKeyringTransaction', () => {
+  it('maps keyring send transactions with token amount data', () => {
+    expect(
+      mapKeyringTransaction({
+        transaction: {
+          id: 'send-id',
+          chain: MultichainNetworks.SOLANA,
+          account: '00000000-0000-4000-8000-000000000000',
+          status: TransactionStatus.Confirmed,
+          timestamp: 1716367781,
+          type: TransactionType.Send,
+          from: [
+            {
+              address: 'from-address',
+              asset: {
+                fungible: true,
+                type: `${MultichainNetworks.SOLANA}/token:usdc`,
+                unit: 'USDC',
+                amount: '2.5',
+              },
+            },
+          ],
+          to: [{ address: 'to-address', asset: null }],
+          fees: [],
+          events: [],
+        },
+      }),
+    ).toStrictEqual({
+      type: 'send',
+      chainId: MultichainNetworks.SOLANA,
+      status: 'success',
+      timestamp: 1716367781000,
+      data: {
+        hash: 'send-id',
+        from: 'from-address',
+        to: 'to-address',
+        token: {
+          amount: '2.5',
+          direction: 'out',
+          symbol: 'USDC',
+        },
+      },
+    });
+  });
+
+  it('maps keyring swap transactions with source and destination token amounts', () => {
+    expect(
+      mapKeyringTransaction({
+        transaction: {
+          id: 'swap-id',
+          chain: MultichainNetworks.SOLANA,
+          account: '00000000-0000-4000-8000-000000000000',
+          status: TransactionStatus.Submitted,
+          timestamp: 1716367781,
+          type: TransactionType.Swap,
+          from: [
+            {
+              address: 'from-address',
+              asset: {
+                fungible: true,
+                type: `${MultichainNetworks.SOLANA}/slip44:501`,
+                unit: 'SOL',
+                amount: '1',
+              },
+            },
+          ],
+          to: [
+            {
+              address: 'to-address',
+              asset: {
+                fungible: true,
+                type: `${MultichainNetworks.SOLANA}/token:usdc`,
+                unit: 'USDC',
+                amount: '100',
+              },
+            },
+          ],
+          fees: [],
+          events: [],
+        },
+      }),
+    ).toStrictEqual({
+      type: 'swap',
+      chainId: MultichainNetworks.SOLANA,
+      status: 'pending',
+      timestamp: 1716367781000,
+      data: {
+        hash: 'swap-id',
+        sourceToken: {
+          amount: '1',
+          direction: 'out',
+          symbol: 'SOL',
+        },
+        destinationToken: {
+          amount: '100',
+          direction: 'in',
+          symbol: 'USDC',
+        },
+      },
+    });
+  });
+});

--- a/shared/lib/activity/adapters/keyring-transaction.ts
+++ b/shared/lib/activity/adapters/keyring-transaction.ts
@@ -1,0 +1,123 @@
+import {
+  type Transaction,
+  TransactionStatus as KeyringTransactionStatus,
+  TransactionType as KeyringTransactionType,
+} from '@metamask/keyring-api';
+import type { ActivityListItem, Status, TokenAmount } from '../types';
+
+type Movement = Transaction['from'][number];
+type FungibleAsset = Extract<
+  NonNullable<Movement['asset']>,
+  { fungible: true }
+>;
+
+function mapStatus(status: Transaction['status']): Status {
+  switch (status) {
+    case KeyringTransactionStatus.Confirmed:
+      return 'success';
+    case KeyringTransactionStatus.Failed:
+      return 'failed';
+    case KeyringTransactionStatus.Submitted:
+    case KeyringTransactionStatus.Unconfirmed:
+    default:
+      return 'pending';
+  }
+}
+
+function mapTimestamp(timestamp: Transaction['timestamp']) {
+  return timestamp ? timestamp * 1000 : 0;
+}
+
+function getAddress(movements: Movement[]) {
+  return movements[0]?.address ?? '';
+}
+
+function hasFungibleAsset(
+  movement: Movement,
+): movement is Movement & { asset: FungibleAsset } {
+  return movement.asset?.fungible === true;
+}
+
+function getToken(movements: Movement[], direction: TokenAmount['direction']) {
+  const movement = movements.find(hasFungibleAsset);
+
+  if (!movement) {
+    return undefined;
+  }
+
+  return {
+    amount: movement.asset.amount,
+    symbol: movement.asset.unit,
+    direction,
+  };
+}
+
+// Converts keyring API transactions into the shared activity item shape
+export function mapKeyringTransaction({
+  transaction,
+}: {
+  transaction: Transaction;
+}): ActivityListItem {
+  const status = mapStatus(transaction.status);
+  const timestamp = mapTimestamp(transaction.timestamp);
+  const chainId = transaction.chain;
+  const from = getAddress(transaction.from);
+  const to = getAddress(transaction.to);
+
+  if (transaction.type === KeyringTransactionType.Send) {
+    return {
+      type: 'send',
+      chainId,
+      status,
+      timestamp,
+      data: {
+        hash: transaction.id,
+        from,
+        to,
+        token: getToken(transaction.from, 'out'),
+      },
+    };
+  }
+
+  if (transaction.type === KeyringTransactionType.Receive) {
+    return {
+      type: 'receive',
+      chainId,
+      status,
+      timestamp,
+      data: {
+        hash: transaction.id,
+        from,
+        to,
+        token: getToken(transaction.to, 'in'),
+      },
+    };
+  }
+
+  if (transaction.type === KeyringTransactionType.Swap) {
+    return {
+      type: 'swap',
+      chainId,
+      status,
+      timestamp,
+      data: {
+        hash: transaction.id,
+        destinationToken: getToken(transaction.to, 'in'),
+        sourceToken: getToken(transaction.from, 'out'),
+      },
+    };
+  }
+
+  return {
+    type: 'contractInteraction',
+    chainId,
+    status,
+    timestamp,
+    data: {
+      hash: transaction.id,
+      from,
+      to,
+      transactionType: transaction.type,
+    },
+  };
+}


### PR DESCRIPTION
## **Description**

Adds a keyring-api `Transaction` adapter for shared activity list items, covering send, receive, swap, and fallback contract interaction shapes.

Part of https://github.com/MetaMask/metamask-extension/pull/42622

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1.  yarn jest shared/lib/activity/adapters/keyring-transaction.test.ts

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new mapping logic for non-EVM keyring transactions into shared activity items; incorrect mapping could mislabel activity status/amounts in the UI, but it’s isolated and covered by unit tests.
> 
> **Overview**
> Adds a new `mapKeyringTransaction` adapter that converts keyring API transactions into shared `ActivityListItem` entries, including status/timestamp normalization, address extraction, and fungible token amount mapping for `send`, `receive`, and `swap`, with a fallback `contractInteraction` shape for other transaction types.
> 
> Includes Jest tests validating `send` and `swap` mappings (status conversion, timestamp millis, and token direction/amount/symbol extraction).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 358e087dc413e94b2ceb67e8759755acb71e12b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->