### PR TITLE
chore: remove redundant statusOnly prop in TransactionStatusLabel

### DIFF
--- a/ui/components/app/multichain-bridge-transaction-list-item/multichain-bridge-transaction-list-item.tsx
+++ b/ui/components/app/multichain-bridge-transaction-list-item/multichain-bridge-transaction-list-item.tsx
@@ -11,7 +11,6 @@ import {
 } from '../../../../shared/lib/bridge-status/utils';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { KEYRING_TRANSACTION_STATUS_KEY } from '../../../hooks/useMultichainTransactionDisplay';
-import { formatTimestamp } from '../multichain-transaction-details-modal/helpers';
 import TransactionIcon from '../transaction-icon';
 import TransactionStatusLabel from '../transaction-status-label/transaction-status-label';
 import { ActivityListItem } from '../../multichain/activity-list-item/activity-list-item';
@@ -177,10 +176,8 @@ const MultichainBridgeTransactionListItem: React.FC<
         >
           {isTerminalState ? (
             <TransactionStatusLabel
-              date={formatTimestamp(transaction.timestamp)}
               error={{}}
               status={KEYRING_TRANSACTION_STATUS_KEY[transaction.status]}
-              statusOnly
               className={
                 isBridgeFullyComplete
                   ? 'transaction-status-label--confirmed'

--- a/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
+++ b/ui/components/app/transaction-list-item-details/transaction-list-item-details.component.js
@@ -231,7 +231,6 @@ export default class TransactionListItemDetails extends PureComponent {
               <div>
                 {isProtectedByEnforcedSimulations ? (
                   <TransactionStatusLabel
-                    statusOnly
                     label={t('cancelled')}
                     tooltip={t('transactionProtectedByEnforcedSimulations')}
                   />

--- a/ui/components/app/transaction-list-item/smart-transaction-list-item.component.js
+++ b/ui/components/app/transaction-list-item/smart-transaction-list-item.component.js
@@ -5,7 +5,6 @@ import { ButtonSize } from '@metamask/design-system-react';
 import TransactionStatusLabel from '../transaction-status-label/transaction-status-label';
 import TransactionIcon from '../transaction-icon';
 import { useTransactionDisplayData } from '../../../hooks/useTransactionDisplayData';
-import { formatDateWithYearContext } from '../../../helpers/utils/util';
 import {
   TransactionGroupStatus,
   SmartTransactionStatus,
@@ -41,8 +40,7 @@ export default function SmartTransactionListItem({
     useTransactionDisplayData(transactionGroup);
   const currentChain = useSelector(getCurrentNetwork);
 
-  const { time, status } = smartTransaction;
-  const date = formatDateWithYearContext(time, 'MMM d, y', 'MMM d');
+  const { status } = smartTransaction;
   let displayedStatusKey;
   if (status === SmartTransactionStatus.pending) {
     displayedStatusKey = TransactionGroupStatus.pending;
@@ -82,7 +80,6 @@ export default function SmartTransactionListItem({
           <TransactionStatusLabel
             isPending
             isEarliestNonce={isEarliestNonce}
-            date={date}
             status={displayedStatusKey}
           />
         }
@@ -114,9 +111,7 @@ export default function SmartTransactionListItem({
             <TransactionStatusLabel
               isPending={isPending}
               isEarliestNonce={isEarliestNonce}
-              date={date}
               status={displayedStatusKey}
-              statusOnly
             />
           )}
           chainId={chainId}

--- a/ui/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/components/app/transaction-list-item/transaction-list-item.component.js
@@ -41,7 +41,6 @@ import {
   TransactionModalContextProvider,
   useTransactionModalContext,
 } from '../../../contexts/transaction-modal';
-import { formatDateWithYearContext } from '../../../helpers/utils/util';
 import CancelButton from '../cancel-button';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import { ActivityListItem } from '../../multichain/activity-list-item';
@@ -187,11 +186,6 @@ function TransactionListItemInner({
     displayedStatusKey === TransactionStatus.submitted &&
     !isBridgeFailed &&
     !isBridgeComplete;
-  const date = formatDateWithYearContext(
-    transactionGroup.primaryTransaction.time,
-    'MMM d, y',
-    'MMM d',
-  );
   const isSignatureReq = category === TransactionGroupCategory.signatureRequest;
   const isApproval = category === TransactionGroupCategory.approval;
   const isUnapproved = status === TransactionStatus.unapproved;

--- a/ui/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/components/app/transaction-list-item/transaction-list-item.component.js
@@ -320,11 +320,9 @@ function TransactionListItemInner({
             />
           ) : (
             <TransactionStatusLabel
-              statusOnly
               isPending={isPending}
               isEarliestNonce={isEarliestNonce || shouldShowPendingBridgeStatus}
               error={error}
-              date={date}
               status={displayedStatusKey}
             />
           )
@@ -402,9 +400,7 @@ function TransactionListItemInner({
                   isEarliestNonce || shouldShowPendingBridgeStatus
                 }
                 error={error}
-                date={date}
                 status={displayedStatusKey}
-                statusOnly
               />
             )}
             chainId={chainId}

--- a/ui/components/app/transaction-status-label/transaction-status-label.js
+++ b/ui/components/app/transaction-status-label/transaction-status-label.js
@@ -15,9 +15,6 @@ const SIGNING_PSUEDO_STATUS = 'signing';
  * as pending. Transactions are only approved or signed for less than a
  * second, usually, and ultimately should be rendered in the UI no
  * differently than a pending transaction.
- *
- * Confirmed transactions are not especially highlighted except that their
- * status label will be the date the transaction was finalized.
  */
 const pendingStatusHash = {
   [TransactionStatus.submitted]: TransactionGroupStatus.pending,
@@ -51,22 +48,16 @@ function getStatusKey(status, isEarliestNonce) {
 
 export default function TransactionStatusLabel({
   status,
-  date,
   error,
   isEarliestNonce,
   className,
-  statusOnly,
   label,
   tooltip,
 }) {
   const t = useI18nContext();
   const statusKey = getStatusKey(status, isEarliestNonce);
   const tooltipText = tooltip || error?.rpc?.message || error?.message;
-  let statusText = label ?? (statusKey && t(statusKey));
-
-  if (!label && statusKey === TransactionStatus.confirmed && !statusOnly) {
-    statusText = date;
-  }
+  const statusText = label ?? (statusKey && t(statusKey));
 
   return (
     <Tooltip
@@ -88,10 +79,8 @@ export default function TransactionStatusLabel({
 TransactionStatusLabel.propTypes = {
   status: PropTypes.string,
   className: PropTypes.string,
-  date: PropTypes.string,
   error: PropTypes.object,
   isEarliestNonce: PropTypes.bool,
-  statusOnly: PropTypes.bool,
   label: PropTypes.string,
   tooltip: PropTypes.string,
 };

--- a/ui/components/app/transaction-status-label/transaction-status-label.test.js
+++ b/ui/components/app/transaction-status-label/transaction-status-label.test.js
@@ -20,15 +20,11 @@ jest.mock('../../ui/tooltip', () => ({
 }));
 
 describe('TransactionStatusLabel Component', () => {
-  it('should render CONFIRMED status and date', () => {
-    const props = {
-      status: 'confirmed',
-      date: 'June 1',
-      statusOnly: false,
-    };
-
-    render(<TransactionStatusLabel {...props} />);
-    expect(screen.getByText('June 1')).toBeInTheDocument();
+  it('renders translated status text for confirmed transactions', () => {
+    render(
+      <TransactionStatusLabel status={TransactionStatus.confirmed} />,
+    );
+    expect(screen.getByText(TransactionStatus.confirmed)).toBeInTheDocument();
   });
 
   it('should render PENDING status when submitted and isEarliestNonce is true', () => {
@@ -134,28 +130,6 @@ describe('TransactionStatusLabel Component', () => {
 
     render(<TransactionStatusLabel {...props} />);
     expect(screen.getByText('queued')).toBeInTheDocument();
-  });
-
-  it('should display date for confirmed transactions when not statusOnly', () => {
-    const props = {
-      status: TransactionStatus.confirmed,
-      date: 'June 1',
-      statusOnly: false,
-    };
-
-    render(<TransactionStatusLabel {...props} />);
-    expect(screen.getByText('June 1')).toBeInTheDocument();
-  });
-
-  it('should display status text for confirmed transactions when statusOnly is true', () => {
-    const props = {
-      status: TransactionStatus.confirmed,
-      date: 'June 1',
-      statusOnly: true,
-    };
-
-    render(<TransactionStatusLabel {...props} />);
-    expect(screen.getByText(TransactionStatus.confirmed)).toBeInTheDocument();
   });
 
   it('label overrides the displayed text', () => {

--- a/ui/components/app/transaction-status-label/transaction-status-label.test.js
+++ b/ui/components/app/transaction-status-label/transaction-status-label.test.js
@@ -21,9 +21,7 @@ jest.mock('../../ui/tooltip', () => ({
 
 describe('TransactionStatusLabel Component', () => {
   it('renders translated status text for confirmed transactions', () => {
-    render(
-      <TransactionStatusLabel status={TransactionStatus.confirmed} />,
-    );
+    render(<TransactionStatusLabel status={TransactionStatus.confirmed} />);
     expect(screen.getByText(TransactionStatus.confirmed)).toBeInTheDocument();
   });
 

--- a/ui/components/multichain/activity-list-item/activity-list-item.stories.js
+++ b/ui/components/multichain/activity-list-item/activity-list-item.stories.js
@@ -55,11 +55,9 @@ DefaultStory.args = {
   ),
   subtitle: (
     <TransactionStatusLabel
-      statusOnly
       isPending
       isEarliestNonce
       error={{}}
-      date={new Date().toDateString()}
       status="pending"
     />
   ),

--- a/ui/components/multichain/activity-v2/activity-details-modal-adapter.tsx
+++ b/ui/components/multichain/activity-v2/activity-details-modal-adapter.tsx
@@ -11,7 +11,6 @@ import { TransactionDetailsModal as LegacyTransactionDetailsModal } from '../../
 import { PAY_TRANSACTION_TYPES } from '../../../pages/confirmations/constants/pay';
 import { useTransactionDisplayData } from '../../../hooks/useTransactionDisplayData';
 import { getStatusKey } from '../../../helpers/utils/transactions.util';
-import { formatDateWithYearContext } from '../../../helpers/utils/util';
 import LegacyTransactionListItemDetails from '../../app/transaction-list-item-details';
 import TransactionStatusLabel from '../../app/transaction-status-label/transaction-status-label';
 import { getSelectedAddress } from '../../../selectors/selectors';
@@ -143,11 +142,6 @@ const TransactionDetailsWrapper = ({
   const displayedStatusKey = getStatusKey(
     transaction as Parameters<typeof getStatusKey>[0],
   );
-  const date = formatDateWithYearContext(
-    transaction.time ?? 0,
-    'MMM d, y',
-    'MMM d',
-  );
   const chainId =
     typeof transaction.chainId === 'string'
       ? transaction.chainId
@@ -169,9 +163,7 @@ const TransactionDetailsWrapper = ({
         <TransactionStatusLabel
           isEarliestNonce={false}
           error={syntheticGroup.primaryTransaction.error}
-          date={date}
           status={displayedStatusKey}
-          statusOnly
         />
       )}
       chainId={chainId}

--- a/ui/components/multichain/activity-v2/activity-list-item.tsx
+++ b/ui/components/multichain/activity-v2/activity-list-item.tsx
@@ -75,7 +75,6 @@ export const ActivityListItem = ({ transaction, onClick }: Props) => {
             <TransactionStatusLabel
               status={transactionStatus}
               error={failureError}
-              statusOnly
               label={isProtected ? t('cancelled') : undefined}
               tooltip={
                 isProtected

--- a/ui/components/multichain/activity-v2/non-evm-activity-list-item.tsx
+++ b/ui/components/multichain/activity-v2/non-evm-activity-list-item.tsx
@@ -60,12 +60,7 @@ export const NonEvmActivityListItem = ({ transaction, onClick }: Props) => {
           </ChainBadge>
         }
         title="Redeposit"
-        subtitle={
-          <TransactionStatusLabel
-            error={{}}
-            status={statusKey}
-          />
-        }
+        subtitle={<TransactionStatusLabel error={{}} status={statusKey} />}
       />
     );
   }
@@ -100,12 +95,7 @@ export const NonEvmActivityListItem = ({ transaction, onClick }: Props) => {
         </Text>
       }
       title={title}
-      subtitle={
-        <TransactionStatusLabel
-          error={{}}
-          status={statusKey}
-        />
-      }
+      subtitle={<TransactionStatusLabel error={{}} status={statusKey} />}
     />
   );
 };

--- a/ui/components/multichain/activity-v2/non-evm-activity-list-item.tsx
+++ b/ui/components/multichain/activity-v2/non-evm-activity-list-item.tsx
@@ -11,7 +11,6 @@ import {
 import { TransactionGroupCategory } from '../../../../shared/constants/transaction';
 import TransactionIcon from '../../app/transaction-icon/transaction-icon';
 import TransactionStatusLabel from '../../app/transaction-status-label/transaction-status-label';
-import { formatTimestamp } from '../../app/multichain-transaction-details-modal/helpers';
 import { ActivityListItem as LegacyActivityListItem } from '../activity-list-item';
 import { ChainBadge } from '../../app/chain-badge/chain-badge';
 import { selectBridgeHistoryForAccountGroup } from '../../../ducks/bridge-status/selectors';
@@ -63,10 +62,8 @@ export const NonEvmActivityListItem = ({ transaction, onClick }: Props) => {
         title="Redeposit"
         subtitle={
           <TransactionStatusLabel
-            date={formatTimestamp(timestamp)}
             error={{}}
             status={statusKey}
-            statusOnly
           />
         }
       />
@@ -105,10 +102,8 @@ export const NonEvmActivityListItem = ({ transaction, onClick }: Props) => {
       title={title}
       subtitle={
         <TransactionStatusLabel
-          date={formatTimestamp(transaction.timestamp)}
           error={{}}
           status={statusKey}
-          statusOnly
         />
       }
     />


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

`statusOnly` prop is not needed, removing unnecessary code to simplify TransactionStatusLabel for future.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a UI-only simplification that removes date-based rendering for confirmed statuses; the main risk is minor visual/regression changes in activity/transaction list subtitles.
> 
> **Overview**
> Simplifies `TransactionStatusLabel` by removing the `statusOnly` and `date` props and always rendering translated status text (with `label` still overriding text).
> 
> Updates all callers (transaction list items, details modals, multichain/non-EVM activity items, and stories) to stop formatting/passing dates and to remove `statusOnly` usage, and adjusts unit tests accordingly (dropping date-display assertions for confirmed transactions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9071fa956c4c3092ac0719c64a1c800ffee667ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->