### PR TITLE
fix: #42683: [Bug]: When global balance is hidden, the Perps balance is still displayed

### DIFF
--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx
@@ -41,6 +41,16 @@ const mockStore = configureStore({
   },
 });
 
+const mockPrivacyModeStore = configureStore({
+  metamask: {
+    ...mockState.metamask,
+    preferences: {
+      ...mockState.metamask.preferences,
+      privacyMode: true,
+    },
+  },
+});
+
 describe('invokePerpsBalanceAction', () => {
   it('logs when callback returns a rejected promise', async () => {
     const consoleErrorSpy = jest
@@ -85,6 +95,24 @@ describe('PerpsBalanceDropdown', () => {
     renderWithProvider(<PerpsBalanceDropdown />, mockStore);
 
     expect(screen.getByText('$15,250')).toBeInTheDocument();
+  });
+
+  it('hides the total balance when privacy mode is enabled', () => {
+    renderWithProvider(<PerpsBalanceDropdown />, mockPrivacyModeStore);
+
+    expect(screen.queryByText('$15,250')).not.toBeInTheDocument();
+    expect(screen.getByText('••••••')).toBeInTheDocument();
+  });
+
+  it('hides the unrealized P&L when privacy mode is enabled', () => {
+    renderWithProvider(
+      <PerpsBalanceDropdown hasPositions />,
+      mockPrivacyModeStore,
+    );
+
+    expect(screen.queryByText(/\+\$375/u)).not.toBeInTheDocument();
+    expect(screen.queryByText(/7\.32%/u)).not.toBeInTheDocument();
+    expect(screen.getAllByText('••••••').length).toBeGreaterThan(0);
   });
 
   it('renders loading skeleton when account data is still loading', () => {

--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
 import {
   twMerge,
   TextVariant,
@@ -20,12 +21,16 @@ import {
   formatPerpsFiat,
   PRICE_RANGES_MINIMAL_VIEW,
 } from '../../../../../shared/lib/perps-formatters';
+import { getPrivacyMode } from '../../../../selectors';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { useFormatters } from '../../../../hooks/useFormatters';
 import { usePerpsEligibility } from '../../../../hooks/perps';
 import { usePerpsLiveAccount } from '../../../../hooks/perps/stream';
 import { PerpsGeoBlockModal } from '../perps-geo-block-modal';
 import { PerpsControlBarSkeleton } from '../perps-skeletons';
+
+/** Mask used to hide fiat amounts when global balance privacy is enabled. */
+const HIDDEN_BALANCE = '••••••';
 
 /** Handler from perps triggers (e.g. deposit / withdraw); may return a Promise. */
 export type PerpsBalanceActionHandler = () => void | Promise<unknown>;
@@ -76,6 +81,7 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
   const { account, isInitialLoading } = usePerpsLiveAccount();
   const { formatPercentWithMinThreshold } = useFormatters();
   const { isEligible } = usePerpsEligibility();
+  const privacyMode = useSelector(getPrivacyMode);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isGeoBlockModalOpen, setIsGeoBlockModalOpen] = useState(false);
 
@@ -180,9 +186,11 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
               gap={2}
             >
               <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
-                {formatPerpsFiat(accountValue, {
-                  ranges: PRICE_RANGES_MINIMAL_VIEW,
-                })}
+                {privacyMode
+                  ? HIDDEN_BALANCE
+                  : formatPerpsFiat(accountValue, {
+                      ranges: PRICE_RANGES_MINIMAL_VIEW,
+                    })}
               </Text>
               <Icon
                 name={isDropdownOpen ? IconName.ArrowUp : IconName.ArrowDown}
@@ -240,7 +248,9 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
             fontWeight={FontWeight.Medium}
             color={isProfit ? TextColor.SuccessDefault : TextColor.ErrorDefault}
           >
-            {formattedPnl} ({formattedRoe})
+            {privacyMode
+              ? HIDDEN_BALANCE
+              : `${formattedPnl} (${formattedRoe})`}
           </Text>
         </Box>
       )}

--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
@@ -248,9 +248,7 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
             fontWeight={FontWeight.Medium}
             color={isProfit ? TextColor.SuccessDefault : TextColor.ErrorDefault}
           >
-            {privacyMode
-              ? HIDDEN_BALANCE
-              : `${formattedPnl} (${formattedRoe})`}
+            {privacyMode ? HIDDEN_BALANCE : `${formattedPnl} (${formattedRoe})`}
           </Text>
         </Box>
       )}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When a user hides their global balance (by tapping the balance on the wallet overview), the Perps tab kept rendering the total balance and unrealized P&L in plain text, leaking the amounts the user asked to hide. The PerpsBalanceDropdown component formatted account.totalBalance and account.unrealizedPnl with formatPerpsFiat but never consulted the privacyMode preference. This change reads privacyMode via the getPrivacyMode selector in ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx and renders a dot mask in place of the formatted total balance and P&L values when privacy mode is enabled, matching how the rest of the wallet hides sensitive amounts (e.g. SensitiveText / AggregatedBalance).

## **Changelog**

CHANGELOG entry: Fixed the Perps balance and unrealized P&L remaining visible on the Perps tab when the global balance is hidden.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/42683

## **Manual testing steps**

1. Check out this branch locally and open the extension.
2. On the wallet overview, click the balance to hide it (enable privacy mode).
3. Navigate to the Perps tab.
4. Confirm the total balance shows a dot mask instead of the fiat amount.
5. With at least one open position, confirm the unrealized P&L row is also masked.
6. Click the balance again to reveal it and confirm the Perps balance and P&L display real values.
7. Run: yarn jest ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- AEP_VISUAL_VALIDATION_START -->
## AEP Visual Validation

- Status: Passed
- Run ID: `67f185f8-ec95-468e-a415-67dc46c629d3`
- LangSmith: https://smith.langchain.com/o/09df0f02-e7c8-47f9-b00a-9e4757168f81/projects/p/metamask-aep

### What was tested
- Skipped visual validation: The changed component PerpsBalanceDropdown renders only inside the Perps tab, which is unreachable in the supported visual harness. (1) Compile-time gate: getIsPerpsExperienceAvailable requires getIsPerpsIncludedInBuild() === PERPS_ENABLED==='true' (shared/lib/environment.ts:30-31), which the standard yarn build:test:webpack does not set, so account-overview__perps-tab is not rendered (account-overview-tabs.tsx:182-191). (2) Remote gate: also requires isPerpsRemoteConfigSatisfied(remoteFeatureFlags.perpsEnabledVersion) (ui/selectors/perps/feature-flags.ts:20-24). (3) Data gate: the masked total balance and P&L come from usePerpsLiveAccount via usePerpsChannel/PerpsStreamManager, a live Hyperliquid WebSocket stream (ui/hooks/perps/stream/usePerpsLiveAccount.ts); with no funded perps account PerpsView stays in PerpsControlBarSkeleton (perps-view.tsx:218-234), so there is no real fiat amount to verify masking against. (4) No supported seeding: none of the available presets (default, withMultipleAccounts, withERC20Tokens, withConnectedDapp, withMainnet, withNFTs, withFiatDisabled, withHSTToken) provide a perps account, custom fixture flags are disallowed, and the withPerpsController builder is not exposed as an mm preset nor would it supply live-stream balance data. The fix is fully covered by the added unit tests (perps-balance-dropdown.test.tsx asserts masked total balance and masked P&L), so visual validation cannot add deterministic evidence.
- metamask-mm-visual-validation: passed. Visual validation did not run.
<!-- AEP_VISUAL_VALIDATION_END -->
