### PR TITLE
chore: extract `addHexPrefix` to shared

### DIFF
--- a/app/scripts/lib/util.ts
+++ b/app/scripts/lib/util.ts
@@ -57,6 +57,7 @@ export {
   isWebOrigin,
 } from '../../../shared/lib/url-utils';
 export { formatValue, isValidAmount } from '../../../shared/lib/format-value';
+export { addHexPrefix } from '../../../shared/lib/add-hex-prefix';
 
 /**
  * Minimal type for User-Agent Client Hints API (NavigatorUAData).
@@ -340,28 +341,6 @@ export const getOs = (): Os => {
   return OS.UNKNOWN;
 };
 
-/**
- * Prefixes a hex string with '0x' or '-0x' and returns it. Idempotent.
- *
- * @param str - The string to prefix.
- * @returns The prefixed string.
- */
-const addHexPrefix = (str: string) => {
-  if (typeof str !== 'string' || str.match(/^-?0x/u)) {
-    return str;
-  }
-
-  if (str.match(/^-?0X/u)) {
-    return str.replace('0X', '0x');
-  }
-
-  if (str.startsWith('-')) {
-    return str.replace('-', '-0x');
-  }
-
-  return `0x${str}`;
-};
-
 function getChainType(chainId: string) {
   if (chainId === CHAIN_IDS.MAINNET) {
     return 'mainnet';
@@ -382,7 +361,7 @@ function checkAlarmExists(alarmList: { name: string }[], alarmName: string) {
   return alarmList.some((alarm) => alarm.name === alarmName);
 }
 
-export { addHexPrefix, checkAlarmExists, getChainType, getPlatform };
+export { checkAlarmExists, getChainType, getPlatform };
 
 // Taken from https://stackoverflow.com/a/1349426/3696652
 const characters =

--- a/shared/lib/add-hex-prefix.ts
+++ b/shared/lib/add-hex-prefix.ts
@@ -1,0 +1,21 @@
+/**
+ * Prefixes a hex string with '0x' or '-0x' and returns it. Idempotent.
+ *
+ * @param str - The string to prefix.
+ * @returns The prefixed string.
+ */
+export const addHexPrefix = (str: string) => {
+  if (typeof str !== 'string' || str.match(/^-?0x/u)) {
+    return str;
+  }
+
+  if (str.match(/^-?0X/u)) {
+    return str.replace('0X', '0x');
+  }
+
+  if (str.startsWith('-')) {
+    return str.replace('-', '-0x');
+  }
+
+  return `0x${str}`;
+};

--- a/shared/lib/swaps-utils.js
+++ b/shared/lib/swaps-utils.js
@@ -14,9 +14,7 @@ import {
   TOKEN_API_BASE_URL,
 } from '../constants/swaps';
 import { SECOND } from '../constants/time';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { addHexPrefix } from '../../app/scripts/lib/util';
+import { addHexPrefix } from './add-hex-prefix';
 import { isValidHexAddress } from './hexstring-utils';
 import { isEqualCaseInsensitive } from './string-utils';
 import { decimalToHex } from './conversion.utils';

--- a/ui/components/multichain/import-tokens-modal/import-tokens-modal.js
+++ b/ui/components/multichain/import-tokens-modal/import-tokens-modal.js
@@ -88,9 +88,7 @@ import {
   isValidHexAddress,
   toChecksumHexAddress,
 } from '../../../../shared/lib/hexstring-utils';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { addHexPrefix } from '../../../../app/scripts/lib/util';
+import { addHexPrefix } from '../../../../shared/lib/add-hex-prefix';
 import { STATIC_MAINNET_TOKEN_LIST } from '../../../../shared/constants/tokens';
 import {
   AssetType,

--- a/ui/helpers/utils/transactions.util.js
+++ b/ui/helpers/utils/transactions.util.js
@@ -3,9 +3,7 @@ import {
   TransactionStatus,
   TransactionType,
 } from '@metamask/transaction-controller';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { addHexPrefix } from '../../../app/scripts/lib/util';
+import { addHexPrefix } from '../../../shared/lib/add-hex-prefix';
 import { TransactionGroupStatus } from '../../../shared/constants/transaction';
 import { readAddressAsContract } from '../../../shared/lib/contract-utils';
 

--- a/ui/pages/confirmations/send-utils/send-content/add-recipient/domain-input.component.js
+++ b/ui/pages/confirmations/send-utils/send-content/add-recipient/domain-input.component.js
@@ -3,9 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'clsx';
 
 import { isHexString } from '@metamask/utils';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { addHexPrefix } from '../../../../../../app/scripts/lib/util';
+import { addHexPrefix } from '../../../../../../shared/lib/add-hex-prefix';
 import { shortenAddress } from '../../../../../helpers/utils/util';
 import {
   isBurnAddress,

--- a/ui/pages/confirmations/send-utils/send.utils.js
+++ b/ui/pages/confirmations/send-utils/send.utils.js
@@ -1,8 +1,6 @@
 import { encode } from '@metamask/abi-utils';
 import { isHexString } from '@metamask/utils';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { addHexPrefix } from '../../../../app/scripts/lib/util';
+import { addHexPrefix } from '../../../../shared/lib/add-hex-prefix';
 import { TokenStandard } from '../../../../shared/constants/transaction';
 import { Numeric } from '../../../../shared/lib/Numeric';
 import { BURN_ADDRESS } from '../../../../shared/lib/hexstring-utils';

--- a/ui/pages/custom-token-import/custom-token-import.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.tsx
@@ -18,9 +18,7 @@ import { ERC20, ERC721, ERC1155 } from '@metamask/controller-utils';
 import { NON_EVM_TESTNET_IDS } from '@metamask/multichain-network-controller';
 import { type CaipChainId, type Hex } from '@metamask/utils';
 import { isValidHexAddress } from '../../../shared/lib/hexstring-utils';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { addHexPrefix } from '../../../app/scripts/lib/util';
+import { addHexPrefix } from '../../../shared/lib/add-hex-prefix';
 
 import { useI18nContext } from '../../hooks/useI18nContext';
 import { Header, Page } from '../../components/multichain/pages/page';

--- a/ui/selectors/custom-gas.js
+++ b/ui/selectors/custom-gas.js
@@ -1,6 +1,4 @@
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { addHexPrefix } from '../../app/scripts/lib/util';
+import { addHexPrefix } from '../../shared/lib/add-hex-prefix';
 import { decEthToConvertedCurrency } from '../../shared/lib/conversion.utils';
 import { formatCurrency } from '../helpers/utils/confirm-tx.util';
 import { formatETHFee } from '../helpers/utils/formatters';


### PR DESCRIPTION
## **Description**

`addHexPrefix` is a pure utility (with custom semantics — not the same as `ethereumjs-util`'s `addHexPrefix`) defined in `app/scripts/lib/util.ts` and used by UI, shared, and background. UI imports it with `// eslint-disable-next-line import-x/no-restricted-paths`, and even `shared/lib/swaps-utils.js` has to disable the rule.

This PR moves it to `shared/lib/add-hex-prefix.ts`. `app/scripts/lib/util.ts` re-exports it so background callers stay unaffected.

Two multi-symbol files (`ui/selectors/selectors.js` and `ui/store/actions.ts`) import `addHexPrefix` together with `getEnvironmentType` on the same line. The parallel #43024 PR already split those imports; this PR leaves them alone to avoid merge conflicts. A small follow-up will finish them once both PRs land.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

None — pure refactor. CI lint + type-check covers correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving move with re-export; no logic changes beyond import paths.
> 
> **Overview**
> **Moves `addHexPrefix` into `shared/lib/add-hex-prefix.ts`** so UI and shared code can use it without importing from `app/scripts/lib/util` or disabling `import-x/no-restricted-paths`. The implementation is unchanged (idempotent `0x` / `-0x` prefixing, including `0X` normalization).
> 
> **`app/scripts/lib/util.ts`** drops the local definition and **re-exports** from shared so existing background imports keep working. Call sites in **swaps**, **import token** flows, **send** helpers, **transaction** utils, and **custom gas** now import from `shared/lib/add-hex-prefix`.
> 
> **Out of scope for this PR:** `ui/store/actions.ts` (and similar multi-import files) still pull `addHexPrefix` from `util` with the eslint override, per the description, to avoid merge conflicts with a related PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2cba960dae197e8528195ea771b6d2fc86cef08e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->