### PR TITLE
chore: Fix network-specific CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -173,8 +173,8 @@ ui/components/ui/nft-collection-image                 @MetaMask/metamask-assets
 app/scripts/controller-init/smart-transactions    @MetaMask/transactions
 app/scripts/lib/smart-transaction                 @MetaMask/transactions
 
-# New networks
-shared/lib/multichain/addresses/* @MetaMask/new-networks
+# Networks Team
+shared/lib/multichain/addresses/* @MetaMask/networks
 
 # QA Team - E2E Framework
 test/e2e/page-objects/                                                @MetaMask/qa


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The current CODEOWNERS file is invalid due to the removal of the `new-networks` team. This PR fixes that by moving the ownership to the newly established networks team.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates `.github/CODEOWNERS` to point a path at a different GitHub team, with no runtime or build impact.
> 
> **Overview**
> Updates `.github/CODEOWNERS` to fix an invalid ownership entry by reassigning `shared/lib/multichain/addresses/*` from the removed `@MetaMask/new-networks` team to `@MetaMask/networks` (and renaming the section comment accordingly).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e435591c445804d6329b1c88b3262323f15e273. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->