### PR TITLE
fix: align warning icon inline with estimated changes row label

### DIFF
--- a/ui/pages/confirmations/components/simulation-details/balance-change-list.tsx
+++ b/ui/pages/confirmations/components/simulation-details/balance-change-list.tsx
@@ -20,6 +20,8 @@ import { sortBalanceChanges } from './sortBalanceChanges';
  * @param props.balanceChanges
  * @param props.testId
  * @param props.labelColor
+ * @param props.labelAlertKey
+ * @param props.labelAlertOwnerId
  * @returns
  */
 export const BalanceChangeList: React.FC<{
@@ -27,7 +29,9 @@ export const BalanceChangeList: React.FC<{
   balanceChanges: BalanceChange[];
   testId?: string;
   labelColor?: TextColor;
-}> = ({ heading, balanceChanges, testId, labelColor }) => {
+  labelAlertKey?: string;
+  labelAlertOwnerId?: string;
+}> = ({ heading, balanceChanges, testId, labelColor, labelAlertKey, labelAlertOwnerId }) => {
   const { currentConfirmation } = useConfirmContext();
   const sortedBalanceChanges = useMemo(() => {
     return sortBalanceChanges(balanceChanges);
@@ -70,6 +74,8 @@ export const BalanceChangeList: React.FC<{
             balanceChange={balanceChange}
             showFiat={!showFiatTotal && !balanceChange.isUnlimitedApproval}
             labelColor={labelColor}
+            labelAlertKey={labelAlertKey}
+            labelAlertOwnerId={labelAlertOwnerId}
           />
         ))}
       </Box>

--- a/ui/pages/confirmations/components/simulation-details/balance-change-row.tsx
+++ b/ui/pages/confirmations/components/simulation-details/balance-change-row.tsx
@@ -34,6 +34,8 @@ import { IndividualFiatDisplay } from './fiat-display';
  * @param props.isFirstRow
  * @param props.hasIncomingTokens
  * @param props.confirmationId
+ * @param props.labelAlertKey
+ * @param props.labelAlertOwnerId
  */
 export const BalanceChangeRow: React.FC<{
   label?: string;
@@ -43,6 +45,8 @@ export const BalanceChangeRow: React.FC<{
   isFirstRow?: boolean;
   hasIncomingTokens?: boolean;
   confirmationId?: string;
+  labelAlertKey?: string;
+  labelAlertOwnerId?: string;
 }> = ({
   label,
   showFiat,
@@ -51,6 +55,8 @@ export const BalanceChangeRow: React.FC<{
   isFirstRow,
   hasIncomingTokens,
   confirmationId,
+  labelAlertKey,
+  labelAlertOwnerId,
 }) => {
   const t = useI18nContext();
 
@@ -69,18 +75,34 @@ export const BalanceChangeRow: React.FC<{
       return null;
     }
 
-    if (hasIncomingTokens && isFirstRow && confirmationId) {
-      return (
-        <ConfirmInfoAlertRow
-          alertKey={RowAlertKey.IncomingTokens}
-          ownerId={confirmationId}
-          label={label}
-          style={{
-            margin: 0,
-            padding: 0,
-          }}
-        />
-      );
+    if (isFirstRow && confirmationId) {
+      if (hasIncomingTokens) {
+        return (
+          <ConfirmInfoAlertRow
+            alertKey={RowAlertKey.IncomingTokens}
+            ownerId={confirmationId}
+            label={label}
+            style={{
+              margin: 0,
+              padding: 0,
+            }}
+          />
+        );
+      }
+
+      if (labelAlertKey && labelAlertOwnerId) {
+        return (
+          <ConfirmInfoAlertRow
+            alertKey={labelAlertKey}
+            ownerId={labelAlertOwnerId}
+            label={label}
+            style={{
+              margin: 0,
+              padding: 0,
+            }}
+          />
+        );
+      }
     }
 
     return (

--- a/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
+++ b/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
@@ -5,13 +5,10 @@ import {
   TransactionMeta,
   TransactionStatus,
 } from '@metamask/transaction-controller';
-import React, { Fragment, useState } from 'react';
+import React from 'react';
 import { useSelector } from 'react-redux';
 import { RevertReason } from '../revert-reason/revert-reason';
 import { selectConfirmationAdvancedDetailsOpen } from '../../selectors/preferences';
-import { useAlertMetrics } from '../../../../components/app/alert-system/contexts/alertMetricsContext';
-import InlineAlert from '../../../../components/app/alert-system/inline-alert';
-import { MultipleAlertModal } from '../../../../components/app/alert-system/multiple-alert-modal';
 import {
   ConfirmInfoAlertRow,
   getAlertTextColors,
@@ -326,51 +323,6 @@ export const SimulationDetailsLayout: React.FC<{
     </Box>
   );
 
-const BalanceChangesAlert = ({ transactionId }: { transactionId: string }) => {
-  const { getFieldAlerts } = useAlerts(transactionId);
-  const fieldAlerts = getFieldAlerts(RowAlertKey.EstimatedChangesStatic);
-  const selectedAlertSeverity = fieldAlerts[0]?.severity;
-  const selectedAlertKey = fieldAlerts[0]?.key;
-
-  const { trackInlineAlertClicked } = useAlertMetrics();
-
-  const [alertModalVisible, setAlertModalVisible] = useState<boolean>(false);
-
-  const handleModalClose = () => {
-    setAlertModalVisible(false);
-  };
-
-  const handleInlineAlertClick = () => {
-    setAlertModalVisible(true);
-    trackInlineAlertClicked(selectedAlertKey);
-  };
-
-  return (
-    <>
-      {fieldAlerts.length > 0 && (
-        <Box marginLeft={1}>
-          <InlineAlert
-            onClick={handleInlineAlertClick}
-            severity={selectedAlertSeverity}
-            showArrow={false}
-            textOverride={''}
-          />
-        </Box>
-      )}
-      {alertModalVisible && (
-        <MultipleAlertModal
-          alertKey={selectedAlertKey}
-          ownerId={transactionId}
-          onFinalAcknowledgeClick={handleModalClose}
-          onClose={handleModalClose}
-          showCloseIcon={false}
-          skipAlertNavigation={true}
-        />
-      )}
-    </>
-  );
-};
-
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function SimulationDetailsSkeleton({
@@ -568,14 +520,14 @@ export const SimulationDetails: React.FC<SimulationDetailsProps> = ({
     >
       <Box display={Display.Flex} flexDirection={FlexDirection.Column} gap={3}>
         {staticRows.map((staticRow, index) => (
-          <Fragment key={index}>
-            <BalanceChangeList
-              heading={staticRow.label}
-              balanceChanges={staticRow.balanceChanges}
-              labelColor={getAlertTextColors(selectedAlertSeverity)}
-            />
-            <BalanceChangesAlert transactionId={transactionId} />
-          </Fragment>
+          <BalanceChangeList
+            key={index}
+            heading={staticRow.label}
+            balanceChanges={staticRow.balanceChanges}
+            labelColor={getAlertTextColors(selectedAlertSeverity)}
+            labelAlertKey={RowAlertKey.EstimatedChangesStatic}
+            labelAlertOwnerId={transactionId}
+          />
         ))}
         <BalanceChangeList
           heading={getOutgoingHeadingText()}


### PR DESCRIPTION
The alert icon for malicious approve simulations was rendering below the "You approve" label instead of next to it. This was caused by the `BalanceChangesAlert` component being a separate `Fragment` child in the static rows loop, placing the icon in its own block outside the row.

Fixes #42928

Replaced `BalanceChangesAlert` with the existing `ConfirmInfoAlertRow` pattern used as the row's label — the same approach already used for the incoming tokens heading and the network fee row. The `BalanceChangeList` and `BalanceChangeRow` components now accept optional `labelAlertKey`/`labelAlertOwnerId` props that wire the alert inline with the first-row heading.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Confirmation UI layout only; reuses existing alert row behavior with no auth, transaction, or simulation logic changes.
> 
> **Overview**
> Fixes **estimated changes** simulation warnings rendering on a separate line below headings like “You approve” by removing the standalone `BalanceChangesAlert` block and wiring alerts into the first row’s label.
> 
> `BalanceChangeList` / `BalanceChangeRow` now accept optional `labelAlertKey` and `labelAlertOwnerId`; on the first row they render `ConfirmInfoAlertRow` beside the heading (same pattern as incoming-token alerts). Static simulation rows pass `RowAlertKey.EstimatedChangesStatic` with the transaction id instead of a sibling `Fragment` + inline alert + modal wrapper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66405eb3cba7c7aa5e615998d39a31a10c66e3bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->