### PR TITLE
fix: suppress protobufjs dynamic require warning

### DIFF
--- a/development/webpack/test/webpack.config.test.ts
+++ b/development/webpack/test/webpack.config.test.ts
@@ -48,9 +48,9 @@ async function getWebpackWarnings(config: Configuration): Promise<string[]> {
       });
     });
 
-    return stats
-      .toJson({ all: false, warnings: true })
-      .warnings.map((warning) => warning.message);
+    return (stats.toJson({ all: false, warnings: true }).warnings ?? []).map(
+      (warning) => warning.message,
+    );
   } finally {
     await new Promise<void>((resolveClose, rejectClose) =>
       compiler.close((error) => (error ? rejectClose(error) : resolveClose())),

--- a/development/webpack/test/webpack.config.test.ts
+++ b/development/webpack/test/webpack.config.test.ts
@@ -7,6 +7,8 @@ import { join, resolve } from 'node:path';
 import {
   type Configuration,
   type FileCacheOptions,
+  type RuleSetRule,
+  type Stats,
   webpack,
   Compiler,
   WebpackPluginInstance,
@@ -24,6 +26,36 @@ function getWebpackInstance(config: Configuration) {
   // so we just delete the watch property.
   delete config.watch;
   return webpack(config);
+}
+
+async function getWebpackWarnings(config: Configuration): Promise<string[]> {
+  const compiler = webpack(config);
+
+  try {
+    const stats = await new Promise<Stats>((resolveStats, rejectStats) => {
+      compiler.run((error, result) => {
+        if (error) {
+          rejectStats(error);
+          return;
+        }
+
+        if (!result) {
+          rejectStats(new Error('Webpack finished without returning stats.'));
+          return;
+        }
+
+        resolveStats(result);
+      });
+    });
+
+    return stats
+      .toJson({ all: false, warnings: true })
+      .warnings.map((warning) => warning.message);
+  } finally {
+    await new Promise<void>((resolveClose, rejectClose) =>
+      compiler.close((error) => (error ? rejectClose(error) : resolveClose())),
+    );
+  }
 }
 
 async function withWatching<T>(
@@ -86,6 +118,8 @@ describe('webpack.config.test.ts', () => {
     metamaskrc: resolve(__dirname, '../../../.metamaskrc'),
     metamaskprodrc: resolve(__dirname, '../../../.metamaskprodrc'),
   };
+  const protobufInquireWarning =
+    'Critical dependency: the request of a dependency is an expression';
 
   before(() => {
     // cache originals before we start messing with them
@@ -276,6 +310,71 @@ ${Object.entries(env)
         (path) => !path.endsWith('.metamaskprodrc'),
       ),
       'missing .metamaskprodrc should not be a cache dependency',
+    );
+  });
+
+  it('suppresses the @protobufjs/inquire dynamic require warning only while it is still needed', async () => {
+    using tempDirectory = fs.mkdtempDisposableSync(
+      join(tmpdir(), 'protobuf-inquire-warning-test-'),
+    );
+    const entryPath = join(tempDirectory.path, 'entry.js');
+    fs.writeFileSync(
+      entryPath,
+      `
+const inquire = require('@protobufjs/inquire');
+inquire('long');
+`,
+    );
+
+    const config: Configuration = getWebpackConfig(['--no-progress']);
+    const protobufInquireRule = config.module?.rules?.find(
+      (rule) =>
+        rule &&
+        typeof rule === 'object' &&
+        'test' in rule &&
+        String(rule.test).includes('@protobufjs'),
+    ) as RuleSetRule | undefined;
+    assert(
+      protobufInquireRule,
+      'Expected a parser rule for @protobufjs/inquire.',
+    );
+
+    const getConfig = (name: string, rules: RuleSetRule[]): Configuration => ({
+      mode: 'development',
+      context: resolve(__dirname, '../../..'),
+      entry: entryPath,
+      output: {
+        path: join(tempDirectory.path, name),
+        filename: 'bundle.js',
+      },
+      cache: false,
+      stats: 'none',
+      infrastructureLogging: { level: 'none' },
+      resolve: {
+        modules: [join(__dirname, '../../../node_modules'), 'node_modules'],
+      },
+      module: { rules },
+    });
+
+    const warningsWithRule = await getWebpackWarnings(
+      getConfig('with-rule', [protobufInquireRule]),
+    );
+    assert.deepStrictEqual(
+      warningsWithRule.filter((warning) =>
+        warning.includes(protobufInquireWarning),
+      ),
+      [],
+      'Expected the @protobufjs/inquire parser rule to suppress the dynamic require warning.',
+    );
+
+    const warningsWithoutRule = await getWebpackWarnings(
+      getConfig('without-rule', []),
+    );
+    assert(
+      warningsWithoutRule.some((warning) =>
+        warning.includes(protobufInquireWarning),
+      ),
+      'Expected @protobufjs/inquire to still emit this warning without the workaround. If this fails, remove the parser rule.',
     );
   });
 

--- a/development/webpack/webpack.config.ts
+++ b/development/webpack/webpack.config.ts
@@ -389,6 +389,13 @@ const config = {
           options: { declarations: [...buildEnvVarDeclarations] },
         },
       },
+      // @protobufjs/inquire intentionally uses `require(moduleName)` to probe
+      // optional modules such as `buffer` and `long`.
+      {
+        test: /[\\/]@protobufjs[\\/]inquire[\\/]index\.js$/u,
+        include: NODE_MODULES_RE,
+        parser: { exprContextCritical: false },
+      },
       // thread-loader pool for UI component files (must appear before SWC rules)
       threadLoader && {
         test: UI_COMPONENT_RE,


### PR DESCRIPTION
## **Description**

- Suppress the known @protobufjs/inquire dynamic require warning with a scoped webpack parser rule.
- Add a regression test that verifies the rule still matches and suppresses the warning.
- Make the test fail once the upstream workaround is no longer required, so the rule can be removed.

## Root cause
@protobufjs/inquire probes optional modules using require(moduleName), which webpack reports as a critical dependency warning when warnings are surfaced.

## Changelog
CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

No more warnings when you run `yarn webpack`

<!--
## **Screenshots/Recordings**

### **Before**

[screenshots/recordings]

### **After**

[screenshots/recordings]
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time webpack config and tests only; no extension runtime, auth, or data-path changes.
> 
> **Overview**
> Adds a **scoped webpack `module.rules` entry** for `@protobufjs/inquire` that sets `parser.exprContextCritical: false`, so webpack stops surfacing the known **“Critical dependency: the request of a dependency is an expression”** warning from that package’s dynamic `require(moduleName)` probes.
> 
> **Tests** add `getWebpackWarnings` and an integration case that bundles a tiny entry requiring `@protobufjs/inquire`: with the rule from the main config, that warning is absent; without it, the warning must still appear—so the workaround can be deleted if upstream behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 347cf500c133837f80713baaedb77990ad57c5b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->