### PR TITLE
ci: add zizmor github actions security lint

### DIFF
--- a/.github/workflows/add-release-label.yml
+++ b/.github/workflows/add-release-label.yml
@@ -7,6 +7,11 @@ on:
     types:
       - closed
 
+# Labelling is performed with RELEASE_LABEL_TOKEN (a PAT), so the
+# workflow GITHUB_TOKEN only needs read access.
+permissions:
+  contents: read
+
 jobs:
   add-release-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/add-team-label.yml
+++ b/.github/workflows/add-team-label.yml
@@ -5,6 +5,10 @@ on:
     types:
       - opened
 
+# Labelling uses TEAM_LABEL_TOKEN (PAT); GITHUB_TOKEN only needs read.
+permissions:
+  contents: read
+
 jobs:
   add-team-label:
     name: Add team label

--- a/.github/workflows/auto-create-release-pr.yml
+++ b/.github/workflows/auto-create-release-pr.yml
@@ -3,6 +3,9 @@ name: Auto Create Release PR
 on:
   create:
 
+permissions:
+  contents: read
+
 jobs:
   extract:
     # Only run for release branch creation (not tags or other branches)

--- a/.github/workflows/auto-create-release-pr.yml
+++ b/.github/workflows/auto-create-release-pr.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - id: out
         shell: bash

--- a/.github/workflows/auto-update-pr-targeting-release.yml
+++ b/.github/workflows/auto-update-pr-targeting-release.yml
@@ -20,6 +20,10 @@ jobs:
     steps:
       # We don't want to use action-checkout-and-setup here because it forces `yarn --immutable`
       - name: Checkout code
+        # zizmor: ignore[artipacked]
+        # Credentials are persisted on purpose: the job runs `git push` at
+        # the end. No artifacts are uploaded from this job, so the
+        # persisted PAT cannot leak.
         uses: actions/checkout@v6
         with:
           # Use PAT to ensure that the commit later can trigger status check workflows

--- a/.github/workflows/benchmark-fp-report.yml
+++ b/.github/workflows/benchmark-fp-report.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: metamask/github-tools/.github/actions/setup-environment@v1

--- a/.github/workflows/block-stable-main-to-main.yml
+++ b/.github/workflows/block-stable-main-to-main.yml
@@ -7,6 +7,9 @@ on:
       - main
   merge_group:
 
+permissions:
+  contents: read
+
 jobs:
   check-branch:
     name: Block stable-main-X.Y.Z to main

--- a/.github/workflows/block-stable-sync-to-release.yml
+++ b/.github/workflows/block-stable-sync-to-release.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - 'release/*'
 
+permissions:
+  contents: read
+
 jobs:
   check-branch:
     name: Block stable-sync-* to release/*

--- a/.github/workflows/build-storybook.yml
+++ b/.github/workflows/build-storybook.yml
@@ -6,6 +6,9 @@ on:
       STORYBOOK_TOKEN:
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   build-storybook:
     name: Build storybook

--- a/.github/workflows/build-ts-migration-dashboard.yml
+++ b/.github/workflows/build-ts-migration-dashboard.yml
@@ -6,6 +6,9 @@ on:
       TS_MIGRATION_DASHBOARD_TOKEN:
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   build-ts-migration-dashboard:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-attributions.yml
+++ b/.github/workflows/check-attributions.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - release/*
 
+permissions:
+  contents: read
+
 jobs:
   check-attributions:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-feature-flag-registry-drift.yml
+++ b/.github/workflows/check-feature-flag-registry-drift.yml
@@ -7,8 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   check-feature-flag-registry:
@@ -16,6 +15,8 @@ jobs:
     environment: default-branch
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    permissions:
+      contents: read
     outputs:
       has-drift: ${{ steps.check.outputs.HAS_DRIFT }}
     steps:
@@ -63,6 +64,9 @@ jobs:
     name: Create PR for feature flag registry drift
     needs: check-feature-flag-registry
     if: needs.check-feature-flag-registry.outputs.has-drift == 'true'
+    permissions:
+      contents: write
+      pull-requests: write
     uses: MetaMask/github-tools/.github/workflows/create-pr-feature-flag-registry-drift.yml@main
     with:
       repository: metamask-extension

--- a/.github/workflows/check-pr-labels.yml
+++ b/.github/workflows/check-pr-labels.yml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ !(contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/heads/stable')) }}
 
+permissions:
+  contents: read
+
 jobs:
   check-pr-labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-template-and-add-labels.yml
+++ b/.github/workflows/check-template-and-add-labels.yml
@@ -12,6 +12,10 @@ on:
     types: [opened, edited, labeled, unlabeled, reopened, synchronize]
   merge_group:
 
+# Labelling uses LABEL_TOKEN (PAT); GITHUB_TOKEN only needs read.
+permissions:
+  contents: read
+
 jobs:
   check-template-and-add-labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-template-and-add-labels.yml
+++ b/.github/workflows/check-template-and-add-labels.yml
@@ -3,6 +3,11 @@ name: Check template and add labels
 on:
   issues:
     types: [opened, edited, labeled, unlabeled, reopened]
+  # zizmor: ignore[dangerous-triggers]
+  # pull_request_target is required so PRs from forks get template-checked
+  # and labeled. The workflow does not check out PR head code — only the
+  # default-branch checkout — so the trigger cannot be used to execute
+  # attacker code.
   pull_request_target:
     types: [opened, edited, labeled, unlabeled, reopened, synchronize]
   merge_group:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -2,6 +2,10 @@ name: 'CLA Signature Bot'
 on:
   issue_comment:
     types: [created]
+  # zizmor: ignore[dangerous-triggers]
+  # pull_request_target is required so the CLA bot can update commit
+  # status and labels on PRs from forks. The job only runs a vetted
+  # MetaMask-published action and does not check out attacker code.
   pull_request_target:
     types: [opened, closed, synchronize]
 

--- a/.github/workflows/close-bug-report.yml
+++ b/.github/workflows/close-bug-report.yml
@@ -7,6 +7,9 @@ on:
     types:
       - closed
 
+permissions:
+  contents: read
+
 jobs:
   close-bug-report:
     runs-on: ubuntu-latest

--- a/.github/workflows/create-bug-report.yml
+++ b/.github/workflows/create-bug-report.yml
@@ -3,6 +3,9 @@ name: Create release bug report issue when release branch gets created
 on:
   create:
 
+permissions:
+  contents: read
+
 jobs:
   create-bug-report:
     # Only run for release branch creation (not tags or other branches)

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -67,6 +67,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - id: out
         shell: bash

--- a/.github/workflows/create-release-pr.yml
+++ b/.github/workflows/create-release-pr.yml
@@ -22,6 +22,9 @@ on:
       GCP_RLS_SHEET_ACCOUNT_BASE64:
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   resolve-bases:
     # Determines if the release is hotfix or not based on semver. Then sets the appropriate base branches for the checkout and release PR.

--- a/.github/workflows/crowdin-download-translations.yml
+++ b/.github/workflows/crowdin-download-translations.yml
@@ -18,6 +18,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           token: ${{ secrets.METAMASKBOT_CROWDIN_TOKEN }}
+          persist-credentials: false
 
       - name: Crowdin download approved translations
         uses: crowdin/github-action@a3160b9e5a9e00739392c23da5e580c6cabe526d

--- a/.github/workflows/crowdin-download-translations.yml
+++ b/.github/workflows/crowdin-download-translations.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 */12 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   download-translations:
     runs-on: ubuntu-latest

--- a/.github/workflows/crowdin-upload-sources.yml
+++ b/.github/workflows/crowdin-upload-sources.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   upload-sources:
     runs-on: ubuntu-latest

--- a/.github/workflows/crowdin-upload-sources.yml
+++ b/.github/workflows/crowdin-upload-sources.yml
@@ -18,6 +18,7 @@ jobs:
         with:
           # Use PAT to ensure that the commit later can trigger status check workflows
           token: ${{ secrets.METAMASKBOT_CROWDIN_TOKEN }}
+          persist-credentials: false
 
       - name: crowdin upload sources
         uses: crowdin/github-action@a3160b9e5a9e00739392c23da5e580c6cabe526d

--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -20,6 +20,9 @@ on:
       INFURA_PROJECT_ID:
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   test-e2e-chrome-browserify:
     uses: ./.github/workflows/run-e2e.yml

--- a/.github/workflows/e2e-firefox.yml
+++ b/.github/workflows/e2e-firefox.yml
@@ -18,6 +18,9 @@ on:
       INFURA_PROJECT_ID:
         required: false
 
+permissions:
+  contents: read
+
 jobs:
   test-e2e-firefox-browserify:
     uses: ./.github/workflows/run-e2e.yml

--- a/.github/workflows/get-release-timelines.yml
+++ b/.github/workflows/get-release-timelines.yml
@@ -8,6 +8,9 @@ on:
         type: string
         description: The version of the release
 
+permissions:
+  contents: read
+
 jobs:
   get-release-timelines:
     name: Get release timelines

--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -63,6 +63,9 @@ jobs:
     name: Filter files changed and decide which jobs to run
     runs-on: ubuntu-latest
     timeout-minutes: 2
+    permissions:
+      contents: read
+      statuses: write # required to post build-source-hash commit status
     outputs:
       builds-from-run: ${{ steps.find-reusable-builds.outputs.builds-from-run || env.RUN_ID }}
       builds-from-sha: ${{ steps.find-reusable-builds.outputs.builds-from-sha || env.HEAD_COMMIT_HASH }}

--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -89,6 +89,7 @@ jobs:
         if: ${{ steps.check-skip-merge-queue.outputs.up-to-date != 'true' }}
         with:
           fetch-depth: 1
+          persist-credentials: false
 
       - name: Fetch HEAD commit for message checks
         if: ${{ steps.check-skip-merge-queue.outputs.up-to-date != 'true' }}

--- a/.github/workflows/identify-codeowners.yml
+++ b/.github/workflows/identify-codeowners.yml
@@ -37,6 +37,7 @@ jobs:
             .github
             .nvmrc
           sparse-checkout-cone-mode: false
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/identify-codeowners.yml
+++ b/.github/workflows/identify-codeowners.yml
@@ -12,6 +12,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ !(contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/heads/stable')) }}
 
+permissions:
+  contents: read
+
 jobs:
   identify-codeowners:
     # Avoid running on cross-repo PRs since we need to write a PR comment

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,10 +34,11 @@ env:
   HEAD_COMMIT_HASH: ${{ github.event.pull_request.head.sha || github.sha }}
   RUN_ID: ${{ github.run_id }}
 
+# Workflow-level grants are read-only. Any job that needs more
+# elevation (S3 OIDC, commit statuses, etc.) declares it inline.
 permissions:
-  contents: write # required for releases
-  id-token: write # required for s3 uploads
-  statuses: write # required for build-source-hash and ci-status-gate
+  contents: read
+  actions: read # required for download-artifact with run-id (cross-run reuse)
 
 jobs:
   get-requirements:
@@ -450,6 +451,10 @@ jobs:
     if: ${{ needs.get-requirements.outputs.skip-everything != 'true' && needs.get-requirements.outputs.builds-from-run == github.run_id }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      actions: read # required for cross-run download-artifact
+      id-token: write # required for OIDC auth in S3 upload
     environment: ${{ github.ref_name == 'main' && 'default-branch' || null }}
     env:
       EXTENSION_BUNDLESIZE_STATS_TOKEN: ${{ secrets.EXTENSION_BUNDLESIZE_STATS_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -431,6 +431,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Download coverage artifact
         uses: actions/download-artifact@v7

--- a/.github/workflows/nightly-build.yml
+++ b/.github/workflows/nightly-build.yml
@@ -8,7 +8,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write # required for s3 uploads
 
 jobs:
   build-dist-browserify:

--- a/.github/workflows/post-merge-validation.yml
+++ b/.github/workflows/post-merge-validation.yml
@@ -10,6 +10,10 @@ on:
         required: false
         default: '1'
 
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   post-merge-validation-tracker:
     runs-on: ubuntu-latest

--- a/.github/workflows/prep-e2e.yml
+++ b/.github/workflows/prep-e2e.yml
@@ -7,6 +7,9 @@ on:
         description: The matrix for the E2E jobs
         value: ${{ jobs.prep-e2e.outputs.use-matrix }}
 
+permissions:
+  contents: read
+
 jobs:
   prep-e2e:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -91,7 +91,9 @@ jobs:
         if: ${{ steps.generate-test-plan.outputs.test_plan_generated == 'true' && vars.AWS_REGION && vars.AWS_IAM_ROLE && vars.AWS_S3_BUCKET }}
         run: |
           mkdir -p build-test-plan/builds
-          cp "test-plan-${{ steps.generate-test-plan.outputs.test_plan_version }}.json" build-test-plan/builds/
+          cp "test-plan-${STEPS_GENERATE_TEST_PLAN_OUTPUTS_TEST_PLAN_VERSION}.json" build-test-plan/builds/
+        env:
+          STEPS_GENERATE_TEST_PLAN_OUTPUTS_TEST_PLAN_VERSION: ${{ steps.generate-test-plan.outputs.test_plan_version }}
 
       - name: Upload test plan to S3
         if: ${{ steps.generate-test-plan.outputs.test_plan_generated == 'true' && vars.AWS_REGION && vars.AWS_IAM_ROLE && vars.AWS_S3_BUCKET }}

--- a/.github/workflows/publish-release-from-release-head.yml
+++ b/.github/workflows/publish-release-from-release-head.yml
@@ -11,7 +11,8 @@ permissions:
   contents: read # publish-release uses EXTENSION_PUBLISH_TOKEN for write operations
   statuses: read # Required by verify-ci-checks.sh to read commit statuses
   actions: read # Required to download artifacts from build jobs
-  id-token: write # Required for OIDC authentication in S3 uploads
+  # id-token: write is granted per-job in run-build.yml — not needed at
+  # workflow level since publish-release itself uses EXTENSION_PUBLISH_TOKEN.
 
 jobs:
   validate-branch:

--- a/.github/workflows/publish-release-from-release-head.yml
+++ b/.github/workflows/publish-release-from-release-head.yml
@@ -30,6 +30,7 @@ jobs:
           ref: ${{ github.sha }}
           sparse-checkout: .github/scripts
           sparse-checkout-cone-mode: false
+          persist-credentials: false
 
       - name: Extract and validate semver from branch
         id: extract-semver

--- a/.github/workflows/qa-stats.yml
+++ b/.github/workflows/qa-stats.yml
@@ -22,7 +22,9 @@ jobs:
 
       - name: Set optional run ID override
         if: ${{ vars.RUN_ID_TO_COLLECT != '' }}
-        run: echo "RUN_ID_TO_COLLECT=${{ vars.RUN_ID_TO_COLLECT }}" >> "$GITHUB_ENV"
+        run: echo "RUN_ID_TO_COLLECT=${VARS_RUN_ID_TO_COLLECT}" >> "$GITHUB_ENV"
+        env:
+          VARS_RUN_ID_TO_COLLECT: ${{ vars.RUN_ID_TO_COLLECT }}
 
       - name: Collect QA stats
         run: yarn tsx .github/scripts/collect-qa-stats.mts

--- a/.github/workflows/rc-slack-notify.yml
+++ b/.github/workflows/rc-slack-notify.yml
@@ -12,6 +12,11 @@
 name: RC Slack notify
 
 on:
+  # zizmor: ignore[dangerous-triggers]
+  # workflow_run is required to post the Slack RC notification only after
+  # a successful Main run on a release/* branch. The job is gated on
+  # conclusion == 'success', branch matches the release semver, and the
+  # event source is push — so it cannot be tricked into running by fork PRs.
   workflow_run:
     workflows:
       - Main

--- a/.github/workflows/release-branch-sync.yml
+++ b/.github/workflows/release-branch-sync.yml
@@ -1,8 +1,9 @@
 name: Release Branch Sync
 
+# The sync uses a separate PAT (STABLE_SYNC_TOKEN) — the workflow
+# GITHUB_TOKEN itself only needs read access for checkout/lookups.
 permissions:
-  pull-requests: write
-  contents: write
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/remove-labels-after-pr-closed.yml
+++ b/.github/workflows/remove-labels-after-pr-closed.yml
@@ -3,9 +3,12 @@ name: Remove labels after issue (or PR) closed
 on:
   issues:
     types: [closed]
+  # zizmor: ignore[dangerous-triggers]
   # Use pull_request_target so closed-PR cleanup always runs with the
   # workflow definition from the default branch (not the PR head SHA).
   # This ensures newly added cleanup labels are applied consistently.
+  # The job only invokes the GitHub REST API to delete labels and never
+  # checks out or executes PR code.
   pull_request_target:
     types: [closed]
 

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -230,6 +230,7 @@ jobs:
             test/e2e/benchmarks/utils/thresholds.ts
             test/e2e/benchmarks/utils/statistics.ts
           sparse-checkout-cone-mode: false
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -305,6 +306,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Download all performance benchmark artifacts
         id: download-perf-benchmark

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -26,6 +26,9 @@ jobs:
     if: ${{ inputs.builds-from-run == github.run_id }} # Only run if builds are from the current run
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    permissions:
+      contents: read
+      id-token: write # required for OIDC auth in S3 uploads
     env:
       # Build parameter
       ENABLE_MV3: ${{ !contains(inputs.build-name, 'mv2') }}

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -107,7 +107,10 @@ jobs:
         run: yarn webpack:tsc
 
       - name: Run build
-        run: ${{ inputs.build-command }}${{ inputs.bundle-analyzer && ' --bundleAnalyzer' || '' }}
+        env:
+          BUILD_COMMAND: ${{ inputs.build-command }}
+          BUNDLE_ANALYZER_FLAG: ${{ inputs.bundle-analyzer && ' --bundleAnalyzer' || '' }}
+        run: $BUILD_COMMAND$BUNDLE_ANALYZER_FLAG
 
       - name: Validate source maps
         run: ${{ contains(inputs.build-name, 'webpack') && 'yarn validate-source-maps:webpack' || 'yarn validate-source-maps' }}

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -50,6 +50,9 @@ jobs:
     name: ${{ inputs.test-suite-name }}${{ inputs.matrix-total > 1 && format(' ({0})', inputs.matrix-index) || '' }}
     runs-on: ubuntu-latest
     timeout-minutes: 40
+    permissions:
+      contents: read
+      actions: read # required for download-artifact with run-id (cross-run)
     env:
       SELENIUM_HEADLESS: true
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -107,8 +107,10 @@ jobs:
           run-id: ${{ inputs.builds-from-run }} # Download from the run that produced the builds.
 
       # if there is a build-command and there is no build artifact, or the specified artifact does not exist, we run the build command
-      - run: ${{ inputs.build-command }}
-        if: ${{ inputs.build-command != '' && (inputs.build-artifact == '' || steps.download-build-artifact.outcome == 'failure') }}
+      - if: ${{ inputs.build-command != '' && (inputs.build-artifact == '' || steps.download-build-artifact.outcome == 'failure') }}
+        env:
+          BUILD_COMMAND: ${{ inputs.build-command }}
+        run: $BUILD_COMMAND
 
       - name: Download changed-files artifact
         if: ${{ env.BRANCH != 'main' }}
@@ -142,12 +144,13 @@ jobs:
 
       - name: Run E2E tests
         timeout-minutes: ${{ inputs.test-timeout-minutes }}
-        run: ${{ inputs.test-command }} --retries 1
         env:
+          TEST_COMMAND: ${{ inputs.test-command }}
           # The properties are picked up by mocha-junit-reporter and added to the XML test results
           PROPERTIES: 'JOB_NAME:${{ env.JOB_NAME }},RUN_ID:${{ env.RUN_ID }},PR_NUMBER:${{ env.PR_NUMBER }}'
           # On re-run, pass the path to previous results to run only failed tests
           PREVIOUS_RESULTS_PATH: ${{ steps.download-previous-results.outcome == 'success' && './previous-test-results/test/test-results/e2e' || '' }}
+        run: $TEST_COMMAND --retries 1
 
       # Merge previous test results with current results to preserve pass/fail history across re-runs.
       # Without this, tests that passed in attempt N but were skipped in attempt N+1 would have no

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -10,6 +10,9 @@ on:
         description: Stored coverage
         value: ${{ jobs.report-coverage.outputs.stored-coverage }}
 
+permissions:
+  contents: read
+
 jobs:
   test-unit:
     name: Unit tests

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -29,7 +29,9 @@ jobs:
           skip-allow-scripts: true
 
       - name: test:unit:coverage
-        run: yarn test:unit:coverage --shard=${{ matrix.shard }}/${{ strategy.job-total }}
+        run: yarn test:unit:coverage --shard=${{ matrix.shard }}/${STRATEGY_JOB_TOTAL}
+        env:
+          STRATEGY_JOB_TOTAL: ${{ strategy.job-total }}
 
       - name: Rename coverage
         run: mv coverage/unit/coverage-final.json coverage/unit/coverage-unit-${{matrix.shard}}.json

--- a/.github/workflows/security-code-scanner.yml
+++ b/.github/workflows/security-code-scanner.yml
@@ -14,6 +14,9 @@ concurrency:
   # This cancels in-progress workflows for all branches except main as it is, we can remove the rest of the conditions as the first one acts as break circuit with the OR
   cancel-in-progress: ${{ !(contains(github.ref, 'refs/heads/main') || contains(github.ref, 'refs/heads/stable')) }}
 
+permissions:
+  contents: read
+
 jobs:
   run-security-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/stable-branch-sync.yml
+++ b/.github/workflows/stable-branch-sync.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Configure Git
         run: |

--- a/.github/workflows/stable-branch-sync.yml
+++ b/.github/workflows/stable-branch-sync.yml
@@ -5,8 +5,10 @@ on:
     branches:
       - stable
 
+# The sync action authenticates with STABLE_SYNC_TOKEN, so the
+# workflow GITHUB_TOKEN itself only needs read access.
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   get-stable-version:

--- a/.github/workflows/tag-release-branch.yml
+++ b/.github/workflows/tag-release-branch.yml
@@ -58,6 +58,9 @@ jobs:
           echo "Using version: ${VERSION}"
 
       - name: Checkout release branch
+        # zizmor: ignore[artipacked]
+        # Credentials are persisted on purpose: subsequent steps push
+        # version tags. No artifacts are uploaded.
         uses: actions/checkout@v6
         with:
           ref: ${{ steps.determine-branch.outputs.branch }}

--- a/.github/workflows/test-storybook.yml
+++ b/.github/workflows/test-storybook.yml
@@ -3,6 +3,9 @@ name: Test storybook
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   test-storybook:
     name: Test storybook

--- a/.github/workflows/triage-and-retry-system.yml
+++ b/.github/workflows/triage-and-retry-system.yml
@@ -173,7 +173,7 @@ jobs:
         id: retry
         if: ${{ steps.classify.outputs.will-retry == 'true' }}
         run: |
-          PR="${{ steps.classify.outputs.pr-number }}"
+          PR="${STEPS_CLASSIFY_OUTPUTS_PR_NUMBER}"
 
           echo "Rerunning failed jobs..."
           gh run rerun "$MAIN_RUN_ID" --failed --repo "$REPO"
@@ -182,6 +182,8 @@ jobs:
           echo "Removing retry-ci label from PR #$PR..."
           gh pr edit "$PR" --repo "$REPO" --remove-label "retry-ci" \
             || echo "::warning::Failed to remove retry-ci label from PR #$PR — label stays"
+        env:
+          STEPS_CLASSIFY_OUTPUTS_PR_NUMBER: ${{ steps.classify.outputs.pr-number }}
 
       # -- Rescue: post deferred failure status when triage job fails --
       #

--- a/.github/workflows/triage-and-retry-system.yml
+++ b/.github/workflows/triage-and-retry-system.yml
@@ -128,6 +128,7 @@ jobs:
             .github
             .nvmrc
           sparse-checkout-cone-mode: false
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/triage-and-retry-system.yml
+++ b/.github/workflows/triage-and-retry-system.yml
@@ -61,6 +61,11 @@
 name: Triage and Retry System
 
 on:
+  # zizmor: ignore[dangerous-triggers]
+  # workflow_run is required to classify failures and retry-trigger after
+  # Main completes. The job is gated to `head_repository == repository`
+  # (no fork events) and is restricted to specific event sources via the
+  # `if:` filter below.
   workflow_run:
     workflows: ['Main']
     types: [completed]

--- a/.github/workflows/triage-and-retry-system.yml
+++ b/.github/workflows/triage-and-retry-system.yml
@@ -133,17 +133,27 @@ jobs:
         run: npm install --no-save @sentry/node@^10.45.0
 
       - name: Get version from package.json
+        id: pkg
+        # The version is pushed through a step output rather than $GITHUB_ENV
+        # so that a malicious package.json from the PR's head SHA can't inject
+        # additional environment variables into later steps.
         run: |
           TMPFILE=$(mktemp)
+          VERSION=unknown
           if curl -sSf -o "$TMPFILE" "https://raw.githubusercontent.com/${REPO}/${HEAD_SHA}/package.json"; then
-            echo "VERSION=$(node -p "JSON.parse(require('fs').readFileSync('$TMPFILE','utf8')).version")" >> "$GITHUB_ENV"
+            VERSION=$(node -p "JSON.parse(require('fs').readFileSync('$TMPFILE','utf8')).version" 2>/dev/null || echo unknown)
           else
             echo "::warning::Could not download package.json — VERSION will be 'unknown'"
           fi
           rm -f "$TMPFILE"
+          # Strip newlines/CR to keep the single-line output well-formed.
+          VERSION=${VERSION//[$'\n\r']/}
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Classify failures
         id: classify
+        env:
+          VERSION: ${{ steps.pkg.outputs.version }}
         run: node .github/scripts/classify-failures.mts
 
       # -- Label-gated retry: requires `retry-ci` label on the originating PR --

--- a/.github/workflows/triage-forwarder.yml
+++ b/.github/workflows/triage-forwarder.yml
@@ -23,8 +23,9 @@ jobs:
         id: exchange
         env:
           OIDC_TOKEN: ${{ steps.oidc.outputs.oidc_token }}
+          VARS_TOKEN_EXCHANGE_URL: ${{ vars.TOKEN_EXCHANGE_URL }}
         run: |
-          RESPONSE=$(curl -sSf -X POST "${{ vars.TOKEN_EXCHANGE_URL }}/api/exchange/token" \
+          RESPONSE=$(curl -sSf -X POST "${VARS_TOKEN_EXCHANGE_URL}/api/exchange/token" \
             -H "Content-Type: application/json" \
             -d "$(jq -cn \
               --arg oidcToken "$OIDC_TOKEN" \
@@ -37,6 +38,9 @@ jobs:
       - name: Dispatch to triage-agent
         env:
           TOKEN: ${{ steps.exchange.outputs.token }}
+          GITHUB_EVENT_REPOSITORY_NAME: ${{ github.event.repository.name }}
+          GITHUB_EVENT_ACTION: ${{ github.event.action }}
+          GITHUB_EVENT_LABEL_NAME: ${{ github.event.label.name }}
         run: |
           curl -sSf -X POST \
             -H "Authorization: token $TOKEN" \
@@ -44,8 +48,8 @@ jobs:
             "https://api.github.com/repos/MetaMask/triage-agent/dispatches" \
             -d "$(jq -cn \
               --arg owner "${{ github.repository_owner }}" \
-              --arg name "${{ github.event.repository.name }}" \
+              --arg name "${GITHUB_EVENT_REPOSITORY_NAME}" \
               --arg number "${{ github.event.issue.number }}" \
-              --arg action "${{ github.event.action }}" \
-              --arg label "${{ github.event.label.name }}" \
+              --arg action "${GITHUB_EVENT_ACTION}" \
+              --arg label "${GITHUB_EVENT_LABEL_NAME}" \
               '{event_type: "triage-issue", client_payload: {repo_owner: $owner, repo_name: $name, issue_number: $number, event_action: $action, event_label_name: $label, trigger_mode: "label"}}')"

--- a/.github/workflows/update-attributions.yml
+++ b/.github/workflows/update-attributions.yml
@@ -19,6 +19,8 @@ jobs:
       IS_CROSS_REPO_PR: ${{ steps.is-cross-repo.outputs.IS_CROSS_REPO_PR }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Determine whether this PR is cross-repo
         id: is-cross-repo
         run: echo "IS_CROSS_REPO_PR=$(gh pr view --json isCrossRepository --jq '.isCrossRepository' "${PR_NUMBER}" )" >> "$GITHUB_OUTPUT"
@@ -36,6 +38,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: React to the comment
         run: |
           gh api \
@@ -61,6 +65,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
         env:
@@ -87,6 +93,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
         env:
@@ -116,6 +124,9 @@ jobs:
     if: ${{ needs.is-cross-repo-pr.outputs.IS_CROSS_REPO_PR == 'false' }}
     steps:
       - name: Checkout repository
+        # zizmor: ignore[artipacked]
+        # Credentials are persisted on purpose: this job pushes the
+        # updated attribution file back to the PR. No artifacts uploaded.
         uses: actions/checkout@v6
         with:
           # Use PAT to ensure that the commit later can trigger status check workflows
@@ -191,6 +202,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          persist-credentials: false
       - name: Post comment if the update failed
         run: |
           passed="${{ needs.check-status.outputs.PASSED }}"

--- a/.github/workflows/update-attributions.yml
+++ b/.github/workflows/update-attributions.yml
@@ -205,7 +205,7 @@ jobs:
           persist-credentials: false
       - name: Post comment if the update failed
         run: |
-          passed="${{ needs.check-status.outputs.PASSED }}"
+          passed="${NEEDS_CHECK_STATUS_OUTPUTS_PASSED}"
           if [[ $passed != "true" ]]; then
             gh pr comment "${PR_NUMBER}" --body "Attributions update failed. You can [review the logs or retry the attributions update here](${ACTION_RUN_URL})"
           fi
@@ -213,3 +213,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.LAVAMOAT_UPDATE_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
           ACTION_RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+          NEEDS_CHECK_STATUS_OUTPUTS_PASSED: ${{ needs.check-status.outputs.PASSED }}

--- a/.github/workflows/update-attributions.yml
+++ b/.github/workflows/update-attributions.yml
@@ -4,6 +4,11 @@ on:
   issue_comment:
     types: created
 
+# Push + PR ops use LAVAMOAT_UPDATE_TOKEN (PAT); GITHUB_TOKEN only
+# needs read access.
+permissions:
+  contents: read
+
 jobs:
   is-cross-repo-pr:
     name: Determine whether this PR is cross-repo

--- a/.github/workflows/update-coverage.yml
+++ b/.github/workflows/update-coverage.yml
@@ -28,6 +28,9 @@ jobs:
       STORED_COVERAGE: ${{ needs.run-tests.outputs.stored-coverage }}
     steps:
       - name: Checkout repository
+        # zizmor: ignore[artipacked]
+        # Credentials are persisted on purpose: the job force-pushes the
+        # `metamaskbot/update-coverage` branch. No artifacts are uploaded.
         uses: actions/checkout@v6
         with:
           token: ${{ secrets.LAVAMOAT_UPDATE_TOKEN }}

--- a/.github/workflows/update-coverage.yml
+++ b/.github/workflows/update-coverage.yml
@@ -6,6 +6,11 @@ on:
     - cron: 0 0 * * *
   workflow_dispatch:
 
+# Push + PR ops use LAVAMOAT_UPDATE_TOKEN (PAT); GITHUB_TOKEN only
+# needs read access.
+permissions:
+  contents: read
+
 jobs:
   run-tests:
     name: Run tests

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -20,6 +20,8 @@ jobs:
       IS_CROSS_REPO_PR: ${{ steps.is-cross-repo.outputs.IS_CROSS_REPO_PR }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Determine whether this PR is cross-repo
         id: is-cross-repo
@@ -38,6 +40,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: React to the comment
         run: |
@@ -65,6 +69,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Checkout pull request
         run: gh pr checkout "${PR_NUMBER}"
@@ -149,6 +155,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ needs.prepare.outputs.BRANCH }}
+          persist-credentials: false
 
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
@@ -218,6 +225,9 @@ jobs:
     environment: default-branch
     steps:
       - name: Checkout repository
+        # zizmor: ignore[artipacked]
+        # Credentials are persisted on purpose: this job pushes the
+        # updated fixtures back to the PR. No artifacts are uploaded.
         uses: actions/checkout@v6
         with:
           token: ${{ secrets.FIXTURE_UPDATE_TOKEN }}
@@ -301,6 +311,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           token: ${{ secrets.FIXTURE_UPDATE_TOKEN }}
+          persist-credentials: false
 
       - name: Post comment if the update failed
         run: |

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -315,7 +315,7 @@ jobs:
 
       - name: Post comment if the update failed
         run: |
-          passed="${{ needs.check-status.outputs.PASSED }}"
+          passed="${NEEDS_CHECK_STATUS_OUTPUTS_PASSED}"
           if [[ $passed != "true" ]]; then
             gh pr comment "${PR_NUMBER}" --body "E2E fixtures update failed. You can [review the logs or retry the fixture update here](${ACTION_RUN_URL})"
           fi
@@ -323,3 +323,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.FIXTURE_UPDATE_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
           ACTION_RUN_URL: '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'
+          NEEDS_CHECK_STATUS_OUTPUTS_PASSED: ${{ needs.check-status.outputs.PASSED }}

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -5,6 +5,11 @@ on:
     types:
       - created
 
+# Push + PR ops use FIXTURE_UPDATE_TOKEN (PAT); GITHUB_TOKEN only
+# needs read access.
+permissions:
+  contents: read
+
 jobs:
   is-cross-repo-pr:
     name: Determine whether this PR is cross-repo

--- a/.github/workflows/update-lavamoat-policies.yml
+++ b/.github/workflows/update-lavamoat-policies.yml
@@ -126,6 +126,9 @@ jobs:
     steps:
       - name: Checkout repository
         if: ${{ env.VALIDATION_FAILED == 'true' }}
+        # zizmor: ignore[artipacked]
+        # Credentials are persisted on purpose: this job pushes the
+        # updated LavaMoat policies. No artifacts are uploaded.
         uses: actions/checkout@v6
         with:
           token: ${{ secrets.LAVAMOAT_UPDATE_TOKEN }}

--- a/.github/workflows/update-lavamoat-policies.yml
+++ b/.github/workflows/update-lavamoat-policies.yml
@@ -8,6 +8,11 @@ concurrency:
   group: update-lavamoat-policies-${{ github.event.issue.number }}
   cancel-in-progress: true
 
+# Push + PR ops use LAVAMOAT_UPDATE_TOKEN (PAT); GITHUB_TOKEN only
+# needs read access.
+permissions:
+  contents: read
+
 jobs:
   prepare:
     name: Prepare

--- a/.github/workflows/upload-extension-to-cws.yml
+++ b/.github/workflows/upload-extension-to-cws.yml
@@ -70,8 +70,8 @@ jobs:
               exit 1
             fi
           done
-          if [[ "${TARGET}" == "production" && "${{ github.ref }}" != "refs/heads/main" ]]; then
-            echo "::error::Production uploads must run from the main branch (current: ${{ github.ref }})"
+          if [[ "${TARGET}" == "production" && "${GITHUB_REF}" != "refs/heads/main" ]]; then
+            echo "::error::Production uploads must run from the main branch (current: ${GITHUB_REF})"
             exit 1
           fi
           if [[ "${TARGET}" == "beta" ]]; then
@@ -232,6 +232,10 @@ jobs:
 
       - name: Summary
         if: always()
+        env:
+          HTTP_CODE: ${{ steps.cws-upload.outputs.http_code || 'n/a' }}
+          UPLOAD_STATE: ${{ steps.cws-upload.outputs.upload_state || 'n/a' }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           {
             echo ""
@@ -239,8 +243,8 @@ jobs:
             echo ""
             echo "| Field | Value |"
             echo "|-------|-------|"
-            echo "| HTTP status | \`${{ steps.cws-upload.outputs.http_code || 'n/a' }}\` |"
-            echo "| CWS uploadState | \`${{ steps.cws-upload.outputs.upload_state || 'n/a' }}\` |"
+            echo "| HTTP status | \`${HTTP_CODE}\` |"
+            echo "| CWS uploadState | \`${UPLOAD_STATE}\` |"
             echo "| Published to users | no (upload only) |"
-            echo "| Workflow run | ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} |"
+            echo "| Workflow run | ${RUN_URL} |"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/validate-conventional-commits.yml
+++ b/.github/workflows/validate-conventional-commits.yml
@@ -5,6 +5,9 @@ on:
       - main
     types: [opened, edited, reopened, synchronize]
 
+permissions:
+  contents: read
+
 jobs:
   pr-title-linter:
     runs-on: ubuntu-latest

--- a/.github/workflows/validate-lavamoat-policies.yml
+++ b/.github/workflows/validate-lavamoat-policies.yml
@@ -20,6 +20,9 @@ env:
   APPLE_FLASK_CLIENT_ID: 00000000000
   TELEGRAM_FLASK_CLIENT_ID: 00000000000
 
+permissions:
+  contents: read
+
 jobs:
   validate-lavamoat-policy-build:
     name: Validate LavaMoat build policy

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -37,11 +37,10 @@ jobs:
 
       - name: Run zizmor
         # The minimum severity is tightened over time as findings are resolved.
-        # Lower the threshold to `low`, then `informational` as the remaining
-        # tiers are cleaned up.
+        # Lower the threshold to `informational` as the last tier is cleaned up.
         run: |
           zizmor --config .github/zizmor.yml \
-            --min-severity=medium \
+            --min-severity=low \
             --format=sarif \
             .github/workflows/ > zizmor.sarif
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,53 @@
+name: zizmor
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '.github/actions/**'
+      - '.github/zizmor.yml'
+      - '.github/workflows/zizmor.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: zizmor static analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install zizmor
+        # The Astral install script verifies a checksum and writes the binary
+        # into $HOME/.cargo/bin. Pinned to a release tag.
+        run: |
+          curl --proto '=https' --tlsv1.2 -LsSf \
+            https://github.com/zizmorcore/zizmor/releases/download/v1.24.1/zizmor-installer.sh \
+            | sh
+          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+
+      - name: Run zizmor
+        # The minimum severity is tightened over time as findings are resolved.
+        # Start with `high`; lower the threshold to `medium`, then `low`, then
+        # `informational` after each tier is cleaned up.
+        run: |
+          zizmor --config .github/zizmor.yml \
+            --min-severity=high \
+            --format=sarif \
+            .github/workflows/ > zizmor.sarif
+
+      - name: Upload SARIF
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: zizmor.sarif
+          category: zizmor

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -27,13 +27,9 @@ jobs:
           persist-credentials: false
 
       - name: Install zizmor
-        # The Astral install script verifies a checksum and writes the binary
-        # into $HOME/.cargo/bin. Pinned to a release tag.
-        run: |
-          curl --proto '=https' --tlsv1.2 -LsSf \
-            https://github.com/zizmorcore/zizmor/releases/download/v1.24.1/zizmor-installer.sh \
-            | sh
-          echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
+        # zizmor ships prebuilt wheels on PyPI that bundle the Rust binary.
+        # pipx keeps it in its own venv so it can't conflict with anything.
+        run: pipx install zizmor==1.24.1
 
       - name: Run zizmor
         # Gate at the strictest possible level. Any new finding (even

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -37,11 +37,11 @@ jobs:
 
       - name: Run zizmor
         # The minimum severity is tightened over time as findings are resolved.
-        # Start with `high`; lower the threshold to `medium`, then `low`, then
-        # `informational` after each tier is cleaned up.
+        # Lower the threshold to `low`, then `informational` as the remaining
+        # tiers are cleaned up.
         run: |
           zizmor --config .github/zizmor.yml \
-            --min-severity=high \
+            --min-severity=medium \
             --format=sarif \
             .github/workflows/ > zizmor.sarif
 

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -36,11 +36,11 @@ jobs:
           echo "$HOME/.cargo/bin" >> "$GITHUB_PATH"
 
       - name: Run zizmor
-        # The minimum severity is tightened over time as findings are resolved.
-        # Lower the threshold to `informational` as the last tier is cleaned up.
+        # Gate at the strictest possible level. Any new finding (even
+        # `informational`) fails this job.
         run: |
           zizmor --config .github/zizmor.yml \
-            --min-severity=low \
+            --min-severity=informational \
             --format=sarif \
             .github/workflows/ > zizmor.sarif
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -15,3 +15,14 @@ rules:
         metamask/*: ref-pin
         # Default for everything else: require a hash pin.
         "*": hash-pin
+
+  # The build and publish workflows call internal reusable workflows
+  # (run-build.yml, run-e2e.yml, publish-prerelease.yml, etc.) that each
+  # consume 40+ secrets. Listing every secret at every call site would
+  # produce ~1500 lines of YAML for no real security gain — caller and
+  # callee live in the same repository and share the same trust boundary.
+  secrets-inherit:
+    ignore:
+      - main.yml
+      - nightly-build.yml
+      - publish-release-from-release-head.yml

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,17 @@
+## zizmor configuration
+## Reference: https://docs.zizmor.sh/configuration/
+
+# Rule-specific tweaks. The CI workflow gates on `--min-severity` and is
+# tightened over time as findings are resolved.
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # Trusted first-party publishers — tag pins (e.g. `@v4`) are accepted.
+        # Hash pinning is still preferred but not required for these.
+        actions/*: ref-pin
+        github/*: ref-pin
+        MetaMask/*: ref-pin
+        metamask/*: ref-pin
+        # Default for everything else: require a hash pin.
+        "*": hash-pin


### PR DESCRIPTION
### zizmor
  
  zizmor (https://docs.zizmor.sh/) is a static analyzer for GitHub Actions workflows — written in Rust, run as a CLI or in CI, emits SARIF for the code-scanning UI. It
  encodes a catalog of known-bad workflow patterns (Trail of Bits / GitHub Security Lab research) as audits with severity + confidence ratings.

###  Why introduce it

  GitHub Actions is a high-blast-radius attack surface: every workflow runs with a token that can read/write the repo, and CI compromise has been the entry point for
  several recent supply-chain incidents (tj-actions/changed-files, reviewdog, Ultralytics, Codecov). The class of bugs zizmor catches is hard to spot in review but easy to
   exploit:
  
  - template-injection — ${{ inputs.x }} substituted directly into a run: script is the GitHub-Actions analogue of eval(userInput). A crafted input becomes shell code.
  - dangerous-triggers — pull_request_target / workflow_run execute with write permissions while being triggered by fork PRs. Default for these is "untrusted code with
  secrets."
  - excessive-permissions — workflow-level contents: write / id-token: write grants apply to every job, even those that only yarn lint. If any single step is compromised,
  the blast radius is the whole token.
  - unpinned-uses — uses: actions/foo@v3 resolves to whatever HEAD the tag points to today. A compromised tag (cf. tj-actions/changed-files) silently rewrites every run.
  - artipacked — actions/checkout persists the GITHUB_TOKEN in .git/config by default. Any subsequent actions/upload-artifact that includes .git/ exfiltrates it.
  - github-env — writes to $GITHUB_ENV can be tricked into smuggling extra env vars via newlines if the value comes from an untrusted source.
  - secrets-inherit — secrets: inherit hands every caller secret to the called workflow, even ones it doesn't need.

###  What this change does

  Wires zizmor into CI (.github/workflows/zizmor.yml) gated at --min-severity=informational so every new finding fails the build, plus a .github/zizmor.yml config that
  codifies the org's pinning policy (tag pins from actions/*, github/*, MetaMask/*; hash pins for everything else). The preceding commits resolve the existing findings —
  least-privileging the GITHUB_TOKEN, moving untrusted expansions out of run: blocks into env:, fixing the package.json-via-$GITHUB_ENV injection vector in the triage
  workflow, and turning off credential persistence on read-only checkouts. The net effect: existing CI hardening is paid down, and the gate prevents future regressions
  from re-introducing the same classes of bug.


CHANGELOG entry: null
