### PR TITLE
feat: support Flask builds in Firefox bundle script + use webpack builds

### DIFF
--- a/.github/scripts/bundle.sh
+++ b/.github/scripts/bundle.sh
@@ -69,7 +69,11 @@ corepack enable
 # 5. Install dependencies
 yarn
 
-# 6. Run the production build command
+# 6. Compile the webpack launcher (generates development/.webpack/launch.js,
+# which the webpack:lavamoat build script loads)
+yarn webpack:tsc
+
+# 7. Run the production build command
 if [ "${1:-}" = "--flask" ]; then
   yarn webpack:lavamoat:build:mv2 --type flask --zip --env production
 else

--- a/.github/scripts/bundle.sh
+++ b/.github/scripts/bundle.sh
@@ -69,9 +69,9 @@ corepack enable
 # 5. Install dependencies
 yarn
 
-# 6. Run the production build command with 4GB of heap space
+# 6. Run the production build command
 if [ "${1:-}" = "--flask" ]; then
-  NODE_OPTIONS='--max-old-space-size=4096' yarn webpack:lavamoat:build:mv2 --type flask --zip --env production
+  yarn webpack:lavamoat:build:mv2 --type flask --zip --env production
 else
-  NODE_OPTIONS='--max-old-space-size=4096' yarn webpack:lavamoat:build:mv2 --zip --env production
+  yarn webpack:lavamoat:build:mv2 --zip --env production
 fi

--- a/.github/scripts/bundle.sh
+++ b/.github/scripts/bundle.sh
@@ -70,4 +70,8 @@ corepack enable
 yarn
 
 # 6. Run the production build command with 4GB of heap space
-NODE_OPTIONS='--max-old-space-size=4096' yarn build prod
+if [ "${1:-}" = "--flask" ]; then
+  NODE_OPTIONS='--max-old-space-size=4096' yarn build --build-type flask prod
+else
+  NODE_OPTIONS='--max-old-space-size=4096' yarn build prod
+fi

--- a/.github/scripts/bundle.sh
+++ b/.github/scripts/bundle.sh
@@ -71,7 +71,7 @@ yarn
 
 # 6. Run the production build command with 4GB of heap space
 if [ "${1:-}" = "--flask" ]; then
-  NODE_OPTIONS='--max-old-space-size=4096' yarn build --build-type flask prod
+  NODE_OPTIONS='--max-old-space-size=4096' yarn webpack:lavamoat:build:mv2 --type flask --zip --env production
 else
-  NODE_OPTIONS='--max-old-space-size=4096' yarn build prod
+  NODE_OPTIONS='--max-old-space-size=4096' yarn webpack:lavamoat:build:mv2 --zip --env production
 fi


### PR DESCRIPTION
## **Description**

Support Flask builds in Firefox bundle script + use webpack builds.

This is needed to support Flask Firefox release preparation: https://github.com/MetaMask/firefox-bundle-script/pull/7
and to start using webpack builds in Firefox as well (we already do so in Chrome).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. `./prepare_release.sh` and `./prepare_release.sh --flask` commands should work on `firefox-bundle-script` repo, once this PR is merged: https://github.com/MetaMask/firefox-bundle-script/pull/7

## **Screenshots/Recordings**

NA

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-script-only change to build commands; no runtime app logic, auth, or data handling.
> 
> **Overview**
> Updates **`.github/scripts/bundle.sh`** so Firefox release bundling uses the **webpack + LavaMoat MV2** pipeline instead of **`yarn build prod`** (and drops the old **4GB heap** `NODE_OPTIONS` workaround).
> 
> The script now runs **`yarn webpack:tsc`** before the build so **`development/.webpack/launch.js`** exists for **`webpack:lavamoat`**. Production output is **`yarn webpack:lavamoat:build:mv2 --zip --env production`**, with an optional **`--flask`** first argument that adds **`--type flask`** for Flask Firefox releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abe5fba83ffba6049526582c22b2b31aaa45a89f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->