### PR TITLE
fix: prevent assets controller background calls cp-13.33.0

### DIFF
--- a/.yarn/patches/@metamask-assets-controller-npm-8.0.1-e54f7ee84e.patch
+++ b/.yarn/patches/@metamask-assets-controller-npm-8.0.1-e54f7ee84e.patch
@@ -1,0 +1,66 @@
+diff --git a/dist/AssetsController.cjs b/dist/AssetsController.cjs
+index 92494173605bb53b1615f0cdb011712b1c9bfadb..084ffd8bc6b15a3474bb4ae65eeb6b195c2aaf2d 100644
+--- a/dist/AssetsController.cjs
++++ b/dist/AssetsController.cjs
+@@ -283,7 +283,7 @@ class AssetsController extends base_controller_1.BaseController {
+         _AssetsController_unsubscribeBasicFunctionality.set(this, null);
+         _AssetsController_queryApiClient.set(this, void 0);
+         _AssetsController_onActiveChainsUpdated.set(this, void 0);
+-        __classPrivateFieldSet(this, _AssetsController_isEnabled, isEnabled(), "f");
++        __classPrivateFieldSet(this, _AssetsController_isEnabled, isEnabled, "f");
+         __classPrivateFieldSet(this, _AssetsController_isBasicFunctionality, isBasicFunctionality ?? (() => true), "f");
+         __classPrivateFieldSet(this, _AssetsController_defaultUpdateInterval, defaultUpdateInterval, "f");
+         __classPrivateFieldSet(this, _AssetsController_trace, trace, "f");
+@@ -361,10 +361,6 @@ class AssetsController extends base_controller_1.BaseController {
+         __classPrivateFieldSet(this, _AssetsController_rpcFallbackMiddleware, new RpcFallbackMiddleware_1.RpcFallbackMiddleware({
+             rpcDataSource: __classPrivateFieldGet(this, _AssetsController_rpcDataSource, "f"),
+         }), "f");
+-        if (!__classPrivateFieldGet(this, _AssetsController_isEnabled, "f")) {
+-            log('AssetsController is disabled, skipping initialization');
+-            return;
+-        }
+         log('Initializing AssetsController', {
+             defaultUpdateInterval: __classPrivateFieldGet(this, _AssetsController_defaultUpdateInterval, "f"),
+         });
+@@ -1146,7 +1142,7 @@ _AssetsController_isEnabled = new WeakMap(), _AssetsController_isBasicFunctional
+ }, _AssetsController_registerActionHandlers = function _AssetsController_registerActionHandlers() {
+     this.messenger.registerMethodActionHandlers(this, MESSENGER_EXPOSED_METHODS);
+ }, _AssetsController_handleActiveChainsUpdate = function _AssetsController_handleActiveChainsUpdate(dataSourceId, activeChains, previousChains) {
+-    if (!__classPrivateFieldGet(this, _AssetsController_isEnabled, "f")) {
++    if (!__classPrivateFieldGet(this, _AssetsController_isEnabled, "f").call(this)) {
+         return;
+     }
+     log('Data source active chains changed', {
+diff --git a/dist/AssetsController.mjs b/dist/AssetsController.mjs
+index 85a913c8536bcdd7690d96cc0d512bf4528e37aa..b6b746b6635e48808e056f89b5d8d39cd31bf1ef 100644
+--- a/dist/AssetsController.mjs
++++ b/dist/AssetsController.mjs
+@@ -277,7 +277,7 @@ export class AssetsController extends BaseController {
+         _AssetsController_unsubscribeBasicFunctionality.set(this, null);
+         _AssetsController_queryApiClient.set(this, void 0);
+         _AssetsController_onActiveChainsUpdated.set(this, void 0);
+-        __classPrivateFieldSet(this, _AssetsController_isEnabled, isEnabled(), "f");
++        __classPrivateFieldSet(this, _AssetsController_isEnabled, isEnabled, "f");
+         __classPrivateFieldSet(this, _AssetsController_isBasicFunctionality, isBasicFunctionality ?? (() => true), "f");
+         __classPrivateFieldSet(this, _AssetsController_defaultUpdateInterval, defaultUpdateInterval, "f");
+         __classPrivateFieldSet(this, _AssetsController_trace, trace, "f");
+@@ -355,10 +355,6 @@ export class AssetsController extends BaseController {
+         __classPrivateFieldSet(this, _AssetsController_rpcFallbackMiddleware, new RpcFallbackMiddleware({
+             rpcDataSource: __classPrivateFieldGet(this, _AssetsController_rpcDataSource, "f"),
+         }), "f");
+-        if (!__classPrivateFieldGet(this, _AssetsController_isEnabled, "f")) {
+-            log('AssetsController is disabled, skipping initialization');
+-            return;
+-        }
+         log('Initializing AssetsController', {
+             defaultUpdateInterval: __classPrivateFieldGet(this, _AssetsController_defaultUpdateInterval, "f"),
+         });
+@@ -1139,7 +1135,7 @@ _AssetsController_isEnabled = new WeakMap(), _AssetsController_isBasicFunctional
+ }, _AssetsController_registerActionHandlers = function _AssetsController_registerActionHandlers() {
+     this.messenger.registerMethodActionHandlers(this, MESSENGER_EXPOSED_METHODS);
+ }, _AssetsController_handleActiveChainsUpdate = function _AssetsController_handleActiveChainsUpdate(dataSourceId, activeChains, previousChains) {
+-    if (!__classPrivateFieldGet(this, _AssetsController_isEnabled, "f")) {
++    if (!__classPrivateFieldGet(this, _AssetsController_isEnabled, "f").call(this)) {
+         return;
+     }
+     log('Data source active chains changed', {

--- a/app/scripts/messenger-client-init/assets/assets-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/assets/assets-controller-init.test.ts
@@ -2,6 +2,7 @@ import {
   AssetsController,
   type AssetsControllerMessenger,
 } from '@metamask/assets-controller';
+import { ClientController } from '@metamask/client-controller';
 import { createApiPlatformClient } from '@metamask/core-backend';
 import { MessengerClientInitRequest } from '../types';
 import { buildControllerInitRequestMock } from '../test/utils';
@@ -23,6 +24,10 @@ jest.mock('@metamask/assets-controller', () => ({
 jest.mock('@metamask/core-backend', () => ({
   createApiPlatformClient: jest.fn().mockReturnValue({ mockApiClient: true }),
 }));
+
+function buildClientControllerMock(isUiOpen = true): ClientController {
+  return { state: { isUiOpen } } as ClientController;
+}
 
 function getInitRequestMock(
   options: {
@@ -57,6 +62,8 @@ function getInitRequestMock(
     }
     throw new Error(`Unexpected action: ${action}`);
   });
+
+  requestMock.getMessengerClient.mockReturnValue(buildClientControllerMock());
 
   return requestMock;
 }
@@ -246,13 +253,32 @@ describe('AssetsControllerInit', () => {
   });
 
   describe('isEnabled', () => {
-    it('always returns true', () => {
-      AssetsControllerInit(getInitRequestMock());
+    it('returns ClientController isUiOpen state when UI is open', () => {
+      const requestMock = getInitRequestMock();
+
+      AssetsControllerInit(requestMock);
 
       const constructorCall = jest.mocked(AssetsController).mock.calls[0][0];
       const isEnabled = constructorCall.isEnabled as () => boolean;
 
       expect(isEnabled()).toBe(true);
+      expect(requestMock.getMessengerClient).toHaveBeenCalledWith(
+        'ClientController',
+      );
+    });
+
+    it('returns false when ClientController isUiOpen is false', () => {
+      const requestMock = getInitRequestMock();
+      requestMock.getMessengerClient.mockReturnValue(
+        buildClientControllerMock(false),
+      );
+
+      AssetsControllerInit(requestMock);
+
+      const constructorCall = jest.mocked(AssetsController).mock.calls[0][0];
+      const isEnabled = constructorCall.isEnabled as () => boolean;
+
+      expect(isEnabled()).toBe(false);
     });
   });
 

--- a/app/scripts/messenger-client-init/assets/assets-controller-init.ts
+++ b/app/scripts/messenger-client-init/assets/assets-controller-init.ts
@@ -106,13 +106,21 @@ function getApiClient(
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @param request.persistedState - The persisted state of the extension.
  * @param request.initMessenger - The init messenger to use for the controller.
+ * @param request.getMessengerClient - The function to get a messenger client.
  * @returns The initialized controller.
  */
 export const AssetsControllerInit: MessengerClientInitFunction<
   AssetsController,
   AssetsControllerMessenger,
   AssetsControllerInitMessenger
-> = ({ controllerMessenger, persistedState, initMessenger }) => {
+> = ({
+  controllerMessenger,
+  persistedState,
+  initMessenger,
+  getMessengerClient,
+}) => {
+  const clientController = () => getMessengerClient('ClientController');
+
   // Get token detection preference
   const tokenDetectionEnabled = safeGetTokenDetectionEnabled(initMessenger);
 
@@ -153,7 +161,7 @@ export const AssetsControllerInit: MessengerClientInitFunction<
   const messengerClient = new AssetsController({
     messenger: controllerMessenger,
     state: persistedState.AssetsController,
-    isEnabled: () => true,
+    isEnabled: () => clientController().state.isUiOpen,
     isBasicFunctionality,
     subscribeToBasicFunctionalityChange,
     queryApiClient: getApiClient(initMessenger),

--- a/app/scripts/messenger-client-init/assets/assets-controller-init.ts
+++ b/app/scripts/messenger-client-init/assets/assets-controller-init.ts
@@ -158,7 +158,6 @@ export const AssetsControllerInit: MessengerClientInitFunction<
 
   // Create the controller - it now creates all data sources internally.
   // queryApiClient is cast to the package's type to avoid duplicate @metamask/core-backend type conflicts.
-  const TWENTY_FOUR_HOURS = 1000 * 60 * 60 * 24;
   const messengerClient = new AssetsController({
     messenger: controllerMessenger,
     state: persistedState.AssetsController,

--- a/package.json
+++ b/package.json
@@ -297,7 +297,9 @@
     "@metamask/permission-controller@npm:^12.2.0": "^13.0.0",
     "@metamask/permission-controller@npm:^12.2.1": "^13.0.0",
     "@metamask/permission-controller@npm:^12.3.0": "^13.0.0",
-    "@metamask/transaction-controller": "patch:@metamask/transaction-controller@npm%3A66.0.0#~/.yarn/patches/@metamask-transaction-controller-npm-66.0.0-23fe4d7dfe.patch"
+    "@metamask/transaction-controller": "patch:@metamask/transaction-controller@npm%3A66.0.0#~/.yarn/patches/@metamask-transaction-controller-npm-66.0.0-23fe4d7dfe.patch",
+    "@metamask/assets-controller@npm:^7.1.2": "patch:@metamask/assets-controller@npm%3A8.0.1#~/.yarn/patches/@metamask-assets-controller-npm-8.0.1-e54f7ee84e.patch",
+    "@metamask/assets-controller@npm:^6.4.0": "patch:@metamask/assets-controller@npm%3A8.0.1#~/.yarn/patches/@metamask-assets-controller-npm-8.0.1-e54f7ee84e.patch"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.29.2#~/.yarn/patches/@babel-runtime-npm-7.29.2-b49cad1c67.patch",
@@ -334,7 +336,7 @@
     "@metamask/address-book-controller": "^7.1.2",
     "@metamask/announcement-controller": "^8.0.0",
     "@metamask/approval-controller": "^9.0.0",
-    "@metamask/assets-controller": "^8.0.1",
+    "@metamask/assets-controller": "patch:@metamask/assets-controller@npm%3A8.0.1#~/.yarn/patches/@metamask-assets-controller-npm-8.0.1-e54f7ee84e.patch",
     "@metamask/assets-controllers": "^108.1.0",
     "@metamask/base-controller": "^9.0.1",
     "@metamask/bitcoin-wallet-snap": "^1.10.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5740,81 +5740,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/assets-controller@npm:^6.4.0":
-  version: 6.4.0
-  resolution: "@metamask/assets-controller@npm:6.4.0"
-  dependencies:
-    "@ethereumjs/util": "npm:^9.1.0"
-    "@ethersproject/abi": "npm:^5.7.0"
-    "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/account-tree-controller": "npm:^7.2.0"
-    "@metamask/accounts-controller": "npm:^38.0.0"
-    "@metamask/assets-controllers": "npm:^106.0.0"
-    "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/client-controller": "npm:^1.0.1"
-    "@metamask/controller-utils": "npm:^11.20.0"
-    "@metamask/core-backend": "npm:^6.2.1"
-    "@metamask/keyring-api": "npm:^23.1.0"
-    "@metamask/keyring-controller": "npm:^25.4.0"
-    "@metamask/keyring-internal-api": "npm:^11.0.1"
-    "@metamask/keyring-snap-client": "npm:^9.0.2"
-    "@metamask/messenger": "npm:^1.2.0"
-    "@metamask/network-controller": "npm:^30.1.0"
-    "@metamask/network-enablement-controller": "npm:^5.1.0"
-    "@metamask/permission-controller": "npm:^13.0.0"
-    "@metamask/phishing-controller": "npm:^17.1.1"
-    "@metamask/polling-controller": "npm:^16.0.4"
-    "@metamask/preferences-controller": "npm:^23.1.0"
-    "@metamask/snaps-controllers": "npm:^19.0.0"
-    "@metamask/snaps-utils": "npm:^12.1.2"
-    "@metamask/transaction-controller": "npm:^65.1.0"
-    "@metamask/utils": "npm:^11.9.0"
-    async-mutex: "npm:^0.5.0"
-    bignumber.js: "npm:^9.1.2"
-    lodash: "npm:^4.17.21"
-    p-limit: "npm:^3.1.0"
-  checksum: 10/f7f664dc0aca065a21b78ec55c063a2a68a0aa32481d760fc92899f8af65af7bd354b5aae3156d93454e1d5f88695f79319c7be83d7e4d9074bbd7c38ccc5714
-  languageName: node
-  linkType: hard
-
-"@metamask/assets-controller@npm:^7.1.2":
-  version: 7.1.2
-  resolution: "@metamask/assets-controller@npm:7.1.2"
-  dependencies:
-    "@ethereumjs/util": "npm:^9.1.0"
-    "@ethersproject/abi": "npm:^5.7.0"
-    "@ethersproject/providers": "npm:^5.7.0"
-    "@metamask/account-tree-controller": "npm:^7.4.0"
-    "@metamask/accounts-controller": "npm:^38.1.1"
-    "@metamask/assets-controllers": "npm:^108.1.0"
-    "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/client-controller": "npm:^1.0.1"
-    "@metamask/controller-utils": "npm:^12.1.0"
-    "@metamask/core-backend": "npm:^6.2.2"
-    "@metamask/keyring-api": "npm:^23.1.0"
-    "@metamask/keyring-controller": "npm:^25.5.0"
-    "@metamask/keyring-internal-api": "npm:^11.0.1"
-    "@metamask/keyring-snap-client": "npm:^9.0.2"
-    "@metamask/messenger": "npm:^1.2.0"
-    "@metamask/network-controller": "npm:^32.0.0"
-    "@metamask/network-enablement-controller": "npm:^5.1.1"
-    "@metamask/permission-controller": "npm:^13.1.1"
-    "@metamask/phishing-controller": "npm:^17.1.2"
-    "@metamask/polling-controller": "npm:^16.0.5"
-    "@metamask/preferences-controller": "npm:^23.1.0"
-    "@metamask/snaps-controllers": "npm:^19.0.0"
-    "@metamask/snaps-utils": "npm:^12.1.2"
-    "@metamask/transaction-controller": "npm:^65.3.0"
-    "@metamask/utils": "npm:^11.9.0"
-    async-mutex: "npm:^0.5.0"
-    bignumber.js: "npm:^9.1.2"
-    lodash: "npm:^4.17.21"
-    p-limit: "npm:^3.1.0"
-  checksum: 10/b6dd422a1c29f67a0a4094907c1b52ad2bda845bbdefc8206601b82868ee8035c600ccdf8f93d61b6d6b84fdf7ad1381415e618c5c29e676721b6b0f2f53fbf2
-  languageName: node
-  linkType: hard
-
-"@metamask/assets-controller@npm:^8.0.1":
+"@metamask/assets-controller@npm:8.0.1":
   version: 8.0.1
   resolution: "@metamask/assets-controller@npm:8.0.1"
   dependencies:
@@ -5848,6 +5774,43 @@ __metadata:
     lodash: "npm:^4.17.21"
     p-limit: "npm:^3.1.0"
   checksum: 10/056627318de4985ea2780f3009f8f803cba7eb4ba45f605b29dc4783146db9a8743e83e9d91ea949ad401c2018105531eef66793f09bf7822d955807446016f1
+  languageName: node
+  linkType: hard
+
+"@metamask/assets-controller@patch:@metamask/assets-controller@npm%3A8.0.1#~/.yarn/patches/@metamask-assets-controller-npm-8.0.1-e54f7ee84e.patch":
+  version: 8.0.1
+  resolution: "@metamask/assets-controller@patch:@metamask/assets-controller@npm%3A8.0.1#~/.yarn/patches/@metamask-assets-controller-npm-8.0.1-e54f7ee84e.patch::version=8.0.1&hash=8d96c4"
+  dependencies:
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@metamask/account-tree-controller": "npm:^7.4.0"
+    "@metamask/accounts-controller": "npm:^38.1.1"
+    "@metamask/assets-controllers": "npm:^108.1.0"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/client-controller": "npm:^1.0.1"
+    "@metamask/controller-utils": "npm:^12.1.0"
+    "@metamask/core-backend": "npm:^6.3.0"
+    "@metamask/keyring-api": "npm:^23.1.0"
+    "@metamask/keyring-controller": "npm:^25.5.0"
+    "@metamask/keyring-internal-api": "npm:^11.0.1"
+    "@metamask/keyring-snap-client": "npm:^9.0.2"
+    "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/network-controller": "npm:^32.0.0"
+    "@metamask/network-enablement-controller": "npm:^5.2.0"
+    "@metamask/permission-controller": "npm:^13.1.1"
+    "@metamask/phishing-controller": "npm:^17.2.0"
+    "@metamask/polling-controller": "npm:^16.0.6"
+    "@metamask/preferences-controller": "npm:^23.1.0"
+    "@metamask/snaps-controllers": "npm:^19.0.0"
+    "@metamask/snaps-utils": "npm:^12.1.2"
+    "@metamask/transaction-controller": "npm:^66.0.0"
+    "@metamask/utils": "npm:^11.9.0"
+    async-mutex: "npm:^0.5.0"
+    bignumber.js: "npm:^9.1.2"
+    lodash: "npm:^4.17.21"
+    p-limit: "npm:^3.1.0"
+  checksum: 10/13b670c5198f0f8b5a29119bb8a7ac04af99cc0fe5f9ae375b593f688768434d414487a469aba96a2430305c76ed6c1d124810f8040f3cc5fe22050696863e3a
   languageName: node
   linkType: hard
 
@@ -33354,7 +33317,7 @@ __metadata:
     "@metamask/announcement-controller": "npm:^8.0.0"
     "@metamask/api-specs": "npm:^0.13.0"
     "@metamask/approval-controller": "npm:^9.0.0"
-    "@metamask/assets-controller": "npm:^8.0.1"
+    "@metamask/assets-controller": "patch:@metamask/assets-controller@npm%3A8.0.1#~/.yarn/patches/@metamask-assets-controller-npm-8.0.1-e54f7ee84e.patch"
     "@metamask/assets-controllers": "npm:^108.1.0"
     "@metamask/auto-changelog": "npm:^5.3.1"
     "@metamask/base-controller": "npm:^9.0.1"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Patches from https://github.com/MetaMask/core/pull/8914

Ensures that AssetsController does not make any calls in the background.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that was causing some calls to services when the app is not open

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/42991

## **Manual testing steps**

Open MetaMask without putting the password
Open Network Tab
Request to price-api happens before the password is added

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/6faa5079-f72b-4f2b-ae56-63d49cb0bdbd



### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when background asset/RPC polling runs and patches upstream controller behavior; mis-timed isUiOpen could affect balances when the popup is closed or delay updates when open.
> 
> **Overview**
> Stops **AssetsController** from hitting balance/price/detection services while the extension UI is closed by wiring `isEnabled` to **`ClientController.state.isUiOpen`** (via `getMessengerClient`) instead of a hard-coded disabled flag.
> 
> A **Yarn patch** on `@metamask/assets-controller@8.0.1` stores `isEnabled` as a callable (not a one-shot boolean), removes the constructor early-return when disabled, and evaluates `.call(this)` when handling active-chain updates so the gate stays dynamic.
> 
> **`assets-controller-init`** replaces 24-hour poll intervals with **30s** balance/staked, **180s** detection/price when the controller is active. Tests cover the new `isEnabled` behavior and interval expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98e753eaa5a8af72542abc439fb06f19d6428e8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->