### PR TITLE
fix: #42897: [Bug]: Onboarding biometrics: Clicking on Still having Trouble link leads to Page not found

### DIFF
--- a/ui/components/app/passkey-troubleshoot-modal/passkey-troubleshoot-modal.test.tsx
+++ b/ui/components/app/passkey-troubleshoot-modal/passkey-troubleshoot-modal.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { renderWithLocalization } from '../../../../test/lib/render-helpers-navigate';
+import { MetaMetricsContext } from '../../../contexts/metametrics';
+import type { MetaMetricsContextValue } from '../../../contexts/metametrics';
+import PasskeyTroubleshootModal from './passkey-troubleshoot-modal';
+
+// The passkeys support article href is asserted as a hardcoded literal so this
+// test fails if ZENDESK_URLS.PASSKEYS is reverted to the broken (404ing) value.
+const EXPECTED_PASSKEYS_SUPPORT_URL =
+  'https://support.metamask.io/configure/wallet/passkeys-and-metamask/?utm_source=extension';
+
+function renderModal() {
+  const trackEvent = jest.fn();
+  const metaMetricsContextValue = {
+    trackEvent,
+    bufferedTrace: jest.fn(),
+    bufferedEndTrace: jest.fn(),
+    onboardingParentContext: { current: null },
+  } as unknown as MetaMetricsContextValue;
+
+  return renderWithLocalization(
+    <MetaMetricsContext.Provider value={metaMetricsContextValue}>
+      <PasskeyTroubleshootModal
+        mode="unlock"
+        location="unlock"
+        onClose={jest.fn()}
+        onOpenFullScreen={jest.fn()}
+      />
+    </MetaMetricsContext.Provider>,
+  );
+}
+
+describe('PasskeyTroubleshootModal', () => {
+  it('points the "Still having trouble" link to the passkeys support article', () => {
+    const { getByTestId } = renderModal();
+
+    const link = getByTestId('passkey-troubleshoot-still-having-trouble-link');
+
+    expect(link).toHaveAttribute('href', EXPECTED_PASSKEYS_SUPPORT_URL);
+  });
+
+  it('opens the support link in a new tab safely', () => {
+    const { getByTestId } = renderModal();
+
+    const link = getByTestId('passkey-troubleshoot-still-having-trouble-link');
+
+    expect(link).toHaveAttribute('target', '_blank');
+    expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+  });
+});

--- a/ui/helpers/constants/zendesk-url.ts
+++ b/ui/helpers/constants/zendesk-url.ts
@@ -30,7 +30,7 @@ const ZENDESK_URLS = {
   LEGACY_WEB3:
     'https://support.metamask.io/third-party-platforms-and-dapps/metamask-legacy-web3/?utm_source=extension',
   PASSKEYS:
-    'https://support.metamask.io/configure/wallet/passkeys/?utm_source=extension',
+    'https://support.metamask.io/configure/wallet/passkeys-and-metamask/?utm_source=extension',
   PASSWORD_ARTICLE:
     'https://support.metamask.io/configure/wallet/passwords-and-metamask/?utm_source=extension',
   PASSWORD_AND_SRP_ARTICLE:


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

From the lock screen, choosing Unlock with Biometrics, cancelling, then opening the Trouble unlocking modal and clicking the 'Still having trouble' link sent users to a Page not found. The link's href comes from the shared ZENDESK_URLS.PASSKEYS constant, which pointed at a non-existent support path (support.metamask.io/configure/wallet/passkeys/), so the anchor rendered by PasskeyTroubleshootModal resolved to a 404.

This corrects the PASSKEYS value in ui/helpers/constants/zendesk-url.ts to the published passkeys support article, keeping the ?utm_source=extension parameter that every other entry uses. Because the URL is read from a single constant, this fixes every consumer of ZENDESK_URLS.PASSKEYS at once. A colocated test for PasskeyTroubleshootModal asserts the 'Still having trouble' link's href and that it opens safely in a new tab.

## **Changelog**

CHANGELOG entry: Fixed the "Still having trouble" link in the biometrics "Trouble unlocking" modal leading to a Page not found

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/42897

## **Manual testing steps**

1. Check out this branch locally and build/load the extension.
2. Lock MetaMask, then click Unlock with Biometrics and click Cancel.
3. Click 'Trouble unlocking', then click 'Still having trouble'.
4. Confirm the opened tab loads the passkeys support article (support.metamask.io/configure/wallet/passkeys-and-metamask/) instead of a Page not found.
5. Run the colocated test: yarn jest ui/components/app/passkey-troubleshoot-modal/passkey-troubleshoot-modal.test.tsx

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- AEP_VISUAL_VALIDATION_START -->
## AEP Visual Validation

- Status: Passed
- Run ID: `d9e88e18-25e1-4acb-943c-ad111834ae25`
- LangSmith: https://smith.langchain.com/o/09df0f02-e7c8-47f9-b00a-9e4757168f81/projects/p/metamask-aep

### What was tested
- Skipped visual validation: The diff changes only the external URL constant ZENDESK_URLS.PASSKEYS (ui/helpers/constants/zendesk-url.ts) plus a unit test. The only consumer that renders this, PasskeyTroubleshootModal (ui/components/app/passkey-troubleshoot-modal/passkey-troubleshoot-modal.tsx:171), uses it as the href of an external anchor (target=_blank to support.metamask.io). The fixed-vs-broken difference (article loads vs Page not found) happens on the external support site, not in the extension UI, and the href is not visible text in the modal, so a screenshot cannot distinguish the fix; we also must not navigate the browser to the real external support domain. Additionally the modal is unreachable in supported fixtures: per unlock-passkey-section.tsx, the troubleshoot entry requires getEnvironmentType()===ENVIRONMENT_TYPE_SIDEPANEL && isPasskeyActive && passkeyInProgress, i.e. a passkey-enrolled wallet in sidepanel with a live WebAuthn ceremony. The default pre-onboarded fixture is a password wallet with no passkey, and there is no passkey/biometrics preset (default, withMultipleAccounts, withERC20Tokens, withConnectedDapp, withMainnet, withNFTs, withFiatDisabled, withHSTToken). The href correctness is already objectively covered by the new colocated test.
- metamask-mm-visual-validation: passed. Visual validation did not run.
<!-- AEP_VISUAL_VALIDATION_END -->
