### PR TITLE
chore: loosen CODEOWNERS gates on dependency-bump files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -240,6 +240,13 @@ shared/lib/deep-links/routes/musd.ts @MetaMask/earn
 /.gitignore                                           @MetaMask/extension-platform
 /.husky/                                              @MetaMask/extension-platform
 /.yarn/                                               @MetaMask/extension-platform
+# Yarn patches – no code owners assigned
+# This allows any org developer to approve routine dependency patch updates.
+# ⚠️ Note: Leaving this rule unassigned disables Code Owner review enforcement for patch files.
+# ⚠️ Important: This rule must appear after the `/.yarn/` rule; last matching pattern wins.
+/.yarn/patches/
+/.yarn/releases/                                      @MetaMask/extension-platform
+/.yarn/plugins/                                       @MetaMask/extension-platform
 /.env.yarn                                            @MetaMask/extension-platform
 /.yarnrc.yml                                          @MetaMask/extension-platform
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Routine dependency maintenance is blocked when root lockfiles and Yarn patch files require `@MetaMask/extension-platform` approval on every PR.

**Reason:** Extension Platform should retain review on Yarn toolchain config (`.yarnrc.yml`, releases, plugins) while allowing any org developer to approve routine `package.json` / `yarn.lock` bumps and patch-file updates.

**Solution:**
- Confirm root `/package.json` and `/yarn.lock` have no CODEOWNERS entries (removed previously in #42868 / Dependencies section removal).
- Carve out `/.yarn/patches/` from the `/.yarn/` rule using the unowned-line pattern from metamask-mobile, with `/.yarn/releases/` and `/.yarn/plugins/` re-restricted immediately after (last match wins).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a3e3434e-e571-4aa1-ac5b-b13b737e36f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3e3434e-e571-4aa1-ac5b-b13b737e36f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

