### PR TITLE
fix: correct MetaMetrics fragment timeout check

### DIFF
--- a/app/scripts/controllers/metametrics-controller.test.ts
+++ b/app/scripts/controllers/metametrics-controller.test.ts
@@ -476,6 +476,80 @@ describe('MetaMetricsController', function () {
     });
   });
 
+  describe('finalizeAbandonedFragments', function () {
+    it('does not process a fragment if its timeout has not elapsed', async function () {
+      await withController(
+        {
+          options: {
+            state: {
+              fragments: {
+                timeoutFragment: {
+                  ...SAMPLE_PERSISTED_EVENT_NO_ID,
+                  id: 'timeoutFragment',
+                  timeout: 30,
+                  lastUpdated: 1730798301000,
+                },
+              },
+            },
+          },
+        },
+        ({ controller }) => {
+          jest.useFakeTimers().setSystemTime(1730798330000);
+          const processAbandonedFragmentSpy = jest.spyOn(
+            controller,
+            'processAbandonedFragment',
+          );
+
+          controller.finalizeAbandonedFragments();
+
+          expect(processAbandonedFragmentSpy).not.toHaveBeenCalled();
+          expect(controller.state.fragments.timeoutFragment).toStrictEqual({
+            ...SAMPLE_PERSISTED_EVENT_NO_ID,
+            id: 'timeoutFragment',
+            timeout: 30,
+            lastUpdated: 1730798301000,
+          });
+        },
+      );
+    });
+
+    it('processes a fragment if its timeout has elapsed', async function () {
+      await withController(
+        {
+          options: {
+            state: {
+              fragments: {
+                timeoutFragment: {
+                  ...SAMPLE_PERSISTED_EVENT_NO_ID,
+                  id: 'timeoutFragment',
+                  timeout: 30,
+                  lastUpdated: 1730798299000,
+                },
+              },
+            },
+          },
+        },
+        ({ controller }) => {
+          jest.useFakeTimers().setSystemTime(1730798330000);
+          const processAbandonedFragmentSpy = jest.spyOn(
+            controller,
+            'processAbandonedFragment',
+          );
+
+          controller.finalizeAbandonedFragments();
+
+          expect(processAbandonedFragmentSpy).toHaveBeenCalledTimes(1);
+          expect(processAbandonedFragmentSpy).toHaveBeenCalledWith(
+            expect.objectContaining({
+              id: 'timeoutFragment',
+            }),
+          );
+          expect(controller.state.fragments.timeoutFragment).toBeUndefined();
+        },
+      );
+    });
+  });
+
   describe('getMetaMetricsId', function () {
     it('should generate or return the metametrics id', async function () {
       await withController(

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -603,7 +603,7 @@ export class MetaMetricsController extends BaseController<
       if (
         fragment.timeout &&
         fragment.lastUpdated &&
-        Date.now() - fragment.lastUpdated / 1000 > fragment.timeout
+        Date.now() - fragment.lastUpdated > fragment.timeout * 1000
       ) {
         this.processAbandonedFragment(fragment);
       }


### PR DESCRIPTION
## Summary
- fix the MetaMetrics fragment timeout comparison to use consistent units
- add regression coverage for fragments before and after the timeout boundary

## Why
The abandonment check was comparing `Date.now()` milliseconds against a `timeout` value documented in seconds, with the old expression relying on the wrong operator grouping. This could mark timed fragments as abandoned earlier than intended.

## Impact
- makes the timeout path behave according to the fragment contract
- protects the behavior with focused unit tests

## Validation
- `yarn test:unit app/scripts/controllers/metametrics-controller.test.ts --runInBand`
- `yarn lint:changed:fix`

Fixes #42895

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the time-based abandonment condition for MetaMetrics event fragments, which can alter when fragments are auto-finalized/deleted and thus affect analytics event emission. Covered by new boundary-focused unit tests to reduce regression risk.
> 
> **Overview**
> Fixes `MetaMetricsController.finalizeAbandonedFragments` to compare `Date.now()` and `fragment.lastUpdated` in **milliseconds**, converting `timeout` (seconds) via `timeout * 1000`.
> 
> Adds regression tests that freeze time and assert fragments are **not** processed just before the timeout boundary and **are** processed (and removed) once the timeout has elapsed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 417b9e3ab8d28e74ed9ed55dcb99e9407bb1091c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->