### PR TITLE
refactor: extract item visibility hook

### DIFF
--- a/ui/components/multichain/activity-v2/activity-list.tsx
+++ b/ui/components/multichain/activity-v2/activity-list.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useMemo,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useMemo, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { Box, Text } from '@metamask/design-system-react';
@@ -12,7 +6,7 @@ import type { Transaction } from '@metamask/keyring-api';
 import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useScrollContainer } from '../../../contexts/scroll-container';
-import { useIntersectionObserver } from '../../../hooks/useIntersectionObserver';
+import { useItemInView } from '../../../hooks/useItemInView';
 import { TransactionActivityEmptyState } from '../../app/transaction-activity-empty-state';
 import { TabEmptyState } from '../../ui/tab-empty-state';
 import { PENDING_STATUS_HASH } from '../../../helpers/constants/transactions';
@@ -47,7 +41,6 @@ import { useTransactionsQuery } from './useTransactionsQuery';
 
 const ITEM_HEIGHT = 70;
 const HEADER_HEIGHT = 36;
-const EVM_PAGINATION_ROOT_MARGIN = '300px 0px';
 
 type Props = {
   filter?: ActivityListFilter;
@@ -189,33 +182,16 @@ export const ActivityList = ({ filter }: Props) => {
     }
   }, [scrollContainerRef, virtualizer]);
 
-  // Fetch more items when the last completed EVM transaction comes into view
-  const { ref: lastCompletedEvmItemRef } = useIntersectionObserver({
+  // Fetch more items when the last completed EVM transaction enters view
+  const observeLastCompletedEvmItem = useItemInView({
+    targetIndex: lastCompletedEvmItemIndex,
     root: scrollContainerRef?.current ?? null,
-    rootMargin: EVM_PAGINATION_ROOT_MARGIN,
-    onChange: (isIntersecting) => {
-      if (isIntersecting && hasNextPage && !isFetchingNextPage) {
+    onVisible: () => {
+      if (hasNextPage && !isFetchingNextPage) {
         fetchNextPage();
       }
     },
   });
-
-  const lastObservedCompletedEvmItemRef = useRef<HTMLDivElement | null>(null);
-
-  const observeLastCompletedEvmItem = useCallback(
-    (node: HTMLDivElement | null, isLastCompletedEvmItem: boolean) => {
-      virtualizer.measureElement(node);
-
-      if (isLastCompletedEvmItem) {
-        lastObservedCompletedEvmItemRef.current = node;
-        lastCompletedEvmItemRef(node);
-      } else if (node && lastObservedCompletedEvmItemRef.current === node) {
-        lastObservedCompletedEvmItemRef.current = null;
-        lastCompletedEvmItemRef(null);
-      }
-    },
-    [lastCompletedEvmItemRef, virtualizer],
-  );
 
   const earliestNonceByChain = useEarliestNonceByChain(localTransactions);
 
@@ -290,17 +266,18 @@ export const ActivityList = ({ filter }: Props) => {
               const item = flattenedItems[virtualItem.index];
               const translateY =
                 virtualItem.start - virtualizer.options.scrollMargin;
-              const isLastCompletedEvmItem =
-                virtualItem.index === lastCompletedEvmItemIndex;
 
               return (
                 <div
                   key={String(virtualItem.key)}
                   className="absolute top-0 left-0 w-full"
                   data-index={virtualItem.index}
-                  ref={(node) =>
-                    observeLastCompletedEvmItem(node, isLastCompletedEvmItem)
-                  }
+                  ref={(node) => {
+                    virtualizer.measureElement(node);
+                    observeLastCompletedEvmItem(node, {
+                      index: virtualItem.index,
+                    });
+                  }}
                   style={{
                     transform: `translateY(${translateY}px)`,
                   }}

--- a/ui/hooks/useItemInView.ts
+++ b/ui/hooks/useItemInView.ts
@@ -1,0 +1,51 @@
+import { useCallback, useRef } from 'react';
+import { useIntersectionObserver } from './useIntersectionObserver';
+
+const defaultRootMargin = '300px 0px';
+
+/**
+ * Returns an `itemRef` callback for a virtualized list that invokes
+ * `onVisible` when the item at `targetIndex` scrolls into view.
+ *
+ * @param options
+ * @param options.targetIndex - Index of the item to observe.
+ * @param options.onVisible - Called when the target item enters view.
+ * @param options.root - Scroll container to observe within. Defaults to the viewport.
+ * @param options.rootMargin - Margin around `root` used to expand the intersection area.
+ */
+export function useItemInView({
+  targetIndex,
+  onVisible,
+  root = null,
+  rootMargin = defaultRootMargin,
+}: {
+  targetIndex: number;
+  onVisible: () => void;
+  root?: Element | null;
+  rootMargin?: string;
+}) {
+  const { ref: targetRef } = useIntersectionObserver({
+    root,
+    rootMargin,
+    onChange: (isIntersecting) => {
+      if (isIntersecting) {
+        onVisible();
+      }
+    },
+  });
+
+  const observedNodeRef = useRef<HTMLDivElement | null>(null);
+
+  return useCallback(
+    (node: HTMLDivElement | null, { index }: { index: number }) => {
+      if (index === targetIndex) {
+        observedNodeRef.current = node;
+        targetRef(node);
+      } else if (node && observedNodeRef.current === node) {
+        observedNodeRef.current = null;
+        targetRef(null);
+      }
+    },
+    [targetIndex, targetRef],
+  );
+}


### PR DESCRIPTION
## **Description**

Extracts virtualized item visibility observation into `useItemInView` and uses it for activity-v2 pagination.

Re-usable for the activity v3 work.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

Not manually tested (refactor only).

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I have followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I have completed the PR template to the best of my ability
- [ ] I have included tests if applicable
- [ ] I have documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I have applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I have manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors the activity list’s infinite-scroll trigger into a new hook; behavior should be equivalent but small changes in intersection/target management could impact pagination fetching in production.
> 
> **Overview**
> **Refactors activity-v2 pagination visibility logic.** The list no longer manages its own `IntersectionObserver` wiring/ref bookkeeping for the “last completed EVM item”; instead it uses a new `useItemInView` hook to trigger `fetchNextPage()` when the target index becomes visible.
> 
> Adds `ui/hooks/useItemInView.ts`, a small wrapper around `useIntersectionObserver` that tracks the currently-observed DOM node for a given virtualized `targetIndex` and detaches when that node is no longer the target.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 124478676397406ea32019bfacf0b96e7c571237. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->