### PR TITLE
refactor: Refactor confirmations-related controllers to remove duplicate messenger types

### DIFF
--- a/app/scripts/messenger-client-init/confirmations/approval-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/approval-controller-init.test.ts
@@ -1,10 +1,10 @@
-import { ApprovalController } from '@metamask/approval-controller';
+import {
+  ApprovalController,
+  ApprovalControllerMessenger,
+} from '@metamask/approval-controller';
 import { MessengerClientInitRequest } from '../types';
 import { buildControllerInitRequestMock } from '../test/utils';
-import {
-  getApprovalControllerMessenger,
-  ApprovalControllerMessenger,
-} from '../messengers';
+import { getApprovalControllerMessenger } from '../messengers';
 import { getRootMessenger } from '../../lib/messenger';
 import { ApprovalControllerInit } from './approval-controller-init';
 

--- a/app/scripts/messenger-client-init/confirmations/approval-controller-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/approval-controller-init.ts
@@ -1,8 +1,10 @@
-import { ApprovalController } from '@metamask/approval-controller';
+import {
+  ApprovalController,
+  ApprovalControllerMessenger,
+} from '@metamask/approval-controller';
 import { ApprovalType } from '@metamask/controller-utils';
 import { DIALOG_APPROVAL_TYPES } from '@metamask/snaps-rpc-methods';
 import { MessengerClientInitFunction } from '../types';
-import { ApprovalControllerMessenger } from '../messengers';
 import { SMART_TRANSACTION_CONFIRMATION_TYPES } from '../../../../shared/constants/app';
 
 /**

--- a/app/scripts/messenger-client-init/confirmations/ens-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/ens-controller-init.test.ts
@@ -1,9 +1,11 @@
-import { EnsController } from '@metamask/ens-controller';
+import {
+  EnsController,
+  EnsControllerMessenger,
+} from '@metamask/ens-controller';
 import { MessengerClientInitRequest } from '../types';
 import { buildControllerInitRequestMock } from '../test/utils';
 import {
   getEnsControllerMessenger,
-  EnsControllerMessenger,
   getEnsControllerInitMessenger,
   EnsControllerInitMessenger,
 } from '../messengers';

--- a/app/scripts/messenger-client-init/confirmations/ens-controller-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/ens-controller-init.ts
@@ -1,8 +1,8 @@
-import { EnsController } from '@metamask/ens-controller';
 import {
-  EnsControllerInitMessenger,
+  EnsController,
   EnsControllerMessenger,
-} from '../messengers';
+} from '@metamask/ens-controller';
+import { EnsControllerInitMessenger } from '../messengers';
 import { MessengerClientInitFunction } from '../types';
 
 /**

--- a/app/scripts/messenger-client-init/confirmations/gas-fee-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/gas-fee-controller-init.test.ts
@@ -1,9 +1,11 @@
-import { GasFeeController } from '@metamask/gas-fee-controller';
+import {
+  GasFeeController,
+  GasFeeMessenger,
+} from '@metamask/gas-fee-controller';
 import { MessengerClientInitRequest } from '../types';
 import { buildControllerInitRequestMock } from '../test/utils';
 import {
   getGasFeeControllerMessenger,
-  GasFeeControllerMessenger,
   getGasFeeControllerInitMessenger,
   GasFeeControllerInitMessenger,
 } from '../messengers';
@@ -13,10 +15,7 @@ import { GasFeeControllerInit } from './gas-fee-controller-init';
 jest.mock('@metamask/gas-fee-controller');
 
 function getInitRequestMock(): jest.Mocked<
-  MessengerClientInitRequest<
-    GasFeeControllerMessenger,
-    GasFeeControllerInitMessenger
-  >
+  MessengerClientInitRequest<GasFeeMessenger, GasFeeControllerInitMessenger>
 > {
   const baseMessenger = getRootMessenger<never, never>();
 

--- a/app/scripts/messenger-client-init/confirmations/gas-fee-controller-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/gas-fee-controller-init.ts
@@ -1,14 +1,14 @@
-import { GasFeeController } from '@metamask/gas-fee-controller';
+import {
+  GasFeeController,
+  GasFeeMessenger,
+} from '@metamask/gas-fee-controller';
 import {
   GAS_API_BASE_URL,
   GAS_DEV_API_BASE_URL,
   SWAPS_CLIENT_ID,
 } from '../../../../shared/constants/swaps';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
-import {
-  GasFeeControllerInitMessenger,
-  GasFeeControllerMessenger,
-} from '../messengers';
+import { GasFeeControllerInitMessenger } from '../messengers';
 import { MessengerClientInitFunction } from '../types';
 import { getGlobalChainId } from '../init-utils';
 
@@ -27,7 +27,7 @@ const GAS_API_URL = process.env.SWAPS_USE_DEV_APIS
  */
 export const GasFeeControllerInit: MessengerClientInitFunction<
   GasFeeController,
-  GasFeeControllerMessenger,
+  GasFeeMessenger,
   GasFeeControllerInitMessenger
 > = ({ controllerMessenger, initMessenger, persistedState }) => {
   const messengerClient = new GasFeeController({

--- a/app/scripts/messenger-client-init/confirmations/signature-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/signature-controller-init.test.ts
@@ -1,11 +1,13 @@
-import { SignatureController } from '@metamask/signature-controller';
+import {
+  SignatureController,
+  SignatureControllerMessenger,
+} from '@metamask/signature-controller';
 import { MessengerClientInitRequest } from '../types';
 import { buildControllerInitRequestMock } from '../test/utils';
 import {
   getSignatureControllerInitMessenger,
   getSignatureControllerMessenger,
   SignatureControllerInitMessenger,
-  SignatureControllerMessenger,
 } from '../messengers';
 import { getRootMessenger } from '../../lib/messenger';
 import { SignatureControllerInit } from './signature-controller-init';

--- a/app/scripts/messenger-client-init/confirmations/signature-controller-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/signature-controller-init.ts
@@ -1,9 +1,9 @@
-import { SignatureController } from '@metamask/signature-controller';
-import { MessengerClientInitFunction } from '../types';
 import {
-  SignatureControllerInitMessenger,
+  SignatureController,
   SignatureControllerMessenger,
-} from '../messengers';
+} from '@metamask/signature-controller';
+import { MessengerClientInitFunction } from '../types';
+import { SignatureControllerInitMessenger } from '../messengers';
 import { trace } from '../../../../shared/lib/trace';
 import { MetaMetricsEventCategory } from '../../../../shared/constants/metametrics';
 

--- a/app/scripts/messenger-client-init/messengers/approval-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/approval-controller-messenger.ts
@@ -1,9 +1,10 @@
-import { Messenger } from '@metamask/messenger';
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { ApprovalControllerMessenger } from '@metamask/approval-controller';
 import { RootMessenger } from '../../lib/messenger';
-
-export type ApprovalControllerMessenger = ReturnType<
-  typeof getApprovalControllerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -13,10 +14,14 @@ export type ApprovalControllerMessenger = ReturnType<
  * messenger.
  */
 export function getApprovalControllerMessenger(
-  messenger: RootMessenger<never, never>,
+  messenger: RootMessenger<
+    MessengerActions<ApprovalControllerMessenger>,
+    MessengerEvents<ApprovalControllerMessenger>
+  >,
 ) {
-  return new Messenger<'ApprovalController', never, never, typeof messenger>({
+  const controllerMessenger: ApprovalControllerMessenger = new Messenger({
     namespace: 'ApprovalController',
     parent: messenger,
   });
+  return controllerMessenger;
 }

--- a/app/scripts/messenger-client-init/messengers/ens-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/ens-controller-messenger.ts
@@ -1,11 +1,11 @@
-import { Messenger } from '@metamask/messenger';
-import { AllowedActions } from '@metamask/ens-controller';
+import {
+  Messenger,
+  MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { EnsControllerMessenger } from '@metamask/ens-controller';
 import { NetworkControllerNetworkDidChangeEvent } from '@metamask/network-controller';
 import { RootMessenger } from '../../lib/messenger';
-
-export type EnsControllerMessenger = ReturnType<
-  typeof getEnsControllerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the ENS
@@ -15,14 +15,12 @@ export type EnsControllerMessenger = ReturnType<
  * messenger.
  */
 export function getEnsControllerMessenger(
-  messenger: RootMessenger<AllowedActions, never>,
+  messenger: RootMessenger<
+    MessengerActions<EnsControllerMessenger>,
+    MessengerEvents<EnsControllerMessenger>
+  >,
 ) {
-  const controllerMessenger = new Messenger<
-    'EnsController',
-    AllowedActions,
-    never,
-    typeof messenger
-  >({
+  const controllerMessenger: EnsControllerMessenger = new Messenger({
     namespace: 'EnsController',
     parent: messenger,
   });

--- a/app/scripts/messenger-client-init/messengers/gas-fee-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/gas-fee-controller-messenger.ts
@@ -1,24 +1,17 @@
-import { Messenger } from '@metamask/messenger';
+import {
+  Messenger,
+  MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { GasFeeMessenger } from '@metamask/gas-fee-controller';
 import {
   type NetworkControllerGetEIP1559CompatibilityAction,
   NetworkControllerGetNetworkClientByIdAction,
   NetworkControllerGetSelectedNetworkClientAction,
   type NetworkControllerGetStateAction,
   NetworkControllerNetworkDidChangeEvent,
-  NetworkControllerStateChangeEvent,
 } from '@metamask/network-controller';
 import { RootMessenger } from '../../lib/messenger';
-
-type AllowedActions =
-  | NetworkControllerGetStateAction
-  | NetworkControllerGetNetworkClientByIdAction
-  | NetworkControllerGetEIP1559CompatibilityAction;
-
-type AllowedEvents = NetworkControllerStateChangeEvent;
-
-export type GasFeeControllerMessenger = ReturnType<
-  typeof getGasFeeControllerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -28,14 +21,12 @@ export type GasFeeControllerMessenger = ReturnType<
  * messenger.
  */
 export function getGasFeeControllerMessenger(
-  messenger: RootMessenger<AllowedActions, AllowedEvents>,
+  messenger: RootMessenger<
+    MessengerActions<GasFeeMessenger>,
+    MessengerEvents<GasFeeMessenger>
+  >,
 ) {
-  const controllerMessenger = new Messenger<
-    'GasFeeController',
-    AllowedActions,
-    AllowedEvents,
-    typeof messenger
-  >({
+  const controllerMessenger: GasFeeMessenger = new Messenger({
     namespace: 'GasFeeController',
     parent: messenger,
   });
@@ -46,7 +37,7 @@ export function getGasFeeControllerMessenger(
       'NetworkController:getNetworkClientById',
       'NetworkController:getState',
     ],
-    events: ['NetworkController:stateChange'],
+    events: ['NetworkController:networkDidChange'],
   });
   return controllerMessenger;
 }

--- a/app/scripts/messenger-client-init/messengers/index.ts
+++ b/app/scripts/messenger-client-init/messengers/index.ts
@@ -233,7 +233,6 @@ export type { AnnouncementControllerMessenger } from './announcement-controller-
 export { getAnnouncementControllerMessenger } from './announcement-controller-messenger';
 export { getAppMetadataControllerMessenger } from './app-metadata-controller-messenger';
 export { getAppStateControllerMessenger } from './app-state-controller-messenger';
-export type { ApprovalControllerMessenger } from './approval-controller-messenger';
 export { getApprovalControllerMessenger } from './approval-controller-messenger';
 export type { BridgeControllerInitMessenger } from './bridge-controller-messenger';
 export {
@@ -262,20 +261,14 @@ export {
 } from './encryption-public-key-controller-messenger';
 export type { EncryptionPublicKeyManagerMessenger } from './encryption-public-key-manager-messenger';
 export { getEncryptionPublicKeyManagerMessenger } from './encryption-public-key-manager-messenger';
-export type {
-  EnsControllerMessenger,
-  EnsControllerInitMessenger,
-} from './ens-controller-messenger';
+export type { EnsControllerInitMessenger } from './ens-controller-messenger';
 export {
   getEnsControllerMessenger,
   getEnsControllerInitMessenger,
 } from './ens-controller-messenger';
 export type { StorageServiceMessenger } from './storage-service-messenger';
 export { getStorageServiceMessenger } from './storage-service-messenger';
-export type {
-  GasFeeControllerMessenger,
-  GasFeeControllerInitMessenger,
-} from './gas-fee-controller-messenger';
+export type { GasFeeControllerInitMessenger } from './gas-fee-controller-messenger';
 export {
   getGasFeeControllerMessenger,
   getGasFeeControllerInitMessenger,
@@ -337,10 +330,7 @@ export {
 } from './remote-feature-flag-controller-messenger';
 export type { SelectedNetworkControllerMessenger } from './selected-network-controller-messenger';
 export { getSelectedNetworkControllerMessenger } from './selected-network-controller-messenger';
-export type {
-  SignatureControllerMessenger,
-  SignatureControllerInitMessenger,
-} from './signature-controller-messenger';
+export type { SignatureControllerInitMessenger } from './signature-controller-messenger';
 export {
   getSignatureControllerMessenger,
   getSignatureControllerInitMessenger,

--- a/app/scripts/messenger-client-init/messengers/ppom-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/ppom-controller-messenger.ts
@@ -10,24 +10,20 @@ import { PPOMControllerMessenger } from '@metamask/ppom-validator';
 import { PreferencesControllerStateChangeEvent } from '@metamask/preferences-controller';
 import { RootMessenger } from '../../lib/messenger';
 
-type MessengerActions = NetworkControllerGetNetworkClientByIdAction;
+type AllowedActions = NetworkControllerGetNetworkClientByIdAction;
 
-type MessengerEvents =
+type AllowedEvents =
   | NetworkControllerStateChangeEvent
   | NetworkControllerNetworkDidChangeEvent
   | PreferencesControllerStateChangeEvent;
 
-export type PPOMControllerInitMessenger = ReturnType<
-  typeof getPPOMControllerInitMessenger
->;
-
 export function getPPOMControllerMessenger(
-  messenger: RootMessenger<MessengerActions, MessengerEvents>,
+  messenger: RootMessenger<AllowedActions, AllowedEvents>,
 ): PPOMControllerMessenger {
   const controllerMessenger = new Messenger<
     'PPOMController',
-    MessengerActions,
-    MessengerEvents,
+    AllowedActions,
+    AllowedEvents,
     typeof messenger
   >({
     namespace: 'PPOMController',
@@ -49,16 +45,20 @@ type AllowedInitializationActions =
   | NetworkControllerGetSelectedNetworkClientAction
   | NetworkControllerGetStateAction;
 
+export type PPOMControllerInitMessenger = ReturnType<
+  typeof getPPOMControllerInitMessenger
+>;
+
 export function getPPOMControllerInitMessenger(
   messenger: RootMessenger<
-    MessengerActions | AllowedInitializationActions,
-    MessengerEvents
+    AllowedActions | AllowedInitializationActions,
+    AllowedEvents
   >,
 ) {
   const controllerInitMessenger = new Messenger<
     'PPOMControllerInit',
-    MessengerActions | AllowedInitializationActions,
-    MessengerEvents,
+    AllowedActions | AllowedInitializationActions,
+    AllowedEvents,
     typeof messenger
   >({
     namespace: 'PPOMControllerInit',

--- a/app/scripts/messenger-client-init/messengers/ppom-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/ppom-controller-messenger.ts
@@ -1,40 +1,30 @@
-import { Messenger } from '@metamask/messenger';
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
 import {
   NetworkControllerGetNetworkClientByIdAction,
   NetworkControllerGetSelectedNetworkClientAction,
   NetworkControllerGetStateAction,
-  NetworkControllerNetworkDidChangeEvent,
-  NetworkControllerStateChangeEvent,
 } from '@metamask/network-controller';
 import { PPOMControllerMessenger } from '@metamask/ppom-validator';
-import { PreferencesControllerStateChangeEvent } from '@metamask/preferences-controller';
 import { RootMessenger } from '../../lib/messenger';
-
-type AllowedActions = NetworkControllerGetNetworkClientByIdAction;
-
-type AllowedEvents =
-  | NetworkControllerStateChangeEvent
-  | NetworkControllerNetworkDidChangeEvent
-  | PreferencesControllerStateChangeEvent;
+import type { PreferencesControllerStateChangeEvent } from '../../controllers/preferences-controller';
 
 export function getPPOMControllerMessenger(
-  messenger: RootMessenger<AllowedActions, AllowedEvents>,
+  messenger: RootMessenger<
+    MessengerActions<PPOMControllerMessenger>,
+    MessengerEvents<PPOMControllerMessenger>
+  >,
 ): PPOMControllerMessenger {
-  const controllerMessenger = new Messenger<
-    'PPOMController',
-    AllowedActions,
-    AllowedEvents,
-    typeof messenger
-  >({
+  const controllerMessenger: PPOMControllerMessenger = new Messenger({
     namespace: 'PPOMController',
     parent: messenger,
   });
   messenger.delegate({
     messenger: controllerMessenger,
-    events: [
-      'NetworkController:stateChange',
-      'NetworkController:networkDidChange',
-    ],
+    events: ['NetworkController:networkDidChange'],
     actions: ['NetworkController:getNetworkClientById'],
   });
   return controllerMessenger;
@@ -45,20 +35,22 @@ type AllowedInitializationActions =
   | NetworkControllerGetSelectedNetworkClientAction
   | NetworkControllerGetStateAction;
 
+type AllowedInitializationEvents = PreferencesControllerStateChangeEvent;
+
 export type PPOMControllerInitMessenger = ReturnType<
   typeof getPPOMControllerInitMessenger
 >;
 
 export function getPPOMControllerInitMessenger(
   messenger: RootMessenger<
-    AllowedActions | AllowedInitializationActions,
-    AllowedEvents
+    AllowedInitializationActions,
+    AllowedInitializationEvents
   >,
 ) {
   const controllerInitMessenger = new Messenger<
     'PPOMControllerInit',
-    AllowedActions | AllowedInitializationActions,
-    AllowedEvents,
+    AllowedInitializationActions,
+    AllowedInitializationEvents,
     typeof messenger
   >({
     namespace: 'PPOMControllerInit',

--- a/app/scripts/messenger-client-init/messengers/signature-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/signature-controller-messenger.ts
@@ -1,31 +1,12 @@
-import { Messenger } from '@metamask/messenger';
-import type { AccountsControllerGetStateAction } from '@metamask/accounts-controller';
-import type { ApprovalControllerAddRequestAction } from '@metamask/approval-controller';
-import type { LoggingControllerAddAction } from '@metamask/logging-controller';
-import type { GatorPermissionsControllerDecodePermissionFromPermissionContextForOriginAction } from '@metamask/gator-permissions-controller';
-import { NetworkControllerGetNetworkClientByIdAction } from '@metamask/network-controller';
-import type {
-  KeyringControllerSignMessageAction,
-  KeyringControllerSignPersonalMessageAction,
-  KeyringControllerSignTypedMessageAction,
-} from '@metamask/keyring-controller';
+import {
+  Messenger,
+  MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { SignatureControllerMessenger } from '@metamask/signature-controller';
 import { PreferencesControllerGetStateAction } from '../../controllers/preferences-controller';
 import { MetaMetricsControllerTrackEventAction } from '../../controllers/metametrics-controller-method-action-types';
 import { RootMessenger } from '../../lib/messenger';
-
-type AllowedActions =
-  | AccountsControllerGetStateAction
-  | ApprovalControllerAddRequestAction
-  | LoggingControllerAddAction
-  | GatorPermissionsControllerDecodePermissionFromPermissionContextForOriginAction
-  | NetworkControllerGetNetworkClientByIdAction
-  | KeyringControllerSignMessageAction
-  | KeyringControllerSignPersonalMessageAction
-  | KeyringControllerSignTypedMessageAction;
-
-export type SignatureControllerMessenger = ReturnType<
-  typeof getSignatureControllerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -35,14 +16,12 @@ export type SignatureControllerMessenger = ReturnType<
  * messenger.
  */
 export function getSignatureControllerMessenger(
-  messenger: RootMessenger<AllowedActions, never>,
+  messenger: RootMessenger<
+    MessengerActions<SignatureControllerMessenger>,
+    MessengerEvents<SignatureControllerMessenger>
+  >,
 ) {
-  const controllerMessenger = new Messenger<
-    'SignatureController',
-    AllowedActions,
-    never,
-    typeof messenger
-  >({
+  const controllerMessenger: SignatureControllerMessenger = new Messenger({
     namespace: 'SignatureController',
     parent: messenger,
   });

--- a/app/scripts/messenger-client-init/messengers/transaction-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/transaction-controller-messenger.ts
@@ -67,23 +67,13 @@ import {
   InstitutionalSnapControllerPublishHookAction,
 } from '../../controllers/institutional-snap/InstitutionalSnapController-method-action-types';
 
-type AllowedActions = MessengerActions<TransactionControllerMessenger>;
-
-type AllowedEvents = MessengerEvents<TransactionControllerMessenger>;
-
-export type TransactionControllerInitMessenger = ReturnType<
-  typeof getTransactionControllerInitMessenger
->;
-
 export function getTransactionControllerMessenger(
-  messenger: RootMessenger<AllowedActions, AllowedEvents>,
-): TransactionControllerMessenger {
-  const controllerMessenger = new Messenger<
-    'TransactionController',
-    AllowedActions,
-    AllowedEvents,
-    typeof messenger
-  >({
+  messenger: RootMessenger<
+    MessengerActions<TransactionControllerMessenger>,
+    MessengerEvents<TransactionControllerMessenger>
+  >,
+) {
+  const controllerMessenger: TransactionControllerMessenger = new Messenger({
     namespace: 'TransactionController',
     parent: messenger,
   });
@@ -109,6 +99,10 @@ export function getTransactionControllerMessenger(
   });
   return controllerMessenger;
 }
+
+export type TransactionControllerInitMessenger = ReturnType<
+  typeof getTransactionControllerInitMessenger
+>;
 
 type InitMessengerActions =
   | AccountsControllerGetSelectedAccountAction

--- a/app/scripts/messenger-client-init/messengers/user-operation-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/user-operation-controller-messenger.ts
@@ -23,10 +23,6 @@ export type UserOperationControllerMessenger = ReturnType<
   typeof getUserOperationControllerMessenger
 >;
 
-export type UserOperationControllerInitMessenger = ReturnType<
-  typeof getUserOperationControllerInitMessenger
->;
-
 /**
  * Create a messenger restricted to the allowed actions and events of the
  * user operation controller.
@@ -58,6 +54,10 @@ export function getUserOperationControllerMessenger(
   });
   return controllerMessenger;
 }
+
+export type UserOperationControllerInitMessenger = ReturnType<
+  typeof getUserOperationControllerInitMessenger
+>;
 
 type InitMessengerActions =
   | TransactionControllerEmulateNewTransactionAction


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This removes some duplicated messenger types, and ensures we use an always up-to-date type in the controller init files.

https://consensyssoftware.atlassian.net/browse/WPC-950

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly a type-safety refactor, but it changes delegated event subscriptions for `GasFeeController` and `PPOMController` messengers, which could affect when these controllers react to network changes.
> 
> **Overview**
> Refactors confirmations-related controller init and messenger factory code to **stop defining local duplicate messenger types** and instead import the canonical `*Messenger` types directly from their respective controller packages (e.g., `@metamask/approval-controller`, `@metamask/ens-controller`, `@metamask/gas-fee-controller`, `@metamask/signature-controller`). Tests and `MessengerClientInitRequest` generics are updated accordingly.
> 
> Tightens messenger typing by parameterizing `RootMessenger` with `MessengerActions`/`MessengerEvents` derived from the controller-provided messenger types, and removes now-redundant type exports from `messengers/index.ts`.
> 
> Adjusts event delegation in a few messengers to match the updated typings, notably switching the `GasFeeController` messenger delegation from `NetworkController:stateChange` to `NetworkController:networkDidChange` and limiting `PPOMController` to `NetworkController:networkDidChange` while scoping init events to `PreferencesController:stateChange`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd0f7b337e11adc15bb58068fa6231faea3e8cd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->