### PR TITLE
feat: added account_type to user traits

### DIFF
--- a/app/scripts/controllers/metametrics-controller.test.ts
+++ b/app/scripts/controllers/metametrics-controller.test.ts
@@ -11,6 +11,10 @@ import {
   TokensControllerState,
 } from '@metamask/assets-controllers';
 import {
+  AuthConnection,
+  type SeedlessOnboardingControllerState,
+} from '@metamask/seedless-onboarding-controller';
+import {
   EthAccountType,
   BtcAccountType,
   SolAccountType,
@@ -2212,6 +2216,7 @@ describe('MetaMetricsController', function () {
           [MetaMetricsUserTrait.SecurityProviders]: ['blockaid'],
           [MetaMetricsUserTrait.IsMetricsOptedIn]: true,
           [MetaMetricsUserTrait.ProfileId]: undefined,
+          [MetaMetricsUserTrait.LoginType]: 'metamask',
           [MetaMetricsUserTrait.PetnameAddressCount]: 3,
           [MetaMetricsUserTrait.TokenSortPreference]: 'token-sort-key',
           [MetaMetricsUserTrait.PrivacyModeEnabled]: true,
@@ -2222,6 +2227,59 @@ describe('MetaMetricsController', function () {
           [MetaMetricsUserTrait.Os]: OS.MACOS,
         });
       });
+    });
+
+    it('uses the seedless auth connection as the login type trait', async function () {
+      await withController(
+        {
+          seedlessOnboardingState: {
+            authConnection: AuthConnection.Google,
+          },
+        },
+        ({ controller }) => {
+          const traits = controller._buildUserTraitsObject({
+            addressBook: {},
+            allTokens: {},
+            ...mockNetworkState({ chainId: CHAIN_IDS.MAINNET }),
+            ledgerTransportType: LedgerTransportTypes.webhid,
+            openSeaEnabled: true,
+            internalAccounts: {
+              accounts: {
+                mock1: {} as InternalAccount,
+              },
+              selectedAccount: 'mock1',
+            },
+            useNftDetection: false,
+            theme: 'default' as ThemeType,
+            useTokenDetection: true,
+            allNfts: {},
+            participateInMetaMetrics: true,
+            dataCollectionForMarketing: false,
+            preferences: {
+              privacyMode: false,
+              tokenNetworkFilter: {},
+              tokenSortConfig: {
+                key: 'token-sort-key',
+                order: 'dsc',
+                sortCallback: 'stringNumeric',
+              },
+              showNativeTokenAsMainBalance: false,
+            } as Preferences,
+            securityAlertsEnabled: false,
+            names: {
+              ethereumAddress: {},
+            },
+            currentCurrency: 'usd',
+            srpSessionData: undefined,
+            keyrings: [],
+            multichainNetworkConfigurationsByChainId: {},
+          });
+
+          expect(traits?.[MetaMetricsUserTrait.LoginType]).toBe(
+            AuthConnection.Google,
+          );
+        },
+      );
     });
 
     it('should return only changed traits object on subsequent calls', async function () {
@@ -3106,6 +3164,7 @@ type WithControllerOptions = {
   currentLocale?: string;
   options?: Partial<MetaMetricsControllerOptions>;
   remoteFeatureFlags?: Record<string, unknown>;
+  seedlessOnboardingState?: Partial<SeedlessOnboardingControllerState>;
   mockNetworkClientConfigurationsByNetworkClientId?: Record<
     NetworkClientId,
     {
@@ -3143,6 +3202,7 @@ async function withController<ReturnValue>(
       options = {},
       currentLocale = LOCALE,
       remoteFeatureFlags = {},
+      seedlessOnboardingState = {},
       mockNetworkClientConfigurationsByNetworkClientId = {
         selectedNetworkClientId: {
           chainId: DEFAULT_CHAIN_ID,
@@ -3186,6 +3246,11 @@ async function withController<ReturnValue>(
       }),
     );
 
+    messenger.registerActionHandler(
+      'SeedlessOnboardingController:getState',
+      jest.fn().mockReturnValue(seedlessOnboardingState),
+    );
+
     const metaMetricsControllerMessenger = new Messenger<
       'MetaMetricsController',
       AllowedActions,
@@ -3202,6 +3267,7 @@ async function withController<ReturnValue>(
         'NetworkController:getState',
         'NetworkController:getNetworkClientById',
         'RemoteFeatureFlagController:getState',
+        'SeedlessOnboardingController:getState',
       ],
       events: [
         'PreferencesController:stateChange',

--- a/app/scripts/controllers/metametrics-controller.test.ts
+++ b/app/scripts/controllers/metametrics-controller.test.ts
@@ -29,6 +29,7 @@ import {
 } from '@metamask/messenger';
 import { merge } from 'lodash';
 import { ThemeType } from '../../../shared/constants/preferences';
+import { FirstTimeFlowType } from '../../../shared/constants/onboarding';
 import {
   DEVICE_TYPE,
   ENVIRONMENT_TYPE_BACKGROUND,
@@ -731,6 +732,7 @@ describe('MetaMetricsController', function () {
             } as Preferences,
             srpSessionData: undefined,
             keyrings: [],
+            firstTimeFlowType: FirstTimeFlowType.create,
           };
 
           controller.handleMetaMaskStateUpdate(metaMaskState);
@@ -1982,6 +1984,7 @@ describe('MetaMetricsController', function () {
       } as Preferences,
       srpSessionData: undefined,
       keyrings: [],
+      firstTimeFlowType: FirstTimeFlowType.create,
     };
   }
 
@@ -2172,6 +2175,7 @@ describe('MetaMetricsController', function () {
           } as Preferences,
           srpSessionData: undefined,
           keyrings: [],
+          firstTimeFlowType: FirstTimeFlowType.create,
         });
 
         expect(traits).toStrictEqual({
@@ -2216,7 +2220,7 @@ describe('MetaMetricsController', function () {
           [MetaMetricsUserTrait.SecurityProviders]: ['blockaid'],
           [MetaMetricsUserTrait.IsMetricsOptedIn]: true,
           [MetaMetricsUserTrait.ProfileId]: undefined,
-          [MetaMetricsUserTrait.LoginType]: 'metamask',
+          [MetaMetricsUserTrait.AccountType]: 'metamask',
           [MetaMetricsUserTrait.PetnameAddressCount]: 3,
           [MetaMetricsUserTrait.TokenSortPreference]: 'token-sort-key',
           [MetaMetricsUserTrait.PrivacyModeEnabled]: true,
@@ -2229,7 +2233,7 @@ describe('MetaMetricsController', function () {
       });
     });
 
-    it('uses the seedless auth connection as the login type trait', async function () {
+    it('uses the social create flow to build the account type trait', async function () {
       await withController(
         {
           seedlessOnboardingState: {
@@ -2272,11 +2276,66 @@ describe('MetaMetricsController', function () {
             currentCurrency: 'usd',
             srpSessionData: undefined,
             keyrings: [],
+            firstTimeFlowType: FirstTimeFlowType.socialCreate,
             multichainNetworkConfigurationsByChainId: {},
           });
 
-          expect(traits?.[MetaMetricsUserTrait.LoginType]).toBe(
-            AuthConnection.Google,
+          expect(traits?.[MetaMetricsUserTrait.AccountType]).toBe(
+            'metamask_google',
+          );
+        },
+      );
+    });
+
+    it('uses the social import flow to build the account type trait', async function () {
+      await withController(
+        {
+          seedlessOnboardingState: {
+            authConnection: AuthConnection.Google,
+          },
+        },
+        ({ controller }) => {
+          const traits = controller._buildUserTraitsObject({
+            addressBook: {},
+            allTokens: {},
+            ...mockNetworkState({ chainId: CHAIN_IDS.MAINNET }),
+            ledgerTransportType: LedgerTransportTypes.webhid,
+            openSeaEnabled: true,
+            internalAccounts: {
+              accounts: {
+                mock1: {} as InternalAccount,
+              },
+              selectedAccount: 'mock1',
+            },
+            useNftDetection: false,
+            theme: 'default' as ThemeType,
+            useTokenDetection: true,
+            allNfts: {},
+            participateInMetaMetrics: true,
+            dataCollectionForMarketing: false,
+            preferences: {
+              privacyMode: false,
+              tokenNetworkFilter: {},
+              tokenSortConfig: {
+                key: 'token-sort-key',
+                order: 'dsc',
+                sortCallback: 'stringNumeric',
+              },
+              showNativeTokenAsMainBalance: false,
+            } as Preferences,
+            securityAlertsEnabled: false,
+            names: {
+              ethereumAddress: {},
+            },
+            currentCurrency: 'usd',
+            srpSessionData: undefined,
+            keyrings: [],
+            firstTimeFlowType: FirstTimeFlowType.socialImport,
+            multichainNetworkConfigurationsByChainId: {},
+          });
+
+          expect(traits?.[MetaMetricsUserTrait.AccountType]).toBe(
+            'imported_google',
           );
         },
       );
@@ -2338,6 +2397,7 @@ describe('MetaMetricsController', function () {
           currentCurrency: 'usd',
           srpSessionData: undefined,
           keyrings: [],
+          firstTimeFlowType: FirstTimeFlowType.create,
           multichainNetworkConfigurationsByChainId: {},
         });
 
@@ -2413,6 +2473,7 @@ describe('MetaMetricsController', function () {
             },
           },
           keyrings: [],
+          firstTimeFlowType: FirstTimeFlowType.import,
           multichainNetworkConfigurationsByChainId: {},
         });
 
@@ -2424,6 +2485,7 @@ describe('MetaMetricsController', function () {
           [MetaMetricsUserTrait.OpenSeaApiEnabled]: false,
           [MetaMetricsUserTrait.ShowNativeTokenAsMainBalance]: false,
           [MetaMetricsUserTrait.ProfileId]: 'profileId',
+          [MetaMetricsUserTrait.AccountType]: 'imported',
         });
       });
     });
@@ -2499,6 +2561,7 @@ describe('MetaMetricsController', function () {
           },
           keyrings: [],
           multichainNetworkConfigurationsByChainId: {},
+          firstTimeFlowType: FirstTimeFlowType.create,
         });
 
         const updatedTraits = controller._buildUserTraitsObject({
@@ -2564,6 +2627,7 @@ describe('MetaMetricsController', function () {
           },
           keyrings: [],
           multichainNetworkConfigurationsByChainId: {},
+          firstTimeFlowType: FirstTimeFlowType.create,
         });
         expect(updatedTraits).toStrictEqual(null);
       });

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -26,6 +26,7 @@ import type {
 import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import type {
   SeedlessOnboardingControllerGetStateAction,
+  SeedlessOnboardingControllerState,
 } from '@metamask/seedless-onboarding-controller';
 import type { Browser } from 'webextension-polyfill';
 import type { Nft } from '@metamask/assets-controllers';
@@ -45,6 +46,7 @@ import {
 import {
   METAMETRICS_ANONYMOUS_ID,
   METAMETRICS_BACKGROUND_PAGE_OBJECT,
+  MetaMetricsEventAccountType,
   MetaMetricsEventCategory,
   MetaMetricsEventName,
   MetaMetricsUserTrait,
@@ -77,6 +79,7 @@ import {
   AnonymousTransactionMetaMetricsEvent,
   TransactionMetaMetricsEvent,
 } from '../../../shared/constants/transaction';
+import { FirstTimeFlowType } from '../../../shared/constants/onboarding';
 import type { SegmentClient } from '../lib/segment';
 import {
   trace,
@@ -198,6 +201,7 @@ export type MetaMaskState = Pick<
   | 'srpSessionData'
   | 'keyrings'
   | 'multichainNetworkConfigurationsByChainId'
+  | 'firstTimeFlowType'
   // TODO: Remove as this is no longer a top-level property of the flattened background state object.
   // | 'security_providers'
 > & {
@@ -1496,7 +1500,9 @@ export class MetaMetricsController extends BaseController<
       [MetaMetricsUserTrait.ProfileId]: Object.entries(
         metamaskState.srpSessionData || {},
       )?.[0]?.[1]?.profile?.profileId,
-      [MetaMetricsUserTrait.AccountType]: this.#getAccountTypeTrait(),
+      [MetaMetricsUserTrait.AccountType]: this.#getAccountTypeTrait(
+        metamaskState.firstTimeFlowType,
+      ),
       [MetaMetricsUserTrait.Platform]: getPlatform(),
       [MetaMetricsUserTrait.InstallType]: getInstallType(),
       [MetaMetricsUserTrait.DeviceType]: getDeviceType(),
@@ -1537,16 +1543,37 @@ export class MetaMetricsController extends BaseController<
     return null;
   }
 
-  #getAccountTypeTrait(): NonNullable<
+  #getAccountTypeTrait(
+    firstTimeFlowType: MetaMaskState['firstTimeFlowType'],
+  ): NonNullable<
     MetaMetricsUserTraits[MetaMetricsUserTrait.AccountType]
   > {
+    switch (firstTimeFlowType) {
+      case FirstTimeFlowType.import:
+      case FirstTimeFlowType.restore:
+        return MetaMetricsEventAccountType.Imported;
+      case FirstTimeFlowType.socialImport:
+        return this.#getSocialAccountType(MetaMetricsEventAccountType.Imported);
+      case FirstTimeFlowType.socialCreate:
+        return this.#getSocialAccountType(MetaMetricsEventAccountType.Default);
+      case FirstTimeFlowType.create:
+      default:
+        return MetaMetricsEventAccountType.Default;
+    }
+  }
+
+  #getSocialAccountType(
+    baseType: MetaMetricsEventAccountType.Default | MetaMetricsEventAccountType.Imported,
+  ): NonNullable<MetaMetricsUserTraits[MetaMetricsUserTrait.AccountType]> {
+    const authConnection = this.#getSeedlessOnboardingState()?.authConnection;
+    return authConnection ? `${baseType}_${authConnection}` : baseType;
+  }
+
+  #getSeedlessOnboardingState(): Partial<SeedlessOnboardingControllerState> | undefined {
     try {
-      return (
-        this.messenger.call('SeedlessOnboardingController:getState')
-          ?.authConnection ?? 'metamask'
-      );
+      return this.messenger.call('SeedlessOnboardingController:getState');
     } catch {
-      return 'metamask';
+      return undefined;
     }
   }
 

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -1545,9 +1545,7 @@ export class MetaMetricsController extends BaseController<
 
   #getAccountTypeTrait(
     firstTimeFlowType: MetaMaskState['firstTimeFlowType'],
-  ): NonNullable<
-    MetaMetricsUserTraits[MetaMetricsUserTrait.AccountType]
-  > {
+  ): NonNullable<MetaMetricsUserTraits[MetaMetricsUserTrait.AccountType]> {
     switch (firstTimeFlowType) {
       case FirstTimeFlowType.import:
       case FirstTimeFlowType.restore:
@@ -1563,13 +1561,17 @@ export class MetaMetricsController extends BaseController<
   }
 
   #getSocialAccountType(
-    baseType: MetaMetricsEventAccountType.Default | MetaMetricsEventAccountType.Imported,
+    baseType:
+      | MetaMetricsEventAccountType.Default
+      | MetaMetricsEventAccountType.Imported,
   ): NonNullable<MetaMetricsUserTraits[MetaMetricsUserTrait.AccountType]> {
     const authConnection = this.#getSeedlessOnboardingState()?.authConnection;
     return authConnection ? `${baseType}_${authConnection}` : baseType;
   }
 
-  #getSeedlessOnboardingState(): Partial<SeedlessOnboardingControllerState> | undefined {
+  #getSeedlessOnboardingState():
+    | Partial<SeedlessOnboardingControllerState>
+    | undefined {
     try {
       return this.messenger.call('SeedlessOnboardingController:getState');
     } catch {

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -24,6 +24,9 @@ import type {
   NetworkControllerNetworkDidChangeEvent,
 } from '@metamask/network-controller';
 import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
+import type {
+  SeedlessOnboardingControllerGetStateAction,
+} from '@metamask/seedless-onboarding-controller';
 import type { Browser } from 'webextension-polyfill';
 import type { Nft } from '@metamask/assets-controllers';
 import {
@@ -343,7 +346,8 @@ export type AllowedActions =
   | PreferencesControllerGetStateAction
   | NetworkControllerGetStateAction
   | NetworkControllerGetNetworkClientByIdAction
-  | RemoteFeatureFlagControllerGetStateAction;
+  | RemoteFeatureFlagControllerGetStateAction
+  | SeedlessOnboardingControllerGetStateAction;
 
 /**
  * Events that this controller is allowed to subscribe.
@@ -1492,6 +1496,7 @@ export class MetaMetricsController extends BaseController<
       [MetaMetricsUserTrait.ProfileId]: Object.entries(
         metamaskState.srpSessionData || {},
       )?.[0]?.[1]?.profile?.profileId,
+      [MetaMetricsUserTrait.AccountType]: this.#getAccountTypeTrait(),
       [MetaMetricsUserTrait.Platform]: getPlatform(),
       [MetaMetricsUserTrait.InstallType]: getInstallType(),
       [MetaMetricsUserTrait.DeviceType]: getDeviceType(),
@@ -1530,6 +1535,19 @@ export class MetaMetricsController extends BaseController<
     }
 
     return null;
+  }
+
+  #getAccountTypeTrait(): NonNullable<
+    MetaMetricsUserTraits[MetaMetricsUserTrait.AccountType]
+  > {
+    try {
+      return (
+        this.messenger.call('SeedlessOnboardingController:getState')
+          ?.authConnection ?? 'metamask'
+      );
+    } catch {
+      return 'metamask';
+    }
   }
 
   /**

--- a/app/scripts/messenger-client-init/messengers/metametrics-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/metametrics-controller-messenger.ts
@@ -24,6 +24,7 @@ export function getMetaMetricsControllerMessenger(
       'NetworkController:getState',
       'PreferencesController:getState',
       'RemoteFeatureFlagController:getState',
+      'SeedlessOnboardingController:getState',
     ],
     events: [
       'PreferencesController:stateChange',

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -1,3 +1,4 @@
+import type { AuthConnection } from '@metamask/seedless-onboarding-controller';
 import { Json } from '@metamask/utils';
 import type {
   DeviceType,
@@ -576,6 +577,11 @@ export type MetaMetricsUserTraits = {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   profile_id?: string;
   /**
+   * The wallet login type used by the user.
+   */
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  account_type?: AuthConnection | 'metamask';
+  /**
    * The configured EVM and non-EVM chain ids in CAIP-2 format.
    */
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -778,6 +784,10 @@ export enum MetaMetricsUserTrait {
    * Identified when the user signs in
    */
   ProfileId = 'profile_id',
+  /**
+   * Identifies the wallet login type used by the user.
+   */
+  AccountType = 'account_type',
   /**
    * Identified when the user adds or removes configured chains (evm or non-evm)
    */

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -577,10 +577,14 @@ export type MetaMetricsUserTraits = {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   profile_id?: string;
   /**
-   * The wallet login type used by the user.
+   * The account type derived from the user's onboarding flow.
    */
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  account_type?: AuthConnection | 'metamask';
+  account_type?:
+    | 'metamask'
+    | 'imported'
+    | `metamask_${AuthConnection}`
+    | `imported_${AuthConnection}`;
   /**
    * The configured EVM and non-EVM chain ids in CAIP-2 format.
    */
@@ -785,7 +789,7 @@ export enum MetaMetricsUserTrait {
    */
   ProfileId = 'profile_id',
   /**
-   * Identifies the wallet login type used by the user.
+   * Identifies the account type derived from the user's onboarding flow.
    */
   AccountType = 'account_type',
   /**

--- a/test/e2e/tests/metrics/segment-user-traits.spec.ts
+++ b/test/e2e/tests/metrics/segment-user-traits.spec.ts
@@ -95,6 +95,8 @@ describe('Segment User Traits', function () {
           is_metrics_opted_in: true,
           // eslint-disable-next-line @typescript-eslint/naming-convention
           has_marketing_consent: true,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          account_type: 'metamask',
         });
       },
     );
@@ -122,6 +124,8 @@ describe('Segment User Traits', function () {
           is_metrics_opted_in: true,
           // eslint-disable-next-line @typescript-eslint/naming-convention
           has_marketing_consent: false,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          account_type: 'metamask',
         });
       },
     );
@@ -181,6 +185,8 @@ describe('Segment User Traits', function () {
           is_metrics_opted_in: true,
           // eslint-disable-next-line @typescript-eslint/naming-convention
           has_marketing_consent: false,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          account_type: 'metamask',
         });
       },
     );
@@ -218,6 +224,8 @@ describe('Segment User Traits', function () {
           is_metrics_opted_in: true,
           // eslint-disable-next-line @typescript-eslint/naming-convention
           has_marketing_consent: true,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          account_type: 'metamask',
         });
       },
     );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Add `account_type` to metametrics user traits. `account_type` can be `metamask`, `apple` or `google`.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: add new user traits in metametrics, `account_type`.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the `identify` user-traits payload for all metrics users and adds a new messenger dependency on `SeedlessOnboardingController:getState`, which could affect analytics pipelines if values/messaging are unexpected.
> 
> **Overview**
> Adds a new MetaMetrics user trait, `account_type`, derived from `firstTimeFlowType` and (for seedless flows) the `SeedlessOnboardingController` `authConnection`, emitting values like `metamask`, `imported`, `metamask_google`, or `imported_google`.
> 
> Wires MetaMetrics to request seedless onboarding state via the messenger (runtime and tests), updates the trait typings/enum (`MetaMetricsUserTrait.AccountType`), and extends unit/e2e tests to assert the new trait is sent on identify.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d4f4c68b2b9a056827bd5bd1a4155efdcd136f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->