### PR TITLE
fix: ensure add custom evm assets invokes new controller

### DIFF
--- a/ui/pages/custom-token-import/custom-token-import.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.tsx
@@ -8,7 +8,10 @@ import React, {
 } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
-import { formatChainIdToHex } from '@metamask/bridge-controller';
+import {
+  formatChainIdToCaip,
+  formatChainIdToHex,
+} from '@metamask/bridge-controller';
 import {
   ButtonIcon,
   ButtonIconSize,
@@ -16,7 +19,13 @@ import {
 } from '@metamask/design-system-react';
 import { ERC20, ERC721, ERC1155 } from '@metamask/controller-utils';
 import { NON_EVM_TESTNET_IDS } from '@metamask/multichain-network-controller';
-import { type CaipChainId, type Hex } from '@metamask/utils';
+import {
+  isCaipChainId,
+  parseCaipChainId,
+  toCaipAssetType,
+  type CaipChainId,
+  type Hex,
+} from '@metamask/utils';
 import { isValidHexAddress } from '../../../shared/lib/hexstring-utils';
 // TODO: Remove restricted import
 // eslint-disable-next-line import-x/no-restricted-paths
@@ -25,6 +34,7 @@ import { addHexPrefix } from '../../../app/scripts/lib/util';
 import { useI18nContext } from '../../hooks/useI18nContext';
 import { Header, Page } from '../../components/multichain/pages/page';
 import {
+  addCustomAsset,
   addImportedTokens,
   getTokenStandardAndDetailsByChain,
 } from '../../store/actions';
@@ -56,6 +66,7 @@ import { AssetType } from '../../../shared/constants/transaction';
 import { MetaMetricsContext } from '../../contexts/metametrics';
 import { type CustomTokenImportNetworkOption } from './custom-token-import-network-selector';
 import { CustomTokenImportForm } from './custom-token-import-form';
+import { getIsAssetsUnifiedStateIncludedInBuild } from '../../../shared/lib/environment';
 
 const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
 const MIN_DECIMAL_VALUE = 0;
@@ -72,6 +83,11 @@ const METRICS_PROPERTIES = {
   tokenSymbol: 'token_symbol',
   viewState: 'view_state',
 } as const;
+
+const normalizeToCaipChainId = (chainId: string): CaipChainId =>
+  chainId.startsWith('0x')
+    ? formatChainIdToCaip(chainId as Hex)
+    : (chainId as CaipChainId);
 
 /**
  * Full-screen "Add a custom token" page.
@@ -106,6 +122,11 @@ export const CustomTokenImportPage = () => {
 
   const [selectedNetwork, setSelectedNetwork] =
     useState<string>(currentChainId);
+
+  const isAssetsUnifiedStateInBuild = useMemo(
+    () => getIsAssetsUnifiedStateIncludedInBuild(),
+    [],
+  );
 
   const availableNetworks = useMemo<CustomTokenImportNetworkOption[]>(
     () =>
@@ -420,6 +441,20 @@ export const CustomTokenImportPage = () => {
     }
     setIsSubmitting(true);
     try {
+      if (isAssetsUnifiedStateInBuild) {
+        const caipChainId = normalizeToCaipChainId(selectedNetwork);
+        if (!isCaipChainId(caipChainId)) {
+          return;
+        }
+
+        const { namespace, reference } = parseCaipChainId(caipChainId);
+
+        // create asset id from address and caipChainId
+        const assetId = toCaipAssetType(namespace, reference, 'erc20', address);
+
+        await dispatch(addCustomAsset(selectedAccount.id, assetId));
+      }
+
       await dispatch(
         addImportedTokens(
           [

--- a/ui/pages/custom-token-import/custom-token-import.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.tsx
@@ -64,9 +64,9 @@ import {
 } from '../../../shared/constants/metametrics';
 import { AssetType } from '../../../shared/constants/transaction';
 import { MetaMetricsContext } from '../../contexts/metametrics';
+import { getIsAssetsUnifiedStateIncludedInBuild } from '../../../shared/lib/environment';
 import { type CustomTokenImportNetworkOption } from './custom-token-import-network-selector';
 import { CustomTokenImportForm } from './custom-token-import-form';
-import { getIsAssetsUnifiedStateIncludedInBuild } from '../../../shared/lib/environment';
 
 const EMPTY_ADDRESS = '0x0000000000000000000000000000000000000000';
 const MIN_DECIMAL_VALUE = 0;
@@ -443,16 +443,19 @@ export const CustomTokenImportPage = () => {
     try {
       if (isAssetsUnifiedStateInBuild) {
         const caipChainId = normalizeToCaipChainId(selectedNetwork);
-        if (!isCaipChainId(caipChainId)) {
-          return;
+        if (isCaipChainId(caipChainId)) {
+          const { namespace, reference } = parseCaipChainId(caipChainId);
+
+          // create asset id from address and caipChainId
+          const assetId = toCaipAssetType(
+            namespace,
+            reference,
+            'erc20',
+            address,
+          );
+
+          await dispatch(addCustomAsset(selectedAccount.id, assetId));
         }
-
-        const { namespace, reference } = parseCaipChainId(caipChainId);
-
-        // create asset id from address and caipChainId
-        const assetId = toCaipAssetType(namespace, reference, 'erc20', address);
-
-        await dispatch(addCustomAsset(selectedAccount.id, assetId));
       }
 
       await dispatch(
@@ -486,11 +489,14 @@ export const CustomTokenImportPage = () => {
   }, [
     address,
     dispatch,
+    isAssetsUnifiedStateInBuild,
     isSubmitting,
     isValid,
     navigate,
     networkClientId,
     parsedDecimals,
+    selectedAccount.id,
+    selectedNetwork,
     symbol,
     trackSubmitAttempt,
   ]);


### PR DESCRIPTION

## **Description**

New controller was not adding custom assets, so was not updating UI.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: fix: ensure add custom evm assets invokes new controller

## **Manual testing steps**

1. Select EVM network (e.g. tempo)
2. Select add custom token
3. Enter a token (e.g. 0x20c0000000000000000000009a4a4b17e0dc6651), and add the token
4. EXPECTED - token should be added and shown in UI

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="961" height="563" alt="Screenshot 2026-05-20 at 19 17 03" src="https://github.com/user-attachments/assets/d5ea9c56-1cfd-4338-a6bc-74d02a10a5ad" />
<img width="961" height="563" alt="Screenshot 2026-05-20 at 19 17 03" src="https://github.com/user-attachments/assets/d5ea9c56-1cfd-4338-a6bc-74d02a10a5ad" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the custom token import flow to also write to the unified assets controller/state when enabled, which affects how tokens appear in the UI. Risk is moderate due to changes in token-add side effects and chain-id/asset-id formatting, though gated behind a build flag.
> 
> **Overview**
> Fixes custom token import so that, when the unified assets state is enabled, importing an ERC-20 also dispatches `addCustomAsset` to the background using a generated CAIP-19 asset id.
> 
> Adds chain-id normalization to CAIP (`normalizeToCaipChainId`) and uses `parseCaipChainId`/`toCaipAssetType` to construct the asset identifier before continuing to call the existing `addImportedTokens` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d80619a43b95cff88ea2c89b8a86f3a42b08c9c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->