### PR TITLE
fix: routing after hardware wallet onboarding

### DIFF
--- a/ui/pages/create-account/connect-hardware/index.test.tsx
+++ b/ui/pages/create-account/connect-hardware/index.test.tsx
@@ -77,13 +77,6 @@ jest.mock('../../../ducks/bridge/selectors', () => ({
   getAllBridgeableNetworks: () => [],
 }));
 
-const MOCK_RECENT_PAGE = '/home';
-jest.mock('../../../ducks/history/history', () => ({
-  getMostRecentOverviewPage: jest
-    .fn()
-    .mockImplementation(() => MOCK_RECENT_PAGE),
-}));
-
 const mockUseNavigate = jest.fn();
 let mockLocationKey = 'default';
 jest.mock('react-router-dom', () => ({
@@ -698,7 +691,7 @@ describe('ConnectHardwareForm', () => {
         expect(unlockButton).toBeDisabled();
       });
 
-      it('navigates to overview page on successful unlock', async () => {
+      it('navigates to home page on successful unlock', async () => {
         const checkboxes = screen.getAllByTestId('hw-account-list__item');
         const firstCheckbox = checkboxes[0].querySelector(
           'input[type="checkbox"]',
@@ -715,7 +708,7 @@ describe('ConnectHardwareForm', () => {
         });
 
         await waitFor(() => {
-          expect(mockUseNavigate).toHaveBeenCalledWith(MOCK_RECENT_PAGE);
+          expect(mockUseNavigate).toHaveBeenCalledWith('/');
         });
       });
 
@@ -787,6 +780,19 @@ describe('ConnectHardwareForm', () => {
             null,
             '',
           );
+        });
+      });
+    });
+
+    describe('onCancel', () => {
+      it('returns to device selection view on cancel', async () => {
+        const cancelButton = screen.getByTestId(
+          'connect-hardware-account-list-cancel-btn',
+        );
+        fireEvent.click(cancelButton);
+
+        await waitFor(() => {
+          expect(screen.getByText(tEn('hardwareWallets'))).toBeInTheDocument();
         });
       });
     });

--- a/ui/pages/create-account/connect-hardware/index.tsx
+++ b/ui/pages/create-account/connect-hardware/index.tsx
@@ -30,7 +30,7 @@ import {
   getActiveQrCodeScanRequest,
 } from '../../../selectors';
 import { formatBalance } from '../../../helpers/utils/util';
-import { getMostRecentOverviewPage } from '../../../ducks/history/history';
+import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import { SECOND } from '../../../../shared/constants/time';
 import {
   HardwareDeviceNames,
@@ -136,7 +136,6 @@ const ConnectHardwareForm = () => {
     (state: { appState: { defaultHdPaths: Record<string, string> } }) =>
       state.appState.defaultHdPaths,
   );
-  const mostRecentOverviewPage = useSelector(getMostRecentOverviewPage);
   const hdEntropyIndex = useSelector(getHDEntropyIndex);
   const keyrings = useSelector(
     (state: { metamask: { keyrings: KeyringObject[] } }) =>
@@ -554,7 +553,7 @@ const ConnectHardwareForm = () => {
           },
         });
 
-        navigate(mostRecentOverviewPage);
+        navigate(DEFAULT_ROUTE);
       } catch (e) {
         const errorMessage = toErrorMessage(e);
 
@@ -585,7 +584,6 @@ const ConnectHardwareForm = () => {
       dispatch,
       hardwareWalletKeyrings,
       hdEntropyIndex,
-      mostRecentOverviewPage,
       navigate,
       selectedAccounts,
       t,
@@ -593,9 +591,17 @@ const ConnectHardwareForm = () => {
     ],
   );
 
+  // Reset the local state so the component re-renders the device selection view
+  // instead of navigating away. Both views live under the same route, so a
+  // route change would be a no-op. The request ID is incremented to discard
+  // any in-flight getPage responses.
   const onCancel = useCallback(() => {
-    navigate(mostRecentOverviewPage);
-  }, [mostRecentOverviewPage, navigate]);
+    setError(null);
+    setSelectedAccounts([]);
+    latestGetPageRequestId.current += 1;
+    setHardwareAccounts([]);
+    setCurrentDevice(null);
+  }, [setCurrentDevice]);
 
   const renderError = () => {
     if (error === U2F_ERROR) {

--- a/ui/pages/create-account/connect-hardware/index.tsx
+++ b/ui/pages/create-account/connect-hardware/index.tsx
@@ -599,6 +599,7 @@ const ConnectHardwareForm = () => {
     setError(null);
     setSelectedAccounts([]);
     latestGetPageRequestId.current += 1;
+    latestPendingDevice.current = null;
     setHardwareAccounts([]);
     setCurrentDevice(null);
   }, [setCurrentDevice]);

--- a/ui/pages/create-account/connect-hardware/index.tsx
+++ b/ui/pages/create-account/connect-hardware/index.tsx
@@ -600,6 +600,7 @@ const ConnectHardwareForm = () => {
     setSelectedAccounts([]);
     latestGetPageRequestId.current += 1;
     latestPendingDevice.current = null;
+    latestHardwareAccounts.current = [];
     setHardwareAccounts([]);
     setCurrentDevice(null);
     setUnlocked(false);

--- a/ui/pages/create-account/connect-hardware/index.tsx
+++ b/ui/pages/create-account/connect-hardware/index.tsx
@@ -602,6 +602,7 @@ const ConnectHardwareForm = () => {
     latestPendingDevice.current = null;
     setHardwareAccounts([]);
     setCurrentDevice(null);
+    setUnlocked(false);
   }, [setCurrentDevice]);
 
   const renderError = () => {


### PR DESCRIPTION
## **Description**
This PR adds fix for page routing after user completes onboarding of hardware wallet.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fix routing after hardware wallet onboarding

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1840

## **Manual testing steps**
1. onboard
2. click accounts list
3. click add wallet
4. click on connect hardware wallet
5. pair any hardware wallet
6. make sure that after clicking unlock, user is routed to the home page

## **Screenshots/Recordings**

### **Before**
Under some circumstances user would be routed to the hardware wallet onboarding page after successful hardware wallet onboarding, instead of being routed to the home page. I couldn't reproduce the issue in the same way as the reporter. Changes made will ensure that user is always routed to the home page (default route).

For more information see [ticket](https://consensyssoftware.atlassian.net/browse/MUL-1840).

### **After**
***Onboarding flow***

https://github.com/user-attachments/assets/f4eef531-f062-4159-b49f-dc8c06171db8

***Cancel flow***

https://github.com/user-attachments/assets/d9ecf537-1120-4c82-a244-36975cf3a444


## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only routing and local state on the hardware connect page; no auth, key material, or backend changes.
> 
> **Overview**
> Fixes **post-onboarding navigation** on the connect-hardware flow so users land on the **home page** (`DEFAULT_ROUTE`, `/`) after a successful unlock, instead of using `getMostRecentOverviewPage`, which could send them back to the hardware onboarding route.
> 
> **Cancel** on the account list no longer navigates away: it **clears local state** (selection, accounts, device, in-flight fetch id) so the UI returns to **device selection** on the same route.
> 
> Tests drop the history mock and assert navigation to `/` plus cancel returning to the hardware wallets picker.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2fdecca361d7c6d3d3991f47ef9e568c43e77c3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->