### PR TITLE
chore: extract URL utils to shared

### DIFF
--- a/app/scripts/lib/util.ts
+++ b/app/scripts/lib/util.ts
@@ -1,4 +1,3 @@
-import urlLib from 'url';
 import ipRegex from 'ip-regex';
 import { AccessList } from '@ethereumjs/tx';
 import {
@@ -49,6 +48,13 @@ import {
 // and keep the sentry bundle lightweight
 export { getInstallType, initInstallType } from './install-type';
 export { getEnvironmentType } from '../../../shared/lib/environment-type';
+export {
+  getValidUrl,
+  isWebUrl,
+  addUrlProtocolPrefix,
+  isValidEmail,
+  isWebOrigin,
+} from '../../../shared/lib/url-utils';
 
 /**
  * Minimal type for User-Agent Client Hints API (NavigatorUAData).
@@ -423,64 +429,6 @@ export function previousValueComparator<A>(
       cache = value;
     }
   };
-}
-
-export function addUrlProtocolPrefix(urlString: string) {
-  let trimmed = urlString.trim();
-
-  if (trimmed.length && !urlLib.parse(trimmed).protocol) {
-    trimmed = `https://${trimmed}`;
-  }
-
-  if (getValidUrl(trimmed) !== null) {
-    return trimmed;
-  }
-
-  return null;
-}
-
-export function getValidUrl(urlString: string): URL | null {
-  try {
-    const url = new URL(urlString);
-
-    if (url.hostname.length === 0 || url.pathname.length === 0) {
-      return null;
-    }
-
-    if (url.hostname !== decodeURIComponent(url.hostname)) {
-      return null; // will happen if there's a %, a space, or other invalid character in the hostname
-    }
-
-    return url;
-  } catch (error) {
-    return null;
-  }
-}
-
-export function isValidEmail(email: string): boolean {
-  return email.match(/^([\w.%+-]+)@([\w-]+\.)+([\w]{2,})$/iu) !== null;
-}
-
-export function isWebUrl(urlString: string): boolean {
-  const url = getValidUrl(urlString);
-
-  return (
-    url !== null && (url.protocol === 'https:' || url.protocol === 'http:')
-  );
-}
-
-/**
- * Checks if an origin string is a web origin (http:// or https://).
- * This is used to filter out non-web origins like chrome://, about://, moz-extension://, etc.
- *
- * @param origin - The origin string to check (e.g., "https://example.com", "chrome://newtab")
- * @returns true if the origin starts with http:// or https://, false otherwise
- */
-export function isWebOrigin(origin: string | undefined | null): boolean {
-  if (!origin) {
-    return false;
-  }
-  return origin.startsWith('http://') || origin.startsWith('https://');
 }
 
 /**

--- a/shared/lib/url-utils.ts
+++ b/shared/lib/url-utils.ts
@@ -1,0 +1,59 @@
+import urlLib from 'url';
+
+export function addUrlProtocolPrefix(urlString: string) {
+  let trimmed = urlString.trim();
+
+  if (trimmed.length && !urlLib.parse(trimmed).protocol) {
+    trimmed = `https://${trimmed}`;
+  }
+
+  if (getValidUrl(trimmed) !== null) {
+    return trimmed;
+  }
+
+  return null;
+}
+
+export function getValidUrl(urlString: string): URL | null {
+  try {
+    const url = new URL(urlString);
+
+    if (url.hostname.length === 0 || url.pathname.length === 0) {
+      return null;
+    }
+
+    if (url.hostname !== decodeURIComponent(url.hostname)) {
+      return null; // will happen if there's a %, a space, or other invalid character in the hostname
+    }
+
+    return url;
+  } catch (error) {
+    return null;
+  }
+}
+
+export function isValidEmail(email: string): boolean {
+  return email.match(/^([\w.%+-]+)@([\w-]+\.)+([\w]{2,})$/iu) !== null;
+}
+
+export function isWebUrl(urlString: string): boolean {
+  const url = getValidUrl(urlString);
+
+  return (
+    url !== null && (url.protocol === 'https:' || url.protocol === 'http:')
+  );
+}
+
+/**
+ * Checks if an origin string is a web origin (http:// or https://).
+ * This is used to filter out non-web origins like chrome://, about://, moz-extension://, etc.
+ *
+ * @param origin - The origin string to check (e.g., "https://example.com", "chrome://newtab")
+ * @returns true if the origin starts with http:// or https://, false otherwise
+ */
+export function isWebOrigin(origin: string | undefined | null): boolean {
+  if (!origin) {
+    return false;
+  }
+  return origin.startsWith('http://') || origin.startsWith('https://');
+}

--- a/ui/components/app/assets/nfts/nft-details/nft-details.tsx
+++ b/ui/components/app/assets/nfts/nft-details/nft-details.tsx
@@ -70,12 +70,10 @@ import { CHAINID_DEFAULT_BLOCK_EXPLORER_URL_MAP } from '../../../../../../shared
 import { getCurrentCurrency } from '../../../../../ducks/metamask/metamask';
 import { getConversionRate } from '../../../../../ducks/metamask/base-selectors';
 import { Numeric } from '../../../../../../shared/lib/Numeric';
-// TODO: Remove restricted import
 import {
   addUrlProtocolPrefix,
   isWebUrl,
-  // eslint-disable-next-line import-x/no-restricted-paths
-} from '../../../../../../app/scripts/lib/util';
+} from '../../../../../../shared/lib/url-utils';
 import useGetAssetImageUrl from '../../../../../hooks/useGetAssetImageUrl';
 import { getImageForChainId } from '../../../../../selectors/multichain';
 import useFetchNftDetailsFromTokenURI from '../../../../../hooks/useFetchNftDetailsFromTokenURI';

--- a/ui/components/app/assets/nfts/nft-details/nft-full-image.tsx
+++ b/ui/components/app/assets/nfts/nft-details/nft-full-image.tsx
@@ -25,9 +25,7 @@ import {
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import useGetAssetImageUrl from '../../../../../hooks/useGetAssetImageUrl';
 import useFetchNftDetailsFromTokenURI from '../../../../../hooks/useFetchNftDetailsFromTokenURI';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { isWebUrl } from '../../../../../../app/scripts/lib/util';
+import { isWebUrl } from '../../../../../../shared/lib/url-utils';
 import { getNetworkConfigurationsByChainId } from '../../../../../../shared/lib/selectors/networks';
 import { getImageForChainId } from '../../../../../selectors/multichain';
 import {

--- a/ui/components/app/assets/nfts/nft-grid/nft-grid.tsx
+++ b/ui/components/app/assets/nfts/nft-grid/nft-grid.tsx
@@ -10,9 +10,7 @@ import useGetAssetImageUrl from '../../../../../hooks/useGetAssetImageUrl';
 import { getImageForChainId } from '../../../../../selectors/multichain';
 import { getNetworkConfigurationsByChainId } from '../../../../../../shared/lib/selectors/networks';
 import useFetchNftDetailsFromTokenURI from '../../../../../hooks/useFetchNftDetailsFromTokenURI';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { isWebUrl } from '../../../../../../app/scripts/lib/util';
+import { isWebUrl } from '../../../../../../shared/lib/url-utils';
 import {
   VirtualizedList,
   noAdjustmentsScroll,

--- a/ui/components/multichain/network-list-menu/add-block-explorer-modal/add-block-explorer-modal.tsx
+++ b/ui/components/multichain/network-list-menu/add-block-explorer-modal/add-block-explorer-modal.tsx
@@ -18,9 +18,7 @@ import {
   TextVariant,
 } from '../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { isWebUrl } from '../../../../../app/scripts/lib/util';
+import { isWebUrl } from '../../../../../shared/lib/url-utils';
 
 const AddBlockExplorerModal = ({
   onAdded,

--- a/ui/components/multichain/network-list-menu/add-rpc-url-modal/add-rpc-url-modal.tsx
+++ b/ui/components/multichain/network-list-menu/add-rpc-url-modal/add-rpc-url-modal.tsx
@@ -18,9 +18,7 @@ import {
   TextVariant,
 } from '../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { isWebUrl } from '../../../../../app/scripts/lib/util';
+import { isWebUrl } from '../../../../../shared/lib/url-utils';
 
 const AddRpcUrlModal = ({
   onAdded,

--- a/ui/hooks/useIsOriginalNativeTokenSymbol.ts
+++ b/ui/hooks/useIsOriginalNativeTokenSymbol.ts
@@ -5,9 +5,7 @@ import { getUseSafeChainsListValidation } from '../selectors';
 import { getMultichainCurrentNetwork } from '../selectors/multichain';
 import { isEvmChainId } from '../../shared/lib/asset-utils';
 
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getValidUrl } from '../../app/scripts/lib/util';
+import { getValidUrl } from '../../shared/lib/url-utils';
 import { isOriginalNativeTokenSymbol } from '../helpers/utils/isOriginalNativeTokenSymbol';
 
 export function useIsOriginalNativeTokenSymbol(

--- a/ui/pages/networks/add-rpc-url-page-form.tsx
+++ b/ui/pages/networks/add-rpc-url-page-form.tsx
@@ -13,9 +13,7 @@ import {
 } from '@metamask/design-system-react';
 import { useI18nContext } from '../../hooks/useI18nContext';
 import { BorderRadius } from '../../helpers/constants/design-system';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { isWebUrl } from '../../../app/scripts/lib/util';
+import { isWebUrl } from '../../../shared/lib/url-utils';
 
 type AddRpcUrlPageFormProps = {
   onCancel: () => void;

--- a/ui/pages/onboarding-flow/privacy-settings/privacy-settings.tsx
+++ b/ui/pages/onboarding-flow/privacy-settings/privacy-settings.tsx
@@ -20,8 +20,7 @@ import {
   FontWeight,
   TextButton,
 } from '@metamask/design-system-react';
-// eslint-disable-next-line import-x/no-restricted-paths
-import { addUrlProtocolPrefix } from '../../../../app/scripts/lib/util';
+import { addUrlProtocolPrefix } from '../../../../shared/lib/url-utils';
 import { TextField } from '../../../components/component-library';
 import {
   MetaMetricsEventCategory,

--- a/ui/pages/settings/privacy-tab/ipfs-gateway-item.tsx
+++ b/ui/pages/settings/privacy-tab/ipfs-gateway-item.tsx
@@ -13,8 +13,7 @@ import {
   IPFS_DEFAULT_GATEWAY_URL,
   IPFS_FORBIDDEN_GATEWAY,
 } from '../../../../shared/constants/network';
-// eslint-disable-next-line import-x/no-restricted-paths
-import { addUrlProtocolPrefix } from '../../../../app/scripts/lib/util';
+import { addUrlProtocolPrefix } from '../../../../shared/lib/url-utils';
 import { THIRD_PARTY_API_ITEMS } from '../search-config';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {

--- a/ui/pages/shield/transaction-shield/claims-form/claims-form.tsx
+++ b/ui/pages/shield/transaction-shield/claims-form/claims-form.tsx
@@ -40,9 +40,7 @@ import {
 } from '../../../../helpers/constants/design-system';
 import { useClaimState } from '../../../../hooks/shield/useClaimState';
 import { useClaimDraft } from '../../../../hooks/shield/useClaimDraft';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { isValidEmail } from '../../../../../app/scripts/lib/util';
+import { isValidEmail } from '../../../../../shared/lib/url-utils';
 import { TRANSACTION_SHIELD_CLAIM_ROUTES } from '../../../../helpers/constants/routes';
 import { submitShieldClaim } from '../../../../store/actions';
 import LoadingScreen from '../../../../components/ui/loading-screen';


### PR DESCRIPTION
## **Description**

`getValidUrl`, `isWebUrl`, `addUrlProtocolPrefix`, `isValidEmail`, and `isWebOrigin` are pure utilities defined in `app/scripts/lib/util.ts` but consumed by both UI and background. UI imports them with `// eslint-disable-next-line import-x/no-restricted-paths`.

This PR moves them into `shared/lib/url-utils.ts`. `app/scripts/lib/util.ts` re-exports them so background callers stay unaffected. UI imports now point at shared and the eslint suppressions (plus stale TODO comments) are removed.

No behavior change — pure refactor.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

None — pure refactor. CI lint + type-check covers correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with re-exports preserving background imports; no logic changes to validation or security-sensitive flows.
> 
> **Overview**
> Moves **pure URL/email helpers** (`getValidUrl`, `isWebUrl`, `addUrlProtocolPrefix`, `isValidEmail`, `isWebOrigin`) out of `app/scripts/lib/util.ts` into new **`shared/lib/url-utils.ts`**, so UI and background can share them without crossing the restricted `app/scripts` import boundary.
> 
> `util.ts` **re-exports** those symbols for existing background callers. UI files that previously imported from `app/scripts/lib/util` (with `import-x/no-restricted-paths` suppressions) now import from **`shared/lib/url-utils`** instead—NFT views, network RPC/explorer modals, onboarding IPFS, privacy settings, native token symbol hook, and Shield claims email validation.
> 
> **No runtime behavior change**; logic is relocated unchanged and the `url` dependency usage stays in the shared module.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ce3b97b5d653072ef99092ad1ad882325af1974. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->