### PR TITLE
fix: replace deprecated Chip component with Tag from component-library in safe-component-list

### DIFF
--- a/ui/components/app/home-notification/home-notification.component.js
+++ b/ui/components/app/home-notification/home-notification.component.js
@@ -1,8 +1,7 @@
 import React, { useState } from 'react';
 import classnames from 'clsx';
 import PropTypes from 'prop-types';
-import { Button, ButtonVariant, Icon, IconName } from '../../component-library';
-import Checkbox from '../../ui/check-box';
+import { Button, ButtonVariant, Checkbox, Icon, IconName } from '../../component-library';
 import Tooltip from '../../ui/tooltip';
 import { IconColor } from '../../../helpers/constants/design-system';
 
@@ -22,9 +21,9 @@ const HomeNotification = ({
   const checkboxElement = checkboxText && (
     <Checkbox
       id="homeNotification_checkbox"
-      checked={checkboxState}
+      isChecked={checkboxState}
       className="home-notification__checkbox"
-      onClick={() => setCheckBoxState((checked) => !checked)}
+      onChange={() => setCheckBoxState((prev) => !prev)}
     />
   );
 

--- a/ui/components/app/metamask-template-renderer/safe-component-list.js
+++ b/ui/components/app/metamask-template-renderer/safe-component-list.js
@@ -4,13 +4,13 @@ import {
   AvatarIcon,
   BannerAlert,
   FormTextField,
+  Tag,
   Text,
 } from '../../component-library';
 import { AccountListItem } from '../../multichain/account-list-item';
 import ActionableMessage from '../../ui/actionable-message/actionable-message';
 import Box from '../../ui/box';
 import Button from '../../ui/button';
-import Chip from '../../ui/chip';
 import DefinitionList from '../../ui/definition-list';
 import Preloader from '../../ui/icon/preloader';
 import OriginPill from '../../ui/origin-pill/origin-pill';
@@ -74,7 +74,7 @@ export const safeComponentList = {
   BannerAlert,
   Box,
   Button,
-  Chip,
+  Tag,
   ConfirmationNetworkSwitch,
   ConfirmInfoRow,
   ConfirmInfoRowAddress,

--- a/ui/components/app/metamask-template-renderer/safe-component-list.js
+++ b/ui/components/app/metamask-template-renderer/safe-component-list.js
@@ -9,7 +9,7 @@ import {
 } from '../../component-library';
 import { AccountListItem } from '../../multichain/account-list-item';
 import ActionableMessage from '../../ui/actionable-message/actionable-message';
-import Box from '../../ui/box';
+import { Box } from '@metamask/design-system-react';
 import Button from '../../ui/button';
 import DefinitionList from '../../ui/definition-list';
 import Preloader from '../../ui/icon/preloader';


### PR DESCRIPTION
## Explanation
This PR replaces the deprecated `Chip` component with the new `Tag` component from the component-library in the Snap template renderer's safe component list.

## Related Issue
Closes #20487

## Changes
- Added `Tag` import from `../../component-library`
- Removed `import Chip from '../../ui/chip'`
- Replaced `Chip` with `Tag` in `safeComponentList`

## References
- [Tag component documentation](https://metamask.github.io/metamask-storybook/?path=/docs/components-componentlibrary-tag--docs)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only component swaps and prop renames in notification and Snap template rendering; no auth, data, or transaction logic changes.
> 
> **Overview**
> Migrates **home notification** checkboxes to the **component-library** `Checkbox`, switching from `checked`/`onClick` to **`isChecked`** / **`onChange`**.
> 
> In the Snap **MetaMask template renderer** allowlist (`safe-component-list`), **`Chip`** is removed in favor of **`Tag`** from the component-library, and **`Box`** is sourced from **`@metamask/design-system-react`** instead of the legacy UI `Box`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b2f145efcf36d49441775564c651151afadc634. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->