### PR TITLE
fix(benchmarks): Unblock benchmark payload upload and baseline update

### DIFF
--- a/.github/scripts/benchmark-stats-commit.sh
+++ b/.github/scripts/benchmark-stats-commit.sh
@@ -197,8 +197,14 @@ fi
 
 TEMP_FILE="${STATS_FILE}.tmp"
 
-jq --arg sha "${HEAD_COMMIT_HASH}" --argjson data "${COMMIT_DATA}" \
-    '. + {($sha): $data}' "${STATS_FILE}" > "${TEMP_FILE}"
+# COMMIT_DATA wraps presets_json and is strictly larger, so it can exceed
+# ARG_MAX too. Read it via --slurpfile from a temp file rather than passing
+# the blob on argv.
+data_file="$(mktemp)"
+printf '%s' "${COMMIT_DATA}" >"${data_file}"
+jq --arg sha "${HEAD_COMMIT_HASH}" --slurpfile data "${data_file}" \
+    '. + {($sha): $data[0]}' "${STATS_FILE}" > "${TEMP_FILE}"
+rm -f "${data_file}"
 mv "${TEMP_FILE}" "${STATS_FILE}"
 
 git add "${STATS_FILE}"

--- a/.github/scripts/benchmark-stats-commit.sh
+++ b/.github/scripts/benchmark-stats-commit.sh
@@ -122,15 +122,21 @@ assemble_performance_data() {
 
     # Merge the startup group into presets (only if any startup files were found).
     if [[ "${page_load_json}" != "{}" ]]; then
-        presets_json=$(echo "${presets_json}" | jq --argjson pl "${page_load_json}" '. + {"pageLoad": $pl}')
+        # Keep large JSON off argv (ARG_MAX): presets_json via stdin, page_load_json
+        # via a temp file read with --slurpfile.
+        pl_file="$(mktemp)"
+        printf '%s' "${page_load_json}" >"${pl_file}"
+        presets_json=$(printf '%s' "${presets_json}" | jq --slurpfile pl "${pl_file}" '. + {"pageLoad": $pl[0]}')
+        rm -f "${pl_file}"
     fi
 
     echo "Collected ${file_count} preset(s)" >&2
 
-    jq -n \
+    # presets_json can exceed ARG_MAX; pass it via stdin instead of as a jq argument
+    # (a too-large argv makes the kernel fail to exec jq with "Argument list too long").
+    printf '%s' "${presets_json}" | jq \
         --argjson timestamp "$(date +%s000)" \
-        --argjson presets "${presets_json}" \
-        '{ timestamp: $timestamp, presets: $presets }'
+        '{ timestamp: $timestamp, presets: . }'
 }
 
 # Resolve stats file and assemble data


### PR DESCRIPTION
## **Description**

`benchmark-stats-commit.sh` builds the aggregated benchmark payload and writes it to the rolling baseline (`extension_benchmark_stats` → `stats/main/performance_data.json`). It passed the large JSON to `jq` as a single command-line argument (`--argjson presets ...`, and later `--argjson data "${COMMIT_DATA}"`). As the payload grew (web vitals, long-task/TBT, more steps, user-journey presets), it crossed the kernel per-argument limit (`MAX_ARG_STRLEN`, ~128KB), so `jq` could not be `exec`'d ("Argument list too long") and the step exited 126.

Because the `store-benchmark-stats` step is `continue-on-error: true`, the failure surfaced as a green check while the rolling baseline silently stopped updating (no user-journey data since 2026-04-02, nothing at all since 2026-05-02). Every PR's benchmark comparison has since been measured against a stale baseline.

**Fix:** pass the large JSON via stdin / `--slurpfile` so nothing large lands on `argv`:
- `presets_json` → piped to `jq` on stdin
- `page_load_json` → written to a temp file, read with `--slurpfile`
- `COMMIT_DATA` (the `{ timestamp, presets }` wrapper, strictly larger than the inner blob) → written to a temp file, read with `--slurpfile`

After this lands, the next push to `main` commits a fresh `performance_data.json` and the rolling baseline self-corrects — no manual reset needed.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: MetaMask/MetaMask-planning#7279

## **Manual testing steps**

1. Generate a `benchmark-results/` directory large enough that the assembled `presets`/`COMMIT_DATA` JSON exceeds ~128KB (e.g. a full multi-preset run including user-journey presets).
2. Run `.github/scripts/benchmark-stats-commit.sh` with `BENCHMARK_DATA_TYPE=performance` and `BENCHMARK_RESULTS_DIR=benchmark-results`.
3. Confirm it no longer exits 126 with `jq: Argument list too long`, and that a fresh entry keyed by the head commit SHA is written to `stats/<branch>/performance_data.json`.
4. After merge, confirm the next `main` push adds a fresh commit to `stats/main/performance_data.json` with all presets including `userJourneyOnboarding*`, and that subsequent PR-comment baselines reflect post-fix data rather than Apr/May stale values.

## **Screenshots/Recordings**

N/A — CI tooling change, no UI.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
