### PR TITLE
fix: replace deprecated @include design-system.H7 with Text component in view-on-block-explorer

### DIFF
--- a/ui/pages/swaps/view-on-block-explorer/index.scss
+++ b/ui/pages/swaps/view-on-block-explorer/index.scss
@@ -1,9 +1,5 @@
-@use "design-system";
-
 .view-on-block-explorer {
   button {
-    @include design-system.H7;
-
     color: var(--color-primary-default);
     background-color: transparent;
   }

--- a/ui/pages/swaps/view-on-block-explorer/view-on-block-explorer.js
+++ b/ui/pages/swaps/view-on-block-explorer/view-on-block-explorer.js
@@ -10,6 +10,11 @@ import {
   MetaMetricsEventLinkType,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
+import {
+  Text,
+  TextColor,
+} from '../../../components/component-library';
+import { TextVariant } from '../../../helpers/constants/design-system';
 
 export default function ViewOnBlockExplorer({
   blockExplorerUrl,
@@ -21,7 +26,10 @@ export default function ViewOnBlockExplorer({
 
   return (
     <Box marginTop={6} className="view-on-block-explorer">
-      <button
+      <Text
+        as="button"
+        variant={TextVariant.bodyXs}
+        color={TextColor.primaryDefault}
         onClick={() => {
           trackEvent({
             event: MetaMetricsEventName.ExternalLinkClicked,
@@ -40,7 +48,7 @@ export default function ViewOnBlockExplorer({
           t('blockExplorerSwapAction'),
           blockExplorerHostName,
         ])}
-      </button>
+      </Text>
     </Box>
   );
 }


### PR DESCRIPTION
Replaces the deprecated `@include design-system.H7` SCSS mixin with the `<Text>` component from component-library.

## Changes
- **view-on-block-explorer.js**: Replaced `<button>` with `<Text as="button" variant={TextVariant.bodyXs} color={TextColor.primaryDefault}>`
- **index.scss**: Removed `@include design-system.H7` and the now-unnecessary `@use "design-system";`

Closes #20496