### PR TITLE
fix(passkey): disable passkey on mobile extension browsers

### DIFF
--- a/ui/components/app/change-password/change-password.test.tsx
+++ b/ui/components/app/change-password/change-password.test.tsx
@@ -42,6 +42,13 @@ jest.mock('../../../../shared/lib/environment-type', () => ({
   getEnvironmentType: jest.fn(),
 }));
 
+jest.mock('../../../../shared/lib/sentry', () => ({
+  ...jest.requireActual<typeof import('../../../../shared/lib/sentry')>(
+    '../../../../shared/lib/sentry',
+  ),
+  captureException: jest.fn(),
+}));
+
 const mockUseNavigate = jest.fn();
 const mockChangePassword = jest
   .fn()

--- a/ui/components/app/change-password/change-password.tsx
+++ b/ui/components/app/change-password/change-password.tsx
@@ -34,6 +34,7 @@ import Mascot from '../../ui/mascot';
 import Spinner from '../../ui/spinner';
 import ToggleButton from '../../ui/toggle-button';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+import { createSentryError } from '../../../../shared/lib/error';
 import {
   getPasskeyAuthMethodKey,
   startPasskeyAuthentication,
@@ -41,6 +42,7 @@ import {
   isPasskeyCeremonySilentError,
   translatePasskeyError,
 } from '../../../../shared/lib/passkey';
+import { captureException } from '../../../../shared/lib/sentry';
 import {
   ExtensionPasskeyErrorCode,
   getPasskeyErrorCode,
@@ -211,6 +213,8 @@ const ChangePassword = ({
         },
       });
     } catch (error) {
+      const errorCode = getPasskeyErrorCode(error);
+      const durationMs = Date.now() - startedAt;
       trackEvent({
         category: MetaMetricsEventCategory.Settings,
         event: MetaMetricsEventName.PasswordChangeWithPasskey,
@@ -220,14 +224,30 @@ const ChangePassword = ({
           // eslint-disable-next-line @typescript-eslint/naming-convention
           passkey_renewal_enabled: isPasskeyRenewalEnabled,
           // eslint-disable-next-line @typescript-eslint/naming-convention
-          duration_ms: Date.now() - startedAt,
-          reason: getPasskeyErrorCode(error),
+          duration_ms: durationMs,
+          reason: errorCode,
         },
       });
 
+      captureException(
+        createSentryError(
+          'Change password with passkey verification failed',
+          error,
+        ),
+        {
+          extra: {
+            isPasskeyRenewalEnabled,
+            errorCode,
+            durationMs,
+          },
+        },
+      );
+
+      // if passkey renewal is not enabled, it's either passkey verification failed or password change failed
       if (!isPasskeyRenewalEnabled) {
         throw error;
       }
+
       const passkeyCode = getPasskeyControllerErrorCode(error);
       // strictly treat vault key renewal failure as a password change success
       if (passkeyCode !== ExtensionPasskeyErrorCode.VaultKeyRenewalFailed) {
@@ -350,6 +370,12 @@ const ChangePassword = ({
           error,
         );
       } else {
+        captureException(
+          createSentryError(
+            'Passkey verification during change password failed',
+            error,
+          ),
+        );
         toast.error(
           <ToastContent
             title={

--- a/ui/components/app/setup-passkey-content.tsx
+++ b/ui/components/app/setup-passkey-content.tsx
@@ -37,6 +37,7 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../shared/constants/metametrics';
+import { createSentryError } from '../../../shared/lib/error';
 import { getPasskeyErrorCode } from '../../../shared/lib/passkey/passkey-error';
 import {
   getPasskeyAuthMethodKey,
@@ -45,6 +46,7 @@ import {
   translatePasskeyError,
   isPasskeyCeremonySilentError,
 } from '../../../shared/lib/passkey';
+import { captureException } from '../../../shared/lib/sentry';
 import {
   protectVaultKeyWithPasskey,
   generatePasskeyRegistrationOptions,
@@ -278,7 +280,15 @@ export default function SetupPasskeyContent({
         return;
       }
 
-      log.error('Passkey registration failed', error);
+      captureException(
+        createSentryError(
+          'Passkey registration during onboarding failed',
+          error,
+        ),
+        {
+          extra: { errorStep: currentStep },
+        },
+      );
       trackEvent({
         category: MetaMetricsEventCategory.Onboarding,
         event: MetaMetricsEventName.PasskeySetup,

--- a/ui/components/app/setup-passkey-content.tsx
+++ b/ui/components/app/setup-passkey-content.tsx
@@ -257,6 +257,7 @@ export default function SetupPasskeyContent({
         goToNextStep();
       }
     } catch (error) {
+      const durationMs = Date.now() - enrollmentStartedAt;
       if (isPasskeyCeremonySilentError(error)) {
         log.debug('Passkey enrollment ceremony cancelled or timed out', error);
         trackEvent({
@@ -268,7 +269,7 @@ export default function SetupPasskeyContent({
             // eslint-disable-next-line @typescript-eslint/naming-convention
             current_step: currentStep,
             // eslint-disable-next-line @typescript-eslint/naming-convention
-            duration_ms: Date.now() - enrollmentStartedAt,
+            duration_ms: durationMs,
           },
         });
 
@@ -280,13 +281,14 @@ export default function SetupPasskeyContent({
         return;
       }
 
+      const errorCode = getPasskeyErrorCode(error);
       captureException(
         createSentryError(
           'Passkey registration during onboarding failed',
           error,
         ),
         {
-          extra: { errorStep: currentStep },
+          extra: { currentStep, durationMs, errorCode },
         },
       );
       trackEvent({
@@ -298,9 +300,8 @@ export default function SetupPasskeyContent({
           // eslint-disable-next-line @typescript-eslint/naming-convention
           error_step: currentStep,
           // eslint-disable-next-line @typescript-eslint/naming-convention
-          duration_ms: Date.now() - enrollmentStartedAt,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          reason: getPasskeyErrorCode(error),
+          duration_ms: durationMs,
+          reason: errorCode,
         },
       });
 

--- a/ui/pages/onboarding-flow/setup-passkey/setup-passkey.test.tsx
+++ b/ui/pages/onboarding-flow/setup-passkey/setup-passkey.test.tsx
@@ -53,6 +53,13 @@ jest.mock('../../../../shared/lib/passkey', () => ({
   }),
 }));
 
+jest.mock('../../../../shared/lib/sentry', () => ({
+  ...jest.requireActual<typeof import('../../../../shared/lib/sentry')>(
+    '../../../../shared/lib/sentry',
+  ),
+  captureException: jest.fn(),
+}));
+
 const mockAuthenticationResponse = {
   id: 'AQ',
   rawId: 'AQ',

--- a/ui/pages/settings/security-and-password-tab/passkey-item.tsx
+++ b/ui/pages/settings/security-and-password-tab/passkey-item.tsx
@@ -16,6 +16,7 @@ import {
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
 import { SECOND } from '../../../../shared/constants/time';
+import { createSentryError } from '../../../../shared/lib/error';
 import {
   getPasskeyAuthMethodKey,
   startPasskeyAuthentication,
@@ -24,6 +25,7 @@ import {
   translatePasskeyError,
   getPasskeyErrorCode,
 } from '../../../../shared/lib/passkey';
+import { captureException } from '../../../../shared/lib/sentry';
 import PasskeyTroubleshootModal from '../../../components/app/passkey-troubleshoot-modal';
 import { toast, ToastContent } from '../../../components/ui/toast/toast';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
@@ -101,6 +103,7 @@ const PasskeyItem = () => {
       return;
     }
 
+    const verificationMethod = 'passkey';
     if (
       environmentType === ENVIRONMENT_TYPE_SIDEPANEL &&
       isEnrolledPasskeyIncompatibleWithSidepanel
@@ -111,7 +114,7 @@ const PasskeyItem = () => {
         event: MetaMetricsEventName.PasskeyTurnOff,
         properties: {
           // eslint-disable-next-line @typescript-eslint/naming-convention
-          verification_method: 'passkey',
+          verification_method: verificationMethod,
           status: 'full_screen_opened',
         },
       });
@@ -123,7 +126,6 @@ const PasskeyItem = () => {
 
     setIsPasskeyOperationPending(true);
     const startedAt = Date.now();
-    const verificationMethod = 'passkey';
     trackEvent({
       category: MetaMetricsEventCategory.Settings,
       event: MetaMetricsEventName.PasskeyTurnOff,
@@ -175,6 +177,8 @@ const PasskeyItem = () => {
       navigate(SECURITY_AND_PASSWORD_ROUTE, { replace: true });
     } catch (error: unknown) {
       let errorStatus = 'failed';
+      const durationMs = Date.now() - startedAt;
+      const errorCode = getPasskeyErrorCode(error);
       if (isPasskeyCeremonySilentError(error)) {
         errorStatus = 'cancelled';
         log.debug(
@@ -182,9 +186,9 @@ const PasskeyItem = () => {
           error,
         );
       } else {
-        log.error(
-          'Passkey verification for disable failed; offering password fallback',
-          error,
+        captureException(
+          createSentryError('Passkey turn off in settings failed', error),
+          { extra: { verificationMethod, durationMs, errorCode } },
         );
         toast.error(
           <ToastContent
@@ -205,8 +209,8 @@ const PasskeyItem = () => {
           verification_method: verificationMethod,
           status: errorStatus,
           // eslint-disable-next-line @typescript-eslint/naming-convention
-          duration_ms: Date.now() - startedAt,
-          reason: getPasskeyErrorCode(error),
+          duration_ms: durationMs,
+          reason: errorCode,
         },
       });
       navigate(SECURITY_TURN_OFF_PASSKEY_ROUTE, { replace: true });

--- a/ui/pages/settings/security-and-password-tab/passkey-register-sub-page.test.tsx
+++ b/ui/pages/settings/security-and-password-tab/passkey-register-sub-page.test.tsx
@@ -84,6 +84,13 @@ jest.mock('../../../../shared/lib/passkey', () => ({
   }),
 }));
 
+jest.mock('../../../../shared/lib/sentry', () => ({
+  ...jest.requireActual<typeof import('../../../../shared/lib/sentry')>(
+    '../../../../shared/lib/sentry',
+  ),
+  captureException: jest.fn(),
+}));
+
 const mockVerifyPassword = jest.fn().mockResolvedValue(undefined);
 
 jest.mock('../../../store/actions', () => ({

--- a/ui/pages/settings/security-and-password-tab/passkey-register-sub-page.tsx
+++ b/ui/pages/settings/security-and-password-tab/passkey-register-sub-page.tsx
@@ -22,6 +22,7 @@ import {
 } from '../../../components/component-library';
 import { SECURITY_AND_PASSWORD_ROUTE } from '../../../helpers/constants/routes';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+import { createSentryError } from '../../../../shared/lib/error';
 import {
   getPasskeyAuthMethodKey,
   startPasskeyRegistration,
@@ -31,6 +32,7 @@ import {
   isPasskeyCeremonySilentError,
 } from '../../../../shared/lib/passkey';
 import { getPasskeyErrorCode } from '../../../../shared/lib/passkey/passkey-error';
+import { captureException } from '../../../../shared/lib/sentry';
 import {
   protectVaultKeyWithPasskey,
   generatePasskeyRegistrationOptions,
@@ -222,6 +224,7 @@ export default function PasskeyRegisterSubPage() {
       });
       goToSettings();
     } catch (error) {
+      const durationMs = Date.now() - enrollmentStartedAt;
       if (isPasskeyCeremonySilentError(error)) {
         trackEvent({
           category: MetaMetricsEventCategory.Settings,
@@ -231,7 +234,7 @@ export default function PasskeyRegisterSubPage() {
             // eslint-disable-next-line @typescript-eslint/naming-convention
             current_step: currentStep,
             // eslint-disable-next-line @typescript-eslint/naming-convention
-            duration_ms: Date.now() - enrollmentStartedAt,
+            duration_ms: durationMs,
           },
         });
         log.debug(
@@ -243,7 +246,13 @@ export default function PasskeyRegisterSubPage() {
         return;
       }
 
-      log.error('Settings passkey enrollment failed', error);
+      const errorCode = getPasskeyErrorCode(error);
+      captureException(
+        createSentryError('Passkey registration in settings failed', error),
+        {
+          extra: { currentStep, durationMs, errorCode },
+        },
+      );
       trackEvent({
         category: MetaMetricsEventCategory.Settings,
         event: MetaMetricsEventName.PasskeySetup,
@@ -252,9 +261,8 @@ export default function PasskeyRegisterSubPage() {
           // eslint-disable-next-line @typescript-eslint/naming-convention
           error_step: currentStep,
           // eslint-disable-next-line @typescript-eslint/naming-convention
-          duration_ms: Date.now() - enrollmentStartedAt,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          reason: getPasskeyErrorCode(error),
+          duration_ms: durationMs,
+          reason: errorCode,
         },
       });
       setEnrollmentError(

--- a/ui/pages/settings/security-and-password-tab/passkey-turn-off-sub-page.test.tsx
+++ b/ui/pages/settings/security-and-password-tab/passkey-turn-off-sub-page.test.tsx
@@ -54,6 +54,13 @@ jest.mock('../../../../shared/lib/passkey', () => ({
   cancelPasskeyCeremony: jest.fn(),
 }));
 
+jest.mock('../../../../shared/lib/sentry', () => ({
+  ...jest.requireActual<typeof import('../../../../shared/lib/sentry')>(
+    '../../../../shared/lib/sentry',
+  ),
+  captureException: jest.fn(),
+}));
+
 const stateWithPasskey = {
   ...mockState,
   metamask: {

--- a/ui/pages/settings/security-and-password-tab/passkey-turn-off-sub-page.tsx
+++ b/ui/pages/settings/security-and-password-tab/passkey-turn-off-sub-page.tsx
@@ -1,7 +1,6 @@
 import React, { useContext, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
-import log from 'loglevel';
 import {
   Box,
   BoxAlignItems,
@@ -18,10 +17,12 @@ import {
 } from '../../../components/component-library';
 import { SECURITY_AND_PASSWORD_ROUTE } from '../../../helpers/constants/routes';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+import { createSentryError } from '../../../../shared/lib/error';
 import {
   getPasskeyAuthMethodKey,
   cancelPasskeyCeremony,
 } from '../../../../shared/lib/passkey';
+import { captureException } from '../../../../shared/lib/sentry';
 import { getPasskeyErrorCode } from '../../../../shared/lib/passkey/passkey-error';
 import {
   forceUpdateMetamaskState,
@@ -127,6 +128,8 @@ export default function PasskeyTurnOffSubPage() {
         });
         goToSettings();
       } catch (error: unknown) {
+        const durationMs = Date.now() - startedAt;
+        const errorCode = getPasskeyErrorCode(error);
         trackEvent({
           category: MetaMetricsEventCategory.Settings,
           event: MetaMetricsEventName.PasskeyTurnOff,
@@ -134,13 +137,13 @@ export default function PasskeyTurnOffSubPage() {
             ...baseProperties,
             status: 'failed',
             // eslint-disable-next-line @typescript-eslint/naming-convention
-            duration_ms: Date.now() - startedAt,
-            reason: getPasskeyErrorCode(error),
+            duration_ms: durationMs,
+            reason: errorCode,
           },
         });
-        log.error(
-          'Passkey turn off with password verification failed after password was verified',
-          error,
+        captureException(
+          createSentryError('Passkey turn off in settings failed', error),
+          { extra: { verificationMethod: 'password', durationMs, errorCode } },
         );
         toast.error(
           <ToastContent

--- a/ui/pages/unlock-page/passkey/unlock-passkey-section.test.tsx
+++ b/ui/pages/unlock-page/passkey/unlock-passkey-section.test.tsx
@@ -13,6 +13,13 @@ import { ENVIRONMENT_TYPE_SIDEPANEL } from '../../../../shared/constants/app';
 import { UNLOCK_ROUTE } from '../../../helpers/constants/routes';
 import { UnlockPasskeySection } from './unlock-passkey-section';
 
+jest.mock('../../../../shared/lib/sentry', () => ({
+  ...jest.requireActual<typeof import('../../../../shared/lib/sentry')>(
+    '../../../../shared/lib/sentry',
+  ),
+  captureException: jest.fn(),
+}));
+
 jest.mock('../../../../shared/lib/environment-type', () => {
   const actual = jest.requireActual<
     typeof import('../../../../shared/lib/environment-type')

--- a/ui/pages/unlock-page/passkey/unlock-passkey-section.tsx
+++ b/ui/pages/unlock-page/passkey/unlock-passkey-section.tsx
@@ -21,6 +21,7 @@ import {
   ButtonVariant,
   ButtonSize,
 } from '@metamask/design-system-react';
+import { createSentryError } from '../../../../shared/lib/error';
 import {
   getPasskeyAuthMethodKey,
   startPasskeyAuthentication,
@@ -29,6 +30,7 @@ import {
   translatePasskeyError,
   getPasskeyErrorCode,
 } from '../../../../shared/lib/passkey';
+import { captureException } from '../../../../shared/lib/sentry';
 import { getEnvironmentType } from '../../../../shared/lib/environment-type';
 import { ENVIRONMENT_TYPE_SIDEPANEL } from '../../../../shared/constants/app';
 import { generatePasskeyAuthenticationOptions } from '../../../store/actions';
@@ -168,6 +170,14 @@ export const UnlockPasskeySection = ({
           setPasskeyError(null);
         } else {
           passkeyFailedAttemptCount.current += 1;
+          captureException(createSentryError('Passkey unlock failed', err), {
+            extra: {
+              ...baseProperties,
+              failedAttempts: passkeyFailedAttemptCount.current,
+              durationMs,
+              errorCode,
+            },
+          });
           trackEvent({
             category: MetaMetricsEventCategory.Navigation,
             event: MetaMetricsEventName.AppUnlockedFailed,

--- a/ui/pages/unlock-page/unlock-page.component.test.tsx
+++ b/ui/pages/unlock-page/unlock-page.component.test.tsx
@@ -26,6 +26,13 @@ jest.mock('@metamask/logo', () => () => ({
   lookAtAndRender: jest.fn(),
 }));
 
+jest.mock('../../../shared/lib/sentry', () => ({
+  ...jest.requireActual<typeof import('../../../shared/lib/sentry')>(
+    '../../../shared/lib/sentry',
+  ),
+  captureException: jest.fn(),
+}));
+
 describe('UnlockPage component (passkey UI)', () => {
   const selectedTestAccountId = 'test-unlock-account-id';
 

--- a/ui/selectors/passkey.test.ts
+++ b/ui/selectors/passkey.test.ts
@@ -1,3 +1,4 @@
+import { DEVICE_TYPE } from '../../shared/constants/app';
 import {
   getIsPasskeyFeatureAvailable,
   getIsPasskeyRegistered,
@@ -16,6 +17,11 @@ jest.mock('../../shared/lib/passkey', () => ({
 
 jest.mock('../../shared/lib/browser-runtime.utils', () => ({
   isFirefoxBrowser: jest.fn(),
+}));
+
+jest.mock('../../app/scripts/lib/util', () => ({
+  ...jest.requireActual('../../app/scripts/lib/util'),
+  getDeviceType: jest.fn(),
 }));
 
 jest.mock('./first-time-flow', () => ({
@@ -40,6 +46,10 @@ const { isFirefoxBrowser } = jest.requireMock(
   isFirefoxBrowser: jest.Mock;
 };
 
+const { getDeviceType } = jest.requireMock('../../app/scripts/lib/util') as {
+  getDeviceType: jest.Mock;
+};
+
 const { getIsSocialLoginFlow } = jest.requireMock('./first-time-flow') as {
   getIsSocialLoginFlow: jest.Mock;
 };
@@ -55,11 +65,12 @@ describe('getIsPasskeyFeatureAvailable', () => {
     jest.resetAllMocks();
   });
 
-  it('returns true when build flag is enabled, WebAuthn is supported, not social login, and not Firefox', () => {
+  it('returns true when build flag is enabled, WebAuthn is supported, not social login, not Firefox, and not mobile', () => {
     getIsPasskeyFeatureEnabled.mockReturnValue(true);
     isWebAuthnSupported.mockReturnValue(true);
     getIsSocialLoginFlow.mockReturnValue(false);
     isFirefoxBrowser.mockReturnValue(false);
+    getDeviceType.mockReturnValue(DEVICE_TYPE.DESKTOP);
 
     expect(getIsPasskeyFeatureAvailable(mockState)).toBe(true);
   });
@@ -69,6 +80,7 @@ describe('getIsPasskeyFeatureAvailable', () => {
     isWebAuthnSupported.mockReturnValue(true);
     getIsSocialLoginFlow.mockReturnValue(false);
     isFirefoxBrowser.mockReturnValue(false);
+    getDeviceType.mockReturnValue(DEVICE_TYPE.DESKTOP);
 
     expect(getIsPasskeyFeatureAvailable(mockState)).toBe(false);
   });
@@ -78,6 +90,7 @@ describe('getIsPasskeyFeatureAvailable', () => {
     isWebAuthnSupported.mockReturnValue(false);
     getIsSocialLoginFlow.mockReturnValue(false);
     isFirefoxBrowser.mockReturnValue(false);
+    getDeviceType.mockReturnValue(DEVICE_TYPE.DESKTOP);
 
     expect(getIsPasskeyFeatureAvailable(mockState)).toBe(false);
   });
@@ -87,6 +100,7 @@ describe('getIsPasskeyFeatureAvailable', () => {
     isWebAuthnSupported.mockReturnValue(true);
     getIsSocialLoginFlow.mockReturnValue(true);
     isFirefoxBrowser.mockReturnValue(false);
+    getDeviceType.mockReturnValue(DEVICE_TYPE.DESKTOP);
 
     expect(getIsPasskeyFeatureAvailable(mockState)).toBe(false);
   });
@@ -96,6 +110,17 @@ describe('getIsPasskeyFeatureAvailable', () => {
     isWebAuthnSupported.mockReturnValue(true);
     getIsSocialLoginFlow.mockReturnValue(false);
     isFirefoxBrowser.mockReturnValue(true);
+    getDeviceType.mockReturnValue(DEVICE_TYPE.DESKTOP);
+
+    expect(getIsPasskeyFeatureAvailable(mockState)).toBe(false);
+  });
+
+  it('returns false when device is mobile (e.g. Kiwi, Yandex)', () => {
+    getIsPasskeyFeatureEnabled.mockReturnValue(true);
+    isWebAuthnSupported.mockReturnValue(true);
+    getIsSocialLoginFlow.mockReturnValue(false);
+    isFirefoxBrowser.mockReturnValue(false);
+    getDeviceType.mockReturnValue(DEVICE_TYPE.MOBILE);
 
     expect(getIsPasskeyFeatureAvailable(mockState)).toBe(false);
   });
@@ -105,6 +130,7 @@ describe('getIsPasskeyFeatureAvailable', () => {
     isWebAuthnSupported.mockReturnValue(false);
     getIsSocialLoginFlow.mockReturnValue(true);
     isFirefoxBrowser.mockReturnValue(true);
+    getDeviceType.mockReturnValue(DEVICE_TYPE.MOBILE);
 
     expect(getIsPasskeyFeatureAvailable(mockState)).toBe(false);
   });

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -73,8 +73,12 @@ import {
 } from './multichain/feature-flags';
 
 // TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { addHexPrefix, getDeviceType, getEnvironmentType } from '../../app/scripts/lib/util';
+import {
+  addHexPrefix,
+  getDeviceType,
+  getEnvironmentType,
+  // eslint-disable-next-line import-x/no-restricted-paths
+} from '../../app/scripts/lib/util';
 import {
   TEST_CHAINS,
   MAINNET_DISPLAY_NAME,

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -74,7 +74,7 @@ import {
 
 // TODO: Remove restricted import
 // eslint-disable-next-line import-x/no-restricted-paths
-import { addHexPrefix, getEnvironmentType } from '../../app/scripts/lib/util';
+import { addHexPrefix, getDeviceType, getEnvironmentType } from '../../app/scripts/lib/util';
 import {
   TEST_CHAINS,
   MAINNET_DISPLAY_NAME,
@@ -138,6 +138,7 @@ import { STATIC_MAINNET_TOKEN_LIST } from '../../shared/constants/tokens';
 import { DAY } from '../../shared/constants/time';
 import { TERMS_OF_USE_LAST_UPDATED } from '../../shared/constants/terms';
 import {
+  DEVICE_TYPE,
   ENVIRONMENT_TYPE_SIDEPANEL,
   ENVIRONMENT_TYPE_POPUP,
 } from '../../shared/constants/app';
@@ -2906,7 +2907,8 @@ export function getIsPasskeyFeatureAvailable(state) {
     getIsPasskeyFeatureEnabled() &&
     isWebAuthnSupported() &&
     !getIsSocialLoginFlow(state) &&
-    !isFirefoxBrowser()
+    !isFirefoxBrowser() &&
+    getDeviceType() !== DEVICE_TYPE.MOBILE
   );
 }
 


### PR DESCRIPTION
## **Description**

Passkey unlock and enrollment are unreliable on mobile browsers (e.g. Kiwi, Yandex) where WebAuthn support is inconsistent or the UX is poor. This PR disables the passkey feature on mobile devices and improves observability for passkey failures on desktop.

**What changed:**

1. **Mobile gating** — `getIsPasskeyFeatureAvailable` now returns `false` when `getDeviceType()` is `DEVICE_TYPE.MOBILE`. That hides passkey UI everywhere the selector is used: unlock, onboarding setup, settings enrollment/turn-off, and change-password passkey verification.
2. **Sentry error capture** — Passkey failures that were previously logged with `log.error` are now reported to Sentry via `captureException` + `createSentryError`, with contextual metadata (error code, duration, verification method, step). User-cancelled ceremonies (`isPasskeyCeremonySilentError`) are still excluded.
3. **Tests** — Added a mobile case to `passkey.test.ts` and mocked Sentry in affected component tests.

## **Changelog**

CHANGELOG entry: Disabled passkey unlock and setup on mobile browsers where the experience is unreliable.

## **Related issues**

Fixes:

## **Manual testing steps**

### Desktop (passkey should still work)

1. Build with passkey enabled (`PASSKEY=1` or equivalent in `.metamaskrc`).
2. **Unlock:** Open the extension on desktop Chrome. Confirm the passkey unlock option appears when a passkey is registered.
3. **Onboarding:** Start a new wallet flow. Confirm the passkey setup step is offered when eligible.
4. **Settings:** Go to Settings → Security & Password. Confirm passkey enrollment and turn-off flows are available.
5. **Change password:** With passkey registered, change password and confirm passkey verification works.

### Mobile browser (passkey should be hidden)

6. Open MetaMask in a mobile browser (or emulate mobile UA, e.g. Kiwi/Yandex or Chrome DevTools device mode with a mobile user agent).
7. **Unlock:** Confirm the passkey unlock section is **not** shown; password unlock still works.
8. **Onboarding:** Confirm passkey setup is **not** offered during wallet creation.
9. **Settings:** Confirm passkey settings item / enrollment options are **not** visible.

### Error reporting (optional / dev verification)

10. On desktop, trigger a passkey failure (e.g. cancel after starting ceremony is silent; use an invalid state to force a real error).
11. Confirm non-cancel errors appear in Sentry with the expected context (error code, duration, flow name).

## **Screenshots/Recordings**

### **Before**

<!-- Mobile unlock page showing passkey option (unreliable UX) -->

### **After**

<!-- Mobile unlock page with passkey hidden; desktop unchanged -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes security UX gating (mobile passkey off) and error reporting on auth-related flows; behavior is mostly additive except hiding passkey on mobile, which is intentional.
> 
> **Overview**
> **Passkey is turned off on mobile extension browsers** by extending `getIsPasskeyFeatureAvailable` with `getDeviceType() !== DEVICE_TYPE.MOBILE`, so unlock, onboarding setup, settings enrollment/turn-off, and change-password passkey UI stay hidden where WebAuthn is unreliable (e.g. Kiwi, Yandex).
> 
> **Failure observability on desktop** replaces `log.error` on real passkey errors with **Sentry** (`captureException` + `createSentryError`) across unlock, onboarding enrollment, settings register/turn-off, and change-password flows. User-cancelled ceremonies (`isPasskeyCeremonySilentError`) are still not reported; several handlers now reuse computed `durationMs` / `errorCode` for metrics and Sentry extras.
> 
> **Tests** add a mobile case in `passkey.test.ts` (mocking `getDeviceType`) and mock `captureException` in affected component tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c61fb88b75b7db47c445766e165ace25eab402d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->