### PR TITLE
test(e2e): add BTC account derivation address surfaces check

### DIFF
--- a/test/e2e/page-objects/pages/home/homepage.ts
+++ b/test/e2e/page-objects/pages/home/homepage.ts
@@ -595,6 +595,11 @@ class HomePage {
     await this.driver.waitForSelector(this.shieldEntryModal);
   }
 
+  async clickOnReceiveButton(): Promise<void> {
+    await this.driver.waitForSelector(this.receiveButton);
+    await this.driver.clickElement(this.receiveButton);
+  }
+
   async clickOnSendButton(): Promise<void> {
     await this.driver.waitForSelector(this.sendButton);
     await this.driver.clickElement(this.sendButton);

--- a/test/e2e/tests/btc/account-derivation.spec.ts
+++ b/test/e2e/tests/btc/account-derivation.spec.ts
@@ -1,0 +1,98 @@
+import { Suite } from 'mocha';
+import { Mockttp } from 'mockttp';
+import { DEFAULT_BTC_ADDRESS } from '../../constants';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
+import { withFixtures } from '../../helpers';
+import { login } from '../../page-objects/flows/login.flow';
+import { switchToNetworkFromNetworkSelect } from '../../page-objects/flows/network.flow';
+import AccountListPage from '../../page-objects/pages/account-list-page';
+import HomePage from '../../page-objects/pages/home/homepage';
+import AddressListModal from '../../page-objects/pages/multichain/address-list-modal';
+import { shortenAddress } from '../../../../ui/helpers/utils/util';
+import { Driver } from '../../webdriver/driver';
+import {
+  mockCurrencyExchangeRates,
+  mockExchangeRates,
+  mockFiatExchangeRates,
+  mockInitialFullScan,
+  mockSolanaSpotPrices,
+  mockSupportedVsCurrencies,
+  mockTokensV2SupportedNetworks,
+  mockTokensV3Assets,
+} from './mocks';
+import { mockPriceMulti, mockPriceMultiBtcAndSol } from './mocks/min-api';
+
+async function mockBtcAccountDerivationMocks(mockServer: Mockttp) {
+  return [
+    await mockInitialFullScan(mockServer),
+    await mockExchangeRates(mockServer),
+    await mockCurrencyExchangeRates(mockServer),
+    await mockFiatExchangeRates(mockServer),
+    await mockSolanaSpotPrices(mockServer),
+    await mockSupportedVsCurrencies(mockServer),
+    await mockPriceMulti(mockServer),
+    await mockPriceMultiBtcAndSol(mockServer),
+    await mockTokensV2SupportedNetworks(mockServer),
+    await mockTokensV3Assets(mockServer),
+  ];
+}
+
+describe('Bitcoin account derivation', function (this: Suite) {
+  this.timeout(180_000);
+
+  it("shows Account 1's Bitcoin address on the Addresses modal", async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilderV2().build(),
+        title: this.test?.fullTitle(),
+        testSpecificMock: mockBtcAccountDerivationMocks,
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await login(driver);
+        await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Bitcoin');
+
+        const homepage = new HomePage(driver);
+        const accountList = new AccountListPage(driver);
+        const addressList = new AddressListModal(driver);
+
+        await homepage.headerNavbar.openAccountMenu();
+        await accountList.checkPageIsLoaded();
+        await accountList.openMultichainAccountMenu({
+          accountLabel: 'Account 1',
+        });
+        await accountList.clickMultichainAccountMenuItem('Addresses');
+
+        await addressList.checkPageIsLoaded();
+        await addressList.checkNetworkNameisDisplayed('Bitcoin');
+        await addressList.checkNetworkAddressIsDisplayed(
+          shortenAddress(DEFAULT_BTC_ADDRESS),
+        );
+      },
+    );
+  });
+
+  it("shows Account 1's Bitcoin address on the Receive page", async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilderV2().build(),
+        title: this.test?.fullTitle(),
+        testSpecificMock: mockBtcAccountDerivationMocks,
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await login(driver);
+        await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Bitcoin');
+
+        const homepage = new HomePage(driver);
+        const addressList = new AddressListModal(driver);
+
+        await homepage.checkPageIsLoaded();
+        await homepage.clickOnReceiveButton();
+
+        await addressList.checkPageIsLoaded();
+        await addressList.checkNetworkAddressIsDisplayed(
+          shortenAddress(DEFAULT_BTC_ADDRESS),
+        );
+      },
+    );
+  });
+});


### PR DESCRIPTION
Verifies that Account 1's Bitcoin address (DEFAULT_BTC_ADDRESS) is rendered on the two address surfaces currently reachable from shipped page objects:
- The Account 'Addresses' modal opened from the account menu.
- The Receive page on the Bitcoin homepage.

Adds `clickOnReceiveButton` to `BitcoinHomepage` so the Receive surface is reachable from a page object.

Deferred to follow-ups: the quick-copy hover-popup surface (needs new `AddressListModal` helpers), the full Account 1-8 derivation loop (needs an SRP-derived expected-address array), and the QR / clipboard assertions.

## **Description**

Adds an e2e spec (`test/e2e/tests/btc/account-derivation.spec.ts`) that asserts the derived Bitcoin address for Account 1 is surfaced correctly to the user. It covers the two address surfaces that are reachable today via shipped page objects: the account "Addresses" modal and the Bitcoin homepage Receive page. A small `clickOnReceiveButton` helper is added to the `BitcoinHomepage` page object to reach the Receive surface.

The motivation is to lock down BTC account-derivation behaviour with automated coverage so regressions in the displayed receive address are caught in CI.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check out the branch and run the new spec: `yarn test:e2e:single test/e2e/tests/btc/account-derivation.spec.ts --browser=chrome`.
2. Confirm both test cases pass: the address is displayed on the Addresses modal and on the Receive page.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes and a small page-object helper; no production wallet or derivation logic is modified.
> 
> **Overview**
> Adds end-to-end coverage so **Account 1’s derived Bitcoin address** (`DEFAULT_BTC_ADDRESS` from the test SRP) appears where users copy or receive funds.
> 
> A new spec **`account-derivation.spec.ts`** logs in, switches to Bitcoin, and asserts the shortened address on the **Addresses** modal (account menu → Addresses) and on the flow opened from the homepage **Receive** button. Both cases reuse existing BTC mock helpers via `mockBtcAccountDerivationMocks`.
> 
> **`HomePage`** gains **`clickOnReceiveButton`**, matching the existing send-button helper pattern so the Receive surface is reachable from the shared homepage page object.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76ca7acba4851de4ee1dc3df6d4d20011e24ffb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->