### PR TITLE
fix: Remove number of promises waiting for unlock from badge

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -2063,12 +2063,9 @@ export function setupController(
 
   function getPendingApprovalCount() {
     try {
-      const pendingApprovalCount =
-        controller.appStateController.waitingForUnlock.length +
-        getAttentionRequiredApprovalCount({
-          approvalController: controller.approvalController,
-        });
-      return pendingApprovalCount;
+      return getAttentionRequiredApprovalCount({
+        approvalController: controller.approvalController,
+      });
     } catch (error) {
       console.error('Failed to get pending approval count:', error);
       return 0;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Remove promises waiting for unlock from the badge count. The reasoning for why we did this has been lost to time and it seems to currently just add confusion. Promises waiting for unlock will trigger a single approval regardless, so the badge will show `1`, instead of `1 + number of promises`. These promises may not result in any approvals for the user to approve anyway.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Remove the number of promises waiting for unlock from the badge


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX adjustment limited to badge count calculation; no changes to approval handling or persistence, but could slightly alter perceived pending-request state for users.
> 
> **Overview**
> Simplifies the toolbar badge pending count to only reflect *attention-required approvals* via `getAttentionRequiredApprovalCount`, removing the extra increment from `appStateController.waitingForUnlock.length`.
> 
> This makes the badge show a single pending approval while locked rather than `1 + N` queued unlock promises, reducing confusing over-counting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 665068c2b203dc494f0510baea25a312b6a2338f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->