### PR TITLE
fix(perps): align Recent activity hover background edge-to-edge

### DIFF
--- a/ui/components/app/perps/perps-market-recent-activity/perps-market-recent-activity.test.tsx
+++ b/ui/components/app/perps/perps-market-recent-activity/perps-market-recent-activity.test.tsx
@@ -199,9 +199,6 @@ describe('PerpsMarketRecentActivity', () => {
       expect(
         screen.getByTestId('perps-market-detail-view-all-activity'),
       ).toBeInTheDocument();
-      expect(
-        screen.getByTestId('perps-market-detail-view-all-activity'),
-      ).toHaveStyle({ paddingLeft: '0px', paddingRight: '0px' });
     });
 
     it('"See All" navigates to PERPS_ACTIVITY_ROUTE', () => {

--- a/ui/components/app/perps/perps-market-recent-activity/perps-market-recent-activity.tsx
+++ b/ui/components/app/perps/perps-market-recent-activity/perps-market-recent-activity.tsx
@@ -96,12 +96,11 @@ export const PerpsMarketRecentActivity: React.FC<
   const handleSeeAll = () => navigate(PERPS_ACTIVITY_ROUTE);
 
   return (
-    <>
+    <Box flexDirection={BoxFlexDirection.Column} gap={3}>
       {hasTransactions ? (
         <ButtonBase
           onClick={handleSeeAll}
-          className="w-full flex flex-row justify-between items-center pt-4 pb-2 bg-transparent rounded-none hover:bg-hover active:bg-pressed"
-          style={{ paddingLeft: 0, paddingRight: 0 }}
+          className="w-full flex flex-row justify-between items-center px-4 py-2 bg-transparent rounded-none hover:bg-hover active:bg-pressed"
           data-testid="perps-market-detail-view-all-activity"
           aria-label={`${t('perpsRecentActivity')}, ${t('perpsSeeAll')}`}
         >
@@ -115,20 +114,22 @@ export const PerpsMarketRecentActivity: React.FC<
           />
         </ButtonBase>
       ) : (
-        <Box paddingTop={4} paddingBottom={2}>
+        <Box paddingLeft={4} paddingRight={4} paddingTop={2} paddingBottom={2}>
           <Text variant={TextVariant.HeadingSm} fontWeight={FontWeight.Medium}>
             {t('perpsRecentActivity')}
           </Text>
         </Box>
       )}
-      {showSkeleton && <RecentActivitySkeleton />}
-      {!showSkeleton && !hasTransactions && <RecentActivityEmpty />}
-      {!showSkeleton && hasTransactions && (
-        <RecentActivityList
-          transactions={transactions}
-          onTransactionClick={handleSeeAll}
-        />
-      )}
-    </>
+      <Box paddingLeft={4} paddingRight={4}>
+        {showSkeleton && <RecentActivitySkeleton />}
+        {!showSkeleton && !hasTransactions && <RecentActivityEmpty />}
+        {!showSkeleton && hasTransactions && (
+          <RecentActivityList
+            transactions={transactions}
+            onTransactionClick={handleSeeAll}
+          />
+        )}
+      </Box>
+    </Box>
   );
 };

--- a/ui/components/app/perps/perps-recent-activity/perps-recent-activity.tsx
+++ b/ui/components/app/perps/perps-recent-activity/perps-recent-activity.tsx
@@ -81,8 +81,8 @@ export const PerpsRecentActivity: React.FC<PerpsRecentActivityProps> = ({
           alignItems={BoxAlignItems.Center}
           paddingLeft={4}
           paddingRight={4}
-          paddingTop={4}
-          marginBottom={2}
+          paddingTop={3}
+          paddingBottom={3}
         >
           <Skeleton className="h-5 w-36" borderRadius={BorderRadius.SM} />
           <Skeleton className="h-4 w-14" borderRadius={BorderRadius.SM} />
@@ -109,8 +109,8 @@ export const PerpsRecentActivity: React.FC<PerpsRecentActivityProps> = ({
           alignItems={BoxAlignItems.Center}
           paddingLeft={4}
           paddingRight={4}
-          paddingTop={4}
-          marginBottom={2}
+          paddingTop={3}
+          paddingBottom={3}
         >
           <Text fontWeight={FontWeight.Medium}>{t('perpsRecentActivity')}</Text>
         </Box>
@@ -134,7 +134,7 @@ export const PerpsRecentActivity: React.FC<PerpsRecentActivityProps> = ({
     >
       {/* Section Header */}
       <ButtonBase
-        className="w-full flex flex-row justify-between items-center px-4 pt-4 mb-2 bg-transparent rounded-none hover:bg-hover active:bg-pressed"
+        className="w-full flex flex-row justify-between items-center px-4 py-3 bg-transparent rounded-none hover:bg-hover active:bg-pressed"
         onClick={handleSeeAll}
         data-testid="perps-recent-activity-see-all"
         aria-label={`${t('perpsRecentActivity')}, ${t('perpsSeeAll')}`}

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -1752,46 +1752,48 @@ const PerpsMarketDetailPage: React.FC = () => {
         </Box>
 
         {/* Recent Activity Section - always visible */}
-        <Box paddingLeft={4} paddingRight={4}>
+        <Box paddingTop={4} paddingBottom={4}>
           <PerpsMarketRecentActivity symbol={decodedSymbol} />
 
-          {/* Learn Section */}
-          <Box
-            className="mt-4 w-full cursor-pointer rounded-xl bg-muted px-4 py-3 hover:bg-muted-hover active:bg-muted-pressed"
-            flexDirection={BoxFlexDirection.Row}
-            justifyContent={BoxJustifyContent.Between}
-            alignItems={BoxAlignItems.Center}
-            data-testid="perps-learn-basics"
-            onClick={() => {
-              track(MetaMetricsEventName.PerpsUiInteraction, {
-                [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
-                  PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
-                [PERPS_EVENT_PROPERTY.BUTTON_TYPE]:
-                  PERPS_EVENT_VALUE.BUTTON_CLICKED.TUTORIAL,
-                [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
-                  PERPS_EVENT_VALUE.BUTTON_LOCATION.ASSET_DETAILS,
-              });
-              dispatch(setTutorialModalOpen(true));
-            }}
-          >
-            <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
-              {t('perpsLearnBasics')}
-            </Text>
-            <Icon
-              name={IconName.ArrowRight}
-              size={IconSize.Sm}
-              color={IconColor.IconAlternative}
-            />
-          </Box>
-
-          {/* Disclaimer */}
-          <Box paddingTop={4} paddingBottom={4}>
-            <Text
-              variant={TextVariant.BodyXs}
-              color={TextColor.TextAlternative}
+          <Box paddingLeft={4} paddingRight={4}>
+            {/* Learn Section */}
+            <Box
+              className="mt-4 w-full cursor-pointer rounded-xl bg-muted px-4 py-3 hover:bg-muted-hover active:bg-muted-pressed"
+              flexDirection={BoxFlexDirection.Row}
+              justifyContent={BoxJustifyContent.Between}
+              alignItems={BoxAlignItems.Center}
+              data-testid="perps-learn-basics"
+              onClick={() => {
+                track(MetaMetricsEventName.PerpsUiInteraction, {
+                  [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+                    PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
+                  [PERPS_EVENT_PROPERTY.BUTTON_TYPE]:
+                    PERPS_EVENT_VALUE.BUTTON_CLICKED.TUTORIAL,
+                  [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
+                    PERPS_EVENT_VALUE.BUTTON_LOCATION.ASSET_DETAILS,
+                });
+                dispatch(setTutorialModalOpen(true));
+              }}
             >
-              {t('perpsDisclaimer')}
-            </Text>
+              <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+                {t('perpsLearnBasics')}
+              </Text>
+              <Icon
+                name={IconName.ArrowRight}
+                size={IconSize.Sm}
+                color={IconColor.IconAlternative}
+              />
+            </Box>
+
+            {/* Disclaimer */}
+            <Box paddingTop={4} paddingBottom={4}>
+              <Text
+                variant={TextVariant.BodyXs}
+                color={TextColor.TextAlternative}
+              >
+                {t('perpsDisclaimer')}
+              </Text>
+            </Box>
           </Box>
         </Box>
       </>


### PR DESCRIPTION
## **Description**

Aligns the Perps "Recent activity" section header on both the Perps tab and the Perp market detail page so the hover background spans the full section row edge-to-edge, with text/icon inset by 16px via the button's own `px-4` (matching the existing Perps tab pattern). Also normalizes vertical padding on the Perps tab header (`pt-4 mb-2` → `py-3`) to match sibling sections.

Before: on the market detail page, the section parent had `paddingLeft={4}`/`paddingRight={4}` and the inner header button forced `paddingLeft: 0` inline — producing a hover stripe that was inset on both sides instead of edge-to-edge.

After: the parent layout moves to a flex column with no horizontal padding at the section level; the header button uses `px-4` directly so the hover stripe goes edge-to-edge while the text/icon stay properly inset.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TAT-3077](https://consensyssoftware.atlassian.net/browse/TAT-3077)

## **Manual testing steps**

1. Open the extension with `PERPS_ENABLED=true` and unlock the wallet.
2. Navigate to the Perps tab and scroll to the "Recent activity" section header.
3. Hover the header row. **Expected:** hover background fills the section edge-to-edge; text/chevron stay inset 16px from edges; vertical padding is symmetric.
4. Open any Perp market detail (e.g. ETH) and scroll to the "Recent activity" header.
5. Hover the header row. **Expected:** hover background spans the section edge-to-edge (no inset stripe); inner button no longer carries inline `paddingLeft: 0` / `paddingRight: 0`; text/icon inset via `px-4`.

## **Screenshots/Recordings**

Forced-hover bg comparison shows the market-detail Recent activity header is now edge-to-edge instead of inset.

<table>
<tr><td colspan="2"><strong>Market detail — Recent activity header hover bg (inset → edge-to-edge) — Hover bg simulated via inline rgba(255,255,255,0.15). Before: stripe inset by parent paddingLeft/Right={4} with inline paddingLeft:0 override. After: stripe spans the section edge-to-edge; text/icon are inset 16px via px-4 on the ButtonBase itself, matching the perps tab pattern.</strong></td></tr>
<tr>
<td align="center" width="50%"><em>Before</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/42883/screenshots/before-ac2-market-detail-hover.png?sha=70a13048cbe366f2" alt="before" width="400" /></td>
<td align="center" width="50%"><em>After</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/42883/screenshots/after-ac2-market-detail-hover.png?sha=2a3bd2e21a2ff77c" alt="after" width="400" /></td>
</tr>
</table>

<table>
<tr><td align="center" width="50%"><strong>Perps tab — Recent activity header hover bg (unchanged horizontal, normalized vertical padding)</strong><br/><em>Perps tab header was already edge-to-edge; the fix normalizes vertical padding (pt-4 mb-2 → py-3) to match the Explore markets sibling.</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/42883/screenshots/after-ac1-perps-tab-hover.png?sha=0dc7e0a6b43c4fd5" alt="Perps tab — Recent activity header hover bg (unchanged horizontal, normalized vertical padding)" width="400" /></td><td></td></tr>
</table>

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

<details>
<summary>Recipe used to validate the fix</summary>

```json
{
  "title": "TAT-3077 — Perps Recent activity hover bg + alignment",
  "description": "Captures Recent activity styling on (1) Perps tab and (2) Perp market detail page. Forces the hover background on the header and screenshots, so the edge-to-edge hover stripe is visible.",
  "schema_version": 1,
  "validate": {
    "workflow": {
      "pre_conditions": ["wallet.unlocked", "perps.feature_enabled"],
      "entry": "setup-open-position",
      "nodes": {
        "setup-open-position": {
          "action": "call",
          "ref": "perps/open-long-position",
          "params": { "symbol": "ETH", "side": "long", "amount": "10" },
          "next": "setup-close-position"
        },
        "setup-close-position": {
          "action": "call",
          "ref": "perps/close-position",
          "params": { "symbol": "ETH", "percent": "100" },
          "next": "setup-nav-perps-tab"
        },
        "setup-nav-perps-tab": {
          "action": "call",
          "ref": "perps/navigate-perps-tab",
          "next": "ac1-wait-recent-activity"
        },
        "ac1-wait-recent-activity": {
          "action": "wait_for",
          "test_id": "perps-recent-activity-see-all",
          "timeout_ms": 10000,
          "next": "ac1-scroll-recent-activity"
        },
        "ac1-scroll-recent-activity": {
          "action": "scroll",
          "test_id": "perps-recent-activity-see-all",
          "next": "ac1-force-hover"
        },
        "ac1-force-hover": {
          "action": "eval_sync",
          "expression": "(function(){var b=document.querySelector('[data-testid=\"perps-recent-activity-see-all\"]');if(!b)return JSON.stringify({ok:false});b.style.backgroundColor='rgba(255,255,255,0.15)';var br=b.getBoundingClientRect();var pr=b.parentElement.getBoundingClientRect();return JSON.stringify({ok:Math.round(br.left)===Math.round(pr.left)&&Math.round(br.right)===Math.round(pr.right),btnLeft:Math.round(br.left),btnRight:Math.round(br.right),parentLeft:Math.round(pr.left),parentRight:Math.round(pr.right)});})()",
          "assert": { "operator": "eq", "field": "ok", "value": true },
          "save_as": "ac1_hover_bounds",
          "next": "ac1-screenshot-perps-tab"
        },
        "ac1-screenshot-perps-tab": {
          "action": "screenshot",
          "filename": "evidence-ac1-perps-tab-hover",
          "note": "AC1: Perps tab Recent activity header hover bg spans full row (edge-to-edge), text/icon inset via px-4",
          "next": "ac1-clear-hover"
        },
        "ac1-clear-hover": {
          "action": "eval_sync",
          "expression": "(function(){var b=document.querySelector('[data-testid=\"perps-recent-activity-see-all\"]');if(b)b.style.backgroundColor='';return JSON.stringify({ok:true});})()",
          "assert": { "operator": "eq", "field": "ok", "value": true },
          "next": "setup-nav-market-detail"
        },
        "setup-nav-market-detail": {
          "action": "call",
          "ref": "perps/navigate-to-market-detail",
          "params": { "symbol": "ETH" },
          "next": "ac2-wait-recent-activity"
        },
        "ac2-wait-recent-activity": {
          "action": "wait_for",
          "test_id": "perps-market-detail-view-all-activity",
          "timeout_ms": 10000,
          "next": "ac2-scroll-recent-activity"
        },
        "ac2-scroll-recent-activity": {
          "action": "scroll",
          "test_id": "perps-market-detail-view-all-activity",
          "next": "ac2-force-hover"
        },
        "ac2-force-hover": {
          "action": "eval_sync",
          "expression": "(function(){var b=document.querySelector('[data-testid=\"perps-market-detail-view-all-activity\"]');if(!b)return JSON.stringify({ok:false});b.style.backgroundColor='rgba(255,255,255,0.15)';var br=b.getBoundingClientRect();var pr=b.parentElement.getBoundingClientRect();var inlinePadL=b.style.paddingLeft;var inlinePadR=b.style.paddingRight;return JSON.stringify({ok:Math.round(br.left)===Math.round(pr.left)&&Math.round(br.right)===Math.round(pr.right)&&!inlinePadL&&!inlinePadR,btnLeft:Math.round(br.left),btnRight:Math.round(br.right),parentLeft:Math.round(pr.left),parentRight:Math.round(pr.right),inlinePadL:inlinePadL||null,inlinePadR:inlinePadR||null});})()",
          "assert": { "operator": "eq", "field": "ok", "value": true },
          "save_as": "ac2_hover_bounds",
          "next": "ac2-screenshot-market-detail"
        },
        "ac2-screenshot-market-detail": {
          "action": "screenshot",
          "filename": "evidence-ac2-market-detail-hover",
          "note": "AC2: Market detail Recent activity header hover bg spans full row edge-to-edge (no parent L/R inset, no inline padding override)",
          "next": "teardown-done"
        },
        "teardown-done": {
          "action": "end",
          "status": "pass"
        }
      }
    }
  }
}
```

</details>

## **Recipe Workflow**

<details>
<summary>Workflow graph (JSON)</summary>

```json
{
  "description": "Captures Recent activity styling on (1) Perps tab and (2) Perp market detail page. Forces the hover background on the header and screenshots, so the edge-to-edge hover stripe is visible.",
  "hooks": {
    "pre_conditions": [
      "wallet.unlocked",
      "perps.feature_enabled"
    ],
    "setup": [],
    "teardown": []
  },
  "inputs": {},
  "playback": {
    "mode": "off",
    "slow_ms": 1000
  },
  "sourcePath": "",
  "title": "TAT-3077 — Perps Recent activity hover bg + alignment",
  "workflow": {
    "entry": "setup-open-position",
    "nodes": {
      "setup-open-position": {
        "action": "call",
        "ref": "perps/open-long-position",
        "params": {
          "symbol": "ETH",
          "side": "long",
          "amount": "10"
        },
        "next": "setup-close-position",
        "id": "setup-open-position"
      },
      "setup-close-position": {
        "action": "call",
        "ref": "perps/close-position",
        "params": {
          "symbol": "ETH",
          "percent": "100"
        },
        "next": "setup-nav-perps-tab",
        "id": "setup-close-position"
      },
      "setup-nav-perps-tab": {
        "action": "call",
        "ref": "perps/navigate-perps-tab",
        "next": "ac1-wait-recent-activity",
        "id": "setup-nav-perps-tab"
      },
      "ac1-wait-recent-activity": {
        "action": "wait_for",
        "test_id": "perps-recent-activity-see-all",
        "timeout_ms": 10000,
        "next": "ac1-scroll-recent-activity",
        "id": "ac1-wait-recent-activity"
      },
      "ac1-scroll-recent-activity": {
        "action": "scroll",
        "test_id": "perps-recent-activity-see-all",
        "next": "ac1-force-hover",
        "id": "ac1-scroll-recent-activity"
      },
      "ac1-force-hover": {
        "action": "eval_sync",
        "expression": "(function(){var b=document.querySelector('[data-testid=\"perps-recent-activity-see-all\"]');if(!b)return JSON.stringify({ok:false});b.style.backgroundColor='rgba(255,255,255,0.15)';var br=b.getBoundingClientRect();var pr=b.parentElement.getBoundingClientRect();return JSON.stringify({ok:Math.round(br.left)===Math.round(pr.left)&&Math.round(br.right)===Math.round(pr.right),btnLeft:Math.round(br.left),btnRight:Math.round(br.right),parentLeft:Math.round(pr.left),parentRight:Math.round(pr.right)});})()",
        "assert": {
          "operator": "eq",
          "field": "ok",
          "value": true
        },
        "save_as": "ac1_hover_bounds",
        "next": "ac1-screenshot-perps-tab",
        "id": "ac1-force-hover"
      },
      "ac1-screenshot-perps-tab": {
        "action": "screenshot",
        "filename": "evidence-ac1-perps-tab-hover",
        "note": "AC1: Perps tab Recent activity header hover bg spans full row (edge-to-edge), text/icon inset via px-4",
        "next": "ac1-clear-hover",
        "id": "ac1-screenshot-perps-tab"
      },
      "ac1-clear-hover": {
        "action": "eval_sync",
        "expression": "(function(){var b=document.querySelector('[data-testid=\"perps-recent-activity-see-all\"]');if(b)b.style.backgroundColor='';return JSON.stringify({ok:true});})()",
        "assert": {
          "operator": "eq",
          "field": "ok",
          "value": true
        },
        "next": "setup-nav-market-detail",
        "id": "ac1-clear-hover"
      },
      "setup-nav-market-detail": {
        "action": "call",
        "ref": "perps/navigate-to-market-detail",
        "params": {
          "symbol": "ETH"
        },
        "next": "ac2-wait-recent-activity",
        "id": "setup-nav-market-detail"
      },
      "ac2-wait-recent-activity": {
        "action": "wait_for",
        "test_id": "perps-market-detail-view-all-activity",
        "timeout_ms": 10000,
        "next": "ac2-scroll-recent-activity",
        "id": "ac2-wait-recent-activity"
      },
      "ac2-scroll-recent-activity": {
        "action": "scroll",
        "test_id": "perps-market-detail-view-all-activity",
        "next": "ac2-force-hover",
        "id": "ac2-scroll-recent-activity"
      },
      "ac2-force-hover": {
        "action": "eval_sync",
        "expression": "(function(){var b=document.querySelector('[data-testid=\"perps-market-detail-view-all-activity\"]');if(!b)return JSON.stringify({ok:false});b.style.backgroundColor='rgba(255,255,255,0.15)';var br=b.getBoundingClientRect();var pr=b.parentElement.getBoundingClientRect();var inlinePadL=b.style.paddingLeft;var inlinePadR=b.style.paddingRight;return JSON.stringify({ok:Math.round(br.left)===Math.round(pr.left)&&Math.round(br.right)===Math.round(pr.right)&&!inlinePadL&&!inlinePadR,btnLeft:Math.round(br.left),btnRight:Math.round(br.right),parentLeft:Math.round(pr.left),parentRight:Math.round(pr.right),inlinePadL:inlinePadL||null,inlinePadR:inlinePadR||null});})()",
        "assert": {
          "operator": "eq",
          "field": "ok",
          "value": true
        },
        "save_as": "ac2_hover_bounds",
        "next": "ac2-screenshot-market-detail",
        "id": "ac2-force-hover"
      },
      "ac2-screenshot-market-detail": {
        "action": "screenshot",
        "filename": "evidence-ac2-market-detail-hover",
        "note": "AC2: Market detail Recent activity header hover bg spans full row edge-to-edge (no parent L/R inset, no inline padding override)",
        "next": "teardown-done",
        "id": "ac2-screenshot-market-detail"
      },
      "teardown-done": {
        "action": "end",
        "status": "pass",
        "id": "teardown-done"
      }
    }
  }
}
```

</details>


[TAT-3077]: https://consensyssoftware.atlassian.net/browse/TAT-3077?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Layout and CSS-only changes to Perps UI; no auth, data, or trading logic.
> 
> **Overview**
> **Recent activity** section headers on the Perps tab and market detail page now use **edge-to-edge** hover backgrounds: horizontal inset is applied on the header button via `px-4` instead of parent padding plus zeroed button padding.
> 
> On **market detail**, `PerpsMarketRecentActivity` is wrapped in a column layout without section-level horizontal padding; list/skeleton/empty content stays in a padded inner box. The page shell drops side padding around that block and keeps **Learn** / **disclaimer** in a separate `paddingLeft`/`paddingRight` container below.
> 
> On the **Perps tab**, loading, empty, and populated headers switch from `pt-4` + `mb-2` to symmetric **`py-3`**, matching **Explore markets**. A test that asserted zero horizontal padding on the detail “See all” control was removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00791031cfe0dd51970a8e6974d8fc98c8c30c11. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

