### PR TITLE
fix: replace deprecated Button with component-library Button (#18896)

### DIFF
--- a/ui/components/app/connected-sites-list/connected-sites-list.component.js
+++ b/ui/components/app/connected-sites-list/connected-sites-list.component.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { isSnapId } from '@metamask/snaps-utils';
-import Button from '../../ui/button';
+import { Button, ButtonVariant } from '../../component-library';
 import { AvatarFavicon, IconSize } from '../../component-library';
 import { stripHttpsSchemeWithoutPort } from '../../../helpers/utils/util';
 import SiteOrigin from '../../ui/site-origin';
@@ -47,7 +47,7 @@ export default class ConnectedSitesList extends Component {
             <Button
               className="connected-sites-list__content-row-link-button"
               onClick={() => onDisconnect(subject.origin)}
-              type="link"
+              variant={ButtonVariant.Link}
             >
               {t('disconnect')}
             </Button>
@@ -72,7 +72,7 @@ export default class ConnectedSitesList extends Component {
           <Button
             className="connected-sites-list__content-row-link-button"
             onClick={() => onDisconnect(subject.origin)}
-            type="link"
+            variant={ButtonVariant.Link}
           >
             {t('disconnect')}
           </Button>


### PR DESCRIPTION
## Explanation

Replaces the deprecated  component from  with the new  component from  in .

## Changes
- **Before:**  with  prop
- **After:**  with  prop

## References
- Closes [#18896](https://github.com/MetaMask/metamask-extension/issues/18896)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mechanical UI component swap with equivalent link button behavior; no auth, data, or disconnect logic changes.
> 
> **Overview**
> **Connected sites list** now uses the shared **component-library** `Button` instead of the legacy `ui/button` import. Both **Disconnect** actions (Snap rows and site rows) keep the same link styling via `variant={ButtonVariant.Link}` instead of `type="link"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 337f05f0773eb03a930248c4e53ded65f194878f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->