### PR TITLE
chore: show hidden tokens in send flow

### DIFF
--- a/ui/pages/confirmations/hooks/send/useSendTokens.test.ts
+++ b/ui/pages/confirmations/hooks/send/useSendTokens.test.ts
@@ -4,7 +4,11 @@ import type { Hex } from '@metamask/utils';
 
 import { renderHookWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import mockState from '../../../../../test/data/mock-state.json';
-import { getAssetsBySelectedAccountGroup } from '../../../../selectors/assets';
+import {
+  getAssetsBySelectedAccountGroup,
+  getAssetsBySelectedAccountGroupIncludingHidden,
+} from '../../../../selectors/assets';
+import { getIsTokenManagementFilterEnabled } from '../../../../selectors/multichain/feature-flags';
 import * as useFiatFormatterModule from '../../../../hooks/useFiatFormatter';
 import { AssetStandard, type Asset } from '../../types/send';
 import * as useChainNetworkNameAndImageModule from '../useChainNetworkNameAndImage';
@@ -102,6 +106,9 @@ describe('useSendTokens', () => {
     jest.clearAllMocks();
 
     mockUseSelector.mockImplementation((selector) => {
+      if (selector === getIsTokenManagementFilterEnabled) {
+        return false;
+      }
       if (selector === getAssetsBySelectedAccountGroup) {
         return mockAssetsData;
       }
@@ -166,6 +173,40 @@ describe('useSendTokens', () => {
       (asset: Asset) => asset.symbol === 'ZERO',
     );
     expect(zeroBalanceAsset).toBeDefined();
+  });
+
+  it('uses hidden-inclusive assets when the token management flag is enabled', async () => {
+    const hiddenAsset = {
+      address: '0xHiddenToken',
+      chainId: '0x1',
+      balance: '1000000000000000000',
+      rawBalance: '0xde0b6b3a7640000',
+      isNative: false,
+      symbol: 'HIDDEN',
+      decimals: 18,
+      fiat: {
+        balance: 100,
+        currency: 'USD',
+      },
+    };
+
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === getIsTokenManagementFilterEnabled) {
+        return true;
+      }
+      if (selector === getAssetsBySelectedAccountGroupIncludingHidden) {
+        return [hiddenAsset];
+      }
+      if (selector === getAssetsBySelectedAccountGroup) {
+        return [];
+      }
+      return undefined;
+    });
+
+    const { result } = renderHookWithProvider(() => useSendTokens(), mockState);
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].symbol).toBe('HIDDEN');
   });
 
   it('filters tokens by chain ID and address when tokenFilter is provided', async () => {

--- a/ui/pages/confirmations/hooks/send/useSendTokens.ts
+++ b/ui/pages/confirmations/hooks/send/useSendTokens.ts
@@ -18,7 +18,11 @@ import {
   toAssetId,
   type AssetMetadata,
 } from '../../../../../shared/lib/asset-utils';
-import { getAssetsBySelectedAccountGroup } from '../../../../selectors/assets';
+import {
+  getAssetsBySelectedAccountGroup,
+  getAssetsBySelectedAccountGroupIncludingHidden,
+} from '../../../../selectors/assets';
+import { getIsTokenManagementFilterEnabled } from '../../../../selectors/multichain/feature-flags';
 import { AssetStandard, type Asset } from '../../types/send';
 import { useChainNetworkNameAndImageMap } from '../useChainNetworkNameAndImage';
 
@@ -42,7 +46,12 @@ export const useSendTokens = (options: UseSendTokensOptions = {}): Asset[] => {
     enrichTokenRequests = EMPTY_ENRICH_TOKEN_REQUESTS,
   } = options;
   const chainNetworkNAmeAndImageMap = useChainNetworkNameAndImageMap();
-  const assets = useSelector(getAssetsBySelectedAccountGroup);
+  const includeHiddenTokens = useSelector(getIsTokenManagementFilterEnabled);
+  const assets = useSelector(
+    includeHiddenTokens
+      ? getAssetsBySelectedAccountGroupIncludingHidden
+      : getAssetsBySelectedAccountGroup,
+  );
   const [enrichedTokensMetadata, setEnrichedTokensMetadata] = useState<
     Record<CaipAssetType, AssetMetadata>
   >({});

--- a/ui/selectors/assets.test.ts
+++ b/ui/selectors/assets.test.ts
@@ -34,6 +34,7 @@ import {
   selectBalanceChangeBySelectedAccountGroup,
   selectAccountGroupBalanceForEmptyState,
   getAssetsBySelectedAccountGroup,
+  getAssetsBySelectedAccountGroupIncludingHidden,
   getAsset,
   getAllIgnoredAssets,
   selectAggregatedBalanceForSelectedAccount,
@@ -1604,6 +1605,48 @@ describe('getAssetsBySelectedAccountGroup', () => {
     const result = getAssetsBySelectedAccountGroup(mockState);
 
     expect(selectorMock).toHaveBeenCalledWith(mockState.metamask);
+    expect(result).toStrictEqual(selectorMockResult);
+  });
+});
+
+describe('getAssetsBySelectedAccountGroupIncludingHidden', () => {
+  beforeEach(() => {
+    getAssetsBySelectedAccountGroupIncludingHidden.clearCache();
+    getAssetsBySelectedAccountGroupIncludingHidden.memoizedResultFunc.clearCache();
+  });
+
+  const mockState = {
+    metamask: {
+      accountTree: 'mockAccountTree',
+      internalAccounts: 'mockInternalAccounts',
+      allTokens: 'mockAllTokens',
+      allIgnoredTokens: 'mockAllIgnoredTokens',
+      tokenBalances: 'mockTokenBalances',
+      marketData: 'mockMarketData',
+      currencyRates: 'mockCurrencyRates',
+      currentCurrency: 'mockCurrentCurrency',
+      networkConfigurationsByChainId: 'mockNetworkConfigurationsByChainId',
+      accountsByChainId: 'mockAccountsByChainId',
+      accountsAssets: 'mockAccountsAssets',
+      assetsMetadata: 'mockAssetsMetadata',
+      allIgnoredAssets: 'mockAllIgnoredAssets',
+      balances: 'mockBalances',
+      conversionRates: 'mockConversionRates',
+    },
+  };
+
+  it('calls the imported selector with ignored assets cleared', () => {
+    const selectorMock = jest.mocked(selectAssetsBySelectedAccountGroup);
+    const selectorMockResult = {};
+    selectorMock.mockReturnValueOnce(selectorMockResult);
+
+    const result = getAssetsBySelectedAccountGroupIncludingHidden(mockState);
+
+    expect(selectorMock).toHaveBeenCalledWith({
+      ...mockState.metamask,
+      allIgnoredTokens: {},
+      allIgnoredAssets: {},
+    });
     expect(result).toStrictEqual(selectorMockResult);
   });
 });

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -1455,6 +1455,17 @@ export const getAssetsBySelectedAccountGroup = createDeepEqualSelector(
     selectAssetsBySelectedAccountGroup(assetListState),
 );
 
+export const getAssetsBySelectedAccountGroupIncludingHidden =
+  createDeepEqualSelector(
+    getStateForAssetSelector,
+    (assetListState: AssetListState) =>
+      selectAssetsBySelectedAccountGroup({
+        ...assetListState,
+        allIgnoredTokens: EMPTY_OBJECT,
+        allIgnoredAssets: EMPTY_OBJECT,
+      }),
+  );
+
 export const selectAccountSupportsEnabledNetworks = createSelector(
   [getSelectedInternalAccount, getAllEnabledNetworksForAllNamespaces],
   (selectedAccount, enabledNetworks) => {


### PR DESCRIPTION
This PR is to show hidden tokens in Send Flow.

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: show hidden tokens in Send Flow

## **Related issues**

Fixes: [issue](https://consensyssoftware.atlassian.net/browse/CEUX-1080?atlOrigin=eyJpIjoiZDk4YTRkOTA2MDQxNDgxNmI4ODE1YjE5MDc0MmJjNGUiLCJwIjoiaiJ9)

## **Manual testing steps**

1. Hide a token in token list
2. Check that hidden token in send flow

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

NA
### **After**

https://github.com/user-attachments/assets/8f466c35-ceb3-4c35-bca0-a8cdcb0dcf04



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to send asset selection behind an existing feature flag, with selector tests and no auth or transaction logic changes.
> 
> **Overview**
> When **token management** is enabled via `getIsTokenManagementFilterEnabled`, the send token picker now loads assets from a new selector **`getAssetsBySelectedAccountGroupIncludingHidden`**, which runs the same account-group asset list but with **`allIgnoredTokens`** and **`allIgnoredAssets`** cleared so user-hidden tokens still appear in send.
> 
> **`useSendTokens`** chooses between the existing filtered selector and the hidden-inclusive one based on that flag; behavior is unchanged when the flag is off.
> 
> Unit tests cover the new selector wiring and the hook’s flag-on path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bb7f2870f6aa7975b67e418d695464fc0b404a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->