### PR TITLE
feat: Add integration for new QR error handling

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -37,9 +37,6 @@
   "QRHardwareUnknownQRCodeTitle": {
     "message": "Fehler"
   },
-  "QRHardwareUnknownWalletQRCode": {
-    "message": "Ungültiger QR-Code. Bitte scannen Sie den QR-Code der Hardware-Wallet."
-  },
   "QRHardwareWalletImporterTitle": {
     "message": "QR-Code scannen"
   },

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -37,9 +37,6 @@
   "QRHardwareUnknownQRCodeTitle": {
     "message": "Σφάλμα"
   },
-  "QRHardwareUnknownWalletQRCode": {
-    "message": "Μη έγκυρος κωδικός QR. Σαρώστε τον κωδικό QR του πορτοφολιού υλικού."
-  },
   "QRHardwareWalletImporterTitle": {
     "message": "Σάρωση κωδικού QR"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -37,9 +37,6 @@
   "QRHardwareUnknownQRCodeTitle": {
     "message": "Error"
   },
-  "QRHardwareUnknownWalletQRCode": {
-    "message": "Invalid QR code. Please scan the sync QR code of the hardware wallet."
-  },
   "QRHardwareWalletImporterTitle": {
     "message": "Scan QR code"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -37,9 +37,6 @@
   "QRHardwareUnknownQRCodeTitle": {
     "message": "Error"
   },
-  "QRHardwareUnknownWalletQRCode": {
-    "message": "Invalid QR code. Please scan the sync QR code of the hardware wallet."
-  },
   "QRHardwareWalletImporterTitle": {
     "message": "Scan QR code"
   },

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -37,9 +37,6 @@
   "QRHardwareUnknownQRCodeTitle": {
     "message": "Error"
   },
-  "QRHardwareUnknownWalletQRCode": {
-    "message": "Código QR no válido. Escanee el QR sincronizado del monedero físico."
-  },
   "QRHardwareWalletImporterTitle": {
     "message": "Escanear código QR"
   },

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -37,9 +37,6 @@
   "QRHardwareUnknownQRCodeTitle": {
     "message": "Erreur"
   },
-  "QRHardwareUnknownWalletQRCode": {
-    "message": "Code QR invalide. Scannez le code QR de synchronisation du portefeuille matériel."
-  },
   "QRHardwareWalletImporterTitle": {
     "message": "Scannez le code QR"
   },

--- a/app/_locales/ga/messages.json
+++ b/app/_locales/ga/messages.json
@@ -37,9 +37,6 @@
   "QRHardwareUnknownQRCodeTitle": {
     "message": "Earráid"
   },
-  "QRHardwareUnknownWalletQRCode": {
-    "message": "Cód QR neamhbhailí. Scanáil an cód QR sioncrónaithe den sparán crua-earraí le do thoil."
-  },
   "QRHardwareWalletImporterTitle": {
     "message": "Scanáil cód QR"
   },

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -37,9 +37,6 @@
   "QRHardwareUnknownQRCodeTitle": {
     "message": "गड़बड़ी"
   },
-  "QRHardwareUnknownWalletQRCode": {
-    "message": "QR कोड ग़लत है। कृपया hardware wallet के सिंक QR कोड को स्कैन करें।"
-  },
   "QRHardwareWalletImporterTitle": {
     "message": "QR कोड स्कैन करें"
   },

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -37,9 +37,6 @@
   "QRHardwareUnknownQRCodeTitle": {
     "message": "Kesalahan"
   },
-  "QRHardwareUnknownWalletQRCode": {
-    "message": "Kode QR tidak valid. Harap pindai kode QR sinkronisasi dari dompet perangkat keras."
-  },
   "QRHardwareWalletImporterTitle": {
     "message": "Pindai kode QR"
   },

--- a/app/_locales/it/messages.json
+++ b/app/_locales/it/messages.json
@@ -29,9 +29,6 @@
   "QRHardwareUnknownQRCodeTitle": {
     "message": "Errore"
   },
-  "QRHardwareUnknownWalletQRCode": {
-    "message": "Codice QR non valido. Scansiona il codice QR di sincronizzazione del portafoglio hardware."
-  },
   "QRHardwareWalletImporterTitle": {
     "message": "Scansiona Codice QR"
   },

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -37,9 +37,6 @@
   "QRHardwareUnknownQRCodeTitle": {
     "message": "エラー"
   },
-  "QRHardwareUnknownWalletQRCode": {
-    "message": "QRコードが無効です。ハードウェアウォレットの同期QRコードをスキャンしてください。"
-  },
   "QRHardwareWalletImporterTitle": {
     "message": "QRコードをスキャン"
   },

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -37,9 +37,6 @@
   "QRHardwareUnknownQRCodeTitle": {
     "message": "오류"
   },
-  "QRHardwareUnknownWalletQRCode": {
-    "message": "잘못된 QR 코드입니다. 하드웨어 지갑의 동기화 QR 코드를 스캔하세요."
-  },
   "QRHardwareWalletImporterTitle": {
     "message": "QR 코드 스캔"
   },

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -37,9 +37,6 @@
   "QRHardwareUnknownQRCodeTitle": {
     "message": "Erro"
   },
-  "QRHardwareUnknownWalletQRCode": {
-    "message": "Código QR inválido. Leia o código QR de sincronização da carteira de hardware."
-  },
   "QRHardwareWalletImporterTitle": {
     "message": "Ler código QR"
   },

--- a/app/_locales/pt_BR/messages.json
+++ b/app/_locales/pt_BR/messages.json
@@ -29,9 +29,6 @@
   "QRHardwareUnknownQRCodeTitle": {
     "message": "Erro"
   },
-  "QRHardwareUnknownWalletQRCode": {
-    "message": "QR code inválido. Escaneie o QR code de sincronização da carteira de hardware."
-  },
   "QRHardwareWalletImporterTitle": {
     "message": "Escanear QR code"
   },

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -37,9 +37,6 @@
   "QRHardwareUnknownQRCodeTitle": {
     "message": "Ошибка"
   },
-  "QRHardwareUnknownWalletQRCode": {
-    "message": "Недействительный QR-код. Отсканируйте QR-код синхронизации аппаратного кошелька."
-  },
   "QRHardwareWalletImporterTitle": {
     "message": "Сканировать QR-код"
   },

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -37,9 +37,6 @@
   "QRHardwareUnknownQRCodeTitle": {
     "message": "Error"
   },
-  "QRHardwareUnknownWalletQRCode": {
-    "message": "Di-wastong QR code. Paki-scan ang sync QR code ng wallet na hardware."
-  },
   "QRHardwareWalletImporterTitle": {
     "message": "Mag-scan ng QR code"
   },

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -37,9 +37,6 @@
   "QRHardwareUnknownQRCodeTitle": {
     "message": "Hata"
   },
-  "QRHardwareUnknownWalletQRCode": {
-    "message": "Geçersiz QR kodu. Lütfen donanım cüzdanının senkronizasyon QR kodunu tarayın."
-  },
   "QRHardwareWalletImporterTitle": {
     "message": "QR kodunu tara"
   },

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -37,9 +37,6 @@
   "QRHardwareUnknownQRCodeTitle": {
     "message": "Lỗi"
   },
-  "QRHardwareUnknownWalletQRCode": {
-    "message": "Mã QR không hợp lệ. Vui lòng quét mã QR đồng bộ của ví cứng."
-  },
   "QRHardwareWalletImporterTitle": {
     "message": "Quét mã QR"
   },

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -37,9 +37,6 @@
   "QRHardwareUnknownQRCodeTitle": {
     "message": "错误"
   },
-  "QRHardwareUnknownWalletQRCode": {
-    "message": "二维码无效。请扫描硬件钱包的同步二维码。"
-  },
   "QRHardwareWalletImporterTitle": {
     "message": "扫描二维码"
   },

--- a/ui/components/app/qr-hardware-popover/base-reader-reducer.ts
+++ b/ui/components/app/qr-hardware-popover/base-reader-reducer.ts
@@ -3,6 +3,7 @@ import {
   type CameraReadyStateValue,
   type WebcamError,
 } from './base-reader.types';
+import type { ScanErrorClassification } from './qr-utils/qr-utils';
 
 export const ActionType = {
   SetReady: 'SET_READY',
@@ -11,6 +12,7 @@ export const ActionType = {
   SetAccessingCamera: 'SET_ACCESSING_CAMERA',
   SetError: 'SET_ERROR',
   ClearError: 'CLEAR_ERROR',
+  SetScanError: 'SET_SCAN_ERROR',
   SetScanProgress: 'SET_SCAN_PROGRESS',
   SetPermissionActionLoading: 'SET_PERMISSION_ACTION_LOADING',
   Reset: 'RESET',
@@ -23,6 +25,7 @@ type Action =
   | { type: typeof ActionType.SetAccessingCamera }
   | { type: typeof ActionType.SetError; payload: WebcamError }
   | { type: typeof ActionType.ClearError }
+  | { type: typeof ActionType.SetScanError; payload: ScanErrorClassification }
   | { type: typeof ActionType.SetScanProgress; payload: number }
   | { type: typeof ActionType.SetPermissionActionLoading; payload: boolean }
   | { type: typeof ActionType.Reset };
@@ -30,6 +33,7 @@ type Action =
 export type BaseReaderState = {
   readyState: CameraReadyStateValue;
   error: WebcamError | null;
+  scanError: ScanErrorClassification | null;
   scanProgress: number;
   permissionActionLoading: boolean;
 };
@@ -44,6 +48,7 @@ export function getInitialState(): BaseReaderState {
   return {
     readyState: CameraReadyState.AccessingCamera,
     error: null,
+    scanError: null,
     scanProgress: 0,
     permissionActionLoading: false,
   };
@@ -88,6 +93,8 @@ export function baseReaderReducer(
       return { ...state, error: action.payload };
     case ActionType.ClearError:
       return { ...state, error: null };
+    case ActionType.SetScanError:
+      return { ...state, scanError: action.payload };
     case ActionType.SetScanProgress:
       return { ...state, scanProgress: action.payload };
     case ActionType.SetPermissionActionLoading:

--- a/ui/components/app/qr-hardware-popover/base-reader.test.tsx
+++ b/ui/components/app/qr-hardware-popover/base-reader.test.tsx
@@ -705,7 +705,7 @@ describe('BaseReader', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders unknown QR code error when scan throws during wallet read', async () => {
+  it('renders QrErrorContent when scan throws during wallet read', async () => {
     setupWebcamUtilsSuccess();
     mockEnhancedReader.mockImplementation((({
       onFrame,
@@ -722,14 +722,11 @@ describe('BaseReader', () => {
     renderWithProvider(<BaseReader {...defaultProps} isReadingWallet />);
 
     expect(
-      await screen.findByText(messages.QRHardwareUnknownWalletQRCode.message),
+      await screen.findByTestId('qr-error-nonUrQrCode-pairing'),
     ).toBeInTheDocument();
-    expect(defaultProps.setErrorTitle).toHaveBeenCalledWith(
-      messages.QRHardwareUnknownQRCodeTitle.message,
-    );
   });
 
-  it('renders unknown QR code error for signing flow when scan throws', async () => {
+  it('renders QrErrorContent for signing flow when scan throws', async () => {
     setupWebcamUtilsSuccess();
     mockEnhancedReader.mockImplementation((({
       onFrame,
@@ -748,11 +745,8 @@ describe('BaseReader', () => {
     );
 
     expect(
-      await screen.findByText(messages.unknownQrCode.message),
+      await screen.findByTestId('qr-error-nonUrQrCode-signing'),
     ).toBeInTheDocument();
-    expect(defaultProps.setErrorTitle).toHaveBeenCalledWith(
-      messages.QRHardwareInvalidTransactionTitle.message,
-    );
   });
 
   // ---- Cancel & Try Again on error UI ------------------------------------

--- a/ui/components/app/qr-hardware-popover/base-reader.tsx
+++ b/ui/components/app/qr-hardware-popover/base-reader.tsx
@@ -35,6 +35,8 @@ import {
   useDecoderLifecycle,
   useCameraPermission,
 } from './qr-hooks';
+import { QrErrorContent, QrErrorFlowContext } from './qr-error-content';
+import { scanCategoryToQrErrorType } from './qr-utils/qr-utils';
 import EnhancedReader from './enhanced-reader';
 
 /**
@@ -76,11 +78,12 @@ const BaseReader = ({
   const { trackEvent } = useContext(MetaMetricsContext);
 
   const {
-    state: { readyState, error, scanProgress, permissionActionLoading },
+    state: { readyState, error, scanError, scanProgress, permissionActionLoading },
     setReady,
     setBlocked,
     setNeeded,
     setError,
+    setScanError,
     setScanProgress,
     setPermissionActionLoading,
     reset,
@@ -154,9 +157,8 @@ const BaseReader = ({
   // ---- Decoder lifecycle --------------------------------------------------
 
   const { handleScan, resetDecoder } = useDecoderLifecycle(
-    { handleSuccess, isReadingWallet, setErrorTitle },
-    { setScanProgress, setError },
-    t,
+    { handleSuccess, isReadingWallet },
+    { setScanProgress, setScanError, setError },
   );
 
   // ---- Camera permission lifecycle ----------------------------------------
@@ -196,7 +198,29 @@ const BaseReader = ({
     });
   }, []);
 
-  // ---- Render: error UI ---------------------------------------------------
+  // ---- Render: classified scan error UI ------------------------------------
+
+  if (scanError) {
+    const flowContext = isReadingWallet
+      ? QrErrorFlowContext.Pairing
+      : QrErrorFlowContext.Signing;
+
+    return (
+      <Box
+        flexDirection={BoxFlexDirection.Column}
+        alignItems={BoxAlignItems.Center}
+        className="qr-scanner"
+      >
+        <QrErrorContent
+          errorType={scanCategoryToQrErrorType(scanError.category)}
+          flowContext={flowContext}
+          onTryAgain={tryAgain}
+        />
+      </Box>
+    );
+  }
+
+  // ---- Render: legacy error UI (webcam / handleSuccess rejection) ---------
 
   if (error) {
     let title: string | undefined;
@@ -205,10 +229,6 @@ const BaseReader = ({
     if (error.type === WebcamErrorType.NoWebcamFound) {
       title = t('noWebcamFoundTitle');
       message = t('noWebcamFound');
-    } else if (error.message === t('unknownQrCode')) {
-      message = isReadingWallet
-        ? t('QRHardwareUnknownWalletQRCode')
-        : t('unknownQrCode');
     } else if (error.message === t('QRHardwareMismatchedSignId')) {
       message = t('QRHardwareMismatchedSignId');
     } else {

--- a/ui/components/app/qr-hardware-popover/base-reader.tsx
+++ b/ui/components/app/qr-hardware-popover/base-reader.tsx
@@ -78,7 +78,13 @@ const BaseReader = ({
   const { trackEvent } = useContext(MetaMetricsContext);
 
   const {
-    state: { readyState, error, scanError, scanProgress, permissionActionLoading },
+    state: {
+      readyState,
+      error,
+      scanError,
+      scanProgress,
+      permissionActionLoading,
+    },
     setReady,
     setBlocked,
     setNeeded,

--- a/ui/components/app/qr-hardware-popover/qr-hardware-sign-request/reader.js
+++ b/ui/components/app/qr-hardware-popover/qr-hardware-sign-request/reader.js
@@ -17,10 +17,6 @@ const Reader = ({
   };
 
   const handleSuccess = async (ur) => {
-    if (ur.type !== 'eth-signature') {
-      setErrorTitle(t('QRHardwareInvalidTransactionTitle'));
-      throw new Error(t('unknownQrCode'));
-    }
     const ethSignature = ETHSignature.fromCBOR(ur.cbor);
     const buffer = ethSignature.getRequestId();
     const signId = uuid.stringify(buffer);

--- a/ui/components/app/qr-hardware-popover/qr-hooks/qr-hooks-utils.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/qr-hooks-utils.ts
@@ -3,6 +3,19 @@ import { CameraPermissionState } from '../../../../contexts/hardware-wallets/con
 import { DOMExceptionName } from '../base-reader.types';
 
 /**
+ * Expected UR types for the wallet-pairing flow.
+ */
+export const PAIRING_EXPECTED_TYPES = [
+  'crypto-hdkey',
+  'crypto-account',
+] as const;
+
+/**
+ * Expected UR types for the transaction-signing flow.
+ */
+export const SIGNING_EXPECTED_TYPES = ['eth-signature'] as const;
+
+/**
  * Determines whether the camera-access-blocked UI should be shown
  * based on the current permission state and browser type.
  *

--- a/ui/components/app/qr-hardware-popover/qr-hooks/qr-hooks.types.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/qr-hooks.types.ts
@@ -1,4 +1,5 @@
 import type { WebcamError } from '../base-reader.types';
+import type { ScanErrorClassification } from '../qr-utils/qr-utils';
 
 /**
  * State dispatch functions consumed by the camera permission hook.
@@ -23,5 +24,6 @@ export type TrackingCallbacks = {
  */
 export type DecoderCallbacks = {
   setScanProgress: (progress: number) => void;
+  setScanError: (scanError: ScanErrorClassification) => void;
   setError: (error: WebcamError) => void;
 };

--- a/ui/components/app/qr-hardware-popover/qr-hooks/useBaseReaderReducer.test.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/useBaseReaderReducer.test.ts
@@ -5,6 +5,8 @@ import {
   getInitialState,
   ActionType,
 } from '../base-reader-reducer';
+import { ScanErrorCategory } from '../qr-utils/qr-utils';
+import type { ScanErrorClassification } from '../qr-utils/qr-utils';
 import { useBaseReaderReducer } from './useBaseReaderReducer';
 
 describe('baseReaderReducer', () => {
@@ -14,6 +16,7 @@ describe('baseReaderReducer', () => {
       expect(state).toStrictEqual({
         readyState: CameraReadyState.AccessingCamera,
         error: null,
+        scanError: null,
         scanProgress: 0,
         permissionActionLoading: false,
       });
@@ -88,6 +91,20 @@ describe('baseReaderReducer', () => {
     });
   });
 
+  describe('SetScanError', () => {
+    it('stores the scan error classification', () => {
+      const scanError: ScanErrorClassification = {
+        category: ScanErrorCategory.NonUrQrScanned,
+        isUrFormat: false,
+      };
+      const next = baseReaderReducer(getInitialState(), {
+        type: ActionType.SetScanError,
+        payload: scanError,
+      });
+      expect(next.scanError).toBe(scanError);
+    });
+  });
+
   describe('SetScanProgress', () => {
     it('updates scanProgress', () => {
       const next = baseReaderReducer(getInitialState(), {
@@ -113,6 +130,11 @@ describe('baseReaderReducer', () => {
       const dirty = {
         readyState: CameraReadyState.Ready,
         error: new Error('whoops'),
+        scanError: {
+          category: ScanErrorCategory.ScanException,
+          isUrFormat: false,
+          rawMessage: 'crash',
+        } as ScanErrorClassification,
         scanProgress: 0.5,
         permissionActionLoading: true,
       };
@@ -164,6 +186,14 @@ describe('useBaseReaderReducer', () => {
 
     act(() => result.current.clearError());
     expect(result.current.state.error).toBeNull();
+
+    const scanError: ScanErrorClassification = {
+      category: ScanErrorCategory.WrongUrType,
+      isUrFormat: true,
+      receivedUrType: 'crypto-psbt',
+    };
+    act(() => result.current.setScanError(scanError));
+    expect(result.current.state.scanError).toBe(scanError);
 
     act(() => result.current.setScanProgress(0.42));
     expect(result.current.state.scanProgress).toBe(0.42);

--- a/ui/components/app/qr-hardware-popover/qr-hooks/useBaseReaderReducer.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/useBaseReaderReducer.ts
@@ -4,6 +4,7 @@ import {
   getInitialState,
   ActionType,
 } from '../base-reader-reducer';
+import type { ScanErrorClassification } from '../qr-utils/qr-utils';
 
 /**
  * Wraps the BaseReader reducer and provides typed dispatch helpers so callers
@@ -46,6 +47,11 @@ export function useBaseReaderReducer() {
     () => dispatch({ type: ActionType.ClearError }),
     [],
   );
+  const setScanError = useCallback(
+    (scanError: ScanErrorClassification) =>
+      dispatch({ type: ActionType.SetScanError, payload: scanError }),
+    [],
+  );
   const setScanProgress = useCallback(
     (progress: number) =>
       dispatch({ type: ActionType.SetScanProgress, payload: progress }),
@@ -69,6 +75,7 @@ export function useBaseReaderReducer() {
     setAccessingCamera,
     setError,
     clearError,
+    setScanError,
     setScanProgress,
     setPermissionActionLoading,
     reset,

--- a/ui/components/app/qr-hardware-popover/qr-hooks/useDecoderLifecycle.test.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/useDecoderLifecycle.test.ts
@@ -1,5 +1,6 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import { URDecoder } from '@ngraveio/bc-ur';
+import { ScanErrorCategory } from '../qr-utils/qr-utils';
 import { useDecoderLifecycle } from './useDecoderLifecycle';
 
 jest.mock('@ngraveio/bc-ur', () => {
@@ -19,19 +20,18 @@ const mockURDecoder = jest.mocked(URDecoder);
 
 describe('useDecoderLifecycle', () => {
   const mockHandleSuccess = jest.fn().mockResolvedValue(undefined);
-  const mockSetErrorTitle = jest.fn();
   const mockSetScanProgress = jest.fn();
+  const mockSetScanError = jest.fn();
   const mockSetError = jest.fn();
-  const mockT = jest.fn((key: string) => key);
 
   const defaultProps = {
     handleSuccess: mockHandleSuccess,
     isReadingWallet: true,
-    setErrorTitle: mockSetErrorTitle,
   };
 
   const defaultCallbacks = {
     setScanProgress: mockSetScanProgress,
+    setScanError: mockSetScanError,
     setError: mockSetError,
   };
 
@@ -43,7 +43,7 @@ describe('useDecoderLifecycle', () => {
     props = defaultProps,
     callbacks = defaultCallbacks,
   ) {
-    return renderHook(() => useDecoderLifecycle(props, callbacks, mockT));
+    return renderHook(() => useDecoderLifecycle(props, callbacks));
   }
 
   describe('handleScan', () => {
@@ -134,7 +134,73 @@ describe('useDecoderLifecycle', () => {
       expect(mockInstance.receivePart).not.toHaveBeenCalled();
     });
 
-    it('sets wallet error title when scan throws and isReadingWallet is true', () => {
+    it('classifies as WrongUrType when decoded UR does not match expected pairing types', () => {
+      const mockInstance = {
+        isComplete: jest
+          .fn()
+          .mockReturnValueOnce(false)
+          .mockReturnValueOnce(true),
+        receivePart: jest.fn(),
+        estimatedPercentComplete: jest.fn().mockReturnValue(1),
+        resultUR: jest.fn().mockReturnValue({ type: 'eth-signature' }),
+      };
+      mockURDecoder.mockImplementation(
+        () => mockInstance as unknown as URDecoder,
+      );
+
+      const { result } = renderDecoderHook({
+        ...defaultProps,
+        isReadingWallet: true,
+      });
+
+      act(() => {
+        result.current.handleScan('ur:eth-signature/complete-frame');
+      });
+
+      expect(mockSetScanError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: ScanErrorCategory.WrongUrType,
+          isUrFormat: true,
+          receivedUrType: 'eth-signature',
+        }),
+      );
+      expect(mockHandleSuccess).not.toHaveBeenCalled();
+    });
+
+    it('classifies as WrongUrType when decoded UR does not match expected signing types', () => {
+      const mockInstance = {
+        isComplete: jest
+          .fn()
+          .mockReturnValueOnce(false)
+          .mockReturnValueOnce(true),
+        receivePart: jest.fn(),
+        estimatedPercentComplete: jest.fn().mockReturnValue(1),
+        resultUR: jest.fn().mockReturnValue({ type: 'crypto-hdkey' }),
+      };
+      mockURDecoder.mockImplementation(
+        () => mockInstance as unknown as URDecoder,
+      );
+
+      const { result } = renderDecoderHook({
+        ...defaultProps,
+        isReadingWallet: false,
+      });
+
+      act(() => {
+        result.current.handleScan('ur:crypto-hdkey/complete-frame');
+      });
+
+      expect(mockSetScanError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: ScanErrorCategory.WrongUrType,
+          isUrFormat: true,
+          receivedUrType: 'crypto-hdkey',
+        }),
+      );
+      expect(mockHandleSuccess).not.toHaveBeenCalled();
+    });
+
+    it('classifies non-UR data as NonUrQrScanned when isReadingWallet is true', () => {
       const mockInstance = {
         isComplete: jest.fn().mockReturnValue(false),
         receivePart: jest.fn().mockImplementation(() => {
@@ -156,15 +222,15 @@ describe('useDecoderLifecycle', () => {
         result.current.handleScan('bad-data');
       });
 
-      expect(mockSetErrorTitle).toHaveBeenCalledWith(
-        'QRHardwareUnknownQRCodeTitle',
-      );
-      expect(mockSetError).toHaveBeenCalledWith(
-        expect.objectContaining({ message: 'unknownQrCode' }),
+      expect(mockSetScanError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: ScanErrorCategory.NonUrQrScanned,
+          isUrFormat: false,
+        }),
       );
     });
 
-    it('sets transaction error title when scan throws and isReadingWallet is false', () => {
+    it('classifies non-UR data as NonUrQrScanned when isReadingWallet is false', () => {
       const mockInstance = {
         isComplete: jest.fn().mockReturnValue(false),
         receivePart: jest.fn().mockImplementation(() => {
@@ -186,8 +252,39 @@ describe('useDecoderLifecycle', () => {
         result.current.handleScan('bad-data');
       });
 
-      expect(mockSetErrorTitle).toHaveBeenCalledWith(
-        'QRHardwareInvalidTransactionTitle',
+      expect(mockSetScanError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: ScanErrorCategory.NonUrQrScanned,
+          isUrFormat: false,
+        }),
+      );
+    });
+
+    it('classifies UR-formatted data that throws as ScanException with isUrFormat true', () => {
+      const mockInstance = {
+        isComplete: jest.fn().mockReturnValue(false),
+        receivePart: jest.fn().mockImplementation(() => {
+          throw new Error('cbor decode failure');
+        }),
+        estimatedPercentComplete: jest.fn(),
+        resultUR: jest.fn(),
+      };
+      mockURDecoder.mockImplementation(
+        () => mockInstance as unknown as URDecoder,
+      );
+
+      const { result } = renderDecoderHook();
+
+      act(() => {
+        result.current.handleScan('ur:crypto-hdkey/corrupted-data');
+      });
+
+      expect(mockSetScanError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: ScanErrorCategory.ScanException,
+          isUrFormat: true,
+          rawMessage: 'cbor decode failure',
+        }),
       );
     });
 

--- a/ui/components/app/qr-hardware-popover/qr-hooks/useDecoderLifecycle.test.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/useDecoderLifecycle.test.ts
@@ -157,13 +157,11 @@ describe('useDecoderLifecycle', () => {
         result.current.handleScan('ur:eth-signature/complete-frame');
       });
 
-      expect(mockSetScanError).toHaveBeenCalledWith(
-        expect.objectContaining({
-          category: ScanErrorCategory.WrongUrType,
-          isUrFormat: true,
-          receivedUrType: 'eth-signature',
-        }),
-      );
+      expect(mockSetScanError).toHaveBeenCalledWith({
+        category: ScanErrorCategory.WrongUrType,
+        isUrFormat: true,
+        receivedUrType: 'eth-signature',
+      });
       expect(mockHandleSuccess).not.toHaveBeenCalled();
     });
 
@@ -190,13 +188,11 @@ describe('useDecoderLifecycle', () => {
         result.current.handleScan('ur:crypto-hdkey/complete-frame');
       });
 
-      expect(mockSetScanError).toHaveBeenCalledWith(
-        expect.objectContaining({
-          category: ScanErrorCategory.WrongUrType,
-          isUrFormat: true,
-          receivedUrType: 'crypto-hdkey',
-        }),
-      );
+      expect(mockSetScanError).toHaveBeenCalledWith({
+        category: ScanErrorCategory.WrongUrType,
+        isUrFormat: true,
+        receivedUrType: 'crypto-hdkey',
+      });
       expect(mockHandleSuccess).not.toHaveBeenCalled();
     });
 
@@ -222,12 +218,11 @@ describe('useDecoderLifecycle', () => {
         result.current.handleScan('bad-data');
       });
 
-      expect(mockSetScanError).toHaveBeenCalledWith(
-        expect.objectContaining({
-          category: ScanErrorCategory.NonUrQrScanned,
-          isUrFormat: false,
-        }),
-      );
+      expect(mockSetScanError).toHaveBeenCalledWith({
+        category: ScanErrorCategory.NonUrQrScanned,
+        isUrFormat: false,
+      });
+      expect(mockHandleSuccess).not.toHaveBeenCalled();
     });
 
     it('classifies non-UR data as NonUrQrScanned when isReadingWallet is false', () => {
@@ -252,12 +247,11 @@ describe('useDecoderLifecycle', () => {
         result.current.handleScan('bad-data');
       });
 
-      expect(mockSetScanError).toHaveBeenCalledWith(
-        expect.objectContaining({
-          category: ScanErrorCategory.NonUrQrScanned,
-          isUrFormat: false,
-        }),
-      );
+      expect(mockSetScanError).toHaveBeenCalledWith({
+        category: ScanErrorCategory.NonUrQrScanned,
+        isUrFormat: false,
+      });
+      expect(mockHandleSuccess).not.toHaveBeenCalled();
     });
 
     it('classifies UR-formatted data that throws as ScanException with isUrFormat true', () => {
@@ -279,13 +273,12 @@ describe('useDecoderLifecycle', () => {
         result.current.handleScan('ur:crypto-hdkey/corrupted-data');
       });
 
-      expect(mockSetScanError).toHaveBeenCalledWith(
-        expect.objectContaining({
-          category: ScanErrorCategory.ScanException,
-          isUrFormat: true,
-          rawMessage: 'cbor decode failure',
-        }),
-      );
+      expect(mockSetScanError).toHaveBeenCalledWith({
+        category: ScanErrorCategory.ScanException,
+        isUrFormat: true,
+        rawMessage: 'cbor decode failure',
+      });
+      expect(mockHandleSuccess).not.toHaveBeenCalled();
     });
 
     it('calls setError when handleSuccess rejects', async () => {

--- a/ui/components/app/qr-hardware-popover/qr-hooks/useDecoderLifecycle.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/useDecoderLifecycle.ts
@@ -1,39 +1,35 @@
 import { useCallback, useRef } from 'react';
 import { URDecoder } from '@ngraveio/bc-ur';
-import type { useI18nContext } from '../../../../hooks/useI18nContext';
 import type { BaseReaderProps, WebcamError } from '../base-reader.types';
+import { classifyScanResult } from '../qr-utils/qr-utils';
 import type { DecoderCallbacks } from './qr-hooks.types';
+import {
+  PAIRING_EXPECTED_TYPES,
+  SIGNING_EXPECTED_TYPES,
+} from './qr-hooks-utils';
 
 /**
  * Manages the URDecoder lifecycle: creating, receiving parts, tracking
  * progress, and forwarding complete URs to the parent handler.
  *
- * The decoder is stored in a ref rather than state because its internal
- * mutation (receivePart) shouldn't trigger re-renders — only the derived
- * `scanProgress` needs to update the UI.
+ * Uses {@link classifyScanResult} to produce granular error classifications
+ * instead of generic error messages when scanning fails.
  *
- * @param props - Subset of BaseReader props needed for decoding:
- * `handleSuccess`, `isReadingWallet`, and `setErrorTitle`.
- * @param callbacks - State dispatchers: `setScanProgress` and `setError`.
- * @param t - i18n translation function used for error messages.
+ * @param props - Subset of BaseReader props needed for decoding.
+ * @param callbacks - State dispatchers for progress and errors.
  * @returns An object with `handleScan` (feed QR frames) and `resetDecoder`
  * (reinitialize the decoder for retry flows).
  */
 export function useDecoderLifecycle(
-  props: Pick<
-    BaseReaderProps,
-    'handleSuccess' | 'isReadingWallet' | 'setErrorTitle'
-  >,
+  props: Pick<BaseReaderProps, 'handleSuccess' | 'isReadingWallet'>,
   callbacks: DecoderCallbacks,
-  t: ReturnType<typeof useI18nContext>,
 ) {
-  const { handleSuccess, isReadingWallet, setErrorTitle } = props;
-  const { setScanProgress, setError } = callbacks;
+  const { handleSuccess, isReadingWallet } = props;
+  const { setScanProgress, setScanError, setError } = callbacks;
   const decoderRef = useRef<URDecoder | null>(null);
+  const lastScannedTextRef = useRef<string | null>(null);
 
   /**
-   * Lazy-init accessor for the URDecoder ref.
-   *
    * Constructs the decoder on first access and returns the same instance on
    * subsequent calls, avoiding wasteful instantiation on every render while
    * providing a guaranteed non-null return type to callers.
@@ -53,12 +49,16 @@ export function useDecoderLifecycle(
    */
   const resetDecoder = useCallback(() => {
     decoderRef.current = new URDecoder();
+    lastScannedTextRef.current = null;
     setScanProgress(0);
   }, [setScanProgress]);
 
   /**
    * Feeds a scanned QR payload into the URDecoder. When the UR is fully
    * assembled, invokes `handleSuccess` with the decoded result.
+   *
+   * On failure, classifies the error via {@link classifyScanResult} and
+   * dispatches the result as a structured `scanError`.
    *
    * @param data - Raw text content of a single scanned QR frame, or null.
    */
@@ -69,31 +69,46 @@ export function useDecoderLifecycle(
         if (!data || decoder.isComplete()) {
           return;
         }
+        lastScannedTextRef.current = data;
         decoder.receivePart(data);
         setScanProgress(decoder.estimatedPercentComplete());
         if (decoder.isComplete()) {
           const result = decoder.resultUR();
+          const expectedTypes = isReadingWallet
+            ? PAIRING_EXPECTED_TYPES
+            : SIGNING_EXPECTED_TYPES;
+
+          const typeCheck = classifyScanResult({
+            decodedType: result.type,
+            expectedTypes,
+          });
+
+          if (typeCheck) {
+            setScanError(typeCheck);
+            return;
+          }
+
           handleSuccess(result).catch((successError: WebcamError) =>
             setError(successError),
           );
         }
-      } catch {
-        if (isReadingWallet) {
-          setErrorTitle(t('QRHardwareUnknownQRCodeTitle'));
-        } else {
-          setErrorTitle(t('QRHardwareInvalidTransactionTitle'));
+      } catch (exception) {
+        const expectedTypes = isReadingWallet
+          ? PAIRING_EXPECTED_TYPES
+          : SIGNING_EXPECTED_TYPES;
+
+        const classification = classifyScanResult({
+          text: lastScannedTextRef.current ?? undefined,
+          expectedTypes,
+          exception,
+        });
+
+        if (classification) {
+          setScanError(classification);
         }
-        setError(new Error(t('unknownQrCode')));
       }
     },
-    [
-      handleSuccess,
-      isReadingWallet,
-      setErrorTitle,
-      t,
-      setScanProgress,
-      setError,
-    ],
+    [handleSuccess, isReadingWallet, setScanProgress, setScanError, setError],
   );
 
   return { handleScan, resetDecoder } as const;

--- a/ui/components/app/qr-hardware-popover/qr-hooks/useDecoderLifecycle.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/useDecoderLifecycle.ts
@@ -12,8 +12,9 @@ import {
  * Manages the URDecoder lifecycle: creating, receiving parts, tracking
  * progress, and forwarding complete URs to the parent handler.
  *
- * Uses {@link classifyScanResult} to produce granular error classifications
- * instead of generic error messages when scanning fails.
+ * The decoder is stored in a ref rather than state because its internal
+ * mutation (receivePart) shouldn't trigger re-renders — only the derived
+ * `scanProgress` needs to update the UI.
  *
  * @param props - Subset of BaseReader props needed for decoding.
  * @param callbacks - State dispatchers for progress and errors.

--- a/ui/components/app/qr-hardware-popover/qr-hooks/useDecoderLifecycle.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/useDecoderLifecycle.ts
@@ -65,6 +65,10 @@ export function useDecoderLifecycle(
    */
   const handleScan = useCallback(
     (data: string | null) => {
+      const expectedTypes = isReadingWallet
+        ? PAIRING_EXPECTED_TYPES
+        : SIGNING_EXPECTED_TYPES;
+
       try {
         const decoder = getDecoder();
         if (!data || decoder.isComplete()) {
@@ -75,9 +79,6 @@ export function useDecoderLifecycle(
         setScanProgress(decoder.estimatedPercentComplete());
         if (decoder.isComplete()) {
           const result = decoder.resultUR();
-          const expectedTypes = isReadingWallet
-            ? PAIRING_EXPECTED_TYPES
-            : SIGNING_EXPECTED_TYPES;
 
           const typeCheck = classifyScanResult({
             decodedType: result.type,
@@ -94,10 +95,6 @@ export function useDecoderLifecycle(
           );
         }
       } catch (exception) {
-        const expectedTypes = isReadingWallet
-          ? PAIRING_EXPECTED_TYPES
-          : SIGNING_EXPECTED_TYPES;
-
         const classification = classifyScanResult({
           text: lastScannedTextRef.current ?? undefined,
           expectedTypes,

--- a/ui/components/app/qr-hardware-popover/qr-hooks/useDecoderLifecycle.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/useDecoderLifecycle.ts
@@ -80,13 +80,13 @@ export function useDecoderLifecycle(
         if (decoder.isComplete()) {
           const result = decoder.resultUR();
 
-          const typeCheck = classifyScanResult({
+          const detectedError = classifyScanResult({
             decodedType: result.type,
             expectedTypes,
           });
 
-          if (typeCheck) {
-            setScanError(typeCheck);
+          if (detectedError) {
+            setScanError(detectedError);
             return;
           }
 
@@ -95,14 +95,14 @@ export function useDecoderLifecycle(
           );
         }
       } catch (exception) {
-        const classification = classifyScanResult({
+        const detectedError = classifyScanResult({
           text: lastScannedTextRef.current ?? undefined,
           expectedTypes,
           exception,
         });
 
-        if (classification) {
-          setScanError(classification);
+        if (detectedError) {
+          setScanError(detectedError);
         }
       }
     },

--- a/ui/components/app/qr-hardware-popover/qr-utils/qr-utils.test.ts
+++ b/ui/components/app/qr-hardware-popover/qr-utils/qr-utils.test.ts
@@ -238,24 +238,29 @@ describe('classifyScanResult', () => {
       expect(result).toBeNull();
     });
 
-    it('infers isUrFormat from text when exception is present', () => {
-      const withUrText = classifyScanResult({
+    it('returns ScanException with isUrFormat true when text is UR-formatted', () => {
+      const result = classifyScanResult({
         text: 'ur:crypto-hdkey/1-2/bad-payload',
         expectedTypes: PAIRING_EXPECTED_TYPES,
         exception: new Error('fail'),
       });
-      expect(withUrText).toStrictEqual(
-        expect.objectContaining({ isUrFormat: true }),
-      );
+      expect(result).toStrictEqual({
+        category: ScanErrorCategory.ScanException,
+        isUrFormat: true,
+        rawMessage: 'fail',
+      });
+    });
 
-      const withNonUrText = classifyScanResult({
+    it('returns NonUrQrScanned when text is non-UR and exception is present', () => {
+      const result = classifyScanResult({
         text: 'https://example.com',
         expectedTypes: PAIRING_EXPECTED_TYPES,
         exception: new Error('fail'),
       });
-      expect(withNonUrText).toStrictEqual(
-        expect.objectContaining({ isUrFormat: false }),
-      );
+      expect(result).toStrictEqual({
+        category: ScanErrorCategory.NonUrQrScanned,
+        isUrFormat: false,
+      });
     });
 
     it('defaults isUrFormat to false when text is absent', () => {

--- a/ui/components/app/qr-hardware-popover/qr-utils/qr-utils.ts
+++ b/ui/components/app/qr-hardware-popover/qr-utils/qr-utils.ts
@@ -82,6 +82,14 @@ export function classifyScanResult(
 
   if (exception !== undefined && exception !== null) {
     const isUrFormat = text === undefined ? false : looksLikeUr(text);
+
+    // The scanned text is clearly not UR-encoded (e.g. a plain address or URL).
+    // The exception is merely a side-effect of feeding non-UR data into the
+    // decoder, so the root cause is "wrong QR type" rather than a decode failure.
+    if (!isUrFormat && text !== undefined && text.length > 0) {
+      return { category: ScanErrorCategory.NonUrQrScanned, isUrFormat: false };
+    }
+
     return {
       category: ScanErrorCategory.ScanException,
       isUrFormat,


### PR DESCRIPTION
## **Description**
This PR adds wiring and minor changes which enable showing new UI for hardware wallet errors and does better error classification.

## **Changelog**
<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->
CHANGELOG entry: Add new UI and error handling for QR scanning

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1769

## **Manual testing steps**
1. Try onboarding new QR hardware wallet.
2. Experiment with invalid QR codes (scan pairing code from another wallet, scan ETH address QR code instead of pairing one, etc.)
3. Check the UI and error messages within it.
4. Make sure that errors are as expected.
5. Check the regular QR hardware wallet flow and make sure there are no regressions.
6. Perform testing in Chromium and Firefox and make sure that the results are consistent.

## **Screenshots/Recordings**

### **Before**
<img width="1042" height="895" alt="Screenshot 2026-05-25 at 15 36 27" src="https://github.com/user-attachments/assets/970cc0db-8afa-4f40-bc1a-e2f24ec5a99f" />
<img width="1042" height="895" alt="Screenshot 2026-05-25 at 15 37 00" src="https://github.com/user-attachments/assets/0846fcb7-3b33-4157-ae07-6c4673ada3ea" />
<img width="1042" height="895" alt="Screenshot 2026-05-25 at 15 37 56" src="https://github.com/user-attachments/assets/6bac20cd-30be-472e-a617-43fd046c0d87" />

### **After**

#### **- - - C H R O M E ---**

***Pairing flow***
<img width="996" height="896" alt="Screenshot 2026-05-25 at 15 05 43" src="https://github.com/user-attachments/assets/e8a2f8b8-49fc-4861-a340-242cdd65cb0a" />
<img width="996" height="912" alt="Screenshot 2026-05-25 at 15 07 02" src="https://github.com/user-attachments/assets/196f633d-8738-4434-b323-9621da057443" />

***Signing flow***
<img width="996" height="912" alt="Screenshot 2026-05-25 at 15 14 08" src="https://github.com/user-attachments/assets/1fe60ae3-dba5-4802-ad32-d0e487425256" />
<img width="996" height="912" alt="Screenshot 2026-05-25 at 15 14 57" src="https://github.com/user-attachments/assets/94e748fb-ebcf-42e4-991d-10b9c7a547a3" />
<img width="395" height="623" alt="Screenshot 2026-05-25 at 15 16 37" src="https://github.com/user-attachments/assets/8dba3da6-9489-48fa-b6bf-f9f12919f7d2" />

#### **- - - F I R E F O X ---**

***Pairing flow***
<img width="915" height="623" alt="Screenshot 2026-05-25 at 15 25 00" src="https://github.com/user-attachments/assets/9f839197-db1d-4b70-bb33-e70e6dc23c1f" />
<img width="915" height="623" alt="Screenshot 2026-05-25 at 15 25 43" src="https://github.com/user-attachments/assets/51162391-5f7c-4b5c-9033-cbc4bb51c3fe" />

***Signing flow***
<img width="915" height="623" alt="Screenshot 2026-05-25 at 15 27 15" src="https://github.com/user-attachments/assets/64a74cb6-b349-403d-9919-e147f904880c" />
<img width="915" height="623" alt="Screenshot 2026-05-25 at 15 27 52" src="https://github.com/user-attachments/assets/1d19bd0c-9953-4a81-84fd-a247c310c2da" />
<img width="399" height="623" alt="Screenshot 2026-05-25 at 15 28 48" src="https://github.com/user-attachments/assets/f0fae58b-69c1-4d47-a673-7585370044a5" />
<img width="399" height="623" alt="Screenshot 2026-05-25 at 15 29 23" src="https://github.com/user-attachments/assets/1bc80a74-f610-46b7-8426-4745ab170dfc" />


## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hardware wallet pairing/signing error paths and UR validation timing; user-facing but localized to QR flows with added tests.
> 
> **Overview**
> QR hardware scanning now routes **decode and wrong-QR failures** through structured classification and the shared **`QrErrorContent`** UI instead of generic legacy error strings.
> 
> **`useDecoderLifecycle`** validates completed UR payloads against flow-specific expected types (pairing: `crypto-hdkey` / `crypto-account`; signing: `eth-signature`), dispatches **`scanError`** on mismatch or failed decode, and **`BaseReader`** renders **`QrErrorContent`** with pairing vs signing context. **`classifyScanResult`** treats non-UR scanned text (e.g. URLs) as **wrong QR type** rather than a decode exception. Duplicate **eth-signature** checks were removed from the sign-request reader; mismatched sign ID still uses the legacy error path. The unused **`QRHardwareUnknownWalletQRCode`** locale entry was removed across locales.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f18316b68ca3a3f90cbd1e3ade84f3d60a6277b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->