### PR TITLE
feat(perps): upgrade perps controller to latest version on extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -405,7 +405,7 @@
     "@metamask/permission-controller": "^13.0.0",
     "@metamask/permission-log-controller": "^5.0.0",
     "@metamask/permissions-kernel-snap": "^1.3.0",
-    "@metamask/perps-controller": "^6.1.0",
+    "@metamask/perps-controller": "^6.3.0",
     "@metamask/phishing-controller": "^17.1.1",
     "@metamask/polling-controller": "^16.0.2",
     "@metamask/post-message-stream": "^10.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7688,9 +7688,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/perps-controller@npm:^6.1.0":
-  version: 6.1.0
-  resolution: "@metamask/perps-controller@npm:6.1.0"
+"@metamask/perps-controller@npm:^6.3.0":
+  version: 6.3.0
+  resolution: "@metamask/perps-controller@npm:6.3.0"
   dependencies:
     "@metamask/abi-utils": "npm:^2.0.3"
     "@metamask/base-controller": "npm:^9.1.0"
@@ -7705,7 +7705,7 @@ __metadata:
   dependenciesMeta:
     "@myx-trade/sdk":
       optional: true
-  checksum: 10/19c8c00cfa5032c954c550692b60bbc21111af56e51f8bf82e3d5aabe69427dfee836ac27860938b0c50b4583493c3956780cf7cc402a6cc0a29ea1662a9040d
+  checksum: 10/5dd4a69ad2749e661b8cd3eccf06196039c709b630f364d989989fbe41bcb8dbe5f2db6bb0f6ca556c498dff67b02b3efc3ce4cbe405c15429704fe2002bfb03
   languageName: node
   linkType: hard
 
@@ -33529,7 +33529,7 @@ __metadata:
     "@metamask/permission-controller": "npm:^13.0.0"
     "@metamask/permission-log-controller": "npm:^5.0.0"
     "@metamask/permissions-kernel-snap": "npm:^1.3.0"
-    "@metamask/perps-controller": "npm:^6.1.0"
+    "@metamask/perps-controller": "npm:^6.3.0"
     "@metamask/phishing-controller": "npm:^17.1.1"
     "@metamask/phishing-warning": "npm:^5.1.0"
     "@metamask/polling-controller": "npm:^16.0.2"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Bumps `@metamask/perps-controller` from `^6.1.0` to `^6.3.0` (latest stable). The 6.1 → 6.3 delta is consumer-API stable: 6.2 wires `isInternal: true` on internal `addTransaction` calls and bumps `@metamask/transaction-controller` to `^66.0.0`; 6.3 adds slippage controls, `vip_tier`/`vip_discount` analytics, an HL outage banner, and deeper subpath `exports`, plus fixes for selected-EVM-account resolution and HyperLiquid builder fee approval. No source changes needed — the v6.0 `availableBalance` → `spendableBalance` / `availableToTradeBalance` → `withdrawableBalance` rename was already past and consumed elsewhere.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TAT-3218](https://consensyssoftware.atlassian.net/browse/TAT-3218)

## **Manual testing steps**

1. Pull the branch, run `yarn install`, load the unpacked extension from `dist/chrome`.
2. Unlock the wallet on the seeded fixture profile.
3. Navigate to the Perps tab and confirm the market list and balance dropdown render.
4. Open `stateHooks.submitRequestToBackground('perpsGetAccountState', [])` in the home-page console; confirm the response includes `spendableBalance`, `withdrawableBalance`, and `totalBalance`.

## **Screenshots/Recordings**

Perps tab renders with hydrated account state after the @metamask/perps-controller 6.3.0 upgrade.

<table>
<tr><td align="center" width="50%"><strong>Perps tab post-upgrade — balance dropdown + market list rendered; controller hydrated (spendable/withdrawable balances visible).</strong><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/features/42915/after-ac1-perps-home.png?sha=c077c7c59df7ac12" alt="Perps tab post-upgrade — balance dropdown + market list rendered; controller hydrated (spendable/withdrawable balances visible)." width="400" /></td><td></td></tr>
</table>


**Video**
Full smoke recipe run end-to-end.
- After: [after.mp4](https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/features/42915/after.mp4?sha=1926db64a78d4024)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

<details>
<summary>Perps controller 6.3.0 upgrade smoke (4/4 passed in 1.68s, 0 console issues)</summary>

```json
{
  "schema_version": 1,
  "title": "Perps controller 6.3.0 upgrade smoke",
  "description": "Smoke-validates the perps surface after bumping @metamask/perps-controller from 6.1.0 to 6.3.0. Proves the upgraded controller still hydrates account state and the perps tab renders without runtime exceptions on the fullscreen extension.",
  "validate": {
    "workflow": {
      "pre_conditions": ["wallet.unlocked", "perps.feature_enabled"],
      "entry": "setup-prime-perps",
      "nodes": {
        "setup-prime-perps": {
          "action": "call",
          "ref": "perps/prime-perps-state",
          "next": "ac1-nav-perps-home"
        },
        "ac1-nav-perps-home": {
          "action": "call",
          "ref": "perps/navigate-perps-tab",
          "next": "ac1-assert-controller-state"
        },
        "ac1-assert-controller-state": {
          "action": "eval_async",
          "expression": "(async()=>{try{var r=await stateHooks.submitRequestToBackground('perpsGetAccountState',[]);var sm=stateHooks.getPerpsStreamManager();var markets=sm&&sm.markets&&sm.markets.getCachedData?sm.markets.getCachedData():[];var hasRenamedFields=!!(r&&Object.prototype.hasOwnProperty.call(r,'spendableBalance')&&Object.prototype.hasOwnProperty.call(r,'withdrawableBalance'));return JSON.stringify({accountReady:!!(r&&r.totalBalance),hasRenamedFields:hasRenamedFields,marketsCount:Array.isArray(markets)?markets.length:0,error:null})}catch(e){return JSON.stringify({accountReady:false,hasRenamedFields:false,marketsCount:0,error:String(e&&e.message||e)})}})()",
          "assert": {
            "all": [
              { "operator": "eq", "field": "accountReady", "value": true },
              { "operator": "eq", "field": "hasRenamedFields", "value": true },
              { "operator": "gt", "field": "marketsCount", "value": 0 },
              { "operator": "eq", "field": "error", "value": null }
            ]
          },
          "save_as": "controller_state",
          "next": "ac1-screenshot-perps-home"
        },
        "ac1-screenshot-perps-home": {
          "action": "screenshot",
          "filename": "evidence-ac1-perps-home.png",
          "note": "AC1: Perps tab rendered post-upgrade — balance dropdown visible, controller state hydrated (hyperliquid provider active, markets cached).",
          "next": "done"
        },
        "done": {
          "action": "end",
          "status": "pass"
        }
      }
    }
  }
}
```

</details>


[TAT-3218]: https://consensyssoftware.atlassian.net/browse/TAT-3218?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches perpetuals trading and transaction paths via a controller bump without local code changes; regression risk is behavioral in the bundled package, not compile-time breaks.
> 
> **Overview**
> Bumps **`@metamask/perps-controller`** from **6.1.0** to **6.3.0** in `package.json` and `yarn.lock` only—no extension source edits.
> 
> Reviewers should treat this as pulling in upstream perps behavior (e.g. internal transaction wiring, slippage and VIP analytics, outage UI, builder-fee fixes) while the extension keeps its existing perps integration and renamed balance fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd2c62e9f7c6b92b1510fb85bdfd11f02f732e57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->