### PR TITLE
feat(confirmations): hide pluggable section for Pay transactions

### DIFF
--- a/ui/pages/confirmations/components/confirm/pluggable-section/pluggable-section.test.tsx
+++ b/ui/pages/confirmations/components/confirm/pluggable-section/pluggable-section.test.tsx
@@ -31,9 +31,10 @@ describe('PluggableSection', () => {
     expect(() => render()).not.toThrow();
   });
 
+  // @ts-expect-error This is missing from the Mocha type definitions
   it.each(PAY_TRANSACTION_TYPES)(
     'returns null for pay transaction type: %s',
-    (transactionType) => {
+    (transactionType: TransactionType) => {
       const { container } = renderWithTransaction(transactionType);
       expect(container).toBeEmptyDOMElement();
     },

--- a/ui/pages/confirmations/components/confirm/pluggable-section/pluggable-section.test.tsx
+++ b/ui/pages/confirmations/components/confirm/pluggable-section/pluggable-section.test.tsx
@@ -1,8 +1,14 @@
 import React from 'react';
+import { TransactionType } from '@metamask/transaction-controller';
 
 import { renderWithConfirmContextProvider } from '../../../../../../test/lib/confirmations/render-helpers';
-import { getMockPersonalSignConfirmState } from '../../../../../../test/data/confirmations/helper';
+import {
+  getMockConfirmStateForTransaction,
+  getMockPersonalSignConfirmState,
+} from '../../../../../../test/data/confirmations/helper';
+import { genUnapprovedContractInteractionConfirmation } from '../../../../../../test/data/confirmations/contract-interaction';
 import configureStore from '../../../../../store/store';
+import { PAY_TRANSACTION_TYPES } from '../../../constants/pay';
 import PluggableSection from './pluggable-section';
 
 const render = () => {
@@ -10,8 +16,26 @@ const render = () => {
   return renderWithConfirmContextProvider(<PluggableSection />, store);
 };
 
+const renderWithTransaction = (type: TransactionType) => {
+  const confirmation = {
+    ...genUnapprovedContractInteractionConfirmation({ chainId: '0x1' }),
+    type,
+  };
+  const state = getMockConfirmStateForTransaction(confirmation);
+  const store = configureStore(state);
+  return renderWithConfirmContextProvider(<PluggableSection />, store);
+};
+
 describe('PluggableSection', () => {
-  it('should render correctly', () => {
+  it('renders without throwing', () => {
     expect(() => render()).not.toThrow();
   });
+
+  it.each(PAY_TRANSACTION_TYPES)(
+    'returns null for pay transaction type: %s',
+    (transactionType) => {
+      const { container } = renderWithTransaction(transactionType);
+      expect(container).toBeEmptyDOMElement();
+    },
+  );
 });

--- a/ui/pages/confirmations/components/confirm/pluggable-section/pluggable-section.tsx
+++ b/ui/pages/confirmations/components/confirm/pluggable-section/pluggable-section.tsx
@@ -1,14 +1,26 @@
 import React from 'react';
 import { ReactComponentLike } from 'prop-types';
+import { TransactionMeta } from '@metamask/transaction-controller';
 
 import { useConfirmContext } from '../../../context/confirm';
 import { SnapsSection } from '../snaps/snaps-section';
+import { PAY_TRANSACTION_TYPES } from '../../../constants/pay';
+import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
 
 // Components to be plugged into confirmation page can be added to the array below
 const pluggedInSections: ReactComponentLike[] = [SnapsSection];
 
 const PluggableSection = () => {
-  const { currentConfirmation } = useConfirmContext();
+  const { currentConfirmation } = useConfirmContext<TransactionMeta>();
+
+  const isPayTransaction = hasTransactionType(
+    currentConfirmation,
+    PAY_TRANSACTION_TYPES,
+  );
+
+  if (isPayTransaction) {
+    return null;
+  }
 
   return (
     <>


### PR DESCRIPTION
## **Description**

The PluggableSection component (which renders Snaps-related sections on the confirmation page) was being shown for Pay transaction types (musdClaim, musdConversion, perpsDeposit, perpsWithdraw). These transaction types use their own dedicated UI flow and should not display the pluggable snaps section.

This change adds an early return of `null` in `PluggableSection` when the current confirmation is a Pay transaction, and adds unit tests covering all Pay transaction types.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: CONF-1431

## **Manual testing steps**

1. Trigger a Pay transaction (e.g. musdConversion, perpsDeposit)
2. Observe the confirmation page does not show the Snaps pluggable section
3. Trigger a regular contract interaction transaction
4. Observe the confirmation page still shows the Snaps pluggable section as before


## **Screenshots/Recordings**

### **Before**

<img width="409" height="611" alt="Screenshot 2026-05-26 at 09 58 46" src="https://github.com/user-attachments/assets/eee680cf-1942-486d-8fda-b9481e67b652" />


### **After**

<img width="407" height="606" alt="Screenshot 2026-05-26 at 09 58 33" src="https://github.com/user-attachments/assets/11361b91-9475-4152-9724-a7cb042fdc90" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only guard on confirmation rendering with unit tests; no auth, data, or transaction execution logic changes.
> 
> **Overview**
> **Pay** confirmation flows (`musdClaim`, `musdConversion`, `perpsDeposit`, `perpsWithdraw`) no longer render the pluggable Snaps section on the confirmation page.
> 
> `PluggableSection` now bails out with `null` when the current confirmation matches `PAY_TRANSACTION_TYPES` via `hasTransactionType`, while other confirmations still map over plugged-in sections (e.g. `SnapsSection`). Tests use `it.each` over all Pay types and assert an empty container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af2e2f9bad08ddee3efa9adc8d3d795ccff719c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->