### PR TITLE
chore: migrate `checkIsSeedlessPasswordOutdated` to `LegacyBackgroundApiService` 

### DIFF
--- a/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
@@ -52,6 +52,8 @@ export function getLegacyBackgroundApiServiceMessenger(
       'KeyringController:getKeyringsByType',
       'KeyringController:addNewKeyring',
       'PreferencesController:setPasswordForgotten',
+      'OnboardingController:getState',
+      'SeedlessOnboardingController:checkIsPasswordOutdated',
     ],
   });
 

--- a/app/scripts/metamask-controller.actions.test.js
+++ b/app/scripts/metamask-controller.actions.test.js
@@ -22,7 +22,6 @@ import { Category, ErrorCode, Severity } from '@metamask/hw-wallet-sdk';
 import browser from 'webextension-polyfill';
 import mockEncryptor from '../../test/lib/mock-encryptor';
 import { HardwareKeyringNames } from '../../shared/constants/hardware-wallets';
-import { FirstTimeFlowType } from '../../shared/constants/onboarding';
 import { ExtensionPasskeyErrorCode } from '../../shared/lib/passkey/passkey-error';
 import { CHAIN_IDS } from '../../shared/constants/network';
 import { toAssetId } from '../../shared/lib/asset-utils';
@@ -806,118 +805,6 @@ describe('MetaMaskController', function () {
     });
   });
 
-  describe('#checkIsSeedlessPasswordOutdated', function () {
-    it('should return undefined if firstTimeFlowType is not seedless', async function () {
-      metamaskController.onboardingController.setFirstTimeFlowType(
-        FirstTimeFlowType.create,
-      );
-      const result = await metamaskController.checkIsSeedlessPasswordOutdated();
-      expect(result).toBeFalsy();
-    });
-
-    it('should return false if firstTimeFlowType is seedless and password is not outdated', async function () {
-      // We now need the Snap keyring after onboarding the wallet.
-      jest.spyOn(getSnapKeyringUtil, 'getSnapKeyring').mockResolvedValue({});
-      metamaskController.onboardingController.setFirstTimeFlowType(
-        FirstTimeFlowType.socialCreate,
-      );
-      metamaskController.onboardingController.completeOnboarding();
-      jest
-        .spyOn(
-          metamaskController.seedlessOnboardingController,
-          'checkIsPasswordOutdated',
-        )
-        .mockResolvedValue(false);
-      const result = await metamaskController.checkIsSeedlessPasswordOutdated();
-      expect(result).toBe(false);
-      expect(
-        metamaskController.seedlessOnboardingController.checkIsPasswordOutdated,
-      ).toHaveBeenCalled();
-    });
-
-    it('should return true if firstTimeFlowType is seedless and password is outdated', async function () {
-      // We now need the Snap keyring after onboarding the wallet.
-      jest.spyOn(getSnapKeyringUtil, 'getSnapKeyring').mockResolvedValue({});
-      metamaskController.onboardingController.setFirstTimeFlowType(
-        FirstTimeFlowType.socialCreate,
-      );
-      metamaskController.onboardingController.completeOnboarding();
-      jest
-        .spyOn(
-          metamaskController.seedlessOnboardingController,
-          'checkIsPasswordOutdated',
-        )
-        .mockResolvedValue(true);
-      const result = await metamaskController.checkIsSeedlessPasswordOutdated();
-      expect(result).toBe(true);
-      expect(
-        metamaskController.seedlessOnboardingController.checkIsPasswordOutdated,
-      ).toHaveBeenCalled();
-    });
-
-    it('captures the error when password check fails and captureSentryError is true', async function () {
-      const error = new Error('Network error');
-
-      jest
-        .spyOn(metamaskController.onboardingController, 'getIsSocialLoginFlow')
-        .mockReturnValue(true);
-      jest
-        .spyOn(metamaskController.onboardingController, 'state', 'get')
-        .mockReturnValue({ completedOnboarding: true });
-      jest
-        .spyOn(metamaskController.controllerMessenger, 'captureException')
-        .mockImplementation();
-      jest
-        .spyOn(
-          metamaskController.seedlessOnboardingController,
-          'checkIsPasswordOutdated',
-        )
-        .mockRejectedValue(error);
-
-      await expect(
-        metamaskController.checkIsSeedlessPasswordOutdated({
-          skipCache: false,
-          captureSentryError: true,
-        }),
-      ).rejects.toThrow(error);
-
-      expect(
-        metamaskController.controllerMessenger.captureException,
-      ).toHaveBeenCalledTimes(1);
-    });
-
-    it('does not capture the error when password check fails and captureSentryError is false', async function () {
-      const error = new Error('Network error');
-
-      jest
-        .spyOn(metamaskController.onboardingController, 'getIsSocialLoginFlow')
-        .mockReturnValue(true);
-      jest
-        .spyOn(metamaskController.onboardingController, 'state', 'get')
-        .mockReturnValue({ completedOnboarding: true });
-      jest
-        .spyOn(metamaskController.controllerMessenger, 'captureException')
-        .mockImplementation();
-      jest
-        .spyOn(
-          metamaskController.seedlessOnboardingController,
-          'checkIsPasswordOutdated',
-        )
-        .mockRejectedValue(error);
-
-      await expect(
-        metamaskController.checkIsSeedlessPasswordOutdated({
-          skipCache: false,
-          captureSentryError: false,
-        }),
-      ).rejects.toThrow(error);
-
-      expect(
-        metamaskController.controllerMessenger.captureException,
-      ).not.toHaveBeenCalled();
-    });
-  });
-
   describe('#syncPasswordAndUnlockWallet', function () {
     const password = 'test@123';
 
@@ -959,7 +846,10 @@ describe('MetaMaskController', function () {
           )
           .mockReturnValue(true);
         jest
-          .spyOn(metamaskController, 'checkIsSeedlessPasswordOutdated')
+          .spyOn(
+            metamaskController.legacyBackgroundApiService,
+            'checkIsSeedlessPasswordOutdated',
+          )
           .mockResolvedValue(false);
 
         const submitPasswordSpy = jest
@@ -984,7 +874,10 @@ describe('MetaMaskController', function () {
           )
           .mockReturnValue(true);
         jest
-          .spyOn(metamaskController, 'checkIsSeedlessPasswordOutdated')
+          .spyOn(
+            metamaskController.legacyBackgroundApiService,
+            'checkIsSeedlessPasswordOutdated',
+          )
           .mockResolvedValue(true);
       });
 
@@ -1112,13 +1005,15 @@ describe('MetaMaskController', function () {
         ).toHaveBeenCalledWith(password);
         expect(metamaskController.syncKeyringEncryptionKey).toHaveBeenCalled();
         expect(
-          metamaskController.checkIsSeedlessPasswordOutdated,
+          metamaskController.legacyBackgroundApiService
+            .checkIsSeedlessPasswordOutdated,
         ).toHaveBeenNthCalledWith(1, {
           skipCache: false,
           captureSentryError: true,
         });
         expect(
-          metamaskController.checkIsSeedlessPasswordOutdated,
+          metamaskController.legacyBackgroundApiService
+            .checkIsSeedlessPasswordOutdated,
         ).toHaveBeenNthCalledWith(2, {
           skipCache: true,
           captureSentryError: true,
@@ -1215,7 +1110,10 @@ describe('MetaMaskController', function () {
 
       it('should unlock wallet when `revokePendingRefreshTokens` fails for non-outdated password', async function () {
         jest
-          .spyOn(metamaskController, 'checkIsSeedlessPasswordOutdated')
+          .spyOn(
+            metamaskController.legacyBackgroundApiService,
+            'checkIsSeedlessPasswordOutdated',
+          )
           .mockResolvedValue(false);
         const keyringSubmitPwdSpy = jest
           .spyOn(metamaskController.keyringController, 'submitPassword')
@@ -1306,7 +1204,10 @@ describe('MetaMaskController', function () {
 
       it('should allow user to unlock the wallet even if checkIsPasswordOutdated fails', async function () {
         jest
-          .spyOn(metamaskController, 'checkIsSeedlessPasswordOutdated')
+          .spyOn(
+            metamaskController.legacyBackgroundApiService,
+            'checkIsSeedlessPasswordOutdated',
+          )
           .mockRejectedValue('Network Error');
         const keyringSubmitPwdSpy = jest
           .spyOn(metamaskController.keyringController, 'submitPassword')

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2910,8 +2910,10 @@ export default class MetamaskController extends EventEmitter {
         this.controllerMessenger,
         'LegacyBackgroundApiService:getAccountsBySnapId',
       ),
-      checkIsSeedlessPasswordOutdated:
-        this.checkIsSeedlessPasswordOutdated.bind(this),
+      checkIsSeedlessPasswordOutdated: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'LegacyBackgroundApiService:checkIsSeedlessPasswordOutdated',
+      ),
       syncPasswordAndUnlockWallet: this.syncPasswordAndUnlockWallet.bind(this),
 
       // subscription
@@ -4421,10 +4423,13 @@ export default class MetamaskController extends EventEmitter {
     let isPasswordOutdated = false;
     if (isSocialLoginFlow) {
       try {
-        isPasswordOutdated = await this.checkIsSeedlessPasswordOutdated({
-          skipCache: false,
-          captureSentryError: true,
-        });
+        isPasswordOutdated =
+          await this.legacyBackgroundApiService.checkIsSeedlessPasswordOutdated(
+            {
+              skipCache: false,
+              captureSentryError: true,
+            },
+          );
       } catch (error) {
         // we don't want to block the unlock flow if the password outdated check fails
         log.error('error while checking if password is outdated', error);
@@ -4510,7 +4515,7 @@ export default class MetamaskController extends EventEmitter {
         await this.syncKeyringEncryptionKey();
 
         // check password outdated again skip cache to reset the cache after successful syncing
-        await this.checkIsSeedlessPasswordOutdated({
+        await this.legacyBackgroundApiService.checkIsSeedlessPasswordOutdated({
           skipCache: true,
           captureSentryError: true,
         });
@@ -4728,45 +4733,6 @@ export default class MetamaskController extends EventEmitter {
     await this.seedlessOnboardingController.storeKeyringEncryptionKey(
       keyringEncryptionKey,
     );
-  }
-
-  /**
-   * Checks if the seedless password is outdated.
-   *
-   * @param {object} args - The arguments for the checkIsSeedlessPasswordOutdated method.
-   * @param {boolean} args.skipCache - whether to skip the cache @default false
-   * @param {boolean} args.captureSentryError - whether to capture the sentry error. @default false
-   * @returns {Promise<boolean | undefined>} true if the password is outdated, false otherwise, undefined if the flow is not seedless
-   */
-  async checkIsSeedlessPasswordOutdated(args) {
-    const skipCache = args?.skipCache || false;
-    const captureSentryError = args?.captureSentryError || false;
-    try {
-      const isSocialLoginFlow =
-        this.onboardingController.getIsSocialLoginFlow();
-      const { completedOnboarding } = this.onboardingController.state;
-
-      if (!isSocialLoginFlow || !completedOnboarding) {
-        // this is only available for seedless onboarding flow and completed onboarding
-        return false;
-      }
-
-      const isPasswordOutdated =
-        await this.seedlessOnboardingController.checkIsPasswordOutdated({
-          skipCache,
-        });
-      return isPasswordOutdated;
-    } catch (error) {
-      if (captureSentryError) {
-        this.controllerMessenger?.captureException?.(
-          createSentryError(
-            'Failed to check if seedless password is outdated',
-            error,
-          ),
-        );
-      }
-      throw error;
-    }
   }
 
   /**

--- a/app/scripts/services/legacy-background-api-service-method-action-types.ts
+++ b/app/scripts/services/legacy-background-api-service-method-action-types.ts
@@ -161,6 +161,19 @@ export type LegacyBackgroundApiServiceGetAccountsBySnapIdAction = {
 };
 
 /**
+ * Checks if the seedless password is outdated.
+ *
+ * @param args - The arguments for the checkIsSeedlessPasswordOutdated method.
+ * @param args.skipCache - whether to skip the cache @default false
+ * @param args.captureSentryError - whether to capture the sentry error. @default false
+ * @returns true if the password is outdated, false otherwise, undefined if the flow is not seedless
+ */
+export type LegacyBackgroundApiServiceCheckIsSeedlessPasswordOutdatedAction = {
+  type: `LegacyBackgroundApiService:checkIsSeedlessPasswordOutdated`;
+  handler: LegacyBackgroundApiService['checkIsSeedlessPasswordOutdated'];
+};
+
+/**
  * Union of all LegacyBackgroundApiService action types.
  */
 export type LegacyBackgroundApiServiceMethodActions =
@@ -178,4 +191,5 @@ export type LegacyBackgroundApiServiceMethodActions =
   | LegacyBackgroundApiServiceRemoveAccountAction
   | LegacyBackgroundApiServiceOnAccountRemovedAction
   | LegacyBackgroundApiServiceImportAccountWithStrategyAction
-  | LegacyBackgroundApiServiceGetAccountsBySnapIdAction;
+  | LegacyBackgroundApiServiceGetAccountsBySnapIdAction
+  | LegacyBackgroundApiServiceCheckIsSeedlessPasswordOutdatedAction;

--- a/app/scripts/services/legacy-background-api-service.test.ts
+++ b/app/scripts/services/legacy-background-api-service.test.ts
@@ -18,6 +18,7 @@ import { SnapId } from '@metamask/snaps-sdk';
 import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
 import mockState from '../../../test/data/mock-state.json';
 import { SMART_TRANSACTION_CONFIRMATION_TYPES } from '../../../shared/constants/app';
+import { createSentryError } from '../../../shared/lib/error';
 import {
   LegacyBackgroundApiService,
   LegacyBackgroundApiServiceMessenger,
@@ -989,6 +990,171 @@ describe('LegacyBackgroundApiService', () => {
       });
     });
   });
+
+  describe('checkIsSeedlessPasswordOutdated', () => {
+    it("returns false if it's a social login flow", async () => {
+      await withService(async ({ rootMessenger }) => {
+        rootMessenger.registerActionHandler(
+          'OnboardingController:getIsSocialLoginFlow',
+          jest.fn().mockReturnValue(true),
+        );
+
+        rootMessenger.registerActionHandler(
+          'OnboardingController:getState',
+          jest.fn().mockReturnValue({ completedOnboarding: false }),
+        );
+
+        const result = await rootMessenger.call(
+          'LegacyBackgroundApiService:checkIsSeedlessPasswordOutdated',
+        );
+
+        expect(result).toStrictEqual(false);
+      });
+    });
+
+    it('returns false if the user has not completed onboarding', async () => {
+      await withService(async ({ rootMessenger }) => {
+        rootMessenger.registerActionHandler(
+          'OnboardingController:getIsSocialLoginFlow',
+          jest.fn().mockReturnValue(false),
+        );
+
+        rootMessenger.registerActionHandler(
+          'OnboardingController:getState',
+          jest.fn().mockReturnValue({ completedOnboarding: false }),
+        );
+
+        const result = await rootMessenger.call(
+          'LegacyBackgroundApiService:checkIsSeedlessPasswordOutdated',
+        );
+
+        expect(result).toStrictEqual(false);
+      });
+    });
+
+    it('returns true if the password is outdated', async () => {
+      await withService(async ({ rootMessenger }) => {
+        rootMessenger.registerActionHandler(
+          'OnboardingController:getIsSocialLoginFlow',
+          jest.fn().mockReturnValue(true),
+        );
+
+        rootMessenger.registerActionHandler(
+          'OnboardingController:getState',
+          jest.fn().mockReturnValue({ completedOnboarding: true }),
+        );
+
+        rootMessenger.registerActionHandler(
+          'SeedlessOnboardingController:checkIsPasswordOutdated',
+          jest.fn().mockResolvedValue(true),
+        );
+
+        const result = await rootMessenger.call(
+          'LegacyBackgroundApiService:checkIsSeedlessPasswordOutdated',
+        );
+
+        expect(result).toStrictEqual(true);
+      });
+    });
+
+    it('returns false if the password is not outdated', async () => {
+      await withService(async ({ rootMessenger }) => {
+        rootMessenger.registerActionHandler(
+          'OnboardingController:getIsSocialLoginFlow',
+          jest.fn().mockReturnValue(true),
+        );
+
+        rootMessenger.registerActionHandler(
+          'OnboardingController:getState',
+          jest.fn().mockReturnValue({ completedOnboarding: true }),
+        );
+
+        rootMessenger.registerActionHandler(
+          'SeedlessOnboardingController:checkIsPasswordOutdated',
+          jest.fn().mockResolvedValue(false),
+        );
+
+        const result = await rootMessenger.call(
+          'LegacyBackgroundApiService:checkIsSeedlessPasswordOutdated',
+        );
+
+        expect(result).toStrictEqual(false);
+      });
+    });
+
+    it('skips the cache if specified', async () => {
+      await withService(async ({ rootMessenger, serviceMessenger }) => {
+        const callSpy = jest.spyOn(serviceMessenger, 'call');
+
+        rootMessenger.registerActionHandler(
+          'OnboardingController:getIsSocialLoginFlow',
+          jest.fn().mockReturnValue(true),
+        );
+
+        rootMessenger.registerActionHandler(
+          'OnboardingController:getState',
+          jest.fn().mockReturnValue({ completedOnboarding: true }),
+        );
+
+        rootMessenger.registerActionHandler(
+          'SeedlessOnboardingController:checkIsPasswordOutdated',
+          jest.fn().mockResolvedValue(false),
+        );
+
+        const result = await rootMessenger.call(
+          'LegacyBackgroundApiService:checkIsSeedlessPasswordOutdated',
+          { skipCache: true },
+        );
+
+        expect(result).toStrictEqual(false);
+
+        expect(callSpy).toHaveBeenCalledWith(
+          'SeedlessOnboardingController:checkIsPasswordOutdated',
+          { skipCache: true },
+        );
+      });
+    });
+
+    it('captures and throws an error', async () => {
+      await withService(async ({ rootMessenger, serviceMessenger }) => {
+        const error = new Error('Test error');
+
+        const captureExceptionSpy = jest.spyOn(
+          serviceMessenger,
+          'captureException',
+        );
+
+        rootMessenger.registerActionHandler(
+          'OnboardingController:getIsSocialLoginFlow',
+          jest.fn().mockReturnValue(true),
+        );
+
+        rootMessenger.registerActionHandler(
+          'OnboardingController:getState',
+          jest.fn().mockReturnValue({ completedOnboarding: true }),
+        );
+
+        rootMessenger.registerActionHandler(
+          'SeedlessOnboardingController:checkIsPasswordOutdated',
+          jest.fn().mockRejectedValue(error),
+        );
+
+        await expect(
+          rootMessenger.call(
+            'LegacyBackgroundApiService:checkIsSeedlessPasswordOutdated',
+            { captureSentryError: true },
+          ),
+        ).rejects.toThrow(error);
+
+        expect(captureExceptionSpy).toHaveBeenCalledWith(
+          createSentryError(
+            'Failed to check if seedless password is outdated',
+            error,
+          ),
+        );
+      });
+    });
+  });
 });
 
 /**
@@ -1074,6 +1240,8 @@ function getMessenger(
       'KeyringController:getKeyringsByType',
       'KeyringController:addNewKeyring',
       'PreferencesController:setPasswordForgotten',
+      'OnboardingController:getState',
+      'SeedlessOnboardingController:checkIsPasswordOutdated',
     ],
   });
 

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -39,6 +39,7 @@ import { BridgeStatusControllerWipeBridgeStatusAction } from '@metamask/bridge-s
 import {
   SecretType,
   SeedlessOnboardingControllerAddNewSecretDataAction,
+  SeedlessOnboardingControllerCheckIsPasswordOutdatedAction,
   SeedlessOnboardingControllerUpdateBackupMetadataStateAction,
 } from '@metamask/seedless-onboarding-controller';
 import { PermissionControllerUpdatePermissionsByCaveatAction } from '@metamask/permission-controller';
@@ -64,6 +65,8 @@ import { OnboardingControllerGetIsSocialLoginFlowAction } from '../controllers/o
 import { getAccountsBySnapId } from '../lib/snap-keyring';
 import { PreferencesControllerSetPasswordForgottenAction } from '../controllers/preferences-controller-method-action-types';
 import { getSnapKeyring } from '../lib/snap-keyring/utils/getSnapKeyring';
+import { OnboardingControllerGetStateAction } from '../controllers/onboarding';
+import { createSentryError } from '../../../shared/lib/error';
 import { LegacyBackgroundApiServiceMethodActions } from './legacy-background-api-service-method-action-types';
 
 const serviceName = 'LegacyBackgroundApiService';
@@ -73,6 +76,7 @@ const serviceName = 'LegacyBackgroundApiService';
  * This is currently empty, but it can be extended in the future to replace `MetaMaskController.getApi()`.
  */
 const MESSENGER_EXPOSED_METHODS = [
+  'checkIsSeedlessPasswordOutdated',
   'getAccountsBySnapId',
   'getCode',
   'getGlobalChainId',
@@ -115,10 +119,12 @@ type AllowedActions =
   | NetworkControllerGetStateAction
   | NetworkControllerResetConnectionAction
   | OnboardingControllerGetIsSocialLoginFlowAction
+  | OnboardingControllerGetStateAction
   | PermissionControllerUpdatePermissionsByCaveatAction
   | PreferencesControllerSetPasswordForgottenAction
   | RemoteFeatureFlagControllerGetStateAction
   | SeedlessOnboardingControllerAddNewSecretDataAction
+  | SeedlessOnboardingControllerCheckIsPasswordOutdatedAction
   | SeedlessOnboardingControllerUpdateBackupMetadataStateAction
   | SmartTransactionsControllerWipeSmartTransactionsAction
   | TransactionControllerGetStateAction
@@ -582,5 +588,50 @@ export class LegacyBackgroundApiService {
       getSnapKeyring.bind(null, this.#messenger),
       snapId,
     );
+  }
+
+  /**
+   * Checks if the seedless password is outdated.
+   *
+   * @param args - The arguments for the checkIsSeedlessPasswordOutdated method.
+   * @param args.skipCache - whether to skip the cache @default false
+   * @param args.captureSentryError - whether to capture the sentry error. @default false
+   * @returns true if the password is outdated, false otherwise, undefined if the flow is not seedless
+   */
+  async checkIsSeedlessPasswordOutdated({
+    skipCache = false,
+    captureSentryError = false,
+  } = {}): Promise<boolean | undefined> {
+    try {
+      const isSocialLoginFlow = this.#messenger.call(
+        'OnboardingController:getIsSocialLoginFlow',
+      );
+      const { completedOnboarding } = this.#messenger.call(
+        'OnboardingController:getState',
+      );
+
+      if (!isSocialLoginFlow || !completedOnboarding) {
+        // this is only available for seedless onboarding flow and completed onboarding
+        return false;
+      }
+
+      const isPasswordOutdated = await this.#messenger.call(
+        'SeedlessOnboardingController:checkIsPasswordOutdated',
+        { skipCache },
+      );
+
+      return isPasswordOutdated;
+    } catch (error) {
+      if (captureSentryError) {
+        this.#messenger.captureException?.(
+          createSentryError(
+            'Failed to check if seedless password is outdated',
+            error,
+          ),
+        );
+      }
+
+      throw error;
+    }
   }
 }

--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -672,17 +672,20 @@ describe('Actions', () => {
         },
       });
 
-      const checkIsSeedlessPasswordOutdated =
-        background.checkIsSeedlessPasswordOutdated.resolves(true);
+      const checkIsSeedlessPasswordOutdatedStub = sinon.stub().resolves(true);
 
-      setBackgroundConnection(background);
+      background.getApi.returns({
+        checkIsSeedlessPasswordOutdated: checkIsSeedlessPasswordOutdatedStub,
+      });
+
+      setBackgroundConnection(background.getApi());
 
       const result = await store.dispatch(
         actions.checkIsSeedlessPasswordOutdated(),
       );
       expect(result).toStrictEqual(true);
-      expect(checkIsSeedlessPasswordOutdated.callCount).toStrictEqual(1);
-      expect(checkIsSeedlessPasswordOutdated.firstCall.args).toStrictEqual([
+      expect(checkIsSeedlessPasswordOutdatedStub.callCount).toStrictEqual(1);
+      expect(checkIsSeedlessPasswordOutdatedStub.firstCall.args).toStrictEqual([
         {
           skipCache: true,
           captureSentryError: true,
@@ -699,16 +702,19 @@ describe('Actions', () => {
         },
       });
 
-      const checkIsSeedlessPasswordOutdated =
-        background.checkIsSeedlessPasswordOutdated.resolves(false);
+      const checkIsSeedlessPasswordOutdatedStub = sinon.stub().resolves(false);
 
-      setBackgroundConnection(background);
+      background.getApi.returns({
+        checkIsSeedlessPasswordOutdated: checkIsSeedlessPasswordOutdatedStub,
+      });
+
+      setBackgroundConnection(background.getApi());
 
       const result = await store.dispatch(
         actions.checkIsSeedlessPasswordOutdated(),
       );
       expect(result).toStrictEqual(false);
-      expect(checkIsSeedlessPasswordOutdated.callCount).toStrictEqual(1);
+      expect(checkIsSeedlessPasswordOutdatedStub.callCount).toStrictEqual(1);
     });
 
     it('passes skipCache and captureSentryError to the background check', async () => {
@@ -720,18 +726,21 @@ describe('Actions', () => {
         },
       });
 
-      const checkIsSeedlessPasswordOutdated =
-        background.checkIsSeedlessPasswordOutdated.resolves(true);
+      const checkIsSeedlessPasswordOutdatedStub = sinon.stub().resolves(true);
 
-      setBackgroundConnection(background);
+      background.getApi.returns({
+        checkIsSeedlessPasswordOutdated: checkIsSeedlessPasswordOutdatedStub,
+      });
+
+      setBackgroundConnection(background.getApi());
 
       const result = await store.dispatch(
         actions.checkIsSeedlessPasswordOutdated(false, false),
       );
 
       expect(result).toStrictEqual(true);
-      expect(checkIsSeedlessPasswordOutdated.callCount).toStrictEqual(1);
-      expect(checkIsSeedlessPasswordOutdated.firstCall.args).toStrictEqual([
+      expect(checkIsSeedlessPasswordOutdatedStub.callCount).toStrictEqual(1);
+      expect(checkIsSeedlessPasswordOutdatedStub.firstCall.args).toStrictEqual([
         {
           skipCache: false,
           captureSentryError: false,
@@ -748,16 +757,21 @@ describe('Actions', () => {
         },
       });
 
-      const checkIsSeedlessPasswordOutdated =
-        background.checkIsSeedlessPasswordOutdated.rejects(new Error('error'));
+      const checkIsSeedlessPasswordOutdatedStub = sinon
+        .stub()
+        .rejects(new Error('error'));
 
-      setBackgroundConnection(background);
+      background.getApi.returns({
+        checkIsSeedlessPasswordOutdated: checkIsSeedlessPasswordOutdatedStub,
+      });
+
+      setBackgroundConnection(background.getApi());
 
       const result = await store.dispatch(
         actions.checkIsSeedlessPasswordOutdated(),
       );
       expect(result).toStrictEqual(false);
-      expect(checkIsSeedlessPasswordOutdated.callCount).toStrictEqual(1);
+      expect(checkIsSeedlessPasswordOutdatedStub.callCount).toStrictEqual(1);
     });
   });
 


### PR DESCRIPTION
## **Description**

This moves `checkIsSeedlessPasswordOutdated` from `MetamaskController` to `LegacyBackgroundApiService`.

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Progresses: https://consensyssoftware.atlassian.net/browse/WPC-957

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior is preserved but the change sits on social-login unlock and password-sync paths, which are security-sensitive.
> 
> **Overview**
> Moves **`checkIsSeedlessPasswordOutdated`** out of **`MetaMaskController`** into **`LegacyBackgroundApiService`**, keeping the same rules (social login + completed onboarding, then **`SeedlessOnboardingController:checkIsPasswordOutdated`**, optional Sentry on failure).
> 
> **`MetaMaskController`** now exposes the check via messenger (`LegacyBackgroundApiService:checkIsSeedlessPasswordOutdated`) and **`syncPasswordAndUnlockWallet`** calls the service instead of a local method. Messenger setup delegates **`OnboardingController:getState`** and **`SeedlessOnboardingController:checkIsPasswordOutdated`**.
> 
> Tests for the check move to **`legacy-background-api-service.test.ts`**; controller tests stub the service; UI store tests stub **`getApi().checkIsSeedlessPasswordOutdated`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7ac50d99ffd86ca7595d4518ea0366f73cf04053. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->