### PR TITLE
feat: suppress RPC connection banner during single-provider outages (WPC-1014)

### DIFF
--- a/app/scripts/lib/util.ts
+++ b/app/scripts/lib/util.ts
@@ -1,4 +1,3 @@
-import ipRegex from 'ip-regex';
 import { AccessList } from '@ethereumjs/tx';
 import {
   TransactionEnvelopeType,
@@ -45,6 +44,7 @@ import {
   getIsQuicknodeEndpointUrl,
   KNOWN_CUSTOM_ENDPOINT_URLS,
 } from '../../../shared/lib/network-utils';
+import { isLocalhostOrIPAddress } from '../../../shared/lib/url-utils';
 // Re-export install type utilities from dedicated module to avoid circular dependencies
 // and keep the sentry bundle lightweight
 export { getInstallType, initInstallType } from './install-type';
@@ -615,33 +615,6 @@ function extractHostname(url: string): string | null {
   } catch {
     return null;
   }
-}
-
-/**
- * Check if a hostname is localhost or an IP address.
- * Public RPC providers use domain names, not raw IP addresses.
- * These should never be considered "public" endpoints even if they appear in chainlist.
- *
- * @param hostname - The hostname to check.
- * @returns True if the hostname is localhost or an IP address (v4 or v6).
- */
-function isLocalhostOrIPAddress(hostname: string): boolean {
-  const lowerHostname = hostname.toLowerCase();
-
-  // Check for localhost
-  if (lowerHostname === 'localhost') {
-    return true;
-  }
-
-  // Remove brackets from IPv6 addresses for testing (e.g., [::1] -> ::1)
-  const hostnameWithoutBrackets = lowerHostname.replace(/^\[|\]$/gu, '');
-
-  // Check for IP address (v4 or v6)
-  if (ipRegex({ exact: true }).test(hostnameWithoutBrackets)) {
-    return true;
-  }
-
-  return false;
 }
 
 // RFC 6761 special-use TLDs that should never be used by real public RPC providers

--- a/package.json
+++ b/package.json
@@ -500,6 +500,7 @@
     "nanoid": "^3.3.8",
     "pify": "^5.0.0",
     "prop-types": "^15.6.1",
+    "psl": "^1.15.0",
     "punycode": "^2.1.1",
     "qrcode-generator": "^2.0.4",
     "qrcode.react": "^4.2.0",

--- a/shared/lib/url-utils.test.ts
+++ b/shared/lib/url-utils.test.ts
@@ -1,4 +1,21 @@
-import { getRegistrableDomain } from './url-utils';
+import { getRegistrableDomain, isLocalhostOrIPAddress } from './url-utils';
+
+describe('isLocalhostOrIPAddress', () => {
+  it.each([
+    ['localhost', true],
+    ['LOCALHOST', true],
+    ['127.0.0.1', true],
+    ['10.0.0.1', true],
+    ['8.8.8.8', true],
+    ['::1', true],
+    ['[::1]', true],
+    ['infura.io', false],
+    ['mainnet.infura.io', false],
+    ['my-custom-rpc', false],
+  ])('returns %p -> %p', (hostname, expected) => {
+    expect(isLocalhostOrIPAddress(hostname)).toBe(expected);
+  });
+});
 
 describe('getRegistrableDomain', () => {
   it('returns the last two labels for a multi-label hostname', () => {

--- a/shared/lib/url-utils.test.ts
+++ b/shared/lib/url-utils.test.ts
@@ -44,6 +44,11 @@ describe('getDomain', () => {
     expect(getDomain('https://alchemy.com/')).toBe('alchemy.com');
   });
 
+  it('handles multi-part public suffixes like .co.uk', () => {
+    expect(getDomain('https://api.example.co.uk/v1')).toBe('example.co.uk');
+    expect(getDomain('https://example.co.uk/')).toBe('example.co.uk');
+  });
+
   it('returns single-label hosts (e.g., localhost) verbatim', () => {
     expect(getDomain('http://localhost:8545')).toBe('localhost');
   });

--- a/shared/lib/url-utils.test.ts
+++ b/shared/lib/url-utils.test.ts
@@ -1,19 +1,26 @@
 import { getRegistrableDomain, isLocalhostOrIPAddress } from './url-utils';
 
 describe('isLocalhostOrIPAddress', () => {
-  it.each([
-    ['localhost', true],
-    ['LOCALHOST', true],
-    ['127.0.0.1', true],
-    ['10.0.0.1', true],
-    ['8.8.8.8', true],
-    ['::1', true],
-    ['[::1]', true],
-    ['infura.io', false],
-    ['mainnet.infura.io', false],
-    ['my-custom-rpc', false],
-  ])('returns %p -> %p', (hostname, expected) => {
-    expect(isLocalhostOrIPAddress(hostname)).toBe(expected);
+  it('returns true for "localhost" (any case)', () => {
+    expect(isLocalhostOrIPAddress('localhost')).toBe(true);
+    expect(isLocalhostOrIPAddress('LOCALHOST')).toBe(true);
+  });
+
+  it('returns true for IPv4 addresses', () => {
+    expect(isLocalhostOrIPAddress('127.0.0.1')).toBe(true);
+    expect(isLocalhostOrIPAddress('10.0.0.1')).toBe(true);
+    expect(isLocalhostOrIPAddress('8.8.8.8')).toBe(true);
+  });
+
+  it('returns true for IPv6 addresses (with or without brackets)', () => {
+    expect(isLocalhostOrIPAddress('::1')).toBe(true);
+    expect(isLocalhostOrIPAddress('[::1]')).toBe(true);
+  });
+
+  it('returns false for regular hostnames', () => {
+    expect(isLocalhostOrIPAddress('infura.io')).toBe(false);
+    expect(isLocalhostOrIPAddress('mainnet.infura.io')).toBe(false);
+    expect(isLocalhostOrIPAddress('my-custom-rpc')).toBe(false);
   });
 });
 

--- a/shared/lib/url-utils.test.ts
+++ b/shared/lib/url-utils.test.ts
@@ -1,4 +1,4 @@
-import { getRegistrableDomain, isLocalhostOrIPAddress } from './url-utils';
+import { getDomain, isLocalhostOrIPAddress } from './url-utils';
 
 describe('isLocalhostOrIPAddress', () => {
   it('returns true for "localhost" (any case)', () => {
@@ -24,39 +24,39 @@ describe('isLocalhostOrIPAddress', () => {
   });
 });
 
-describe('getRegistrableDomain', () => {
+describe('getDomain', () => {
   it('returns the last two labels for a multi-label hostname', () => {
-    expect(getRegistrableDomain('https://mainnet.infura.io/v3/abc')).toBe(
+    expect(getDomain('https://mainnet.infura.io/v3/abc')).toBe(
       'infura.io',
     );
   });
 
   it('groups subdomain-heavy hostnames under the same registrable domain', () => {
-    expect(getRegistrableDomain('https://linea-mainnet.infura.io/v3/abc')).toBe(
+    expect(getDomain('https://linea-mainnet.infura.io/v3/abc')).toBe(
       'infura.io',
     );
     expect(
-      getRegistrableDomain('https://polygon-mainnet.g.alchemy.com/v2/abc'),
+      getDomain('https://polygon-mainnet.g.alchemy.com/v2/abc'),
     ).toBe('alchemy.com');
   });
 
   it('returns the hostname as-is when it has exactly two labels', () => {
-    expect(getRegistrableDomain('https://alchemy.com/')).toBe('alchemy.com');
+    expect(getDomain('https://alchemy.com/')).toBe('alchemy.com');
   });
 
   it('returns single-label hosts (e.g., localhost) verbatim', () => {
-    expect(getRegistrableDomain('http://localhost:8545')).toBe('localhost');
+    expect(getDomain('http://localhost:8545')).toBe('localhost');
   });
 
   it('returns IPv4 addresses verbatim', () => {
-    expect(getRegistrableDomain('http://127.0.0.1:8545')).toBe('127.0.0.1');
+    expect(getDomain('http://127.0.0.1:8545')).toBe('127.0.0.1');
   });
 
   it('returns IPv6 addresses verbatim, including brackets', () => {
-    expect(getRegistrableDomain('http://[::1]:8545')).toBe('[::1]');
+    expect(getDomain('http://[::1]:8545')).toBe('[::1]');
   });
 
   it('returns null for an invalid URL', () => {
-    expect(getRegistrableDomain('not a url')).toBeNull();
+    expect(getDomain('not a url')).toBeNull();
   });
 });

--- a/shared/lib/url-utils.test.ts
+++ b/shared/lib/url-utils.test.ts
@@ -1,0 +1,38 @@
+import { getRegistrableDomain } from './url-utils';
+
+describe('getRegistrableDomain', () => {
+  it('returns the last two labels for a multi-label hostname', () => {
+    expect(getRegistrableDomain('https://mainnet.infura.io/v3/abc')).toBe(
+      'infura.io',
+    );
+  });
+
+  it('groups subdomain-heavy hostnames under the same registrable domain', () => {
+    expect(getRegistrableDomain('https://linea-mainnet.infura.io/v3/abc')).toBe(
+      'infura.io',
+    );
+    expect(
+      getRegistrableDomain('https://polygon-mainnet.g.alchemy.com/v2/abc'),
+    ).toBe('alchemy.com');
+  });
+
+  it('returns the hostname as-is when it has exactly two labels', () => {
+    expect(getRegistrableDomain('https://alchemy.com/')).toBe('alchemy.com');
+  });
+
+  it('returns single-label hosts (e.g., localhost) verbatim', () => {
+    expect(getRegistrableDomain('http://localhost:8545')).toBe('localhost');
+  });
+
+  it('returns IPv4 addresses verbatim', () => {
+    expect(getRegistrableDomain('http://127.0.0.1:8545')).toBe('127.0.0.1');
+  });
+
+  it('returns IPv6 addresses verbatim, including brackets', () => {
+    expect(getRegistrableDomain('http://[::1]:8545')).toBe('[::1]');
+  });
+
+  it('returns null for an invalid URL', () => {
+    expect(getRegistrableDomain('not a url')).toBeNull();
+  });
+});

--- a/shared/lib/url-utils.test.ts
+++ b/shared/lib/url-utils.test.ts
@@ -26,18 +26,16 @@ describe('isLocalhostOrIPAddress', () => {
 
 describe('getDomain', () => {
   it('returns the last two labels for a multi-label hostname', () => {
-    expect(getDomain('https://mainnet.infura.io/v3/abc')).toBe(
-      'infura.io',
-    );
+    expect(getDomain('https://mainnet.infura.io/v3/abc')).toBe('infura.io');
   });
 
   it('groups subdomain-heavy hostnames under the same registrable domain', () => {
     expect(getDomain('https://linea-mainnet.infura.io/v3/abc')).toBe(
       'infura.io',
     );
-    expect(
-      getDomain('https://polygon-mainnet.g.alchemy.com/v2/abc'),
-    ).toBe('alchemy.com');
+    expect(getDomain('https://polygon-mainnet.g.alchemy.com/v2/abc')).toBe(
+      'alchemy.com',
+    );
   });
 
   it('returns the hostname as-is when it has exactly two labels', () => {

--- a/shared/lib/url-utils.ts
+++ b/shared/lib/url-utils.ts
@@ -57,3 +57,38 @@ export function isWebOrigin(origin: string | undefined | null): boolean {
   }
   return origin.startsWith('http://') || origin.startsWith('https://');
 }
+
+/**
+ * Best-effort registrable domain (eTLD+1) for a URL, using the last two
+ * hostname labels. Used to group RPC endpoints by provider so a single
+ * provider's wide outage (e.g. *.infura.io) is treated as one failure
+ * rather than many. Not a Public Suffix List implementation — multi-part
+ * suffixes like ".co.uk" are not handled, which is fine for the RPC URL
+ * universe but not for arbitrary web hosts.
+ *
+ * Localhost and IP addresses are returned verbatim.
+ *
+ * @param urlString - The URL to extract a registrable domain from.
+ * @returns The registrable domain, or null if the URL is invalid.
+ */
+export function getRegistrableDomain(urlString: string): string | null {
+  const url = getValidUrl(urlString);
+  if (url === null) {
+    return null;
+  }
+
+  const { hostname } = url;
+
+  // IPv6 literal — URL.hostname wraps these in brackets.
+  if (hostname.startsWith('[')) {
+    return hostname;
+  }
+
+  // IPv4 literal or single-label host (e.g., "localhost").
+  if (/^\d+\.\d+\.\d+\.\d+$/u.test(hostname) || !hostname.includes('.')) {
+    return hostname;
+  }
+
+  const labels = hostname.split('.');
+  return labels.slice(-2).join('.');
+}

--- a/shared/lib/url-utils.ts
+++ b/shared/lib/url-utils.ts
@@ -81,19 +81,20 @@ export function isLocalhostOrIPAddress(hostname: string): boolean {
 }
 
 /**
- * Best-effort registrable domain (eTLD+1) for a URL, using the last two
- * hostname labels. Used to group RPC endpoints by provider so a single
- * provider's wide outage (e.g. *.infura.io) is treated as one failure
- * rather than many. Not a Public Suffix List implementation — multi-part
- * suffixes like ".co.uk" are not handled, which is fine for the RPC URL
- * universe but not for arbitrary web hosts.
+ * Best-effort domain (eTLD+1) for a URL, using the last two hostname labels.
+ * Used to group RPC endpoints by provider so a single provider's wide outage
+ * (e.g. *.infura.io) is treated as one failure rather than many. Not a Public
+ * Suffix List implementation — multi-part suffixes like ".co.uk" are not
+ * handled, which is fine for the RPC URL universe but not for arbitrary web
+ * hosts.
  *
- * Localhost, IP literals, and single-label hosts are returned verbatim.
+ * Localhost, IP literals, and single-label hosts are returned verbatim rather
+ * than reduced to a domain (so callers can still distinguish them).
  *
- * @param urlString - The URL to extract a registrable domain from.
- * @returns The registrable domain, or null if the URL is invalid.
+ * @param urlString - The URL to extract a domain from.
+ * @returns The domain, or null if the URL is invalid.
  */
-export function getRegistrableDomain(urlString: string): string | null {
+export function getDomain(urlString: string): string | null {
   const url = getValidUrl(urlString);
   if (url === null) {
     return null;

--- a/shared/lib/url-utils.ts
+++ b/shared/lib/url-utils.ts
@@ -1,4 +1,5 @@
 import urlLib from 'url';
+import ipRegex from 'ip-regex';
 
 export function addUrlProtocolPrefix(urlString: string) {
   let trimmed = urlString.trim();
@@ -59,6 +60,27 @@ export function isWebOrigin(origin: string | undefined | null): boolean {
 }
 
 /**
+ * Check if a hostname is localhost or an IP address.
+ * Public RPC providers use domain names, not raw IP addresses.
+ * These should never be considered "public" endpoints even if they appear in chainlist.
+ *
+ * @param hostname - The hostname to check.
+ * @returns True if the hostname is localhost or an IP address (v4 or v6).
+ */
+export function isLocalhostOrIPAddress(hostname: string): boolean {
+  const lowerHostname = hostname.toLowerCase();
+
+  if (lowerHostname === 'localhost') {
+    return true;
+  }
+
+  // Remove brackets from IPv6 addresses for testing (e.g., [::1] -> ::1)
+  const hostnameWithoutBrackets = lowerHostname.replace(/^\[|\]$/gu, '');
+
+  return ipRegex({ exact: true }).test(hostnameWithoutBrackets);
+}
+
+/**
  * Best-effort registrable domain (eTLD+1) for a URL, using the last two
  * hostname labels. Used to group RPC endpoints by provider so a single
  * provider's wide outage (e.g. *.infura.io) is treated as one failure
@@ -66,7 +88,7 @@ export function isWebOrigin(origin: string | undefined | null): boolean {
  * suffixes like ".co.uk" are not handled, which is fine for the RPC URL
  * universe but not for arbitrary web hosts.
  *
- * Localhost and IP addresses are returned verbatim.
+ * Localhost, IP literals, and single-label hosts are returned verbatim.
  *
  * @param urlString - The URL to extract a registrable domain from.
  * @returns The registrable domain, or null if the URL is invalid.
@@ -79,13 +101,7 @@ export function getRegistrableDomain(urlString: string): string | null {
 
   const { hostname } = url;
 
-  // IPv6 literal — URL.hostname wraps these in brackets.
-  if (hostname.startsWith('[')) {
-    return hostname;
-  }
-
-  // IPv4 literal or single-label host (e.g., "localhost").
-  if (/^\d+\.\d+\.\d+\.\d+$/u.test(hostname) || !hostname.includes('.')) {
+  if (!hostname.includes('.') || isLocalhostOrIPAddress(hostname)) {
     return hostname;
   }
 

--- a/shared/lib/url-utils.ts
+++ b/shared/lib/url-utils.ts
@@ -1,5 +1,6 @@
 import urlLib from 'url';
 import ipRegex from 'ip-regex';
+import psl from 'psl';
 
 export function addUrlProtocolPrefix(urlString: string) {
   let trimmed = urlString.trim();
@@ -81,15 +82,14 @@ export function isLocalhostOrIPAddress(hostname: string): boolean {
 }
 
 /**
- * Best-effort domain (eTLD+1) for a URL, using the last two hostname labels.
- * Used to group RPC endpoints by provider so a single provider's wide outage
- * (e.g. *.infura.io) is treated as one failure rather than many. Not a Public
- * Suffix List implementation — multi-part suffixes like ".co.uk" are not
- * handled, which is fine for the RPC URL universe but not for arbitrary web
- * hosts.
+ * Registrable domain (eTLD+1) for a URL, computed via the Public Suffix List
+ * so multi-part suffixes like ".co.uk" resolve correctly. Used to group RPC
+ * endpoints by provider so a single provider's wide outage (e.g. *.infura.io)
+ * is treated as one failure rather than many.
  *
  * Localhost, IP literals, and single-label hosts are returned verbatim rather
- * than reduced to a domain (so callers can still distinguish them).
+ * than reduced to a domain (psl returns null or garbage for those, and callers
+ * grouping by domain still need to distinguish them).
  *
  * @param urlString - The URL to extract a domain from.
  * @returns The domain, or null if the URL is invalid.
@@ -106,6 +106,5 @@ export function getDomain(urlString: string): string | null {
     return hostname;
   }
 
-  const labels = hostname.split('.');
-  return labels.slice(-2).join('.');
+  return psl.get(hostname) ?? hostname;
 }

--- a/types/psl.d.ts
+++ b/types/psl.d.ts
@@ -1,0 +1,17 @@
+// psl ships its own types at psl/types/index.d.ts, but its package.json
+// `exports` map omits a `types` condition so TypeScript's moduleResolution:node16
+// can't find them. Mirror the small surface we use.
+declare module 'psl' {
+  export function get(domain: string | null): string | null;
+  export function isValid(domain: string): boolean;
+  export function parse(domain: string):
+    | {
+        tld: string | null;
+        sld: string | null;
+        domain: string | null;
+        subdomain: string | null;
+        listed: boolean;
+        input: string;
+      }
+    | { input: string; error: { message: string; code: string } };
+}

--- a/ui/hooks/useNetworkConnectionBanner.test.ts
+++ b/ui/hooks/useNetworkConnectionBanner.test.ts
@@ -1,7 +1,7 @@
 import { act } from '@testing-library/react';
 import { RpcEndpointType } from '@metamask/network-controller';
 import { renderHookWithProviderTyped } from '../../test/lib/render-helpers-navigate';
-import { selectFirstUnavailableEvmNetwork } from '../selectors/multichain/networks';
+import { selectNetworkForConnectionBanner } from '../selectors/multichain/networks';
 import {
   getNetworkConnectionBanner,
   getIsDeviceOffline,
@@ -23,7 +23,7 @@ jest.mock('../../shared/constants/network', () => {
 jest.mock('../selectors/multichain/networks', () => {
   return {
     ...jest.requireActual('../selectors/multichain/networks'),
-    selectFirstUnavailableEvmNetwork: jest.fn(),
+    selectNetworkForConnectionBanner: jest.fn(),
   };
 });
 
@@ -72,8 +72,8 @@ jest.mock('../store/background-connection', () => {
   };
 });
 
-const mockSelectFirstUnavailableEvmNetwork = jest.mocked(
-  selectFirstUnavailableEvmNetwork,
+const mockSelectNetworkForConnectionBanner = jest.mocked(
+  selectNetworkForConnectionBanner,
 );
 const mockGetNetworkConnectionBanner = jest.mocked(getNetworkConnectionBanner);
 const mockGetIsDeviceOffline = jest.mocked(getIsDeviceOffline);
@@ -118,7 +118,7 @@ describe('useNetworkConnectionBanner', () => {
 
   describe('when all networks are available', () => {
     it("updates the status of the banner to 'available' if not already updated", () => {
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue(null);
+      mockSelectNetworkForConnectionBanner.mockReturnValue(null);
       mockGetNetworkConnectionBanner.mockReturnValue({ status: 'unknown' });
 
       renderHookWithProviderTyped(
@@ -132,7 +132,7 @@ describe('useNetworkConnectionBanner', () => {
     });
 
     it("does not update the status of the banner to 'available' if already updated", () => {
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue(null);
+      mockSelectNetworkForConnectionBanner.mockReturnValue(null);
       mockGetNetworkConnectionBanner.mockReturnValue({
         status: 'available',
       });
@@ -146,7 +146,7 @@ describe('useNetworkConnectionBanner', () => {
     });
 
     it('does not create a MetaMetrics event', () => {
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue(null);
+      mockSelectNetworkForConnectionBanner.mockReturnValue(null);
       mockGetNetworkConnectionBanner.mockReturnValue({ status: 'unknown' });
       const mockTrackEvent = jest.fn();
 
@@ -166,7 +166,7 @@ describe('useNetworkConnectionBanner', () => {
     describe('if the status of the banner is "unknown"', () => {
       describe('if at least one network is still not available after 5 seconds', () => {
         it('updates the status of the banner to "degraded"', () => {
-          mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+          mockSelectNetworkForConnectionBanner.mockReturnValue({
             networkName: 'Ethereum Mainnet',
             networkClientId: 'mainnet',
             chainId: '0x1',
@@ -194,7 +194,7 @@ describe('useNetworkConnectionBanner', () => {
         });
 
         it('creates a MetaMetrics event to capture that the status changed', async () => {
-          mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+          mockSelectNetworkForConnectionBanner.mockReturnValue({
             networkName: 'Ethereum Mainnet',
             networkClientId: 'mainnet',
             chainId: '0x1',
@@ -236,7 +236,7 @@ describe('useNetworkConnectionBanner', () => {
 
     describe('if the status of the banner is "available"', () => {
       it('updates the status of the banner to "degraded" after 5 seconds', () => {
-        mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+        mockSelectNetworkForConnectionBanner.mockReturnValue({
           networkName: 'Ethereum Mainnet',
           networkClientId: 'mainnet',
           chainId: '0x1',
@@ -268,7 +268,7 @@ describe('useNetworkConnectionBanner', () => {
 
     describe('if the status of the banner is "degraded"', () => {
       it('updates the status of the banner to "unavailable" after 25 seconds', () => {
-        mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+        mockSelectNetworkForConnectionBanner.mockReturnValue({
           networkName: 'Ethereum Mainnet',
           networkClientId: 'mainnet',
           chainId: '0x1',
@@ -303,7 +303,7 @@ describe('useNetworkConnectionBanner', () => {
       });
 
       it('creates a MetaMetrics event to capture that the status changed', async () => {
-        mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+        mockSelectNetworkForConnectionBanner.mockReturnValue({
           networkName: 'Ethereum Mainnet',
           networkClientId: 'mainnet',
           chainId: '0x1',
@@ -352,7 +352,7 @@ describe('useNetworkConnectionBanner', () => {
 
   describe('when some network is unavailable and then all become available', () => {
     it('clears timers and updates the status of the banner to "available"', () => {
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+      mockSelectNetworkForConnectionBanner.mockReturnValue({
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',
         chainId: '0x1',
@@ -365,7 +365,7 @@ describe('useNetworkConnectionBanner', () => {
         () => useNetworkConnectionBanner(),
         mockState,
       );
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue(null);
+      mockSelectNetworkForConnectionBanner.mockReturnValue(null);
       rerender();
       act(() => {
         jest.advanceTimersByTime(30000);
@@ -380,7 +380,7 @@ describe('useNetworkConnectionBanner', () => {
 
   describe('on unmount', () => {
     it('clears any timers to show the degraded and unavailable banners', () => {
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+      mockSelectNetworkForConnectionBanner.mockReturnValue({
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',
         chainId: '0x1',
@@ -409,7 +409,7 @@ describe('useNetworkConnectionBanner', () => {
     });
 
     it('does not show degraded banner even if network is unavailable', () => {
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+      mockSelectNetworkForConnectionBanner.mockReturnValue({
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',
         chainId: '0x1',
@@ -436,7 +436,7 @@ describe('useNetworkConnectionBanner', () => {
     });
 
     it('resets banner to available when device goes offline while showing degraded', () => {
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+      mockSelectNetworkForConnectionBanner.mockReturnValue({
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',
         chainId: '0x1',
@@ -463,7 +463,7 @@ describe('useNetworkConnectionBanner', () => {
     });
 
     it('does not update banner if already available when offline', () => {
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+      mockSelectNetworkForConnectionBanner.mockReturnValue({
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',
         chainId: '0x1',
@@ -483,7 +483,7 @@ describe('useNetworkConnectionBanner', () => {
     it('does not progress from degraded to unavailable when device goes offline', () => {
       // Device is offline with degraded banner showing
       mockGetIsDeviceOffline.mockReturnValue(true);
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+      mockSelectNetworkForConnectionBanner.mockReturnValue({
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',
         chainId: '0x1',
@@ -521,7 +521,7 @@ describe('useNetworkConnectionBanner', () => {
     it('resumes normal behavior when device comes back online', () => {
       // Start offline
       mockGetIsDeviceOffline.mockReturnValue(true);
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+      mockSelectNetworkForConnectionBanner.mockReturnValue({
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',
         chainId: '0x1',
@@ -590,7 +590,7 @@ describe('useNetworkConnectionBanner', () => {
           typeof mockGetNetworkConfigurationsByChainId
         >,
       );
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue(null);
+      mockSelectNetworkForConnectionBanner.mockReturnValue(null);
       mockGetNetworkConnectionBanner.mockReturnValue({
         status: 'unavailable',
         networkName: 'Arbitrum One',
@@ -620,7 +620,7 @@ describe('useNetworkConnectionBanner', () => {
     });
 
     it('does nothing when status is available', async () => {
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue(null);
+      mockSelectNetworkForConnectionBanner.mockReturnValue(null);
       mockGetNetworkConnectionBanner.mockReturnValue({ status: 'available' });
 
       const { result } = renderHookWithProviderTyped(
@@ -637,7 +637,7 @@ describe('useNetworkConnectionBanner', () => {
     });
 
     it('does nothing when infuraEndpointIndex is undefined', async () => {
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue(null);
+      mockSelectNetworkForConnectionBanner.mockReturnValue(null);
       mockGetNetworkConnectionBanner.mockReturnValue({
         status: 'unavailable',
         networkName: 'Custom Network',
@@ -694,7 +694,7 @@ describe('useNetworkConnectionBanner', () => {
           typeof mockGetNetworkConfigurationsByChainId
         >,
       );
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue(null);
+      mockSelectNetworkForConnectionBanner.mockReturnValue(null);
       mockGetNetworkConnectionBanner.mockReturnValue({
         status: 'unavailable',
         networkName: 'Arbitrum One',
@@ -759,7 +759,7 @@ describe('useNetworkConnectionBanner', () => {
       });
 
       // But selector now returns Infura endpoint (fresh data after switch)
-      mockSelectFirstUnavailableEvmNetwork.mockReturnValue({
+      mockSelectNetworkForConnectionBanner.mockReturnValue({
         networkName: 'Arbitrum One',
         networkClientId: 'arbitrum-mainnet',
         chainId: '0xa4b1',

--- a/ui/hooks/useNetworkConnectionBanner.test.ts
+++ b/ui/hooks/useNetworkConnectionBanner.test.ts
@@ -1,7 +1,7 @@
 import { act } from '@testing-library/react';
 import { RpcEndpointType } from '@metamask/network-controller';
 import { renderHookWithProviderTyped } from '../../test/lib/render-helpers-navigate';
-import { selectNetworkForConnectionBanner } from '../selectors/multichain/networks';
+import { selectFirstFailedNetworkForNetworkConnectionBanner } from '../selectors/multichain/networks';
 import {
   getNetworkConnectionBanner,
   getIsDeviceOffline,
@@ -23,7 +23,7 @@ jest.mock('../../shared/constants/network', () => {
 jest.mock('../selectors/multichain/networks', () => {
   return {
     ...jest.requireActual('../selectors/multichain/networks'),
-    selectNetworkForConnectionBanner: jest.fn(),
+    selectFirstFailedNetworkForNetworkConnectionBanner: jest.fn(),
   };
 });
 
@@ -72,8 +72,8 @@ jest.mock('../store/background-connection', () => {
   };
 });
 
-const mockSelectNetworkForConnectionBanner = jest.mocked(
-  selectNetworkForConnectionBanner,
+const mockSelectFirstFailedNetworkForNetworkConnectionBanner = jest.mocked(
+  selectFirstFailedNetworkForNetworkConnectionBanner,
 );
 const mockGetNetworkConnectionBanner = jest.mocked(getNetworkConnectionBanner);
 const mockGetIsDeviceOffline = jest.mocked(getIsDeviceOffline);
@@ -118,7 +118,7 @@ describe('useNetworkConnectionBanner', () => {
 
   describe('when all networks are available', () => {
     it("updates the status of the banner to 'available' if not already updated", () => {
-      mockSelectNetworkForConnectionBanner.mockReturnValue(null);
+      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue(null);
       mockGetNetworkConnectionBanner.mockReturnValue({ status: 'unknown' });
 
       renderHookWithProviderTyped(
@@ -132,7 +132,7 @@ describe('useNetworkConnectionBanner', () => {
     });
 
     it("does not update the status of the banner to 'available' if already updated", () => {
-      mockSelectNetworkForConnectionBanner.mockReturnValue(null);
+      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue(null);
       mockGetNetworkConnectionBanner.mockReturnValue({
         status: 'available',
       });
@@ -146,7 +146,7 @@ describe('useNetworkConnectionBanner', () => {
     });
 
     it('does not create a MetaMetrics event', () => {
-      mockSelectNetworkForConnectionBanner.mockReturnValue(null);
+      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue(null);
       mockGetNetworkConnectionBanner.mockReturnValue({ status: 'unknown' });
       const mockTrackEvent = jest.fn();
 
@@ -166,7 +166,7 @@ describe('useNetworkConnectionBanner', () => {
     describe('if the status of the banner is "unknown"', () => {
       describe('if at least one network is still not available after 5 seconds', () => {
         it('updates the status of the banner to "degraded"', () => {
-          mockSelectNetworkForConnectionBanner.mockReturnValue({
+          mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue({
             networkName: 'Ethereum Mainnet',
             networkClientId: 'mainnet',
             chainId: '0x1',
@@ -194,7 +194,7 @@ describe('useNetworkConnectionBanner', () => {
         });
 
         it('creates a MetaMetrics event to capture that the status changed', async () => {
-          mockSelectNetworkForConnectionBanner.mockReturnValue({
+          mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue({
             networkName: 'Ethereum Mainnet',
             networkClientId: 'mainnet',
             chainId: '0x1',
@@ -236,7 +236,7 @@ describe('useNetworkConnectionBanner', () => {
 
     describe('if the status of the banner is "available"', () => {
       it('updates the status of the banner to "degraded" after 5 seconds', () => {
-        mockSelectNetworkForConnectionBanner.mockReturnValue({
+        mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue({
           networkName: 'Ethereum Mainnet',
           networkClientId: 'mainnet',
           chainId: '0x1',
@@ -268,7 +268,7 @@ describe('useNetworkConnectionBanner', () => {
 
     describe('if the status of the banner is "degraded"', () => {
       it('updates the status of the banner to "unavailable" after 25 seconds', () => {
-        mockSelectNetworkForConnectionBanner.mockReturnValue({
+        mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue({
           networkName: 'Ethereum Mainnet',
           networkClientId: 'mainnet',
           chainId: '0x1',
@@ -303,7 +303,7 @@ describe('useNetworkConnectionBanner', () => {
       });
 
       it('creates a MetaMetrics event to capture that the status changed', async () => {
-        mockSelectNetworkForConnectionBanner.mockReturnValue({
+        mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue({
           networkName: 'Ethereum Mainnet',
           networkClientId: 'mainnet',
           chainId: '0x1',
@@ -352,7 +352,7 @@ describe('useNetworkConnectionBanner', () => {
 
   describe('when some network is unavailable and then all become available', () => {
     it('clears timers and updates the status of the banner to "available"', () => {
-      mockSelectNetworkForConnectionBanner.mockReturnValue({
+      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue({
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',
         chainId: '0x1',
@@ -365,7 +365,7 @@ describe('useNetworkConnectionBanner', () => {
         () => useNetworkConnectionBanner(),
         mockState,
       );
-      mockSelectNetworkForConnectionBanner.mockReturnValue(null);
+      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue(null);
       rerender();
       act(() => {
         jest.advanceTimersByTime(30000);
@@ -380,7 +380,7 @@ describe('useNetworkConnectionBanner', () => {
 
   describe('on unmount', () => {
     it('clears any timers to show the degraded and unavailable banners', () => {
-      mockSelectNetworkForConnectionBanner.mockReturnValue({
+      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue({
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',
         chainId: '0x1',
@@ -409,7 +409,7 @@ describe('useNetworkConnectionBanner', () => {
     });
 
     it('does not show degraded banner even if network is unavailable', () => {
-      mockSelectNetworkForConnectionBanner.mockReturnValue({
+      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue({
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',
         chainId: '0x1',
@@ -436,7 +436,7 @@ describe('useNetworkConnectionBanner', () => {
     });
 
     it('resets banner to available when device goes offline while showing degraded', () => {
-      mockSelectNetworkForConnectionBanner.mockReturnValue({
+      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue({
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',
         chainId: '0x1',
@@ -463,7 +463,7 @@ describe('useNetworkConnectionBanner', () => {
     });
 
     it('does not update banner if already available when offline', () => {
-      mockSelectNetworkForConnectionBanner.mockReturnValue({
+      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue({
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',
         chainId: '0x1',
@@ -483,7 +483,7 @@ describe('useNetworkConnectionBanner', () => {
     it('does not progress from degraded to unavailable when device goes offline', () => {
       // Device is offline with degraded banner showing
       mockGetIsDeviceOffline.mockReturnValue(true);
-      mockSelectNetworkForConnectionBanner.mockReturnValue({
+      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue({
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',
         chainId: '0x1',
@@ -521,7 +521,7 @@ describe('useNetworkConnectionBanner', () => {
     it('resumes normal behavior when device comes back online', () => {
       // Start offline
       mockGetIsDeviceOffline.mockReturnValue(true);
-      mockSelectNetworkForConnectionBanner.mockReturnValue({
+      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue({
         networkName: 'Ethereum Mainnet',
         networkClientId: 'mainnet',
         chainId: '0x1',
@@ -590,7 +590,7 @@ describe('useNetworkConnectionBanner', () => {
           typeof mockGetNetworkConfigurationsByChainId
         >,
       );
-      mockSelectNetworkForConnectionBanner.mockReturnValue(null);
+      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue(null);
       mockGetNetworkConnectionBanner.mockReturnValue({
         status: 'unavailable',
         networkName: 'Arbitrum One',
@@ -620,7 +620,7 @@ describe('useNetworkConnectionBanner', () => {
     });
 
     it('does nothing when status is available', async () => {
-      mockSelectNetworkForConnectionBanner.mockReturnValue(null);
+      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue(null);
       mockGetNetworkConnectionBanner.mockReturnValue({ status: 'available' });
 
       const { result } = renderHookWithProviderTyped(
@@ -637,7 +637,7 @@ describe('useNetworkConnectionBanner', () => {
     });
 
     it('does nothing when infuraEndpointIndex is undefined', async () => {
-      mockSelectNetworkForConnectionBanner.mockReturnValue(null);
+      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue(null);
       mockGetNetworkConnectionBanner.mockReturnValue({
         status: 'unavailable',
         networkName: 'Custom Network',
@@ -694,7 +694,7 @@ describe('useNetworkConnectionBanner', () => {
           typeof mockGetNetworkConfigurationsByChainId
         >,
       );
-      mockSelectNetworkForConnectionBanner.mockReturnValue(null);
+      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue(null);
       mockGetNetworkConnectionBanner.mockReturnValue({
         status: 'unavailable',
         networkName: 'Arbitrum One',
@@ -759,7 +759,7 @@ describe('useNetworkConnectionBanner', () => {
       });
 
       // But selector now returns Infura endpoint (fresh data after switch)
-      mockSelectNetworkForConnectionBanner.mockReturnValue({
+      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue({
         networkName: 'Arbitrum One',
         networkClientId: 'arbitrum-mainnet',
         chainId: '0xa4b1',

--- a/ui/hooks/useNetworkConnectionBanner.test.ts
+++ b/ui/hooks/useNetworkConnectionBanner.test.ts
@@ -118,7 +118,9 @@ describe('useNetworkConnectionBanner', () => {
 
   describe('when all networks are available', () => {
     it("updates the status of the banner to 'available' if not already updated", () => {
-      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue(null);
+      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue(
+        null,
+      );
       mockGetNetworkConnectionBanner.mockReturnValue({ status: 'unknown' });
 
       renderHookWithProviderTyped(
@@ -132,7 +134,9 @@ describe('useNetworkConnectionBanner', () => {
     });
 
     it("does not update the status of the banner to 'available' if already updated", () => {
-      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue(null);
+      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue(
+        null,
+      );
       mockGetNetworkConnectionBanner.mockReturnValue({
         status: 'available',
       });
@@ -146,7 +150,9 @@ describe('useNetworkConnectionBanner', () => {
     });
 
     it('does not create a MetaMetrics event', () => {
-      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue(null);
+      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue(
+        null,
+      );
       mockGetNetworkConnectionBanner.mockReturnValue({ status: 'unknown' });
       const mockTrackEvent = jest.fn();
 
@@ -166,13 +172,15 @@ describe('useNetworkConnectionBanner', () => {
     describe('if the status of the banner is "unknown"', () => {
       describe('if at least one network is still not available after 5 seconds', () => {
         it('updates the status of the banner to "degraded"', () => {
-          mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue({
-            networkName: 'Ethereum Mainnet',
-            networkClientId: 'mainnet',
-            chainId: '0x1',
-            isInfuraEndpoint: true,
-            infuraEndpointIndex: undefined,
-          });
+          mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue(
+            {
+              networkName: 'Ethereum Mainnet',
+              networkClientId: 'mainnet',
+              chainId: '0x1',
+              isInfuraEndpoint: true,
+              infuraEndpointIndex: undefined,
+            },
+          );
           mockGetNetworkConnectionBanner.mockReturnValue({ status: 'unknown' });
 
           renderHookWithProviderTyped(
@@ -194,13 +202,15 @@ describe('useNetworkConnectionBanner', () => {
         });
 
         it('creates a MetaMetrics event to capture that the status changed', async () => {
-          mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue({
-            networkName: 'Ethereum Mainnet',
-            networkClientId: 'mainnet',
-            chainId: '0x1',
-            isInfuraEndpoint: true,
-            infuraEndpointIndex: undefined,
-          });
+          mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue(
+            {
+              networkName: 'Ethereum Mainnet',
+              networkClientId: 'mainnet',
+              chainId: '0x1',
+              isInfuraEndpoint: true,
+              infuraEndpointIndex: undefined,
+            },
+          );
           mockGetNetworkConnectionBanner.mockReturnValue({ status: 'unknown' });
           const mockTrackEvent = jest.fn();
 
@@ -365,7 +375,9 @@ describe('useNetworkConnectionBanner', () => {
         () => useNetworkConnectionBanner(),
         mockState,
       );
-      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue(null);
+      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue(
+        null,
+      );
       rerender();
       act(() => {
         jest.advanceTimersByTime(30000);
@@ -590,7 +602,9 @@ describe('useNetworkConnectionBanner', () => {
           typeof mockGetNetworkConfigurationsByChainId
         >,
       );
-      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue(null);
+      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue(
+        null,
+      );
       mockGetNetworkConnectionBanner.mockReturnValue({
         status: 'unavailable',
         networkName: 'Arbitrum One',
@@ -620,7 +634,9 @@ describe('useNetworkConnectionBanner', () => {
     });
 
     it('does nothing when status is available', async () => {
-      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue(null);
+      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue(
+        null,
+      );
       mockGetNetworkConnectionBanner.mockReturnValue({ status: 'available' });
 
       const { result } = renderHookWithProviderTyped(
@@ -637,7 +653,9 @@ describe('useNetworkConnectionBanner', () => {
     });
 
     it('does nothing when infuraEndpointIndex is undefined', async () => {
-      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue(null);
+      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue(
+        null,
+      );
       mockGetNetworkConnectionBanner.mockReturnValue({
         status: 'unavailable',
         networkName: 'Custom Network',
@@ -694,7 +712,9 @@ describe('useNetworkConnectionBanner', () => {
           typeof mockGetNetworkConfigurationsByChainId
         >,
       );
-      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue(null);
+      mockSelectFirstFailedNetworkForNetworkConnectionBanner.mockReturnValue(
+        null,
+      );
       mockGetNetworkConnectionBanner.mockReturnValue({
         status: 'unavailable',
         networkName: 'Arbitrum One',

--- a/ui/hooks/useNetworkConnectionBanner.ts
+++ b/ui/hooks/useNetworkConnectionBanner.ts
@@ -1,7 +1,7 @@
 import { useEffect, useCallback, useRef, useContext } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { Hex, hexToNumber } from '@metamask/utils';
-import { selectNetworkForConnectionBanner } from '../selectors/multichain/networks';
+import { selectFirstFailedNetworkForNetworkConnectionBanner } from '../selectors/multichain/networks';
 import {
   getNetworkConnectionBanner,
   getIsDeviceOffline,
@@ -25,7 +25,7 @@ type UseNetworkConnectionBannerResult = NetworkConnectionBanner & {
     networkClientId: string;
   }) => void;
   /**
-   * Switch the default RPC endpoint to Infura for the current unavailable network.
+   * Switch the default RPC endpoint to Infura for the current failed network.
    * Only available when the network has an Infura endpoint to switch to.
    * Returns a promise that resolves when the switch is complete (or rejects on error).
    */
@@ -40,7 +40,9 @@ export const useNetworkConnectionBanner =
     const dispatch = useDispatch();
     const { trackEvent } = useContext(MetaMetricsContext);
     const isOffline = useSelector(getIsDeviceOffline);
-    const bannerNetwork = useSelector(selectNetworkForConnectionBanner);
+    const failedNetwork = useSelector(
+      selectFirstFailedNetworkForNetworkConnectionBanner,
+    );
     const networkConnectionBannerState = useSelector(
       getNetworkConnectionBanner,
     );
@@ -138,26 +140,26 @@ export const useNetworkConnectionBanner =
       clearUnavailableTimer();
 
       timersRef.current.unavailableTimer = setTimeout(() => {
-        if (bannerNetwork) {
+        if (failedNetwork) {
           trackNetworkBannerEvent({
             bannerType: 'unavailable',
             eventName: MetaMetricsEventName.NetworkConnectionBannerShown,
-            networkClientId: bannerNetwork.networkClientId,
+            networkClientId: failedNetwork.networkClientId,
           });
           dispatch(
             updateNetworkConnectionBanner({
               status: 'unavailable',
-              networkName: bannerNetwork.networkName,
-              networkClientId: bannerNetwork.networkClientId,
-              chainId: bannerNetwork.chainId,
-              isInfuraEndpoint: bannerNetwork.isInfuraEndpoint,
-              infuraEndpointIndex: bannerNetwork.infuraEndpointIndex,
+              networkName: failedNetwork.networkName,
+              networkClientId: failedNetwork.networkClientId,
+              chainId: failedNetwork.chainId,
+              isInfuraEndpoint: failedNetwork.isInfuraEndpoint,
+              infuraEndpointIndex: failedNetwork.infuraEndpointIndex,
             }),
           );
         }
       }, UNAVAILABLE_BANNER_TIMEOUT - DEGRADED_BANNER_TIMEOUT);
     }, [
-      bannerNetwork,
+      failedNetwork,
       trackNetworkBannerEvent,
       dispatch,
       clearUnavailableTimer,
@@ -167,20 +169,20 @@ export const useNetworkConnectionBanner =
       clearDegradedTimer();
 
       timersRef.current.degradedTimer = setTimeout(() => {
-        if (bannerNetwork) {
+        if (failedNetwork) {
           trackNetworkBannerEvent({
             bannerType: 'degraded',
             eventName: MetaMetricsEventName.NetworkConnectionBannerShown,
-            networkClientId: bannerNetwork.networkClientId,
+            networkClientId: failedNetwork.networkClientId,
           });
           dispatch(
             updateNetworkConnectionBanner({
               status: 'degraded',
-              networkName: bannerNetwork.networkName,
-              networkClientId: bannerNetwork.networkClientId,
-              chainId: bannerNetwork.chainId,
-              isInfuraEndpoint: bannerNetwork.isInfuraEndpoint,
-              infuraEndpointIndex: bannerNetwork.infuraEndpointIndex,
+              networkName: failedNetwork.networkName,
+              networkClientId: failedNetwork.networkClientId,
+              chainId: failedNetwork.chainId,
+              isInfuraEndpoint: failedNetwork.isInfuraEndpoint,
+              infuraEndpointIndex: failedNetwork.infuraEndpointIndex,
             }),
           );
 
@@ -188,15 +190,15 @@ export const useNetworkConnectionBanner =
         }
       }, DEGRADED_BANNER_TIMEOUT);
     }, [
-      bannerNetwork,
+      failedNetwork,
       trackNetworkBannerEvent,
       dispatch,
       startUnavailableTimer,
       clearDegradedTimer,
     ]);
 
-    // If the first unavailable network does not change but the status changes, start the degraded or unavailable timer
-    // If the first unavailable network changes, reset all timers and change the status
+    // If the failed network does not change but the banner status changes, start the degraded or unavailable timer
+    // If the failed network changes, reset all timers and change the status
     // If the device is offline, don't show network banners - the issue is device connectivity, not the network
     useEffect(() => {
       // When device is offline, clear timers and reset banner state
@@ -210,7 +212,7 @@ export const useNetworkConnectionBanner =
         return;
       }
 
-      if (bannerNetwork) {
+      if (failedNetwork) {
         if (networkConnectionBannerState.status === 'degraded') {
           startUnavailableTimer();
         } else if (
@@ -228,7 +230,7 @@ export const useNetworkConnectionBanner =
       };
     }, [
       isOffline,
-      bannerNetwork,
+      failedNetwork,
       clearTimers,
       dispatch,
       networkConnectionBannerState.status,
@@ -288,16 +290,16 @@ export const useNetworkConnectionBanner =
     if (
       (networkConnectionBannerState.status === 'degraded' ||
         networkConnectionBannerState.status === 'unavailable') &&
-      bannerNetwork
+      failedNetwork
     ) {
       return {
         ...networkConnectionBannerState,
         // Override with fresh data from selector
-        networkClientId: bannerNetwork.networkClientId,
-        networkName: bannerNetwork.networkName,
-        chainId: bannerNetwork.chainId,
-        isInfuraEndpoint: bannerNetwork.isInfuraEndpoint,
-        infuraEndpointIndex: bannerNetwork.infuraEndpointIndex,
+        networkClientId: failedNetwork.networkClientId,
+        networkName: failedNetwork.networkName,
+        chainId: failedNetwork.chainId,
+        isInfuraEndpoint: failedNetwork.isInfuraEndpoint,
+        infuraEndpointIndex: failedNetwork.infuraEndpointIndex,
         trackNetworkBannerEvent,
         switchToInfura,
       };

--- a/ui/hooks/useNetworkConnectionBanner.ts
+++ b/ui/hooks/useNetworkConnectionBanner.ts
@@ -1,7 +1,7 @@
 import { useEffect, useCallback, useRef, useContext } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { Hex, hexToNumber } from '@metamask/utils';
-import { selectFirstUnavailableEvmNetwork } from '../selectors/multichain/networks';
+import { selectNetworkForConnectionBanner } from '../selectors/multichain/networks';
 import {
   getNetworkConnectionBanner,
   getIsDeviceOffline,
@@ -40,9 +40,7 @@ export const useNetworkConnectionBanner =
     const dispatch = useDispatch();
     const { trackEvent } = useContext(MetaMetricsContext);
     const isOffline = useSelector(getIsDeviceOffline);
-    const firstUnavailableEvmNetwork = useSelector(
-      selectFirstUnavailableEvmNetwork,
-    );
+    const bannerNetwork = useSelector(selectNetworkForConnectionBanner);
     const networkConnectionBannerState = useSelector(
       getNetworkConnectionBanner,
     );
@@ -140,27 +138,26 @@ export const useNetworkConnectionBanner =
       clearUnavailableTimer();
 
       timersRef.current.unavailableTimer = setTimeout(() => {
-        if (firstUnavailableEvmNetwork) {
+        if (bannerNetwork) {
           trackNetworkBannerEvent({
             bannerType: 'unavailable',
             eventName: MetaMetricsEventName.NetworkConnectionBannerShown,
-            networkClientId: firstUnavailableEvmNetwork.networkClientId,
+            networkClientId: bannerNetwork.networkClientId,
           });
           dispatch(
             updateNetworkConnectionBanner({
               status: 'unavailable',
-              networkName: firstUnavailableEvmNetwork.networkName,
-              networkClientId: firstUnavailableEvmNetwork.networkClientId,
-              chainId: firstUnavailableEvmNetwork.chainId,
-              isInfuraEndpoint: firstUnavailableEvmNetwork.isInfuraEndpoint,
-              infuraEndpointIndex:
-                firstUnavailableEvmNetwork.infuraEndpointIndex,
+              networkName: bannerNetwork.networkName,
+              networkClientId: bannerNetwork.networkClientId,
+              chainId: bannerNetwork.chainId,
+              isInfuraEndpoint: bannerNetwork.isInfuraEndpoint,
+              infuraEndpointIndex: bannerNetwork.infuraEndpointIndex,
             }),
           );
         }
       }, UNAVAILABLE_BANNER_TIMEOUT - DEGRADED_BANNER_TIMEOUT);
     }, [
-      firstUnavailableEvmNetwork,
+      bannerNetwork,
       trackNetworkBannerEvent,
       dispatch,
       clearUnavailableTimer,
@@ -170,21 +167,20 @@ export const useNetworkConnectionBanner =
       clearDegradedTimer();
 
       timersRef.current.degradedTimer = setTimeout(() => {
-        if (firstUnavailableEvmNetwork) {
+        if (bannerNetwork) {
           trackNetworkBannerEvent({
             bannerType: 'degraded',
             eventName: MetaMetricsEventName.NetworkConnectionBannerShown,
-            networkClientId: firstUnavailableEvmNetwork.networkClientId,
+            networkClientId: bannerNetwork.networkClientId,
           });
           dispatch(
             updateNetworkConnectionBanner({
               status: 'degraded',
-              networkName: firstUnavailableEvmNetwork.networkName,
-              networkClientId: firstUnavailableEvmNetwork.networkClientId,
-              chainId: firstUnavailableEvmNetwork.chainId,
-              isInfuraEndpoint: firstUnavailableEvmNetwork.isInfuraEndpoint,
-              infuraEndpointIndex:
-                firstUnavailableEvmNetwork.infuraEndpointIndex,
+              networkName: bannerNetwork.networkName,
+              networkClientId: bannerNetwork.networkClientId,
+              chainId: bannerNetwork.chainId,
+              isInfuraEndpoint: bannerNetwork.isInfuraEndpoint,
+              infuraEndpointIndex: bannerNetwork.infuraEndpointIndex,
             }),
           );
 
@@ -192,7 +188,7 @@ export const useNetworkConnectionBanner =
         }
       }, DEGRADED_BANNER_TIMEOUT);
     }, [
-      firstUnavailableEvmNetwork,
+      bannerNetwork,
       trackNetworkBannerEvent,
       dispatch,
       startUnavailableTimer,
@@ -214,7 +210,7 @@ export const useNetworkConnectionBanner =
         return;
       }
 
-      if (firstUnavailableEvmNetwork) {
+      if (bannerNetwork) {
         if (networkConnectionBannerState.status === 'degraded') {
           startUnavailableTimer();
         } else if (
@@ -232,7 +228,7 @@ export const useNetworkConnectionBanner =
       };
     }, [
       isOffline,
-      firstUnavailableEvmNetwork,
+      bannerNetwork,
       clearTimers,
       dispatch,
       networkConnectionBannerState.status,
@@ -292,16 +288,16 @@ export const useNetworkConnectionBanner =
     if (
       (networkConnectionBannerState.status === 'degraded' ||
         networkConnectionBannerState.status === 'unavailable') &&
-      firstUnavailableEvmNetwork
+      bannerNetwork
     ) {
       return {
         ...networkConnectionBannerState,
         // Override with fresh data from selector
-        networkClientId: firstUnavailableEvmNetwork.networkClientId,
-        networkName: firstUnavailableEvmNetwork.networkName,
-        chainId: firstUnavailableEvmNetwork.chainId,
-        isInfuraEndpoint: firstUnavailableEvmNetwork.isInfuraEndpoint,
-        infuraEndpointIndex: firstUnavailableEvmNetwork.infuraEndpointIndex,
+        networkClientId: bannerNetwork.networkClientId,
+        networkName: bannerNetwork.networkName,
+        chainId: bannerNetwork.chainId,
+        isInfuraEndpoint: bannerNetwork.isInfuraEndpoint,
+        infuraEndpointIndex: bannerNetwork.infuraEndpointIndex,
         trackNetworkBannerEvent,
         switchToInfura,
       };

--- a/ui/selectors/multichain/networks.test.ts
+++ b/ui/selectors/multichain/networks.test.ts
@@ -26,7 +26,7 @@ import {
   getSelectedMultichainNetworkChainId,
   getSelectedMultichainNetworkConfiguration,
   getIsEvmMultichainNetworkSelected,
-  selectNetworkForConnectionBanner,
+  selectFirstFailedNetworkForNetworkConnectionBanner,
   getEvmMultichainNetworkConfigurations,
   getAllMultichainNetworkConfigurations,
 } from './networks';
@@ -595,8 +595,8 @@ describe('Multichain network selectors', () => {
     });
   });
 
-  describe('selectNetworkForConnectionBanner', () => {
-    it('returns the first unavailable network when every enabled network is unavailable (all-down escape hatch)', () => {
+  describe('selectFirstFailedNetworkForNetworkConnectionBanner', () => {
+    it('returns the first failed network when every enabled network has failed (all-down escape hatch)', () => {
       const mockStateWithMultipleUnavailableNetworks = {
         metamask: {
           enabledNetworkMap: {
@@ -652,7 +652,7 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectNetworkForConnectionBanner(
+        selectFirstFailedNetworkForNetworkConnectionBanner(
           mockStateWithMultipleUnavailableNetworks,
         ),
       ).toStrictEqual({
@@ -664,7 +664,7 @@ describe('Multichain network selectors', () => {
       });
     });
 
-    it('returns the unavailable custom network when both a custom and Infura network are down', () => {
+    it('returns the failed custom network when both a custom and Infura network are down', () => {
       const mockStateWithMultipleUnavailableNetworks = {
         metamask: {
           enabledNetworkMap: {
@@ -720,7 +720,7 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectNetworkForConnectionBanner(
+        selectFirstFailedNetworkForNetworkConnectionBanner(
           mockStateWithMultipleUnavailableNetworks,
         ),
       ).toStrictEqual({
@@ -788,7 +788,7 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectNetworkForConnectionBanner(mockStateWithAvailableEvmNetworks),
+        selectFirstFailedNetworkForNetworkConnectionBanner(mockStateWithAvailableEvmNetworks),
       ).toBeNull();
     });
 
@@ -805,7 +805,7 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectNetworkForConnectionBanner(mockStateWithNoEnabledEvmNetworks),
+        selectFirstFailedNetworkForNetworkConnectionBanner(mockStateWithNoEnabledEvmNetworks),
       ).toBeNull();
     });
 
@@ -840,7 +840,7 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectNetworkForConnectionBanner(mockStateWithMissingMetadata),
+        selectFirstFailedNetworkForNetworkConnectionBanner(mockStateWithMissingMetadata),
       ).toBeNull();
     });
 
@@ -864,7 +864,7 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectNetworkForConnectionBanner(mockStateWithMissingNetworkConfig),
+        selectFirstFailedNetworkForNetworkConnectionBanner(mockStateWithMissingNetworkConfig),
       ).toBeNull();
     });
 
@@ -909,9 +909,9 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectNetworkForConnectionBanner(
+        selectFirstFailedNetworkForNetworkConnectionBanner(
           mockStateWithCustomAndInfuraEndpoints as Parameters<
-            typeof selectNetworkForConnectionBanner
+            typeof selectFirstFailedNetworkForNetworkConnectionBanner
           >[0],
         ),
       ).toStrictEqual({
@@ -959,7 +959,7 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectNetworkForConnectionBanner(mockStateWithOnlyCustomEndpoint),
+        selectFirstFailedNetworkForNetworkConnectionBanner(mockStateWithOnlyCustomEndpoint),
       ).toStrictEqual({
         networkName: 'Custom Network',
         networkClientId: 'custom-network',
@@ -969,7 +969,7 @@ describe('Multichain network selectors', () => {
       });
     });
 
-    it('returns the network when only one network is enabled and it is unavailable (all-down escape hatch)', () => {
+    it('returns the network when only one network is enabled and it has failed (all-down escape hatch)', () => {
       const mockStateWithInfuraAsDefault = {
         metamask: {
           enabledNetworkMap: {
@@ -1004,7 +1004,7 @@ describe('Multichain network selectors', () => {
         },
       };
 
-      const result = selectNetworkForConnectionBanner(
+      const result = selectFirstFailedNetworkForNetworkConnectionBanner(
         mockStateWithInfuraAsDefault,
       );
       expect(result).toStrictEqual({
@@ -1016,7 +1016,7 @@ describe('Multichain network selectors', () => {
       });
     });
 
-    it('returns null when only one Infura network out of many enabled is unavailable', () => {
+    it('returns null when only one Infura network out of many enabled has failed', () => {
       // Single Infura blip in an otherwise-healthy set: 1 distinct domain,
       // not all-down. Suppress to avoid the noisy banner. See WPC-1014.
       const mockStateWithSingleInfuraDown = {
@@ -1074,14 +1074,14 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectNetworkForConnectionBanner(mockStateWithSingleInfuraDown),
+        selectFirstFailedNetworkForNetworkConnectionBanner(mockStateWithSingleInfuraDown),
       ).toBeNull();
     });
 
     it('returns null when multiple Infura networks fail together but stay on one domain and others remain available', () => {
       // Infura-wide partial outage: three *.infura.io networks down, but two
       // popular non-Infura RPCs are still healthy. Only 1 distinct domain in
-      // the unavailable set, not all-down -> suppress the banner.
+      // the failed set, not all-down -> suppress the banner.
       const mockStateWithInfuraPartialOutage = {
         metamask: {
           enabledNetworkMap: {
@@ -1182,15 +1182,15 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectNetworkForConnectionBanner(
+        selectFirstFailedNetworkForNetworkConnectionBanner(
           mockStateWithInfuraPartialOutage as unknown as Parameters<
-            typeof selectNetworkForConnectionBanner
+            typeof selectFirstFailedNetworkForNetworkConnectionBanner
           >[0],
         ),
       ).toBeNull();
     });
 
-    it('returns the first unavailable network when failures span 2+ registrable domains', () => {
+    it('returns the first failed network when failures span 2+ registrable domains', () => {
       const mockStateWithTwoDomainsDown = {
         metamask: {
           enabledNetworkMap: {
@@ -1259,11 +1259,11 @@ describe('Multichain network selectors', () => {
         },
       };
 
-      // Both Mainnet (Infura) and the Alchemy-backed Arbitrum are unavailable
+      // Both Mainnet (Infura) and the Alchemy-backed Arbitrum have failed
       // -> 2 distinct domains -> banner. The Alchemy RPC is custom so the
       // override surfaces it for the CTA.
       expect(
-        selectNetworkForConnectionBanner(mockStateWithTwoDomainsDown),
+        selectFirstFailedNetworkForNetworkConnectionBanner(mockStateWithTwoDomainsDown),
       ).toStrictEqual({
         networkName: 'Arbitrum One',
         networkClientId: 'arbitrum-alchemy',
@@ -1273,7 +1273,7 @@ describe('Multichain network selectors', () => {
       });
     });
 
-    it('returns the unavailable custom network even when other networks are available (custom override)', () => {
+    it('returns the failed custom network even when other networks are available (custom override)', () => {
       const mockStateWithCustomDownAmongAvailable = {
         metamask: {
           enabledNetworkMap: {
@@ -1343,7 +1343,7 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectNetworkForConnectionBanner(mockStateWithCustomDownAmongAvailable),
+        selectFirstFailedNetworkForNetworkConnectionBanner(mockStateWithCustomDownAmongAvailable),
       ).toStrictEqual({
         networkName: 'Custom Network',
         networkClientId: 'custom-network',

--- a/ui/selectors/multichain/networks.test.ts
+++ b/ui/selectors/multichain/networks.test.ts
@@ -1182,7 +1182,11 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectNetworkForConnectionBanner(mockStateWithInfuraPartialOutage),
+        selectNetworkForConnectionBanner(
+          mockStateWithInfuraPartialOutage as unknown as Parameters<
+            typeof selectNetworkForConnectionBanner
+          >[0],
+        ),
       ).toBeNull();
     });
 

--- a/ui/selectors/multichain/networks.test.ts
+++ b/ui/selectors/multichain/networks.test.ts
@@ -1190,7 +1190,7 @@ describe('Multichain network selectors', () => {
       ).toBeNull();
     });
 
-    it('returns the first failed network when failures span 2+ registrable domains', () => {
+    it('returns the first failed network when failures span 2+ domains', () => {
       const mockStateWithTwoDomainsDown = {
         metamask: {
           enabledNetworkMap: {

--- a/ui/selectors/multichain/networks.test.ts
+++ b/ui/selectors/multichain/networks.test.ts
@@ -26,7 +26,7 @@ import {
   getSelectedMultichainNetworkChainId,
   getSelectedMultichainNetworkConfiguration,
   getIsEvmMultichainNetworkSelected,
-  selectFirstUnavailableEvmNetwork,
+  selectNetworkForConnectionBanner,
   getEvmMultichainNetworkConfigurations,
   getAllMultichainNetworkConfigurations,
 } from './networks';
@@ -595,8 +595,8 @@ describe('Multichain network selectors', () => {
     });
   });
 
-  describe('selectFirstUnavailableEvmNetwork', () => {
-    it('returns the first EVM Infura-powered network that does not have a status of "available"', () => {
+  describe('selectNetworkForConnectionBanner', () => {
+    it('returns the first unavailable network when every enabled network is unavailable (all-down escape hatch)', () => {
       const mockStateWithMultipleUnavailableNetworks = {
         metamask: {
           enabledNetworkMap: {
@@ -652,7 +652,7 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectFirstUnavailableEvmNetwork(
+        selectNetworkForConnectionBanner(
           mockStateWithMultipleUnavailableNetworks,
         ),
       ).toStrictEqual({
@@ -664,7 +664,7 @@ describe('Multichain network selectors', () => {
       });
     });
 
-    it('returns the first EVM custom network that does not have a status of "available"', () => {
+    it('returns the unavailable custom network when both a custom and Infura network are down', () => {
       const mockStateWithMultipleUnavailableNetworks = {
         metamask: {
           enabledNetworkMap: {
@@ -720,7 +720,7 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectFirstUnavailableEvmNetwork(
+        selectNetworkForConnectionBanner(
           mockStateWithMultipleUnavailableNetworks,
         ),
       ).toStrictEqual({
@@ -788,7 +788,7 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectFirstUnavailableEvmNetwork(mockStateWithAvailableEvmNetworks),
+        selectNetworkForConnectionBanner(mockStateWithAvailableEvmNetworks),
       ).toBeNull();
     });
 
@@ -805,7 +805,7 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectFirstUnavailableEvmNetwork(mockStateWithNoEnabledEvmNetworks),
+        selectNetworkForConnectionBanner(mockStateWithNoEnabledEvmNetworks),
       ).toBeNull();
     });
 
@@ -840,7 +840,7 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectFirstUnavailableEvmNetwork(mockStateWithMissingMetadata),
+        selectNetworkForConnectionBanner(mockStateWithMissingMetadata),
       ).toBeNull();
     });
 
@@ -864,7 +864,7 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectFirstUnavailableEvmNetwork(mockStateWithMissingNetworkConfig),
+        selectNetworkForConnectionBanner(mockStateWithMissingNetworkConfig),
       ).toBeNull();
     });
 
@@ -909,9 +909,9 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectFirstUnavailableEvmNetwork(
+        selectNetworkForConnectionBanner(
           mockStateWithCustomAndInfuraEndpoints as Parameters<
-            typeof selectFirstUnavailableEvmNetwork
+            typeof selectNetworkForConnectionBanner
           >[0],
         ),
       ).toStrictEqual({
@@ -959,7 +959,7 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectFirstUnavailableEvmNetwork(mockStateWithOnlyCustomEndpoint),
+        selectNetworkForConnectionBanner(mockStateWithOnlyCustomEndpoint),
       ).toStrictEqual({
         networkName: 'Custom Network',
         networkClientId: 'custom-network',
@@ -969,7 +969,7 @@ describe('Multichain network selectors', () => {
       });
     });
 
-    it('does not return infuraEndpointIndex when already using Infura endpoint', () => {
+    it('returns the network when only one network is enabled and it is unavailable (all-down escape hatch)', () => {
       const mockStateWithInfuraAsDefault = {
         metamask: {
           enabledNetworkMap: {
@@ -1004,7 +1004,7 @@ describe('Multichain network selectors', () => {
         },
       };
 
-      const result = selectFirstUnavailableEvmNetwork(
+      const result = selectNetworkForConnectionBanner(
         mockStateWithInfuraAsDefault,
       );
       expect(result).toStrictEqual({
@@ -1012,6 +1012,339 @@ describe('Multichain network selectors', () => {
         networkClientId: 'mainnet',
         chainId: '0x1',
         isInfuraEndpoint: true,
+        infuraEndpointIndex: undefined,
+      });
+    });
+
+    it('returns null when only one Infura network out of many enabled is unavailable', () => {
+      // Single Infura blip in an otherwise-healthy set: 1 distinct domain,
+      // not all-down. Suppress to avoid the noisy banner. See WPC-1014.
+      const mockStateWithSingleInfuraDown = {
+        metamask: {
+          enabledNetworkMap: {
+            [KnownCaipNamespace.Eip155]: {
+              '0x1': true,
+              '0xaa36a7': true,
+            },
+          },
+          networksMetadata: {
+            mainnet: {
+              EIPS: {},
+              status: NetworkStatus.Available,
+            },
+            sepolia: {
+              EIPS: {},
+              status: NetworkStatus.Unavailable,
+            },
+          },
+          networkConfigurationsByChainId: {
+            '0x1': {
+              chainId: '0x1' as const,
+              name: 'Ethereum Mainnet',
+              nativeCurrency: 'ETH',
+              rpcEndpoints: [
+                {
+                  type: RpcEndpointType.Infura as const,
+                  url: 'https://mainnet.infura.io/v3/{infuraProjectId}' as const,
+                  networkClientId: 'mainnet' as const,
+                },
+              ],
+              defaultRpcEndpointIndex: 0,
+              blockExplorerUrls: [],
+              defaultBlockExplorerUrlIndex: 0,
+            },
+            '0xaa36a7': {
+              chainId: '0xaa36a7' as const,
+              name: 'Sepolia',
+              nativeCurrency: 'SepoliaETH',
+              rpcEndpoints: [
+                {
+                  type: RpcEndpointType.Infura as const,
+                  url: 'https://sepolia.infura.io/v3/{infuraProjectId}' as const,
+                  networkClientId: 'sepolia' as const,
+                },
+              ],
+              defaultRpcEndpointIndex: 0,
+              blockExplorerUrls: [],
+              defaultBlockExplorerUrlIndex: 0,
+            },
+          },
+          selectedNetworkClientId: 'mainnet',
+        },
+      };
+
+      expect(
+        selectNetworkForConnectionBanner(mockStateWithSingleInfuraDown),
+      ).toBeNull();
+    });
+
+    it('returns null when multiple Infura networks fail together but stay on one domain and others remain available', () => {
+      // Infura-wide partial outage: three *.infura.io networks down, but two
+      // popular non-Infura RPCs are still healthy. Only 1 distinct domain in
+      // the unavailable set, not all-down -> suppress the banner.
+      const mockStateWithInfuraPartialOutage = {
+        metamask: {
+          enabledNetworkMap: {
+            [KnownCaipNamespace.Eip155]: {
+              '0x1': true,
+              '0xaa36a7': true,
+              '0xe708': true,
+              '0xa4b1': true,
+              '0xa': true,
+            },
+          },
+          networksMetadata: {
+            mainnet: { EIPS: {}, status: NetworkStatus.Unavailable },
+            sepolia: { EIPS: {}, status: NetworkStatus.Unavailable },
+            linea: { EIPS: {}, status: NetworkStatus.Unavailable },
+            'arbitrum-alchemy': { EIPS: {}, status: NetworkStatus.Available },
+            'optimism-alchemy': { EIPS: {}, status: NetworkStatus.Available },
+          },
+          networkConfigurationsByChainId: {
+            '0x1': {
+              chainId: '0x1' as const,
+              name: 'Ethereum Mainnet',
+              nativeCurrency: 'ETH',
+              rpcEndpoints: [
+                {
+                  type: RpcEndpointType.Infura as const,
+                  url: 'https://mainnet.infura.io/v3/{infuraProjectId}' as const,
+                  networkClientId: 'mainnet' as const,
+                },
+              ],
+              defaultRpcEndpointIndex: 0,
+              blockExplorerUrls: [],
+              defaultBlockExplorerUrlIndex: 0,
+            },
+            '0xaa36a7': {
+              chainId: '0xaa36a7' as const,
+              name: 'Sepolia',
+              nativeCurrency: 'SepoliaETH',
+              rpcEndpoints: [
+                {
+                  type: RpcEndpointType.Infura as const,
+                  url: 'https://sepolia.infura.io/v3/{infuraProjectId}' as const,
+                  networkClientId: 'sepolia' as const,
+                },
+              ],
+              defaultRpcEndpointIndex: 0,
+              blockExplorerUrls: [],
+              defaultBlockExplorerUrlIndex: 0,
+            },
+            '0xe708': {
+              chainId: '0xe708' as const,
+              name: 'Linea',
+              nativeCurrency: 'ETH',
+              rpcEndpoints: [
+                {
+                  type: RpcEndpointType.Infura as const,
+                  url: 'https://linea-mainnet.infura.io/v3/{infuraProjectId}' as const,
+                  networkClientId: 'linea' as const,
+                },
+              ],
+              defaultRpcEndpointIndex: 0,
+              blockExplorerUrls: [],
+              defaultBlockExplorerUrlIndex: 0,
+            },
+            '0xa4b1': {
+              chainId: '0xa4b1' as const,
+              name: 'Arbitrum One',
+              nativeCurrency: 'ETH',
+              rpcEndpoints: [
+                {
+                  type: RpcEndpointType.Infura as const,
+                  url: 'https://arbitrum-mainnet.infura.io/v3/{infuraProjectId}' as const,
+                  networkClientId: 'arbitrum-alchemy' as const,
+                },
+              ],
+              defaultRpcEndpointIndex: 0,
+              blockExplorerUrls: [],
+              defaultBlockExplorerUrlIndex: 0,
+            },
+            '0xa': {
+              chainId: '0xa' as const,
+              name: 'Optimism',
+              nativeCurrency: 'ETH',
+              rpcEndpoints: [
+                {
+                  type: RpcEndpointType.Infura as const,
+                  url: 'https://optimism-mainnet.infura.io/v3/{infuraProjectId}' as const,
+                  networkClientId: 'optimism-alchemy' as const,
+                },
+              ],
+              defaultRpcEndpointIndex: 0,
+              blockExplorerUrls: [],
+              defaultBlockExplorerUrlIndex: 0,
+            },
+          },
+          selectedNetworkClientId: 'mainnet',
+        },
+      };
+
+      expect(
+        selectNetworkForConnectionBanner(mockStateWithInfuraPartialOutage),
+      ).toBeNull();
+    });
+
+    it('returns the first unavailable network when failures span 2+ registrable domains', () => {
+      const mockStateWithTwoDomainsDown = {
+        metamask: {
+          enabledNetworkMap: {
+            [KnownCaipNamespace.Eip155]: {
+              '0x1': true,
+              '0xa4b1': true,
+              '0xaa36a7': true,
+            },
+          },
+          networksMetadata: {
+            mainnet: { EIPS: {}, status: NetworkStatus.Unavailable },
+            'arbitrum-alchemy': {
+              EIPS: {},
+              status: NetworkStatus.Unavailable,
+            },
+            sepolia: { EIPS: {}, status: NetworkStatus.Available },
+          },
+          networkConfigurationsByChainId: {
+            '0x1': {
+              chainId: '0x1' as const,
+              name: 'Ethereum Mainnet',
+              nativeCurrency: 'ETH',
+              rpcEndpoints: [
+                {
+                  type: RpcEndpointType.Infura as const,
+                  url: 'https://mainnet.infura.io/v3/{infuraProjectId}' as const,
+                  networkClientId: 'mainnet' as const,
+                },
+              ],
+              defaultRpcEndpointIndex: 0,
+              blockExplorerUrls: [],
+              defaultBlockExplorerUrlIndex: 0,
+            },
+            '0xa4b1': {
+              chainId: '0xa4b1' as const,
+              name: 'Arbitrum One',
+              nativeCurrency: 'ETH',
+              rpcEndpoints: [
+                {
+                  type: RpcEndpointType.Custom as const,
+                  url: 'https://arb-mainnet.g.alchemy.com/v2/abc',
+                  networkClientId: 'arbitrum-alchemy' as const,
+                },
+              ],
+              defaultRpcEndpointIndex: 0,
+              blockExplorerUrls: [],
+              defaultBlockExplorerUrlIndex: 0,
+            },
+            '0xaa36a7': {
+              chainId: '0xaa36a7' as const,
+              name: 'Sepolia',
+              nativeCurrency: 'SepoliaETH',
+              rpcEndpoints: [
+                {
+                  type: RpcEndpointType.Infura as const,
+                  url: 'https://sepolia.infura.io/v3/{infuraProjectId}' as const,
+                  networkClientId: 'sepolia' as const,
+                },
+              ],
+              defaultRpcEndpointIndex: 0,
+              blockExplorerUrls: [],
+              defaultBlockExplorerUrlIndex: 0,
+            },
+          },
+          selectedNetworkClientId: 'mainnet',
+        },
+      };
+
+      // Both Mainnet (Infura) and the Alchemy-backed Arbitrum are unavailable
+      // -> 2 distinct domains -> banner. The Alchemy RPC is custom so the
+      // override surfaces it for the CTA.
+      expect(
+        selectNetworkForConnectionBanner(mockStateWithTwoDomainsDown),
+      ).toStrictEqual({
+        networkName: 'Arbitrum One',
+        networkClientId: 'arbitrum-alchemy',
+        chainId: '0xa4b1',
+        isInfuraEndpoint: false,
+        infuraEndpointIndex: undefined,
+      });
+    });
+
+    it('returns the unavailable custom network even when other networks are available (custom override)', () => {
+      const mockStateWithCustomDownAmongAvailable = {
+        metamask: {
+          enabledNetworkMap: {
+            [KnownCaipNamespace.Eip155]: {
+              '0x1': true,
+              '0xaa36a7': true,
+              '0x1000': true,
+            },
+          },
+          networksMetadata: {
+            mainnet: { EIPS: {}, status: NetworkStatus.Available },
+            sepolia: { EIPS: {}, status: NetworkStatus.Available },
+            'custom-network': {
+              EIPS: {},
+              status: NetworkStatus.Unavailable,
+            },
+          },
+          networkConfigurationsByChainId: {
+            '0x1': {
+              chainId: '0x1' as const,
+              name: 'Ethereum Mainnet',
+              nativeCurrency: 'ETH',
+              rpcEndpoints: [
+                {
+                  type: RpcEndpointType.Infura as const,
+                  url: 'https://mainnet.infura.io/v3/{infuraProjectId}' as const,
+                  networkClientId: 'mainnet' as const,
+                },
+              ],
+              defaultRpcEndpointIndex: 0,
+              blockExplorerUrls: [],
+              defaultBlockExplorerUrlIndex: 0,
+            },
+            '0xaa36a7': {
+              chainId: '0xaa36a7' as const,
+              name: 'Sepolia',
+              nativeCurrency: 'SepoliaETH',
+              rpcEndpoints: [
+                {
+                  type: RpcEndpointType.Infura as const,
+                  url: 'https://sepolia.infura.io/v3/{infuraProjectId}' as const,
+                  networkClientId: 'sepolia' as const,
+                },
+              ],
+              defaultRpcEndpointIndex: 0,
+              blockExplorerUrls: [],
+              defaultBlockExplorerUrlIndex: 0,
+            },
+            '0x1000': {
+              chainId: '0x1000' as const,
+              name: 'Custom Network',
+              nativeCurrency: 'ETH',
+              rpcEndpoints: [
+                {
+                  type: RpcEndpointType.Custom as const,
+                  url: 'https://custom.network',
+                  networkClientId: 'custom-network' as const,
+                },
+              ],
+              defaultRpcEndpointIndex: 0,
+              blockExplorerUrls: [],
+              defaultBlockExplorerUrlIndex: 0,
+            },
+          },
+          selectedNetworkClientId: 'mainnet',
+        },
+      };
+
+      expect(
+        selectNetworkForConnectionBanner(mockStateWithCustomDownAmongAvailable),
+      ).toStrictEqual({
+        networkName: 'Custom Network',
+        networkClientId: 'custom-network',
+        chainId: '0x1000',
+        isInfuraEndpoint: false,
         infuraEndpointIndex: undefined,
       });
     });

--- a/ui/selectors/multichain/networks.test.ts
+++ b/ui/selectors/multichain/networks.test.ts
@@ -788,7 +788,9 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectFirstFailedNetworkForNetworkConnectionBanner(mockStateWithAvailableEvmNetworks),
+        selectFirstFailedNetworkForNetworkConnectionBanner(
+          mockStateWithAvailableEvmNetworks,
+        ),
       ).toBeNull();
     });
 
@@ -805,7 +807,9 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectFirstFailedNetworkForNetworkConnectionBanner(mockStateWithNoEnabledEvmNetworks),
+        selectFirstFailedNetworkForNetworkConnectionBanner(
+          mockStateWithNoEnabledEvmNetworks,
+        ),
       ).toBeNull();
     });
 
@@ -840,7 +844,9 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectFirstFailedNetworkForNetworkConnectionBanner(mockStateWithMissingMetadata),
+        selectFirstFailedNetworkForNetworkConnectionBanner(
+          mockStateWithMissingMetadata,
+        ),
       ).toBeNull();
     });
 
@@ -864,7 +870,9 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectFirstFailedNetworkForNetworkConnectionBanner(mockStateWithMissingNetworkConfig),
+        selectFirstFailedNetworkForNetworkConnectionBanner(
+          mockStateWithMissingNetworkConfig,
+        ),
       ).toBeNull();
     });
 
@@ -959,7 +967,9 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectFirstFailedNetworkForNetworkConnectionBanner(mockStateWithOnlyCustomEndpoint),
+        selectFirstFailedNetworkForNetworkConnectionBanner(
+          mockStateWithOnlyCustomEndpoint,
+        ),
       ).toStrictEqual({
         networkName: 'Custom Network',
         networkClientId: 'custom-network',
@@ -1074,7 +1084,9 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectFirstFailedNetworkForNetworkConnectionBanner(mockStateWithSingleInfuraDown),
+        selectFirstFailedNetworkForNetworkConnectionBanner(
+          mockStateWithSingleInfuraDown,
+        ),
       ).toBeNull();
     });
 
@@ -1263,7 +1275,9 @@ describe('Multichain network selectors', () => {
       // -> 2 distinct domains -> banner. The Alchemy RPC is custom so the
       // override surfaces it for the CTA.
       expect(
-        selectFirstFailedNetworkForNetworkConnectionBanner(mockStateWithTwoDomainsDown),
+        selectFirstFailedNetworkForNetworkConnectionBanner(
+          mockStateWithTwoDomainsDown,
+        ),
       ).toStrictEqual({
         networkName: 'Arbitrum One',
         networkClientId: 'arbitrum-alchemy',
@@ -1343,7 +1357,9 @@ describe('Multichain network selectors', () => {
       };
 
       expect(
-        selectFirstFailedNetworkForNetworkConnectionBanner(mockStateWithCustomDownAmongAvailable),
+        selectFirstFailedNetworkForNetworkConnectionBanner(
+          mockStateWithCustomDownAmongAvailable,
+        ),
       ).toStrictEqual({
         networkName: 'Custom Network',
         networkClientId: 'custom-network',

--- a/ui/selectors/multichain/networks.ts
+++ b/ui/selectors/multichain/networks.ts
@@ -485,16 +485,14 @@ export const selectFirstFailedNetworkForNetworkConnectionBanner =
         .filter(([, isEnabled]) => isEnabled)
         .map(([chainId]) => chainId as Hex);
 
-      type FailedNetwork = {
+      const failed: {
         networkClientId: string;
         chainId: Hex;
         networkName: string;
         isInfuraEndpoint: boolean;
         infuraEndpointIndex: number | undefined;
         registrableDomain: string | null;
-      };
-
-      const failed: FailedNetwork[] = [];
+      }[] = [];
       let totalEnabled = 0;
 
       for (const chainId of enabledChainIds) {

--- a/ui/selectors/multichain/networks.ts
+++ b/ui/selectors/multichain/networks.ts
@@ -454,6 +454,147 @@ export const selectAnyEnabledNetworksAreAvailable = createSelector(
 );
 
 /**
+ * Network configurations annotated per-rpcEndpoint with the bits the banner
+ * logic cares about: whether the endpoint is an Infura URL, whether its
+ * current metadata status is anything other than Available ("failed"), and
+ * its registrable domain. The network itself also gets an `infuraEndpointIndex`
+ * pointing at the first Infura endpoint (used by the "Switch to Infura" CTA).
+ *
+ * Computed for every configured network, not just enabled ones, so the
+ * memoised result can be reused across selectors.
+ */
+const selectEnhancedNetworkConfigurationsByChainId = createSelector(
+  getNetworkConfigurationsByChainId,
+  getNetworksMetadata,
+  (networkConfigurationsByChainId, networksMetadata) => {
+    const enhanced: Record<
+      Hex,
+      Omit<(typeof networkConfigurationsByChainId)[Hex], 'rpcEndpoints'> & {
+        rpcEndpoints: {
+          networkClientId: string;
+          url: string;
+          isInfuraEndpoint: boolean;
+          isFailed: boolean;
+          domain: string | null;
+        }[];
+        infuraEndpointIndex: number | undefined;
+      }
+    > = {};
+
+    for (const [chainId, networkConfiguration] of Object.entries(
+      networkConfigurationsByChainId,
+    )) {
+      const enhancedRpcEndpoints = networkConfiguration.rpcEndpoints.map(
+        (rpcEndpoint) => {
+          const metadata = networksMetadata[rpcEndpoint.networkClientId];
+          // We have to use this function to check whether the endpoint is
+          // an Infura endpoint because some Infura endpoint URLs use the
+          // wrong type.
+          const isInfuraEndpoint = getIsMetaMaskInfuraEndpointUrl(
+            rpcEndpoint.url,
+            infuraProjectId ?? '',
+          );
+          const isFailed =
+            metadata !== undefined &&
+            metadata.status !== NetworkStatus.Available;
+
+          return {
+            networkClientId: rpcEndpoint.networkClientId,
+            url: rpcEndpoint.url,
+            isInfuraEndpoint,
+            isFailed,
+            domain: getDomain(rpcEndpoint.url),
+          };
+        },
+      );
+
+      const firstInfuraIndex = enhancedRpcEndpoints.findIndex(
+        (rpcEndpoint) => rpcEndpoint.isInfuraEndpoint,
+      );
+
+      enhanced[chainId as Hex] = {
+        ...networkConfiguration,
+        rpcEndpoints: enhancedRpcEndpoints,
+        infuraEndpointIndex:
+          firstInfuraIndex === -1 ? undefined : firstInfuraIndex,
+      };
+    }
+
+    return enhanced;
+  },
+);
+
+/**
+ * The list of enabled EVM networks whose default RPC endpoint is currently
+ * failing, plus a flag for whether every enabled network is failing. Used as
+ * the input to the banner show/hide rule.
+ */
+const selectEnabledFailedNetworksResult = createSelector(
+  getEnabledNetworks,
+  selectEnhancedNetworkConfigurationsByChainId,
+  (enabledNetworks, enhancedNetworkConfigurationsByChainId) => {
+    const enabledEvmNetworks = enabledNetworks[KnownCaipNamespace.Eip155] ?? {};
+    const enabledChainIds = Object.entries(enabledEvmNetworks)
+      .filter(([, isEnabled]) => isEnabled)
+      .map(([chainId]) => chainId as Hex);
+
+    const failedNetworks: {
+      networkClientId: string;
+      chainId: Hex;
+      networkName: string;
+      isInfuraEndpoint: boolean;
+      infuraEndpointIndex: number | undefined;
+      domain: string | null;
+    }[] = [];
+    let totalEnabled = 0;
+
+    for (const chainId of enabledChainIds) {
+      const networkConfiguration =
+        enhancedNetworkConfigurationsByChainId[chainId];
+      if (!networkConfiguration) {
+        continue;
+      }
+
+      const {
+        rpcEndpoints,
+        defaultRpcEndpointIndex,
+        name,
+        infuraEndpointIndex,
+      } = networkConfiguration;
+      const defaultRpcEndpoint = rpcEndpoints[defaultRpcEndpointIndex];
+      if (!defaultRpcEndpoint) {
+        continue;
+      }
+
+      totalEnabled += 1;
+
+      if (!defaultRpcEndpoint.isFailed) {
+        continue;
+      }
+
+      failedNetworks.push({
+        networkClientId: defaultRpcEndpoint.networkClientId,
+        chainId,
+        networkName: name,
+        isInfuraEndpoint: defaultRpcEndpoint.isInfuraEndpoint,
+        // Only useful when the default is non-Infura — otherwise the CTA to
+        // switch to Infura is hidden anyway.
+        infuraEndpointIndex: defaultRpcEndpoint.isInfuraEndpoint
+          ? undefined
+          : infuraEndpointIndex,
+        domain: defaultRpcEndpoint.domain,
+      });
+    }
+
+    return {
+      failedNetworks,
+      areAllEnabledNetworksFailed:
+        failedNetworks.length > 0 && failedNetworks.length === totalEnabled,
+    };
+  },
+);
+
+/**
  * Returns the first failed EVM network that should drive the network connection
  * banner, or null when no banner should be shown.
  *
@@ -475,106 +616,31 @@ export const selectAnyEnabledNetworksAreAvailable = createSelector(
  */
 export const selectFirstFailedNetworkForNetworkConnectionBanner =
   createSelector(
-    getEnabledNetworks,
-    getNetworkConfigurationsByChainId,
-    getNetworksMetadata,
-    (enabledNetworks, networkConfigurationsByChainId, networksMetadata) => {
-      const enabledEvmNetworks =
-        enabledNetworks[KnownCaipNamespace.Eip155] ?? {};
-      const enabledChainIds = Object.entries(enabledEvmNetworks)
-        .filter(([, isEnabled]) => isEnabled)
-        .map(([chainId]) => chainId as Hex);
-
-      const failed: {
-        networkClientId: string;
-        chainId: Hex;
-        networkName: string;
-        isInfuraEndpoint: boolean;
-        infuraEndpointIndex: number | undefined;
-        domain: string | null;
-      }[] = [];
-      let totalEnabled = 0;
-
-      for (const chainId of enabledChainIds) {
-        const networkConfiguration = networkConfigurationsByChainId[chainId];
-        if (!networkConfiguration) {
-          continue;
-        }
-
-        const { rpcEndpoints, defaultRpcEndpointIndex, name } =
-          networkConfiguration;
-        const rpcEndpoint = rpcEndpoints[defaultRpcEndpointIndex];
-        if (!rpcEndpoint) {
-          continue;
-        }
-
-        totalEnabled += 1;
-
-        const metadata = networksMetadata[rpcEndpoint.networkClientId];
-        if (
-          metadata === undefined ||
-          metadata.status === NetworkStatus.Available
-        ) {
-          continue;
-        }
-
-        const isInfuraEndpoint = getIsMetaMaskInfuraEndpointUrl(
-          rpcEndpoint.url,
-          infuraProjectId ?? '',
-        );
-
-        // For custom endpoints (non-Infura), check if there's an Infura
-        // endpoint available for this network that we can switch to
-        let infuraEndpointIndex: number | undefined;
-        if (!isInfuraEndpoint) {
-          infuraEndpointIndex = rpcEndpoints.findIndex(
-            (endpoint, index) =>
-              index !== defaultRpcEndpointIndex &&
-              getIsMetaMaskInfuraEndpointUrl(
-                endpoint.url,
-                infuraProjectId ?? '',
-              ),
-          );
-          if (infuraEndpointIndex === -1) {
-            infuraEndpointIndex = undefined;
-          }
-        }
-
-        failed.push({
-          networkClientId: rpcEndpoint.networkClientId,
-          chainId,
-          networkName: name,
-          // We have to use this function to check whether the endpoint is
-          // an Infura endpoint because some Infura endpoint URLs use the
-          // wrong type.
-          isInfuraEndpoint,
-          // Index of an available Infura endpoint (for custom networks that
-          // have one) that can be used to switch to Infura
-          infuraEndpointIndex,
-          domain: getDomain(rpcEndpoint.url),
-        });
-      }
-
-      if (failed.length === 0) {
+    selectEnabledFailedNetworksResult,
+    ({ failedNetworks, areAllEnabledNetworksFailed }) => {
+      if (failedNetworks.length === 0) {
         return null;
       }
 
-      const firstCustomFailed = failed.find((n) => !n.isInfuraEndpoint);
+      const firstCustomFailed = failedNetworks.find((n) => !n.isInfuraEndpoint);
       const distinctDomains = new Set(
-        failed
+        failedNetworks
           .map((n) => n.domain)
           .filter((domain): domain is string => domain !== null),
       ).size;
-      const allFailed = failed.length === totalEnabled;
 
-      if (!firstCustomFailed && distinctDomains < 2 && !allFailed) {
+      if (
+        !firstCustomFailed &&
+        distinctDomains < 2 &&
+        !areAllEnabledNetworksFailed
+      ) {
         return null;
       }
 
       // Prefer a custom-RPC network when one is among the failed set so the
-      // banner's "Switch to MetaMask default RPC" CTA points at the network the
-      // user can actually act on.
-      const selected = firstCustomFailed ?? failed[0];
+      // banner's "Switch to MetaMask default RPC" CTA points at the network
+      // the user can actually act on.
+      const selected = firstCustomFailed ?? failedNetworks[0];
 
       return {
         networkClientId: selected.networkClientId,

--- a/ui/selectors/multichain/networks.ts
+++ b/ui/selectors/multichain/networks.ts
@@ -45,7 +45,7 @@ import {
 import { createDeepEqualSelector } from '../../../shared/lib/selectors/selector-creators';
 import { getEnabledNetworks } from '../../../shared/lib/selectors/multichain';
 import { getIsMetaMaskInfuraEndpointUrl } from '../../../shared/lib/network-utils';
-import { getRegistrableDomain } from '../../../shared/lib/url-utils';
+import { getDomain } from '../../../shared/lib/url-utils';
 import type { RemoteFeatureFlagsState } from '../../../shared/lib/selectors/remote-feature-flags';
 import {
   type AccountsState,
@@ -465,9 +465,9 @@ export const selectAnyEnabledNetworksAreAvailable = createSelector(
  * (e.g. an Infura-wide hiccup that takes down many *.infura.io networks at
  * once) is suppressed because it looks like many failed networks but is really
  * one provider. The banner shows only when failed RPCs span 2+ distinct
- * registrable domains (likely client-side), or every enabled EVM network has
- * failed (covers single-network setups), or any failed network's active RPC
- * is a non-Infura (custom) endpoint — these have no automatic failover so the
+ * domains (likely client-side), or every enabled EVM network has failed
+ * (covers single-network setups), or any failed network's active RPC is a
+ * non-Infura (custom) endpoint — these have no automatic failover so the
  * user must be told.
  *
  * When the custom override fires alongside other failed networks, the custom
@@ -491,7 +491,7 @@ export const selectFirstFailedNetworkForNetworkConnectionBanner =
         networkName: string;
         isInfuraEndpoint: boolean;
         infuraEndpointIndex: number | undefined;
-        registrableDomain: string | null;
+        domain: string | null;
       }[] = [];
       let totalEnabled = 0;
 
@@ -551,7 +551,7 @@ export const selectFirstFailedNetworkForNetworkConnectionBanner =
           // Index of an available Infura endpoint (for custom networks that
           // have one) that can be used to switch to Infura
           infuraEndpointIndex,
-          registrableDomain: getRegistrableDomain(rpcEndpoint.url),
+          domain: getDomain(rpcEndpoint.url),
         });
       }
 
@@ -562,7 +562,7 @@ export const selectFirstFailedNetworkForNetworkConnectionBanner =
       const firstCustomFailed = failed.find((n) => !n.isInfuraEndpoint);
       const distinctDomains = new Set(
         failed
-          .map((n) => n.registrableDomain)
+          .map((n) => n.domain)
           .filter((domain): domain is string => domain !== null),
       ).size;
       const allFailed = failed.length === totalEnabled;

--- a/ui/selectors/multichain/networks.ts
+++ b/ui/selectors/multichain/networks.ts
@@ -454,20 +454,18 @@ export const selectAnyEnabledNetworksAreAvailable = createSelector(
 );
 
 /**
- * Network configurations annotated per-rpcEndpoint with the bits the banner
- * logic cares about: whether the endpoint is an Infura URL, whether its
- * current metadata status is anything other than Available ("failed"), and
- * its registrable domain. The network itself also gets an `infuraEndpointIndex`
- * pointing at the first Infura endpoint (used by the "Switch to Infura" CTA).
- *
- * Computed for every configured network, not just enabled ones, so the
- * memoised result can be reused across selectors.
+ * Network configurations and their RPC endpoints annotated with information
+ * that the network connection banner logic cares about: whether the endpoint is
+ * an Infura URL, whether its current metadata status is anything other than
+ * Available ("failed"), and its registrable domain. The network itself also
+ * gets an `infuraEndpointIndex` pointing at the first Infura endpoint (used by
+ * the "Switch to Infura" CTA).
  */
 const selectEnhancedNetworkConfigurationsByChainId = createSelector(
   getNetworkConfigurationsByChainId,
   getNetworksMetadata,
   (networkConfigurationsByChainId, networksMetadata) => {
-    const enhanced: Record<
+    const enhancedNetworkConfigurationsByChainId: Record<
       Hex,
       Omit<(typeof networkConfigurationsByChainId)[Hex], 'rpcEndpoints'> & {
         rpcEndpoints: {
@@ -512,7 +510,7 @@ const selectEnhancedNetworkConfigurationsByChainId = createSelector(
         (rpcEndpoint) => rpcEndpoint.isInfuraEndpoint,
       );
 
-      enhanced[chainId as Hex] = {
+      enhancedNetworkConfigurationsByChainId[chainId as Hex] = {
         ...networkConfiguration,
         rpcEndpoints: enhancedRpcEndpoints,
         infuraEndpointIndex:
@@ -520,21 +518,21 @@ const selectEnhancedNetworkConfigurationsByChainId = createSelector(
       };
     }
 
-    return enhanced;
+    return enhancedNetworkConfigurationsByChainId;
   },
 );
 
 /**
  * The list of enabled EVM networks whose default RPC endpoint is currently
  * failing, plus a flag for whether every enabled network is failing. Used as
- * the input to the banner show/hide rule.
+ * the input to the network connection banner show/hide rule.
  */
 const selectEnabledFailedNetworksResult = createSelector(
   getEnabledNetworks,
   selectEnhancedNetworkConfigurationsByChainId,
   (enabledNetworks, enhancedNetworkConfigurationsByChainId) => {
     const enabledEvmNetworks = enabledNetworks[KnownCaipNamespace.Eip155] ?? {};
-    const enabledChainIds = Object.entries(enabledEvmNetworks)
+    const enabledEvmChainIds = Object.entries(enabledEvmNetworks)
       .filter(([, isEnabled]) => isEnabled)
       .map(([chainId]) => chainId as Hex);
 
@@ -548,7 +546,7 @@ const selectEnabledFailedNetworksResult = createSelector(
     }[] = [];
     let totalEnabled = 0;
 
-    for (const chainId of enabledChainIds) {
+    for (const chainId of enabledEvmChainIds) {
       const networkConfiguration =
         enhancedNetworkConfigurationsByChainId[chainId];
       if (!networkConfiguration) {
@@ -598,30 +596,25 @@ const selectEnabledFailedNetworksResult = createSelector(
  * Returns the first failed EVM network that should drive the network connection
  * banner, or null when no banner should be shown.
  *
- * A network is "failed" here when its default RPC endpoint's metadata status is
- * anything other than NetworkStatus.Available. (Note that NetworkStatus.Unavailable
- * is a specific circuit-broken state — "failed" is the broader bucket we use.)
+ * A network is "failed" here when its default RPC endpoint's status is anything
+ * other than `NetworkStatus.Available`.
  *
- * The banner is intentionally noisy-averse. A single provider's wide outage
- * (e.g. an Infura-wide hiccup that takes down many *.infura.io networks at
- * once) is suppressed because it looks like many failed networks but is really
- * one provider. The banner shows only when failed RPCs span 2+ distinct
- * domains (likely client-side), or every enabled EVM network has failed
- * (covers single-network setups), or any failed network's active RPC is a
- * non-Infura (custom) endpoint — these have no automatic failover so the
+ * The banner always shows for custom networks because users always have the
+ * option to switch to a built-in network, and we surface that custom network
+ * first so the "Switch to MetaMask default RPC" CTA points at it. For all
+ * other networks the banner is intentionally noisy-averse: a single provider's
+ * wide outage (e.g. an Infura-wide hiccup that takes down many *.infura.io
+ * networks at once) is suppressed because it looks like many failed networks
+ * but is really one provider. The banner shows only when failed RPCs span
+ * 2+ distinct domains (likely client-side), or every enabled EVM network has
+ * failed (covers single-network setups), or any failed network's active RPC
+ * is a non-Infura (custom) endpoint — these have no automatic failover so the
  * user must be told.
- *
- * When the custom override fires alongside other failed networks, the custom
- * one is surfaced so the "Switch to MetaMask default RPC" CTA targets it.
  */
 export const selectFirstFailedNetworkForNetworkConnectionBanner =
   createSelector(
     selectEnabledFailedNetworksResult,
     ({ failedNetworks, areAllEnabledNetworksFailed }) => {
-      if (failedNetworks.length === 0) {
-        return null;
-      }
-
       const firstCustomFailed = failedNetworks.find((n) => !n.isInfuraEndpoint);
       const distinctDomains = new Set(
         failedNetworks
@@ -629,26 +622,29 @@ export const selectFirstFailedNetworkForNetworkConnectionBanner =
           .filter((domain): domain is string => domain !== null),
       ).size;
 
+      // Show the banner if:
+      // - The first failing network is a custom network (we assume users always
+      //   want to be informed about errors with RPC endpoints they've chosen)
+      // - There are failures across more than one domain (likely client-side
+      //   issue)
+      // - All enabled networks are failing (likely client-side issue)
       if (
-        !firstCustomFailed &&
-        distinctDomains < 2 &&
-        !areAllEnabledNetworksFailed
+        firstCustomFailed ||
+        distinctDomains > 1 ||
+        areAllEnabledNetworksFailed
       ) {
-        return null;
+        const selected = firstCustomFailed ?? failedNetworks[0];
+
+        return {
+          networkClientId: selected.networkClientId,
+          chainId: selected.chainId,
+          networkName: selected.networkName,
+          isInfuraEndpoint: selected.isInfuraEndpoint,
+          infuraEndpointIndex: selected.infuraEndpointIndex,
+        };
       }
 
-      // Prefer a custom-RPC network when one is among the failed set so the
-      // banner's "Switch to MetaMask default RPC" CTA points at the network
-      // the user can actually act on.
-      const selected = firstCustomFailed ?? failedNetworks[0];
-
-      return {
-        networkClientId: selected.networkClientId,
-        chainId: selected.chainId,
-        networkName: selected.networkName,
-        isInfuraEndpoint: selected.isInfuraEndpoint,
-        infuraEndpointIndex: selected.infuraEndpointIndex,
-      };
+      return null;
     },
   );
 

--- a/ui/selectors/multichain/networks.ts
+++ b/ui/selectors/multichain/networks.ts
@@ -45,6 +45,7 @@ import {
 import { createDeepEqualSelector } from '../../../shared/lib/selectors/selector-creators';
 import { getEnabledNetworks } from '../../../shared/lib/selectors/multichain';
 import { getIsMetaMaskInfuraEndpointUrl } from '../../../shared/lib/network-utils';
+import { getRegistrableDomain } from '../../../shared/lib/url-utils';
 import type { RemoteFeatureFlagsState } from '../../../shared/lib/selectors/remote-feature-flags';
 import {
   type AccountsState,
@@ -452,7 +453,23 @@ export const selectAnyEnabledNetworksAreAvailable = createSelector(
   },
 );
 
-export const selectFirstUnavailableEvmNetwork = createSelector(
+/**
+ * Returns the unavailable EVM network that should drive the connection banner,
+ * or null when no banner should be shown.
+ *
+ * The banner is intentionally noisy-averse. A single provider's wide outage
+ * (e.g. an Infura-wide hiccup that takes down many *.infura.io networks at
+ * once) is suppressed because it looks like many unavailable networks but is
+ * really one provider. The banner shows only when unavailable RPCs span 2+
+ * distinct registrable domains (likely client-side), or every enabled EVM
+ * network is unavailable (covers single-network setups), or any unavailable
+ * network's active RPC is a non-Infura (custom) endpoint — these have no
+ * automatic failover so the user must be told.
+ *
+ * When the custom override fires alongside other unavailable networks, the
+ * custom one is surfaced so the "Switch to MetaMask default RPC" CTA targets it.
+ */
+export const selectNetworkForConnectionBanner = createSelector(
   getEnabledNetworks,
   getNetworkConfigurationsByChainId,
   getNetworksMetadata,
@@ -462,61 +479,103 @@ export const selectFirstUnavailableEvmNetwork = createSelector(
       .filter(([, isEnabled]) => isEnabled)
       .map(([chainId]) => chainId as Hex);
 
+    type UnavailableNetwork = {
+      networkClientId: string;
+      chainId: Hex;
+      networkName: string;
+      isInfuraEndpoint: boolean;
+      infuraEndpointIndex: number | undefined;
+      registrableDomain: string | null;
+    };
+
+    const unavailable: UnavailableNetwork[] = [];
+    let totalEnabled = 0;
+
     for (const chainId of enabledChainIds) {
       const networkConfiguration = networkConfigurationsByChainId[chainId];
-      if (networkConfiguration) {
-        // Get the network client ID directly from the network configuration
-        const { rpcEndpoints, defaultRpcEndpointIndex, name } =
-          networkConfiguration;
-        const rpcEndpoint = rpcEndpoints[defaultRpcEndpointIndex];
+      if (!networkConfiguration) {
+        continue;
+      }
 
-        if (rpcEndpoint) {
-          const metadata = networksMetadata[rpcEndpoint.networkClientId];
+      const { rpcEndpoints, defaultRpcEndpointIndex, name } =
+        networkConfiguration;
+      const rpcEndpoint = rpcEndpoints[defaultRpcEndpointIndex];
+      if (!rpcEndpoint) {
+        continue;
+      }
 
-          if (
-            metadata !== undefined &&
-            metadata.status !== NetworkStatus.Available
-          ) {
-            const isInfuraEndpoint = getIsMetaMaskInfuraEndpointUrl(
-              rpcEndpoint.url,
-              infuraProjectId ?? '',
-            );
+      totalEnabled += 1;
 
-            // For custom endpoints (non-Infura), check if there's an Infura
-            // endpoint available for this network that we can switch to
-            let infuraEndpointIndex: number | undefined;
-            if (!isInfuraEndpoint) {
-              infuraEndpointIndex = rpcEndpoints.findIndex(
-                (endpoint, index) =>
-                  index !== defaultRpcEndpointIndex &&
-                  getIsMetaMaskInfuraEndpointUrl(
-                    endpoint.url,
-                    infuraProjectId ?? '',
-                  ),
-              );
-              // If no Infura endpoint found, set to undefined
-              if (infuraEndpointIndex === -1) {
-                infuraEndpointIndex = undefined;
-              }
-            }
+      const metadata = networksMetadata[rpcEndpoint.networkClientId];
+      if (
+        metadata === undefined ||
+        metadata.status === NetworkStatus.Available
+      ) {
+        continue;
+      }
 
-            return {
-              networkClientId: rpcEndpoint.networkClientId,
-              chainId,
-              networkName: name,
-              // We have to use this function to check whether the endpoint is
-              // an Infura endpoint because some Infura endpoint URLs use the
-              // wrong type.
-              isInfuraEndpoint,
-              // Index of an available Infura endpoint (for custom networks that
-              // have one) that can be used to switch to Infura
-              infuraEndpointIndex,
-            };
-          }
+      const isInfuraEndpoint = getIsMetaMaskInfuraEndpointUrl(
+        rpcEndpoint.url,
+        infuraProjectId ?? '',
+      );
+
+      // For custom endpoints (non-Infura), check if there's an Infura
+      // endpoint available for this network that we can switch to
+      let infuraEndpointIndex: number | undefined;
+      if (!isInfuraEndpoint) {
+        infuraEndpointIndex = rpcEndpoints.findIndex(
+          (endpoint, index) =>
+            index !== defaultRpcEndpointIndex &&
+            getIsMetaMaskInfuraEndpointUrl(endpoint.url, infuraProjectId ?? ''),
+        );
+        if (infuraEndpointIndex === -1) {
+          infuraEndpointIndex = undefined;
         }
       }
+
+      unavailable.push({
+        networkClientId: rpcEndpoint.networkClientId,
+        chainId,
+        networkName: name,
+        // We have to use this function to check whether the endpoint is
+        // an Infura endpoint because some Infura endpoint URLs use the
+        // wrong type.
+        isInfuraEndpoint,
+        // Index of an available Infura endpoint (for custom networks that
+        // have one) that can be used to switch to Infura
+        infuraEndpointIndex,
+        registrableDomain: getRegistrableDomain(rpcEndpoint.url),
+      });
     }
-    return null;
+
+    if (unavailable.length === 0) {
+      return null;
+    }
+
+    const firstCustomUnavailable = unavailable.find((n) => !n.isInfuraEndpoint);
+    const distinctDomains = new Set(
+      unavailable
+        .map((n) => n.registrableDomain)
+        .filter((domain): domain is string => domain !== null),
+    ).size;
+    const allUnavailable = unavailable.length === totalEnabled;
+
+    if (!firstCustomUnavailable && distinctDomains < 2 && !allUnavailable) {
+      return null;
+    }
+
+    // Prefer a custom-RPC network when one is among the unavailable set so the
+    // banner's "Switch to MetaMask default RPC" CTA points at the network the
+    // user can actually act on.
+    const selected = firstCustomUnavailable ?? unavailable[0];
+
+    return {
+      networkClientId: selected.networkClientId,
+      chainId: selected.chainId,
+      networkName: selected.networkName,
+      isInfuraEndpoint: selected.isInfuraEndpoint,
+      infuraEndpointIndex: selected.infuraEndpointIndex,
+    };
   },
 );
 

--- a/ui/selectors/multichain/networks.ts
+++ b/ui/selectors/multichain/networks.ts
@@ -454,130 +454,139 @@ export const selectAnyEnabledNetworksAreAvailable = createSelector(
 );
 
 /**
- * Returns the unavailable EVM network that should drive the connection banner,
- * or null when no banner should be shown.
+ * Returns the first failed EVM network that should drive the network connection
+ * banner, or null when no banner should be shown.
+ *
+ * A network is "failed" here when its default RPC endpoint's metadata status is
+ * anything other than NetworkStatus.Available. (Note that NetworkStatus.Unavailable
+ * is a specific circuit-broken state — "failed" is the broader bucket we use.)
  *
  * The banner is intentionally noisy-averse. A single provider's wide outage
  * (e.g. an Infura-wide hiccup that takes down many *.infura.io networks at
- * once) is suppressed because it looks like many unavailable networks but is
- * really one provider. The banner shows only when unavailable RPCs span 2+
- * distinct registrable domains (likely client-side), or every enabled EVM
- * network is unavailable (covers single-network setups), or any unavailable
- * network's active RPC is a non-Infura (custom) endpoint — these have no
- * automatic failover so the user must be told.
+ * once) is suppressed because it looks like many failed networks but is really
+ * one provider. The banner shows only when failed RPCs span 2+ distinct
+ * registrable domains (likely client-side), or every enabled EVM network has
+ * failed (covers single-network setups), or any failed network's active RPC
+ * is a non-Infura (custom) endpoint — these have no automatic failover so the
+ * user must be told.
  *
- * When the custom override fires alongside other unavailable networks, the
- * custom one is surfaced so the "Switch to MetaMask default RPC" CTA targets it.
+ * When the custom override fires alongside other failed networks, the custom
+ * one is surfaced so the "Switch to MetaMask default RPC" CTA targets it.
  */
-export const selectNetworkForConnectionBanner = createSelector(
-  getEnabledNetworks,
-  getNetworkConfigurationsByChainId,
-  getNetworksMetadata,
-  (enabledNetworks, networkConfigurationsByChainId, networksMetadata) => {
-    const enabledEvmNetworks = enabledNetworks[KnownCaipNamespace.Eip155] ?? {};
-    const enabledChainIds = Object.entries(enabledEvmNetworks)
-      .filter(([, isEnabled]) => isEnabled)
-      .map(([chainId]) => chainId as Hex);
+export const selectFirstFailedNetworkForNetworkConnectionBanner =
+  createSelector(
+    getEnabledNetworks,
+    getNetworkConfigurationsByChainId,
+    getNetworksMetadata,
+    (enabledNetworks, networkConfigurationsByChainId, networksMetadata) => {
+      const enabledEvmNetworks =
+        enabledNetworks[KnownCaipNamespace.Eip155] ?? {};
+      const enabledChainIds = Object.entries(enabledEvmNetworks)
+        .filter(([, isEnabled]) => isEnabled)
+        .map(([chainId]) => chainId as Hex);
 
-    type UnavailableNetwork = {
-      networkClientId: string;
-      chainId: Hex;
-      networkName: string;
-      isInfuraEndpoint: boolean;
-      infuraEndpointIndex: number | undefined;
-      registrableDomain: string | null;
-    };
+      type FailedNetwork = {
+        networkClientId: string;
+        chainId: Hex;
+        networkName: string;
+        isInfuraEndpoint: boolean;
+        infuraEndpointIndex: number | undefined;
+        registrableDomain: string | null;
+      };
 
-    const unavailable: UnavailableNetwork[] = [];
-    let totalEnabled = 0;
+      const failed: FailedNetwork[] = [];
+      let totalEnabled = 0;
 
-    for (const chainId of enabledChainIds) {
-      const networkConfiguration = networkConfigurationsByChainId[chainId];
-      if (!networkConfiguration) {
-        continue;
-      }
-
-      const { rpcEndpoints, defaultRpcEndpointIndex, name } =
-        networkConfiguration;
-      const rpcEndpoint = rpcEndpoints[defaultRpcEndpointIndex];
-      if (!rpcEndpoint) {
-        continue;
-      }
-
-      totalEnabled += 1;
-
-      const metadata = networksMetadata[rpcEndpoint.networkClientId];
-      if (
-        metadata === undefined ||
-        metadata.status === NetworkStatus.Available
-      ) {
-        continue;
-      }
-
-      const isInfuraEndpoint = getIsMetaMaskInfuraEndpointUrl(
-        rpcEndpoint.url,
-        infuraProjectId ?? '',
-      );
-
-      // For custom endpoints (non-Infura), check if there's an Infura
-      // endpoint available for this network that we can switch to
-      let infuraEndpointIndex: number | undefined;
-      if (!isInfuraEndpoint) {
-        infuraEndpointIndex = rpcEndpoints.findIndex(
-          (endpoint, index) =>
-            index !== defaultRpcEndpointIndex &&
-            getIsMetaMaskInfuraEndpointUrl(endpoint.url, infuraProjectId ?? ''),
-        );
-        if (infuraEndpointIndex === -1) {
-          infuraEndpointIndex = undefined;
+      for (const chainId of enabledChainIds) {
+        const networkConfiguration = networkConfigurationsByChainId[chainId];
+        if (!networkConfiguration) {
+          continue;
         }
+
+        const { rpcEndpoints, defaultRpcEndpointIndex, name } =
+          networkConfiguration;
+        const rpcEndpoint = rpcEndpoints[defaultRpcEndpointIndex];
+        if (!rpcEndpoint) {
+          continue;
+        }
+
+        totalEnabled += 1;
+
+        const metadata = networksMetadata[rpcEndpoint.networkClientId];
+        if (
+          metadata === undefined ||
+          metadata.status === NetworkStatus.Available
+        ) {
+          continue;
+        }
+
+        const isInfuraEndpoint = getIsMetaMaskInfuraEndpointUrl(
+          rpcEndpoint.url,
+          infuraProjectId ?? '',
+        );
+
+        // For custom endpoints (non-Infura), check if there's an Infura
+        // endpoint available for this network that we can switch to
+        let infuraEndpointIndex: number | undefined;
+        if (!isInfuraEndpoint) {
+          infuraEndpointIndex = rpcEndpoints.findIndex(
+            (endpoint, index) =>
+              index !== defaultRpcEndpointIndex &&
+              getIsMetaMaskInfuraEndpointUrl(
+                endpoint.url,
+                infuraProjectId ?? '',
+              ),
+          );
+          if (infuraEndpointIndex === -1) {
+            infuraEndpointIndex = undefined;
+          }
+        }
+
+        failed.push({
+          networkClientId: rpcEndpoint.networkClientId,
+          chainId,
+          networkName: name,
+          // We have to use this function to check whether the endpoint is
+          // an Infura endpoint because some Infura endpoint URLs use the
+          // wrong type.
+          isInfuraEndpoint,
+          // Index of an available Infura endpoint (for custom networks that
+          // have one) that can be used to switch to Infura
+          infuraEndpointIndex,
+          registrableDomain: getRegistrableDomain(rpcEndpoint.url),
+        });
       }
 
-      unavailable.push({
-        networkClientId: rpcEndpoint.networkClientId,
-        chainId,
-        networkName: name,
-        // We have to use this function to check whether the endpoint is
-        // an Infura endpoint because some Infura endpoint URLs use the
-        // wrong type.
-        isInfuraEndpoint,
-        // Index of an available Infura endpoint (for custom networks that
-        // have one) that can be used to switch to Infura
-        infuraEndpointIndex,
-        registrableDomain: getRegistrableDomain(rpcEndpoint.url),
-      });
-    }
+      if (failed.length === 0) {
+        return null;
+      }
 
-    if (unavailable.length === 0) {
-      return null;
-    }
+      const firstCustomFailed = failed.find((n) => !n.isInfuraEndpoint);
+      const distinctDomains = new Set(
+        failed
+          .map((n) => n.registrableDomain)
+          .filter((domain): domain is string => domain !== null),
+      ).size;
+      const allFailed = failed.length === totalEnabled;
 
-    const firstCustomUnavailable = unavailable.find((n) => !n.isInfuraEndpoint);
-    const distinctDomains = new Set(
-      unavailable
-        .map((n) => n.registrableDomain)
-        .filter((domain): domain is string => domain !== null),
-    ).size;
-    const allUnavailable = unavailable.length === totalEnabled;
+      if (!firstCustomFailed && distinctDomains < 2 && !allFailed) {
+        return null;
+      }
 
-    if (!firstCustomUnavailable && distinctDomains < 2 && !allUnavailable) {
-      return null;
-    }
+      // Prefer a custom-RPC network when one is among the failed set so the
+      // banner's "Switch to MetaMask default RPC" CTA points at the network the
+      // user can actually act on.
+      const selected = firstCustomFailed ?? failed[0];
 
-    // Prefer a custom-RPC network when one is among the unavailable set so the
-    // banner's "Switch to MetaMask default RPC" CTA points at the network the
-    // user can actually act on.
-    const selected = firstCustomUnavailable ?? unavailable[0];
-
-    return {
-      networkClientId: selected.networkClientId,
-      chainId: selected.chainId,
-      networkName: selected.networkName,
-      isInfuraEndpoint: selected.isInfuraEndpoint,
-      infuraEndpointIndex: selected.infuraEndpointIndex,
-    };
-  },
-);
+      return {
+        networkClientId: selected.networkClientId,
+        chainId: selected.chainId,
+        networkName: selected.networkName,
+        isInfuraEndpoint: selected.isInfuraEndpoint,
+        infuraEndpointIndex: selected.infuraEndpointIndex,
+      };
+    },
+  );
 
 // TODO: Remove after updating to @metamask/network-controller 20.0.0
 type ProviderConfigWithImageUrlAndExplorerUrl = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -33818,6 +33818,7 @@ __metadata:
     prettier-plugin-sort-json: "npm:^4.1.1"
     process: "npm:^0.11.10"
     prop-types: "npm:^15.6.1"
+    psl: "npm:^1.15.0"
     pumpify: "npm:^2.0.1"
     punycode: "npm:^2.1.1"
     qrcode-generator: "npm:^2.0.4"
@@ -37382,10 +37383,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"psl@npm:^1.1.33":
-  version: 1.9.0
-  resolution: "psl@npm:1.9.0"
-  checksum: 10/d07879d4bfd0ac74796306a8e5a36a93cfb9c4f4e8ee8e63fbb909066c192fe1008cd8f12abd8ba2f62ca28247949a20c8fb32e1d18831d9e71285a1569720f9
+"psl@npm:^1.1.33, psl@npm:^1.15.0":
+  version: 1.15.0
+  resolution: "psl@npm:1.15.0"
+  dependencies:
+    punycode: "npm:^2.3.1"
+  checksum: 10/5e7467eb5196eb7900d156783d12907d445c0122f76c73203ce96b148a6ccf8c5450cc805887ffada38ff92d634afcf33720c24053cb01d5b6598d1c913c5caf
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

The "Still connecting" / "Unable to connect" banner currently fires whenever any single enabled EVM network's default RPC is unavailable for >5s. With "All popular networks" selected (the default), the client polls every popular chain every ~30s, so a single transient Infura blip pops the banner. Worse, when Infura itself has a wide outage, many networks fail simultaneously and the user sees the banner even though it's really one provider hiccup, not a wallet-wide problem.

This PR keeps the existing banner UI, timer thresholds, and analytics untouched and only changes the show/hide rule. The banner now shows when:

- failed RPCs span 2+ distinct domains (eTLD+1 via the Public Suffix List, so all `*.infura.io` collapse to one),
- every enabled EVM network has failed (single-network setups still get a signal), or
- any failed network's active RPC is a non-Infura (custom) endpoint — these have no automatic failover and the user has to act.

A network is "failed" here when its default RPC endpoint's metadata status is anything other than `NetworkStatus.Available`. The word "unavailable" is reserved for the specific `NetworkStatus.Unavailable` circuit-broken state and the banner's own `'degraded' | 'unavailable'` state machine.

When the custom override fires alongside an Infura outage, the custom network is surfaced first so the "Switch to MetaMask default RPC" CTA targets the one the user can act on.

Implementation:
- New `getDomain` helper in `shared/lib/url-utils.ts` backed by the `psl` library (already a transitive dep, promoted to a direct dep here). Handles multi-part public suffixes like `.co.uk`. Localhost and IP literals short-circuit to the hostname so callers grouping by domain can still distinguish them.
- Relocates the existing `isLocalhostOrIPAddress` helper from `app/scripts/lib/util.ts` to `shared/lib/url-utils.ts` so it can be reused for the short-circuit. No behavior change for its existing caller (`isPublicEndpointUrl`).
- Banner selector renamed `selectFirstUnavailableEvmNetwork` → `selectFirstFailedNetworkForNetworkConnectionBanner` and split into three composed layers: `selectEnhancedNetworkConfigurationsByChainId` (annotates every RPC endpoint with `isInfuraEndpoint` / `isFailed` / `domain`), `selectEnabledFailedNetworksResult` (the failed subset for enabled EVM networks + an `areAllEnabledNetworksFailed` flag), and the top-level selector which is now just the show-banner rule.
- Hook is import-only (`bannerNetwork` → `failedNetwork`).

## **Changelog**

CHANGELOG entry: Reduced false-positive RPC connection banners — single-provider outages no longer pop the banner, even when many popular networks fail at once.

## **Related issues**

Fixes: [WPC-1014](https://consensyssoftware.atlassian.net/browse/WPC-1014)

## **Manual testing steps**

1. Enable "All popular networks" in the network selector.
2. DevTools → Network → block all `*.infura.io` hosts. Wait 5+ seconds. Expect: **no banner** (one domain, suppressed).
3. Block `*.infura.io` and an Alchemy or QuickNode RPC simultaneously. Expect: degraded banner at 5s, unavailable at 30s (2 distinct domains).
4. Add a custom RPC and make it the default endpoint for any network. Block only that host. Expect: banner appears (custom override).
5. Disable all but one network and block its (Infura) host. Expect: banner appears (all-down escape hatch).
6. Turn off wifi. Expect: no banner (existing device-offline short-circuit).

## **Screenshots/Recordings**

### **Before**

<!-- banner shown during a one-provider Infura outage -->

### **After**

<!-- no banner for one-provider outage; banner shown when failures span 2+ providers -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[WPC-1014]: https://consensyssoftware.atlassian.net/browse/WPC-1014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when users see connectivity warnings during RPC outages; logic is well-tested but mis-grouping domains could hide real issues or show banners too often.
> 
> **Overview**
> **Suppresses false-positive RPC connection banners** by changing only which failures drive the existing degraded/unavailable UI and timers (WPC-1014).
> 
> The banner selector is renamed to `selectFirstFailedNetworkForNetworkConnectionBanner` and refactored into layers that annotate each default RPC with **Infura vs custom**, **failed** (status ≠ `Available`), and **registrable domain** via new `getDomain` in `shared/lib/url-utils.ts` (Public Suffix List via `psl`). The banner shows when failures span **2+ domains**, **every enabled EVM network** has failed, or any failed default is a **custom** RPC (custom failures are preferred for the Infura switch CTA). **Single-provider outages** (e.g. many `*.infura.io` networks down while others are healthy) no longer trigger the banner.
> 
> `isLocalhostOrIPAddress` moves from `app/scripts/lib/util.ts` to `url-utils` for reuse; `useNetworkConnectionBanner` only updates imports/variable names.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a99b91fb0992642858f9bace7e172cfc9b07c49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


