### PR TITLE
feat(perps): gate VIP discount and badge behind vipProgramEnabled feature flag

### DIFF
--- a/test/e2e/feature-flags/feature-flag-registry.ts
+++ b/test/e2e/feature-flags/feature-flag-registry.ts
@@ -2234,6 +2234,14 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     productionDefault: 'xyz:*',
     status: FeatureFlagStatus.Active,
   },
+
+  vipProgramEnabled: {
+    name: 'vipProgramEnabled',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: false,
+    status: FeatureFlagStatus.Active,
+  },
   rewardsBitcoinEnabledExtension: {
     name: 'rewardsBitcoinEnabledExtension',
     type: FeatureFlagType.Remote,

--- a/test/e2e/feature-flags/feature-flag-registry.ts
+++ b/test/e2e/feature-flags/feature-flag-registry.ts
@@ -2239,7 +2239,10 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     name: 'vipProgramEnabled',
     type: FeatureFlagType.Remote,
     inProd: true,
-    productionDefault: false,
+    productionDefault: {
+      enabled: false,
+      minimumVersion: '0.0.0',
+    },
     status: FeatureFlagStatus.Active,
   },
   rewardsBitcoinEnabledExtension: {

--- a/ui/components/app/rewards/RewardsVipBadge.test.tsx
+++ b/ui/components/app/rewards/RewardsVipBadge.test.tsx
@@ -16,7 +16,7 @@ const vipEnabledStore = () => {
   const store = createBridgeMockStore();
   store.metamask.remoteFeatureFlags = {
     ...store.metamask.remoteFeatureFlags,
-    vipProgramEnabled: true,
+    vipProgramEnabled: { enabled: true, minimumVersion: '0.0.0' },
   };
   return store;
 };

--- a/ui/components/app/rewards/RewardsVipBadge.test.tsx
+++ b/ui/components/app/rewards/RewardsVipBadge.test.tsx
@@ -14,9 +14,9 @@ setBackgroundConnection({
 
 const vipEnabledStore = () => {
   const store = createBridgeMockStore();
-  store.metamask.remoteFeatureFlags = {
-    ...store.metamask.remoteFeatureFlags,
-    vipProgramEnabled: { enabled: true, minimumVersion: '0.0.0' },
+  store.metamask.remoteFeatureFlags.vipProgramEnabled = {
+    enabled: true,
+    minimumVersion: '0.0.0',
   };
   return store;
 };

--- a/ui/components/app/rewards/RewardsVipBadge.test.tsx
+++ b/ui/components/app/rewards/RewardsVipBadge.test.tsx
@@ -12,6 +12,15 @@ setBackgroundConnection({
     mockGetVipTierForAccount(...args),
 } as never);
 
+const vipEnabledStore = () => {
+  const store = createBridgeMockStore();
+  store.metamask.remoteFeatureFlags = {
+    ...store.metamask.remoteFeatureFlags,
+    vipProgramEnabled: true,
+  };
+  return store;
+};
+
 describe('RewardsVipBadge', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -22,7 +31,7 @@ describe('RewardsVipBadge', () => {
 
     const { container } = renderWithProvider(
       <RewardsVipBadge />,
-      configureStore(createBridgeMockStore()),
+      configureStore(vipEnabledStore()),
     );
 
     await waitFor(() => {
@@ -36,7 +45,7 @@ describe('RewardsVipBadge', () => {
 
     const { container } = renderWithProvider(
       <RewardsVipBadge />,
-      configureStore(createBridgeMockStore()),
+      configureStore(vipEnabledStore()),
     );
 
     await waitFor(() => {
@@ -50,7 +59,7 @@ describe('RewardsVipBadge', () => {
 
     const { container } = renderWithProvider(
       <RewardsVipBadge />,
-      configureStore(createBridgeMockStore()),
+      configureStore(vipEnabledStore()),
     );
 
     await waitFor(() => {
@@ -92,12 +101,24 @@ describe('RewardsVipBadge', () => {
 
     const { container } = renderWithProvider(
       <RewardsVipBadge />,
-      configureStore(createBridgeMockStore()),
+      configureStore(vipEnabledStore()),
     );
 
     await waitFor(() => {
       expect(mockGetVipTierForAccount).toHaveBeenCalledTimes(1);
       expect(container).toMatchInlineSnapshot(`<div />`);
     });
+  });
+
+  it('renders null and skips the lookup when vipProgramEnabled is false', () => {
+    mockGetVipTierForAccount.mockResolvedValueOnce(5);
+
+    const { container } = renderWithProvider(
+      <RewardsVipBadge />,
+      configureStore(createBridgeMockStore()),
+    );
+
+    expect(container).toMatchInlineSnapshot(`<div />`);
+    expect(mockGetVipTierForAccount).not.toHaveBeenCalled();
   });
 });

--- a/ui/ducks/rewards/selectors.ts
+++ b/ui/ducks/rewards/selectors.ts
@@ -74,12 +74,25 @@ export const selectRewardsDeeplinkUrl = (state: MetaMaskReduxState) =>
 /**
  * Whether the VIP program (fee discounts + VIP badge) is enabled.
  *
- * Reads the `vipProgramEnabled` remote feature flag. When `false` or absent,
- * VIP tier lookups and discount calculations are suppressed across the app
- * (perps, bridge, etc.).
+ * Reads the `vipProgramEnabled` remote feature flag. Supports both a plain
+ * boolean and a version-gated object (`{ enabled, minimumVersion }`). When
+ * `false`, absent, or the current version doesn't meet the minimum, VIP tier
+ * lookups and discount calculations are suppressed across the app (perps,
+ * bridge, etc.).
  */
 export const selectVipProgramEnabled = createSelector(
   getRemoteFeatureFlags,
-  (remoteFeatureFlags): boolean =>
-    remoteFeatureFlags.vipProgramEnabled === true,
+  (remoteFeatureFlags): boolean => {
+    const flag = remoteFeatureFlags?.vipProgramEnabled as
+      | VersionGatedFeatureFlag
+      | boolean
+      | undefined;
+
+    if (typeof flag === 'boolean') {
+      return flag;
+    }
+    return Boolean(
+      validatedVersionGatedFeatureFlag(flag as VersionGatedFeatureFlag),
+    );
+  },
 );

--- a/ui/ducks/rewards/selectors.ts
+++ b/ui/ducks/rewards/selectors.ts
@@ -70,3 +70,16 @@ export const selectRewardsAccountLinkedTimestamp = (
 
 export const selectRewardsDeeplinkUrl = (state: MetaMaskReduxState) =>
   state.rewards.rewardsDeeplinkUrl ?? null;
+
+/**
+ * Whether the VIP program (fee discounts + VIP badge) is enabled.
+ *
+ * Reads the `vipProgramEnabled` remote feature flag. When `false` or absent,
+ * VIP tier lookups and discount calculations are suppressed across the app
+ * (perps, bridge, etc.).
+ */
+export const selectVipProgramEnabled = createSelector(
+  getRemoteFeatureFlags,
+  (remoteFeatureFlags): boolean =>
+    remoteFeatureFlags.vipProgramEnabled === true,
+);

--- a/ui/hooks/perps/usePerpsMetamaskFeeDiscountBips.test.ts
+++ b/ui/hooks/perps/usePerpsMetamaskFeeDiscountBips.test.ts
@@ -2,6 +2,7 @@ import { renderHook, act } from '@testing-library/react-hooks';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
 import { getSelectedInternalAccount } from '../../../shared/lib/selectors/accounts';
 import { getCurrentChainId } from '../../../shared/lib/selectors/networks';
+import { getIsVipProgramEnabled } from '../../selectors/perps/feature-flags';
 import {
   clearPerpsFeeDiscountCacheForTests,
   usePerpsMetamaskFeeDiscountBips,
@@ -26,16 +27,24 @@ const TEST_CAIP_ACCOUNT_ID = `eip155:42161:${toChecksumHexAddress(
 const ORIGINAL_METAMASK_FEE_BIPS = 10;
 
 function setSelectors(
-  overrides: { address?: string | null; chainId?: string } = {},
+  overrides: {
+    address?: string | null;
+    chainId?: string;
+    vipProgramEnabled?: boolean;
+  } = {},
 ) {
   const address = 'address' in overrides ? overrides.address : TEST_ADDRESS;
   const chainId = overrides.chainId ?? TEST_CHAIN_ID;
+  const vipProgramEnabled = overrides.vipProgramEnabled ?? true;
   mockUseSelector.mockImplementation((selector) => {
     if (selector === getSelectedInternalAccount) {
       return address ? { address } : undefined;
     }
     if (selector === getCurrentChainId) {
       return chainId;
+    }
+    if (selector === getIsVipProgramEnabled) {
+      return vipProgramEnabled;
     }
     return undefined;
   });
@@ -129,6 +138,21 @@ describe('usePerpsMetamaskFeeDiscountBips', () => {
     });
 
     expect(result.current).toBeUndefined();
+  });
+
+  it('returns undefined and skips the lookup when vipProgramEnabled is false', async () => {
+    setSelectors({ vipProgramEnabled: false });
+    setDiscountResponse(5000);
+
+    const { result } = renderHook(() =>
+      usePerpsMetamaskFeeDiscountBips(ORIGINAL_METAMASK_FEE_BIPS),
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(result.current).toBeUndefined();
+    expect(mockSubmitRequestToBackground).not.toHaveBeenCalled();
   });
 
   it('returns undefined and skips the lookup entirely when no account is selected', async () => {

--- a/ui/hooks/perps/usePerpsMetamaskFeeDiscountBips.ts
+++ b/ui/hooks/perps/usePerpsMetamaskFeeDiscountBips.ts
@@ -7,6 +7,7 @@ import { toChecksumHexAddress } from '@metamask/controller-utils';
 import { submitRequestToBackground } from '../../store/background-connection';
 import { getSelectedInternalAccount } from '../../../shared/lib/selectors/accounts';
 import { getCurrentChainId } from '../../../shared/lib/selectors/networks';
+import { getIsVipProgramEnabled } from '../../selectors/perps/feature-flags';
 
 /**
  * Cache TTL for the per-address fee discount lookup. Mirrors mobile's
@@ -91,6 +92,7 @@ export function usePerpsMetamaskFeeDiscountBips(
   const selectedAccount = useSelector(getSelectedInternalAccount);
   const selectedAddress = selectedAccount?.address;
   const currentChainId = useSelector(getCurrentChainId);
+  const isVipProgramEnabled = useSelector(getIsVipProgramEnabled);
 
   const [discountBips, setDiscountBips] = useState<number | undefined>(
     undefined,
@@ -98,7 +100,7 @@ export function usePerpsMetamaskFeeDiscountBips(
 
   useEffect(() => {
     let cancelled = false;
-    if (!selectedAddress) {
+    if (!isVipProgramEnabled || !selectedAddress) {
       setDiscountBips(undefined);
       return undefined;
     }
@@ -155,7 +157,7 @@ export function usePerpsMetamaskFeeDiscountBips(
     return () => {
       cancelled = true;
     };
-  }, [selectedAddress, currentChainId, baseFeeBips]);
+  }, [isVipProgramEnabled, selectedAddress, currentChainId, baseFeeBips]);
 
   return discountBips !== undefined && discountBips > 0
     ? Math.min(discountBips, MAX_DISCOUNT_BIPS)

--- a/ui/hooks/perps/usePerpsOrderFees.test.ts
+++ b/ui/hooks/perps/usePerpsOrderFees.test.ts
@@ -3,6 +3,7 @@ import type { FeeCalculationResult } from '@metamask/perps-controller';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
 import { getSelectedInternalAccount } from '../../../shared/lib/selectors/accounts';
 import { getCurrentChainId } from '../../../shared/lib/selectors/networks';
+import { getIsVipProgramEnabled } from '../../selectors/perps/feature-flags';
 import { clearPerpsFeeDiscountCacheForTests } from './usePerpsMetamaskFeeDiscountBips';
 import { usePerpsOrderFees } from './usePerpsOrderFees';
 
@@ -34,6 +35,9 @@ function setSelectors(
     }
     if (selector === getCurrentChainId) {
       return chainId;
+    }
+    if (selector === getIsVipProgramEnabled) {
+      return true;
     }
     return undefined;
   });

--- a/ui/hooks/rewards/useVipTier.test.ts
+++ b/ui/hooks/rewards/useVipTier.test.ts
@@ -37,7 +37,9 @@ const stateWithAccount = {
         defaultRpcEndpointIndex: 0,
       },
     },
-    remoteFeatureFlags: { vipProgramEnabled: true },
+    remoteFeatureFlags: {
+      vipProgramEnabled: { enabled: true, minimumVersion: '0.0.0' },
+    },
   },
 };
 
@@ -52,14 +54,18 @@ const stateWithoutAccount = {
         defaultRpcEndpointIndex: 0,
       },
     },
-    remoteFeatureFlags: { vipProgramEnabled: true },
+    remoteFeatureFlags: {
+      vipProgramEnabled: { enabled: true, minimumVersion: '0.0.0' },
+    },
   },
 };
 
 const stateWithVipDisabled = {
   metamask: {
     ...stateWithAccount.metamask,
-    remoteFeatureFlags: { vipProgramEnabled: false },
+    remoteFeatureFlags: {
+      vipProgramEnabled: { enabled: false, minimumVersion: '0.0.0' },
+    },
   },
 };
 

--- a/ui/hooks/rewards/useVipTier.test.ts
+++ b/ui/hooks/rewards/useVipTier.test.ts
@@ -37,6 +37,7 @@ const stateWithAccount = {
         defaultRpcEndpointIndex: 0,
       },
     },
+    remoteFeatureFlags: { vipProgramEnabled: true },
   },
 };
 
@@ -51,6 +52,14 @@ const stateWithoutAccount = {
         defaultRpcEndpointIndex: 0,
       },
     },
+    remoteFeatureFlags: { vipProgramEnabled: true },
+  },
+};
+
+const stateWithVipDisabled = {
+  metamask: {
+    ...stateWithAccount.metamask,
+    remoteFeatureFlags: { vipProgramEnabled: false },
   },
 };
 
@@ -125,5 +134,17 @@ describe('useVipTier', () => {
     });
 
     expect(result.current).toBeNull();
+  });
+
+  it('returns null and skips the lookup when vipProgramEnabled is false', () => {
+    mockGetVipTierForAccount.mockResolvedValue(3);
+
+    const { result } = renderHookWithProvider(
+      () => useVipTier(),
+      stateWithVipDisabled,
+    );
+
+    expect(result.current).toBeNull();
+    expect(mockGetVipTierForAccount).not.toHaveBeenCalled();
   });
 });

--- a/ui/hooks/rewards/useVipTier.ts
+++ b/ui/hooks/rewards/useVipTier.ts
@@ -5,18 +5,25 @@ import { submitRequestToBackground } from '../../store/background-connection';
 import { getSelectedInternalAccount } from '../../../shared/lib/selectors/accounts';
 import { getCurrentChainId } from '../../../shared/lib/selectors/networks';
 import { formatAccountToCaipAccountId } from '../../helpers/utils/rewards-utils';
+import { selectVipProgramEnabled } from '../../ducks/rewards/selectors';
 
 /**
  * Derives the selected account's CAIP-10 ID and fetches its VIP tier from the
  * background's `rewardsGetVipTierForAccount` handler.
  *
- * @returns The numeric VIP tier (`null` while loading, on error, or when the
- * account has no VIP tier).
+ * Gated by the `vipProgramEnabled` remote feature flag — returns `null`
+ * immediately and skips the background lookup when the flag is off.
+ *
+ * @returns The numeric VIP tier (`null` while loading, on error, when the
+ * VIP program is disabled, or when the account has no VIP tier).
  */
 export function useVipTier(): number | null {
+  const isVipProgramEnabled = useSelector(selectVipProgramEnabled);
   const accountId = useVipTierAccountId();
 
-  const { data } = useRewardsVipTierQuery(accountId);
+  const { data } = useRewardsVipTierQuery(
+    isVipProgramEnabled ? accountId : null,
+  );
 
   return data ?? null;
 }

--- a/ui/pages/bridge/prepare/bridge-vip-fee-message.test.tsx
+++ b/ui/pages/bridge/prepare/bridge-vip-fee-message.test.tsx
@@ -157,10 +157,12 @@ describe('BridgeVipFeeMessage', () => {
   });
 
   it('renders discounted fee copy and VIP badge when a VIP discount applies', async () => {
-    renderWithProvider(
-      <BridgeVipFeeMessage />,
-      configureStore(createBridgeStoreWithQuotes(createDiscountedQuotes())),
-    );
+    const store = createBridgeStoreWithQuotes(createDiscountedQuotes());
+    store.metamask.remoteFeatureFlags.vipProgramEnabled = {
+      enabled: true,
+      minimumVersion: '0.0.0',
+    };
+    renderWithProvider(<BridgeVipFeeMessage />, configureStore(store));
 
     expect(screen.getByText(messages.includes.message)).toBeInTheDocument();
     expect(
@@ -180,10 +182,12 @@ describe('BridgeVipFeeMessage', () => {
   it('renders fee copy without VIP badge when tier fetch returns null', async () => {
     mockGetVipTierForAccount.mockResolvedValueOnce(null);
 
-    renderWithProvider(
-      <BridgeVipFeeMessage />,
-      configureStore(createBridgeStoreWithQuotes(createDiscountedQuotes())),
-    );
+    const store = createBridgeStoreWithQuotes(createDiscountedQuotes());
+    store.metamask.remoteFeatureFlags.vipProgramEnabled = {
+      enabled: true,
+      minimumVersion: '0.0.0',
+    };
+    renderWithProvider(<BridgeVipFeeMessage />, configureStore(store));
 
     expect(screen.getByText(messages.includes.message)).toBeInTheDocument();
     expect(

--- a/ui/selectors/perps/feature-flags.test.ts
+++ b/ui/selectors/perps/feature-flags.test.ts
@@ -1,7 +1,10 @@
 import semver from 'semver';
 import { PerpsFeatureFlag } from '../../../shared/lib/perps-feature-flags';
 import { getIsPerpsIncludedInBuild } from '../../../shared/lib/environment';
-import { getIsPerpsExperienceAvailable } from './feature-flags';
+import {
+  getIsPerpsExperienceAvailable,
+  getIsVipProgramEnabled,
+} from './feature-flags';
 
 jest.mock('semver');
 jest.mock('../../../package.json', () => ({
@@ -168,6 +171,34 @@ describe('Perps Feature Flags', () => {
         expect(getIsPerpsExperienceAvailable(state)).toBe(true);
         expect(semverGteMock).toHaveBeenCalledWith('12.5.0', '12.5.0-beta.1');
       });
+    });
+  });
+
+  describe('getIsVipProgramEnabled', () => {
+    it('returns true when vipProgramEnabled is true', () => {
+      const state = {
+        metamask: { remoteFeatureFlags: { vipProgramEnabled: true } },
+      };
+      expect(getIsVipProgramEnabled(state)).toBe(true);
+    });
+
+    it('returns false when vipProgramEnabled is false', () => {
+      const state = {
+        metamask: { remoteFeatureFlags: { vipProgramEnabled: false } },
+      };
+      expect(getIsVipProgramEnabled(state)).toBe(false);
+    });
+
+    it('returns false when vipProgramEnabled is absent', () => {
+      const state = { metamask: { remoteFeatureFlags: {} } };
+      expect(getIsVipProgramEnabled(state)).toBe(false);
+    });
+
+    it('returns false when vipProgramEnabled is a non-boolean truthy value', () => {
+      const state = {
+        metamask: { remoteFeatureFlags: { vipProgramEnabled: 'yes' } },
+      };
+      expect(getIsVipProgramEnabled(state)).toBe(false);
     });
   });
 });

--- a/ui/selectors/perps/feature-flags.test.ts
+++ b/ui/selectors/perps/feature-flags.test.ts
@@ -175,14 +175,14 @@ describe('Perps Feature Flags', () => {
   });
 
   describe('getIsVipProgramEnabled', () => {
-    it('returns true when vipProgramEnabled is true', () => {
+    it('returns true when vipProgramEnabled is boolean true', () => {
       const state = {
         metamask: { remoteFeatureFlags: { vipProgramEnabled: true } },
       };
       expect(getIsVipProgramEnabled(state)).toBe(true);
     });
 
-    it('returns false when vipProgramEnabled is false', () => {
+    it('returns false when vipProgramEnabled is boolean false', () => {
       const state = {
         metamask: { remoteFeatureFlags: { vipProgramEnabled: false } },
       };
@@ -194,9 +194,37 @@ describe('Perps Feature Flags', () => {
       expect(getIsVipProgramEnabled(state)).toBe(false);
     });
 
-    it('returns false when vipProgramEnabled is a non-boolean truthy value', () => {
+    it('returns true when version-gated flag is enabled and version satisfies', () => {
+      semverGteMock.mockReturnValue(true);
       const state = {
-        metamask: { remoteFeatureFlags: { vipProgramEnabled: 'yes' } },
+        metamask: {
+          remoteFeatureFlags: {
+            vipProgramEnabled: { enabled: true, minimumVersion: '0.0.0' },
+          },
+        },
+      };
+      expect(getIsVipProgramEnabled(state)).toBe(true);
+    });
+
+    it('returns false when version-gated flag is enabled but version does not satisfy', () => {
+      semverGteMock.mockReturnValue(false);
+      const state = {
+        metamask: {
+          remoteFeatureFlags: {
+            vipProgramEnabled: { enabled: true, minimumVersion: '99.0.0' },
+          },
+        },
+      };
+      expect(getIsVipProgramEnabled(state)).toBe(false);
+    });
+
+    it('returns false when version-gated flag has enabled false', () => {
+      const state = {
+        metamask: {
+          remoteFeatureFlags: {
+            vipProgramEnabled: { enabled: false, minimumVersion: '0.0.0' },
+          },
+        },
       };
       expect(getIsVipProgramEnabled(state)).toBe(false);
     });

--- a/ui/selectors/perps/feature-flags.ts
+++ b/ui/selectors/perps/feature-flags.ts
@@ -89,3 +89,7 @@ export const getHip3AllowedSourcesSet = createSelector(
   getHip3AllowedSources,
   (allowedSources): Set<string> => new Set(allowedSources),
 );
+
+// Re-export the VIP program flag so perps consumers can import from this
+// domain module without reaching into the rewards duck directly.
+export { selectVipProgramEnabled as getIsVipProgramEnabled } from '../../ducks/rewards/selectors';


### PR DESCRIPTION
## **Description**

The VIP program (fee discounts and VIP badge) in Perps and Bridge was not gated behind a dedicated feature flag — it relied solely on the broader `rewardsEnabled` flag and backend responses. This made it impossible to independently control VIP rollout.

This PR introduces a `vipProgramEnabled` remote feature flag that gates the entire VIP experience:

- **`usePerpsMetamaskFeeDiscountBips`** — skips the discount lookup when the flag is off
- **`useVipTier`** — skips the VIP tier fetch when the flag is off, which in turn suppresses the `RewardsVipBadge` across both Perps and Bridge
- **`selectVipProgramEnabled`** — new canonical selector in the rewards duck, supporting both plain boolean and version-gated (`{ enabled, minimumVersion }`) formats
- **Feature flag registry** — `vipProgramEnabled` registered with `productionDefault: { enabled: false, minimumVersion: "0.0.0" }` (disabled by default)

The perps feature-flags module re-exports the selector as `getIsVipProgramEnabled` so perps consumers don't need to reach into the rewards duck directly.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

<!--
Fixes:
-->

## **Manual testing steps**

**Feature: VIP program gated by vipProgramEnabled feature flag**

**Scenario: VIP discount and badge are hidden when flag is disabled (default)**
- Given the extension is built with `PERPS_ENABLED=true`
- And the `vipProgramEnabled` remote feature flag is absent or `{ enabled: false, minimumVersion: "0.0.0" }`
- When the user navigates to the Perps order entry screen
- Then no VIP badge is displayed
- And the fee shown is the full undiscounted fee
- And no `rewardsGetPerpsDiscountForAccount` or `rewardsGetVipTierForAccount` background requests are made

**Scenario: VIP discount and badge appear when flag is enabled**
- Given the `vipProgramEnabled` remote feature flag is `{ enabled: true, minimumVersion: "0.0.0" }`
- And the user has a VIP-eligible rewards subscription
- When the user navigates to the Perps order entry screen
- Then the VIP badge is displayed
- And the fee shown reflects the discounted rate with a struck-through original fee

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new gating that changes when fee discounts and VIP tier lookups occur, which can affect perps fee calculations and bridge messaging if misconfigured. Default is disabled, but rollout depends on correct remote-flag values and version-gating.
> 
> **Overview**
> Adds a new remote feature flag, `vipProgramEnabled` (default **off**), and a canonical selector `selectVipProgramEnabled` that supports both boolean and version-gated flag formats.
> 
> Updates the perps discount hook (`usePerpsMetamaskFeeDiscountBips`) and rewards VIP tier hook (`useVipTier`, which drives `RewardsVipBadge`) to **skip background lookups and return `undefined`/`null` immediately** when the flag is disabled, preventing VIP discounts/badges from appearing.
> 
> Perps feature-flag selectors re-export the VIP selector as `getIsVipProgramEnabled`, and unit tests are updated/added across rewards, perps, and bridge to cover both enabled and disabled flag behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 765766cf9f18836798f3a347f578f1e8c360047b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->