### PR TITLE
test: fix flaky test `Speed Up and Cancel Transaction Tests Cancel transaction Successfully cancels a pending transaction`

### DIFF
--- a/test/e2e/page-objects/pages/home/activity-list.ts
+++ b/test/e2e/page-objects/pages/home/activity-list.ts
@@ -527,6 +527,9 @@ class ActivityListPage {
   }
 
   async clickCancelTransaction() {
+    // Ensure the Speed Up button is present before canceling
+    // to avoid component re-render, resulting in auto-closing the modal
+    await this.checkSpeedUpInlineButtonIsPresent();
     await this.driver.clickElement(this.cancelTransactionButton);
   }
 

--- a/test/e2e/tests/confirmations/transactions/speed-up-and-cancel-confirmations.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/speed-up-and-cancel-confirmations.spec.ts
@@ -115,7 +115,6 @@ describe('Speed Up and Cancel Transaction Tests', function () {
 
           const activityListPage = new ActivityListPage(driver);
           await activityListPage.checkPendingTxNumberDisplayedInActivity(1);
-          await activityListPage.checkSpeedUpInlineButtonIsPresent();
 
           await activityListPage.clickCancelTransaction();
 

--- a/test/e2e/tests/confirmations/transactions/speed-up-and-cancel-confirmations.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/speed-up-and-cancel-confirmations.spec.ts
@@ -115,6 +115,7 @@ describe('Speed Up and Cancel Transaction Tests', function () {
 
           const activityListPage = new ActivityListPage(driver);
           await activityListPage.checkPendingTxNumberDisplayedInActivity(1);
+          await activityListPage.checkSpeedUpInlineButtonIsPresent();
 
           await activityListPage.clickCancelTransaction();
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The cancel transaction test is flaky as whenever we click Cancel, the cancel modal is open, but after that, the transaction component is re-rendered (Speed up button appears), causing the modal to automatically close.

We now wait until the re-render happens before triggering the Cancel, to avoid the autoclose.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

No modal is open after click Cancel, due to re-render of component (loaded Speed up button)

<img width="780" height="493" alt="image" src="https://github.com/user-attachments/assets/6ac6a481-c8ae-49e6-bc55-080c5f9e09b0" />

### **After**
Wait for the Speed up button before clicking cancel, to avoid re-render and auto-closing modal


https://github.com/user-attachments/assets/691c3b83-d64b-4682-8c38-dfe95f629600



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only page object synchronization; no production or wallet logic changes.
> 
> **Overview**
> Stabilizes the **cancel pending transaction** e2e flow by changing `ActivityListPage.clickCancelTransaction` to wait for the inline **Speed up** control before clicking **Cancel**.
> 
> The wait uses the existing `checkSpeedUpInlineButtonIsPresent` helper so the activity row finishes re-rendering (when Speed up appears) before the cancel modal opens, preventing the modal from closing immediately due to a mid-test UI update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0d347e0d7fa19983751ba226593a27b2a67ebdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->