### PR TITLE
refactor: Refactor accounts-related controllers to remove duplicate messenger types

### DIFF
--- a/app/scripts/messenger-client-init/accounts/account-tree-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/accounts/account-tree-controller-init.test.ts
@@ -1,10 +1,10 @@
 import { AccountTreeController } from '@metamask/account-tree-controller';
 import { buildControllerInitRequestMock } from '../test/utils';
 import { MessengerClientInitRequest } from '../types';
+import { AccountTreeControllerMessenger } from '@metamask/account-tree-controller';
 import {
   getAccountTreeControllerMessenger,
   getAccountTreeControllerInitMessenger,
-  AccountTreeControllerMessenger,
   AccountTreeControllerInitMessenger,
 } from '../messengers/accounts';
 import { getRootMessenger } from '../../lib/messenger';

--- a/app/scripts/messenger-client-init/accounts/account-tree-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/accounts/account-tree-controller-init.test.ts
@@ -1,7 +1,6 @@
-import { AccountTreeController } from '@metamask/account-tree-controller';
+import { AccountTreeController , AccountTreeControllerMessenger } from '@metamask/account-tree-controller';
 import { buildControllerInitRequestMock } from '../test/utils';
 import { MessengerClientInitRequest } from '../types';
-import { AccountTreeControllerMessenger } from '@metamask/account-tree-controller';
 import {
   getAccountTreeControllerMessenger,
   getAccountTreeControllerInitMessenger,

--- a/app/scripts/messenger-client-init/accounts/account-tree-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/accounts/account-tree-controller-init.test.ts
@@ -1,4 +1,7 @@
-import { AccountTreeController , AccountTreeControllerMessenger } from '@metamask/account-tree-controller';
+import {
+  AccountTreeController,
+  AccountTreeControllerMessenger,
+} from '@metamask/account-tree-controller';
 import { buildControllerInitRequestMock } from '../test/utils';
 import { MessengerClientInitRequest } from '../types';
 import {

--- a/app/scripts/messenger-client-init/accounts/account-tree-controller-init.ts
+++ b/app/scripts/messenger-client-init/accounts/account-tree-controller-init.ts
@@ -1,7 +1,9 @@
-import { AccountTreeController } from '@metamask/account-tree-controller';
+import {
+  AccountTreeController,
+  AccountTreeControllerMessenger,
+} from '@metamask/account-tree-controller';
 import { AccountId } from '@metamask/keyring-utils';
 import { MessengerClientInitFunction } from '../types';
-import { AccountTreeControllerMessenger } from '../messengers/accounts';
 import { trace } from '../../../../shared/lib/trace';
 import { AccountTreeControllerInitMessenger } from '../messengers/accounts/account-tree-controller-messenger';
 import {

--- a/app/scripts/messenger-client-init/accounts/snap-keyring-builder-init.test.ts
+++ b/app/scripts/messenger-client-init/accounts/snap-keyring-builder-init.test.ts
@@ -3,11 +3,11 @@ import { MessengerClientInitRequest } from '../types';
 import {
   getSnapKeyringBuilderMessenger,
   getSnapKeyringBuilderInitMessenger,
-  SnapKeyringBuilderMessenger,
   SnapKeyringBuilderInitMessenger,
 } from '../messengers/accounts';
 import { getRootMessenger } from '../../lib/messenger';
 import { snapKeyringBuilder } from '../../lib/snap-keyring';
+import type { SnapKeyringBuilderMessenger } from '../../lib/snap-keyring/types';
 import { SnapKeyringBuilderInit } from './snap-keyring-builder-init';
 
 jest.mock('../../lib/snap-keyring/snap-keyring');

--- a/app/scripts/messenger-client-init/accounts/snap-keyring-builder-init.ts
+++ b/app/scripts/messenger-client-init/accounts/snap-keyring-builder-init.ts
@@ -1,12 +1,10 @@
 import { MessengerClientInitFunction } from '../types';
-import {
-  SnapKeyringBuilderInitMessenger,
-  SnapKeyringBuilderMessenger,
-} from '../messengers/accounts';
+import { SnapKeyringBuilderInitMessenger } from '../messengers/accounts';
 import {
   snapKeyringBuilder,
   SnapKeyringBuilder,
 } from '../../lib/snap-keyring/snap-keyring';
+import { SnapKeyringBuilderMessenger } from '../../lib/snap-keyring/types';
 
 /**
  * Initialize the Snap keyring builder.

--- a/app/scripts/messenger-client-init/messengers/accounts/account-tree-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/accounts/account-tree-controller-messenger.ts
@@ -2,43 +2,15 @@ import {
   AccountsControllerAccountsAddedEvent,
   AccountsControllerAccountsRemovedEvent,
   AccountsControllerGetAccountAction,
-  AccountsControllerGetSelectedMultichainAccountAction,
-  AccountsControllerListMultichainAccountsAction,
   AccountsControllerSelectedAccountChangeEvent,
-  AccountsControllerSetSelectedAccountAction,
 } from '@metamask/accounts-controller';
-import { Messenger } from '@metamask/messenger';
-import {
-  AuthenticationController,
-  UserStorageController,
-} from '@metamask/profile-sync-controller';
-import { SnapControllerGetSnapAction } from '@metamask/snaps-controllers';
-import { KeyringControllerGetStateAction } from '@metamask/keyring-controller';
-import {
-  MultichainAccountServiceCreateMultichainAccountGroupAction,
-  MultichainAccountServiceCreateMultichainAccountGroupsAction,
-  MultichainAccountServiceWalletStatusChangeEvent,
-} from '@metamask/multichain-account-service';
-import type { AccountTreeControllerMessenger as AccountTreeControllerMessengerType } from '@metamask/account-tree-controller';
+import { Messenger, MessengerActions, MessengerEvents } from '@metamask/messenger';
+import { UserStorageController } from '@metamask/profile-sync-controller';
+import { MultichainAccountServiceWalletStatusChangeEvent } from '@metamask/multichain-account-service';
+import type { AccountTreeControllerMessenger } from '@metamask/account-tree-controller';
 import { MetaMetricsControllerTrackEventAction } from '../../../controllers/metametrics-controller-method-action-types';
 import { RootMessenger } from '../../../lib/messenger';
 import { AccountOrderControllerGetStateAction } from '../../../controllers/account-order';
-
-type Actions =
-  | AccountsControllerGetAccountAction
-  | AccountsControllerGetSelectedMultichainAccountAction
-  | AccountsControllerSetSelectedAccountAction
-  | AccountsControllerListMultichainAccountsAction
-  | SnapControllerGetSnapAction
-  | KeyringControllerGetStateAction
-  | UserStorageController.UserStorageControllerGetStateAction
-  | UserStorageController.UserStorageControllerPerformGetStorageAction
-  | UserStorageController.UserStorageControllerPerformGetStorageAllFeatureEntriesAction
-  | UserStorageController.UserStorageControllerPerformSetStorageAction
-  | UserStorageController.UserStorageControllerPerformBatchSetStorageAction
-  | AuthenticationController.AuthenticationControllerGetSessionProfileAction
-  | MultichainAccountServiceCreateMultichainAccountGroupAction
-  | MultichainAccountServiceCreateMultichainAccountGroupsAction;
 
 type Events =
   | AccountsControllerAccountsAddedEvent
@@ -46,8 +18,6 @@ type Events =
   | AccountsControllerSelectedAccountChangeEvent
   | UserStorageController.UserStorageControllerStateChangeEvent
   | MultichainAccountServiceWalletStatusChangeEvent;
-
-export type AccountTreeControllerMessenger = AccountTreeControllerMessengerType;
 
 /**
  * Get a restricted messenger for the account tree controller. This is scoped to the
@@ -57,17 +27,16 @@ export type AccountTreeControllerMessenger = AccountTreeControllerMessengerType;
  * @returns The restricted controller messenger.
  */
 export function getAccountTreeControllerMessenger(
-  messenger: RootMessenger<Actions, Events>,
+  messenger: RootMessenger<
+    MessengerActions<AccountTreeControllerMessenger>,
+    MessengerEvents<AccountTreeControllerMessenger>
+  >,
 ) {
-  const accountTreeControllerMessenger = new Messenger<
-    'AccountTreeController',
-    Actions,
-    Events,
-    typeof messenger
-  >({
-    namespace: 'AccountTreeController',
-    parent: messenger,
-  });
+  const accountTreeControllerMessenger: AccountTreeControllerMessenger =
+    new Messenger({
+      namespace: 'AccountTreeController',
+      parent: messenger,
+    });
   messenger.delegate({
     messenger: accountTreeControllerMessenger,
     events: [
@@ -94,7 +63,7 @@ export function getAccountTreeControllerMessenger(
       'KeyringController:getState',
     ],
   });
-  return accountTreeControllerMessenger as unknown as AccountTreeControllerMessengerType;
+  return accountTreeControllerMessenger;
 }
 
 export type AllowedInitializationActions =

--- a/app/scripts/messenger-client-init/messengers/accounts/account-tree-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/accounts/account-tree-controller-messenger.ts
@@ -1,16 +1,9 @@
-import {
-  AccountsControllerAccountsAddedEvent,
-  AccountsControllerAccountsRemovedEvent,
-  AccountsControllerGetAccountAction,
-  AccountsControllerSelectedAccountChangeEvent,
-} from '@metamask/accounts-controller';
+import { AccountsControllerGetAccountAction } from '@metamask/accounts-controller';
 import {
   Messenger,
   MessengerActions,
   MessengerEvents,
 } from '@metamask/messenger';
-import { UserStorageController } from '@metamask/profile-sync-controller';
-import { MultichainAccountServiceWalletStatusChangeEvent } from '@metamask/multichain-account-service';
 import type { AccountTreeControllerMessenger } from '@metamask/account-tree-controller';
 import { MetaMetricsControllerTrackEventAction } from '../../../controllers/metametrics-controller-method-action-types';
 import { RootMessenger } from '../../../lib/messenger';

--- a/app/scripts/messenger-client-init/messengers/accounts/account-tree-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/accounts/account-tree-controller-messenger.ts
@@ -4,7 +4,11 @@ import {
   AccountsControllerGetAccountAction,
   AccountsControllerSelectedAccountChangeEvent,
 } from '@metamask/accounts-controller';
-import { Messenger, MessengerActions, MessengerEvents } from '@metamask/messenger';
+import {
+  Messenger,
+  MessengerActions,
+  MessengerEvents,
+} from '@metamask/messenger';
 import { UserStorageController } from '@metamask/profile-sync-controller';
 import { MultichainAccountServiceWalletStatusChangeEvent } from '@metamask/multichain-account-service';
 import type { AccountTreeControllerMessenger } from '@metamask/account-tree-controller';

--- a/app/scripts/messenger-client-init/messengers/accounts/account-tree-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/accounts/account-tree-controller-messenger.ts
@@ -1,9 +1,16 @@
-import { AccountsControllerGetAccountAction } from '@metamask/accounts-controller';
+import {
+  AccountsControllerAccountsAddedEvent,
+  AccountsControllerAccountsRemovedEvent,
+  AccountsControllerGetAccountAction,
+  AccountsControllerSelectedAccountChangeEvent,
+} from '@metamask/accounts-controller';
 import {
   Messenger,
   MessengerActions,
   MessengerEvents,
 } from '@metamask/messenger';
+import { UserStorageController } from '@metamask/profile-sync-controller';
+import { MultichainAccountServiceWalletStatusChangeEvent } from '@metamask/multichain-account-service';
 import type { AccountTreeControllerMessenger } from '@metamask/account-tree-controller';
 import { MetaMetricsControllerTrackEventAction } from '../../../controllers/metametrics-controller-method-action-types';
 import { RootMessenger } from '../../../lib/messenger';

--- a/app/scripts/messenger-client-init/messengers/accounts/account-tree-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/accounts/account-tree-controller-messenger.ts
@@ -1,27 +1,13 @@
-import {
-  AccountsControllerAccountsAddedEvent,
-  AccountsControllerAccountsRemovedEvent,
-  AccountsControllerGetAccountAction,
-  AccountsControllerSelectedAccountChangeEvent,
-} from '@metamask/accounts-controller';
+import { AccountsControllerGetAccountAction } from '@metamask/accounts-controller';
 import {
   Messenger,
   MessengerActions,
   MessengerEvents,
 } from '@metamask/messenger';
-import { UserStorageController } from '@metamask/profile-sync-controller';
-import { MultichainAccountServiceWalletStatusChangeEvent } from '@metamask/multichain-account-service';
 import type { AccountTreeControllerMessenger } from '@metamask/account-tree-controller';
 import { MetaMetricsControllerTrackEventAction } from '../../../controllers/metametrics-controller-method-action-types';
 import { RootMessenger } from '../../../lib/messenger';
 import { AccountOrderControllerGetStateAction } from '../../../controllers/account-order';
-
-type Events =
-  | AccountsControllerAccountsAddedEvent
-  | AccountsControllerAccountsRemovedEvent
-  | AccountsControllerSelectedAccountChangeEvent
-  | UserStorageController.UserStorageControllerStateChangeEvent
-  | MultichainAccountServiceWalletStatusChangeEvent;
 
 /**
  * Get a restricted messenger for the account tree controller. This is scoped to the
@@ -87,12 +73,12 @@ export type AccountTreeControllerInitMessenger = ReturnType<
  * @returns The restricted controller messenger.
  */
 export function getAccountTreeControllerInitMessenger(
-  messenger: RootMessenger<AllowedInitializationActions, Events>,
+  messenger: RootMessenger<AllowedInitializationActions, never>,
 ) {
   const accountTreeControllerInitMessenger = new Messenger<
     'AccountTreeControllerInit',
     AllowedInitializationActions,
-    Events,
+    never,
     typeof messenger
   >({
     namespace: 'AccountTreeControllerInit',

--- a/app/scripts/messenger-client-init/messengers/accounts/index.ts
+++ b/app/scripts/messenger-client-init/messengers/accounts/index.ts
@@ -8,20 +8,11 @@ export {
 } from './multichain-account-service-messenger';
 export { getInstitutionalSnapControllerMessenger } from './institutional-snap-controller-messenger';
 
-export type {
-  AccountTreeControllerMessenger,
-  AccountTreeControllerInitMessenger,
-} from './account-tree-controller-messenger';
-export type {
-  MultichainAccountServiceMessenger,
-  MultichainAccountServiceInitMessenger,
-} from './multichain-account-service-messenger';
+export type { AccountTreeControllerInitMessenger } from './account-tree-controller-messenger';
+export type { MultichainAccountServiceInitMessenger } from './multichain-account-service-messenger';
 export type { InstitutionalSnapControllerMessenger } from './institutional-snap-controller-messenger';
 
-export type {
-  SnapKeyringBuilderMessenger,
-  SnapKeyringBuilderInitMessenger,
-} from './snap-keyring-builder-messenger';
+export type { SnapKeyringBuilderInitMessenger } from './snap-keyring-builder-messenger';
 export {
   getSnapKeyringBuilderMessenger,
   getSnapKeyringBuilderInitMessenger,

--- a/app/scripts/messenger-client-init/messengers/accounts/multichain-account-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/accounts/multichain-account-service-messenger.ts
@@ -11,16 +11,6 @@ import {
 } from '../../../controllers/preferences-controller';
 import { RootMessenger } from '../../../lib/messenger';
 
-type AllowedInitializationActions =
-  | PreferencesControllerGetStateAction
-  | RemoteFeatureFlagControllerGetStateAction;
-
-type AllowedInitializationEvents = PreferencesControllerStateChangeEvent;
-
-export type MultichainAccountServiceInitMessenger = ReturnType<
-  typeof getMultichainAccountServiceInitMessenger
->;
-
 /**
  * Get a restricted messenger for the account wallet controller. This is scoped to the
  * actions and events that this controller is allowed to handle.
@@ -65,6 +55,16 @@ export function getMultichainAccountServiceMessenger(
   });
   return serviceMessenger;
 }
+
+type AllowedInitializationActions =
+  | PreferencesControllerGetStateAction
+  | RemoteFeatureFlagControllerGetStateAction;
+
+type AllowedInitializationEvents = PreferencesControllerStateChangeEvent;
+
+export type MultichainAccountServiceInitMessenger = ReturnType<
+  typeof getMultichainAccountServiceInitMessenger
+>;
 
 /**
  * Get a restricted messenger for the account wallet controller. This is scoped to the

--- a/app/scripts/messenger-client-init/messengers/accounts/multichain-account-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/accounts/multichain-account-service-messenger.ts
@@ -1,66 +1,20 @@
-import { Messenger } from '@metamask/messenger';
-import {
-  AccountsControllerAccountAddedEvent,
-  AccountsControllerAccountRemovedEvent,
-  AccountsControllerGetAccountAction,
-  AccountsControllerGetAccountsAction,
-  AccountsControllerGetAccountByAddressAction,
-  AccountsControllerListMultichainAccountsAction,
-} from '@metamask/accounts-controller';
-import {
-  SnapControllerStateChangeEvent,
-  SnapControllerGetStateAction,
-  SnapControllerHandleRequestAction,
-} from '@metamask/snaps-controllers';
-import {
-  KeyringControllerWithKeyringAction,
-  KeyringControllerGetStateAction,
-  KeyringControllerStateChangeEvent,
-  KeyringControllerAddNewKeyringAction,
-  KeyringControllerGetKeyringsByTypeAction,
-  KeyringControllerCreateNewVaultAndKeychainAction,
-  KeyringControllerCreateNewVaultAndRestoreAction,
-} from '@metamask/keyring-controller';
-import {
-  NetworkControllerFindNetworkClientIdByChainIdAction,
-  NetworkControllerGetNetworkClientByIdAction,
-} from '@metamask/network-controller';
-import {
-  RemoteFeatureFlagControllerStateChangeEvent,
-  RemoteFeatureFlagControllerGetStateAction,
-} from '@metamask/remote-feature-flag-controller';
+import { Messenger, MessengerActions, MessengerEvents } from '@metamask/messenger';
+import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
+import type { MultichainAccountServiceMessenger } from '@metamask/multichain-account-service';
 import {
   PreferencesControllerGetStateAction,
   PreferencesControllerStateChangeEvent,
 } from '../../../controllers/preferences-controller';
 import { RootMessenger } from '../../../lib/messenger';
 
-type Actions =
-  | AccountsControllerListMultichainAccountsAction
-  | AccountsControllerGetAccountAction
-  | AccountsControllerGetAccountsAction
-  | AccountsControllerGetAccountByAddressAction
-  | SnapControllerGetStateAction
-  | SnapControllerHandleRequestAction
-  | KeyringControllerGetStateAction
-  | KeyringControllerWithKeyringAction
-  | KeyringControllerAddNewKeyringAction
-  | KeyringControllerGetKeyringsByTypeAction
-  | KeyringControllerCreateNewVaultAndKeychainAction
-  | KeyringControllerCreateNewVaultAndRestoreAction
-  | NetworkControllerGetNetworkClientByIdAction
-  | NetworkControllerFindNetworkClientIdByChainIdAction;
+type AllowedInitializationActions =
+  | PreferencesControllerGetStateAction
+  | RemoteFeatureFlagControllerGetStateAction;
 
-type Events =
-  | SnapControllerStateChangeEvent
-  | KeyringControllerStateChangeEvent
-  | AccountsControllerAccountAddedEvent
-  | AccountsControllerAccountRemovedEvent
-  | RemoteFeatureFlagControllerStateChangeEvent
-  | SnapControllerStateChangeEvent;
+type AllowedInitializationEvents = PreferencesControllerStateChangeEvent;
 
-export type MultichainAccountServiceMessenger = ReturnType<
-  typeof getMultichainAccountServiceMessenger
+export type MultichainAccountServiceInitMessenger = ReturnType<
+  typeof getMultichainAccountServiceInitMessenger
 >;
 
 /**
@@ -71,14 +25,12 @@ export type MultichainAccountServiceMessenger = ReturnType<
  * @returns The restricted controller messenger.
  */
 export function getMultichainAccountServiceMessenger(
-  messenger: RootMessenger<Actions, Events>,
+  messenger: RootMessenger<
+    MessengerActions<MultichainAccountServiceMessenger>,
+    MessengerEvents<MultichainAccountServiceMessenger>
+  >,
 ) {
-  const serviceMessenger = new Messenger<
-    'MultichainAccountService',
-    Actions,
-    Events,
-    typeof messenger
-  >({
+  const serviceMessenger: MultichainAccountServiceMessenger = new Messenger({
     namespace: 'MultichainAccountService',
     parent: messenger,
   });
@@ -110,16 +62,6 @@ export function getMultichainAccountServiceMessenger(
   });
   return serviceMessenger;
 }
-
-type AllowedInitializationActions =
-  | PreferencesControllerGetStateAction
-  | RemoteFeatureFlagControllerGetStateAction;
-
-type AllowedInitializationEvents = PreferencesControllerStateChangeEvent;
-
-export type MultichainAccountServiceInitMessenger = ReturnType<
-  typeof getMultichainAccountServiceInitMessenger
->;
 
 /**
  * Get a restricted messenger for the account wallet controller. This is scoped to the

--- a/app/scripts/messenger-client-init/messengers/accounts/multichain-account-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/accounts/multichain-account-service-messenger.ts
@@ -1,4 +1,8 @@
-import { Messenger, MessengerActions, MessengerEvents } from '@metamask/messenger';
+import {
+  Messenger,
+  MessengerActions,
+  MessengerEvents,
+} from '@metamask/messenger';
 import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import type { MultichainAccountServiceMessenger } from '@metamask/multichain-account-service';
 import {

--- a/app/scripts/messenger-client-init/messengers/accounts/multichain-account-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/accounts/multichain-account-service-messenger.ts
@@ -45,7 +45,6 @@ export function getMultichainAccountServiceMessenger(
       'SnapController:stateChange',
       'AccountsController:accountAdded',
       'AccountsController:accountRemoved',
-      'RemoteFeatureFlagController:stateChange',
     ],
     actions: [
       'AccountsController:listMultichainAccounts',

--- a/app/scripts/messenger-client-init/messengers/accounts/snap-keyring-builder-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/accounts/snap-keyring-builder-messenger.ts
@@ -1,13 +1,9 @@
-import { Messenger } from '@metamask/messenger';
+import { Messenger, MessengerActions } from '@metamask/messenger';
 import { KeyringControllerPersistAllKeyringsAction } from '@metamask/keyring-controller';
 import { AccountsControllerUpdateAccountsAction } from '@metamask/accounts-controller';
-import { SnapKeyringBuilderAllowActions } from '../../../lib/snap-keyring/types';
 import { MetaMetricsControllerTrackEventAction } from '../../../controllers/metametrics-controller-method-action-types';
 import { RootMessenger } from '../../../lib/messenger';
-
-export type SnapKeyringBuilderMessenger = ReturnType<
-  typeof getSnapKeyringBuilderMessenger
->;
+import type { SnapKeyringBuilderMessenger } from '../../../lib/snap-keyring/types';
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -17,14 +13,12 @@ export type SnapKeyringBuilderMessenger = ReturnType<
  * @returns The restricted controller messenger.
  */
 export function getSnapKeyringBuilderMessenger(
-  messenger: RootMessenger<SnapKeyringBuilderAllowActions, never>,
+  messenger: RootMessenger<
+    MessengerActions<SnapKeyringBuilderMessenger>,
+    never
+  >,
 ) {
-  const keyringMessenger = new Messenger<
-    'SnapKeyring',
-    SnapKeyringBuilderAllowActions,
-    never,
-    typeof messenger
-  >({
+  const keyringMessenger: SnapKeyringBuilderMessenger = new Messenger({
     namespace: 'SnapKeyring',
     parent: messenger,
   });

--- a/app/scripts/messenger-client-init/multichain/multichain-account-service-init.test.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-account-service-init.test.ts
@@ -7,11 +7,11 @@ import {
 } from '@metamask/messenger';
 import { buildControllerInitRequestMock } from '../test/utils';
 import { MessengerClientInitRequest } from '../types';
+import { MultichainAccountServiceMessenger } from '@metamask/multichain-account-service';
 import {
   getMultichainAccountServiceInitMessenger,
   getMultichainAccountServiceMessenger,
   MultichainAccountServiceInitMessenger,
-  MultichainAccountServiceMessenger,
 } from '../messengers/accounts';
 import { PreferencesControllerGetStateAction } from '../../controllers/preferences-controller';
 import { MultichainAccountServiceInit } from './multichain-account-service-init';

--- a/app/scripts/messenger-client-init/multichain/multichain-account-service-init.test.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-account-service-init.test.ts
@@ -1,4 +1,7 @@
-import { MultichainAccountService , MultichainAccountServiceMessenger } from '@metamask/multichain-account-service';
+import {
+  MultichainAccountService,
+  MultichainAccountServiceMessenger,
+} from '@metamask/multichain-account-service';
 import {
   ActionConstraint,
   MOCK_ANY_NAMESPACE,

--- a/app/scripts/messenger-client-init/multichain/multichain-account-service-init.test.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-account-service-init.test.ts
@@ -1,4 +1,4 @@
-import { MultichainAccountService } from '@metamask/multichain-account-service';
+import { MultichainAccountService , MultichainAccountServiceMessenger } from '@metamask/multichain-account-service';
 import {
   ActionConstraint,
   MOCK_ANY_NAMESPACE,
@@ -7,7 +7,6 @@ import {
 } from '@metamask/messenger';
 import { buildControllerInitRequestMock } from '../test/utils';
 import { MessengerClientInitRequest } from '../types';
-import { MultichainAccountServiceMessenger } from '@metamask/multichain-account-service';
 import {
   getMultichainAccountServiceInitMessenger,
   getMultichainAccountServiceMessenger,

--- a/app/scripts/messenger-client-init/multichain/multichain-account-service-init.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-account-service-init.ts
@@ -1,14 +1,12 @@
 import {
   MultichainAccountService,
+  MultichainAccountServiceMessenger,
   SOL_ACCOUNT_PROVIDER_NAME,
   TRX_ACCOUNT_PROVIDER_NAME,
   BTC_ACCOUNT_PROVIDER_NAME,
 } from '@metamask/multichain-account-service';
 import { MessengerClientInitFunction } from '../types';
-import {
-  MultichainAccountServiceMessenger,
-  MultichainAccountServiceInitMessenger,
-} from '../messengers/accounts';
+import { MultichainAccountServiceInitMessenger } from '../messengers/accounts';
 import { previousValueComparator } from '../../lib/util';
 import { trace } from '../../../../shared/lib/trace';
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This removes some duplicated messenger types, and ensures we use an always up-to-date type in the controller init files.

https://consensyssoftware.atlassian.net/browse/WPC-950

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a type-level refactor, but it touches messenger restriction/delegation wiring (including event/action lists), so incorrect typing or missing delegated events could break controller communication at runtime.
> 
> **Overview**
> Refactors accounts-related controller init and messenger factories to **stop defining/exports local messenger type aliases** and instead use the messenger types exported by the owning packages (e.g. `@metamask/account-tree-controller`, `@metamask/multichain-account-service`, and snap-keyring types).
> 
> Messenger builders (`account-tree-controller-messenger`, `multichain-account-service-messenger`, `snap-keyring-builder-messenger`) now type their `RootMessenger` inputs via `MessengerActions<>`/`MessengerEvents<>` and return the concrete package messenger types directly; the accounts messengers `index.ts` correspondingly drops re-exported messenger types that were duplicates. Tests and init modules are updated to import the new types from the source packages, and `AccountTreeControllerInit`’s init messenger is tightened to `never` events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 159799cde215fa2becb13dd8a9e10465e6529f2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->