### PR TITLE
chore: add network select callback

### DIFF
--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
 import type { NetworkConfiguration } from '@metamask/network-controller';
@@ -245,5 +245,25 @@ describe('NFTs options', () => {
       'Import tokens',
     );
     expect(queryByTestId('manageTokens__button')).not.toBeInTheDocument();
+  });
+
+  it('calls onNetworkSelect with CAIP IDs when one network is enabled', async () => {
+    const onNetworkSelect = jest.fn();
+    const state = createMockState();
+    state.metamask.enabledNetworkMap = {
+      eip155: {
+        '0x1': true,
+      },
+    };
+    const store = configureMockStore([thunk])(state);
+
+    renderWithProvider(
+      <AssetListControlBar onNetworkSelect={onNetworkSelect} />,
+      store,
+    );
+
+    await waitFor(() =>
+      expect(onNetworkSelect).toHaveBeenCalledWith(['eip155:1']),
+    );
   });
 });

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
@@ -175,24 +175,8 @@ const AssetListControlBar = ({
     if (!onNetworkSelect) {
       return;
     }
-
-    if (totalEnabledNetworkCount === 1) {
-      const chainId = allEnabledNetworksForAllNamespaces[0];
-      const caipChainId = isStrictHexString(chainId)
-        ? toEvmCaipChainId(chainId)
-        : chainId;
-
-      onNetworkSelect([caipChainId]);
-      return;
-    }
-
     onNetworkSelect(selectedCaipChainIds);
-  }, [
-    allEnabledNetworksForAllNamespaces,
-    onNetworkSelect,
-    selectedCaipChainIds,
-    totalEnabledNetworkCount,
-  ]);
+  }, [onNetworkSelect, selectedCaipChainIds]);
 
   const isTestNetwork = useMemo(() => {
     return (TEST_CHAINS as string[]).includes(

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
@@ -22,6 +22,7 @@ import { selectAccountSupportsEnabledNetworks } from '../../../../../selectors/a
 import {
   getAllEnabledNetworksForAllNamespaces,
   getEnabledNetworksByNamespace,
+  selectEnabledNetworksAsCaipChainIds,
 } from '../../../../../selectors/multichain/networks';
 import {
   getAllNetworkConfigurationsByCaipChainId,
@@ -97,12 +98,14 @@ type AssetListControlBarProps = {
   showTokensLinks?: boolean;
   showImportTokenButton?: boolean;
   showSortControl?: boolean;
+  onNetworkSelect?: (networks: string[]) => void;
 };
 
 const AssetListControlBar = ({
   showTokensLinks,
   showImportTokenButton = true,
   showSortControl = true,
+  onNetworkSelect,
 }: AssetListControlBarProps) => {
   const t = useI18nContext();
   const dispatch = useDispatch();
@@ -133,6 +136,7 @@ const AssetListControlBar = ({
   const allEnabledNetworksForAllNamespaces = useSelector(
     getAllEnabledNetworksForAllNamespaces,
   );
+  const selectedCaipChainIds = useSelector(selectEnabledNetworksAsCaipChainIds);
   const tokenNetworkFilter = useSelector(getTokenNetworkFilter);
   const [isTokenSortPopoverOpen, setIsTokenSortPopoverOpen] = useState(false);
   const [isImportTokensPopoverOpen, setIsImportTokensPopoverOpen] =
@@ -166,6 +170,29 @@ const AssetListControlBar = ({
     () => !shouldShowRefreshButtons && !useNftDetection,
     [shouldShowRefreshButtons, useNftDetection],
   );
+
+  useEffect(() => {
+    if (!onNetworkSelect) {
+      return;
+    }
+
+    if (totalEnabledNetworkCount === 1) {
+      const chainId = allEnabledNetworksForAllNamespaces[0];
+      const caipChainId = isStrictHexString(chainId)
+        ? toEvmCaipChainId(chainId)
+        : chainId;
+
+      onNetworkSelect([caipChainId]);
+      return;
+    }
+
+    onNetworkSelect(selectedCaipChainIds);
+  }, [
+    allEnabledNetworksForAllNamespaces,
+    onNetworkSelect,
+    selectedCaipChainIds,
+    totalEnabledNetworkCount,
+  ]);
 
   const isTestNetwork = useMemo(() => {
     return (TEST_CHAINS as string[]).includes(


### PR DESCRIPTION
## **Description**

Adds optional `onNetworkSelect` so consumer can receive the selected network.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A (extracted from #42837)

## **Manual testing steps**

1. Run: `npx jest ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx --no-coverage`
2. Confirm tests pass.
3. Confirm only `asset-list-control-bar.tsx` changed.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cf1be00e-e221-45f2-923f-409e1b0a9033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cf1be00e-e221-45f2-923f-409e1b0a9033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small optional callback and effect on the assets control bar; no auth, security, or data-path changes.
> 
> **Overview**
> Adds an optional **`onNetworkSelect`** callback to **`AssetListControlBar`** so parent views can react when the user’s **enabled networks** change.
> 
> On mount and whenever enabled networks update, the bar reads **`selectEnabledNetworksAsCaipChainIds`** from Redux and invokes the callback with those **CAIP chain ID** strings (e.g. `eip155:1`). If the prop is omitted, behavior is unchanged.
> 
> A unit test asserts that with one enabled EVM network, **`onNetworkSelect`** is called with **`['eip155:1']`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31cfb69e3bb8abc68cdc7124c36c2d60d6194351. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->