### PR TITLE
feat(passkey): link troubleshoot modal support to passkeys article cp-13.32.0

### DIFF
--- a/ui/components/app/passkey-troubleshoot-modal/passkey-troubleshoot-modal.tsx
+++ b/ui/components/app/passkey-troubleshoot-modal/passkey-troubleshoot-modal.tsx
@@ -18,7 +18,7 @@ import {
   ModalOverlay,
 } from '../../component-library';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { SUPPORT_LINK } from '../../../helpers/constants/common';
+import ZENDESK_URLS from '../../../helpers/constants/zendesk-url';
 import {
   MetaMetricsContextProp,
   MetaMetricsEventCategory,
@@ -75,7 +75,7 @@ export default function PasskeyTroubleshootModal({
         category: MetaMetricsEventCategory.Navigation,
         event: MetaMetricsEventName.SupportLinkClicked,
         properties: {
-          url: SUPPORT_LINK,
+          url: ZENDESK_URLS.PASSKEYS,
         },
       },
       {
@@ -165,7 +165,7 @@ export default function PasskeyTroubleshootModal({
             >
               <a
                 data-testid="passkey-troubleshoot-still-having-trouble-link"
-                href={SUPPORT_LINK}
+                href={ZENDESK_URLS.PASSKEYS}
                 target="_blank"
                 rel="noopener noreferrer"
               >

--- a/ui/helpers/constants/zendesk-url.ts
+++ b/ui/helpers/constants/zendesk-url.ts
@@ -29,6 +29,8 @@ const ZENDESK_URLS = {
     'https://support.ledger.com/hc/en-us/articles/10371387758493-MetaMask-Firefox-Ledger-Integration-Issue?support=true',
   LEGACY_WEB3:
     'https://support.metamask.io/third-party-platforms-and-dapps/metamask-legacy-web3/?utm_source=extension',
+  PASSKEYS:
+    'https://support.metamask.io/configure/wallet/passkeys/?utm_source=extension',
   PASSWORD_ARTICLE:
     'https://support.metamask.io/configure/wallet/passwords-and-metamask/?utm_source=extension',
   PASSWORD_AND_SRP_ARTICLE:


### PR DESCRIPTION
## **Description**

The passkey troubleshoot modal ("Still having trouble?") previously used the generic `SUPPORT_LINK` (MetaMask support homepage from env). It now opens the dedicated passkeys help article.

**Reason:** Users troubleshooting passkey unlock or verification should land on passkey-specific guidance, not the general support home page.

**Solution:**
- Added `ZENDESK_URLS.PASSKEYS` in `ui/helpers/constants/zendesk-url.ts` (same pattern as other feature-specific support URLs).
- Updated `passkey-troubleshoot-modal.tsx` to use `ZENDESK_URLS.PASSKEYS` for the link `href` and `SupportLinkClicked` analytics `url`.

All entry points that use this modal are covered automatically: unlock, change password, and security settings passkey flows.

## **Changelog**

CHANGELOG entry: Updated the passkey troubleshoot support link to open the passkeys help article instead of the general support homepage.

## **Related issues**

Fixes: <!-- e.g. #12345 — add ticket if applicable -->

## **Manual testing steps**

1. Build/load the extension with passkeys enabled.
2. **Unlock:** On the unlock screen with passkey available, open troubleshoot (e.g. "Trouble unlocking?"), click **Still having trouble?**, and confirm the tab opens `https://support.metamask.io/configure/wallet/passkeys/` (with `utm_source=extension` if present).
3. **Change password:** Start change password with passkey verification, open troubleshoot ("Trouble verifying?" or equivalent), click **Still having trouble?**, and confirm the same URL.
4. **Settings:** Security → passkey settings, open troubleshoot from the verify flow, click **Still having trouble?**, and confirm the same URL.
5. (Optional) Confirm `SupportLinkClicked` segment event includes the passkeys article URL.

<!--
## **Screenshots/Recordings**


### **Before**

### **After**
-->
<img width="1801" height="785" alt="image" src="https://github.com/user-attachments/assets/13951e76-443e-402b-aa89-601f27d56fc8" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates a help link target and the associated `SupportLinkClicked` analytics URL, with no changes to auth, passkey behavior, or data handling.
> 
> **Overview**
> Updates the passkey troubleshoot modal’s **“Still having trouble?”** link to open a dedicated passkeys Zendesk article instead of the generic `SUPPORT_LINK`.
> 
> Adds `ZENDESK_URLS.PASSKEYS` and uses it both for the anchor `href` and for the `SupportLinkClicked` MetaMetrics event property.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ae2e5f566271b3bbd921de5913434db5c2cb9b3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->