### PR TITLE
feat: biometrics for restore SRP (forgot password flow)

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4502,12 +4502,8 @@ export default class MetamaskController extends EventEmitter {
     authenticationResponse,
     password,
   ) {
-    const { completedOnboarding, firstTimeFlowType } =
-      this.onboardingController.state;
-    if (
-      completedOnboarding &&
-      firstTimeFlowType !== FirstTimeFlowType.restore
-    ) {
+    const { completedOnboarding } = this.onboardingController.state;
+    if ( completedOnboarding ) {
       // password is required when onboarding is complete
       if (!password) {
         throw new Error('Password required to register passkey');

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4502,8 +4502,8 @@ export default class MetamaskController extends EventEmitter {
     authenticationResponse,
     password,
   ) {
-    const { completedOnboarding } = this.onboardingController.state;
-    if (completedOnboarding) {
+    const { completedOnboarding, firstTimeFlowType } = this.onboardingController.state;
+    if (completedOnboarding && firstTimeFlowType !== FirstTimeFlowType.restore) {
       // password is required when onboarding is complete
       if (!password) {
         throw new Error('Password required to register passkey');

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4502,8 +4502,12 @@ export default class MetamaskController extends EventEmitter {
     authenticationResponse,
     password,
   ) {
-    const { completedOnboarding, firstTimeFlowType } = this.onboardingController.state;
-    if (completedOnboarding && firstTimeFlowType !== FirstTimeFlowType.restore) {
+    const { completedOnboarding, firstTimeFlowType } =
+      this.onboardingController.state;
+    if (
+      completedOnboarding &&
+      firstTimeFlowType !== FirstTimeFlowType.restore
+    ) {
       // password is required when onboarding is complete
       if (!password) {
         throw new Error('Password required to register passkey');

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -4503,7 +4503,7 @@ export default class MetamaskController extends EventEmitter {
     password,
   ) {
     const { completedOnboarding } = this.onboardingController.state;
-    if ( completedOnboarding ) {
+    if (completedOnboarding) {
       // password is required when onboarding is complete
       if (!password) {
         throw new Error('Password required to register passkey');

--- a/test/e2e/page-objects/pages/onboarding/setup-passkey-page.ts
+++ b/test/e2e/page-objects/pages/onboarding/setup-passkey-page.ts
@@ -34,7 +34,7 @@ class SetupPasskeyPage {
   }
 
   async skipPasskeySetup(): Promise<void> {
-    console.log('Skip passkey setup during onboarding');
+    console.log('Skip passkey setup');
     await this.driver.clickElementAndWaitToDisappear(this.maybeLaterButton);
   }
 

--- a/test/e2e/tests/account/forgot-password.spec.ts
+++ b/test/e2e/tests/account/forgot-password.spec.ts
@@ -11,6 +11,7 @@ import {
   lockAndWaitForLoginPage,
   login,
 } from '../../page-objects/flows/login.flow';
+import SetupPasskeyPage from 'test/e2e/page-objects/pages/onboarding/setup-passkey-page';
 
 const newPassword = 'this is the best password ever';
 
@@ -51,6 +52,12 @@ describe('Forgot password', function () {
 
         await resetPasswordPage.resetPassword(E2E_SRP, newPassword);
         await resetPasswordPage.waitForPasswordInputToNotBeVisible();
+
+        // Assert passkey setup is shown
+        const setupPasskeyPage = new SetupPasskeyPage(driver);
+        await setupPasskeyPage.checkPageIsLoaded();
+        await setupPasskeyPage.skipPasskeySetup();
+
         await homePage.headerNavbar.checkPageIsLoaded();
         await driver.delay(1000); // to avoid a race condition where the wallet is not locked yet
         // Lock wallet again

--- a/test/e2e/tests/account/forgot-password.spec.ts
+++ b/test/e2e/tests/account/forgot-password.spec.ts
@@ -1,3 +1,4 @@
+import { Browser } from 'selenium-webdriver';
 import { withFixtures } from '../../helpers';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { Driver } from '../../webdriver/driver';
@@ -53,10 +54,13 @@ describe('Forgot password', function () {
         await resetPasswordPage.resetPassword(E2E_SRP, newPassword);
         await resetPasswordPage.waitForPasswordInputToNotBeVisible();
 
-        // Assert passkey setup is shown
-        const setupPasskeyPage = new SetupPasskeyPage(driver);
-        await setupPasskeyPage.checkPageIsLoaded();
-        await setupPasskeyPage.skipPasskeySetup();
+        // Assert passkey setup is shown for chrome
+        const isFirefox = process.env.SELENIUM_BROWSER === Browser.FIREFOX;
+        if (!isFirefox) {
+          const setupPasskeyPage = new SetupPasskeyPage(driver);
+          await setupPasskeyPage.checkPageIsLoaded();
+          await setupPasskeyPage.skipPasskeySetup();
+        }
 
         await homePage.headerNavbar.checkPageIsLoaded();
         await driver.delay(1000); // to avoid a race condition where the wallet is not locked yet

--- a/test/e2e/tests/account/forgot-password.spec.ts
+++ b/test/e2e/tests/account/forgot-password.spec.ts
@@ -11,7 +11,7 @@ import {
   lockAndWaitForLoginPage,
   login,
 } from '../../page-objects/flows/login.flow';
-import SetupPasskeyPage from 'test/e2e/page-objects/pages/onboarding/setup-passkey-page';
+import SetupPasskeyPage from '../../page-objects/pages/onboarding/setup-passkey-page';
 
 const newPassword = 'this is the best password ever';
 

--- a/test/e2e/tests/multichain-accounts/add-account.spec.ts
+++ b/test/e2e/tests/multichain-accounts/add-account.spec.ts
@@ -16,6 +16,7 @@ import MultichainAccountDetailsPage from '../../page-objects/pages/multichain/mu
 import ResetPasswordPage from '../../page-objects/pages/reset-password-page';
 import { Driver } from '../../webdriver/driver';
 import { MOCK_ETH_CONVERSION_RATE, mockPriceApi } from '../tokens/utils/mocks';
+import SetupPasskeyPage from 'test/e2e/page-objects/pages/onboarding/setup-passkey-page';
 
 const SECOND_ACCOUNT_NAME = 'Account 2';
 const IMPORTED_ACCOUNT_NAME = 'Imported Account 1';
@@ -97,6 +98,11 @@ describe('Add account', function () {
         await resetPasswordPage.checkPageIsLoaded();
         await resetPasswordPage.resetPassword(E2E_SRP, WALLET_PASSWORD);
         await resetPasswordPage.waitForPasswordInputToNotBeVisible();
+
+        // Assert passkey setup is shown
+        const setupPasskeyPage = new SetupPasskeyPage(driver);
+        await setupPasskeyPage.checkPageIsLoaded();
+        await setupPasskeyPage.skipPasskeySetup();
 
         // Check wallet balance for both accounts
         await homePage.checkPageIsLoaded();

--- a/test/e2e/tests/multichain-accounts/add-account.spec.ts
+++ b/test/e2e/tests/multichain-accounts/add-account.spec.ts
@@ -1,4 +1,5 @@
 import { Mockttp } from 'mockttp';
+import { Browser } from 'selenium-webdriver';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { withFixtures } from '../../helpers';
 import { E2E_SRP, WALLET_PASSWORD } from '../../constants';
@@ -99,10 +100,13 @@ describe('Add account', function () {
         await resetPasswordPage.resetPassword(E2E_SRP, WALLET_PASSWORD);
         await resetPasswordPage.waitForPasswordInputToNotBeVisible();
 
-        // Assert passkey setup is shown
-        const setupPasskeyPage = new SetupPasskeyPage(driver);
-        await setupPasskeyPage.checkPageIsLoaded();
-        await setupPasskeyPage.skipPasskeySetup();
+        // Assert passkey setup is shown for chrome
+        const isFirefox = process.env.SELENIUM_BROWSER === Browser.FIREFOX;
+        if (!isFirefox) {
+          const setupPasskeyPage = new SetupPasskeyPage(driver);
+          await setupPasskeyPage.checkPageIsLoaded();
+          await setupPasskeyPage.skipPasskeySetup();
+        }
 
         // Check wallet balance for both accounts
         await homePage.checkPageIsLoaded();

--- a/test/e2e/tests/multichain-accounts/add-account.spec.ts
+++ b/test/e2e/tests/multichain-accounts/add-account.spec.ts
@@ -16,7 +16,7 @@ import MultichainAccountDetailsPage from '../../page-objects/pages/multichain/mu
 import ResetPasswordPage from '../../page-objects/pages/reset-password-page';
 import { Driver } from '../../webdriver/driver';
 import { MOCK_ETH_CONVERSION_RATE, mockPriceApi } from '../tokens/utils/mocks';
-import SetupPasskeyPage from 'test/e2e/page-objects/pages/onboarding/setup-passkey-page';
+import SetupPasskeyPage from '../../page-objects/pages/onboarding/setup-passkey-page';
 
 const SECOND_ACCOUNT_NAME = 'Account 2';
 const IMPORTED_ACCOUNT_NAME = 'Imported Account 1';

--- a/test/e2e/tests/responsive-ui/metamask-responsive-ui.spec.ts
+++ b/test/e2e/tests/responsive-ui/metamask-responsive-ui.spec.ts
@@ -13,6 +13,7 @@ import { sendRedesignedTransactionToAddress } from '../../page-objects/flows/sen
 import { CHAIN_IDS } from '../../../../shared/constants/network';
 import { PAGES } from '../../webdriver/driver';
 import { getProductionRemoteFlagApiResponse } from '../../feature-flags';
+import SetupPasskeyPage from 'test/e2e/page-objects/pages/onboarding/setup-passkey-page';
 
 const FEATURE_FLAGS_URL = 'https://client-config.api.cx.metamask.io/v1/flags';
 
@@ -105,6 +106,11 @@ describe('MetaMask Responsive UI', function (this: Suite) {
         await resetPasswordPage.checkPageIsLoaded();
         await resetPasswordPage.resetPassword(E2E_SRP, WALLET_PASSWORD);
         await resetPasswordPage.waitForPasswordInputToNotBeVisible();
+
+        // Assert passkey setup is shown
+        const setupPasskeyPage = new SetupPasskeyPage(driver);
+        await setupPasskeyPage.checkPageIsLoaded();
+        await setupPasskeyPage.skipPasskeySetup();
 
         // Check balance renders correctly
         const homePage = new HomePage(driver);

--- a/test/e2e/tests/responsive-ui/metamask-responsive-ui.spec.ts
+++ b/test/e2e/tests/responsive-ui/metamask-responsive-ui.spec.ts
@@ -13,7 +13,7 @@ import { sendRedesignedTransactionToAddress } from '../../page-objects/flows/sen
 import { CHAIN_IDS } from '../../../../shared/constants/network';
 import { PAGES } from '../../webdriver/driver';
 import { getProductionRemoteFlagApiResponse } from '../../feature-flags';
-import SetupPasskeyPage from 'test/e2e/page-objects/pages/onboarding/setup-passkey-page';
+import SetupPasskeyPage from '../../page-objects/pages/onboarding/setup-passkey-page';
 
 const FEATURE_FLAGS_URL = 'https://client-config.api.cx.metamask.io/v1/flags';
 

--- a/test/e2e/tests/responsive-ui/metamask-responsive-ui.spec.ts
+++ b/test/e2e/tests/responsive-ui/metamask-responsive-ui.spec.ts
@@ -1,5 +1,6 @@
 import { Suite } from 'mocha';
 import { Mockttp } from 'mockttp';
+import { Browser } from 'selenium-webdriver';
 import { E2E_SRP, WALLET_PASSWORD } from '../../constants';
 import { withFixtures } from '../../helpers';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
@@ -107,10 +108,13 @@ describe('MetaMask Responsive UI', function (this: Suite) {
         await resetPasswordPage.resetPassword(E2E_SRP, WALLET_PASSWORD);
         await resetPasswordPage.waitForPasswordInputToNotBeVisible();
 
-        // Assert passkey setup is shown
-        const setupPasskeyPage = new SetupPasskeyPage(driver);
-        await setupPasskeyPage.checkPageIsLoaded();
-        await setupPasskeyPage.skipPasskeySetup();
+        // Assert passkey setup is shown for chrome
+        const isFirefox = process.env.SELENIUM_BROWSER === Browser.FIREFOX;
+        if (!isFirefox) {
+          const setupPasskeyPage = new SetupPasskeyPage(driver);
+          await setupPasskeyPage.checkPageIsLoaded();
+          await setupPasskeyPage.skipPasskeySetup();
+        }
 
         // Check balance renders correctly
         const homePage = new HomePage(driver);

--- a/ui/components/app/setup-passkey-content.tsx
+++ b/ui/components/app/setup-passkey-content.tsx
@@ -1,0 +1,413 @@
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import log from 'loglevel';
+import {
+  Box,
+  Text,
+  BoxFlexDirection,
+  BoxAlignItems,
+  BoxJustifyContent,
+  ButtonSize,
+  ButtonVariant,
+  Button,
+  TextButton,
+  TextVariant,
+  FontWeight,
+  TextColor,
+  TextAlign,
+} from '@metamask/design-system-react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useI18nContext } from '../../hooks/useI18nContext';
+import {
+  getFirstTimeFlowType,
+  getIsPasskeyRegistered,
+  getIsSocialLoginFlow,
+  getPasskeyDerivationMethod,
+  getSocialLoginType,
+} from '../../selectors';
+import { FirstTimeFlowType } from '../../../shared/constants/onboarding';
+import {
+  MetaMetricsEventAccountType,
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../shared/constants/metametrics';
+import { getPasskeyErrorCode } from '../../../shared/lib/passkey/passkey-error';
+import {
+  getPasskeyAuthMethodKey,
+  startPasskeyRegistration,
+  startPasskeyAuthentication,
+  translatePasskeyError,
+  isPasskeyCeremonySilentError,
+} from '../../../shared/lib/passkey';
+import {
+  protectVaultKeyWithPasskey,
+  generatePasskeyRegistrationOptions,
+  generatePasskeyPostRegistrationAuthenticationOptions,
+  forceUpdateMetamaskState,
+} from '../../store/actions';
+import { MetaMetricsContext } from '../../contexts/metametrics';
+import {
+  PasskeyEnrollmentSteps,
+  type PasskeyEnrollmentStepStatus,
+} from './passkey-enrollment-steps';
+
+/** Pause after enrollment succeeds so step completion is visible before navigation. */
+const PASSKEY_ENROLLMENT_SUCCESS_DISPLAY_MS = 1000;
+
+/** Default row status before enrollment starts or after the user silently dismisses WebAuthn. */
+const DEFAULT_PASSKEY_ENROLLMENT_STEP_PHASE: PasskeyEnrollmentStepStatus =
+  'idle';
+
+export type SetupPasskeyContentProps = {
+  onNext: () => void;
+};
+
+/**
+ * Reusable passkey setup content used by onboarding and restore-vault flows.
+ *
+ * @param options0 - Component props.
+ * @param options0.onNext - Called after the passkey step is skipped or completed.
+ */
+export default function SetupPasskeyContent({
+  onNext,
+}: SetupPasskeyContentProps) {
+  const dispatch = useDispatch();
+  const { trackEvent } = useContext(MetaMetricsContext);
+  const t = useI18nContext() as (
+    key: string,
+    substitutions?: string[],
+  ) => string;
+  const passkeyMethodLabel = t(getPasskeyAuthMethodKey());
+  const passkeyMethodSpecificLabel = t(
+    getPasskeyAuthMethodKey({ specific: true }),
+  );
+  const firstTimeFlowType = useSelector(getFirstTimeFlowType);
+  const isPasskeyRegistered = useSelector(getIsPasskeyRegistered);
+  const isSocialLoginFlow = useSelector(getIsSocialLoginFlow);
+  const socialLoginType = useSelector(getSocialLoginType);
+
+  const accountTypeForMetrics = useMemo(() => {
+    const baseType =
+      firstTimeFlowType === FirstTimeFlowType.import ||
+      firstTimeFlowType === FirstTimeFlowType.restore
+        ? MetaMetricsEventAccountType.Imported
+        : MetaMetricsEventAccountType.Default;
+
+    if (isSocialLoginFlow && socialLoginType) {
+      const socialProvider = String(socialLoginType).toLowerCase();
+      return `${baseType}_${socialProvider}`;
+    }
+
+    return baseType;
+  }, [firstTimeFlowType, isSocialLoginFlow, socialLoginType]);
+  const [isEnrollmentInProgress, setIsEnrollmentInProgress] = useState(false);
+  const [registerStepPhase, setRegisterStepPhase] =
+    useState<PasskeyEnrollmentStepStatus>(
+      DEFAULT_PASSKEY_ENROLLMENT_STEP_PHASE,
+    );
+  const [verifyStepPhase, setVerifyStepPhase] =
+    useState<PasskeyEnrollmentStepStatus>(
+      DEFAULT_PASSKEY_ENROLLMENT_STEP_PHASE,
+    );
+  const [enrollmentError, setEnrollmentError] = useState<string | null>(null);
+  const isMountedRef = useRef(true);
+  const hasAdvancedRef = useRef(false);
+  const hasTrackedView = useRef(false);
+
+  const baseProperties = useMemo(
+    () => ({
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      account_type: accountTypeForMetrics,
+    }),
+    [accountTypeForMetrics],
+  );
+
+  const goToNextStep = useCallback(() => {
+    if (hasAdvancedRef.current) {
+      return;
+    }
+
+    hasAdvancedRef.current = true;
+    onNext();
+  }, [onNext]);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    if (isPasskeyRegistered || hasTrackedView.current) {
+      return;
+    }
+
+    hasTrackedView.current = true;
+    trackEvent({
+      category: MetaMetricsEventCategory.Onboarding,
+      event: MetaMetricsEventName.PasskeyOnboardingSetup,
+      properties: {
+        ...baseProperties,
+        status: 'viewed',
+      },
+    });
+  }, [baseProperties, isPasskeyRegistered, trackEvent]);
+
+  useEffect(() => {
+    if (!isPasskeyRegistered || isEnrollmentInProgress) {
+      return;
+    }
+
+    goToNextStep();
+  }, [goToNextStep, isEnrollmentInProgress, isPasskeyRegistered]);
+
+  const handleMaybeLater = () => {
+    trackEvent({
+      category: MetaMetricsEventCategory.Onboarding,
+      event: MetaMetricsEventName.PasskeyOnboardingSetup,
+      properties: {
+        ...baseProperties,
+        status: 'skipped',
+      },
+    });
+
+    goToNextStep();
+  };
+
+  const handleSetupPasskey = useCallback(async () => {
+    const enrollmentStartedAt = Date.now();
+    let currentStep = 'register';
+
+    setEnrollmentError(null);
+    setRegisterStepPhase('loading');
+    setVerifyStepPhase(DEFAULT_PASSKEY_ENROLLMENT_STEP_PHASE);
+    setIsEnrollmentInProgress(true);
+
+    trackEvent({
+      category: MetaMetricsEventCategory.Onboarding,
+      event: MetaMetricsEventName.PasskeySetup,
+      properties: {
+        ...baseProperties,
+        status: 'started',
+      },
+    });
+
+    try {
+      const registrationOptions = await generatePasskeyRegistrationOptions();
+      const registrationResponse =
+        await startPasskeyRegistration(registrationOptions);
+
+      setRegisterStepPhase('success');
+      setVerifyStepPhase('loading');
+
+      currentStep = 'verify';
+      const postRegAuthOptions =
+        await generatePasskeyPostRegistrationAuthenticationOptions(
+          registrationResponse,
+        );
+      const postRegAuthenticationResponse =
+        await startPasskeyAuthentication(postRegAuthOptions);
+
+      currentStep = 'enroll';
+      await protectVaultKeyWithPasskey(
+        registrationResponse,
+        postRegAuthenticationResponse,
+      );
+
+      const newMetamaskState = await forceUpdateMetamaskState(dispatch);
+      setVerifyStepPhase('success');
+
+      currentStep = 'complete';
+      const derivationMethod = getPasskeyDerivationMethod({
+        metamask: newMetamaskState,
+      });
+
+      trackEvent({
+        category: MetaMetricsEventCategory.Onboarding,
+        event: MetaMetricsEventName.PasskeySetup,
+        properties: {
+          ...baseProperties,
+          status: 'completed',
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          derivation_method: derivationMethod,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          duration_ms: Date.now() - enrollmentStartedAt,
+        },
+      });
+
+      await new Promise((resolve) => {
+        setTimeout(resolve, PASSKEY_ENROLLMENT_SUCCESS_DISPLAY_MS);
+      });
+
+      if (isMountedRef.current) {
+        goToNextStep();
+      }
+    } catch (error) {
+      if (isPasskeyCeremonySilentError(error)) {
+        log.debug(
+          'Passkey enrollment ceremony cancelled or timed out',
+          error,
+        );
+        trackEvent({
+          category: MetaMetricsEventCategory.Onboarding,
+          event: MetaMetricsEventName.PasskeySetup,
+          properties: {
+            ...baseProperties,
+            status: 'cancelled',
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            current_step: currentStep,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            duration_ms: Date.now() - enrollmentStartedAt,
+          },
+        });
+
+        if (isMountedRef.current) {
+          setRegisterStepPhase(DEFAULT_PASSKEY_ENROLLMENT_STEP_PHASE);
+          setVerifyStepPhase(DEFAULT_PASSKEY_ENROLLMENT_STEP_PHASE);
+        }
+
+        return;
+      }
+
+      log.error('Passkey registration failed', error);
+      trackEvent({
+        category: MetaMetricsEventCategory.Onboarding,
+        event: MetaMetricsEventName.PasskeySetup,
+        properties: {
+          ...baseProperties,
+          status: 'failed',
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          error_step: currentStep,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          duration_ms: Date.now() - enrollmentStartedAt,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          reason: getPasskeyErrorCode(error),
+        },
+      });
+
+      if (isMountedRef.current) {
+        setEnrollmentError(
+          translatePasskeyError(error, t, passkeyMethodLabel) ??
+            t('passkeyErrorRegistrationFailed', [passkeyMethodLabel]),
+        );
+      }
+    } finally {
+      if (isMountedRef.current) {
+        setIsEnrollmentInProgress(false);
+        setRegisterStepPhase((prev) => (prev === 'loading' ? 'idle' : prev));
+        setVerifyStepPhase((prev) => (prev === 'loading' ? 'idle' : prev));
+      }
+    }
+  }, [
+    baseProperties,
+    dispatch,
+    goToNextStep,
+    t,
+    passkeyMethodLabel,
+    trackEvent,
+  ]);
+
+  if (isPasskeyRegistered && !isEnrollmentInProgress) {
+    return null;
+  }
+
+  return (
+    <Box flexDirection={BoxFlexDirection.Column} gap={4} className="h-full">
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        justifyContent={BoxJustifyContent.Center}
+        alignItems={BoxAlignItems.Center}
+        className="my-8"
+      >
+        <img
+          src="images/biometric.png"
+          alt="Biometrics"
+          width={200}
+          height={200}
+        />
+      </Box>
+
+      {isEnrollmentInProgress ? (
+        <>
+          <Text
+            variant={TextVariant.HeadingLg}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextDefault}
+          >
+            {t('settingUpPasskey', [passkeyMethodLabel])}
+          </Text>
+
+          <PasskeyEnrollmentSteps
+            registerStatus={registerStepPhase}
+            verifyStatus={verifyStepPhase}
+            registerLabel={t('passkeySetupStepRegister', [
+              passkeyMethodSpecificLabel,
+            ])}
+            verifyLabel={t('passkeySetupStepVerify', [
+              passkeyMethodSpecificLabel,
+            ])}
+            className="w-full"
+          />
+        </>
+      ) : (
+        <>
+          <Text
+            variant={TextVariant.HeadingLg}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextDefault}
+          >
+            {t('unlockWithPasskey', [passkeyMethodLabel])}
+          </Text>
+          <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
+            {t('passkeyDescription', [passkeyMethodSpecificLabel])}
+          </Text>
+
+          {enrollmentError ? (
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.ErrorDefault}
+              textAlign={TextAlign.Center}
+              data-testid="passkey-enrollment-error"
+            >
+              {enrollmentError}
+            </Text>
+          ) : null}
+
+          <Box
+            flexDirection={BoxFlexDirection.Column}
+            gap={4}
+            className="mt-auto w-full"
+          >
+            <Button
+              variant={ButtonVariant.Primary}
+              size={ButtonSize.Lg}
+              className="w-full"
+              data-testid="passkey-set-up-button"
+              aria-label={t('setUpPasskey', [passkeyMethodLabel])}
+              onClick={handleSetupPasskey}
+            >
+              {t('setUpPasskey', [passkeyMethodLabel])}
+            </Button>
+            <TextButton
+              type="button"
+              className="w-full"
+              color={TextColor.PrimaryDefault}
+              data-testid="passkey-maybe-later-button"
+              onClick={handleMaybeLater}
+            >
+              {t('maybeLater')}
+            </TextButton>
+          </Box>
+        </>
+      )}
+    </Box>
+  );
+}

--- a/ui/components/app/setup-passkey-content.tsx
+++ b/ui/components/app/setup-passkey-content.tsx
@@ -65,7 +65,8 @@ const DEFAULT_PASSKEY_ENROLLMENT_STEP_PHASE: PasskeyEnrollmentStepStatus =
   'idle';
 
 export type SetupPasskeyContentProps = {
-  onNext: () => void;
+  readonly onNext: () => void;
+  readonly password?: string;
 };
 
 /**
@@ -73,9 +74,11 @@ export type SetupPasskeyContentProps = {
  *
  * @param options0 - Component props.
  * @param options0.onNext - Called after the passkey step is skipped or completed.
+ * @param options0.password - Wallet password when vault is restored.
  */
 export default function SetupPasskeyContent({
   onNext,
+  password,
 }: SetupPasskeyContentProps) {
   const dispatch = useDispatch();
   const { trackEvent } = useContext(MetaMetricsContext);
@@ -220,6 +223,7 @@ export default function SetupPasskeyContent({
       await protectVaultKeyWithPasskey(
         registrationResponse,
         postRegAuthenticationResponse,
+        password,
       );
 
       const newMetamaskState = await forceUpdateMetamaskState(dispatch);

--- a/ui/components/app/setup-passkey-content.tsx
+++ b/ui/components/app/setup-passkey-content.tsx
@@ -252,10 +252,7 @@ export default function SetupPasskeyContent({
       }
     } catch (error) {
       if (isPasskeyCeremonySilentError(error)) {
-        log.debug(
-          'Passkey enrollment ceremony cancelled or timed out',
-          error,
-        );
+        log.debug('Passkey enrollment ceremony cancelled or timed out', error);
         trackEvent({
           category: MetaMetricsEventCategory.Onboarding,
           event: MetaMetricsEventName.PasskeySetup,

--- a/ui/components/app/setup-passkey-content.tsx
+++ b/ui/components/app/setup-passkey-content.tsx
@@ -314,6 +314,7 @@ export default function SetupPasskeyContent({
     t,
     passkeyMethodLabel,
     trackEvent,
+    password,
   ]);
 
   if (isPasskeyRegistered && !isEnrollmentInProgress) {

--- a/ui/pages/keychains/restore-vault.test.tsx
+++ b/ui/pages/keychains/restore-vault.test.tsx
@@ -255,9 +255,12 @@ describe('Restore vault Component', () => {
       expect(queryByTestId('create-password')).toBeInTheDocument();
     });
 
-    fireEvent.change(queryByTestId('create-password-new-input') as HTMLElement, {
-      target: { value: '12345678' },
-    });
+    fireEvent.change(
+      queryByTestId('create-password-new-input') as HTMLElement,
+      {
+        target: { value: '12345678' },
+      },
+    );
     fireEvent.change(
       queryByTestId('create-password-confirm-input') as HTMLElement,
       {

--- a/ui/pages/keychains/restore-vault.test.tsx
+++ b/ui/pages/keychains/restore-vault.test.tsx
@@ -7,6 +7,10 @@ import { fireEvent, waitFor } from '@testing-library/react';
 import { renderWithProvider } from '../../../test/lib/render-helpers-navigate';
 import * as actions from '../../store/actions';
 import { DEFAULT_ROUTE } from '../../helpers/constants/routes';
+import {
+  getIsPasskeyFeatureAvailable,
+  getIsSocialLoginFlow,
+} from '../../selectors';
 import RestoreVaultPage from './restore-vault';
 
 const mockUseNavigate = jest.fn();
@@ -14,6 +18,12 @@ const mockUseNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockUseNavigate,
+}));
+
+jest.mock('../../selectors', () => ({
+  ...jest.requireActual('../../selectors'),
+  getIsPasskeyFeatureAvailable: jest.fn(),
+  getIsSocialLoginFlow: jest.fn(),
 }));
 
 const TEST_SEED =
@@ -24,6 +34,12 @@ describe('Restore vault Component', () => {
 
   beforeEach(() => {
     mockUseNavigate.mockClear();
+    jest.mocked(getIsPasskeyFeatureAvailable).mockReturnValue(false);
+    jest.mocked(getIsSocialLoginFlow).mockReturnValue(false);
+  });
+
+  afterEach(() => {
+    sinon.restore();
   });
 
   it('renders match snapshot', () => {
@@ -174,13 +190,96 @@ describe('Restore vault Component', () => {
       true,
     );
 
-    // Restore the stubs
-    (actions.unMarkPasswordForgotten as sinon.SinonStub).restore();
-    (actions.createNewVaultAndRestore as sinon.SinonStub).restore();
-    (actions.setFirstTimeFlowType as sinon.SinonStub).restore();
-    (actions.resetWallet as sinon.SinonStub).restore();
-
     // Verify navigation to default route
+    expect(mockUseNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE, {
+      replace: true,
+    });
+  });
+
+  it('renders passkey setup inline after restoring when passkeys are available', async () => {
+    jest.mocked(getIsPasskeyFeatureAvailable).mockReturnValue(true);
+
+    const mockCreateNewVaultAndRestore = sinon.stub().resolves();
+    const mockSetFirstTimeFlowType = sinon.stub().resolves();
+    const mockUnMarkPasswordForgotten = sinon.stub().returns({ type: 'MOCK' });
+    const mockResetWallet = sinon.stub().resolves();
+
+    const testStore = mockStore({
+      metamask: { currentLocale: 'en' },
+      appState: { isLoading: false },
+    });
+
+    sinon
+      .stub(actions, 'unMarkPasswordForgotten')
+      .returns(
+        mockUnMarkPasswordForgotten as ReturnType<
+          typeof actions.unMarkPasswordForgotten
+        >,
+      );
+    sinon.stub(actions, 'createNewVaultAndRestore').callsFake(((
+      pw: string,
+      seed: string,
+    ) => {
+      return () => {
+        mockCreateNewVaultAndRestore(pw, seed);
+        return Promise.resolve();
+      };
+    }) as typeof actions.createNewVaultAndRestore);
+    sinon.stub(actions, 'setFirstTimeFlowType').callsFake(((type) => {
+      return () => {
+        mockSetFirstTimeFlowType(type);
+        return Promise.resolve();
+      };
+    }) as typeof actions.setFirstTimeFlowType);
+    sinon.stub(actions, 'resetWallet').callsFake(((restoreOnly?: boolean) => {
+      return () => {
+        mockResetWallet(restoreOnly);
+        return Promise.resolve();
+      };
+    }) as typeof actions.resetWallet);
+
+    const { queryByTestId } = renderWithProvider(
+      <RestoreVaultPage />,
+      testStore,
+    );
+
+    const srpNote = queryByTestId('srp-input-import__srp-note');
+    expect(srpNote).toBeInTheDocument();
+
+    (srpNote as HTMLElement).focus();
+    await userEvent.paste(TEST_SEED);
+
+    fireEvent.click(queryByTestId('import-srp-confirm') as HTMLElement);
+
+    await waitFor(() => {
+      expect(queryByTestId('create-password')).toBeInTheDocument();
+    });
+
+    fireEvent.change(queryByTestId('create-password-new-input') as HTMLElement, {
+      target: { value: '12345678' },
+    });
+    fireEvent.change(
+      queryByTestId('create-password-confirm-input') as HTMLElement,
+      {
+        target: { value: '12345678' },
+      },
+    );
+
+    fireEvent.click(queryByTestId('create-password-terms') as HTMLElement);
+    fireEvent.submit(queryByTestId('create-password') as HTMLElement);
+
+    await waitFor(() => {
+      expect(mockCreateNewVaultAndRestore.calledOnce).toBe(true);
+    });
+
+    await waitFor(() => {
+      expect(queryByTestId('passkey-set-up-button')).toBeInTheDocument();
+    });
+
+    expect(mockUseNavigate).not.toHaveBeenCalled();
+
+    fireEvent.click(queryByTestId('passkey-maybe-later-button') as HTMLElement);
+
     expect(mockUseNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE, {
       replace: true,
     });

--- a/ui/pages/keychains/restore-vault.tsx
+++ b/ui/pages/keychains/restore-vault.tsx
@@ -87,6 +87,8 @@ function RestoreVaultPage() {
         });
 
         setRestorePassword(password);
+        // clear SRP from state after restoring vault is successful
+        setSecretRecoveryPhrase('');
 
         if (isPasskeyFeatureAvailable) {
           setLoading(false);

--- a/ui/pages/keychains/restore-vault.tsx
+++ b/ui/pages/keychains/restore-vault.tsx
@@ -57,6 +57,7 @@ function RestoreVaultPage() {
   const [toggleSrpDetailsModal, setToggleSrpDetailsModal] = useState(false);
   const [showPasswordInput, setShowPasswordInput] = useState(false);
   const [showPasskeySetup, setShowPasskeySetup] = useState(false);
+  const [restorePassword, setRestorePassword] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState(false);
 
   const handleImport = useCallback(
@@ -84,6 +85,8 @@ function RestoreVaultPage() {
           category: MetaMetricsEventCategory.Retention,
           event: MetaMetricsEventName.WalletRestored,
         });
+
+        setRestorePassword(password);
 
         if (isPasskeyFeatureAvailable) {
           setLoading(false);
@@ -137,7 +140,7 @@ function RestoreVaultPage() {
 
   let content;
   if (showPasskeySetup) {
-    content = <SetupPasskeyContent onNext={handlePasskeySetupComplete} />;
+    content = <SetupPasskeyContent onNext={handlePasskeySetupComplete} password={restorePassword} />;
   } else if (shouldShowPasswordForm) {
     content = (
       <CreatePasswordForm

--- a/ui/pages/keychains/restore-vault.tsx
+++ b/ui/pages/keychains/restore-vault.tsx
@@ -31,8 +31,12 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../shared/constants/metametrics';
-import { getIsSocialLoginFlow } from '../../selectors';
+import {
+  getIsPasskeyFeatureAvailable,
+  getIsSocialLoginFlow,
+} from '../../selectors';
 import { FirstTimeFlowType } from '../../../shared/constants/onboarding';
+import SetupPasskeyContent from '../../components/app/setup-passkey-content';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0021): route-isolation backlog
 import SrpInputForm from '../srp-input-form';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0021): route-isolation backlog
@@ -46,11 +50,13 @@ function RestoreVaultPage() {
   const t = useI18nContext();
   const { trackEvent } = React.useContext(MetaMetricsContext);
   const isSocialLoginFlow = useSelector(getIsSocialLoginFlow);
+  const isPasskeyFeatureAvailable = useSelector(getIsPasskeyFeatureAvailable);
 
   const [srpError, setSrpError] = useState('');
   const [secretRecoveryPhrase, setSecretRecoveryPhrase] = useState('');
   const [toggleSrpDetailsModal, setToggleSrpDetailsModal] = useState(false);
   const [showPasswordInput, setShowPasswordInput] = useState(false);
+  const [showPasskeySetup, setShowPasskeySetup] = useState(false);
   const [loading, setLoading] = useState(false);
 
   const handleImport = useCallback(
@@ -79,6 +85,13 @@ function RestoreVaultPage() {
           event: MetaMetricsEventName.WalletRestored,
         });
 
+        if (isPasskeyFeatureAvailable) {
+          setLoading(false);
+          setShowPasswordInput(false);
+          setShowPasskeySetup(true);
+          return;
+        }
+
         navigate(DEFAULT_ROUTE, { replace: true });
       } catch (error) {
         setLoading(false);
@@ -86,7 +99,14 @@ function RestoreVaultPage() {
         console.error('[RestoreVault] Error during import:', error);
       }
     },
-    [isSocialLoginFlow, secretRecoveryPhrase, dispatch, trackEvent, navigate],
+    [
+      isSocialLoginFlow,
+      isPasskeyFeatureAvailable,
+      secretRecoveryPhrase,
+      dispatch,
+      trackEvent,
+      navigate,
+    ],
   );
 
   const handleContinue = useCallback(() => {
@@ -111,6 +131,80 @@ function RestoreVaultPage() {
 
   const shouldShowPasswordForm = showPasswordInput || loading;
 
+  const handlePasskeySetupComplete = useCallback(() => {
+    navigate(DEFAULT_ROUTE, { replace: true });
+  }, [navigate]);
+
+  let content;
+  if (showPasskeySetup) {
+    content = <SetupPasskeyContent onNext={handlePasskeySetupComplete} />;
+  } else if (shouldShowPasswordForm) {
+    content = (
+      <CreatePasswordForm
+        isSocialLoginFlow={false}
+        onSubmit={handleImport}
+        onBack={handleBack}
+        loading={loading}
+      />
+    );
+  } else {
+    content = (
+      <>
+        <Box>
+          <Box marginBottom={4}>
+            <ButtonIcon
+              iconName={IconName.ArrowLeft}
+              color={IconColor.IconDefault}
+              size={ButtonIconSize.Md}
+              data-testid="import-srp-back-button"
+              onClick={handleBackButtonClick}
+              ariaLabel={t('back')}
+            />
+          </Box>
+          <Box className="text-left" marginBottom={2}>
+            <Text variant={TextVariant.HeadingLg}>{t('importAWallet')}</Text>
+          </Box>
+          <Box marginBottom={4}>
+            <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
+              {t('restoreWalletDescription', [
+                <TextButton
+                  key="secret-recovery-phrase"
+                  onClick={() => setToggleSrpDetailsModal(true)}
+                >
+                  {t('secretRecoveryPhrase')}
+                </TextButton>,
+              ])}
+            </Text>
+          </Box>
+          <SrpInputForm
+            error={srpError}
+            setSecretRecoveryPhrase={setSecretRecoveryPhrase}
+            onClearCallback={() => setSrpError('')}
+            showDescription={false}
+            toggleSrpDetailsModal={toggleSrpDetailsModal}
+            onSrpDetailsModalClose={() => setToggleSrpDetailsModal(false)}
+          />
+        </Box>
+        <Box
+          flexDirection={BoxFlexDirection.Column}
+          justifyContent={BoxJustifyContent.Center}
+          alignItems={BoxAlignItems.Center}
+          className="w-full text-left"
+        >
+          <Button
+            size={ButtonSize.Lg}
+            data-testid="import-srp-confirm"
+            onClick={handleContinue}
+            disabled={!secretRecoveryPhrase.trim() || Boolean(srpError)}
+            className="import-srp__continue-button w-full"
+          >
+            {t('continue')}
+          </Button>
+        </Box>
+      </>
+    );
+  }
+
   return (
     <Box
       flexDirection={BoxFlexDirection.Column}
@@ -121,71 +215,7 @@ function RestoreVaultPage() {
       borderColor={BoxBorderColor.BorderMuted}
       backgroundColor={BoxBackgroundColor.BackgroundDefault}
     >
-      {shouldShowPasswordForm ? (
-        <CreatePasswordForm
-          isSocialLoginFlow={false}
-          onSubmit={handleImport}
-          onBack={handleBack}
-          loading={loading}
-        />
-      ) : (
-        <>
-          <Box>
-            <Box marginBottom={4}>
-              <ButtonIcon
-                iconName={IconName.ArrowLeft}
-                color={IconColor.IconDefault}
-                size={ButtonIconSize.Md}
-                data-testid="import-srp-back-button"
-                onClick={handleBackButtonClick}
-                ariaLabel={t('back')}
-              />
-            </Box>
-            <Box className="text-left" marginBottom={2}>
-              <Text variant={TextVariant.HeadingLg}>{t('importAWallet')}</Text>
-            </Box>
-            <Box marginBottom={4}>
-              <Text
-                variant={TextVariant.BodyMd}
-                color={TextColor.TextAlternative}
-              >
-                {t('restoreWalletDescription', [
-                  <TextButton
-                    key="secret-recovery-phrase"
-                    onClick={() => setToggleSrpDetailsModal(true)}
-                  >
-                    {t('secretRecoveryPhrase')}
-                  </TextButton>,
-                ])}
-              </Text>
-            </Box>
-            <SrpInputForm
-              error={srpError}
-              setSecretRecoveryPhrase={setSecretRecoveryPhrase}
-              onClearCallback={() => setSrpError('')}
-              showDescription={false}
-              toggleSrpDetailsModal={toggleSrpDetailsModal}
-              onSrpDetailsModalClose={() => setToggleSrpDetailsModal(false)}
-            />
-          </Box>
-          <Box
-            flexDirection={BoxFlexDirection.Column}
-            justifyContent={BoxJustifyContent.Center}
-            alignItems={BoxAlignItems.Center}
-            className="w-full text-left"
-          >
-            <Button
-              size={ButtonSize.Lg}
-              data-testid="import-srp-confirm"
-              onClick={handleContinue}
-              disabled={!secretRecoveryPhrase.trim() || Boolean(srpError)}
-              className="import-srp__continue-button w-full"
-            >
-              {t('continue')}
-            </Button>
-          </Box>
-        </>
-      )}
+      {content}
     </Box>
   );
 }

--- a/ui/pages/keychains/restore-vault.tsx
+++ b/ui/pages/keychains/restore-vault.tsx
@@ -165,7 +165,10 @@ function RestoreVaultPage() {
             <Text variant={TextVariant.HeadingLg}>{t('importAWallet')}</Text>
           </Box>
           <Box marginBottom={4}>
-            <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
+            <Text
+              variant={TextVariant.BodyMd}
+              color={TextColor.TextAlternative}
+            >
               {t('restoreWalletDescription', [
                 <TextButton
                   key="secret-recovery-phrase"

--- a/ui/pages/keychains/restore-vault.tsx
+++ b/ui/pages/keychains/restore-vault.tsx
@@ -57,7 +57,9 @@ function RestoreVaultPage() {
   const [toggleSrpDetailsModal, setToggleSrpDetailsModal] = useState(false);
   const [showPasswordInput, setShowPasswordInput] = useState(false);
   const [showPasskeySetup, setShowPasskeySetup] = useState(false);
-  const [restorePassword, setRestorePassword] = useState<string | undefined>(undefined);
+  const [restorePassword, setRestorePassword] = useState<string | undefined>(
+    undefined,
+  );
   const [loading, setLoading] = useState(false);
 
   const handleImport = useCallback(
@@ -142,7 +144,12 @@ function RestoreVaultPage() {
 
   let content;
   if (showPasskeySetup) {
-    content = <SetupPasskeyContent onNext={handlePasskeySetupComplete} password={restorePassword} />;
+    content = (
+      <SetupPasskeyContent
+        onNext={handlePasskeySetupComplete}
+        password={restorePassword}
+      />
+    );
   } else if (shouldShowPasswordForm) {
     content = (
       <CreatePasswordForm

--- a/ui/pages/onboarding-flow/setup-passkey/setup-passkey.test.tsx
+++ b/ui/pages/onboarding-flow/setup-passkey/setup-passkey.test.tsx
@@ -23,6 +23,7 @@ import {
   startPasskeyRegistration,
   startPasskeyAuthentication,
 } from '../../../../shared/lib/passkey';
+import SetupPasskeyContent from '../../../components/app/setup-passkey-content';
 import SetupPasskey from './setup-passkey';
 
 jest.mock('../../../../shared/lib/passkey', () => ({
@@ -156,6 +157,21 @@ describe('SetupPasskey', () => {
 
   function renderSetupPasskey(mockStore: ReturnType<typeof buildMockStore>) {
     return renderWithProvider(<SetupPasskey />, mockStore, '/', render);
+  }
+
+  function renderSetupPasskeyContent(
+    mockStore: ReturnType<typeof buildMockStore>,
+    onNext = jest.fn(),
+  ) {
+    return {
+      onNext,
+      ...renderWithProvider(
+        <SetupPasskeyContent onNext={onNext} />,
+        mockStore,
+        '/',
+        render,
+      ),
+    };
   }
 
   it('renders core passkey setup actions', () => {
@@ -293,6 +309,15 @@ describe('SetupPasskey', () => {
           replace: true,
         },
       );
+    });
+
+    it('calls onNext when maybe later is clicked in the reusable content', () => {
+      const mockStore = buildMockStore(FirstTimeFlowType.restore);
+      const { getByText, onNext } = renderSetupPasskeyContent(mockStore);
+
+      fireEvent.click(getByText(messages.maybeLater.message));
+
+      expect(onNext).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -449,6 +474,29 @@ describe('SetupPasskey', () => {
         );
       });
       expect(mockUseNavigate).not.toHaveBeenCalled();
+    });
+
+    it('calls onNext after successful enrollment in the reusable content', async () => {
+      const mockStore = buildMockStore(FirstTimeFlowType.restore);
+      jest
+        .mocked(forceUpdateMetamaskState)
+        .mockImplementation(async (dispatch) => {
+          dispatch({
+            type: UPDATE_METAMASK_STATE,
+            value: { passkeyRecord: testPasskeyRecord },
+          });
+        });
+
+      const { getByTestId, onNext } = renderSetupPasskeyContent(mockStore);
+
+      fireEvent.click(getByTestId('passkey-set-up-button'));
+
+      await waitFor(
+        () => {
+          expect(onNext).toHaveBeenCalledTimes(1);
+        },
+        { timeout: 4000 },
+      );
     });
   });
 });

--- a/ui/pages/onboarding-flow/setup-passkey/setup-passkey.tsx
+++ b/ui/pages/onboarding-flow/setup-passkey/setup-passkey.tsx
@@ -1,165 +1,36 @@
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
-import log from 'loglevel';
-import {
-  Box,
-  Text,
-  BoxFlexDirection,
-  BoxAlignItems,
-  BoxJustifyContent,
-  ButtonSize,
-  ButtonVariant,
-  Button,
-  TextButton,
-  TextVariant,
-  FontWeight,
-  TextColor,
-  TextAlign,
-} from '@metamask/design-system-react';
+import React, { useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useDispatch, useSelector } from 'react-redux';
+import { useSelector } from 'react-redux';
 import {
   ONBOARDING_COMPLETION_ROUTE,
   ONBOARDING_REVIEW_SRP_ROUTE,
   ONBOARDING_METAMETRICS,
 } from '../../../helpers/constants/routes';
-import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   getFirstTimeFlowType,
   getIsParticipateInMetaMetricsSet,
-  getIsPasskeyRegistered,
-  getIsSocialLoginFlow,
-  getPasskeyDerivationMethod,
-  getSocialLoginType,
 } from '../../../selectors';
+import SetupPasskeyContent from '../../../components/app/setup-passkey-content';
 import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
 import { PLATFORM_FIREFOX } from '../../../../shared/constants/app';
-import {
-  MetaMetricsEventAccountType,
-  MetaMetricsEventCategory,
-  MetaMetricsEventName,
-} from '../../../../shared/constants/metametrics';
 import { getBrowserName } from '../../../../shared/lib/browser-runtime.utils';
-import { getPasskeyErrorCode } from '../../../../shared/lib/passkey/passkey-error';
-import {
-  getPasskeyAuthMethodKey,
-  startPasskeyRegistration,
-  startPasskeyAuthentication,
-  translatePasskeyError,
-  isPasskeyCeremonySilentError,
-} from '../../../../shared/lib/passkey';
-import {
-  protectVaultKeyWithPasskey,
-  generatePasskeyRegistrationOptions,
-  generatePasskeyPostRegistrationAuthenticationOptions,
-  forceUpdateMetamaskState,
-} from '../../../store/actions';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
-import {
-  PasskeyEnrollmentSteps,
-  type PasskeyEnrollmentStepStatus,
-} from '../../../components/app/passkey-enrollment-steps';
-
-/** Pause after enrollment succeeds so step completion is visible before navigation. */
-const PASSKEY_ENROLLMENT_SUCCESS_DISPLAY_MS = 1000;
-
-/** Default row status before enrollment starts or after the user silently dismisses WebAuthn. */
-const DEFAULT_PASSKEY_ENROLLMENT_STEP_PHASE: PasskeyEnrollmentStepStatus =
-  'idle';
 
 /**
- * Passkey enrollment uses the vault encryption key from the background.
- * Runs WebAuthn `create()`, post-registration `get()`, then protects the vault key.
- * If a passkey is already enrolled (`passkeyRecord` present), redirect away — this route is
- * only for users who still need to enroll.
+ * Onboarding wrapper that renders the reusable passkey setup content and
+ * advances to the next onboarding step.
  */
 export default function SetupPasskey() {
   const navigate = useNavigate();
-  const dispatch = useDispatch();
-  const { trackEvent } = useContext(MetaMetricsContext);
-  const t = useI18nContext() as (
-    key: string,
-    substitutions?: string[],
-  ) => string;
-  const passkeyMethodLabel = t(getPasskeyAuthMethodKey());
-  const passkeyMethodSpecificLabel = t(
-    getPasskeyAuthMethodKey({ specific: true }),
-  );
   const firstTimeFlowType = useSelector(getFirstTimeFlowType);
   const isParticipateInMetaMetricsSet = useSelector(
     getIsParticipateInMetaMetricsSet,
   );
-  const isPasskeyRegistered = useSelector(getIsPasskeyRegistered);
-  const isSocialLoginFlow = useSelector(getIsSocialLoginFlow);
-  const socialLoginType = useSelector(getSocialLoginType);
 
-  const accountTypeForMetrics = useMemo(() => {
-    const baseType =
-      firstTimeFlowType === FirstTimeFlowType.import
-        ? MetaMetricsEventAccountType.Imported
-        : MetaMetricsEventAccountType.Default;
-    if (isSocialLoginFlow && socialLoginType) {
-      const socialProvider = String(socialLoginType).toLowerCase();
-      return `${baseType}_${socialProvider}`;
-    }
-    return baseType;
-  }, [firstTimeFlowType, isSocialLoginFlow, socialLoginType]);
-  const [isEnrollmentInProgress, setIsEnrollmentInProgress] = useState(false);
-  const [registerStepPhase, setRegisterStepPhase] =
-    useState<PasskeyEnrollmentStepStatus>(
-      DEFAULT_PASSKEY_ENROLLMENT_STEP_PHASE,
-    );
-  const [verifyStepPhase, setVerifyStepPhase] =
-    useState<PasskeyEnrollmentStepStatus>(
-      DEFAULT_PASSKEY_ENROLLMENT_STEP_PHASE,
-    );
-  const [enrollmentError, setEnrollmentError] = useState<string | null>(null);
-  const isMountedRef = useRef(true);
-  const hasTrackedView = useRef(false);
-
-  const baseProperties = useMemo(
-    () => ({
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      account_type: accountTypeForMetrics,
-    }),
-    [accountTypeForMetrics],
-  );
-
-  useEffect(() => {
-    isMountedRef.current = true;
-    return () => {
-      isMountedRef.current = false;
-    };
-  }, []);
-
-  useEffect(() => {
-    if (isPasskeyRegistered) {
-      return;
-    }
-    if (hasTrackedView.current) {
-      return;
-    }
-    hasTrackedView.current = true;
-    trackEvent({
-      category: MetaMetricsEventCategory.Onboarding,
-      event: MetaMetricsEventName.PasskeyOnboardingSetup,
-      properties: {
-        ...baseProperties,
-        status: 'viewed',
-      },
-    });
-  }, [baseProperties, isPasskeyRegistered, trackEvent]);
-
-  const goToNextStep = useCallback(() => {
+  const handleNext = useCallback(() => {
     const isFirefox = getBrowserName() === PLATFORM_FIREFOX;
 
     let nextRoute: string;
+
     if (firstTimeFlowType === FirstTimeFlowType.create) {
       nextRoute = ONBOARDING_REVIEW_SRP_ROUTE;
     } else if (firstTimeFlowType === FirstTimeFlowType.import) {
@@ -177,253 +48,5 @@ export default function SetupPasskey() {
     navigate(nextRoute, { replace: true });
   }, [firstTimeFlowType, navigate, isParticipateInMetaMetricsSet]);
 
-  useEffect(() => {
-    if (!isPasskeyRegistered) {
-      return;
-    }
-    // During an in-flight enrollment, completion navigates after PASSKEY_ENROLLMENT_SUCCESS_DISPLAY_MS.
-    if (isEnrollmentInProgress) {
-      return;
-    }
-    goToNextStep();
-  }, [goToNextStep, isEnrollmentInProgress, isPasskeyRegistered]);
-
-  const handleMaybeLater = () => {
-    trackEvent({
-      category: MetaMetricsEventCategory.Onboarding,
-      event: MetaMetricsEventName.PasskeyOnboardingSetup,
-      properties: {
-        ...baseProperties,
-        status: 'skipped',
-      },
-    });
-    goToNextStep();
-  };
-
-  const handleSetupPasskey = useCallback(async () => {
-    const enrollmentStartedAt = Date.now();
-    let currentStep = 'register';
-
-    setEnrollmentError(null);
-    setRegisterStepPhase('loading');
-    setVerifyStepPhase(DEFAULT_PASSKEY_ENROLLMENT_STEP_PHASE);
-    setIsEnrollmentInProgress(true);
-
-    trackEvent({
-      category: MetaMetricsEventCategory.Onboarding,
-      event: MetaMetricsEventName.PasskeySetup,
-      properties: {
-        ...baseProperties,
-        status: 'started',
-      },
-    });
-
-    try {
-      // create passkey
-      const registrationOptions = await generatePasskeyRegistrationOptions();
-      const registrationResponse =
-        await startPasskeyRegistration(registrationOptions);
-      setRegisterStepPhase('success');
-      setVerifyStepPhase('loading');
-
-      // verify passkey
-      currentStep = 'verify';
-      const postRegAuthOptions =
-        await generatePasskeyPostRegistrationAuthenticationOptions(
-          registrationResponse,
-        );
-      const postRegAuthenticationResponse =
-        await startPasskeyAuthentication(postRegAuthOptions);
-
-      // enroll passkey
-      currentStep = 'enroll';
-      await protectVaultKeyWithPasskey(
-        registrationResponse,
-        postRegAuthenticationResponse,
-      );
-      const newMetamaskState = await forceUpdateMetamaskState(dispatch);
-      setVerifyStepPhase('success');
-
-      currentStep = 'complete';
-      const derivationMethod = getPasskeyDerivationMethod({
-        metamask: newMetamaskState,
-      });
-      trackEvent({
-        category: MetaMetricsEventCategory.Onboarding,
-        event: MetaMetricsEventName.PasskeySetup,
-        properties: {
-          ...baseProperties,
-          status: 'completed',
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          derivation_method: derivationMethod,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          duration_ms: Date.now() - enrollmentStartedAt,
-        },
-      });
-
-      // wait for success display
-      await new Promise((resolve) => {
-        setTimeout(resolve, PASSKEY_ENROLLMENT_SUCCESS_DISPLAY_MS);
-      });
-      if (isMountedRef.current) {
-        goToNextStep();
-      }
-    } catch (error) {
-      // handle error
-      if (isPasskeyCeremonySilentError(error)) {
-        log.debug(
-          'Onboarding passkey enrollment ceremony cancelled or timed out',
-          error,
-        );
-        trackEvent({
-          category: MetaMetricsEventCategory.Onboarding,
-          event: MetaMetricsEventName.PasskeySetup,
-          properties: {
-            ...baseProperties,
-            status: 'cancelled',
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            current_step: currentStep,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            duration_ms: Date.now() - enrollmentStartedAt,
-          },
-        });
-        if (isMountedRef.current) {
-          setRegisterStepPhase(DEFAULT_PASSKEY_ENROLLMENT_STEP_PHASE);
-          setVerifyStepPhase(DEFAULT_PASSKEY_ENROLLMENT_STEP_PHASE);
-        }
-        return;
-      }
-
-      log.error('Onboarding passkey registration failed', error);
-      trackEvent({
-        category: MetaMetricsEventCategory.Onboarding,
-        event: MetaMetricsEventName.PasskeySetup,
-        properties: {
-          ...baseProperties,
-          status: 'failed',
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          error_step: currentStep,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          duration_ms: Date.now() - enrollmentStartedAt,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          reason: getPasskeyErrorCode(error),
-        },
-      });
-      if (isMountedRef.current) {
-        setEnrollmentError(
-          translatePasskeyError(error, t, passkeyMethodLabel) ??
-            t('passkeyErrorRegistrationFailed', [passkeyMethodLabel]),
-        );
-      }
-    } finally {
-      if (isMountedRef.current) {
-        setIsEnrollmentInProgress(false);
-        setRegisterStepPhase((prev) => (prev === 'loading' ? 'idle' : prev));
-        setVerifyStepPhase((prev) => (prev === 'loading' ? 'idle' : prev));
-      }
-    }
-  }, [
-    baseProperties,
-    dispatch,
-    goToNextStep,
-    t,
-    passkeyMethodLabel,
-    trackEvent,
-  ]);
-
-  if (isPasskeyRegistered && !isEnrollmentInProgress) {
-    return null;
-  }
-
-  return (
-    <Box flexDirection={BoxFlexDirection.Column} gap={4} className="h-full">
-      <Box
-        flexDirection={BoxFlexDirection.Row}
-        justifyContent={BoxJustifyContent.Center}
-        alignItems={BoxAlignItems.Center}
-        className="my-8"
-      >
-        <img
-          src="images/biometric.png"
-          alt="Biometrics"
-          width={200}
-          height={200}
-        />
-      </Box>
-
-      {isEnrollmentInProgress ? (
-        <>
-          <Text
-            variant={TextVariant.HeadingLg}
-            fontWeight={FontWeight.Medium}
-            color={TextColor.TextDefault}
-          >
-            {t('settingUpPasskey', [passkeyMethodLabel])}
-          </Text>
-
-          <PasskeyEnrollmentSteps
-            registerStatus={registerStepPhase}
-            verifyStatus={verifyStepPhase}
-            registerLabel={t('passkeySetupStepRegister', [
-              passkeyMethodSpecificLabel,
-            ])}
-            verifyLabel={t('passkeySetupStepVerify', [
-              passkeyMethodSpecificLabel,
-            ])}
-            className="w-full"
-          />
-        </>
-      ) : (
-        <>
-          <Text
-            variant={TextVariant.HeadingLg}
-            fontWeight={FontWeight.Medium}
-            color={TextColor.TextDefault}
-          >
-            {t('unlockWithPasskey', [passkeyMethodLabel])}
-          </Text>
-          <Text variant={TextVariant.BodyMd} color={TextColor.TextAlternative}>
-            {t('passkeyDescription', [passkeyMethodSpecificLabel])}
-          </Text>
-
-          {enrollmentError ? (
-            <Text
-              variant={TextVariant.BodySm}
-              color={TextColor.ErrorDefault}
-              textAlign={TextAlign.Center}
-              data-testid="passkey-enrollment-error"
-            >
-              {enrollmentError}
-            </Text>
-          ) : null}
-
-          <Box
-            flexDirection={BoxFlexDirection.Column}
-            gap={4}
-            className="mt-auto w-full"
-          >
-            <Button
-              variant={ButtonVariant.Primary}
-              size={ButtonSize.Lg}
-              className="w-full"
-              data-testid="passkey-set-up-button"
-              aria-label={t('setUpPasskey', [passkeyMethodLabel])}
-              onClick={handleSetupPasskey}
-            >
-              {t('setUpPasskey', [passkeyMethodLabel])}
-            </Button>
-            <TextButton
-              type="button"
-              className="w-full"
-              color={TextColor.PrimaryDefault}
-              data-testid="passkey-maybe-later-button"
-              onClick={handleMaybeLater}
-            >
-              {t('maybeLater')}
-            </TextButton>
-          </Box>
-        </>
-      )}
-    </Box>
-  );
+  return <SetupPasskeyContent onNext={handleNext} />;
 }


### PR DESCRIPTION
## **Description**

This PR updates the forgot-password wallet restore flow to show the biometrics/passkey setup step after a wallet is successfully restored and before the user lands on the home page.

To support that cleanly, it extracts the shared passkey setup UI and logic into a reusable component, keeps the onboarding `setup-passkey` route as a thin wrapper, and renders the passkey step inline in `restore-vault` instead of routing through a standalone page. It also adds focused unit coverage for both the onboarding and restore-vault passkey flows.

## **Changelog**

CHANGELOG entry: Added a biometrics setup step after restoring a wallet (in forgot password flow) so users can enable passkey unlock before returning home.

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Open the forgot-password / restore wallet flow.
2. Enter a valid Secret Recovery Phrase and continue to the password step.
3. Submit a valid password and verify that, when passkeys are available, the biometrics setup step is shown inline instead of navigating directly to the home page.
4. Click `Maybe later` and verify the wallet lands on the home page.
5. Repeat the flow and complete passkey enrollment, then verify the wallet lands on the home page after successful setup.
6. Sanity check the onboarding create/import flows and verify the existing passkey setup route still advances to the correct onboarding next step.

## **Screenshots/Recordings**

### **Before**

<!-- TODO: Add recording/screenshot showing restore vault navigating directly to the home page after password submission. -->

### **After**

<!-- TODO: Add recording/screenshot showing restore vault rendering the inline biometrics step before navigating to the home page. -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the post-restore navigation flow to optionally insert an inline passkey enrollment step, and refactors passkey enrollment logic into a shared component; mistakes could block users from reaching the wallet after restore or alter enrollment/metrics behavior.
> 
> **Overview**
> Adds an *inline passkey/biometrics setup step* immediately after successful SRP restore (forgot-password flow) when passkeys are available, delaying navigation to `DEFAULT_ROUTE` until the user completes or skips setup.
> 
> Extracts the onboarding passkey setup UI/logic into a reusable `SetupPasskeyContent` component (including metrics and error handling), and turns the onboarding `setup-passkey` page into a thin wrapper that only decides the next onboarding route.
> 
> Updates unit and e2e coverage to expect the new passkey step after password reset (skipped on Firefox), including a new `restore-vault` test that asserts inline rendering and navigation after "Maybe later".
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fa4f3232c26bd6dd2bb853dec81880ab00c8654. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->