### PR TITLE
chore: extract `formatValue` and `isValidAmount` to shared

### DIFF
--- a/app/scripts/lib/util.ts
+++ b/app/scripts/lib/util.ts
@@ -56,6 +56,7 @@ export {
   isValidEmail,
   isWebOrigin,
 } from '../../../shared/lib/url-utils';
+export { formatValue, isValidAmount } from '../../../shared/lib/format-value';
 
 /**
  * Minimal type for User-Agent Client Hints API (NavigatorUAData).
@@ -535,24 +536,6 @@ export function formatTxMetaForRpcResult(
   }
 
   return formattedTxMeta;
-}
-
-export const isValidAmount = (amount: number | null | undefined): boolean =>
-  amount !== null && amount !== undefined && !Number.isNaN(amount);
-
-export function formatValue(
-  value: number | null | undefined,
-  includeParentheses: boolean,
-): string {
-  if (!isValidAmount(value)) {
-    return '';
-  }
-
-  const numericValue = value as number;
-  const sign = numericValue >= 0 ? '+' : '';
-  const formattedNumber = `${sign}${numericValue.toFixed(2)}%`;
-
-  return includeParentheses ? `(${formattedNumber})` : formattedNumber;
 }
 
 type MethodData = {

--- a/shared/lib/format-value.ts
+++ b/shared/lib/format-value.ts
@@ -1,0 +1,17 @@
+export const isValidAmount = (amount: number | null | undefined): boolean =>
+  amount !== null && amount !== undefined && !Number.isNaN(amount);
+
+export function formatValue(
+  value: number | null | undefined,
+  includeParentheses: boolean,
+): string {
+  if (!isValidAmount(value)) {
+    return '';
+  }
+
+  const numericValue = value as number;
+  const sign = numericValue >= 0 ? '+' : '';
+  const formattedNumber = `${sign}${numericValue.toFixed(2)}%`;
+
+  return includeParentheses ? `(${formattedNumber})` : formattedNumber;
+}

--- a/ui/components/app/wallet-overview/aggregated-percentage-overview-cross-chains.tsx
+++ b/ui/components/app/wallet-overview/aggregated-percentage-overview-cross-chains.tsx
@@ -14,9 +14,7 @@ import {
 import { getPreferences } from '../../../../shared/lib/selectors/preferences';
 import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
 
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { formatValue, isValidAmount } from '../../../../app/scripts/lib/util';
+import { formatValue, isValidAmount } from '../../../../shared/lib/format-value';
 import { useFormatters } from '../../../hooks/useFormatters';
 import {
   Display,

--- a/ui/components/app/wallet-overview/aggregated-percentage-overview-cross-chains.tsx
+++ b/ui/components/app/wallet-overview/aggregated-percentage-overview-cross-chains.tsx
@@ -14,7 +14,10 @@ import {
 import { getPreferences } from '../../../../shared/lib/selectors/preferences';
 import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
 
-import { formatValue, isValidAmount } from '../../../../shared/lib/format-value';
+import {
+  formatValue,
+  isValidAmount,
+} from '../../../../shared/lib/format-value';
 import { useFormatters } from '../../../hooks/useFormatters';
 import {
   Display,

--- a/ui/components/app/wallet-overview/aggregated-percentage-overview.tsx
+++ b/ui/components/app/wallet-overview/aggregated-percentage-overview.tsx
@@ -13,7 +13,10 @@ import { getPreferences } from '../../../../shared/lib/selectors/preferences';
 import { getSelectedInternalAccount } from '../../../../shared/lib/selectors/accounts';
 import { getCurrentChainId } from '../../../../shared/lib/selectors/networks';
 import { useAccountTotalFiatBalance } from '../../../hooks/useAccountTotalFiatBalance';
-import { formatValue, isValidAmount } from '../../../../shared/lib/format-value';
+import {
+  formatValue,
+  isValidAmount,
+} from '../../../../shared/lib/format-value';
 import { getIntlLocale } from '../../../ducks/locale/locale';
 import {
   Display,

--- a/ui/components/app/wallet-overview/aggregated-percentage-overview.tsx
+++ b/ui/components/app/wallet-overview/aggregated-percentage-overview.tsx
@@ -13,9 +13,7 @@ import { getPreferences } from '../../../../shared/lib/selectors/preferences';
 import { getSelectedInternalAccount } from '../../../../shared/lib/selectors/accounts';
 import { getCurrentChainId } from '../../../../shared/lib/selectors/networks';
 import { useAccountTotalFiatBalance } from '../../../hooks/useAccountTotalFiatBalance';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
-import { formatValue, isValidAmount } from '../../../../app/scripts/lib/util';
+import { formatValue, isValidAmount } from '../../../../shared/lib/format-value';
 import { getIntlLocale } from '../../../ducks/locale/locale';
 import {
   Display,


### PR DESCRIPTION
## **Description**

`formatValue` and `isValidAmount` are pure number-formatting helpers defined in `app/scripts/lib/util.ts` and used by two UI percentage-overview components with `// eslint-disable-next-line import-x/no-restricted-paths`.

This PR moves them to `shared/lib/format-value.ts`. `app/scripts/lib/util.ts` re-exports them so any background callers stay unaffected.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

None — pure refactor. CI lint + type-check covers correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor with no logic changes; only import paths and module placement.
> 
> **Overview**
> **`formatValue`** and **`isValidAmount`** are moved out of **`app/scripts/lib/util.ts`** into **`shared/lib/format-value.ts`**, with the same implementations. **`util.ts`** re-exports them so background callers keep the same import path.
> 
> The wallet overview components **`aggregated-percentage-overview.tsx`** and **`aggregated-percentage-overview-cross-chains.tsx`** now import from **`shared/lib/format-value`** instead of **`app/scripts/lib/util`**, removing restricted-path **`eslint-disable`** comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fc03cc86813cbf2ee9bcd01525e54debe1246fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->