### PR TITLE
fix(ci): drop phantom benchmark-gate fallback from FP-rate proxy

### DIFF
--- a/.github/scripts/benchmark-fp-rate.mts
+++ b/.github/scripts/benchmark-fp-rate.mts
@@ -38,7 +38,6 @@ type FpReportFile = Record<string, WeeklyReport>;
 
 const SKIP_LABEL = 'skip-benchmark-gate';
 const GATE_CHECK_NAME = 'quality-gate';
-const GATE_CHECK_NAME_FALLBACK = 'benchmark-gate';
 
 function loadEnv(): Env {
   const token = process.env.GITHUB_TOKEN;
@@ -134,23 +133,14 @@ async function gateRanAndStatus(
   // merge commit has hundreds of check runs (e.g. ~350 in this repo). A plain
   // per_page:100 fetch would miss the gate check on pages 2+ and silently drop
   // those PRs from the denominator, biasing the FP-rate proxy upward.
-  const [primary, fallback] = await Promise.all([
-    octokit.rest.checks.listForRef({
-      owner,
-      repo,
-      ref: sha,
-      check_name: GATE_CHECK_NAME,
-      per_page: 100,
-    }),
-    octokit.rest.checks.listForRef({
-      owner,
-      repo,
-      ref: sha,
-      check_name: GATE_CHECK_NAME_FALLBACK,
-      per_page: 100,
-    }),
-  ]);
-  const gateChecks = [...primary.data.check_runs, ...fallback.data.check_runs];
+  const { data } = await octokit.rest.checks.listForRef({
+    owner,
+    repo,
+    ref: sha,
+    check_name: GATE_CHECK_NAME,
+    per_page: 100,
+  });
+  const gateChecks = data.check_runs;
   if (gateChecks.length === 0) {
     return { ran: false, failed: false };
   }


### PR DESCRIPTION
CHANGELOG entry: null

## Summary

- The weekly benchmark FP-rate proxy (`.github/scripts/benchmark-fp-rate.mts`) queried two check-run names per PR: `quality-gate` and a `benchmark-gate` fallback.
- `benchmark-gate` has **never existed** as a check — the only real identifiers are the `quality-gate` check (`run-benchmarks.yml`) and the `skip-benchmark-gate` *label*. The fallback `listForRef` call always returned empty, wasting an API call per PR and implying a check that isn't real.
- Removes the fabricated constant and collapses the dual `Promise.all` lookup to a single `quality-gate` query. No behavior change to the computed rate.

## Context

Part of the Performance Quality Gates work (MetaMask/MetaMask-planning#6944). The FP/FN monitoring substrate feeds the automated-drift-prevention follow-up (MetaMask/MetaMask-planning#7287); this removes a misleading no-op from that path.

## Test plan

- [ ] `quality-gate` check resolution unchanged for merged PRs (the only real check name is still queried).
- [ ] Next weekly `Benchmark FP rate report` run produces the same `fp-rates.json` shape, with one fewer API call per PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small CI maintenance script change with no production or security impact; reported metrics should be unchanged.
> 
> **Overview**
> The weekly benchmark false-positive-rate script in `.github/scripts/benchmark-fp-rate.mts` no longer looks up a non-existent `benchmark-gate` check run alongside `quality-gate`. It drops the `GATE_CHECK_NAME_FALLBACK` constant and replaces the parallel `listForRef` calls with one query filtered on `quality-gate`, which matches the real job name in `run-benchmarks.yml`.
> 
> That removes one GitHub API call per merged PR in the report window. The FP-rate proxy (skip label vs. gated merges) should stay the same because the fallback never returned runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 303afa85e915ecf9c5e92cee05265b6d6fb25860. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
