### PR TITLE
feat: Box from DSR (no codeowners, part 3)

### DIFF
--- a/ui/components/app/confirm/info/row/__snapshots__/currency.test.tsx.snap
+++ b/ui/components/app/confirm/info/row/__snapshots__/currency.test.tsx.snap
@@ -46,4 +46,3 @@ exports[`ConfirmInfoRowCurrency should display value in user preferred currency 
   </div>
 </div>
 `;
-

--- a/ui/components/app/multichain-bridge-transaction-list-item/multichain-bridge-transaction-list-item.tsx
+++ b/ui/components/app/multichain-bridge-transaction-list-item/multichain-bridge-transaction-list-item.tsx
@@ -5,6 +5,7 @@ import { BigNumber } from 'bignumber.js';
 import { type Transaction, TransactionStatus } from '@metamask/keyring-api';
 import { type BridgeHistoryItem } from '@metamask/bridge-status-controller';
 import { StatusTypes } from '@metamask/bridge-controller';
+import { Box } from '@metamask/design-system-react';
 import {
   isBridgeComplete,
   isBridgeFailed,
@@ -17,8 +18,6 @@ import { ActivityListItem } from '../../multichain/activity-list-item/activity-l
 import Segment from '../../../pages/bridge/transaction-details/segment';
 import {
   Display,
-  FlexDirection,
-  BlockSize,
   TextColor,
   FontWeight,
   TextAlign,
@@ -26,7 +25,6 @@ import {
   BorderColor,
 } from '../../../helpers/constants/design-system';
 import {
-  Box,
   Text,
   BadgeWrapper,
   AvatarNetwork,
@@ -179,11 +177,7 @@ const MultichainBridgeTransactionListItem: React.FC<
       }
       title={title}
       subtitle={
-        <Box
-          display={Display.Flex}
-          flexDirection={FlexDirection.Column}
-          gap={1}
-        >
+        <Box className="flex flex-col" gap={1}>
           {isTerminalState ? (
             <TransactionStatusLabel
               error={{}}
@@ -195,20 +189,14 @@ const MultichainBridgeTransactionListItem: React.FC<
               }
             />
           ) : (
-            <Box
-              marginTop={0}
-              display={Display.Flex}
-              flexDirection={FlexDirection.Column}
-              gap={1}
-              width={BlockSize.Full}
-            >
+            <Box marginTop={0} className="flex flex-col w-full" gap={1}>
               <Text
                 color={TextColor.textAlternative}
                 variant={TextVariant.bodySm}
               >
                 {t('bridgeTransactionProgress', [txIndex])}
               </Text>
-              <Box display={Display.Flex} gap={2} width={BlockSize.Full}>
+              <Box className="flex w-full" gap={2}>
                 <Segment type={srcSegmentStatus} />
                 <Segment type={destSegmentStatus} />
               </Box>

--- a/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.tsx
+++ b/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.tsx
@@ -8,7 +8,6 @@ import {
 import { useSelector } from 'react-redux';
 import {
   Box,
-  BoxFlexDirection,
   BoxAlignItems,
   BoxJustifyContent,
 } from '@metamask/design-system-react';

--- a/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.tsx
+++ b/ui/components/app/multichain-transaction-details-modal/multichain-transaction-details-modal.tsx
@@ -7,10 +7,13 @@ import {
 } from '@metamask/keyring-api';
 import { useSelector } from 'react-redux';
 import {
-  Display,
-  FlexDirection,
+  Box,
+  BoxFlexDirection,
+  BoxAlignItems,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
+import {
   AlignItems,
-  JustifyContent,
   TextVariant,
   IconColor,
   FontWeight,
@@ -23,7 +26,6 @@ import {
   ModalContent,
   ModalHeader,
   Modal,
-  Box,
   Text,
   ModalFooter,
   Button,
@@ -76,11 +78,11 @@ const AccountRow = ({ label, address, chain }: Props) => {
   }
 
   return (
-    <Box display={Display.Flex} justifyContent={JustifyContent.spaceBetween}>
+    <Box className="flex" justifyContent={BoxJustifyContent.Between}>
       <Text variant={TextVariant.bodyMd} fontWeight={FontWeight.Medium}>
         {label}
       </Text>
-      <Box display={Display.Flex} alignItems={AlignItems.center} gap={1}>
+      <Box className="flex" alignItems={BoxAlignItems.Center} gap={1}>
         <ButtonLink
           size={ButtonLinkSize.Inherit}
           textProps={{
@@ -180,15 +182,11 @@ export function MultichainTransactionDetailsModal({
     }
 
     return (
-      <Box display={Display.Flex} justifyContent={JustifyContent.spaceBetween}>
+      <Box className="flex" justifyContent={BoxJustifyContent.Between}>
         <Text variant={TextVariant.bodyMd} fontWeight={FontWeight.Medium}>
           {label}
         </Text>
-        <Box
-          display={Display.Flex}
-          flexDirection={FlexDirection.Column}
-          alignItems={AlignItems.flexEnd}
-        >
+        <Box className="flex flex-col items-end">
           <Text variant={TextVariant.bodyMd} data-testid={dataTestId}>
             {asset.amount} {asset.unit}
           </Text>
@@ -218,8 +216,7 @@ export function MultichainTransactionDetailsModal({
       <ModalOverlay />
       <ModalContent
         modalDialogProps={{
-          display: Display.Flex,
-          flexDirection: FlexDirection.Column,
+          className: 'flex flex-col',
           padding: 4,
         }}
       >
@@ -240,17 +237,10 @@ export function MultichainTransactionDetailsModal({
           <Divider />
         </Box>
         <Box>
-          <Box
-            display={Display.Flex}
-            flexDirection={FlexDirection.Column}
-            gap={4}
-          >
+          <Box className="flex flex-col" gap={4}>
             {/* Status */}
             {status && (
-              <Box
-                display={Display.Flex}
-                justifyContent={JustifyContent.spaceBetween}
-              >
+              <Box className="flex" justifyContent={BoxJustifyContent.Between}>
                 <Text
                   variant={TextVariant.bodyMd}
                   fontWeight={FontWeight.Medium}
@@ -267,18 +257,11 @@ export function MultichainTransactionDetailsModal({
             )}
 
             {/* Transaction ID */}
-            <Box
-              display={Display.Flex}
-              justifyContent={JustifyContent.spaceBetween}
-            >
+            <Box className="flex" justifyContent={BoxJustifyContent.Between}>
               <Text variant={TextVariant.bodyMd} fontWeight={FontWeight.Medium}>
                 {t('notificationItemTransactionId')}
               </Text>
-              <Box
-                display={Display.Flex}
-                alignItems={AlignItems.center}
-                gap={1}
-              >
+              <Box className="flex" alignItems={BoxAlignItems.Center} gap={1}>
                 <ButtonLink
                   size={ButtonLinkSize.Inherit}
                   textProps={{
@@ -312,11 +295,7 @@ export function MultichainTransactionDetailsModal({
             <Divider />
           </Box>
 
-          <Box
-            display={Display.Flex}
-            flexDirection={FlexDirection.Column}
-            gap={4}
-          >
+          <Box className="flex flex-col" gap={4}>
             {/* From */}
             <AccountRow label={t('from')} address={fromAddress} chain={chain} />
 

--- a/ui/components/app/permission-cell/permission-cell.js
+++ b/ui/components/app/permission-cell/permission-cell.js
@@ -3,17 +3,18 @@ import PropTypes from 'prop-types';
 import classnames from 'clsx';
 import { useSelector } from 'react-redux';
 import {
-  AlignItems,
+  Box,
+  BoxFlexDirection,
+  BoxAlignItems,
+  BoxJustifyContent,
+  BoxFlexWrap,
+} from '@metamask/design-system-react';
+import {
   Color,
   IconColor,
-  JustifyContent,
   Size,
   TextColor,
   TextVariant,
-  Display,
-  BlockSize,
-  FlexWrap,
-  FlexDirection,
 } from '../../../helpers/constants/design-system';
 import {
   AvatarIcon,
@@ -22,7 +23,6 @@ import {
   IconName,
   IconSize,
   Text,
-  Box,
 } from '../../component-library';
 import Tooltip from '../../ui/tooltip';
 import { getRequestingNetworkInfo } from '../../../selectors';
@@ -110,14 +110,13 @@ const PermissionCell = ({
 
   return (
     <Box
-      className="permission-cell"
-      display={Display.Flex}
-      justifyContent={JustifyContent.center}
-      alignItems={AlignItems.flexStart}
+      className="permission-cell flex"
+      justifyContent={BoxJustifyContent.Center}
+      alignItems={BoxAlignItems.Start}
       paddingTop={2}
       paddingBottom={2}
     >
-      <Box display={Display.Flex}>
+      <Box className="flex">
         {typeof permissionIcon === 'string' ? (
           <AvatarIcon
             iconName={permissionIcon}
@@ -133,10 +132,9 @@ const PermissionCell = ({
         )}
       </Box>
       <Box
-        display={Display.Flex}
-        flexWrap={FlexWrap.Wrap}
-        flexDirection={FlexDirection.Column}
-        width={BlockSize.Full}
+        className="flex w-full"
+        flexWrap={BoxFlexWrap.Wrap}
+        flexDirection={BoxFlexDirection.Column}
         marginLeft={4}
         marginRight={4}
       >
@@ -159,7 +157,7 @@ const PermissionCell = ({
           />
         )}
       </Box>
-      <Box display={Display.Flex}>
+      <Box className="flex">
         {showOptions && snapId ? (
           <PermissionCellOptions
             snapId={snapId}

--- a/ui/components/app/permission-connect-header/permission-connect-header.js
+++ b/ui/components/app/permission-connect-header/permission-connect-header.js
@@ -2,9 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import {
   Box,
-  BoxFlexDirection,
   BoxAlignItems,
-  BoxJustifyContent,
   BoxBackgroundColor,
 } from '@metamask/design-system-react';
 import {

--- a/ui/components/app/permission-connect-header/permission-connect-header.js
+++ b/ui/components/app/permission-connect-header/permission-connect-header.js
@@ -1,20 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import {
+  Box,
+  BoxFlexDirection,
+  BoxAlignItems,
+  BoxJustifyContent,
+  BoxBackgroundColor,
+} from '@metamask/design-system-react';
+import {
   AlignItems,
+  Display,
   JustifyContent,
   TextColor,
   TextVariant,
-  Display,
-  BlockSize,
   FontWeight,
-  FlexDirection,
   BackgroundColor,
 } from '../../../helpers/constants/design-system';
 import {
   IconSize,
   Text,
-  Box,
   AvatarFavicon,
   AvatarBase,
 } from '../../component-library';
@@ -36,10 +40,9 @@ const PermissionConnectHeader = ({ requestId, origin, iconUrl }) => {
     <>
       <Nav confirmationId={requestId} />
       <Box
-        backgroundColor={BackgroundColor.backgroundDefault}
-        width={BlockSize.Full}
-        alignItems={AlignItems.center}
-        display={Display.Flex}
+        backgroundColor={BoxBackgroundColor.BackgroundDefault}
+        className="flex w-full"
+        alignItems={BoxAlignItems.Center}
         padding={4}
         style={{
           boxShadow: 'var(--shadow-size-lg) var(--color-shadow-default)',
@@ -70,8 +73,7 @@ const PermissionConnectHeader = ({ requestId, origin, iconUrl }) => {
         <Box
           marginLeft={4}
           marginRight={4}
-          display={Display.Flex}
-          flexDirection={FlexDirection.Column}
+          className="flex flex-col"
           style={{ overflow: 'hidden' }}
         >
           <Text ellipsis fontWeight={FontWeight.Medium}>

--- a/ui/components/app/permission-page-container/permission-page-container-content/permission-page-container-content.component.js
+++ b/ui/components/app/permission-page-container/permission-page-container-content/permission-page-container-content.component.js
@@ -6,20 +6,19 @@ import {
   Caip25EndowmentPermissionName,
   getPermittedEthChainIds,
 } from '@metamask/chain-agnostic-permission';
+import {
+  Box,
+  BoxAlignItems,
+  BoxJustifyContent,
+  BoxBackgroundColor,
+} from '@metamask/design-system-react';
 import PermissionsConnectPermissionList from '../../permissions-connect-permission-list';
 import {
-  AlignItems,
-  BackgroundColor,
-  BlockSize,
-  BorderRadius,
-  Display,
-  FlexDirection,
   FontWeight,
-  JustifyContent,
   TextAlign,
   TextVariant,
 } from '../../../../helpers/constants/design-system';
-import { Box, Text } from '../../../component-library';
+import { Text } from '../../../component-library';
 import { getURLHost } from '../../../../helpers/utils/util';
 
 export default class PermissionPageContainerContent extends PureComponent {
@@ -88,21 +87,17 @@ export default class PermissionPageContainerContent extends PureComponent {
     );
     return (
       <Box
-        className="permission-page-container-content"
-        display={Display.Flex}
-        flexDirection={FlexDirection.Column}
-        justifyContent={JustifyContent.flexStart}
-        alignItems={AlignItems.center}
-        height={BlockSize.Full}
+        className="permission-page-container-content flex flex-col h-full"
+        justifyContent={BoxJustifyContent.Start}
+        alignItems={BoxAlignItems.Center}
         paddingLeft={4}
         paddingRight={4}
-        backgroundColor={BackgroundColor.backgroundDefault}
+        backgroundColor={BoxBackgroundColor.BackgroundDefault}
       >
         <Box
-          display={Display.Flex}
-          flexDirection={FlexDirection.Column}
-          justifyContent={JustifyContent.center}
-          alignItems={AlignItems.center}
+          className="flex flex-col"
+          justifyContent={BoxJustifyContent.Center}
+          alignItems={BoxAlignItems.Center}
           paddingTop={4}
           paddingBottom={4}
         >
@@ -123,13 +118,12 @@ export default class PermissionPageContainerContent extends PureComponent {
           </Text>
         </Box>
         <Box
-          display={Display.Flex}
-          backgroundColor={BackgroundColor.backgroundDefault}
+          className="flex rounded-xl"
+          backgroundColor={BoxBackgroundColor.BackgroundDefault}
           paddingLeft={4}
           paddingRight={4}
           paddingTop={2}
           paddingBottom={2}
-          borderRadius={BorderRadius.XL}
         >
           <PermissionsConnectPermissionList
             isRequestApprovalPermittedChains={Boolean(

--- a/ui/components/app/permission-page-container/permission-page-container.component.js
+++ b/ui/components/app/permission-page-container/permission-page-container.component.js
@@ -11,6 +11,7 @@ import {
   getAllScopesFromCaip25CaveatValue,
 } from '@metamask/chain-agnostic-permission';
 import { SubjectType } from '@metamask/permission-controller';
+import { Box } from '@metamask/design-system-react';
 import { MetaMetricsEventCategory } from '../../../../shared/constants/metametrics';
 import PermissionsConnectFooter from '../permissions-connect-footer';
 import { RestrictedMethods } from '../../../../shared/constants/permissions';
@@ -18,11 +19,6 @@ import { RestrictedMethods } from '../../../../shared/constants/permissions';
 import SnapPrivacyWarning from '../snaps/snap-privacy-warning';
 import { getDedupedSnaps } from '../../../helpers/utils/util';
 
-import {
-  Display,
-  FlexDirection,
-} from '../../../helpers/constants/design-system';
-import { Box } from '../../component-library';
 import {
   getCaip25CaveatValueFromPermissions,
   getCaip25PermissionsResponse,
@@ -287,7 +283,7 @@ export default class PermissionPageContainer extends Component {
           selectedAccounts={selectedAccounts}
           allAccountsSelected={allAccountsSelected}
         />
-        <Box display={Display.Flex} flexDirection={FlexDirection.Column}>
+        <Box className="flex flex-col">
           {targetSubjectMetadata?.subjectType !== SubjectType.Snap && (
             <PermissionsConnectFooter />
           )}

--- a/ui/components/app/permissions-connect-footer/permissions-connect-footer.component.js
+++ b/ui/components/app/permissions-connect-footer/permissions-connect-footer.component.js
@@ -1,13 +1,13 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
-import ZENDESK_URLS from '../../../helpers/constants/zendesk-url';
 import {
-  AlignItems,
-  Display,
-  JustifyContent,
-  TextVariant,
-} from '../../../helpers/constants/design-system';
-import { Box, ButtonLink, ButtonLinkSize, Text } from '../../component-library';
+  Box,
+  BoxAlignItems,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
+import ZENDESK_URLS from '../../../helpers/constants/zendesk-url';
+import { TextVariant } from '../../../helpers/constants/design-system';
+import { ButtonLink, ButtonLinkSize, Text } from '../../component-library';
 
 export default class PermissionsConnectFooter extends Component {
   static contextTypes = {
@@ -18,9 +18,9 @@ export default class PermissionsConnectFooter extends Component {
     const { t } = this.context;
     return (
       <Box
-        display={Display.Flex}
-        alignItems={AlignItems.center}
-        justifyContent={JustifyContent.center}
+        className="flex"
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Center}
       >
         <Text variant={TextVariant.bodyMd}>
           {t('onlyConnectTrust', [

--- a/ui/components/app/permissions-connect-permission-list/permissions-connect-permission-list.js
+++ b/ui/components/app/permissions-connect-permission-list/permissions-connect-permission-list.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useSelector } from 'react-redux';
+import { Box } from '@metamask/design-system-react';
 import { getWeightedPermissions } from '../../../helpers/utils/permission';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { getSnapsMetadata } from '../../../selectors';
 import { getSnapName } from '../../../helpers/utils/util';
 import PermissionCell from '../permission-cell';
-import { Box } from '../../component-library';
 
 /**
  * Get one or more permission descriptions for a permission name.
@@ -53,22 +53,24 @@ export default function PermissionsConnectPermissionList({
   const snapsMetadata = useSelector(getSnapsMetadata);
 
   return (
-    <Box as="span">
-      {getWeightedPermissions({
-        t,
-        isRequestApprovalPermittedChains,
-        permissions,
-        getSubjectName: getSnapName(snapsMetadata),
-        subjectName,
-      }).map((permission, index) => {
-        return getDescriptionNode({
-          permission,
-          index,
-          accounts,
-          requestedChainIds,
-          caipChainIds,
-        });
-      })}
+    <Box asChild>
+      <span>
+        {getWeightedPermissions({
+          t,
+          isRequestApprovalPermittedChains,
+          permissions,
+          getSubjectName: getSnapName(snapsMetadata),
+          subjectName,
+        }).map((permission, index) => {
+          return getDescriptionNode({
+            permission,
+            index,
+            accounts,
+            requestedChainIds,
+            caipChainIds,
+          });
+        })}
+      </span>
     </Box>
   );
 }

--- a/ui/components/app/qr-hardware-popover/qr-hardware-sign-request/player.js
+++ b/ui/components/app/qr-hardware-popover/qr-hardware-sign-request/player.js
@@ -2,15 +2,15 @@ import React, { useEffect, useMemo, useState } from 'react';
 import { QRCodeSVG } from 'qrcode.react';
 import { UR, UREncoder } from '@ngraveio/bc-ur';
 import PropTypes from 'prop-types';
-import { useI18nContext } from '../../../../hooks/useI18nContext';
 import {
-  AlignItems,
-  Display,
-  FlexDirection,
-  TextAlign,
-} from '../../../../helpers/constants/design-system';
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+} from '@metamask/design-system-react';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { TextAlign } from '../../../../helpers/constants/design-system';
 import { PageContainerFooter } from '../../../ui/page-container';
-import { Text, Box } from '../../../component-library';
+import { Text } from '../../../component-library';
 
 // QR code configuration constants to help with memory optimization
 const QR_FRAGMENT_SIZE = 200;
@@ -43,9 +43,9 @@ const Player = ({ type, cbor, cancelQRHardwareSignRequest, toRead }) => {
       <Box
         paddingTop={4}
         paddingBottom={4}
-        display={Display.Flex}
-        alignItems={AlignItems.center}
-        flexDirection={FlexDirection.Column}
+        className="flex"
+        alignItems={BoxAlignItems.Center}
+        flexDirection={BoxFlexDirection.Column}
       >
         <div
           style={{

--- a/ui/components/app/recovery-phrase-reminder/recovery-phrase-reminder.js
+++ b/ui/components/app/recovery-phrase-reminder/recovery-phrase-reminder.js
@@ -1,21 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 // Helpers
 import {
+  AlignItems,
   TextAlign,
   TextVariant,
-  AlignItems,
-  Display,
-  FlexDirection,
-  BlockSize,
-  JustifyContent,
   TextColor,
 } from '../../../helpers/constants/design-system';
 import { ONBOARDING_REVEAL_SRP_ROUTE } from '../../../helpers/constants/routes';
 import {
-  Box,
   ButtonLink,
   ButtonLinkSize,
   ButtonPrimary,
@@ -44,9 +45,8 @@ export default function RecoveryPhraseReminder({ onConfirm }) {
       <ModalContent alignItems={AlignItems.center}>
         <ModalHeader onClose={onConfirm}>
           <Box
-            display={Display.Flex}
-            flexDirection={FlexDirection.Column}
-            alignItems={AlignItems.center}
+            className="flex flex-col"
+            alignItems={BoxAlignItems.Center}
             gap={4}
           >
             <Text variant={TextVariant.headingSm} textAlign={TextAlign.Center}>
@@ -56,10 +56,9 @@ export default function RecoveryPhraseReminder({ onConfirm }) {
         </ModalHeader>
         <ModalBody>
           <Box
-            width={BlockSize.Full}
-            display={Display.Flex}
-            alignItems={AlignItems.center}
-            justifyContent={JustifyContent.center}
+            className="flex w-full"
+            alignItems={BoxAlignItems.Center}
+            justifyContent={BoxJustifyContent.Center}
             marginBottom={4}
           >
             <img
@@ -74,11 +73,7 @@ export default function RecoveryPhraseReminder({ onConfirm }) {
           </Text>
         </ModalBody>
         <ModalFooter>
-          <Box
-            display={Display.Flex}
-            flexDirection={FlexDirection.Column}
-            gap={2}
-          >
+          <Box className="flex flex-col" gap={2}>
             <ButtonPrimary size={ButtonSize.Lg} block onClick={handleBackUp}>
               {t('recoveryPhraseReminderBackupStart')}
             </ButtonPrimary>

--- a/ui/components/app/recovery-phrase-reminder/recovery-phrase-reminder.js
+++ b/ui/components/app/recovery-phrase-reminder/recovery-phrase-reminder.js
@@ -4,7 +4,6 @@ import { useNavigate } from 'react-router-dom';
 import {
   Box,
   BoxAlignItems,
-  BoxFlexDirection,
   BoxJustifyContent,
 } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../hooks/useI18nContext';

--- a/ui/components/app/reveal-srp-list/reveal-srp-list.tsx
+++ b/ui/components/app/reveal-srp-list/reveal-srp-list.tsx
@@ -3,19 +3,16 @@ import { useNavigate } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { AuthConnection } from '@metamask/seedless-onboarding-controller';
 import { capitalize } from 'lodash';
-import { Box, Icon, IconName, IconSize, Text } from '../../component-library';
+import { Box, BoxAlignItems } from '@metamask/design-system-react';
+import { Icon, IconName, IconSize, Text } from '../../component-library';
 import { SrpList } from '../../multichain/multi-srp/srp-list/srp-list';
 import {
   TextVariant,
   TextColor,
   TextTransform,
   BackgroundColor,
-  Display,
-  FlexDirection,
-  AlignItems,
   IconColor,
   FontWeight,
-  BlockSize,
 } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
@@ -76,16 +73,11 @@ export const RevealSrpList = () => {
             border={false}
           >
             <Box
-              display={Display.Flex}
-              flexDirection={FlexDirection.Row}
-              alignItems={AlignItems.center}
+              className="flex flex-row"
+              alignItems={BoxAlignItems.Center}
               gap={3}
             >
-              <Box
-                display={Display.Flex}
-                alignItems={AlignItems.center}
-                gap={2}
-              >
+              <Box className="flex" alignItems={BoxAlignItems.Center} gap={2}>
                 {socialLoginType === AuthConnection.Apple ? (
                   <Icon
                     name={IconName.Apple}
@@ -100,7 +92,7 @@ export const RevealSrpList = () => {
                   />
                 )}
               </Box>
-              <Box flexDirection={FlexDirection.Column}>
+              <Box className="flex-col flex">
                 <Text fontWeight={FontWeight.Medium}>
                   {t('securitySocialLoginEnabled')}
                 </Text>
@@ -124,11 +116,7 @@ export const RevealSrpList = () => {
               capitalize(socialLoginType),
             ])}
           </Text>
-          <Box
-            width={BlockSize.Full}
-            className="srp-reveal-list__divider"
-            marginTop={4}
-          />
+          <Box className="srp-reveal-list__divider w-full" marginTop={4} />
         </Box>
       )}
       <Box

--- a/ui/components/app/srp-quiz-modal/QuizContent/QuizContent.tsx
+++ b/ui/components/app/srp-quiz-modal/QuizContent/QuizContent.tsx
@@ -36,7 +36,7 @@ export default function QuizContent({
         </Box>
       )}
       {image && (
-        <Box className="flex text-center mx-auto">
+        <Box className="flex text-center m-auto">
           <img
             src={image}
             alt={t('srpSecurityQuizImgAlt')}

--- a/ui/components/app/srp-quiz-modal/QuizContent/QuizContent.tsx
+++ b/ui/components/app/srp-quiz-modal/QuizContent/QuizContent.tsx
@@ -36,7 +36,7 @@ export default function QuizContent({
         </Box>
       )}
       {image && (
-        <Box className="flex text-center" margin="auto">
+        <Box className="flex text-center mx-auto">
           <img
             src={image}
             alt={t('srpSecurityQuizImgAlt')}

--- a/ui/components/app/srp-quiz-modal/QuizContent/QuizContent.tsx
+++ b/ui/components/app/srp-quiz-modal/QuizContent/QuizContent.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 import {
-  AlignItems,
+  Box,
+  BoxAlignItems,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
+import {
   BlockSize,
-  Display,
-  FlexDirection,
-  JustifyContent,
   TextAlign,
   TextVariant,
 } from '../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
-import { Button, Box, Text } from '../../../component-library';
+import { Button, Text } from '../../../component-library';
 import { IQuizInformationProps } from '../types';
 
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
@@ -27,16 +28,15 @@ export default function QuizContent({
     <>
       {icon && (
         <Box
-          display={Display.Flex}
-          flexDirection={FlexDirection.Row}
-          alignItems={AlignItems.center}
-          justifyContent={JustifyContent.center}
+          className="flex flex-row"
+          alignItems={BoxAlignItems.Center}
+          justifyContent={BoxJustifyContent.Center}
         >
           {icon}
         </Box>
       )}
       {image && (
-        <Box display={Display.Flex} margin="auto" textAlign={TextAlign.Center}>
+        <Box className="flex text-center" margin="auto">
           <img
             src={image}
             alt={t('srpSecurityQuizImgAlt')}

--- a/ui/components/app/update-modal/__snapshots__/update-modal.test.tsx.snap
+++ b/ui/components/app/update-modal/__snapshots__/update-modal.test.tsx.snap
@@ -55,7 +55,7 @@ exports[`UpdateModal renders correctly with required props 1`] = `
             class="mm-box mm-modal-body mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-flex mm-box--flex-direction-column"
           >
             <div
-              class="mm-box mm-box--padding-10 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--rounded-sm"
+              class="items-center justify-center p-10 flex rounded-sm"
             >
               <img
                 height="160"

--- a/ui/components/app/update-modal/update-modal.tsx
+++ b/ui/components/app/update-modal/update-modal.tsx
@@ -1,21 +1,22 @@
 import React, { useState, useEffect, useContext, useCallback } from 'react';
 import {
+  Box,
+  BoxAlignItems,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
+import {
   Modal,
   ModalContent,
   ModalOverlay,
   ModalBody,
   ModalFooter,
-  Box,
   Text,
   ModalHeader,
 } from '../../component-library';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
-  AlignItems,
   Display,
   FlexDirection,
-  JustifyContent,
-  BorderRadius,
   TextAlign,
   TextVariant,
 } from '../../../helpers/constants/design-system';
@@ -85,10 +86,9 @@ function UpdateModal() {
         />
         <ModalBody display={Display.Flex} flexDirection={FlexDirection.Column}>
           <Box
-            display={Display.Flex}
-            alignItems={AlignItems.center}
-            justifyContent={JustifyContent.center}
-            borderRadius={BorderRadius.SM}
+            className="flex rounded-sm"
+            alignItems={BoxAlignItems.Center}
+            justifyContent={BoxJustifyContent.Center}
             padding={10}
           >
             <img src="/images/logo/metamask-fox.svg" width={160} height={160} />

--- a/ui/components/app/wallet-overview/__snapshots__/aggregated-percentage-overview-cross-chains.test.tsx.snap
+++ b/ui/components/app/wallet-overview/__snapshots__/aggregated-percentage-overview-cross-chains.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`AggregatedPercentageOverviewCrossChains render renders correctly 1`] = `
 <div>
   <div
-    class="mm-box gap-1 mm-box--display-flex"
+    class="flex gap-1"
   >
     <p
       class="mm-box mm-text mm-text--body-md-medium mm-text--ellipsis mm-box--color-success-default"

--- a/ui/components/app/wallet-overview/__snapshots__/aggregated-percentage-overview.test.tsx.snap
+++ b/ui/components/app/wallet-overview/__snapshots__/aggregated-percentage-overview.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`AggregatedMultichainPercentageOverview render renders correctly with negative values 1`] = `
 <div>
   <div
-    class="mm-box mm-box--display-flex"
+    class="flex"
   >
     <p
       class="mm-box mm-text mm-text--body-md-medium mm-text--ellipsis mm-box--color-error-default"
@@ -30,7 +30,7 @@ exports[`AggregatedMultichainPercentageOverview render renders correctly with ne
 exports[`AggregatedMultichainPercentageOverview render renders correctly with positive values 1`] = `
 <div>
   <div
-    class="mm-box mm-box--display-flex"
+    class="flex"
   >
     <p
       class="mm-box mm-text mm-text--body-md-medium mm-text--ellipsis mm-box--color-success-default"
@@ -60,7 +60,7 @@ exports[`AggregatedMultichainPercentageOverview render renders correctly with ze
     class="mm-box mm-skeleton mm-box--background-color-icon-alternative mm-box--rounded-sm"
   >
     <div
-      class="mm-box mm-box--display-flex"
+      class="flex"
     >
       <p
         class="mm-box mm-text mm-text--body-md-medium mm-text--ellipsis mm-box--color-text-alternative"
@@ -91,7 +91,7 @@ exports[`AggregatedPercentageOverview render renders correctly 1`] = `
     class="mm-box mm-skeleton mm-box--background-color-icon-alternative mm-box--rounded-sm"
   >
     <div
-      class="mm-box gap-1 mm-box--display-flex"
+      class="flex gap-1"
     >
       <p
         class="mm-box mm-text mm-text--body-md-medium mm-text--ellipsis mm-box--color-text-alternative"

--- a/ui/components/app/wallet-overview/aggregated-percentage-overview-cross-chains.tsx
+++ b/ui/components/app/wallet-overview/aggregated-percentage-overview-cross-chains.tsx
@@ -4,6 +4,7 @@ import { useSelector } from 'react-redux';
 import { toChecksumAddress } from 'ethereumjs-util';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { Hex } from '@metamask/utils';
+import { Box } from '@metamask/design-system-react';
 import {
   getSelectedAccount,
   getShouldHideZeroBalanceTokens,
@@ -19,11 +20,10 @@ import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
 import { formatValue, isValidAmount } from '../../../../app/scripts/lib/util';
 import { useFormatters } from '../../../hooks/useFormatters';
 import {
-  Display,
   TextColor,
   TextVariant,
 } from '../../../helpers/constants/design-system';
-import { Box, SensitiveText } from '../../component-library';
+import { SensitiveText } from '../../component-library';
 import { getCalculatedTokenAmount1dAgo } from '../../../helpers/utils/util';
 import { useAccountTotalCrossChainFiatBalance } from '../../../hooks/useAccountTotalCrossChainFiatBalance';
 import { useGetFormattedTokensPerChain } from '../../../hooks/useGetFormattedTokensPerChain';
@@ -166,7 +166,7 @@ export const AggregatedPercentageOverviewCrossChains = ({
         isZeroAmount(formattedAmountChangeCrossChains)
       }
     >
-      <Box display={Display.Flex} className="gap-1">
+      <Box className="flex gap-1">
         <SensitiveText
           variant={TextVariant.bodyMdMedium}
           color={color}

--- a/ui/components/app/wallet-overview/aggregated-percentage-overview.tsx
+++ b/ui/components/app/wallet-overview/aggregated-percentage-overview.tsx
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { toChecksumAddress } from 'ethereumjs-util';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
+import { Box } from '@metamask/design-system-react';
 import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
 import {
   getSelectedAccount,
@@ -18,11 +19,10 @@ import { useAccountTotalFiatBalance } from '../../../hooks/useAccountTotalFiatBa
 import { formatValue, isValidAmount } from '../../../../app/scripts/lib/util';
 import { getIntlLocale } from '../../../ducks/locale/locale';
 import {
-  Display,
   TextColor,
   TextVariant,
 } from '../../../helpers/constants/design-system';
-import { Box, SensitiveText } from '../../component-library';
+import { SensitiveText } from '../../component-library';
 import { getCalculatedTokenAmount1dAgo } from '../../../helpers/utils/util';
 import { getHistoricalMultichainAggregatedBalance } from '../../../selectors/assets';
 import { formatWithThreshold } from '../assets/util/formatWithThreshold';
@@ -125,7 +125,7 @@ export const AggregatedPercentageOverview = ({
     <Skeleton
       isLoading={!anyEnabledNetworksAreAvailable && isZeroAmount(amountChange)}
     >
-      <Box display={Display.Flex} className="gap-1">
+      <Box className="flex gap-1">
         <SensitiveText
           variant={TextVariant.bodyMdMedium}
           color={color}
@@ -215,7 +215,7 @@ export const AggregatedMultichainPercentageOverview = ({
         !anyEnabledNetworksAreAvailable && isZeroAmount(singleDayAmountChange)
       }
     >
-      <Box display={Display.Flex}>
+      <Box className="flex">
         <SensitiveText
           variant={TextVariant.bodyMdMedium}
           color={color}

--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -11,6 +11,7 @@ import {
 import { getNativeAssetForChainId } from '@metamask/bridge-controller';
 
 import { InternalAccount } from '@metamask/keyring-internal-api';
+import { Box, BoxJustifyContent } from '@metamask/design-system-react';
 import { ChainId } from '../../../../shared/constants/network';
 import { transitionForward } from '../../ui/transition';
 
@@ -30,13 +31,8 @@ import {
   MetaMetricsSwapsEventSource,
 } from '../../../../shared/constants/metametrics';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
-import {
-  BlockSize,
-  Display,
-  IconColor,
-  JustifyContent,
-} from '../../../helpers/constants/design-system';
-import { Box, Icon, IconName, IconSize } from '../../component-library';
+import { BlockSize, IconColor } from '../../../helpers/constants/design-system';
+import { Icon, IconName, IconSize } from '../../component-library';
 import IconButton from '../../ui/icon-button';
 import useRamps from '../../../hooks/ramps/useRamps/useRamps';
 import useBridging from '../../../hooks/bridge/useBridging';
@@ -338,9 +334,8 @@ const CoinButtons = ({
 
   return (
     <Box
-      display={Display.Flex}
-      justifyContent={JustifyContent.spaceBetween}
-      width={BlockSize.Full}
+      className="flex w-full"
+      justifyContent={BoxJustifyContent.Between}
       gap={3}
     >
       <IconButton

--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -6,7 +6,8 @@ import { CaipChainId } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 
 import { InternalAccount } from '@metamask/keyring-internal-api';
-import { Box, ButtonLink, IconName } from '../../component-library';
+import { Box } from '@metamask/design-system-react';
+import { ButtonLink, IconName } from '../../component-library';
 import { TextVariant } from '../../../helpers/constants/design-system';
 import { getPortfolioUrl } from '../../../helpers/utils/portfolio';
 import { MetaMetricsContext } from '../../../contexts/metametrics';

--- a/ui/components/ui/aggregated-balance/aggregated-balance.tsx
+++ b/ui/components/ui/aggregated-balance/aggregated-balance.tsx
@@ -2,13 +2,9 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import classnames from 'clsx';
 import { MULTICHAIN_NETWORK_DECIMAL_PLACES } from '@metamask/multichain-network-controller';
-import {
-  AlignItems,
-  Display,
-  FlexWrap,
-  TextVariant,
-} from '../../../helpers/constants/design-system';
-import { Box, SensitiveText } from '../../component-library';
+import { Box, BoxAlignItems, BoxFlexWrap } from '@metamask/design-system-react';
+import { TextVariant } from '../../../helpers/constants/design-system';
+import { SensitiveText } from '../../component-library';
 import {
   getCurrentCurrency,
   getTokenBalances,
@@ -107,13 +103,12 @@ export const AggregatedBalance = ({
       marginBottom={1}
     >
       <Box
-        className={classnames(`${classPrefix}-overview__primary-balance`, {
+        className={classnames(`flex ${classPrefix}-overview__primary-balance`, {
           [`${classPrefix}-overview__cached-balance`]: balanceIsCached,
         })}
         data-testid={`${classPrefix}-overview__primary-currency`}
-        display={Display.Flex}
-        alignItems={AlignItems.center}
-        flexWrap={FlexWrap.Wrap}
+        alignItems={BoxAlignItems.Center}
+        flexWrap={BoxFlexWrap.Wrap}
       >
         <SensitiveText
           ellipsis

--- a/ui/components/ui/callout/callout.stories.js
+++ b/ui/components/ui/callout/callout.stories.js
@@ -1,11 +1,12 @@
 import React from 'react';
+import { Box } from '@metamask/design-system-react';
 import {
   BorderColor,
   SEVERITIES,
   TextVariant,
 } from '../../../helpers/constants/design-system';
 
-import { Text, Box } from '../../component-library';
+import { Text } from '../../component-library';
 import Callout from './callout';
 
 export default {

--- a/ui/components/ui/editable-label/editable-label.js
+++ b/ui/components/ui/editable-label/editable-label.js
@@ -1,14 +1,10 @@
 import React, { Component } from 'react';
 import classnames from 'clsx';
 import PropTypes from 'prop-types';
-import {
-  AlignItems,
-  Color,
-  Display,
-  TextVariant,
-} from '../../../helpers/constants/design-system';
+import { Box, BoxAlignItems } from '@metamask/design-system-react';
+import { Color, TextVariant } from '../../../helpers/constants/design-system';
 import { getAccountNameErrorMessage } from '../../../helpers/utils/accounts';
-import { ButtonIcon, IconName, Text, Box } from '../../component-library';
+import { ButtonIcon, IconName, Text } from '../../component-library';
 import { FormTextField } from '../../component-library/form-text-field/deprecated';
 
 export default class EditableLabel extends Component {
@@ -47,8 +43,7 @@ export default class EditableLabel extends Component {
 
     return (
       <Box
-        className={classnames('editable-label', this.props.className)}
-        display={Display.Flex}
+        className={classnames('flex editable-label', this.props.className)}
         gap={3}
       >
         <FormTextField
@@ -79,7 +74,7 @@ export default class EditableLabel extends Component {
 
   renderReadonly() {
     return (
-      <Box display={Display.Flex} alignItems={AlignItems.center} gap={3}>
+      <Box className="flex" alignItems={BoxAlignItems.Center} gap={3}>
         <Text
           variant={TextVariant.bodyLgMedium}
           style={{ wordBreak: 'break-word' }}

--- a/ui/components/ui/export-text-container/export-text-container.component.js
+++ b/ui/components/ui/export-text-container/export-text-container.component.js
@@ -25,7 +25,7 @@ function ExportTextContainer({ text = '', onClickCopy = null }) {
 
   return (
     <Box
-      className="flex rounded-md"
+      className="flex rounded-md border border-solid"
       justifyContent={BoxJustifyContent.Center}
       flexDirection={BoxFlexDirection.Column}
       alignItems={BoxAlignItems.Center}

--- a/ui/components/ui/export-text-container/export-text-container.component.js
+++ b/ui/components/ui/export-text-container/export-text-container.component.js
@@ -1,18 +1,21 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import {
+  Box,
+  BoxAlignItems,
+  BoxBorderColor,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
 import { MINUTE } from '../../../../shared/constants/time';
 import {
-  AlignItems,
-  BorderColor,
-  BorderRadius,
   Display,
-  FlexDirection,
   JustifyContent,
   TextVariant,
 } from '../../../helpers/constants/design-system';
 import { useCopyToClipboard } from '../../../hooks/useCopyToClipboard';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { Box, ButtonSecondary, Text } from '../../component-library';
+import { ButtonSecondary, Text } from '../../component-library';
 
 function ExportTextContainer({ text = '', onClickCopy = null }) {
   const t = useI18nContext();
@@ -22,12 +25,11 @@ function ExportTextContainer({ text = '', onClickCopy = null }) {
 
   return (
     <Box
-      display={Display.Flex}
-      justifyContent={JustifyContent.center}
-      flexDirection={FlexDirection.Column}
-      alignItems={AlignItems.center}
-      borderColor={BorderColor.borderDefault}
-      borderRadius={BorderRadius.MD}
+      className="flex rounded-md"
+      justifyContent={BoxJustifyContent.Center}
+      flexDirection={BoxFlexDirection.Column}
+      alignItems={BoxAlignItems.Center}
+      borderColor={BoxBorderColor.BorderDefault}
       padding={4}
       gap={4}
     >

--- a/ui/components/ui/loading-indicator/loading-indicator.js
+++ b/ui/components/ui/loading-indicator/loading-indicator.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Box } from '../../component-library';
+import { Box } from '@metamask/design-system-react';
 
 export default function LoadingIndicator({
   alt,

--- a/ui/components/ui/loading-screen/loading-screen.component.js
+++ b/ui/components/ui/loading-screen/loading-screen.component.js
@@ -1,13 +1,12 @@
 import React, { isValidElement } from 'react';
 import PropTypes from 'prop-types';
-import Spinner from '../spinner';
-import { Box } from '../../component-library';
 import {
-  AlignItems,
-  Display,
-  FlexDirection,
-  JustifyContent,
-} from '../../../helpers/constants/design-system';
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
+import Spinner from '../spinner';
 
 const LoadingScreen = ({
   header,
@@ -33,10 +32,10 @@ const LoadingScreen = ({
         {showLoadingSpinner && <Spinner className="loading-overlay__spinner" />}
       </Box>
       <Box
-        display={Display.Flex}
-        flexDirection={FlexDirection.Row}
-        justifyContent={JustifyContent.center}
-        alignItems={AlignItems.center}
+        className="flex"
+        flexDirection={BoxFlexDirection.Row}
+        justifyContent={BoxJustifyContent.Center}
+        alignItems={BoxAlignItems.Center}
       >
         {renderMessage()}
       </Box>

--- a/ui/components/ui/logo/logo.stories.js
+++ b/ui/components/ui/logo/logo.stories.js
@@ -1,8 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 
+import { Box } from '@metamask/design-system-react';
 import { BackgroundColor } from '../../../helpers/constants/design-system';
-import { Text, Box } from '../../component-library';
+import { Text } from '../../component-library';
 
 import Card from '../card';
 

--- a/ui/components/ui/qr-code-view/qr-code-view.tsx
+++ b/ui/components/ui/qr-code-view/qr-code-view.tsx
@@ -112,12 +112,11 @@ function QrCodeView({
         {addressEnd}
       </Text>
       <Box
-        className="flex"
         marginBottom={4}
         gap={2}
         alignItems={BoxAlignItems.Center}
         color={TextColor.primaryDefault}
-        className="qr-code__copy-button"
+        className="flex qr-code__copy-button"
         data-testid="address-copy-button-text"
         data-clipboard-text={checksummedAddress}
         onClick={() => {

--- a/ui/components/ui/qr-code-view/qr-code-view.tsx
+++ b/ui/components/ui/qr-code-view/qr-code-view.tsx
@@ -2,12 +2,11 @@ import PropTypes from 'prop-types';
 import React, { useContext } from 'react';
 import qrCode from 'qrcode-generator';
 import { isHexPrefixed } from 'ethereumjs-util';
+import { Box, BoxAlignItems } from '@metamask/design-system-react';
 import { normalizeSafeAddress } from '../../../../shared/lib/multichain/address';
-import { Box, Icon, IconName, IconSize, Text } from '../../component-library';
+import { Icon, IconName, IconSize, Text } from '../../component-library';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
-  AlignItems,
-  Display,
   IconColor,
   TextAlign,
   TextColor,
@@ -113,10 +112,10 @@ function QrCodeView({
         {addressEnd}
       </Text>
       <Box
-        display={Display.Flex}
+        className="flex"
         marginBottom={4}
         gap={2}
-        alignItems={AlignItems.center}
+        alignItems={BoxAlignItems.Center}
         color={TextColor.primaryDefault}
         className="qr-code__copy-button"
         data-testid="address-copy-button-text"

--- a/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
+++ b/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
@@ -40,10 +40,10 @@ exports[`AssetPage should render a native asset 1`] = `
       </p>
     </div>
     <div
-      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--rounded-lg"
+      class="flex-col flex rounded-lg"
     >
       <div
-        class="mm-box mm-box--margin-right-4 mm-box--margin-left-4"
+        class="mr-4 ml-4"
       >
         <h1
           class="mm-box mm-text mm-text--display-md mm-text--font-weight-medium mm-box--margin-bottom-1 mm-box--color-text-default mm-box--rounded-lg"
@@ -74,11 +74,11 @@ exports[`AssetPage should render a native asset 1`] = `
         </div>
       </div>
       <div
-        class="mm-box mm-box--margin-top-4 mm-box--display-flex mm-box--flex-direction-column mm-box--background-color-transparent mm-box--rounded-lg"
+        class="flex-col mt-4 bg-transparent flex rounded-lg"
         data-testid="asset-price-chart"
       >
         <div
-          class="mm-box asset-chart__empty-or-loading-state-container"
+          class="asset-chart__empty-or-loading-state-container"
           data-testid="asset-chart-loading"
         >
           <div
@@ -92,7 +92,7 @@ exports[`AssetPage should render a native asset 1`] = `
           </div>
         </div>
         <div
-          class="mm-box mm-box--margin-top-2 mm-box--margin-right-3 mm-box--margin-left-3 mm-box--display-flex mm-box--justify-content-space-between"
+          class="justify-between mt-2 mr-3 ml-3 flex"
         >
           <button
             class="mm-box mm-text mm-button-base mm-button-base--size-sm time-range-button time-range-button__selected mm-text--body-xs-medium mm-box--padding-0 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-alternative mm-box--background-color-transparent mm-box--rounded-xl"
@@ -131,7 +131,7 @@ exports[`AssetPage should render a native asset 1`] = `
       class="mt-4 pr-4 pl-4"
     >
       <div
-        class="mm-box mm-box--display-flex mm-box--gap-3 mm-box--justify-content-space-between mm-box--width-full"
+        class="gap-3 justify-between flex w-full"
       >
         <button
           class="mm-box mm-text mm-button-base mm-button-base--size-md icon-button coin-overview__button mm-text--body-md-medium mm-box--padding-0 mm-box--padding-top-3 mm-box--padding-right-2 mm-box--padding-bottom-3 mm-box--padding-left-2 mm-box--display-inline-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--align-items-center mm-box--width-full mm-box--color-text-default mm-box--background-color-background-muted mm-box--rounded-xl"
@@ -458,10 +458,10 @@ exports[`AssetPage should render an ERC20 asset without prices 1`] = `
       </p>
     </div>
     <div
-      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--rounded-lg"
+      class="flex-col flex rounded-lg"
     >
       <div
-        class="mm-box mm-box--margin-right-4 mm-box--margin-left-4"
+        class="mr-4 ml-4"
       >
         <h1
           class="mm-box mm-text mm-text--display-md mm-box--margin-bottom-1 mm-box--color-text-default"
@@ -475,11 +475,11 @@ exports[`AssetPage should render an ERC20 asset without prices 1`] = `
         </p>
       </div>
       <div
-        class="mm-box mm-box--margin-top-4 mm-box--display-flex mm-box--flex-direction-column mm-box--background-color-transparent mm-box--rounded-lg"
+        class="flex-col mt-4 bg-transparent flex rounded-lg"
         data-testid="asset-price-chart"
       >
         <div
-          class="mm-box asset-chart__empty-or-loading-state-container"
+          class="asset-chart__empty-or-loading-state-container"
           data-testid="asset-chart-empty-state"
         >
           <div
@@ -499,7 +499,7 @@ exports[`AssetPage should render an ERC20 asset without prices 1`] = `
           </div>
         </div>
         <div
-          class="mm-box mm-box--margin-top-2 mm-box--margin-right-3 mm-box--margin-left-3 mm-box--display-flex mm-box--justify-content-space-between"
+          class="justify-between mt-2 mr-3 ml-3 flex"
         >
           <button
             class="mm-box mm-text mm-button-base mm-button-base--size-sm time-range-button time-range-button__selected mm-text--body-xs-medium mm-box--padding-0 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-alternative mm-box--background-color-transparent mm-box--rounded-xl"
@@ -538,7 +538,7 @@ exports[`AssetPage should render an ERC20 asset without prices 1`] = `
       class="mt-4 pr-4 pl-4"
     >
       <div
-        class="mm-box mm-box--display-flex mm-box--gap-3 mm-box--justify-content-space-evenly"
+        class="gap-3 justify-evenly flex"
       >
         <button
           class="mm-box mm-text mm-button-base mm-button-base--size-md icon-button token-overview__button mm-text--body-md-medium mm-box--padding-0 mm-box--padding-top-3 mm-box--padding-right-2 mm-box--padding-bottom-3 mm-box--padding-left-2 mm-box--display-inline-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-muted mm-box--rounded-xl"
@@ -869,10 +869,10 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
       </p>
     </div>
     <div
-      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--rounded-lg"
+      class="flex-col flex rounded-lg"
     >
       <div
-        class="mm-box mm-box--margin-right-4 mm-box--margin-left-4"
+        class="mr-4 ml-4"
       >
         <h1
           class="mm-box mm-text mm-text--display-md mm-text--font-weight-medium mm-box--margin-bottom-1 mm-box--color-text-default mm-box--rounded-lg"
@@ -903,11 +903,11 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
         </div>
       </div>
       <div
-        class="mm-box mm-box--margin-top-4 mm-box--display-flex mm-box--flex-direction-column mm-box--background-color-transparent mm-box--rounded-lg"
+        class="flex-col mt-4 bg-transparent flex rounded-lg"
         data-testid="asset-price-chart"
       >
         <div
-          class="mm-box asset-chart__empty-or-loading-state-container"
+          class="asset-chart__empty-or-loading-state-container"
           data-testid="asset-chart-loading"
         >
           <div
@@ -921,7 +921,7 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
           </div>
         </div>
         <div
-          class="mm-box mm-box--margin-top-2 mm-box--margin-right-3 mm-box--margin-left-3 mm-box--display-flex mm-box--justify-content-space-between"
+          class="justify-between mt-2 mr-3 ml-3 flex"
         >
           <button
             class="mm-box mm-text mm-button-base mm-button-base--size-sm time-range-button time-range-button__selected mm-text--body-xs-medium mm-box--padding-0 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-alternative mm-box--background-color-transparent mm-box--rounded-xl"
@@ -960,7 +960,7 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
       class="mt-4 pr-4 pl-4"
     >
       <div
-        class="mm-box mm-box--display-flex mm-box--gap-3 mm-box--justify-content-space-evenly"
+        class="gap-3 justify-evenly flex"
       >
         <button
           class="mm-box mm-text mm-button-base mm-button-base--size-md icon-button token-overview__button mm-text--body-md-medium mm-box--padding-0 mm-box--padding-top-3 mm-box--padding-right-2 mm-box--padding-bottom-3 mm-box--padding-left-2 mm-box--display-inline-flex mm-box--flex-direction-column mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-muted mm-box--rounded-xl"
@@ -1231,10 +1231,10 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
           </div>
         </div>
         <div
-          class="mm-box"
+          class=""
         >
           <div
-            class="mm-box mm-box--margin-bottom-2 mm-box--margin-inline-4 mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
+            class="mb-2 border-muted mx-4"
             style="height: 1px; border-bottom-width: 0;"
           />
           <h4
@@ -1243,10 +1243,10 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
             Market details
           </h4>
           <div
-            class="mm-box mm-box--padding-inline-4 mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-column"
+            class="flex-col gap-2 flex px-4"
           >
             <div
-              class="mm-box mm-box--display-flex mm-box--justify-content-space-between"
+              class="justify-between flex"
             >
               <p
                 class="mm-box mm-text mm-text--body-md-medium mm-box--color-text-alternative"

--- a/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
+++ b/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
@@ -1234,7 +1234,7 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
           class=""
         >
           <div
-            class="mb-2 border-muted mx-4"
+            class="mb-2 border-muted mx-4 border border-solid"
             style="height: 1px; border-bottom-width: 0;"
           />
           <h4

--- a/ui/pages/asset/components/asset-market-details.tsx
+++ b/ui/pages/asset/components/asset-market-details.tsx
@@ -115,7 +115,7 @@ export const AssetMarketDetails = ({
   return (
     <Box>
       <Box
-        className="mx-4"
+        className="mx-4 border border-solid"
         marginBottom={2}
         borderColor={BoxBorderColor.BorderMuted}
         style={{ height: '1px', borderBottomWidth: 0 }}

--- a/ui/pages/asset/components/asset-market-details.tsx
+++ b/ui/pages/asset/components/asset-market-details.tsx
@@ -2,16 +2,18 @@ import React, { ReactNode } from 'react';
 import { useSelector } from 'react-redux';
 import { CaipAssetType, Hex } from '@metamask/utils';
 import { BigNumber } from 'bignumber.js';
+import {
+  Box,
+  BoxBorderColor,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
 import { formatCurrency } from '../../../helpers/utils/confirm-tx.util';
 
 import { getPricePrecision } from '../util';
 
-import { Box, Text } from '../../../components/component-library';
+import { Text } from '../../../components/component-library';
 import {
-  BorderColor,
-  Display,
-  FlexDirection,
-  JustifyContent,
   TextColor,
   TextVariant,
 } from '../../../helpers/constants/design-system';
@@ -113,9 +115,9 @@ export const AssetMarketDetails = ({
   return (
     <Box>
       <Box
+        className="mx-4"
         marginBottom={2}
-        borderColor={BorderColor.borderMuted}
-        marginInline={4}
+        borderColor={BoxBorderColor.BorderMuted}
         style={{ height: '1px', borderBottomWidth: 0 }}
       ></Box>
       <Text
@@ -127,9 +129,8 @@ export const AssetMarketDetails = ({
         {t('marketDetails')}
       </Text>
       <Box
-        paddingInline={4}
-        display={Display.Flex}
-        flexDirection={FlexDirection.Column}
+        className="flex px-4"
+        flexDirection={BoxFlexDirection.Column}
         gap={2}
       >
         {marketCap > 0 &&
@@ -185,7 +186,7 @@ export const AssetMarketDetails = ({
 
 function renderRow(leftColumn: string, rightColumn: ReactNode) {
   return (
-    <Box display={Display.Flex} justifyContent={JustifyContent.spaceBetween}>
+    <Box className="flex" justifyContent={BoxJustifyContent.Between}>
       <Text
         color={TextColor.textAlternative}
         variant={TextVariant.bodyMdMedium}

--- a/ui/pages/asset/components/chart/asset-chart-empty-state.tsx
+++ b/ui/pages/asset/components/chart/asset-chart-empty-state.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Box } from '../../../../components/component-library';
+import { Box } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { useTheme } from '../../../../hooks/useTheme';
 import { TabEmptyState } from '../../../../components/ui/tab-empty-state';

--- a/ui/pages/asset/components/chart/asset-chart-loading.tsx
+++ b/ui/pages/asset/components/chart/asset-chart-loading.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { Skeleton } from '@metamask/design-system-react';
-
-import { Box } from '../../../../components/component-library';
+import { Box, Skeleton } from '@metamask/design-system-react';
 
 export const AssetChartLoading = () => {
   return (

--- a/ui/pages/asset/components/chart/asset-chart-price.tsx
+++ b/ui/pages/asset/components/chart/asset-chart-price.tsx
@@ -1,14 +1,13 @@
 import React, { useState, forwardRef, useImperativeHandle } from 'react';
-import { Skeleton } from '@metamask/design-system-react';
+import { Box, BoxFlexDirection, Skeleton } from '@metamask/design-system-react';
 import {
   BorderRadius,
   Display,
-  FlexDirection,
   FontWeight,
   TextColor,
   TextVariant,
 } from '../../../../helpers/constants/design-system';
-import { Box, Text } from '../../../../components/component-library';
+import { Text } from '../../../../components/component-library';
 import { loadingOpacity, getDynamicShortDate } from '../../util';
 import { useFormatters } from '../../../../hooks/useFormatters';
 import { TokenCellPercentChange } from '../../../../components/app/assets/token-cell/cells';
@@ -119,8 +118,8 @@ const AssetChartPrice = forwardRef(
         {(shouldShowDelta || shouldShowDeltaMuted) && (
           <Box
             style={{ opacity: loading ? loadingOpacity : 1 }}
-            display={Display.Flex}
-            flexDirection={FlexDirection.Row}
+            className="flex"
+            flexDirection={BoxFlexDirection.Row}
           >
             {props.asset && (
               <TokenCellPercentChange

--- a/ui/pages/asset/components/chart/asset-chart.tsx
+++ b/ui/pages/asset/components/chart/asset-chart.tsx
@@ -17,18 +17,19 @@ import { brandColor } from '@metamask/design-tokens';
 import { Hex } from '@metamask/utils';
 import { trim } from 'lodash';
 import { Duration } from 'luxon';
+import {
+  Box,
+  BoxBackgroundColor,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
 import { useTheme } from '../../../../hooks/useTheme';
 import {
   BackgroundColor,
-  Display,
-  JustifyContent,
   TextColor,
   TextVariant,
-  BorderRadius,
-  FlexDirection,
 } from '../../../../helpers/constants/design-system';
 import {
-  Box,
   ButtonBase,
   ButtonBaseSize,
 } from '../../../../components/component-library';
@@ -196,11 +197,7 @@ const AssetChart = ({
   }, [currentPrice]);
 
   return (
-    <Box
-      borderRadius={BorderRadius.LG}
-      display={Display.Flex}
-      flexDirection={FlexDirection.Column}
-    >
+    <Box className="flex rounded-lg" flexDirection={BoxFlexDirection.Column}>
       <AssetChartPrice
         ref={priceRef}
         loading={loading}
@@ -213,15 +210,14 @@ const AssetChart = ({
 
       <Box
         data-testid="asset-price-chart"
+        className="flex rounded-lg"
         marginTop={4}
         backgroundColor={
           loading && !prices
-            ? BackgroundColor.backgroundSection
-            : BackgroundColor.transparent
+            ? BoxBackgroundColor.BackgroundSection
+            : BoxBackgroundColor.Transparent
         }
-        borderRadius={BorderRadius.LG}
-        display={Display.Flex}
-        flexDirection={FlexDirection.Column}
+        flexDirection={BoxFlexDirection.Column}
       >
         {shouldShowChartLoading && <AssetChartLoading />}
         {shouldShowChartEmptyState && <AssetChartEmptyState />}
@@ -235,10 +231,10 @@ const AssetChart = ({
             />
             <Box
               style={{ aspectRatio: `${options.aspectRatio}` }}
-              display={Display.Flex}
-              flexDirection={FlexDirection.Column}
+              className="flex"
+              flexDirection={BoxFlexDirection.Column}
               justifyContent={
-                currentPrice ? JustifyContent.flexEnd : JustifyContent.flexStart
+                currentPrice ? BoxJustifyContent.End : BoxJustifyContent.Start
               }
             >
               <Line
@@ -290,8 +286,8 @@ const AssetChart = ({
 
         <Box
           style={prices ? undefined : { visibility: `hidden` }}
-          display={Display.Flex}
-          justifyContent={JustifyContent.spaceBetween}
+          className="flex"
+          justifyContent={BoxJustifyContent.Between}
           marginTop={2}
           marginLeft={3}
           marginRight={3}

--- a/ui/pages/asset/components/chart/chart-tooltip.tsx
+++ b/ui/pages/asset/components/chart/chart-tooltip.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
 // @ts-expect-error suppress CommonJS vs ECMAScript error
 import { Point } from 'chart.js';
-import {
-  Box,
-  Text,
-  TextDirection,
-} from '../../../../components/component-library';
+import { Box } from '@metamask/design-system-react';
+import { Text, TextDirection } from '../../../../components/component-library';
 import { useFormatters } from '../../../../hooks/useFormatters';
 import {
   TextAlign,

--- a/ui/pages/asset/components/token-buttons.tsx
+++ b/ui/pages/asset/components/token-buttons.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useContext, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
+import { Box, BoxJustifyContent } from '@metamask/design-system-react';
 import { I18nContext } from '../../../contexts/i18n';
 import useRamps from '../../../hooks/ramps/useRamps/useRamps';
 import { getUseExternalServices } from '../../../selectors';
@@ -15,14 +16,9 @@ import {
   MetaMetricsEventName,
   MetaMetricsSwapsEventSource,
 } from '../../../../shared/constants/metametrics';
-import {
-  Display,
-  IconColor,
-  JustifyContent,
-} from '../../../helpers/constants/design-system';
+import { IconColor } from '../../../helpers/constants/design-system';
 import IconButton from '../../../components/ui/icon-button/icon-button';
 import {
-  Box,
   Icon,
   IconName,
   IconSize,
@@ -129,11 +125,7 @@ const TokenButtons = ({
   }, [token, openBridgeExperience]);
 
   return (
-    <Box
-      display={Display.Flex}
-      gap={3}
-      justifyContent={JustifyContent.spaceEvenly}
-    >
+    <Box className="flex" gap={3} justifyContent={BoxJustifyContent.Evenly}>
       <IconButton
         className="token-overview__button"
         Icon={

--- a/ui/pages/asset/components/tron-daily-resources.tsx
+++ b/ui/pages/asset/components/tron-daily-resources.tsx
@@ -2,20 +2,21 @@ import React from 'react';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import {
   Box,
+  BoxAlignItems,
+  BoxBackgroundColor,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
+import {
   Text,
   Icon,
   IconName,
   IconSize,
 } from '../../../components/component-library';
 import {
-  AlignItems,
-  Display,
-  FlexDirection,
-  JustifyContent,
   TextColor,
   TextVariant,
   IconColor,
-  BackgroundColor,
 } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useTronResources, TronResource } from '../hooks/useTronResources';
@@ -81,10 +82,10 @@ const ResourceCircle = ({ resource, iconName }: ResourceCircleProps) => {
       </svg>
       {/* Icon in the center */}
       <Box
-        display={Display.Flex}
-        alignItems={AlignItems.center}
-        justifyContent={JustifyContent.center}
-        backgroundColor={BackgroundColor.backgroundAlternative}
+        className="flex"
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Center}
+        backgroundColor={BoxBackgroundColor.BackgroundAlternative}
         style={{
           position: 'absolute',
           top: '50%',
@@ -124,24 +125,20 @@ const ResourceRow = ({
 }: ResourceRowProps) => {
   return (
     <Box
-      display={Display.Flex}
-      flexDirection={FlexDirection.Row}
-      alignItems={AlignItems.center}
-      justifyContent={JustifyContent.spaceBetween}
+      className="flex"
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      justifyContent={BoxJustifyContent.Between}
       marginTop={3}
     >
       <Box
-        display={Display.Flex}
-        flexDirection={FlexDirection.Row}
-        alignItems={AlignItems.center}
+        className="flex"
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
         gap={4}
       >
         <ResourceCircle resource={resource} iconName={iconName} />
-        <Box
-          display={Display.Flex}
-          flexDirection={FlexDirection.Column}
-          gap={1}
-        >
+        <Box className="flex" flexDirection={BoxFlexDirection.Column} gap={1}>
           <Text
             variant={TextVariant.bodyLgMedium}
             color={TextColor.textDefault}
@@ -153,7 +150,7 @@ const ResourceRow = ({
           </Text>
         </Box>
       </Box>
-      <Box display={Display.Flex} flexDirection={FlexDirection.Row}>
+      <Box className="flex" flexDirection={BoxFlexDirection.Row}>
         <Text variant={TextVariant.bodyMd} color={TextColor.textDefault}>
           {currentValue}
         </Text>
@@ -200,16 +197,16 @@ export const TronDailyResources = ({
 
   return (
     <Box
-      display={Display.Flex}
-      flexDirection={FlexDirection.Column}
+      className="flex"
+      flexDirection={BoxFlexDirection.Column}
       paddingLeft={4}
       paddingRight={4}
       paddingTop={1}
       paddingBottom={3}
     >
       <Box
-        display={Display.Flex}
-        flexDirection={FlexDirection.Column}
+        className="flex"
+        flexDirection={BoxFlexDirection.Column}
         gap={2}
         marginBottom={3}
       >

--- a/ui/pages/connected-accounts/connected-accounts.component.js
+++ b/ui/pages/connected-accounts/connected-accounts.component.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { useSelector } from 'react-redux';
 import { WALLET_SNAP_PERMISSION_KEY } from '@metamask/snaps-utils';
+import { Box } from '@metamask/design-system-react';
 import Popover from '../../components/ui/popover';
 import ConnectedAccountsList from '../../components/app/connected-accounts-list';
 import ConnectedAccountsPermissions from '../../components/app/connected-accounts-permissions';
@@ -9,7 +10,7 @@ import { getURLHost } from '../../helpers/utils/util';
 import { useI18nContext } from '../../hooks/useI18nContext';
 import ConnectedSnaps from '../../components/app/connected-sites-list/connected-snaps';
 import { TextColor, TextVariant } from '../../helpers/constants/design-system';
-import { Box, Text } from '../../components/component-library';
+import { Text } from '../../components/component-library';
 import { getInternalAccounts } from '../../selectors';
 
 export default function ConnectedAccounts({

--- a/ui/pages/defi/components/__snapshots__/defi-details-list.test.tsx.snap
+++ b/ui/pages/defi/components/__snapshots__/defi-details-list.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`DefiDetailsList renders defi details list 1`] = `
 <div>
   <div
-    class="mm-box"
+    class=""
   >
     <div
-      class="mm-box"
+      class=""
     >
       <p
         class="mm-box mm-text mm-text--body-md-medium mm-box--padding-left-4 mm-box--color-text-alternative"
@@ -19,7 +19,7 @@ exports[`DefiDetailsList renders defi details list 1`] = `
       />
     </div>
     <div
-      class="mm-box"
+      class=""
     >
       <p
         class="mm-box mm-text mm-text--body-md-medium mm-box--padding-left-4 mm-box--color-text-alternative"

--- a/ui/pages/defi/components/__snapshots__/defi-details-page.test.tsx.snap
+++ b/ui/pages/defi/components/__snapshots__/defi-details-page.test.tsx.snap
@@ -3,10 +3,10 @@
 exports[`DeFiDetailsPage renders defi asset page 1`] = `
 <div>
   <div
-    class="mm-box main-container asset__container"
+    class="main-container asset__container"
   >
     <div
-      class="mm-box pt-4 sticky top-0 z-10 bg-background-default mm-box--padding-bottom-4 mm-box--padding-left-2 mm-box--display-flex"
+      class="pb-4 pl-2 flex pt-4 sticky top-0 z-10 bg-background-default"
     >
       <button
         aria-label="Back"
@@ -20,7 +20,7 @@ exports[`DeFiDetailsPage renders defi asset page 1`] = `
       </button>
     </div>
     <div
-      class="mm-box mm-box--padding-right-4 mm-box--display-flex mm-box--flex-direction-row mm-box--justify-content-space-between"
+      class="flex-row justify-between pr-4 flex"
     >
       <h2
         class="mm-box mm-text mm-text--heading-lg mm-box--padding-bottom-2 mm-box--padding-left-4 mm-box--color-text-default"
@@ -57,7 +57,7 @@ exports[`DeFiDetailsPage renders defi asset page 1`] = `
       </div>
     </div>
     <div
-      class="mm-box mm-box--padding-bottom-4 mm-box--padding-left-4"
+      class="pb-4 pl-4"
     >
       <span
         class="mm-box mm-text mm-box--color-text-alternative mm-text--inherit mm-text--ellipsis mm-box--color-text-default"
@@ -67,18 +67,18 @@ exports[`DeFiDetailsPage renders defi asset page 1`] = `
       </span>
     </div>
     <div
-      class="mm-box mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4"
+      class="pr-4 pb-4 pl-4"
     >
       <hr />
     </div>
     <div
-      class="mm-box mm-box--display-flex mm-box--flex-direction-column"
+      class="flex-col flex"
     >
       <div
-        class="mm-box"
+        class=""
       >
         <div
-          class="mm-box"
+          class=""
         >
           <p
             class="mm-box mm-text mm-text--body-md-medium mm-box--padding-left-4 mm-box--color-text-alternative"

--- a/ui/pages/defi/components/defi-details-list.tsx
+++ b/ui/pages/defi/components/defi-details-list.tsx
@@ -2,12 +2,13 @@ import React, { useMemo } from 'react';
 
 import { GroupedDeFiPositions } from '@metamask/assets-controllers';
 import { useSelector } from 'react-redux';
+import { Box } from '@metamask/design-system-react';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
 import {
   TextColor,
   TextVariant,
 } from '../../../helpers/constants/design-system';
-import { Box, Text } from '../../../components/component-library';
+import { Text } from '../../../components/component-library';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import TokenCell from '../../../components/app/assets/token-cell';
 import { getPreferences } from '../../../../shared/lib/selectors/preferences';

--- a/ui/pages/defi/components/defi-details-page.tsx
+++ b/ui/pages/defi/components/defi-details-page.tsx
@@ -2,14 +2,15 @@ import React, { useMemo } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import {
-  Display,
-  FlexDirection,
+  Box,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
+import {
   IconColor,
-  JustifyContent,
   TextVariant,
 } from '../../../helpers/constants/design-system';
 import {
-  Box,
   ButtonIcon,
   ButtonIconSize,
   IconName,
@@ -90,10 +91,9 @@ const DeFiPage = () => {
   return (
     <Box className="main-container asset__container">
       <Box
+        className="flex pt-4 sticky top-0 z-10 bg-background-default"
         paddingLeft={2}
-        display={Display.Flex}
         paddingBottom={4}
-        className="pt-4 sticky top-0 z-10 bg-background-default"
       >
         <ButtonIcon
           data-testid="defi-details-page-back-button"
@@ -107,9 +107,9 @@ const DeFiPage = () => {
       </Box>
 
       <Box
-        display={Display.Flex}
-        flexDirection={FlexDirection.Row}
-        justifyContent={JustifyContent.spaceBetween}
+        className="flex"
+        flexDirection={BoxFlexDirection.Row}
+        justifyContent={BoxJustifyContent.Between}
         paddingRight={4}
       >
         <Text
@@ -145,7 +145,7 @@ const DeFiPage = () => {
       <Box paddingLeft={4} paddingBottom={4} paddingRight={4}>
         <hr style={{ border: '1px solid var(--border-muted, #858B9A33)' }} />
       </Box>
-      <Box display={Display.Flex} flexDirection={FlexDirection.Column}>
+      <Box className="flex" flexDirection={BoxFlexDirection.Column}>
         {Object.keys(PositionTypeLabels).map((positionType) =>
           protocolPosition.positionTypes[positionType as PositionTypeKeys] ? (
             <DefiDetailsList

--- a/ui/pages/error-page/error-page.component.tsx
+++ b/ui/pages/error-page/error-page.component.tsx
@@ -1,11 +1,17 @@
 import React, { useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 
+import {
+  Box,
+  BoxAlignItems,
+  BoxBackgroundColor,
+  BoxFlexDirection,
+  BoxJustifyContent,
+} from '@metamask/design-system-react';
 import { getParticipateInMetaMetrics } from '../../selectors';
 import { useI18nContext } from '../../hooks/useI18nContext';
 import {
   BannerAlert,
-  Box,
   Icon,
   IconName,
   IconSize,
@@ -21,9 +27,7 @@ import {
 } from '../../components/component-library';
 import {
   AlignItems,
-  BackgroundColor,
   BlockSize,
-  BorderRadius,
   Display,
   FlexDirection,
   IconColor,
@@ -93,10 +97,9 @@ const ErrorPage: React.FC<ErrorPageProps> = ({ error }) => {
     <section className="error-page">
       <section className="error-page__inner-wrapper">
         <Box
-          className="error-page__header"
-          display={Display.Flex}
-          flexDirection={FlexDirection.Column}
-          alignItems={AlignItems.center}
+          className="flex error-page__header"
+          flexDirection={BoxFlexDirection.Column}
+          alignItems={BoxAlignItems.Center}
         >
           <Icon
             name={IconName.Danger}
@@ -127,14 +130,12 @@ const ErrorPage: React.FC<ErrorPageProps> = ({ error }) => {
         </Text>
 
         <Box
-          borderRadius={BorderRadius.LG}
+          className="flex rounded-lg error-page__error-message-wrapper"
           marginBottom={2}
           marginTop={2}
-          backgroundColor={BackgroundColor.errorMuted}
-          display={Display.Flex}
-          flexDirection={FlexDirection.Column}
+          backgroundColor={BoxBackgroundColor.ErrorMuted}
+          flexDirection={BoxFlexDirection.Column}
           padding={2}
-          className="error-page__error-message-wrapper"
         >
           {error.message ? (
             <Text
@@ -209,7 +210,7 @@ const ErrorPage: React.FC<ErrorPageProps> = ({ error }) => {
                 />
               </ModalBody>
               <ModalFooter>
-                <Box display={Display.Flex} gap={4}>
+                <Box className="flex" gap={4}>
                   <Button
                     variant={ButtonVariant.Secondary}
                     width={BlockSize.Half}
@@ -270,11 +271,10 @@ const ErrorPage: React.FC<ErrorPageProps> = ({ error }) => {
           />
         )}
         <Box
-          width={BlockSize.Full}
-          display={Display.Flex}
-          flexDirection={FlexDirection.Column}
-          alignItems={AlignItems.center}
-          justifyContent={JustifyContent.center}
+          className="flex w-full"
+          flexDirection={BoxFlexDirection.Column}
+          alignItems={BoxAlignItems.Center}
+          justifyContent={BoxJustifyContent.Center}
           marginTop={4}
         >
           {isMetaMetricsEnabled && (

--- a/ui/pages/permissions-connect/permissions-connect.stories.js
+++ b/ui/pages/permissions-connect/permissions-connect.stories.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import { Box } from '../../components/component-library';
+import { Box, BoxBackgroundColor } from '@metamask/design-system-react';
 import { PermissionPageContainerContent } from '../../components/app/permission-page-container';
 import PermissionsConnectFooter from '../../components/app/permissions-connect-footer';
 import { PageContainerFooter } from '../../components/ui/page-container';
-import { BackgroundColor } from '../../helpers/constants/design-system';
 
 export default {
   title: 'Pages/PermissionsConnect',
@@ -25,7 +24,7 @@ export const PermissionPageContainerComponent = () => {
       />
       <Box
         className="permission-approval-container__footers"
-        backgroundColor={BackgroundColor.backgroundAlternative}
+        backgroundColor={BoxBackgroundColor.BackgroundAlternative}
       >
         <PermissionsConnectFooter />
         <PageContainerFooter

--- a/ui/pages/permissions-connect/permissions-connect.tsx
+++ b/ui/pages/permissions-connect/permissions-connect.tsx
@@ -36,6 +36,7 @@ import {
   parseCaipAccountId,
   parseCaipChainId,
 } from '@metamask/utils';
+import { Box } from '@metamask/design-system-react';
 import { toRelativeRoutePath } from '../routes/utils';
 import {
   isEthAddress,
@@ -73,7 +74,6 @@ import {
 } from '../../store/actions';
 import { getAccountGroupWithInternalAccounts } from '../../selectors/multichain-accounts/account-tree';
 import PermissionPageContainer from '../../components/app/permission-page-container';
-import { Box } from '../../components/component-library';
 import SnapAuthorshipHeader from '../../components/app/snaps/snap-authorship-header/snap-authorship-header';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0021): route-isolation backlog
 import { MultichainAccountsConnectPage } from '../multichain-accounts/multichain-accounts-connect-page/multichain-accounts-connect-page';

--- a/ui/pages/smart-transactions/smart-transaction-status-page/smart-transaction-status-animation.tsx
+++ b/ui/pages/smart-transactions/smart-transaction-status-page/smart-transaction-status-animation.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useCallback } from 'react';
 import { SmartTransactionStatuses } from '@metamask/smart-transactions-controller';
-import { Box } from '../../../components/component-library';
-import { Display } from '../../../helpers/constants/design-system';
+import { Box } from '@metamask/design-system-react';
 import { LottieAnimation } from '../../../components/component-library/lottie-animation';
 
 const ANIMATIONS_FOLDER = 'images/animations/smart-transaction-status';
@@ -68,7 +67,7 @@ export const SmartTransactionStatusAnimation = ({
   }, [status, isIntro]);
 
   return (
-    <Box display={Display.Flex} style={{ width: '96px', height: '96px' }}>
+    <Box className="flex" style={{ width: '96px', height: '96px' }}>
       <LottieAnimation
         path={animation.path}
         loop={animation.loop}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Use `Box` from DSR (no codeowners, part 3).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-433

## **Manual testing steps**

1. Check modified files
2. Open app and make sure there is no regressions

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="492" height="1064" alt="image" src="https://github.com/user-attachments/assets/70ede695-7685-49ef-92ca-2583e7882b47" />

### **After**

<img width="492" height="1043" alt="image" src="https://github.com/user-attachments/assets/9a09a3ac-dce3-4c1c-9cbb-bb3f32dd9505" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentational layout migration with snapshot updates; no auth, transaction, or permission logic changes beyond import/API swaps for Box.
> 
> **Overview**
> This PR continues migrating layout containers from **component-library** `Box` to **`@metamask/design-system-react` `Box`**, replacing legacy `Display` / `FlexDirection` / `JustifyContent` / `AlignItems` / `BlockSize` props with **Tailwind-style `className`s** (e.g. `flex`, `flex-col`, `w-full`) and DSR enums (`BoxJustifyContent`, `BoxAlignItems`, `BoxBackgroundColor`, etc.).
> 
> Touched areas include **permissions connect** (cells, headers, footers, permission list with `asChild` + `<span>`), **multichain** transaction/bridge UI, **wallet overview** (aggregated %, coin buttons), **asset/DeFi pages** and charts, **onboarding/security** modals (SRP, recovery, update), and assorted UI utilities. **Jest snapshots** were updated where rendered `mm-box--display-*` classes became utility classes.
> 
> Behavior should be equivalent; risk is mainly **visual/regression** on flex/spacing, not business logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e518cfc9325fcc8c6f8ee94e8db20a193166fabc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->