### PR TITLE
feat(perps): [ADR58 POC - DO NOT MERGE] show debug banner when BTC perps position open [NOT-READY]

### DIFF
--- a/ui/components/app/perps/perps-view.tsx
+++ b/ui/components/app/perps/perps-view.tsx
@@ -203,6 +203,9 @@ export const PerpsView: React.FC = () => {
   }, [isEligible, applyOrdersSnapshot, orders.length, t]);
 
   const hasPositions = positions.length > 0;
+  // ADR58 POC (DO NOT MERGE): surface a debug banner whenever the account
+  // holds an open BTC perps position. Remove with this block.
+  const hasBtcPosition = positions.some((p) => p.symbol === 'BTC');
   // Only the single-position view can mirror a card-level RoE; for zero or
   // multiple positions, summary RoE remains the account aggregate.
   const singlePosition = positions.length === 1 ? positions[0] : undefined;
@@ -282,6 +285,21 @@ export const PerpsView: React.FC = () => {
         <Text variant={TextVariant.BodySm} color={TextColor.ErrorDefault}>
           {batchActionError}
         </Text>
+      ) : null}
+
+      {hasBtcPosition ? (
+        <div
+          data-testid="adr58-btc-debug-banner"
+          style={{
+            backgroundColor: 'red',
+            color: 'white',
+            padding: '8px 12px',
+            fontWeight: 'bold',
+            textAlign: 'center',
+          }}
+        >
+          ADR58 POC: BTC POSITION DETECTED
+        </div>
       ) : null}
 
       <PerpsPositionsOrders


### PR DESCRIPTION
<!-- DO NOT MERGE — ADR58 POC -->

## **Description**

ADR58 POC. Adds a red debug banner to the Perps home tab (`PerpsView`) that appears only when the connected account holds an open BTC perps position. The banner reads `ADR58 POC: BTC POSITION DETECTED` and is rendered above the positions list. Implementation is intentionally minimal (single conditional `<div>` with inline styles + a `data-testid`) so it is trivial to revert.

This change is a proof of concept and **must not be merged**.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TAT-3216](https://consensyssoftware.atlassian.net/browse/TAT-3216)

## **Manual testing steps**

1. Open the Perps tab with no open BTC position — confirm no banner appears above the positions list.
2. Open a BTC perps position (any direction/size).
3. Return to the Perps home tab — confirm a red banner with white text reading `ADR58 POC: BTC POSITION DETECTED` is rendered immediately above the positions list.
4. Close the BTC position — confirm the banner disappears.

## **Screenshots/Recordings**

_Evidence will be added after upload._

### **Before**

_Evidence will be added after upload._

### **After**

_Evidence will be added after upload._

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

<details>
<summary>artifacts/recipe.json</summary>

```json
{
  "title": "TAT-3216 — ADR58 POC: BTC debug banner on Perps home",
  "description": "Proves the red ADR58 banner only appears on Perps home when an open BTC position exists, and is rendered above the positions list.",
  "schema_version": 1,
  "validate": {
    "workflow": {
      "pre_conditions": [
        "wallet.unlocked",
        "perps.feature_enabled",
        "perps.ready_to_trade",
        "perps.sufficient_balance"
      ],
      "setup": [
        { "id": "setup-prime-perps", "action": "call", "ref": "perps/prime-perps-state" },
        { "id": "setup-close-existing-btc", "action": "call", "ref": "perps/close-position", "params": { "symbol": "BTC", "percent": "100" } }
      ],
      "teardown": [
        { "id": "teardown-close-btc", "action": "call", "ref": "perps/close-position", "params": { "symbol": "BTC", "percent": "100" } }
      ],
      "entry": "ac1-nav-perps-no-btc",
      "nodes": {
        "ac1-nav-perps-no-btc": { "action": "call", "ref": "perps/navigate-perps-tab", "next": "ac1-wait-perps" },
        "ac1-wait-perps": { "action": "wait_for", "test_id": "perps-balance-dropdown", "timeout_ms": 10000, "next": "ac1-confirm-no-btc-position" },
        "ac1-confirm-no-btc-position": { "action": "eval_async", "assert": { "operator": "eq", "field": "btcCount", "value": 0 }, "next": "ac1-assert-banner-absent" },
        "ac1-assert-banner-absent": { "action": "eval_sync", "assert": { "operator": "eq", "field": "present", "value": false }, "next": "ac1-screenshot-no-banner" },
        "ac1-screenshot-no-banner": { "action": "screenshot", "filename": "evidence-ac1-no-btc-no-banner.png", "next": "setup-open-btc-long" },
        "setup-open-btc-long": { "action": "call", "ref": "perps/open-long-position", "params": { "side": "long", "symbol": "BTC", "amount": "11" }, "next": "ac2-nav-perps-with-btc" },
        "ac2-nav-perps-with-btc": { "action": "call", "ref": "perps/navigate-perps-tab", "next": "ac2-wait-banner" },
        "ac2-wait-banner": { "action": "wait_for", "test_id": "adr58-btc-debug-banner", "timeout_ms": 10000, "next": "ac2-assert-banner-text" },
        "ac2-assert-banner-text": { "action": "eval_sync", "assert": { "all": [ { "operator": "eq", "field": "text", "value": "ADR58 POC: BTC POSITION DETECTED" }, { "operator": "eq", "field": "bg", "value": "rgb(255, 0, 0)" }, { "operator": "eq", "field": "color", "value": "rgb(255, 255, 255)" } ] }, "next": "ac2-assert-order" },
        "ac2-assert-order": { "action": "eval_sync", "assert": { "all": [ { "operator": "eq", "field": "bannerFound", "value": true }, { "operator": "eq", "field": "positionsFound", "value": true }, { "operator": "eq", "field": "bannerAbove", "value": true } ] }, "next": "ac2-screenshot-banner" },
        "ac2-screenshot-banner": { "action": "screenshot", "filename": "evidence-ac2-btc-banner-above-positions.png", "next": "done" },
        "done": { "action": "end", "status": "pass" }
      }
    }
  }
}
```

</details>

Live run: `11/11 passed`. Full recipe: `temp/tasks/feat/tat-3216-0525-195236/artifacts/recipe.json`.


[TAT-3216]: https://consensyssoftware.atlassian.net/browse/TAT-3216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ