### PR TITLE
test(e2e): expand BTC account derivation to 8 accounts and add quick-copy surface

### DIFF
--- a/test/e2e/constants.ts
+++ b/test/e2e/constants.ts
@@ -173,6 +173,27 @@ export const DAPP_PATH = Object.freeze({
 /* Default BTC address created using test SRP (E2E_SRP) with BIP84 derivation */
 export const DEFAULT_BTC_ADDRESS = 'bc1qg6whd6pc0cguh6gpp3ewujm53hv32ta9hdp252';
 
+/* Expected BTC addresses derived from E2E_SRP via BIP84 (m/84'/0'/<index>'/0/0). */
+export const EXPECTED_BTC_ADDRESSES_BY_INDEX = [
+  DEFAULT_BTC_ADDRESS,
+  'bc1qk9u7870r6zrjr6euzkdyx5np94wkduvul0zmg7',
+  'bc1q587h8r5vhgur5smhze893m24vws85sta828ary',
+  'bc1qt3juyvv225hevnqcq9kw9ana8e65zapl9xyl56',
+  'bc1q7eajm5mfj6m9xq78zmwkf8y3a97wjm8z56kf52',
+  'bc1qmfvnnyrgyqf2vpxkzdr6e56x9fv0z4dpca2qv2',
+  'bc1qcg5q0z0znp7kt0uhvckj88zkq6fnuftl0qfwye',
+  'bc1quy3j2zc7ans6ukmnqc90j5yt3cx4q4q528nzej',
+] as const satisfies readonly [
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+];
+
 /* Default BTC Account name */
 export const DEFAULT_BTC_ACCOUNT_NAME = 'Bitcoin Account 1';
 

--- a/test/e2e/page-objects/pages/home/bitcoin-homepage.ts
+++ b/test/e2e/page-objects/pages/home/bitcoin-homepage.ts
@@ -119,6 +119,15 @@ class BitcoinHomepage extends HomePage {
     await this.driver.waitForSelector(this.swapButton);
     await this.driver.clickElement(this.swapButton);
   }
+
+  /**
+   * Clicks the receive button on bitcoin account homepage.
+   */
+  async clickOnReceiveButton(): Promise<void> {
+    console.log('Clicking receive button on Bitcoin homepage');
+    await this.driver.waitForSelector(this.receiveButton);
+    await this.driver.clickElement(this.receiveButton);
+  }
 }
 
 export default BitcoinHomepage;

--- a/test/e2e/page-objects/pages/multichain/address-list-modal.ts
+++ b/test/e2e/page-objects/pages/multichain/address-list-modal.ts
@@ -1,3 +1,5 @@
+import { strict as assert } from 'assert';
+import { WebElement } from 'selenium-webdriver';
 import { Driver } from '../../../webdriver/driver';
 
 class AddressListModal {
@@ -5,6 +7,8 @@ class AddressListModal {
 
   private readonly accountAddress =
     '[data-testid="multichain-address-row-address"]';
+
+  private readonly addressRow = '[data-testid="multichain-address-row"]';
 
   private readonly copyButton =
     '[data-testid="multichain-address-row-copy-button"]';
@@ -43,12 +47,39 @@ class AddressListModal {
     console.log('Address list modal is loaded');
   }
 
+  async checkQuickCopyPopoverIsLoaded(): Promise<void> {
+    try {
+      await this.driver.waitForSelector(this.addressRow);
+    } catch (e) {
+      console.log(
+        'Timeout while waiting for quick-copy address popover to be loaded',
+        e,
+      );
+      throw e;
+    }
+    console.log('Quick-copy address popover is loaded');
+  }
+
   async checkNetworkNameisDisplayed(networkName: string): Promise<void> {
     console.log(`Check network "${networkName}" is displayed`);
     await this.driver.waitForSelector({
       text: networkName,
       tag: 'p',
     });
+  }
+
+  async checkQuickCopyAddressIsDisplayedForNetwork({
+    networkName,
+    networkAddress,
+  }: {
+    networkName: string;
+    networkAddress: string;
+  }): Promise<void> {
+    console.log(
+      `Check quick-copy ${networkName} address "${networkAddress}" is displayed`,
+    );
+    const row = await this.findQuickCopyAddressRowByNetworkName(networkName);
+    assert.ok((await row.getText()).includes(networkAddress));
   }
 
   async checkNetworkAddressIsDisplayed(networkAddress: string): Promise<void> {
@@ -89,6 +120,34 @@ class AddressListModal {
 
   async goBack(): Promise<void> {
     await this.driver.clickElementAndWaitToDisappear(this.backButton);
+  }
+
+  private async findQuickCopyAddressRowByNetworkName(
+    networkName: string,
+  ): Promise<WebElement> {
+    let matchingRow: WebElement | undefined;
+
+    await this.driver.waitUntil(
+      async () => {
+        const rows = await this.driver.findElements(this.addressRow);
+        for (const row of rows) {
+          if ((await row.getText()).includes(networkName)) {
+            matchingRow = row;
+            return true;
+          }
+        }
+        return false;
+      },
+      { timeout: 10000, interval: 500 },
+    );
+
+    if (!matchingRow) {
+      throw new Error(
+        `Could not find quick-copy address row for network ${networkName}`,
+      );
+    }
+
+    return matchingRow;
   }
 }
 

--- a/test/e2e/tests/btc/account-derivation.spec.ts
+++ b/test/e2e/tests/btc/account-derivation.spec.ts
@@ -1,0 +1,99 @@
+import { Suite } from 'mocha';
+import { Mockttp } from 'mockttp';
+import { DEFAULT_BTC_ADDRESS } from '../../constants';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
+import { withFixtures } from '../../helpers';
+import { login } from '../../page-objects/flows/login.flow';
+import { switchToNetworkFromNetworkSelect } from '../../page-objects/flows/network.flow';
+import AccountListPage from '../../page-objects/pages/account-list-page';
+import BitcoinHomepage from '../../page-objects/pages/home/bitcoin-homepage';
+import HomePage from '../../page-objects/pages/home/homepage';
+import AddressListModal from '../../page-objects/pages/multichain/address-list-modal';
+import { shortenAddress } from '../../../../ui/helpers/utils/util';
+import { Driver } from '../../webdriver/driver';
+import {
+  mockCurrencyExchangeRates,
+  mockExchangeRates,
+  mockFiatExchangeRates,
+  mockInitialFullScan,
+  mockSolanaSpotPrices,
+  mockSupportedVsCurrencies,
+  mockTokensV2SupportedNetworks,
+  mockTokensV3Assets,
+} from './mocks';
+import { mockPriceMulti, mockPriceMultiBtcAndSol } from './mocks/min-api';
+
+async function mockBtcAccountDerivationMocks(mockServer: Mockttp) {
+  return [
+    await mockInitialFullScan(mockServer),
+    await mockExchangeRates(mockServer),
+    await mockCurrencyExchangeRates(mockServer),
+    await mockFiatExchangeRates(mockServer),
+    await mockSolanaSpotPrices(mockServer),
+    await mockSupportedVsCurrencies(mockServer),
+    await mockPriceMulti(mockServer),
+    await mockPriceMultiBtcAndSol(mockServer),
+    await mockTokensV2SupportedNetworks(mockServer),
+    await mockTokensV3Assets(mockServer),
+  ];
+}
+
+describe('Bitcoin account derivation', function (this: Suite) {
+  this.timeout(180_000);
+
+  it("shows Account 1's Bitcoin address on the Addresses modal", async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilderV2().build(),
+        title: this.test?.fullTitle(),
+        testSpecificMock: mockBtcAccountDerivationMocks,
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await login(driver);
+        await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Bitcoin');
+
+        const homepage = new HomePage(driver);
+        const accountList = new AccountListPage(driver);
+        const addressList = new AddressListModal(driver);
+
+        await homepage.headerNavbar.openAccountMenu();
+        await accountList.checkPageIsLoaded();
+        await accountList.openMultichainAccountMenu({
+          accountLabel: 'Account 1',
+        });
+        await accountList.clickMultichainAccountMenuItem('Addresses');
+
+        await addressList.checkPageIsLoaded();
+        await addressList.checkNetworkNameisDisplayed('Bitcoin');
+        await addressList.checkNetworkAddressIsDisplayed(
+          shortenAddress(DEFAULT_BTC_ADDRESS),
+        );
+      },
+    );
+  });
+
+  it("shows Account 1's Bitcoin address on the Receive page", async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilderV2().build(),
+        title: this.test?.fullTitle(),
+        testSpecificMock: mockBtcAccountDerivationMocks,
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await login(driver);
+        await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Bitcoin');
+
+        const bitcoinHomepage = new BitcoinHomepage(driver);
+        const addressList = new AddressListModal(driver);
+
+        await bitcoinHomepage.checkPageIsLoaded();
+        await bitcoinHomepage.clickOnReceiveButton();
+
+        await addressList.checkPageIsLoaded();
+        await addressList.checkNetworkAddressIsDisplayed(
+          shortenAddress(DEFAULT_BTC_ADDRESS),
+        );
+      },
+    );
+  });
+});

--- a/test/e2e/tests/btc/account-derivation.spec.ts
+++ b/test/e2e/tests/btc/account-derivation.spec.ts
@@ -1,6 +1,9 @@
 import { Suite } from 'mocha';
 import { Mockttp } from 'mockttp';
-import { DEFAULT_BTC_ADDRESS } from '../../constants';
+import {
+  DEFAULT_BTC_ADDRESS,
+  EXPECTED_BTC_ADDRESSES_BY_INDEX,
+} from '../../constants';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { withFixtures } from '../../helpers';
 import { login } from '../../page-objects/flows/login.flow';
@@ -39,7 +42,7 @@ async function mockBtcAccountDerivationMocks(mockServer: Mockttp) {
 }
 
 describe('Bitcoin account derivation', function (this: Suite) {
-  this.timeout(180_000);
+  this.timeout(240_000);
 
   it("shows Account 1's Bitcoin address on the Addresses modal", async function () {
     await withFixtures(
@@ -93,6 +96,72 @@ describe('Bitcoin account derivation', function (this: Suite) {
         await addressList.checkNetworkAddressIsDisplayed(
           shortenAddress(DEFAULT_BTC_ADDRESS),
         );
+      },
+    );
+  });
+
+  it('derives Bitcoin addresses while adding multichain accounts from Account 1 to Account 8', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilderV2().build(),
+        title: this.test?.fullTitle(),
+        testSpecificMock: mockBtcAccountDerivationMocks,
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await login(driver);
+        await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Bitcoin');
+
+        const homepage = new HomePage(driver);
+        const accountList = new AccountListPage(driver);
+        const addressList = new AddressListModal(driver);
+
+        await homepage.headerNavbar.openAccountMenu();
+        await accountList.checkPageIsLoaded();
+
+        for (let index = 0; index < 8; index += 1) {
+          const accountLabel = `Account ${index + 1}`;
+          const expected = EXPECTED_BTC_ADDRESSES_BY_INDEX[index];
+
+          if (index > 0) {
+            await accountList.addMultichainAccount();
+            await accountList.checkMultichainAccountNameDisplayed(accountLabel);
+          }
+
+          await accountList.openMultichainAccountMenu({ accountLabel });
+          await accountList.clickMultichainAccountMenuItem('Addresses');
+          await addressList.checkPageIsLoaded();
+          await addressList.checkNetworkNameisDisplayed('Bitcoin');
+          await addressList.checkNetworkAddressIsDisplayed(
+            shortenAddress(expected),
+          );
+          await addressList.goBack();
+        }
+
+        await accountList.closeMultichainAccountsPage();
+      },
+    );
+  });
+
+  it("shows Account 1's Bitcoin address on the quick-copy popover", async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilderV2().build(),
+        title: this.test?.fullTitle(),
+        testSpecificMock: mockBtcAccountDerivationMocks,
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await login(driver);
+        await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Bitcoin');
+
+        const homepage = new HomePage(driver);
+        const addressList = new AddressListModal(driver);
+
+        await homepage.headerNavbar.clickNetworkAddresses();
+        await addressList.checkQuickCopyPopoverIsLoaded();
+        await addressList.checkQuickCopyAddressIsDisplayedForNetwork({
+          networkName: 'Bitcoin',
+          networkAddress: shortenAddress(DEFAULT_BTC_ADDRESS),
+        });
       },
     );
   });


### PR DESCRIPTION
## **Description**

Follow-up to the initial BTC account-derivation E2E PR, which only covered Account 1 on the Addresses modal and the Receive page. This PR rounds out the suite with the two remaining surfaces that fit shipped page objects:

- **Full 8-account derivation loop.** Adds Accounts 2 through 8 via the multichain account list and asserts each derived BTC address on the per-account Addresses modal against an `EXPECTED_BTC_ADDRESSES_BY_INDEX` constant.
- **Quick-copy hover popover.** Opens the header network-addresses popover and asserts Account 1's Bitcoin row is present with the expected shortened address.

Derivation: BIP84 P2WPKH at `m/84'/0'/<index>'/0/0` from `E2E_SRP`. Index 0 equals the existing `DEFAULT_BTC_ADDRESS`; indices 1-7 were computed against the same SRP and locked into the constant.

The QR popup surface remains out of scope for BTC for the same reason it was skipped for Tron: the row's QR button opens the EVM QR modal.

POM additions on `AddressListModal` (mirroring the Tron mega-branch shape, scoped to what this PR uses):
- `checkQuickCopyPopoverIsLoaded()`
- `checkQuickCopyAddressIsDisplayedForNetwork({ networkName, networkAddress })`
- private `findQuickCopyAddressRowByNetworkName()`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. `yarn build:test`
2. `yarn test:e2e:single test/e2e/tests/btc/account-derivation.spec.ts --browser=chrome`
3. Confirm all four `it` blocks pass.

## **Screenshots/Recordings**

### **Before**

N/A — adds new test coverage.

### **After**

N/A — adds new test coverage.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
