### PR TITLE
feat(perps): show hovered volume bar value on chart y-axis

### DIFF
--- a/ui/components/app/perps/perps-candlestick-chart/perps-candlestick-chart.test.tsx
+++ b/ui/components/app/perps/perps-candlestick-chart/perps-candlestick-chart.test.tsx
@@ -1,0 +1,267 @@
+import React from 'react';
+import { screen } from '@testing-library/react';
+import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
+import configureStore from '../../../../store/store';
+import mockState from '../../../../../test/data/mock-state.json';
+import PerpsCandlestickChart from './perps-candlestick-chart';
+
+const mockUseTheme = jest.fn();
+jest.mock('../../../../hooks/useTheme', () => ({
+  useTheme: () => mockUseTheme(),
+}));
+
+type CrosshairParam = {
+  paneIndex?: number;
+  point?: { x: number; y: number };
+  time?: number;
+  seriesData: Map<unknown, unknown>;
+};
+
+let mockCrosshairCallback: ((param: CrosshairParam) => void) | undefined;
+let mockCreatedSeries: { ref: object }[] = [];
+
+jest.mock('lightweight-charts', () => ({
+  createChart: () => {
+    mockCreatedSeries = [];
+    return {
+      addSeries: () => {
+        const series = {
+          ref: {},
+          setData: jest.fn(),
+          update: jest.fn(),
+          createPriceLine: jest.fn().mockReturnValue({ options: jest.fn() }),
+          removePriceLine: jest.fn(),
+          priceScale: jest.fn().mockReturnValue({ applyOptions: jest.fn() }),
+          applyOptions: jest.fn(),
+        };
+        mockCreatedSeries.push(series);
+        return series;
+      },
+      applyOptions: jest.fn(),
+      timeScale: jest.fn().mockReturnValue({
+        fitContent: jest.fn(),
+        scrollToPosition: jest.fn(),
+        scrollToRealTime: jest.fn(),
+        getVisibleLogicalRange: jest.fn(),
+        setVisibleLogicalRange: jest.fn(),
+        subscribeVisibleLogicalRangeChange: jest.fn(),
+        unsubscribeVisibleLogicalRangeChange: jest.fn(),
+        applyOptions: jest.fn(),
+      }),
+      panes: jest.fn().mockReturnValue([
+        { getHeight: () => 200 },
+        { getHeight: () => 60 },
+      ]),
+      priceScale: jest.fn().mockReturnValue({ applyOptions: jest.fn() }),
+      resize: jest.fn(),
+      remove: jest.fn(),
+      subscribeCrosshairMove: jest.fn((cb) => {
+        mockCrosshairCallback = cb;
+      }),
+      unsubscribeCrosshairMove: jest.fn(),
+    };
+  },
+  CandlestickSeries: 'CandlestickSeries',
+  HistogramSeries: 'HistogramSeries',
+  ColorType: { Solid: 'Solid' },
+  CrosshairMode: { Normal: 0 },
+  LineStyle: { Dashed: 2, Solid: 0 },
+  PriceScaleMode: { Normal: 0 },
+}));
+
+const mockStore = configureStore({
+  metamask: { ...mockState.metamask },
+});
+
+// The component creates the candlestick series first, then the volume series.
+const getCandlestickSeries = () => mockCreatedSeries[0];
+const getVolumeSeries = () => mockCreatedSeries[1];
+
+const buildSeriesDataMap = (volumeValue?: number, candle?: object) => {
+  const map = new Map<unknown, unknown>();
+  if (volumeValue !== undefined) {
+    map.set(getVolumeSeries(), { value: volumeValue });
+  }
+  if (candle) {
+    map.set(getCandlestickSeries(), candle);
+  }
+  return map;
+};
+
+describe('PerpsCandlestickChart — volume axis label on hover (TAT-2970)', () => {
+  beforeEach(() => {
+    mockCrosshairCallback = undefined;
+    mockCreatedSeries = [];
+    mockUseTheme.mockReturnValue('light');
+  });
+
+  it('renders the volume axis label overlay element with the expected testId', () => {
+    renderWithProvider(<PerpsCandlestickChart />, mockStore);
+    const label = screen.getByTestId('perps-volume-axis-label');
+    expect(label).toBeInTheDocument();
+  });
+
+  it('starts with the volume label hidden', () => {
+    renderWithProvider(<PerpsCandlestickChart />, mockStore);
+    const label = screen.getByTestId('perps-volume-axis-label');
+    expect(label.style.display).toBe('none');
+  });
+
+  it('shows the formatted volume when the cursor hovers the volume pane on a bar with positive volume', () => {
+    renderWithProvider(<PerpsCandlestickChart />, mockStore);
+    expect(mockCrosshairCallback).toBeDefined();
+
+    mockCrosshairCallback?.({
+      paneIndex: 1,
+      point: { x: 100, y: 40 },
+      time: 1_700_000_000,
+      seriesData: buildSeriesDataMap(14_900_000),
+    });
+
+    const label = screen.getByTestId('perps-volume-axis-label');
+    expect(label.style.display).toBe('block');
+    // formatVolume(14_900_000, 1) → "$14.9M"
+    expect(label.textContent).toBe('$14.9M');
+  });
+
+  it('positions the label using cumulative pane heights + the in-pane y offset', () => {
+    renderWithProvider(<PerpsCandlestickChart />, mockStore);
+    expect(mockCrosshairCallback).toBeDefined();
+
+    mockCrosshairCallback?.({
+      paneIndex: 1,
+      point: { x: 100, y: 40 },
+      time: 1_700_000_000,
+      seriesData: buildSeriesDataMap(2_600_000),
+    });
+
+    const label = screen.getByTestId('perps-volume-axis-label');
+    // pane 0 height (200) + 1px separator + in-pane y (40) = 241
+    expect(label.style.top).toBe('241px');
+  });
+
+  it('hides the label when the cursor is in the candle pane (paneIndex 0)', () => {
+    renderWithProvider(<PerpsCandlestickChart />, mockStore);
+    expect(mockCrosshairCallback).toBeDefined();
+
+    // First show the label
+    mockCrosshairCallback?.({
+      paneIndex: 1,
+      point: { x: 100, y: 40 },
+      time: 1_700_000_000,
+      seriesData: buildSeriesDataMap(2_600_000),
+    });
+    expect(screen.getByTestId('perps-volume-axis-label').style.display).toBe(
+      'block',
+    );
+
+    // Then move to the candle pane
+    mockCrosshairCallback?.({
+      paneIndex: 0,
+      point: { x: 100, y: 40 },
+      time: 1_700_000_000,
+      seriesData: buildSeriesDataMap(2_600_000, {
+        open: 100,
+        high: 110,
+        low: 90,
+        close: 105,
+      }),
+    });
+    expect(screen.getByTestId('perps-volume-axis-label').style.display).toBe(
+      'none',
+    );
+  });
+
+  it('hides the label when the hovered volume bar has zero volume', () => {
+    renderWithProvider(<PerpsCandlestickChart />, mockStore);
+    expect(mockCrosshairCallback).toBeDefined();
+
+    mockCrosshairCallback?.({
+      paneIndex: 1,
+      point: { x: 100, y: 40 },
+      time: 1_700_000_000,
+      seriesData: buildSeriesDataMap(0),
+    });
+
+    expect(screen.getByTestId('perps-volume-axis-label').style.display).toBe(
+      'none',
+    );
+  });
+
+  it('hides the label when the cursor leaves the chart (no point)', () => {
+    renderWithProvider(<PerpsCandlestickChart />, mockStore);
+    expect(mockCrosshairCallback).toBeDefined();
+
+    // Show it first
+    mockCrosshairCallback?.({
+      paneIndex: 1,
+      point: { x: 100, y: 40 },
+      time: 1_700_000_000,
+      seriesData: buildSeriesDataMap(2_600_000),
+    });
+    expect(screen.getByTestId('perps-volume-axis-label').style.display).toBe(
+      'block',
+    );
+
+    // Crosshair leaves the chart area: no `point`, empty seriesData
+    mockCrosshairCallback?.({
+      paneIndex: undefined,
+      point: undefined,
+      time: undefined,
+      seriesData: new Map(),
+    });
+    expect(screen.getByTestId('perps-volume-axis-label').style.display).toBe(
+      'none',
+    );
+  });
+
+  it('forwards the hovered candle (including volume) to onCrosshairMove when provided', () => {
+    const onCrosshairMove = jest.fn();
+    renderWithProvider(
+      <PerpsCandlestickChart onCrosshairMove={onCrosshairMove} />,
+      mockStore,
+    );
+    expect(mockCrosshairCallback).toBeDefined();
+
+    mockCrosshairCallback?.({
+      paneIndex: 0,
+      point: { x: 100, y: 40 },
+      time: 1_700_000_000,
+      seriesData: buildSeriesDataMap(2_600_000, {
+        open: 100,
+        high: 110,
+        low: 90,
+        close: 105,
+      }),
+    });
+
+    expect(onCrosshairMove).toHaveBeenCalledWith(
+      expect.objectContaining({
+        time: 1_700_000_000_000,
+        open: '100',
+        high: '110',
+        low: '90',
+        close: '105',
+        volume: '2600000',
+      }),
+    );
+  });
+
+  it('reports null to onCrosshairMove when the crosshair leaves the chart', () => {
+    const onCrosshairMove = jest.fn();
+    renderWithProvider(
+      <PerpsCandlestickChart onCrosshairMove={onCrosshairMove} />,
+      mockStore,
+    );
+    expect(mockCrosshairCallback).toBeDefined();
+
+    mockCrosshairCallback?.({
+      paneIndex: undefined,
+      point: undefined,
+      time: undefined,
+      seriesData: new Map(),
+    });
+
+    expect(onCrosshairMove).toHaveBeenCalledWith(null);
+  });
+});

--- a/ui/components/app/perps/perps-candlestick-chart/perps-candlestick-chart.test.tsx
+++ b/ui/components/app/perps/perps-candlestick-chart/perps-candlestick-chart.test.tsx
@@ -48,10 +48,9 @@ jest.mock('lightweight-charts', () => ({
         unsubscribeVisibleLogicalRangeChange: jest.fn(),
         applyOptions: jest.fn(),
       }),
-      panes: jest.fn().mockReturnValue([
-        { getHeight: () => 200 },
-        { getHeight: () => 60 },
-      ]),
+      panes: jest
+        .fn()
+        .mockReturnValue([{ getHeight: () => 200 }, { getHeight: () => 60 }]),
       priceScale: jest.fn().mockReturnValue({ applyOptions: jest.fn() }),
       resize: jest.fn(),
       remove: jest.fn(),

--- a/ui/components/app/perps/perps-candlestick-chart/perps-candlestick-chart.tsx
+++ b/ui/components/app/perps/perps-candlestick-chart/perps-candlestick-chart.tsx
@@ -17,7 +17,10 @@ import { useSelector } from 'react-redux';
 import { brandColor } from '@metamask/design-tokens';
 import { Box } from '@metamask/design-system-react';
 import type { CandleData, CandleStick } from '@metamask/perps-controller';
-import { PRICE_THRESHOLD } from '../../../../../shared/lib/perps-formatters';
+import {
+  formatVolume,
+  PRICE_THRESHOLD,
+} from '../../../../../shared/lib/perps-formatters';
 import { CandlePeriod, ZOOM_CONFIG } from '../constants/chartConfig';
 import { useTheme } from '../../../../hooks/useTheme';
 import { getIntlLocale } from '../../../../ducks/locale/locale';
@@ -179,6 +182,7 @@ const PerpsCandlestickChart = forwardRef<
       : 'rgba(0, 0, 0, 0.4)';
 
     const containerRef = useRef<HTMLDivElement>(null);
+    const volumeLabelRef = useRef<HTMLDivElement>(null);
     const chartRef = useRef<IChartApi | null>(null);
     const seriesRef = useRef<ISeriesApi<'Candlestick'> | null>(null);
     const volumeSeriesRef = useRef<ISeriesApi<'Histogram'> | null>(null);
@@ -401,10 +405,45 @@ const PerpsCandlestickChart = forwardRef<
         }
       });
 
-      // Crosshair move: report hovered candle for OHLCV bar
+      // Crosshair move:
+      // 1. report hovered candle to the parent OHLCV bar (existing)
+      // 2. swap the right-side y-axis label to show the bar's volume when the
+      //    cursor is inside the volume pane — without this the price scale
+      //    extrapolates pane-0 prices into pane-1 and prints the chart's low.
       chart.subscribeCrosshairMove((param) => {
         // Skip during our own data updates to prevent loop: update/setData → crosshair → setState → re-render → effect → update
-        if (isApplyingDataUpdateRef.current || !onCrosshairMoveRef.current) {
+        if (isApplyingDataUpdateRef.current) {
+          return;
+        }
+
+        const volumeData = param.seriesData.get(volumeSeries);
+        const volumeValue =
+          volumeData && 'value' in volumeData ? volumeData.value : undefined;
+
+        const labelEl = volumeLabelRef.current;
+        if (labelEl) {
+          if (
+            param.paneIndex === 1 &&
+            param.point !== undefined &&
+            typeof volumeValue === 'number' &&
+            volumeValue > 0
+          ) {
+            // param.point.y is pane-local. Translate to chart-container coords by
+            // adding the cumulative height of preceding panes + 1px separator each.
+            const panes = chart.panes();
+            let paneTop = 0;
+            for (let i = 0; i < param.paneIndex; i += 1) {
+              paneTop += panes[i].getHeight() + 1;
+            }
+            labelEl.textContent = formatVolume(volumeValue, 1);
+            labelEl.style.top = `${paneTop + param.point.y}px`;
+            labelEl.style.display = 'block';
+          } else {
+            labelEl.style.display = 'none';
+          }
+        }
+
+        if (!onCrosshairMoveRef.current) {
           return;
         }
 
@@ -425,14 +464,8 @@ const PerpsCandlestickChart = forwardRef<
             high: String(candleSeriesData.high),
             low: String(candleSeriesData.low),
             close: String(candleSeriesData.close),
-            volume: '0', // Volume from histogram series if needed
+            volume: typeof volumeValue === 'number' ? String(volumeValue) : '0',
           };
-
-          // Try to get volume from the histogram series
-          const volumeData = param.seriesData.get(volumeSeries);
-          if (volumeData && 'value' in volumeData) {
-            hoveredCandle.volume = String(volumeData.value);
-          }
 
           onCrosshairMoveRef.current(hoveredCandle);
         }
@@ -650,16 +683,43 @@ const PerpsCandlestickChart = forwardRef<
 
     return (
       <Box
-        ref={containerRef}
-        className="perps-candlestick-chart"
         data-testid="perps-candlestick-chart"
         style={{
+          position: 'relative',
           width: '100%',
           height,
           borderRadius: '8px',
           overflow: 'hidden',
         }}
-      />
+      >
+        <Box
+          ref={containerRef}
+          className="perps-candlestick-chart"
+          style={{ width: '100%', height: '100%' }}
+        />
+        <div
+          ref={volumeLabelRef}
+          data-testid="perps-volume-axis-label"
+          style={{
+            position: 'absolute',
+            right: 0,
+            top: 0,
+            display: 'none',
+            transform: 'translateY(-50%)',
+            padding: '1px 4px',
+            fontSize: '11px',
+            lineHeight: '12px',
+            color: isDark ? 'rgba(255, 255, 255, 0.9)' : 'rgba(0, 0, 0, 0.9)',
+            backgroundColor: isDark ? brandColor.grey800 : brandColor.white,
+            border: `1px solid ${crosshairColor}`,
+            borderRadius: '2px',
+            pointerEvents: 'none',
+            zIndex: 2,
+            whiteSpace: 'nowrap',
+            fontFamily: 'monospace',
+          }}
+        />
+      </Box>
     );
   },
 );


### PR DESCRIPTION
## **Description**

When the user hovers a volume bar on the Perps candlestick chart, the y-axis now displays the bar's volume formatted with one decimal and a K/M/B suffix (e.g. `$14.9M`) at the cursor's height inside the volume pane. Previously the right price scale showed the extrapolated chart-range low price because the lower (volume) pane has no visible price scale — confusing for active traders trying to gauge market liquidity. Reverts to the default chart state when the cursor leaves.

## **Changelog**

CHANGELOG entry: Added a volume value label on the Perps chart y-axis that appears when hovering a volume bar.

## **Related issues**

Fixes: [TAT-2970]()

## **Manual testing steps**

1. Open the Perps tab and navigate to any market detail page (e.g. `#/perps/market/BTC`).
2. Wait for the candlestick chart to render with the volume histogram in the lower pane.
3. Hover the cursor over a volume bar. **Expected:** a small label appears on the right edge of the volume pane showing the bar's volume in `$X.X[K|M|B]` form (e.g. `$2.6M`), at the cursor's height. The candle price scale label above keeps showing the candlestick price as usual.
4. Move the cursor back into the candle pane or off the chart. **Expected:** the volume label disappears; the chart returns to its default display.
5. Repeat on a small-volume market: very small values render as `$X.X` (no suffix).

## **Screenshots/Recordings**

Before: y-axis showed the chart-range low price when hovering volume bars. After: it shows the bar's volume with 1 decimal + K/M/B suffix; reverts cleanly on hover-off.

<table>
<tr><td colspan="2"><strong>Volume y-axis label on hover (AC1+AC2) — Right edge of the lower (volume) pane shows the formatted volume ($14.9M) at the bar height; candle price scale stays as-is.</strong></td></tr>
<tr>
<td align="center" width="50%"><em>Before</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/features/42882/before-baseline-chart.png?sha=c5fbf892d06b0f7e" alt="before" width="400" /></td>
<td align="center" width="50%"><em>After</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/features/42882/after-ac1-volume-label-on-hover.png?sha=93e565610131dff8" alt="after" width="400" /></td>
</tr>
</table>

<table>
<tr><td align="center" width="50%"><strong>Hover-off reverts to default (AC3)</strong><br/><em>Cursor leaves chart; volume axis label removed; chart returns to default state.</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/features/42882/after-ac3-label-reverted.png?sha=d8c38aadb0e209af" alt="Hover-off reverts to default (AC3)" width="400" /></td><td></td></tr>
</table>

**Video**
Slow-motion recipe replay showing AC1, AC2, AC3 in sequence.
- After: [after.mp4](https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/features/42882/after.mp4?sha=3cd82504791638da)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

<details>
<summary>Recipe (12/12 PASS against the rebuilt extension, recipe-issues review status `clean`)</summary>

```json
{
  "schema_version": 1,
  "title": "TAT-2970 — volume y-axis label on hover",
  "description": "Asserts that hovering a volume bar in the Perps candlestick chart displays the bar's volume on the y-axis (formatted with 1 decimal + K/M/B suffix) and reverts on hover-off.",
  "validate": {
    "workflow": {
      "pre_conditions": ["wallet.unlocked", "perps.feature_enabled"],
      "entry": "gate-nav-market",
      "nodes": {
        "gate-nav-market": { "action": "call", "ref": "perps/navigate-to-market-detail", "params": { "symbol": "BTC" }, "next": "gate-wait-chart" },
        "gate-wait-chart":  { "action": "wait_for", "test_id": "perps-candlestick-chart", "timeout_ms": 8000, "next": "gate-wait-data" },
        "gate-wait-data":   { "action": "wait", "ms": 400, "next": "ac1-hover-volume-bar" },
        "ac1-hover-volume-bar":      { "action": "eval_sync", "expression": "/* dispatch mouseenter+mousemove on element at chart pane-1 coords */", "assert": { "all": [{ "field": "dispatched", "operator": "eq", "value": true }] }, "next": "ac1-wait-label" },
        "ac1-wait-label":            { "action": "wait", "ms": 120, "next": "ac1-assert-volume-label" },
        "ac1-assert-volume-label":   { "action": "eval_sync", "expression": "/* assert [data-testid=perps-volume-axis-label] is visible and text matches /^\\$\\d+(\\.\\d)?[KMB]?$/ */", "assert": { "all": [{ "field": "present", "operator": "eq", "value": true }, { "field": "visible", "operator": "eq", "value": true }, { "field": "matchesFormat", "operator": "eq", "value": true }] }, "next": "ac1-screenshot-hovered" },
        "ac1-screenshot-hovered":    { "action": "screenshot", "filename": "evidence-ac1-volume-label-on-hover.png", "note": "AC1+AC2: y-axis displays the bar's volume at the bar's height.", "next": "ac2-assert-not-price-low" },
        "ac2-assert-not-price-low":  { "action": "eval_sync", "expression": "/* assert label is on the right half AND within the lower-pane vertical region (not the chart-range low) */", "assert": { "all": [{ "field": "onRight", "operator": "eq", "value": true }, { "field": "inVolumePaneVertical", "operator": "eq", "value": true }] }, "next": "ac3-move-pointer-out" },
        "ac3-move-pointer-out":      { "action": "eval_sync", "expression": "/* dispatch mouseout+mouseleave inside chart, then mousemove on document.body outside */", "assert": { "all": [{ "field": "dispatched", "operator": "eq", "value": true }] }, "next": "ac3-wait-hide" },
        "ac3-wait-hide":             { "action": "wait", "ms": 200, "next": "ac3-assert-label-hidden" },
        "ac3-assert-label-hidden":   { "action": "eval_sync", "expression": "/* assert volume label is display:none or removed */", "assert": { "all": [{ "field": "removedOrHidden", "operator": "eq", "value": true }] }, "next": "ac3-screenshot-reverted" },
        "ac3-screenshot-reverted":   { "action": "screenshot", "filename": "evidence-ac3-label-reverted.png", "note": "AC3: chart returns to default state after cursor leaves.", "next": "done" },
        "done": { "action": "end", "status": "pass" }
      }
    }
  }
}
```

Full recipe with verbatim `eval_sync` expressions: `temp/tasks/feat/tat-2970-0522-185512/artifacts/recipe.json`.

</details>

[TAT-2970]: https://consensyssoftware.atlassian.net/browse/TAT-2970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches crosshair-move handling and DOM overlay positioning inside the trading chart, which could impact hover behavior/performance or interfere with existing OHLCV callbacks. Changes are UI-only and scoped to the perps chart, with added unit coverage.
> 
> **Overview**
> Adds a right-edge overlay label that appears **only while hovering the volume (pane 1) histogram**, showing the hovered bar’s volume formatted via `formatVolume(..., 1)` and positioned at the cursor’s y-offset within the volume pane.
> 
> Updates crosshair-move handling to (a) toggle/position this label and (b) include the hovered histogram volume in the `onCrosshairMove` candle payload when available. Adds a dedicated Jest test suite that mocks `lightweight-charts` to verify label visibility/positioning and `onCrosshairMove` behavior on hover and hover-off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 526a8e0dd60fe7eb280fb589fc7bf4110dba8cea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

