### PR TITLE
fix: always use replacementSelectedRpcEndpointIndex option in network…

### DIFF
--- a/ui/components/multichain/networks-form/networks-form.tsx
+++ b/ui/components/multichain/networks-form/networks-form.tsx
@@ -304,14 +304,12 @@ export const NetworksForm = ({
         };
 
         if (existingNetwork) {
-          const options = toggleNetworkMenuAfterSubmit
-            ? {
-                replacementSelectedRpcEndpointIndex:
-                  chainIdHex === existingNetwork.chainId
-                    ? rpcUrls?.defaultRpcEndpointIndex
-                    : undefined,
-              }
-            : {};
+          const options = {
+            replacementSelectedRpcEndpointIndex:
+              chainIdHex === existingNetwork.chainId
+                ? rpcUrls?.defaultRpcEndpointIndex
+                : undefined,
+          };
           await dispatch(updateNetwork(networkPayload, options));
           if (
             toggleNetworkMenuAfterSubmit &&


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Fix for issue https://github.com/MetaMask/metamask-extension/issues/42903 "Cannot delete custom RPC, after Save, the RPC is still present error message".

When trying to remove a second RPC for a Network from the Network Picker, there are conditions in which the code attempts to remove the RPC without reassigning the remaining RPC as default one, causing the RPC removal to be canceled in the code.
From a user perspective, it feels like the user tries to remove that second RPC, but when they close the modal the RPC is still there.
From a developer perspective, if opening the console, one can see:
```
Could not update network: Cannot update RPC endpoints in such a way that the selected network '08b7f81c-8d4d-46eb-b96a-2b2ac243aeab' would be removed without a replacement. Choose a different RPC endpoint as the selected network via the `replacementSelectedRpcEndpointIndex` option.
```

This PR removes the `toggleNetworkMenuAfterSubmit ?` pre-condition for having a replacement RPC assigned when removing one, in `networks-form.tsx`. Since this variable was false in the conditions of the bug, this solves the issue.

Disclaimer: I am not entirely sure what was the original intent being this `toggleNetworkMenuAfterSubmit ?` and thus would recommend non-regression for RPC removal.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: removes `toggleNetworkMenuAfterSubmit ?` pre-condition for replacement RPC networks-form 

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/42903 (Jira https://consensyssoftware.atlassian.net/browse/NEB-1257?atlOrigin=eyJpIjoiMWQwNWMwMDM1OTQ1NDg2ZGFlODg4N2FmN2UzOGVjMjAiLCJwIjoiaiJ9)

## **Manual testing steps**

I've been struggling to reproduce this, as I couldn't find a clear pattern.
What allowed me to reproduce it the quickest was:
 
1. Use a fresh SRP.
2. From the asset-picker, click on the Networks filter.
3. Select Ethereum network as current active network using the picker.
4. Open the picker again to assign a second RPC to Ethereum mainnet with `https://eth.blockrazor.xyz/` as both URL and title.
5. Close all modals to reach the asset picker.
6. Open the networks filter again and go to Ethereum settings again.
7. Open the RPCs combo box, click on the trash icon for the second RPC. Click on the "Save" button directly without doing to click aside to close the combobox.

**Before the fix:** The second RPC remains there and active.
**After the fix:** The second RPC effectively goes away and the default Infura one is selected.

**Non-regression:** Please if you are aware of other ways to edit Networks, try something similar with this branch to ensure non-regression in editing RPCs in general.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional removal in the networks form submit path; behavior change is limited to network edit persistence when `toggleNetworkMenuAfterSubmit` is false.
> 
> **Overview**
> When saving an **existing** network from the multichain networks form, **`updateNetwork` now always receives `replacementSelectedRpcEndpointIndex`** (when the chain ID is unchanged), instead of only passing that option when `toggleNetworkMenuAfterSubmit` is true.
> 
> That aligns RPC endpoint list edits—including **removing custom RPCs**—with the user’s selected default endpoint on flows like the **Networks page**, where the menu is not toggled after submit. Previously an empty `options` object on those saves could leave deleted RPCs appearing to stick around after Save.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5bf7be566fff2ebce53c4b266d5c735432ead6cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->