### PR TITLE
fix: dead settings routes after Settings V2 migration

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5535,7 +5535,7 @@
     "message": "“$1” was successfully added!"
   },
   "newNFTDetectedInImportNFTsMessageStrongText": {
-    "message": "Settings > Security and privacy"
+    "message": "Settings > Assets"
   },
   "newNFTDetectedInImportNFTsMsg": {
     "message": "To use Opensea to see your NFTs, turn on 'Display NFT Media' in $1.",

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5535,7 +5535,7 @@
     "message": "“$1” was successfully added!"
   },
   "newNFTDetectedInImportNFTsMessageStrongText": {
-    "message": "Settings > Security and privacy"
+    "message": "Settings > Assets"
   },
   "newNFTDetectedInImportNFTsMsg": {
     "message": "To use Opensea to see your NFTs, turn on 'Display NFT Media' in $1.",

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
@@ -8,7 +8,7 @@ import mockState from '../../../../../../test/data/mock-state.json';
 import * as actions from '../../../../../store/actions';
 import { setBackgroundConnection } from '../../../../../store/background-connection';
 import {
-  SECURITY_ROUTE,
+  ASSETS_ROUTE,
   TOKEN_MANAGEMENT_ROUTE,
 } from '../../../../../helpers/constants/routes';
 import AssetListControlBar from './asset-list-control-bar';
@@ -190,7 +190,9 @@ describe('NFTs options', () => {
     expect(autodetectButton).toBeInTheDocument();
 
     fireEvent.click(autodetectButton);
-    expect(mockUseNavigate).toHaveBeenCalledWith(SECURITY_ROUTE);
+    expect(mockUseNavigate).toHaveBeenCalledWith(
+      `${ASSETS_ROUTE}#autodetect-tokens`,
+    );
   });
 
   it('shows Manage tokens instead of Import tokens when the token management feature flag is enabled', async () => {

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
@@ -88,7 +88,7 @@ import {
 } from '../../../../../selectors/multichain';
 import { useNftsCollections } from '../../../../../hooks/useNftsCollections';
 import {
-  SECURITY_ROUTE,
+  ASSETS_ROUTE,
   TOKEN_MANAGEMENT_ROUTE,
 } from '../../../../../helpers/constants/routes';
 import { getIsAssetsUnifyStateEnabled } from '../../../../../selectors/assets-unify-state/feature-flags';
@@ -304,7 +304,7 @@ const AssetListControlBar = ({
   };
 
   const onEnableAutoDetect = () => {
-    navigate(SECURITY_ROUTE);
+    navigate(`${ASSETS_ROUTE}#autodetect-tokens`);
   };
 
   const handleNetworkManager = useCallback(() => {

--- a/ui/components/app/assets/nfts/nfts-detection-notice-import-nfts/nfts-detection-notice-import-nfts.tsx
+++ b/ui/components/app/assets/nfts/nfts-detection-notice-import-nfts/nfts-detection-notice-import-nfts.tsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { useNavigate } from 'react-router-dom';
 import { BannerAlert } from '../../../../component-library';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
-import { SECURITY_ROUTE } from '../../../../../helpers/constants/routes';
+import { ASSETS_ROUTE } from '../../../../../helpers/constants/routes';
 
 type NftsDetectionNoticeImportNFTsProps = {
   onActionButtonClick: () => void;
@@ -23,7 +23,7 @@ export default function NftsDetectionNoticeImportNFTs({
       actionButtonLabel={t('selectEnableDisplayMediaPrivacyPreference')}
       actionButtonOnClick={(e) => {
         e.preventDefault();
-        navigate(`${SECURITY_ROUTE}#display-nft-media`);
+        navigate(`${ASSETS_ROUTE}#display-nft-media`);
         onActionButtonClick?.();
       }}
     >

--- a/ui/components/app/change-password/change-password.test.tsx
+++ b/ui/components/app/change-password/change-password.test.tsx
@@ -13,7 +13,7 @@ import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate
 import { tEn } from '../../../../test/lib/i18n-helpers';
 import mockState from '../../../../test/data/mock-state.json';
 import {
-  SECURITY_ROUTE,
+  SECURITY_AND_PASSWORD_ROUTE,
   SECURITY_PASSWORD_CHANGE_V2_ROUTE,
 } from '../../../helpers/constants/routes';
 import * as selectors from '../../../selectors';
@@ -284,7 +284,9 @@ describe('ChangePassword', () => {
           mockNewPassword,
           mockPassword,
         );
-        expect(mockUseNavigate).toHaveBeenCalledWith(SECURITY_ROUTE);
+        expect(mockUseNavigate).toHaveBeenCalledWith(
+          SECURITY_AND_PASSWORD_ROUTE,
+        );
       });
     });
   });
@@ -383,7 +385,9 @@ describe('ChangePassword', () => {
           mockNewPassword,
           mockPassword,
         );
-        expect(mockUseNavigate).toHaveBeenCalledWith(SECURITY_ROUTE);
+        expect(mockUseNavigate).toHaveBeenCalledWith(
+          SECURITY_AND_PASSWORD_ROUTE,
+        );
       });
     });
   });
@@ -822,7 +826,9 @@ describe('ChangePassword', () => {
           mockRemovePasskeyWithPasswordVerification,
         ).not.toHaveBeenCalled();
         expect(mockForceUpdateMetamaskState).toHaveBeenCalled();
-        expect(mockUseNavigate).toHaveBeenCalledWith(SECURITY_ROUTE);
+        expect(mockUseNavigate).toHaveBeenCalledWith(
+          SECURITY_AND_PASSWORD_ROUTE,
+        );
       });
     });
 
@@ -872,7 +878,9 @@ describe('ChangePassword', () => {
           mockRemovePasskeyWithPasswordVerification.mock.invocationCallOrder[0],
         ).toBeLessThan(mockChangePassword.mock.invocationCallOrder[0]);
         expect(mockForceUpdateMetamaskState).toHaveBeenCalled();
-        expect(mockUseNavigate).toHaveBeenCalledWith(SECURITY_ROUTE);
+        expect(mockUseNavigate).toHaveBeenCalledWith(
+          SECURITY_AND_PASSWORD_ROUTE,
+        );
       });
     });
 
@@ -899,7 +907,9 @@ describe('ChangePassword', () => {
           { renewVaultKeyProtection: true },
         );
         expect(mockForceUpdateMetamaskState).toHaveBeenCalled();
-        expect(mockUseNavigate).toHaveBeenCalledWith(SECURITY_ROUTE);
+        expect(mockUseNavigate).toHaveBeenCalledWith(
+          SECURITY_AND_PASSWORD_ROUTE,
+        );
       });
     });
 
@@ -941,7 +951,9 @@ describe('ChangePassword', () => {
           mockRemovePasskeyWithPasswordVerification,
         ).not.toHaveBeenCalled();
         expect(mockForceUpdateMetamaskState).toHaveBeenCalled();
-        expect(mockUseNavigate).toHaveBeenCalledWith(SECURITY_ROUTE);
+        expect(mockUseNavigate).toHaveBeenCalledWith(
+          SECURITY_AND_PASSWORD_ROUTE,
+        );
       });
     });
 
@@ -984,7 +996,7 @@ describe('ChangePassword', () => {
         ]),
       );
       expect(mockForceUpdateMetamaskState).toHaveBeenCalled();
-      expect(mockUseNavigate).toHaveBeenCalledWith(SECURITY_ROUTE);
+      expect(mockUseNavigate).toHaveBeenCalledWith(SECURITY_AND_PASSWORD_ROUTE);
     });
   });
 });

--- a/ui/components/app/change-password/change-password.tsx
+++ b/ui/components/app/change-password/change-password.tsx
@@ -67,7 +67,7 @@ import { getEnvironmentType } from '../../../../shared/lib/environment-type';
 import { ENVIRONMENT_TYPE_SIDEPANEL } from '../../../../shared/constants/app';
 import PasswordForm from '../password-form/password-form';
 import {
-  SECURITY_ROUTE,
+  SECURITY_AND_PASSWORD_ROUTE,
   SECURITY_PASSWORD_CHANGE_V2_ROUTE,
 } from '../../../helpers/constants/routes';
 import { toast, ToastContent } from '../../ui/toast/toast';
@@ -96,7 +96,7 @@ type ChangePasswordProps = {
 };
 
 const ChangePassword = ({
-  redirectRoute = SECURITY_ROUTE,
+  redirectRoute = SECURITY_AND_PASSWORD_ROUTE,
 }: ChangePasswordProps) => {
   const t = useI18nContext();
   const passkeyMethodLabel = t(getPasskeyAuthMethodKey());

--- a/ui/components/app/modals/pna25-modal/pna25-modal.tsx
+++ b/ui/components/app/modals/pna25-modal/pna25-modal.tsx
@@ -25,7 +25,7 @@ import {
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { MetaMetricsContext } from '../../../../contexts/metametrics';
 import { MetaMetricsEventName } from '../../../../../shared/constants/metametrics';
-import { SECURITY_ROUTE } from '../../../../helpers/constants/routes';
+import { PRIVACY_ROUTE } from '../../../../helpers/constants/routes';
 import { setPna25Acknowledged } from '../../../../store/actions';
 import { PNA25_BLOG_POST_LINK, Pna25NoticeAction } from './constants';
 
@@ -58,7 +58,7 @@ export default function Pna25Modal() {
       }
 
       if (action === Pna25NoticeAction.OpenSettings) {
-        navigate(SECURITY_ROUTE);
+        navigate(PRIVACY_ROUTE);
       }
     },
     [trackEvent, dispatch, navigate],

--- a/ui/components/multichain-accounts/multichain-address-rows-triggered-list/default-address.tsx
+++ b/ui/components/multichain-accounts/multichain-address-rows-triggered-list/default-address.tsx
@@ -15,7 +15,7 @@ import {
 import { useNavigate } from 'react-router-dom';
 import ToggleButton from '../../ui/toggle-button';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { GENERAL_ROUTE } from '../../../helpers/constants/routes';
+import { PREFERENCES_AND_DISPLAY_ROUTE } from '../../../helpers/constants/routes';
 import {
   DEFAULT_ADDRESS_DISPLAY_KEY_BY_SCOPE,
   DefaultAddressScope,
@@ -81,7 +81,9 @@ export const DefaultAddress = () => {
                     settings_type: 'show_default_address',
                   },
                 });
-                navigate(`${GENERAL_ROUTE}#show-default-address`);
+                navigate(
+                  `${PREFERENCES_AND_DISPLAY_ROUTE}#show-default-address`,
+                );
               }}
               data-testid="change-in-settings-link"
             >

--- a/ui/components/multichain/import-tokens-modal/import-tokens-modal.js
+++ b/ui/components/multichain/import-tokens-modal/import-tokens-modal.js
@@ -79,10 +79,7 @@ import {
   TextVariant,
 } from '../../../helpers/constants/design-system';
 
-import {
-  SECURITY_ROUTE,
-  DEFAULT_ROUTE,
-} from '../../../helpers/constants/routes';
+import { ASSETS_ROUTE, DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import ZENDESK_URLS from '../../../helpers/constants/zendesk-url';
 import {
   isValidHexAddress,
@@ -989,7 +986,7 @@ export const ImportTokensModal = ({ onClose }) => {
                                     onClick={() => {
                                       onClose();
                                       navigate(
-                                        `${SECURITY_ROUTE}#auto-detect-tokens`,
+                                        `${ASSETS_ROUTE}#autodetect-tokens`,
                                       );
                                     }}
                                   >

--- a/ui/helpers/constants/routes.ts
+++ b/ui/helpers/constants/routes.ts
@@ -38,8 +38,6 @@ export const SECURITY_TURN_OFF_PASSKEY_ROUTE =
   '/settings/security-and-password/turn-off-passkey';
 export const DEVELOPER_TOOLS_ROUTE = '/settings/developer-tools';
 export const DEBUG_ROUTE = '/settings/debug';
-export const GENERAL_ROUTE = '/settings/general';
-export const ADVANCED_ROUTE = '/settings/advanced';
 export const DEVELOPER_OPTIONS_ROUTE = DEBUG_ROUTE;
 export const EXPERIMENTAL_ROUTE = '/settings/experimental';
 export const TRANSACTION_SHIELD_ROUTE = '/settings/transaction-shield';
@@ -68,7 +66,6 @@ export const TRANSACTION_SHIELD_CLAIM_ROUTES = {
     RELATIVE: '/view-history-claim',
   },
 } as const;
-export const SECURITY_ROUTE = '/settings/security';
 export const ABOUT_US_ROUTE = '/settings/about-us';
 export const NETWORKS_ROUTE = '/networks';
 export const NETWORKS_FORM_ROUTE = '/networks/form';
@@ -303,16 +300,6 @@ export const ROUTES = [
     trackInAnalytics: true,
   },
   {
-    path: GENERAL_ROUTE,
-    label: 'General Settings Page',
-    trackInAnalytics: true,
-  },
-  {
-    path: ADVANCED_ROUTE,
-    label: 'Advanced Settings Page',
-    trackInAnalytics: true,
-  },
-  {
     path: DEVELOPER_OPTIONS_ROUTE,
     label: 'Developer Options Page',
     // DEVELOPER_OPTIONS_ROUTE not in PATH_NAME_MAP because we're not tracking analytics for this page
@@ -321,11 +308,6 @@ export const ROUTES = [
   {
     path: EXPERIMENTAL_ROUTE,
     label: 'Experimental Settings Page',
-    trackInAnalytics: true,
-  },
-  {
-    path: SECURITY_ROUTE,
-    label: 'Security Settings Page',
     trackInAnalytics: true,
   },
   {

--- a/ui/pages/basic-functionality-required/basic-functionality-required.test.tsx
+++ b/ui/pages/basic-functionality-required/basic-functionality-required.test.tsx
@@ -124,7 +124,7 @@ describe('BasicFunctionalityOff', () => {
     renderWithStore(<BasicFunctionalityOff />);
     screen.getByTestId('basic-functionality-off-review-in-settings').click();
 
-    expect(mockNavigate).toHaveBeenCalledWith('/settings/security');
+    expect(mockNavigate).toHaveBeenCalledWith('/settings/privacy');
   });
 
   it('renders Go to the home page link', () => {

--- a/ui/pages/basic-functionality-required/basic-functionality-required.tsx
+++ b/ui/pages/basic-functionality-required/basic-functionality-required.tsx
@@ -25,7 +25,7 @@ import {
 } from '../../helpers/constants/design-system';
 import { Container } from '../../components/component-library/container/container';
 import ToggleButton from '../../components/ui/toggle-button';
-import { DEFAULT_ROUTE, SECURITY_ROUTE } from '../../helpers/constants/routes';
+import { DEFAULT_ROUTE, PRIVACY_ROUTE } from '../../helpers/constants/routes';
 import { getUseExternalServices } from '../../selectors';
 import { toggleExternalServices } from '../../store/actions';
 import type { BasicFunctionalityOffState } from '../../helpers/higher-order-components/require-basic-functionality/require-basic-functionality';
@@ -145,7 +145,7 @@ export const BasicFunctionalityOff = () => {
             />
           </Box>
           <TextButton
-            onClick={() => navigate(SECURITY_ROUTE)}
+            onClick={() => navigate(PRIVACY_ROUTE)}
             data-testid="basic-functionality-off-review-in-settings"
           >
             {t('basicFunctionalityRequired_reviewInSettings')}

--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.tsx
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.tsx
@@ -31,7 +31,7 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   ONBOARDING_PRIVACY_SETTINGS_ROUTE,
   DEFAULT_ROUTE,
-  SECURITY_ROUTE,
+  SECURITY_AND_PASSWORD_ROUTE,
 } from '../../../helpers/constants/routes';
 import {
   getBackupAndSyncOnboardingToggleState,
@@ -255,7 +255,9 @@ export default function CreationSuccessful() {
 
   const onDone = useCallback(async () => {
     if (isFromReminder) {
-      navigate(isFromSettingsSecurity ? SECURITY_ROUTE : DEFAULT_ROUTE);
+      navigate(
+        isFromSettingsSecurity ? SECURITY_AND_PASSWORD_ROUTE : DEFAULT_ROUTE,
+      );
       return;
     }
 

--- a/ui/pages/onboarding-flow/onboarding-flow.tsx
+++ b/ui/pages/onboarding-flow/onboarding-flow.tsx
@@ -32,7 +32,7 @@ import {
   ONBOARDING_METAMETRICS,
   ONBOARDING_ACCOUNT_EXIST,
   ONBOARDING_ACCOUNT_NOT_FOUND,
-  SECURITY_ROUTE,
+  SECURITY_AND_PASSWORD_ROUTE,
   ONBOARDING_REVEAL_SRP_ROUTE,
   ONBOARDING_DOWNLOAD_APP_ROUTE,
   ONBOARDING_SETUP_PASSKEY_ROUTE,
@@ -189,9 +189,12 @@ export default function OnboardingFlow() {
       isSRPBackupRoute &&
       completedOnboarding
     ) {
-      navigate(isFromSettingsSecurity ? SECURITY_ROUTE : DEFAULT_ROUTE, {
-        replace: true,
-      });
+      navigate(
+        isFromSettingsSecurity ? SECURITY_AND_PASSWORD_ROUTE : DEFAULT_ROUTE,
+        {
+          replace: true,
+        },
+      );
     }
   }, [
     isUnlocked,


### PR DESCRIPTION
## **Description**

After the Settings V2 migration, several in-app links still navigated to pre-migration paths (`/settings/security`, `/settings/general`) that no longer exist in the settings registry. Those URLs would go to the root settings screen, and hash fragments (for example `#auto-detect-tokens`) did not scroll to the intended control.

This PR updates navigation to the canonical Settings routes and removes unused legacy route constants from `routes.ts`.

**What is the improvement/solution?**  
- Point deep links and CTAs at the correct tab routes (`/settings/security-and-password`, `/settings/assets`, `/settings/preferences-and-display`, `/settings/privacy`).
- Use setting ids that match the new Settings registry hashes (for example `#autodetect-tokens` instead of `#auto-detect-tokens`).
- Delete unused `SECURITY_ROUTE`, `GENERAL_ROUTE`, and `ADVANCED_ROUTE` constants 

| Old navigation | New navigation |
|----------------|----------------|
| `/settings/security` (password, onboarding return) | `SECURITY_AND_PASSWORD_ROUTE` |
| `/settings/security` (basic functionality off, PNA25 “open settings”) | `PRIVACY_ROUTE` |
| `/settings/security#auto-detect-tokens` | `ASSETS_ROUTE#autodetect-tokens` |
| `/settings/security#display-nft-media` | `ASSETS_ROUTE#display-nft-media` |
| `/settings/general#show-default-address` | `PREFERENCES_AND_DISPLAY_ROUTE#show-default-address` |

## **Changelog**

CHANGELOG entry: update legacy settings routes to new correct ones 

## **Related issues**

Fixes:

## **Manual testing steps**

1. On NFT tab with an account with zero nfts, click the three dot menu and confirm Enable autodetect goes to **Settings → Assets**
5. Change password from **Settings → Security & password** and confirm redirect returns to Security & password (not a blank/wrong tab).
7. Complete onboarding when returning from Security settings and confirm return navigation goes to Security & password.
8. On multichain default address UI on the homepage, click **Change in settings** and confirm it opens **Preferences and display** at show default address

## **Screenshots/Recordings**

### **Before**


### **After**


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation and copy-only changes with no auth or data-layer logic; risk is limited to wrong-tab UX if a hash id is mistyped.
> 
> **Overview**
> Fixes **broken Settings deep links** after Settings V2 by routing in-app CTAs and post-flow redirects to the **canonical tab paths** instead of removed URLs like `/settings/security` and `/settings/general`.
> 
> **Token/NFT and assets:** autodetect and “display NFT media” flows now go to **`ASSETS_ROUTE`** with registry-aligned hashes (`#autodetect-tokens`, `#display-nft-media`). Copy in locale strings now points users to **Settings → Assets**.
> 
> **Security vs privacy:** password change, onboarding return-from-security, and similar flows use **`SECURITY_AND_PASSWORD_ROUTE`**. Basic functionality off, PNA25 “open settings”, and related privacy CTAs use **`PRIVACY_ROUTE`**.
> 
> **Preferences:** default-address “change in settings” uses **`PREFERENCES_AND_DISPLAY_ROUTE#show-default-address`**.
> 
> Removes unused **`SECURITY_ROUTE`**, **`GENERAL_ROUTE`**, and **`ADVANCED_ROUTE`** from `routes.ts` and updates affected tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6bdded227f5f09dfa72fac3c8ca891471426348. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->