### PR TITLE
feat: extend virtualized list item measurement support

### DIFF
--- a/ui/components/ui/virtualized-list/virtualized-list.tsx
+++ b/ui/components/ui/virtualized-list/virtualized-list.tsx
@@ -1,4 +1,4 @@
-import React, { type ReactNode, useEffect } from 'react';
+import React, { type ReactNode, useCallback, useEffect, useState } from 'react';
 import {
   useVirtualizer,
   type VirtualizerOptions,
@@ -16,39 +16,62 @@ export const noAdjustmentsScroll: ScrollToFn = (offset, options, instance) => {
 
 type Props<TItem> = {
   data: TItem[];
-  estimatedItemSize: number;
+  estimatedItemSize: number | ((item: TItem, index: number) => number);
   keyExtractor?: (item: TItem, index: number) => string;
+  itemRef?: (
+    node: HTMLDivElement | null,
+    info: { item: TItem; index: number },
+  ) => void;
   listEmptyComponent?: ReactNode;
   listFooterComponent?: ReactNode;
   overscan?: number;
   renderItem: (info: { item: TItem; index: number }) => ReactNode;
   scrollToFn?: ScrollToFn;
+  enableScrollMargin?: boolean;
 };
 
 export const VirtualizedList = <TItem,>({
   data,
   estimatedItemSize,
   keyExtractor,
+  itemRef,
   listEmptyComponent,
   listFooterComponent,
   overscan = 5,
   renderItem,
   scrollToFn,
+  enableScrollMargin,
 }: Props<TItem>) => {
   const scrollContainerRef = useScrollContainer();
   const disabled = process.env.IN_TEST;
+  const [scrollMargin, setScrollMargin] = useState(0);
 
   const virtualizer = useVirtualizer({
     count: data.length,
     getScrollElement: () =>
       disabled ? null : (scrollContainerRef?.current ?? null),
-    estimateSize: () => estimatedItemSize,
+    estimateSize: (index) =>
+      typeof estimatedItemSize === 'function'
+        ? estimatedItemSize(data[index], index)
+        : estimatedItemSize,
     getItemKey: (index) =>
       keyExtractor ? keyExtractor(data[index], index) : index,
     overscan,
     initialOffset: scrollContainerRef?.current?.scrollTop,
     ...(scrollToFn ? { scrollToFn } : {}),
+    ...(enableScrollMargin ? { scrollMargin } : {}),
   });
+
+  const listRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      if (!enableScrollMargin || !node) {
+        return;
+      }
+
+      setScrollMargin(node.offsetTop);
+    },
+    [enableScrollMargin],
+  );
 
   useEffect(() => {
     if (scrollContainerRef?.current) {
@@ -72,7 +95,11 @@ export const VirtualizedList = <TItem,>({
           const key = keyExtractor
             ? keyExtractor(item, index)
             : index.toString();
-          return <div key={key}>{renderItem({ item, index })}</div>;
+          return (
+            <div key={key} ref={(node) => itemRef?.(node, { item, index })}>
+              {renderItem({ item, index })}
+            </div>
+          );
         })}
         {listFooterComponent}
       </>
@@ -84,26 +111,33 @@ export const VirtualizedList = <TItem,>({
   return (
     <>
       <div
+        ref={listRef}
         className="relative w-full"
         style={{ height: virtualizer.getTotalSize() }}
       >
         {virtualItems.map((virtualItem) => {
-          const item = data[virtualItem.index];
+          const { index } = virtualItem;
+          const item = data[index];
           const key = keyExtractor
-            ? keyExtractor(item, virtualItem.index)
+            ? keyExtractor(item, index)
             : virtualItem.key.toString();
 
           return (
             <div
               key={key}
-              data-index={virtualItem.index}
-              ref={virtualizer.measureElement}
+              data-index={index}
+              ref={(node) => {
+                virtualizer.measureElement(node);
+                itemRef?.(node, { item, index });
+              }}
               className="absolute top-0 left-0 w-full"
               style={{
-                transform: `translateY(${virtualItem.start}px)`,
+                transform: `translateY(${
+                  virtualItem.start - virtualizer.options.scrollMargin
+                }px)`,
               }}
             >
-              {renderItem({ item, index: virtualItem.index })}
+              {renderItem({ item, index })}
             </div>
           );
         })}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds optional features to the VirtualizedList component
- support for dynamic item sizing via `estimatedItemSize`
- `itemRef` callback for per-item observation
-  `enableScrollMargin` to align correctly with container offset

These features to be used in upcoming activity list redesign

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this tabs that use the VirtualizedList
2. List renders and scrolls as expected

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Shared list primitive changes are additive and opt-in; existing consumers keep the same numeric size API with no new props required.
> 
> **Overview**
> **`VirtualizedList`** gains optional capabilities for the upcoming activity list work while keeping existing numeric `estimatedItemSize` call sites valid.
> 
> `estimatedItemSize` can now be a **per-item function** instead of a single fixed height. An optional **`itemRef`** runs for each row in both the virtualized path and the `IN_TEST` non-virtualized fallback, so callers can observe DOM nodes without breaking `measureElement`. **`enableScrollMargin`** measures the list wrapper’s `offsetTop`, passes it to TanStack Virtual as `scrollMargin`, and subtracts it from row `translateY` so items line up when the list sits below other content in the scroll container.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5cd4ff10b030d7afa5eca962d6734bbc06e6069c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->