### PR TITLE
fix: remove redundant title for selecting accounts in hardware wallet onboarding cp-13.33.0

### DIFF
--- a/ui/pages/create-account/connect-hardware/account-list.tsx
+++ b/ui/pages/create-account/connect-hardware/account-list.tsx
@@ -160,13 +160,6 @@ const AccountList = ({
         <h3>{t('selectAnAccount')}</h3>
       </Text>
       {shouldShowHDPaths ? renderHdPathSelector() : null}
-      <Text
-        asChild
-        variant={TextVariant.HeadingSm}
-        className="hw-connect__hdPath__title"
-      >
-        <h3>{t('selectAnAccount')}</h3>
-      </Text>
     </Box>
   );
 


### PR DESCRIPTION
## **Description**
This PR removes redundant title saying "Select an account" on a screen used in hardware wallet onboarding flow.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Remove redundant title for selecting accounts in hardware wallet onboarding

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1837

## **Manual testing steps**
1. Connect any hardware wallet 
2. Get to the last step of account creation
3. Make sure that there is only one title saying "Select an account"

## **Screenshots/Recordings**
### **Before**
***Ledger***
<img width="963" height="668" alt="Screenshot 2026-05-27 at 12 20 28" src="https://github.com/user-attachments/assets/38e14656-e891-4ed6-9434-6954c2e67c23" />
***QR***
<img width="3456" height="1802" alt="image" src="https://github.com/user-attachments/assets/f587702a-597f-4178-967e-5032b175093d" />


### **After**
***Ledger***
<img width="963" height="668" alt="Screenshot 2026-05-27 at 12 21 39" src="https://github.com/user-attachments/assets/08673904-bfb5-4dd6-b54a-527fc10a7792" />
***QR***
<img width="963" height="665" alt="Screenshot 2026-05-27 at 12 23 12" src="https://github.com/user-attachments/assets/aebb776d-7b8d-4601-bddc-cacc0970b4ec" />

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only UI change in the hardware connect account list header with no logic or data handling impact.
> 
> **Overview**
> Removes a **second** “Select an account” heading from the hardware wallet account picker header in `account-list.tsx`, so the screen shows that title only once at the top.
> 
> When HD path selection is shown (Ledger, Lattice, Trezor, OneKey), the flow now goes from that single account title into “Select HD path” and the account list, without repeating the same heading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddfe8f16f112a9601fc663b7a7a0a6318d8404a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->