### PR TITLE
refactor: e2e activity list selectors

### DIFF
--- a/test/e2e/benchmarks/flows/interaction/confirm-tx.ts
+++ b/test/e2e/benchmarks/flows/interaction/confirm-tx.ts
@@ -51,11 +51,11 @@ export async function run(): Promise<BenchmarkRunResult> {
         );
         await driver.wait(async () => {
           const confirmedTxes = await driver.findElements(
-            '.transaction-status-label--confirmed',
+            '[data-tx-status="confirmed"]',
           );
           return confirmedTxes.length === 1;
         }, 10000);
-        await driver.waitForSelector('.transaction-status-label--confirmed');
+        await driver.waitForSelector('[data-tx-status="confirmed"]');
         const timestampAfterAction = new Date();
         loadingTimes =
           timestampAfterAction.getTime() - timestampBeforeAction.getTime();

--- a/test/e2e/flask/user-operations.spec.ts
+++ b/test/e2e/flask/user-operations.spec.ts
@@ -116,10 +116,7 @@ async function openConfirmedTransaction(driver: Driver) {
   await driver.switchToWindowWithTitle(WINDOW_TITLES.ExtensionInFullScreenView);
   await driver.clickElement('[data-testid="account-overview__activity-tab"]');
 
-  await driver.clickElement({
-    css: '[data-testid="activity-list-item"]',
-    text: 'Confirmed',
-  });
+  await driver.clickElement('[data-tx-status="confirmed"]');
 }
 
 async function expectTransactionDetail(

--- a/test/e2e/page-objects/pages/home/activity-list.ts
+++ b/test/e2e/page-objects/pages/home/activity-list.ts
@@ -40,7 +40,8 @@ class ActivityListPage {
   private readonly gasPrice =
     '[data-testid="transaction-breakdown__gas-price"]';
 
-  private readonly pendingTransactionItems = '[data-tx-status="pending"]';
+  private readonly pendingTransactionItems =
+    '[data-tx-status="submitted"], [data-tx-status="approved"], [data-tx-status="unapproved"], [data-tx-status="pending"]';
 
   private readonly speedupInlineButton = '[data-testid="speed-up-button"]';
 

--- a/test/e2e/page-objects/pages/home/activity-list.ts
+++ b/test/e2e/page-objects/pages/home/activity-list.ts
@@ -14,8 +14,7 @@ class ActivityListPage {
     xpath: "//div[contains(text(), 'Base fee')]",
   };
 
-  private readonly bridgeTransactionCompleted =
-    '.transaction-status-label--confirmed';
+  private readonly bridgeTransactionCompleted = '[data-tx-status="confirmed"]';
 
   private readonly bridgeTransactionPending =
     '.bridge-transaction-details__segment--pending';
@@ -27,10 +26,7 @@ class ActivityListPage {
 
   private readonly completedTransactions = '[data-testid="activity-list-item"]';
 
-  private readonly confirmedTransactions = {
-    text: 'Confirmed',
-    css: '.transaction-status-label--confirmed',
-  };
+  private readonly confirmedTransactions = '[data-tx-status="confirmed"]';
 
   private readonly copyTransactionHashButton = {
     text: 'Copy transaction ID',
@@ -551,7 +547,7 @@ class ActivityListPage {
   async checkWaitForTransactionStatus(
     status: 'confirmed' | 'cancelled' | 'pending',
   ) {
-    await this.driver.waitForSelector(`.transaction-status-label--${status}`, {
+    await this.driver.waitForSelector(`[data-tx-status="${status}"]`, {
       timeout: 5000,
     });
   }

--- a/test/e2e/page-objects/pages/home/activity-list.ts
+++ b/test/e2e/page-objects/pages/home/activity-list.ts
@@ -33,18 +33,14 @@ class ActivityListPage {
     tag: 'button',
   };
 
-  private readonly failedTransactions = {
-    text: 'Failed',
-    css: '.transaction-status-label--failed',
-  };
+  private readonly failedTransactions = '[data-tx-status="failed"]';
 
   private readonly feeValues = '.currency-display-component__text';
 
   private readonly gasPrice =
     '[data-testid="transaction-breakdown__gas-price"]';
 
-  private readonly pendingTransactionItems =
-    '.transaction-status-label--pending';
+  private readonly pendingTransactionItems = '[data-tx-status="pending"]';
 
   private readonly speedupInlineButton = '[data-testid="speed-up-button"]';
 

--- a/test/e2e/tests/confirmations/transactions/erc721-approve-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/erc721-approve-redesign.spec.ts
@@ -104,7 +104,7 @@ async function confirmMintTransaction(driver: Driver) {
   // Verify Mint Transaction is Confirmed before proceeding
   await driver.switchToWindowWithTitle(WINDOW_TITLES.ExtensionInFullScreenView);
   await driver.clickElement('[data-testid="account-overview__activity-tab"]');
-  await driver.waitForSelector('.transaction-status-label--confirmed');
+  await driver.waitForSelector('[data-tx-status="confirmed"]');
   await driver.switchToWindowWithTitle(WINDOW_TITLES.TestDApp);
 }
 
@@ -170,7 +170,5 @@ async function confirmApproveTransaction(driver: Driver) {
   await driver.switchToWindowWithTitle(WINDOW_TITLES.ExtensionInFullScreenView);
 
   await driver.clickElement({ text: 'Activity', tag: 'button' });
-  await driver.waitForSelector(
-    '.transaction-status-label--confirmed:nth-of-type(1)',
-  );
+  await driver.waitForSelector('[data-tx-status="confirmed"]');
 }

--- a/ui/components/app/multichain-bridge-transaction-list-item/multichain-bridge-transaction-list-item.tsx
+++ b/ui/components/app/multichain-bridge-transaction-list-item/multichain-bridge-transaction-list-item.tsx
@@ -37,7 +37,10 @@ import {
   MULTICHAIN_NETWORK_TO_NICKNAME,
   MULTICHAIN_TOKEN_IMAGE_MAP,
 } from '../../../../shared/constants/multichain/networks';
-import { TransactionGroupCategory } from '../../../../shared/constants/transaction';
+import {
+  TransactionGroupCategory,
+  TransactionGroupStatus,
+} from '../../../../shared/constants/transaction';
 import { NETWORK_TO_SHORT_NETWORK_NAME_MAP } from '../../../../shared/constants/bridge';
 import useBridgeChainInfo from '../../../hooks/bridge/useBridgeChainInfo';
 import { formatAmount } from '../../../pages/confirmations/components/simulation-details/formatAmount';
@@ -111,10 +114,17 @@ const MultichainBridgeTransactionListItem: React.FC<
     ? `${t('bridgeTo')} ${displayChainName}`
     : capitalize(type);
 
+  let status = TransactionStatus.Unconfirmed;
+  if (isBridgeFullyComplete) {
+    status = TransactionStatus.Confirmed;
+  } else if (isBridgeFailedOrSourceFailed) {
+    status = TransactionStatus.Failed;
+  }
+
   return (
     <ActivityListItem
       className="multichain-bridge-transaction-list-item"
-      data-testid="multichain-bridge-activity-item"
+      status={KEYRING_TRANSACTION_STATUS_KEY[status]}
       onClick={() => toggleShowDetails(transaction)}
       icon={
         <BadgeWrapper

--- a/ui/components/app/transaction-list-item/smart-transaction-list-item.component.js
+++ b/ui/components/app/transaction-list-item/smart-transaction-list-item.component.js
@@ -56,6 +56,7 @@ export default function SmartTransactionListItem({
     <>
       <ActivityListItem
         className={className}
+        status={displayedStatusKey}
         title={title}
         onClick={toggleShowDetails}
         icon={

--- a/ui/components/app/transaction-list-item/transaction-list-item.component.js
+++ b/ui/components/app/transaction-list-item/transaction-list-item.component.js
@@ -290,7 +290,7 @@ function TransactionListItemInner({
   return (
     <>
       <ActivityListItem
-        data-testid="activity-list-item"
+        status={displayedStatusKey}
         onClick={
           isUnifiedSwapTx && showBridgeTxDetails
             ? showBridgeTxDetails

--- a/ui/components/multichain/activity-list-item/__snapshots__/activity-list-item.test.js.snap
+++ b/ui/components/multichain/activity-list-item/__snapshots__/activity-list-item.test.js.snap
@@ -4,6 +4,7 @@ exports[`ActivityListItem should match snapshot with no props 1`] = `
 <div>
   <div
     class="mm-box activity-list-item activity-list-item--single-content-row mm-box--padding-top-3 mm-box--padding-bottom-3 mm-box--padding-inline-4 mm-box--display-flex mm-box--gap-4 mm-box--flex-wrap-wrap mm-box--width-full mm-box--background-color-background-default"
+    data-testid="activity-list-item"
     tabindex="0"
   >
     <div
@@ -34,7 +35,7 @@ exports[`ActivityListItem should match snapshot with props 1`] = `
 <div>
   <div
     class="mm-box activity-list-item list-item-test mm-box--padding-top-3 mm-box--padding-bottom-3 mm-box--padding-inline-4 mm-box--display-flex mm-box--gap-4 mm-box--flex-wrap-wrap mm-box--width-full mm-box--background-color-background-default"
-    data-testid="test-id"
+    data-testid="activity-list-item"
     tabindex="0"
   >
     <p

--- a/ui/components/multichain/activity-list-item/activity-list-item.js
+++ b/ui/components/multichain/activity-list-item/activity-list-item.js
@@ -26,7 +26,7 @@ export const ActivityListItem = ({
   rightContent,
   onClick,
   className,
-  'data-testid': dataTestId,
+  status,
 }) => {
   const primaryClassName = classnames('activity-list-item', className, {
     'activity-list-item--single-content-row': !(subtitle || children),
@@ -43,7 +43,8 @@ export const ActivityListItem = ({
           onClick();
         }
       }}
-      data-testid={dataTestId}
+      data-testid="activity-list-item"
+      data-tx-status={status}
       paddingInline={4}
       paddingTop={3}
       paddingBottom={3}
@@ -174,7 +175,7 @@ ActivityListItem.propTypes = {
    */
   className: PropTypes.string,
   /**
-   * Test ID for this component
+   * Status key for this component
    */
-  'data-testid': PropTypes.string,
+  status: PropTypes.string,
 };

--- a/ui/components/multichain/activity-list-item/activity-list-item.stories.js
+++ b/ui/components/multichain/activity-list-item/activity-list-item.stories.js
@@ -29,7 +29,6 @@ const Template = (args) => <ActivityListItem {...args} />;
 
 export const DefaultStory = Template.bind({});
 DefaultStory.args = {
-  'data-testid': 'activity-list-item',
   onClick: () => undefined,
   className: 'custom-class',
   title: 'Activity Title',

--- a/ui/components/multichain/activity-list-item/activity-list-item.test.js
+++ b/ui/components/multichain/activity-list-item/activity-list-item.test.js
@@ -15,7 +15,6 @@ describe('ActivityListItem', () => {
   const defaultProps = {
     className: CLASSNAME,
     title: TITLE,
-    'data-testid': 'test-id',
     subtitle: SUBTITLE,
     rightContent: RIGHT_CONTENT,
     midContent: MID_CONTENT,
@@ -39,7 +38,18 @@ describe('ActivityListItem', () => {
 
   it('calls onClick when clicked', () => {
     const { getByTestId } = render(<ActivityListItem {...defaultProps} />);
-    fireEvent.click(getByTestId('test-id'));
+    fireEvent.click(getByTestId('activity-list-item'));
     expect(defaultProps.onClick).toHaveBeenCalled();
+  });
+
+  it('renders the transaction status attribute when status is provided', () => {
+    const { getByTestId } = render(
+      <ActivityListItem {...defaultProps} status="confirmed" />,
+    );
+
+    expect(getByTestId('activity-list-item')).toHaveAttribute(
+      'data-tx-status',
+      'confirmed',
+    );
   });
 });

--- a/ui/components/multichain/activity-v2/activity-list-item.tsx
+++ b/ui/components/multichain/activity-v2/activity-list-item.tsx
@@ -52,6 +52,7 @@ export const ActivityListItem = ({ transaction, onClick }: Props) => {
       className="px-4 py-3 bg-background-default cursor-pointer hover:bg-hover activity-list-item"
       onClick={onClick}
       data-testid="activity-list-item"
+      data-tx-status={transactionStatus}
     >
       <div className="flex gap-4 items-center">
         <div className="flex-shrink-0">

--- a/ui/components/multichain/activity-v2/non-evm-activity-list-item.tsx
+++ b/ui/components/multichain/activity-v2/non-evm-activity-list-item.tsx
@@ -49,7 +49,7 @@ export const NonEvmActivityListItem = ({ transaction, onClick }: Props) => {
   if (isRedeposit) {
     return (
       <LegacyActivityListItem
-        data-testid="activity-list-item"
+        status={statusKey}
         onClick={() => onClick(transaction)}
         icon={
           <ChainBadge chainId={transaction.chain}>
@@ -78,7 +78,7 @@ export const NonEvmActivityListItem = ({ transaction, onClick }: Props) => {
 
   return (
     <LegacyActivityListItem
-      data-testid="activity-list-item"
+      status={statusKey}
       onClick={() => onClick(transaction)}
       icon={
         <ChainBadge chainId={transaction.chain}>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Replace class-based selectors with data attributes in preparation for activity page redesign

The classes are coupled to a status component that is no longer present in the new design


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> DOM/test-hook and selector changes for the activity list ahead of a UI redesign; no auth, funds, or transaction submission logic changes.
> 
> **Overview**
> Activity list rows now expose transaction state on the DOM via **`data-tx-status`** (and a fixed **`data-testid="activity-list-item"`**), driven by a new **`status`** prop on the shared **`ActivityListItem`** and mirrored on activity v2. EVM, smart, bridge, and non-EVM list items pass their displayed status keys into that attribute instead of relying on status label CSS classes for targeting.
> 
> **E2E and benchmarks** were updated to wait and click using **`[data-tx-status="confirmed"]`**, **`failed`**, and a combined pending selector (**`submitted` / `approved` / `unapproved` / `pending`**), replacing **`.transaction-status-label--*`** and text-based “Confirmed” clicks. Unit tests cover the new attribute; snapshots reflect the stable test id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43c6533a67b679c998770e5fa57c968dd3a2d5bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->