### PR TITLE
fix: do not load TELGRAM_CLIENT_ID if TELEGRAM feature is disabled cp-13.34.0

### DIFF
--- a/builds.yml
+++ b/builds.yml
@@ -454,7 +454,7 @@ env:
   - GOOGLE_CLIENT_ID_UAT: ''
   - APPLE_CLIENT_ID_UAT: ''
   - TELEGRAM_CLIENT_ID_UAT: ''
-  - TELEGRAM_LOGIN_ENABLED: 'true'
+  - TELEGRAM_LOGIN_ENABLED: 'false'
 
   # Metamask Shield
   - METAMASK_SHIELD_ENABLED: 'true'

--- a/development/build/set-environment-variables.js
+++ b/development/build/set-environment-variables.js
@@ -41,7 +41,9 @@ function setEnvironmentVariables({
     development: isDevBuild,
   };
 
-  const TELEGRAM_LOGIN_ENABLED = isProductionOrReleaseCandidateBuild(environment)
+  const TELEGRAM_LOGIN_ENABLED = isProductionOrReleaseCandidateBuild(
+    environment,
+  )
     ? 'false'
     : variables.getMaybe('TELEGRAM_LOGIN_ENABLED');
 
@@ -53,9 +55,10 @@ function setEnvironmentVariables({
     ? getOAuthClientId({ ...oauthClientIdOptions, provider: 'GOOGLE' })
     : '';
 
-  const TELEGRAM_CLIENT_ID = isSeedlessOnboardingEnabled && Boolean(TELEGRAM_LOGIN_ENABLED)
-    ? getOAuthClientId({ ...oauthClientIdOptions, provider: 'TELEGRAM' })
-    : '';
+  const TELEGRAM_CLIENT_ID =
+    isSeedlessOnboardingEnabled && TELEGRAM_LOGIN_ENABLED.toString() === 'true'
+      ? getOAuthClientId({ ...oauthClientIdOptions, provider: 'TELEGRAM' })
+      : '';
 
   variables.set({
     DEBUG: isDevBuild || isTestBuild ? variables.getMaybe('DEBUG') : undefined,

--- a/development/build/set-environment-variables.js
+++ b/development/build/set-environment-variables.js
@@ -41,6 +41,10 @@ function setEnvironmentVariables({
     development: isDevBuild,
   };
 
+  const TELEGRAM_LOGIN_ENABLED = isProductionOrReleaseCandidateBuild(environment)
+    ? 'false'
+    : variables.getMaybe('TELEGRAM_LOGIN_ENABLED');
+
   const APPLE_CLIENT_ID = isSeedlessOnboardingEnabled
     ? getOAuthClientId({ ...oauthClientIdOptions, provider: 'APPLE' })
     : '';
@@ -49,7 +53,7 @@ function setEnvironmentVariables({
     ? getOAuthClientId({ ...oauthClientIdOptions, provider: 'GOOGLE' })
     : '';
 
-  const TELEGRAM_CLIENT_ID = isSeedlessOnboardingEnabled
+  const TELEGRAM_CLIENT_ID = isSeedlessOnboardingEnabled && Boolean(TELEGRAM_LOGIN_ENABLED)
     ? getOAuthClientId({ ...oauthClientIdOptions, provider: 'TELEGRAM' })
     : '';
 
@@ -98,9 +102,7 @@ function setEnvironmentVariables({
     METAMASK_SHIELD_ENABLED: isTestBuild
       ? 'true'
       : variables.getMaybe('METAMASK_SHIELD_ENABLED'),
-    TELEGRAM_LOGIN_ENABLED: isProductionOrReleaseCandidateBuild(environment)
-      ? 'false'
-      : variables.getMaybe('TELEGRAM_LOGIN_ENABLED'),
+    TELEGRAM_LOGIN_ENABLED,
     PERPS_ENABLED: isTestBuild ? 'true' : variables.getMaybe('PERPS_ENABLED'),
     ASSETS_UNIFIED_STATE_ENABLED: isTestBuild
       ? 'false'


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR fixes the build issue where `TELEGRAM_CLIENT_ID` is loaded in the build script even when the `TELEGRAM_LOGIN` is disabled.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time env gating only; no runtime auth or user-data path changes beyond omitting Telegram client ID when the feature is off.
> 
> **Overview**
> Fixes a build-time mismatch where **`TELEGRAM_CLIENT_ID`** could still be resolved when Telegram social login was off.
> 
> **`set-environment-variables.js`** now derives **`TELEGRAM_LOGIN_ENABLED`** once (forced **`false`** on production / release-candidate builds, otherwise from config) and only calls **`getOAuthClientId`** for Telegram when seedless onboarding is on **and** that flag is **`true`**. The same value is written into the build env instead of duplicating the prod/rc override inline.
> 
> **`builds.yml`** changes the default **`TELEGRAM_LOGIN_ENABLED`** from **`true`** to **`false`**, so Telegram OAuth IDs are not pulled unless explicitly enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc82eefc0ce04ea9f1979645136342b644b41562. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->