### PR TITLE
fix: OneKey hardware wallet routing cp-13.33.0

### DIFF
--- a/ui/pages/create-account/connect-hardware/select-hardware.test.tsx
+++ b/ui/pages/create-account/connect-hardware/select-hardware.test.tsx
@@ -125,7 +125,7 @@ describe('SelectHardware', () => {
       );
     });
 
-    it('connects to OneKey via QR device', () => {
+    it('connects to OneKey via QR device onboarding flow', () => {
       render();
       fireEvent.click(screen.getByTestId('connect-hardware-wallet-onekey'));
       expect(mockConnectToHardwareWallet).toHaveBeenCalledWith(

--- a/ui/pages/create-account/connect-hardware/select-hardware.test.tsx
+++ b/ui/pages/create-account/connect-hardware/select-hardware.test.tsx
@@ -125,11 +125,11 @@ describe('SelectHardware', () => {
       );
     });
 
-    it('connects to OneKey', () => {
+    it('connects to OneKey via QR device', () => {
       render();
       fireEvent.click(screen.getByTestId('connect-hardware-wallet-onekey'));
       expect(mockConnectToHardwareWallet).toHaveBeenCalledWith(
-        HardwareDeviceNames.oneKey,
+        HardwareDeviceNames.qr,
       );
     });
 

--- a/ui/pages/create-account/connect-hardware/select-hardware.tsx
+++ b/ui/pages/create-account/connect-hardware/select-hardware.tsx
@@ -91,7 +91,7 @@ const WALLET_OPTIONS: WalletOption[] = [
     id: 'onekey',
     type: 'image',
     labelKey: 'oneKey',
-    device: HardwareDeviceNames.oneKey,
+    device: HardwareDeviceNames.qr,
     testId: 'connect-hardware-wallet-onekey',
     imageSrc: 'images/hardware-wallets/onekey.svg',
   },


### PR DESCRIPTION
## **Description**
This PR adds fix for OneKey hardware wallet. 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix onboarding routing for OneKey hardware wallet

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1838

## **Manual testing steps**
1. Create a wallet.
2. Click on the accounts list
3. Click on connect hardware wallet
4. Click on OneKey
5. Make sure that it proceeds with QR hardware wallet onboarding flow.

## **Screenshots/Recordings**

### **Before**
No UI Changes, just UX. The previous flow was routing to Trezor hardware wallet onboarding.

### **After**
No UI changes, just UX. Now we're routing `OneKey` to the standard QR hardware wallet onboarding flow.

https://github.com/user-attachments/assets/2d2f50b7-0ab7-4c7f-9154-a30aab661afd


## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UX routing fix on the hardware selection screen with an updated unit test; no auth, data, or API changes.
> 
> **Overview**
> **OneKey** on the connect-hardware wallet picker now starts the same onboarding path as **Keystone** and **Other QR wallet**, by passing `HardwareDeviceNames.qr` instead of `HardwareDeviceNames.oneKey` into `connectToHardwareWallet`. The OneKey tile, label, and test id are unchanged; only the device type used for routing is updated. The unit test is renamed and expects the QR flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42046ea2e8fd88a96c58a053b7d273373fb75de1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->