### PR TITLE
fix: prevent premature gas station defaults

### DIFF
--- a/app/scripts/lib/transaction/metrics-builders/gasless.test.ts
+++ b/app/scripts/lib/transaction/metrics-builders/gasless.test.ts
@@ -2,6 +2,8 @@
 import { getGaslessMetricsProperties } from './gasless';
 import { createBuilderRequest } from './test-utils';
 
+const ACCOUNT_BALANCE_MOCK = '0xffffffffffffffff';
+
 describe('gasless builder', () => {
   it('builds gasless token and insufficient native balance metrics', async () => {
     const result = await getGaslessMetricsProperties(
@@ -33,5 +35,58 @@ describe('gasless builder', () => {
     expect(result.properties.gas_paid_with).toBe('pre-funded_ETH');
     expect(result.properties.gas_insufficient_native_asset).toBe(true);
     expect(result.sensitiveProperties).toStrictEqual({});
+  });
+
+  it('includes nested transaction values in insufficient native balance metrics', async () => {
+    const request = createBuilderRequest();
+    request.transactionMetricsRequest.getAccountBalance = jest
+      .fn()
+      .mockReturnValue('0x20');
+    request.transactionMeta = {
+      ...request.transactionMeta,
+      nestedTransactions: [{ value: '0x20' }],
+      txParams: {
+        ...request.transactionMeta.txParams,
+        gas: '0x0',
+        gasPrice: '0x1',
+        value: '0x10',
+      },
+    } as never;
+
+    const result = await getGaslessMetricsProperties(request);
+
+    expect(result.properties.gas_insufficient_native_asset).toBe(true);
+  });
+
+  it('includes layer 1 gas fee in insufficient native balance metrics', async () => {
+    const request = createBuilderRequest();
+    request.transactionMetricsRequest.getAccountBalance = jest
+      .fn()
+      .mockReturnValue('0x20');
+    request.transactionMeta = {
+      ...request.transactionMeta,
+      layer1GasFee: '0x20',
+      txParams: {
+        ...request.transactionMeta.txParams,
+        gas: '0x0',
+        gasPrice: '0x1',
+        value: '0x10',
+      },
+    } as never;
+
+    const result = await getGaslessMetricsProperties(request);
+
+    expect(result.properties.gas_insufficient_native_asset).toBe(true);
+  });
+
+  it('returns sufficient native balance metrics when balance covers gas and value', async () => {
+    const request = createBuilderRequest();
+    request.transactionMetricsRequest.getAccountBalance = jest
+      .fn()
+      .mockReturnValue(ACCOUNT_BALANCE_MOCK);
+
+    const result = await getGaslessMetricsProperties(request);
+
+    expect(result.properties.gas_insufficient_native_asset).toBe(false);
   });
 });

--- a/app/scripts/lib/transaction/metrics-builders/gasless.ts
+++ b/app/scripts/lib/transaction/metrics-builders/gasless.ts
@@ -1,10 +1,11 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import { add0x } from '@metamask/utils';
 import { NATIVE_TOKEN_ADDRESS } from '../../../../../shared/constants/transaction';
 import { getMaximumGasTotalInHexWei } from '../../../../../shared/lib/gas.utils';
 import { Numeric } from '../../../../../shared/lib/Numeric';
-import { addHexes } from '../../../../../shared/lib/conversion.utils';
+import { sumHexes } from '../../../../../shared/lib/conversion.utils';
 import type { MetricsProperties, TransactionMetricsBuilder } from './types';
+
+const ZERO_HEX = '0x0';
 
 export const getGaslessMetricsProperties: TransactionMetricsBuilder = ({
   transactionMeta,
@@ -37,9 +38,22 @@ export const getGaslessMetricsProperties: TransactionMetricsBuilder = ({
     maxFeePerGas: transactionMeta.txParams.maxFeePerGas,
   });
 
-  const totalCost = add0x(
-    addHexes(gasCost, transactionMeta.txParams.value ?? '0x0'),
+  const nestedTransactionValues =
+    transactionMeta.nestedTransactions?.map(
+      ({ value }) => (value as string | undefined) ?? ZERO_HEX,
+    ) ?? [];
+
+  const totalTransactionValue = sumHexes(
+    transactionMeta.txParams.value ?? ZERO_HEX,
+    ...nestedTransactionValues,
   );
+
+  const totalGasCost = sumHexes(
+    gasCost,
+    transactionMeta.layer1GasFee ?? ZERO_HEX,
+  );
+
+  const totalCost = sumHexes(totalGasCost, totalTransactionValue);
   properties.gas_insufficient_native_asset = new Numeric(
     totalCost,
     16,

--- a/ui/pages/confirmations/hooks/gas/useIsGaslessLoading.test.ts
+++ b/ui/pages/confirmations/hooks/gas/useIsGaslessLoading.test.ts
@@ -38,6 +38,7 @@ async function runHook({
   });
   mockedUseHasInsufficientBalance.mockReturnValue({
     hasInsufficientBalance: insufficientBalance,
+    isNativeBalanceKnown: true,
     nativeCurrency: 'USD',
   });
 

--- a/ui/pages/confirmations/hooks/useAutomaticGasFeeTokenSelect.test.ts
+++ b/ui/pages/confirmations/hooks/useAutomaticGasFeeTokenSelect.test.ts
@@ -74,6 +74,7 @@ describe('useAutomaticGasFeeTokenSelect', () => {
     jest.resetAllMocks();
     useHasInsufficientBalanceMock.mockReturnValue({
       hasInsufficientBalance: true,
+      isNativeBalanceKnown: true,
       nativeCurrency: 'ETH',
     });
     updateSelectedGasFeeTokenMock.mockResolvedValue();
@@ -106,6 +107,7 @@ describe('useAutomaticGasFeeTokenSelect', () => {
     expect(mockUpdateTransactionEventFragment).toHaveBeenCalledWith(
       {
         properties: {
+          gas_insufficient_native_asset: true,
           gas_payment_token_default: true,
           gas_payment_token_default_symbol: GAS_FEE_TOKEN_MOCK.symbol,
         },
@@ -208,6 +210,7 @@ describe('useAutomaticGasFeeTokenSelect', () => {
     expect(mockUpdateTransactionEventFragment).toHaveBeenCalledWith(
       {
         properties: {
+          gas_insufficient_native_asset: true,
           gas_payment_token_default: true,
           gas_payment_token_default_symbol: GAS_FEE_TOKEN_MOCK.symbol,
         },
@@ -235,6 +238,7 @@ describe('useAutomaticGasFeeTokenSelect', () => {
   it('does not select first gas fee token if sufficient balance', async () => {
     useHasInsufficientBalanceMock.mockReturnValue({
       hasInsufficientBalance: false,
+      isNativeBalanceKnown: true,
       nativeCurrency: 'ETH',
     });
 
@@ -250,6 +254,7 @@ describe('useAutomaticGasFeeTokenSelect', () => {
   it('selects first gas fee token when insufficient balance appears after first render', async () => {
     let balanceInfo = {
       hasInsufficientBalance: false,
+      isNativeBalanceKnown: true,
       nativeCurrency: 'ETH',
     };
     useHasInsufficientBalanceMock.mockImplementation(() => balanceInfo);
@@ -270,6 +275,7 @@ describe('useAutomaticGasFeeTokenSelect', () => {
 
     balanceInfo = {
       hasInsufficientBalance: true,
+      isNativeBalanceKnown: true,
       nativeCurrency: 'ETH',
     };
 
@@ -288,12 +294,55 @@ describe('useAutomaticGasFeeTokenSelect', () => {
     expect(mockUpdateTransactionEventFragment).toHaveBeenCalledWith(
       {
         properties: {
+          gas_insufficient_native_asset: true,
           gas_payment_token_default: true,
           gas_payment_token_default_symbol: GAS_FEE_TOKEN_MOCK.symbol,
         },
       },
       expect.any(String),
     );
+  });
+
+  it('does not select first gas fee token until native balance is known', async () => {
+    let balanceInfo = {
+      hasInsufficientBalance: true,
+      isNativeBalanceKnown: false,
+      nativeCurrency: 'ETH',
+    };
+    useHasInsufficientBalanceMock.mockImplementation(() => balanceInfo);
+
+    const { rerender, store } = runHook({
+      selectedGasFeeToken: undefined,
+    });
+
+    if (!store) {
+      throw new Error('Expected store to be defined');
+    }
+
+    await flushAsyncUpdates();
+
+    expect(updateSelectedGasFeeTokenMock).toHaveBeenCalledTimes(0);
+    expect(forceUpdateMetamaskStateMock).toHaveBeenCalledTimes(0);
+    expect(mockUpdateTransactionEventFragment).not.toHaveBeenCalled();
+
+    balanceInfo = {
+      hasInsufficientBalance: true,
+      isNativeBalanceKnown: true,
+      nativeCurrency: 'ETH',
+    };
+
+    rerender();
+
+    await flushAsyncUpdates();
+
+    expect(updateSelectedGasFeeTokenMock).toHaveBeenCalledTimes(1);
+    expect(updateSelectedGasFeeTokenMock).toHaveBeenCalledWith(
+      expect.any(String),
+      GAS_FEE_TOKEN_MOCK.tokenAddress,
+    );
+    expect(forceUpdateMetamaskStateMock).toHaveBeenCalledTimes(1);
+    expect(forceUpdateMetamaskStateMock).toHaveBeenCalledWith(store.dispatch);
+    expect(mockUpdateTransactionEventFragment).toHaveBeenCalledTimes(1);
   });
 
   it('does not select first gas fee token after firstCheck is set to false', async () => {
@@ -410,6 +459,7 @@ describe('useAutomaticGasFeeTokenSelect', () => {
     expect(mockUpdateTransactionEventFragment).toHaveBeenCalledWith(
       {
         properties: {
+          gas_insufficient_native_asset: true,
           gas_payment_token_default: true,
           gas_payment_token_default_symbol: GAS_FEE_TOKEN_MOCK.symbol,
         },

--- a/ui/pages/confirmations/hooks/useAutomaticGasFeeTokenSelect.ts
+++ b/ui/pages/confirmations/hooks/useAutomaticGasFeeTokenSelect.ts
@@ -23,7 +23,8 @@ export function useAutomaticGasFeeTokenSelect() {
   const { currentConfirmation: transactionMeta } =
     useConfirmContext<TransactionMeta>();
 
-  const { hasInsufficientBalance } = useHasInsufficientBalance();
+  const { hasInsufficientBalance, isNativeBalanceKnown } =
+    useHasInsufficientBalance();
   const { updateTransactionEventFragment } = useTransactionEventFragment();
 
   const {
@@ -64,11 +65,15 @@ export function useAutomaticGasFeeTokenSelect() {
         selectedGasFeeToken.toLocaleLowerCase(),
     );
 
+  const shouldSelectForInsufficientNativeBalance =
+    isGaslessSupportedAndFinished &&
+    isNativeBalanceKnown &&
+    hasInsufficientBalance &&
+    !selectedGasFeeToken;
+
   const shouldSelect =
     Boolean(firstGasFeeTokenAddress) &&
-    ((isGaslessSupportedAndFinished &&
-      hasInsufficientBalance &&
-      !selectedGasFeeToken) ||
+    (shouldSelectForInsufficientNativeBalance ||
       hasSelectedGasFeeTokenNotInList);
 
   useAsyncResult(async () => {
@@ -84,6 +89,12 @@ export function useAutomaticGasFeeTokenSelect() {
       updateTransactionEventFragment(
         {
           properties: {
+            ...(shouldSelectForInsufficientNativeBalance
+              ? {
+                  // eslint-disable-next-line @typescript-eslint/naming-convention
+                  gas_insufficient_native_asset: true,
+                }
+              : {}),
             // eslint-disable-next-line @typescript-eslint/naming-convention
             gas_payment_token_default: true,
             // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -102,5 +113,6 @@ export function useAutomaticGasFeeTokenSelect() {
     transactionId,
     updateTransactionEventFragment,
     firstGasFeeTokenAddress,
+    shouldSelectForInsufficientNativeBalance,
   ]);
 }

--- a/ui/pages/confirmations/hooks/useHasInsufficientBalance.test.ts
+++ b/ui/pages/confirmations/hooks/useHasInsufficientBalance.test.ts
@@ -35,6 +35,7 @@ function buildState({
   selectedNetworkClientId,
   chainId,
   excludeNativeTokenForFee,
+  omitNativeBalance,
 }: {
   balance?: number;
   currentConfirmation?: Partial<TransactionMeta>;
@@ -42,6 +43,7 @@ function buildState({
   selectedNetworkClientId?: string;
   chainId?: string;
   excludeNativeTokenForFee?: boolean;
+  omitNativeBalance?: boolean;
 } = {}) {
   const accountAddress = transaction?.txParams?.from as string;
 
@@ -59,13 +61,15 @@ function buildState({
     metamask: {
       selectedNetworkClientId: selectedNetworkClientId ?? 'goerli',
       pendingApprovals,
-      accountsByChainId: {
-        [chainId ?? '0x5']: {
-          [toChecksumHexAddress(accountAddress)]: {
-            balance: toHex(balance ?? 0),
+      accountsByChainId: omitNativeBalance
+        ? {}
+        : {
+            [chainId ?? '0x5']: {
+              [toChecksumHexAddress(accountAddress)]: {
+                balance: toHex(balance ?? 0),
+              },
+            },
           },
-        },
-      },
       transactions: transaction
         ? [
             {
@@ -93,12 +97,14 @@ describe('useHasInsufficientBalance', () => {
   it('returns false if balance sufficient for value + fee', () => {
     const result = runHook({ balance: 900000000000 });
     expect(result.hasInsufficientBalance).toBe(false);
+    expect(result.isNativeBalanceKnown).toBe(true);
     expect(result.nativeCurrency).toBe('ETH');
   });
 
   it('returns true if balance insufficient for value + fee', () => {
     const result = runHook({ balance: 0 });
     expect(result.hasInsufficientBalance).toBe(true);
+    expect(result.isNativeBalanceKnown).toBe(true);
   });
 
   it('sums nested transaction values correctly', () => {
@@ -130,9 +136,10 @@ describe('useHasInsufficientBalance', () => {
     expect(result.nativeCurrency).toBe('ETH');
   });
 
-  it('returns 0x0 if balance missing', () => {
-    const result = runHook({ balance: undefined });
+  it('returns whether native balance is missing from state', () => {
+    const result = runHook({ omitNativeBalance: true });
     expect(result.hasInsufficientBalance).toBe(true);
+    expect(result.isNativeBalanceKnown).toBe(false);
   });
 
   it('always return true for Tempo if `excludeNativeTokenForFee` is true', () => {
@@ -142,6 +149,7 @@ describe('useHasInsufficientBalance', () => {
       excludeNativeTokenForFee: true,
     });
     expect(result.hasInsufficientBalance).toBe(true);
+    expect(result.isNativeBalanceKnown).toBe(true);
     expect(result.nativeCurrency).toBe('pathUSD');
   });
 
@@ -152,6 +160,7 @@ describe('useHasInsufficientBalance', () => {
       excludeNativeTokenForFee: true,
     });
     expect(result.hasInsufficientBalance).toBe(true);
+    expect(result.isNativeBalanceKnown).toBe(true);
     expect(result.nativeCurrency).toBe('pathUSD');
   });
 
@@ -161,6 +170,7 @@ describe('useHasInsufficientBalance', () => {
       chainId: '0x1079',
     });
     expect(result.hasInsufficientBalance).toBe(false);
+    expect(result.isNativeBalanceKnown).toBe(true);
     expect(result.nativeCurrency).toBe('pathUSD');
   });
 
@@ -170,6 +180,7 @@ describe('useHasInsufficientBalance', () => {
       chainId: '0xa5bf',
     });
     expect(result.hasInsufficientBalance).toBe(false);
+    expect(result.isNativeBalanceKnown).toBe(true);
     expect(result.nativeCurrency).toBe('pathUSD');
   });
 });

--- a/ui/pages/confirmations/hooks/useHasInsufficientBalance.ts
+++ b/ui/pages/confirmations/hooks/useHasInsufficientBalance.ts
@@ -15,6 +15,7 @@ const ZERO_HEX_FALLBACK = '0x0';
 
 export function useHasInsufficientBalance(): {
   hasInsufficientBalance: boolean;
+  isNativeBalanceKnown: boolean;
   nativeCurrency?: string;
 } {
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
@@ -33,7 +34,14 @@ export function useHasInsufficientBalance(): {
     getNativeTokenCachedBalanceByChainIdSelector(state, fromAddress ?? ''),
   ) as Record<Hex, Hex>;
 
-  const balance = chainBalances?.[chainId as Hex] ?? ZERO_HEX_FALLBACK;
+  const hasNoNativeAsset = NO_NATIVE_ASSET_CHAIN_IDS.has(chainId);
+  const isNativeBalanceKnown =
+    hasNoNativeAsset ||
+    Boolean(chainId && Object.hasOwn(chainBalances ?? {}, chainId));
+
+  const balance = isNativeBalanceKnown
+    ? (chainBalances?.[chainId as Hex] ?? ZERO_HEX_FALLBACK)
+    : ZERO_HEX_FALLBACK;
 
   const totalValue = sumHexes(value, ...batchTransactionValues);
 
@@ -44,7 +52,6 @@ export function useHasInsufficientBalance(): {
   );
 
   const { nativeCurrencySymbol } = useNativeCurrencySymbol(chainId);
-  const hasNoNativeAsset = NO_NATIVE_ASSET_CHAIN_IDS.has(chainId);
   /**
    * Tempo (7702) special case: Force "enough native balance" in legacy flow
    * (when `excludeNativeTokenForFee` is false) to restore old MetaMask behavior.
@@ -61,6 +68,7 @@ export function useHasInsufficientBalance(): {
 
   return {
     hasInsufficientBalance,
+    isNativeBalanceKnown,
     nativeCurrency: nativeCurrencySymbol,
   };
 }


### PR DESCRIPTION
## **Description**

This fixes false-positive gas station defaults and aligns the related gasless metrics with the confirmation UI decision.

The auto gas-fee-token selector used `useHasInsufficientBalance`, which treated a missing cached native balance as `0x0`. When gas fee tokens loaded before the account's native balance, extension could select a gas station token even though the user actually had enough native asset. By submit time, metrics could see the real balance and record `gas_insufficient_native_asset: false`, producing the orange-bar false positives.

This PR now:

- Keeps the existing insufficient-balance behavior for alerts, but exposes whether the native balance is known. Automatic gas fee token selection waits until the balance for the transaction account and chain is present before defaulting to gas station. No-native-asset networks keep their existing special-case behavior.
- Updates the gasless metrics builder to include nested transaction values and `layer1GasFee` in `gas_insufficient_native_asset`, matching the cost components used by the confirmation UI.
- Records `gas_insufficient_native_asset: true` at the auto-selection decision point when gas station is defaulted because a known native balance is insufficient. That preserves the reason even if smart-transaction submission later rewrites gas fields for the selected gas-fee token before final metrics are built.

## Fixes

https://consensyssoftware.atlassian.net/browse/CONF-1398

## **Changelog**

CHANGELOG entry: Fixed a bug that could default transactions to gas station before the native balance finished loading, and corrected gasless native-balance metrics for nested and L1-fee transactions.

<!--
## **Related issues**

Fixes:
-->

<!--
## **Manual testing steps**

1. Go to this page...
2.
3.
-->

<!--
## **Screenshots/Recordings**

### **Before**

[screenshots/recordings]

### **After**

[screenshots/recordings]
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation**

- `yarn test:unit app/scripts/lib/transaction/metrics-builders/gasless.test.ts ui/pages/confirmations/hooks/useAutomaticGasFeeTokenSelect.test.ts ui/pages/confirmations/hooks/useHasInsufficientBalance.test.ts`
- `yarn test:unit ui/pages/confirmations/hooks/gas/useIsGaslessLoading.test.ts`
- `yarn lint:changed:fix`
- `yarn lint:format`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 9db8ee117d2cc7116acfe7ce13f24b7d333d926e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->