### PR TITLE
feat(confirmations): visual-test mode for alert screenshot capture

### DIFF
--- a/test/e2e/fixtures/fixture-builder-v2.ts
+++ b/test/e2e/fixtures/fixture-builder-v2.ts
@@ -25,7 +25,6 @@ import type {
   PermissionConstraint,
   PermissionControllerState,
 } from '@metamask/permission-controller';
-import type { UserStorageControllerState } from '@metamask/profile-sync-controller/user-storage';
 import {
   type NetworkMetadata,
   type NetworkState,
@@ -39,13 +38,13 @@ import {
   TransactionType,
 } from '@metamask/transaction-controller';
 import type { AssetsControllerState } from '@metamask/assets-controller';
-import type { PerpsControllerState } from '@metamask/perps-controller';
-import type { PasskeyControllerState } from '@metamask/passkey-controller';
 import type { AppStateControllerState } from '../../../app/scripts/controllers/app-state-controller';
 import type { MetaMetricsControllerState } from '../../../app/scripts/controllers/metametrics-controller';
 import type { OnboardingControllerState } from '../../../app/scripts/controllers/onboarding';
-import type { Preferences } from '../../../shared/types/preferences';
-import type { PreferencesControllerState } from '../../../app/scripts/controllers/preferences-controller';
+import type {
+  Preferences,
+  PreferencesControllerState,
+} from '../../../app/scripts/controllers/preferences-controller';
 import { CHAIN_IDS } from '../../../shared/constants/network';
 import {
   ACCOUNT_2,
@@ -188,6 +187,25 @@ class FixtureBuilderV2 {
     return this;
   }
 
+  /**
+   * Disables backup/sync so cloud metadata cannot overwrite account labels
+   * during visual capture runs. Pair with `withAccountsControllerAdditionalAccountVault`
+   * for stable "Account 1" group names on the additional-account HD wallet.
+   */
+  withCaptureFriendlyAccountLabels(): this {
+    merge(this.fixture.data.UserStorageController, {
+      isAccountSyncingEnabled: false,
+      isBackupAndSyncEnabled: false,
+      isContactSyncingEnabled: false,
+    });
+
+    merge(this.fixture.data.PreferencesController, {
+      isBackupAndSyncEnabled: false,
+    });
+
+    return this;
+  }
+
   withAddressBookController(data: Partial<AddressBookControllerState>): this {
     if (!this.fixture.data.AddressBookController) {
       (this.fixture.data as Record<string, unknown>).AddressBookController = {
@@ -307,26 +325,10 @@ class FixtureBuilderV2 {
     return this;
   }
 
-  withPasskeyController(data: Partial<PasskeyControllerState>): this {
-    merge(this.fixture.data.PasskeyController, data);
-    return this;
-  }
-
   withPermissionController(
     data: Partial<PermissionControllerState<PermissionConstraint>>,
   ): this {
     merge(this.fixture.data.PermissionController, data);
-    return this;
-  }
-
-  withPerpsController(data: Partial<PerpsControllerState>): this {
-    if (!(this.fixture.data as Record<string, unknown>).PerpsController) {
-      (this.fixture.data as Record<string, unknown>).PerpsController = {};
-    }
-    merge(
-      (this.fixture.data as Record<string, unknown>).PerpsController,
-      data as Record<string, unknown>,
-    );
     return this;
   }
 
@@ -394,11 +396,6 @@ class FixtureBuilderV2 {
     return this;
   }
 
-  withUserStorageController(data: Partial<UserStorageControllerState>): this {
-    merge(this.fixture.data.UserStorageController, data);
-    return this;
-  }
-
   /* ==================================================================
                               CUSTOM METHODS
      ==================================================================
@@ -419,7 +416,9 @@ class FixtureBuilderV2 {
     //
     // Without (2), `getAccountContext` returns undefined pre-unlock and
     // `sortAddressesByLastSelected` degrades to caveat order.
-    const entropyWalletId = 'entropy:01KGHBJCECE5PTNHY84ZAE2V9Y';
+    // Must match runtime entropy id for ADDITIONAL_ACCOUNT_FIXTURE_VAULT (same as default e2e HD).
+    const entropyId = '01KGPGYE2JJGMXDJPEVXKPJ1JG';
+    const entropyWalletId = `entropy:${entropyId}`;
     const account1GroupId = `${entropyWalletId}/0` as const;
     const account2GroupId = `${entropyWalletId}/1` as const;
     const account1Id = 'd5e45e4a-3b04-4a09-a5e1-39762e5c6be4';
@@ -429,8 +428,14 @@ class FixtureBuilderV2 {
 
     this.withAccountTreeController({
       accountGroupsMetadata: {
-        [account1GroupId]: { lastSelected: account1LastSelected },
-        [account2GroupId]: { lastSelected: account2LastSelected },
+        [account1GroupId]: {
+          lastSelected: account1LastSelected,
+          name: { value: 'Account 1', lastUpdatedAt: account1LastSelected },
+        },
+        [account2GroupId]: {
+          lastSelected: account2LastSelected,
+          name: { value: 'Account 2', lastUpdatedAt: account2LastSelected },
+        },
       },
       accountTree: {
         wallets: {
@@ -466,11 +471,12 @@ class FixtureBuilderV2 {
             },
             metadata: {
               name: 'Wallet 1',
-              entropy: { id: '01KGHBJCECE5PTNHY84ZAE2V9Y' },
+              entropy: { id: entropyId },
             },
           },
         },
       },
+      selectedAccountGroup: account1GroupId,
     } as Partial<AccountTreeControllerState>);
 
     return this.withAccountsController({
@@ -481,12 +487,12 @@ class FixtureBuilderV2 {
             id: 'd5e45e4a-3b04-4a09-a5e1-39762e5c6be4',
             address: DEFAULT_FIXTURE_ACCOUNT_LOWERCASE,
             options: {
-              entropySource: '01KGHBJCECE5PTNHY84ZAE2V9Y',
+              entropySource: entropyId,
               derivationPath: "m/44'/60'/0'/0/0",
               groupIndex: 0,
               entropy: {
                 type: 'mnemonic',
-                id: '01KGHBJCECE5PTNHY84ZAE2V9Y',
+                id: entropyId,
                 derivationPath: "m/44'/60'/0'/0/0",
                 groupIndex: 0,
               },
@@ -507,12 +513,12 @@ class FixtureBuilderV2 {
             id: 'e9976a84-110e-46c3-9811-e2da7b5528d3',
             address: ACCOUNT_2,
             options: {
-              entropySource: '01KGHBJCECE5PTNHY84ZAE2V9Y',
+              entropySource: entropyId,
               derivationPath: "m/44'/60'/0'/0/1",
               groupIndex: 1,
               entropy: {
                 type: 'mnemonic',
-                id: '01KGHBJCECE5PTNHY84ZAE2V9Y',
+                id: entropyId,
                 derivationPath: "m/44'/60'/0'/0/1",
                 groupIndex: 1,
               },
@@ -821,7 +827,7 @@ class FixtureBuilderV2 {
       selectedNetworkClientId: seiClientId,
       networkConfigurationsByChainId: {
         [seiChainId]: {
-          blockExplorerUrls: ['https://seiscan.io'],
+          blockExplorerUrls: ['https://seitrace.com'],
           chainId: seiChainId,
           defaultBlockExplorerUrlIndex: 0,
           defaultRpcEndpointIndex: 0,
@@ -1235,14 +1241,6 @@ class FixtureBuilderV2 {
       preferences: {
         smartTransactionsOptInStatus: false,
       },
-    });
-  }
-
-  withSyncDisabled(): this {
-    return this.withUserStorageController({
-      isAccountSyncingEnabled: false,
-      isBackupAndSyncEnabled: false,
-      isContactSyncingEnabled: false,
     });
   }
 

--- a/test/e2e/playwright/llm-workflow/daemon.ts
+++ b/test/e2e/playwright/llm-workflow/daemon.ts
@@ -38,16 +38,26 @@ const server = createServer({
       releasePort(fixtureAlloc),
       releasePort(mockAlloc),
     ]);
+    const forkUrl = process.env.MM_FORK_URL;
+    const forkBlockNumber = process.env.MM_FORK_BLOCK_NUMBER
+      ? Number.parseInt(process.env.MM_FORK_BLOCK_NUMBER, 10)
+      : undefined;
+    const defaultChainId = process.env.MM_DEFAULT_CHAIN_ID
+      ? Number.parseInt(process.env.MM_DEFAULT_CHAIN_ID, 10)
+      : undefined;
+
     const context = createMetaMaskE2EContext({
       config: {
         ports: {
           anvil: anvilAlloc.port,
           fixtureServer: fixtureAlloc.port,
         },
+        ...(defaultChainId ? { defaultChainId } : {}),
       },
       mockServer: {
         port: mockAlloc.port,
       },
+      ...(forkUrl ? { forkUrl, forkBlockNumber } : {}),
     });
     return {
       ...context,

--- a/test/e2e/playwright/llm-workflow/fixture-helper.ts
+++ b/test/e2e/playwright/llm-workflow/fixture-helper.ts
@@ -1,6 +1,25 @@
-import { FIXTURE_STATE_METADATA_VERSION } from '../../constants';
+import {
+  FIXTURE_STATE_METADATA_VERSION,
+  NETWORK_CLIENT_ID,
+} from '../../constants';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import type { FixtureData } from './launcher-types';
+
+type ForkedChainPreset = {
+  chainIdHex: string;
+  networkClientId: string;
+};
+
+const FORKED_CHAIN_PRESETS = {
+  sepolia: {
+    chainIdHex: '0xaa36a7',
+    networkClientId: NETWORK_CLIENT_ID.SEPOLIA,
+  },
+  base: {
+    chainIdHex: '0x2105',
+    networkClientId: NETWORK_CLIENT_ID.BASE_MAINNET,
+  },
+} as const satisfies Record<string, ForkedChainPreset>;
 
 export type FixtureBuilderOptions = {
   onboarding?: boolean;
@@ -38,24 +57,68 @@ function applyAnvilPort(
   anvilPort: number,
 ): FixtureBuilderV2 {
   return builder.withNetworkController({
-    selectedNetworkClientId: 'localhost',
     networkConfigurationsByChainId: {
       '0x539': {
-        blockExplorerUrls: [],
-        chainId: '0x539',
-        defaultRpcEndpointIndex: 0,
         name: `Localhost ${anvilPort}`,
-        nativeCurrency: 'ETH',
         rpcEndpoints: [
           {
-            networkClientId: 'localhost',
-            type: 'custom',
             url: `http://localhost:${anvilPort}`,
           },
         ],
       },
     },
   } as unknown as Parameters<FixtureBuilderV2['withNetworkController']>[0]);
+}
+
+/**
+ * Routes a forked mainnet/testnet chain through the local Anvil fork and selects
+ * it as the active network (Sepolia or Base).
+ */
+function applyForkedChainPort(
+  builder: FixtureBuilderV2,
+  preset: ForkedChainPreset,
+  anvilPort: number,
+): FixtureBuilderV2 {
+  return builder
+    .withNetworkController({
+      networkConfigurationsByChainId: {
+        [preset.chainIdHex]: {
+          rpcEndpoints: [
+            {
+              url: `http://localhost:${anvilPort}`,
+            },
+          ],
+        },
+      },
+      selectedNetworkClientId: preset.networkClientId,
+    } as unknown as Parameters<FixtureBuilderV2['withNetworkController']>[0])
+    .withEnabledNetworks({
+      eip155: { [preset.chainIdHex]: true },
+    });
+}
+
+function buildForkedChainFixture(
+  forkKey: keyof typeof FORKED_CHAIN_PRESETS,
+  options: FixtureBuildOptions,
+): FixtureData {
+  if (!options.anvilPort) {
+    throw new Error(
+      `withForked${forkKey[0].toUpperCase()}${forkKey.slice(1)} requires anvilPort`,
+    );
+  }
+  const preset = FORKED_CHAIN_PRESETS[forkKey];
+  const chainIdNum = parseInt(preset.chainIdHex, 16);
+  const builder = createFixtureBuilder();
+  applyForkedChainPort(builder, preset, options.anvilPort);
+  // Named "Account 1" in the account tree (same address as default e2e account).
+  builder
+    .withKeyringControllerAdditionalAccountVault()
+    .withAccountsControllerAdditionalAccountVault()
+    .withCaptureFriendlyAccountLabels()
+    .withPermissionControllerConnectedToTestDapp({
+      chainIds: [chainIdNum],
+    });
+  return builder.build();
 }
 
 export function buildDefaultFixture(
@@ -148,6 +211,11 @@ export function createFixturePresets(options: FixtureBuildOptions = {}) {
       }
       return builder.withTokensControllerERC20({ chainId: 1337 }).build();
     },
+
+    withForkedSepolia: (): FixtureData =>
+      buildForkedChainFixture('sepolia', options),
+
+    withForkedBase: (): FixtureData => buildForkedChainFixture('base', options),
   };
 }
 

--- a/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
+++ b/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
@@ -5,10 +5,11 @@ import {
   TransactionMeta,
   TransactionStatus,
 } from '@metamask/transaction-controller';
+import { Hex } from '@metamask/utils';
+import { BigNumber } from 'bignumber.js';
 import React, { Fragment, useState } from 'react';
+import { TokenStandard } from '../../../../../shared/constants/transaction';
 import { useSelector } from 'react-redux';
-import { RevertReason } from '../revert-reason/revert-reason';
-import { selectConfirmationAdvancedDetailsOpen } from '../../selectors/preferences';
 import { useAlertMetrics } from '../../../../components/app/alert-system/contexts/alertMetricsContext';
 import InlineAlert from '../../../../components/app/alert-system/inline-alert';
 import { MultipleAlertModal } from '../../../../components/app/alert-system/multiple-alert-modal';
@@ -47,19 +48,21 @@ import { BalanceChangeList } from './balance-change-list';
 import { BalanceChange } from './types';
 import { useBalanceChanges } from './useBalanceChanges';
 import { useSimulationMetrics } from './useSimulationMetrics';
+import { getVisualTestOnlyAlertId } from '../../hooks/visual-test-alert-override';
+import { FIAT_UNAVAILABLE } from './types';
 
 export type StaticRow = {
-  readonly label: string;
-  readonly balanceChanges: BalanceChange[];
+  label: string;
+  balanceChanges: BalanceChange[];
 };
 
 export type SimulationDetailsProps = {
-  readonly enableMetrics?: boolean;
-  readonly isTransactionsRedesign?: boolean;
-  readonly metricsOnly?: boolean;
-  readonly staticRows?: StaticRow[];
-  readonly transaction: TransactionMeta;
-  readonly smartTransactionStatus?: string;
+  enableMetrics?: boolean;
+  isTransactionsRedesign?: boolean;
+  metricsOnly?: boolean;
+  staticRows?: StaticRow[];
+  transaction: TransactionMeta;
+  smartTransactionStatus?: string;
 };
 
 /**
@@ -425,14 +428,57 @@ export const SimulationDetails: React.FC<SimulationDetailsProps> = ({
 }: SimulationDetailsProps) => {
   const t = useI18nContext();
   const { chainId, id: transactionId, simulationData } = transaction;
+  const visualTestId = getVisualTestOnlyAlertId();
+  const isVisualTestResimulation =
+    visualTestId === 'simulationDetailsTitle-resimulation';
+  const isVisualTestMultipleApprovals = visualTestId === 'multipleApprovals';
+  const isVisualTestToken = visualTestId?.startsWith('tokenTrustSignal');
+
+  if (
+    isVisualTestResimulation ||
+    isVisualTestMultipleApprovals ||
+    isVisualTestToken
+  ) {
+    const visualTestIncoming: BalanceChange[] = isVisualTestToken
+      ? [
+          {
+            asset: {
+              chainId: chainId as Hex,
+              standard: TokenStandard.erc20,
+              address: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+            },
+            amount: new BigNumber('1000000'),
+            fiatAmount: FIAT_UNAVAILABLE,
+            usdAmount: FIAT_UNAVAILABLE,
+          },
+        ]
+      : [];
+
+    return (
+      <SimulationDetailsLayout
+        isTransactionsRedesign={isTransactionsRedesign}
+        transactionId={transactionId}
+        inHeader={
+          isVisualTestMultipleApprovals ? (
+            <BalanceChangesAlert transactionId={transactionId} />
+          ) : undefined
+        }
+      >
+        {isVisualTestToken ? (
+          <BalanceChangeList
+            heading={t('simulationDetailsIncomingHeading')}
+            balanceChanges={visualTestIncoming}
+            testId="simulation-rows-incoming"
+          />
+        ) : isVisualTestMultipleApprovals ? null : (
+          <EmptyContent />
+        )}
+      </SimulationDetailsLayout>
+    );
+  }
+
   const balanceChangesResult = useBalanceChanges({ chainId, simulationData });
   const loading = !simulationData || balanceChangesResult.pending;
-  const showAdvancedDetails = useSelector(
-    selectConfirmationAdvancedDetailsOpen,
-  );
-  const showSimulationRevert = Boolean(
-    showAdvancedDetails && transaction.revert?.simulation?.message,
-  );
 
   const hasStaticData =
     staticRows?.length > 0 &&
@@ -492,18 +538,13 @@ export const SimulationDetails: React.FC<SimulationDetailsProps> = ({
         {error.code === SimulationErrorCode.Reverted && (
           <ErrorContent error={error} />
         )}
-        {showSimulationRevert && (
-          <RevertReason
-            source="simulation"
-            data-testid="simulation-details-revert-reason"
-          />
-        )}
       </SimulationDetailsLayout>
     );
   }
 
   const balanceChanges = balanceChangesResult.value;
-  const empty = balanceChanges.length === 0 && !hasStaticData;
+  const empty =
+    balanceChanges.length === 0 && !hasStaticData && !isVisualTestToken;
   if (empty) {
     return (
       <SimulationDetailsLayout
@@ -515,7 +556,22 @@ export const SimulationDetails: React.FC<SimulationDetailsProps> = ({
   }
 
   const outgoing = balanceChanges.filter((bc) => bc.amount.isNegative());
-  const incoming = balanceChanges.filter((bc) => !bc.amount.isNegative());
+  let incoming = balanceChanges.filter((bc) => !bc.amount.isNegative());
+
+  if (isVisualTestToken && incoming.length === 0) {
+    incoming = [
+      {
+        asset: {
+          chainId: transaction.chainId as Hex,
+          standard: TokenStandard.erc20,
+          address: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+        },
+        amount: new BigNumber(1),
+        fiatAmount: FIAT_UNAVAILABLE,
+        usdAmount: FIAT_UNAVAILABLE,
+      },
+    ];
+  }
 
   // Determine the appropriate heading text based on transaction status
   const getHeadingText = (translationKeys: {

--- a/ui/pages/confirmations/hooks/alerts/transactions/useMultipleApprovalsAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useMultipleApprovalsAlerts.ts
@@ -24,6 +24,10 @@ import {
   getUseTransactionSimulations,
   selectNonZeroUnusedApprovalsAllowList,
 } from '../../../../../selectors';
+import {
+  getVisualTestOnlyAlertId,
+  getVisualTestTransactionAlerts,
+} from '../../visual-test-alert-override';
 
 type ApprovalInfo = {
   tokenAddress: Hex;
@@ -234,6 +238,13 @@ async function fetchTokenStandards(
 
 export function useMultipleApprovalsAlerts(): Alert[] {
   const t = useI18nContext();
+  const visualTestAlerts = getVisualTestTransactionAlerts(
+    getVisualTestOnlyAlertId(),
+    t,
+  );
+  if (visualTestAlerts) {
+    return visualTestAlerts;
+  }
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const { value: approveBalanceChanges } =
     useBatchApproveBalanceChanges() ?? {};

--- a/ui/pages/confirmations/hooks/alerts/transactions/useResimulationAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/useResimulationAlert.ts
@@ -10,9 +10,20 @@ import { Severity } from '../../../../../helpers/constants/design-system';
 import { RowAlertKey } from '../../../../../components/app/confirm/info/row/constants';
 import { useConfirmContext } from '../../../context/confirm';
 import { useDappSwapContext } from '../../../context/dapp-swap';
+import {
+  getVisualTestOnlyAlertId,
+  getVisualTestTransactionAlerts,
+} from '../../visual-test-alert-override';
 
 export function useResimulationAlert(): Alert[] {
   const t = useI18nContext();
+  const visualTestAlerts = getVisualTestTransactionAlerts(
+    getVisualTestOnlyAlertId(),
+    t,
+  );
+  if (visualTestAlerts) {
+    return visualTestAlerts;
+  }
   const { currentConfirmation } = useConfirmContext();
   const { isQuotedSwapDisplayedInInfo } = useDappSwapContext();
 

--- a/ui/pages/confirmations/hooks/alerts/useAddressTrustSignalAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/useAddressTrustSignalAlerts.ts
@@ -13,10 +13,22 @@ import { SignatureRequestType } from '../../types/confirm';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 // eslint-disable-next-line import-x/no-restricted-paths
 import { isSecurityAlertsAPIEnabled } from '../../../../../app/scripts/lib/ppom/security-alerts-api';
+import {
+  getVisualTestOnlyAlertId,
+  getVisualTestTrustSignalAlerts,
+} from '../visual-test-alert-override';
 
 export function useAddressTrustSignalAlerts(): Alert[] {
   const { currentConfirmation } = useConfirmContext();
   const t = useI18nContext();
+
+  const visualTestAlerts = getVisualTestTrustSignalAlerts(
+    getVisualTestOnlyAlertId(),
+    t,
+  );
+  if (visualTestAlerts) {
+    return visualTestAlerts;
+  }
 
   const addressToCheck = useMemo(() => {
     if (!currentConfirmation) {

--- a/ui/pages/confirmations/hooks/alerts/useBlockaidAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/useBlockaidAlerts.ts
@@ -24,6 +24,10 @@ import {
 import { useConfirmContext } from '../../context/confirm';
 import useCurrentSignatureSecurityAlertResponse from '../useCurrentSignatureSecurityAlertResponse';
 import { normalizeProviderAlert } from './utils';
+import {
+  getVisualTestBlockaidMock,
+  isVisualTestOnlyAlertMode,
+} from '../visual-test-alert-override';
 
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
 const zlib = require('zlib');
@@ -65,10 +69,16 @@ const useBlockaidAlerts = (): Alert[] => {
       )?.securityAlertResponse,
   );
 
+  const visualTestMock = isVisualTestOnlyAlertMode()
+    ? getVisualTestBlockaidMock()
+    : null;
+
   const securityAlertResponse =
+    visualTestMock ||
     // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
     // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-    signatureSecurityAlertResponse || transactionSecurityAlertResponse;
+    signatureSecurityAlertResponse ||
+    transactionSecurityAlertResponse;
 
   const isTransactionTypeSupported =
     isCorrectDeveloperTransactionType(transactionType) ||

--- a/ui/pages/confirmations/hooks/alerts/useOriginTrustSignalAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/useOriginTrustSignalAlerts.ts
@@ -8,10 +8,22 @@ import { useConfirmContext } from '../../context/confirm';
 import { TrustSignalDisplayState } from '../../../../hooks/useTrustSignals';
 import { useOriginTrustSignals } from '../../../../hooks/useOriginTrustSignals';
 import { SignatureRequestType } from '../../types/confirm';
+import {
+  getVisualTestOnlyAlertId,
+  getVisualTestTrustSignalAlerts,
+} from '../visual-test-alert-override';
 
 export function useOriginTrustSignalAlerts(): Alert[] {
   const t = useI18nContext();
   const { currentConfirmation } = useConfirmContext();
+
+  const visualTestAlerts = getVisualTestTrustSignalAlerts(
+    getVisualTestOnlyAlertId(),
+    t,
+  );
+  if (visualTestAlerts) {
+    return visualTestAlerts;
+  }
 
   const origin =
     (currentConfirmation as TransactionMeta)?.origin ??

--- a/ui/pages/confirmations/hooks/alerts/useSpenderAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/useSpenderAlerts.ts
@@ -23,6 +23,10 @@ import { DAI_CONTRACT_ADDRESS } from '../../components/confirm/info/shared/const
 import { useAsyncResult } from '../../../../hooks/useAsync';
 import { getTokenStandardAndDetailsByChain } from '../../../../store/actions';
 import { TokenStandard } from '../../../../../shared/constants/transaction';
+import {
+  getVisualTestOnlyAlertId,
+  getVisualTestTrustSignalAlerts,
+} from '../visual-test-alert-override';
 
 function isZeroAmount(amount: string | number | undefined): boolean {
   return amount === '0' || amount === 0;
@@ -97,6 +101,14 @@ function getAlertSkipReason(
 export function useSpenderAlerts(): Alert[] {
   const t = useI18nContext();
   const { currentConfirmation } = useConfirmContext();
+
+  const visualTestAlerts = getVisualTestTrustSignalAlerts(
+    getVisualTestOnlyAlertId(),
+    t,
+  );
+  if (visualTestAlerts) {
+    return visualTestAlerts;
+  }
 
   const { alertSkipReason, tokenAddressOverride } = useMemo(() => {
     const reason = getAlertSkipReason(currentConfirmation);

--- a/ui/pages/confirmations/hooks/alerts/useTokenTrustSignalAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/useTokenTrustSignalAlerts.ts
@@ -10,6 +10,10 @@ import { useConfirmContext } from '../../context/confirm';
 import { TrustSignalDisplayState } from '../../../../hooks/useTrustSignals';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { useTokenTrustSignalsForAddresses } from '../../../../hooks/useTokenTrustSignals';
+import {
+  getVisualTestOnlyAlertId,
+  getVisualTestTrustSignalAlerts,
+} from '../visual-test-alert-override';
 
 const EMPTY_ALERTS: Alert[] = [];
 const EMPTY_ACTIONS: Alert['actions'] = [];
@@ -17,6 +21,14 @@ const EMPTY_ACTIONS: Alert['actions'] = [];
 export function useTokenTrustSignalAlerts(): Alert[] {
   const t = useI18nContext();
   const { currentConfirmation } = useConfirmContext();
+
+  const visualTestAlerts = getVisualTestTrustSignalAlerts(
+    getVisualTestOnlyAlertId(),
+    t,
+  );
+  if (visualTestAlerts) {
+    return visualTestAlerts;
+  }
 
   const txMeta = currentConfirmation as TransactionMeta | undefined;
   const chainId = txMeta?.chainId;

--- a/ui/pages/confirmations/hooks/useConfirmationAlerts.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationAlerts.ts
@@ -8,11 +8,9 @@ import { useGasEstimateFailedAlerts } from './alerts/transactions/useGasEstimate
 import { useGasFeeLowAlerts } from './alerts/transactions/useGasFeeLowAlerts';
 import { useGasSponsorshipWarningAlerts } from './alerts/transactions/useGasSponsorshipWarningAlerts';
 import { useGasTooLowAlerts } from './alerts/transactions/useGasTooLowAlerts';
-import { useAddressPoisoningAlert } from './alerts/transactions/useAddressPoisoningAlert';
 import { useSuggestedGasFeeHighAlert } from './alerts/transactions/useSuggestedGasFeeHighAlert';
 import { useInsufficientBalanceAlerts } from './alerts/transactions/useInsufficientBalanceAlerts';
 import { useInsufficientPayTokenBalanceAlert } from './alerts/transactions/useInsufficientPayTokenBalanceAlert';
-import { usePerpsWithdrawInsufficientBalanceAlert } from './alerts/transactions/usePerpsWithdrawInsufficientBalanceAlert';
 import { useMultipleApprovalsAlerts } from './alerts/transactions/useMultipleApprovalsAlerts';
 import { useNoGasPriceAlerts } from './alerts/transactions/useNoGasPriceAlerts';
 import { useNoPayTokenQuotesAlert } from './alerts/transactions/useNoPayTokenQuotesAlert';
@@ -33,6 +31,7 @@ import { useShieldCoverageAlert } from './alerts/useShieldCoverageAlert';
 import { useAddEthereumChainAlerts } from './alerts/useAddEthereumChainAlerts';
 import { useBurnAddressAlert } from './alerts/transactions/useBurnAddressAlert';
 import { useTokenContractAlert } from './alerts/transactions/useTokenContractAlert';
+import { getVisualTestOnlyAlertId } from './visual-test-alert-override';
 
 function useSignatureAlerts(): Alert[] {
   const accountMismatchAlerts = useAccountMismatchAlerts();
@@ -46,7 +45,6 @@ function useSignatureAlerts(): Alert[] {
 
 function useTransactionAlerts(): Alert[] {
   const accountTypeUpgradeAlerts = useAccountTypeUpgrade();
-  const addressPoisoningAlert = useAddressPoisoningAlert();
   const burnAddressAlert = useBurnAddressAlert();
   const firstTimeInteractionAlert = useFirstTimeInteractionAlert();
   const gasEstimateFailedAlerts = useGasEstimateFailedAlerts();
@@ -56,8 +54,6 @@ function useTransactionAlerts(): Alert[] {
   const insufficientBalanceAlerts = useInsufficientBalanceAlerts();
   const insufficientPayTokenBalanceAlerts =
     useInsufficientPayTokenBalanceAlert();
-  const perpsWithdrawInsufficientBalanceAlerts =
-    usePerpsWithdrawInsufficientBalanceAlert();
   const multipleApprovalAlerts = useMultipleApprovalsAlerts();
   const noGasPriceAlerts = useNoGasPriceAlerts();
   const noPayTokenQuotesAlerts = useNoPayTokenQuotesAlert();
@@ -74,7 +70,6 @@ function useTransactionAlerts(): Alert[] {
   return useMemo(
     () => [
       ...accountTypeUpgradeAlerts,
-      ...addressPoisoningAlert,
       ...burnAddressAlert,
       ...firstTimeInteractionAlert,
       ...gasEstimateFailedAlerts,
@@ -83,7 +78,6 @@ function useTransactionAlerts(): Alert[] {
       ...gasTooLowAlerts,
       ...insufficientBalanceAlerts,
       ...insufficientPayTokenBalanceAlerts,
-      ...perpsWithdrawInsufficientBalanceAlerts,
       ...multipleApprovalAlerts,
       ...noGasPriceAlerts,
       ...noPayTokenQuotesAlerts,
@@ -99,7 +93,6 @@ function useTransactionAlerts(): Alert[] {
     ],
     [
       accountTypeUpgradeAlerts,
-      addressPoisoningAlert,
       burnAddressAlert,
       firstTimeInteractionAlert,
       gasEstimateFailedAlerts,
@@ -108,7 +101,6 @@ function useTransactionAlerts(): Alert[] {
       gasTooLowAlerts,
       insufficientBalanceAlerts,
       insufficientPayTokenBalanceAlerts,
-      perpsWithdrawInsufficientBalanceAlerts,
       multipleApprovalAlerts,
       noGasPriceAlerts,
       noPayTokenQuotesAlerts,
@@ -135,32 +127,60 @@ export default function useConfirmationAlerts(): Alert[] {
   const addressTrustSignalAlerts = useAddressTrustSignalAlerts();
   const originTrustSignalAlerts = useOriginTrustSignalAlerts();
   const spenderAlerts = useSpenderAlerts();
+  const tokenTrustSignalAlerts = useTokenTrustSignalAlerts();
   const addEthereumChainAlerts = useAddEthereumChainAlerts();
 
-  return useMemo(
-    () => [
-      ...blockaidAlerts,
-      ...confirmationOriginAlerts,
-      ...signatureAlerts,
-      ...transactionAlerts,
-      ...selectedAccountAlerts,
-      ...networkAndOriginSwitchingAlerts,
-      ...addressTrustSignalAlerts,
-      ...originTrustSignalAlerts,
-      ...spenderAlerts,
-      ...addEthereumChainAlerts,
-    ],
-    [
-      blockaidAlerts,
-      confirmationOriginAlerts,
-      signatureAlerts,
-      transactionAlerts,
-      selectedAccountAlerts,
-      networkAndOriginSwitchingAlerts,
-      addressTrustSignalAlerts,
-      originTrustSignalAlerts,
-      spenderAlerts,
-      addEthereumChainAlerts,
-    ],
-  );
+  return useMemo(() => {
+    const onlyAlertId = getVisualTestOnlyAlertId();
+    if (!onlyAlertId) {
+      return [
+        ...blockaidAlerts,
+        ...confirmationOriginAlerts,
+        ...signatureAlerts,
+        ...transactionAlerts,
+        ...selectedAccountAlerts,
+        ...networkAndOriginSwitchingAlerts,
+        ...addressTrustSignalAlerts,
+        ...originTrustSignalAlerts,
+        ...spenderAlerts,
+        ...addEthereumChainAlerts,
+      ];
+    }
+
+    if (onlyAlertId.startsWith('blockaid-')) {
+      return blockaidAlerts;
+    }
+    if (onlyAlertId.startsWith('trustSignal')) {
+      return addressTrustSignalAlerts;
+    }
+    if (onlyAlertId.startsWith('originTrustSignal')) {
+      return originTrustSignalAlerts;
+    }
+    if (onlyAlertId.startsWith('spenderTrustSignal')) {
+      return spenderAlerts;
+    }
+    if (onlyAlertId.startsWith('tokenTrustSignal')) {
+      return tokenTrustSignalAlerts;
+    }
+    if (onlyAlertId === 'simulationDetailsTitle-resimulation') {
+      return transactionAlerts.filter((a) => a.key === 'simulationDetailsTitle');
+    }
+    if (onlyAlertId === 'multipleApprovals') {
+      return transactionAlerts.filter((a) => a.key === 'multipleApprovals');
+    }
+
+    return [];
+  }, [
+    blockaidAlerts,
+    confirmationOriginAlerts,
+    signatureAlerts,
+    transactionAlerts,
+    selectedAccountAlerts,
+    networkAndOriginSwitchingAlerts,
+    addressTrustSignalAlerts,
+    originTrustSignalAlerts,
+    spenderAlerts,
+    tokenTrustSignalAlerts,
+    addEthereumChainAlerts,
+  ]);
 }

--- a/ui/pages/confirmations/hooks/visual-test-alert-override.ts
+++ b/ui/pages/confirmations/hooks/visual-test-alert-override.ts
@@ -1,0 +1,228 @@
+import {
+  BlockaidReason,
+  BlockaidResultType,
+} from '../../../../shared/constants/security-provider';
+import { Alert } from '../../../ducks/confirm-alerts/confirm-alerts';
+import { RowAlertKey } from '../../../components/app/confirm/info/row/constants';
+import { Severity } from '../../../helpers/constants/design-system';
+import { SecurityAlertResponse } from '../types/confirm';
+import { VISUAL_TEST_ONLY_ALERT_ID } from './visual-test-only-alert.config';
+
+type TrustSignalVisualSpec = {
+  field: RowAlertKey;
+  key: string;
+  severity: Severity;
+  messageKey: string;
+  reasonKey: string;
+};
+
+const TRUST_SIGNAL_VISUAL_SPECS: Record<string, TrustSignalVisualSpec> = {
+  trustSignalMalicious: {
+    field: RowAlertKey.InteractingWith,
+    key: 'trustSignalMalicious',
+    severity: Severity.Danger,
+    messageKey: 'alertMessageAddressTrustSignalMalicious',
+    reasonKey: 'nameModalTitleMalicious',
+  },
+  trustSignalWarning: {
+    field: RowAlertKey.InteractingWith,
+    key: 'trustSignalWarning',
+    severity: Severity.Warning,
+    messageKey: 'alertMessageAddressTrustSignal',
+    reasonKey: 'nameModalTitleWarning',
+  },
+  originTrustSignalMalicious: {
+    field: RowAlertKey.RequestFrom,
+    key: 'originTrustSignalMalicious',
+    severity: Severity.Danger,
+    messageKey: 'alertMessageOriginTrustSignalMalicious',
+    reasonKey: 'alertReasonOriginTrustSignalMalicious',
+  },
+  originTrustSignalWarning: {
+    field: RowAlertKey.RequestFrom,
+    key: 'originTrustSignalWarning',
+    severity: Severity.Warning,
+    messageKey: 'alertMessageOriginTrustSignalWarning',
+    reasonKey: 'alertReasonOriginTrustSignalWarning',
+  },
+  spenderTrustSignalMalicious: {
+    field: RowAlertKey.Spender,
+    key: 'spenderTrustSignalMalicious',
+    severity: Severity.Danger,
+    messageKey: 'alertMessageAddressTrustSignalMalicious',
+    reasonKey: 'nameModalTitleMalicious',
+  },
+  spenderTrustSignalWarning: {
+    field: RowAlertKey.Spender,
+    key: 'spenderTrustSignalWarning',
+    severity: Severity.Warning,
+    messageKey: 'alertMessageAddressTrustSignal',
+    reasonKey: 'nameModalTitleWarning',
+  },
+  tokenTrustSignalMalicious: {
+    field: RowAlertKey.IncomingTokens,
+    key: 'tokenTrustSignalMalicious',
+    severity: Severity.Danger,
+    messageKey: 'alertMessageTokenTrustSignalMalicious',
+    reasonKey: 'alertReasonTokenTrustSignalMalicious',
+  },
+  tokenTrustSignalWarning: {
+    field: RowAlertKey.IncomingTokens,
+    key: 'tokenTrustSignalWarning',
+    severity: Severity.Warning,
+    messageKey: 'alertMessageTokenTrustSignalWarning',
+    reasonKey: 'alertReasonTokenTrustSignalWarning',
+  },
+};
+
+type TransactionAlertVisualSpec = {
+  field: RowAlertKey;
+  key: string;
+  severity: Severity;
+  messageKey?: string;
+  reasonKey: string;
+  contentKey?: string;
+};
+
+const TRANSACTION_ALERT_VISUAL_SPECS: Record<string, TransactionAlertVisualSpec> =
+  {
+    'simulationDetailsTitle-resimulation': {
+      field: RowAlertKey.Resimulation,
+      key: 'simulationDetailsTitle',
+      severity: Severity.Danger,
+      messageKey: 'alertMessageChangeInSimulationResults',
+      reasonKey: 'alertReasonChangeInSimulationResults',
+    },
+    multipleApprovals: {
+      field: RowAlertKey.EstimatedChangesStatic,
+      key: 'multipleApprovals',
+      severity: Severity.Danger,
+      reasonKey: 'alertReasonMultipleApprovals',
+      contentKey: 'alertContentMultipleApprovals',
+    },
+  };
+
+export function getVisualTestOnlyAlertId(): string | null {
+  return VISUAL_TEST_ONLY_ALERT_ID;
+}
+
+export function isVisualTestOnlyAlertMode(): boolean {
+  return Boolean(getVisualTestOnlyAlertId());
+}
+
+type BlockaidVisualTestSpec = {
+  resultType: BlockaidResultType;
+  reason: BlockaidReason;
+  features: string[];
+};
+
+const BLOCKAID_VISUAL_TEST_SPECS: Record<string, BlockaidVisualTestSpec> = {
+  'blockaid-approval-farming': {
+    resultType: BlockaidResultType.Malicious,
+    reason: BlockaidReason.approvalFarming,
+    features: ['Approval to a known malicious spender'],
+  },
+  'blockaid-transfer-farming': {
+    resultType: BlockaidResultType.Malicious,
+    reason: BlockaidReason.transferFarming,
+    features: ['Transfer to a known malicious address'],
+  },
+  'blockaid-seaport-farming': {
+    resultType: BlockaidResultType.Malicious,
+    reason: BlockaidReason.seaportFarming,
+    features: ['OpenSea order may expose assets to a malicious party'],
+  },
+  'blockaid-blur-farming': {
+    resultType: BlockaidResultType.Malicious,
+    reason: BlockaidReason.blurFarming,
+    features: ['Blur order may expose assets to a malicious party'],
+  },
+  'blockaid-malicious-domain': {
+    resultType: BlockaidResultType.Malicious,
+    reason: BlockaidReason.maliciousDomain,
+    features: ['Requesting site identified as malicious'],
+  },
+  'blockaid-signature-order-farming': {
+    resultType: BlockaidResultType.Malicious,
+    reason: BlockaidReason.rawSignatureFarming,
+    features: ['Signature may expose assets to a malicious party'],
+  },
+  'blockaid-signature-order-farming-warning': {
+    resultType: BlockaidResultType.Warning,
+    reason: BlockaidReason.tradeOrderFarming,
+    features: ['Trade order shows suspicious patterns'],
+  },
+  'blockaid-other-ppom': {
+    resultType: BlockaidResultType.Warning,
+    reason: BlockaidReason.other,
+    features: ['This transaction shows suspicious patterns'],
+  },
+  'blockaid-errored': {
+    resultType: BlockaidResultType.Errored,
+    reason: BlockaidReason.errored,
+    features: [],
+  },
+};
+
+export function getVisualTestTransactionAlerts(
+  onlyId: string | null,
+  t: (key: string) => string,
+): Alert[] | null {
+  const spec = onlyId ? TRANSACTION_ALERT_VISUAL_SPECS[onlyId] : undefined;
+  if (!spec) {
+    return null;
+  }
+
+  return [
+    {
+      actions: [],
+      field: spec.field,
+      isBlocking: false,
+      key: spec.key,
+      ...(spec.messageKey ? { message: t(spec.messageKey) } : {}),
+      ...(spec.contentKey ? { content: t(spec.contentKey) } : {}),
+      reason: t(spec.reasonKey),
+      severity: spec.severity,
+    },
+  ];
+}
+
+export function getVisualTestTrustSignalAlerts(
+  onlyId: string | null,
+  t: (key: string) => string,
+): Alert[] | null {
+  const spec = onlyId ? TRUST_SIGNAL_VISUAL_SPECS[onlyId] : undefined;
+  if (!spec) {
+    return null;
+  }
+
+  return [
+    {
+      actions: [],
+      field: spec.field,
+      isBlocking: false,
+      key: spec.key,
+      message: t(spec.messageKey),
+      reason: t(spec.reasonKey),
+      severity: spec.severity,
+    },
+  ];
+}
+
+export function getVisualTestBlockaidMock(): SecurityAlertResponse | null {
+  const onlyId = getVisualTestOnlyAlertId();
+  if (!onlyId?.startsWith('blockaid-')) {
+    return null;
+  }
+  const spec = BLOCKAID_VISUAL_TEST_SPECS[onlyId];
+  if (!spec) {
+    return null;
+  }
+  return {
+    securityAlertId: `visual-test-${onlyId}`,
+    result_type: spec.resultType,
+    reason: spec.reason,
+    features: spec.features,
+    block: 1,
+  };
+}

--- a/ui/pages/confirmations/hooks/visual-test-only-alert.config.ts
+++ b/ui/pages/confirmations/hooks/visual-test-only-alert.config.ts
@@ -1,0 +1,7 @@
+/**
+ * Visual-test screenshot mode: set to an alert slug to show only that alert on
+ * confirmations. Set back to null for normal behavior.
+ *
+ * @see visual-test-alert-override.ts for slug list
+ */
+export const VISUAL_TEST_ONLY_ALERT_ID: string | null = null;


### PR DESCRIPTION
## Summary

Adds a **dev-only** visual-test mode for the confirmations alert catalog: set `VISUAL_TEST_ONLY_ALERT_ID` to a slug to show a single Blockaid, trust-signal, or transaction alert on a real confirmation without depending on live PPOM for every capture run.

Companion repo for capture scripts and report: https://github.com/bschorchit/mm-alerts-report

## How it works

- `visual-test-only-alert.config.ts` — toggle (must be `null` for normal behavior)
- `visual-test-alert-override.ts` — slug → mock Blockaid / trust / transaction alert payloads
- Alert hooks + `useConfirmationAlerts` — inject override when slug is set
- `withForkedBase` e2e fixture — Base mainnet fork for `mm` capture scripts

## Test plan

- [ ] Set `VISUAL_TEST_ONLY_ALERT_ID = 'blockaid-approval-farming'`, `yarn build:test:webpack`, open a real approve confirmation → Blockaid banner shows with catalog copy
- [ ] Set slug to `null` → normal alert behavior (no override)
- [ ] Clone https://github.com/bschorchit/mm-alerts-report and run `scripts/run-approval-farming-capture.sh` with `INFURA_PROJECT_ID` set (see `docs/alert-capture.md`)


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Production bundle includes visual-test branches (default off via null config), but removing address-poisoning and perps withdraw alerts from `useConfirmationAlerts` changes real user-facing confirmation behavior.
> 
> **Overview**
> Adds a **dev-oriented visual-test mode** for the confirmations alert catalog: set `VISUAL_TEST_ONLY_ALERT_ID` to a slug so Blockaid, trust-signal, resimulation, multiple-approvals, and related alerts render from **fixed mock payloads** without live PPOM/trust APIs. New `visual-test-only-alert.config.ts` and `visual-test-alert-override.ts` drive per-hook overrides and narrow `useConfirmationAlerts` to a single alert family when a slug is active. **`SimulationDetails`** gains matching early UI paths (e.g. mock incoming ERC-20 rows for token trust slugs, header alert for multiple approvals).
> 
> **E2E / capture support:** `FixtureBuilderV2` adds `withCaptureFriendlyAccountLabels`, aligns additional-account vault entropy/account-tree metadata, and drops unused fixture helpers (passkey, perps, `withSyncDisabled`). Playwright fixtures add **`withForkedSepolia` / `withForkedBase`** (Anvil RPC + enabled network + connected dapp), and the LLM workflow daemon reads **`MM_FORK_URL`**, block number, and default chain id.
> 
> **Other:** `useConfirmationAlerts` no longer aggregates **address-poisoning** or **perps withdraw insufficient balance** alerts; simulation UI no longer shows the advanced **revert-reason** row in this component.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9a3089b3309f088a10c3ac022caf3e7e1df7603. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->