### PR TITLE
fix: Update malicious site warning button label in Reveal Seed Phrase flow

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -9555,7 +9555,7 @@
     "description": "Warning message shown when a malicious site is detected. $1 is the hostname of the current tab."
   },
   "srpRevealMaliciousBlockDismiss": {
-    "message": "Back to safety"
+    "message": "Got it"
   },
   "srpRevealMaliciousBlockHeading": {
     "message": "You might be getting scammed right now"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -9555,7 +9555,7 @@
     "description": "Warning message shown when a malicious site is detected. $1 is the hostname of the current tab."
   },
   "srpRevealMaliciousBlockDismiss": {
-    "message": "Back to safety"
+    "message": "Got it"
   },
   "srpRevealMaliciousBlockHeading": {
     "message": "You might be getting scammed right now"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Both locale files are updated correctly. Here is the execution summary:

## **Changelog**

CHANGELOG entry: Fixed both locale files are updated correctly. Here is the execution summary:

## **Related issues**

Fixes: null

## **Manual testing steps**

1. Open MetaMask.
2. Navigate to the Reveal Seed Phrase flow.
3. Trigger or reach the malicious site warning block page.
4. Observe the dismiss / primary button label.
5. Notice that it says "Back to safety".

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.