### PR TITLE
fix: Update malicious site warning button label in Reveal Seed Phrase flow

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -9555,7 +9555,7 @@
     "description": "Warning message shown when a malicious site is detected. $1 is the hostname of the current tab."
   },
   "srpRevealMaliciousBlockDismiss": {
-    "message": "Back to safety"
+    "message": "Got it"
   },
   "srpRevealMaliciousBlockHeading": {
     "message": "You might be getting scammed right now"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -9555,7 +9555,7 @@
     "description": "Warning message shown when a malicious site is detected. $1 is the hostname of the current tab."
   },
   "srpRevealMaliciousBlockDismiss": {
-    "message": "Back to safety"
+    "message": "Got it"
   },
   "srpRevealMaliciousBlockHeading": {
     "message": "You might be getting scammed right now"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Both files are updated correctly. Here is the execution summary:

## **Changelog**

CHANGELOG entry: Fixed both files are updated correctly. Here is the execution summary:

## **Related issues**

Fixes: Test

## **Manual testing steps**

1. Open MetaMask.
2. Navigate to the Reveal Seed Phrase flow.
3. Trigger or reach the malicious site warning block page.
4. Observe the dismiss / primary button label.
5. Notice that it says "Back to safety".

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- AEP_VISUAL_VALIDATION_START -->
## AEP Visual Validation

- Status: Passed
- Run ID: `0e444263-174f-4092-b82c-1e713ae3e905`

### What was tested
- Visual validation passed: PR #43014 renames the dismiss button label in `RevealSeedMaliciousBlock` from "Back to safety" to "Got it" by updating the `srpRevealMaliciousBlockDismiss` locale key in both `app/_locales/en/messages.json` and `app/_locales/en_GB/messages.json`. Source-level inspection confirmed both files carry `"Got it"` for that key. The full Reveal Seed quiz flow (Settings → Security & Privacy → reveal-seed-words → Q1 correct → Q2 correct) was navigated successfully and reached the PASSWORD_PROMPT_SCREEN, where `reveal-seed-password-form` was confirmed present, `reveal-seed-malicious-block` was confirmed absent (expected for default fixture), and no legacy "Back to safety" text was found anywhere on screen. A 36 KB screenshot artifact was captured at the PASSWORD_PROMPT_SCREEN. The primary limitation is that `RevealSeedMaliciousBlock` itself was never rendered — the component only activates when the active tab is flagged as a phishing site, which is not achievable in the default fixture. The "Got it" button label on that component is therefore validated by locale-file content inspection rather than live pixel evidence, which lowers confidence from high to medium.
- metamask-mm-visual-validation: passed. Visual validation of PR #43014 (Update malicious site warning button label from "Back to safety" to "Got it" in Reveal Seed Phrase flow) passed all assertions. The locale files were verified to contain "Got it" for the `srpRevealMaliciousBlockDismiss` key. The full Reveal Seed quiz flow was navigated successfully: Settings → Security and password → reveal-seed-words → quiz intro → Q1 correct → Q2 correct → PASSWORD_PROMPT_SCREEN. After completing the quiz, the `reveal-seed-password-form` testid was confirmed visible, `reveal-seed-malicious-block` was absent from the DOM (correct for default fixture), and no "Back to safety" text was found anywhere on screen. Screenshot captured at the PASSWORD_PROMPT_SCREEN after quiz completion confirms the non-malicious path is unaffected by the locale change.

### Screenshots
- reveal-seed-password-prompt-after-quiz-1779956905213.png: run://0e444263-174f-4092-b82c-1e713ae3e905/artifacts/reveal-seed-password-prompt-after-quiz-1779956905213.png
<!-- AEP_VISUAL_VALIDATION_END -->
