### PR TITLE
feat: add assets concurrently in the two controllers

### DIFF
--- a/ui/pages/token-management/token-management.tsx
+++ b/ui/pages/token-management/token-management.tsx
@@ -1169,9 +1169,9 @@ export const TokenManagementPage = () => {
         ? false
         : Boolean(
             accountIdForChain &&
-              allIgnoredAssetsByAccount[accountIdForChain]?.some(
-                (assetId) => String(assetId).toLowerCase() === lowerAssetId,
-              ),
+            allIgnoredAssetsByAccount[accountIdForChain]?.some(
+              (assetId) => String(assetId).toLowerCase() === lowerAssetId,
+            ),
           );
       const isHidden =
         stagedHideKeys.has(lowerAssetId) ||

--- a/ui/pages/token-management/token-management.tsx
+++ b/ui/pages/token-management/token-management.tsx
@@ -1010,32 +1010,26 @@ export const TokenManagementPage = () => {
           if (!evmAccount?.id) {
             return;
           }
-          const actions = [
-            () =>
-              dispatch(
-                addImportedTokens(
-                  [
-                    {
-                      address: payload.assetReference,
-                      symbol: payload.symbol,
-                      decimals: payload.decimals,
-                      isERC721: false,
-                      name: payload.name,
-                      ...(payload.iconUrl ? { image: payload.iconUrl } : {}),
-                    },
-                  ],
-                  networkClientId,
-                ),
+          await Promise.all([
+            dispatch(
+              addImportedTokens(
+                [
+                  {
+                    address: payload.assetReference,
+                    symbol: payload.symbol,
+                    decimals: payload.decimals,
+                    isERC721: false,
+                    name: payload.name,
+                    ...(payload.iconUrl ? { image: payload.iconUrl } : {}),
+                  },
+                ],
+                networkClientId,
               ),
-          ];
-
-          if (isAssetsUnifiedStateInBuild) {
-            actions.push(() =>
-              dispatch(addCustomAsset(evmAccount.id, payload.assetId)),
-            );
-          }
-
-          await Promise.all(actions.map((action) => action()));
+            ),
+            ...(isAssetsUnifiedStateInBuild
+              ? [dispatch(addCustomAsset(evmAccount.id, payload.assetId))]
+              : []),
+          ]);
 
           return;
         }
@@ -1045,17 +1039,12 @@ export const TokenManagementPage = () => {
           return;
         }
 
-        const actions = [
-          () => dispatch(multichainAddAssets([payload.assetId], account.id)),
-        ];
-
-        if (isAssetsUnifiedStateInBuild) {
-          actions.push(() =>
-            dispatch(addCustomAsset(account.id, payload.assetId)),
-          );
-        }
-
-        await Promise.all(actions.map((action) => action()));
+        await Promise.all([
+          dispatch(multichainAddAssets([payload.assetId], account.id)),
+          ...(isAssetsUnifiedStateInBuild
+            ? [dispatch(addCustomAsset(account.id, payload.assetId))]
+            : []),
+        ]);
       } finally {
         removePendingKey(stagedKey);
       }
@@ -1169,9 +1158,9 @@ export const TokenManagementPage = () => {
         ? false
         : Boolean(
             accountIdForChain &&
-            allIgnoredAssetsByAccount[accountIdForChain]?.some(
-              (assetId) => String(assetId).toLowerCase() === lowerAssetId,
-            ),
+              allIgnoredAssetsByAccount[accountIdForChain]?.some(
+                (assetId) => String(assetId).toLowerCase() === lowerAssetId,
+              ),
           );
       const isHidden =
         stagedHideKeys.has(lowerAssetId) ||

--- a/ui/pages/token-management/token-management.tsx
+++ b/ui/pages/token-management/token-management.tsx
@@ -1158,9 +1158,9 @@ export const TokenManagementPage = () => {
         ? false
         : Boolean(
             accountIdForChain &&
-              allIgnoredAssetsByAccount[accountIdForChain]?.some(
-                (assetId) => String(assetId).toLowerCase() === lowerAssetId,
-              ),
+            allIgnoredAssetsByAccount[accountIdForChain]?.some(
+              (assetId) => String(assetId).toLowerCase() === lowerAssetId,
+            ),
           );
       const isHidden =
         stagedHideKeys.has(lowerAssetId) ||

--- a/ui/pages/token-management/token-management.tsx
+++ b/ui/pages/token-management/token-management.tsx
@@ -1010,24 +1010,33 @@ export const TokenManagementPage = () => {
           if (!evmAccount?.id) {
             return;
           }
-          await dispatch(
-            addImportedTokens(
-              [
-                {
-                  address: payload.assetReference,
-                  symbol: payload.symbol,
-                  decimals: payload.decimals,
-                  isERC721: false,
-                  name: payload.name,
-                  ...(payload.iconUrl ? { image: payload.iconUrl } : {}),
-                },
-              ],
-              networkClientId,
-            ),
-          );
+          const actions = [
+            () =>
+              dispatch(
+                addImportedTokens(
+                  [
+                    {
+                      address: payload.assetReference,
+                      symbol: payload.symbol,
+                      decimals: payload.decimals,
+                      isERC721: false,
+                      name: payload.name,
+                      ...(payload.iconUrl ? { image: payload.iconUrl } : {}),
+                    },
+                  ],
+                  networkClientId,
+                ),
+              ),
+          ];
+
           if (isAssetsUnifiedStateInBuild) {
-            await dispatch(addCustomAsset(evmAccount.id, payload.assetId));
+            actions.push(() =>
+              dispatch(addCustomAsset(evmAccount.id, payload.assetId)),
+            );
           }
+
+          await Promise.all(actions.map((action) => action()));
+
           return;
         }
 
@@ -1035,10 +1044,18 @@ export const TokenManagementPage = () => {
         if (!account?.id) {
           return;
         }
-        await dispatch(multichainAddAssets([payload.assetId], account.id));
+
+        const actions = [
+          () => dispatch(multichainAddAssets([payload.assetId], account.id)),
+        ];
+
         if (isAssetsUnifiedStateInBuild) {
-          await dispatch(addCustomAsset(account.id, payload.assetId));
+          actions.push(() =>
+            dispatch(addCustomAsset(account.id, payload.assetId)),
+          );
         }
+
+        await Promise.all(actions.map((action) => action()));
       } finally {
         removePendingKey(stagedKey);
       }
@@ -1152,9 +1169,9 @@ export const TokenManagementPage = () => {
         ? false
         : Boolean(
             accountIdForChain &&
-            allIgnoredAssetsByAccount[accountIdForChain]?.some(
-              (assetId) => String(assetId).toLowerCase() === lowerAssetId,
-            ),
+              allIgnoredAssetsByAccount[accountIdForChain]?.some(
+                (assetId) => String(assetId).toLowerCase() === lowerAssetId,
+              ),
           );
       const isHidden =
         stagedHideKeys.has(lowerAssetId) ||


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

When adding assets to both the old and new controllers, do so concurrently instead of sequentially.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3261

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Switches sequential asset-add dispatches to concurrent `Promise.all` calls, which can change timing and error surfacing between the two controllers. Scope is small and localized to token import, but race conditions or partial-success handling could regress if downstream actions assume ordering.
> 
> **Overview**
> Updates token import in `TokenManagementPage` to add assets to the legacy controller and (when enabled) the unified assets controller **concurrently** rather than awaiting each dispatch sequentially.
> 
> This applies to both EVM imports (`addImportedTokens` + optional `addCustomAsset`) and non‑EVM imports (`multichainAddAssets` + optional `addCustomAsset`), reducing overall latency while keeping the existing feature-flagged behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89ce9db437a6148a072edcf619b5a7cfe45bda8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->