### PR TITLE
feat: show custom token with toggle

### DIFF
--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -1372,6 +1372,9 @@
     "ui/pages/confirmations/utils/confirm.test.ts": {
       "error: Failed to detect if URL": 1
     },
+    "ui/pages/custom-token-import/custom-token-import.test.tsx": {
+      "React: Act warnings (component updates not wrapped)": 2
+    },
     "ui/pages/defi/components/defi-details-page.test.tsx": {
       "Reselect: Identity function warnings": 1
     },

--- a/ui/pages/custom-token-import/custom-token-import.test.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.test.tsx
@@ -38,6 +38,10 @@ jest.mock('react-router-dom', () => {
   };
 });
 
+jest.mock('../../../shared/lib/assets-unify-state/remote-feature-flag', () =>
+  jest.requireActual('../../../shared/lib/assets-unify-state/remote-feature-flag'),
+);
+
 // The page kicks off real on-chain probes through `getTokenStandardAndDetailsByChain`
 // and `tokenInfoGetter`. Replace them with deterministic stubs so the unit
 // test never reaches the background script.
@@ -46,6 +50,7 @@ jest.mock('../../store/actions', () => {
   return {
     ...actual,
     addImportedTokens: jest.fn(() => () => Promise.resolve()),
+    importCustomAssetsBatch: jest.fn(() => () => Promise.resolve()),
     getTokenStandardAndDetailsByChain: jest.fn().mockResolvedValue({
       standard: 'ERC20',
       symbol: 'APE',
@@ -69,15 +74,27 @@ jest.mock('../../helpers/utils/token-util', () => {
 const getMockedActions = () =>
   jest.requireMock('../../store/actions') as {
     addImportedTokens: jest.Mock;
+    importCustomAssetsBatch: jest.Mock;
   };
+
+const ASSETS_UNIFY_STATE_FLAG_ON = {
+  assetsUnifyState: {
+    enabled: true,
+    featureVersion: '1',
+  },
+};
 
 describe('CustomTokenImportPage', () => {
   beforeEach(() => {
     mockNavigate.mockClear();
-    getMockedActions().addImportedTokens.mockClear();
+    const actions = getMockedActions();
+    actions.addImportedTokens.mockClear();
+    actions.importCustomAssetsBatch.mockClear();
   });
 
-  const buildState = () => ({
+  const buildState = (
+    metamaskOverrides: Record<string, unknown> = {},
+  ) => ({
     ...mockState,
     metamask: {
       ...mockState.metamask,
@@ -98,11 +115,15 @@ describe('CustomTokenImportPage', () => {
           ],
         },
       },
+      ...metamaskOverrides,
     },
   });
 
-  const renderPage = (trackEvent = jest.fn()) => {
-    const store = configureStore(buildState());
+  const renderPage = (
+    trackEvent = jest.fn(),
+    metamaskOverrides: Record<string, unknown> = {},
+  ) => {
+    const store = configureStore(buildState(metamaskOverrides));
     return {
       store,
       ...renderWithProvider(
@@ -113,6 +134,28 @@ describe('CustomTokenImportPage', () => {
         () => trackEvent,
       ),
     };
+  };
+
+  const submitCustomToken = async (
+    metamaskOverrides: Record<string, unknown> = {},
+  ) => {
+    const trackEvent = jest.fn();
+    const rendered = renderPage(trackEvent, metamaskOverrides);
+
+    fireEvent.change(screen.getByTestId('custom-token-import-address-input'), {
+      target: { value: '0x1111111111111111111111111111111111111111' },
+    });
+
+    await screen.findByTestId('custom-token-import-symbol-input');
+    await waitFor(() =>
+      expect(
+        screen.getByTestId('custom-token-import-submit-button'),
+      ).not.toBeDisabled(),
+    );
+
+    fireEvent.click(screen.getByTestId('custom-token-import-submit-button'));
+
+    return { trackEvent, ...rendered };
   };
 
   it('renders the form scaffolding without crashing', () => {
@@ -185,21 +228,7 @@ describe('CustomTokenImportPage', () => {
 
   it('returns to token management with success toast state after submitting a custom token', async () => {
     const actions = getMockedActions();
-    const trackEvent = jest.fn();
-    renderPage(trackEvent);
-
-    fireEvent.change(screen.getByTestId('custom-token-import-address-input'), {
-      target: { value: '0x1111111111111111111111111111111111111111' },
-    });
-
-    await screen.findByTestId('custom-token-import-symbol-input');
-    await waitFor(() =>
-      expect(
-        screen.getByTestId('custom-token-import-submit-button'),
-      ).not.toBeDisabled(),
-    );
-
-    fireEvent.click(screen.getByTestId('custom-token-import-submit-button'));
+    const { trackEvent } = await submitCustomToken();
 
     await waitFor(() =>
       expect(actions.addImportedTokens).toHaveBeenCalledWith(
@@ -240,5 +269,172 @@ describe('CustomTokenImportPage', () => {
         },
       }),
     );
+  });
+
+  describe('when the assets-unify-state remote feature flag is enabled', () => {
+    it('seeds AssetsController via importCustomAssetsBatch so the token appears in the manage-tokens list', async () => {
+      const actions = getMockedActions();
+
+      await submitCustomToken({
+        remoteFeatureFlags: ASSETS_UNIFY_STATE_FLAG_ON,
+      });
+
+      const expectedAssetId =
+        'eip155:1/erc20:0x1111111111111111111111111111111111111111';
+
+      await waitFor(() =>
+        expect(actions.importCustomAssetsBatch).toHaveBeenCalledWith(
+          'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3',
+          [
+            {
+              assetId: expectedAssetId,
+              isHidden: false,
+            },
+          ],
+          {
+            [expectedAssetId]: expect.objectContaining({
+              address: '0x1111111111111111111111111111111111111111',
+              symbol: 'APE',
+              name: 'APE',
+              decimals: 18,
+              chainId: '0x1',
+              unlisted: true,
+            }),
+          },
+        ),
+      );
+
+      await waitFor(() =>
+        expect(actions.addImportedTokens).toHaveBeenCalled(),
+      );
+    });
+
+    it('marks the asset as previously hidden when assetPreferences has hidden: true for it', async () => {
+      const actions = getMockedActions();
+      const assetId =
+        'eip155:1/erc20:0x1111111111111111111111111111111111111111';
+
+      await submitCustomToken({
+        remoteFeatureFlags: ASSETS_UNIFY_STATE_FLAG_ON,
+        assetPreferences: {
+          [assetId]: { hidden: true },
+        },
+      });
+
+      await waitFor(() =>
+        expect(actions.importCustomAssetsBatch).toHaveBeenCalledWith(
+          'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3',
+          [
+            {
+              assetId,
+              isHidden: true,
+            },
+          ],
+          expect.any(Object),
+        ),
+      );
+    });
+
+    it('allows re-importing a token that is currently hidden in assetPreferences without showing "tokenAlreadyAdded"', async () => {
+      const actions = getMockedActions();
+      const tokenAddress = '0x1111111111111111111111111111111111111111';
+      const assetId = `eip155:1/erc20:${tokenAddress}`;
+      const accountId = 'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3';
+
+      renderPage(jest.fn(), {
+        remoteFeatureFlags: ASSETS_UNIFY_STATE_FLAG_ON,
+        // Simulate state after the user hid the token from the manage tokens
+        // list when assets-unify-state is on: the token remains in
+        // `customAssets` (so the unified `getAllTokens` selector still
+        // returns it) and `assetPreferences[assetId].hidden` is `true`.
+        customAssets: { [accountId]: [assetId] },
+        assetsInfo: {
+          [assetId]: {
+            type: 'erc20',
+            symbol: 'APE',
+            name: 'ApeCoin',
+            decimals: 18,
+          },
+        },
+        assetPreferences: {
+          [assetId]: { hidden: true },
+        },
+      });
+
+      fireEvent.change(
+        screen.getByTestId('custom-token-import-address-input'),
+        { target: { value: tokenAddress } },
+      );
+
+      await screen.findByTestId('custom-token-import-symbol-input');
+
+      expect(
+        screen.queryByText(messages.tokenAlreadyAdded.message),
+      ).not.toBeInTheDocument();
+      await waitFor(() =>
+        expect(
+          screen.getByTestId('custom-token-import-submit-button'),
+        ).not.toBeDisabled(),
+      );
+
+      fireEvent.click(screen.getByTestId('custom-token-import-submit-button'));
+
+      await waitFor(() =>
+        expect(actions.importCustomAssetsBatch).toHaveBeenCalledWith(
+          accountId,
+          [
+            {
+              assetId,
+              isHidden: true,
+            },
+          ],
+          expect.any(Object),
+        ),
+      );
+    });
+  });
+
+  it('still shows "tokenAlreadyAdded" for a visible (non-hidden) token even when assets-unify-state is enabled', async () => {
+    const tokenAddress = '0x1111111111111111111111111111111111111111';
+    const assetId = `eip155:1/erc20:${tokenAddress}`;
+    const accountId = 'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3';
+
+    renderPage(jest.fn(), {
+      remoteFeatureFlags: ASSETS_UNIFY_STATE_FLAG_ON,
+      // Token is present in `customAssets` but NOT hidden: the unified
+      // selector should still return it, so the "already added" guard
+      // must trigger.
+      customAssets: { [accountId]: [assetId] },
+      assetsInfo: {
+        [assetId]: {
+          type: 'erc20',
+          symbol: 'APE',
+          name: 'ApeCoin',
+          decimals: 18,
+        },
+      },
+    });
+
+    fireEvent.change(screen.getByTestId('custom-token-import-address-input'), {
+      target: { value: tokenAddress },
+    });
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(messages.tokenAlreadyAdded.message),
+      ).toBeInTheDocument(),
+    );
+    expect(
+      screen.getByTestId('custom-token-import-submit-button'),
+    ).toBeDisabled();
+  });
+
+  it('does not call importCustomAssetsBatch when the assets-unify-state remote feature flag is off', async () => {
+    const actions = getMockedActions();
+
+    await submitCustomToken();
+
+    await waitFor(() => expect(actions.addImportedTokens).toHaveBeenCalled());
+    expect(actions.importCustomAssetsBatch).not.toHaveBeenCalled();
   });
 });

--- a/ui/pages/custom-token-import/custom-token-import.test.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.test.tsx
@@ -295,7 +295,7 @@ describe('CustomTokenImportPage', () => {
             [expectedAssetId]: expect.objectContaining({
               address: '0x1111111111111111111111111111111111111111',
               symbol: 'APE',
-              name: 'APE',
+              name: 'ApeCoin',
               decimals: 18,
               chainId: '0x1',
               unlisted: true,
@@ -305,6 +305,28 @@ describe('CustomTokenImportPage', () => {
       );
 
       await waitFor(() => expect(actions.addImportedTokens).toHaveBeenCalled());
+    });
+
+    it('passes the full token name (not the symbol) as the name field in metadata', async () => {
+      const actions = getMockedActions();
+
+      await submitCustomToken({
+        remoteFeatureFlags: ASSETS_UNIFY_STATE_FLAG_ON,
+      });
+
+      const expectedAssetId =
+        'eip155:1/erc20:0x1111111111111111111111111111111111111111';
+
+      await waitFor(() => {
+        const metadataArg = actions.importCustomAssetsBatch.mock.calls[0][2];
+        const metadata = metadataArg[expectedAssetId];
+        // tokenInfoGetter mock returns name: 'ApeCoin' and symbol: 'APE'.
+        // These must be stored separately; the symbol must not be used in place
+        // of the name.
+        expect(metadata.name).toBe('ApeCoin');
+        expect(metadata.symbol).toBe('APE');
+        expect(metadata.name).not.toBe(metadata.symbol);
+      });
     });
 
     it('marks the asset as previously hidden when assetPreferences has hidden: true for it', async () => {

--- a/ui/pages/custom-token-import/custom-token-import.test.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.test.tsx
@@ -39,7 +39,9 @@ jest.mock('react-router-dom', () => {
 });
 
 jest.mock('../../../shared/lib/assets-unify-state/remote-feature-flag', () =>
-  jest.requireActual('../../../shared/lib/assets-unify-state/remote-feature-flag'),
+  jest.requireActual(
+    '../../../shared/lib/assets-unify-state/remote-feature-flag',
+  ),
 );
 
 // The page kicks off real on-chain probes through `getTokenStandardAndDetailsByChain`
@@ -92,9 +94,7 @@ describe('CustomTokenImportPage', () => {
     actions.importCustomAssetsBatch.mockClear();
   });
 
-  const buildState = (
-    metamaskOverrides: Record<string, unknown> = {},
-  ) => ({
+  const buildState = (metamaskOverrides: Record<string, unknown> = {}) => ({
     ...mockState,
     metamask: {
       ...mockState.metamask,
@@ -304,9 +304,7 @@ describe('CustomTokenImportPage', () => {
         ),
       );
 
-      await waitFor(() =>
-        expect(actions.addImportedTokens).toHaveBeenCalled(),
-      );
+      await waitFor(() => expect(actions.addImportedTokens).toHaveBeenCalled());
     });
 
     it('marks the asset as previously hidden when assetPreferences has hidden: true for it', async () => {

--- a/ui/pages/custom-token-import/custom-token-import.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.tsx
@@ -27,6 +27,7 @@ import { Header, Page } from '../../components/multichain/pages/page';
 import {
   addImportedTokens,
   getTokenStandardAndDetailsByChain,
+  importCustomAssetsBatch,
 } from '../../store/actions';
 import {
   TOKEN_MANAGEMENT_ROUTE,
@@ -43,11 +44,16 @@ import {
   getAllTokens,
   selectERC20TokensByChain,
 } from '../../selectors';
+import { getIsAssetsUnifyStateEnabled } from '../../selectors/assets-unify-state/feature-flags';
+import {
+  getAssetsControllerAssetPreferences,
+  isAssetIdHiddenInPreferencesMap,
+} from '../../selectors/assets-unify-state/asset-preferences';
 import { checkExistingAddresses } from '../../helpers/utils/util';
 import { tokenInfoGetter } from '../../helpers/utils/token-util';
 import { STATIC_MAINNET_TOKEN_LIST } from '../../../shared/constants/tokens';
 import { CHAIN_IDS } from '../../../shared/constants/network';
-import { isEvmChainId } from '../../../shared/lib/asset-utils';
+import { isEvmChainId, toAssetId } from '../../../shared/lib/asset-utils';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
@@ -95,6 +101,10 @@ export const CustomTokenImportPage = () => {
     string,
     Record<string, { address: string }[]>
   >;
+  const assetsUnifyStateFeatureEnabled = useSelector(
+    getIsAssetsUnifyStateEnabled,
+  );
+  const assetPreferences = useSelector(getAssetsControllerAssetPreferences);
   // Chain-scoped token-list cache, same source the backend uses inside
   // `getTokenStandardAndDetailsByChain`. Provides the metadata fallback for
   // `tokenInfoGetter` when on-chain `symbol()`/`decimals()`/`name()` calls
@@ -137,10 +147,41 @@ export const CustomTokenImportPage = () => {
       ]?.networkClientId
     : undefined;
 
-  const existingTokens = useMemo(
-    () => allTokens?.[selectedNetwork]?.[selectedAccount?.address ?? ''] ?? [],
-    [allTokens, selectedNetwork, selectedAccount?.address],
-  );
+  const existingTokens = useMemo(() => {
+    const tokens =
+      allTokens?.[selectedNetwork]?.[selectedAccount?.address ?? ''] ?? [];
+
+    // When assets-unify-state is enabled, `allTokens` is derived from
+    // AssetsController state. Hiding a token only flips
+    // `assetPreferences[assetId].hidden = true`; the token stays in
+    // `customAssets`, so it still appears in `allTokens`. Treat hidden tokens
+    // as not-yet-imported so users can re-import them — `handleSubmit`
+    // dispatches `importCustomAssetsBatch` with `isHidden: true`, which
+    // unhides the asset rather than adding a duplicate.
+    if (!assetsUnifyStateFeatureEnabled) {
+      return tokens;
+    }
+
+    return tokens.filter((token) => {
+      if (!token?.address) {
+        return true;
+      }
+      const assetId = toAssetId(
+        token.address as Hex,
+        selectedNetwork as CaipChainId | Hex,
+      );
+      if (!assetId) {
+        return true;
+      }
+      return !isAssetIdHiddenInPreferencesMap(assetPreferences, assetId);
+    });
+  }, [
+    allTokens,
+    assetPreferences,
+    assetsUnifyStateFeatureEnabled,
+    selectedAccount?.address,
+    selectedNetwork,
+  ]);
 
   const tokenListForSelectedNetwork =
     erc20TokensByChain?.[selectedNetwork]?.data;
@@ -433,6 +474,43 @@ export const CustomTokenImportPage = () => {
           networkClientId,
         ),
       );
+
+      // When assets-unify-state is enabled, the manage-tokens list reads from
+      // AssetsController (customAssets + assetsInfo) rather than
+      // TokensController.allTokens.
+      if (assetsUnifyStateFeatureEnabled && selectedAccount?.id) {
+        const assetId = toAssetId(
+          address as Hex,
+          selectedNetwork as CaipChainId | Hex,
+        );
+        if (assetId) {
+          await dispatch(
+            importCustomAssetsBatch(
+              selectedAccount.id,
+              [
+                {
+                  assetId,
+                  isHidden: isAssetIdHiddenInPreferencesMap(
+                    assetPreferences,
+                    assetId,
+                  ),
+                },
+              ],
+              {
+                [assetId]: {
+                  address,
+                  symbol,
+                  name: symbol,
+                  decimals: parsedDecimals,
+                  chainId: selectedNetwork,
+                  unlisted: true,
+                },
+              },
+            ),
+          );
+        }
+      }
+
       trackSubmitAttempt(1);
       navigate(TOKEN_MANAGEMENT_ROUTE, {
         state: {
@@ -450,12 +528,16 @@ export const CustomTokenImportPage = () => {
     }
   }, [
     address,
+    assetPreferences,
+    assetsUnifyStateFeatureEnabled,
     dispatch,
     isSubmitting,
     isValid,
     navigate,
     networkClientId,
     parsedDecimals,
+    selectedAccount?.id,
+    selectedNetwork,
     symbol,
     trackSubmitAttempt,
   ]);

--- a/ui/pages/custom-token-import/custom-token-import.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.tsx
@@ -188,6 +188,7 @@ export const CustomTokenImportPage = () => {
 
   const [address, setAddress] = useState('');
   const [symbol, setSymbol] = useState('');
+  const [name, setName] = useState('');
   const [decimals, setDecimals] = useState('');
   const [addressError, setAddressError] = useState<string | null>(null);
   const [symbolError, setSymbolError] = useState<string | null>(null);
@@ -230,6 +231,7 @@ export const CustomTokenImportPage = () => {
   const clearFormData = useCallback(() => {
     setAddress('');
     setSymbol('');
+    setName('');
     setDecimals('');
     resetValidation();
   }, [resetValidation]);
@@ -240,6 +242,7 @@ export const CustomTokenImportPage = () => {
       setAddress(trimmed);
       resetValidation();
       setSymbol('');
+      setName('');
       setDecimals('');
 
       // Invalidate any in-flight lookup so its eventual result is ignored.
@@ -328,6 +331,7 @@ export const CustomTokenImportPage = () => {
             ? ''
             : String(rawDecimals);
         setSymbol(info?.symbol ?? '');
+        setName(info?.name ?? '');
         setDecimals(nextDecimals);
         setShowSymbolAndDecimals(true);
         if (!info?.symbol || nextDecimals === '') {
@@ -500,7 +504,7 @@ export const CustomTokenImportPage = () => {
                 [assetId]: {
                   address,
                   symbol,
-                  name: symbol,
+                  name: name || symbol,
                   decimals: parsedDecimals,
                   chainId: selectedNetwork,
                   unlisted: true,
@@ -533,6 +537,7 @@ export const CustomTokenImportPage = () => {
     dispatch,
     isSubmitting,
     isValid,
+    name,
     navigate,
     networkClientId,
     parsedDecimals,


### PR DESCRIPTION
This PR is to fix:
1.  Show imported custom token in the token list
2. If a user manually hides a token, they should be able to import it with custom token route

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
3. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Start extension with assets unified state enabled (ASSETS_UNIFIED_STATE_ENABLED=true) and remote flag assetsUnifyState.enabled=true, featureVersion='1'.
2. Open wallet, go to Manage tokens, and ensure an ERC20 token can be found/imported (or use one already imported).
4. Hide that token from Manage tokens (toggle off), then leave and return to confirm it is hidden.
5. Go to Add custom token and enter the same token contract address you just hid.
6. Verify you do not see the error “Token has already been added”.
7. Verify symbol/decimals autofill still works and the Import button becomes enabled.
8. Click Import and verify you are returned to Manage tokens with the success toast.
9. In Manage tokens, verify that token is now visible again with toggle on.
10. Validate regression case: with a token that is already visible (not hidden), open Add custom token and enter that token’s address.
11. Verify you do see “Token has already been added” and import remains blocked.
12. Validate legacy behavior toggle: disable remote flag (assetsUnifyState.enabled=false) and repeat step 9 to confirm existing “already added” validation still works as before.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/8c6372f9-eab2-477e-bf1f-e14a3f765fb8



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates custom token import behavior under the `assets-unify-state` flag, affecting token visibility/rehydration and dispatching additional controller actions; mistakes could cause tokens not to appear or to be incorrectly marked hidden/visible.
> 
> **Overview**
> Fixes custom token import when **`assets-unify-state` is enabled** by (1) treating *hidden* assets in `assetPreferences` as eligible for re-import (so the “tokenAlreadyAdded” guard won’t block them) and (2) dispatching `importCustomAssetsBatch` on submit to seed AssetsController metadata so newly imported tokens show up in Manage Tokens.
> 
> Adds `name` to the autofill state and persists `name`/`symbol` separately in the AssetsController metadata (defaulting `name` to `symbol` if missing), while preserving legacy behavior when the feature flag is off.
> 
> Extends `custom-token-import` unit tests to cover the new flag-gated behavior (including hidden-token re-import) and updates the Jest console baseline for the added test warnings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51467ca6784138c03e5ba6410e42bc59d7e338fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->