### PR TITLE
ci: Update `add-team-label` and `check-template-and-add-labels workflows` to use OIDC token exchange

### DIFF
--- a/.github/workflows/add-team-label.yml
+++ b/.github/workflows/add-team-label.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   add-team-label:
     name: Add team label
-    if: ${{ !github.event.pull_request.head.repo.fork }}
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
     permissions:
       id-token: write

--- a/.github/workflows/add-team-label.yml
+++ b/.github/workflows/add-team-label.yml
@@ -8,11 +8,31 @@ on:
 jobs:
   add-team-label:
     name: Add team label
+    if: ${{ !github.event.pull_request.head.repo.fork }}
     runs-on: ubuntu-latest
-    # Only same-repo PRs — TEAM_LABEL_TOKEN is not available to cross-repo PRs.
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    permissions:
+      id-token: write
     steps:
+      - name: Get planning token
+        id: planning-token
+        uses: MetaMask/github-tools/.github/actions/get-token@v1
+        with:
+          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
+          target-repository: MetaMask/MetaMask-planning
+          permissions: |
+            contents: read
+
+      - name: Get label token
+        id: label-token
+        uses: MetaMask/github-tools/.github/actions/get-token@v1
+        with:
+          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
+          permissions: |
+            contents: read
+            pull_requests: write
+
       - name: Add team label
         uses: MetaMask/github-tools/.github/actions/add-team-label@v1
         with:
-          team-label-token: ${{ secrets.TEAM_LABEL_TOKEN }}
+          planning-token: ${{ steps.planning-token.outputs.token }}
+          team-label-token: ${{ steps.label-token.outputs.token }}

--- a/.github/workflows/add-team-label.yml
+++ b/.github/workflows/add-team-label.yml
@@ -8,8 +8,8 @@ on:
 jobs:
   add-team-label:
     name: Add team label
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
     permissions:
       id-token: write
     steps:

--- a/.github/workflows/check-template-and-add-labels.yml
+++ b/.github/workflows/check-template-and-add-labels.yml
@@ -8,25 +8,11 @@ on:
   merge_group:
 
 jobs:
-  is-fork-pull-request:
-    name: Determine whether this is a pull request from a fork
-    runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request_target' }}
-    outputs:
-      IS_FORK: ${{ steps.is-fork.outputs.IS_FORK }}
-    steps:
-      - uses: actions/checkout@v4
-      - name: Determine whether this PR is from a fork
-        id: is-fork
-        run: echo "IS_FORK=$(gh pr view --json isCrossRepository --jq '.isCrossRepository' "${PR_NUMBER}" )" >> "$GITHUB_OUTPUT"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.number }}
-
   check-template-and-add-labels:
     runs-on: ubuntu-latest
-    needs: [is-fork-pull-request]
-    if: ${{ always() && github.event_name != 'merge_group' && (github.event_name == 'issues' || (github.event_name == 'pull_request_target' && needs.is-fork-pull-request.outputs.IS_FORK == 'false')) }}
+    if: >
+      github.event_name == 'issues' ||
+      (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/check-template-and-add-labels.yml
+++ b/.github/workflows/check-template-and-add-labels.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   check-template-and-add-labels:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: >
       github.event_name == 'issues' ||
       (github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name == github.repository)

--- a/.github/workflows/check-template-and-add-labels.yml
+++ b/.github/workflows/check-template-and-add-labels.yml
@@ -8,10 +8,28 @@ on:
   merge_group:
 
 jobs:
+  is-fork-pull-request:
+    name: Determine whether this is a pull request from a fork
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request_target' }}
+    outputs:
+      IS_FORK: ${{ steps.is-fork.outputs.IS_FORK }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Determine whether this PR is from a fork
+        id: is-fork
+        run: echo "IS_FORK=$(gh pr view --json isCrossRepository --jq '.isCrossRepository' "${PR_NUMBER}" )" >> "$GITHUB_OUTPUT"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
+
   check-template-and-add-labels:
     runs-on: ubuntu-latest
-    timeout-minutes: 30
-    if: ${{ github.event_name != 'merge_group' }} # Skip this step for merge_group events
+    needs: [is-fork-pull-request]
+    if: ${{ always() && github.event_name != 'merge_group' && (github.event_name == 'issues' || (github.event_name == 'pull_request_target' && needs.is-fork-pull-request.outputs.IS_FORK == 'false')) }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v3
@@ -19,8 +37,18 @@ jobs:
           is-high-risk-environment: false
           skip-allow-scripts: true
 
+      - name: Get access token
+        id: get-token
+        uses: MetaMask/github-tools/.github/actions/get-token@v1
+        with:
+          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
+          permissions: |
+            issues: write
+            members: read
+            pull_requests: write
+
       - name: Check template and add labels
         id: check-template-and-add-labels
         env:
-          LABEL_TOKEN: ${{ secrets.LABEL_TOKEN }}
+          LABEL_TOKEN: ${{ steps.get-token.outputs.token }}
         run: npm run check-template-and-add-labels


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This updates the `add-team-label` and `check-template-and-add-labels` workflows to use OIDC token exchange.

This is based on the same change I made in MetaMask/metamask-mobile#30840, where we were previously using Patroll tokens. AFAIK we don't use Patroll for the tokens here yet, but we want to move away from PATs anyway, so I updated the workflows here as example for how to use `token-exchange-service`.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how GitHub Actions authenticate for labeling; misconfiguration could break automation, but scope is limited to CI and moves off long-lived PATs.
> 
> **Overview**
> Replaces long-lived GitHub **PAT secrets** in two automation workflows with **OIDC-based token exchange** via `MetaMask/github-tools` `get-token` and `vars.TOKEN_EXCHANGE_URL`.
> 
> **`add-team-label`** now requests separate short-lived tokens for reading **MetaMask-planning** and for **pull request write** access, and passes them into `add-team-label` instead of `secrets.TEAM_LABEL_TOKEN`. It grants **`id-token: write`** for OIDC.
> 
> **`check-template-and-add-labels`** mints a token with **issues**, **members**, and **pull_requests** write/read scopes for the existing `LABEL_TOKEN` env var, adds **`id-token: write`**, and tightens **when** `pull_request_target` runs so only **same-repo** PRs are labeled (issues still run as before). The old **merge_group** skip is folded into this `if` expression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0baa60c92c0b9acf69cfd99179c3fae5ae6ba4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->