### PR TITLE
fix: show fallback token icons in confirmation rows

### DIFF
--- a/ui/hooks/useDisplayName.test.ts
+++ b/ui/hooks/useDisplayName.test.ts
@@ -7,6 +7,7 @@ import {
   FIRST_PARTY_CONTRACT_NAMES,
 } from '../../shared/constants/first-party-contracts';
 import { buildEvmCaip19AssetId } from '../../shared/lib/multichain/buildEvmCaip19AssetId';
+import { getAssetImageUrl } from '../../shared/lib/asset-utils';
 import mockState from '../../test/data/mock-state.json';
 import { renderHookWithProvider } from '../../test/lib/render-helpers-navigate';
 import { getDomainResolutions } from '../ducks/domains';
@@ -236,6 +237,28 @@ describe('useDisplayName', () => {
         icon: null,
         subtitle: null,
       });
+    });
+
+    it('derives the token icon URL when the API omits iconUrl', () => {
+      const ADDRESS = '0xaca92e438df0b2401ff60da7e4337b687a2435da';
+      const CHAIN_ID = CHAIN_IDS.MAINNET;
+
+      mockERC20Token(ADDRESS, CHAIN_ID, ERC20_TOKEN_NAME_MOCK, SYMBOL_MOCK, '');
+
+      const { result } = renderHookWithProvider(
+        () =>
+          useDisplayName({
+            value: ADDRESS,
+            type: NameType.ETHEREUM_ADDRESS,
+            variation: CHAIN_ID,
+          }),
+        state,
+      );
+
+      expect(result.current.image).toBe(getAssetImageUrl(ADDRESS, CHAIN_ID));
+      expect(result.current.image).toBe(
+        `https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/${ADDRESS}.png`,
+      );
     });
 
     it('returns ERC-20 token symbol', () => {

--- a/ui/hooks/useDisplayName.ts
+++ b/ui/hooks/useDisplayName.ts
@@ -17,6 +17,7 @@ import {
   getAccountTree,
 } from '../selectors/multichain-accounts/account-tree';
 import { buildEvmCaip19AssetId } from '../../shared/lib/multichain/buildEvmCaip19AssetId';
+import { getAssetImageUrl } from '../../shared/lib/asset-utils';
 import { useNames } from './useName';
 import { TrustSignalDisplayState, useTrustSignals } from './useTrustSignals';
 import { useTokensData } from './useTokensData';
@@ -146,7 +147,16 @@ function useERC20Tokens(
       const name =
         preferContractSymbol && token?.symbol ? token.symbol : token?.name;
 
-      return { name, image: token?.iconUrl };
+      // The token API omits `iconUrl` for some recognized tokens (e.g. mUSD)
+      // even though the canonical icon exists, so derive it from the address.
+      const image =
+        token &&
+        (token.iconUrl ||
+          (isStrictHexString(variation)
+            ? getAssetImageUrl(value as Hex, variation as Hex)
+            : undefined));
+
+      return { name, image: image || undefined };
     },
   );
 }

--- a/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
@@ -181,6 +181,20 @@ describe('PayWithRow', () => {
     expect(screen.getByTestId('pay-with-symbol')).toHaveTextContent('ETH');
   });
 
+  it('renders the receive token fallback icon when metadata is missing', () => {
+    useSendTokensMock.mockReturnValue([]);
+
+    const store = mockStore(getMockState());
+    const { container } = renderWithProvider(<PayWithRow />, store);
+
+    const img = container.querySelector('.mm-avatar-token img');
+    expect(img).toHaveAttribute(
+      'src',
+      `https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/${ADDRESS_MOCK}.png`,
+    );
+    expect(img).toHaveAttribute('alt', 'ETH logo');
+  });
+
   it('opens modal when clicked', () => {
     const store = mockStore(getMockState());
     renderWithProvider(<PayWithRow />, store);

--- a/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -208,6 +208,7 @@ function PayWithRowInline({
           <TokenIcon
             chainId={displayToken.chainId as `0x${string}`}
             tokenAddress={displayToken.address as `0x${string}`}
+            symbol={displayToken.symbol}
             size="xs"
           />
         </Box>
@@ -256,6 +257,7 @@ function PayWithRowPill({
       <TokenIcon
         chainId={displayToken.chainId as `0x${string}`}
         tokenAddress={displayToken.address as `0x${string}`}
+        symbol={displayToken.symbol}
       />
       <Text
         variant={TextVariant.bodyMdMedium}

--- a/ui/pages/confirmations/components/token-icon/token-icon.test.tsx
+++ b/ui/pages/confirmations/components/token-icon/token-icon.test.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import { render } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureStore from 'redux-mock-store';
+import type { Hex } from '@metamask/utils';
+import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { useSendTokens } from '../../hooks/send/useSendTokens';
 import { TokenIcon } from './token-icon';
 
@@ -13,6 +15,12 @@ const CHAIN_ID_MOCK = '0x1';
 const TOKEN_ADDRESS_MOCK = '0xdac17f958d2ee523a2206206994597c13d831ec7';
 const TOKEN_SYMBOL_MOCK = 'USDT';
 const TOKEN_IMAGE_MOCK = 'https://example.com/token.png';
+const MISSING_ADDRESS_MOCK = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+const SUPPORTED_CHAIN_ICON_CASES: [string, Hex, string][] = [
+  ['mainnet', '0x1', '1'],
+  ['Linea', '0xe708', '59144'],
+  ['BSC', '0x38', '56'],
+];
 
 function renderTokenIcon(props = {}) {
   const store = mockStore({
@@ -93,5 +101,70 @@ describe('TokenIcon', () => {
     renderTokenIcon();
 
     expect(useSendTokensMock).toHaveBeenCalledWith({ includeNoBalance: true });
+  });
+
+  it('renders the token icon URL fallback when token metadata is missing', () => {
+    useSendTokensMock.mockReturnValue([]);
+
+    const { container } = renderTokenIcon({
+      tokenAddress: MISSING_ADDRESS_MOCK,
+      symbol: 'ABC',
+    });
+
+    const img = container.querySelector('.mm-avatar-token img');
+    expect(img).toHaveAttribute(
+      'src',
+      `https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/${MISSING_ADDRESS_MOCK}.png`,
+    );
+    expect(img).toHaveAttribute('alt', 'ABC logo');
+  });
+
+  it('falls back to the token icon URL when the matched token image is empty', () => {
+    useSendTokensMock.mockReturnValue([
+      {
+        address: TOKEN_ADDRESS_MOCK,
+        chainId: CHAIN_ID_MOCK,
+        symbol: TOKEN_SYMBOL_MOCK,
+        image: '',
+      },
+    ]);
+
+    const { container } = renderTokenIcon();
+
+    expect(container.querySelector('.mm-avatar-token img')).toHaveAttribute(
+      'src',
+      `https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/1/erc20/${TOKEN_ADDRESS_MOCK}.png`,
+    );
+  });
+
+  SUPPORTED_CHAIN_ICON_CASES.forEach(
+    ([networkName, chainId, decimalChainId]) => {
+      it(`renders the token icon URL fallback for ${networkName} when token metadata is missing`, () => {
+        useSendTokensMock.mockReturnValue([]);
+
+        const { container } = renderTokenIcon({
+          chainId,
+          tokenAddress: MISSING_ADDRESS_MOCK,
+          symbol: 'ABC',
+        });
+
+        expect(container.querySelector('.mm-avatar-token img')).toHaveAttribute(
+          'src',
+          `https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/${decimalChainId}/erc20/${MISSING_ADDRESS_MOCK}.png`,
+        );
+      });
+    },
+  );
+
+  it('does not use the URL fallback for the native token address', () => {
+    useSendTokensMock.mockReturnValue([]);
+
+    const { container } = renderTokenIcon({
+      tokenAddress: getNativeTokenAddress(CHAIN_ID_MOCK),
+      symbol: 'ETH',
+    });
+
+    expect(container.querySelector('.mm-avatar-token img')).toBeNull();
+    expect(container.querySelector('.mm-avatar-token')).toHaveTextContent('E');
   });
 });

--- a/ui/pages/confirmations/components/token-icon/token-icon.tsx
+++ b/ui/pages/confirmations/components/token-icon/token-icon.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
+import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import type { Hex } from '@metamask/utils';
 import { CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP } from '../../../../../shared/constants/network';
 import {
@@ -13,6 +14,7 @@ import {
   selectNetworkConfigurationByChainId,
   type NetworkConfigurationsByChainIdState,
 } from '../../../../../shared/lib/selectors/networks';
+import { getAssetImageUrl } from '../../../../../shared/lib/asset-utils';
 import { useSendTokens } from '../../hooks/send/useSendTokens';
 
 export type TokenIconSize = 'xs' | 'sm' | 'md';
@@ -20,6 +22,7 @@ export type TokenIconSize = 'xs' | 'sm' | 'md';
 export type TokenIconProps = {
   chainId: Hex;
   tokenAddress: Hex;
+  symbol?: string;
   size?: TokenIconSize;
 };
 
@@ -45,6 +48,7 @@ const NETWORK_BADGE_STYLE_MAP: Record<TokenIconSize, React.CSSProperties> = {
 export function TokenIcon({
   chainId,
   tokenAddress,
+  symbol: symbolProp,
   size = 'md',
 }: TokenIconProps) {
   const sendTokens = useSendTokens({ includeNoBalance: true });
@@ -62,6 +66,12 @@ export function TokenIcon({
     );
   }, [tokenAddress, chainId, sendTokens]);
 
+  const symbol = matchedToken?.symbol ?? symbolProp;
+  // The token list / token API often omits the icon for some tokens (e.g. mUSD)
+  // even though the canonical icon exists at the deterministic URL, so fall back
+  // when the matched image is missing or empty.
+  const src = matchedToken?.image || getTokenIconUrl(tokenAddress, chainId);
+
   return (
     <BadgeWrapper
       badge={
@@ -75,10 +85,20 @@ export function TokenIcon({
     >
       <AvatarToken
         size={TOKEN_ICON_SIZE_MAP[size]}
-        src={matchedToken?.image}
-        name={matchedToken?.symbol}
+        src={src}
+        name={symbol}
         showHalo={false}
       />
     </BadgeWrapper>
   );
+}
+
+function getTokenIconUrl(tokenAddress: Hex, chainId: Hex) {
+  if (
+    tokenAddress?.toLowerCase() === getNativeTokenAddress(chainId).toLowerCase()
+  ) {
+    return undefined;
+  }
+
+  return getAssetImageUrl(tokenAddress, chainId);
 }


### PR DESCRIPTION
## **Description**

Fixes missing token icons in confirmation flows when token metadata is unavailable from the tokens API. The MetaMask tokens API omits `iconUrl` for some recognized tokens (e.g. mUSD) even though the canonical icon exists at the deterministic static URL, so any UI relying on the API's `iconUrl` (or the locally cached token `image`) rendered a placeholder.

This change derives the icon URL from the token's address and chain when the resolved image is missing or empty:

- Confirmation `TokenIcon` (the "Pay with" / "Receive" pill used in Perps/Predict deposit & withdraw custom-amount confirmations) now falls back to the derived icon URL, and also treats an empty-string image as missing.
- `Name`-based simulation rows ("You approve / You send / You receive") now derive the icon URL for recognized ERC-20 tokens when the API omits `iconUrl`.

Similar fallback PR for mobile that was merged: https://github.com/MetaMask/metamask-mobile/pull/30502

## **Changelog**

CHANGELOG entry: Fixed missing token icons (e.g. mUSD) in transaction confirmation rows and estimated changes.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1448

## **Manual testing steps**

~~~gherkin
Feature: Confirmation token icon fallback

  Scenario: Perps withdraw receive token
    Given the user has an mUSD balance
    When the user starts a Perps withdraw flow
    Then the mUSD icon is shown in the "Receive" row instead of a placeholder

  Scenario: Swap simulation rows
    Given the user swaps mUSD to USDC via a dapp (e.g. Uniswap)
    When the Transaction request screen shows the estimated changes
    Then the mUSD icon is shown in the "You approve" and "You send" rows
~~~

## **Screenshots/Recordings**

### **Before**

<!-- mUSD rows showed a placeholder/blockie instead of the token icon -->

### **After**
<img width="397" height="605" alt="image" src="https://github.com/user-attachments/assets/23e69ac5-fbcd-4114-8570-46bec6433bbb" />

<img width="393" height="334" alt="image" src="https://github.com/user-attachments/assets/6fa158ca-125c-4c1f-8149-b35149542df6" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only fallback URLs with existing getAssetImageUrl; no auth, transaction, or payment logic changes.
> 
> **Overview**
> When token metadata omits or clears the icon (e.g. mUSD), confirmation UI now shows the **canonical static token icon** built from **address + chain** instead of a placeholder.
> 
> **`TokenIcon`** uses `getAssetImageUrl` when the send-token list has no image or an empty string, accepts an optional **`symbol`** for alt/initials when metadata is missing, and **skips** that URL for the **native** token address so ETH still uses letter avatars. **`PayWithRow`** passes **`symbol`** into **`TokenIcon`**.
> 
> **`useDisplayName`** applies the same fallback for recognized ERC-20 rows (simulation “You approve / send / receive”) when **`iconUrl`** is absent. Tests cover missing metadata, empty images, multiple chains, and native-token behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc0a5de69a8cee4a70f712a24bf9181055b5432d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->