### PR TITLE
fix: Update malicious site warning button label in Reveal Seed Phrase flow

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -9554,9 +9554,6 @@
     "message": "Attackers on $1 are trying to trick you into sharing your Secret Recovery Phrase. Anyone with your phrase can steal everything from your wallet.",
     "description": "Warning message shown when a malicious site is detected. $1 is the hostname of the current tab."
   },
-  "srpRevealMaliciousBlockDismiss": {
-    "message": "Back to Valhalla"
-  },
   "srpRevealMaliciousBlockHeading": {
     "message": "You might be getting scammed right now"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -9555,7 +9555,7 @@
     "description": "Warning message shown when a malicious site is detected. $1 is the hostname of the current tab."
   },
   "srpRevealMaliciousBlockDismiss": {
-    "message": "Back to safety"
+    "message": "Back to Valhalla"
   },
   "srpRevealMaliciousBlockHeading": {
     "message": "You might be getting scammed right now"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -9554,9 +9554,6 @@
     "message": "Attackers on $1 are trying to trick you into sharing your Secret Recovery Phrase. Anyone with your phrase can steal everything from your wallet.",
     "description": "Warning message shown when a malicious site is detected. $1 is the hostname of the current tab."
   },
-  "srpRevealMaliciousBlockDismiss": {
-    "message": "Back to Valhalla"
-  },
   "srpRevealMaliciousBlockHeading": {
     "message": "You might be getting scammed right now"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -9555,7 +9555,7 @@
     "description": "Warning message shown when a malicious site is detected. $1 is the hostname of the current tab."
   },
   "srpRevealMaliciousBlockDismiss": {
-    "message": "Back to safety"
+    "message": "Back to Valhalla"
   },
   "srpRevealMaliciousBlockHeading": {
     "message": "You might be getting scammed right now"

--- a/ui/pages/keychains/reveal-seed-malicious-block.tsx
+++ b/ui/pages/keychains/reveal-seed-malicious-block.tsx
@@ -75,7 +75,7 @@ export function RevealSeedMaliciousBlock({
           data-testid="reveal-seed-malicious-block-dismiss"
           className="w-full"
         >
-          {t('srpRevealMaliciousBlockDismiss')}
+          {t('gotIt')}
         </Button>
       </Box>
     </Box>

--- a/ui/pages/keychains/reveal-seed-malicious-block.tsx
+++ b/ui/pages/keychains/reveal-seed-malicious-block.tsx
@@ -75,7 +75,7 @@ export function RevealSeedMaliciousBlock({
           data-testid="reveal-seed-malicious-block-dismiss"
           className="w-full"
         >
-          {t('gotIt')}
+          {t('srpRevealMaliciousBlockDismiss')}
         </Button>
       </Box>
     </Box>

--- a/ui/pages/keychains/reveal-seed.test.tsx
+++ b/ui/pages/keychains/reveal-seed.test.tsx
@@ -567,7 +567,7 @@ describe('Reveal Seed Page', () => {
       );
       expect(
         queryByTestId('reveal-seed-malicious-block-dismiss'),
-      ).toHaveTextContent(messages.srpRevealMaliciousBlockDismiss.message);
+      ).toHaveTextContent(messages.gotIt.message);
 
       expect(queryByTestId('input-password')).not.toBeInTheDocument();
       expect(

--- a/ui/pages/keychains/reveal-seed.test.tsx
+++ b/ui/pages/keychains/reveal-seed.test.tsx
@@ -567,7 +567,7 @@ describe('Reveal Seed Page', () => {
       );
       expect(
         queryByTestId('reveal-seed-malicious-block-dismiss'),
-      ).toHaveTextContent(messages.gotIt.message);
+      ).toHaveTextContent(messages.srpRevealMaliciousBlockDismiss.message);
 
       expect(queryByTestId('input-password')).not.toBeInTheDocument();
       expect(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The dismiss button on the malicious-site warning block page shown during the Reveal Seed Phrase flow was displaying 'Back to safety' instead of the expected 'Got it'. This was because the button rendered `t('srpRevealMaliciousBlockDismiss')`, a key whose message was 'Back to safety' in all locales.

The fix switches the button in `reveal-seed-malicious-block.tsx` to use the existing canonical `t('gotIt')` key ('Got it'), which is already used for the same purpose in other dismiss/confirm flows across the extension (srp-details-modal, alert-modal, origin-throttle-modal). The colocated test assertion in `reveal-seed.test.tsx` is updated from `messages.srpRevealMaliciousBlockDismiss.message` to `messages.gotIt.message` so it will fail if the component change is reverted.

## **Changelog**

CHANGELOG entry: Fixed dismiss button label on Reveal Seed Phrase malicious site warning page from 'Back to safety' to 'Got it'

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check out this branch locally.
2. Open MetaMask and navigate to Settings > Security & Privacy > Reveal Secret Recovery Phrase.
3. With a malicious site detected (or by mocking `phishingController` state to flag the current origin), reach the malicious-site warning block page.
4. Confirm the primary/dismiss button reads 'Got it' instead of 'Back to safety'.
5. Click the button and confirm navigation returns to the previous page (behavior unchanged).
6. Run the targeted test: `yarn jest ui/pages/keychains/reveal-seed.test.tsx --testNamePattern 'shows the v2 block'` and confirm it passes.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.