### PR TITLE
chore(perps): remove "Fox" from VIP tier message

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -10731,7 +10731,7 @@
     "description": "$1 is the action type. e.g (Account, Transaction, Swap)"
   },
   "vip": {
-    "message": "VIP Fox $1",
+    "message": "VIP $1",
     "description": "$1 is the VIP tier number"
   },
   "visitSite": {

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -10731,7 +10731,7 @@
     "description": "$1 is the action type. e.g (Account, Transaction, Swap)"
   },
   "vip": {
-    "message": "VIP Fox $1",
+    "message": "VIP $1",
     "description": "$1 is the VIP tier number"
   },
   "visitSite": {

--- a/ui/components/app/rewards/RewardsVipBadge.test.tsx
+++ b/ui/components/app/rewards/RewardsVipBadge.test.tsx
@@ -77,7 +77,7 @@ describe('RewardsVipBadge', () => {
                 <p
                   class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-medium font-default"
                 >
-                  VIP Fox 5
+                  VIP 5
                 </p>
               </div>
             </div>

--- a/ui/pages/bridge/prepare/bridge-vip-fee-message.test.tsx
+++ b/ui/pages/bridge/prepare/bridge-vip-fee-message.test.tsx
@@ -172,7 +172,7 @@ describe('BridgeVipFeeMessage', () => {
 
     await waitFor(() => {
       expect(screen.getByTestId('rewards-vip-badge')).toBeInTheDocument();
-      expect(screen.getByText('VIP Fox 5')).toBeInTheDocument();
+      expect(screen.getByText('VIP 5')).toBeInTheDocument();
     });
     expect(mockGetVipTierForAccount).toHaveBeenCalledTimes(1);
   });


### PR DESCRIPTION
## **Description**

The VIP tier locale message incorrectly included the word "Fox" (`"VIP Fox $1"`). This removes it so the message reads `"VIP $1"`, matching the intended copy.

## **Changelog**

CHANGELOG entry: Fixed the VIP tier label to display "VIP" instead of "VIP Fox"

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Build the extension and navigate to any screen that renders the VIP tier badge.
2. Verify the label reads "VIP 1" (or the appropriate tier number) without the word "Fox".

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk copy-only change to locale strings with corresponding test snapshot/text updates; no business logic changes.
> 
> **Overview**
> Removes the word **"Fox"** from the VIP tier label by changing the `vip` locale message from `"VIP Fox $1"` to `"VIP $1"` (in `en` and `en_GB`). Updates the affected UI tests/snapshots to expect the new VIP badge text (e.g., `"VIP 5"`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a08f64bb82510c8134ad763ec201b2c3ee13458. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->