### PR TITLE
fix(tokens): merge RPC and token list metadata on custom import

### DIFF
--- a/ui/pages/custom-token-import/custom-token-import.test.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.test.tsx
@@ -15,7 +15,10 @@ import {
   MetaMetricsEventName,
 } from '../../../shared/constants/metametrics';
 import { AssetType } from '../../../shared/constants/transaction';
-import { CustomTokenImportPage } from './custom-token-import';
+import {
+  CustomTokenImportPage,
+  mergeCustomTokenMetadataForImport,
+} from './custom-token-import';
 
 const METRICS_PROPERTIES = {
   addedToken: 'added_token',
@@ -63,15 +66,24 @@ jest.mock('../../store/actions', () => {
 
 jest.mock('../../helpers/utils/token-util', () => {
   const actual = jest.requireActual('../../helpers/utils/token-util');
+  const mockTokenListLookup = jest.fn(async () => ({
+    symbol: 'APE',
+    decimals: 18,
+    name: 'ApeCoin',
+  }));
   return {
     ...actual,
-    tokenInfoGetter: () => async () => ({
-      symbol: 'APE',
-      decimals: 18,
-      name: 'ApeCoin',
-    }),
+    tokenInfoGetter: () => mockTokenListLookup,
+    mockTokenListLookup,
   };
 });
+
+type TokenUtilModuleWithMock = typeof import('../../helpers/utils/token-util') & {
+  mockTokenListLookup: jest.Mock;
+};
+
+const getMockedTokenUtil = () =>
+  jest.requireMock('../../helpers/utils/token-util') as TokenUtilModuleWithMock;
 
 const getMockedActions = () =>
   jest.requireMock('../../store/actions') as {
@@ -86,12 +98,74 @@ const ASSETS_UNIFY_STATE_FLAG_ON = {
   },
 };
 
+describe('mergeCustomTokenMetadataForImport', () => {
+  it('prefers RPC when the token list returns empty strings and placeholder decimals', () => {
+    expect(
+      mergeCustomTokenMetadataForImport(
+        { symbol: 'OSO', decimals: '18', name: '' },
+        { symbol: '', decimals: '0', name: '' },
+      ),
+    ).toStrictEqual({
+      symbol: 'OSO',
+      name: '',
+      decimals: '18',
+    });
+  });
+
+  it('falls back to the token list when RPC omits a field', () => {
+    expect(
+      mergeCustomTokenMetadataForImport(
+        { symbol: 'OSO', decimals: '18' },
+        { symbol: 'LIST', decimals: 6, name: 'Listed Name' },
+      ),
+    ).toStrictEqual({
+      symbol: 'OSO',
+      name: 'Listed Name',
+      decimals: '18',
+    });
+  });
+
+  it('uses the token list when RPC has no metadata', () => {
+    expect(
+      mergeCustomTokenMetadataForImport(undefined, {
+        symbol: 'DAI',
+        decimals: '18',
+        name: 'Dai Stablecoin',
+      }),
+    ).toStrictEqual({
+      symbol: 'DAI',
+      name: 'Dai Stablecoin',
+      decimals: '18',
+    });
+  });
+
+  it('trims whitespace from both sources', () => {
+    expect(
+      mergeCustomTokenMetadataForImport(
+        { symbol: '  OSO  ', decimals: '  18  ' },
+        { symbol: '  ', decimals: '0' },
+      ),
+    ).toStrictEqual({
+      symbol: 'OSO',
+      name: '',
+      decimals: '18',
+    });
+  });
+});
+
 describe('CustomTokenImportPage', () => {
   beforeEach(() => {
     mockNavigate.mockClear();
     const actions = getMockedActions();
     actions.addImportedTokens.mockClear();
     actions.importCustomAssetsBatch.mockClear();
+    const tokenUtil = getMockedTokenUtil();
+    tokenUtil.mockTokenListLookup.mockReset();
+    tokenUtil.mockTokenListLookup.mockResolvedValue({
+      symbol: 'APE',
+      decimals: 18,
+      name: 'ApeCoin',
+    });
   });
 
   const buildState = (metamaskOverrides: Record<string, unknown> = {}) => ({
@@ -211,6 +285,29 @@ describe('CustomTokenImportPage', () => {
     expect(
       screen.getByTestId('custom-token-import-submit-button'),
     ).toBeDisabled();
+  });
+
+  it('fills symbol and decimals from RPC when the token list returns only empty placeholders', async () => {
+    getMockedTokenUtil().mockTokenListLookup.mockResolvedValue({
+      symbol: '',
+      decimals: '0',
+      name: '',
+    });
+    renderPage();
+
+    fireEvent.change(screen.getByTestId('custom-token-import-address-input'), {
+      target: { value: '0x1111111111111111111111111111111111111111' },
+    });
+
+    const symbolInput = await screen.findByTestId(
+      'custom-token-import-symbol-input',
+    );
+    await waitFor(() => {
+      expect(symbolInput).toHaveValue('APE');
+    });
+    expect(screen.getByTestId('custom-token-import-decimal-input')).toHaveValue(
+      18,
+    );
   });
 
   it('opens the custom import network selector when the network picker is clicked', () => {

--- a/ui/pages/custom-token-import/custom-token-import.test.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.test.tsx
@@ -78,9 +78,10 @@ jest.mock('../../helpers/utils/token-util', () => {
   };
 });
 
-type TokenUtilModuleWithMock = typeof import('../../helpers/utils/token-util') & {
-  mockTokenListLookup: jest.Mock;
-};
+type TokenUtilModuleWithMock =
+  typeof import('../../helpers/utils/token-util') & {
+    mockTokenListLookup: jest.Mock;
+  };
 
 const getMockedTokenUtil = () =>
   jest.requireMock('../../helpers/utils/token-util') as TokenUtilModuleWithMock;

--- a/ui/pages/custom-token-import/custom-token-import.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.tsx
@@ -365,8 +365,11 @@ export const CustomTokenImportPage = () => {
         if (!isLatestLookup()) {
           return;
         }
-        const { symbol: mergedSymbol, name: mergedName, decimals: mergedDecimals } =
-          mergeCustomTokenMetadataForImport(rpcTokenInfo, info);
+        const {
+          symbol: mergedSymbol,
+          name: mergedName,
+          decimals: mergedDecimals,
+        } = mergeCustomTokenMetadataForImport(rpcTokenInfo, info);
         setSymbol(mergedSymbol);
         setName(mergedName);
         setDecimals(mergedDecimals);

--- a/ui/pages/custom-token-import/custom-token-import.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.tsx
@@ -79,6 +79,45 @@ const METRICS_PROPERTIES = {
   viewState: 'view_state',
 } as const;
 
+type TokenMetadataSource = {
+  symbol?: string | null;
+  name?: string | null;
+  decimals?: string | number | null;
+};
+
+function trimImportedTokenField(value: unknown): string {
+  if (value === undefined || value === null) {
+    return '';
+  }
+  return String(value).trim();
+}
+
+/**
+ * Merges on-chain RPC metadata with token-list lookup for the import form.
+ *
+ * Prefer RPC first, then the token list. RPC-first avoids empty strings or a
+ * placeholder `decimals` of `'0'` from the list shadowing real contract
+ * values. When RPC omits a field (e.g. `name`), the list value is still used.
+ *
+ * @param rpcTokenInfo - Result from {@link getTokenStandardAndDetailsByChain}.
+ * @param info - Result from {@link tokenInfoGetter} for the current network.
+ */
+export function mergeCustomTokenMetadataForImport(
+  rpcTokenInfo: TokenMetadataSource | undefined,
+  info: TokenMetadataSource | undefined,
+): { symbol: string; name: string; decimals: string } {
+  const symbol =
+    trimImportedTokenField(rpcTokenInfo?.symbol) ||
+    trimImportedTokenField(info?.symbol);
+  const name =
+    trimImportedTokenField(rpcTokenInfo?.name) ||
+    trimImportedTokenField(info?.name);
+  const decimals =
+    trimImportedTokenField(rpcTokenInfo?.decimals) ||
+    trimImportedTokenField(info?.decimals);
+  return { symbol, name, decimals };
+}
+
 /**
  * Full-screen "Add a custom token" page.
  */
@@ -264,15 +303,16 @@ export const CustomTokenImportPage = () => {
       // branches, matching the order of the legacy `import-tokens-modal`
       // switch.
       let standard: string | undefined;
+      let rpcTokenInfo;
       if (addressIsValid) {
         try {
-          const result = await getTokenStandardAndDetailsByChain(
+          rpcTokenInfo = await getTokenStandardAndDetailsByChain(
             standardAddress,
             selectedAccount?.address,
             undefined,
             selectedNetwork,
           );
-          standard = result?.standard;
+          standard = rpcTokenInfo?.standard;
         } catch {
           // ignore probe failures
         }
@@ -325,16 +365,13 @@ export const CustomTokenImportPage = () => {
         if (!isLatestLookup()) {
           return;
         }
-        const rawDecimals = info?.decimals;
-        const nextDecimals =
-          rawDecimals === undefined || rawDecimals === null
-            ? ''
-            : String(rawDecimals);
-        setSymbol(info?.symbol ?? '');
-        setName(info?.name ?? '');
-        setDecimals(nextDecimals);
+        const { symbol: mergedSymbol, name: mergedName, decimals: mergedDecimals } =
+          mergeCustomTokenMetadataForImport(rpcTokenInfo, info);
+        setSymbol(mergedSymbol);
+        setName(mergedName);
+        setDecimals(mergedDecimals);
         setShowSymbolAndDecimals(true);
-        if (!info?.symbol || nextDecimals === '') {
+        if (!mergedSymbol || mergedDecimals === '') {
           trackViewed(CUSTOM_TOKEN_IMPORT_LOOKUP_FAILED_VIEW_STATE);
         }
       } catch {


### PR DESCRIPTION
Prefer non-empty on-chain fields over empty token-list placeholders so symbol, name, and decimals auto-fill correctly. Add merge helper tests and an integration case for empty list responses.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: merge RPC and token list metadata on custom import

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/45e15000-b23e-41e1-b04e-2afdf249f0df



### **After**


https://github.com/user-attachments/assets/a8525e85-8e56-4263-bb2e-3850136fe675



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: scoped UI auto-fill logic change for custom token import, with added unit/integration tests to cover placeholder token-list responses.
> 
> **Overview**
> Custom token import now **merges on-chain (RPC) token metadata with token-list lookup**, preferring non-empty RPC fields so token-list placeholders (e.g., empty `symbol`/`name` or `decimals: '0'`) don’t blank out the import form.
> 
> Adds `mergeCustomTokenMetadataForImport` (with trimming and fallback behavior) and updates the address lookup flow to use it, plus new tests covering merge edge cases and an integration scenario where the token list returns only placeholders.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9767517eff3a90ebae930b8f4a55f7920fecfa1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->