### PR TITLE
feat: update networks modal close on manage tokens page

### DIFF
--- a/ui/components/multichain/network-manager/network-manager.test.tsx
+++ b/ui/components/multichain/network-manager/network-manager.test.tsx
@@ -317,15 +317,15 @@ describe('NetworkManager Component', () => {
   it('keeps the current route when dismissed outside from token management', () => {
     renderNetworkManagerWithLocationDisplay(TOKEN_MANAGEMENT_ROUTE);
 
-    expect(screen.getByTestId('network-manager-current-route')).toHaveTextContent(
-      TOKEN_MANAGEMENT_ROUTE,
-    );
+    expect(
+      screen.getByTestId('network-manager-current-route'),
+    ).toHaveTextContent(TOKEN_MANAGEMENT_ROUTE);
 
     fireEvent.mouseDown(document.body);
 
-    expect(screen.getByTestId('network-manager-current-route')).toHaveTextContent(
-      TOKEN_MANAGEMENT_ROUTE,
-    );
+    expect(
+      screen.getByTestId('network-manager-current-route'),
+    ).toHaveTextContent(TOKEN_MANAGEMENT_ROUTE);
   });
 
   it('submitting a new RPC URL from add-rpc view switches to add view', async () => {

--- a/ui/components/multichain/network-manager/network-manager.test.tsx
+++ b/ui/components/multichain/network-manager/network-manager.test.tsx
@@ -3,11 +3,13 @@ import { screen, fireEvent } from '@testing-library/react';
 import { RpcEndpointType } from '@metamask/network-controller';
 import { SolScope } from '@metamask/keyring-api';
 import { NetworkEnablementControllerState } from '@metamask/network-enablement-controller';
+import { useLocation } from 'react-router-dom';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import configureStore from '../../../store/store';
 import mockState from '../../../../test/data/mock-state.json';
 import { SOLANA_WALLET_SNAP_ID } from '../../../../shared/lib/accounts';
+import { TOKEN_MANAGEMENT_ROUTE } from '../../../helpers/constants/routes';
 import { NetworkManager } from './network-manager';
 
 // Mock the store actions
@@ -101,6 +103,17 @@ const mockNetworkConfigurations = {
   },
 };
 
+const LocationDisplay = () => {
+  const location = useLocation();
+
+  return (
+    <div data-testid="network-manager-current-route">
+      {location.pathname}
+      {location.search}
+    </div>
+  );
+};
+
 describe('NetworkManager Component', () => {
   const renderNetworkManager = (pathname = '/') => {
     const store = configureStore({
@@ -127,6 +140,40 @@ describe('NetworkManager Component', () => {
       },
     });
     return renderWithProvider(<NetworkManager />, store, pathname);
+  };
+
+  const renderNetworkManagerWithLocationDisplay = (pathname: string) => {
+    const store = configureStore({
+      ...mockState,
+      metamask: {
+        ...mockState.metamask,
+        networkConfigurationsByChainId: mockNetworkConfigurations,
+        selectedNetworkClientId: 'mainnet',
+        providerConfig: {
+          chainId: '0x1',
+          rpcUrl: 'https://mainnet.infura.io/v3/123',
+          type: 'rpc',
+          ticker: 'ETH',
+        },
+        enabledNetworkMap: {
+          eip155: {
+            '0x1': true,
+            '0xa': true,
+            '0xa4b1': true,
+            '0xa86a': true,
+            '0x2105': true,
+          },
+        },
+      },
+    });
+    return renderWithProvider(
+      <>
+        <NetworkManager />
+        <LocationDisplay />
+      </>,
+      store,
+      pathname,
+    );
   };
 
   const renderNetworkManagerWithEditedNetwork = (pathname = '/') => {
@@ -265,6 +312,20 @@ describe('NetworkManager Component', () => {
     expect(
       screen.getByText(messages.addCustomNetwork.message),
     ).toBeInTheDocument();
+  });
+
+  it('keeps the current route when dismissed outside from token management', () => {
+    renderNetworkManagerWithLocationDisplay(TOKEN_MANAGEMENT_ROUTE);
+
+    expect(screen.getByTestId('network-manager-current-route')).toHaveTextContent(
+      TOKEN_MANAGEMENT_ROUTE,
+    );
+
+    fireEvent.mouseDown(document.body);
+
+    expect(screen.getByTestId('network-manager-current-route')).toHaveTextContent(
+      TOKEN_MANAGEMENT_ROUTE,
+    );
   });
 
   it('submitting a new RPC URL from add-rpc view switches to add view', async () => {

--- a/ui/components/multichain/network-manager/network-manager.tsx
+++ b/ui/components/multichain/network-manager/network-manager.tsx
@@ -3,9 +3,9 @@ import {
   RpcEndpointType,
   UpdateNetworkFields,
 } from '@metamask/network-controller';
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { useNavigate, useSearchParams } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import * as URI from 'uri-js';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useNetworkFormState } from '../networks-form/networks-form-state';
@@ -23,7 +23,6 @@ import {
 import AddBlockExplorerModal from '../network-list-menu/add-block-explorer-modal/add-block-explorer-modal';
 import AddRpcUrlModal from '../network-list-menu/add-rpc-url-modal/add-rpc-url-modal';
 import { SelectRpcUrlModal } from '../network-list-menu/select-rpc-url-modal/select-rpc-url-modal';
-import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import { AddNetwork } from './components/add-network';
 import { NetworkTabs } from './network-tabs';
 import { useNetworkManagerInitialTab } from './hooks/useNetworkManagerState';
@@ -31,9 +30,10 @@ import { useNetworkManagerInitialTab } from './hooks/useNetworkManagerState';
 export const NetworkManager = () => {
   const dispatch = useDispatch();
   const t = useI18nContext();
-  const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
   const view = searchParams.get('view') ?? '';
+  const viewRef = useRef(view);
+  viewRef.current = view;
 
   const { initialTab } = useNetworkManagerInitialTab();
   const handleNewNetwork = () => {
@@ -117,11 +117,13 @@ export const NetworkManager = () => {
     [networkFormState, setSearchParams, view],
   );
 
-  const handleClose = () => {
+  const handleClose = useCallback(() => {
     dispatch(hideModal());
     dispatch(setEditedNetwork());
-    navigate(DEFAULT_ROUTE);
-  };
+    if (viewRef.current) {
+      setSearchParams({});
+    }
+  }, [dispatch, setSearchParams]);
 
   const handleGoHome = () => {
     setSearchParams({});


### PR DESCRIPTION
  Fixes the Network Manager close behavior when opened from the Manage Tokens page. Previously, dismissing the modal by clicking outside always navigated to /, sending the user back to the homepage. The close handler now only closes the modal, clears edited network state, and clears Network Manager internal view query state when needed.


## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: #42815 

## **Manual testing steps**

  1. Open Manage Tokens.
  2. Click the network filter to open Network Manager.
  3. Click outside the modal.
  4. Confirm the modal closes and the user remains on Manage Tokens.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/bdb0ef6f-d792-4418-9a3e-2be3adce78f4


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-behavior change limited to Network Manager modal close handling; main risk is unintended retention/clearing of `view` query params across entry points.
> 
> **Overview**
> Fixes Network Manager modal dismiss behavior so closing (including outside click) no longer forces navigation to the default route.
> 
> `handleClose` now only hides the modal, clears edited-network state, and conditionally clears the Network Manager `view` search param (tracked via a ref) when an internal subview is active. Adds a regression test to ensure dismissing the modal from `TOKEN_MANAGEMENT_ROUTE` preserves the current route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 999d78e134add629e4b13b5403a8964ac6804686. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->