### PR TITLE
fix: normalise EIP-7702 authorization signature encoding

### DIFF
--- a/app/scripts/lib/transaction/delegation.test.ts
+++ b/app/scripts/lib/transaction/delegation.test.ts
@@ -9,6 +9,7 @@ import {
   TransactionControllerGetNonceLockAction,
   TransactionControllerIsAtomicBatchSupportedAction,
   TransactionMeta,
+  decodeAuthorizationSignature,
 } from '@metamask/transaction-controller';
 import {
   createExactExecutionBatchTerms,
@@ -27,7 +28,6 @@ import {
   getDeleGatorEnvironment,
 } from '../../../../shared/lib/delegation';
 
-import { stripSingleLeadingZero } from './util';
 import {
   convertTransactionToRedeemDelegations,
   DelegationMessenger,
@@ -48,9 +48,9 @@ jest.mock('@metamask/delegation-core', () => ({
   createExactExecutionBatchTerms: jest.fn(),
 }));
 
-jest.mock('./util', () => ({
-  ...jest.requireActual('./util'),
-  stripSingleLeadingZero: jest.fn(),
+jest.mock('@metamask/transaction-controller', () => ({
+  ...jest.requireActual('@metamask/transaction-controller'),
+  decodeAuthorizationSignature: jest.fn(),
 }));
 
 const DELEGATION_MANAGER_ADDRESS_MOCK = '0xDelegationManagerAddress' as Hex;
@@ -98,7 +98,9 @@ const TRANSACTION_META_MOCK = {
 describe('delegation', () => {
   const getDeleGatorEnvironmentMock = jest.mocked(getDeleGatorEnvironment);
   const encodeRedeemDelegationsMock = jest.mocked(encodeRedeemDelegations);
-  const stripSingleLeadingZeroMock = jest.mocked(stripSingleLeadingZero);
+  const decodeAuthorizationSignatureMock = jest.mocked(
+    decodeAuthorizationSignature,
+  );
   const createLimitedCallsTermsMock = jest.mocked(createLimitedCallsTerms);
   const createExactExecutionTermsMock = jest.mocked(createExactExecutionTerms);
   const createExactExecutionBatchTermsMock = jest.mocked(
@@ -218,7 +220,11 @@ describe('delegation', () => {
       releaseLock: jest.fn(),
     } as never);
 
-    stripSingleLeadingZeroMock.mockImplementation((value) => value as never);
+    decodeAuthorizationSignatureMock.mockReturnValue({
+      r: `0x${'1'.repeat(64)}` as Hex,
+      s: `0x${'1'.repeat(64)}` as Hex,
+      yParity: '0x1' as Hex,
+    });
   });
 
   describe('convertTransactionToRedeemDelegations', () => {
@@ -582,7 +588,9 @@ describe('delegation', () => {
         from: TRANSACTION_META_MOCK.txParams.from,
         nonce: 9,
       });
-      expect(stripSingleLeadingZeroMock).toHaveBeenCalledTimes(2);
+      expect(decodeAuthorizationSignatureMock).toHaveBeenCalledWith(
+        AUTHORIZATION_SIGNATURE_MOCK,
+      );
       expect(result.authorizationList).toEqual([
         {
           address: UPGRADE_CONTRACT_ADDRESS_MOCK,
@@ -591,6 +599,33 @@ describe('delegation', () => {
           r: `0x${'1'.repeat(64)}`,
           s: `0x${'1'.repeat(64)}`,
           yParity: '0x1',
+        },
+      ]);
+    });
+
+    it('strips all leading zero nibbles from r, s, yParity via upstream util', async () => {
+      decodeAuthorizationSignatureMock.mockReturnValue({
+        r: '0x1' as Hex,
+        s: '0x2' as Hex,
+        yParity: '0x0' as Hex,
+      });
+
+      const result = await convertTransactionToRedeemDelegations({
+        transaction: TRANSACTION_META_MOCK,
+        messenger,
+        authorization: {
+          upgradeContractAddress: UPGRADE_CONTRACT_ADDRESS_MOCK,
+        },
+      });
+
+      expect(result.authorizationList).toEqual([
+        {
+          address: UPGRADE_CONTRACT_ADDRESS_MOCK,
+          chainId: '0x1',
+          nonce: '0x9',
+          r: '0x1',
+          s: '0x2',
+          yParity: '0x0',
         },
       ]);
     });

--- a/app/scripts/lib/transaction/delegation.ts
+++ b/app/scripts/lib/transaction/delegation.ts
@@ -2,12 +2,13 @@ import {
   AuthorizationList,
   TransactionEnvelopeType,
   TransactionMeta,
+  decodeAuthorizationSignature,
 } from '@metamask/transaction-controller';
 import type {
   TransactionControllerIsAtomicBatchSupportedAction,
   TransactionControllerGetNonceLockAction,
 } from '@metamask/transaction-controller';
-import { Hex, add0x, bytesToHex, createProjectLogger } from '@metamask/utils';
+import { Hex, bytesToHex, createProjectLogger } from '@metamask/utils';
 import { toHex } from '@metamask/controller-utils';
 import type { Messenger } from '@metamask/messenger';
 import type { DelegationControllerSignDelegationAction } from '@metamask/delegation-controller';
@@ -30,7 +31,6 @@ import {
   type Delegation,
   type UnsignedDelegation,
 } from '../../../../shared/lib/delegation';
-import { stripSingleLeadingZero } from './util';
 
 const log = createProjectLogger('transaction-delegation');
 
@@ -345,19 +345,6 @@ async function getNextNonce(
 
   nonceLock.releaseLock();
   return toHex(nonceLock.nextNonce);
-}
-
-function decodeAuthorizationSignature(signature: Hex) {
-  const r = stripSingleLeadingZero(signature.slice(0, 66)) as Hex;
-  const s = stripSingleLeadingZero(add0x(signature.slice(66, 130))) as Hex;
-  const v = parseInt(signature.slice(130, 132), 16);
-  const yParity = toHex(v - 27 === 0 ? 0 : 1);
-
-  return {
-    r,
-    s,
-    yParity,
-  };
 }
 
 async function resolveUpgradeContractAddress(


### PR DESCRIPTION
## **Description**

The `r` and `s` values in EIP-7702 authorization lists were not fully RLP-canonical — leading zero bytes weren't fully stripped, which could cause relay and RPC rejections. Replaced the local decoding logic with the shared `decodeAuthorizationSignature` util from `@metamask/transaction-controller`, which handles this correctly.

Port of [metamask-mobile#29717](https://github.com/MetaMask/metamask-mobile/pull/29717).

## **Changelog**

CHANGELOG entry: Fixed an issue where EIP-7702 authorization signatures with leading zero bytes in `r` or `s` could be rejected by relays and public RPCs.

## **Related issues**

<!--
## **Manual testing steps**

## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how authorization list fields are encoded on the EIP-7702 upgrade path for delegation transactions; incorrect encoding could still break relays, but the change aligns with the canonical shared util and is covered by updated unit tests.
> 
> **Overview**
> Delegation flows that build EIP-7702 **authorization lists** now decode the keyring’s authorization signature with **`decodeAuthorizationSignature`** from `@metamask/transaction-controller` instead of a local helper that only stripped a single leading zero from `r`/`s`.
> 
> The in-file decoder and its dependency on `./util`’s `stripSingleLeadingZero` are removed; **`buildAuthorizationList`** passes through the shared util’s canonical `r`, `s`, and `yParity`. Tests mock **`decodeAuthorizationSignature`** and assert the authorization list reflects minimally encoded signature fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cce796ac3e5680b57add1e6c7aab26dd9297891. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->