### PR TITLE
feat: always show musd with the native tokens

### DIFF
--- a/test/e2e/tests/multichain/asset-list.spec.ts
+++ b/test/e2e/tests/multichain/asset-list.spec.ts
@@ -111,7 +111,7 @@ describe('Multichain Asset List', function (this: Suite) {
           NETWORK_NAME_MAINNET,
         );
         // Only Ethereum network is selected so only 1 token visible
-        await assetListPage.checkTokenItemNumber(1);
+        await assetListPage.checkTokenItemNumber(2);
         await assetListPage.clickOnAsset('Ether');
         await assetListPage.checkBuySellButtonIsPresent();
         await assetListPage.checkMultichainTokenListButtonIsPresent();

--- a/test/e2e/tests/tokens/import-tokens.spec.ts
+++ b/test/e2e/tests/tokens/import-tokens.spec.ts
@@ -395,7 +395,7 @@ async function mockAssetsV3(mockServer: Mockttp) {
 }
 
 describe('Import flow', function () {
-  it('allows importing multiple tokens from search', async function () {
+  it.only('allows importing multiple tokens from search', async function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilderV2()
@@ -508,7 +508,7 @@ describe('Import flow', function () {
 
         const tokenList = new AssetListPage(driver);
 
-        // Native Tokens: Ethereum ETH, Linea ETH, Base ETH
+        // Native Tokens: Ethereum ETH, Linea ETH, Base ETH, mUSD
         // ERC20 Tokens: Chain Games, Chai, ChangeX
         await tokenList.checkTokenItemNumber(7);
         await tokenList.checkTokenExistsInList('Ethereum');
@@ -614,9 +614,9 @@ describe('Import flow', function () {
         );
         const tokenList = new AssetListPage(driver);
 
-        // Native Tokens: Ethereum ETH, Linea ETH, Base ETH, Polygon POL
+        // Native Tokens: Ethereum ETH, Linea ETH, Base ETH, Polygon POL, mUSD
         // ERC20 Tokens: Polygon USDT
-        await tokenList.checkTokenItemNumber(5);
+        await tokenList.checkTokenItemNumber(6);
 
         await tokenList.checkTokenExistsInList('Ether');
         await tokenList.checkTokenExistsInList('USDT');

--- a/test/e2e/tests/tokens/import-tokens.spec.ts
+++ b/test/e2e/tests/tokens/import-tokens.spec.ts
@@ -395,7 +395,7 @@ async function mockAssetsV3(mockServer: Mockttp) {
 }
 
 describe('Import flow', function () {
-  it.only('allows importing multiple tokens from search', async function () {
+  it('allows importing multiple tokens from search', async function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilderV2()

--- a/test/e2e/tests/tokens/import-tokens.spec.ts
+++ b/test/e2e/tests/tokens/import-tokens.spec.ts
@@ -510,7 +510,7 @@ describe('Import flow', function () {
 
         // Native Tokens: Ethereum ETH, Linea ETH, Base ETH
         // ERC20 Tokens: Chain Games, Chai, ChangeX
-        await tokenList.checkTokenItemNumber(6);
+        await tokenList.checkTokenItemNumber(7);
         await tokenList.checkTokenExistsInList('Ethereum');
         await tokenList.checkTokenExistsInList('Chain Games');
         await tokenList.checkTokenExistsInList('ChangeX');

--- a/ui/components/app/assets/token-list/token-list.test.tsx
+++ b/ui/components/app/assets/token-list/token-list.test.tsx
@@ -304,13 +304,15 @@ describe('TokenList', () => {
     expect(screen.queryByTestId('low-value-assets-toggle')).toBeNull();
   });
 
-  it('does not render zero-balance mUSD imported by token detection', () => {
+  it('renders zero-balance mUSD outside the low value bucket', () => {
+    jest.mocked(getShouldHideZeroBalanceTokens).mockReturnValue(true);
     jest.mocked(getAssetsBySelectedAccountGroup).mockReturnValue(
       createAccountGroupAssets([
         createAsset({
           symbol: 'MUSD',
           address: MUSD_TOKEN_ADDRESS,
           balance: '0',
+          fiatBalance: 0,
         }),
         createAsset({ symbol: 'USDC', fiatBalance: 25 }),
       ]),
@@ -319,7 +321,8 @@ describe('TokenList', () => {
     render();
 
     expect(screen.getByTestId('token-cell-USDC')).toBeInTheDocument();
-    expect(screen.queryByTestId('token-cell-MUSD')).not.toBeInTheDocument();
+    expect(screen.getByTestId('token-cell-MUSD')).toBeInTheDocument();
+    expect(screen.queryByTestId('low-value-assets-toggle')).toBeNull();
   });
 
   it('renders mUSD when it has a balance', () => {

--- a/ui/components/app/assets/token-list/token-list.tsx
+++ b/ui/components/app/assets/token-list/token-list.tsx
@@ -119,6 +119,7 @@ const isLowValueAsset = (
 
   return (
     !token.isNative &&
+    !isMusdToken(token.address) &&
     tokenFiatAmount !== null &&
     tokenFiatAmount !== undefined &&
     Number.isFinite(tokenFiatAmount) &&
@@ -228,13 +229,10 @@ function TokenList({ onTokenClick, safeChains }: TokenListProps) {
             return false;
           }
           if (
-            'address' in asset &&
-            isMusdToken(asset.address) &&
-            asset.balance === '0'
+            shouldHideZeroBalanceTokens &&
+            asset.balance === '0' &&
+            !('address' in asset && isMusdToken(asset.address))
           ) {
-            return false;
-          }
-          if (shouldHideZeroBalanceTokens && asset.balance === '0') {
             return false;
           }
           return true;


### PR DESCRIPTION
This PR is to always show musd when the token balance is zero

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

  1. Run extension
  2. Go to homepage, asset list
  3. Use Mainnet or Linea as the selected/enabled network.
  6. Verify mUSD is visible even with 0 balance.
  7. Enable “Hide zero-balance tokens”.
  8. Verify mUSD is still visible.
  9. Ensure token sort is declining balance and low-value assets are collapsed.
  10. Verify mUSD is not hidden inside the low-value collapsed section.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Home-screen token list filtering only; no auth, payments, or persistence changes.
> 
> **Overview**
> **mUSD** stays visible on the home asset list even at **zero balance**, including when **Hide zero-balance tokens** is on—it is no longer dropped by the zero-balance filter or treated as a low-value collapsed token.
> 
> `TokenList` exempts **mUSD** from the low-value bucket (same idea as native tokens for that UI) and folds zero-balance hiding into one rule: hide zero balances except **mUSD**. Unit and e2e expectations were bumped because **mUSD** now counts as an extra row in multichain/import flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f90268310a650f08ad489bbc5afd02b0ccd773f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->