### PR TITLE
refactor: Refactor remaining controllers to remove duplicate messenger types

### DIFF
--- a/app/scripts/messenger-client-init/account-tracker-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/account-tracker-controller-init.test.ts
@@ -5,7 +5,10 @@ import {
   MockAnyNamespace,
 } from '@metamask/messenger';
 import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
-import { AccountTrackerController } from '@metamask/assets-controllers';
+import {
+  AccountTrackerController,
+  AccountTrackerControllerMessenger,
+} from '@metamask/assets-controllers';
 import {
   AutoManagedNetworkClient,
   CustomNetworkClientConfiguration,
@@ -21,7 +24,6 @@ import { MessengerClientInitRequest } from './types';
 import { buildControllerInitRequestMock } from './test/utils';
 import {
   getAccountTrackerControllerMessenger,
-  AccountTrackerControllerMessenger,
   getAccountTrackerControllerInitMessenger,
   AccountTrackerControllerInitMessenger,
 } from './messengers';

--- a/app/scripts/messenger-client-init/account-tracker-controller-init.ts
+++ b/app/scripts/messenger-client-init/account-tracker-controller-init.ts
@@ -1,10 +1,10 @@
-import { AccountTrackerController } from '@metamask/assets-controllers';
+import {
+  AccountTrackerController,
+  AccountTrackerControllerMessenger,
+} from '@metamask/assets-controllers';
 import { NetworkClientId } from '@metamask/network-controller';
 import { MessengerClientInitFunction } from './types';
-import {
-  AccountTrackerControllerInitMessenger,
-  AccountTrackerControllerMessenger,
-} from './messengers';
+import { AccountTrackerControllerInitMessenger } from './messengers';
 
 export const AccountTrackerControllerInit: MessengerClientInitFunction<
   AccountTrackerController,

--- a/app/scripts/messenger-client-init/accounts-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/accounts-controller-init.test.ts
@@ -1,11 +1,11 @@
-import { AccountsController } from '@metamask/accounts-controller';
+import {
+  AccountsController,
+  AccountsControllerMessenger,
+} from '@metamask/accounts-controller';
 import { getRootMessenger } from '../lib/messenger';
 import { MessengerClientInitRequest } from './types';
 import { buildControllerInitRequestMock } from './test/utils';
-import {
-  getAccountsControllerMessenger,
-  AccountsControllerMessenger,
-} from './messengers';
+import { getAccountsControllerMessenger } from './messengers';
 import { AccountsControllerInit } from './accounts-controller-init';
 
 jest.mock('@metamask/accounts-controller');

--- a/app/scripts/messenger-client-init/accounts-controller-init.ts
+++ b/app/scripts/messenger-client-init/accounts-controller-init.ts
@@ -1,6 +1,8 @@
-import { AccountsController } from '@metamask/accounts-controller';
+import {
+  AccountsController,
+  AccountsControllerMessenger,
+} from '@metamask/accounts-controller';
 import { MessengerClientInitFunction } from './types';
-import { AccountsControllerMessenger } from './messengers';
 
 /**
  * Initialize the accounts controller.

--- a/app/scripts/messenger-client-init/announcement-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/announcement-controller-init.test.ts
@@ -1,12 +1,12 @@
-import { AnnouncementController } from '@metamask/announcement-controller';
+import {
+  AnnouncementController,
+  AnnouncementControllerMessenger,
+} from '@metamask/announcement-controller';
 import { UI_NOTIFICATIONS } from '../../../shared/notifications';
 import { getRootMessenger } from '../lib/messenger';
 import { MessengerClientInitRequest } from './types';
 import { buildControllerInitRequestMock } from './test/utils';
-import {
-  getAnnouncementControllerMessenger,
-  AnnouncementControllerMessenger,
-} from './messengers';
+import { getAnnouncementControllerMessenger } from './messengers';
 import { AnnouncementControllerInit } from './announcement-controller-init';
 
 jest.mock('@metamask/announcement-controller');

--- a/app/scripts/messenger-client-init/announcement-controller-init.ts
+++ b/app/scripts/messenger-client-init/announcement-controller-init.ts
@@ -1,7 +1,9 @@
-import { AnnouncementController } from '@metamask/announcement-controller';
+import {
+  AnnouncementController,
+  AnnouncementControllerMessenger,
+} from '@metamask/announcement-controller';
 import { UI_NOTIFICATIONS } from '../../../shared/notifications';
 import { MessengerClientInitFunction } from './types';
-import { AnnouncementControllerMessenger } from './messengers';
 
 /**
  * Initialize the announcement controller.

--- a/app/scripts/messenger-client-init/assets/assets-contract-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/assets/assets-contract-controller-init.test.ts
@@ -4,7 +4,10 @@ import {
   Messenger,
   MockAnyNamespace,
 } from '@metamask/messenger';
-import { AssetsContractController } from '@metamask/assets-controllers';
+import {
+  AssetsContractController,
+  AssetsContractControllerMessenger,
+} from '@metamask/assets-controllers';
 import {
   NetworkControllerGetNetworkClientByIdAction,
   NetworkControllerGetStateAction,
@@ -13,7 +16,6 @@ import { buildControllerInitRequestMock, CHAIN_ID_MOCK } from '../test/utils';
 import { MessengerClientInitRequest } from '../types';
 import {
   AssetsContractControllerInitMessenger,
-  AssetsContractControllerMessenger,
   getAssetsContractControllerInitMessenger,
   getAssetsContractControllerMessenger,
 } from '../messengers/assets';

--- a/app/scripts/messenger-client-init/assets/assets-contract-controller-init.ts
+++ b/app/scripts/messenger-client-init/assets/assets-contract-controller-init.ts
@@ -1,9 +1,9 @@
-import { AssetsContractController } from '@metamask/assets-controllers';
-import { MessengerClientInitFunction } from '../types';
 import {
-  AssetsContractControllerInitMessenger,
+  AssetsContractController,
   AssetsContractControllerMessenger,
-} from '../messengers/assets';
+} from '@metamask/assets-controllers';
+import { MessengerClientInitFunction } from '../types';
+import { AssetsContractControllerInitMessenger } from '../messengers/assets';
 import { getGlobalChainId } from '../init-utils';
 
 /**

--- a/app/scripts/messenger-client-init/assets/assets-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/assets/assets-controller-init.test.ts
@@ -3,6 +3,7 @@ import {
   AssetsControllerMessenger,
 } from '@metamask/assets-controller';
 import { createApiPlatformClient } from '@metamask/core-backend';
+import type { AssetsControllerMessenger } from '@metamask/assets-controller';
 import { MessengerClientInitRequest } from '../types';
 import { buildControllerInitRequestMock } from '../test/utils';
 import { getRootMessenger } from '../../lib/messenger';

--- a/app/scripts/messenger-client-init/assets/assets-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/assets/assets-controller-init.test.ts
@@ -1,9 +1,8 @@
 import {
   AssetsController,
-  AssetsControllerMessenger,
+  type AssetsControllerMessenger,
 } from '@metamask/assets-controller';
 import { createApiPlatformClient } from '@metamask/core-backend';
-import type { AssetsControllerMessenger } from '@metamask/assets-controller';
 import { MessengerClientInitRequest } from '../types';
 import { buildControllerInitRequestMock } from '../test/utils';
 import { getRootMessenger } from '../../lib/messenger';

--- a/app/scripts/messenger-client-init/assets/assets-controller-init.ts
+++ b/app/scripts/messenger-client-init/assets/assets-controller-init.ts
@@ -2,6 +2,7 @@ import {
   AssetsController,
   type AssetsControllerMessenger,
   type AssetsControllerOptions,
+  AssetsControllerMessenger,
 } from '@metamask/assets-controller';
 import type { PreferencesState } from '@metamask/preferences-controller';
 import { createApiPlatformClient } from '@metamask/core-backend';

--- a/app/scripts/messenger-client-init/assets/assets-controller-init.ts
+++ b/app/scripts/messenger-client-init/assets/assets-controller-init.ts
@@ -2,7 +2,6 @@ import {
   AssetsController,
   type AssetsControllerMessenger,
   type AssetsControllerOptions,
-  AssetsControllerMessenger,
 } from '@metamask/assets-controller';
 import type { PreferencesState } from '@metamask/preferences-controller';
 import { createApiPlatformClient } from '@metamask/core-backend';

--- a/app/scripts/messenger-client-init/assets/client-controller-init.ts
+++ b/app/scripts/messenger-client-init/assets/client-controller-init.ts
@@ -1,6 +1,6 @@
 import { ClientController } from '@metamask/client-controller';
+import type { ClientControllerMessenger } from '@metamask/client-controller';
 import { type MessengerClientInitFunction } from '../types';
-import type { ClientControllerMessenger } from '../messengers/assets';
 
 /**
  * Initialize the ClientController.

--- a/app/scripts/messenger-client-init/assets/network-enablement-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/assets/network-enablement-controller-init.test.ts
@@ -3,7 +3,10 @@ import {
   MOCK_ANY_NAMESPACE,
   MockAnyNamespace,
 } from '@metamask/messenger';
-import { NetworkEnablementController } from '@metamask/network-enablement-controller';
+import {
+  NetworkEnablementController,
+  NetworkEnablementControllerMessenger,
+} from '@metamask/network-enablement-controller';
 import { BtcScope, SolAccountType, SolScope } from '@metamask/keyring-api';
 import { AccountsControllerSelectedAccountChangeEvent } from '@metamask/accounts-controller';
 import {
@@ -18,7 +21,6 @@ import {
   getNetworkEnablementControllerInitMessenger,
   getNetworkEnablementControllerMessenger,
   NetworkEnablementControllerInitMessenger,
-  NetworkEnablementControllerMessenger,
 } from '../messengers/assets';
 import { getRootMessenger } from '../../lib/messenger';
 import { NetworkEnablementControllerInit } from './network-enablement-controller-init';

--- a/app/scripts/messenger-client-init/assets/network-enablement-controller-init.ts
+++ b/app/scripts/messenger-client-init/assets/network-enablement-controller-init.ts
@@ -1,6 +1,7 @@
 import {
   NetworkEnablementController,
   NetworkEnablementControllerState,
+  NetworkEnablementControllerMessenger,
 } from '@metamask/network-enablement-controller';
 import { NetworkState } from '@metamask/network-controller';
 import { MultichainNetworkControllerState } from '@metamask/multichain-network-controller';
@@ -17,10 +18,7 @@ import {
   KnownCaipNamespace,
   parseCaipChainId,
 } from '@metamask/utils';
-import {
-  NetworkEnablementControllerMessenger,
-  NetworkEnablementControllerInitMessenger,
-} from '../messengers/assets';
+import { NetworkEnablementControllerInitMessenger } from '../messengers/assets';
 import { MessengerClientInitFunction } from '../types';
 import {
   CHAIN_IDS,

--- a/app/scripts/messenger-client-init/assets/nft-controller-init.ts
+++ b/app/scripts/messenger-client-init/assets/nft-controller-init.ts
@@ -1,10 +1,10 @@
-import { NftController } from '@metamask/assets-controllers';
+import {
+  NftController,
+  NftControllerMessenger,
+} from '@metamask/assets-controllers';
 import { AssetType } from '@metamask/bridge-controller';
 import { MessengerClientInitFunction } from '../types';
-import {
-  NftControllerMessenger,
-  NftControllerInitMessenger,
-} from '../messengers/assets';
+import { NftControllerInitMessenger } from '../messengers/assets';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,

--- a/app/scripts/messenger-client-init/assets/nft-detection-controller-init.ts
+++ b/app/scripts/messenger-client-init/assets/nft-detection-controller-init.ts
@@ -1,6 +1,8 @@
-import { NftDetectionController } from '@metamask/assets-controllers';
+import {
+  NftDetectionController,
+  NftDetectionControllerMessenger,
+} from '@metamask/assets-controllers';
 import { MessengerClientInitFunction } from '../types';
-import { NftDetectionControllerMessenger } from '../messengers/assets';
 
 /**
  * Initialize the NFT detection controller.

--- a/app/scripts/messenger-client-init/assets/token-rates-controller-init.ts
+++ b/app/scripts/messenger-client-init/assets/token-rates-controller-init.ts
@@ -1,12 +1,10 @@
 import {
   CodefiTokenPricesServiceV2,
   TokenRatesController,
+  TokenRatesControllerMessenger,
 } from '@metamask/assets-controllers';
 import { MessengerClientInitFunction } from '../types';
-import {
-  TokenRatesControllerMessenger,
-  TokenRatesControllerInitMessenger,
-} from '../messengers/assets';
+import { TokenRatesControllerInitMessenger } from '../messengers/assets';
 import { previousValueComparator } from '../../lib/util';
 
 /**

--- a/app/scripts/messenger-client-init/confirmations/address-book-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/address-book-controller-init.test.ts
@@ -1,10 +1,10 @@
-import { AddressBookController } from '@metamask/address-book-controller';
+import {
+  AddressBookController,
+  AddressBookControllerMessenger,
+} from '@metamask/address-book-controller';
 import { MessengerClientInitRequest } from '../types';
 import { buildControllerInitRequestMock } from '../test/utils';
-import {
-  getAddressBookControllerMessenger,
-  AddressBookControllerMessenger,
-} from '../messengers';
+import { getAddressBookControllerMessenger } from '../messengers';
 import { getRootMessenger } from '../../lib/messenger';
 import { AddressBookControllerInit } from './address-book-controller-init';
 

--- a/app/scripts/messenger-client-init/confirmations/address-book-controller-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/address-book-controller-init.ts
@@ -1,6 +1,8 @@
-import { AddressBookController } from '@metamask/address-book-controller';
+import {
+  AddressBookController,
+  AddressBookControllerMessenger,
+} from '@metamask/address-book-controller';
 import { MessengerClientInitFunction } from '../types';
-import { AddressBookControllerMessenger } from '../messengers';
 
 /**
  * Initialize the address book controller.

--- a/app/scripts/messenger-client-init/confirmations/decrypt-message-manager-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/decrypt-message-manager-init.test.ts
@@ -1,10 +1,10 @@
-import { DecryptMessageManager } from '@metamask/message-manager';
+import {
+  DecryptMessageManager,
+  DecryptMessageManagerMessenger,
+} from '@metamask/message-manager';
 import { MessengerClientInitRequest } from '../types';
 import { buildControllerInitRequestMock } from '../test/utils';
-import {
-  getDecryptMessageManagerMessenger,
-  DecryptMessageManagerMessenger,
-} from '../messengers';
+import { getDecryptMessageManagerMessenger } from '../messengers';
 import { getRootMessenger } from '../../lib/messenger';
 import { DecryptMessageManagerInit } from './decrypt-message-manager-init';
 

--- a/app/scripts/messenger-client-init/confirmations/decrypt-message-manager-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/decrypt-message-manager-init.ts
@@ -1,6 +1,8 @@
-import { DecryptMessageManager } from '@metamask/message-manager';
+import {
+  DecryptMessageManager,
+  DecryptMessageManagerMessenger,
+} from '@metamask/message-manager';
 import { MessengerClientInitFunction } from '../types';
-import { DecryptMessageManagerMessenger } from '../messengers';
 
 /**
  * Initialize the decrypt message manager.

--- a/app/scripts/messenger-client-init/confirmations/encryption-public-key-message-manager-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/encryption-public-key-message-manager-init.test.ts
@@ -1,10 +1,10 @@
-import { EncryptionPublicKeyManager } from '@metamask/message-manager';
+import {
+  EncryptionPublicKeyManager,
+  EncryptionPublicKeyManagerMessenger,
+} from '@metamask/message-manager';
 import { MessengerClientInitRequest } from '../types';
 import { buildControllerInitRequestMock } from '../test/utils';
-import {
-  getEncryptionPublicKeyManagerMessenger,
-  EncryptionPublicKeyManagerMessenger,
-} from '../messengers';
+import { getEncryptionPublicKeyManagerMessenger } from '../messengers';
 import { getRootMessenger } from '../../lib/messenger';
 import { EncryptionPublicKeyManagerInit } from './encryption-public-key-message-manager-init';
 

--- a/app/scripts/messenger-client-init/confirmations/encryption-public-key-message-manager-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/encryption-public-key-message-manager-init.ts
@@ -1,6 +1,8 @@
-import { EncryptionPublicKeyManager } from '@metamask/message-manager';
+import {
+  EncryptionPublicKeyManager,
+  EncryptionPublicKeyManagerMessenger,
+} from '@metamask/message-manager';
 import { MessengerClientInitFunction } from '../types';
-import { EncryptionPublicKeyManagerMessenger } from '../messengers';
 
 /**
  * Initialize the encryption public key message manager.

--- a/app/scripts/messenger-client-init/confirmations/name-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/name-controller-init.test.ts
@@ -1,9 +1,11 @@
-import { NameController } from '@metamask/name-controller';
+import {
+  NameController,
+  NameControllerMessenger,
+} from '@metamask/name-controller';
 import { MessengerClientInitRequest } from '../types';
 import { buildControllerInitRequestMock } from '../test/utils';
 import {
   getNameControllerMessenger,
-  NameControllerMessenger,
   getNameControllerInitMessenger,
   NameControllerInitMessenger,
 } from '../messengers';

--- a/app/scripts/messenger-client-init/confirmations/name-controller-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/name-controller-init.ts
@@ -4,11 +4,9 @@ import {
   LensNameProvider,
   NameController,
   TokenNameProvider,
-} from '@metamask/name-controller';
-import {
-  NameControllerInitMessenger,
   NameControllerMessenger,
-} from '../messengers';
+} from '@metamask/name-controller';
+import { NameControllerInitMessenger } from '../messengers';
 import { MessengerClientInitFunction } from '../types';
 
 /**

--- a/app/scripts/messenger-client-init/confirmations/user-operation-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/confirmations/user-operation-controller-init.test.ts
@@ -1,10 +1,12 @@
-import { UserOperationController } from '@metamask/user-operation-controller';
+import {
+  UserOperationController,
+  UserOperationControllerMessenger,
+} from '@metamask/user-operation-controller';
 import { MessengerClientInitRequest } from '../types';
 import { buildControllerInitRequestMock } from '../test/utils';
 import {
   getUserOperationControllerMessenger,
   getUserOperationControllerInitMessenger,
-  UserOperationControllerMessenger,
   UserOperationControllerInitMessenger,
 } from '../messengers';
 import { getRootMessenger } from '../../lib/messenger';

--- a/app/scripts/messenger-client-init/confirmations/user-operation-controller-init.ts
+++ b/app/scripts/messenger-client-init/confirmations/user-operation-controller-init.ts
@@ -1,9 +1,9 @@
-import { UserOperationController } from '@metamask/user-operation-controller';
-import { MessengerClientInitFunction } from '../types';
 import {
+  UserOperationController,
   UserOperationControllerMessenger,
-  UserOperationControllerInitMessenger,
-} from '../messengers';
+} from '@metamask/user-operation-controller';
+import { MessengerClientInitFunction } from '../types';
+import { UserOperationControllerInitMessenger } from '../messengers';
 
 /**
  * Initialize the user operation controller.

--- a/app/scripts/messenger-client-init/currency-rate-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/currency-rate-controller-init.test.ts
@@ -1,13 +1,13 @@
 import {
   CodefiTokenPricesServiceV2,
   CurrencyRateController,
+  CurrencyRateMessenger,
 } from '@metamask/assets-controllers';
 import { getRootMessenger } from '../lib/messenger';
 import { MessengerClientInitRequest } from './types';
 import { buildControllerInitRequestMock } from './test/utils';
 import {
   getCurrencyRateControllerMessenger,
-  CurrencyRateControllerMessenger,
   getCurrencyRateControllerInitMessenger,
   CurrencyRateControllerInitMessenger,
 } from './messengers';
@@ -31,7 +31,7 @@ jest.mock('@metamask/assets-controllers', () => ({
 
 function getInitRequestMock(): jest.Mocked<
   MessengerClientInitRequest<
-    CurrencyRateControllerMessenger,
+    CurrencyRateMessenger,
     CurrencyRateControllerInitMessenger
   >
 > {

--- a/app/scripts/messenger-client-init/currency-rate-controller-init.ts
+++ b/app/scripts/messenger-client-init/currency-rate-controller-init.ts
@@ -1,11 +1,9 @@
 import {
   CodefiTokenPricesServiceV2,
   CurrencyRateController,
+  CurrencyRateMessenger,
 } from '@metamask/assets-controllers';
-import {
-  CurrencyRateControllerInitMessenger,
-  CurrencyRateControllerMessenger,
-} from './messengers';
+import { CurrencyRateControllerInitMessenger } from './messengers';
 import { MessengerClientInitFunction } from './types';
 
 /**
@@ -19,10 +17,9 @@ import { MessengerClientInitFunction } from './types';
  */
 export const CurrencyRateControllerInit: MessengerClientInitFunction<
   CurrencyRateController,
-  CurrencyRateControllerMessenger,
+  CurrencyRateMessenger,
   CurrencyRateControllerInitMessenger
 > = ({ controllerMessenger, initMessenger, persistedState }) => {
-  // TODO: Fix CurrencyRateControllerMessenger type - add CurrencyRateControllerActions & CurrencyRateControllerEvents
   // TODO: Bump @metamask/network-controller to match assets-controllers
   const messengerClient = new CurrencyRateController({
     // @ts-expect-error - CurrencyRateController is persisted as 'CurrencyController' but init pattern expects 'CurrencyRateController'

--- a/app/scripts/messenger-client-init/defi-positions/defi-positions-controller-init.ts
+++ b/app/scripts/messenger-client-init/defi-positions/defi-positions-controller-init.ts
@@ -1,9 +1,9 @@
-import { DeFiPositionsController } from '@metamask/assets-controllers';
-import { MessengerClientInitFunction } from '../types';
 import {
+  DeFiPositionsController,
   DeFiPositionsControllerMessenger,
-  DeFiPositionsControllerInitMessenger,
-} from '../messengers/defi-positions';
+} from '@metamask/assets-controllers';
+import { MessengerClientInitFunction } from '../types';
+import { DeFiPositionsControllerInitMessenger } from '../messengers/defi-positions';
 import {
   DEFAULT_FEATURE_FLAG_VALUES,
   FeatureFlagNames,

--- a/app/scripts/messenger-client-init/institutional-snap/institutional-snap-controller-init.ts
+++ b/app/scripts/messenger-client-init/institutional-snap/institutional-snap-controller-init.ts
@@ -1,5 +1,5 @@
 import { InstitutionalSnapController } from '../../controllers/institutional-snap/InstitutionalSnapController';
-import { InstitutionalSnapControllerMessenger } from '../messengers/accounts/institutional-snap-controller-messenger';
+import type { InstitutionalSnapControllerMessenger } from '../../controllers/institutional-snap/InstitutionalSnapController';
 import { MessengerClientInitFunction } from '../types';
 
 export const InstitutionalSnapControllerInit: MessengerClientInitFunction<

--- a/app/scripts/messenger-client-init/keyring-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/keyring-controller-init.test.ts
@@ -5,12 +5,14 @@ import {
   MockAnyNamespace,
 } from '@metamask/messenger';
 import { NetworkControllerGetSelectedNetworkClientAction } from '@metamask/network-controller';
-import { KeyringController } from '@metamask/keyring-controller';
+import {
+  KeyringController,
+  KeyringControllerMessenger,
+} from '@metamask/keyring-controller';
 import { MessengerClientInitRequest } from './types';
 import { buildControllerInitRequestMock } from './test/utils';
 import {
   getKeyringControllerMessenger,
-  KeyringControllerMessenger,
   getKeyringControllerInitMessenger,
   KeyringControllerInitMessenger,
 } from './messengers';

--- a/app/scripts/messenger-client-init/keyring-controller-init.ts
+++ b/app/scripts/messenger-client-init/keyring-controller-init.ts
@@ -1,6 +1,7 @@
 import {
   keyringBuilderFactory,
   KeyringController,
+  KeyringControllerMessenger,
 } from '@metamask/keyring-controller';
 import { QrKeyring, QrKeyringScannerBridge } from '@metamask/eth-qr-keyring';
 import { KeyringClass } from '@metamask/keyring-utils';
@@ -22,10 +23,7 @@ import { TrezorOffscreenBridge } from '../lib/offscreen-bridge/trezor-offscreen-
 import { LedgerOffscreenBridge } from '../lib/offscreen-bridge/ledger-offscreen-bridge';
 import { LatticeKeyringOffscreen } from '../lib/offscreen-bridge/lattice-offscreen-keyring';
 import { MessengerClientInitFunction } from './types';
-import {
-  KeyringControllerMessenger,
-  KeyringControllerInitMessenger,
-} from './messengers';
+import { KeyringControllerInitMessenger } from './messengers';
 
 /**
  * Initialize the keyring controller.

--- a/app/scripts/messenger-client-init/logging-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/logging-controller-init.test.ts
@@ -1,11 +1,12 @@
-import { LoggingController, LogType } from '@metamask/logging-controller';
+import {
+  LoggingController,
+  LogType,
+  LoggingControllerMessenger,
+} from '@metamask/logging-controller';
 import { getRootMessenger } from '../lib/messenger';
 import { MessengerClientInitRequest } from './types';
 import { buildControllerInitRequestMock } from './test/utils';
-import {
-  getLoggingControllerMessenger,
-  LoggingControllerMessenger,
-} from './messengers';
+import { getLoggingControllerMessenger } from './messengers';
 import { LoggingControllerInit } from './logging-controller-init';
 
 jest.mock('@metamask/logging-controller');

--- a/app/scripts/messenger-client-init/logging-controller-init.ts
+++ b/app/scripts/messenger-client-init/logging-controller-init.ts
@@ -1,7 +1,10 @@
-import { LoggingController, LogType } from '@metamask/logging-controller';
+import {
+  LoggingController,
+  LoggingControllerMessenger,
+  LogType,
+} from '@metamask/logging-controller';
 import { LOG_EVENT } from '../../../shared/constants/logs';
 import { MessengerClientInitFunction } from './types';
-import { LoggingControllerMessenger } from './messengers';
 
 /**
  * Initialize the logging controller.

--- a/app/scripts/messenger-client-init/messengers/account-order-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/account-order-controller-messenger.ts
@@ -1,10 +1,10 @@
-import { Messenger } from '@metamask/messenger';
-import { AccountOrderControllerMessengerActions } from '../../controllers/account-order';
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { AccountOrderControllerMessenger } from '../../controllers/account-order';
 import { RootMessenger } from '../../lib/messenger';
-
-export type AccountOrderControllerMessenger = ReturnType<
-  typeof getAccountOrderControllerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -12,17 +12,18 @@ export type AccountOrderControllerMessenger = ReturnType<
  *
  * @param messenger - The base messenger used to create the restricted
  * messenger.
+ * @returns The restricted messenger.
  */
 export function getAccountOrderControllerMessenger(
-  messenger: RootMessenger<AccountOrderControllerMessengerActions, never>,
-) {
-  return new Messenger<
-    'AccountOrderController',
-    never,
-    never,
-    typeof messenger
-  >({
-    namespace: 'AccountOrderController',
-    parent: messenger,
-  });
+  messenger: RootMessenger<
+    MessengerActions<AccountOrderControllerMessenger>,
+    MessengerEvents<AccountOrderControllerMessenger>
+  >,
+): AccountOrderControllerMessenger {
+  const accountOrderControllerMessenger: AccountOrderControllerMessenger =
+    new Messenger({
+      namespace: 'AccountOrderController',
+      parent: messenger,
+    });
+  return accountOrderControllerMessenger;
 }

--- a/app/scripts/messenger-client-init/messengers/account-tracker-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/account-tracker-controller-messenger.ts
@@ -1,53 +1,13 @@
-import { Messenger } from '@metamask/messenger';
 import {
-  NetworkControllerGetNetworkClientByIdAction,
-  NetworkControllerGetStateAction,
-  NetworkControllerNetworkAddedEvent,
-  NetworkControllerNetworkDidChangeEvent,
-} from '@metamask/network-controller';
-import {
-  NetworkEnablementControllerGetStateAction,
-  NetworkEnablementControllerListPopularEvmNetworksAction,
-} from '@metamask/network-enablement-controller';
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { AccountTrackerControllerMessenger } from '@metamask/assets-controllers';
 import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
-import {
-  AccountsControllerGetSelectedAccountAction,
-  AccountsControllerListAccountsAction,
-  AccountsControllerSelectedEvmAccountChangeEvent,
-} from '@metamask/accounts-controller';
-import {
-  TransactionControllerTransactionConfirmedEvent,
-  TransactionControllerUnapprovedTransactionAddedEvent,
-} from '@metamask/transaction-controller';
-import {
-  KeyringControllerGetStateAction,
-  KeyringControllerLockEvent,
-  KeyringControllerUnlockEvent,
-} from '@metamask/keyring-controller';
+import { NetworkControllerNetworkDidChangeEvent } from '@metamask/network-controller';
 import { RootMessenger } from '../../lib/messenger';
 import { PreferencesControllerGetStateAction } from '../../controllers/preferences-controller';
-
-export type AccountTrackerControllerMessenger = ReturnType<
-  typeof getAccountTrackerControllerMessenger
->;
-
-type AllowedActions =
-  | AccountsControllerGetSelectedAccountAction
-  | AccountsControllerListAccountsAction
-  | NetworkControllerGetNetworkClientByIdAction
-  | NetworkControllerGetStateAction
-  | NetworkEnablementControllerGetStateAction
-  | NetworkEnablementControllerListPopularEvmNetworksAction
-  | PreferencesControllerGetStateAction
-  | KeyringControllerGetStateAction;
-
-type AllowedEvents =
-  | AccountsControllerSelectedEvmAccountChangeEvent
-  | TransactionControllerTransactionConfirmedEvent
-  | TransactionControllerUnapprovedTransactionAddedEvent
-  | NetworkControllerNetworkAddedEvent
-  | KeyringControllerLockEvent
-  | KeyringControllerUnlockEvent;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -57,17 +17,16 @@ type AllowedEvents =
  * messenger.
  */
 export function getAccountTrackerControllerMessenger(
-  messenger: RootMessenger<AllowedActions, AllowedEvents>,
-) {
-  const accountTrackerControllerMessenger = new Messenger<
-    'AccountTrackerController',
-    AllowedActions,
-    AllowedEvents,
-    typeof messenger
-  >({
-    namespace: 'AccountTrackerController',
-    parent: messenger,
-  });
+  messenger: RootMessenger<
+    MessengerActions<AccountTrackerControllerMessenger>,
+    MessengerEvents<AccountTrackerControllerMessenger>
+  >,
+): AccountTrackerControllerMessenger {
+  const accountTrackerControllerMessenger: AccountTrackerControllerMessenger =
+    new Messenger({
+      namespace: 'AccountTrackerController',
+      parent: messenger,
+    });
   messenger.delegate({
     messenger: accountTrackerControllerMessenger,
     actions: [

--- a/app/scripts/messenger-client-init/messengers/accounts-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/accounts-controller-messenger.ts
@@ -1,10 +1,10 @@
-import { AllowedActions, AllowedEvents } from '@metamask/accounts-controller';
-import { Messenger } from '@metamask/messenger';
+import { AccountsControllerMessenger } from '@metamask/accounts-controller';
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
 import { RootMessenger } from '../../lib/messenger';
-
-export type AccountsControllerMessenger = ReturnType<
-  typeof getAccountsControllerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -14,17 +14,16 @@ export type AccountsControllerMessenger = ReturnType<
  * messenger.
  */
 export function getAccountsControllerMessenger(
-  messenger: RootMessenger<AllowedActions, AllowedEvents>,
-) {
-  const accountsControllerMessenger = new Messenger<
-    'AccountsController',
-    AllowedActions,
-    AllowedEvents,
-    typeof messenger
-  >({
-    namespace: 'AccountsController',
-    parent: messenger,
-  });
+  messenger: RootMessenger<
+    MessengerActions<AccountsControllerMessenger>,
+    MessengerEvents<AccountsControllerMessenger>
+  >,
+): AccountsControllerMessenger {
+  const accountsControllerMessenger: AccountsControllerMessenger =
+    new Messenger({
+      namespace: 'AccountsController',
+      parent: messenger,
+    });
   messenger.delegate({
     messenger: accountsControllerMessenger,
     actions: [

--- a/app/scripts/messenger-client-init/messengers/accounts/index.ts
+++ b/app/scripts/messenger-client-init/messengers/accounts/index.ts
@@ -10,7 +10,6 @@ export { getInstitutionalSnapControllerMessenger } from './institutional-snap-co
 
 export type { AccountTreeControllerInitMessenger } from './account-tree-controller-messenger';
 export type { MultichainAccountServiceInitMessenger } from './multichain-account-service-messenger';
-export type { InstitutionalSnapControllerMessenger } from './institutional-snap-controller-messenger';
 
 export type { SnapKeyringBuilderInitMessenger } from './snap-keyring-builder-messenger';
 export {

--- a/app/scripts/messenger-client-init/messengers/accounts/institutional-snap-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/accounts/institutional-snap-controller-messenger.ts
@@ -1,28 +1,10 @@
-import { AccountsControllerGetAccountByAddressAction } from '@metamask/accounts-controller';
-import { Messenger } from '@metamask/messenger';
-import { SnapControllerHandleRequestAction } from '@metamask/snaps-controllers';
-import { TransactionControllerUpdateCustodialTransactionAction } from '@metamask/transaction-controller';
-
-import { InstitutionalSnapControllerMethodActions } from '../../../controllers/institutional-snap/InstitutionalSnapController-method-action-types';
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
 import { RootMessenger } from '../../../lib/messenger';
-
-export type InstitutionalSnapRequestSearchParameters = {
-  from: string;
-  to: string;
-  value: string;
-  data: string;
-  chainId: string;
-};
-
-type Actions =
-  | SnapControllerHandleRequestAction
-  | AccountsControllerGetAccountByAddressAction
-  | TransactionControllerUpdateCustodialTransactionAction
-  | InstitutionalSnapControllerMethodActions;
-
-export type InstitutionalSnapControllerMessenger = ReturnType<
-  typeof getInstitutionalSnapControllerMessenger
->;
+import type { InstitutionalSnapControllerMessenger } from '../../../controllers/institutional-snap/InstitutionalSnapController';
 
 /**
  * Get a restricted controller messenger for the rate limit controller. This is
@@ -33,17 +15,16 @@ export type InstitutionalSnapControllerMessenger = ReturnType<
  * @returns The controller messenger.
  */
 export function getInstitutionalSnapControllerMessenger(
-  messenger: RootMessenger<Actions, never>,
+  messenger: RootMessenger<
+    MessengerActions<InstitutionalSnapControllerMessenger>,
+    MessengerEvents<InstitutionalSnapControllerMessenger>
+  >,
 ) {
-  const institutionalSnapControllerMessenger = new Messenger<
-    'InstitutionalSnapController',
-    Actions,
-    never,
-    typeof messenger
-  >({
-    namespace: 'InstitutionalSnapController',
-    parent: messenger,
-  });
+  const institutionalSnapControllerMessenger: InstitutionalSnapControllerMessenger =
+    new Messenger({
+      namespace: 'InstitutionalSnapController',
+      parent: messenger,
+    });
   messenger.delegate({
     messenger: institutionalSnapControllerMessenger,
     actions: [

--- a/app/scripts/messenger-client-init/messengers/address-book-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/address-book-controller-messenger.ts
@@ -1,9 +1,10 @@
-import { Messenger } from '@metamask/messenger';
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { AddressBookControllerMessenger } from '@metamask/address-book-controller';
 import { RootMessenger } from '../../lib/messenger';
-
-export type AddressBookControllerMessenger = ReturnType<
-  typeof getAddressBookControllerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -13,12 +14,14 @@ export type AddressBookControllerMessenger = ReturnType<
  * messenger.
  */
 export function getAddressBookControllerMessenger(
-  messenger: RootMessenger<never, never>,
-) {
-  return new Messenger<'AddressBookController', never, never, typeof messenger>(
-    {
-      namespace: 'AddressBookController',
-      parent: messenger,
-    },
-  );
+  messenger: RootMessenger<
+    MessengerActions<AddressBookControllerMessenger>,
+    MessengerEvents<AddressBookControllerMessenger>
+  >,
+): AddressBookControllerMessenger {
+  const controllerMessenger: AddressBookControllerMessenger = new Messenger({
+    namespace: 'AddressBookController',
+    parent: messenger,
+  });
+  return controllerMessenger;
 }

--- a/app/scripts/messenger-client-init/messengers/announcement-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/announcement-controller-messenger.ts
@@ -1,9 +1,10 @@
-import { Messenger } from '@metamask/messenger';
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { AnnouncementControllerMessenger } from '@metamask/announcement-controller';
 import { RootMessenger } from '../../lib/messenger';
-
-export type AnnouncementControllerMessenger = ReturnType<
-  typeof getAnnouncementControllerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -13,15 +14,14 @@ export type AnnouncementControllerMessenger = ReturnType<
  * messenger.
  */
 export function getAnnouncementControllerMessenger(
-  messenger: RootMessenger<never, never>,
-) {
-  return new Messenger<
-    'AnnouncementController',
-    never,
-    never,
-    typeof messenger
-  >({
+  messenger: RootMessenger<
+    MessengerActions<AnnouncementControllerMessenger>,
+    MessengerEvents<AnnouncementControllerMessenger>
+  >,
+): AnnouncementControllerMessenger {
+  const controllerMessenger: AnnouncementControllerMessenger = new Messenger({
     namespace: 'AnnouncementController',
     parent: messenger,
   });
+  return controllerMessenger;
 }

--- a/app/scripts/messenger-client-init/messengers/assets/assets-contract-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/assets/assets-contract-controller-messenger.ts
@@ -1,27 +1,14 @@
-import { Messenger } from '@metamask/messenger';
 import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { AssetsContractControllerMessenger } from '@metamask/assets-controllers';
+import type {
   NetworkControllerGetNetworkClientByIdAction,
-  NetworkControllerGetNetworkConfigurationByNetworkClientId,
-  NetworkControllerGetSelectedNetworkClientAction,
   NetworkControllerGetStateAction,
-  NetworkControllerNetworkDidChangeEvent,
 } from '@metamask/network-controller';
-import { PreferencesControllerStateChangeEvent } from '@metamask/preferences-controller';
 import { RootMessenger } from '../../../lib/messenger';
-
-type Actions =
-  | NetworkControllerGetNetworkClientByIdAction
-  | NetworkControllerGetNetworkConfigurationByNetworkClientId
-  | NetworkControllerGetSelectedNetworkClientAction
-  | NetworkControllerGetStateAction;
-
-type Events =
-  | PreferencesControllerStateChangeEvent
-  | NetworkControllerNetworkDidChangeEvent;
-
-export type AssetsContractControllerMessenger = ReturnType<
-  typeof getAssetsContractControllerMessenger
->;
 
 /**
  * Get a restricted messenger for the AssetsContractController. This is scoped to the
@@ -31,14 +18,12 @@ export type AssetsContractControllerMessenger = ReturnType<
  * @returns The restricted controller messenger.
  */
 export function getAssetsContractControllerMessenger(
-  messenger: RootMessenger<Actions, Events>,
-) {
-  const controllerMessenger = new Messenger<
-    'AssetsContractController',
-    Actions,
-    Events,
-    typeof messenger
-  >({
+  messenger: RootMessenger<
+    MessengerActions<AssetsContractControllerMessenger>,
+    MessengerEvents<AssetsContractControllerMessenger>
+  >,
+): AssetsContractControllerMessenger {
+  const controllerMessenger: AssetsContractControllerMessenger = new Messenger({
     namespace: 'AssetsContractController',
     parent: messenger,
   });

--- a/app/scripts/messenger-client-init/messengers/assets/assets-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/assets/assets-controller-messenger.ts
@@ -1,7 +1,7 @@
 import {
   Messenger,
-  MessengerActions,
-  MessengerEvents,
+  type MessengerActions,
+  type MessengerEvents,
 } from '@metamask/messenger';
 import type { AssetsControllerMessenger } from '@metamask/assets-controller';
 import type { SnapControllerHandleRequestAction } from '@metamask/snaps-controllers';
@@ -11,6 +11,7 @@ import {
   OnboardingControllerStateChangeEvent,
 } from '../../../controllers/onboarding';
 import { RootMessenger } from '../../../lib/messenger';
+import type { PreferencesControllerGetStateAction } from '../../../controllers/preferences-controller';
 
 /**
  * Messenger type for AssetsController initialization.
@@ -82,14 +83,6 @@ export function getAssetsControllerMessenger(
 
   return controllerMessenger;
 }
-
-/**
- * PreferencesController:getState action.
- */
-type PreferencesControllerGetStateAction = {
-  type: 'PreferencesController:getState';
-  handler: () => { useTokenDetection: boolean; [key: string]: unknown };
-};
 
 /**
  * Actions needed during AssetsController initialization.

--- a/app/scripts/messenger-client-init/messengers/assets/client-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/assets/client-controller-messenger.ts
@@ -6,8 +6,6 @@ import {
 import { type ClientControllerMessenger } from '@metamask/client-controller';
 import { RootMessenger } from '../../../lib/messenger';
 
-export type { ClientControllerMessenger } from '@metamask/client-controller';
-
 /**
  * Get a messenger for the ClientController.
  *
@@ -20,13 +18,9 @@ export function getClientControllerMessenger(
     MessengerEvents<ClientControllerMessenger>
   >,
 ): ClientControllerMessenger {
-  return new Messenger<
-    'ClientController',
-    MessengerActions<ClientControllerMessenger>,
-    MessengerEvents<ClientControllerMessenger>,
-    typeof messenger
-  >({
+  const controllerMessenger: ClientControllerMessenger = new Messenger({
     namespace: 'ClientController',
     parent: messenger,
   });
+  return controllerMessenger;
 }

--- a/app/scripts/messenger-client-init/messengers/assets/index.ts
+++ b/app/scripts/messenger-client-init/messengers/assets/index.ts
@@ -2,31 +2,21 @@ export {
   getTokenRatesControllerMessenger,
   getTokenRatesControllerInitMessenger,
 } from './token-rates-controller-messenger';
-export type {
-  TokenRatesControllerMessenger,
-  TokenRatesControllerInitMessenger,
-} from './token-rates-controller-messenger';
+export type { TokenRatesControllerInitMessenger } from './token-rates-controller-messenger';
 
 export {
   getNftControllerMessenger,
   getNftControllerInitMessenger,
 } from './nft-controller-messenger';
-export type {
-  NftControllerMessenger,
-  NftControllerInitMessenger,
-} from './nft-controller-messenger';
+export type { NftControllerInitMessenger } from './nft-controller-messenger';
 
 export { getNftDetectionControllerMessenger } from './nft-detection-controller-messenger';
-export type { NftDetectionControllerMessenger } from './nft-detection-controller-messenger';
 
 export {
   getAssetsContractControllerMessenger,
   getAssetsContractControllerInitMessenger,
 } from './assets-contract-controller-messenger';
-export type {
-  AssetsContractControllerMessenger,
-  AssetsContractControllerInitMessenger,
-} from './assets-contract-controller-messenger';
+export type { AssetsContractControllerInitMessenger } from './assets-contract-controller-messenger';
 
 export { getNetworkOrderControllerMessenger } from './network-order-controller-messenger';
 
@@ -34,10 +24,7 @@ export {
   getNetworkEnablementControllerMessenger,
   getNetworkEnablementControllerInitMessenger,
 } from './network-enablement-controller-messenger';
-export type {
-  NetworkEnablementControllerMessenger,
-  NetworkEnablementControllerInitMessenger,
-} from './network-enablement-controller-messenger';
+export type { NetworkEnablementControllerInitMessenger } from './network-enablement-controller-messenger';
 
 export {
   getAssetsControllerMessenger,
@@ -46,4 +33,3 @@ export {
 export type { AssetsControllerInitMessenger } from './assets-controller-messenger';
 
 export { getClientControllerMessenger } from './client-controller-messenger';
-export type { ClientControllerMessenger } from './client-controller-messenger';

--- a/app/scripts/messenger-client-init/messengers/assets/network-enablement-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/assets/network-enablement-controller-messenger.ts
@@ -1,12 +1,9 @@
-import { Messenger } from '@metamask/messenger';
-import { MultichainNetworkControllerGetStateAction } from '@metamask/multichain-network-controller';
 import {
-  NetworkControllerGetStateAction,
-  NetworkControllerStateChangeEvent,
-  NetworkControllerNetworkRemovedEvent,
-  NetworkControllerNetworkAddedEvent,
-} from '@metamask/network-controller';
-import { TransactionControllerTransactionSubmittedEvent } from '@metamask/transaction-controller';
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { NetworkEnablementControllerMessenger } from '@metamask/network-enablement-controller';
 import { AccountsControllerSelectedAccountChangeEvent } from '@metamask/accounts-controller';
 import {
   AccountTreeControllerGetAccountsFromSelectedAccountGroupAction,
@@ -14,32 +11,17 @@ import {
 } from '@metamask/account-tree-controller';
 import { RootMessenger } from '../../../lib/messenger';
 
-type Actions =
-  | NetworkControllerGetStateAction
-  | MultichainNetworkControllerGetStateAction;
-
-type Events =
-  | NetworkControllerNetworkAddedEvent
-  | NetworkControllerNetworkRemovedEvent
-  | NetworkControllerStateChangeEvent
-  | TransactionControllerTransactionSubmittedEvent;
-
-export type NetworkEnablementControllerMessenger = ReturnType<
-  typeof getNetworkEnablementControllerMessenger
->;
-
 export function getNetworkEnablementControllerMessenger(
-  messenger: RootMessenger<Actions, Events>,
-) {
-  const controllerMessenger = new Messenger<
-    'NetworkEnablementController',
-    Actions,
-    Events,
-    typeof messenger
-  >({
-    namespace: 'NetworkEnablementController',
-    parent: messenger,
-  });
+  messenger: RootMessenger<
+    MessengerActions<NetworkEnablementControllerMessenger>,
+    MessengerEvents<NetworkEnablementControllerMessenger>
+  >,
+): NetworkEnablementControllerMessenger {
+  const controllerMessenger: NetworkEnablementControllerMessenger =
+    new Messenger({
+      namespace: 'NetworkEnablementController',
+      parent: messenger,
+    });
   messenger.delegate({
     messenger: controllerMessenger,
     actions: [

--- a/app/scripts/messenger-client-init/messengers/assets/nft-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/assets/nft-controller-messenger.ts
@@ -1,44 +1,11 @@
-import { Messenger } from '@metamask/messenger';
 import {
-  NetworkControllerFindNetworkClientIdByChainIdAction,
-  NetworkControllerGetNetworkClientByIdAction,
-} from '@metamask/network-controller';
-import {
-  AccountsControllerGetSelectedAccountAction,
-  AccountsControllerGetAccountAction,
-  AccountsControllerSelectedEvmAccountChangeEvent,
-} from '@metamask/accounts-controller';
-import { PreferencesControllerStateChangeEvent } from '@metamask/preferences-controller';
-import {
-  AssetsContractControllerGetERC1155TokenURIAction,
-  AssetsContractControllerGetERC721AssetNameAction,
-  AssetsContractControllerGetERC721AssetSymbolAction,
-  AssetsContractControllerGetERC721TokenURIAction,
-} from '@metamask/assets-controllers';
-import { ApprovalControllerAddRequestAction } from '@metamask/approval-controller';
-import { PhishingControllerBulkScanUrlsAction } from '@metamask/phishing-controller';
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { NftControllerMessenger } from '@metamask/assets-controllers';
 import { MetaMetricsControllerTrackEventAction } from '../../../controllers/metametrics-controller-method-action-types';
 import { RootMessenger } from '../../../lib/messenger';
-
-type Actions =
-  | ApprovalControllerAddRequestAction
-  | AccountsControllerGetAccountAction
-  | AccountsControllerGetSelectedAccountAction
-  | NetworkControllerGetNetworkClientByIdAction
-  | AssetsContractControllerGetERC721AssetNameAction
-  | AssetsContractControllerGetERC721AssetSymbolAction
-  | AssetsContractControllerGetERC721TokenURIAction
-  | AssetsContractControllerGetERC1155TokenURIAction
-  | NetworkControllerFindNetworkClientIdByChainIdAction
-  | PhishingControllerBulkScanUrlsAction;
-
-type Events =
-  | PreferencesControllerStateChangeEvent
-  | AccountsControllerSelectedEvmAccountChangeEvent;
-
-export type NftControllerMessenger = ReturnType<
-  typeof getNftControllerMessenger
->;
 
 /**
  * Get a restricted messenger for the NFT controller. This is scoped to the
@@ -48,14 +15,12 @@ export type NftControllerMessenger = ReturnType<
  * @returns The restricted controller messenger.
  */
 export function getNftControllerMessenger(
-  messenger: RootMessenger<Actions, Events>,
-) {
-  const controllerMessenger = new Messenger<
-    'NftController',
-    Actions,
-    Events,
-    typeof messenger
-  >({
+  messenger: RootMessenger<
+    MessengerActions<NftControllerMessenger>,
+    MessengerEvents<NftControllerMessenger>
+  >,
+): NftControllerMessenger {
+  const controllerMessenger: NftControllerMessenger = new Messenger({
     namespace: 'NftController',
     parent: messenger,
   });

--- a/app/scripts/messenger-client-init/messengers/assets/nft-detection-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/assets/nft-detection-controller-messenger.ts
@@ -1,29 +1,10 @@
-import { Messenger } from '@metamask/messenger';
 import {
-  NetworkControllerFindNetworkClientIdByChainIdAction,
-  NetworkControllerGetNetworkClientByIdAction,
-  NetworkControllerGetStateAction,
-  NetworkControllerStateChangeEvent,
-} from '@metamask/network-controller';
-import { AccountsControllerGetSelectedAccountAction } from '@metamask/accounts-controller';
-import { PreferencesControllerStateChangeEvent } from '@metamask/preferences-controller';
-import { ApprovalControllerAddRequestAction } from '@metamask/approval-controller';
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { NftDetectionControllerMessenger } from '@metamask/assets-controllers';
 import { RootMessenger } from '../../../lib/messenger';
-
-type Actions =
-  | ApprovalControllerAddRequestAction
-  | NetworkControllerGetStateAction
-  | AccountsControllerGetSelectedAccountAction
-  | NetworkControllerGetNetworkClientByIdAction
-  | NetworkControllerFindNetworkClientIdByChainIdAction;
-
-type Events =
-  | PreferencesControllerStateChangeEvent
-  | NetworkControllerStateChangeEvent;
-
-export type NftDetectionControllerMessenger = ReturnType<
-  typeof getNftDetectionControllerMessenger
->;
 
 /**
  * Get a restricted messenger for the NFT detection controller. This is scoped to the
@@ -33,14 +14,12 @@ export type NftDetectionControllerMessenger = ReturnType<
  * @returns The restricted controller messenger.
  */
 export function getNftDetectionControllerMessenger(
-  messenger: RootMessenger<Actions, Events>,
-) {
-  const controllerMessenger = new Messenger<
-    'NftDetectionController',
-    Actions,
-    Events,
-    typeof messenger
-  >({
+  messenger: RootMessenger<
+    MessengerActions<NftDetectionControllerMessenger>,
+    MessengerEvents<NftDetectionControllerMessenger>
+  >,
+): NftDetectionControllerMessenger {
+  const controllerMessenger: NftDetectionControllerMessenger = new Messenger({
     namespace: 'NftDetectionController',
     parent: messenger,
   });

--- a/app/scripts/messenger-client-init/messengers/assets/token-rates-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/assets/token-rates-controller-messenger.ts
@@ -1,31 +1,14 @@
-import { Messenger } from '@metamask/messenger';
 import {
-  NetworkControllerGetStateAction,
-  NetworkControllerStateChangeEvent,
-} from '@metamask/network-controller';
-import { NetworkEnablementControllerGetStateAction } from '@metamask/network-enablement-controller';
-import {
-  TokensControllerGetStateAction,
-  TokensControllerStateChangeEvent,
-} from '@metamask/assets-controllers';
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { TokenRatesControllerMessenger } from '@metamask/assets-controllers';
 import {
   PreferencesControllerGetStateAction,
   PreferencesControllerStateChangeEvent,
 } from '../../../controllers/preferences-controller';
 import { RootMessenger } from '../../../lib/messenger';
-
-type Actions =
-  | TokensControllerGetStateAction
-  | NetworkControllerGetStateAction
-  | NetworkEnablementControllerGetStateAction;
-
-type Events =
-  | TokensControllerStateChangeEvent
-  | NetworkControllerStateChangeEvent;
-
-export type TokenRatesControllerMessenger = ReturnType<
-  typeof getTokenRatesControllerMessenger
->;
 
 /**
  * Get a restricted messenger for the Token Rates controller. This is scoped to the
@@ -35,14 +18,12 @@ export type TokenRatesControllerMessenger = ReturnType<
  * @returns The restricted controller messenger.
  */
 export function getTokenRatesControllerMessenger(
-  messenger: RootMessenger<Actions, Events>,
-) {
-  const controllerMessenger = new Messenger<
-    'TokenRatesController',
-    Actions,
-    Events,
-    typeof messenger
-  >({
+  messenger: RootMessenger<
+    MessengerActions<TokenRatesControllerMessenger>,
+    MessengerEvents<TokenRatesControllerMessenger>
+  >,
+): TokenRatesControllerMessenger {
+  const controllerMessenger: TokenRatesControllerMessenger = new Messenger({
     namespace: 'TokenRatesController',
     parent: messenger,
   });

--- a/app/scripts/messenger-client-init/messengers/connectivity/connectivity-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/connectivity/connectivity-controller-messenger.ts
@@ -18,13 +18,9 @@ export function getConnectivityControllerMessenger(
     MessengerEvents<ConnectivityControllerMessenger>
   >,
 ): ConnectivityControllerMessenger {
-  return new Messenger<
-    'ConnectivityController',
-    MessengerActions<ConnectivityControllerMessenger>,
-    MessengerEvents<ConnectivityControllerMessenger>,
-    typeof messenger
-  >({
+  const controllerMessenger: ConnectivityControllerMessenger = new Messenger({
     namespace: 'ConnectivityController',
     parent: messenger,
   });
+  return controllerMessenger;
 }

--- a/app/scripts/messenger-client-init/messengers/core-backend/account-activity-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/core-backend/account-activity-service-messenger.ts
@@ -6,10 +6,6 @@ import {
 } from '@metamask/messenger';
 import { RootMessenger } from '../../../lib/messenger';
 
-type Actions = MessengerActions<AccountActivityServiceMessenger>;
-
-type Events = MessengerEvents<AccountActivityServiceMessenger>;
-
 /**
  * Get a restricted messenger for the Account Activity service. This is scoped to the
  * actions and events that the Account Activity service is allowed to handle.
@@ -18,14 +14,12 @@ type Events = MessengerEvents<AccountActivityServiceMessenger>;
  * @returns The restricted messenger.
  */
 export function getAccountActivityServiceMessenger(
-  messenger: RootMessenger<Actions, Events>,
+  messenger: RootMessenger<
+    MessengerActions<AccountActivityServiceMessenger>,
+    MessengerEvents<AccountActivityServiceMessenger>
+  >,
 ): AccountActivityServiceMessenger {
-  const serviceMessenger = new Messenger<
-    'AccountActivityService',
-    Actions,
-    Events,
-    typeof messenger
-  >({
+  const serviceMessenger: AccountActivityServiceMessenger = new Messenger({
     namespace: 'AccountActivityService',
     parent: messenger,
   });

--- a/app/scripts/messenger-client-init/messengers/core-backend/backend-websocket-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/core-backend/backend-websocket-service-messenger.ts
@@ -11,10 +11,6 @@ import { RootMessenger } from '../../../lib/messenger';
 export type BackendWebSocketServiceMessenger =
   BackendPlatformWebSocketServiceMessenger;
 
-type Actions = MessengerActions<BackendWebSocketServiceMessenger>;
-
-type Events = MessengerEvents<BackendWebSocketServiceMessenger>;
-
 /**
  * Get a restricted messenger for the Backend Platform WebSocket service.
  * This is scoped to backend platform operations and services.
@@ -23,14 +19,12 @@ type Events = MessengerEvents<BackendWebSocketServiceMessenger>;
  * @returns The restricted messenger.
  */
 export function getBackendWebSocketServiceMessenger(
-  messenger: RootMessenger<Actions, Events>,
+  messenger: RootMessenger<
+    MessengerActions<BackendWebSocketServiceMessenger>,
+    MessengerEvents<BackendWebSocketServiceMessenger>
+  >,
 ): BackendPlatformWebSocketServiceMessenger {
-  const serviceMessenger = new Messenger<
-    'BackendWebSocketService',
-    Actions,
-    Events,
-    typeof messenger
-  >({
+  const serviceMessenger: BackendWebSocketServiceMessenger = new Messenger({
     namespace: 'BackendWebSocketService',
     parent: messenger,
   });
@@ -48,13 +42,13 @@ export function getBackendWebSocketServiceMessenger(
   return serviceMessenger;
 }
 
-export type BackendWebSocketServiceInitMessenger = ReturnType<
-  typeof getBackendWebSocketServiceInitMessenger
->;
-
 type AllowedInitializationActions =
   | RemoteFeatureFlagControllerGetStateAction
   | AuthenticationControllerGetBearerTokenAction;
+
+export type BackendWebSocketServiceInitMessenger = ReturnType<
+  typeof getBackendWebSocketServiceInitMessenger
+>;
 
 export function getBackendWebSocketServiceInitMessenger(
   messenger: RootMessenger<AllowedInitializationActions, never>,

--- a/app/scripts/messenger-client-init/messengers/currency-rate-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/currency-rate-controller-messenger.ts
@@ -1,18 +1,11 @@
-import { Messenger } from '@metamask/messenger';
 import {
-  NetworkControllerGetNetworkClientByIdAction,
-  NetworkControllerGetStateAction,
-} from '@metamask/network-controller';
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { CurrencyRateMessenger } from '@metamask/assets-controllers';
 import { PreferencesControllerGetStateAction } from '../../controllers/preferences-controller';
 import { RootMessenger } from '../../lib/messenger';
-
-type AllowedActions =
-  | NetworkControllerGetNetworkClientByIdAction
-  | NetworkControllerGetStateAction;
-
-export type CurrencyRateControllerMessenger = ReturnType<
-  typeof getCurrencyRateControllerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -22,14 +15,12 @@ export type CurrencyRateControllerMessenger = ReturnType<
  * messenger.
  */
 export function getCurrencyRateControllerMessenger(
-  messenger: RootMessenger<AllowedActions, never>,
-) {
-  const controllerMessenger = new Messenger<
-    'CurrencyRateController',
-    AllowedActions,
-    never,
-    typeof messenger
-  >({
+  messenger: RootMessenger<
+    MessengerActions<CurrencyRateMessenger>,
+    MessengerEvents<CurrencyRateMessenger>
+  >,
+): CurrencyRateMessenger {
+  const controllerMessenger: CurrencyRateMessenger = new Messenger({
     namespace: 'CurrencyRateController',
     parent: messenger,
   });

--- a/app/scripts/messenger-client-init/messengers/decrypt-message-manager-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/decrypt-message-manager-messenger.ts
@@ -1,9 +1,10 @@
-import { Messenger } from '@metamask/messenger';
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { DecryptMessageManagerMessenger } from '@metamask/message-manager';
 import { RootMessenger } from '../../lib/messenger';
-
-export type DecryptMessageManagerMessenger = ReturnType<
-  typeof getDecryptMessageManagerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -11,14 +12,18 @@ export type DecryptMessageManagerMessenger = ReturnType<
  *
  * @param messenger - The base messenger used to create the restricted
  * messenger.
+ * @returns The restricted messenger.
  */
 export function getDecryptMessageManagerMessenger(
-  messenger: RootMessenger<never, never>,
-) {
-  return new Messenger<'DecryptMessageManager', never, never, typeof messenger>(
-    {
+  messenger: RootMessenger<
+    MessengerActions<DecryptMessageManagerMessenger>,
+    MessengerEvents<DecryptMessageManagerMessenger>
+  >,
+): DecryptMessageManagerMessenger {
+  const decryptMessageManagerMessenger: DecryptMessageManagerMessenger =
+    new Messenger({
       namespace: 'DecryptMessageManager',
       parent: messenger,
-    },
-  );
+    });
+  return decryptMessageManagerMessenger;
 }

--- a/app/scripts/messenger-client-init/messengers/defi-positions/defi-positions-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/defi-positions/defi-positions-controller-messenger.ts
@@ -1,24 +1,12 @@
-import { Messenger } from '@metamask/messenger';
-import { TransactionControllerTransactionConfirmedEvent } from '@metamask/transaction-controller';
-import { KeyringControllerLockEvent } from '@metamask/keyring-controller';
-import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import {
-  AccountTreeControllerGetAccountsFromSelectedAccountGroupAction,
-  AccountTreeControllerSelectedAccountGroupChangeEvent,
-} from '@metamask/account-tree-controller';
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { DeFiPositionsControllerMessenger } from '@metamask/assets-controllers';
+import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import { MetaMetricsControllerTrackEventAction } from '../../../controllers/metametrics-controller-method-action-types';
 import { RootMessenger } from '../../../lib/messenger';
-
-type Actions = AccountTreeControllerGetAccountsFromSelectedAccountGroupAction;
-
-type Events =
-  | KeyringControllerLockEvent
-  | TransactionControllerTransactionConfirmedEvent
-  | AccountTreeControllerSelectedAccountGroupChangeEvent;
-
-export type DeFiPositionsControllerMessenger = ReturnType<
-  typeof getDeFiPositionsControllerMessenger
->;
 
 /**
  * Get a restricted messenger for the Defi Positions controller. This is scoped to the
@@ -28,14 +16,12 @@ export type DeFiPositionsControllerMessenger = ReturnType<
  * @returns The restricted controller messenger.
  */
 export function getDeFiPositionsControllerMessenger(
-  messenger: RootMessenger<Actions, Events>,
-) {
-  const controllerMessenger = new Messenger<
-    'DeFiPositionsController',
-    Actions,
-    Events,
-    typeof messenger
-  >({
+  messenger: RootMessenger<
+    MessengerActions<DeFiPositionsControllerMessenger>,
+    MessengerEvents<DeFiPositionsControllerMessenger>
+  >,
+): DeFiPositionsControllerMessenger {
+  const controllerMessenger: DeFiPositionsControllerMessenger = new Messenger({
     namespace: 'DeFiPositionsController',
     parent: messenger,
   });

--- a/app/scripts/messenger-client-init/messengers/defi-positions/index.ts
+++ b/app/scripts/messenger-client-init/messengers/defi-positions/index.ts
@@ -3,7 +3,4 @@ export {
   getDeFiPositionsControllerInitMessenger,
 } from './defi-positions-controller-messenger';
 
-export type {
-  DeFiPositionsControllerMessenger,
-  DeFiPositionsControllerInitMessenger,
-} from './defi-positions-controller-messenger';
+export type { DeFiPositionsControllerInitMessenger } from './defi-positions-controller-messenger';

--- a/app/scripts/messenger-client-init/messengers/encryption-public-key-manager-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/encryption-public-key-manager-messenger.ts
@@ -1,9 +1,10 @@
-import { Messenger } from '@metamask/messenger';
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { EncryptionPublicKeyManagerMessenger } from '@metamask/message-manager';
 import { RootMessenger } from '../../lib/messenger';
-
-export type EncryptionPublicKeyManagerMessenger = ReturnType<
-  typeof getEncryptionPublicKeyManagerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -11,17 +12,18 @@ export type EncryptionPublicKeyManagerMessenger = ReturnType<
  *
  * @param messenger - The base messenger used to create the restricted
  * messenger.
+ * @returns The restricted messenger.
  */
 export function getEncryptionPublicKeyManagerMessenger(
-  messenger: RootMessenger<never, never>,
-) {
-  return new Messenger<
-    'EncryptionPublicKeyManager',
-    never,
-    never,
-    typeof messenger
-  >({
-    namespace: 'EncryptionPublicKeyManager',
-    parent: messenger,
-  });
+  messenger: RootMessenger<
+    MessengerActions<EncryptionPublicKeyManagerMessenger>,
+    MessengerEvents<EncryptionPublicKeyManagerMessenger>
+  >,
+): EncryptionPublicKeyManagerMessenger {
+  const encryptionPublicKeyManagerMessenger: EncryptionPublicKeyManagerMessenger =
+    new Messenger({
+      namespace: 'EncryptionPublicKeyManager',
+      parent: messenger,
+    });
+  return encryptionPublicKeyManagerMessenger;
 }

--- a/app/scripts/messenger-client-init/messengers/geolocation-api-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/geolocation-api-service-messenger.ts
@@ -4,29 +4,24 @@ import {
   type MessengerEvents,
 } from '@metamask/messenger';
 import type { GeolocationApiServiceMessenger } from '@metamask/geolocation-controller';
-import type { RootMessenger } from '../../lib/messenger';
+import { RootMessenger } from '../../lib/messenger';
 
 /**
  * Get the messenger for the GeolocationApiService. This is scoped to the
  * actions and events that the geolocation API service is allowed to handle.
  *
- * @param rootMessenger - The root messenger.
+ * @param messenger - The root messenger.
  * @returns The GeolocationApiServiceMessenger.
  */
 export function getGeolocationApiServiceMessenger(
-  rootMessenger: RootMessenger<
+  messenger: RootMessenger<
     MessengerActions<GeolocationApiServiceMessenger>,
     MessengerEvents<GeolocationApiServiceMessenger>
   >,
 ): GeolocationApiServiceMessenger {
-  const messenger = new Messenger<
-    'GeolocationApiService',
-    MessengerActions<GeolocationApiServiceMessenger>,
-    MessengerEvents<GeolocationApiServiceMessenger>,
-    typeof rootMessenger
-  >({
+  const serviceMessenger: GeolocationApiServiceMessenger = new Messenger({
     namespace: 'GeolocationApiService',
-    parent: rootMessenger,
+    parent: messenger,
   });
-  return messenger;
+  return serviceMessenger;
 }

--- a/app/scripts/messenger-client-init/messengers/geolocation-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/geolocation-controller-messenger.ts
@@ -4,7 +4,7 @@ import {
   type MessengerEvents,
 } from '@metamask/messenger';
 import type { GeolocationControllerMessenger } from '@metamask/geolocation-controller';
-import type { RootMessenger } from '../../lib/messenger';
+import { RootMessenger } from '../../lib/messenger';
 
 export type {
   GeolocationControllerActions,
@@ -16,30 +16,24 @@ export type {
  * GeolocationApiService:fetchGeolocation action so the controller can
  * call the API service via the messenger.
  *
- * @param rootMessenger - The root messenger.
+ * @param messenger - The root messenger.
  * @returns The GeolocationControllerMessenger.
  */
 export function getGeolocationControllerMessenger(
-  rootMessenger: RootMessenger<
+  messenger: RootMessenger<
     MessengerActions<GeolocationControllerMessenger>,
     MessengerEvents<GeolocationControllerMessenger>
   >,
 ): GeolocationControllerMessenger {
-  const messenger = new Messenger<
-    'GeolocationController',
-    MessengerActions<GeolocationControllerMessenger>,
-    MessengerEvents<GeolocationControllerMessenger>,
-    typeof rootMessenger
-  >({
+  const controllerMessenger: GeolocationControllerMessenger = new Messenger({
     namespace: 'GeolocationController',
-    parent: rootMessenger,
+    parent: messenger,
   });
 
-  rootMessenger.delegate({
-    messenger,
+  messenger.delegate({
+    messenger: controllerMessenger,
     actions: ['GeolocationApiService:fetchGeolocation'],
-    events: [],
   });
 
-  return messenger;
+  return controllerMessenger;
 }

--- a/app/scripts/messenger-client-init/messengers/index.ts
+++ b/app/scripts/messenger-client-init/messengers/index.ts
@@ -213,20 +213,14 @@ import { getDataDeletionServiceMessenger } from './data-deletion-service-messeng
 import { getLegacyBackgroundApiServiceMessenger } from './legacy-background-api-service-messenger';
 
 export { getAccountOrderControllerMessenger } from './account-order-controller-messenger';
-export type {
-  AccountTrackerControllerMessenger,
-  AccountTrackerControllerInitMessenger,
-} from './account-tracker-controller-messenger';
+export type { AccountTrackerControllerInitMessenger } from './account-tracker-controller-messenger';
 export {
   getAccountTrackerControllerMessenger,
   getAccountTrackerControllerInitMessenger,
 } from './account-tracker-controller-messenger';
-export type { AccountsControllerMessenger } from './accounts-controller-messenger';
 export { getAccountsControllerMessenger } from './accounts-controller-messenger';
-export type { AddressBookControllerMessenger } from './address-book-controller-messenger';
 export { getAddressBookControllerMessenger } from './address-book-controller-messenger';
 export { getAlertControllerMessenger } from './alert-controller-messenger';
-export type { AnnouncementControllerMessenger } from './announcement-controller-messenger';
 export { getAnnouncementControllerMessenger } from './announcement-controller-messenger';
 export { getAppMetadataControllerMessenger } from './app-metadata-controller-messenger';
 export { getAppStateControllerMessenger } from './app-state-controller-messenger';
@@ -237,10 +231,7 @@ export {
   getBridgeControllerInitMessenger,
 } from './bridge-controller-messenger';
 export { getBridgeStatusControllerMessenger } from './bridge-status-controller-messenger';
-export type {
-  CurrencyRateControllerMessenger,
-  CurrencyRateControllerInitMessenger,
-} from './currency-rate-controller-messenger';
+export type { CurrencyRateControllerInitMessenger } from './currency-rate-controller-messenger';
 export {
   getCurrencyRateControllerMessenger,
   getCurrencyRateControllerInitMessenger,
@@ -249,14 +240,12 @@ export {
   getDecryptMessageControllerMessenger,
   getDecryptMessageControllerInitMessenger,
 } from './decrypt-message-controller-messenger';
-export type { DecryptMessageManagerMessenger } from './decrypt-message-manager-messenger';
 export { getDecryptMessageManagerMessenger } from './decrypt-message-manager-messenger';
 export type { EncryptionPublicKeyControllerInitMessenger } from './encryption-public-key-controller-messenger';
 export {
   getEncryptionPublicKeyControllerMessenger,
   getEncryptionPublicKeyControllerInitMessenger,
 } from './encryption-public-key-controller-messenger';
-export type { EncryptionPublicKeyManagerMessenger } from './encryption-public-key-manager-messenger';
 export { getEncryptionPublicKeyManagerMessenger } from './encryption-public-key-manager-messenger';
 export type { EnsControllerInitMessenger } from './ens-controller-messenger';
 export {
@@ -270,16 +259,13 @@ export {
   getGasFeeControllerMessenger,
   getGasFeeControllerInitMessenger,
 } from './gas-fee-controller-messenger';
-export type {
-  KeyringControllerMessenger,
-  KeyringControllerInitMessenger,
-} from './keyring-controller-messenger';
+export type { KeyringControllerInitMessenger } from './keyring-controller-messenger';
 export {
   getKeyringControllerMessenger,
   getKeyringControllerInitMessenger,
 } from './keyring-controller-messenger';
-export type { LoggingControllerMessenger } from './logging-controller-messenger';
 export { getLoggingControllerMessenger } from './logging-controller-messenger';
+
 export { getMetaMetricsControllerMessenger } from './metametrics-controller-messenger';
 export { getMetaMetricsDataDeletionControllerMessenger } from './metametrics-data-deletion-controller-messenger';
 export type { NetworkControllerInitMessenger } from './network-controller-messenger';
@@ -287,18 +273,13 @@ export {
   getNetworkControllerMessenger,
   getNetworkControllerInitMessenger,
 } from './network-controller-messenger';
-export type { RatesControllerMessenger } from './rates-controller-messenger';
 export { getRatesControllerMessenger } from './rates-controller-messenger';
-export type {
-  NameControllerMessenger,
-  NameControllerInitMessenger,
-} from './name-controller-messenger';
+export type { NameControllerInitMessenger } from './name-controller-messenger';
 export {
   getNameControllerMessenger,
   getNameControllerInitMessenger,
 } from './name-controller-messenger';
 export { getOnboardingControllerMessenger } from './onboarding-controller-messenger';
-export type { PasskeyControllerMessenger } from './passkey-controller-messenger';
 export { getPasskeyControllerMessenger } from './passkey-controller-messenger';
 export { getPreferencesControllerMessenger } from './preferences-controller-messenger';
 export type {
@@ -309,36 +290,26 @@ export {
   getPermissionControllerMessenger,
   getPermissionControllerInitMessenger,
 } from './permission-controller-messenger';
-export type { PermissionLogControllerMessenger } from './permission-log-controller-messenger';
 export { getPermissionLogControllerMessenger } from './permission-log-controller-messenger';
 export { getGeolocationApiServiceMessenger } from './geolocation-api-service-messenger';
 export { getGeolocationControllerMessenger } from './geolocation-controller-messenger';
 export type { PerpsControllerMessenger } from './perps-controller-messenger';
 export { getPerpsControllerMessenger } from './perps-controller-messenger';
-export type { PhishingControllerMessenger } from './phishing-controller-messenger';
 export { getPhishingControllerMessenger } from './phishing-controller-messenger';
-export type {
-  RemoteFeatureFlagControllerMessenger,
-  RemoteFeatureFlagControllerInitMessenger,
-} from './remote-feature-flag-controller-messenger';
+export type { RemoteFeatureFlagControllerInitMessenger } from './remote-feature-flag-controller-messenger';
 export {
   getRemoteFeatureFlagControllerMessenger,
   getRemoteFeatureFlagControllerInitMessenger,
 } from './remote-feature-flag-controller-messenger';
-export type { SelectedNetworkControllerMessenger } from './selected-network-controller-messenger';
 export { getSelectedNetworkControllerMessenger } from './selected-network-controller-messenger';
 export type { SignatureControllerInitMessenger } from './signature-controller-messenger';
 export {
   getSignatureControllerMessenger,
   getSignatureControllerInitMessenger,
 } from './signature-controller-messenger';
-export type { SubjectMetadataControllerMessenger } from './subject-metadata-controller-messenger';
 export { getSubjectMetadataControllerMessenger } from './subject-metadata-controller-messenger';
 export { getRewardsControllerMessenger } from './rewards-controller-messenger';
-export type {
-  TokenBalancesControllerMessenger,
-  TokenBalancesControllerInitMessenger,
-} from './token-balances-controller-messenger';
+export type { TokenBalancesControllerInitMessenger } from './token-balances-controller-messenger';
 export {
   getTokenBalancesControllerMessenger,
   getTokenBalancesControllerInitMessenger,
@@ -348,26 +319,17 @@ export {
   getStaticAssetsControllerMessenger,
   getStaticAssetsControllerInitMessenger,
 } from './static-assets-controller-messenger';
-export type {
-  TokenDetectionControllerMessenger,
-  TokenDetectionControllerInitMessenger,
-} from './token-detection-controller-messenger';
+export type { TokenDetectionControllerInitMessenger } from './token-detection-controller-messenger';
 export {
   getTokenDetectionControllerMessenger,
   getTokenDetectionControllerInitMessenger,
 } from './token-detection-controller-messenger';
-export type {
-  TokenListControllerMessenger,
-  TokenListControllerInitMessenger,
-} from './token-list-controller-messenger';
+export type { TokenListControllerInitMessenger } from './token-list-controller-messenger';
 export {
   getTokenListControllerMessenger,
   getTokenListControllerInitMessenger,
 } from './token-list-controller-messenger';
-export type {
-  TokensControllerMessenger,
-  TokensControllerInitMessenger,
-} from './tokens-controller-messenger';
+export type { TokensControllerInitMessenger } from './tokens-controller-messenger';
 export {
   getTokensControllerMessenger,
   getTokensControllerInitMessenger,
@@ -377,10 +339,7 @@ export {
   getTransactionPayControllerMessenger,
   getTransactionPayControllerInitMessenger,
 } from './transaction-pay-controller-messenger';
-export type {
-  UserOperationControllerMessenger,
-  UserOperationControllerInitMessenger,
-} from './user-operation-controller-messenger';
+export type { UserOperationControllerInitMessenger } from './user-operation-controller-messenger';
 export {
   getUserOperationControllerMessenger,
   getUserOperationControllerInitMessenger,

--- a/app/scripts/messenger-client-init/messengers/keyring-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/keyring-controller-messenger.ts
@@ -1,10 +1,11 @@
-import { Messenger } from '@metamask/messenger';
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { KeyringControllerMessenger } from '@metamask/keyring-controller';
 import { AppStateControllerRequestQrCodeScanAction } from '../../controllers/app-state-controller-method-action-types';
 import { RootMessenger } from '../../lib/messenger';
-
-export type KeyringControllerMessenger = ReturnType<
-  typeof getKeyringControllerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -14,12 +15,16 @@ export type KeyringControllerMessenger = ReturnType<
  * messenger.
  */
 export function getKeyringControllerMessenger(
-  messenger: RootMessenger<never, never>,
-) {
-  return new Messenger<'KeyringController', never, never, typeof messenger>({
+  messenger: RootMessenger<
+    MessengerActions<KeyringControllerMessenger>,
+    MessengerEvents<KeyringControllerMessenger>
+  >,
+): KeyringControllerMessenger {
+  const controllerMessenger: KeyringControllerMessenger = new Messenger({
     namespace: 'KeyringController',
     parent: messenger,
   });
+  return controllerMessenger;
 }
 
 type AllowedInitializationActions = AppStateControllerRequestQrCodeScanAction;

--- a/app/scripts/messenger-client-init/messengers/logging-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/logging-controller-messenger.ts
@@ -1,9 +1,10 @@
-import { Messenger } from '@metamask/messenger';
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { LoggingControllerMessenger } from '@metamask/logging-controller';
 import { RootMessenger } from '../../lib/messenger';
-
-export type LoggingControllerMessenger = ReturnType<
-  typeof getLoggingControllerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -13,10 +14,14 @@ export type LoggingControllerMessenger = ReturnType<
  * messenger.
  */
 export function getLoggingControllerMessenger(
-  messenger: RootMessenger<never, never>,
-) {
-  return new Messenger<'LoggingController', never, never, typeof messenger>({
+  messenger: RootMessenger<
+    MessengerActions<LoggingControllerMessenger>,
+    MessengerEvents<LoggingControllerMessenger>
+  >,
+): LoggingControllerMessenger {
+  const controllerMessenger: LoggingControllerMessenger = new Messenger({
     namespace: 'LoggingController',
     parent: messenger,
   });
+  return controllerMessenger;
 }

--- a/app/scripts/messenger-client-init/messengers/multichain/index.ts
+++ b/app/scripts/messenger-client-init/messengers/multichain/index.ts
@@ -3,8 +3,3 @@ export { getMultichainAssetsRatesControllerMessenger } from './multichain-assets
 export { getMultichainBalancesControllerMessenger } from './multichain-balances-controller-messenger';
 export { getMultichainTransactionsControllerMessenger } from './multichain-transactions-controller-messenger';
 export { getMultichainNetworkControllerMessenger } from './multichain-network-controller-messenger';
-
-export type { MultichainAssetsRatesControllerMessenger } from './multichain-assets-rates-controller-messenger';
-export type { MultichainBalancesControllerMessenger } from './multichain-balances-controller-messenger';
-export type { MultichainTransactionsControllerMessenger } from './multichain-transactions-controller-messenger';
-export type { MultichainNetworkControllerMessenger } from './multichain-network-controller-messenger';

--- a/app/scripts/messenger-client-init/messengers/multichain/multichain-assets-rates-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/multichain/multichain-assets-rates-controller-messenger.ts
@@ -1,39 +1,10 @@
-import { Messenger } from '@metamask/messenger';
 import {
-  AccountsControllerAccountAddedEvent,
-  AccountsControllerGetSelectedMultichainAccountAction,
-  AccountsControllerListMultichainAccountsAction,
-} from '@metamask/accounts-controller';
-import {
-  CurrencyRateStateChange,
-  CurrencyRateControllerGetStateAction,
-  MultichainAssetsControllerAccountAssetListUpdatedEvent,
-  MultichainAssetsControllerGetStateAction,
-} from '@metamask/assets-controllers';
-import {
-  KeyringControllerLockEvent,
-  KeyringControllerUnlockEvent,
-} from '@metamask/keyring-controller';
-import { SnapControllerHandleRequestAction } from '@metamask/snaps-controllers';
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { MultichainAssetsRatesControllerMessenger } from '@metamask/assets-controllers';
 import { RootMessenger } from '../../../lib/messenger';
-
-type Actions =
-  | SnapControllerHandleRequestAction
-  | AccountsControllerListMultichainAccountsAction
-  | CurrencyRateControllerGetStateAction
-  | MultichainAssetsControllerGetStateAction
-  | AccountsControllerGetSelectedMultichainAccountAction;
-
-type Events =
-  | KeyringControllerLockEvent
-  | KeyringControllerUnlockEvent
-  | AccountsControllerAccountAddedEvent
-  | CurrencyRateStateChange
-  | MultichainAssetsControllerAccountAssetListUpdatedEvent;
-
-export type MultichainAssetsRatesControllerMessenger = ReturnType<
-  typeof getMultichainAssetsRatesControllerMessenger
->;
 
 /**
  * Get a restricted messenger for the Multichain Assets Rate controller. This is scoped to the
@@ -43,17 +14,16 @@ export type MultichainAssetsRatesControllerMessenger = ReturnType<
  * @returns The restricted controller messenger.
  */
 export function getMultichainAssetsRatesControllerMessenger(
-  messenger: RootMessenger<Actions, Events>,
-) {
-  const controllerMessenger = new Messenger<
-    'MultichainAssetsRatesController',
-    Actions,
-    Events,
-    typeof messenger
-  >({
-    namespace: 'MultichainAssetsRatesController',
-    parent: messenger,
-  });
+  messenger: RootMessenger<
+    MessengerActions<MultichainAssetsRatesControllerMessenger>,
+    MessengerEvents<MultichainAssetsRatesControllerMessenger>
+  >,
+): MultichainAssetsRatesControllerMessenger {
+  const controllerMessenger: MultichainAssetsRatesControllerMessenger =
+    new Messenger({
+      namespace: 'MultichainAssetsRatesController',
+      parent: messenger,
+    });
   messenger.delegate({
     messenger: controllerMessenger,
     events: [

--- a/app/scripts/messenger-client-init/messengers/multichain/multichain-balances-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/multichain/multichain-balances-controller-messenger.ts
@@ -1,33 +1,10 @@
-import { Messenger } from '@metamask/messenger';
 import {
-  AccountsControllerAccountAddedEvent,
-  AccountsControllerAccountRemovedEvent,
-  AccountsControllerListMultichainAccountsAction,
-  AccountsControllerAccountBalancesUpdatesEvent,
-} from '@metamask/accounts-controller';
-import { SnapControllerHandleRequestAction } from '@metamask/snaps-controllers';
-import {
-  MultichainAssetsControllerAccountAssetListUpdatedEvent,
-  MultichainAssetsControllerGetStateAction,
-} from '@metamask/assets-controllers';
-import { KeyringControllerGetStateAction } from '@metamask/keyring-controller';
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { MultichainBalancesControllerMessenger } from '@metamask/assets-controllers';
 import { RootMessenger } from '../../../lib/messenger';
-
-type Actions =
-  | AccountsControllerListMultichainAccountsAction
-  | SnapControllerHandleRequestAction
-  | MultichainAssetsControllerGetStateAction
-  | KeyringControllerGetStateAction;
-
-type Events =
-  | AccountsControllerAccountAddedEvent
-  | AccountsControllerAccountRemovedEvent
-  | AccountsControllerAccountBalancesUpdatesEvent
-  | MultichainAssetsControllerAccountAssetListUpdatedEvent;
-
-export type MultichainBalancesControllerMessenger = ReturnType<
-  typeof getMultichainBalancesControllerMessenger
->;
 
 /**
  * Get a restricted messenger for the Multichain Balances controller. This is scoped to the
@@ -37,17 +14,16 @@ export type MultichainBalancesControllerMessenger = ReturnType<
  * @returns The restricted controller messenger.
  */
 export function getMultichainBalancesControllerMessenger(
-  messenger: RootMessenger<Actions, Events>,
-) {
-  const controllerMessenger = new Messenger<
-    'MultichainBalancesController',
-    Actions,
-    Events,
-    typeof messenger
-  >({
-    namespace: 'MultichainBalancesController',
-    parent: messenger,
-  });
+  messenger: RootMessenger<
+    MessengerActions<MultichainBalancesControllerMessenger>,
+    MessengerEvents<MultichainBalancesControllerMessenger>
+  >,
+): MultichainBalancesControllerMessenger {
+  const controllerMessenger: MultichainBalancesControllerMessenger =
+    new Messenger({
+      namespace: 'MultichainBalancesController',
+      parent: messenger,
+    });
   messenger.delegate({
     messenger: controllerMessenger,
     events: [

--- a/app/scripts/messenger-client-init/messengers/multichain/multichain-network-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/multichain/multichain-network-controller-messenger.ts
@@ -1,30 +1,10 @@
-import { Messenger } from '@metamask/messenger';
 import {
-  AccountsControllerListMultichainAccountsAction,
-  AccountsControllerSelectedAccountChangeEvent,
-} from '@metamask/accounts-controller';
-import {
-  type NetworkControllerSetActiveNetworkAction,
-  type NetworkControllerGetStateAction,
-  type NetworkControllerRemoveNetworkAction,
-  type NetworkControllerGetSelectedChainIdAction,
-  type NetworkControllerFindNetworkClientIdByChainIdAction,
-} from '@metamask/network-controller';
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { MultichainNetworkControllerMessenger } from '@metamask/multichain-network-controller';
 import { RootMessenger } from '../../../lib/messenger';
-
-type Actions =
-  | NetworkControllerGetStateAction
-  | NetworkControllerSetActiveNetworkAction
-  | NetworkControllerRemoveNetworkAction
-  | NetworkControllerGetSelectedChainIdAction
-  | NetworkControllerFindNetworkClientIdByChainIdAction
-  | AccountsControllerListMultichainAccountsAction;
-
-type Events = AccountsControllerSelectedAccountChangeEvent;
-
-export type MultichainNetworkControllerMessenger = ReturnType<
-  typeof getMultichainNetworkControllerMessenger
->;
 
 /**
  * Get a restricted messenger for the Multichain Network controller. This is scoped to the
@@ -34,17 +14,16 @@ export type MultichainNetworkControllerMessenger = ReturnType<
  * @returns The restricted controller messenger.
  */
 export function getMultichainNetworkControllerMessenger(
-  messenger: RootMessenger<Actions, Events>,
-) {
-  const controllerMessenger = new Messenger<
-    'MultichainNetworkController',
-    Actions,
-    Events,
-    typeof messenger
-  >({
-    namespace: 'MultichainNetworkController',
-    parent: messenger,
-  });
+  messenger: RootMessenger<
+    MessengerActions<MultichainNetworkControllerMessenger>,
+    MessengerEvents<MultichainNetworkControllerMessenger>
+  >,
+): MultichainNetworkControllerMessenger {
+  const controllerMessenger: MultichainNetworkControllerMessenger =
+    new Messenger({
+      namespace: 'MultichainNetworkController',
+      parent: messenger,
+    });
   messenger.delegate({
     messenger: controllerMessenger,
     actions: [

--- a/app/scripts/messenger-client-init/messengers/multichain/multichain-transactions-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/multichain/multichain-transactions-controller-messenger.ts
@@ -1,27 +1,10 @@
-import { Messenger } from '@metamask/messenger';
 import {
-  AccountsControllerAccountAddedEvent,
-  AccountsControllerAccountRemovedEvent,
-  AccountsControllerListMultichainAccountsAction,
-  AccountsControllerAccountTransactionsUpdatedEvent,
-} from '@metamask/accounts-controller';
-import { SnapControllerHandleRequestAction } from '@metamask/snaps-controllers';
-import { KeyringControllerGetStateAction } from '@metamask/keyring-controller';
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { MultichainTransactionsControllerMessenger } from '@metamask/multichain-transactions-controller';
 import { RootMessenger } from '../../../lib/messenger';
-
-type Actions =
-  | AccountsControllerListMultichainAccountsAction
-  | SnapControllerHandleRequestAction
-  | KeyringControllerGetStateAction;
-
-type Events =
-  | AccountsControllerAccountAddedEvent
-  | AccountsControllerAccountRemovedEvent
-  | AccountsControllerAccountTransactionsUpdatedEvent;
-
-export type MultichainTransactionsControllerMessenger = ReturnType<
-  typeof getMultichainTransactionsControllerMessenger
->;
 
 /**
  * Get a restricted messenger for the Multichain Transactions controller. This is scoped to the
@@ -31,17 +14,16 @@ export type MultichainTransactionsControllerMessenger = ReturnType<
  * @returns The restricted controller messenger.
  */
 export function getMultichainTransactionsControllerMessenger(
-  messenger: RootMessenger<Actions, Events>,
-) {
-  const controllerMessenger = new Messenger<
-    'MultichainTransactionsController',
-    Actions,
-    Events,
-    typeof messenger
-  >({
-    namespace: 'MultichainTransactionsController',
-    parent: messenger,
-  });
+  messenger: RootMessenger<
+    MessengerActions<MultichainTransactionsControllerMessenger>,
+    MessengerEvents<MultichainTransactionsControllerMessenger>
+  >,
+): MultichainTransactionsControllerMessenger {
+  const controllerMessenger: MultichainTransactionsControllerMessenger =
+    new Messenger({
+      namespace: 'MultichainTransactionsController',
+      parent: messenger,
+    });
   messenger.delegate({
     messenger: controllerMessenger,
     events: [

--- a/app/scripts/messenger-client-init/messengers/name-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/name-controller-messenger.ts
@@ -1,10 +1,11 @@
-import { Messenger } from '@metamask/messenger';
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { NameControllerMessenger } from '@metamask/name-controller';
 import { PreferencesControllerGetStateAction } from '../../controllers/preferences-controller';
 import { RootMessenger } from '../../lib/messenger';
-
-export type NameControllerMessenger = ReturnType<
-  typeof getNameControllerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the name
@@ -14,12 +15,16 @@ export type NameControllerMessenger = ReturnType<
  * messenger.
  */
 export function getNameControllerMessenger(
-  messenger: RootMessenger<never, never>,
-) {
-  return new Messenger<'NameController', never, never, typeof messenger>({
+  messenger: RootMessenger<
+    MessengerActions<NameControllerMessenger>,
+    MessengerEvents<NameControllerMessenger>
+  >,
+): NameControllerMessenger {
+  const controllerMessenger: NameControllerMessenger = new Messenger({
     namespace: 'NameController',
     parent: messenger,
   });
+  return controllerMessenger;
 }
 
 type AllowedInitializationActions = PreferencesControllerGetStateAction;

--- a/app/scripts/messenger-client-init/messengers/network-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/network-controller-messenger.ts
@@ -26,14 +26,12 @@ import { RootMessenger } from '../../lib/messenger';
  * @returns The restricted messenger.
  */
 export function getNetworkControllerMessenger(
-  messenger: RootMessenger,
-): NetworkControllerMessenger {
-  const controllerMessenger = new Messenger<
-    'NetworkController',
+  messenger: RootMessenger<
     MessengerActions<NetworkControllerMessenger>,
-    MessengerEvents<NetworkControllerMessenger>,
-    RootMessenger
-  >({
+    MessengerEvents<NetworkControllerMessenger>
+  >,
+): NetworkControllerMessenger {
+  const controllerMessenger: NetworkControllerMessenger = new Messenger({
     namespace: 'NetworkController',
     parent: messenger,
   });

--- a/app/scripts/messenger-client-init/messengers/notifications/notification-services-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/notifications/notification-services-controller-messenger.ts
@@ -6,22 +6,17 @@ import {
 import { type NotificationServicesControllerMessenger } from '@metamask/notification-services-controller/notification-services';
 import { RootMessenger } from '../../../lib/messenger';
 
-type Actions = MessengerActions<NotificationServicesControllerMessenger>;
-
-type Events = MessengerEvents<NotificationServicesControllerMessenger>;
-
 export function getNotificationServicesControllerMessenger(
-  messenger: RootMessenger<Actions, Events>,
+  messenger: RootMessenger<
+    MessengerActions<NotificationServicesControllerMessenger>,
+    MessengerEvents<NotificationServicesControllerMessenger>
+  >,
 ): NotificationServicesControllerMessenger {
-  const controllerMessenger = new Messenger<
-    'NotificationServicesController',
-    Actions,
-    Events,
-    typeof messenger
-  >({
-    namespace: 'NotificationServicesController',
-    parent: messenger,
-  });
+  const controllerMessenger: NotificationServicesControllerMessenger =
+    new Messenger({
+      namespace: 'NotificationServicesController',
+      parent: messenger,
+    });
   messenger.delegate({
     messenger: controllerMessenger,
     actions: [

--- a/app/scripts/messenger-client-init/messengers/notifications/notification-services-push-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/notifications/notification-services-push-controller-messenger.ts
@@ -11,10 +11,6 @@ import type {
 import { MetaMetricsControllerTrackEventAction } from '../../../controllers/metametrics-controller-method-action-types';
 import { RootMessenger } from '../../../lib/messenger';
 
-type Actions = MessengerActions<NotificationServicesPushControllerMessenger>;
-
-type Events = MessengerEvents<NotificationServicesPushControllerMessenger>;
-
 /**
  * Create a messenger restricted to the allowed actions and events of the
  * notification services push controller.
@@ -24,17 +20,16 @@ type Events = MessengerEvents<NotificationServicesPushControllerMessenger>;
  * @returns The restricted messenger.
  */
 export function getNotificationServicesPushControllerMessenger(
-  messenger: RootMessenger<Actions, Events>,
+  messenger: RootMessenger<
+    MessengerActions<NotificationServicesPushControllerMessenger>,
+    MessengerEvents<NotificationServicesPushControllerMessenger>
+  >,
 ) {
-  const controllerMessenger = new Messenger<
-    'NotificationServicesPushController',
-    Actions,
-    Events,
-    typeof messenger
-  >({
-    namespace: 'NotificationServicesPushController',
-    parent: messenger,
-  });
+  const controllerMessenger: NotificationServicesPushControllerMessenger =
+    new Messenger({
+      namespace: 'NotificationServicesPushController',
+      parent: messenger,
+    });
   messenger.delegate({
     messenger: controllerMessenger,
     actions: ['AuthenticationController:getBearerToken'],

--- a/app/scripts/messenger-client-init/messengers/passkey-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/passkey-controller-messenger.ts
@@ -1,9 +1,10 @@
-import { Messenger } from '@metamask/messenger';
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { PasskeyControllerMessenger } from '@metamask/passkey-controller';
 import { RootMessenger } from '../../lib/messenger';
-
-export type PasskeyControllerMessenger = ReturnType<
-  typeof getPasskeyControllerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -13,10 +14,14 @@ export type PasskeyControllerMessenger = ReturnType<
  * messenger.
  */
 export function getPasskeyControllerMessenger(
-  messenger: RootMessenger<never, never>,
-) {
-  return new Messenger<'PasskeyController', never, never, typeof messenger>({
+  messenger: RootMessenger<
+    MessengerActions<PasskeyControllerMessenger>,
+    MessengerEvents<PasskeyControllerMessenger>
+  >,
+): PasskeyControllerMessenger {
+  const controllerMessenger: PasskeyControllerMessenger = new Messenger({
     namespace: 'PasskeyController',
     parent: messenger,
   });
+  return controllerMessenger;
 }

--- a/app/scripts/messenger-client-init/messengers/permission-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/permission-controller-messenger.ts
@@ -26,6 +26,10 @@ type AllowedActions =
   | SnapControllerGetPermittedSnapsAction
   | SnapControllerInstallSnapsAction;
 
+// TODO: Ideally we remove this type, but we request more permissions than
+// defined in the permission controller's own messenger (to support certain
+// side effects), so we can't currently use the controller's messenger type as
+// the allowed actions for the controller's messenger.
 export type PermissionControllerMessenger = ReturnType<
   typeof getPermissionControllerMessenger
 >;

--- a/app/scripts/messenger-client-init/messengers/permission-log-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/permission-log-controller-messenger.ts
@@ -1,9 +1,10 @@
-import { Messenger } from '@metamask/messenger';
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { PermissionLogControllerMessenger } from '@metamask/permission-log-controller';
 import { RootMessenger } from '../../lib/messenger';
-
-export type PermissionLogControllerMessenger = ReturnType<
-  typeof getPermissionLogControllerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -13,15 +14,14 @@ export type PermissionLogControllerMessenger = ReturnType<
  * messenger.
  */
 export function getPermissionLogControllerMessenger(
-  messenger: RootMessenger<never, never>,
-) {
-  return new Messenger<
-    'PermissionLogController',
-    never,
-    never,
-    typeof messenger
-  >({
+  messenger: RootMessenger<
+    MessengerActions<PermissionLogControllerMessenger>,
+    MessengerEvents<PermissionLogControllerMessenger>
+  >,
+): PermissionLogControllerMessenger {
+  const controllerMessenger: PermissionLogControllerMessenger = new Messenger({
     namespace: 'PermissionLogController',
     parent: messenger,
   });
+  return controllerMessenger;
 }

--- a/app/scripts/messenger-client-init/messengers/perps-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/perps-controller-messenger.ts
@@ -49,8 +49,10 @@ type AllowedEvents =
   | RemoteFeatureFlagControllerStateChangeEvent
   | AccountTreeControllerSelectedAccountGroupChangeEvent;
 
-export type PerpsControllerMessenger = ReturnType<
-  typeof getPerpsControllerMessenger
+export type PerpsControllerMessenger = Messenger<
+  'PerpsController',
+  AllowedActions,
+  AllowedEvents
 >;
 
 /**
@@ -63,13 +65,8 @@ export type PerpsControllerMessenger = ReturnType<
  */
 export function getPerpsControllerMessenger(
   messenger: RootMessenger<AllowedActions, AllowedEvents>,
-) {
-  const perpsControllerMessenger = new Messenger<
-    'PerpsController',
-    AllowedActions,
-    AllowedEvents,
-    typeof messenger
-  >({
+): PerpsControllerMessenger {
+  const perpsControllerMessenger: PerpsControllerMessenger = new Messenger({
     namespace: 'PerpsController',
     parent: messenger,
   });

--- a/app/scripts/messenger-client-init/messengers/phishing-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/phishing-controller-messenger.ts
@@ -1,16 +1,10 @@
-import { Messenger } from '@metamask/messenger';
-import { AllowedEvents } from '@metamask/phishing-controller';
-import type { AddressBookControllerGetStateAction } from '@metamask/address-book-controller';
-import type { TransactionControllerGetStateAction } from '@metamask/transaction-controller';
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { PhishingControllerMessenger } from '@metamask/phishing-controller';
 import { RootMessenger } from '../../lib/messenger';
-
-type AllowedActions =
-  | AddressBookControllerGetStateAction
-  | TransactionControllerGetStateAction;
-
-export type PhishingControllerMessenger = ReturnType<
-  typeof getPhishingControllerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -20,14 +14,12 @@ export type PhishingControllerMessenger = ReturnType<
  * messenger.
  */
 export function getPhishingControllerMessenger(
-  messenger: RootMessenger<AllowedActions, AllowedEvents>,
-) {
-  const controllerMessenger = new Messenger<
-    'PhishingController',
-    AllowedActions,
-    AllowedEvents,
-    typeof messenger
-  >({
+  messenger: RootMessenger<
+    MessengerActions<PhishingControllerMessenger>,
+    MessengerEvents<PhishingControllerMessenger>
+  >,
+): PhishingControllerMessenger {
+  const controllerMessenger: PhishingControllerMessenger = new Messenger({
     namespace: 'PhishingController',
     parent: messenger,
   });

--- a/app/scripts/messenger-client-init/messengers/profile-metrics-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/profile-metrics-controller-messenger.ts
@@ -6,10 +6,6 @@ import {
 } from '@metamask/messenger';
 import { RootMessenger } from '../../lib/messenger';
 
-type AllowedActions = MessengerActions<ProfileMetricsControllerMessenger>;
-
-type AllowedEvents = MessengerEvents<ProfileMetricsControllerMessenger>;
-
 /**
  * Create a messenger restricted to the allowed actions and events of the
  * profile metrics controller.
@@ -18,14 +14,12 @@ type AllowedEvents = MessengerEvents<ProfileMetricsControllerMessenger>;
  * messenger.
  */
 export function getProfileMetricsControllerMessenger(
-  messenger: RootMessenger<AllowedActions, AllowedEvents>,
+  messenger: RootMessenger<
+    MessengerActions<ProfileMetricsControllerMessenger>,
+    MessengerEvents<ProfileMetricsControllerMessenger>
+  >,
 ) {
-  const controllerMessenger = new Messenger<
-    'ProfileMetricsController',
-    AllowedActions,
-    AllowedEvents,
-    typeof messenger
-  >({
+  const controllerMessenger: ProfileMetricsControllerMessenger = new Messenger({
     namespace: 'ProfileMetricsController',
     parent: messenger,
   });

--- a/app/scripts/messenger-client-init/messengers/profile-metrics-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/profile-metrics-service-messenger.ts
@@ -6,10 +6,6 @@ import {
 } from '@metamask/messenger';
 import { RootMessenger } from '../../lib/messenger';
 
-type AllowedActions = MessengerActions<ProfileMetricsServiceMessenger>;
-
-type AllowedEvents = MessengerEvents<ProfileMetricsServiceMessenger>;
-
 /**
  * Create a messenger restricted to the allowed actions and events of the
  * profile metrics service.
@@ -18,14 +14,12 @@ type AllowedEvents = MessengerEvents<ProfileMetricsServiceMessenger>;
  * messenger.
  */
 export function getProfileMetricsServiceMessenger(
-  messenger: RootMessenger<AllowedActions, AllowedEvents>,
+  messenger: RootMessenger<
+    MessengerActions<ProfileMetricsServiceMessenger>,
+    MessengerEvents<ProfileMetricsServiceMessenger>
+  >,
 ): ProfileMetricsServiceMessenger {
-  const serviceMessenger = new Messenger<
-    'ProfileMetricsService',
-    AllowedActions,
-    AllowedEvents,
-    typeof messenger
-  >({
+  const serviceMessenger: ProfileMetricsServiceMessenger = new Messenger({
     namespace: 'ProfileMetricsService',
     parent: messenger,
   });

--- a/app/scripts/messenger-client-init/messengers/rates-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/rates-controller-messenger.ts
@@ -1,9 +1,10 @@
-import { Messenger } from '@metamask/messenger';
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { RatesControllerMessenger } from '@metamask/assets-controllers';
 import { RootMessenger } from '../../lib/messenger';
-
-export type RatesControllerMessenger = ReturnType<
-  typeof getRatesControllerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -13,10 +14,14 @@ export type RatesControllerMessenger = ReturnType<
  * messenger.
  */
 export function getRatesControllerMessenger(
-  messenger: RootMessenger<never, never>,
-) {
-  return new Messenger<'RatesController', never, never, typeof messenger>({
+  messenger: RootMessenger<
+    MessengerActions<RatesControllerMessenger>,
+    MessengerEvents<RatesControllerMessenger>
+  >,
+): RatesControllerMessenger {
+  const controllerMessenger: RatesControllerMessenger = new Messenger({
     namespace: 'RatesController',
     parent: messenger,
   });
+  return controllerMessenger;
 }

--- a/app/scripts/messenger-client-init/messengers/remote-feature-flag-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/remote-feature-flag-controller-messenger.ts
@@ -1,4 +1,9 @@
-import { Messenger } from '@metamask/messenger';
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { RemoteFeatureFlagControllerMessenger } from '@metamask/remote-feature-flag-controller';
 import { MetaMetricsControllerGetMetaMetricsIdAction } from '../../controllers/metametrics-controller-method-action-types';
 import {
   PreferencesControllerGetStateAction,
@@ -10,10 +15,6 @@ import type {
   OnboardingControllerStateChangeEvent,
 } from '../../controllers/onboarding';
 
-export type RemoteFeatureFlagControllerMessenger = ReturnType<
-  typeof getRemoteFeatureFlagControllerMessenger
->;
-
 /**
  * Create a messenger restricted to the allowed actions and events of the
  * remote feature flag controller.
@@ -22,17 +23,17 @@ export type RemoteFeatureFlagControllerMessenger = ReturnType<
  * messenger.
  */
 export function getRemoteFeatureFlagControllerMessenger(
-  messenger: RootMessenger<never, never>,
-) {
-  return new Messenger<
-    'RemoteFeatureFlagController',
-    never,
-    never,
-    typeof messenger
-  >({
-    namespace: 'RemoteFeatureFlagController',
-    parent: messenger,
-  });
+  messenger: RootMessenger<
+    MessengerActions<RemoteFeatureFlagControllerMessenger>,
+    MessengerEvents<RemoteFeatureFlagControllerMessenger>
+  >,
+): RemoteFeatureFlagControllerMessenger {
+  const controllerMessenger: RemoteFeatureFlagControllerMessenger =
+    new Messenger({
+      namespace: 'RemoteFeatureFlagController',
+      parent: messenger,
+    });
+  return controllerMessenger;
 }
 
 type AllowedInitializationActions =

--- a/app/scripts/messenger-client-init/messengers/seedless-onboarding/index.ts
+++ b/app/scripts/messenger-client-init/messengers/seedless-onboarding/index.ts
@@ -3,7 +3,4 @@ export {
   getSeedlessOnboardingControllerMessenger,
   getSeedlessOnboardingControllerInitMessenger,
 } from './seedless-onboarding-controller-messenger';
-export type {
-  SeedlessOnboardingControllerMessenger,
-  SeedlessOnboardingControllerInitMessenger,
-} from './seedless-onboarding-controller-messenger';
+export type { SeedlessOnboardingControllerInitMessenger } from './seedless-onboarding-controller-messenger';

--- a/app/scripts/messenger-client-init/messengers/seedless-onboarding/seedless-onboarding-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/seedless-onboarding/seedless-onboarding-controller-messenger.ts
@@ -1,29 +1,15 @@
-import { Messenger } from '@metamask/messenger';
 import {
-  KeyringControllerLockEvent,
-  KeyringControllerUnlockEvent,
-} from '@metamask/keyring-controller';
-import {
-  SeedlessOnboardingControllerGetStateAction,
-  SeedlessOnboardingControllerStateChangeEvent,
-} from '@metamask/seedless-onboarding-controller';
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { SeedlessOnboardingControllerMessenger } from '@metamask/seedless-onboarding-controller';
 import {
   OAuthServiceGetNewRefreshTokenAction,
   OAuthServiceRevokeRefreshTokenAction,
   OAuthServiceRenewRefreshTokenAction,
 } from '../../../services/oauth/types';
 import { RootMessenger } from '../../../lib/messenger';
-
-type MessengerActions = SeedlessOnboardingControllerGetStateAction;
-
-type MessengerEvents =
-  | SeedlessOnboardingControllerStateChangeEvent
-  | KeyringControllerLockEvent
-  | KeyringControllerUnlockEvent;
-
-export type SeedlessOnboardingControllerMessenger = ReturnType<
-  typeof getSeedlessOnboardingControllerMessenger
->;
 
 /**
  * Get a restricted messenger for the Seedless Onboarding controller. This is scoped to the
@@ -33,17 +19,17 @@ export type SeedlessOnboardingControllerMessenger = ReturnType<
  * @returns The restricted messenger.
  */
 export function getSeedlessOnboardingControllerMessenger(
-  messenger: RootMessenger<MessengerActions, MessengerEvents>,
-) {
-  return new Messenger<
-    'SeedlessOnboardingController',
-    MessengerActions,
-    MessengerEvents,
-    typeof messenger
-  >({
-    namespace: 'SeedlessOnboardingController',
-    parent: messenger,
-  });
+  messenger: RootMessenger<
+    MessengerActions<SeedlessOnboardingControllerMessenger>,
+    MessengerEvents<SeedlessOnboardingControllerMessenger>
+  >,
+): SeedlessOnboardingControllerMessenger {
+  const controllerMessenger: SeedlessOnboardingControllerMessenger =
+    new Messenger({
+      namespace: 'SeedlessOnboardingController',
+      parent: messenger,
+    });
+  return controllerMessenger;
 }
 
 type InitActions =

--- a/app/scripts/messenger-client-init/messengers/selected-network-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/selected-network-controller-messenger.ts
@@ -1,31 +1,10 @@
-import { Messenger } from '@metamask/messenger';
 import {
-  NetworkControllerGetNetworkClientByIdAction,
-  NetworkControllerGetSelectedNetworkClientAction,
-  NetworkControllerGetStateAction,
-  NetworkControllerStateChangeEvent,
-} from '@metamask/network-controller';
-import {
-  HasPermissions,
-  GetSubjects,
-  PermissionControllerStateChange,
-} from '@metamask/permission-controller';
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { SelectedNetworkControllerMessenger } from '@metamask/selected-network-controller';
 import { RootMessenger } from '../../lib/messenger';
-
-type AllowedActions =
-  | NetworkControllerGetNetworkClientByIdAction
-  | NetworkControllerGetSelectedNetworkClientAction
-  | NetworkControllerGetStateAction
-  | GetSubjects
-  | HasPermissions;
-
-type AllowedEvents =
-  | NetworkControllerStateChangeEvent
-  | PermissionControllerStateChange;
-
-export type SelectedNetworkControllerMessenger = ReturnType<
-  typeof getSelectedNetworkControllerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -35,17 +14,17 @@ export type SelectedNetworkControllerMessenger = ReturnType<
  * messenger.
  */
 export function getSelectedNetworkControllerMessenger(
-  messenger: RootMessenger<AllowedActions, AllowedEvents>,
-) {
-  const controllerMessenger = new Messenger<
-    'SelectedNetworkController',
-    AllowedActions,
-    AllowedEvents,
-    typeof messenger
-  >({
-    namespace: 'SelectedNetworkController',
-    parent: messenger,
-  });
+  messenger: RootMessenger<
+    MessengerActions<SelectedNetworkControllerMessenger>,
+    MessengerEvents<SelectedNetworkControllerMessenger>
+  >,
+): SelectedNetworkControllerMessenger {
+  const controllerMessenger: SelectedNetworkControllerMessenger = new Messenger(
+    {
+      namespace: 'SelectedNetworkController',
+      parent: messenger,
+    },
+  );
   messenger.delegate({
     messenger: controllerMessenger,
     actions: [

--- a/app/scripts/messenger-client-init/messengers/storage-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/storage-service-messenger.ts
@@ -9,9 +9,6 @@ import { RootMessenger } from '../../lib/messenger';
 // Re-export the type from core for convenience
 export type StorageServiceMessenger = CoreStorageServiceMessenger;
 
-type AllowedActions = MessengerActions<StorageServiceMessenger>;
-type AllowedEvents = MessengerEvents<StorageServiceMessenger>;
-
 /**
  * Create the messenger for StorageService.
  *
@@ -22,14 +19,12 @@ type AllowedEvents = MessengerEvents<StorageServiceMessenger>;
  * @returns The StorageService messenger
  */
 export function getStorageServiceMessenger(
-  messenger: RootMessenger<AllowedActions, AllowedEvents>,
+  messenger: RootMessenger<
+    MessengerActions<StorageServiceMessenger>,
+    MessengerEvents<StorageServiceMessenger>
+  >,
 ): StorageServiceMessenger {
-  const serviceMessenger = new Messenger<
-    'StorageService',
-    AllowedActions,
-    AllowedEvents,
-    typeof messenger
-  >({
+  const serviceMessenger: StorageServiceMessenger = new Messenger({
     namespace: 'StorageService',
     parent: messenger,
   });

--- a/app/scripts/messenger-client-init/messengers/subject-metadata-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/subject-metadata-controller-messenger.ts
@@ -1,12 +1,10 @@
-import { Messenger } from '@metamask/messenger';
-import type { HasPermissions } from '@metamask/permission-controller';
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { SubjectMetadataControllerMessenger } from '@metamask/permission-controller';
 import { RootMessenger } from '../../lib/messenger';
-
-type AllowedActions = HasPermissions;
-
-export type SubjectMetadataControllerMessenger = ReturnType<
-  typeof getSubjectMetadataControllerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -16,17 +14,17 @@ export type SubjectMetadataControllerMessenger = ReturnType<
  * messenger.
  */
 export function getSubjectMetadataControllerMessenger(
-  messenger: RootMessenger<AllowedActions, never>,
-) {
-  const controllerMessenger = new Messenger<
-    'SubjectMetadataController',
-    AllowedActions,
-    never,
-    typeof messenger
-  >({
-    namespace: 'SubjectMetadataController',
-    parent: messenger,
-  });
+  messenger: RootMessenger<
+    MessengerActions<SubjectMetadataControllerMessenger>,
+    MessengerEvents<SubjectMetadataControllerMessenger>
+  >,
+): SubjectMetadataControllerMessenger {
+  const controllerMessenger: SubjectMetadataControllerMessenger = new Messenger(
+    {
+      namespace: 'SubjectMetadataController',
+      parent: messenger,
+    },
+  );
   messenger.delegate({
     messenger: controllerMessenger,
     actions: ['PermissionController:hasPermissions'],

--- a/app/scripts/messenger-client-init/messengers/token-balances-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/token-balances-controller-messenger.ts
@@ -1,93 +1,13 @@
-import type {
-  ControllerGetStateAction,
-  ControllerStateChangeEvent,
-} from '@metamask/base-controller';
-import { Messenger } from '@metamask/messenger';
-import type {
-  NetworkControllerGetNetworkClientByIdAction,
-  NetworkControllerGetStateAction,
-  NetworkControllerStateChangeEvent,
-} from '@metamask/network-controller';
-import { AuthenticationController } from '@metamask/profile-sync-controller';
 import {
-  AccountsControllerGetSelectedAccountAction,
-  AccountsControllerListAccountsAction,
-  AccountsControllerSelectedEvmAccountChangeEvent,
-} from '@metamask/accounts-controller';
-import {
-  AccountTrackerControllerUpdateNativeBalancesAction,
-  AccountTrackerControllerUpdateStakedBalancesAction,
-  AccountTrackerControllerGetStateAction,
-  TokensControllerState,
-  type TokenDetectionControllerAddDetectedTokensViaWsAction,
-  TokenDetectionControllerAddDetectedTokensViaPollingAction,
-  TokenDetectionControllerDetectTokensAction,
-} from '@metamask/assets-controllers';
-import {
-  TransactionControllerIncomingTransactionsReceivedEvent,
-  TransactionControllerTransactionConfirmedEvent,
-} from '@metamask/transaction-controller';
-import {
-  KeyringControllerAccountRemovedEvent,
-  KeyringControllerGetStateAction,
-  KeyringControllerLockEvent,
-  KeyringControllerUnlockEvent,
-} from '@metamask/keyring-controller';
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { TokenBalancesControllerMessenger } from '@metamask/assets-controllers';
 import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
-import type {
-  AccountActivityServiceStatusChangedEvent,
-  AccountActivityServiceBalanceUpdatedEvent,
-} from '@metamask/core-backend';
-import type {
-  PreferencesControllerGetStateAction,
-  PreferencesControllerStateChangeEvent,
-} from '@metamask/preferences-controller';
+import type { PreferencesControllerGetStateAction } from '@metamask/preferences-controller';
 import { OnboardingControllerGetStateAction } from '../../controllers/onboarding';
 import { RootMessenger } from '../../lib/messenger';
-
-// Not exported from `@metamask/assets-controllers`.
-type TokensControllerGetStateAction = ControllerGetStateAction<
-  'TokensController',
-  TokensControllerState
->;
-
-type TokensControllerStateChangeEvent = ControllerStateChangeEvent<
-  'TokensController',
-  TokensControllerState
->;
-
-type AllowedActions =
-  | NetworkControllerGetNetworkClientByIdAction
-  | NetworkControllerGetStateAction
-  | TokensControllerGetStateAction
-  | TokenDetectionControllerAddDetectedTokensViaPollingAction
-  | TokenDetectionControllerAddDetectedTokensViaWsAction
-  | TokenDetectionControllerDetectTokensAction
-  | PreferencesControllerGetStateAction
-  | AccountsControllerGetSelectedAccountAction
-  | AccountsControllerListAccountsAction
-  | AccountTrackerControllerGetStateAction
-  | AccountTrackerControllerUpdateNativeBalancesAction
-  | AccountTrackerControllerUpdateStakedBalancesAction
-  | KeyringControllerGetStateAction
-  | AuthenticationController.AuthenticationControllerGetBearerTokenAction;
-
-type AllowedEvents =
-  | TokensControllerStateChangeEvent
-  | PreferencesControllerStateChangeEvent
-  | NetworkControllerStateChangeEvent
-  | KeyringControllerAccountRemovedEvent
-  | KeyringControllerLockEvent
-  | KeyringControllerUnlockEvent
-  | AccountActivityServiceBalanceUpdatedEvent
-  | AccountActivityServiceStatusChangedEvent
-  | AccountsControllerSelectedEvmAccountChangeEvent
-  | TransactionControllerTransactionConfirmedEvent
-  | TransactionControllerIncomingTransactionsReceivedEvent;
-
-export type TokenBalancesControllerMessenger = ReturnType<
-  typeof getTokenBalancesControllerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -97,14 +17,12 @@ export type TokenBalancesControllerMessenger = ReturnType<
  * messenger.
  */
 export function getTokenBalancesControllerMessenger(
-  messenger: RootMessenger<AllowedActions, AllowedEvents>,
-) {
-  const controllerMessenger = new Messenger<
-    'TokenBalancesController',
-    AllowedActions,
-    AllowedEvents,
-    typeof messenger
-  >({
+  messenger: RootMessenger<
+    MessengerActions<TokenBalancesControllerMessenger>,
+    MessengerEvents<TokenBalancesControllerMessenger>
+  >,
+): TokenBalancesControllerMessenger {
+  const controllerMessenger: TokenBalancesControllerMessenger = new Messenger({
     namespace: 'TokenBalancesController',
     parent: messenger,
   });

--- a/app/scripts/messenger-client-init/messengers/token-detection-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/token-detection-controller-messenger.ts
@@ -1,61 +1,16 @@
-import { Messenger } from '@metamask/messenger';
-import type {
-  NetworkControllerFindNetworkClientIdByChainIdAction,
-  NetworkControllerGetNetworkClientByIdAction,
-  NetworkControllerGetNetworkConfigurationByNetworkClientId,
-  NetworkControllerGetStateAction,
-  NetworkControllerNetworkDidChangeEvent,
-} from '@metamask/network-controller';
-import { AuthenticationController } from '@metamask/profile-sync-controller';
 import {
-  AccountsControllerGetAccountAction,
-  AccountsControllerGetSelectedAccountAction,
-  AccountsControllerSelectedEvmAccountChangeEvent,
-} from '@metamask/accounts-controller';
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
 import {
-  KeyringControllerGetStateAction,
-  KeyringControllerLockEvent,
-  KeyringControllerUnlockEvent,
-} from '@metamask/keyring-controller';
-import {
-  TokensControllerAddDetectedTokensAction,
-  TokensControllerAddTokensAction,
-  TokensControllerGetStateAction,
+  TokenDetectionControllerMessenger,
   AssetsContractControllerGetBalancesInSingleCallAction,
 } from '@metamask/assets-controllers';
-import { TransactionControllerTransactionConfirmedEvent } from '@metamask/transaction-controller';
-import type {
-  PreferencesControllerGetStateAction,
-  PreferencesControllerStateChangeEvent,
-} from '@metamask/preferences-controller';
+import type { NetworkControllerGetStateAction } from '@metamask/network-controller';
+import type { PreferencesControllerGetStateAction } from '@metamask/preferences-controller';
 import { MetaMetricsControllerTrackEventAction } from '../../controllers/metametrics-controller-method-action-types';
 import { RootMessenger } from '../../lib/messenger';
-
-type AllowedActions =
-  | AccountsControllerGetSelectedAccountAction
-  | AccountsControllerGetAccountAction
-  | NetworkControllerGetNetworkClientByIdAction
-  | NetworkControllerGetNetworkConfigurationByNetworkClientId
-  | NetworkControllerGetStateAction
-  | KeyringControllerGetStateAction
-  | PreferencesControllerGetStateAction
-  | TokensControllerGetStateAction
-  | TokensControllerAddDetectedTokensAction
-  | TokensControllerAddTokensAction
-  | NetworkControllerFindNetworkClientIdByChainIdAction
-  | AuthenticationController.AuthenticationControllerGetBearerTokenAction;
-
-type AllowedEvents =
-  | AccountsControllerSelectedEvmAccountChangeEvent
-  | NetworkControllerNetworkDidChangeEvent
-  | KeyringControllerLockEvent
-  | KeyringControllerUnlockEvent
-  | PreferencesControllerStateChangeEvent
-  | TransactionControllerTransactionConfirmedEvent;
-
-export type TokenDetectionControllerMessenger = ReturnType<
-  typeof getTokenDetectionControllerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -65,14 +20,12 @@ export type TokenDetectionControllerMessenger = ReturnType<
  * messenger.
  */
 export function getTokenDetectionControllerMessenger(
-  messenger: RootMessenger<AllowedActions, AllowedEvents>,
-) {
-  const controllerMessenger = new Messenger<
-    'TokenDetectionController',
-    AllowedActions,
-    AllowedEvents,
-    typeof messenger
-  >({
+  messenger: RootMessenger<
+    MessengerActions<TokenDetectionControllerMessenger>,
+    MessengerEvents<TokenDetectionControllerMessenger>
+  >,
+): TokenDetectionControllerMessenger {
+  const controllerMessenger: TokenDetectionControllerMessenger = new Messenger({
     namespace: 'TokenDetectionController',
     parent: messenger,
   });

--- a/app/scripts/messenger-client-init/messengers/token-list-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/token-list-controller-messenger.ts
@@ -1,31 +1,18 @@
-import { Messenger } from '@metamask/messenger';
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { TokenListControllerMessenger } from '@metamask/assets-controllers';
 import type {
   NetworkControllerGetNetworkClientByIdAction,
   NetworkControllerGetStateAction,
-  NetworkControllerStateChangeEvent,
 } from '@metamask/network-controller';
-import {
-  StorageServiceGetAllKeysAction,
-  StorageServiceGetItemAction,
-  StorageServiceSetItemAction,
-} from '@metamask/storage-service';
 import {
   PreferencesControllerGetStateAction,
   PreferencesControllerStateChangeEvent,
 } from '../../controllers/preferences-controller';
 import { RootMessenger } from '../../lib/messenger';
-
-type AllowedActions =
-  | NetworkControllerGetNetworkClientByIdAction
-  | StorageServiceGetAllKeysAction
-  | StorageServiceSetItemAction
-  | StorageServiceGetItemAction;
-
-type AllowedEvents = NetworkControllerStateChangeEvent;
-
-export type TokenListControllerMessenger = ReturnType<
-  typeof getTokenListControllerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -35,14 +22,12 @@ export type TokenListControllerMessenger = ReturnType<
  * messenger.
  */
 export function getTokenListControllerMessenger(
-  messenger: RootMessenger<AllowedActions, AllowedEvents>,
-) {
-  const controllerMessenger = new Messenger<
-    'TokenListController',
-    AllowedActions,
-    AllowedEvents,
-    typeof messenger
-  >({
+  messenger: RootMessenger<
+    MessengerActions<TokenListControllerMessenger>,
+    MessengerEvents<TokenListControllerMessenger>
+  >,
+): TokenListControllerMessenger {
+  const controllerMessenger: TokenListControllerMessenger = new Messenger({
     namespace: 'TokenListController',
     parent: messenger,
   });

--- a/app/scripts/messenger-client-init/messengers/tokens-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/tokens-controller-messenger.ts
@@ -1,39 +1,15 @@
-import { Messenger } from '@metamask/messenger';
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { TokensControllerMessenger } from '@metamask/assets-controllers';
 import type {
   NetworkControllerGetNetworkClientByIdAction,
   NetworkControllerGetSelectedNetworkClientAction,
   NetworkControllerGetStateAction,
-  NetworkControllerNetworkDidChangeEvent,
-  NetworkControllerStateChangeEvent,
 } from '@metamask/network-controller';
-import { ApprovalControllerAddRequestAction } from '@metamask/approval-controller';
-import {
-  AccountsControllerGetAccountAction,
-  AccountsControllerGetSelectedAccountAction,
-  AccountsControllerListAccountsAction,
-  AccountsControllerSelectedEvmAccountChangeEvent,
-} from '@metamask/accounts-controller';
-import { KeyringControllerAccountRemovedEvent } from '@metamask/keyring-controller';
-import { PreferencesControllerStateChangeEvent } from '../../controllers/preferences-controller';
 import { RootMessenger } from '../../lib/messenger';
-
-type AllowedActions =
-  | AccountsControllerGetAccountAction
-  | AccountsControllerGetSelectedAccountAction
-  | AccountsControllerListAccountsAction
-  | ApprovalControllerAddRequestAction
-  | NetworkControllerGetNetworkClientByIdAction;
-
-type AllowedEvents =
-  | AccountsControllerSelectedEvmAccountChangeEvent
-  | KeyringControllerAccountRemovedEvent
-  | NetworkControllerNetworkDidChangeEvent
-  | NetworkControllerStateChangeEvent
-  | PreferencesControllerStateChangeEvent;
-
-export type TokensControllerMessenger = ReturnType<
-  typeof getTokensControllerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -43,14 +19,12 @@ export type TokensControllerMessenger = ReturnType<
  * messenger.
  */
 export function getTokensControllerMessenger(
-  messenger: RootMessenger<AllowedActions, AllowedEvents>,
-) {
-  const controllerMessenger = new Messenger<
-    'TokensController',
-    AllowedActions,
-    AllowedEvents,
-    typeof messenger
-  >({
+  messenger: RootMessenger<
+    MessengerActions<TokensControllerMessenger>,
+    MessengerEvents<TokensControllerMessenger>
+  >,
+): TokensControllerMessenger {
+  const controllerMessenger: TokensControllerMessenger = new Messenger({
     namespace: 'TokensController',
     parent: messenger,
   });
@@ -68,7 +42,6 @@ export function getTokensControllerMessenger(
       'KeyringController:accountRemoved',
       'NetworkController:networkDidChange',
       'NetworkController:stateChange',
-      'PreferencesController:stateChange',
     ],
   });
   return controllerMessenger;

--- a/app/scripts/messenger-client-init/messengers/transaction-pay-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/transaction-pay-controller-messenger.ts
@@ -15,14 +15,12 @@ import { getIsAssetsUnifiedStateIncludedInBuild } from '../../../../shared/lib/e
 import { getAssetsControllerMessenger } from './assets/assets-controller-messenger';
 
 export function getTransactionPayControllerMessenger(
-  messenger: RootMessenger,
-): TransactionPayControllerMessenger {
-  const controllerMessenger = new Messenger<
-    'TransactionPayController',
+  messenger: RootMessenger<
     MessengerActions<TransactionPayControllerMessenger>,
-    MessengerEvents<TransactionPayControllerMessenger>,
-    typeof messenger
-  >({
+    MessengerEvents<TransactionPayControllerMessenger>
+  >,
+): TransactionPayControllerMessenger {
+  const controllerMessenger: TransactionPayControllerMessenger = new Messenger({
     namespace: 'TransactionPayController',
     parent: messenger,
   });

--- a/app/scripts/messenger-client-init/messengers/user-operation-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/user-operation-controller-messenger.ts
@@ -1,27 +1,14 @@
-import { Messenger } from '@metamask/messenger';
-import { ApprovalControllerAddRequestAction } from '@metamask/approval-controller';
-import { NetworkControllerGetNetworkClientByIdAction } from '@metamask/network-controller';
 import {
-  KeyringControllerPatchUserOperationAction,
-  KeyringControllerPrepareUserOperationAction,
-  KeyringControllerSignUserOperationAction,
-} from '@metamask/keyring-controller';
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import { UserOperationControllerMessenger } from '@metamask/user-operation-controller';
 import type {
   TransactionControllerEmulateNewTransactionAction,
   TransactionControllerEmulateTransactionUpdateAction,
 } from '@metamask/transaction-controller';
 import { RootMessenger } from '../../lib/messenger';
-
-type AllowedActions =
-  | ApprovalControllerAddRequestAction
-  | KeyringControllerPatchUserOperationAction
-  | KeyringControllerPrepareUserOperationAction
-  | KeyringControllerSignUserOperationAction
-  | NetworkControllerGetNetworkClientByIdAction;
-
-export type UserOperationControllerMessenger = ReturnType<
-  typeof getUserOperationControllerMessenger
->;
 
 /**
  * Create a messenger restricted to the allowed actions and events of the
@@ -29,16 +16,15 @@ export type UserOperationControllerMessenger = ReturnType<
  *
  * @param messenger - The base messenger used to create the restricted
  * messenger.
+ * @returns The restricted messenger.
  */
 export function getUserOperationControllerMessenger(
-  messenger: RootMessenger<AllowedActions, never>,
-) {
-  const controllerMessenger = new Messenger<
-    'UserOperationController',
-    AllowedActions,
-    never,
-    typeof messenger
-  >({
+  messenger: RootMessenger<
+    MessengerActions<UserOperationControllerMessenger>,
+    MessengerEvents<UserOperationControllerMessenger>
+  >,
+): UserOperationControllerMessenger {
+  const controllerMessenger: UserOperationControllerMessenger = new Messenger({
     namespace: 'UserOperationController',
     parent: messenger,
   });

--- a/app/scripts/messenger-client-init/multichain/multichain-balances-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-balances-controller-init.test.ts
@@ -1,10 +1,10 @@
-import { MultichainBalancesController } from '@metamask/assets-controllers';
+import {
+  MultichainBalancesController,
+  MultichainBalancesControllerMessenger,
+} from '@metamask/assets-controllers';
 import { buildControllerInitRequestMock } from '../test/utils';
 import { MessengerClientInitRequest } from '../types';
-import {
-  getMultichainBalancesControllerMessenger,
-  MultichainBalancesControllerMessenger,
-} from '../messengers/multichain';
+import { getMultichainBalancesControllerMessenger } from '../messengers/multichain';
 import { getRootMessenger } from '../../lib/messenger';
 import { MultichainBalancesControllerInit } from './multichain-balances-controller-init';
 

--- a/app/scripts/messenger-client-init/multichain/multichain-balances-controller-init.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-balances-controller-init.ts
@@ -1,6 +1,8 @@
-import { MultichainBalancesController } from '@metamask/assets-controllers';
+import {
+  MultichainBalancesController,
+  MultichainBalancesControllerMessenger,
+} from '@metamask/assets-controllers';
 import { MessengerClientInitFunction } from '../types';
-import { MultichainBalancesControllerMessenger } from '../messengers/multichain';
 
 /**
  * Initialize the Multichain Balances controller.

--- a/app/scripts/messenger-client-init/multichain/multichain-network-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-network-controller-init.test.ts
@@ -1,10 +1,10 @@
-import { MultichainNetworkController } from '@metamask/multichain-network-controller';
+import {
+  MultichainNetworkController,
+  MultichainNetworkControllerMessenger,
+} from '@metamask/multichain-network-controller';
 import { buildControllerInitRequestMock } from '../test/utils';
 import { MessengerClientInitRequest } from '../types';
-import {
-  MultichainNetworkControllerMessenger,
-  getMultichainNetworkControllerMessenger,
-} from '../messengers/multichain';
+import { getMultichainNetworkControllerMessenger } from '../messengers/multichain';
 import { getRootMessenger } from '../../lib/messenger';
 import { MultichainNetworkControllerInit } from './multichain-network-controller-init';
 

--- a/app/scripts/messenger-client-init/multichain/multichain-network-controller-init.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-network-controller-init.ts
@@ -1,9 +1,11 @@
-import { MultichainNetworkController } from '@metamask/multichain-network-controller';
+import {
+  MultichainNetworkController,
+  MultichainNetworkControllerMessenger,
+} from '@metamask/multichain-network-controller';
 import {
   MessengerClientInitFunction,
   MessengerClientInitRequest,
 } from '../types';
-import { MultichainNetworkControllerMessenger } from '../messengers/multichain';
 import { MultichainNetworkServiceInit } from './multichain-network-service-init';
 
 /**

--- a/app/scripts/messenger-client-init/multichain/multichain-rates-assets-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-rates-assets-controller-init.test.ts
@@ -1,10 +1,10 @@
-import { MultichainAssetsRatesController } from '@metamask/assets-controllers';
+import {
+  MultichainAssetsRatesController,
+  MultichainAssetsRatesControllerMessenger,
+} from '@metamask/assets-controllers';
 import { buildControllerInitRequestMock } from '../test/utils';
 import { MessengerClientInitRequest } from '../types';
-import {
-  getMultichainAssetsRatesControllerMessenger,
-  MultichainAssetsRatesControllerMessenger,
-} from '../messengers/multichain';
+import { getMultichainAssetsRatesControllerMessenger } from '../messengers/multichain';
 import { getRootMessenger } from '../../lib/messenger';
 import { MultichainAssetsRatesControllerInit } from './multichain-rates-assets-controller-init';
 

--- a/app/scripts/messenger-client-init/multichain/multichain-rates-assets-controller-init.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-rates-assets-controller-init.ts
@@ -1,6 +1,8 @@
-import { MultichainAssetsRatesController } from '@metamask/assets-controllers';
+import {
+  MultichainAssetsRatesController,
+  MultichainAssetsRatesControllerMessenger,
+} from '@metamask/assets-controllers';
 import { MessengerClientInitFunction } from '../types';
-import { MultichainAssetsRatesControllerMessenger } from '../messengers/multichain';
 
 /**
  * Initialize the Multichain Assets Rate controller.

--- a/app/scripts/messenger-client-init/multichain/multichain-transactions-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-transactions-controller-init.test.ts
@@ -1,10 +1,10 @@
-import { MultichainTransactionsController } from '@metamask/multichain-transactions-controller';
+import {
+  MultichainTransactionsController,
+  MultichainTransactionsControllerMessenger,
+} from '@metamask/multichain-transactions-controller';
 import { buildControllerInitRequestMock } from '../test/utils';
 import { MessengerClientInitRequest } from '../types';
-import {
-  getMultichainTransactionsControllerMessenger,
-  MultichainTransactionsControllerMessenger,
-} from '../messengers/multichain';
+import { getMultichainTransactionsControllerMessenger } from '../messengers/multichain';
 import { getRootMessenger } from '../../lib/messenger';
 import { MultichainTransactionsControllerInit } from './multichain-transactions-controller-init';
 

--- a/app/scripts/messenger-client-init/multichain/multichain-transactions-controller-init.ts
+++ b/app/scripts/messenger-client-init/multichain/multichain-transactions-controller-init.ts
@@ -1,6 +1,8 @@
-import { MultichainTransactionsController } from '@metamask/multichain-transactions-controller';
+import {
+  MultichainTransactionsController,
+  MultichainTransactionsControllerMessenger,
+} from '@metamask/multichain-transactions-controller';
 import { MessengerClientInitFunction } from '../types';
-import { MultichainTransactionsControllerMessenger } from '../messengers/multichain';
 
 /**
  * Initialize the Multichain Transactions controller.

--- a/app/scripts/messenger-client-init/passkey-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/passkey-controller-init.test.ts
@@ -1,10 +1,10 @@
-import { PasskeyController } from '@metamask/passkey-controller';
+import {
+  PasskeyController,
+  PasskeyControllerMessenger,
+} from '@metamask/passkey-controller';
 import { getRootMessenger } from '../lib/messenger';
 import { buildControllerInitRequestMock } from './test/utils';
-import {
-  getPasskeyControllerMessenger,
-  PasskeyControllerMessenger,
-} from './messengers';
+import { getPasskeyControllerMessenger } from './messengers';
 import { PasskeyControllerInit } from './passkey-controller-init';
 import { MessengerClientInitRequest } from './types';
 

--- a/app/scripts/messenger-client-init/passkey-controller-init.ts
+++ b/app/scripts/messenger-client-init/passkey-controller-init.ts
@@ -1,5 +1,7 @@
-import { PasskeyController } from '@metamask/passkey-controller';
-import type { PasskeyControllerMessenger } from './messengers';
+import {
+  PasskeyController,
+  PasskeyControllerMessenger,
+} from '@metamask/passkey-controller';
 import { MessengerClientInitFunction } from './types';
 
 const PASSKEY_RP_NAME = 'MetaMask';

--- a/app/scripts/messenger-client-init/permission-log-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/permission-log-controller-init.test.ts
@@ -1,11 +1,11 @@
-import { PermissionLogController } from '@metamask/permission-log-controller';
+import {
+  PermissionLogController,
+  PermissionLogControllerMessenger,
+} from '@metamask/permission-log-controller';
 import { getRootMessenger } from '../lib/messenger';
 import { MessengerClientInitRequest } from './types';
 import { buildControllerInitRequestMock } from './test/utils';
-import {
-  getPermissionLogControllerMessenger,
-  PermissionLogControllerMessenger,
-} from './messengers';
+import { getPermissionLogControllerMessenger } from './messengers';
 import { PermissionLogControllerInit } from './permission-log-controller-init';
 
 jest.mock('@metamask/permission-log-controller');

--- a/app/scripts/messenger-client-init/permission-log-controller-init.ts
+++ b/app/scripts/messenger-client-init/permission-log-controller-init.ts
@@ -1,6 +1,8 @@
-import { PermissionLogController } from '@metamask/permission-log-controller';
+import {
+  PermissionLogController,
+  PermissionLogControllerMessenger,
+} from '@metamask/permission-log-controller';
 import { RestrictedMethods } from '../../../shared/constants/permissions';
-import { PermissionLogControllerMessenger } from './messengers';
 import { MessengerClientInitFunction } from './types';
 
 /**

--- a/app/scripts/messenger-client-init/phishing-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/phishing-controller-init.test.ts
@@ -1,11 +1,11 @@
-import { PhishingController } from '@metamask/phishing-controller';
+import {
+  PhishingController,
+  PhishingControllerMessenger,
+} from '@metamask/phishing-controller';
 import { getRootMessenger } from '../lib/messenger';
 import { MessengerClientInitRequest } from './types';
 import { buildControllerInitRequestMock } from './test/utils';
-import {
-  getPhishingControllerMessenger,
-  PhishingControllerMessenger,
-} from './messengers';
+import { getPhishingControllerMessenger } from './messengers';
 import { PhishingControllerInit } from './phishing-controller-init';
 
 jest.mock('@metamask/phishing-controller');

--- a/app/scripts/messenger-client-init/phishing-controller-init.ts
+++ b/app/scripts/messenger-client-init/phishing-controller-init.ts
@@ -1,7 +1,9 @@
-import { PhishingController } from '@metamask/phishing-controller';
+import {
+  PhishingController,
+  PhishingControllerMessenger,
+} from '@metamask/phishing-controller';
 import { Duration, inMilliseconds } from '@metamask/utils';
 import { MessengerClientInitFunction } from './types';
-import { PhishingControllerMessenger } from './messengers';
 
 /**
  * Initialize the phishing controller.

--- a/app/scripts/messenger-client-init/rates-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/rates-controller-init.test.ts
@@ -1,11 +1,11 @@
-import { RatesController } from '@metamask/assets-controllers';
+import {
+  RatesController,
+  RatesControllerMessenger,
+} from '@metamask/assets-controllers';
 import { getRootMessenger } from '../lib/messenger';
 import { MessengerClientInitRequest } from './types';
 import { buildControllerInitRequestMock } from './test/utils';
-import {
-  getRatesControllerMessenger,
-  RatesControllerMessenger,
-} from './messengers';
+import { getRatesControllerMessenger } from './messengers';
 import { RatesControllerInit } from './rates-controller-init';
 
 jest.mock('@metamask/assets-controllers');

--- a/app/scripts/messenger-client-init/rates-controller-init.ts
+++ b/app/scripts/messenger-client-init/rates-controller-init.ts
@@ -1,5 +1,7 @@
-import { RatesController } from '@metamask/assets-controllers';
-import { RatesControllerMessenger } from './messengers';
+import {
+  RatesController,
+  RatesControllerMessenger,
+} from '@metamask/assets-controllers';
 import { MessengerClientInitFunction } from './types';
 
 /**

--- a/app/scripts/messenger-client-init/remote-feature-flag-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/remote-feature-flag-controller-init.test.ts
@@ -1,6 +1,7 @@
 import {
   ClientConfigApiService,
   RemoteFeatureFlagController,
+  RemoteFeatureFlagControllerMessenger,
 } from '@metamask/remote-feature-flag-controller';
 import {
   ActionConstraint,
@@ -20,7 +21,6 @@ import {
   getRemoteFeatureFlagControllerInitMessenger,
   getRemoteFeatureFlagControllerMessenger,
   RemoteFeatureFlagControllerInitMessenger,
-  RemoteFeatureFlagControllerMessenger,
 } from './messengers';
 import { buildControllerInitRequestMock } from './test/utils';
 

--- a/app/scripts/messenger-client-init/remote-feature-flag-controller-init.ts
+++ b/app/scripts/messenger-client-init/remote-feature-flag-controller-init.ts
@@ -5,15 +5,13 @@ import {
   DistributionType,
   EnvironmentType,
   RemoteFeatureFlagController,
+  RemoteFeatureFlagControllerMessenger,
 } from '@metamask/remote-feature-flag-controller';
 import { ENVIRONMENT } from '../../../development/build/constants';
 import { previousValueComparator } from '../lib/util';
 import { getBaseSemVerVersion } from '../../../shared/lib/feature-flags/version-gating';
 import { MessengerClientInitFunction } from './types';
-import {
-  RemoteFeatureFlagControllerInitMessenger,
-  RemoteFeatureFlagControllerMessenger,
-} from './messengers';
+import { RemoteFeatureFlagControllerInitMessenger } from './messengers';
 
 const BUILD_TYPE_MAPPING = {
   flask: DistributionType.Flask,

--- a/app/scripts/messenger-client-init/seedless-onboarding/seedless-onboarding-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/seedless-onboarding/seedless-onboarding-controller-init.test.ts
@@ -1,13 +1,13 @@
 import {
   SeedlessOnboardingController,
   Web3AuthNetwork,
+  SeedlessOnboardingControllerMessenger,
 } from '@metamask/seedless-onboarding-controller';
 import { MessengerClientInitRequest } from '../types';
 import {
   getSeedlessOnboardingControllerInitMessenger,
   getSeedlessOnboardingControllerMessenger,
   SeedlessOnboardingControllerInitMessenger,
-  SeedlessOnboardingControllerMessenger,
 } from '../messengers/seedless-onboarding';
 import { getRootMessenger } from '../../lib/messenger';
 import { buildControllerInitRequestMock } from '../test/utils';

--- a/app/scripts/messenger-client-init/selected-network-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/selected-network-controller-init.test.ts
@@ -1,12 +1,12 @@
-import { SelectedNetworkController } from '@metamask/selected-network-controller';
+import {
+  SelectedNetworkController,
+  SelectedNetworkControllerMessenger,
+} from '@metamask/selected-network-controller';
 import { WeakRefObjectMap } from '../lib/WeakRefObjectMap';
 import { getRootMessenger } from '../lib/messenger';
 import { MessengerClientInitRequest } from './types';
 import { buildControllerInitRequestMock } from './test/utils';
-import {
-  getSelectedNetworkControllerMessenger,
-  SelectedNetworkControllerMessenger,
-} from './messengers';
+import { getSelectedNetworkControllerMessenger } from './messengers';
 import { SelectedNetworkControllerInit } from './selected-network-controller-init';
 
 jest.mock('@metamask/selected-network-controller');

--- a/app/scripts/messenger-client-init/selected-network-controller-init.ts
+++ b/app/scripts/messenger-client-init/selected-network-controller-init.ts
@@ -1,6 +1,8 @@
-import { SelectedNetworkController } from '@metamask/selected-network-controller';
+import {
+  SelectedNetworkController,
+  SelectedNetworkControllerMessenger,
+} from '@metamask/selected-network-controller';
 import { WeakRefObjectMap } from '../lib/WeakRefObjectMap';
-import { SelectedNetworkControllerMessenger } from './messengers';
 import { MessengerClientInitFunction } from './types';
 
 /**

--- a/app/scripts/messenger-client-init/subject-metadata-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/subject-metadata-controller-init.test.ts
@@ -1,11 +1,11 @@
-import { SubjectMetadataController } from '@metamask/permission-controller';
+import {
+  SubjectMetadataController,
+  SubjectMetadataControllerMessenger,
+} from '@metamask/permission-controller';
 import { getRootMessenger } from '../lib/messenger';
 import { MessengerClientInitRequest } from './types';
 import { buildControllerInitRequestMock } from './test/utils';
-import {
-  getSubjectMetadataControllerMessenger,
-  SubjectMetadataControllerMessenger,
-} from './messengers';
+import { getSubjectMetadataControllerMessenger } from './messengers';
 import { SubjectMetadataControllerInit } from './subject-metadata-controller-init';
 
 jest.mock('@metamask/permission-controller');

--- a/app/scripts/messenger-client-init/subject-metadata-controller-init.ts
+++ b/app/scripts/messenger-client-init/subject-metadata-controller-init.ts
@@ -1,5 +1,7 @@
-import { SubjectMetadataController } from '@metamask/permission-controller';
-import { SubjectMetadataControllerMessenger } from './messengers';
+import {
+  SubjectMetadataController,
+  SubjectMetadataControllerMessenger,
+} from '@metamask/permission-controller';
 import { MessengerClientInitFunction } from './types';
 
 /**

--- a/app/scripts/messenger-client-init/token-balances-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/token-balances-controller-init.test.ts
@@ -4,7 +4,10 @@ import {
   MockAnyNamespace,
   MOCK_ANY_NAMESPACE,
 } from '@metamask/messenger';
-import { TokenBalancesController } from '@metamask/assets-controllers';
+import {
+  TokenBalancesController,
+  TokenBalancesControllerMessenger,
+} from '@metamask/assets-controllers';
 import { PreferencesControllerGetStateAction } from '../controllers/preferences-controller';
 import { MessengerClientInitRequest } from './types';
 import { buildControllerInitRequestMock } from './test/utils';
@@ -12,7 +15,6 @@ import {
   getTokenBalancesControllerInitMessenger,
   getTokenBalancesControllerMessenger,
   TokenBalancesControllerInitMessenger,
-  TokenBalancesControllerMessenger,
 } from './messengers';
 import { TokenBalancesControllerInit } from './token-balances-controller-init';
 

--- a/app/scripts/messenger-client-init/token-balances-controller-init.ts
+++ b/app/scripts/messenger-client-init/token-balances-controller-init.ts
@@ -1,10 +1,10 @@
-import { TokenBalancesController } from '@metamask/assets-controllers';
+import {
+  TokenBalancesController,
+  TokenBalancesControllerMessenger,
+} from '@metamask/assets-controllers';
 import type { PreferencesControllerState } from '../controllers/preferences-controller';
 import { MessengerClientInitFunction } from './types';
-import {
-  TokenBalancesControllerMessenger,
-  TokenBalancesControllerInitMessenger,
-} from './messengers';
+import { TokenBalancesControllerInitMessenger } from './messengers';
 
 export const TokenBalancesControllerInit: MessengerClientInitFunction<
   TokenBalancesController,

--- a/app/scripts/messenger-client-init/token-detection-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/token-detection-controller-init.test.ts
@@ -1,4 +1,7 @@
-import { TokenDetectionController } from '@metamask/assets-controllers';
+import {
+  TokenDetectionController,
+  TokenDetectionControllerMessenger,
+} from '@metamask/assets-controllers';
 import { getRootMessenger } from '../lib/messenger';
 import { MessengerClientInitRequest } from './types';
 import { buildControllerInitRequestMock } from './test/utils';
@@ -6,7 +9,6 @@ import {
   getTokenDetectionControllerInitMessenger,
   getTokenDetectionControllerMessenger,
   TokenDetectionControllerInitMessenger,
-  TokenDetectionControllerMessenger,
 } from './messengers';
 import { TokenDetectionControllerInit } from './token-detection-controller-init';
 

--- a/app/scripts/messenger-client-init/token-detection-controller-init.ts
+++ b/app/scripts/messenger-client-init/token-detection-controller-init.ts
@@ -1,10 +1,10 @@
-import { TokenDetectionController } from '@metamask/assets-controllers';
+import {
+  TokenDetectionController,
+  TokenDetectionControllerMessenger,
+} from '@metamask/assets-controllers';
 import type { PreferencesControllerState } from '../controllers/preferences-controller';
 import { MessengerClientInitFunction } from './types';
-import {
-  TokenDetectionControllerMessenger,
-  TokenDetectionControllerInitMessenger,
-} from './messengers';
+import { TokenDetectionControllerInitMessenger } from './messengers';
 import { tokenListService } from './token-list-service';
 
 export const TokenDetectionControllerInit: MessengerClientInitFunction<

--- a/app/scripts/messenger-client-init/token-list-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/token-list-controller-init.test.ts
@@ -1,4 +1,7 @@
-import { TokenListController } from '@metamask/assets-controllers';
+import {
+  TokenListController,
+  TokenListControllerMessenger,
+} from '@metamask/assets-controllers';
 import {
   NetworkControllerGetNetworkClientByIdAction,
   NetworkControllerGetStateAction,
@@ -16,7 +19,6 @@ import {
   getTokenListControllerInitMessenger,
   getTokenListControllerMessenger,
   TokenListControllerInitMessenger,
-  TokenListControllerMessenger,
 } from './messengers';
 import { TokenListControllerInit } from './token-list-controller-init';
 

--- a/app/scripts/messenger-client-init/token-list-controller-init.ts
+++ b/app/scripts/messenger-client-init/token-list-controller-init.ts
@@ -1,9 +1,9 @@
-import { TokenListController } from '@metamask/assets-controllers';
-import { MessengerClientInitFunction } from './types';
 import {
+  TokenListController,
   TokenListControllerMessenger,
-  TokenListControllerInitMessenger,
-} from './messengers';
+} from '@metamask/assets-controllers';
+import { MessengerClientInitFunction } from './types';
+import { TokenListControllerInitMessenger } from './messengers';
 import { getGlobalChainId } from './init-utils';
 
 export const TokenListControllerInit: MessengerClientInitFunction<

--- a/app/scripts/messenger-client-init/tokens-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/tokens-controller-init.test.ts
@@ -4,7 +4,10 @@ import {
   MOCK_ANY_NAMESPACE,
   MockAnyNamespace,
 } from '@metamask/messenger';
-import { TokensController } from '@metamask/assets-controllers';
+import {
+  TokensController,
+  TokensControllerMessenger,
+} from '@metamask/assets-controllers';
 import {
   NetworkControllerGetNetworkClientByIdAction,
   NetworkControllerGetSelectedNetworkClientAction,
@@ -16,7 +19,6 @@ import {
   getTokensControllerInitMessenger,
   getTokensControllerMessenger,
   TokensControllerInitMessenger,
-  TokensControllerMessenger,
 } from './messengers';
 import { TokensControllerInit } from './tokens-controller-init';
 

--- a/app/scripts/messenger-client-init/tokens-controller-init.ts
+++ b/app/scripts/messenger-client-init/tokens-controller-init.ts
@@ -1,10 +1,10 @@
-import { TokensController } from '@metamask/assets-controllers';
+import {
+  TokensController,
+  TokensControllerMessenger,
+} from '@metamask/assets-controllers';
 import { assert } from '@metamask/utils';
 import { MessengerClientInitFunction } from './types';
-import {
-  TokensControllerMessenger,
-  TokensControllerInitMessenger,
-} from './messengers';
+import { TokensControllerInitMessenger } from './messengers';
 import { getGlobalChainId } from './init-utils';
 import { tokenListService } from './token-list-service';
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This refactors all remaining messenger client init files to do the following:

- Remove duplicated messenger type.
- Consistently declare messenger and remove the need for generics.
- Update imports for local duplicated messengers to messengers exported by packages directly.

https://consensyssoftware.atlassian.net/browse/WPC-950

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Large but mechanical typing/import refactor across init and messenger factories; runtime delegate behavior is intended unchanged, with compile-time risk if delegated actions diverge from package messenger definitions.
> 
> **Overview**
> This PR finishes the messenger-client-init cleanup by **sourcing controller messenger types from their owning packages** (or local controllers where applicable) instead of duplicating `ReturnType<typeof get*Messenger>` aliases under `messengers/`.
> 
> **Init modules** (`*-init.ts` / tests) now import `*ControllerMessenger` next to the controller from `@metamask/*` (e.g. assets, accounts, keyring, multichain). **Messenger factories** use `MessengerActions` / `MessengerEvents` on `RootMessenger`, construct messengers with the non-generic `new Messenger({ namespace, parent })`, and return the package-defined messenger type while keeping existing `delegate` wiring. Barrel files drop re-exports of controller messenger types and keep only **init** messenger types where still defined locally.
> 
> Notable renames/imports: **`CurrencyRateMessenger`** replaces the local `CurrencyRateControllerMessenger` name; **`InstitutionalSnapControllerMessenger`** is imported from the extension controller module. A few spots still use extension-specific messenger shapes (e.g. `PermissionController`, `PerpsController`) with TODOs where the package type is narrower than runtime delegation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06d6126ab6f70f4a80d70b81864a50ab1f0b5a45. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->