### PR TITLE
docs: tell agents when to use oxfmt, and when to use Prettier

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,15 +21,16 @@ Instructions for AI coding agents working on MetaMask Browser Extension.
 3. **ALWAYS update LavaMoat policies** after dependency changes: `yarn lavamoat:auto`
 4. **ALWAYS colocate tests** with source files (`.test.ts`/`.test.tsx`)
 5. **ALWAYS use yarn.cmd** if you're running in PowerShell
-6. **NEVER use class components** (use functional components with hooks)
-7. **NEVER modify git config** or run destructive git operations
-8. **NEVER commit** unless explicitly requested by user
-9. **NEVER stage changes** unless explicitly requested by user
-10. **WHEN asked to commit, use Conventional Commits** format for commit messages
-11. **WHEN asked to open a PR, use a Conventional Commits title** unless user specifies otherwise
-12. **WHEN asked to open a PR, open it as DRAFT** unless user specifies otherwise
-13. **WHEN using `.github/pull-request-template.md`, comment out non-applicable sections including the section title**
-14. **BEFORE modifying any `.github/workflows/` file**, read `.github/AGENTS.md` for CI-specific rules (consolidation patterns, required job wiring, merge queue considerations)
+6. **ALWAYS use `oxfmt` for code formatting**; Prettier is only for JSON formatting and changelog validation
+7. **NEVER use class components** (use functional components with hooks)
+8. **NEVER modify git config** or run destructive git operations
+9. **NEVER commit** unless explicitly requested by user
+10. **NEVER stage changes** unless explicitly requested by user
+11. **WHEN asked to commit, use Conventional Commits** format for commit messages
+12. **WHEN asked to open a PR, use a Conventional Commits title** unless user specifies otherwise
+13. **WHEN asked to open a PR, open it as DRAFT** unless user specifies otherwise
+14. **WHEN using `.github/pull-request-template.md`, comment out non-applicable sections including the section title**
+15. **BEFORE modifying any `.github/workflows/` file**, read `.github/AGENTS.md` for CI-specific rules (consolidation patterns, required job wiring, merge queue considerations)
 
 ### Comprehensive Guidelines Location
 
@@ -176,23 +177,32 @@ yarn test:e2e:benchmark    # Performance benchmarks
 
 ```bash
 # Run all linters
-yarn lint                  # Prettier + ESLint + TypeScript + Styles + Images
+yarn lint                  # JSON formatting + oxfmt + ESLint + TypeScript + Styles + Images
 
 # Individual linters
+yarn lint:json             # Prettier JSON formatting check
+yarn lint:format           # oxfmt code formatting check
 yarn lint:eslint           # ESLint only
 yarn lint:tsc              # TypeScript type checking
-yarn lint:prettier         # Prettier formatting check
 yarn lint:styles           # Stylelint for SCSS
 
 # Auto-fix
 yarn lint:fix              # Fix all auto-fixable issues
+yarn lint:json:fix         # Fix JSON formatting with Prettier
+yarn lint:format:fix       # Fix code formatting with oxfmt
 yarn lint:eslint:fix       # Fix ESLint issues
-yarn lint:prettier:fix     # Fix formatting
 
 # Lint only changed files (faster)
 yarn lint:changed
 yarn lint:changed:fix
 ```
+
+**Formatter Notes:**
+
+- Use `yarn lint:changed:fix` for normal agent work; it applies the repo's formatter choices to changed files.
+- Use `yarn lint:format:fix` or `oxfmt -c oxfmt.config.mts` for JavaScript, TypeScript, JSX, TSX, and other code formatting.
+- Use `yarn lint:json:fix` for JSON files such as `package.json`; this is the main remaining Prettier formatting path.
+- Do not run Prettier directly on code files.
 
 ### Development Tools
 


### PR DESCRIPTION
## **Description**

My agent said "Prettier has opinions about the edited files, unsurprisingly" more than once, and I questioned it.

> You’re right. I was using “Prettier” as shorthand, but that was sloppy.
> 
> Current repo split is:
> - `lint:format`: `oxfmt -c oxfmt.config.mts --check`
> - `lint:format:fix`: `oxfmt -c oxfmt.config.mts`
> - `lint:json`: `prettier --check --cache -- '**/*.json'`
> - `lint:json:fix`: `prettier --write --cache -- '**/*.json'`
> 
> So for the TypeScript files I should have said “the formatter” or specifically `oxfmt`. `package.json` is the main case where Prettier still applies because `oxfmt.config.mts` ignores `**/*.json`.
> 
> I also checked the changed TS files with `yarn.cmd oxfmt -c oxfmt.config.mts --check ...`, and they pass.

So now I'm updating the AGENTS.md file so future agents get less confused.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Sister PR: MetaMask/skills#10

<!--## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only update clarifying formatting responsibilities; no runtime or build logic is changed.
> 
> **Overview**
> Updates `AGENTS.md` to explicitly direct agents to use `oxfmt` for code formatting while reserving Prettier for JSON (and changelog validation).
> 
> Refreshes the linting section to reflect the `lint:json`/`lint:format` split, adds the corresponding `:fix` commands, and documents when to use each formatter (including avoiding running Prettier on code files).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a2a487ce5973c6d7980bbee79426b2dfba1b23e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->