### PR TITLE
feat: enable telegram login for uat builds

### DIFF
--- a/builds.yml
+++ b/builds.yml
@@ -454,7 +454,7 @@ env:
   - GOOGLE_CLIENT_ID_UAT: ''
   - APPLE_CLIENT_ID_UAT: ''
   - TELEGRAM_CLIENT_ID_UAT: ''
-  - TELEGRAM_LOGIN_ENABLED: 'false'
+  - TELEGRAM_LOGIN_ENABLED: 'true'
 
   # Metamask Shield
   - METAMASK_SHIELD_ENABLED: 'true'

--- a/development/build/set-environment-variables.js
+++ b/development/build/set-environment-variables.js
@@ -3,8 +3,10 @@ const assert = require('node:assert');
 const { ENVIRONMENT } = require('./constants');
 
 function isProductionOrReleaseCandidateBuild(environment) {
-  return environment === ENVIRONMENT.PRODUCTION ||
-    environment === ENVIRONMENT.RELEASE_CANDIDATE;
+  return (
+    environment === ENVIRONMENT.PRODUCTION ||
+    environment === ENVIRONMENT.RELEASE_CANDIDATE
+  );
 }
 
 /**

--- a/development/build/set-environment-variables.js
+++ b/development/build/set-environment-variables.js
@@ -2,6 +2,11 @@ const { readFileSync } = require('node:fs');
 const assert = require('node:assert');
 const { ENVIRONMENT } = require('./constants');
 
+function isProductionOrReleaseCandidateBuild(environment) {
+  return environment === ENVIRONMENT.PRODUCTION ||
+    environment === ENVIRONMENT.RELEASE_CANDIDATE;
+}
+
 /**
  * Sets environment variables to inject in the current build.
  *
@@ -91,6 +96,9 @@ function setEnvironmentVariables({
     METAMASK_SHIELD_ENABLED: isTestBuild
       ? 'true'
       : variables.getMaybe('METAMASK_SHIELD_ENABLED'),
+    TELEGRAM_LOGIN_ENABLED: isProductionOrReleaseCandidateBuild(environment)
+      ? 'false'
+      : variables.getMaybe('TELEGRAM_LOGIN_ENABLED'),
     PERPS_ENABLED: isTestBuild ? 'true' : variables.getMaybe('PERPS_ENABLED'),
     ASSETS_UNIFIED_STATE_ENABLED: isTestBuild
       ? 'false'
@@ -205,10 +213,7 @@ function getOAuthClientId({
 }) {
   const clientIdEnv = `${provider}_CLIENT_ID`;
 
-  if (
-    environment === ENVIRONMENT.PRODUCTION ||
-    environment === ENVIRONMENT.RELEASE_CANDIDATE
-  ) {
+  if (isProductionOrReleaseCandidateBuild(environment)) {
     // Production and release-candidate builds resolve the client ID indirectly so
     // each build can point at the right secret without changing code.
     const clientIdRef = assertAndLoadEnvVar(

--- a/development/build/set-environment-variables.test.ts
+++ b/development/build/set-environment-variables.test.ts
@@ -1,6 +1,6 @@
 import { Variables } from '../lib/variables';
 import { ENVIRONMENT } from './constants';
-import { getOAuthClientId } from './set-environment-variables';
+import { getOAuthClientId, setEnvironmentVariables } from './set-environment-variables';
 
 type ProviderConfig = {
   clientIdEnv: string;
@@ -134,6 +134,80 @@ const providerEntries = Object.entries(PROVIDER_CONFIG) as [
   ProviderConfig,
 ][];
 
+const SET_ENVIRONMENT_VARIABLES_DECLARED_VARIABLES = [
+  ...DECLARED_VARIABLES,
+  'DEBUG',
+  'EIP_4337_ENTRYPOINT',
+  'IN_TEST',
+  'INFURA_PROJECT_ID',
+  'INFURA_ENV_KEY_REF',
+  'INFURA_PROD_PROJECT_ID',
+  'METAMASK_DEBUG',
+  'SENTRY_DISTRIBUTED_TRACING_DISABLED',
+  'METAMASK_BUILD_NAME',
+  'METAMASK_BUILD_APP_ID',
+  'METAMASK_BUILD_ICON',
+  'METAMASK_ENVIRONMENT',
+  'METAMASK_VERSION',
+  'METAMASK_BUILD_TYPE',
+  'NODE_ENV',
+  'PHISHING_WARNING_PAGE_URL',
+  'SEGMENT_WRITE_KEY',
+  'SEGMENT_WRITE_KEY_REF',
+  'SEGMENT_PROD_WRITE_KEY',
+  'TEST_GAS_FEE_FLOWS',
+  'DEEP_LINK_HOST',
+  'DEEP_LINK_PUBLIC_KEY',
+  'SEEDLESS_ONBOARDING_ENABLED',
+  'METAMASK_SHIELD_ENABLED',
+  'TELEGRAM_LOGIN_ENABLED',
+  'PERPS_ENABLED',
+  'ASSETS_UNIFIED_STATE_ENABLED',
+];
+
+function getVariablesForSetEnvironmentVariables() {
+  const variables = new Variables(SET_ENVIRONMENT_VARIABLES_DECLARED_VARIABLES);
+
+  variables.set({
+    DEBUG: false,
+    EIP_4337_ENTRYPOINT: '0x0000000000000000000000000000000000000000',
+    INFURA_PROJECT_ID: 'direct-infura-project-id',
+    INFURA_ENV_KEY_REF: 'INFURA_PROD_PROJECT_ID',
+    INFURA_PROD_PROJECT_ID: 'prod-infura-project-id',
+    METAMASK_DEBUG: false,
+    SENTRY_DISTRIBUTED_TRACING_DISABLED: false,
+    PHISHING_WARNING_PAGE_URL: 'https://example.test/',
+    SEGMENT_WRITE_KEY: 'direct-segment-write-key',
+    SEGMENT_WRITE_KEY_REF: 'SEGMENT_PROD_WRITE_KEY',
+    SEGMENT_PROD_WRITE_KEY: 'prod-segment-write-key',
+    TEST_GAS_FEE_FLOWS: false,
+    DEEP_LINK_HOST: 'https://deep-link.example.test',
+    DEEP_LINK_PUBLIC_KEY: 'public-key',
+    SEEDLESS_ONBOARDING_ENABLED: 'false',
+    METAMASK_SHIELD_ENABLED: 'false',
+    TELEGRAM_LOGIN_ENABLED: 'true',
+    PERPS_ENABLED: 'false',
+    ASSETS_UNIFIED_STATE_ENABLED: 'false',
+    GOOGLE_CLIENT_ID: 'google-dev-client-id',
+    APPLE_CLIENT_ID: 'apple-dev-client-id',
+    TELEGRAM_CLIENT_ID: 'telegram-dev-client-id',
+    GOOGLE_CLIENT_ID_REF: 'GOOGLE_PROD_CLIENT_ID',
+    APPLE_CLIENT_ID_REF: 'APPLE_PROD_CLIENT_ID',
+    TELEGRAM_CLIENT_ID_REF: 'TELEGRAM_PROD_CLIENT_ID',
+    GOOGLE_PROD_CLIENT_ID: 'google-prod-client-id',
+    APPLE_PROD_CLIENT_ID: 'apple-prod-client-id',
+    TELEGRAM_PROD_CLIENT_ID: 'telegram-prod-client-id',
+    GOOGLE_CLIENT_ID_UAT: 'google-uat-client-id',
+    APPLE_CLIENT_ID_UAT: 'apple-uat-client-id',
+    TELEGRAM_CLIENT_ID_UAT: 'telegram-uat-client-id',
+    GOOGLE_CLIENT_ID_FLASK_UAT: 'google-flask-uat-client-id',
+    APPLE_CLIENT_ID_FLASK_UAT: 'apple-flask-uat-client-id',
+    TELEGRAM_CLIENT_ID_FLASK_UAT: 'telegram-flask-uat-client-id',
+  });
+
+  return variables;
+}
+
 describe('getOAuthClientId', () => {
   for (const [provider, config] of providerEntries) {
     describe(`when the provider is ${provider}`, () => {
@@ -244,4 +318,54 @@ describe('getOAuthClientId', () => {
       });
     });
   }
+});
+
+describe('setEnvironmentVariables', () => {
+  it('forces TELEGRAM_LOGIN_ENABLED to false for production builds', () => {
+    const variables = getVariablesForSetEnvironmentVariables();
+
+      setEnvironmentVariables({
+        buildName: 'MetaMask',
+        buildType: 'main',
+        environment: ENVIRONMENT.PRODUCTION,
+        isDevBuild: false,
+        isTestBuild: false,
+        variables,
+        version: '1.0.0',
+      });
+
+      expect(variables.get('TELEGRAM_LOGIN_ENABLED')).toBe('false');
+  });
+
+  it('forces TELEGRAM_LOGIN_ENABLED to false for release candidate builds', () => {
+    const variables = getVariablesForSetEnvironmentVariables();
+
+      setEnvironmentVariables({
+        buildName: 'MetaMask',
+        buildType: 'main',
+        environment: ENVIRONMENT.RELEASE_CANDIDATE,
+        isDevBuild: false,
+        isTestBuild: false,
+        variables,
+        version: '1.0.0',
+      });
+
+      expect(variables.get('TELEGRAM_LOGIN_ENABLED')).toBe('false');
+  });
+
+  it('preserves TELEGRAM_LOGIN_ENABLED outside production and release builds', () => {
+    const variables = getVariablesForSetEnvironmentVariables();
+
+    setEnvironmentVariables({
+      buildName: 'MetaMask',
+      buildType: 'main',
+      environment: ENVIRONMENT.TESTING,
+      isDevBuild: false,
+      isTestBuild: true,
+      variables,
+      version: '1.0.0',
+    });
+
+    expect(variables.get('TELEGRAM_LOGIN_ENABLED')).toBe('true');
+  });
 });

--- a/development/build/set-environment-variables.test.ts
+++ b/development/build/set-environment-variables.test.ts
@@ -1,6 +1,9 @@
 import { Variables } from '../lib/variables';
 import { ENVIRONMENT } from './constants';
-import { getOAuthClientId, setEnvironmentVariables } from './set-environment-variables';
+import {
+  getOAuthClientId,
+  setEnvironmentVariables,
+} from './set-environment-variables';
 
 type ProviderConfig = {
   clientIdEnv: string;
@@ -324,33 +327,33 @@ describe('setEnvironmentVariables', () => {
   it('forces TELEGRAM_LOGIN_ENABLED to false for production builds', () => {
     const variables = getVariablesForSetEnvironmentVariables();
 
-      setEnvironmentVariables({
-        buildName: 'MetaMask',
-        buildType: 'main',
-        environment: ENVIRONMENT.PRODUCTION,
-        isDevBuild: false,
-        isTestBuild: false,
-        variables,
-        version: '1.0.0',
-      });
+    setEnvironmentVariables({
+      buildName: 'MetaMask',
+      buildType: 'main',
+      environment: ENVIRONMENT.PRODUCTION,
+      isDevBuild: false,
+      isTestBuild: false,
+      variables,
+      version: '1.0.0',
+    });
 
-      expect(variables.get('TELEGRAM_LOGIN_ENABLED')).toBe('false');
+    expect(variables.get('TELEGRAM_LOGIN_ENABLED')).toBe('false');
   });
 
   it('forces TELEGRAM_LOGIN_ENABLED to false for release candidate builds', () => {
     const variables = getVariablesForSetEnvironmentVariables();
 
-      setEnvironmentVariables({
-        buildName: 'MetaMask',
-        buildType: 'main',
-        environment: ENVIRONMENT.RELEASE_CANDIDATE,
-        isDevBuild: false,
-        isTestBuild: false,
-        variables,
-        version: '1.0.0',
-      });
+    setEnvironmentVariables({
+      buildName: 'MetaMask',
+      buildType: 'main',
+      environment: ENVIRONMENT.RELEASE_CANDIDATE,
+      isDevBuild: false,
+      isTestBuild: false,
+      variables,
+      version: '1.0.0',
+    });
 
-      expect(variables.get('TELEGRAM_LOGIN_ENABLED')).toBe('false');
+    expect(variables.get('TELEGRAM_LOGIN_ENABLED')).toBe('false');
   });
 
   it('preserves TELEGRAM_LOGIN_ENABLED outside production and release builds', () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
This PR enables `Telegram` login for the UAT builds.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Download the builds from this PR. Install to Chrome/Firefox
2. Select Telegram login option during the onboarding.
3. User should be able to create/rehydrate the wallet and successfully log in.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes authentication surface area for UAT while explicitly gating prod/RC off; misconfiguration could expose Telegram login where it should stay disabled.
> 
> **Overview**
> Turns on **Telegram login** for non-production builds by defaulting `TELEGRAM_LOGIN_ENABLED` to `'true'` in `builds.yml`, while the build script **forces it off** for production and release-candidate builds so store/release artifacts cannot ship with Telegram login even if the YAML says otherwise.
> 
> `set-environment-variables.js` adds a shared `isProductionOrReleaseCandidateBuild` helper (also used for OAuth client ID resolution) and wires `TELEGRAM_LOGIN_ENABLED` through that gate. Tests cover prod/RC override vs preserving the flag on testing builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cd8e4b5033878da3a35ae02b666b243b277f46a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->