### PR TITLE
chore: route UI `getEnvironmentType` imports through shared

### DIFF
--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
@@ -62,9 +62,7 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../../../shared/constants/metametrics';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../../../../shared/lib/environment-type';
 import {
   ENVIRONMENT_TYPE_NOTIFICATION,
   ENVIRONMENT_TYPE_POPUP,

--- a/ui/components/app/modals/modal.js
+++ b/ui/components/app/modals/modal.js
@@ -5,9 +5,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
 import { connect } from 'react-redux';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../../shared/lib/environment-type';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
 import isMobileView from '../../../helpers/utils/is-mobile-view';
 import * as actions from '../../../store/actions';

--- a/ui/components/app/modals/qr-scanner/qr-scanner.component.js
+++ b/ui/components/app/modals/qr-scanner/qr-scanner.component.js
@@ -4,9 +4,7 @@ import log from 'loglevel';
 import { BrowserQRCodeReader } from '@zxing/browser';
 import { usePrevious } from '../../../../hooks/usePrevious';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../../../shared/lib/environment-type';
 import { getURL } from '../../../../helpers/utils/util';
 import WebcamUtils from '../../../../helpers/utils/webcam-utils';
 import PageContainerFooter from '../../../ui/page-container/page-container-footer/page-container-footer.component';

--- a/ui/components/app/multi-rpc-edit-modal/multi-rpc-edit-modal.tsx
+++ b/ui/components/app/multi-rpc-edit-modal/multi-rpc-edit-modal.tsx
@@ -21,9 +21,7 @@ import {
   TextVariant,
 } from '../../../helpers/constants/design-system';
 import { setShowMultiRpcModal } from '../../../store/actions';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../../shared/lib/environment-type';
 import { getNetworkConfigurationsByChainId } from '../../../../shared/lib/selectors/networks';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
 import NetworkListItem from './network-list-item/network-list-item';

--- a/ui/components/app/perps/perps-tutorial-modal/PerpsTutorialAnimation.test.tsx
+++ b/ui/components/app/perps/perps-tutorial-modal/PerpsTutorialAnimation.test.tsx
@@ -60,7 +60,8 @@ jest.mock('../../../../hooks/useTheme', () => ({
 
 // Mock environment type utility
 const mockGetEnvironmentType = jest.fn();
-jest.mock('../../../../../app/scripts/lib/util', () => ({
+jest.mock('../../../../../shared/lib/environment-type', () => ({
+  ...jest.requireActual('../../../../../shared/lib/environment-type'),
   getEnvironmentType: () => mockGetEnvironmentType(),
 }));
 

--- a/ui/components/app/perps/perps-tutorial-modal/PerpsTutorialAnimation.tsx
+++ b/ui/components/app/perps/perps-tutorial-modal/PerpsTutorialAnimation.tsx
@@ -13,8 +13,7 @@ import {
 } from '../../../../contexts/rive-wasm';
 import { useTheme } from '../../../../hooks/useTheme';
 import { ThemeType } from '../../../../../shared/constants/preferences';
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../../../shared/lib/environment-type';
 import {
   ENVIRONMENT_TYPE_POPUP,
   ENVIRONMENT_TYPE_SIDEPANEL,

--- a/ui/components/app/perps/perps-tutorial-modal/PerpsTutorialModal.test.tsx
+++ b/ui/components/app/perps/perps-tutorial-modal/PerpsTutorialModal.test.tsx
@@ -22,7 +22,8 @@ jest.mock('../../../../hooks/useTheme', () => ({
 }));
 
 // Mock environment type
-jest.mock('../../../../../app/scripts/lib/util', () => ({
+jest.mock('../../../../../shared/lib/environment-type', () => ({
+  ...jest.requireActual('../../../../../shared/lib/environment-type'),
   getEnvironmentType: () => 'fullscreen',
 }));
 

--- a/ui/components/app/perps/perps-tutorial-modal/PerpsTutorialModal.tsx
+++ b/ui/components/app/perps/perps-tutorial-modal/PerpsTutorialModal.tsx
@@ -26,8 +26,7 @@ import {
   TUTORIAL_STEPS_ORDER,
 } from '../../../../ducks/perps';
 import { useTheme } from '../../../../hooks/useTheme';
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../../../shared/lib/environment-type';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../../shared/constants/app';
 import { MetaMetricsEventName } from '../../../../../shared/constants/metametrics';
 import { usePerpsEventTracking } from '../../../../hooks/perps';

--- a/ui/components/app/perps/perps-tutorial-modal/steps/WhatArePerpsStep.tsx
+++ b/ui/components/app/perps/perps-tutorial-modal/steps/WhatArePerpsStep.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import { Box, Text, TextVariant } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../../../../shared/lib/environment-type';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../../../shared/constants/app';
 
 const WhatArePerpsStep: React.FC = () => {

--- a/ui/components/app/shield-entry-modal/shield-entry-modal.tsx
+++ b/ui/components/app/shield-entry-modal/shield-entry-modal.tsx
@@ -58,9 +58,7 @@ import {
   determineSubscriptionMetricsSourceFromMarketingUtmParams,
   getShieldMarketingUtmParamsForMetrics,
 } from '../../../../shared/lib/shield';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../../shared/lib/environment-type';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
 import ShieldIllustrationAnimation from './shield-illustration-animation';
 

--- a/ui/components/app/srp-input-import/srp-input-import.test.tsx
+++ b/ui/components/app/srp-input-import/srp-input-import.test.tsx
@@ -18,8 +18,8 @@ jest.mock('webextension-polyfill', () => ({
 
 const mockGetEnvironmentType = jest.fn().mockReturnValue('popup');
 
-jest.mock('../../../../app/scripts/lib/util', () => ({
-  ...jest.requireActual('../../../../app/scripts/lib/util'),
+jest.mock('../../../../shared/lib/environment-type', () => ({
+  ...jest.requireActual('../../../../shared/lib/environment-type'),
   getEnvironmentType: () => mockGetEnvironmentType(),
 }));
 

--- a/ui/components/app/srp-input-import/srp-input-import.tsx
+++ b/ui/components/app/srp-input-import/srp-input-import.tsx
@@ -23,9 +23,7 @@ import {
   PLATFORM_FIREFOX,
 } from '../../../../shared/constants/app';
 import { getBrowserName } from '../../../../shared/lib/browser-runtime.utils';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../../shared/lib/environment-type';
 import { parseSecretRecoveryPhrase } from './parse-secret-recovery-phrase';
 
 const SRP_LENGTHS = [12, 15, 18, 21, 24];

--- a/ui/components/app/toast-master/toast-master.js
+++ b/ui/components/app/toast-master/toast-master.js
@@ -10,8 +10,7 @@ import {
 import { PRODUCT_TYPES } from '@metamask/subscription-controller';
 import { SECOND } from '../../../../shared/constants/time';
 import { ENVIRONMENT_TYPE_SIDEPANEL } from '../../../../shared/constants/app';
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../../shared/lib/environment-type';
 import { PRIVACY_POLICY_LINK } from '../../../../shared/lib/ui-utils';
 import {
   BorderRadius,

--- a/ui/components/app/wallet-overview/wallet-overview.js
+++ b/ui/components/app/wallet-overview/wallet-overview.js
@@ -2,9 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'clsx';
 
-// TODO: Move this function to shared
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../../shared/lib/environment-type';
 import { ENVIRONMENT_TYPE_FULLSCREEN } from '../../../../shared/constants/app';
 
 const WalletOverview = ({ balance, buttons, className }) => {

--- a/ui/components/multichain/app-header/app-header.js
+++ b/ui/components/multichain/app-header/app-header.js
@@ -25,9 +25,7 @@ import { Box } from '../../component-library';
 import { getUnapprovedTransactions } from '../../../selectors';
 
 import { toggleNetworkMenu } from '../../../store/actions';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../../shared/lib/environment-type';
 import {
   ENVIRONMENT_TYPE_POPUP,
   ENVIRONMENT_TYPE_SIDEPANEL,

--- a/ui/components/multichain/global-menu-drawer/global-menu-drawer.test.tsx
+++ b/ui/components/multichain/global-menu-drawer/global-menu-drawer.test.tsx
@@ -12,12 +12,12 @@ import { isGatorPermissionsRevocationFeatureEnabled } from '../../../../shared/l
 import { GlobalMenuDrawer } from './global-menu-drawer';
 import { GlobalMenuDrawerWithList } from './global-menu-drawer-with-list';
 
-// eslint-disable-next-line import-x/no-restricted-paths
-const getEnvironmentType = jest.requireMock('../../../../app/scripts/lib/util')
-  .getEnvironmentType as jest.Mock;
+const getEnvironmentType = jest.requireMock(
+  '../../../../shared/lib/environment-type',
+).getEnvironmentType as jest.Mock;
 
-jest.mock('../../../../app/scripts/lib/util', () => ({
-  ...jest.requireActual('../../../../app/scripts/lib/util'),
+jest.mock('../../../../shared/lib/environment-type', () => ({
+  ...jest.requireActual('../../../../shared/lib/environment-type'),
   getEnvironmentType: jest.fn(),
 }));
 

--- a/ui/components/multichain/global-menu-drawer/global-menu-drawer.tsx
+++ b/ui/components/multichain/global-menu-drawer/global-menu-drawer.tsx
@@ -10,9 +10,7 @@ import {
   IconName,
 } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../../shared/lib/environment-type';
 import {
   ENVIRONMENT_TYPE_FULLSCREEN,
   ENVIRONMENT_TYPE_SIDEPANEL,

--- a/ui/components/multichain/global-menu-drawer/useGlobalMenuSections.tsx
+++ b/ui/components/multichain/global-menu-drawer/useGlobalMenuSections.tsx
@@ -42,9 +42,7 @@ import {
 } from '../../../selectors/metamask-notifications/metamask-notifications';
 import { selectIsBackupAndSyncEnabled } from '../../../selectors/identity/backup-and-sync';
 import { Tag } from '../../component-library';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../../shared/lib/environment-type';
 import {
   ENVIRONMENT_TYPE_POPUP,
   ENVIRONMENT_TYPE_SIDEPANEL,

--- a/ui/components/multichain/network-list-menu/popular-network-list/popular-network-list.tsx
+++ b/ui/components/multichain/network-list-menu/popular-network-list/popular-network-list.tsx
@@ -26,9 +26,7 @@ import {
   toggleNetworkMenu,
   addNetwork,
 } from '../../../../store/actions';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../../../shared/lib/environment-type';
 import {
   AlignItems,
   BackgroundColor,

--- a/ui/components/multichain/nft-item/nft-item.tsx
+++ b/ui/components/multichain/nft-item/nft-item.tsx
@@ -29,8 +29,7 @@ import {
 import { NFT } from '../asset-picker-amount/asset-picker-modal/types';
 import Tooltip from '../../ui/tooltip/tooltip';
 import { ENVIRONMENT_TYPE_FULLSCREEN } from '../../../../shared/constants/app';
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../../shared/lib/environment-type';
 
 type NftItemProps = {
   nft?: NFT;

--- a/ui/contexts/metametrics.tsx
+++ b/ui/contexts/metametrics.tsx
@@ -20,9 +20,7 @@ import type { Span } from '@sentry/types';
 import { omit } from 'lodash';
 
 import { captureException, captureMessage } from '../../shared/lib/sentry';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../shared/lib/environment-type';
 import {
   PATH_NAME_MAP,
   getPaths,

--- a/ui/helpers/utils/tags.test.ts
+++ b/ui/helpers/utils/tags.test.ts
@@ -1,6 +1,4 @@
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../shared/lib/environment-type';
 import { ENVIRONMENT_TYPE_FULLSCREEN } from '../../../shared/constants/app';
 import { MetaMaskReduxState } from '../../store/store';
 import { getStartupTraceTags } from './tags';

--- a/ui/helpers/utils/tags.test.ts
+++ b/ui/helpers/utils/tags.test.ts
@@ -3,8 +3,8 @@ import { ENVIRONMENT_TYPE_FULLSCREEN } from '../../../shared/constants/app';
 import { MetaMaskReduxState } from '../../store/store';
 import { getStartupTraceTags } from './tags';
 
-jest.mock('../../../app/scripts/lib/util', () => ({
-  ...jest.requireActual('../../../app/scripts/lib/util'),
+jest.mock('../../../shared/lib/environment-type', () => ({
+  ...jest.requireActual('../../../shared/lib/environment-type'),
   getEnvironmentType: jest.fn(),
 }));
 

--- a/ui/helpers/utils/tags.ts
+++ b/ui/helpers/utils/tags.ts
@@ -1,6 +1,4 @@
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../shared/lib/environment-type';
 import { getIsUnlocked } from '../../ducks/metamask/base-selectors';
 import {
   getInternalAccounts,

--- a/ui/hooks/useEventFragment.js
+++ b/ui/hooks/useEventFragment.js
@@ -1,8 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../shared/lib/environment-type';
 import { selectMatchingFragment } from '../selectors';
 import {
   finalizeEventFragment,

--- a/ui/index.js
+++ b/ui/index.js
@@ -7,9 +7,7 @@ import { isInternalAccountInPermittedAccountIds } from '@metamask/chain-agnostic
 
 import { captureException } from '../shared/lib/sentry';
 import { withResolvers } from '../shared/lib/promise-with-resolvers';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../app/scripts/lib/util';
+import { getEnvironmentType } from '../shared/lib/environment-type';
 import { AlertTypes } from '../shared/constants/alerts';
 import { maskObject } from '../shared/lib/object.utils';
 // TODO: Remove restricted import

--- a/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
@@ -89,7 +89,8 @@ jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
   useDispatch: () => mockDispatch,
 }));
-jest.mock('../../../../../../app/scripts/lib/util', () => ({
+jest.mock('../../../../../../shared/lib/environment-type', () => ({
+  ...jest.requireActual('../../../../../../shared/lib/environment-type'),
   getEnvironmentType: (...args: unknown[]) => mockGetEnvironmentType(...args),
 }));
 jest.mock('../../../../../store/background-connection', () => ({

--- a/ui/pages/confirmations/components/confirm/ledger-info/ledger-info.tsx
+++ b/ui/pages/confirmations/components/confirm/ledger-info/ledger-info.tsx
@@ -1,8 +1,6 @@
 import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../../../../shared/lib/environment-type';
 import { ENVIRONMENT_TYPE_FULLSCREEN } from '../../../../../../shared/constants/app';
 import {
   HardwareTransportStates,

--- a/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.test.ts
@@ -31,7 +31,8 @@ import { useTransactionConfirm } from './useTransactionConfirm';
 
 const mockGetEnvironmentType = jest.fn();
 
-jest.mock('../../../../../app/scripts/lib/util', () => ({
+jest.mock('../../../../../shared/lib/environment-type', () => ({
+  ...jest.requireActual('../../../../../shared/lib/environment-type'),
   getEnvironmentType: (...args: unknown[]) => mockGetEnvironmentType(...args),
 }));
 const mockIsHardwareWalletError = jest.fn();

--- a/ui/pages/confirmations/hooks/useTransactionFocusEffect.test.ts
+++ b/ui/pages/confirmations/hooks/useTransactionFocusEffect.test.ts
@@ -1,8 +1,7 @@
 import { TransactionType } from '@metamask/transaction-controller';
 import { renderHook } from '@testing-library/react-hooks';
 import { useDispatch } from 'react-redux';
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../../shared/lib/environment-type';
 import {
   ENVIRONMENT_TYPE_POPUP,
   ENVIRONMENT_TYPE_SIDEPANEL,

--- a/ui/pages/confirmations/hooks/useTransactionFocusEffect.test.ts
+++ b/ui/pages/confirmations/hooks/useTransactionFocusEffect.test.ts
@@ -29,7 +29,8 @@ jest.mock('../../../store/actions', () => ({
   setTransactionActive: jest.fn(),
 }));
 
-jest.mock('../../../../app/scripts/lib/util', () => ({
+jest.mock('../../../../shared/lib/environment-type', () => ({
+  ...jest.requireActual('../../../../shared/lib/environment-type'),
   getEnvironmentType: jest.fn(),
 }));
 

--- a/ui/pages/confirmations/hooks/useTransactionFocusEffect.ts
+++ b/ui/pages/confirmations/hooks/useTransactionFocusEffect.ts
@@ -3,8 +3,7 @@ import { useDispatch } from 'react-redux';
 import { TransactionType } from '@metamask/transaction-controller';
 
 import { ENVIRONMENT_TYPE_SIDEPANEL } from '../../../../shared/constants/app';
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../../shared/lib/environment-type';
 import { setTransactionActive } from '../../../store/actions';
 import { useWindowFocus } from '../../../hooks/useWindowFocus';
 import { useConfirmContext } from '../context/confirm';

--- a/ui/pages/home/home.container.js
+++ b/ui/pages/home/home.container.js
@@ -62,9 +62,7 @@ import {
   selectRewardsModalOpen,
 } from '../../ducks/rewards/selectors';
 import { selectShowPna25Modal } from '../../components/app/toast-master/selectors';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../shared/lib/environment-type';
 import { getIsBrowserDeprecated } from '../../helpers/utils/util';
 import {
   ENVIRONMENT_TYPE_NOTIFICATION,

--- a/ui/pages/onboarding-flow/onboarding-app-header/onboarding-app-header.tsx
+++ b/ui/pages/onboarding-flow/onboarding-app-header/onboarding-app-header.tsx
@@ -32,9 +32,7 @@ import {
   ONBOARDING_COMPLETION_ROUTE,
   ONBOARDING_WELCOME_ROUTE,
 } from '../../../helpers/constants/routes';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../../shared/lib/environment-type';
 import { ENVIRONMENT_TYPE_SIDEPANEL } from '../../../../shared/constants/app';
 
 type OnboardingAppHeaderProps = {

--- a/ui/pages/onboarding-flow/onboarding-flow.tsx
+++ b/ui/pages/onboarding-flow/onboarding-flow.tsx
@@ -60,8 +60,7 @@ import {
 } from '../../selectors';
 import { MetaMetricsContext } from '../../contexts/metametrics';
 import { submitRequestToBackgroundAndCatch } from '../../components/app/toast-master/utils';
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../shared/lib/environment-type';
 import {
   ENVIRONMENT_TYPE_POPUP,
   ENVIRONMENT_TYPE_SIDEPANEL,

--- a/ui/pages/routes/confirmation-router.tsx
+++ b/ui/pages/routes/confirmation-router.tsx
@@ -16,8 +16,7 @@ import {
   TRANSACTION_SHIELD_ROUTE,
 } from '../../helpers/constants/routes';
 import { getConfirmationRoute } from '../confirmations/hooks/useConfirmationNavigation';
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../shared/lib/environment-type';
 import {
   ENVIRONMENT_TYPE_FULLSCREEN,
   ENVIRONMENT_TYPE_NOTIFICATION,

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -106,9 +106,7 @@ import {
   ENVIRONMENT_TYPE_SIDEPANEL,
   SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES,
 } from '../../../shared/constants/app';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../shared/lib/environment-type';
 import QRHardwarePopover from '../../components/app/qr-hardware-popover';
 import { ToggleIpfsModal } from '../../components/app/assets/nfts/nft-default-image/toggle-ipfs-modal';
 import { BasicConfigurationModal } from '../../components/app/basic-configuration-modal';

--- a/ui/pages/routes/utils.js
+++ b/ui/pages/routes/utils.js
@@ -1,6 +1,5 @@
 import { matchPath } from 'react-router-dom';
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../shared/lib/environment-type';
 import {
   ENVIRONMENT_TYPE_NOTIFICATION,
   ENVIRONMENT_TYPE_POPUP,

--- a/ui/pages/settings/debug-tab/debug-content/debug-content.tsx
+++ b/ui/pages/settings/debug-tab/debug-content/debug-content.tsx
@@ -29,9 +29,7 @@ import {
   setServiceWorkerKeepAlivePreference,
 } from '../../../../store/actions';
 import { selectPerpsIsTestnet } from '../../../../selectors/perps-controller';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../../../shared/lib/environment-type';
 import { ENVIRONMENT_TYPE_POPUP } from '../../../../../shared/constants/app';
 import { getRemoteFeatureFlags } from '../../../../../shared/lib/selectors/remote-feature-flags';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0021): route-isolation backlog

--- a/ui/pages/settings/settings.test.tsx
+++ b/ui/pages/settings/settings.test.tsx
@@ -27,7 +27,8 @@ jest.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
 }));
 
-jest.mock('../../../app/scripts/lib/util', () => ({
+jest.mock('../../../shared/lib/environment-type', () => ({
+  ...jest.requireActual('../../../shared/lib/environment-type'),
   getEnvironmentType: () => mockGetEnvironmentType(),
 }));
 

--- a/ui/pages/settings/settings.tsx
+++ b/ui/pages/settings/settings.tsx
@@ -38,9 +38,7 @@ import {
   TRANSACTION_SHIELD_ROUTE,
 } from '../../helpers/constants/routes';
 import { SnapSettingsRenderer } from '../../components/app/snaps/snap-settings-page';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../shared/lib/environment-type';
 import {
   ENVIRONMENT_TYPE_POPUP,
   ENVIRONMENT_TYPE_SIDEPANEL,

--- a/ui/pages/unlock-page/unlock-page.container.ts
+++ b/ui/pages/unlock-page/unlock-page.container.ts
@@ -3,9 +3,7 @@ import { connect } from 'react-redux';
 import { compose } from 'redux';
 import { Location as RouterLocation, NavigateFunction } from 'react-router-dom';
 import type { PasskeyAuthenticationResponse } from '@metamask/passkey-controller';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType } from '../../../app/scripts/lib/util';
+import { getEnvironmentType } from '../../../shared/lib/environment-type';
 import {
   ENVIRONMENT_TYPE_POPUP,
   ENVIRONMENT_TYPE_SIDEPANEL,

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -72,11 +72,11 @@ import {
   getIsTronTestnetSupportEnabled,
 } from './multichain/feature-flags';
 
+import { getEnvironmentType } from '../../shared/lib/environment-type';
 // TODO: Remove restricted import
 import {
   addHexPrefix,
   getDeviceType,
-  getEnvironmentType,
   // eslint-disable-next-line import-x/no-restricted-paths
 } from '../../app/scripts/lib/util';
 import {

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -4140,7 +4140,7 @@ describe('getPermissionsForActiveTab', () => {
   });
 
   it('should return permissions for popup context using activeTab.origin', () => {
-    const util = jest.requireMock('../../app/scripts/lib/util');
+    const util = jest.requireMock('../../shared/lib/environment-type');
     util.getEnvironmentType.mockReturnValue('popup');
 
     const result = selectors.getPermissionsForActiveTab(permissionsTestState);
@@ -4151,7 +4151,7 @@ describe('getPermissionsForActiveTab', () => {
   });
 
   it('should return permissions for sidepanel context using appActiveTab.origin', () => {
-    const util = jest.requireMock('../../app/scripts/lib/util');
+    const util = jest.requireMock('../../shared/lib/environment-type');
     util.getEnvironmentType.mockReturnValue('sidepanel');
 
     const result = selectors.getPermissionsForActiveTab(permissionsTestState);
@@ -4163,7 +4163,7 @@ describe('getPermissionsForActiveTab', () => {
   });
 
   it('should return empty array when no permissions exist for the origin', () => {
-    const util = jest.requireMock('../../app/scripts/lib/util');
+    const util = jest.requireMock('../../shared/lib/environment-type');
     util.getEnvironmentType.mockReturnValue('popup');
 
     const stateWithoutPermissions = {
@@ -4182,7 +4182,7 @@ describe('getPermissionsForActiveTab', () => {
   });
 
   it('should return empty array when origin is undefined in popup context', () => {
-    const util = jest.requireMock('../../app/scripts/lib/util');
+    const util = jest.requireMock('../../shared/lib/environment-type');
     util.getEnvironmentType.mockReturnValue('popup');
 
     const stateWithoutOrigin = {
@@ -4196,7 +4196,7 @@ describe('getPermissionsForActiveTab', () => {
   });
 
   it('should return empty array when appActiveTab is undefined in sidepanel context', () => {
-    const util = jest.requireMock('../../app/scripts/lib/util');
+    const util = jest.requireMock('../../shared/lib/environment-type');
     util.getEnvironmentType.mockReturnValue('sidepanel');
 
     const stateWithoutAppActiveTab = {

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -34,8 +34,8 @@ jest.mock('../../shared/lib/selectors/networks', () => ({
   ...jest.requireActual('../../shared/lib/selectors/networks'),
 }));
 
-jest.mock('../../app/scripts/lib/util', () => ({
-  ...jest.requireActual('../../app/scripts/lib/util'),
+jest.mock('../../shared/lib/environment-type', () => ({
+  ...jest.requireActual('../../shared/lib/environment-type'),
   getEnvironmentType: jest.fn().mockReturnValue('popup'),
 }));
 

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -110,9 +110,10 @@ import {
   ORIGIN_METAMASK,
   POLLING_TOKEN_ENVIRONMENT_TYPES,
 } from '../../shared/constants/app';
+import { getEnvironmentType } from '../../shared/lib/environment-type';
 // TODO: Remove restricted import
 // eslint-disable-next-line import-x/no-restricted-paths
-import { getEnvironmentType, addHexPrefix } from '../../app/scripts/lib/util';
+import { addHexPrefix } from '../../app/scripts/lib/util';
 import {
   getMetaMaskAccounts,
   hasTransactionPendingApprovals,


### PR DESCRIPTION
## **Description**

The UI and background bundles are intentionally built separately, but ~30 UI files import `getEnvironmentType` from `app/scripts/lib/util` with `// eslint-disable-next-line import-x/no-restricted-paths`. That symbol is already re-exported from `shared/lib/environment-type` (see `app/scripts/lib/util.ts:51`), so we can point UI imports directly at the shared module and drop the eslint suppressions.

The two files that import `getEnvironmentType` alongside `addHexPrefix` (`ui/selectors/selectors.js` and `ui/store/actions.ts`) are split — `getEnvironmentType` now comes from shared, and the `addHexPrefix` import keeps its existing eslint-disable until a follow-up PR moves it to shared too.

No behavior change — only import paths.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

None — import-path refactor only. CI lint + type-check covers correctness.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-path refactor only; `getEnvironmentType` behavior is unchanged and already defined in shared.
> 
> **Overview**
> UI code that depended on **`getEnvironmentType`** via restricted imports from **`app/scripts/lib/util`** now imports it from **`shared/lib/environment-type`**, matching the background re-export and removing many **`import-x/no-restricted-paths`** suppressions.
> 
> **`ui/selectors/selectors.js`** and **`ui/store/actions.ts`** still pull **`addHexPrefix`** (and related symbols) from **`app/scripts/lib/util`**; only **`getEnvironmentType`** moved to shared. Jest tests that stubbed environment type were updated to mock **`shared/lib/environment-type`** (often with **`jest.requireActual`**) instead of **`app/scripts/lib/util`**.
> 
> No runtime behavior change—the shared module is the canonical implementation already re-exported from util.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ed6be13b15478e9c3a0d47692155998e54a5e783. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->