### PR TITLE
fix: cp-13.32.0 add `isAtomicBatchSupported` action to `TransactionPayController` init messenger

### DIFF
--- a/app/scripts/messenger-client-init/messengers/transaction-pay-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/transaction-pay-controller-messenger.ts
@@ -6,7 +6,10 @@ import {
 import type { TransactionPayControllerMessenger } from '@metamask/transaction-pay-controller';
 import type { DelegationControllerSignDelegationAction } from '@metamask/delegation-controller';
 import type { KeyringControllerSignEip7702AuthorizationAction } from '@metamask/keyring-controller';
-import type { TransactionControllerGetNonceLockAction } from '@metamask/transaction-controller';
+import type {
+  TransactionControllerGetNonceLockAction,
+  TransactionControllerIsAtomicBatchSupportedAction,
+} from '@metamask/transaction-controller';
 import type { RootMessenger } from '../../lib/messenger';
 import { getIsAssetsUnifiedStateIncludedInBuild } from '../../../../shared/lib/environment';
 import { getAssetsControllerMessenger } from './assets/assets-controller-messenger';
@@ -70,7 +73,8 @@ export function getTransactionPayControllerMessenger(
 type InitMessengerActions =
   | DelegationControllerSignDelegationAction
   | KeyringControllerSignEip7702AuthorizationAction
-  | TransactionControllerGetNonceLockAction;
+  | TransactionControllerGetNonceLockAction
+  | TransactionControllerIsAtomicBatchSupportedAction;
 
 type InitMessengerEvents = never;
 
@@ -97,6 +101,7 @@ export function getTransactionPayControllerInitMessenger(
       'DelegationController:signDelegation',
       'KeyringController:signEip7702Authorization',
       'TransactionController:getNonceLock',
+      'TransactionController:isAtomicBatchSupported',
     ],
     events: [],
   });


### PR DESCRIPTION
## **Description**

Add `TransactionControllerIsAtomicBatchSupportedAction` to the `TransactionPayControllerInit` messenger. This enables the init messenger to delegate the `TransactionController:isAtomicBatchSupported` action, which is needed during controller initialization to check atomic batch support.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #42781

## **Manual testing steps**

1. Build the extension with `yarn start`
2. Verify the extension loads without errors
3. Verify transaction pay functionality works as expected

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only expands the `TransactionPayControllerInit` messenger action types and delegation list to include `TransactionController:isAtomicBatchSupported`. Main risk is a missing/incorrect action wiring causing initialization/runtime errors in transaction pay flows.
> 
> **Overview**
> Adds support for calling `TransactionController:isAtomicBatchSupported` during `TransactionPayController` initialization by extending `InitMessengerActions` and delegating the action in `getTransactionPayControllerInitMessenger()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efc46b7099e3884a85c465712418747ba413be62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->