### PR TITLE
fix: skip missing optional rc cache dependencies

### DIFF
--- a/development/webpack/test/webpack.config.test.ts
+++ b/development/webpack/test/webpack.config.test.ts
@@ -6,6 +6,7 @@ import process from 'node:process';
 import { join, resolve } from 'node:path';
 import {
   type Configuration,
+  type FileCacheOptions,
   webpack,
   Compiler,
   WebpackPluginInstance,
@@ -80,10 +81,17 @@ describe('webpack.config.test.ts', () => {
   let originalArgv: string[];
   let originalEnv: NodeJS.ProcessEnv;
   const originalReadFileSync = fs.readFileSync;
+  let originalExistsSync: typeof fs.existsSync;
+  const optionalRcPaths = {
+    metamaskrc: resolve(__dirname, '../../../.metamaskrc'),
+    metamaskprodrc: resolve(__dirname, '../../../.metamaskprodrc'),
+  };
+
   before(() => {
     // cache originals before we start messing with them
     originalArgv = process.argv;
     originalEnv = process.env;
+    originalExistsSync = fs.existsSync;
   });
   after(() => {
     // restore originals for other tests
@@ -125,7 +133,28 @@ ${Object.entries(env)
     return require('../webpack.config.ts').default;
   }
 
+  function mockOptionalRcFiles({
+    metamaskrc = false,
+    metamaskprodrc = false,
+  } = {}) {
+    mock.method(
+      fs,
+      'existsSync',
+      (path: Parameters<typeof fs.existsSync>[0]) => {
+        if (path === optionalRcPaths.metamaskrc) {
+          return metamaskrc;
+        }
+        if (path === optionalRcPaths.metamaskprodrc) {
+          return metamaskprodrc;
+        }
+        return originalExistsSync(path);
+      },
+    );
+  }
+
   it('should have the correct defaults', () => {
+    mockOptionalRcFiles();
+
     const config: Configuration = getWebpackConfig();
     // check that options are valid
     const { options } = webpack(config);
@@ -145,6 +174,15 @@ ${Object.entries(env)
     assert.strictEqual(options.optimization.removeAvailableModules, false);
     assert.strictEqual(options.optimization.usedExports, false);
     assert.strictEqual(options.watch, false);
+    const cache = config.cache as FileCacheOptions;
+    const configBuildDependencies = cache.buildDependencies?.config ?? [];
+    assert.ok(
+      configBuildDependencies.every(
+        (path) =>
+          !path.endsWith('.metamaskrc') && !path.endsWith('.metamaskprodrc'),
+      ),
+      'optional rc files should not be cache dependencies when they do not exist',
+    );
 
     const runtimeChunk = options.optimization.runtimeChunk as
       | {
@@ -220,6 +258,25 @@ ${Object.entries(env)
       (plugin) => plugin && plugin.constructor.name === 'ProgressPlugin',
     );
     assert(progressPlugin, 'Progress plugin should present');
+  });
+
+  it('includes existing optional rc files in cache dependencies', () => {
+    mockOptionalRcFiles({ metamaskrc: true });
+
+    const config: Configuration = getWebpackConfig();
+    const cache = config.cache as FileCacheOptions;
+    const configBuildDependencies = cache.buildDependencies?.config ?? [];
+
+    assert.ok(
+      configBuildDependencies.some((path) => path.endsWith('.metamaskrc')),
+      'existing .metamaskrc should be a cache dependency',
+    );
+    assert.ok(
+      configBuildDependencies.every(
+        (path) => !path.endsWith('.metamaskprodrc'),
+      ),
+      'missing .metamaskprodrc should not be a cache dependency',
+    );
   });
 
   it('should apply non-default options', () => {

--- a/development/webpack/webpack.config.ts
+++ b/development/webpack/webpack.config.ts
@@ -2,7 +2,7 @@
  * @file The main webpack configuration file for the browser extension.
  */
 
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { argv, exit } from 'node:process';
 import {
@@ -49,9 +49,10 @@ if (args.dryRun) {
 
 const context = join(__dirname, '../../app');
 const nodeModules = join(__dirname, '../../node_modules');
+const root = join(context, '..');
 const isDevelopment = args.mode === MODES.DEVELOPMENT;
 const MANIFEST_VERSION = args.manifestVersion;
-const browsersListPath = join(context, '../.browserslistrc');
+const browsersListPath = join(root, '.browserslistrc');
 // read .browserslist now to stop it from searching for the file over and over
 const browsersListQuery = readFileSync(browsersListPath, 'utf8');
 const { variables, safeVariables, version, buildEnvVarDeclarations } =
@@ -81,9 +82,10 @@ const cache = args.cache
         // `buildDependencies`
         config: [
           __filename,
-          join(context, '../.metamaskprodrc'),
-          join(context, '../.metamaskrc'),
-          join(context, '../builds.yml'),
+          ...[join(root, '.metamaskprodrc'), join(root, '.metamaskrc')].filter(
+            existsSync,
+          ),
+          join(root, 'builds.yml'),
           browsersListPath,
         ],
       },


### PR DESCRIPTION
## **Description**

Fixes webpack filesystem cache warnings when optional rc files are absent. `cache.buildDependencies.config` listed `.metamaskrc` and `.metamaskprodrc` unconditionally, so webpack tried to resolve missing files while storing the pack cache.

This updates the webpack config to derive repo-root paths once and only include optional rc files in cache dependencies when they exist. Required cache inputs such as `builds.yml` and `.browserslistrc` remain unconditional.

Validation:
- `yarn lint:changed:fix`
- `yarn test:unit:webpack`
- `yarn webpack:tsc`

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

<!--
## **Manual testing steps**

1.
-->

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-tooling cache dependency logic only; no runtime extension, auth, or data-path changes.
> 
> **Overview**
> Fixes webpack filesystem cache warnings when optional repo-root rc files are missing by only listing **`.metamaskrc`** and **`.metamaskprodrc`** in `cache.buildDependencies.config` when `existsSync` finds them. Required inputs (**`builds.yml`**, **`.browserslistrc`**, config file) stay unconditional; repo paths are centralized via a **`root`** helper.
> 
> Unit tests mock optional rc presence and assert cache dependency lists include existing optional files and omit missing ones.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 735dcdc8408ad65a299616b39c66dae6c0ad44fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->