### PR TITLE
fix(webpack): patch bundle analyzer report controls

### DIFF
--- a/.yarn/patches/webpack-bundle-analyzer-npm-5.3.0-946883e2fa.patch
+++ b/.yarn/patches/webpack-bundle-analyzer-npm-5.3.0-946883e2fa.patch
@@ -1,0 +1,30 @@
+diff --git a/lib/template.js b/lib/template.js
+index 7e52a73bb5885a5beb4dd486954323f1f8bb1f84..6d604304cb4cceda2f50d0addb8a7ca00cd6084f 100644
+--- a/lib/template.js
++++ b/lib/template.js
+@@ -33,7 +33,14 @@ function getAssetContent(filename) {
+   if (!assetPath.startsWith(assetsRoot)) {
+     throw new Error(`"${filename}" is outside of the assets root`);
+   }
+-  return fs.readFileSync(assetPath, "utf8");
++  const content = fs.readFileSync(assetPath, "utf8");
++  if (filename === "viewer.js") {
++    return content.replace(
++      "this.handleSelectedChunksChange=e=>{Ar.setSelectedSize(e)}",
++      "this.handleSelectedChunksChange=e=>{Ar.setSelectedChunks(e)}"
++    );
++  }
++  return content;
+ }
+ 
+ /**
+@@ -53,8 +60,7 @@ function html(strings, ...values) {
+  */
+ function getScript(filename, mode) {
+   if (mode === "static") {
+-    return `<!-- ${escape(filename)} -->
+-<script>${getAssetContent(filename)}</script>`;
++    return `<script>${getAssetContent(filename)}</script>`;
+   }
+   return `<script src="${escape(filename)}"></script>`;
+ }

--- a/package.json
+++ b/package.json
@@ -814,7 +814,7 @@
     "web-vitals": "^4.2.4",
     "webextension-polyfill": "^0.8.0",
     "webpack": "^5.104.1",
-    "webpack-bundle-analyzer": "^5.3.0",
+    "webpack-bundle-analyzer": "patch:webpack-bundle-analyzer@npm%3A5.3.0#~/.yarn/patches/webpack-bundle-analyzer-npm-5.3.0-946883e2fa.patch",
     "webpack-cli": "^6.0.1",
     "webpack-dev-server": "^5.2.4",
     "ws": "^8.20.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -34096,7 +34096,7 @@ __metadata:
     web-vitals: "npm:^4.2.4"
     webextension-polyfill: "npm:^0.8.0"
     webpack: "npm:^5.104.1"
-    webpack-bundle-analyzer: "npm:^5.3.0"
+    webpack-bundle-analyzer: "patch:webpack-bundle-analyzer@npm%3A5.3.0#~/.yarn/patches/webpack-bundle-analyzer-npm-5.3.0-946883e2fa.patch"
     webpack-cli: "npm:^6.0.1"
     webpack-dev-server: "npm:^5.2.4"
     ws: "npm:^8.20.1"
@@ -45061,7 +45061,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack-bundle-analyzer@npm:^5.3.0":
+"webpack-bundle-analyzer@npm:5.3.0":
   version: 5.3.0
   resolution: "webpack-bundle-analyzer@npm:5.3.0"
   dependencies:
@@ -45078,6 +45078,26 @@ __metadata:
   bin:
     webpack-bundle-analyzer: lib/bin/analyzer.js
   checksum: 10/debed08160f10ea0890548907d530a7cef26ae049a5f650998ba85e71c1267a453ca0b262f121822ad08954b9241706455ade86dd05769c6a129a348f5cf4087
+  languageName: node
+  linkType: hard
+
+"webpack-bundle-analyzer@patch:webpack-bundle-analyzer@npm%3A5.3.0#~/.yarn/patches/webpack-bundle-analyzer-npm-5.3.0-946883e2fa.patch":
+  version: 5.3.0
+  resolution: "webpack-bundle-analyzer@patch:webpack-bundle-analyzer@npm%3A5.3.0#~/.yarn/patches/webpack-bundle-analyzer-npm-5.3.0-946883e2fa.patch::version=5.3.0&hash=441f37"
+  dependencies:
+    "@discoveryjs/json-ext": "npm:^0.6.3"
+    acorn: "npm:^8.0.4"
+    acorn-walk: "npm:^8.0.0"
+    commander: "npm:^14.0.2"
+    escape-string-regexp: "npm:^5.0.0"
+    html-escaper: "npm:^3.0.3"
+    opener: "npm:^1.5.2"
+    picocolors: "npm:^1.0.0"
+    sirv: "npm:^3.0.2"
+    ws: "npm:^8.19.0"
+  bin:
+    webpack-bundle-analyzer: lib/bin/analyzer.js
+  checksum: 10/1284d9f22e7ce2edcb11f04b802b2af0f317d2cc83f2fe8a35fb20297769b5b2877d31623b420f0a850394d3da0ad1a63ef5596022cc28ae6a6c05dee33c9cc9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

This PR patches `webpack-bundle-analyzer@5.3.0` for the static report generated by our webpack bundle analyzer workflow.

Root cause:

- `webpack-bundle-analyzer@5.3.0` generated viewer code wires chunk checkbox changes to `setSelectedSize` instead of `setSelectedChunks`, so changing chunk selection corrupts the active size state and the report UI falls back to `Stat`.
- The static template includes an HTML comment marker before the embedded `viewer.js`. LavaMoat's SES source transform rewrites HTML comment tokens inside JavaScript source, which makes the marker render visibly as `< ! -- viewer.js -- >` in the analyzer report.

This patch fixes the static embedded viewer output by replacing the bad minified handler during template rendering, and removes the static `viewer.js` HTML comment marker. This is standalone and is not part of the bundle-size stats PR stack.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open the bundle analyzer link on https://github.com/MetaMask/metamask-extension/pull/42799#issuecomment-4491869024
2. Confirm the top of the report does not show `< ! -- viewer.js -- >`.
3. Click `Gzipped`, `Parsed`, and `Stat`, and confirm the selected size mode changes correctly.
4. Toggle chunk checkboxes in the sidebar, and confirm the treemap responds to the selected chunks.

<!--
## **Screenshots/Recordings**

### **Before**

[screenshots/recordings]

### **After**

[screenshots/recordings]
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

Validation:

- `yarn install`
- `yarn lint:changed:fix`
- `yarn lint:lockfile`
- `git diff --check`
- `yarn test:unit:webpack`
- `yarn node` smoke check for `renderViewer({ mode: 'static' })` confirming the fixed chunk handler is present and the HTML comment marker is absent.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
