### PR TITLE
chore: bump profile-sync-controller to 28.2.0

### DIFF
--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -819,7 +819,7 @@
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
         "@metamask/keyring-controller": true,
-        "@metamask/profile-sync-controller": true,
+        "@metamask/account-tree-controller>@metamask/profile-sync-controller": true,
         "@metamask/snaps-utils": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
@@ -1871,6 +1871,40 @@
         "@metamask/keyring-controller>ulid": true
       }
     },
+    "@metamask/account-tree-controller>@metamask/profile-sync-controller>@metamask/keyring-controller": {
+      "globals": {
+        "console.error": true
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/base-controller": true,
+        "@metamask/eth-hd-keyring": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/keyring-controller>@metamask/eth-simple-keyring": true,
+        "@metamask/utils": true,
+        "async-mutex": true,
+        "@metamask/keyring-controller>ethereumjs-wallet": true,
+        "lodash": true,
+        "@metamask/keyring-controller>ulid": true
+      }
+    },
+    "@metamask/profile-metrics-controller>@metamask/profile-sync-controller>@metamask/keyring-controller": {
+      "globals": {
+        "console.error": true
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/base-controller": true,
+        "@metamask/eth-hd-keyring": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/keyring-controller>@metamask/eth-simple-keyring": true,
+        "@metamask/utils": true,
+        "async-mutex": true,
+        "@metamask/keyring-controller>ethereumjs-wallet": true,
+        "lodash": true,
+        "@metamask/keyring-controller>ulid": true
+      }
+    },
     "@metamask/keyring-internal-api": {
       "packages": {
         "@metamask/keyring-api": true,
@@ -2284,7 +2318,7 @@
       "packages": {
         "@metamask/profile-metrics-controller>@metamask/controller-utils": true,
         "@metamask/polling-controller": true,
-        "@metamask/profile-sync-controller": true,
+        "@metamask/profile-metrics-controller>@metamask/profile-sync-controller": true,
         "@metamask/utils": true,
         "async-mutex": true
       }
@@ -2309,6 +2343,58 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/profile-sync-controller>@metamask/keyring-controller": true,
+        "@noble/ciphers": true,
+        "@noble/hashes": true,
+        "browserify>buffer": true,
+        "@metamask/profile-sync-controller>siwe": true
+      }
+    },
+    "@metamask/account-tree-controller>@metamask/profile-sync-controller": {
+      "globals": {
+        "Event": true,
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "addEventListener": true,
+        "atob": true,
+        "btoa": true,
+        "console.error": true,
+        "console.warn": true,
+        "dispatchEvent": true,
+        "fetch": true,
+        "removeEventListener": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/account-tree-controller>@metamask/profile-sync-controller>@metamask/keyring-controller": true,
+        "@noble/ciphers": true,
+        "@noble/hashes": true,
+        "browserify>buffer": true,
+        "@metamask/profile-sync-controller>siwe": true
+      }
+    },
+    "@metamask/profile-metrics-controller>@metamask/profile-sync-controller": {
+      "globals": {
+        "Event": true,
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "addEventListener": true,
+        "atob": true,
+        "btoa": true,
+        "console.error": true,
+        "console.warn": true,
+        "dispatchEvent": true,
+        "fetch": true,
+        "removeEventListener": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/profile-metrics-controller>@metamask/profile-sync-controller>@metamask/keyring-controller": true,
         "@noble/ciphers": true,
         "@noble/hashes": true,
         "browserify>buffer": true,

--- a/lavamoat/browserify/experimental/policy.json
+++ b/lavamoat/browserify/experimental/policy.json
@@ -819,7 +819,7 @@
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
         "@metamask/keyring-controller": true,
-        "@metamask/profile-sync-controller": true,
+        "@metamask/account-tree-controller>@metamask/profile-sync-controller": true,
         "@metamask/snaps-utils": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
@@ -1871,6 +1871,40 @@
         "@metamask/keyring-controller>ulid": true
       }
     },
+    "@metamask/account-tree-controller>@metamask/profile-sync-controller>@metamask/keyring-controller": {
+      "globals": {
+        "console.error": true
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/base-controller": true,
+        "@metamask/eth-hd-keyring": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/keyring-controller>@metamask/eth-simple-keyring": true,
+        "@metamask/utils": true,
+        "async-mutex": true,
+        "@metamask/keyring-controller>ethereumjs-wallet": true,
+        "lodash": true,
+        "@metamask/keyring-controller>ulid": true
+      }
+    },
+    "@metamask/profile-metrics-controller>@metamask/profile-sync-controller>@metamask/keyring-controller": {
+      "globals": {
+        "console.error": true
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/base-controller": true,
+        "@metamask/eth-hd-keyring": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/keyring-controller>@metamask/eth-simple-keyring": true,
+        "@metamask/utils": true,
+        "async-mutex": true,
+        "@metamask/keyring-controller>ethereumjs-wallet": true,
+        "lodash": true,
+        "@metamask/keyring-controller>ulid": true
+      }
+    },
     "@metamask/keyring-internal-api": {
       "packages": {
         "@metamask/keyring-api": true,
@@ -2284,7 +2318,7 @@
       "packages": {
         "@metamask/profile-metrics-controller>@metamask/controller-utils": true,
         "@metamask/polling-controller": true,
-        "@metamask/profile-sync-controller": true,
+        "@metamask/profile-metrics-controller>@metamask/profile-sync-controller": true,
         "@metamask/utils": true,
         "async-mutex": true
       }
@@ -2309,6 +2343,58 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/profile-sync-controller>@metamask/keyring-controller": true,
+        "@noble/ciphers": true,
+        "@noble/hashes": true,
+        "browserify>buffer": true,
+        "@metamask/profile-sync-controller>siwe": true
+      }
+    },
+    "@metamask/account-tree-controller>@metamask/profile-sync-controller": {
+      "globals": {
+        "Event": true,
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "addEventListener": true,
+        "atob": true,
+        "btoa": true,
+        "console.error": true,
+        "console.warn": true,
+        "dispatchEvent": true,
+        "fetch": true,
+        "removeEventListener": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/account-tree-controller>@metamask/profile-sync-controller>@metamask/keyring-controller": true,
+        "@noble/ciphers": true,
+        "@noble/hashes": true,
+        "browserify>buffer": true,
+        "@metamask/profile-sync-controller>siwe": true
+      }
+    },
+    "@metamask/profile-metrics-controller>@metamask/profile-sync-controller": {
+      "globals": {
+        "Event": true,
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "addEventListener": true,
+        "atob": true,
+        "btoa": true,
+        "console.error": true,
+        "console.warn": true,
+        "dispatchEvent": true,
+        "fetch": true,
+        "removeEventListener": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/profile-metrics-controller>@metamask/profile-sync-controller>@metamask/keyring-controller": true,
         "@noble/ciphers": true,
         "@noble/hashes": true,
         "browserify>buffer": true,

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -819,7 +819,7 @@
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
         "@metamask/keyring-controller": true,
-        "@metamask/profile-sync-controller": true,
+        "@metamask/account-tree-controller>@metamask/profile-sync-controller": true,
         "@metamask/snaps-utils": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
@@ -1871,6 +1871,40 @@
         "@metamask/keyring-controller>ulid": true
       }
     },
+    "@metamask/account-tree-controller>@metamask/profile-sync-controller>@metamask/keyring-controller": {
+      "globals": {
+        "console.error": true
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/base-controller": true,
+        "@metamask/eth-hd-keyring": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/keyring-controller>@metamask/eth-simple-keyring": true,
+        "@metamask/utils": true,
+        "async-mutex": true,
+        "@metamask/keyring-controller>ethereumjs-wallet": true,
+        "lodash": true,
+        "@metamask/keyring-controller>ulid": true
+      }
+    },
+    "@metamask/profile-metrics-controller>@metamask/profile-sync-controller>@metamask/keyring-controller": {
+      "globals": {
+        "console.error": true
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/base-controller": true,
+        "@metamask/eth-hd-keyring": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/keyring-controller>@metamask/eth-simple-keyring": true,
+        "@metamask/utils": true,
+        "async-mutex": true,
+        "@metamask/keyring-controller>ethereumjs-wallet": true,
+        "lodash": true,
+        "@metamask/keyring-controller>ulid": true
+      }
+    },
     "@metamask/keyring-internal-api": {
       "packages": {
         "@metamask/keyring-api": true,
@@ -2284,7 +2318,7 @@
       "packages": {
         "@metamask/profile-metrics-controller>@metamask/controller-utils": true,
         "@metamask/polling-controller": true,
-        "@metamask/profile-sync-controller": true,
+        "@metamask/profile-metrics-controller>@metamask/profile-sync-controller": true,
         "@metamask/utils": true,
         "async-mutex": true
       }
@@ -2309,6 +2343,58 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/profile-sync-controller>@metamask/keyring-controller": true,
+        "@noble/ciphers": true,
+        "@noble/hashes": true,
+        "browserify>buffer": true,
+        "@metamask/profile-sync-controller>siwe": true
+      }
+    },
+    "@metamask/account-tree-controller>@metamask/profile-sync-controller": {
+      "globals": {
+        "Event": true,
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "addEventListener": true,
+        "atob": true,
+        "btoa": true,
+        "console.error": true,
+        "console.warn": true,
+        "dispatchEvent": true,
+        "fetch": true,
+        "removeEventListener": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/account-tree-controller>@metamask/profile-sync-controller>@metamask/keyring-controller": true,
+        "@noble/ciphers": true,
+        "@noble/hashes": true,
+        "browserify>buffer": true,
+        "@metamask/profile-sync-controller>siwe": true
+      }
+    },
+    "@metamask/profile-metrics-controller>@metamask/profile-sync-controller": {
+      "globals": {
+        "Event": true,
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "addEventListener": true,
+        "atob": true,
+        "btoa": true,
+        "console.error": true,
+        "console.warn": true,
+        "dispatchEvent": true,
+        "fetch": true,
+        "removeEventListener": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/profile-metrics-controller>@metamask/profile-sync-controller>@metamask/keyring-controller": true,
         "@noble/ciphers": true,
         "@noble/hashes": true,
         "browserify>buffer": true,

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -819,7 +819,7 @@
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
         "@metamask/keyring-controller": true,
-        "@metamask/profile-sync-controller": true,
+        "@metamask/account-tree-controller>@metamask/profile-sync-controller": true,
         "@metamask/snaps-utils": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
@@ -1871,6 +1871,40 @@
         "@metamask/keyring-controller>ulid": true
       }
     },
+    "@metamask/account-tree-controller>@metamask/profile-sync-controller>@metamask/keyring-controller": {
+      "globals": {
+        "console.error": true
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/base-controller": true,
+        "@metamask/eth-hd-keyring": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/keyring-controller>@metamask/eth-simple-keyring": true,
+        "@metamask/utils": true,
+        "async-mutex": true,
+        "@metamask/keyring-controller>ethereumjs-wallet": true,
+        "lodash": true,
+        "@metamask/keyring-controller>ulid": true
+      }
+    },
+    "@metamask/profile-metrics-controller>@metamask/profile-sync-controller>@metamask/keyring-controller": {
+      "globals": {
+        "console.error": true
+      },
+      "packages": {
+        "@ethereumjs/tx>@ethereumjs/util": true,
+        "@metamask/base-controller": true,
+        "@metamask/eth-hd-keyring": true,
+        "@metamask/eth-sig-util": true,
+        "@metamask/keyring-controller>@metamask/eth-simple-keyring": true,
+        "@metamask/utils": true,
+        "async-mutex": true,
+        "@metamask/keyring-controller>ethereumjs-wallet": true,
+        "lodash": true,
+        "@metamask/keyring-controller>ulid": true
+      }
+    },
     "@metamask/keyring-internal-api": {
       "packages": {
         "@metamask/keyring-api": true,
@@ -2284,7 +2318,7 @@
       "packages": {
         "@metamask/profile-metrics-controller>@metamask/controller-utils": true,
         "@metamask/polling-controller": true,
-        "@metamask/profile-sync-controller": true,
+        "@metamask/profile-metrics-controller>@metamask/profile-sync-controller": true,
         "@metamask/utils": true,
         "async-mutex": true
       }
@@ -2309,6 +2343,58 @@
       "packages": {
         "@metamask/base-controller": true,
         "@metamask/profile-sync-controller>@metamask/keyring-controller": true,
+        "@noble/ciphers": true,
+        "@noble/hashes": true,
+        "browserify>buffer": true,
+        "@metamask/profile-sync-controller>siwe": true
+      }
+    },
+    "@metamask/account-tree-controller>@metamask/profile-sync-controller": {
+      "globals": {
+        "Event": true,
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "addEventListener": true,
+        "atob": true,
+        "btoa": true,
+        "console.error": true,
+        "console.warn": true,
+        "dispatchEvent": true,
+        "fetch": true,
+        "removeEventListener": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/account-tree-controller>@metamask/profile-sync-controller>@metamask/keyring-controller": true,
+        "@noble/ciphers": true,
+        "@noble/hashes": true,
+        "browserify>buffer": true,
+        "@metamask/profile-sync-controller>siwe": true
+      }
+    },
+    "@metamask/profile-metrics-controller>@metamask/profile-sync-controller": {
+      "globals": {
+        "Event": true,
+        "TextDecoder": true,
+        "TextEncoder": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "addEventListener": true,
+        "atob": true,
+        "btoa": true,
+        "console.error": true,
+        "console.warn": true,
+        "dispatchEvent": true,
+        "fetch": true,
+        "removeEventListener": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/profile-metrics-controller>@metamask/profile-sync-controller>@metamask/keyring-controller": true,
         "@noble/ciphers": true,
         "@noble/hashes": true,
         "browserify>buffer": true,

--- a/lavamoat/webpack/mv2/beta/policy.json
+++ b/lavamoat/webpack/mv2/beta/policy.json
@@ -759,7 +759,7 @@
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
         "@metamask/keyring-controller": true,
-        "@metamask/profile-sync-controller": true,
+        "@metamask/account-tree-controller>@metamask/profile-sync-controller": true,
         "@metamask/snaps-utils": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
@@ -2186,7 +2186,7 @@
       "packages": {
         "@metamask/profile-metrics-controller>@metamask/controller-utils": true,
         "@metamask/polling-controller": true,
-        "@metamask/profile-sync-controller": true,
+        "@metamask/profile-metrics-controller>@metamask/profile-sync-controller": true,
         "@metamask/utils": true,
         "async-mutex": true
       }

--- a/lavamoat/webpack/mv2/experimental/policy.json
+++ b/lavamoat/webpack/mv2/experimental/policy.json
@@ -759,7 +759,7 @@
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
         "@metamask/keyring-controller": true,
-        "@metamask/profile-sync-controller": true,
+        "@metamask/account-tree-controller>@metamask/profile-sync-controller": true,
         "@metamask/snaps-utils": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
@@ -2186,7 +2186,7 @@
       "packages": {
         "@metamask/profile-metrics-controller>@metamask/controller-utils": true,
         "@metamask/polling-controller": true,
-        "@metamask/profile-sync-controller": true,
+        "@metamask/profile-metrics-controller>@metamask/profile-sync-controller": true,
         "@metamask/utils": true,
         "async-mutex": true
       }

--- a/lavamoat/webpack/mv2/flask/policy.json
+++ b/lavamoat/webpack/mv2/flask/policy.json
@@ -759,7 +759,7 @@
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
         "@metamask/keyring-controller": true,
-        "@metamask/profile-sync-controller": true,
+        "@metamask/account-tree-controller>@metamask/profile-sync-controller": true,
         "@metamask/snaps-utils": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
@@ -2186,7 +2186,7 @@
       "packages": {
         "@metamask/profile-metrics-controller>@metamask/controller-utils": true,
         "@metamask/polling-controller": true,
-        "@metamask/profile-sync-controller": true,
+        "@metamask/profile-metrics-controller>@metamask/profile-sync-controller": true,
         "@metamask/utils": true,
         "async-mutex": true
       }

--- a/lavamoat/webpack/mv2/main/policy.json
+++ b/lavamoat/webpack/mv2/main/policy.json
@@ -759,7 +759,7 @@
         "@metamask/base-controller": true,
         "@metamask/keyring-api": true,
         "@metamask/keyring-controller": true,
-        "@metamask/profile-sync-controller": true,
+        "@metamask/account-tree-controller>@metamask/profile-sync-controller": true,
         "@metamask/snaps-utils": true,
         "@metamask/superstruct": true,
         "@metamask/utils": true,
@@ -2186,7 +2186,7 @@
       "packages": {
         "@metamask/profile-metrics-controller>@metamask/controller-utils": true,
         "@metamask/polling-controller": true,
-        "@metamask/profile-sync-controller": true,
+        "@metamask/profile-metrics-controller>@metamask/profile-sync-controller": true,
         "@metamask/utils": true,
         "async-mutex": true
       }

--- a/package.json
+++ b/package.json
@@ -412,7 +412,7 @@
     "@metamask/ppom-validator": "0.39.1",
     "@metamask/preinstalled-example-snap": "^0.7.2",
     "@metamask/profile-metrics-controller": "^3.0.4",
-    "@metamask/profile-sync-controller": "npm:@metamask-previews/profile-sync-controller@28.1.1-preview-1e1b476aa",
+    "@metamask/profile-sync-controller": "npm:@metamask-previews/profile-sync-controller@28.1.1-preview-3a34409",
     "@metamask/providers": "^22.1.1",
     "@metamask/rate-limit-controller": "^7.0.0",
     "@metamask/react-data-query": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -412,7 +412,7 @@
     "@metamask/ppom-validator": "0.39.1",
     "@metamask/preinstalled-example-snap": "^0.7.2",
     "@metamask/profile-metrics-controller": "^3.0.4",
-    "@metamask/profile-sync-controller": "^28.1.0",
+    "@metamask/profile-sync-controller": "npm:@metamask-previews/profile-sync-controller@28.1.1-preview-1e1b476aa",
     "@metamask/providers": "^22.1.1",
     "@metamask/rate-limit-controller": "^7.0.0",
     "@metamask/react-data-query": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7867,9 +7867,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/profile-sync-controller@npm:@metamask-previews/profile-sync-controller@28.1.1-preview-1e1b476aa":
-  version: 28.1.1-preview-1e1b476aa
-  resolution: "@metamask-previews/profile-sync-controller@npm:28.1.1-preview-1e1b476aa"
+"@metamask/profile-sync-controller@npm:@metamask-previews/profile-sync-controller@28.1.1-preview-3a34409":
+  version: 28.1.1-preview-3a34409
+  resolution: "@metamask-previews/profile-sync-controller@npm:28.1.1-preview-3a34409"
   dependencies:
     "@metamask/address-book-controller": "npm:^7.1.2"
     "@metamask/base-controller": "npm:^9.1.0"
@@ -7887,7 +7887,7 @@ __metadata:
   peerDependencies:
     "@metamask/providers": ^22.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/12c800b133cd5d7f34978f0b2002fe46e04b8e9b785eb3be982431862c6a8a2a11d45d086a303a84b874513885126247a69e4448e2467ade2fbd8f783c2e79ea
+  checksum: 10/160527a3f5b388e0f84b43506bc6204edd0958a56329d8a09f67b6097fd40b1532cdeefbe69f275ce378b34d90bb9134bc502e9b8c5652efa06b9c5ad22881f4
   languageName: node
   linkType: hard
 
@@ -33563,7 +33563,7 @@ __metadata:
     "@metamask/preferences-controller": "npm:^23.0.0"
     "@metamask/preinstalled-example-snap": "npm:^0.7.2"
     "@metamask/profile-metrics-controller": "npm:^3.0.4"
-    "@metamask/profile-sync-controller": "npm:@metamask-previews/profile-sync-controller@28.1.1-preview-1e1b476aa"
+    "@metamask/profile-sync-controller": "npm:@metamask-previews/profile-sync-controller@28.1.1-preview-3a34409"
     "@metamask/providers": "npm:^22.1.1"
     "@metamask/rate-limit-controller": "npm:^7.0.0"
     "@metamask/react-data-query": "npm:^0.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7867,6 +7867,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/profile-sync-controller@npm:@metamask-previews/profile-sync-controller@28.1.1-preview-1e1b476aa":
+  version: 28.1.1-preview-1e1b476aa
+  resolution: "@metamask-previews/profile-sync-controller@npm:28.1.1-preview-1e1b476aa"
+  dependencies:
+    "@metamask/address-book-controller": "npm:^7.1.2"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/keyring-controller": "npm:^26.0.0"
+    "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/snaps-controllers": "npm:^19.0.0"
+    "@metamask/snaps-sdk": "npm:^11.0.0"
+    "@metamask/snaps-utils": "npm:^12.1.2"
+    "@metamask/utils": "npm:^11.9.0"
+    "@noble/ciphers": "npm:^1.3.0"
+    "@noble/hashes": "npm:^1.8.0"
+    immer: "npm:^9.0.6"
+    loglevel: "npm:^1.8.1"
+    siwe: "npm:^2.3.2"
+  peerDependencies:
+    "@metamask/providers": ^22.0.0
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
+  checksum: 10/12c800b133cd5d7f34978f0b2002fe46e04b8e9b785eb3be982431862c6a8a2a11d45d086a303a84b874513885126247a69e4448e2467ade2fbd8f783c2e79ea
+  languageName: node
+  linkType: hard
+
 "@metamask/profile-sync-controller@npm:^28.0.2, @metamask/profile-sync-controller@npm:^28.1.0, @metamask/profile-sync-controller@npm:^28.1.1":
   version: 28.1.1
   resolution: "@metamask/profile-sync-controller@npm:28.1.1"
@@ -33539,7 +33563,7 @@ __metadata:
     "@metamask/preferences-controller": "npm:^23.0.0"
     "@metamask/preinstalled-example-snap": "npm:^0.7.2"
     "@metamask/profile-metrics-controller": "npm:^3.0.4"
-    "@metamask/profile-sync-controller": "npm:^28.1.0"
+    "@metamask/profile-sync-controller": "npm:@metamask-previews/profile-sync-controller@28.1.1-preview-1e1b476aa"
     "@metamask/providers": "npm:^22.1.1"
     "@metamask/rate-limit-controller": "npm:^7.0.0"
     "@metamask/react-data-query": "npm:^0.2.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Uses a non-release preview of profile-sync-controller and adjusts LavaMoat compartments around profile sync and keyring-related nested dependencies, which affects the extension supply-chain and sandbox boundaries.
> 
> **Overview**
> Pins the extension’s direct **`@metamask/profile-sync-controller`** dependency to a **preview build** (`@metamask-previews/profile-sync-controller@28.1.1-preview-3a34409`) via an npm alias in **`package.json`**, with matching **`yarn.lock`** resolution.
> 
> **LavaMoat** policies (browserify beta/experimental/flask/main and webpack mv2 variants) are updated so **`profile-sync-controller`** is referenced on **parent-scoped paths** (e.g. `@metamask/account-tree-controller>@metamask/profile-sync-controller` and `@metamask/profile-metrics-controller>@metamask/profile-sync-controller`), including new policy blocks for those paths and their nested **`keyring-controller`** edges. Direct consumers no longer use the unscoped `@metamask/profile-sync-controller` package key in those compartments.
> 
> *Note: the PR title mentions 28.2.0; the diff installs **28.1.1-preview-3a34409**.*
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5dc3e823e6d73d17e13e75e720ca7addac9ede28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->