### PR TITLE
feat: update manage networks to show sections

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3165,6 +3165,9 @@
   "default": {
     "message": "Default"
   },
+  "defaultNetworks": {
+    "message": "Default networks"
+  },
   "defaultRpcUrl": {
     "message": "Default RPC URL"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -3165,6 +3165,9 @@
   "default": {
     "message": "Default"
   },
+  "defaultNetworks": {
+    "message": "Default networks"
+  },
   "defaultRpcUrl": {
     "message": "Default RPC URL"
   },

--- a/ui/components/multichain/network-list-menu/__snapshots__/network-list-menu.test.tsx.snap
+++ b/ui/components/multichain/network-list-menu/__snapshots__/network-list-menu.test.tsx.snap
@@ -85,19 +85,19 @@ exports[`NetworkListMenu renders properly 1`] = `
               class="mm-box"
             >
               <div
-                class="mm-box mm-box--padding-4 mm-box--display-flex mm-box--justify-content-space-between"
-              >
-                <p
-                  class="mm-box mm-text mm-text--body-md mm-box--color-text-alternative"
-                >
-                  Enabled networks
-                </p>
-              </div>
-              <div
                 class="mm-box characters"
                 data-rbd-droppable-context-id="0"
                 data-rbd-droppable-id="characters"
               >
+                <div
+                  class="mm-box mm-box--padding-4 mm-box--display-flex mm-box--justify-content-space-between"
+                >
+                  <p
+                    class="mm-box mm-text mm-text--body-md mm-box--color-text-alternative"
+                  >
+                    Default networks
+                  </p>
+                </div>
                 <div
                   aria-describedby="rbd-hidden-text-0-hidden-text-0"
                   class="mm-box"
@@ -291,65 +291,6 @@ exports[`NetworkListMenu renders properly 1`] = `
                   aria-describedby="rbd-hidden-text-0-hidden-text-0"
                   class="mm-box"
                   data-rbd-drag-handle-context-id="0"
-                  data-rbd-drag-handle-draggable-id="eip155:5"
-                  data-rbd-draggable-context-id="0"
-                  data-rbd-draggable-id="eip155:5"
-                  draggable="false"
-                  role="button"
-                  tabindex="0"
-                >
-                  <div
-                    class="mm-box multichain-network-list-item multichain-network-list-item--deselected multichain-network-list-item--not-selectable mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
-                    data-testid="network-list-item-eip155:5"
-                  >
-                    <div
-                      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
-                    >
-                      C
-                    </div>
-                    <div
-                      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
-                      style="overflow: hidden;"
-                    >
-                      <div
-                        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
-                        data-testid="Chain 5"
-                      >
-                        <div
-                          class="multichain-network-list-item__tooltip"
-                        >
-                          <div
-                            class=""
-                            style="display: inline;"
-                            tabindex="0"
-                            title=""
-                          >
-                            <p
-                              class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
-                              tabindex="0"
-                            >
-                              Chain 5
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                    <button
-                      aria-label="Network options"
-                      class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
-                      data-testid="network-list-item-options-button-eip155:5"
-                    >
-                      <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
-                        style="mask-image: url('./images/icons/more-vertical.svg');"
-                      />
-                    </button>
-                  </div>
-                </div>
-                <div
-                  aria-describedby="rbd-hidden-text-0-hidden-text-0"
-                  class="mm-box"
-                  data-rbd-drag-handle-context-id="0"
                   data-rbd-drag-handle-draggable-id="eip155:143"
                   data-rbd-draggable-context-id="0"
                   data-rbd-draggable-id="eip155:143"
@@ -409,6 +350,115 @@ exports[`NetworkListMenu renders properly 1`] = `
                     </button>
                   </div>
                 </div>
+                <div
+                  class="mm-box mm-box--padding-4 mm-box--display-flex mm-box--justify-content-space-between"
+                >
+                  <p
+                    class="mm-box mm-text mm-text--body-md mm-box--color-text-alternative"
+                  >
+                    Custom networks
+                  </p>
+                </div>
+                <div
+                  aria-describedby="rbd-hidden-text-0-hidden-text-0"
+                  class="mm-box"
+                  data-rbd-drag-handle-context-id="0"
+                  data-rbd-drag-handle-draggable-id="eip155:5"
+                  data-rbd-draggable-context-id="0"
+                  data-rbd-draggable-id="eip155:5"
+                  draggable="false"
+                  role="button"
+                  tabindex="0"
+                >
+                  <div
+                    class="mm-box multichain-network-list-item multichain-network-list-item--deselected multichain-network-list-item--not-selectable mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
+                    data-testid="network-list-item-eip155:5"
+                  >
+                    <div
+                      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+                    >
+                      C
+                    </div>
+                    <div
+                      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
+                      style="overflow: hidden;"
+                    >
+                      <div
+                        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
+                        data-testid="Chain 5"
+                      >
+                        <div
+                          class="multichain-network-list-item__tooltip"
+                        >
+                          <div
+                            class=""
+                            style="display: inline;"
+                            tabindex="0"
+                            title=""
+                          >
+                            <p
+                              class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
+                              tabindex="0"
+                            >
+                              Chain 5
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <button
+                      aria-label="Network options"
+                      class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
+                      data-testid="network-list-item-options-button-eip155:5"
+                    >
+                      <span
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                        style="mask-image: url('./images/icons/more-vertical.svg');"
+                      />
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="mm-box mm-box--padding-top-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--justify-content-space-between"
+              >
+                <p
+                  class="mm-box mm-text mm-text--body-md mm-box--color-text-alternative"
+                >
+                  Show test networks
+                </p>
+                <label
+                  class="toggle-button toggle-button--off"
+                  tabindex="0"
+                >
+                  <div
+                    style="display: flex; width: 52px; align-items: center; justify-content: flex-start; position: relative; cursor: pointer; background-color: transparent; border: 0px; padding: 0px; user-select: none;"
+                  >
+                    <div
+                      style="width: 40px; height: 24px; padding: 0px; border-radius: 26px; display: flex; align-items: center; justify-content: center; background-color: rgb(186, 187, 190);"
+                    >
+                      <div
+                        style="font-size: 11px; display: flex; align-items: center; justify-content: center; font-family: 'Helvetica Neue', Helvetica, sans-serif; position: relative; color: rgb(250, 250, 250); margin-top: auto; margin-bottom: auto; line-height: 0; opacity: 0; width: 26px; height: 20px; left: 4px;"
+                      />
+                      <div
+                        style="font-size: 11px; display: flex; align-items: center; justify-content: center; font-family: 'Helvetica Neue', Helvetica, sans-serif; position: relative; color: rgba(255, 255, 255, 0.6); bottom: 0px; margin-top: auto; margin-bottom: auto; padding-right: 5px; line-height: 0; width: 26px; height: 20px; opacity: 1;"
+                      />
+                    </div>
+                    <div
+                      style="position: absolute; height: 100%; top: 0px; left: 0px; display: flex; flex: 1; align-self: stretch; align-items: center; justify-content: flex-start;"
+                    >
+                      <div
+                        style="width: 18px; height: 18px; display: flex; align-self: center; box-shadow: var(--shadow-size-xs) var(--color-shadow-default); border-radius: 50%; box-sizing: border-box; position: relative; background-color: rgb(255, 255, 255); left: 3px;"
+                      />
+                    </div>
+                    <input
+                      data-testid="network-menu-show-test-networks"
+                      style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px;"
+                      type="checkbox"
+                      value="false"
+                    />
+                  </div>
+                </label>
               </div>
               <div
                 class="mm-box new-network-list__networks-container"
@@ -918,47 +968,6 @@ exports[`NetworkListMenu renders properly 1`] = `
                     </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="mm-box mm-box--padding-top-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--justify-content-space-between"
-              >
-                <p
-                  class="mm-box mm-text mm-text--body-md mm-box--color-text-alternative"
-                >
-                  Show test networks
-                </p>
-                <label
-                  class="toggle-button toggle-button--off"
-                  tabindex="0"
-                >
-                  <div
-                    style="display: flex; width: 52px; align-items: center; justify-content: flex-start; position: relative; cursor: pointer; background-color: transparent; border: 0px; padding: 0px; user-select: none;"
-                  >
-                    <div
-                      style="width: 40px; height: 24px; padding: 0px; border-radius: 26px; display: flex; align-items: center; justify-content: center; background-color: rgb(186, 187, 190);"
-                    >
-                      <div
-                        style="font-size: 11px; display: flex; align-items: center; justify-content: center; font-family: 'Helvetica Neue', Helvetica, sans-serif; position: relative; color: rgb(250, 250, 250); margin-top: auto; margin-bottom: auto; line-height: 0; opacity: 0; width: 26px; height: 20px; left: 4px;"
-                      />
-                      <div
-                        style="font-size: 11px; display: flex; align-items: center; justify-content: center; font-family: 'Helvetica Neue', Helvetica, sans-serif; position: relative; color: rgba(255, 255, 255, 0.6); bottom: 0px; margin-top: auto; margin-bottom: auto; padding-right: 5px; line-height: 0; width: 26px; height: 20px; opacity: 1;"
-                      />
-                    </div>
-                    <div
-                      style="position: absolute; height: 100%; top: 0px; left: 0px; display: flex; flex: 1; align-self: stretch; align-items: center; justify-content: flex-start;"
-                    >
-                      <div
-                        style="width: 18px; height: 18px; display: flex; align-self: center; box-shadow: var(--shadow-size-xs) var(--color-shadow-default); border-radius: 50%; box-sizing: border-box; position: relative; background-color: rgb(255, 255, 255); left: 3px;"
-                      />
-                    </div>
-                    <input
-                      data-testid="network-menu-show-test-networks"
-                      style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px;"
-                      type="checkbox"
-                      value="false"
-                    />
-                  </div>
-                </label>
               </div>
             </div>
           </div>
@@ -1361,19 +1370,19 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
               class="mm-box"
             >
               <div
-                class="mm-box mm-box--padding-4 mm-box--display-flex mm-box--justify-content-space-between"
-              >
-                <p
-                  class="mm-box mm-text mm-text--body-md mm-box--color-text-alternative"
-                >
-                  Enabled networks
-                </p>
-              </div>
-              <div
                 class="mm-box characters"
                 data-rbd-droppable-context-id="1"
                 data-rbd-droppable-id="characters"
               >
+                <div
+                  class="mm-box mm-box--padding-4 mm-box--display-flex mm-box--justify-content-space-between"
+                >
+                  <p
+                    class="mm-box mm-text mm-text--body-md mm-box--color-text-alternative"
+                  >
+                    Default networks
+                  </p>
+                </div>
                 <div
                   aria-describedby="rbd-hidden-text-1-hidden-text-7"
                   class="mm-box"
@@ -1567,65 +1576,6 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                   aria-describedby="rbd-hidden-text-1-hidden-text-7"
                   class="mm-box"
                   data-rbd-drag-handle-context-id="1"
-                  data-rbd-drag-handle-draggable-id="eip155:5"
-                  data-rbd-draggable-context-id="1"
-                  data-rbd-draggable-id="eip155:5"
-                  draggable="false"
-                  role="button"
-                  tabindex="0"
-                >
-                  <div
-                    class="mm-box multichain-network-list-item multichain-network-list-item--deselected multichain-network-list-item--not-selectable mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
-                    data-testid="network-list-item-eip155:5"
-                  >
-                    <div
-                      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
-                    >
-                      C
-                    </div>
-                    <div
-                      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
-                      style="overflow: hidden;"
-                    >
-                      <div
-                        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
-                        data-testid="Chain 5"
-                      >
-                        <div
-                          class="multichain-network-list-item__tooltip"
-                        >
-                          <div
-                            class=""
-                            style="display: inline;"
-                            tabindex="0"
-                            title=""
-                          >
-                            <p
-                              class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
-                              tabindex="0"
-                            >
-                              Chain 5
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-                    <button
-                      aria-label="Network options"
-                      class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
-                      data-testid="network-list-item-options-button-eip155:5"
-                    >
-                      <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
-                        style="mask-image: url('./images/icons/more-vertical.svg');"
-                      />
-                    </button>
-                  </div>
-                </div>
-                <div
-                  aria-describedby="rbd-hidden-text-1-hidden-text-7"
-                  class="mm-box"
-                  data-rbd-drag-handle-context-id="1"
                   data-rbd-drag-handle-draggable-id="eip155:143"
                   data-rbd-draggable-context-id="1"
                   data-rbd-draggable-id="eip155:143"
@@ -1685,6 +1635,115 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                     </button>
                   </div>
                 </div>
+                <div
+                  class="mm-box mm-box--padding-4 mm-box--display-flex mm-box--justify-content-space-between"
+                >
+                  <p
+                    class="mm-box mm-text mm-text--body-md mm-box--color-text-alternative"
+                  >
+                    Custom networks
+                  </p>
+                </div>
+                <div
+                  aria-describedby="rbd-hidden-text-1-hidden-text-7"
+                  class="mm-box"
+                  data-rbd-drag-handle-context-id="1"
+                  data-rbd-drag-handle-draggable-id="eip155:5"
+                  data-rbd-draggable-context-id="1"
+                  data-rbd-draggable-id="eip155:5"
+                  draggable="false"
+                  role="button"
+                  tabindex="0"
+                >
+                  <div
+                    class="mm-box multichain-network-list-item multichain-network-list-item--deselected multichain-network-list-item--not-selectable mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
+                    data-testid="network-list-item-eip155:5"
+                  >
+                    <div
+                      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+                    >
+                      C
+                    </div>
+                    <div
+                      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
+                      style="overflow: hidden;"
+                    >
+                      <div
+                        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
+                        data-testid="Chain 5"
+                      >
+                        <div
+                          class="multichain-network-list-item__tooltip"
+                        >
+                          <div
+                            class=""
+                            style="display: inline;"
+                            tabindex="0"
+                            title=""
+                          >
+                            <p
+                              class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
+                              tabindex="0"
+                            >
+                              Chain 5
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                    <button
+                      aria-label="Network options"
+                      class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
+                      data-testid="network-list-item-options-button-eip155:5"
+                    >
+                      <span
+                        class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                        style="mask-image: url('./images/icons/more-vertical.svg');"
+                      />
+                    </button>
+                  </div>
+                </div>
+              </div>
+              <div
+                class="mm-box mm-box--padding-top-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--justify-content-space-between"
+              >
+                <p
+                  class="mm-box mm-text mm-text--body-md mm-box--color-text-alternative"
+                >
+                  Show test networks
+                </p>
+                <label
+                  class="toggle-button toggle-button--off"
+                  tabindex="0"
+                >
+                  <div
+                    style="display: flex; width: 52px; align-items: center; justify-content: flex-start; position: relative; cursor: pointer; background-color: transparent; border: 0px; padding: 0px; user-select: none;"
+                  >
+                    <div
+                      style="width: 40px; height: 24px; padding: 0px; border-radius: 26px; display: flex; align-items: center; justify-content: center; background-color: rgb(186, 187, 190);"
+                    >
+                      <div
+                        style="font-size: 11px; display: flex; align-items: center; justify-content: center; font-family: 'Helvetica Neue', Helvetica, sans-serif; position: relative; color: rgb(250, 250, 250); margin-top: auto; margin-bottom: auto; line-height: 0; opacity: 0; width: 26px; height: 20px; left: 4px;"
+                      />
+                      <div
+                        style="font-size: 11px; display: flex; align-items: center; justify-content: center; font-family: 'Helvetica Neue', Helvetica, sans-serif; position: relative; color: rgba(255, 255, 255, 0.6); bottom: 0px; margin-top: auto; margin-bottom: auto; padding-right: 5px; line-height: 0; width: 26px; height: 20px; opacity: 1;"
+                      />
+                    </div>
+                    <div
+                      style="position: absolute; height: 100%; top: 0px; left: 0px; display: flex; flex: 1; align-self: stretch; align-items: center; justify-content: flex-start;"
+                    >
+                      <div
+                        style="width: 18px; height: 18px; display: flex; align-self: center; box-shadow: var(--shadow-size-xs) var(--color-shadow-default); border-radius: 50%; box-sizing: border-box; position: relative; background-color: rgb(255, 255, 255); left: 3px;"
+                      />
+                    </div>
+                    <input
+                      data-testid="network-menu-show-test-networks"
+                      style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px;"
+                      type="checkbox"
+                      value="false"
+                    />
+                  </div>
+                </label>
               </div>
               <div
                 class="mm-box new-network-list__networks-container"
@@ -2194,47 +2253,6 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                     </div>
                   </div>
                 </div>
-              </div>
-              <div
-                class="mm-box mm-box--padding-top-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--justify-content-space-between"
-              >
-                <p
-                  class="mm-box mm-text mm-text--body-md mm-box--color-text-alternative"
-                >
-                  Show test networks
-                </p>
-                <label
-                  class="toggle-button toggle-button--off"
-                  tabindex="0"
-                >
-                  <div
-                    style="display: flex; width: 52px; align-items: center; justify-content: flex-start; position: relative; cursor: pointer; background-color: transparent; border: 0px; padding: 0px; user-select: none;"
-                  >
-                    <div
-                      style="width: 40px; height: 24px; padding: 0px; border-radius: 26px; display: flex; align-items: center; justify-content: center; background-color: rgb(186, 187, 190);"
-                    >
-                      <div
-                        style="font-size: 11px; display: flex; align-items: center; justify-content: center; font-family: 'Helvetica Neue', Helvetica, sans-serif; position: relative; color: rgb(250, 250, 250); margin-top: auto; margin-bottom: auto; line-height: 0; opacity: 0; width: 26px; height: 20px; left: 4px;"
-                      />
-                      <div
-                        style="font-size: 11px; display: flex; align-items: center; justify-content: center; font-family: 'Helvetica Neue', Helvetica, sans-serif; position: relative; color: rgba(255, 255, 255, 0.6); bottom: 0px; margin-top: auto; margin-bottom: auto; padding-right: 5px; line-height: 0; width: 26px; height: 20px; opacity: 1;"
-                      />
-                    </div>
-                    <div
-                      style="position: absolute; height: 100%; top: 0px; left: 0px; display: flex; flex: 1; align-self: stretch; align-items: center; justify-content: flex-start;"
-                    >
-                      <div
-                        style="width: 18px; height: 18px; display: flex; align-self: center; box-shadow: var(--shadow-size-xs) var(--color-shadow-default); border-radius: 50%; box-sizing: border-box; position: relative; background-color: rgb(255, 255, 255); left: 3px;"
-                      />
-                    </div>
-                    <input
-                      data-testid="network-menu-show-test-networks"
-                      style="border: 0px; height: 1px; margin: -1px; overflow: hidden; padding: 0px; position: absolute; width: 1px;"
-                      type="checkbox"
-                      value="false"
-                    />
-                  </div>
-                </label>
               </div>
             </div>
           </div>

--- a/ui/components/multichain/network-list-menu/__snapshots__/network-list-menu.test.tsx.snap
+++ b/ui/components/multichain/network-list-menu/__snapshots__/network-list-menu.test.tsx.snap
@@ -420,7 +420,7 @@ exports[`NetworkListMenu renders properly 1`] = `
                 </div>
               </div>
               <div
-                class="mm-box mm-box--padding-top-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--justify-content-space-between"
+                class="mm-box mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--justify-content-space-between"
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-text-alternative"
@@ -1705,7 +1705,7 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                 </div>
               </div>
               <div
-                class="mm-box mm-box--padding-top-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--justify-content-space-between"
+                class="mm-box mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--justify-content-space-between"
               >
                 <p
                   class="mm-box mm-text mm-text--body-md mm-box--color-text-alternative"

--- a/ui/components/multichain/network-list-menu/network-list-menu.test.tsx
+++ b/ui/components/multichain/network-list-menu/network-list-menu.test.tsx
@@ -80,6 +80,9 @@ jest.mock('../../../store/actions.ts', () => ({
 }));
 
 const MOCK_ORIGIN = 'https://app.metamask.io';
+const CUSTOM_CHAIN_ID = '0x12345';
+const CUSTOM_NETWORK_NAME = 'Custom network 1';
+const CUSTOM_NETWORK_CLIENT_ID = 'custom-network-1';
 
 type TestRenderProps = Partial<{
   currentChainId?: string;
@@ -92,6 +95,8 @@ type TestRenderProps = Partial<{
   isAccessedFromDappConnectedSitePopover?: boolean;
   editedNetwork?: { chainId: string };
   neNetworkDiscoverButton?: Record<string, boolean>;
+  additionalNetworkConfigurationsByChainId?: Record<string, unknown>;
+  includeCustomNetworks?: boolean;
 }>;
 
 const render = ({
@@ -104,6 +109,8 @@ const render = ({
   isAccessedFromDappConnectedSitePopover = false,
   editedNetwork = undefined,
   neNetworkDiscoverButton = { '0x531': true, '0xe708': true, '0x8f': true },
+  additionalNetworkConfigurationsByChainId = {},
+  includeCustomNetworks = true,
 }: TestRenderProps = {}) => {
   const state = {
     appState: {
@@ -153,19 +160,23 @@ const render = ({
             },
           ],
         },
-        '0x5': {
-          nativeCurrency: 'ETH',
-          chainId: '0x5',
-          name: 'Chain 5',
-          defaultRpcEndpointIndex: 0,
-          rpcEndpoints: [
-            {
-              url: 'http://localhost/rpc',
-              type: RpcEndpointType.Custom,
-              networkClientId: 'goerli',
-            },
-          ],
-        },
+        ...(includeCustomNetworks
+          ? {
+              '0x5': {
+                nativeCurrency: 'ETH',
+                chainId: '0x5',
+                name: 'Chain 5',
+                defaultRpcEndpointIndex: 0,
+                rpcEndpoints: [
+                  {
+                    url: 'http://localhost/rpc',
+                    type: RpcEndpointType.Custom,
+                    networkClientId: 'goerli',
+                  },
+                ],
+              },
+            }
+          : {}),
         '0x539': {
           nativeCurrency: 'ETH',
           chainId: '0x539',
@@ -218,6 +229,7 @@ const render = ({
             },
           ],
         },
+        ...additionalNetworkConfigurationsByChainId,
       },
       isUnlocked,
       selectedNetworkClientId: NETWORK_TYPES.MAINNET,
@@ -282,6 +294,52 @@ describe('NetworkListMenu', () => {
   it('renders mainnet item', () => {
     const { getByText } = render();
     expect(getByText(MAINNET_DISPLAY_NAME)).toBeInTheDocument();
+  });
+
+  it('does not render the custom networks section when there are no custom networks', () => {
+    const { queryByText } = render({ includeCustomNetworks: false });
+
+    expect(queryByText(messages.customNetworks.message)).not.toBeInTheDocument();
+  });
+
+  it('renders custom networks in a separate section when custom networks are available', () => {
+    const { getByText } = render({
+      additionalNetworkConfigurationsByChainId: {
+        [CUSTOM_CHAIN_ID]: {
+          nativeCurrency: 'ETH',
+          chainId: CUSTOM_CHAIN_ID,
+          name: CUSTOM_NETWORK_NAME,
+          defaultRpcEndpointIndex: 0,
+          rpcEndpoints: [
+            {
+              url: 'http://localhost/custom-rpc',
+              type: RpcEndpointType.Custom,
+              networkClientId: CUSTOM_NETWORK_CLIENT_ID,
+            },
+          ],
+        },
+      },
+    });
+
+    const defaultNetworksHeader = getByText(messages.defaultNetworks.message);
+    const customNetworksHeader = getByText(messages.customNetworks.message);
+    const showTestNetworksHeader = getByText(
+      messages.showTestnetNetworks.message,
+    );
+    const additionalNetworksHeader = getByText(
+      messages.additionalNetworks.message,
+    );
+
+    expect(getByText(CUSTOM_NETWORK_NAME)).toBeInTheDocument();
+    expect(
+      defaultNetworksHeader.compareDocumentPosition(customNetworksHeader),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(
+      customNetworksHeader.compareDocumentPosition(showTestNetworksHeader),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(
+      showTestNetworksHeader.compareDocumentPosition(additionalNetworksHeader),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
   });
 
   it('renders test networks when it should', () => {

--- a/ui/components/multichain/network-list-menu/network-list-menu.test.tsx
+++ b/ui/components/multichain/network-list-menu/network-list-menu.test.tsx
@@ -299,7 +299,9 @@ describe('NetworkListMenu', () => {
   it('does not render the custom networks section when there are no custom networks', () => {
     const { queryByText } = render({ includeCustomNetworks: false });
 
-    expect(queryByText(messages.customNetworks.message)).not.toBeInTheDocument();
+    expect(
+      queryByText(messages.customNetworks.message),
+    ).not.toBeInTheDocument();
   });
 
   it('renders custom networks in a separate section when custom networks are available', () => {

--- a/ui/components/multichain/network-list-menu/network-list-menu.tsx
+++ b/ui/components/multichain/network-list-menu/network-list-menu.tsx
@@ -715,6 +715,7 @@ export const NetworkListMenu = ({ onClose }: NetworkListMenuProps) => {
                   paddingBottom={4}
                   paddingTop={4}
                   paddingLeft={4}
+                  paddingRight={4}
                   display={Display.Flex}
                   justifyContent={JustifyContent.spaceBetween}
                 >

--- a/ui/components/multichain/network-list-menu/network-list-menu.tsx
+++ b/ui/components/multichain/network-list-menu/network-list-menu.tsx
@@ -142,6 +142,27 @@ type NetworkListMenuProps = {
   onClose: () => void;
 };
 
+const isCustomNetworkConfiguration = (
+  network: MultichainNetworkConfiguration,
+): boolean => {
+  const chainId = network.isEvm
+    ? convertCaipToHexChainId(network.chainId)
+    : network.chainId;
+
+  const isBuiltInNetwork = Object.values(BUILT_IN_NETWORKS).some(
+    (builtInNetwork) => builtInNetwork.chainId === chainId,
+  );
+  const isFeaturedRpc = FEATURED_RPCS.some(
+    (featuredRpc) => featuredRpc.chainId === chainId,
+  );
+  const isMultichainProviderConfig = Object.values(MultichainNetworks).some(
+    (multichainNetwork) =>
+      multichainNetwork === network.chainId || multichainNetwork === chainId,
+  );
+
+  return !isBuiltInNetwork && !isFeaturedRpc && !isMultichainProviderConfig;
+};
+
 export const NetworkListMenu = ({ onClose }: NetworkListMenuProps) => {
   const t = useI18nContext();
   const dispatch = useDispatch();
@@ -262,17 +283,6 @@ export const NetworkListMenu = ({ onClose }: NetworkListMenuProps) => {
     [nonTestNetworks, orderedNetworksList],
   );
 
-  // Re-orders networks when the user drag + drops them
-  const onDragEnd = (result: DropResult) => {
-    if (result.destination) {
-      const newOrderedNetworks = [...orderedNetworks];
-      const [removed] = newOrderedNetworks.splice(result.source.index, 1);
-      newOrderedNetworks.splice(result.destination.index, 0, removed);
-      dispatch(updateNetworksList(newOrderedNetworks.map((n) => n.chainId)));
-      setOrderedNetworks(newOrderedNetworks);
-    }
-  };
-
   const featuredNetworksNotYetEnabled = useMemo(() => {
     // Filter out networks that are already enabled
     const availableNetworks = FEATURED_RPCS.filter(
@@ -317,6 +327,39 @@ export const NetworkListMenu = ({ onClose }: NetworkListMenuProps) => {
     Object.values(testNetworks),
     searchQuery,
   );
+  const searchedDefaultNetworks = searchedEnabledNetworks.filter(
+    (network) => !isCustomNetworkConfiguration(network),
+  );
+  const searchedCustomNetworks = searchedEnabledNetworks.filter(
+    isCustomNetworkConfiguration,
+  );
+  const searchedEnabledNetworkSections = [
+    {
+      title: t('defaultNetworks'),
+      networks: searchedDefaultNetworks,
+    },
+    {
+      title: t('customNetworks'),
+      networks: searchedCustomNetworks,
+    },
+  ].filter(({ networks }) => networks.length > 0);
+  const displayedEnabledNetworks = searchedEnabledNetworkSections.flatMap(
+    ({ networks }) => networks,
+  );
+  const hasEnabledNetworkResults =
+    searchedDefaultNetworks.length > 0 || searchedCustomNetworks.length > 0;
+
+  // Re-orders networks when the user drag + drops them.
+  const onDragEnd = (result: DropResult) => {
+    if (result.destination) {
+      const newOrderedNetworks = [...displayedEnabledNetworks];
+      const [removed] = newOrderedNetworks.splice(result.source.index, 1);
+      newOrderedNetworks.splice(result.destination.index, 0, removed);
+      dispatch(updateNetworksList(newOrderedNetworks.map((n) => n.chainId)));
+      setOrderedNetworks(newOrderedNetworks);
+    }
+  };
+
   // A sorted list of test networks that put Sepolia first then Linea Sepolia at the top
   // and the rest of the test networks in alphabetical order.
   const sortedTestNetworks = useMemo(() => {
@@ -405,28 +448,6 @@ export const NetworkListMenu = ({ onClose }: NetworkListMenuProps) => {
       ? convertCaipToHexChainId(currentChainId)
       : currentChainId;
 
-    // Check if the destination network is custom (not built-in, featured, or multichain)
-    const hexChainId = chain.isEvm
-      ? convertCaipToHexChainId(chain.chainId)
-      : chain.chainId;
-
-    const isBuiltInNetwork = Object.values(BUILT_IN_NETWORKS).some(
-      (builtInNetwork) => builtInNetwork.chainId === hexChainId,
-    );
-    const isFeaturedRpc = FEATURED_RPCS.some(
-      (featuredRpc) => featuredRpc.chainId === hexChainId,
-    );
-    const isMultichainProviderConfig = Object.values(MultichainNetworks).some(
-      (multichainNetwork) =>
-        multichainNetwork === chain.chainId ||
-        (chain.isEvm
-          ? convertCaipToHexChainId(chain.chainId)
-          : chain.chainId) === multichainNetwork,
-    );
-
-    const isCustomNetwork =
-      !isBuiltInNetwork && !isFeaturedRpc && !isMultichainProviderConfig;
-
     trackEvent({
       event: MetaMetricsEventName.NavNetworkSwitched,
       category: MetaMetricsEventCategory.Network,
@@ -443,7 +464,7 @@ export const NetworkListMenu = ({ onClose }: NetworkListMenuProps) => {
         to_network: chainIdToTrack,
         // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
         // eslint-disable-next-line @typescript-eslint/naming-convention
-        custom_network: isCustomNetwork,
+        custom_network: isCustomNetworkConfiguration(chain),
       },
     });
   };
@@ -610,6 +631,8 @@ export const NetworkListMenu = ({ onClose }: NetworkListMenuProps) => {
 
   const render = () => {
     if (actionMode === ACTION_MODE.LIST) {
+      let draggableIndex = 0;
+
       return (
         <>
           <Box className="multichain-network-list-menu">
@@ -619,19 +642,7 @@ export const NetworkListMenu = ({ onClose }: NetworkListMenuProps) => {
               setFocusSearch={setFocusSearch}
             />
             <Box>
-              {searchedEnabledNetworks.length > 0 && (
-                <Box
-                  padding={4}
-                  display={Display.Flex}
-                  justifyContent={JustifyContent.spaceBetween}
-                >
-                  <Text color={TextColor.textAlternative}>
-                    {t('enabledNetworks')}
-                  </Text>
-                </Box>
-              )}
-
-              {searchedEnabledNetworks.length === 0 &&
+              {!hasEnabledNetworkResults &&
               searchedFeaturedNetworks.length === 0 &&
               searchedTestNetworks.length === 0 &&
               focusSearch ? (
@@ -652,25 +663,46 @@ export const NetworkListMenu = ({ onClose }: NetworkListMenuProps) => {
                         {...provided.droppableProps}
                         ref={provided.innerRef}
                       >
-                        {searchedEnabledNetworks.map((network, index) => {
-                          return (
-                            <Draggable
-                              key={network.chainId}
-                              draggableId={network.chainId}
-                              index={index}
-                            >
-                              {(providedDrag) => (
-                                <Box
-                                  ref={providedDrag.innerRef}
-                                  {...providedDrag.draggableProps}
-                                  {...providedDrag.dragHandleProps}
-                                >
-                                  {generateMultichainNetworkListItem(network)}
-                                </Box>
-                              )}
-                            </Draggable>
-                          );
-                        })}
+                        {searchedEnabledNetworkSections.map(
+                          ({ title: sectionTitle, networks }) => (
+                            <React.Fragment key={sectionTitle}>
+                              <Box
+                                padding={4}
+                                display={Display.Flex}
+                                justifyContent={JustifyContent.spaceBetween}
+                              >
+                                <Text color={TextColor.textAlternative}>
+                                  {sectionTitle}
+                                </Text>
+                              </Box>
+                              {networks.map((network) => {
+                                const index = draggableIndex;
+                                draggableIndex += 1;
+
+                                return (
+                                  <Draggable
+                                    key={network.chainId}
+                                    draggableId={network.chainId}
+                                    index={index}
+                                    isDragDisabled={searchQuery !== ''}
+                                  >
+                                    {(providedDrag) => (
+                                      <Box
+                                        ref={providedDrag.innerRef}
+                                        {...providedDrag.draggableProps}
+                                        {...providedDrag.dragHandleProps}
+                                      >
+                                        {generateMultichainNetworkListItem(
+                                          network,
+                                        )}
+                                      </Box>
+                                    )}
+                                  </Draggable>
+                                );
+                              })}
+                            </React.Fragment>
+                          ),
+                        )}
                         {provided.placeholder}
                       </Box>
                     )}
@@ -678,10 +710,6 @@ export const NetworkListMenu = ({ onClose }: NetworkListMenuProps) => {
                 </DragDropContext>
               )}
 
-              <PopularNetworkList
-                searchAddNetworkResults={searchedFeaturedNetworks}
-                data-testid="add-popular-network-view"
-              />
               {searchedTestNetworks.length > 0 ? (
                 <Box
                   paddingBottom={4}
@@ -719,6 +747,11 @@ export const NetworkListMenu = ({ onClose }: NetworkListMenuProps) => {
                   )}
                 </Box>
               ) : null}
+
+              <PopularNetworkList
+                searchAddNetworkResults={searchedFeaturedNetworks}
+                data-testid="add-popular-network-view"
+              />
             </Box>
           </Box>
 

--- a/ui/components/multichain/network-manager/components/additional-networks-info/__snapshots__/additional-networks-info.test.tsx.snap
+++ b/ui/components/multichain/network-manager/components/additional-networks-info/__snapshots__/additional-networks-info.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`AdditionalNetworksInfo renders correctly 1`] = `
 <div>
   <div
-    class="mm-box mm-box--padding-top-2 mm-box--padding-right-4 mm-box--padding-left-4"
+    class="mm-box mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4"
   >
     <div
       class="mm-box mm-box--display-flex mm-box--justify-content-space-between"

--- a/ui/components/multichain/network-manager/components/additional-networks-info/additional-networks-info.tsx
+++ b/ui/components/multichain/network-manager/components/additional-networks-info/additional-networks-info.tsx
@@ -58,7 +58,8 @@ export const AdditionalNetworksInfo = memo(() => {
 
   return (
     <Box
-      paddingTop={2}
+      paddingTop={4}
+      paddingBottom={4}
       paddingRight={4}
       paddingLeft={4}
       onMouseLeave={handleMouseLeave}

--- a/ui/pages/networks/networks-page-list.tsx
+++ b/ui/pages/networks/networks-page-list.tsx
@@ -155,6 +155,8 @@ const AdditionalNetworkRow = ({ network }: { network: AddNetworkFields }) => {
   );
 };
 
+const SectionDivider = () => <Box className="mx-4 border-t border-muted" />;
+
 type NetworksPageListProps = {
   searchQuery: string;
   footerContent?: React.ReactNode;
@@ -305,45 +307,54 @@ export const NetworksPageList = ({
         <Box>{defaultNetworks.map(renderNetworkListItem)}</Box>
 
         {customNetworks.length > 0 ? (
-          <Box
-            padding={4}
-            paddingBottom={2}
-            flexDirection={BoxFlexDirection.Row}
-            justifyContent={BoxJustifyContent.Between}
-          >
-            <Text color={TextColor.TextAlternative}>{t('customNetworks')}</Text>
-          </Box>
+          <>
+            <SectionDivider />
+            <Box
+              padding={4}
+              paddingBottom={2}
+              flexDirection={BoxFlexDirection.Row}
+              justifyContent={BoxJustifyContent.Between}
+            >
+              <Text color={TextColor.TextAlternative}>
+                {t('customNetworks')}
+              </Text>
+            </Box>
+          </>
         ) : null}
 
         <Box>{customNetworks.map(renderNetworkListItem)}</Box>
 
         {sortedTestNetworks.length > 0 ? (
-          <Box
-            paddingBottom={4}
-            paddingTop={4}
-            paddingLeft={4}
-            paddingRight={4}
-            flexDirection={BoxFlexDirection.Row}
-            justifyContent={BoxJustifyContent.Between}
-            alignItems={BoxAlignItems.Center}
-          >
-            <Text color={TextColor.TextAlternative}>
-              {t('showTestnetNetworks')}
-            </Text>
-            <ToggleButton
-              dataTestId="networks-page-show-test-networks"
-              value={showTestnets}
-              onToggle={handleToggleTestNetworks}
-            />
-          </Box>
+          <>
+            <SectionDivider />
+            <Box
+              paddingBottom={4}
+              paddingTop={4}
+              paddingLeft={4}
+              paddingRight={4}
+              flexDirection={BoxFlexDirection.Row}
+              justifyContent={BoxJustifyContent.Between}
+              alignItems={BoxAlignItems.Center}
+            >
+              <Text color={TextColor.TextAlternative}>
+                {t('showTestnetNetworks')}
+              </Text>
+              <ToggleButton
+                dataTestId="networks-page-show-test-networks"
+                value={showTestnets}
+                onToggle={handleToggleTestNetworks}
+              />
+            </Box>
+          </>
         ) : null}
 
         {showTestnets ? (
-          <Box>{sortedTestNetworks.map(renderNetworkListItem)}</Box>
+          <>{sortedTestNetworks.map(renderNetworkListItem)}</>
         ) : null}
 
         {featuredNetworksNotYetEnabled.length > 0 ? (
           <>
+            <SectionDivider />
             <AdditionalNetworksInfo />
             <Box>
               {featuredNetworksNotYetEnabled.map((network) => (

--- a/ui/pages/networks/networks-page-list.tsx
+++ b/ui/pages/networks/networks-page-list.tsx
@@ -37,7 +37,7 @@ import { MetaMetricsContext } from '../../contexts/metametrics';
 import { useI18nContext } from '../../hooks/useI18nContext';
 import { useIsNetworkGasSponsored } from '../../hooks/useIsNetworkGasSponsored';
 import { selectAdditionalNetworksBlacklistFeatureFlag } from '../../selectors/network-blacklist/network-blacklist';
-import { getMultichainNetworkConfigurationsByChainId } from '../../selectors/multichain/networks';
+import { getSelectedMultichainNetworkChainId } from '../../selectors/multichain/networks';
 import {
   getOrderedNetworksList,
   getShowTestNetworks,
@@ -63,6 +63,7 @@ import {
   sortNetworksByPrioity,
 } from '../../../shared/lib/network.utils';
 import { useNetworkManagerState } from '../../components/multichain/network-manager/hooks/useNetworkManagerState';
+import { getNetworkConfigurationsByChainId } from '../../../shared/lib/selectors/networks';
 
 const filterNetworks = <
   NetworkRecord extends {
@@ -173,9 +174,10 @@ export const NetworksPageList = ({
 
   const orderedNetworksList = useSelector(getOrderedNetworksList);
   const showTestnets = useSelector(getShowTestNetworks);
-  const [, evmNetworks] = useSelector(
-    getMultichainNetworkConfigurationsByChainId,
+  const currentMultichainChainId = useSelector(
+    getSelectedMultichainNetworkChainId,
   );
+  const evmNetworks = useSelector(getNetworkConfigurationsByChainId);
   const blacklistedChainIds = useSelector(
     selectAdditionalNetworksBlacklistFeatureFlag,
   );
@@ -232,6 +234,14 @@ export const NetworksPageList = ({
     [testNetworks, searchQuery],
   );
 
+  const currentlyOnTestnet = useMemo(
+    () =>
+      Object.values(testNetworks).some(
+        (network) => network.chainId === currentMultichainChainId,
+      ),
+    [currentMultichainChainId, testNetworks],
+  );
+
   const renderNetworkListItem = useCallback(
     (network: MultichainNetworkConfiguration) => {
       const { onDelete, onEdit, onDiscoverClick, onRpcSelect } =
@@ -272,6 +282,10 @@ export const NetworksPageList = ({
 
   const handleToggleTestNetworks = useCallback(
     (value: boolean) => {
+      if (currentlyOnTestnet) {
+        return;
+      }
+
       const newValue = !value;
       dispatch(setShowTestNetworks(newValue));
       trackEvent({
@@ -282,7 +296,7 @@ export const NetworksPageList = ({
         },
       });
     },
-    [dispatch, trackEvent],
+    [currentlyOnTestnet, dispatch, trackEvent],
   );
 
   return (
@@ -341,14 +355,15 @@ export const NetworksPageList = ({
               </Text>
               <ToggleButton
                 dataTestId="networks-page-show-test-networks"
-                value={showTestnets}
+                value={showTestnets || currentlyOnTestnet}
+                disabled={currentlyOnTestnet}
                 onToggle={handleToggleTestNetworks}
               />
             </Box>
           </>
         ) : null}
 
-        {showTestnets ? (
+        {showTestnets || currentlyOnTestnet ? (
           <>{sortedTestNetworks.map(renderNetworkListItem)}</>
         ) : null}
 

--- a/ui/pages/networks/networks-page-list.tsx
+++ b/ui/pages/networks/networks-page-list.tsx
@@ -311,9 +311,7 @@ export const NetworksPageList = ({
             flexDirection={BoxFlexDirection.Row}
             justifyContent={BoxJustifyContent.Between}
           >
-            <Text color={TextColor.TextAlternative}>
-              {t('customNetworks')}
-            </Text>
+            <Text color={TextColor.TextAlternative}>{t('customNetworks')}</Text>
           </Box>
         ) : null}
 

--- a/ui/pages/networks/networks-page-list.tsx
+++ b/ui/pages/networks/networks-page-list.tsx
@@ -178,9 +178,10 @@ export const NetworksPageList = ({
     selectAdditionalNetworksBlacklistFeatureFlag,
   );
 
-  const { nonTestNetworks, testNetworks } = useNetworkManagerState({
-    showDefaultNetworks: true,
-  });
+  const { nonTestNetworks, testNetworks, isNetworkInDefaultNetworkTab } =
+    useNetworkManagerState({
+      showDefaultNetworks: true,
+    });
   const { getItemCallbacks, hasMultiRpcOptions, isNetworkEnabled } =
     useNetworkItemCallbacks();
   const { handleNetworkChange } = useNetworkChangeHandlers();
@@ -192,6 +193,19 @@ export const NetworksPageList = ({
         searchQuery,
       ),
     [nonTestNetworks, orderedNetworksList, searchQuery],
+  );
+
+  const defaultNetworks = useMemo(
+    () => orderedNetworks.filter(isNetworkInDefaultNetworkTab),
+    [isNetworkInDefaultNetworkTab, orderedNetworks],
+  );
+
+  const customNetworks = useMemo(
+    () =>
+      orderedNetworks.filter(
+        (network) => !isNetworkInDefaultNetworkTab(network),
+      ),
+    [isNetworkInDefaultNetworkTab, orderedNetworks],
   );
 
   const featuredNetworksNotYetEnabled = useMemo(() => {
@@ -275,7 +289,7 @@ export const NetworksPageList = ({
       data-testid="networks-page-list"
     >
       <Box className="flex-1 overflow-y-auto pt-2">
-        {orderedNetworks.length > 0 ? (
+        {defaultNetworks.length > 0 ? (
           <Box
             padding={4}
             paddingBottom={2}
@@ -283,32 +297,37 @@ export const NetworksPageList = ({
             justifyContent={BoxJustifyContent.Between}
           >
             <Text color={TextColor.TextAlternative}>
-              {t('enabledNetworks')}
+              {t('defaultNetworks')}
             </Text>
           </Box>
         ) : null}
 
-        <Box>{orderedNetworks.map(renderNetworkListItem)}</Box>
+        <Box>{defaultNetworks.map(renderNetworkListItem)}</Box>
 
-        {featuredNetworksNotYetEnabled.length > 0 ? (
-          <>
-            <AdditionalNetworksInfo />
-            <Box>
-              {featuredNetworksNotYetEnabled.map((network) => (
-                <AdditionalNetworkRow key={network.chainId} network={network} />
-              ))}
-            </Box>
-          </>
+        {customNetworks.length > 0 ? (
+          <Box
+            padding={4}
+            paddingBottom={2}
+            flexDirection={BoxFlexDirection.Row}
+            justifyContent={BoxJustifyContent.Between}
+          >
+            <Text color={TextColor.TextAlternative}>
+              {t('customNetworks')}
+            </Text>
+          </Box>
         ) : null}
+
+        <Box>{customNetworks.map(renderNetworkListItem)}</Box>
 
         {sortedTestNetworks.length > 0 ? (
           <Box
             paddingBottom={4}
             paddingTop={4}
+            paddingLeft={4}
+            paddingRight={4}
             flexDirection={BoxFlexDirection.Row}
             justifyContent={BoxJustifyContent.Between}
             alignItems={BoxAlignItems.Center}
-            className="px-4"
           >
             <Text color={TextColor.TextAlternative}>
               {t('showTestnetNetworks')}
@@ -323,6 +342,17 @@ export const NetworksPageList = ({
 
         {showTestnets ? (
           <Box>{sortedTestNetworks.map(renderNetworkListItem)}</Box>
+        ) : null}
+
+        {featuredNetworksNotYetEnabled.length > 0 ? (
+          <>
+            <AdditionalNetworksInfo />
+            <Box>
+              {featuredNetworksNotYetEnabled.map((network) => (
+                <AdditionalNetworkRow key={network.chainId} network={network} />
+              ))}
+            </Box>
+          </>
         ) : null}
       </Box>
 

--- a/ui/pages/networks/networks-page.test.tsx
+++ b/ui/pages/networks/networks-page.test.tsx
@@ -17,16 +17,19 @@ jest.mock('../../components/ui/toggle-button', () => {
     __esModule: true,
     default: ({
       dataTestId,
+      disabled,
       value,
       onToggle,
     }: {
       dataTestId: string;
+      disabled?: boolean;
       value: boolean;
       onToggle: (value: boolean) => void;
     }) =>
       ReactActual.createElement('input', {
         'data-testid': dataTestId,
         checked: value,
+        disabled,
         onChange: () => onToggle(value),
         type: 'checkbox',
       }),
@@ -91,10 +94,20 @@ describe('NetworksPage', () => {
   const renderNetworksPage = ({
     pathname = NETWORKS_ROUTE,
     networkConfigurationsByChainId = mockNetworkConfigurations,
+    selectedNetworkClientId = 'mainnet',
+    selectedProviderChainId = '0x1',
+    enabledNetworkMap = {
+      eip155: {
+        '0x1': true,
+      },
+    },
     showTestNetworks = false,
   }: {
     pathname?: string;
     networkConfigurationsByChainId?: typeof mockNetworkConfigurations;
+    selectedNetworkClientId?: string;
+    selectedProviderChainId?: string;
+    enabledNetworkMap?: Record<string, Record<string, boolean>>;
     showTestNetworks?: boolean;
   } = {}) => {
     const store = configureStore({
@@ -102,18 +115,14 @@ describe('NetworksPage', () => {
       metamask: {
         ...mockState.metamask,
         networkConfigurationsByChainId,
-        selectedNetworkClientId: 'mainnet',
+        selectedNetworkClientId,
         providerConfig: {
-          chainId: '0x1',
+          chainId: selectedProviderChainId,
           rpcUrl: 'https://mainnet.infura.io/v3/123',
           type: 'rpc',
           ticker: 'ETH',
         },
-        enabledNetworkMap: {
-          eip155: {
-            '0x1': true,
-          },
-        },
+        enabledNetworkMap,
         preferences: {
           ...mockState.metamask.preferences,
           showTestNetworks,
@@ -124,14 +133,21 @@ describe('NetworksPage', () => {
     return renderWithProvider(<NetworksPage />, store, pathname);
   };
 
-  it('renders the sectioned networks view on the root route', () => {
+  it('renders the sectioned networks view and keeps testnets visible while selected on a testnet', () => {
     renderNetworksPage({
       networkConfigurationsByChainId: {
         ...mockNetworkConfigurations,
         ...customNetworkConfiguration,
         ...testNetworkConfiguration,
       },
-      showTestNetworks: true,
+      selectedNetworkClientId: 'sepolia',
+      selectedProviderChainId: '0xaa36a7',
+      enabledNetworkMap: {
+        eip155: {
+          '0xaa36a7': true,
+        },
+      },
+      showTestNetworks: false,
     });
 
     const defaultNetworksHeader = screen.getByText(
@@ -148,6 +164,7 @@ describe('NetworksPage', () => {
     );
 
     expect(screen.getByText('Custom network 1')).toBeInTheDocument();
+    expect(screen.getByText('Sepolia')).toBeInTheDocument();
     expect(
       defaultNetworksHeader.compareDocumentPosition(customNetworksHeader),
     ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
@@ -160,6 +177,13 @@ describe('NetworksPage', () => {
     expect(
       screen.getByText(messages.addACustomNetwork.message),
     ).toBeInTheDocument();
+
+    const testnetToggle = screen.getByTestId(
+      'networks-page-show-test-networks',
+    );
+
+    expect(testnetToggle).toBeChecked();
+    expect(testnetToggle).toBeDisabled();
   });
 
   it('renders the add network flow from the query param', () => {

--- a/ui/pages/networks/networks-page.test.tsx
+++ b/ui/pages/networks/networks-page.test.tsx
@@ -9,6 +9,30 @@ import mockState from '../../../test/data/mock-state.json';
 import { NETWORKS_ROUTE } from '../../helpers/constants/routes';
 import { NetworksPage } from './networks-page';
 
+jest.mock('../../components/ui/toggle-button', () => {
+  const ReactActual = jest.requireActual('react');
+
+  return {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    __esModule: true,
+    default: ({
+      dataTestId,
+      value,
+      onToggle,
+    }: {
+      dataTestId: string;
+      value: boolean;
+      onToggle: (value: boolean) => void;
+    }) =>
+      ReactActual.createElement('input', {
+        'data-testid': dataTestId,
+        checked: value,
+        onChange: () => onToggle(value),
+        type: 'checkbox',
+      }),
+  };
+});
+
 const mockNetworkConfigurations = {
   '0x1': {
     chainId: '0x1',
@@ -27,13 +51,57 @@ const mockNetworkConfigurations = {
   },
 };
 
+const customNetworkConfiguration = {
+  '0x12345': {
+    chainId: '0x12345',
+    name: 'Custom network 1',
+    rpcEndpoints: [
+      {
+        url: 'https://custom-rpc.example.com',
+        type: RpcEndpointType.Custom,
+        networkClientId: 'custom-network-1',
+      },
+    ],
+    defaultRpcEndpointIndex: 0,
+    blockExplorerUrls: [],
+    defaultBlockExplorerUrlIndex: 0,
+    nativeCurrency: 'ETH',
+  },
+};
+
+const testNetworkConfiguration = {
+  '0xaa36a7': {
+    chainId: '0xaa36a7',
+    name: 'Sepolia',
+    rpcEndpoints: [
+      {
+        url: 'https://sepolia.infura.io/v3/123',
+        type: RpcEndpointType.Infura,
+        networkClientId: 'sepolia',
+      },
+    ],
+    defaultRpcEndpointIndex: 0,
+    blockExplorerUrls: [],
+    defaultBlockExplorerUrlIndex: 0,
+    nativeCurrency: 'ETH',
+  },
+};
+
 describe('NetworksPage', () => {
-  const renderNetworksPage = (pathname = NETWORKS_ROUTE) => {
+  const renderNetworksPage = ({
+    pathname = NETWORKS_ROUTE,
+    networkConfigurationsByChainId = mockNetworkConfigurations,
+    showTestNetworks = false,
+  }: {
+    pathname?: string;
+    networkConfigurationsByChainId?: typeof mockNetworkConfigurations;
+    showTestNetworks?: boolean;
+  } = {}) => {
     const store = configureStore({
       ...mockState,
       metamask: {
         ...mockState.metamask,
-        networkConfigurationsByChainId: mockNetworkConfigurations,
+        networkConfigurationsByChainId,
         selectedNetworkClientId: 'mainnet',
         providerConfig: {
           chainId: '0x1',
@@ -46,6 +114,10 @@ describe('NetworksPage', () => {
             '0x1': true,
           },
         },
+        preferences: {
+          ...mockState.metamask.preferences,
+          showTestNetworks,
+        },
       },
     });
 
@@ -53,24 +125,51 @@ describe('NetworksPage', () => {
   };
 
   it('renders the sectioned networks view on the root route', () => {
-    renderNetworksPage();
+    renderNetworksPage({
+      networkConfigurationsByChainId: {
+        ...mockNetworkConfigurations,
+        ...customNetworkConfiguration,
+        ...testNetworkConfiguration,
+      },
+      showTestNetworks: true,
+    });
 
+    const defaultNetworksHeader = screen.getByText(
+      messages.defaultNetworks.message,
+    );
+    const customNetworksHeader = screen.getByText(
+      messages.customNetworks.message,
+    );
+    const showTestNetworksHeader = screen.getByText(
+      messages.showTestnetNetworks.message,
+    );
+    const additionalNetworksHeader = screen.getByText(
+      messages.additionalNetworks.message,
+    );
+
+    expect(screen.getByText('Custom network 1')).toBeInTheDocument();
     expect(
-      screen.getByText(messages.enabledNetworks.message),
-    ).toBeInTheDocument();
+      defaultNetworksHeader.compareDocumentPosition(customNetworksHeader),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(
+      customNetworksHeader.compareDocumentPosition(showTestNetworksHeader),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(
+      showTestNetworksHeader.compareDocumentPosition(additionalNetworksHeader),
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
     expect(
       screen.getByText(messages.addACustomNetwork.message),
     ).toBeInTheDocument();
   });
 
   it('renders the add network flow from the query param', () => {
-    renderNetworksPage(`${NETWORKS_ROUTE}?view=add`);
+    renderNetworksPage({ pathname: `${NETWORKS_ROUTE}?view=add` });
 
     expect(screen.getByText(messages.addNetwork.message)).toBeInTheDocument();
   });
 
   it('renders the custom rpc page with footer actions and adds the rpc', async () => {
-    renderNetworksPage(`${NETWORKS_ROUTE}?view=edit-rpc`);
+    renderNetworksPage({ pathname: `${NETWORKS_ROUTE}?view=edit-rpc` });
 
     expect(
       screen.getByTestId('page-container-footer-cancel'),


### PR DESCRIPTION
This PR is to update manage networks page to add the custom network section and update the sections

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: added section to manage networks

## **Related issues**

Fixes: [issue](https://consensyssoftware.atlassian.net/browse/CEUX-1082)

## **Manual testing steps**

 1. Open MetaMask and unlock the wallet.
  2. Open the global network menu.
  3. Click Manage networks.
  4. Verify enabled default networks appear under Default networks.
  5. Verify Custom networks is not shown if the wallet has no custom networks.
  6. Click Add custom network.
  7. Add a custom network.
  8. Return to the global network menu.
  9. Click Manage networks again.
  10. Verify the new custom network appears under Custom networks.
  11. Verify the section order is:
  12. Default networks
  13. Custom networks
  14. Show test networks
  15. Additional networks
  16. Add custom network
  17. Toggle Show test networks on.
  18. Verify test networks appear below the Show test networks row and above Additional networks.
  19. Use search to find the custom network.
  20. Verify the matching custom network still appears under Custom networks.
  21. Search for a network name that does not exist.
  22. Verify the no-results state appears.
  23. Clear search.
  24. Click a default network and verify network switching still works.
  25. Reopen Manage Networks.
  26. Click the custom network and verify network switching still works.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/695f0b8c-ada7-4be1-abb3-119d4ca68738



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI layout, copy, and network list ordering only; no auth, RPC, or transaction logic changes.
> 
> **Overview**
> **Manage networks** and the **global network menu** now group enabled chains into **Default networks** and **Custom networks** (custom = not built-in, featured, or multichain provider config). The **Custom networks** header only appears when there is at least one custom chain.
> 
> Section order is aligned across both UIs: default → custom → **Show test networks** (moved above featured/additional networks) → **Additional networks**. On the networks page, dividers separate sections; **Additional networks** spacing is tweaked.
> 
> **Test networks**: while the active chain is a testnet, the toggle stays on and disabled so testnets remain visible; toggling is ignored in that state. Drag-reorder in the menu uses the combined default+custom list and disables drag while searching.
> 
> Adds the `defaultNetworks` locale string (en/en_GB) and tests for section order, hidden custom section, and testnet toggle behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dc77ef33565339b4842c1846ccb360747c26846. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->