### PR TITLE
feat: add on_create trigger mode to triage forwarder

### DIFF
--- a/.github/workflows/triage-forwarder.yml
+++ b/.github/workflows/triage-forwarder.yml
@@ -4,13 +4,29 @@ on:
   issues:
     types: [labeled, opened]
 
+concurrency:
+  group: triage-forwarder-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
-  forward-labeled:
+  forward:
     runs-on: ubuntu-latest
-    if: github.event.action == 'labeled' && github.event.label.name == 'ta-needs-triage'
+    if: >-
+      (github.event.action == 'opened') ||
+      (github.event.action == 'labeled' && github.event.label.name == 'ta-needs-triage')
     permissions:
       id-token: write
     steps:
+      - name: Determine trigger mode
+        id: trigger
+        run: |
+          if [ "${{ github.event.action }}" = "opened" ]; then
+            TRIGGER_MODE="on_create"
+          else
+            TRIGGER_MODE="label"
+          fi
+          echo "trigger_mode=$TRIGGER_MODE" >> "$GITHUB_OUTPUT"
+
       - name: Get OIDC Token
         id: oidc
         run: |
@@ -48,47 +64,5 @@ jobs:
               --arg number "${{ github.event.issue.number }}" \
               --arg action "${{ github.event.action }}" \
               --arg label "${{ github.event.label.name }}" \
-              '{event_type: "triage-issue", client_payload: {repo_owner: $owner, repo_name: $name, issue_number: $number, event_action: $action, event_label_name: $label, trigger_mode: "label"}}')"
-
-  forward-opened:
-    runs-on: ubuntu-latest
-    if: github.event.action == 'opened'
-    permissions:
-      id-token: write
-    steps:
-      - name: Get OIDC Token
-        id: oidc
-        run: |
-          OIDC_TOKEN=$(curl -sSf -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api://token-exchange-service" | jq -r '.value')
-          echo "::add-mask::$OIDC_TOKEN"
-          echo "oidc_token=$OIDC_TOKEN" >> "$GITHUB_OUTPUT"
-
-      - name: Exchange for Installation Token
-        id: exchange
-        env:
-          OIDC_TOKEN: ${{ steps.oidc.outputs.oidc_token }}
-        run: |
-          RESPONSE=$(curl -sSf -X POST "${{ vars.TOKEN_EXCHANGE_URL }}/api/exchange/token" \
-            -H "Content-Type: application/json" \
-            -d "$(jq -cn \
-              --arg oidcToken "$OIDC_TOKEN" \
-              --arg targetRepo "MetaMask/triage-agent" \
-              '{oidcToken: $oidcToken, targetRepo: $targetRepo, requested_permissions: {contents: "write", metadata: "read"}}')")
-          TOKEN=$(echo "$RESPONSE" | jq -r '.token')
-          echo "::add-mask::$TOKEN"
-          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
-
-      - name: Dispatch to triage-agent
-        env:
-          TOKEN: ${{ steps.exchange.outputs.token }}
-        run: |
-          curl -sSf -X POST \
-            -H "Authorization: token $TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/MetaMask/triage-agent/dispatches" \
-            -d "$(jq -cn \
-              --arg owner "${{ github.repository_owner }}" \
-              --arg name "${{ github.event.repository.name }}" \
-              --arg number "${{ github.event.issue.number }}" \
-              '{event_type: "triage-issue", client_payload: {repo_owner: $owner, repo_name: $name, issue_number: $number, event_action: "opened", trigger_mode: "on_create"}}')"
+              --arg trigger_mode "${{ steps.trigger.outputs.trigger_mode }}" \
+              '{event_type: "triage-issue", client_payload: {repo_owner: $owner, repo_name: $name, issue_number: $number, event_action: $action, event_label_name: $label, trigger_mode: $trigger_mode}}')"

--- a/.github/workflows/triage-forwarder.yml
+++ b/.github/workflows/triage-forwarder.yml
@@ -2,12 +2,12 @@ name: Triage Agent Forwarder
 
 on:
   issues:
-    types: [labeled]
+    types: [labeled, opened]
 
 jobs:
-  forward:
+  forward-labeled:
     runs-on: ubuntu-latest
-    if: github.event.label.name == 'ta-needs-triage'
+    if: github.event.action == 'labeled' && github.event.label.name == 'ta-needs-triage'
     permissions:
       id-token: write
     steps:
@@ -49,3 +49,46 @@ jobs:
               --arg action "${{ github.event.action }}" \
               --arg label "${{ github.event.label.name }}" \
               '{event_type: "triage-issue", client_payload: {repo_owner: $owner, repo_name: $name, issue_number: $number, event_action: $action, event_label_name: $label, trigger_mode: "label"}}')"
+
+  forward-opened:
+    runs-on: ubuntu-latest
+    if: github.event.action == 'opened'
+    permissions:
+      id-token: write
+    steps:
+      - name: Get OIDC Token
+        id: oidc
+        run: |
+          OIDC_TOKEN=$(curl -sSf -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api://token-exchange-service" | jq -r '.value')
+          echo "::add-mask::$OIDC_TOKEN"
+          echo "oidc_token=$OIDC_TOKEN" >> "$GITHUB_OUTPUT"
+
+      - name: Exchange for Installation Token
+        id: exchange
+        env:
+          OIDC_TOKEN: ${{ steps.oidc.outputs.oidc_token }}
+        run: |
+          RESPONSE=$(curl -sSf -X POST "${{ vars.TOKEN_EXCHANGE_URL }}/api/exchange/token" \
+            -H "Content-Type: application/json" \
+            -d "$(jq -cn \
+              --arg oidcToken "$OIDC_TOKEN" \
+              --arg targetRepo "MetaMask/triage-agent" \
+              '{oidcToken: $oidcToken, targetRepo: $targetRepo, requested_permissions: {contents: "write", metadata: "read"}}')")
+          TOKEN=$(echo "$RESPONSE" | jq -r '.token')
+          echo "::add-mask::$TOKEN"
+          echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
+
+      - name: Dispatch to triage-agent
+        env:
+          TOKEN: ${{ steps.exchange.outputs.token }}
+        run: |
+          curl -sSf -X POST \
+            -H "Authorization: token $TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/MetaMask/triage-agent/dispatches" \
+            -d "$(jq -cn \
+              --arg owner "${{ github.repository_owner }}" \
+              --arg name "${{ github.event.repository.name }}" \
+              --arg number "${{ github.event.issue.number }}" \
+              '{event_type: "triage-issue", client_payload: {repo_owner: $owner, repo_name: $name, issue_number: $number, event_action: "opened", trigger_mode: "on_create"}}')"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Add `on_create` trigger mode to the triage forwarder workflow. When a new issue is opened, it now dispatches to `triage-agent` with `trigger_mode: "on_create"` so the issue gets auto-triaged immediately.

The existing label-based trigger (`ta-needs-triage`) is preserved as a separate `forward-labeled` job for manual re-triage. Both paths use OIDC token exchange. The `ta-bot-triage` lock label prevents double-processing when both triggers fire on the same issue.

**This PR should NOT be merged until June 1 rollout.**

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open the Actions tab and verify both `forward-labeled` and `forward-opened` jobs exist in the Triage Agent Forwarder workflow.
2. Create a new issue — verify `forward-opened` job triggers and dispatches to triage-agent with `trigger_mode: "on_create"`.
3. Apply `ta-needs-triage` label to an existing issue — verify `forward-labeled` job triggers and dispatches with `trigger_mode: "label"`.

## **Screenshots/Recordings**

N/A — workflow-only change, no UI impact.

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when and how often triage-agent runs (new issue-open path plus concurrency), which can affect automation volume and duplicate handling if downstream lock logic is missing.
> 
> **Overview**
> **Extends the Triage Agent Forwarder** so new issues can be forwarded to `triage-agent` as soon as they are **opened**, not only when someone applies the `ta-needs-triage` label.
> 
> The workflow now listens for `issues` events **`opened`** and **`labeled`**, uses **per-issue concurrency** (cancels overlapping runs for the same issue), and sets **`trigger_mode`** in the repository dispatch payload to **`on_create`** vs **`label`** based on whether the run was triggered by open vs label. The existing label path for `ta-needs-triage` is unchanged aside from that dynamic mode value.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ea09ceaafd4b135632aaf45d1b88ff4ef3c9bdb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->