### PR TITLE
feat: only show RPC connection banner for actionable failures (WPC-1014)

### DIFF
--- a/ui/hooks/useNetworkConnectionBanner.test.ts
+++ b/ui/hooks/useNetworkConnectionBanner.test.ts
@@ -1,7 +1,7 @@
 import { act } from '@testing-library/react';
 import { RpcEndpointType } from '@metamask/network-controller';
 import { renderHookWithProviderTyped } from '../../test/lib/render-helpers-navigate';
-import { selectFirstUnavailableEvmNetwork } from '../selectors/multichain/networks';
+import { selectNetworkForConnectionBanner } from '../selectors/multichain/networks';
 import {
   getNetworkConnectionBanner,
   getIsDeviceOffline,
@@ -23,7 +23,7 @@ jest.mock('../../shared/constants/network', () => {
 jest.mock('../selectors/multichain/networks', () => {
   return {
     ...jest.requireActual('../selectors/multichain/networks'),
-    selectFirstUnavailableEvmNetwork: jest.fn(),
+    selectNetworkForConnectionBanner: jest.fn(),
   };
 });
 
@@ -72,8 +72,8 @@ jest.mock('../store/background-connection', () => {
   };
 });
 
-const mockSelectFirstUnavailableEvmNetwork = jest.mocked(
-  selectFirstUnavailableEvmNetwork,
+const mockSelectNetworkForConnectionBanner = jest.mocked(
+  selectNetworkForConnectionBanner,
 );
 const mockGetNetworkConnectionBanner = jest.mocked(getNetworkConnectionBanner);
 const mockGetIsDeviceOffline = jest.mocked(getIsDeviceOffline);
@@ -118,7 +118,7 @@ describe('useNetworkConnectionBanner', () => {
 
   describe('when all networks are available', () => {
     it("updates the status of the banner to 'available' if not already updated", () => {
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue(null);
+      mockSelectNetworkForConnectionBanner.mockReturnValue(null);
       mockGetNetworkConnectionBanner.mockReturnValue({ status: 'unknown' });
 
       renderHookWithProviderTyped(
@@ -132,7 +132,7 @@ describe('useNetworkConnectionBanner', () => {
     });
 
     it("does not update the status of the banner to 'available' if already updated", () => {
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue(null);
+      mockSelectNetworkForConnectionBanner.mockReturnValue(null);
       mockGetNetworkConnectionBanner.mockReturnValue({
         status: 'available',
       });
@@ -146,7 +146,7 @@ describe('useNetworkConnectionBanner', () => {
     });
 
     it('does not create a MetaMetrics event', () => {
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue(null);
+      mockSelectNetworkForConnectionBanner.mockReturnValue(null);
       mockGetNetworkConnectionBanner.mockReturnValue({ status: 'unknown' });
       const mockTrackEvent = jest.fn();
 
@@ -166,7 +166,7 @@ describe('useNetworkConnectionBanner', () => {
     describe('if the status of the banner is "unknown"', () => {
       describe('if at least one network is still not available after 5 seconds', () => {
         it('updates the status of the banner to "degraded"', () => {
-          mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+          mockSelectNetworkForConnectionBanner.mockReturnValue({
             networkName: 'Ethereum Mainnet',
             networkClientId: 'mainnet',
             chainId: '0x1',
@@ -194,7 +194,7 @@ describe('useNetworkConnectionBanner', () => {
         });
 
         it('creates a MetaMetrics event to capture that the status changed', async () => {
-          mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+          mockSelectNetworkForConnectionBanner.mockReturnValue({
             networkName: 'Ethereum Mainnet',
             networkClientId: 'mainnet',
             chainId: '0x1',
@@ -236,7 +236,7 @@ describe('useNetworkConnectionBanner', () => {
 
     describe('if the status of the banner is "available"', () => {
       it('updates the status of the banner to "degraded" after 5 seconds', () => {
-        mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+        mockSelectNetworkForConnectionBanner.mockReturnValue({
           networkName: 'Ethereum Mainnet',
           networkClientId: 'mainnet',
           chainId: '0x1',
@@ -268,7 +268,7 @@ describe('useNetworkConnectionBanner', () => {
 
     describe('if the status of the banner is "degraded"', () => {
       it('updates the status of the banner to "unavailable" after 25 seconds', () => {
-        mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+        mockSelectNetworkForConnectionBanner.mockReturnValue({
           networkName: 'Ethereum Mainnet',
           networkClientId: 'mainnet',
           chainId: '0x1',
@@ -303,7 +303,7 @@ describe('useNetworkConnectionBanner', () => {
       });
 
       it('creates a MetaMetrics event to capture that the status changed', async () => {
-        mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+        mockSelectNetworkForConnectionBanner.mockReturnValue({
           networkName: 'Ethereum Mainnet',
           networkClientId: 'mainnet',
           chainId: '0x1',
@@ -352,7 +352,7 @@ describe('useNetworkConnectionBanner', () => {
 
   describe('when some network is unavailable and then all become available', () => {
     it('clears timers and updates the status of the banner to "available"', () => {
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+      mockSelectNetworkForConnectionBanner.mockReturnValue({
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',
         chainId: '0x1',
@@ -365,7 +365,7 @@ describe('useNetworkConnectionBanner', () => {
         () => useNetworkConnectionBanner(),
         mockState,
       );
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue(null);
+      mockSelectNetworkForConnectionBanner.mockReturnValue(null);
       rerender();
       act(() => {
         jest.advanceTimersByTime(30000);
@@ -380,7 +380,7 @@ describe('useNetworkConnectionBanner', () => {
 
   describe('on unmount', () => {
     it('clears any timers to show the degraded and unavailable banners', () => {
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+      mockSelectNetworkForConnectionBanner.mockReturnValue({
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',
         chainId: '0x1',
@@ -409,7 +409,7 @@ describe('useNetworkConnectionBanner', () => {
     });
 
     it('does not show degraded banner even if network is unavailable', () => {
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+      mockSelectNetworkForConnectionBanner.mockReturnValue({
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',
         chainId: '0x1',
@@ -436,7 +436,7 @@ describe('useNetworkConnectionBanner', () => {
     });
 
     it('resets banner to available when device goes offline while showing degraded', () => {
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+      mockSelectNetworkForConnectionBanner.mockReturnValue({
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',
         chainId: '0x1',
@@ -463,7 +463,7 @@ describe('useNetworkConnectionBanner', () => {
     });
 
     it('does not update banner if already available when offline', () => {
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+      mockSelectNetworkForConnectionBanner.mockReturnValue({
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',
         chainId: '0x1',
@@ -483,7 +483,7 @@ describe('useNetworkConnectionBanner', () => {
     it('does not progress from degraded to unavailable when device goes offline', () => {
       // Device is offline with degraded banner showing
       mockGetIsDeviceOffline.mockReturnValue(true);
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+      mockSelectNetworkForConnectionBanner.mockReturnValue({
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',
         chainId: '0x1',
@@ -521,7 +521,7 @@ describe('useNetworkConnectionBanner', () => {
     it('resumes normal behavior when device comes back online', () => {
       // Start offline
       mockGetIsDeviceOffline.mockReturnValue(true);
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+      mockSelectNetworkForConnectionBanner.mockReturnValue({
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',
         chainId: '0x1',
@@ -590,7 +590,7 @@ describe('useNetworkConnectionBanner', () => {
           typeof mockGetNetworkConfigurationsByChainId
         >,
       );
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue(null);
+      mockSelectNetworkForConnectionBanner.mockReturnValue(null);
       mockGetNetworkConnectionBanner.mockReturnValue({
         status: 'unavailable',
         networkName: 'Arbitrum One',
@@ -620,7 +620,7 @@ describe('useNetworkConnectionBanner', () => {
     });
 
     it('does nothing when status is available', async () => {
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue(null);
+      mockSelectNetworkForConnectionBanner.mockReturnValue(null);
       mockGetNetworkConnectionBanner.mockReturnValue({ status: 'available' });
 
       const { result } = renderHookWithProviderTyped(
@@ -637,7 +637,7 @@ describe('useNetworkConnectionBanner', () => {
     });
 
     it('does nothing when infuraEndpointIndex is undefined', async () => {
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue(null);
+      mockSelectNetworkForConnectionBanner.mockReturnValue(null);
       mockGetNetworkConnectionBanner.mockReturnValue({
         status: 'unavailable',
         networkName: 'Custom Network',
@@ -694,7 +694,7 @@ describe('useNetworkConnectionBanner', () => {
           typeof mockGetNetworkConfigurationsByChainId
         >,
       );
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue(null);
+      mockSelectNetworkForConnectionBanner.mockReturnValue(null);
       mockGetNetworkConnectionBanner.mockReturnValue({
         status: 'unavailable',
         networkName: 'Arbitrum One',
@@ -759,7 +759,7 @@ describe('useNetworkConnectionBanner', () => {
       });
 
       // But selector now returns Infura endpoint (fresh data after switch)
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+      mockSelectNetworkForConnectionBanner.mockReturnValue({
         networkName: 'Arbitrum One',
         networkClientId: 'arbitrum-mainnet',
         chainId: '0xa4b1',

--- a/ui/hooks/useNetworkConnectionBanner.ts
+++ b/ui/hooks/useNetworkConnectionBanner.ts
@@ -1,7 +1,7 @@
 import { useEffect, useCallback, useRef, useContext } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { Hex, hexToNumber } from '@metamask/utils';
-import { selectFirstUnavailableEvmNetwork } from '../selectors/multichain/networks';
+import { selectNetworkForConnectionBanner } from '../selectors/multichain/networks';
 import {
   getNetworkConnectionBanner,
   getIsDeviceOffline,
@@ -40,9 +40,7 @@ export const useNetworkConnectionBanner =
     const dispatch = useDispatch();
     const { trackEvent } = useContext(MetaMetricsContext);
     const isOffline = useSelector(getIsDeviceOffline);
-    const firstUnavailableEvmNetwork = useSelector(
-      selectFirstUnavailableEvmNetwork,
-    );
+    const bannerNetwork = useSelector(selectNetworkForConnectionBanner);
     const networkConnectionBannerState = useSelector(
       getNetworkConnectionBanner,
     );
@@ -140,27 +138,27 @@ export const useNetworkConnectionBanner =
       clearUnavailableTimer();
 
       timersRef.current.unavailableTimer = setTimeout(() => {
-        if (firstUnavailableEvmNetwork) {
+        if (bannerNetwork) {
           trackNetworkBannerEvent({
             bannerType: 'unavailable',
             eventName: MetaMetricsEventName.NetworkConnectionBannerShown,
-            networkClientId: firstUnavailableEvmNetwork.networkClientId,
+            networkClientId: bannerNetwork.networkClientId,
           });
           dispatch(
             updateNetworkConnectionBanner({
               status: 'unavailable',
-              networkName: firstUnavailableEvmNetwork.networkName,
-              networkClientId: firstUnavailableEvmNetwork.networkClientId,
-              chainId: firstUnavailableEvmNetwork.chainId,
-              isInfuraEndpoint: firstUnavailableEvmNetwork.isInfuraEndpoint,
+              networkName: bannerNetwork.networkName,
+              networkClientId: bannerNetwork.networkClientId,
+              chainId: bannerNetwork.chainId,
+              isInfuraEndpoint: bannerNetwork.isInfuraEndpoint,
               infuraEndpointIndex:
-                firstUnavailableEvmNetwork.infuraEndpointIndex,
+                bannerNetwork.infuraEndpointIndex,
             }),
           );
         }
       }, UNAVAILABLE_BANNER_TIMEOUT - DEGRADED_BANNER_TIMEOUT);
     }, [
-      firstUnavailableEvmNetwork,
+      bannerNetwork,
       trackNetworkBannerEvent,
       dispatch,
       clearUnavailableTimer,
@@ -170,21 +168,21 @@ export const useNetworkConnectionBanner =
       clearDegradedTimer();
 
       timersRef.current.degradedTimer = setTimeout(() => {
-        if (firstUnavailableEvmNetwork) {
+        if (bannerNetwork) {
           trackNetworkBannerEvent({
             bannerType: 'degraded',
             eventName: MetaMetricsEventName.NetworkConnectionBannerShown,
-            networkClientId: firstUnavailableEvmNetwork.networkClientId,
+            networkClientId: bannerNetwork.networkClientId,
           });
           dispatch(
             updateNetworkConnectionBanner({
               status: 'degraded',
-              networkName: firstUnavailableEvmNetwork.networkName,
-              networkClientId: firstUnavailableEvmNetwork.networkClientId,
-              chainId: firstUnavailableEvmNetwork.chainId,
-              isInfuraEndpoint: firstUnavailableEvmNetwork.isInfuraEndpoint,
+              networkName: bannerNetwork.networkName,
+              networkClientId: bannerNetwork.networkClientId,
+              chainId: bannerNetwork.chainId,
+              isInfuraEndpoint: bannerNetwork.isInfuraEndpoint,
               infuraEndpointIndex:
-                firstUnavailableEvmNetwork.infuraEndpointIndex,
+                bannerNetwork.infuraEndpointIndex,
             }),
           );
 
@@ -192,7 +190,7 @@ export const useNetworkConnectionBanner =
         }
       }, DEGRADED_BANNER_TIMEOUT);
     }, [
-      firstUnavailableEvmNetwork,
+      bannerNetwork,
       trackNetworkBannerEvent,
       dispatch,
       startUnavailableTimer,
@@ -214,7 +212,7 @@ export const useNetworkConnectionBanner =
         return;
       }
 
-      if (firstUnavailableEvmNetwork) {
+      if (bannerNetwork) {
         if (networkConnectionBannerState.status === 'degraded') {
           startUnavailableTimer();
         } else if (
@@ -232,7 +230,7 @@ export const useNetworkConnectionBanner =
       };
     }, [
       isOffline,
-      firstUnavailableEvmNetwork,
+      bannerNetwork,
       clearTimers,
       dispatch,
       networkConnectionBannerState.status,
@@ -292,16 +290,16 @@ export const useNetworkConnectionBanner =
     if (
       (networkConnectionBannerState.status === 'degraded' ||
         networkConnectionBannerState.status === 'unavailable') &&
-      firstUnavailableEvmNetwork
+      bannerNetwork
     ) {
       return {
         ...networkConnectionBannerState,
         // Override with fresh data from selector
-        networkClientId: firstUnavailableEvmNetwork.networkClientId,
-        networkName: firstUnavailableEvmNetwork.networkName,
-        chainId: firstUnavailableEvmNetwork.chainId,
-        isInfuraEndpoint: firstUnavailableEvmNetwork.isInfuraEndpoint,
-        infuraEndpointIndex: firstUnavailableEvmNetwork.infuraEndpointIndex,
+        networkClientId: bannerNetwork.networkClientId,
+        networkName: bannerNetwork.networkName,
+        chainId: bannerNetwork.chainId,
+        isInfuraEndpoint: bannerNetwork.isInfuraEndpoint,
+        infuraEndpointIndex: bannerNetwork.infuraEndpointIndex,
         trackNetworkBannerEvent,
         switchToInfura,
       };

--- a/ui/selectors/multichain/networks.test.ts
+++ b/ui/selectors/multichain/networks.test.ts
@@ -26,7 +26,7 @@ import {
   getSelectedMultichainNetworkChainId,
   getSelectedMultichainNetworkConfiguration,
   getIsEvmMultichainNetworkSelected,
-  selectFirstUnavailableEvmNetwork,
+  selectNetworkForConnectionBanner,
   getEvmMultichainNetworkConfigurations,
   getAllMultichainNetworkConfigurations,
 } from './networks';
@@ -595,8 +595,8 @@ describe('Multichain network selectors', () => {
     });
   });
 
-  describe('selectFirstUnavailableEvmNetwork', () => {
-    it('returns the first EVM Infura-powered network that does not have a status of "available"', () => {
+  describe('selectNetworkForConnectionBanner', () => {
+    it('returns the first unavailable Infura network when multiple Infura networks are unavailable', () => {
       const mockStateWithMultipleUnavailableNetworks = {
         metamask: {
           enabledNetworkMap: {
@@ -652,7 +652,7 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectFirstUnavailableEvmNetwork(
+        selectNetworkForConnectionBanner(
           mockStateWithMultipleUnavailableNetworks,
         ),
       ).toStrictEqual({
@@ -664,7 +664,7 @@ describe('Multichain network selectors', () => {
       });
     });
 
-    it('returns the first EVM custom network that does not have a status of "available"', () => {
+    it('returns the unavailable custom network when both a custom and Infura network are down', () => {
       const mockStateWithMultipleUnavailableNetworks = {
         metamask: {
           enabledNetworkMap: {
@@ -720,7 +720,7 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectFirstUnavailableEvmNetwork(
+        selectNetworkForConnectionBanner(
           mockStateWithMultipleUnavailableNetworks,
         ),
       ).toStrictEqual({
@@ -788,7 +788,7 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectFirstUnavailableEvmNetwork(mockStateWithAvailableEvmNetworks),
+        selectNetworkForConnectionBanner(mockStateWithAvailableEvmNetworks),
       ).toBeNull();
     });
 
@@ -805,7 +805,7 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectFirstUnavailableEvmNetwork(mockStateWithNoEnabledEvmNetworks),
+        selectNetworkForConnectionBanner(mockStateWithNoEnabledEvmNetworks),
       ).toBeNull();
     });
 
@@ -840,7 +840,7 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectFirstUnavailableEvmNetwork(mockStateWithMissingMetadata),
+        selectNetworkForConnectionBanner(mockStateWithMissingMetadata),
       ).toBeNull();
     });
 
@@ -864,7 +864,7 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectFirstUnavailableEvmNetwork(mockStateWithMissingNetworkConfig),
+        selectNetworkForConnectionBanner(mockStateWithMissingNetworkConfig),
       ).toBeNull();
     });
 
@@ -909,9 +909,9 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectFirstUnavailableEvmNetwork(
+        selectNetworkForConnectionBanner(
           mockStateWithCustomAndInfuraEndpoints as Parameters<
-            typeof selectFirstUnavailableEvmNetwork
+            typeof selectNetworkForConnectionBanner
           >[0],
         ),
       ).toStrictEqual({
@@ -959,7 +959,7 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectFirstUnavailableEvmNetwork(mockStateWithOnlyCustomEndpoint),
+        selectNetworkForConnectionBanner(mockStateWithOnlyCustomEndpoint),
       ).toStrictEqual({
         networkName: 'Custom Network',
         networkClientId: 'custom-network',
@@ -969,7 +969,7 @@ describe('Multichain network selectors', () => {
       });
     });
 
-    it('does not return infuraEndpointIndex when already using Infura endpoint', () => {
+    it('returns the network when only one network is enabled and it is unavailable (all-unavailable rule)', () => {
       const mockStateWithInfuraAsDefault = {
         metamask: {
           enabledNetworkMap: {
@@ -1004,7 +1004,7 @@ describe('Multichain network selectors', () => {
         },
       };
 
-      const result = selectFirstUnavailableEvmNetwork(
+      const result = selectNetworkForConnectionBanner(
         mockStateWithInfuraAsDefault,
       );
       expect(result).toStrictEqual({
@@ -1012,6 +1012,224 @@ describe('Multichain network selectors', () => {
         networkClientId: 'mainnet',
         chainId: '0x1',
         isInfuraEndpoint: true,
+        infuraEndpointIndex: undefined,
+      });
+    });
+
+    it('returns null when only one Infura network out of many enabled is unavailable', () => {
+      // Suppresses noisy banners for transient single-network Infura issues
+      // while other networks remain available. See WPC-1014.
+      const mockStateWithSingleInfuraDown = {
+        metamask: {
+          enabledNetworkMap: {
+            [KnownCaipNamespace.Eip155]: {
+              '0x1': true,
+              '0xaa36a7': true,
+            },
+          },
+          networksMetadata: {
+            mainnet: {
+              EIPS: {},
+              status: NetworkStatus.Available,
+            },
+            sepolia: {
+              EIPS: {},
+              status: NetworkStatus.Unavailable,
+            },
+          },
+          networkConfigurationsByChainId: {
+            '0x1': {
+              chainId: '0x1' as const,
+              name: 'Ethereum Mainnet',
+              nativeCurrency: 'ETH',
+              rpcEndpoints: [
+                {
+                  type: RpcEndpointType.Infura as const,
+                  url: 'https://mainnet.infura.io/v3/{infuraProjectId}' as const,
+                  networkClientId: 'mainnet' as const,
+                },
+              ],
+              defaultRpcEndpointIndex: 0,
+              blockExplorerUrls: [],
+              defaultBlockExplorerUrlIndex: 0,
+            },
+            '0xaa36a7': {
+              chainId: '0xaa36a7' as const,
+              name: 'Sepolia',
+              nativeCurrency: 'SepoliaETH',
+              rpcEndpoints: [
+                {
+                  type: RpcEndpointType.Infura as const,
+                  url: 'https://sepolia.infura.io/v3/{infuraProjectId}' as const,
+                  networkClientId: 'sepolia' as const,
+                },
+              ],
+              defaultRpcEndpointIndex: 0,
+              blockExplorerUrls: [],
+              defaultBlockExplorerUrlIndex: 0,
+            },
+          },
+          selectedNetworkClientId: 'mainnet',
+        },
+      };
+
+      expect(
+        selectNetworkForConnectionBanner(mockStateWithSingleInfuraDown),
+      ).toBeNull();
+    });
+
+    it('returns the unavailable custom network even when other networks are available (custom override)', () => {
+      const mockStateWithCustomDownAmongAvailable = {
+        metamask: {
+          enabledNetworkMap: {
+            [KnownCaipNamespace.Eip155]: {
+              '0x1': true,
+              '0xaa36a7': true,
+              '0x1000': true,
+            },
+          },
+          networksMetadata: {
+            mainnet: {
+              EIPS: {},
+              status: NetworkStatus.Available,
+            },
+            sepolia: {
+              EIPS: {},
+              status: NetworkStatus.Available,
+            },
+            'custom-network': {
+              EIPS: {},
+              status: NetworkStatus.Unavailable,
+            },
+          },
+          networkConfigurationsByChainId: {
+            '0x1': {
+              chainId: '0x1' as const,
+              name: 'Ethereum Mainnet',
+              nativeCurrency: 'ETH',
+              rpcEndpoints: [
+                {
+                  type: RpcEndpointType.Infura as const,
+                  url: 'https://mainnet.infura.io/v3/{infuraProjectId}' as const,
+                  networkClientId: 'mainnet' as const,
+                },
+              ],
+              defaultRpcEndpointIndex: 0,
+              blockExplorerUrls: [],
+              defaultBlockExplorerUrlIndex: 0,
+            },
+            '0xaa36a7': {
+              chainId: '0xaa36a7' as const,
+              name: 'Sepolia',
+              nativeCurrency: 'SepoliaETH',
+              rpcEndpoints: [
+                {
+                  type: RpcEndpointType.Infura as const,
+                  url: 'https://sepolia.infura.io/v3/{infuraProjectId}' as const,
+                  networkClientId: 'sepolia' as const,
+                },
+              ],
+              defaultRpcEndpointIndex: 0,
+              blockExplorerUrls: [],
+              defaultBlockExplorerUrlIndex: 0,
+            },
+            '0x1000': {
+              chainId: '0x1000' as const,
+              name: 'Custom Network',
+              nativeCurrency: 'ETH',
+              rpcEndpoints: [
+                {
+                  type: RpcEndpointType.Custom as const,
+                  url: 'https://custom.network',
+                  networkClientId: 'custom-network' as const,
+                },
+              ],
+              defaultRpcEndpointIndex: 0,
+              blockExplorerUrls: [],
+              defaultBlockExplorerUrlIndex: 0,
+            },
+          },
+          selectedNetworkClientId: 'mainnet',
+        },
+      };
+
+      expect(
+        selectNetworkForConnectionBanner(
+          mockStateWithCustomDownAmongAvailable,
+        ),
+      ).toStrictEqual({
+        networkName: 'Custom Network',
+        networkClientId: 'custom-network',
+        chainId: '0x1000',
+        isInfuraEndpoint: false,
+        infuraEndpointIndex: undefined,
+      });
+    });
+
+    it('prefers the custom unavailable network over an Infura unavailable one when both are down', () => {
+      // Iteration order would surface Mainnet first, but the custom-RPC
+      // override routes the banner CTA to the network the user can act on.
+      const mockStateWithCustomAndInfuraDown = {
+        metamask: {
+          enabledNetworkMap: {
+            [KnownCaipNamespace.Eip155]: {
+              '0x1': true,
+              '0x1000': true,
+            },
+          },
+          networksMetadata: {
+            mainnet: {
+              EIPS: {},
+              status: NetworkStatus.Unavailable,
+            },
+            'custom-network': {
+              EIPS: {},
+              status: NetworkStatus.Unavailable,
+            },
+          },
+          networkConfigurationsByChainId: {
+            '0x1': {
+              chainId: '0x1' as const,
+              name: 'Ethereum Mainnet',
+              nativeCurrency: 'ETH',
+              rpcEndpoints: [
+                {
+                  type: RpcEndpointType.Infura as const,
+                  url: 'https://mainnet.infura.io/v3/{infuraProjectId}' as const,
+                  networkClientId: 'mainnet' as const,
+                },
+              ],
+              defaultRpcEndpointIndex: 0,
+              blockExplorerUrls: [],
+              defaultBlockExplorerUrlIndex: 0,
+            },
+            '0x1000': {
+              chainId: '0x1000' as const,
+              name: 'Custom Network',
+              nativeCurrency: 'ETH',
+              rpcEndpoints: [
+                {
+                  type: RpcEndpointType.Custom as const,
+                  url: 'https://custom.network',
+                  networkClientId: 'custom-network' as const,
+                },
+              ],
+              defaultRpcEndpointIndex: 0,
+              blockExplorerUrls: [],
+              defaultBlockExplorerUrlIndex: 0,
+            },
+          },
+          selectedNetworkClientId: 'mainnet',
+        },
+      };
+
+      expect(
+        selectNetworkForConnectionBanner(mockStateWithCustomAndInfuraDown),
+      ).toStrictEqual({
+        networkName: 'Custom Network',
+        networkClientId: 'custom-network',
+        chainId: '0x1000',
+        isInfuraEndpoint: false,
         infuraEndpointIndex: undefined,
       });
     });

--- a/ui/selectors/multichain/networks.ts
+++ b/ui/selectors/multichain/networks.ts
@@ -452,7 +452,21 @@ export const selectAnyEnabledNetworksAreAvailable = createSelector(
   },
 );
 
-export const selectFirstUnavailableEvmNetwork = createSelector(
+/**
+ * Returns the unavailable EVM network that should drive the connection banner,
+ * or null when no banner should be shown.
+ *
+ * The banner is intentionally noisy-averse: a single Infura-backed network
+ * failing is usually a server-side blip, so we suppress it. The banner shows
+ * only when 2+ enabled EVM networks are unavailable (likely client-side), or
+ * every enabled EVM network is unavailable (catches single-network setups), or
+ * any unavailable network's active RPC is a non-Infura (custom) endpoint —
+ * these have no automatic failover so the user must be told.
+ *
+ * When the custom override fires alongside other unavailable networks, the
+ * custom one is surfaced so the "Switch to MetaMask default RPC" CTA targets it.
+ */
+export const selectNetworkForConnectionBanner = createSelector(
   getEnabledNetworks,
   getNetworkConfigurationsByChainId,
   getNetworksMetadata,
@@ -462,61 +476,100 @@ export const selectFirstUnavailableEvmNetwork = createSelector(
       .filter(([, isEnabled]) => isEnabled)
       .map(([chainId]) => chainId as Hex);
 
+    type UnavailableNetwork = {
+      networkClientId: string;
+      chainId: Hex;
+      networkName: string;
+      isInfuraEndpoint: boolean;
+      infuraEndpointIndex: number | undefined;
+    };
+
+    const unavailable: UnavailableNetwork[] = [];
+    let totalEnabled = 0;
+
     for (const chainId of enabledChainIds) {
       const networkConfiguration = networkConfigurationsByChainId[chainId];
-      if (networkConfiguration) {
-        // Get the network client ID directly from the network configuration
-        const { rpcEndpoints, defaultRpcEndpointIndex, name } =
-          networkConfiguration;
-        const rpcEndpoint = rpcEndpoints[defaultRpcEndpointIndex];
+      if (!networkConfiguration) {
+        continue;
+      }
 
-        if (rpcEndpoint) {
-          const metadata = networksMetadata[rpcEndpoint.networkClientId];
+      const { rpcEndpoints, defaultRpcEndpointIndex, name } =
+        networkConfiguration;
+      const rpcEndpoint = rpcEndpoints[defaultRpcEndpointIndex];
+      if (!rpcEndpoint) {
+        continue;
+      }
 
-          if (
-            metadata !== undefined &&
-            metadata.status !== NetworkStatus.Available
-          ) {
-            const isInfuraEndpoint = getIsMetaMaskInfuraEndpointUrl(
-              rpcEndpoint.url,
+      totalEnabled += 1;
+
+      const metadata = networksMetadata[rpcEndpoint.networkClientId];
+      if (
+        metadata === undefined ||
+        metadata.status === NetworkStatus.Available
+      ) {
+        continue;
+      }
+
+      const isInfuraEndpoint = getIsMetaMaskInfuraEndpointUrl(
+        rpcEndpoint.url,
+        infuraProjectId ?? '',
+      );
+
+      // For custom endpoints (non-Infura), check if there's an Infura
+      // endpoint available for this network that we can switch to
+      let infuraEndpointIndex: number | undefined;
+      if (!isInfuraEndpoint) {
+        infuraEndpointIndex = rpcEndpoints.findIndex(
+          (endpoint, index) =>
+            index !== defaultRpcEndpointIndex &&
+            getIsMetaMaskInfuraEndpointUrl(
+              endpoint.url,
               infuraProjectId ?? '',
-            );
-
-            // For custom endpoints (non-Infura), check if there's an Infura
-            // endpoint available for this network that we can switch to
-            let infuraEndpointIndex: number | undefined;
-            if (!isInfuraEndpoint) {
-              infuraEndpointIndex = rpcEndpoints.findIndex(
-                (endpoint, index) =>
-                  index !== defaultRpcEndpointIndex &&
-                  getIsMetaMaskInfuraEndpointUrl(
-                    endpoint.url,
-                    infuraProjectId ?? '',
-                  ),
-              );
-              // If no Infura endpoint found, set to undefined
-              if (infuraEndpointIndex === -1) {
-                infuraEndpointIndex = undefined;
-              }
-            }
-
-            return {
-              networkClientId: rpcEndpoint.networkClientId,
-              chainId,
-              networkName: name,
-              // We have to use this function to check whether the endpoint is
-              // an Infura endpoint because some Infura endpoint URLs use the
-              // wrong type.
-              isInfuraEndpoint,
-              // Index of an available Infura endpoint (for custom networks that
-              // have one) that can be used to switch to Infura
-              infuraEndpointIndex,
-            };
-          }
+            ),
+        );
+        if (infuraEndpointIndex === -1) {
+          infuraEndpointIndex = undefined;
         }
       }
+
+      unavailable.push({
+        networkClientId: rpcEndpoint.networkClientId,
+        chainId,
+        networkName: name,
+        // We have to use this function to check whether the endpoint is
+        // an Infura endpoint because some Infura endpoint URLs use the
+        // wrong type.
+        isInfuraEndpoint,
+        // Index of an available Infura endpoint (for custom networks that
+        // have one) that can be used to switch to Infura
+        infuraEndpointIndex,
+      });
     }
-    return null;
+
+    if (unavailable.length === 0) {
+      return null;
+    }
+
+    const firstCustomUnavailable = unavailable.find((n) => !n.isInfuraEndpoint);
+    const multipleUnavailable = unavailable.length >= 2;
+    const allUnavailable = unavailable.length === totalEnabled;
+
+    if (!firstCustomUnavailable && !multipleUnavailable && !allUnavailable) {
+      return null;
+    }
+
+    // Prefer a custom-RPC network when one is among the unavailable set so the
+    // banner's "Switch to MetaMask default RPC" CTA points at the network the
+    // user can actually act on.
+    const selected = firstCustomUnavailable ?? unavailable[0];
+
+    return {
+      networkClientId: selected.networkClientId,
+      chainId: selected.chainId,
+      networkName: selected.networkName,
+      isInfuraEndpoint: selected.isInfuraEndpoint,
+      infuraEndpointIndex: selected.infuraEndpointIndex,
+    };
   },
 );
 


### PR DESCRIPTION
## **Description**

Currently the RPC connection banner ("Still connecting" / "Unable to connect") shows whenever any single enabled EVM network's default RPC is unavailable for >5s. With "All popular networks" selected, the client polls every popular chain every ~30s, so a single transient Infura blip on Linea or Polygon pops the banner even though the wallet remains fully functional. PMs and users have repeatedly flagged this as noisy.

This PR keeps the existing banner UI and timer thresholds untouched and only changes when it shows:

- 2+ enabled EVM networks unavailable (likely client-side), or
- every enabled EVM network unavailable (covers single-network setups), or
- any unavailable network whose active RPC is a non-Infura (custom) endpoint — these have no automatic failover so the user must be told.

When the custom override fires alongside an Infura outage, the custom network is surfaced first so the "Switch to MetaMask default RPC" CTA targets the one the user can act on.

Selector `selectFirstUnavailableEvmNetwork` is renamed to `selectNetworkForConnectionBanner` to reflect the new semantics. Hook source, banner component, and analytics events are otherwise unchanged.

## **Changelog**

CHANGELOG entry: Reduced false-positive RPC connection banners — the "Still connecting" banner no longer appears when a single popular network is briefly unreachable while others are working.

## **Related issues**

Fixes: [WPC-1014](https://consensyssoftware.atlassian.net/browse/WPC-1014)

## **Manual testing steps**

1. Enable "All popular networks" in the network selector.
2. Open DevTools → Network → block one popular network's RPC host (e.g. `linea-mainnet.infura.io`). Wait 5+ seconds. Expect: no banner.
3. Block 2+ popular network hosts. Wait 5s → expect degraded banner. Wait 30s total → expect unavailable banner.
4. Add a custom RPC for any network and make it the default endpoint. Block only that host. Expect: banner appears (custom override).
5. Disable all networks except one, then block that one host. Expect: banner appears (all-down case).
6. Turn off wifi entirely. Expect: no banner (existing device-offline short-circuit still wins).

## **Screenshots/Recordings**

### **Before**

<!-- banner shown for single-network blip -->

### **After**

<!-- no banner for single-network blip; banner still shown for multi-network outage -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[WPC-1014]: https://consensyssoftware.atlassian.net/browse/WPC-1014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ