### PR TITLE
fix: fix aggregated balance

### DIFF
--- a/ui/components/app/assets/account-group-balance/account-group-balance.test.tsx
+++ b/ui/components/app/assets/account-group-balance/account-group-balance.test.tsx
@@ -92,9 +92,7 @@ describe('AccountGroupBalance', () => {
     };
   };
 
-  const renderComponent = (
-    props: Partial<AccountGroupBalanceProps> = {},
-  ) =>
+  const renderComponent = (props: Partial<AccountGroupBalanceProps> = {}) =>
     renderWithProvider(
       <AccountGroupBalance
         classPrefix={props.classPrefix || 'coin'}

--- a/ui/components/app/assets/account-group-balance/account-group-balance.test.tsx
+++ b/ui/components/app/assets/account-group-balance/account-group-balance.test.tsx
@@ -8,12 +8,12 @@ import { getIntlLocale } from '../../../../ducks/locale/locale';
 import { getCurrentCurrency } from '../../../../ducks/metamask/metamask';
 import {
   getEnabledNetworksByNamespace,
+  getShowFiatInTestnets,
   selectAnyEnabledNetworksAreAvailable,
 } from '../../../../selectors';
 import { getPreferences } from '../../../../../shared/lib/selectors/preferences';
 import { selectBalanceBySelectedAccountGroup } from '../../../../selectors/assets';
 import * as useMultichainSelectorHook from '../../../../hooks/useMultichainSelector';
-import * as multichainSelectors from '../../../../selectors/multichain';
 import {
   AccountGroupBalance,
   AccountGroupBalanceProps,
@@ -21,14 +21,13 @@ import {
 
 const mockStore = configureMockStore()(mockState);
 
+const SEPOLIA_CHAIN_ID = '0xaa36a7';
+const MAINNET_CHAIN_ID = '0x1';
+
 jest.mock('../../../../selectors/assets');
 jest.mock('../../../../selectors');
 jest.mock('../../../../ducks/locale/locale');
 jest.mock('../../../../ducks/metamask/metamask');
-jest.mock('../../../../selectors/multichain', () => ({
-  ...jest.requireActual('../../../../selectors/multichain'),
-  getMultichainIsTestnet: jest.fn(),
-}));
 jest.mock('../../../../../shared/lib/selectors/preferences');
 
 describe('AccountGroupBalance', () => {
@@ -39,12 +38,23 @@ describe('AccountGroupBalance', () => {
     userCurrency: 'usd',
   });
 
-  const arrange = (
-    selectedGroupBalance: AccountGroupBalanceType | null = null,
-    showNativeTokenAsMainBalance: boolean = false,
-    isTestnet: boolean = false,
-    anyEnabledNetworksAreAvailable: boolean = true,
-  ) => {
+  type ArrangeOptions = {
+    selectedGroupBalance?: AccountGroupBalanceType | null;
+    showNativeTokenAsMainBalance?: boolean;
+    enabledNetworksByNamespace?: Record<string, boolean>;
+    anyEnabledNetworksAreAvailable?: boolean;
+    showFiatInTestnets?: boolean;
+    privacyMode?: boolean;
+  };
+
+  const arrange = ({
+    selectedGroupBalance = null,
+    showNativeTokenAsMainBalance = false,
+    enabledNetworksByNamespace = { [MAINNET_CHAIN_ID]: true },
+    anyEnabledNetworksAreAvailable = true,
+    showFiatInTestnets = false,
+    privacyMode = false,
+  }: ArrangeOptions = {}) => {
     const mockSelectBalanceBySelectedAccountGroup = jest
       .mocked(selectBalanceBySelectedAccountGroup)
       .mockReturnValue(selectedGroupBalance);
@@ -54,15 +64,13 @@ describe('AccountGroupBalance', () => {
       .mockReturnValue(anyEnabledNetworksAreAvailable);
 
     const mockGetPreferences = jest.mocked(getPreferences).mockReturnValue({
-      privacyMode: false,
+      privacyMode,
       showNativeTokenAsMainBalance,
     } as ReturnType<typeof getPreferences>);
 
     const mockGetEnabledNetworksByNamespace = jest
       .mocked(getEnabledNetworksByNamespace)
-      .mockReturnValue({
-        '0x1': true,
-      });
+      .mockReturnValue(enabledNetworksByNamespace);
 
     const mockGetIntlLocale = jest.mocked(getIntlLocale).mockReturnValue('en');
 
@@ -70,9 +78,9 @@ describe('AccountGroupBalance', () => {
       .mocked(getCurrentCurrency)
       .mockReturnValue('usd');
 
-    const mockGetMultichainIsTestnet = jest
-      .mocked(multichainSelectors.getMultichainIsTestnet)
-      .mockReturnValue(isTestnet);
+    const mockGetShowFiatInTestnets = jest
+      .mocked(getShowFiatInTestnets)
+      .mockReturnValue(showFiatInTestnets);
 
     return {
       mockSelectBalanceBySelectedAccountGroup,
@@ -80,18 +88,12 @@ describe('AccountGroupBalance', () => {
       mockGetIntlLocale,
       mockGetCurrentCurrency,
       mockGetEnabledNetworksByNamespace,
-      mockGetMultichainIsTestnet,
+      mockGetShowFiatInTestnets,
     };
   };
 
   const renderComponent = (
-    props: Partial<AccountGroupBalanceProps> = {
-      classPrefix: 'coin',
-      balanceIsCached: false,
-      handleSensitiveToggle: () => undefined,
-      balance: '1000000000000000000',
-      chainId: '0x1',
-    },
+    props: Partial<AccountGroupBalanceProps> = {},
   ) =>
     renderWithProvider(
       <AccountGroupBalance
@@ -99,7 +101,7 @@ describe('AccountGroupBalance', () => {
         balanceIsCached={props.balanceIsCached || false}
         handleSensitiveToggle={props.handleSensitiveToggle || (() => undefined)}
         balance={props.balance || '1000000000000000000'}
-        chainId={props.chainId || '0x1'}
+        chainId={props.chainId || MAINNET_CHAIN_ID}
       />,
       mockStore,
     );
@@ -110,14 +112,13 @@ describe('AccountGroupBalance', () => {
   };
 
   const actAssertBalanceContent = (props: {
-    currency: string;
     amount: string;
-    balance: string;
-    chainId: string;
+    balance?: string;
+    chainId?: string;
   }) => {
     const { getByText } = renderComponent({
       balance: props.balance,
-      chainId: props.chainId as CaipChainId | Hex,
+      chainId: props.chainId as CaipChainId | Hex | undefined,
     });
     expect(
       getByText((content) => content.includes(props.amount)),
@@ -129,51 +130,94 @@ describe('AccountGroupBalance', () => {
   });
 
   it('renders a skeleton when no selected group balance and no networks available', () => {
-    arrange(null, false, false, false);
+    arrange({ anyEnabledNetworksAreAvailable: false });
     actAssertSkeletonPresent();
   });
 
   it('renders formatted balance and currency when data available', () => {
-    arrange(createMockBalance());
+    arrange({ selectedGroupBalance: createMockBalance() });
     actAssertBalanceContent({
-      currency: 'USD',
       amount: '$123.45',
       balance: '1000000000000000000',
-      chainId: '0x1',
+      chainId: MAINNET_CHAIN_ID,
     });
   });
 
   it('renders native balance when setting showNativeTokenAsMainBalance to true', () => {
-    jest
-      .spyOn(useMultichainSelectorHook, 'useMultichainSelector')
-      .mockReturnValue('ETH');
-    arrange(createMockBalance(), true);
+    arrange({
+      selectedGroupBalance: createMockBalance(),
+      showNativeTokenAsMainBalance: true,
+    });
     actAssertBalanceContent({
-      currency: 'ETH',
       amount: '0.000589',
       balance: '0x0217b4f7389e02',
-      chainId: '0x1',
+      chainId: MAINNET_CHAIN_ID,
     });
   });
 
-  it('renders native balance when on testnet regardless of showNativeTokenAsMainBalance setting', () => {
-    jest
-      .spyOn(useMultichainSelectorHook, 'useMultichainSelector')
-      .mockReturnValue('SepoliaETH');
-    arrange(createMockBalance(), false, true);
+  it('renders native balance when only a testnet is enabled, regardless of showNativeTokenAsMainBalance', () => {
+    arrange({
+      selectedGroupBalance: createMockBalance(),
+      enabledNetworksByNamespace: { [SEPOLIA_CHAIN_ID]: true },
+    });
     actAssertBalanceContent({
-      currency: 'SepoliaETH',
       amount: '0.000589',
       balance: '0x0217b4f7389e02',
-      chainId: '0xaa36a7',
+      chainId: SEPOLIA_CHAIN_ID,
+    });
+  });
+
+  it('renders fiat conversion on testnet when showFiatInTestnets is enabled', () => {
+    arrange({
+      selectedGroupBalance: createMockBalance(),
+      enabledNetworksByNamespace: { [SEPOLIA_CHAIN_ID]: true },
+      showFiatInTestnets: true,
+    });
+    actAssertBalanceContent({
+      amount: '$123.45',
+      balance: '0x0217b4f7389e02',
+      chainId: SEPOLIA_CHAIN_ID,
+    });
+  });
+
+  it('does not treat a single non-testnet network as testnet-selected', () => {
+    arrange({
+      selectedGroupBalance: createMockBalance(),
+      enabledNetworksByNamespace: { [MAINNET_CHAIN_ID]: true },
+    });
+    actAssertBalanceContent({
+      amount: '$123.45',
+      balance: '1000000000000000000',
+      chainId: MAINNET_CHAIN_ID,
+    });
+  });
+
+  it('falls back to fiat when multiple networks are enabled even with showNativeTokenAsMainBalance', () => {
+    arrange({
+      selectedGroupBalance: createMockBalance(),
+      showNativeTokenAsMainBalance: true,
+      enabledNetworksByNamespace: {
+        [MAINNET_CHAIN_ID]: true,
+        '0x5': true,
+      },
+    });
+    actAssertBalanceContent({
+      amount: '$123.45',
+      balance: '1000000000000000000',
+      chainId: MAINNET_CHAIN_ID,
     });
   });
 
   it('renders balance from selectedGroupBalance.totalBalanceInUserCurrency', () => {
-    arrange({ ...createMockBalance(), totalBalanceInUserCurrency: 99.5 });
+    arrange({
+      selectedGroupBalance: {
+        ...createMockBalance(),
+        totalBalanceInUserCurrency: 99.5,
+      },
+    });
     const { getByText } = renderComponent({
       balance: '1000000000000000000',
-      chainId: '0x1',
+      chainId: MAINNET_CHAIN_ID,
     });
     expect(
       getByText(
@@ -182,27 +226,17 @@ describe('AccountGroupBalance', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders formatted balance from selectedGroupBalance', () => {
-    arrange(createMockBalance());
-    actAssertBalanceContent({
-      currency: 'USD',
-      amount: '$123.45',
-      balance: '1000000000000000000',
-      chainId: '0x1',
-    });
-  });
-
   it('renders skeleton when no networks available and no balance', () => {
-    arrange(null, false, false, false);
+    arrange({ anyEnabledNetworksAreAvailable: false });
     actAssertSkeletonPresent();
   });
 
   it('applies cached balance class when balanceIsCached is true', () => {
-    arrange(createMockBalance());
+    arrange({ selectedGroupBalance: createMockBalance() });
     const { container } = renderComponent({
       balanceIsCached: true,
       balance: '1000000000000000000',
-      chainId: '0x1',
+      chainId: MAINNET_CHAIN_ID,
     });
     expect(
       container.querySelector('.coin-overview__cached-balance'),
@@ -210,13 +244,31 @@ describe('AccountGroupBalance', () => {
   });
 
   it('renders masked balance when privacy mode is enabled', () => {
-    arrange(createMockBalance());
-    jest.mocked(getPreferences).mockReturnValue({
+    arrange({
+      selectedGroupBalance: createMockBalance(),
       privacyMode: true,
-      showNativeTokenAsMainBalance: false,
-    } as ReturnType<typeof getPreferences>);
+    });
     const { getByText } = renderComponent();
     // SensitiveText shows bullet pattern when isHidden (privacyMode) is true
     expect(getByText('••••••')).toBeInTheDocument();
+  });
+
+  it('does not call useMultichainSelector for the native currency symbol on EVM chains', () => {
+    const useMultichainSelectorSpy = jest.spyOn(
+      useMultichainSelectorHook,
+      'useMultichainSelector',
+    );
+    arrange({
+      selectedGroupBalance: createMockBalance(),
+      showNativeTokenAsMainBalance: true,
+    });
+    renderComponent({
+      balance: '0x0217b4f7389e02',
+      chainId: MAINNET_CHAIN_ID,
+    });
+    // The native symbol now comes from networkConfigurationsByChainId, so
+    // even if useMultichainSelector returns something unrelated it should not
+    // appear in the rendered output.
+    useMultichainSelectorSpy.mockReturnValue('UNEXPECTED');
   });
 });

--- a/ui/components/app/assets/account-group-balance/account-group-balance.tsx
+++ b/ui/components/app/assets/account-group-balance/account-group-balance.tsx
@@ -17,10 +17,8 @@ import {
 } from '../../../../helpers/constants/design-system';
 import { Box, SensitiveText } from '../../../component-library';
 import {
-  getAllMultichainNetworkConfigurations,
   getEnabledNetworksByNamespace,
   getMultichainNetwork,
-  getMultichainNetworkConfigurationsByChainId,
   getShowFiatInTestnets,
   selectAnyEnabledNetworksAreAvailable,
 } from '../../../../selectors';
@@ -74,12 +72,11 @@ export const AccountGroupBalance: React.FC<AccountGroupBalanceProps> = ({
   );
 
   const isEvm = isEvmChainId(chainId);
-  const enabledNetworksByNamespace = useSelector(getEnabledNetworksByNamespace);
 
   const isTestnetSelected = Boolean(
-    Object.keys(enabledNetworksByNamespace).length === 1 &&
+    Object.keys(enabledNetworks).length === 1 &&
     TEST_CHAINS.includes(
-      Object.keys(enabledNetworksByNamespace)[0] as `0x${string}`,
+      Object.keys(enabledNetworks)[0] as `0x${string}`,
     ),
   );
 
@@ -100,18 +97,18 @@ export const AccountGroupBalance: React.FC<AccountGroupBalanceProps> = ({
 
   const nativeCurrencySymbol: string = useMemo(() => {
     if (isEvm) {
-      return Object.keys(enabledNetworksByNamespace).length === 1
+      return Object.keys(enabledNetworks).length === 1
         ? networkConfigurationsByChainId[
-            Object.keys(enabledNetworksByNamespace)[0] as `0x${string}`
+            Object.keys(enabledNetworks)[0] as `0x${string}`
           ]?.nativeCurrency
         : fallbackCurrency;
     }
 
-    return Object.keys(enabledNetworksByNamespace).length === 1
+    return Object.keys(enabledNetworks).length === 1
       ? networks.network.ticker
       : fallbackCurrency;
   }, [
-    enabledNetworksByNamespace,
+    enabledNetworks,
     networkConfigurationsByChainId,
     isEvm,
     networks,

--- a/ui/components/app/assets/account-group-balance/account-group-balance.tsx
+++ b/ui/components/app/assets/account-group-balance/account-group-balance.tsx
@@ -17,7 +17,11 @@ import {
 } from '../../../../helpers/constants/design-system';
 import { Box, SensitiveText } from '../../../component-library';
 import {
+  getAllMultichainNetworkConfigurations,
   getEnabledNetworksByNamespace,
+  getMultichainNetwork,
+  getMultichainNetworkConfigurationsByChainId,
+  getShowFiatInTestnets,
   selectAnyEnabledNetworksAreAvailable,
 } from '../../../../selectors';
 import { getPreferences } from '../../../../../shared/lib/selectors/preferences';
@@ -27,11 +31,12 @@ import { isZeroAmount } from '../../../../helpers/utils/number-utils';
 import { useMultichainSelector } from '../../../../hooks/useMultichainSelector';
 import {
   getMultichainNativeCurrency,
-  getMultichainIsTestnet,
 } from '../../../../selectors/multichain';
 import { getInternalAccountBySelectedAccountGroupAndCaip } from '../../../../selectors/multichain-accounts/account-tree';
 import { isEvmChainId } from '../../../../../shared/lib/asset-utils';
 import { hexWEIToDecETH } from '../../../../../shared/lib/conversion.utils';
+import { TEST_CHAINS } from '../../../../../shared/constants/network';
+import { getNetworkConfigurationsByChainId } from '../../../../../shared/lib/selectors/networks';
 
 export type AccountGroupBalanceProps = {
   classPrefix: string;
@@ -71,42 +76,65 @@ export const AccountGroupBalance: React.FC<AccountGroupBalanceProps> = ({
   );
 
   const isEvm = isEvmChainId(chainId);
+  const enabledNetworksByNamespace = useSelector(getEnabledNetworksByNamespace);
 
-  const isTestnet = useSelector(getMultichainIsTestnet);
+  const isTestnetSelected = Boolean(
+    Object.keys(enabledNetworksByNamespace).length === 1 &&
+    TEST_CHAINS.includes(
+      Object.keys(enabledNetworksByNamespace)[0] as `0x${string}`,
+    ),
+  );
 
+  const networkConfigurationsByChainId = useSelector(getNetworkConfigurationsByChainId);
+  const networks = useSelector(getMultichainNetwork);
   const showNativeTokenAsMain = Boolean(
     showNativeTokenAsMainBalance && Object.keys(enabledNetworks).length === 1,
   );
+
+  const showConversionForTestnets = useSelector(getShowFiatInTestnets);
 
   const nativeCurrency = useMultichainSelector(
     getMultichainNativeCurrency,
     selectedAccount,
   );
 
+  const nativeCurrencySymbol: string = useMemo(() => {
+    if (isEvm) {
+      return Object.keys(enabledNetworksByNamespace).length === 1 ?
+      networkConfigurationsByChainId[Object.keys(enabledNetworksByNamespace)[0] as `0x${string}`]?.nativeCurrency : fallbackCurrency;
+    }
+
+    return Object.keys(enabledNetworksByNamespace).length === 1 ?
+    networks.network.ticker : fallbackCurrency;
+  }, [enabledNetworksByNamespace, networkConfigurationsByChainId, isEvm, networks, fallbackCurrency]);
+
+
+  const total = selectedGroupBalance?.totalBalanceInUserCurrency;
+
+
   let formattedNativeBalance = null;
-  if (showNativeTokenAsMain || isTestnet) {
+  if (showNativeTokenAsMain || isTestnetSelected) {
     if (isEvm) {
       const decimalBalance = parseFloat(hexWEIToDecETH(balance));
 
       formattedNativeBalance = formatTokenQuantity(
         decimalBalance,
-        nativeCurrency,
+        nativeCurrencySymbol,
       );
     } else {
       formattedNativeBalance = formatTokenQuantity(
         Number(multichainNativeTokenBalance.amount),
-        nativeCurrency,
+        nativeCurrencySymbol,
       );
     }
   }
 
-  const total = selectedGroupBalance?.totalBalanceInUserCurrency;
   const currency = selectedGroupBalance
     ? (selectedGroupBalance.userCurrency ?? fallbackCurrency)
     : undefined;
 
   const formattedTotal = useMemo(() => {
-    if (showNativeTokenAsMain || isTestnet) {
+    if (showNativeTokenAsMain || isTestnetSelected && !showConversionForTestnets) {
       return formattedNativeBalance;
     }
     if (total === undefined) {
@@ -115,11 +143,12 @@ export const AccountGroupBalance: React.FC<AccountGroupBalanceProps> = ({
     return formatCurrency(total, currency);
   }, [
     showNativeTokenAsMain,
-    isTestnet,
+    isTestnetSelected,
     total,
     formatCurrency,
     currency,
     formattedNativeBalance,
+    showConversionForTestnets,
   ]);
 
   return (

--- a/ui/components/app/assets/account-group-balance/account-group-balance.tsx
+++ b/ui/components/app/assets/account-group-balance/account-group-balance.tsx
@@ -78,9 +78,9 @@ export const AccountGroupBalance: React.FC<AccountGroupBalanceProps> = ({
 
   const isTestnetSelected = Boolean(
     Object.keys(enabledNetworksByNamespace).length === 1 &&
-      TEST_CHAINS.includes(
-        Object.keys(enabledNetworksByNamespace)[0] as `0x${string}`,
-      ),
+    TEST_CHAINS.includes(
+      Object.keys(enabledNetworksByNamespace)[0] as `0x${string}`,
+    ),
   );
 
   const networkConfigurationsByChainId = useSelector(

--- a/ui/components/app/assets/account-group-balance/account-group-balance.tsx
+++ b/ui/components/app/assets/account-group-balance/account-group-balance.tsx
@@ -29,9 +29,7 @@ import { useFormatters } from '../../../../hooks/useFormatters';
 import { getCurrentCurrency } from '../../../../ducks/metamask/metamask';
 import { isZeroAmount } from '../../../../helpers/utils/number-utils';
 import { useMultichainSelector } from '../../../../hooks/useMultichainSelector';
-import {
-  getMultichainNativeCurrency,
-} from '../../../../selectors/multichain';
+import { getMultichainNativeCurrency } from '../../../../selectors/multichain';
 import { getInternalAccountBySelectedAccountGroupAndCaip } from '../../../../selectors/multichain-accounts/account-tree';
 import { isEvmChainId } from '../../../../../shared/lib/asset-utils';
 import { hexWEIToDecETH } from '../../../../../shared/lib/conversion.utils';
@@ -80,12 +78,14 @@ export const AccountGroupBalance: React.FC<AccountGroupBalanceProps> = ({
 
   const isTestnetSelected = Boolean(
     Object.keys(enabledNetworksByNamespace).length === 1 &&
-    TEST_CHAINS.includes(
-      Object.keys(enabledNetworksByNamespace)[0] as `0x${string}`,
-    ),
+      TEST_CHAINS.includes(
+        Object.keys(enabledNetworksByNamespace)[0] as `0x${string}`,
+      ),
   );
 
-  const networkConfigurationsByChainId = useSelector(getNetworkConfigurationsByChainId);
+  const networkConfigurationsByChainId = useSelector(
+    getNetworkConfigurationsByChainId,
+  );
   const networks = useSelector(getMultichainNetwork);
   const showNativeTokenAsMain = Boolean(
     showNativeTokenAsMainBalance && Object.keys(enabledNetworks).length === 1,
@@ -100,17 +100,25 @@ export const AccountGroupBalance: React.FC<AccountGroupBalanceProps> = ({
 
   const nativeCurrencySymbol: string = useMemo(() => {
     if (isEvm) {
-      return Object.keys(enabledNetworksByNamespace).length === 1 ?
-      networkConfigurationsByChainId[Object.keys(enabledNetworksByNamespace)[0] as `0x${string}`]?.nativeCurrency : fallbackCurrency;
+      return Object.keys(enabledNetworksByNamespace).length === 1
+        ? networkConfigurationsByChainId[
+            Object.keys(enabledNetworksByNamespace)[0] as `0x${string}`
+          ]?.nativeCurrency
+        : fallbackCurrency;
     }
 
-    return Object.keys(enabledNetworksByNamespace).length === 1 ?
-    networks.network.ticker : fallbackCurrency;
-  }, [enabledNetworksByNamespace, networkConfigurationsByChainId, isEvm, networks, fallbackCurrency]);
-
+    return Object.keys(enabledNetworksByNamespace).length === 1
+      ? networks.network.ticker
+      : fallbackCurrency;
+  }, [
+    enabledNetworksByNamespace,
+    networkConfigurationsByChainId,
+    isEvm,
+    networks,
+    fallbackCurrency,
+  ]);
 
   const total = selectedGroupBalance?.totalBalanceInUserCurrency;
-
 
   let formattedNativeBalance = null;
   if (showNativeTokenAsMain || isTestnetSelected) {
@@ -134,7 +142,10 @@ export const AccountGroupBalance: React.FC<AccountGroupBalanceProps> = ({
     : undefined;
 
   const formattedTotal = useMemo(() => {
-    if (showNativeTokenAsMain || isTestnetSelected && !showConversionForTestnets) {
+    if (
+      showNativeTokenAsMain ||
+      (isTestnetSelected && !showConversionForTestnets)
+    ) {
       return formattedNativeBalance;
     }
     if (total === undefined) {

--- a/ui/components/app/assets/account-group-balance/account-group-balance.tsx
+++ b/ui/components/app/assets/account-group-balance/account-group-balance.tsx
@@ -75,9 +75,7 @@ export const AccountGroupBalance: React.FC<AccountGroupBalanceProps> = ({
 
   const isTestnetSelected = Boolean(
     Object.keys(enabledNetworks).length === 1 &&
-    TEST_CHAINS.includes(
-      Object.keys(enabledNetworks)[0] as `0x${string}`,
-    ),
+    TEST_CHAINS.includes(Object.keys(enabledNetworks)[0] as `0x${string}`),
   );
 
   const networkConfigurationsByChainId = useSelector(

--- a/ui/components/app/assets/account-group-balance/account-group-balance.tsx
+++ b/ui/components/app/assets/account-group-balance/account-group-balance.tsx
@@ -26,8 +26,6 @@ import { getPreferences } from '../../../../../shared/lib/selectors/preferences'
 import { useFormatters } from '../../../../hooks/useFormatters';
 import { getCurrentCurrency } from '../../../../ducks/metamask/metamask';
 import { isZeroAmount } from '../../../../helpers/utils/number-utils';
-import { useMultichainSelector } from '../../../../hooks/useMultichainSelector';
-import { getMultichainNativeCurrency } from '../../../../selectors/multichain';
 import { getInternalAccountBySelectedAccountGroupAndCaip } from '../../../../selectors/multichain-accounts/account-tree';
 import { isEvmChainId } from '../../../../../shared/lib/asset-utils';
 import { hexWEIToDecETH } from '../../../../../shared/lib/conversion.utils';
@@ -87,11 +85,6 @@ export const AccountGroupBalance: React.FC<AccountGroupBalanceProps> = ({
   );
 
   const showConversionForTestnets = useSelector(getShowFiatInTestnets);
-
-  const nativeCurrency = useMultichainSelector(
-    getMultichainNativeCurrency,
-    selectedAccount,
-  );
 
   const nativeCurrencySymbol: string = useMemo(() => {
     if (isEvm) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix aggregated balance

## **Related issues**

Fixes: #43019 

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/d9a822de-9b10-4774-91de-708126092779



### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/b097f8a9-db47-48ec-9937-4a9f8b0c577f




## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes balance display rules for testnets, multi-network, and native vs fiat; user-visible wallet UI with moderate regression risk if edge cases are missed.
> 
> **Overview**
> Fixes incorrect **aggregated balance** display in `AccountGroupBalance` by changing when the UI shows fiat vs native token amounts.
> 
> **Testnet detection** no longer uses `getMultichainIsTestnet`; it treats a selection as testnet only when **exactly one** enabled network is in `TEST_CHAINS`. **Fiat on testnets** respects `getShowFiatInTestnets` so users can still see dollar totals when that preference is on.
> 
> **Native currency labels** for formatting come from `networkConfigurationsByChainId` on EVM (and multichain network ticker otherwise), removing `useMultichainSelector` / `getMultichainNativeCurrency` for this path. With **multiple networks enabled**, the component **always shows aggregated fiat**, even if `showNativeTokenAsMainBalance` is set.
> 
> Tests were refactored and expanded for single testnet, fiat-on-testnet, mainnet-only, and multi-network cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5da6db8c562157b8b2caa306cb8dd433353a0495. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->