### PR TITLE
feat: Add QR error utils

### DIFF
--- a/ui/components/app/qr-hardware-popover/qr-utils/qr-utils.test.ts
+++ b/ui/components/app/qr-hardware-popover/qr-utils/qr-utils.test.ts
@@ -2,8 +2,8 @@ import { QrErrorType } from '../qr-error-content';
 import {
   classifyScanResult,
   scanCategoryToQrErrorType,
-  type ClassifyScanInput,
-  type ScanClassification,
+  type ScanClassificationInput,
+  type ScanErrorClassification,
 } from './qr-utils';
 
 describe('classifyScanResult', () => {
@@ -374,7 +374,7 @@ describe('classifyScanResult', () => {
     });
 
     it('when exception is explicitly undefined', () => {
-      const input: ClassifyScanInput = {
+      const input: ScanClassificationInput = {
         text: 'ur:crypto-hdkey/1-2/data',
         expectedTypes: PAIRING_EXPECTED_TYPES,
         exception: undefined,
@@ -462,12 +462,12 @@ describe('scanCategoryToQrErrorType', () => {
   });
 });
 
-describe('ScanClassification type discrimination', () => {
+describe('ScanErrorClassification type discrimination', () => {
   it('narrows non_ur_qr_scanned to { isUrFormat: false }', () => {
     const result = classifyScanResult({
       text: 'plain text',
       expectedTypes: ['crypto-hdkey'],
-    }) as ScanClassification;
+    }) as ScanErrorClassification;
 
     expect(result.category).toBe('non_ur_qr_scanned');
     expect(result.isUrFormat).toBe(false);
@@ -477,7 +477,7 @@ describe('ScanClassification type discrimination', () => {
     const result = classifyScanResult({
       decodedType: 'crypto-psbt',
       expectedTypes: ['crypto-hdkey'],
-    }) as ScanClassification;
+    }) as ScanErrorClassification;
 
     expect(result.category).toBe('wrong_ur_type');
     if (result.category === 'wrong_ur_type') {
@@ -490,7 +490,7 @@ describe('ScanClassification type discrimination', () => {
     const result = classifyScanResult({
       expectedTypes: ['crypto-hdkey'],
       exception: new Error('crash'),
-    }) as ScanClassification;
+    }) as ScanErrorClassification;
 
     expect(result.category).toBe('scan_exception');
     if (result.category === 'scan_exception') {

--- a/ui/components/app/qr-hardware-popover/qr-utils/qr-utils.test.ts
+++ b/ui/components/app/qr-hardware-popover/qr-utils/qr-utils.test.ts
@@ -2,6 +2,7 @@ import { QrErrorType } from '../qr-error-content';
 import {
   classifyScanResult,
   scanCategoryToQrErrorType,
+  ScanErrorCategory,
   type ScanClassificationInput,
   type ScanErrorClassification,
 } from './qr-utils';
@@ -17,7 +18,10 @@ describe('classifyScanResult', () => {
           text: 'https://metamask.io',
           expectedTypes: PAIRING_EXPECTED_TYPES,
         }),
-      ).toStrictEqual({ category: 'non_ur_qr_scanned', isUrFormat: false });
+      ).toStrictEqual({
+        category: ScanErrorCategory.NonUrQrScanned,
+        isUrFormat: false,
+      });
     });
 
     it('classifies an Ethereum address as non-UR', () => {
@@ -26,7 +30,10 @@ describe('classifyScanResult', () => {
           text: '0x742d35Cc6634C0532925a3b844Bc9e7595f2bD28',
           expectedTypes: PAIRING_EXPECTED_TYPES,
         }),
-      ).toStrictEqual({ category: 'non_ur_qr_scanned', isUrFormat: false });
+      ).toStrictEqual({
+        category: ScanErrorCategory.NonUrQrScanned,
+        isUrFormat: false,
+      });
     });
 
     it('classifies arbitrary text as non-UR', () => {
@@ -35,7 +42,10 @@ describe('classifyScanResult', () => {
           text: 'Hello World!',
           expectedTypes: PAIRING_EXPECTED_TYPES,
         }),
-      ).toStrictEqual({ category: 'non_ur_qr_scanned', isUrFormat: false });
+      ).toStrictEqual({
+        category: ScanErrorCategory.NonUrQrScanned,
+        isUrFormat: false,
+      });
     });
 
     it('classifies numeric string as non-UR', () => {
@@ -44,7 +54,10 @@ describe('classifyScanResult', () => {
           text: '1234567890',
           expectedTypes: PAIRING_EXPECTED_TYPES,
         }),
-      ).toStrictEqual({ category: 'non_ur_qr_scanned', isUrFormat: false });
+      ).toStrictEqual({
+        category: ScanErrorCategory.NonUrQrScanned,
+        isUrFormat: false,
+      });
     });
 
     it('returns null for empty text', () => {
@@ -65,7 +78,7 @@ describe('classifyScanResult', () => {
       });
 
       expect(result).toStrictEqual({
-        category: 'wrong_ur_type',
+        category: ScanErrorCategory.WrongUrType,
         isUrFormat: true,
         receivedUrType: 'crypto-hdkey',
       });
@@ -78,7 +91,7 @@ describe('classifyScanResult', () => {
       });
 
       expect(result).toStrictEqual({
-        category: 'wrong_ur_type',
+        category: ScanErrorCategory.WrongUrType,
         isUrFormat: true,
         receivedUrType: 'eth-signature',
       });
@@ -91,7 +104,7 @@ describe('classifyScanResult', () => {
       });
 
       expect(result).toStrictEqual({
-        category: 'wrong_ur_type',
+        category: ScanErrorCategory.WrongUrType,
         isUrFormat: true,
         receivedUrType: 'crypto-psbt',
       });
@@ -131,7 +144,7 @@ describe('classifyScanResult', () => {
       });
 
       expect(result).toStrictEqual({
-        category: 'wrong_ur_type',
+        category: ScanErrorCategory.WrongUrType,
         isUrFormat: true,
         receivedUrType: 'crypto-hdkey',
       });
@@ -146,7 +159,7 @@ describe('classifyScanResult', () => {
       });
 
       expect(result).toStrictEqual({
-        category: 'ur_decode_error',
+        category: ScanErrorCategory.UrDecodeError,
         isUrFormat: true,
       });
     });
@@ -159,7 +172,7 @@ describe('classifyScanResult', () => {
       });
 
       expect(result).toStrictEqual({
-        category: 'ur_decode_error',
+        category: ScanErrorCategory.UrDecodeError,
         isUrFormat: true,
       });
     });
@@ -183,7 +196,7 @@ describe('classifyScanResult', () => {
       });
 
       expect(result).toStrictEqual({
-        category: 'scan_exception',
+        category: ScanErrorCategory.ScanException,
         isUrFormat: false,
         rawMessage: 'CBOR decode failed',
       });
@@ -196,7 +209,7 @@ describe('classifyScanResult', () => {
       });
 
       expect(result).toStrictEqual({
-        category: 'scan_exception',
+        category: ScanErrorCategory.ScanException,
         isUrFormat: false,
         rawMessage: 'something went wrong',
       });
@@ -209,7 +222,7 @@ describe('classifyScanResult', () => {
       });
 
       expect(result).toStrictEqual({
-        category: 'scan_exception',
+        category: ScanErrorCategory.ScanException,
         isUrFormat: false,
         rawMessage: '42',
       });
@@ -275,7 +288,7 @@ describe('classifyScanResult', () => {
         exception: new Error('runtime crash'),
       });
 
-      expect(result?.category).toBe('scan_exception');
+      expect(result?.category).toBe(ScanErrorCategory.ScanException);
     });
 
     it('exception > wrong UR type', () => {
@@ -285,7 +298,7 @@ describe('classifyScanResult', () => {
         exception: new Error('processing error'),
       });
 
-      expect(result?.category).toBe('scan_exception');
+      expect(result?.category).toBe(ScanErrorCategory.ScanException);
     });
 
     it('decoderError > wrong UR type', () => {
@@ -295,7 +308,7 @@ describe('classifyScanResult', () => {
         expectedTypes: PAIRING_EXPECTED_TYPES,
       });
 
-      expect(result?.category).toBe('ur_decode_error');
+      expect(result?.category).toBe(ScanErrorCategory.UrDecodeError);
     });
 
     it('decoderError > non-UR text', () => {
@@ -305,7 +318,7 @@ describe('classifyScanResult', () => {
         expectedTypes: PAIRING_EXPECTED_TYPES,
       });
 
-      expect(result?.category).toBe('ur_decode_error');
+      expect(result?.category).toBe(ScanErrorCategory.UrDecodeError);
     });
 
     it('wrong UR type > non-UR text', () => {
@@ -315,7 +328,7 @@ describe('classifyScanResult', () => {
         expectedTypes: PAIRING_EXPECTED_TYPES,
       });
 
-      expect(result?.category).toBe('wrong_ur_type');
+      expect(result?.category).toBe(ScanErrorCategory.WrongUrType);
     });
   });
 
@@ -381,20 +394,20 @@ describe('classifyScanResult', () => {
   });
 
   describe('end-to-end acceptance scenarios', () => {
-    it('A4: AirGap V3 format scanned during pairing results in wrong_ur_type', () => {
+    it('A4: AirGap V3 format scanned during pairing results in WrongUrType', () => {
       const result = classifyScanResult({
         decodedType: 'crypto-multi-accounts',
         expectedTypes: PAIRING_EXPECTED_TYPES,
       });
 
       expect(result).toStrictEqual({
-        category: 'wrong_ur_type',
+        category: ScanErrorCategory.WrongUrType,
         isUrFormat: true,
         receivedUrType: 'crypto-multi-accounts',
       });
     });
 
-    it('A9: partially obscured QR results in ur_decode_error', () => {
+    it('A9: partially obscured QR results in UrDecodeError', () => {
       const result = classifyScanResult({
         text: 'ur:crypto-hdkey/1-5/partial',
         decoderError: true,
@@ -402,7 +415,7 @@ describe('classifyScanResult', () => {
       });
 
       expect(result).toStrictEqual({
-        category: 'ur_decode_error',
+        category: ScanErrorCategory.UrDecodeError,
         isUrFormat: true,
       });
     });
@@ -426,26 +439,26 @@ describe('classifyScanResult', () => {
 });
 
 describe('scanCategoryToQrErrorType', () => {
-  it('maps non_ur_qr_scanned to NonUrQrCode', () => {
-    expect(scanCategoryToQrErrorType('non_ur_qr_scanned')).toBe(
+  it('maps NonUrQrScanned to NonUrQrCode', () => {
+    expect(scanCategoryToQrErrorType(ScanErrorCategory.NonUrQrScanned)).toBe(
       QrErrorType.NonUrQrCode,
     );
   });
 
-  it('maps wrong_ur_type to WrongUrType', () => {
-    expect(scanCategoryToQrErrorType('wrong_ur_type')).toBe(
+  it('maps WrongUrType to WrongUrType', () => {
+    expect(scanCategoryToQrErrorType(ScanErrorCategory.WrongUrType)).toBe(
       QrErrorType.WrongUrType,
     );
   });
 
-  it('maps ur_decode_error to UrDecodeError', () => {
-    expect(scanCategoryToQrErrorType('ur_decode_error')).toBe(
+  it('maps UrDecodeError to UrDecodeError', () => {
+    expect(scanCategoryToQrErrorType(ScanErrorCategory.UrDecodeError)).toBe(
       QrErrorType.UrDecodeError,
     );
   });
 
-  it('maps scan_exception to UrDecodeError', () => {
-    expect(scanCategoryToQrErrorType('scan_exception')).toBe(
+  it('maps ScanException to UrDecodeError', () => {
+    expect(scanCategoryToQrErrorType(ScanErrorCategory.ScanException)).toBe(
       QrErrorType.UrDecodeError,
     );
   });
@@ -459,37 +472,37 @@ describe('scanCategoryToQrErrorType', () => {
 });
 
 describe('ScanErrorClassification type discrimination', () => {
-  it('narrows non_ur_qr_scanned to { isUrFormat: false }', () => {
+  it('narrows NonUrQrScanned to { isUrFormat: false }', () => {
     const result = classifyScanResult({
       text: 'plain text',
       expectedTypes: ['crypto-hdkey'],
     }) as ScanErrorClassification;
 
-    expect(result.category).toBe('non_ur_qr_scanned');
+    expect(result.category).toBe(ScanErrorCategory.NonUrQrScanned);
     expect(result.isUrFormat).toBe(false);
   });
 
-  it('narrows wrong_ur_type to { isUrFormat: true, receivedUrType }', () => {
+  it('narrows WrongUrType to { isUrFormat: true, receivedUrType }', () => {
     const result = classifyScanResult({
       decodedType: 'crypto-psbt',
       expectedTypes: ['crypto-hdkey'],
     }) as ScanErrorClassification;
 
-    expect(result.category).toBe('wrong_ur_type');
-    if (result.category === 'wrong_ur_type') {
+    expect(result.category).toBe(ScanErrorCategory.WrongUrType);
+    if (result.category === ScanErrorCategory.WrongUrType) {
       expect(result.isUrFormat).toBe(true);
       expect(result.receivedUrType).toBe('crypto-psbt');
     }
   });
 
-  it('narrows scan_exception to { isUrFormat, rawMessage }', () => {
+  it('narrows ScanException to { isUrFormat, rawMessage }', () => {
     const result = classifyScanResult({
       expectedTypes: ['crypto-hdkey'],
       exception: new Error('crash'),
     }) as ScanErrorClassification;
 
-    expect(result.category).toBe('scan_exception');
-    if (result.category === 'scan_exception') {
+    expect(result.category).toBe(ScanErrorCategory.ScanException);
+    if (result.category === ScanErrorCategory.ScanException) {
       expect(result.rawMessage).toBe('crash');
       expect(typeof result.isUrFormat).toBe('boolean');
     }

--- a/ui/components/app/qr-hardware-popover/qr-utils/qr-utils.test.ts
+++ b/ui/components/app/qr-hardware-popover/qr-utils/qr-utils.test.ts
@@ -1,0 +1,501 @@
+import { QrErrorType } from '../qr-error-content';
+import {
+  classifyScanResult,
+  scanCategoryToQrErrorType,
+  type ClassifyScanInput,
+  type ScanClassification,
+} from './qr-utils';
+
+describe('classifyScanResult', () => {
+  const PAIRING_EXPECTED_TYPES = ['crypto-hdkey', 'crypto-account'] as const;
+  const SIGNING_EXPECTED_TYPES = ['eth-signature'] as const;
+
+  describe('non_ur_qr_scanned - text is not UR-encoded', () => {
+    it('classifies a URL as non-UR', () => {
+      expect(
+        classifyScanResult({
+          text: 'https://metamask.io',
+          expectedTypes: PAIRING_EXPECTED_TYPES,
+        }),
+      ).toStrictEqual({ category: 'non_ur_qr_scanned', isUrFormat: false });
+    });
+
+    it('classifies an Ethereum address as non-UR', () => {
+      expect(
+        classifyScanResult({
+          text: '0x742d35Cc6634C0532925a3b844Bc9e7595f2bD28',
+          expectedTypes: PAIRING_EXPECTED_TYPES,
+        }),
+      ).toStrictEqual({ category: 'non_ur_qr_scanned', isUrFormat: false });
+    });
+
+    it('classifies arbitrary text as non-UR', () => {
+      expect(
+        classifyScanResult({
+          text: 'Hello World!',
+          expectedTypes: PAIRING_EXPECTED_TYPES,
+        }),
+      ).toStrictEqual({ category: 'non_ur_qr_scanned', isUrFormat: false });
+    });
+
+    it('classifies numeric string as non-UR', () => {
+      expect(
+        classifyScanResult({
+          text: '1234567890',
+          expectedTypes: PAIRING_EXPECTED_TYPES,
+        }),
+      ).toStrictEqual({ category: 'non_ur_qr_scanned', isUrFormat: false });
+    });
+
+    it('returns null for empty text', () => {
+      expect(
+        classifyScanResult({
+          text: '',
+          expectedTypes: PAIRING_EXPECTED_TYPES,
+        }),
+      ).toBeNull();
+    });
+  });
+
+  describe('wrong_ur_type - valid UR with unexpected type', () => {
+    it('detects crypto-hdkey during a signing flow', () => {
+      const result = classifyScanResult({
+        decodedType: 'crypto-hdkey',
+        expectedTypes: SIGNING_EXPECTED_TYPES,
+      });
+
+      expect(result).toStrictEqual({
+        category: 'wrong_ur_type',
+        isUrFormat: true,
+        receivedUrType: 'crypto-hdkey',
+      });
+    });
+
+    it('detects eth-signature during a pairing flow', () => {
+      const result = classifyScanResult({
+        decodedType: 'eth-signature',
+        expectedTypes: PAIRING_EXPECTED_TYPES,
+      });
+
+      expect(result).toStrictEqual({
+        category: 'wrong_ur_type',
+        isUrFormat: true,
+        receivedUrType: 'eth-signature',
+      });
+    });
+
+    it('treats any type not in expectedTypes as wrong', () => {
+      const result = classifyScanResult({
+        decodedType: 'crypto-psbt',
+        expectedTypes: [...PAIRING_EXPECTED_TYPES, ...SIGNING_EXPECTED_TYPES],
+      });
+
+      expect(result).toStrictEqual({
+        category: 'wrong_ur_type',
+        isUrFormat: true,
+        receivedUrType: 'crypto-psbt',
+      });
+    });
+
+    it('compares types case-insensitively', () => {
+      expect(
+        classifyScanResult({
+          decodedType: 'CRYPTO-HDKEY',
+          expectedTypes: ['crypto-hdkey'],
+        }),
+      ).toBeNull();
+
+      expect(
+        classifyScanResult({
+          decodedType: 'crypto-hdkey',
+          expectedTypes: ['CRYPTO-HDKEY'],
+        }),
+      ).toBeNull();
+    });
+
+    it('preserves original casing in receivedUrType', () => {
+      const result = classifyScanResult({
+        decodedType: 'Eth-Signature',
+        expectedTypes: PAIRING_EXPECTED_TYPES,
+      });
+
+      expect(result).toStrictEqual(
+        expect.objectContaining({ receivedUrType: 'Eth-Signature' }),
+      );
+    });
+
+    it('reports wrong type when expectedTypes is empty', () => {
+      const result = classifyScanResult({
+        decodedType: 'crypto-hdkey',
+        expectedTypes: [],
+      });
+
+      expect(result).toStrictEqual({
+        category: 'wrong_ur_type',
+        isUrFormat: true,
+        receivedUrType: 'crypto-hdkey',
+      });
+    });
+  });
+
+  describe('ur_decode_error - decoder failed to reassemble', () => {
+    it('classifies when decoderError is true', () => {
+      const result = classifyScanResult({
+        decoderError: true,
+        expectedTypes: PAIRING_EXPECTED_TYPES,
+      });
+
+      expect(result).toStrictEqual({
+        category: 'ur_decode_error',
+        isUrFormat: true,
+      });
+    });
+
+    it('classifies even when UR text is also present', () => {
+      const result = classifyScanResult({
+        text: 'ur:crypto-hdkey/1-3/partial-data',
+        decoderError: true,
+        expectedTypes: PAIRING_EXPECTED_TYPES,
+      });
+
+      expect(result).toStrictEqual({
+        category: 'ur_decode_error',
+        isUrFormat: true,
+      });
+    });
+
+    it('does not classify when decoderError is false', () => {
+      const result = classifyScanResult({
+        text: 'ur:crypto-hdkey/1-3/some-data',
+        decoderError: false,
+        expectedTypes: PAIRING_EXPECTED_TYPES,
+      });
+
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('scan_exception - runtime exception caught', () => {
+    it('extracts message from an Error instance', () => {
+      const result = classifyScanResult({
+        expectedTypes: PAIRING_EXPECTED_TYPES,
+        exception: new Error('CBOR decode failed'),
+      });
+
+      expect(result).toStrictEqual({
+        category: 'scan_exception',
+        isUrFormat: false,
+        rawMessage: 'CBOR decode failed',
+      });
+    });
+
+    it('uses string exceptions directly as rawMessage', () => {
+      const result = classifyScanResult({
+        expectedTypes: PAIRING_EXPECTED_TYPES,
+        exception: 'something went wrong',
+      });
+
+      expect(result).toStrictEqual({
+        category: 'scan_exception',
+        isUrFormat: false,
+        rawMessage: 'something went wrong',
+      });
+    });
+
+    it('stringifies non-Error non-string exceptions', () => {
+      const result = classifyScanResult({
+        expectedTypes: PAIRING_EXPECTED_TYPES,
+        exception: 42,
+      });
+
+      expect(result).toStrictEqual({
+        category: 'scan_exception',
+        isUrFormat: false,
+        rawMessage: '42',
+      });
+    });
+
+    it('treats null as a present exception value', () => {
+      const result = classifyScanResult({
+        text: 'ur:crypto-hdkey/data',
+        expectedTypes: PAIRING_EXPECTED_TYPES,
+        exception: null,
+      });
+
+      expect(result).toStrictEqual({
+        category: 'scan_exception',
+        isUrFormat: true,
+        rawMessage: 'null',
+      });
+    });
+
+    it('infers isUrFormat from text when exception is present', () => {
+      const withUrText = classifyScanResult({
+        text: 'ur:crypto-hdkey/1-2/bad-payload',
+        expectedTypes: PAIRING_EXPECTED_TYPES,
+        exception: new Error('fail'),
+      });
+      expect(withUrText).toStrictEqual(
+        expect.objectContaining({ isUrFormat: true }),
+      );
+
+      const withNonUrText = classifyScanResult({
+        text: 'https://example.com',
+        expectedTypes: PAIRING_EXPECTED_TYPES,
+        exception: new Error('fail'),
+      });
+      expect(withNonUrText).toStrictEqual(
+        expect.objectContaining({ isUrFormat: false }),
+      );
+    });
+
+    it('defaults isUrFormat to false when text is absent', () => {
+      const result = classifyScanResult({
+        expectedTypes: SIGNING_EXPECTED_TYPES,
+        exception: new Error('timeout'),
+      });
+
+      expect(result).toStrictEqual(
+        expect.objectContaining({ isUrFormat: false }),
+      );
+    });
+
+    it('handles an Error with empty message', () => {
+      const result = classifyScanResult({
+        expectedTypes: PAIRING_EXPECTED_TYPES,
+        exception: new Error(''),
+      });
+
+      expect(result).toStrictEqual(expect.objectContaining({ rawMessage: '' }));
+    });
+  });
+
+  describe('priority ordering', () => {
+    it('exception > decoderError', () => {
+      const result = classifyScanResult({
+        text: 'ur:crypto-hdkey/1-2/data',
+        decoderError: true,
+        expectedTypes: PAIRING_EXPECTED_TYPES,
+        exception: new Error('runtime crash'),
+      });
+
+      expect(result?.category).toBe('scan_exception');
+    });
+
+    it('exception > wrong UR type', () => {
+      const result = classifyScanResult({
+        decodedType: 'crypto-psbt',
+        expectedTypes: PAIRING_EXPECTED_TYPES,
+        exception: new Error('processing error'),
+      });
+
+      expect(result?.category).toBe('scan_exception');
+    });
+
+    it('decoderError > wrong UR type', () => {
+      const result = classifyScanResult({
+        decodedType: 'crypto-psbt',
+        decoderError: true,
+        expectedTypes: PAIRING_EXPECTED_TYPES,
+      });
+
+      expect(result?.category).toBe('ur_decode_error');
+    });
+
+    it('decoderError > non-UR text', () => {
+      const result = classifyScanResult({
+        text: 'https://example.com',
+        decoderError: true,
+        expectedTypes: PAIRING_EXPECTED_TYPES,
+      });
+
+      expect(result?.category).toBe('ur_decode_error');
+    });
+
+    it('wrong UR type > non-UR text', () => {
+      const result = classifyScanResult({
+        text: 'https://example.com',
+        decodedType: 'crypto-psbt',
+        expectedTypes: PAIRING_EXPECTED_TYPES,
+      });
+
+      expect(result?.category).toBe('wrong_ur_type');
+    });
+  });
+
+  describe('returns null (no error detected)', () => {
+    it('when decoded type matches an expected type', () => {
+      expect(
+        classifyScanResult({
+          decodedType: 'crypto-hdkey',
+          expectedTypes: PAIRING_EXPECTED_TYPES,
+        }),
+      ).toBeNull();
+    });
+
+    it('when text looks like a UR still being decoded', () => {
+      expect(
+        classifyScanResult({
+          text: 'ur:crypto-hdkey/1-5/some-encoded-data',
+          expectedTypes: PAIRING_EXPECTED_TYPES,
+        }),
+      ).toBeNull();
+    });
+
+    it('when only expectedTypes is provided (scanner idle)', () => {
+      expect(
+        classifyScanResult({ expectedTypes: PAIRING_EXPECTED_TYPES }),
+      ).toBeNull();
+    });
+
+    it('for case-variant UR prefixes (UR:, Ur:)', () => {
+      expect(
+        classifyScanResult({
+          text: 'UR:CRYPTO-HDKEY/1-2/DATA',
+          expectedTypes: PAIRING_EXPECTED_TYPES,
+        }),
+      ).toBeNull();
+
+      expect(
+        classifyScanResult({
+          text: 'Ur:Crypto-Hdkey/1-2/data',
+          expectedTypes: PAIRING_EXPECTED_TYPES,
+        }),
+      ).toBeNull();
+    });
+
+    it('for bare ur: prefix with no type segment', () => {
+      expect(
+        classifyScanResult({
+          text: 'ur:',
+          expectedTypes: PAIRING_EXPECTED_TYPES,
+        }),
+      ).toBeNull();
+    });
+
+    it('when exception is explicitly undefined', () => {
+      const input: ClassifyScanInput = {
+        text: 'ur:crypto-hdkey/1-2/data',
+        expectedTypes: PAIRING_EXPECTED_TYPES,
+        exception: undefined,
+      };
+
+      expect(classifyScanResult(input)).toBeNull();
+    });
+  });
+
+  describe('end-to-end acceptance scenarios', () => {
+    it('A4: AirGap V3 format scanned during pairing results in wrong_ur_type', () => {
+      const result = classifyScanResult({
+        decodedType: 'crypto-multi-accounts',
+        expectedTypes: PAIRING_EXPECTED_TYPES,
+      });
+
+      expect(result).toStrictEqual({
+        category: 'wrong_ur_type',
+        isUrFormat: true,
+        receivedUrType: 'crypto-multi-accounts',
+      });
+    });
+
+    it('A9: partially obscured QR results in ur_decode_error', () => {
+      const result = classifyScanResult({
+        text: 'ur:crypto-hdkey/1-5/partial',
+        decoderError: true,
+        expectedTypes: PAIRING_EXPECTED_TYPES,
+      });
+
+      expect(result).toStrictEqual({
+        category: 'ur_decode_error',
+        isUrFormat: true,
+      });
+    });
+
+    it('A11-A13: successful pairing and signing returns null', () => {
+      expect(
+        classifyScanResult({
+          decodedType: 'crypto-hdkey',
+          expectedTypes: PAIRING_EXPECTED_TYPES,
+        }),
+      ).toBeNull();
+
+      expect(
+        classifyScanResult({
+          decodedType: 'eth-signature',
+          expectedTypes: SIGNING_EXPECTED_TYPES,
+        }),
+      ).toBeNull();
+    });
+  });
+});
+
+describe('scanCategoryToQrErrorType', () => {
+  it('maps non_ur_qr_scanned to NonUrQrCode', () => {
+    expect(scanCategoryToQrErrorType('non_ur_qr_scanned')).toBe(
+      QrErrorType.NonUrQrCode,
+    );
+  });
+
+  it('maps wrong_ur_type to WrongUrType', () => {
+    expect(scanCategoryToQrErrorType('wrong_ur_type')).toBe(
+      QrErrorType.WrongUrType,
+    );
+  });
+
+  it('maps ur_decode_error to UrDecodeError', () => {
+    expect(scanCategoryToQrErrorType('ur_decode_error')).toBe(
+      QrErrorType.UrDecodeError,
+    );
+  });
+
+  it('maps scan_exception to UrDecodeError', () => {
+    expect(scanCategoryToQrErrorType('scan_exception')).toBe(
+      QrErrorType.UrDecodeError,
+    );
+  });
+
+  it('falls back to UrDecodeError for unknown categories', () => {
+    const unknownCategory = 'future_category' as never;
+    expect(scanCategoryToQrErrorType(unknownCategory)).toBe(
+      QrErrorType.UrDecodeError,
+    );
+  });
+});
+
+describe('ScanClassification type discrimination', () => {
+  it('narrows non_ur_qr_scanned to { isUrFormat: false }', () => {
+    const result = classifyScanResult({
+      text: 'plain text',
+      expectedTypes: ['crypto-hdkey'],
+    }) as ScanClassification;
+
+    expect(result.category).toBe('non_ur_qr_scanned');
+    expect(result.isUrFormat).toBe(false);
+  });
+
+  it('narrows wrong_ur_type to { isUrFormat: true, receivedUrType }', () => {
+    const result = classifyScanResult({
+      decodedType: 'crypto-psbt',
+      expectedTypes: ['crypto-hdkey'],
+    }) as ScanClassification;
+
+    expect(result.category).toBe('wrong_ur_type');
+    if (result.category === 'wrong_ur_type') {
+      expect(result.isUrFormat).toBe(true);
+      expect(result.receivedUrType).toBe('crypto-psbt');
+    }
+  });
+
+  it('narrows scan_exception to { isUrFormat, rawMessage }', () => {
+    const result = classifyScanResult({
+      expectedTypes: ['crypto-hdkey'],
+      exception: new Error('crash'),
+    }) as ScanClassification;
+
+    expect(result.category).toBe('scan_exception');
+    if (result.category === 'scan_exception') {
+      expect(result.rawMessage).toBe('crash');
+      expect(typeof result.isUrFormat).toBe('boolean');
+    }
+  });
+});

--- a/ui/components/app/qr-hardware-popover/qr-utils/qr-utils.test.ts
+++ b/ui/components/app/qr-hardware-popover/qr-utils/qr-utils.test.ts
@@ -215,18 +215,14 @@ describe('classifyScanResult', () => {
       });
     });
 
-    it('treats null as a present exception value', () => {
+    it('treats null exception as absent and falls through to other checks', () => {
       const result = classifyScanResult({
         text: 'ur:crypto-hdkey/data',
         expectedTypes: PAIRING_EXPECTED_TYPES,
         exception: null,
       });
 
-      expect(result).toStrictEqual({
-        category: 'scan_exception',
-        isUrFormat: true,
-        rawMessage: 'null',
-      });
+      expect(result).toBeNull();
     });
 
     it('infers isUrFormat from text when exception is present', () => {

--- a/ui/components/app/qr-hardware-popover/qr-utils/qr-utils.ts
+++ b/ui/components/app/qr-hardware-popover/qr-utils/qr-utils.ts
@@ -4,26 +4,38 @@ import { extractMessageFromUnknownError } from '../../../../contexts/hardware-wa
 /**
  * Error categories for QR scan results.
  *
- * - `non_ur_qr_scanned` - scanned data is not UR-encoded (URL, plain address, etc.).
- * - `wrong_ur_type` - valid UR whose type does not match the current flow.
- * - `ur_decode_error` - the UR decoder failed to reassemble frames.
- * - `scan_exception` - an unexpected runtime exception during processing.
+ * - `NonUrQrScanned` - scanned data is not UR-encoded (URL, plain address, etc.).
+ * - `WrongUrType` - valid UR whose type does not match the current flow.
+ * - `UrDecodeError` - the UR decoder failed to reassemble frames.
+ * - `ScanException` - an unexpected runtime exception during processing.
  */
+export const ScanErrorCategory = {
+  NonUrQrScanned: 'non_ur_qr_scanned',
+  WrongUrType: 'wrong_ur_type',
+  UrDecodeError: 'ur_decode_error',
+  ScanException: 'scan_exception',
+} as const;
+
 export type ScanErrorCategory =
-  | 'non_ur_qr_scanned'
-  | 'wrong_ur_type'
-  | 'ur_decode_error'
-  | 'scan_exception';
+  (typeof ScanErrorCategory)[keyof typeof ScanErrorCategory];
 
 /**
  * Discriminated union describing a classified scan error.
  * Each variant carries only the metadata relevant to its category.
  */
 export type ScanErrorClassification =
-  | { category: 'non_ur_qr_scanned'; isUrFormat: false }
-  | { category: 'wrong_ur_type'; isUrFormat: true; receivedUrType: string }
-  | { category: 'ur_decode_error'; isUrFormat: true }
-  | { category: 'scan_exception'; isUrFormat: boolean; rawMessage: string };
+  | { category: typeof ScanErrorCategory.NonUrQrScanned; isUrFormat: false }
+  | {
+      category: typeof ScanErrorCategory.WrongUrType;
+      isUrFormat: true;
+      receivedUrType: string;
+    }
+  | { category: typeof ScanErrorCategory.UrDecodeError; isUrFormat: true }
+  | {
+      category: typeof ScanErrorCategory.ScanException;
+      isUrFormat: boolean;
+      rawMessage: string;
+    };
 
 /**
  * Input for {@link classifyScanResult}. Callers populate only the fields
@@ -71,14 +83,14 @@ export function classifyScanResult(
   if (exception !== undefined && exception !== null) {
     const isUrFormat = text === undefined ? false : looksLikeUr(text);
     return {
-      category: 'scan_exception',
+      category: ScanErrorCategory.ScanException,
       isUrFormat,
       rawMessage: extractMessageFromUnknownError(exception),
     };
   }
 
   if (decoderError === true) {
-    return { category: 'ur_decode_error', isUrFormat: true };
+    return { category: ScanErrorCategory.UrDecodeError, isUrFormat: true };
   }
 
   if (decodedType !== undefined) {
@@ -88,7 +100,7 @@ export function classifyScanResult(
     );
     if (!isExpected) {
       return {
-        category: 'wrong_ur_type',
+        category: ScanErrorCategory.WrongUrType,
         isUrFormat: true,
         receivedUrType: decodedType,
       };
@@ -97,7 +109,7 @@ export function classifyScanResult(
   }
 
   if (text !== undefined && text.length > 0 && !looksLikeUr(text)) {
-    return { category: 'non_ur_qr_scanned', isUrFormat: false };
+    return { category: ScanErrorCategory.NonUrQrScanned, isUrFormat: false };
   }
 
   return null;
@@ -115,12 +127,12 @@ export function scanCategoryToQrErrorType(
   category: ScanErrorCategory,
 ): QrErrorType {
   switch (category) {
-    case 'non_ur_qr_scanned':
+    case ScanErrorCategory.NonUrQrScanned:
       return QrErrorType.NonUrQrCode;
-    case 'wrong_ur_type':
+    case ScanErrorCategory.WrongUrType:
       return QrErrorType.WrongUrType;
-    case 'ur_decode_error':
-    case 'scan_exception':
+    case ScanErrorCategory.UrDecodeError:
+    case ScanErrorCategory.ScanException:
       return QrErrorType.UrDecodeError;
     default:
       return QrErrorType.UrDecodeError;

--- a/ui/components/app/qr-hardware-popover/qr-utils/qr-utils.ts
+++ b/ui/components/app/qr-hardware-popover/qr-utils/qr-utils.ts
@@ -1,0 +1,143 @@
+import { QrErrorType } from '../qr-error-content';
+
+/**
+ * Error categories for QR scan results.
+ *
+ * - `non_ur_qr_scanned` - scanned data is not UR-encoded (URL, plain address, etc.).
+ * - `wrong_ur_type` - valid UR whose type does not match the current flow.
+ * - `ur_decode_error` - the UR decoder failed to reassemble frames.
+ * - `scan_exception` - an unexpected runtime exception during processing.
+ */
+export type ScanErrorCategory =
+  | 'non_ur_qr_scanned'
+  | 'wrong_ur_type'
+  | 'ur_decode_error'
+  | 'scan_exception';
+
+/**
+ * Discriminated union describing the classification of a scan result.
+ * Each variant carries only the metadata relevant to its category.
+ */
+export type ScanClassification =
+  | { category: 'non_ur_qr_scanned'; isUrFormat: false }
+  | { category: 'wrong_ur_type'; isUrFormat: true; receivedUrType: string }
+  | { category: 'ur_decode_error'; isUrFormat: true }
+  | { category: 'scan_exception'; isUrFormat: boolean; rawMessage: string };
+
+/**
+ * Input for {@link classifyScanResult}. Callers populate only the fields
+ * relevant to the point where the error was detected.
+ */
+export type ClassifyScanInput = {
+  text?: string;
+  decodedType?: string;
+  expectedTypes: readonly string[];
+  decoderError?: boolean;
+  exception?: unknown;
+};
+
+const UR_PREFIX = 'ur:';
+
+/**
+ * Checks whether text starts with the case-insensitive `ur:` prefix.
+ *
+ * @param text - Raw scanned QR text.
+ * @returns True if the text looks like a UR-encoded payload.
+ */
+function looksLikeUr(text: string): boolean {
+  return text.toLowerCase().startsWith(UR_PREFIX);
+}
+
+/**
+ * Extracts a string message from an unknown caught value.
+ *
+ * @param exception - The caught value.
+ * @returns The error message or stringified value.
+ */
+function extractMessage(exception: unknown): string {
+  if (exception instanceof Error) {
+    return exception.message;
+  }
+  if (typeof exception === 'string') {
+    return exception;
+  }
+  return String(exception);
+}
+
+/**
+ * Classifies a QR scan result into one of four error categories.
+ *
+ * Priority (highest to lowest):
+ * 1. Runtime exception (`exception` is set).
+ * 2. Decoder error (`decoderError` is true).
+ * 3. Wrong UR type (`decodedType` not in `expectedTypes`).
+ * 4. Non-UR content (`text` does not start with `ur:`).
+ *
+ * Returns `null` when no error is detected.
+ *
+ * @param input - Scan context fields.
+ * @returns A classification result or `null`.
+ */
+export function classifyScanResult(
+  input: ClassifyScanInput,
+): ScanClassification | null {
+  const { text, decodedType, expectedTypes, decoderError, exception } = input;
+
+  if (exception !== undefined) {
+    const isUrFormat = text === undefined ? false : looksLikeUr(text);
+    return {
+      category: 'scan_exception',
+      isUrFormat,
+      rawMessage: extractMessage(exception),
+    };
+  }
+
+  if (decoderError === true) {
+    return { category: 'ur_decode_error', isUrFormat: true };
+  }
+
+  if (decodedType !== undefined) {
+    const normalizedDecoded = decodedType.toLowerCase();
+    const isExpected = expectedTypes.some(
+      (t) => t.toLowerCase() === normalizedDecoded,
+    );
+    if (!isExpected) {
+      return {
+        category: 'wrong_ur_type',
+        isUrFormat: true,
+        receivedUrType: decodedType,
+      };
+    }
+    return null;
+  }
+
+  if (text !== undefined && text.length > 0 && !looksLikeUr(text)) {
+    return { category: 'non_ur_qr_scanned', isUrFormat: false };
+  }
+
+  return null;
+}
+
+/**
+ * Maps a {@link ScanErrorCategory} to the {@link QrErrorType} used by the
+ * error-content UI. `scan_exception` maps to `UrDecodeError` because the
+ * UI uses the same generic messaging for runtime failures.
+ *
+ * @param category - The classified scan error category.
+ * @returns The corresponding QrErrorType value.
+ */
+export function scanCategoryToQrErrorType(
+  category: ScanErrorCategory,
+): QrErrorType {
+  switch (category) {
+    case 'non_ur_qr_scanned':
+      return QrErrorType.NonUrQrCode;
+    case 'wrong_ur_type':
+      return QrErrorType.WrongUrType;
+    case 'ur_decode_error':
+    case 'scan_exception':
+      return QrErrorType.UrDecodeError;
+    default:
+      return QrErrorType.UrDecodeError;
+  }
+}

--- a/ui/components/app/qr-hardware-popover/qr-utils/qr-utils.ts
+++ b/ui/components/app/qr-hardware-popover/qr-utils/qr-utils.ts
@@ -15,10 +15,10 @@ export type ScanErrorCategory =
   | 'scan_exception';
 
 /**
- * Discriminated union describing the classification of a scan result.
+ * Discriminated union describing a classified scan error.
  * Each variant carries only the metadata relevant to its category.
  */
-export type ScanClassification =
+export type ScanErrorClassification =
   | { category: 'non_ur_qr_scanned'; isUrFormat: false }
   | { category: 'wrong_ur_type'; isUrFormat: true; receivedUrType: string }
   | { category: 'ur_decode_error'; isUrFormat: true }
@@ -28,7 +28,7 @@ export type ScanClassification =
  * Input for {@link classifyScanResult}. Callers populate only the fields
  * relevant to the point where the error was detected.
  */
-export type ClassifyScanInput = {
+export type ScanClassificationInput = {
   text?: string;
   decodedType?: string;
   expectedTypes: readonly string[];
@@ -79,8 +79,8 @@ function extractMessage(exception: unknown): string {
  * @returns A classification result or `null`.
  */
 export function classifyScanResult(
-  input: ClassifyScanInput,
-): ScanClassification | null {
+  input: ScanClassificationInput,
+): ScanErrorClassification | null {
   const { text, decodedType, expectedTypes, decoderError, exception } = input;
 
   if (exception !== undefined) {

--- a/ui/components/app/qr-hardware-popover/qr-utils/qr-utils.ts
+++ b/ui/components/app/qr-hardware-popover/qr-utils/qr-utils.ts
@@ -1,4 +1,5 @@
 import { QrErrorType } from '../qr-error-content';
+import { extractMessageFromUnknownError } from '../../../../contexts/hardware-wallets';
 
 /**
  * Error categories for QR scan results.
@@ -49,22 +50,6 @@ function looksLikeUr(text: string): boolean {
 }
 
 /**
- * Extracts a string message from an unknown caught value.
- *
- * @param exception - The caught value.
- * @returns The error message or stringified value.
- */
-function extractMessage(exception: unknown): string {
-  if (exception instanceof Error) {
-    return exception.message;
-  }
-  if (typeof exception === 'string') {
-    return exception;
-  }
-  return String(exception);
-}
-
-/**
  * Classifies a QR scan result into one of four error categories.
  *
  * Priority (highest to lowest):
@@ -83,12 +68,12 @@ export function classifyScanResult(
 ): ScanErrorClassification | null {
   const { text, decodedType, expectedTypes, decoderError, exception } = input;
 
-  if (exception !== undefined) {
+  if (exception !== undefined && exception !== null) {
     const isUrFormat = text === undefined ? false : looksLikeUr(text);
     return {
       category: 'scan_exception',
       isUrFormat,
-      rawMessage: extractMessage(exception),
+      rawMessage: extractMessageFromUnknownError(exception),
     };
   }
 


### PR DESCRIPTION
## **Description**
This PR adds utilities in form of types and functions which we can use to handle QR related errors more precisely.


## **Changelog**
<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->
CHANGELOG entry: null

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1767

## **Manual testing steps**
These are just utilities which we're going to use in the next phases with QR error handling. 
Nothing can be tested manually right now.

## **Screenshots/Recordings**

### **Before**
**No UI changes**

### **After**
**No UI changes**

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new QR scan error utility functions/types plus unit tests, with no changes to existing runtime flows beyond new imports when adopted later.
> 
> **Overview**
> Adds `qr-utils` to classify QR scan outcomes into structured error categories (`non_ur_qr_scanned`, `wrong_ur_type`, `ur_decode_error`, `scan_exception`) with explicit priority rules and metadata (e.g., `receivedUrType`, `rawMessage`).
> 
> Introduces `scanCategoryToQrErrorType` to translate these classifications into existing UI `QrErrorType` values (treating runtime exceptions as `UrDecodeError`), and adds comprehensive unit tests covering edge cases (case-insensitive UR detection/type matching, null/undefined handling, and priority ordering).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8289492d8703234f9b01065b3dc4086f12b06141. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->