### PR TITLE
fix: protect webpack cache shutdown from signals

### DIFF
--- a/development/webpack/build.ts
+++ b/development/webpack/build.ts
@@ -58,15 +58,13 @@ export function build(onComplete: () => void = noop) {
     } else {
       compiler.run((err, stats) => {
         logStats(err ?? undefined, stats);
-        // `onComplete` must be called synchronously _before_ `compiler.close`
-        // or the caller might observe output from the `close` command.
         const removeCacheShutdownSignalHandlers =
-          options.cache !== null &&
-          typeof options.cache === 'object' &&
           options.cache.type === 'filesystem'
-            ? ignoreCacheShutdownSignals()
+            ? ignoreCacheShutdownSignals(process)
             : noop;
         try {
+          // `onComplete` must be called synchronously _before_ `compiler.close`
+          // or the caller might observe output from the `close` command.
           onComplete();
           compiler.close(removeCacheShutdownSignalHandlers);
         } catch (error) {

--- a/development/webpack/build.ts
+++ b/development/webpack/build.ts
@@ -58,8 +58,8 @@ export function build(onComplete: () => void = noop) {
     } else {
       compiler.run((err, stats) => {
         logStats(err ?? undefined, stats);
-        // Install before `onComplete` signals the parent process so a Ctrl+C
-        // forwarded during that handoff cannot interrupt cache shutdown.
+        // Install before `onComplete` signals the parent process so shutdown
+        // signals forwarded during that handoff cannot interrupt cache writes.
         const removeCacheShutdownSignalHandlers =
           options.cache.type === 'filesystem'
             ? ignoreCacheShutdownSignal(process)

--- a/development/webpack/build.ts
+++ b/development/webpack/build.ts
@@ -1,6 +1,11 @@
 import { webpack } from 'webpack';
 import type WebpackDevServerType from 'webpack-dev-server';
-import { noop, logStats, __HMR_READY__ } from './utils/helpers';
+import {
+  noop,
+  logStats,
+  __HMR_READY__,
+  ignoreCacheShutdownSignals,
+} from './utils/helpers';
 import config from './webpack.config';
 import { MODES } from './utils/constants';
 
@@ -55,8 +60,19 @@ export function build(onComplete: () => void = noop) {
         logStats(err ?? undefined, stats);
         // `onComplete` must be called synchronously _before_ `compiler.close`
         // or the caller might observe output from the `close` command.
-        onComplete();
-        compiler.close(noop);
+        const removeCacheShutdownSignalHandlers =
+          options.cache !== null &&
+          typeof options.cache === 'object' &&
+          options.cache.type === 'filesystem'
+            ? ignoreCacheShutdownSignals()
+            : noop;
+        try {
+          onComplete();
+          compiler.close(removeCacheShutdownSignalHandlers);
+        } catch (error) {
+          removeCacheShutdownSignalHandlers();
+          throw error;
+        }
       });
     }
   }

--- a/development/webpack/build.ts
+++ b/development/webpack/build.ts
@@ -4,7 +4,7 @@ import {
   noop,
   logStats,
   __HMR_READY__,
-  ignoreCacheShutdownSignals,
+  ignoreCacheShutdownSignal,
 } from './utils/helpers';
 import config from './webpack.config';
 import { MODES } from './utils/constants';
@@ -58,15 +58,17 @@ export function build(onComplete: () => void = noop) {
     } else {
       compiler.run((err, stats) => {
         logStats(err ?? undefined, stats);
+        // Install before `onComplete` signals the parent process so a Ctrl+C
+        // forwarded during that handoff cannot interrupt cache shutdown.
         const removeCacheShutdownSignalHandlers =
           options.cache.type === 'filesystem'
-            ? ignoreCacheShutdownSignals(process)
+            ? ignoreCacheShutdownSignal(process)
             : noop;
         try {
           // `onComplete` must be called synchronously _before_ `compiler.close`
           // or the caller might observe output from the `close` command.
           onComplete();
-          compiler.close(removeCacheShutdownSignalHandlers);
+          compiler.close(() => removeCacheShutdownSignalHandlers());
         } catch (error) {
           removeCacheShutdownSignalHandlers();
           throw error;

--- a/development/webpack/test/helpers.test.ts
+++ b/development/webpack/test/helpers.test.ts
@@ -21,17 +21,19 @@ describe('./utils/helpers.ts', () => {
   describe('ignoreCacheShutdownSignal', () => {
     it('silently ignores SIGINT until cleanup', () => {
       const listeners = new Map<NodeJS.Signals, () => void>();
+      const on = mock.fn((signal: NodeJS.Signals, listener: () => void) => {
+        listeners.set(signal, listener);
+      });
+      const removeListener = mock.fn(
+        (signal: NodeJS.Signals, listener: () => void) => {
+          if (listeners.get(signal) === listener) {
+            listeners.delete(signal);
+          }
+        },
+      );
       const signalProcess = {
-        on: mock.fn((signal: NodeJS.Signals, listener: () => void) => {
-          listeners.set(signal, listener);
-        }),
-        removeListener: mock.fn(
-          (signal: NodeJS.Signals, listener: () => void) => {
-            if (listeners.get(signal) === listener) {
-              listeners.delete(signal);
-            }
-          },
-        ),
+        on,
+        removeListener,
       } as unknown as NodeJS.Process;
       const { mock: error } = mock.method(console, 'error', helpers.noop);
 
@@ -43,8 +45,8 @@ describe('./utils/helpers.ts', () => {
       cleanup();
 
       assert.strictEqual(error.callCount(), 0);
-      assert.strictEqual(signalProcess.on.mock.callCount(), 1);
-      assert.strictEqual(signalProcess.removeListener.mock.callCount(), 1);
+      assert.strictEqual(on.mock.callCount(), 1);
+      assert.strictEqual(removeListener.mock.callCount(), 1);
       assert.strictEqual(listeners.has('SIGINT'), false);
       assert.strictEqual(listeners.has('SIGTERM'), false);
     });

--- a/development/webpack/test/helpers.test.ts
+++ b/development/webpack/test/helpers.test.ts
@@ -18,9 +18,8 @@ describe('./utils/helpers.ts', () => {
     assert.strictEqual(nothing, undefined);
   });
 
-  describe('ignoreCacheShutdownSignals', () => {
-    it('ignores shutdown signals until cleanup', () => {
-      const calls: unknown[] = [];
+  describe('ignoreCacheShutdownSignal', () => {
+    it('silently ignores SIGINT until cleanup', () => {
       const listeners = new Map<NodeJS.Signals, () => void>();
       const signalProcess = {
         on: mock.fn((signal: NodeJS.Signals, listener: () => void) => {
@@ -33,30 +32,21 @@ describe('./utils/helpers.ts', () => {
             }
           },
         ),
-      };
-      mock.method(console, 'error', (message: unknown) => {
-        calls.push(message);
-      });
+      } as unknown as NodeJS.Process;
+      const { mock: error } = mock.method(console, 'error', helpers.noop);
 
-      const cleanup = helpers.ignoreCacheShutdownSignals(signalProcess);
+      const cleanup = helpers.ignoreCacheShutdownSignal(signalProcess);
 
-      const signals = ['SIGINT', 'SIGTERM'] as const;
-      signals.forEach((signal) => {
-        const listener = listeners.get(signal);
-        assert(listener, `${signal} listener should be set`);
-        listener();
-      });
+      const listener = listeners.get('SIGINT');
+      assert(listener, 'SIGINT listener should be set');
+      listener();
       cleanup();
 
-      assert.deepStrictEqual(calls, [
-        '🦊 Still shutting down; waiting for webpack to finish writing its cache…',
-        '🦊 Still shutting down; waiting for webpack to finish writing its cache…',
-      ]);
-      assert.strictEqual(signalProcess.on.mock.callCount(), 2);
-      assert.strictEqual(signalProcess.removeListener.mock.callCount(), 2);
-      signals.forEach((signal) =>
-        assert.strictEqual(listeners.has(signal), false),
-      );
+      assert.strictEqual(error.callCount(), 0);
+      assert.strictEqual(signalProcess.on.mock.callCount(), 1);
+      assert.strictEqual(signalProcess.removeListener.mock.callCount(), 1);
+      assert.strictEqual(listeners.has('SIGINT'), false);
+      assert.strictEqual(listeners.has('SIGTERM'), false);
     });
   });
 

--- a/development/webpack/test/helpers.test.ts
+++ b/development/webpack/test/helpers.test.ts
@@ -18,6 +18,47 @@ describe('./utils/helpers.ts', () => {
     assert.strictEqual(nothing, undefined);
   });
 
+  describe('ignoreCacheShutdownSignals', () => {
+    it('ignores shutdown signals until cleanup', () => {
+      const calls: unknown[] = [];
+      const listeners = new Map<NodeJS.Signals, () => void>();
+      const signalProcess = {
+        on: mock.fn(
+          (signal: NodeJS.Signals, listener: () => void) => {
+            listeners.set(signal, listener);
+          },
+        ),
+        removeListener: mock.fn(
+          (signal: NodeJS.Signals, listener: () => void) => {
+            if (listeners.get(signal) === listener) {
+              listeners.delete(signal);
+            }
+          },
+        ),
+      };
+      mock.method(console, 'error', (message) => {
+        calls.push(message);
+      });
+
+      const cleanup = helpers.ignoreCacheShutdownSignals({
+        process: signalProcess,
+        signals: ['SIGINT'],
+      });
+
+      const listener = listeners.get('SIGINT');
+      assert(listener, 'SIGINT listener should be set');
+      listener();
+      cleanup();
+
+      assert.deepStrictEqual(calls, [
+        '🦊 Still shutting down; waiting for webpack to finish writing its cache…',
+      ]);
+      assert.strictEqual(signalProcess.on.mock.callCount(), 1);
+      assert.strictEqual(signalProcess.removeListener.mock.callCount(), 1);
+      assert.strictEqual(listeners.has('SIGINT'), false);
+    });
+  });
+
   describe('logStats', () => {
     const getStatsMock = (
       stats: 'normal' | 'none',

--- a/development/webpack/test/helpers.test.ts
+++ b/development/webpack/test/helpers.test.ts
@@ -24,13 +24,11 @@ describe('./utils/helpers.ts', () => {
       const on = mock.fn((signal: NodeJS.Signals, listener: () => void) => {
         listeners.set(signal, listener);
       });
-      const off = mock.fn(
-        (signal: NodeJS.Signals, listener: () => void) => {
-          if (listeners.get(signal) === listener) {
-            listeners.delete(signal);
-          }
-        },
-      );
+      const off = mock.fn((signal: NodeJS.Signals, listener: () => void) => {
+        if (listeners.get(signal) === listener) {
+          listeners.delete(signal);
+        }
+      });
       const signalProcess = {
         on,
         off,

--- a/development/webpack/test/helpers.test.ts
+++ b/development/webpack/test/helpers.test.ts
@@ -23,11 +23,9 @@ describe('./utils/helpers.ts', () => {
       const calls: unknown[] = [];
       const listeners = new Map<NodeJS.Signals, () => void>();
       const signalProcess = {
-        on: mock.fn(
-          (signal: NodeJS.Signals, listener: () => void) => {
-            listeners.set(signal, listener);
-          },
-        ),
+        on: mock.fn((signal: NodeJS.Signals, listener: () => void) => {
+          listeners.set(signal, listener);
+        }),
         removeListener: mock.fn(
           (signal: NodeJS.Signals, listener: () => void) => {
             if (listeners.get(signal) === listener) {
@@ -36,7 +34,7 @@ describe('./utils/helpers.ts', () => {
           },
         ),
       };
-      mock.method(console, 'error', (message) => {
+      mock.method(console, 'error', (message: unknown) => {
         calls.push(message);
       });
 

--- a/development/webpack/test/helpers.test.ts
+++ b/development/webpack/test/helpers.test.ts
@@ -19,12 +19,12 @@ describe('./utils/helpers.ts', () => {
   });
 
   describe('ignoreCacheShutdownSignal', () => {
-    it('silently ignores SIGINT until cleanup', () => {
+    it('silently ignores shutdown signals until cleanup', () => {
       const listeners = new Map<NodeJS.Signals, () => void>();
       const on = mock.fn((signal: NodeJS.Signals, listener: () => void) => {
         listeners.set(signal, listener);
       });
-      const removeListener = mock.fn(
+      const off = mock.fn(
         (signal: NodeJS.Signals, listener: () => void) => {
           if (listeners.get(signal) === listener) {
             listeners.delete(signal);
@@ -33,22 +33,26 @@ describe('./utils/helpers.ts', () => {
       );
       const signalProcess = {
         on,
-        removeListener,
+        off,
       } as unknown as NodeJS.Process;
       const { mock: error } = mock.method(console, 'error', helpers.noop);
 
       const cleanup = helpers.ignoreCacheShutdownSignal(signalProcess);
 
-      const listener = listeners.get('SIGINT');
-      assert(listener, 'SIGINT listener should be set');
-      listener();
+      const signals = ['SIGINT', 'SIGTERM'] as const;
+      signals.forEach((signal) => {
+        const listener = listeners.get(signal);
+        assert(listener, `${signal} listener should be set`);
+        listener();
+      });
       cleanup();
 
       assert.strictEqual(error.callCount(), 0);
-      assert.strictEqual(on.mock.callCount(), 1);
-      assert.strictEqual(removeListener.mock.callCount(), 1);
-      assert.strictEqual(listeners.has('SIGINT'), false);
-      assert.strictEqual(listeners.has('SIGTERM'), false);
+      assert.strictEqual(on.mock.callCount(), signals.length);
+      assert.strictEqual(off.mock.callCount(), signals.length);
+      signals.forEach((signal) =>
+        assert.strictEqual(listeners.has(signal), false),
+      );
     });
   });
 

--- a/development/webpack/test/helpers.test.ts
+++ b/development/webpack/test/helpers.test.ts
@@ -38,22 +38,25 @@ describe('./utils/helpers.ts', () => {
         calls.push(message);
       });
 
-      const cleanup = helpers.ignoreCacheShutdownSignals({
-        process: signalProcess,
-        signals: ['SIGINT'],
-      });
+      const cleanup = helpers.ignoreCacheShutdownSignals(signalProcess);
 
-      const listener = listeners.get('SIGINT');
-      assert(listener, 'SIGINT listener should be set');
-      listener();
+      const signals = ['SIGINT', 'SIGTERM'] as const;
+      signals.forEach((signal) => {
+        const listener = listeners.get(signal);
+        assert(listener, `${signal} listener should be set`);
+        listener();
+      });
       cleanup();
 
       assert.deepStrictEqual(calls, [
         '🦊 Still shutting down; waiting for webpack to finish writing its cache…',
+        '🦊 Still shutting down; waiting for webpack to finish writing its cache…',
       ]);
-      assert.strictEqual(signalProcess.on.mock.callCount(), 1);
-      assert.strictEqual(signalProcess.removeListener.mock.callCount(), 1);
-      assert.strictEqual(listeners.has('SIGINT'), false);
+      assert.strictEqual(signalProcess.on.mock.callCount(), 2);
+      assert.strictEqual(signalProcess.removeListener.mock.callCount(), 2);
+      signals.forEach((signal) =>
+        assert.strictEqual(listeners.has(signal), false),
+      );
     });
   });
 

--- a/development/webpack/test/loaders.swcLoader.test.ts
+++ b/development/webpack/test/loaders.swcLoader.test.ts
@@ -20,10 +20,7 @@ describe('swcLoader', () => {
     // swc doesn't use node's fs module, so we can't mock
     const resourcePath = 'test.ts';
 
-    // `withResolvers` is supported by Node.js LTS. It's optional in global type due to older
-    // browser support.
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    const { promise, resolve } = Promise.withResolvers!<CallbackArgs>();
+    const { promise, resolve } = Promise.withResolvers<CallbackArgs>();
     const mockContext = {
       mode: 'production',
       sourceMap: true,

--- a/development/webpack/test/loaders.swcLoader.test.ts
+++ b/development/webpack/test/loaders.swcLoader.test.ts
@@ -20,7 +20,10 @@ describe('swcLoader', () => {
     // swc doesn't use node's fs module, so we can't mock
     const resourcePath = 'test.ts';
 
-    const { promise, resolve } = Promise.withResolvers<CallbackArgs>();
+    // `withResolvers` is supported by Node.js LTS. It's optional in global type due to older
+    // browser support.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    const { promise, resolve } = Promise.withResolvers!<CallbackArgs>();
     const mockContext = {
       mode: 'production',
       sourceMap: true,

--- a/development/webpack/utils/helpers.ts
+++ b/development/webpack/utils/helpers.ts
@@ -80,10 +80,7 @@ export const noop = () => undefined;
 type SignalListener = () => void;
 type SignalProcess = {
   on: (signal: NodeJS.Signals, listener: SignalListener) => unknown;
-  removeListener: (
-    signal: NodeJS.Signals,
-    listener: SignalListener,
-  ) => unknown;
+  removeListener: (signal: NodeJS.Signals, listener: SignalListener) => unknown;
 };
 
 type IgnoreCacheShutdownSignalsOptions = {
@@ -108,7 +105,7 @@ const CACHE_SHUTDOWN_SIGNALS = ['SIGINT', 'SIGTERM'] as const;
  * @returns A cleanup function that removes the installed listeners.
  */
 export function ignoreCacheShutdownSignals({
-  process: signalProcess = process,
+  process: signalProcess = process as unknown as SignalProcess,
   signals = CACHE_SHUTDOWN_SIGNALS,
 }: IgnoreCacheShutdownSignalsOptions = {}): () => void {
   const listener = () => {

--- a/development/webpack/utils/helpers.ts
+++ b/development/webpack/utils/helpers.ts
@@ -83,11 +83,6 @@ type SignalProcess = {
   removeListener: (signal: NodeJS.Signals, listener: SignalListener) => unknown;
 };
 
-type IgnoreCacheShutdownSignalsOptions = {
-  process?: SignalProcess;
-  signals?: readonly NodeJS.Signals[];
-};
-
 const CACHE_SHUTDOWN_SIGNALS = ['SIGINT', 'SIGTERM'] as const;
 
 /**
@@ -99,27 +94,22 @@ const CACHE_SHUTDOWN_SIGNALS = ['SIGINT', 'SIGTERM'] as const;
  * another shutdown signal during that close window, Node's default handling
  * would terminate the process and can leave the cache partially written.
  *
- * @param options - Optional process and signals overrides for tests.
- * @param options.process
- * @param options.signals
+ * @param signalProcess - The process to install listeners on.
  * @returns A cleanup function that removes the installed listeners.
  */
-export function ignoreCacheShutdownSignals({
-  process: signalProcess = process as unknown as SignalProcess,
-  signals = CACHE_SHUTDOWN_SIGNALS,
-}: IgnoreCacheShutdownSignalsOptions = {}): () => void {
+export function ignoreCacheShutdownSignals(signalProcess: SignalProcess) {
   const listener = () => {
     console.error(
       '🦊 Still shutting down; waiting for webpack to finish writing its cache…',
     );
   };
 
-  for (const signal of signals) {
+  for (const signal of CACHE_SHUTDOWN_SIGNALS) {
     signalProcess.on(signal, listener);
   }
 
   return () => {
-    for (const signal of signals) {
+    for (const signal of CACHE_SHUTDOWN_SIGNALS) {
       signalProcess.removeListener(signal, listener);
     }
   };

--- a/development/webpack/utils/helpers.ts
+++ b/development/webpack/utils/helpers.ts
@@ -78,22 +78,23 @@ export const UI_COMPONENT_RE = new RegExp(
 export const noop = () => undefined;
 
 /**
- * Temporarily ignores Ctrl+C while webpack closes its filesystem cache.
+ * Temporarily ignores 'SIGINT' and 'SIGTERM' while webpack closes its
+ * filesystem cache.
  *
- * Non-watch builds hand the terminal back before `compiler.close()` completes
- * so webpack can persist the cache in the background. If the process receives
- * a forwarded Ctrl+C during that close window, Node's default handling would
- * terminate the process and can leave the cache partially written.
+ * In the forked build path, the parent exits before `compiler.close()`
+ * completes so webpack can persist the cache in the background. During that
+ * handoff the parent can still forward shutdown signals to the child: Ctrl+C
+ * becomes 'SIGINT', and process managers or CI can send 'SIGTERM'. Node's
+ * default behavior would terminate the child and can leave the cache partially
+ * written.
  *
- * @param signalProcess - The process to install listeners on.
+ * @param process - The process to install signal listeners on.
  * @returns A cleanup function that removes the installed listeners.
  */
-export function ignoreCacheShutdownSignal(signalProcess: NodeJS.Process) {
-  signalProcess.on('SIGINT', noop);
-  // @ts-expect-error - `removeListener` is the correct method, but TypeScript's
-  // types don't allow it because our tsconfig is importing electron types which
-  // aren't correct for Node.
-  return () => signalProcess.removeListener('SIGINT', noop);
+export function ignoreCacheShutdownSignal(process: NodeJS.Process) {
+  const signals = ['SIGINT', 'SIGTERM'] as const;
+  signals.forEach((signal) => process.on(signal, noop));
+  return () => signals.forEach((signal) => process.off(signal, noop));
 }
 
 /**

--- a/development/webpack/utils/helpers.ts
+++ b/development/webpack/utils/helpers.ts
@@ -77,42 +77,23 @@ export const UI_COMPONENT_RE = new RegExp(
  */
 export const noop = () => undefined;
 
-type SignalListener = () => void;
-type SignalProcess = {
-  on: (signal: NodeJS.Signals, listener: SignalListener) => unknown;
-  removeListener: (signal: NodeJS.Signals, listener: SignalListener) => unknown;
-};
-
-const CACHE_SHUTDOWN_SIGNALS = ['SIGINT', 'SIGTERM'] as const;
-
 /**
- * Temporarily ignores shutdown signals while webpack closes its filesystem
- * cache.
+ * Temporarily ignores Ctrl+C while webpack closes its filesystem cache.
  *
  * Non-watch builds hand the terminal back before `compiler.close()` completes
  * so webpack can persist the cache in the background. If the process receives
- * another shutdown signal during that close window, Node's default handling
- * would terminate the process and can leave the cache partially written.
+ * a forwarded Ctrl+C during that close window, Node's default handling would
+ * terminate the process and can leave the cache partially written.
  *
  * @param signalProcess - The process to install listeners on.
  * @returns A cleanup function that removes the installed listeners.
  */
-export function ignoreCacheShutdownSignals(signalProcess: SignalProcess) {
-  const listener = () => {
-    console.error(
-      '🦊 Still shutting down; waiting for webpack to finish writing its cache…',
-    );
-  };
-
-  for (const signal of CACHE_SHUTDOWN_SIGNALS) {
-    signalProcess.on(signal, listener);
-  }
-
-  return () => {
-    for (const signal of CACHE_SHUTDOWN_SIGNALS) {
-      signalProcess.removeListener(signal, listener);
-    }
-  };
+export function ignoreCacheShutdownSignal(signalProcess: NodeJS.Process) {
+  signalProcess.on('SIGINT', noop);
+  // @ts-expect-error - `removeListener` is the correct method, but TypeScript's
+  // types don't allow it because our tsconfig is importing electron types which
+  // aren't correct for Node.
+  return () => signalProcess.removeListener('SIGINT', noop);
 }
 
 /**

--- a/development/webpack/utils/helpers.ts
+++ b/development/webpack/utils/helpers.ts
@@ -77,6 +77,57 @@ export const UI_COMPONENT_RE = new RegExp(
  */
 export const noop = () => undefined;
 
+type SignalListener = () => void;
+type SignalProcess = {
+  on: (signal: NodeJS.Signals, listener: SignalListener) => unknown;
+  removeListener: (
+    signal: NodeJS.Signals,
+    listener: SignalListener,
+  ) => unknown;
+};
+
+type IgnoreCacheShutdownSignalsOptions = {
+  process?: SignalProcess;
+  signals?: readonly NodeJS.Signals[];
+};
+
+const CACHE_SHUTDOWN_SIGNALS = ['SIGINT', 'SIGTERM'] as const;
+
+/**
+ * Temporarily ignores shutdown signals while webpack closes its filesystem
+ * cache.
+ *
+ * Non-watch builds hand the terminal back before `compiler.close()` completes
+ * so webpack can persist the cache in the background. If the process receives
+ * another shutdown signal during that close window, Node's default handling
+ * would terminate the process and can leave the cache partially written.
+ *
+ * @param options - Optional process and signals overrides for tests.
+ * @param options.process
+ * @param options.signals
+ * @returns A cleanup function that removes the installed listeners.
+ */
+export function ignoreCacheShutdownSignals({
+  process: signalProcess = process,
+  signals = CACHE_SHUTDOWN_SIGNALS,
+}: IgnoreCacheShutdownSignalsOptions = {}): () => void {
+  const listener = () => {
+    console.error(
+      '🦊 Still shutting down; waiting for webpack to finish writing its cache…',
+    );
+  };
+
+  for (const signal of signals) {
+    signalProcess.on(signal, listener);
+  }
+
+  return () => {
+    for (const signal of signals) {
+      signalProcess.removeListener(signal, listener);
+    }
+  };
+}
+
 /**
  * @param filename
  * @returns filename with .js extension (.ts | .tsx | .mjs -> .js)


### PR DESCRIPTION
## **Description**

Non-watch webpack builds hand control back to the parent process before `compiler.close()` finishes so the filesystem cache can be persisted in the background. This adds a temporary SIGINT/SIGTERM guard during that cache shutdown window so an extra shutdown signal does not terminate webpack mid-write.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

Its a race condition that is very difficult to cause intentionally. No repro steps available.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only webpack build orchestration; no runtime extension, auth, or user data paths.
> 
> **Overview**
> Non-watch webpack builds still call **`onComplete()`** before **`compiler.close()`** so the parent can exit while the child finishes persisting a **filesystem** cache. That window could let forwarded **SIGINT** / **SIGTERM** kill the child mid-write.
> 
> The build now installs **`ignoreCacheShutdownSignal`** (noop handlers for those signals) only when **`options.cache.type === 'filesystem'`**, removes them in the **`compiler.close`** callback, and cleans up on sync errors in the same **`try`/`catch`**. Unit tests cover install, silent handling, and teardown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccb89ad3e078882cf8a9b9d2140a92b1cf61c1ac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->