### PR TITLE
fix: add guard to asset-util to prevent infinite recursion

### DIFF
--- a/shared/lib/asset-utils.test.ts
+++ b/shared/lib/asset-utils.test.ts
@@ -504,6 +504,20 @@ describe('asset-utils', () => {
       expect(isEvmChainId('0x59f' as Hex)).toBe(true); // Hex format
       expect(isEvmChainId('eip155:1439' as CaipChainId)).toBe(true); // CAIP format
     });
+
+    it('returns false for non-string chain ids without recursing', () => {
+      let depth = 0;
+      const chainId = {
+        toString() {
+          depth += 1;
+          isEvmChainId(chainId as never);
+          return '0x1';
+        },
+      };
+
+      expect(isEvmChainId(chainId as never)).toBe(false);
+      expect(depth).toBe(0);
+    });
   });
 
   describe('isTronSpecialAsset', () => {

--- a/shared/lib/asset-utils.ts
+++ b/shared/lib/asset-utils.ts
@@ -237,6 +237,10 @@ export const fetchAssetMetadataForAssetIds = async (
  * @returns `true` if the chain ID is an EVM chain ID, `false` otherwise.
  */
 export const isEvmChainId = (chainId: CaipChainId | Hex) => {
+  if (typeof chainId !== 'string') {
+    return false;
+  }
+
   let chainIdInCaip: CaipChainId;
 
   if (isCaipChainId(chainId)) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This update modifies the `isEvmChainId` function to return false for non-string chain IDs, improving type safety. Additionally, a new test case has been added to ensure that non-string chain IDs do not cause recursion, maintaining the function's integrity.

Unit tests have been updated to reflect these changes.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: add guard to asset-util to prevent infinite recursion

## **Related issues**

Fixes: https://metamask.sentry.io/issues/7507512731/?notification_uuid=d9a66fe5-c53e-41a2-bc0d-69f99e0e6520&project=273505&referrer=assigned_activity-slack

## **Manual testing steps**

N/A -- edge-case see unit test added

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive type guard in shared asset chain-id detection with a focused unit test; no auth, payment, or broad behavior changes for valid string chain IDs.
> 
> **Overview**
> Adds an early **`typeof chainId !== 'string'`** check in **`isEvmChainId`** so non-string inputs return **`false`** immediately instead of flowing into CAIP/hex logic that can coerce values via **`toString()`** and **re-enter** the same function.
> 
> A unit test asserts that object-shaped “chain ids” whose **`toString`** would call **`isEvmChainId`** again are rejected **without** invoking **`toString`**, addressing a **Sentry** infinite-recursion report.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 17946dbb10fe69cc6eb7e3f9faa04a8837f80c15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->