### PR TITLE
refactor: Refactor delegation-related controllers to remove duplicate messenger types

### DIFF
--- a/app/scripts/messenger-client-init/delegation/delegation-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/delegation/delegation-controller-init.test.ts
@@ -2,34 +2,24 @@ import { DelegationController } from '@metamask/delegation-controller';
 import { type DelegationControllerMessenger } from '@metamask/delegation-controller';
 import { buildControllerInitRequestMock } from '../test/utils';
 import type { MessengerClientInitRequest } from '../types';
-import {
-  type DelegationControllerInitMessenger,
-  getDelegationControllerMessenger,
-  getDelegationControllerInitMessenger,
-} from '../messengers/delegation/delegation-controller-messenger';
+import { getDelegationControllerMessenger } from '../messengers/delegation/delegation-controller-messenger';
 import { getRootMessenger } from '../../lib/messenger';
 import { DelegationControllerInit } from './delegation-controller-init';
 
 jest.mock('@metamask/delegation-controller');
 
 function buildInitRequestMock(): jest.Mocked<
-  MessengerClientInitRequest<
-    DelegationControllerMessenger,
-    DelegationControllerInitMessenger
-  >
+  MessengerClientInitRequest<DelegationControllerMessenger>
 > {
   const baseControllerMessenger = getRootMessenger();
   const controllerMessenger = getDelegationControllerMessenger(
-    baseControllerMessenger,
-  );
-  const initMessenger = getDelegationControllerInitMessenger(
     baseControllerMessenger,
   );
 
   return {
     ...buildControllerInitRequestMock(),
     controllerMessenger,
-    initMessenger,
+    initMessenger: undefined,
   };
 }
 

--- a/app/scripts/messenger-client-init/delegation/delegation-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/delegation/delegation-controller-init.test.ts
@@ -1,8 +1,8 @@
 import { DelegationController } from '@metamask/delegation-controller';
+import { type DelegationControllerMessenger } from '@metamask/delegation-controller';
 import { buildControllerInitRequestMock } from '../test/utils';
 import type { MessengerClientInitRequest } from '../types';
 import {
-  type DelegationControllerMessenger,
   type DelegationControllerInitMessenger,
   getDelegationControllerMessenger,
   getDelegationControllerInitMessenger,

--- a/app/scripts/messenger-client-init/delegation/delegation-controller-init.ts
+++ b/app/scripts/messenger-client-init/delegation/delegation-controller-init.ts
@@ -4,7 +4,6 @@ import {
 } from '@metamask/delegation-controller';
 import { type Hex } from '../../../../shared/lib/delegation/utils';
 import { getDeleGatorEnvironment } from '../../../../shared/lib/delegation';
-import type { DelegationControllerInitMessenger } from '../messengers/delegation/delegation-controller-messenger';
 import type { MessengerClientInitFunction } from '../types';
 
 const getDelegationEnvironment = (chainId: Hex) => {
@@ -21,8 +20,7 @@ const getDelegationEnvironment = (chainId: Hex) => {
  */
 export const DelegationControllerInit: MessengerClientInitFunction<
   DelegationController,
-  DelegationControllerMessenger,
-  DelegationControllerInitMessenger
+  DelegationControllerMessenger
 > = ({ controllerMessenger, persistedState }) => {
   const messengerClient = new DelegationController({
     messenger: controllerMessenger,

--- a/app/scripts/messenger-client-init/gator-permissions/gator-permissions-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/gator-permissions/gator-permissions-controller-init.test.ts
@@ -1,6 +1,7 @@
 import {
   GatorPermissionsController,
   SupportedPermissionType,
+  GatorPermissionsControllerMessenger,
 } from '@metamask/gator-permissions-controller';
 import { buildControllerInitRequestMock } from '../test/utils';
 import type { MessengerClientInitRequest } from '../types';
@@ -8,10 +9,7 @@ import {
   ENABLED_ADVANCED_PERMISSIONS_FEATURE_FLAG,
   getEnabledAdvancedPermissions,
 } from '../../../../shared/lib/gator-permissions/feature-flags';
-import {
-  getGatorPermissionsControllerMessenger,
-  GatorPermissionsControllerMessenger,
-} from '../messengers/gator-permissions';
+import { getGatorPermissionsControllerMessenger } from '../messengers/gator-permissions';
 import { getRootMessenger } from '../../lib/messenger';
 import { GatorPermissionsControllerInit } from './gator-permissions-controller-init';
 

--- a/app/scripts/messenger-client-init/gator-permissions/gator-permissions-controller-init.ts
+++ b/app/scripts/messenger-client-init/gator-permissions/gator-permissions-controller-init.ts
@@ -1,9 +1,9 @@
 import {
   GatorPermissionsController,
+  type GatorPermissionsControllerMessenger,
   type GatorPermissionsControllerConfig,
 } from '@metamask/gator-permissions-controller';
 import { assertIsValidSnapId } from '@metamask/snaps-utils';
-import { GatorPermissionsControllerMessenger } from '@metamask/gator-permissions-controller';
 import { MessengerClientInitFunction } from '../types';
 import { getEnabledAdvancedPermissions } from '../../../../shared/lib/gator-permissions/feature-flags';
 

--- a/app/scripts/messenger-client-init/gator-permissions/gator-permissions-controller-init.ts
+++ b/app/scripts/messenger-client-init/gator-permissions/gator-permissions-controller-init.ts
@@ -3,9 +3,9 @@ import {
   type GatorPermissionsControllerConfig,
 } from '@metamask/gator-permissions-controller';
 import { assertIsValidSnapId } from '@metamask/snaps-utils';
+import { GatorPermissionsControllerMessenger } from '@metamask/gator-permissions-controller';
 import { MessengerClientInitFunction } from '../types';
 import { getEnabledAdvancedPermissions } from '../../../../shared/lib/gator-permissions/feature-flags';
-import { GatorPermissionsControllerMessenger } from '../messengers/gator-permissions';
 
 const createGatorPermissionsConfig = (
   remoteFeatureFlagControllerState: Parameters<

--- a/app/scripts/messenger-client-init/messengers/delegation/delegation-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/delegation/delegation-controller-messenger.ts
@@ -18,10 +18,7 @@ export function getDelegationControllerMessenger(
   });
   messenger.delegate({
     messenger: controllerMessenger,
-    actions: [
-      'AccountsController:getSelectedAccount',
-      'KeyringController:signTypedMessage',
-    ],
+    actions: ['KeyringController:signTypedMessage'],
   });
   return controllerMessenger;
 }

--- a/app/scripts/messenger-client-init/messengers/delegation/delegation-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/delegation/delegation-controller-messenger.ts
@@ -1,44 +1,42 @@
-import { Messenger } from '@metamask/messenger';
+import {
+  Messenger,
+  MessengerActions,
+  MessengerEvents,
+} from '@metamask/messenger';
 import { type DelegationControllerMessenger } from '@metamask/delegation-controller';
-import { type KeyringControllerSignTypedMessageAction } from '@metamask/keyring-controller';
 import { RootMessenger } from '../../../lib/messenger';
 
-export { type DelegationControllerMessenger } from '@metamask/delegation-controller';
-
-export type DelegationControllerInitMessenger = ReturnType<
-  typeof getDelegationControllerInitMessenger
->;
-
-type AllowedActions = KeyringControllerSignTypedMessageAction;
-
-type AllowedEvents = never;
-
 export function getDelegationControllerMessenger(
-  messenger: RootMessenger<AllowedActions>,
+  messenger: RootMessenger<
+    MessengerActions<DelegationControllerMessenger>,
+    MessengerEvents<DelegationControllerMessenger>
+  >,
 ): DelegationControllerMessenger {
-  const controllerMessenger = new Messenger<
-    'DelegationController',
-    AllowedActions,
-    AllowedEvents,
-    typeof messenger
-  >({
+  const controllerMessenger: DelegationControllerMessenger = new Messenger({
     namespace: 'DelegationController',
     parent: messenger,
   });
   messenger.delegate({
     messenger: controllerMessenger,
-    actions: ['KeyringController:signTypedMessage'],
+    actions: [
+      'AccountsController:getSelectedAccount',
+      'KeyringController:signTypedMessage',
+    ],
   });
   return controllerMessenger;
 }
 
+export type DelegationControllerInitMessenger = ReturnType<
+  typeof getDelegationControllerInitMessenger
+>;
+
 export function getDelegationControllerInitMessenger(
-  messenger: RootMessenger<AllowedActions>,
+  messenger: RootMessenger<never, never>,
 ) {
   const controllerInitMessenger = new Messenger<
     'DelegationControllerInit',
-    AllowedActions,
-    AllowedEvents,
+    never,
+    never,
     typeof messenger
   >({
     namespace: 'DelegationControllerInit',

--- a/app/scripts/messenger-client-init/messengers/delegation/delegation-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/delegation/delegation-controller-messenger.ts
@@ -22,25 +22,3 @@ export function getDelegationControllerMessenger(
   });
   return controllerMessenger;
 }
-
-export type DelegationControllerInitMessenger = ReturnType<
-  typeof getDelegationControllerInitMessenger
->;
-
-export function getDelegationControllerInitMessenger(
-  messenger: RootMessenger<never, never>,
-) {
-  const controllerInitMessenger = new Messenger<
-    'DelegationControllerInit',
-    never,
-    never,
-    typeof messenger
-  >({
-    namespace: 'DelegationControllerInit',
-    parent: messenger,
-  });
-  messenger.delegate({
-    messenger: controllerInitMessenger,
-  });
-  return controllerInitMessenger;
-}

--- a/app/scripts/messenger-client-init/messengers/gator-permissions/gator-permissions-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/gator-permissions/gator-permissions-controller-messenger.ts
@@ -1,39 +1,10 @@
-import { Messenger } from '@metamask/messenger';
-import { GatorPermissionsControllerStateChangeEvent } from '@metamask/gator-permissions-controller';
 import {
-  SnapControllerHandleRequestAction,
-  SnapControllerHasSnapAction,
-} from '@metamask/snaps-controllers';
-import {
-  TransactionControllerTransactionApprovedEvent,
-  TransactionControllerTransactionRejectedEvent,
-  TransactionControllerTransactionConfirmedEvent,
-  TransactionControllerTransactionFailedEvent,
-  TransactionControllerTransactionDroppedEvent,
-} from '@metamask/transaction-controller';
-import {
-  NetworkControllerFindNetworkClientIdByChainIdAction,
-  NetworkControllerGetNetworkClientByIdAction,
-} from '@metamask/network-controller';
+  Messenger,
+  MessengerActions,
+  MessengerEvents,
+} from '@metamask/messenger';
+import { GatorPermissionsControllerMessenger } from '@metamask/gator-permissions-controller';
 import { RootMessenger } from '../../../lib/messenger';
-
-export type GatorPermissionsControllerMessenger = ReturnType<
-  typeof getGatorPermissionsControllerMessenger
->;
-
-type MessengerActions =
-  | SnapControllerHandleRequestAction
-  | SnapControllerHasSnapAction
-  | NetworkControllerFindNetworkClientIdByChainIdAction
-  | NetworkControllerGetNetworkClientByIdAction;
-
-type MessengerEvents =
-  | GatorPermissionsControllerStateChangeEvent
-  | TransactionControllerTransactionApprovedEvent
-  | TransactionControllerTransactionRejectedEvent
-  | TransactionControllerTransactionConfirmedEvent
-  | TransactionControllerTransactionFailedEvent
-  | TransactionControllerTransactionDroppedEvent;
 
 /**
  * Get a restricted messenger for the Gator Permissions controller. This is scoped to the
@@ -43,17 +14,16 @@ type MessengerEvents =
  * @returns The restricted messenger.
  */
 export function getGatorPermissionsControllerMessenger(
-  messenger: RootMessenger<MessengerActions, MessengerEvents>,
+  messenger: RootMessenger<
+    MessengerActions<GatorPermissionsControllerMessenger>,
+    MessengerEvents<GatorPermissionsControllerMessenger>
+  >,
 ) {
-  const controllerMessenger = new Messenger<
-    'GatorPermissionsController',
-    MessengerActions,
-    MessengerEvents,
-    typeof messenger
-  >({
-    namespace: 'GatorPermissionsController',
-    parent: messenger,
-  });
+  const controllerMessenger: GatorPermissionsControllerMessenger =
+    new Messenger({
+      namespace: 'GatorPermissionsController',
+      parent: messenger,
+    });
   messenger.delegate({
     messenger: controllerMessenger,
     actions: [

--- a/app/scripts/messenger-client-init/messengers/gator-permissions/index.ts
+++ b/app/scripts/messenger-client-init/messengers/gator-permissions/index.ts
@@ -1,2 +1,1 @@
 export { getGatorPermissionsControllerMessenger } from './gator-permissions-controller-messenger';
-export type { GatorPermissionsControllerMessenger } from './gator-permissions-controller-messenger';

--- a/app/scripts/messenger-client-init/messengers/index.ts
+++ b/app/scripts/messenger-client-init/messengers/index.ts
@@ -493,6 +493,7 @@ export const MESSENGER_FACTORIES = {
   },
   DelegationController: {
     getMessenger: getDelegationControllerMessenger,
+    getInitMessenger: noop,
   },
   EncryptionPublicKeyController: {
     getMessenger: getEncryptionPublicKeyControllerMessenger,

--- a/app/scripts/messenger-client-init/messengers/index.ts
+++ b/app/scripts/messenger-client-init/messengers/index.ts
@@ -65,10 +65,7 @@ import {
 } from './notifications';
 import { getDeFiPositionsControllerMessenger } from './defi-positions';
 import { getDeFiPositionsControllerInitMessenger } from './defi-positions/defi-positions-controller-messenger';
-import {
-  getDelegationControllerInitMessenger,
-  getDelegationControllerMessenger,
-} from './delegation/delegation-controller-messenger';
+import { getDelegationControllerMessenger } from './delegation/delegation-controller-messenger';
 import {
   getAccountTreeControllerMessenger,
   getAccountTreeControllerInitMessenger,
@@ -496,7 +493,6 @@ export const MESSENGER_FACTORIES = {
   },
   DelegationController: {
     getMessenger: getDelegationControllerMessenger,
-    getInitMessenger: getDelegationControllerInitMessenger,
   },
   EncryptionPublicKeyController: {
     getMessenger: getEncryptionPublicKeyControllerMessenger,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This removes some duplicated messenger types, and ensures we use an always up-to-date type in the controller init files.

https://consensyssoftware.atlassian.net/browse/WPC-950

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor focused on TypeScript typing and messenger factory wiring, with no behavior changes beyond removing unused init messengers. Risk is limited to potential type mismatches affecting compilation or controller initialization wiring.
> 
> **Overview**
> Refactors `DelegationController` and `GatorPermissionsController` initialization/messenger code to **stop defining local messenger types** and instead import the controller-provided `*ControllerMessenger` types directly from their packages.
> 
> Removes the extra `DelegationControllerInit` messenger and updates `MESSENGER_FACTORIES` so `DelegationController` uses `noop` for `getInitMessenger`; tests are updated accordingly to pass `initMessenger: undefined` and use the new type imports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e31d6912d12c0160e8a800c387ca145d997ae668. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->