### PR TITLE
fix: replace deprecated TextField with component-library TextField in customize-nonce

### DIFF
--- a/ui/components/app/metamask-template-renderer/safe-component-list.js
+++ b/ui/components/app/metamask-template-renderer/safe-component-list.js
@@ -4,13 +4,13 @@ import {
   AvatarIcon,
   BannerAlert,
   FormTextField,
+  Tag,
   Text,
 } from '../../component-library';
 import { AccountListItem } from '../../multichain/account-list-item';
 import ActionableMessage from '../../ui/actionable-message/actionable-message';
 import Box from '../../ui/box';
 import Button from '../../ui/button';
-import Chip from '../../ui/chip';
 import DefinitionList from '../../ui/definition-list';
 import Preloader from '../../ui/icon/preloader';
 import OriginPill from '../../ui/origin-pill/origin-pill';
@@ -74,7 +74,7 @@ export const safeComponentList = {
   BannerAlert,
   Box,
   Button,
-  Chip,
+  Tag,
   ConfirmationNetworkSwitch,
   ConfirmInfoRow,
   ConfirmInfoRowAddress,

--- a/ui/components/app/modals/customize-nonce/customize-nonce.component.js
+++ b/ui/components/app/modals/customize-nonce/customize-nonce.component.js
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import Modal from '../../modal';
-import TextField from '../../../ui/text-field';
+import { TextField, TextFieldType } from '../../../component-library';
 import {
   TextVariant,
   AlignItems,
@@ -106,17 +106,16 @@ const CustomizeNonce = ({
           </Box>
           <div className="customize-nonce-modal__input">
             <TextField
-              type="number"
-              data-testid="custom-nonce-input"
-              min="0"
+              type={TextFieldType.Number}
+              testId="custom-nonce-input"
+              inputProps={{ min: 0 }}
               placeholder={defaultNonce}
               onChange={(e) => {
                 // Prevent decimal nonce values
                 const sanitizedValue = e.target.value.replace(/[.,]/gu, '');
                 setCustomNonce(sanitizedValue);
               }}
-              fullWidth
-              margin="dense"
+              width={BlockSize.Full}
               value={customNonce}
               id="custom-nonce-id"
             />


### PR DESCRIPTION
## Explanation
Replaces the deprecated `TextField` component (from `ui/components/ui/text-field`) with the new `TextField` from the component-library in the `customize-nonce` modal component.

### Changes
- Changed import from `TextField` to `{ TextField, TextFieldType }` from the component-library
- Updated props to match new TextField API:
  - `type="number"` → `type={TextFieldType.Number}`
  - `data-testid="..."` → `testId="..."`
  - `min="0"` → `inputProps={{ min: 0 }}`
  - `fullWidth` → `width={BlockSize.Full}`
  - Removed deprecated `margin="dense"`

### Related issues
- Closes #20483 (partially)