### PR TITLE
fix: prevent Firefox password suggestion overlay anchoring to bottom of input

### DIFF
--- a/ui/components/component-library/text-field/text-field.scss
+++ b/ui/components/component-library/text-field/text-field.scss
@@ -39,6 +39,7 @@
 
   &__input {
     width: 100%;
+    height: 100%;
     flex-grow: 1;
   }
 }


### PR DESCRIPTION
## **Description**

Firefox's native password manager overlay (the "Manage Passwords" suggestion dropdown) was anchoring to the bottom of the `TextField` input instead of appearing adjacent to the input field.

The root cause is that `.mm-text-field__input` is a flex child with `flex-grow: 1` but no explicit `height`. Firefox uses the input element's computed height to determine where to position its native password overlay. Without `height: 100%`, Firefox sees a near-zero intrinsic height on the flex child and anchors the overlay to the bottom of the containing flex box rather than the input itself.

Adding `height: 100%` ensures the input element fills its flex container, giving Firefox the correct anchor point for the password suggestion overlay.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open the extension in Firefox
2. Navigate to a page with a password input (e.g. unlock page or create password flow)
3. Focus the password input — the "Manage Passwords" overlay should appear at/near the input, not anchored to the bottom

## **Screenshots/Recordings**

### **Before**

`<input>` didn't stretch the full height of the `TextField`

<img width="917" height="740" alt="Screenshot 2026-05-21 at 2 17 32 PM" src="https://github.com/user-attachments/assets/0e2a1cf6-3306-4143-ba86-5d16caf9d7c8" />

### **After**

`<input>` takes up 100% height of TextField

<img width="889" height="704" alt="Screenshot 2026-05-21 at 2 18 04 PM" src="https://github.com/user-attachments/assets/a6e55340-579f-43a8-b087-33be124ea60f" />

Chrome

https://github.com/user-attachments/assets/e3c52a42-7f19-4b6d-a624-dbd1782f382f

Firefox

https://github.com/user-attachments/assets/76af1ad4-add9-4d15-b487-cfa1f3f50c62

Storybook all stories smoke test no visual or behavioural regressions


https://github.com/user-attachments/assets/adb20fc5-5172-455f-b96b-1bbf8bb353d8

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only change that makes the `TextField` input fill its container; potential impact is limited to layout/visuals for this component across browsers.
> 
> **Overview**
> Fixes Firefox-native password manager dropdown positioning by setting `.mm-text-field__input` to `height: 100%`, ensuring the input fills the `TextField`’s fixed-height flex container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 915b98ca57a95bb2597236110b0abc51eedc8da3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->