### PR TITLE
fix: cp-13.33.0 resolve infinite loading in metamask pay confirmations

### DIFF
--- a/.yarn/patches/@metamask-transaction-pay-controller-npm-22.6.0-ecc6df0372.patch
+++ b/.yarn/patches/@metamask-transaction-pay-controller-npm-22.6.0-ecc6df0372.patch
@@ -1,0 +1,32 @@
+diff --git a/dist/utils/transaction.cjs b/dist/utils/transaction.cjs
+index 5336822c5e96ed4c45d6456cac067de098fef80c..c2c1a35086aecd69db93fc99db6146cc8f5e0347 100644
+--- a/dist/utils/transaction.cjs
++++ b/dist/utils/transaction.cjs
+@@ -80,10 +80,7 @@ function subscribeAssetChanges(messenger, getControllerState, updateTransactionD
+             onTransactionChange(transaction, messenger, updateTransactionData);
+         }
+     };
+-    if ((0, feature_flags_1.getAssetsUnifyStateFeature)(messenger)) {
+-        messenger.subscribe('AssetsController:stateChange', buildHandler('AssetsController'));
+-        return;
+-    }
++    messenger.subscribe('AssetsController:stateChange', buildHandler('AssetsController'));
+     messenger.subscribe('TokensController:stateChange', buildHandler('TokensController'));
+     messenger.subscribe('TokenRatesController:stateChange', buildHandler('TokenRatesController'));
+     messenger.subscribe('CurrencyRateController:stateChange', buildHandler('CurrencyRateController'));
+diff --git a/dist/utils/transaction.mjs b/dist/utils/transaction.mjs
+index 8cb6b5c320af451c5144f69dae729169343a26cb..e09628fb22497255955bae2550c829292e55556a 100644
+--- a/dist/utils/transaction.mjs
++++ b/dist/utils/transaction.mjs
+@@ -76,10 +76,7 @@ export function subscribeAssetChanges(messenger, getControllerState, updateTrans
+             onTransactionChange(transaction, messenger, updateTransactionData);
+         }
+     };
+-    if (getAssetsUnifyStateFeature(messenger)) {
+-        messenger.subscribe('AssetsController:stateChange', buildHandler('AssetsController'));
+-        return;
+-    }
++    messenger.subscribe('AssetsController:stateChange', buildHandler('AssetsController'));
+     messenger.subscribe('TokensController:stateChange', buildHandler('TokensController'));
+     messenger.subscribe('TokenRatesController:stateChange', buildHandler('TokenRatesController'));
+     messenger.subscribe('CurrencyRateController:stateChange', buildHandler('CurrencyRateController'));

--- a/package.json
+++ b/package.json
@@ -297,7 +297,8 @@
     "@metamask/permission-controller@npm:^12.2.0": "^13.0.0",
     "@metamask/permission-controller@npm:^12.2.1": "^13.0.0",
     "@metamask/permission-controller@npm:^12.3.0": "^13.0.0",
-    "@metamask/transaction-controller": "patch:@metamask/transaction-controller@npm%3A66.0.0#~/.yarn/patches/@metamask-transaction-controller-npm-66.0.0-23fe4d7dfe.patch"
+    "@metamask/transaction-controller": "patch:@metamask/transaction-controller@npm%3A66.0.0#~/.yarn/patches/@metamask-transaction-controller-npm-66.0.0-23fe4d7dfe.patch",
+    "@metamask/transaction-pay-controller@npm:^22.6.0": "patch:@metamask/transaction-pay-controller@npm%3A22.6.0#~/.yarn/patches/@metamask-transaction-pay-controller-npm-22.6.0-ecc6df0372.patch"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.29.2#~/.yarn/patches/@babel-runtime-npm-7.29.2-b49cad1c67.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8590,7 +8590,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/transaction-pay-controller@npm:^22.6.0":
+"@metamask/transaction-pay-controller@npm:22.6.0":
   version: 22.6.0
   resolution: "@metamask/transaction-pay-controller@npm:22.6.0"
   dependencies:
@@ -8616,6 +8616,35 @@ __metadata:
     immer: "npm:^9.0.6"
     lodash: "npm:^4.17.21"
   checksum: 10/85c2d08d1a494e6596c9d82eeb9b10de0da96fea7018573543174f540a90e3a12771985a8e0d149166ff56e8ee40e4ab6b8d2fe70ba05728994da56320d8ce3e
+  languageName: node
+  linkType: hard
+
+"@metamask/transaction-pay-controller@patch:@metamask/transaction-pay-controller@npm%3A22.6.0#~/.yarn/patches/@metamask-transaction-pay-controller-npm-22.6.0-ecc6df0372.patch":
+  version: 22.6.0
+  resolution: "@metamask/transaction-pay-controller@patch:@metamask/transaction-pay-controller@npm%3A22.6.0#~/.yarn/patches/@metamask-transaction-pay-controller-npm-22.6.0-ecc6df0372.patch::version=22.6.0&hash=91c425"
+  dependencies:
+    "@ethersproject/abi": "npm:^5.7.0"
+    "@ethersproject/contracts": "npm:^5.7.0"
+    "@ethersproject/providers": "npm:^5.7.0"
+    "@metamask/assets-controller": "npm:^7.1.2"
+    "@metamask/assets-controllers": "npm:^108.1.0"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/bridge-controller": "npm:^72.0.4"
+    "@metamask/bridge-status-controller": "npm:^71.2.0"
+    "@metamask/controller-utils": "npm:^12.1.0"
+    "@metamask/gas-fee-controller": "npm:^26.2.2"
+    "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/metamask-eth-abis": "npm:^3.1.1"
+    "@metamask/network-controller": "npm:^32.0.0"
+    "@metamask/ramps-controller": "npm:^13.3.1"
+    "@metamask/remote-feature-flag-controller": "npm:^4.2.1"
+    "@metamask/transaction-controller": "npm:^66.0.0"
+    "@metamask/utils": "npm:^11.9.0"
+    bignumber.js: "npm:^9.1.2"
+    bn.js: "npm:^5.2.1"
+    immer: "npm:^9.0.6"
+    lodash: "npm:^4.17.21"
+  checksum: 10/253bc5cff9d8b189302886765865a70db5ad334f36a6763811a99a15887a2e52f47fed9cfb5ffffefaa96016db77cb88a024b532482cbc17b3da346d18ab6ce3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

`TransactionPayController` uses asset state changes to re-parse required tokens for in-flight transactions when token metadata hasn't resolved yet. The subscription logic in `subscribeAssetChanges` branched on the `assetsUnifyState` remote feature flag: when the flag was enabled it subscribed only to `AssetsController:stateChange`, otherwise it subscribed to `TokensController`, `TokenRatesController`, and `CurrencyRateController`.

The root cause of the infinite loading in Pay confirmations was that the `RemoteFeatureFlagController` state isn't populated at the point `TransactionPayController` initialises during onboarding — the remote flags haven't been fetched yet — so `assetsUnifyState` defaults to `false`. This caused the controller to subscribe only to the legacy controllers, which meant required-token resolution never fired when the extension was running with the unified assets state, leaving the confirmation spinner indefinitely.

This PR applies a yarn patch to `@metamask/transaction-pay-controller@22.5.0` that removes the conditional branch and always subscribes to all four controllers unconditionally. Both the CJS and ESM dist files are patched.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #42989 

## **Manual testing steps**

1. Load the extension via a fresh onboarding.
2. Initiate a Pay transaction that requires a token not yet in local state.
3. Confirm the required token resolves and the confirmation no longer hangs on an infinite spinner.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Pay transaction asset subscription behavior at controller init; limited scope but affects confirmation UX and token resolution timing.
> 
> **Overview**
> Fixes **MetaMask Pay** confirmations that could spin forever when required token metadata was not ready yet.
> 
> The extension adds a **Yarn patch** on `@metamask/transaction-pay-controller@22.6.0` so `subscribeAssetChanges` no longer branches on the `assetsUnifyState` remote feature flag. That flag often reads as disabled during early startup (e.g. onboarding before remote flags load), which left the controller listening only to legacy token/rate controllers while the app used unified assets—so required-token resolution never ran.
> 
> The patch always registers listeners on **`AssetsController`**, **`TokensController`**, **`TokenRatesController`**, and **`CurrencyRateController`** (CJS and ESM dist). **`package.json`** resolutions and **`yarn.lock`** point installs at the patched package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2609a339f1b8ed83784c74e202c5f00cc6ff5e4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->