### PR TITLE
feat: Box from DSR (no codeowners, part 2)

### DIFF
--- a/ui/components/app/permission-cell/permission-cell-status.js
+++ b/ui/components/app/permission-cell/permission-cell-status.js
@@ -1,21 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
-import { AvatarAccountSize } from '@metamask/design-system-react';
+import {
+  AvatarAccountSize,
+  Box,
+  BoxFlexDirection,
+  BoxAlignItems,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
 import {
   AvatarNetwork,
   AvatarNetworkSize,
   AvatarTokenSize,
-  Box,
   Text,
 } from '../../component-library';
 import {
-  AlignItems,
   BlockSize,
   BorderColor,
   Display,
-  FlexDirection,
-  JustifyContent,
   TextAlign,
   TextColor,
   TextVariant,
@@ -56,97 +58,95 @@ export const PermissionCellStatus = ({
     <>
       {networks.length > 0 ? (
         <Box
-          as="span"
-          className="permission-cell__status__accounts-group-box"
-          display={Display.InlineFlex}
+          asChild
+          className="permission-cell__status__accounts-group-box inline-flex"
         >
-          <Box display={Display.Flex} flexDirection={FlexDirection.Column}>
-            {networks?.map((network, index) => {
-              // Get network icon: try EVM chain ID map first, then rpcPrefs.imageUrl for non-EVM
-              const networkImageUrl =
-                CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP[network.chainId] ??
-                network.rpcPrefs?.imageUrl ??
-                network.nativeTokenIconUrl;
-              return (
-                <Box
-                  key={`${network.name}_${index}`}
-                  display={Display.Flex}
-                  justifyContent={JustifyContent.flexStart}
-                  alignItems={AlignItems.center}
-                  marginTop={2}
-                >
-                  <AvatarNetwork
-                    size={AvatarNetworkSize.Xs}
-                    src={networkImageUrl}
-                    name={network.name}
-                  />
-                  <Text variant={TextVariant.bodyMdMedium} marginLeft={2}>
-                    {network.name}
-                  </Text>
-                </Box>
-              );
-            })}
-          </Box>
+          <span>
+            <Box className="flex flex-col">
+              {networks?.map((network, index) => {
+                // Get network icon: try EVM chain ID map first, then rpcPrefs.imageUrl for non-EVM
+                const networkImageUrl =
+                  CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP[network.chainId] ??
+                  network.rpcPrefs?.imageUrl ??
+                  network.nativeTokenIconUrl;
+                return (
+                  <Box
+                    key={`${network.name}_${index}`}
+                    className="flex"
+                    justifyContent={BoxJustifyContent.Start}
+                    alignItems={BoxAlignItems.Center}
+                    marginTop={2}
+                  >
+                    <AvatarNetwork
+                      size={AvatarNetworkSize.Xs}
+                      src={networkImageUrl}
+                      name={network.name}
+                    />
+                    <Text variant={TextVariant.bodyMdMedium} marginLeft={2}>
+                      {network.name}
+                    </Text>
+                  </Box>
+                );
+              })}
+            </Box>
+          </span>
         </Box>
       ) : (
         <Box
-          as="span"
-          className="permission-cell__status__accounts-group-box"
-          display={Display.InlineFlex}
+          asChild
+          className="permission-cell__status__accounts-group-box inline-flex"
         >
-          <Tooltip
-            position="bottom"
-            html={
-              <Box
-                display={Display.Flex}
-                flexDirection={FlexDirection.Column}
-                justifyContent={JustifyContent.center}
-                alignItems={AlignItems.center}
-              >
-                <Text
-                  variant={TextVariant.headingSm}
-                  color={TextColor.textAlternative}
-                  textAlign={TextAlign.Center}
-                >
-                  {t('accounts')}
-                </Text>
+          <span>
+            <Tooltip
+              position="bottom"
+              html={
                 <Box
-                  display={Display.Flex}
-                  flexDirection={FlexDirection.Column}
+                  className="flex flex-col"
+                  justifyContent={BoxJustifyContent.Center}
+                  alignItems={BoxAlignItems.Center}
                 >
-                  {accounts.map((account, index) => (
-                    <Box
-                      key={`${account.avatarValue}_${index}`}
-                      display={Display.Flex}
-                      justifyContent={JustifyContent.flexStart}
-                      alignItems={AlignItems.center}
-                      marginTop={2}
-                    >
-                      <PreferredAvatar
-                        address={account.avatarValue}
-                        size={AvatarAccountSize.Xs}
-                      />
-                      <Text variant={TextVariant.bodyMdMedium} marginLeft={2}>
-                        {account.avatarName}
-                      </Text>
-                    </Box>
-                  ))}
+                  <Text
+                    variant={TextVariant.headingSm}
+                    color={TextColor.textAlternative}
+                    textAlign={TextAlign.Center}
+                  >
+                    {t('accounts')}
+                  </Text>
+                  <Box className="flex flex-col">
+                    {accounts.map((account, index) => (
+                      <Box
+                        key={`${account.avatarValue}_${index}`}
+                        className="flex"
+                        justifyContent={BoxJustifyContent.Start}
+                        alignItems={BoxAlignItems.Center}
+                        marginTop={2}
+                      >
+                        <PreferredAvatar
+                          address={account.avatarValue}
+                          size={AvatarAccountSize.Xs}
+                        />
+                        <Text variant={TextVariant.bodyMdMedium} marginLeft={2}>
+                          {account.avatarName}
+                        </Text>
+                      </Box>
+                    ))}
+                  </Box>
                 </Box>
-              </Box>
-            }
-          >
-            <AvatarGroup
-              limit={3}
-              members={accounts}
-              avatarType={AvatarType.ACCOUNT}
-              variant={avatarAccountVariant}
-              size={AvatarTokenSize.Xs}
-              width={BlockSize.Min}
-              borderColor={BorderColor.backgroundDefault}
-              marginLeft={4}
-              paddingLeft={4}
-            />
-          </Tooltip>
+              }
+            >
+              <AvatarGroup
+                limit={3}
+                members={accounts}
+                avatarType={AvatarType.ACCOUNT}
+                variant={avatarAccountVariant}
+                size={AvatarTokenSize.Xs}
+                width={BlockSize.Min}
+                borderColor={BorderColor.backgroundDefault}
+                marginLeft={4}
+                paddingLeft={4}
+              />
+            </Tooltip>
+          </span>
         </Box>
       )}
     </>

--- a/ui/components/app/permission-cell/permission-cell-status.js
+++ b/ui/components/app/permission-cell/permission-cell-status.js
@@ -4,7 +4,6 @@ import { useSelector } from 'react-redux';
 import {
   AvatarAccountSize,
   Box,
-  BoxFlexDirection,
   BoxAlignItems,
   BoxJustifyContent,
 } from '@metamask/design-system-react';

--- a/ui/components/app/tab-bar/tab-bar.js
+++ b/ui/components/app/tab-bar/tab-bar.js
@@ -2,12 +2,9 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'clsx';
 
-import { Icon, IconName, IconSize, Box } from '../../component-library';
-import {
-  BorderRadius,
-  Color,
-  Display,
-} from '../../../helpers/constants/design-system';
+import { Box } from '@metamask/design-system-react';
+import { Icon, IconName, IconSize } from '../../component-library';
+import { BorderRadius, Color } from '../../../helpers/constants/design-system';
 
 const TabBar = (props) => {
   const { tabs = [], onSelect, isActive } = props;
@@ -16,34 +13,37 @@ const TabBar = (props) => {
     <div className="tab-bar">
       {tabs.map(({ key, content, icon }) => (
         <Box
-          as="button"
+          asChild
           key={key}
           paddingTop={5}
           paddingBottom={5}
           paddingLeft={4}
           paddingRight={4}
-          className={classnames('tab-bar__tab pointer', {
-            'tab-bar__tab--active': isActive(key, content),
-          })}
-          onClick={() => onSelect(key)}
         >
-          {isActive(key, content) && (
-            <Box
-              className="tab-bar__tab__selected-indicator"
-              borderRadius={BorderRadius.pill}
-              backgroundColor={Color.primaryDefault}
-              display={[Display.None, Display.Block]}
+          <button
+            type="button"
+            className={classnames('tab-bar__tab pointer', {
+              'tab-bar__tab--active': isActive(key, content),
+            })}
+            onClick={() => onSelect(key)}
+          >
+            {isActive(key, content) && (
+              <Box
+                className="tab-bar__tab__selected-indicator hidden sm:block"
+                borderRadius={BorderRadius.pill}
+                backgroundColor={Color.primaryDefault}
+              />
+            )}
+            <div className="tab-bar__tab__content">
+              <div className="tab-bar__tab__content__icon">{icon}</div>
+              <div className="tab-bar__tab__content__title">{content}</div>
+            </div>
+            <Icon
+              name={IconName.ArrowRight}
+              size={IconSize.Sm}
+              className="tab-bar__tab__caret"
             />
-          )}
-          <div className="tab-bar__tab__content">
-            <div className="tab-bar__tab__content__icon">{icon}</div>
-            <div className="tab-bar__tab__content__title">{content}</div>
-          </div>
-          <Icon
-            name={IconName.ArrowRight}
-            size={IconSize.Sm}
-            className="tab-bar__tab__caret"
-          />
+          </button>
         </Box>
       ))}
     </div>

--- a/ui/components/app/terms-of-use-popup/terms-of-use-popup.js
+++ b/ui/components/app/terms-of-use-popup/terms-of-use-popup.js
@@ -1,8 +1,8 @@
 import React, { useContext, useEffect, useState, useRef } from 'react';
 import PropTypes from 'prop-types';
+import { Box, BoxAlignItems } from '@metamask/design-system-react';
 import { I18nContext } from '../../../contexts/i18n';
 import {
-  Box,
   Button,
   ButtonLink,
   ButtonPrimary,
@@ -27,8 +27,6 @@ import {
   AlignItems,
   BlockSize,
   BorderRadius,
-  Display,
-  FlexDirection,
   TextAlign,
   TextColor,
   TextVariant,
@@ -110,10 +108,7 @@ export default function TermsOfUsePopup({ onClose, onAccept }) {
             {t('termsOfUseTitle')}
           </Text>
         </ModalHeader>
-        <Box
-          display={Display.Flex}
-          className="terms-of-use-popup__body-container"
-        >
+        <Box className="flex terms-of-use-popup__body-container">
           <Box ref={scrollContainerRef} className="terms-of-use-popup__body">
             <Text variant={TextVariant.bodySm} marginBottom={4}>
               IMPORTANT NOTICE: THIS AGREEMENT IS SUBJECT TO BINDING ARBITRATION
@@ -998,38 +993,36 @@ export default function TermsOfUsePopup({ onClose, onAccept }) {
               please provide us a written notice at the address below with the
               following information:
             </Text>
-            <Box
-              as="ol"
-              marginLeft={4}
-              className="terms-of-use-old__terms-list"
-            >
-              <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
-                an electronic or physical signature of the person authorized to
-                act on behalf of the owner of the copyright or other
-                intellectual property interest;
-              </Text>
-              <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
-                a description of the copyrighted work or other intellectual
-                property that you claim has been infringed;
-              </Text>
-              <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
-                a description of where the material that you claim is infringing
-                is located with respect to the Offerings;
-              </Text>
-              <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
-                your address, telephone number, and email address;
-              </Text>
-              <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
-                a statement by you that you have a good faith belief that the
-                disputed use is not authorized by the copyright owner, its
-                agent, or the law;
-              </Text>
-              <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
-                a statement by you, made under penalty of perjury, that the
-                above information in your notice is accurate and that you are
-                the copyright or intellectual property owner or authorized to
-                act on the copyright or intellectual property owner’s behalf.
-              </Text>
+            <Box asChild marginLeft={4}>
+              <ol className="terms-of-use-old__terms-list">
+                <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
+                  an electronic or physical signature of the person authorized
+                  to act on behalf of the owner of the copyright or other
+                  intellectual property interest;
+                </Text>
+                <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
+                  a description of the copyrighted work or other intellectual
+                  property that you claim has been infringed;
+                </Text>
+                <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
+                  a description of where the material that you claim is
+                  infringing is located with respect to the Offerings;
+                </Text>
+                <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
+                  your address, telephone number, and email address;
+                </Text>
+                <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
+                  a statement by you that you have a good faith belief that the
+                  disputed use is not authorized by the copyright owner, its
+                  agent, or the law;
+                </Text>
+                <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
+                  a statement by you, made under penalty of perjury, that the
+                  above information in your notice is accurate and that you are
+                  the copyright or intellectual property owner or authorized to
+                  act on the copyright or intellectual property owner’s behalf.
+                </Text>
+              </ol>
             </Box>
             <Text variant={TextVariant.bodySm} marginBottom={4}>
               You can reach us at:
@@ -1057,50 +1050,48 @@ export default function TermsOfUsePopup({ onClose, onAccept }) {
               may be updated by us from time to time. You agree not to, and not
               to allow third parties to, use the Offerings:
             </Text>
-            <Box
-              as="ol"
-              marginLeft={4}
-              className="terms-of-use-old__terms-list"
-            >
-              <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
-                to violate, or encourage the violation of, the legal rights of
-                others (for example, this may include allowing End Users to
-                infringe or misappropriate the intellectual property rights of
-                others in violation of the Digital Millennium Copyright Act);
-              </Text>
-              <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
-                to engage in, promote or encourage any illegal or infringing
-                content;
-              </Text>
-              <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
-                for any unlawful, invasive, infringing, defamatory or fraudulent
-                purpose (for example, this may include phishing, creating a
-                pyramid scheme or mirroring a website);
-              </Text>
-              <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
-                to intentionally distribute viruses, worms, Trojan horses,
-                corrupted files, hoaxes, or other items of a destructive or
-                deceptive nature;
-              </Text>
-              <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
-                to interfere with the use of the Offerings, or the equipment
-                used to provide the Offerings, by customers, authorized
-                resellers, or other authorized users;
-              </Text>
-              <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
-                to disable, interfere with or circumvent any aspect of the
-                Offerings (for example, any thresholds or limits);
-              </Text>
-              <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
-                to generate, distribute, publish or facilitate unsolicited mass
-                email, promotions, advertising or other solicitation; or
-              </Text>
-              <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
-                to use the Offerings, or any interfaces provided with the
-                Offerings, to access any other product or service in a manner
-                that violates the terms of service of such other product or
-                service.
-              </Text>
+            <Box asChild marginLeft={4}>
+              <ol className="terms-of-use-old__terms-list">
+                <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
+                  to violate, or encourage the violation of, the legal rights of
+                  others (for example, this may include allowing End Users to
+                  infringe or misappropriate the intellectual property rights of
+                  others in violation of the Digital Millennium Copyright Act);
+                </Text>
+                <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
+                  to engage in, promote or encourage any illegal or infringing
+                  content;
+                </Text>
+                <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
+                  for any unlawful, invasive, infringing, defamatory or
+                  fraudulent purpose (for example, this may include phishing,
+                  creating a pyramid scheme or mirroring a website);
+                </Text>
+                <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
+                  to intentionally distribute viruses, worms, Trojan horses,
+                  corrupted files, hoaxes, or other items of a destructive or
+                  deceptive nature;
+                </Text>
+                <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
+                  to interfere with the use of the Offerings, or the equipment
+                  used to provide the Offerings, by customers, authorized
+                  resellers, or other authorized users;
+                </Text>
+                <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
+                  to disable, interfere with or circumvent any aspect of the
+                  Offerings (for example, any thresholds or limits);
+                </Text>
+                <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
+                  to generate, distribute, publish or facilitate unsolicited
+                  mass email, promotions, advertising or other solicitation; or
+                </Text>
+                <Text as="li" variant={TextVariant.bodySm} marginBottom={2}>
+                  to use the Offerings, or any interfaces provided with the
+                  Offerings, to access any other product or service in a manner
+                  that violates the terms of service of such other product or
+                  service.
+                </Text>
+              </ol>
             </Box>
             <Text variant={TextVariant.bodySm} marginBottom={4}>
               “API” means an application program interface.
@@ -1224,12 +1215,9 @@ export default function TermsOfUsePopup({ onClose, onAccept }) {
         </Box>
         {/* Not using ModalFooter since the confirm button text can't be changed to `agree`*/}
         <Box
-          className="terms-of-use-popup__footer"
-          display={Display.Flex}
-          flexDirection={FlexDirection.Column}
-          alignItems={AlignItems.center}
+          className="terms-of-use-popup__footer flex flex-col mx-4"
+          alignItems={BoxAlignItems.Center}
           marginTop={6}
-          marginInline={4}
           paddingTop={6}
           gap={6}
         >

--- a/ui/components/ui/form-field/form-field.js
+++ b/ui/components/ui/form-field/form-field.js
@@ -2,17 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'clsx';
 
+import { Box, BoxAlignItems } from '@metamask/design-system-react';
 import {
-  TextAlign,
   Display,
   TextVariant,
-  AlignItems,
   TextColor,
 } from '../../../helpers/constants/design-system';
 
 import NumericInput from '../numeric-input/numeric-input.component';
 import InfoTooltip from '../info-tooltip/info-tooltip';
-import { Text, Box } from '../../component-library';
+import { Text } from '../../component-library';
 
 /**
  * @deprecated The `<FormField />` component has been deprecated in favor of the new `<FormTextField>` component from the component-library.
@@ -59,124 +58,124 @@ export default function FormField({
         'form-field__row--error': error,
       })}
     >
-      <Box as="label" {...wrappingLabelProps}>
-        <div className="form-field__heading">
-          <Box
-            className="form-field__heading-title"
-            display={Display.Flex}
-            alignItems={AlignItems.baseline}
-            {...titleHeadingWrapperProps}
-          >
-            {TitleTextCustomComponent ||
-              (titleText && (
-                <Text
-                  as="h6"
-                  variant={TextVariant.bodySmBold}
-                  display={Display.InlineBlock}
-                >
-                  {titleText}
-                </Text>
-              ))}
-            {TitleUnitCustomComponent ||
-              (titleUnit && (
-                <Text
-                  as="h6"
-                  variant={TextVariant.bodySm}
-                  color={TextColor.textAlternative}
-                  display={Display.InlineBlock}
-                >
-                  {titleUnit}
-                </Text>
-              ))}
-            {TooltipCustomComponent ||
-              (tooltipText && (
-                <InfoTooltip position="top" contentText={tooltipText} />
-              ))}
-          </Box>
-          {titleDetail && (
+      <Box asChild {...wrappingLabelProps}>
+        <label>
+          <div className="form-field__heading">
             <Box
-              className="form-field__heading-detail"
-              textAlign={TextAlign.End}
-              marginRight={2}
-              {...titleDetailWrapperProps}
+              className="form-field__heading-title flex"
+              alignItems={BoxAlignItems.Baseline}
+              {...titleHeadingWrapperProps}
             >
-              {titleDetail}
+              {TitleTextCustomComponent ||
+                (titleText && (
+                  <Text
+                    as="h6"
+                    variant={TextVariant.bodySmBold}
+                    display={Display.InlineBlock}
+                  >
+                    {titleText}
+                  </Text>
+                ))}
+              {TitleUnitCustomComponent ||
+                (titleUnit && (
+                  <Text
+                    as="h6"
+                    variant={TextVariant.bodySm}
+                    color={TextColor.textAlternative}
+                    display={Display.InlineBlock}
+                  >
+                    {titleUnit}
+                  </Text>
+                ))}
+              {TooltipCustomComponent ||
+                (tooltipText && (
+                  <InfoTooltip position="top" contentText={tooltipText} />
+                ))}
             </Box>
+            {titleDetail && (
+              <Box
+                className="form-field__heading-detail text-right"
+                marginRight={2}
+                {...titleDetailWrapperProps}
+              >
+                {titleDetail}
+              </Box>
+            )}
+          </div>
+          {numeric ? (
+            <NumericInput
+              error={error}
+              onChange={onChange}
+              value={value}
+              detailText={detailText}
+              autoFocus={autoFocus}
+              allowDecimals={allowDecimals}
+              disabled={disabled}
+              dataTestId={dataTestId}
+              placeholder={placeholder}
+              id={id}
+              inputRef={inputRef}
+            />
+          ) : (
+            <input
+              className={classNames('form-field__input', {
+                'form-field__input--error': error,
+                'form-field__input--warning': warning,
+              })}
+              onChange={(e) => onChange(e.target.value)}
+              value={value}
+              type={password ? 'password' : 'text'}
+              autoFocus={autoFocus}
+              disabled={disabled}
+              data-testid={dataTestId}
+              placeholder={placeholder}
+              id={id}
+              ref={inputRef}
+              {...inputProps}
+            />
           )}
-        </div>
-        {numeric ? (
-          <NumericInput
-            error={error}
-            onChange={onChange}
-            value={value}
-            detailText={detailText}
-            autoFocus={autoFocus}
-            allowDecimals={allowDecimals}
-            disabled={disabled}
-            dataTestId={dataTestId}
-            placeholder={placeholder}
-            id={id}
-            inputRef={inputRef}
-          />
-        ) : (
-          <input
-            className={classNames('form-field__input', {
-              'form-field__input--error': error,
-              'form-field__input--warning': warning,
-            })}
-            onChange={(e) => onChange(e.target.value)}
-            value={value}
-            type={password ? 'password' : 'text'}
-            autoFocus={autoFocus}
-            disabled={disabled}
-            data-testid={dataTestId}
-            placeholder={placeholder}
-            id={id}
-            ref={inputRef}
-            {...inputProps}
-          />
-        )}
-        {error && (
-          <Text
-            color={TextColor.errorDefault}
-            variant={TextVariant.bodySm}
-            as="h6"
-            className="form-field__error"
-          >
-            {error}
-          </Text>
-        )}
-        {warning && (
-          <Text
-            color={TextColor.textAlternative}
-            variant={TextVariant.bodySm}
-            as="h6"
-            className="form-field__warning"
-            {...warningProps}
-          >
-            {warning}
-          </Text>
-        )}
-        {passwordStrength && (
-          <Text
-            color={TextColor.textDefault}
-            variant={TextVariant.bodySm}
-            as="h6"
-            className="form-field__password-strength"
-          >
-            {passwordStrength}
-          </Text>
-        )}
-        {passwordStrengthText && (
-          <Text
-            color={TextColor.textAlternative}
-            variant={TextVariant.bodyXs}
-            as="h6"
-            className="form-field__password-strength-text"
-          >
-            {passwordStrengthText}
-          </Text>
-        )}
+          {error && (
+            <Text
+              color={TextColor.errorDefault}
+              variant={TextVariant.bodySm}
+              as="h6"
+              className="form-field__error"
+            >
+              {error}
+            </Text>
+          )}
+          {warning && (
+            <Text
+              color={TextColor.textAlternative}
+              variant={TextVariant.bodySm}
+              as="h6"
+              className="form-field__warning"
+              {...warningProps}
+            >
+              {warning}
+            </Text>
+          )}
+          {passwordStrength && (
+            <Text
+              color={TextColor.textDefault}
+              variant={TextVariant.bodySm}
+              as="h6"
+              className="form-field__password-strength"
+            >
+              {passwordStrength}
+            </Text>
+          )}
+          {passwordStrengthText && (
+            <Text
+              color={TextColor.textAlternative}
+              variant={TextVariant.bodyXs}
+              as="h6"
+              className="form-field__password-strength-text"
+            >
+              {passwordStrengthText}
+            </Text>
+          )}
+        </label>
       </Box>
     </div>
   );

--- a/ui/pages/confirm-add-suggested-nft/__snapshots__/confirm-add-suggested-nft.test.js.snap
+++ b/ui/pages/confirm-add-suggested-nft/__snapshots__/confirm-add-suggested-nft.test.js.snap
@@ -9,10 +9,10 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
     />
     <div>
       <div
-        class="mm-box confirm-add-suggested-nft page-container h-full confirm-add-suggested-nft--has-app-header-multichain mm-box--display-flex mm-box--flex-direction-column mm-box--width-full mm-box--height-full"
+        class="flex-col flex w-full confirm-add-suggested-nft page-container h-full confirm-add-suggested-nft--has-app-header-multichain"
       >
         <div
-          class="mm-box confirm-add-suggested-nft__header mm-box--padding-bottom-2"
+          class="pb-2 confirm-add-suggested-nft__header"
         >
           <div
             class="box network-account-balance-header box--padding-4 box--display-flex box--flex-direction-row box--justify-content-space-between box--align-items-center"
@@ -111,7 +111,7 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
             </div>
           </div>
           <div
-            class="mm-box mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-flex mm-box--justify-content-center"
+            class="justify-center pt-4 pr-4 pl-4 flex"
           >
             <div
               class="site-origin"
@@ -158,16 +158,16 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
           </p>
         </div>
         <div
-          class="mm-box page-container__content confirm-add-suggested-nft__content"
+          class="page-container__content confirm-add-suggested-nft__content"
         >
           <div
-            class="mm-box confirm-add-suggested-nft__card mm-box--padding-2 mm-box--rounded-md"
+            class="p-2 rounded-md confirm-add-suggested-nft__card"
           >
             <div
-              class="mm-box"
+              class=""
             >
               <div
-                class="mm-box confirm-add-suggested-nft__nft-single mm-box--margin-0 mm-box--padding-0 mm-box--rounded-md"
+                class="m-0 p-0 rounded-md confirm-add-suggested-nft__nft-single"
               >
                 <div
                   class="mm-box confirm-add-suggested-nft__nft-single-image-default nft-default mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--rounded-lg"
@@ -175,10 +175,10 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
                   tabindex="0"
                 />
                 <div
-                  class="mm-box mm-box--padding-1 mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between"
+                  class="flex-row items-center justify-between p-1 flex"
                 >
                   <div
-                    class="mm-box confirm-add-suggested-nft__nft-single-sub-details mm-box--display-flex mm-box--flex-direction-column mm-box--flex-wrap-nowrap mm-box--justify-content-space-evenly mm-box--width-full"
+                    class="flex-col flex-nowrap justify-evenly flex w-full confirm-add-suggested-nft__nft-single-sub-details"
                   >
                     <a
                       class="mm-box mm-text mm-button-base confirm-add-suggested-nft__nft-name mm-button-link mm-button-link--size-inherit mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
@@ -223,10 +223,10 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
   </body>,
   "container": <div>
     <div
-      class="mm-box confirm-add-suggested-nft page-container h-full confirm-add-suggested-nft--has-app-header-multichain mm-box--display-flex mm-box--flex-direction-column mm-box--width-full mm-box--height-full"
+      class="flex-col flex w-full confirm-add-suggested-nft page-container h-full confirm-add-suggested-nft--has-app-header-multichain"
     >
       <div
-        class="mm-box confirm-add-suggested-nft__header mm-box--padding-bottom-2"
+        class="pb-2 confirm-add-suggested-nft__header"
       >
         <div
           class="box network-account-balance-header box--padding-4 box--display-flex box--flex-direction-row box--justify-content-space-between box--align-items-center"
@@ -325,7 +325,7 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
           </div>
         </div>
         <div
-          class="mm-box mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-flex mm-box--justify-content-center"
+          class="justify-center pt-4 pr-4 pl-4 flex"
         >
           <div
             class="site-origin"
@@ -372,16 +372,16 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
         </p>
       </div>
       <div
-        class="mm-box page-container__content confirm-add-suggested-nft__content"
+        class="page-container__content confirm-add-suggested-nft__content"
       >
         <div
-          class="mm-box confirm-add-suggested-nft__card mm-box--padding-2 mm-box--rounded-md"
+          class="p-2 rounded-md confirm-add-suggested-nft__card"
         >
           <div
-            class="mm-box"
+            class=""
           >
             <div
-              class="mm-box confirm-add-suggested-nft__nft-single mm-box--margin-0 mm-box--padding-0 mm-box--rounded-md"
+              class="m-0 p-0 rounded-md confirm-add-suggested-nft__nft-single"
             >
               <div
                 class="mm-box confirm-add-suggested-nft__nft-single-image-default nft-default mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--rounded-lg"
@@ -389,10 +389,10 @@ exports[`ConfirmAddSuggestedNFT Component should match snapshot 1`] = `
                 tabindex="0"
               />
               <div
-                class="mm-box mm-box--padding-1 mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between"
+                class="flex-row items-center justify-between p-1 flex"
               >
                 <div
-                  class="mm-box confirm-add-suggested-nft__nft-single-sub-details mm-box--display-flex mm-box--flex-direction-column mm-box--flex-wrap-nowrap mm-box--justify-content-space-evenly mm-box--width-full"
+                  class="flex-col flex-nowrap justify-evenly flex w-full confirm-add-suggested-nft__nft-single-sub-details"
                 >
                   <a
                     class="mm-box mm-text mm-button-base confirm-add-suggested-nft__nft-name mm-button-link mm-button-link--size-inherit mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"

--- a/ui/pages/confirm-add-suggested-nft/confirm-add-suggested-nft.js
+++ b/ui/pages/confirm-add-suggested-nft/confirm-add-suggested-nft.js
@@ -4,6 +4,13 @@ import { useNavigate, useLocation } from 'react-router-dom';
 import { providerErrors, serializeError } from '@metamask/rpc-errors';
 import { getTokenTrackerLink } from '@metamask/etherscan-link';
 import classnames from 'clsx';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxFlexWrap,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
 import { PageContainerFooter } from '../../components/ui/page-container';
 import { I18nContext } from '../../contexts/i18n';
 import { MetaMetricsContext } from '../../contexts/metametrics';
@@ -24,7 +31,6 @@ import {
   ButtonIconSize,
   ButtonLink,
   IconName,
-  Box,
   Text,
 } from '../../components/component-library';
 import { getCurrentChainId } from '../../../shared/lib/selectors/networks';
@@ -40,16 +46,9 @@ import { getSelectedInternalAccount } from '../../../shared/lib/selectors/accoun
 import NftDefaultImage from '../../components/app/assets/nfts/nft-default-image/nft-default-image';
 import { getAssetImageURL, shortenAddress } from '../../helpers/utils/util';
 import {
-  AlignItems,
-  BorderRadius,
-  Display,
-  FlexDirection,
-  FlexWrap,
   IconColor,
-  JustifyContent,
   TextAlign,
   TextVariant,
-  BlockSize,
   TextColor,
 } from '../../helpers/constants/design-system';
 import NetworkAccountBalanceHeader from '../../components/app/network-account-balance-header/network-account-balance-header';
@@ -195,11 +194,8 @@ const ConfirmAddSuggestedNFT = () => {
 
   return (
     <Box
-      className={classNames}
-      height={BlockSize.Full}
-      width={BlockSize.Full}
-      display={Display.Flex}
-      flexDirection={FlexDirection.Column}
+      className={`flex h-full w-full ${classNames}`}
+      flexDirection={BoxFlexDirection.Column}
     >
       <Nav confirmationId={approvalId} />
       <Box paddingBottom={2} className="confirm-add-suggested-nft__header">
@@ -211,11 +207,11 @@ const ConfirmAddSuggestedNFT = () => {
           chainId={chainId}
         />
         <Box
+          className="flex"
           paddingTop={4}
           paddingRight={4}
           paddingLeft={4}
-          display={Display.Flex}
-          justifyContent={JustifyContent.center}
+          justifyContent={BoxJustifyContent.Center}
         >
           <SiteOrigin
             chip
@@ -252,11 +248,7 @@ const ConfirmAddSuggestedNFT = () => {
         </Text>
       </Box>
       <Box className="page-container__content confirm-add-suggested-nft__content">
-        <Box
-          className="confirm-add-suggested-nft__card"
-          padding={2}
-          borderRadius={BorderRadius.MD}
-        >
+        <Box className="rounded-md confirm-add-suggested-nft__card" padding={2}>
           <Box
             className={classnames({
               'confirm-add-suggested-nft__nft-list': suggestedNfts.length > 1,
@@ -294,9 +286,8 @@ const ConfirmAddSuggestedNFT = () => {
                 if (suggestedNfts.length === 1) {
                   return (
                     <Box
-                      className="confirm-add-suggested-nft__nft-single"
+                      className="rounded-md confirm-add-suggested-nft__nft-single"
                       key={`confirm-add-suggested-nft__nft-single-${id}`}
-                      borderRadius={BorderRadius.MD}
                       margin={0}
                       padding={0}
                     >
@@ -314,19 +305,17 @@ const ConfirmAddSuggestedNFT = () => {
                         />
                       )}
                       <Box
+                        className="flex"
                         padding={1}
-                        display={Display.Flex}
-                        flexDirection={FlexDirection.Row}
-                        justifyContent={JustifyContent.spaceBetween}
-                        alignItems={AlignItems.Center}
+                        flexDirection={BoxFlexDirection.Row}
+                        justifyContent={BoxJustifyContent.Between}
+                        alignItems={BoxAlignItems.Center}
                       >
                         <Box
-                          display={Display.Flex}
-                          flexDirection={FlexDirection.Column}
-                          justifyContent={JustifyContent.spaceEvenly}
-                          flexWrap={FlexWrap.NoWrap}
-                          width={BlockSize.Full}
-                          className="confirm-add-suggested-nft__nft-single-sub-details"
+                          className="flex w-full confirm-add-suggested-nft__nft-single-sub-details"
+                          flexDirection={BoxFlexDirection.Column}
+                          justifyContent={BoxJustifyContent.Evenly}
+                          flexWrap={BoxFlexWrap.NoWrap}
                         >
                           {rpcPrefs.blockExplorerUrl ? (
                             <ButtonLink
@@ -361,21 +350,20 @@ const ConfirmAddSuggestedNFT = () => {
                 }
                 return (
                   <Box
-                    display={Display.Flex}
-                    flexDirection={FlexDirection.Row}
-                    flexWrap={FlexWrap.NoWrap}
-                    alignItems={AlignItems.Center}
-                    justifyContent={JustifyContent.spaceBetween}
+                    className="flex confirm-add-suggested-nft__nft-list-item"
+                    flexDirection={BoxFlexDirection.Row}
+                    flexWrap={BoxFlexWrap.NoWrap}
+                    alignItems={BoxAlignItems.Center}
+                    justifyContent={BoxJustifyContent.Between}
                     marginBottom={4}
-                    className="confirm-add-suggested-nft__nft-list-item"
                     key={`${address}-${tokenId}`}
                   >
                     <Box
-                      display={Display.Flex}
-                      flexDirection={FlexDirection.Row}
-                      flexWrap={FlexWrap.NoWrap}
-                      alignItems={AlignItems.Center}
-                      justifyContent={JustifyContent.spaceBetween}
+                      className="flex"
+                      flexDirection={BoxFlexDirection.Row}
+                      flexWrap={BoxFlexWrap.NoWrap}
+                      alignItems={BoxAlignItems.Center}
+                      justifyContent={BoxJustifyContent.Between}
                     >
                       {nftImageURL ? (
                         <img
@@ -387,12 +375,10 @@ const ConfirmAddSuggestedNFT = () => {
                         <NftDefaultImage className="confirm-add-suggested-nft__nft-image-default" />
                       )}
                       <Box
-                        display={Display.Flex}
-                        flexDirection={FlexDirection.Column}
-                        justifyContent={JustifyContent.spaceEvenly}
-                        flexWrap={FlexWrap.NoWrap}
-                        width={BlockSize.Full}
-                        className="confirm-add-suggested-nft__nft-sub-details"
+                        className="flex w-full confirm-add-suggested-nft__nft-sub-details"
+                        flexDirection={BoxFlexDirection.Column}
+                        justifyContent={BoxJustifyContent.Evenly}
+                        flexWrap={BoxFlexWrap.NoWrap}
                       >
                         {rpcPrefs.blockExplorerUrl ? (
                           <ButtonLink

--- a/ui/pages/permissions-connect/redirect/permissions-redirect.component.js
+++ b/ui/pages/permissions-connect/redirect/permissions-redirect.component.js
@@ -52,7 +52,8 @@ export default function PermissionsRedirect({ subjectMetadata }) {
         alignItems={BoxAlignItems.Center}
         justifyContent={BoxJustifyContent.Center}
         backgroundColor={BoxBackgroundColor.BackgroundDefault}
-        border={`1px solid ${BoxBorderColor.BorderMuted}`}
+        borderColor={BoxBorderColor.BorderMuted}
+        borderWidth={1}
         boxShadow="var(--shadow-size-lg) var(--color-shadow-default)"
       >
         <Box className="flex" marginBottom={4}>

--- a/ui/pages/permissions-connect/redirect/permissions-redirect.component.js
+++ b/ui/pages/permissions-connect/redirect/permissions-redirect.component.js
@@ -1,22 +1,22 @@
 import React, { useContext, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
 import {
-  JustifyContent,
-  AlignItems,
-  Display,
-  TextVariant,
+  Box,
+  BoxAlignItems,
+  BoxBackgroundColor,
+  BoxBorderColor,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
+import {
   BlockSize,
-  BorderColor,
-  FlexDirection,
-  BackgroundColor,
-  BorderRadius,
+  TextVariant,
   IconColor,
 } from '../../../helpers/constants/design-system';
 import { I18nContext } from '../../../contexts/i18n';
 import {
   AvatarToken,
   AvatarTokenSize,
-  Box,
   Button,
   ButtonSize,
   ButtonVariant,
@@ -42,31 +42,25 @@ export default function PermissionsRedirect({ subjectMetadata }) {
 
   return (
     <Box
-      display={Display.Flex}
-      flexDirection={FlexDirection.Column}
-      width={BlockSize.Full}
-      height={BlockSize.Full}
-      justifyContent={JustifyContent.spaceBetween}
+      className="flex h-full w-full"
+      flexDirection={BoxFlexDirection.Column}
+      justifyContent={BoxJustifyContent.Between}
     >
       <Box
-        display={Display.Flex}
-        flexDirection={FlexDirection.Column}
-        alignItems={AlignItems.center}
-        justifyContent={JustifyContent.center}
-        width={BlockSize.Full}
-        height={BlockSize.Full}
-        backgroundColor={BackgroundColor.backgroundDefault}
-        borderRadius={BorderRadius.XS}
-        border={`1px solid ${BorderColor.borderMuted}`}
+        className="flex h-full w-full rounded-sm"
+        flexDirection={BoxFlexDirection.Column}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Center}
+        backgroundColor={BoxBackgroundColor.BackgroundDefault}
+        border={`1px solid ${BoxBorderColor.BorderMuted}`}
         boxShadow="var(--shadow-size-lg) var(--color-shadow-default)"
       >
-        <Box display={Display.Flex} marginBottom={4}>
+        <Box className="flex" marginBottom={4}>
           <Text variant={TextVariant.headingMd}>{t('connecting')}</Text>
         </Box>
         <Box
-          display={Display.Flex}
-          backgroundColor={BackgroundColor.infoMuted}
-          borderRadius={BorderRadius.pill}
+          className="flex rounded-full"
+          backgroundColor={BoxBackgroundColor.InfoMuted}
           padding={2}
         >
           <AvatarToken
@@ -75,9 +69,9 @@ export default function PermissionsRedirect({ subjectMetadata }) {
             size={AvatarTokenSize.Lg}
           />
           <Box
-            display={Display.Flex}
-            alignItems={AlignItems.center}
-            justifyContent={JustifyContent.center}
+            className="flex"
+            alignItems={BoxAlignItems.Center}
+            justifyContent={BoxJustifyContent.Center}
             paddingLeft={4}
             paddingRight={4}
           >
@@ -94,15 +88,14 @@ export default function PermissionsRedirect({ subjectMetadata }) {
           />
         </Box>
       </Box>
-      <Box backgroundColor={BackgroundColor.backgroundDefault} padding={4}>
-        <Box display={Display.Flex} flexDirection={FlexDirection.Column}>
+      <Box backgroundColor={BoxBackgroundColor.BackgroundDefault} padding={4}>
+        <Box className="flex" flexDirection={BoxFlexDirection.Column}>
           <PermissionsConnectFooter />
           <Box
-            display={Display.Flex}
+            className="flex w-full"
             paddingTop={4}
-            width={BlockSize.Full}
-            justifyContent={JustifyContent.center}
-            alignItems={AlignItems.center}
+            justifyContent={BoxJustifyContent.Center}
+            alignItems={BoxAlignItems.Center}
           >
             <Button
               variant={ButtonVariant.Secondary}

--- a/ui/pages/smart-transactions/smart-transaction-status-page/__snapshots__/smart-transactions-status-page.test.tsx.snap
+++ b/ui/pages/smart-transactions/smart-transaction-status-page/__snapshots__/smart-transactions-status-page.test.tsx.snap
@@ -3,14 +3,14 @@
 exports[`SmartTransactionStatusPage renders the "failed" STX status: smart-transaction-status-failed 1`] = `
 <div>
   <div
-    class="mm-box smart-transaction-status-page mm-box--margin-bottom-0 mm-box--display-flex mm-box--flex-direction-column mm-box--align-items-center mm-box--width-full mm-box--height-full mm-box--border-style-none"
+    class="flex-col items-center mb-0 flex h-full w-full smart-transaction-status-page"
   >
     <div
-      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--align-items-center mm-box--width-full"
+      class="flex-col items-center justify-center flex w-full"
       style="flex-grow: 1;"
     >
       <div
-        class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--align-items-center mm-box--width-full"
+        class="flex-col items-center flex w-full"
       >
         <div
           data-status="reverted"
@@ -22,7 +22,7 @@ exports[`SmartTransactionStatusPage renders the "failed" STX status: smart-trans
           Your transaction failed
         </h4>
         <div
-          class="mm-box smart-transaction-status-page__description mm-box--display-flex mm-box--flex-direction-column mm-box--align-items-center"
+          class="flex-col items-center flex smart-transaction-status-page__description"
         >
           <p
             class="mm-box mm-text mm-text--body-sm mm-box--margin-top-2 mm-box--color-text-alternative"
@@ -31,7 +31,7 @@ exports[`SmartTransactionStatusPage renders the "failed" STX status: smart-trans
           </p>
         </div>
         <div
-          class="mm-box mm-box--margin-top-2 mm-box--display-flex mm-box--flex-direction-column"
+          class="flex-col mt-2 flex"
         >
           <button
             class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
@@ -43,7 +43,7 @@ exports[`SmartTransactionStatusPage renders the "failed" STX status: smart-trans
       </div>
     </div>
     <div
-      class="mm-box smart-transaction-status-page__footer mm-box--padding-4 mm-box--padding-bottom-0 mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
+      class="flex-col p-4 pb-0 flex w-full smart-transaction-status-page__footer"
     >
       <button
         class="mm-box mm-text mm-button-base mm-button-base--size-md mm-button-secondary mm-text--body-md-medium mm-box--margin-top-3 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--width-full mm-box--color-text-default mm-box--background-color-background-muted mm-box--rounded-xl"
@@ -59,14 +59,14 @@ exports[`SmartTransactionStatusPage renders the "failed" STX status: smart-trans
 exports[`SmartTransactionStatusPage renders the "pending" STX status: smart-transaction-status-pending 1`] = `
 <div>
   <div
-    class="mm-box smart-transaction-status-page mm-box--margin-bottom-0 mm-box--display-flex mm-box--flex-direction-column mm-box--align-items-center mm-box--width-full mm-box--height-full mm-box--border-style-none"
+    class="flex-col items-center mb-0 flex h-full w-full smart-transaction-status-page"
   >
     <div
-      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--align-items-center mm-box--width-full"
+      class="flex-col items-center justify-center flex w-full"
       style="flex-grow: 1;"
     >
       <div
-        class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--align-items-center mm-box--width-full"
+        class="flex-col items-center flex w-full"
       >
         <div
           data-status="pending"
@@ -78,7 +78,7 @@ exports[`SmartTransactionStatusPage renders the "pending" STX status: smart-tran
           Your transaction was submitted
         </h4>
         <div
-          class="mm-box mm-box--margin-top-2 mm-box--display-flex mm-box--flex-direction-column"
+          class="flex-col mt-2 flex"
         >
           <button
             class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
@@ -90,7 +90,7 @@ exports[`SmartTransactionStatusPage renders the "pending" STX status: smart-tran
       </div>
     </div>
     <div
-      class="mm-box smart-transaction-status-page__footer mm-box--padding-4 mm-box--padding-bottom-0 mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
+      class="flex-col p-4 pb-0 flex w-full smart-transaction-status-page__footer"
     >
       <button
         class="mm-box mm-text mm-button-base mm-button-base--size-md mm-button-secondary mm-text--body-md-medium mm-box--margin-top-3 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--width-full mm-box--color-text-default mm-box--background-color-background-muted mm-box--rounded-xl"
@@ -106,14 +106,14 @@ exports[`SmartTransactionStatusPage renders the "pending" STX status: smart-tran
 exports[`SmartTransactionStatusPage renders the "success" STX status: smart-transaction-status-success 1`] = `
 <div>
   <div
-    class="mm-box smart-transaction-status-page mm-box--margin-bottom-0 mm-box--display-flex mm-box--flex-direction-column mm-box--align-items-center mm-box--width-full mm-box--height-full mm-box--border-style-none"
+    class="flex-col items-center mb-0 flex h-full w-full smart-transaction-status-page"
   >
     <div
-      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--align-items-center mm-box--width-full"
+      class="flex-col items-center justify-center flex w-full"
       style="flex-grow: 1;"
     >
       <div
-        class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--align-items-center mm-box--width-full"
+        class="flex-col items-center flex w-full"
       >
         <div
           data-status="success"
@@ -125,7 +125,7 @@ exports[`SmartTransactionStatusPage renders the "success" STX status: smart-tran
           Your transaction is complete
         </h4>
         <div
-          class="mm-box mm-box--margin-top-2 mm-box--display-flex mm-box--flex-direction-column"
+          class="flex-col mt-2 flex"
         >
           <button
             class="mm-box mm-text mm-button-base mm-button-link mm-button-link--size-auto mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-0 mm-box--padding-left-0 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent"
@@ -137,7 +137,7 @@ exports[`SmartTransactionStatusPage renders the "success" STX status: smart-tran
       </div>
     </div>
     <div
-      class="mm-box smart-transaction-status-page__footer mm-box--padding-4 mm-box--padding-bottom-0 mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
+      class="flex-col p-4 pb-0 flex w-full smart-transaction-status-page__footer"
     >
       <button
         class="mm-box mm-text mm-button-base mm-button-base--size-md mm-button-secondary mm-text--body-md-medium mm-box--margin-top-3 mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--width-full mm-box--color-text-default mm-box--background-color-background-muted mm-box--rounded-xl"

--- a/ui/pages/smart-transactions/smart-transaction-status-page/smart-transaction-status-page.tsx
+++ b/ui/pages/smart-transactions/smart-transaction-status-page/smart-transaction-status-page.tsx
@@ -7,6 +7,11 @@ import {
 
 import {
   Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
+import {
   Text,
   IconName,
   Button,
@@ -14,12 +19,7 @@ import {
   ButtonSecondary,
 } from '../../../components/component-library';
 import {
-  AlignItems,
   BlockSize,
-  BorderStyle,
-  Display,
-  FlexDirection,
-  JustifyContent,
   TextVariant,
   TextColor,
   FontWeight,
@@ -105,10 +105,9 @@ const Description = ({ description }: { description: string | undefined }) => {
 
   return (
     <Box
-      display={Display.Flex}
-      flexDirection={FlexDirection.Column}
-      alignItems={AlignItems.center}
-      className="smart-transaction-status-page__description"
+      className="flex smart-transaction-status-page__description"
+      flexDirection={BoxFlexDirection.Column}
+      alignItems={BoxAlignItems.Center}
     >
       <Text
         marginTop={2}
@@ -151,11 +150,7 @@ const PortfolioSmartTransactionStatusUrl = ({
     return null;
   }
   return (
-    <Box
-      display={Display.Flex}
-      flexDirection={FlexDirection.Column}
-      marginTop={2}
-    >
+    <Box className="flex" flexDirection={BoxFlexDirection.Column} marginTop={2}>
       <Button
         type="link"
         variant={ButtonVariant.Link}
@@ -248,10 +243,8 @@ const SmartTransactionsStatusPageFooter = ({
 }) => {
   return (
     <Box
-      className="smart-transaction-status-page__footer"
-      display={Display.Flex}
-      flexDirection={FlexDirection.Column}
-      width={BlockSize.Full}
+      className="flex w-full smart-transaction-status-page__footer"
+      flexDirection={BoxFlexDirection.Column}
       padding={4}
       paddingBottom={0}
     >
@@ -327,28 +320,22 @@ export const SmartTransactionStatusPage = ({
 
   return (
     <Box
-      className="smart-transaction-status-page"
-      height={BlockSize.Full}
-      width={BlockSize.Full}
-      display={Display.Flex}
-      borderStyle={BorderStyle.none}
-      flexDirection={FlexDirection.Column}
-      alignItems={AlignItems.center}
+      className="flex h-full w-full smart-transaction-status-page"
+      flexDirection={BoxFlexDirection.Column}
+      alignItems={BoxAlignItems.Center}
       marginBottom={0}
     >
       <Box
-        display={Display.Flex}
-        flexDirection={FlexDirection.Column}
-        alignItems={AlignItems.center}
-        justifyContent={JustifyContent.center}
-        width={BlockSize.Full}
+        className="flex w-full"
+        flexDirection={BoxFlexDirection.Column}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Center}
         style={{ flexGrow: 1 }}
       >
         <Box
-          display={Display.Flex}
-          flexDirection={FlexDirection.Column}
-          alignItems={AlignItems.center}
-          width={BlockSize.Full}
+          className="flex w-full"
+          flexDirection={BoxFlexDirection.Column}
+          alignItems={BoxAlignItems.Center}
         >
           <SmartTransactionStatusAnimation
             status={smartTransaction?.status as SmartTransactionStatuses}
@@ -364,7 +351,7 @@ export const SmartTransactionStatusPage = ({
           />
         </Box>
         {canShowSimulationDetails && (
-          <Box width={BlockSize.Full}>
+          <Box className="w-full">
             <SimulationDetails
               transaction={fullTxData}
               smartTransactionStatus={smartTransaction?.status?.toLowerCase()}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Use `Box` from DSR (no codeowners, part 2).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-433

## **Manual testing steps**

1. Check affected files
2. Open corresponding pages/component in extension to be sure that this PR doesn't introduce regressions

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="471" height="732" alt="image" src="https://github.com/user-attachments/assets/1c22e130-596b-44d7-93f9-81d3e374869f" />

### **After**

<img width="471" height="732" alt="image" src="https://github.com/user-attachments/assets/15eba276-d1e3-4757-8187-99aa8f5af6f2" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a UI refactor switching layout primitives to `@metamask/design-system-react` `Box` and utility classes; main risk is minor visual/layout regressions on the touched pages.
> 
> **Overview**
> Migrates multiple UI surfaces to use `Box` from `@metamask/design-system-react`, replacing legacy `Box` usage and many `Display`/`Flex*` constants with `Box*` enums plus `flex`/Tailwind-style utility classes.
> 
> This refactor touches permission status rendering, `TabBar` (wrapping actual `<button>` via `asChild`), Terms of Use popup layout (including ordered lists via `asChild`), the deprecated `FormField` label wrapper, the suggested-NFT confirmation page, and the permissions redirect screen. Jest snapshots for suggested NFT and smart transaction status pages are updated to match the new class output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46bfafdbafd4237e0755ad1792ed2b9d766f58d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->