### PR TITLE
feat: add local transaction adapter

### DIFF
--- a/shared/lib/activity/adapters/local-transaction.test.ts
+++ b/shared/lib/activity/adapters/local-transaction.test.ts
@@ -1,0 +1,207 @@
+import {
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import { CHAIN_IDS } from '../../../constants/network';
+import type { TransactionGroup } from '../../multichain/types';
+import { mapLocalTransaction } from './local-transaction';
+
+const from = '0x9bed78535d6a03a955f1504aadba974d9a29e292';
+const to = '0x80181d3ba89220cdb80234fc7aa19d5cc56229cc';
+
+describe('mapLocalTransaction', () => {
+  it('maps a pending native send to a Send activity', () => {
+    const transaction = {
+      chainId: CHAIN_IDS.MAINNET,
+      id: 'send-id',
+      hash: '0xsend',
+      status: TransactionStatus.submitted,
+      time: 1716367781000,
+      type: TransactionType.simpleSend,
+      txParams: {
+        from,
+        to,
+        value: '0x1',
+      },
+    };
+
+    expect(
+      mapLocalTransaction({
+        transactionGroup: {
+          hasCancelled: false,
+          hasRetried: false,
+          initialTransaction: transaction,
+          nonce: '0x1',
+          primaryTransaction: transaction,
+          transactions: [transaction],
+        } as unknown as TransactionGroup,
+      }),
+    ).toStrictEqual({
+      type: 'send',
+      chainId: 'eip155:1',
+      status: 'pending',
+      timestamp: 1716367781000,
+      data: {
+        hash: '0xsend',
+        from,
+        to,
+        token: {
+          direction: 'out',
+          symbol: 'ETH',
+        },
+      },
+    });
+  });
+
+  it('maps a token send recipient from transaction data', () => {
+    const tokenContractAddress = '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+    const recipient = '0x50A9D56C2B8BA9A5c7f2C08C3d26E0499F23a706';
+    const transaction = {
+      chainId: CHAIN_IDS.MAINNET,
+      id: 'token-send-id',
+      hash: '0xtokensend',
+      status: TransactionStatus.submitted,
+      time: 1716367781000,
+      transferInformation: {
+        contractAddress: tokenContractAddress,
+        decimals: 6,
+        symbol: 'USDC',
+      },
+      type: TransactionType.tokenMethodTransfer,
+      txParams: {
+        from,
+        to: tokenContractAddress,
+        data: '0xa9059cbb00000000000000000000000050a9d56c2b8ba9a5c7f2c08c3d26e0499f23a7060000000000000000000000000000000000000000000000000000000000004e20',
+      },
+    };
+
+    expect(
+      mapLocalTransaction({
+        transactionGroup: {
+          hasCancelled: false,
+          hasRetried: false,
+          initialTransaction: transaction,
+          nonce: '0x1',
+          primaryTransaction: transaction,
+          transactions: [transaction],
+        } as unknown as TransactionGroup,
+      }),
+    ).toStrictEqual({
+      type: 'send',
+      chainId: 'eip155:1',
+      status: 'pending',
+      timestamp: 1716367781000,
+      data: {
+        hash: '0xtokensend',
+        from,
+        to: recipient,
+        token: {
+          direction: 'out',
+          symbol: 'USDC',
+        },
+      },
+    });
+  });
+
+  it('uses the original transaction type and primary transaction status', () => {
+    const initialTransaction = {
+      chainId: CHAIN_IDS.LINEA_MAINNET,
+      id: 'approve-id',
+      hash: '0xapprove',
+      status: TransactionStatus.submitted,
+      time: 1716367781000,
+      transferInformation: {
+        contractAddress: '0x239fd4b0c4db49fa8660e65b97619d43d0e0a79d',
+        decimals: 0,
+        symbol: 'TDN',
+      },
+      type: TransactionType.tokenMethodApprove,
+      txParams: {
+        from,
+        to: '0x239fd4b0c4db49fa8660e65b97619d43d0e0a79d',
+        data: '0xa22cb465',
+      },
+    };
+    const primaryTransaction = {
+      ...initialTransaction,
+      id: 'retry-id',
+      hash: '0xretry',
+      status: TransactionStatus.approved,
+      time: 1716367881000,
+      type: TransactionType.retry,
+    };
+
+    expect(
+      mapLocalTransaction({
+        transactionGroup: {
+          hasCancelled: false,
+          hasRetried: true,
+          initialTransaction,
+          nonce: '0x2',
+          primaryTransaction,
+          transactions: [initialTransaction, primaryTransaction],
+        } as unknown as TransactionGroup,
+      }),
+    ).toStrictEqual({
+      type: 'approveSpendingCap',
+      chainId: 'eip155:59144',
+      status: 'pending',
+      timestamp: 1716367881000,
+      data: {
+        hash: '0xretry',
+        tokenSymbol: 'TDN',
+      },
+    });
+  });
+
+  it('maps swap metadata token symbols to a Swap activity', () => {
+    const transaction = {
+      chainId: CHAIN_IDS.BASE,
+      id: 'swap-id',
+      hash: '0xswap',
+      status: TransactionStatus.confirmed,
+      time: 1716367781000,
+      swapMetaData: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        token_from: 'ETH',
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        token_to: 'USDC',
+      },
+      type: TransactionType.swap,
+      txParams: {
+        from,
+        to: '0x9dda6ef3d919c9bc8885d5560999a3640431e8e6',
+        value: '0x246139ca8000',
+      },
+    };
+
+    expect(
+      mapLocalTransaction({
+        transactionGroup: {
+          hasCancelled: false,
+          hasRetried: false,
+          initialTransaction: transaction,
+          nonce: '0x3',
+          primaryTransaction: transaction,
+          transactions: [transaction],
+        } as unknown as TransactionGroup,
+      }),
+    ).toStrictEqual({
+      type: 'swap',
+      chainId: 'eip155:8453',
+      status: 'success',
+      timestamp: 1716367781000,
+      data: {
+        hash: '0xswap',
+        sourceToken: {
+          direction: 'out',
+          symbol: 'ETH',
+        },
+        destinationToken: {
+          direction: 'in',
+          symbol: 'USDC',
+        },
+      },
+    });
+  });
+});

--- a/shared/lib/activity/adapters/local-transaction.ts
+++ b/shared/lib/activity/adapters/local-transaction.ts
@@ -1,0 +1,252 @@
+import {
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import { KnownCaipNamespace, toCaipChainId } from '@metamask/utils';
+import { CHAIN_ID_TO_CURRENCY_SYMBOL_MAP } from '../../../constants/network';
+import { parseStandardTokenTransactionData } from '../../transaction.utils';
+import type { TransactionGroup } from '../../multichain/types';
+import type { ActivityListItem, Status, TokenAmount } from '../types';
+
+function mapStatus(
+  status: TransactionGroup['primaryTransaction']['status'],
+): Status {
+  switch (status) {
+    case TransactionStatus.confirmed:
+      return 'success';
+    case TransactionStatus.cancelled:
+    case TransactionStatus.dropped:
+    case TransactionStatus.failed:
+    case TransactionStatus.rejected:
+      return 'failed';
+    default:
+      return 'pending';
+  }
+}
+
+function getNativeTokenSymbol(chainId: string) {
+  return CHAIN_ID_TO_CURRENCY_SYMBOL_MAP[
+    chainId as keyof typeof CHAIN_ID_TO_CURRENCY_SYMBOL_MAP
+  ];
+}
+
+function getTokenSymbol(transaction: TransactionGroup['initialTransaction']) {
+  return (
+    transaction.transferInformation?.symbol ??
+    transaction.sourceTokenSymbol ??
+    transaction.destinationTokenSymbol ??
+    getNativeTokenSymbol(transaction.chainId)
+  );
+}
+
+function getSwapMetaDataTokenSymbol(
+  transaction: TransactionGroup['initialTransaction'],
+  key: 'token_from' | 'token_to',
+) {
+  const tokenSymbol = transaction.swapMetaData?.[key];
+  return typeof tokenSymbol === 'string' ? tokenSymbol : undefined;
+}
+
+function getToken(
+  symbol: string | undefined,
+  direction: TokenAmount['direction'],
+) {
+  return symbol ? { symbol, direction } : undefined;
+}
+
+function hasNativeValue(transaction: TransactionGroup['initialTransaction']) {
+  const { value } = transaction.txParams;
+  return Boolean(value && value !== '0' && value !== '0x0');
+}
+
+function getTokenTransferRecipient(
+  transaction: TransactionGroup['initialTransaction'],
+) {
+  const { data, to } = transaction.txParams;
+
+  if (!data) {
+    return to ?? '';
+  }
+
+  const transactionData = parseStandardTokenTransactionData(data);
+  const recipient = transactionData?.args?._to ?? transactionData?.args?.to;
+
+  return typeof recipient === 'string' ? recipient : (to ?? '');
+}
+
+// Converts local TransactionController groups into activity items
+export function mapLocalTransaction({
+  transactionGroup,
+}: {
+  transactionGroup: TransactionGroup;
+}): ActivityListItem {
+  const { initialTransaction, primaryTransaction } = transactionGroup;
+  const chainId = toCaipChainId(
+    KnownCaipNamespace.Eip155,
+    Number.parseInt(initialTransaction.chainId, 16).toString(),
+  );
+  const status = mapStatus(primaryTransaction.status);
+  const timestamp = primaryTransaction.time ?? initialTransaction.time;
+  const hash =
+    primaryTransaction.hash ?? initialTransaction.hash ?? primaryTransaction.id;
+  const from = initialTransaction.txParams.from ?? '';
+  const to = initialTransaction.txParams.to ?? '';
+
+  switch (initialTransaction.type) {
+    case TransactionType.simpleSend:
+      return {
+        type: 'send',
+        chainId,
+        status,
+        timestamp,
+        data: {
+          hash,
+          from,
+          to,
+          token: getToken(getTokenSymbol(initialTransaction), 'out'),
+        },
+      };
+
+    case TransactionType.tokenMethodSafeTransferFrom:
+    case TransactionType.tokenMethodTransfer:
+    case TransactionType.tokenMethodTransferFrom: {
+      const recipient = getTokenTransferRecipient(initialTransaction);
+
+      return {
+        type: 'send',
+        chainId,
+        status,
+        timestamp,
+        data: {
+          hash,
+          from,
+          to: recipient,
+          token: getToken(getTokenSymbol(initialTransaction), 'out'),
+        },
+      };
+    }
+
+    case TransactionType.incoming:
+      return {
+        type: 'receive',
+        chainId,
+        status,
+        timestamp,
+        data: {
+          hash,
+          from,
+          to,
+          token: getToken(getTokenSymbol(initialTransaction), 'in'),
+        },
+      };
+
+    case TransactionType.swap:
+    case TransactionType.swapAndSend: {
+      const sourceTokenSymbol =
+        initialTransaction.sourceTokenSymbol ??
+        primaryTransaction.sourceTokenSymbol ??
+        getSwapMetaDataTokenSymbol(initialTransaction, 'token_from') ??
+        getSwapMetaDataTokenSymbol(primaryTransaction, 'token_from') ??
+        (hasNativeValue(initialTransaction)
+          ? getNativeTokenSymbol(initialTransaction.chainId)
+          : undefined);
+      const destinationTokenSymbol =
+        initialTransaction.destinationTokenSymbol ??
+        primaryTransaction.destinationTokenSymbol ??
+        getSwapMetaDataTokenSymbol(initialTransaction, 'token_to') ??
+        getSwapMetaDataTokenSymbol(primaryTransaction, 'token_to');
+
+      if (!destinationTokenSymbol) {
+        return {
+          type: 'swapIncomplete',
+          chainId,
+          status,
+          timestamp,
+          data: {
+            hash,
+            sourceToken: getToken(sourceTokenSymbol, 'out'),
+          },
+        };
+      }
+
+      return {
+        type: 'swap',
+        chainId,
+        status,
+        timestamp,
+        data: {
+          hash,
+          sourceToken: getToken(sourceTokenSymbol, 'out'),
+          destinationToken: getToken(destinationTokenSymbol, 'in'),
+        },
+      };
+    }
+
+    case TransactionType.bridgeApproval:
+    case TransactionType.shieldSubscriptionApprove:
+    case TransactionType.swapApproval:
+    case TransactionType.tokenMethodApprove:
+    case TransactionType.tokenMethodSetApprovalForAll:
+      return {
+        type: 'approveSpendingCap',
+        chainId,
+        status,
+        timestamp,
+        data: {
+          hash,
+          tokenSymbol: getTokenSymbol(initialTransaction),
+        },
+      };
+
+    case TransactionType.tokenMethodIncreaseAllowance:
+      return {
+        type: 'increaseSpendingCap',
+        chainId,
+        status,
+        timestamp,
+        data: {
+          hash,
+          tokenSymbol: getTokenSymbol(initialTransaction),
+        },
+      };
+
+    case TransactionType.lendingDeposit:
+    case TransactionType.stakingDeposit:
+      return {
+        type: 'lendingDeposit',
+        chainId,
+        status,
+        timestamp,
+        data: {
+          hash,
+          token: getToken(getTokenSymbol(initialTransaction), 'out'),
+        },
+      };
+
+    case TransactionType.musdClaim:
+      return {
+        type: 'claimMusdBonus',
+        chainId,
+        status,
+        timestamp,
+        data: {
+          hash,
+        },
+      };
+
+    default:
+      return {
+        type: 'contractInteraction',
+        chainId,
+        status,
+        timestamp,
+        data: {
+          hash,
+          from,
+          to,
+          methodId: initialTransaction.txParams.data?.slice(0, 10),
+          transactionType: initialTransaction.type,
+        },
+      };
+  }
+}


### PR DESCRIPTION
## **Description**

Adds a local TransactionController group adapter for shared activity list items, including pending/success status mapping, send/receive token data, swap token metadata, approvals, lending deposits, claims, and fallback contract interactions.

Part of https://github.com/MetaMask/metamask-extension/pull/42622

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. yarn test:unit shared/lib/activity/adapters/local-transaction.test.ts

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new mapping logic from local transaction groups into user-visible activity items; incorrect type/status/token inference could cause misclassification or missing details in the activity feed.
> 
> **Overview**
> Adds a new `mapLocalTransaction` adapter that converts `TransactionController` `TransactionGroup`s into shared `ActivityListItem`s, including CAIP chain ID formatting, status normalization, and hash/timestamp selection from the primary transaction.
> 
> Implements activity-type mapping for sends/receives, swaps (including `swapMetaData` symbol fallbacks and `swapIncomplete`), approvals/increase allowance, lending/staking deposits, and mUSD claims, with a fallback `contractInteraction` that includes `methodId` and `transactionType`. Includes unit tests covering native sends, token-transfer recipient parsing from calldata, retry groups using initial type + primary status, and swap metadata symbol extraction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f05e595a0bff3e66ee6508f8eac0a235e0882341. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->