### PR TITLE
chore: extract `getConversionRatesForNativeAsset` to shared

### DIFF
--- a/app/scripts/lib/util.ts
+++ b/app/scripts/lib/util.ts
@@ -5,10 +5,13 @@ import {
   TransactionMeta,
 } from '@metamask/transaction-controller';
 import type { Provider } from '@metamask/network-controller';
+<<<<<<< HEAD
 import { CaipAssetType, parseCaipAssetType } from '@metamask/utils';
 import { MultichainAssetsRatesControllerState } from '@metamask/assets-controllers';
 import { AssetConversion, FungibleAssetMarketData } from '@metamask/snaps-sdk';
 import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
+=======
+>>>>>>> 205334ea18 (chore: extract getConversionRatesForNativeAsset to shared)
 import {
   DEVICE_TYPE,
   OS,
@@ -58,6 +61,7 @@ export {
 } from '../../../shared/lib/url-utils';
 export { formatValue, isValidAmount } from '../../../shared/lib/format-value';
 export { addHexPrefix } from '../../../shared/lib/add-hex-prefix';
+export { getConversionRatesForNativeAsset } from '../../../shared/lib/asset-conversion-rates';
 
 /**
  * Minimal type for User-Agent Client Hints API (NavigatorUAData).
@@ -564,38 +568,6 @@ export const getMethodDataName = async (
  */
 export function getBooleanFlag(value: string | boolean | undefined): boolean {
   return value === true || value === 'true';
-}
-
-type AssetsRatesState = {
-  metamask: MultichainAssetsRatesControllerState;
-};
-
-export function getConversionRatesForNativeAsset({
-  conversionRates,
-  chainId,
-}: {
-  conversionRates: AssetsRatesState['metamask']['conversionRates'];
-  chainId: string;
-}): (AssetConversion & { marketData?: FungibleAssetMarketData }) | null {
-  // Return early if conversionRates is falsy
-  if (!conversionRates) {
-    return null;
-  }
-
-  let conversionRateResult = null;
-
-  Object.entries(conversionRates).forEach(
-    ([caip19Identifier, conversionRate]) => {
-      const { assetNamespace, chainId: caipChainId } = parseCaipAssetType(
-        caip19Identifier as CaipAssetType,
-      );
-      if (assetNamespace === 'slip44' && caipChainId === chainId) {
-        conversionRateResult = conversionRate;
-      }
-    },
-  );
-
-  return conversionRateResult;
 }
 
 // Cache for known domains

--- a/app/scripts/lib/util.ts
+++ b/app/scripts/lib/util.ts
@@ -5,13 +5,7 @@ import {
   TransactionMeta,
 } from '@metamask/transaction-controller';
 import type { Provider } from '@metamask/network-controller';
-<<<<<<< HEAD
-import { CaipAssetType, parseCaipAssetType } from '@metamask/utils';
-import { MultichainAssetsRatesControllerState } from '@metamask/assets-controllers';
-import { AssetConversion, FungibleAssetMarketData } from '@metamask/snaps-sdk';
 import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
-=======
->>>>>>> 205334ea18 (chore: extract getConversionRatesForNativeAsset to shared)
 import {
   DEVICE_TYPE,
   OS,

--- a/shared/lib/asset-conversion-rates.ts
+++ b/shared/lib/asset-conversion-rates.ts
@@ -1,0 +1,35 @@
+import { CaipAssetType, parseCaipAssetType } from '@metamask/utils';
+import { MultichainAssetsRatesControllerState } from '@metamask/assets-controllers';
+import { AssetConversion, FungibleAssetMarketData } from '@metamask/snaps-sdk';
+
+type AssetsRatesState = {
+  metamask: MultichainAssetsRatesControllerState;
+};
+
+export function getConversionRatesForNativeAsset({
+  conversionRates,
+  chainId,
+}: {
+  conversionRates: AssetsRatesState['metamask']['conversionRates'];
+  chainId: string;
+}): (AssetConversion & { marketData?: FungibleAssetMarketData }) | null {
+  // Return early if conversionRates is falsy
+  if (!conversionRates) {
+    return null;
+  }
+
+  let conversionRateResult = null;
+
+  Object.entries(conversionRates).forEach(
+    ([caip19Identifier, conversionRate]) => {
+      const { assetNamespace, chainId: caipChainId } = parseCaipAssetType(
+        caip19Identifier as CaipAssetType,
+      );
+      if (assetNamespace === 'slip44' && caipChainId === chainId) {
+        conversionRateResult = conversionRate;
+      }
+    },
+  );
+
+  return conversionRateResult;
+}

--- a/ui/pages/asset/components/asset-market-details.test.tsx
+++ b/ui/pages/asset/components/asset-market-details.test.tsx
@@ -3,8 +3,7 @@ import { render } from '@testing-library/react';
 import { useSelector } from 'react-redux';
 import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
 import { isEvmChainId } from '../../../../shared/lib/asset-utils';
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getConversionRatesForNativeAsset } from '../../../../app/scripts/lib/util';
+import { getConversionRatesForNativeAsset } from '../../../../shared/lib/asset-conversion-rates';
 import { AssetType } from '../../../../shared/constants/transaction';
 import { Asset } from '../types/asset';
 import { I18nContext } from '../../../contexts/i18n';
@@ -40,7 +39,7 @@ jest.mock('../../../../shared/lib/asset-utils', () => ({
   isEvmChainId: jest.fn(),
 }));
 
-jest.mock('../../../../app/scripts/lib/util', () => ({
+jest.mock('../../../../shared/lib/asset-conversion-rates', () => ({
   getConversionRatesForNativeAsset: jest.fn(),
 }));
 

--- a/ui/pages/asset/components/asset-market-details.tsx
+++ b/ui/pages/asset/components/asset-market-details.tsx
@@ -28,8 +28,7 @@ import { getAssetsRates } from '../../../selectors/assets';
 import { getCurrencyRates, getMarketData } from '../../../selectors/selectors';
 import { AssetType } from '../../../../shared/constants/transaction';
 import { Asset } from '../types/asset';
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getConversionRatesForNativeAsset } from '../../../../app/scripts/lib/util';
+import { getConversionRatesForNativeAsset } from '../../../../shared/lib/asset-conversion-rates';
 import { isEvmChainId } from '../../../../shared/lib/asset-utils';
 import { useFormatters } from '../../../hooks/useFormatters';
 

--- a/ui/selectors/multichain.test.ts
+++ b/ui/selectors/multichain.test.ts
@@ -35,8 +35,7 @@ import {
   MAINNET_DISPLAY_NAME,
 } from '../../shared/constants/network';
 import { MultichainNativeAssets } from '../../shared/constants/multichain/assets';
-// eslint-disable-next-line import-x/no-restricted-paths -- align with multichain.ts spy target
-import * as utilModule from '../../app/scripts/lib/util';
+import * as utilModule from '../../shared/lib/asset-conversion-rates';
 import { mockNetworkState } from '../../test/stub/networks';
 import { getProviderConfig } from '../../shared/lib/selectors/networks';
 import type { MetaMaskReduxState } from '../store/store';

--- a/ui/selectors/multichain.ts
+++ b/ui/selectors/multichain.ts
@@ -50,8 +50,7 @@ import {
   getProviderConfig,
   NetworkState,
 } from '../../shared/lib/selectors/networks';
-// eslint-disable-next-line import-x/no-restricted-paths
-import { getConversionRatesForNativeAsset } from '../../app/scripts/lib/util';
+import { getConversionRatesForNativeAsset } from '../../shared/lib/asset-conversion-rates';
 import { createDeepEqualSelector } from '../../shared/lib/selectors/selector-creators';
 import {
   type AccountsState,


### PR DESCRIPTION
## **Description**

`getConversionRatesForNativeAsset` is a pure utility defined in `app/scripts/lib/util.ts` but consumed by UI selectors and an asset market details page. UI imports it with `// eslint-disable-next-line import-x/no-restricted-paths`.

This PR moves it to `shared/lib/asset-conversion-rates.ts`. `app/scripts/lib/util.ts` re-exports it so background callers stay unaffected.

The `jest.mock` / `jest.spyOn` targets in `ui/pages/asset/components/asset-market-details.test.tsx` and `ui/selectors/multichain.test.ts` were updated to follow the function to the new module path — otherwise the mocks would silently miss.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

None — pure refactor. CI lint + type-check covers correctness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure move with re-export; logic unchanged and only import paths and test mocks were updated.
> 
> **Overview**
> Moves **`getConversionRatesForNativeAsset`** out of `app/scripts/lib/util.ts` into **`shared/lib/asset-conversion-rates.ts`** so UI can import it without crossing restricted `app/scripts` paths.
> 
> **`util.ts`** now **re-exports** the helper from shared so existing background callers keep the same import surface. **`asset-market-details`** and **`multichain`** selectors (plus their tests) import from **`shared/lib/asset-conversion-rates`** directly; **`jest.mock`** / **`jest.spyOn`** targets were updated to match so mocks still apply.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e99f784c8fbf1f1fd852f9d0a70db9b51e6eed4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->