### PR TITLE
fix: replace broken Learn more URL in Added Protection row

### DIFF
--- a/shared/lib/ui-utils.ts
+++ b/shared/lib/ui-utils.ts
@@ -21,6 +21,9 @@ export const SECURITY_ALERTS_LEARN_MORE_LINK =
 export const TRANSACTION_SIMULATIONS_LEARN_MORE_LINK =
   'https://support.metamask.io/transactions-and-gas/transactions/simulations/?utm_source=extension';
 
+export const ENFORCED_SIMULATIONS_LEARN_MORE_LINK =
+  'https://support.metamask.io/transactions-and-gas/transactions/simulations/?utm_source=extension';
+
 export const GAS_FEES_LEARN_MORE_URL =
   'https://community.metamask.io/t/what-is-gas-why-do-transactions-take-so-long/3172';
 

--- a/shared/lib/ui-utils.ts
+++ b/shared/lib/ui-utils.ts
@@ -21,9 +21,6 @@ export const SECURITY_ALERTS_LEARN_MORE_LINK =
 export const TRANSACTION_SIMULATIONS_LEARN_MORE_LINK =
   'https://support.metamask.io/transactions-and-gas/transactions/simulations/?utm_source=extension';
 
-export const ENFORCED_SIMULATIONS_LEARN_MORE_LINK =
-  'https://support.metamask.io/transactions-and-gas/transactions/simulations/?utm_source=extension';
-
 export const GAS_FEES_LEARN_MORE_URL =
   'https://community.metamask.io/t/what-is-gas-why-do-transactions-take-so-long/3172';
 

--- a/ui/pages/confirmations/components/rows/enforced-simulations-row/enforced-simulations-row.tsx
+++ b/ui/pages/confirmations/components/rows/enforced-simulations-row/enforced-simulations-row.tsx
@@ -25,7 +25,7 @@ import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { useConfirmContext } from '../../../context/confirm';
 import { applyTransactionContainersExisting } from '../../../../../store/actions';
 import { useIsEnforcedSimulationsEligible } from '../../../hooks/useIsEnforcedSimulationsEligible';
-import { ENFORCED_SIMULATIONS_LEARN_MORE_LINK } from '../../../../../../shared/lib/ui-utils';
+import { TRANSACTION_SIMULATIONS_LEARN_MORE_LINK } from '../../../../../../shared/lib/ui-utils';
 
 export function EnforcedSimulationsRow() {
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
@@ -221,7 +221,7 @@ function Description() {
     <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
       {t('addedProtectionDescription')}{' '}
       <a
-        href={ENFORCED_SIMULATIONS_LEARN_MORE_LINK}
+        href={TRANSACTION_SIMULATIONS_LEARN_MORE_LINK}
         target="_blank"
         rel="noopener noreferrer"
         data-testid="enforced-simulations-learn-more"

--- a/ui/pages/confirmations/components/rows/enforced-simulations-row/enforced-simulations-row.tsx
+++ b/ui/pages/confirmations/components/rows/enforced-simulations-row/enforced-simulations-row.tsx
@@ -25,9 +25,7 @@ import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { useConfirmContext } from '../../../context/confirm';
 import { applyTransactionContainersExisting } from '../../../../../store/actions';
 import { useIsEnforcedSimulationsEligible } from '../../../hooks/useIsEnforcedSimulationsEligible';
-
-const ADDED_PROTECTION_LEARN_MORE_URL =
-  'https://support.metamask.io/privacy-and-security/staying-safe-in-web3/what-are-enforced-simulations/';
+import { ENFORCED_SIMULATIONS_LEARN_MORE_LINK } from '../../../../../../shared/lib/ui-utils';
 
 export function EnforcedSimulationsRow() {
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
@@ -223,7 +221,7 @@ function Description() {
     <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
       {t('addedProtectionDescription')}{' '}
       <a
-        href={ADDED_PROTECTION_LEARN_MORE_URL}
+        href={ENFORCED_SIMULATIONS_LEARN_MORE_LINK}
         target="_blank"
         rel="noopener noreferrer"
         data-testid="enforced-simulations-learn-more"


### PR DESCRIPTION
## Summary

- The \"Learn more\" link in the **Added Protection** section of transaction confirmations (introduced in v13.33.0) pointed to `https://support.metamask.io/privacy-and-security/staying-safe-in-web3/what-are-enforced-simulations/` — a URL that was never published, resulting in a 404.
- Moved the URL to a named constant `ENFORCED_SIMULATIONS_LEARN_MORE_LINK` in `shared/lib/ui-utils.ts`, pointing to the existing simulations support article (`transactions-and-gas/transactions/simulations/`).
- Removed the stale local constant from `enforced-simulations-row.tsx` and imported the new one — matching the pattern used by `shield-footer-agreement.tsx`.

Fixes #42908

## Test plan

- [ ] Open a transaction confirmation that shows the Added Protection row
- [ ] Click \"Learn more\" — should navigate to the valid MetaMask simulations support article (no 404)
- [ ] Existing unit tests pass (`yarn test:unit` for the affected component)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single UI href change with no auth, transaction, or data-handling impact.
> 
> **Overview**
> Fixes the **Added Protection** row **Learn more** link on transaction confirmations, which previously used an unpublished support URL that returned **404**.
> 
> The row now uses the shared `TRANSACTION_SIMULATIONS_LEARN_MORE_LINK` from `shared/lib/ui-utils` (the published simulations article) instead of a local constant, aligning with other simulations help links in the extension.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f47b5653ba10e699359c8e39ffc691bf22bb8c21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->