### PR TITLE
chore: added FF for network manager

### DIFF
--- a/test/e2e/feature-flags/feature-flag-registry.ts
+++ b/test/e2e/feature-flags/feature-flag-registry.ts
@@ -2169,6 +2169,14 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
+  extensionUxNetworkManagement: {
+    name: 'extensionUxNetworkManagement',
+    type: FeatureFlagType.Remote,
+    inProd: true,
+    productionDefault: false,
+    status: FeatureFlagStatus.Active,
+  },
+
   extensionUxTokenManagementFilter: {
     name: 'extensionUxTokenManagementFilter',
     type: FeatureFlagType.Remote,

--- a/ui/selectors/multichain/feature-flags.test.ts
+++ b/ui/selectors/multichain/feature-flags.test.ts
@@ -1,4 +1,7 @@
-import { getIsTokenManagementFilterEnabled } from './feature-flags';
+import {
+  getIsNetworkManagementEnabled,
+  getIsTokenManagementFilterEnabled,
+} from './feature-flags';
 
 const buildState = (
   remoteFeatureFlags: Record<string, unknown> = {},
@@ -86,6 +89,88 @@ describe('getIsTokenManagementFilterEnabled', () => {
     expect(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       getIsTokenManagementFilterEnabled(buildState() as any),
+    ).toBe(false);
+  });
+});
+
+describe('getIsNetworkManagementEnabled', () => {
+  it('returns true when the flag is true', () => {
+    expect(
+      getIsNetworkManagementEnabled(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        buildState({ extensionUxNetworkManagement: true }) as any,
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false when the flag is false', () => {
+    expect(
+      getIsNetworkManagementEnabled(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        buildState({ extensionUxNetworkManagement: false }) as any,
+      ),
+    ).toBe(false);
+  });
+
+  it('returns true for a version-gated flag whose minimumVersion is satisfied', () => {
+    expect(
+      getIsNetworkManagementEnabled(
+        buildState({
+          extensionUxNetworkManagement: {
+            enabled: true,
+            minimumVersion: '0.0.0',
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }) as any,
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for a version-gated flag whose minimumVersion is in the future', () => {
+    expect(
+      getIsNetworkManagementEnabled(
+        buildState({
+          extensionUxNetworkManagement: {
+            enabled: true,
+            minimumVersion: '999.0.0',
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }) as any,
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false when the version-gated flag is explicitly disabled', () => {
+    expect(
+      getIsNetworkManagementEnabled(
+        buildState({
+          extensionUxNetworkManagement: {
+            enabled: false,
+            minimumVersion: '0.0.0',
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }) as any,
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false for malformed objects missing the minimumVersion field', () => {
+    expect(
+      getIsNetworkManagementEnabled(
+        buildState({
+          extensionUxNetworkManagement: {
+            enabled: true,
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }) as any,
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false when the flag is missing', () => {
+    expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      getIsNetworkManagementEnabled(buildState() as any),
     ).toBe(false);
   });
 });

--- a/ui/selectors/multichain/feature-flags.ts
+++ b/ui/selectors/multichain/feature-flags.ts
@@ -99,3 +99,15 @@ export const getIsTokenManagementFilterEnabled = createSelector(
   ({ extensionUxTokenManagementFilter }) =>
     getBooleanFeatureFlag(extensionUxTokenManagementFilter, false),
 );
+
+/**
+ * Get the state of the `extensionUxNetworkManagement` remote feature flag.
+ *
+ * @param _state - The MetaMask state object
+ * @returns boolean - True if the feature is enabled, false otherwise.
+ */
+export const getIsNetworkManagementEnabled = createSelector(
+  getRemoteFeatureFlags,
+  ({ extensionUxNetworkManagement }) =>
+    getBooleanFeatureFlag(extensionUxNetworkManagement, false),
+);


### PR DESCRIPTION
This PR is to set up the remote FF for network manager update in homepage

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

NA
## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Flag-only change with production default false and no behavioral UI changes in this PR.
> 
> **Overview**
> Introduces the remote feature flag **`extensionUxNetworkManagement`** so homepage network-manager UX can be rolled out gradually. The flag is registered for E2E/production-accurate mocking (default **off**), exposed via **`getIsNetworkManagementEnabled`** using the same boolean/version-gated resolution as other extension UX flags, and covered by unit tests. **No UI wiring** appears in this diff—only flag plumbing for follow-up work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac114866ba76c607b85268bd818a4aef3b2cbc6b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->