### PR TITLE
chore: bump @metamask/bitcoin-wallet-snap to ^1.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -339,7 +339,7 @@
     "@metamask/assets-controller": "^8.3.1",
     "@metamask/assets-controllers": "^108.3.0",
     "@metamask/base-controller": "^9.0.1",
-    "@metamask/bitcoin-wallet-snap": "^1.11.0",
+    "@metamask/bitcoin-wallet-snap": "^1.12.0",
     "@metamask/bridge-controller": "^72.0.0",
     "@metamask/bridge-status-controller": "^71.2.0",
     "@metamask/browser-passworder": "^6.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6040,10 +6040,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bitcoin-wallet-snap@npm:^1.11.0":
-  version: 1.11.0
-  resolution: "@metamask/bitcoin-wallet-snap@npm:1.11.0"
-  checksum: 10/1784489c84fddeff9d89bd71fdd50ffd204ca2cb58a257181dfa25afd6f0650013e0620cb9fc294f8962f0b225a032ee5c08f7f4392f2e7f2721ccf624e28237
+"@metamask/bitcoin-wallet-snap@npm:^1.12.0":
+  version: 1.12.0
+  resolution: "@metamask/bitcoin-wallet-snap@npm:1.12.0"
+  checksum: 10/ff8fd75953ddcb376c60381cca9e80a30d0c42a7f53bfb3da7f91bc4039456d0f5ec3cfe1dec0d5571e849c284c51a540cb4f05556bc5a86c57e6886464f5ed1
   languageName: node
   linkType: hard
 
@@ -33416,7 +33416,7 @@ __metadata:
     "@metamask/assets-controllers": "npm:^108.3.0"
     "@metamask/auto-changelog": "npm:^5.3.1"
     "@metamask/base-controller": "npm:^9.0.1"
-    "@metamask/bitcoin-wallet-snap": "npm:^1.11.0"
+    "@metamask/bitcoin-wallet-snap": "npm:^1.12.0"
     "@metamask/bridge-controller": "npm:^72.0.0"
     "@metamask/bridge-status-controller": "npm:^71.2.0"
     "@metamask/browser-passworder": "npm:^6.0.0"


### PR DESCRIPTION
## **Description**

Bumps the bundled Bitcoin wallet Snap (`@metamask/bitcoin-wallet-snap`) from `1.11.0` to `1.12.0` by updating the dependency in `package.json` and refreshing `yarn.lock`. There are no extension source changes — only the dependency resolution and checksum for the new Snap release.

The `1.12.0` Snap release includes: a self-send warning in the send confirmation, the filled PSBT shown in the `signPsbt` confirmation dialog, and the new `createMany` account use case.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Build and run the extension with this branch.
2. Add/import a Bitcoin account and confirm the BTC wallet loads.
3. Start a send and verify the confirmation renders (incl. self-send warning when sending to your own address).

## **Screenshots/Recordings**

N/A — dependency bump only, no UI changes in this repo.

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the preinstalled Bitcoin wallet snap that handles signing and confirmations; risk is moderate because send/PSBT/account flows change in the snap, though the extension diff itself is minimal.
> 
> **Overview**
> Bumps the bundled preinstalled **`@metamask/bitcoin-wallet-snap`** from **1.11.0** to **1.12.0** in `package.json` and `yarn.lock` only—no extension application code changes. The extension still loads the snap via `preinstalled-snap.json` from that package (e.g. `app/scripts/constants/snaps.ts`).
> 
> Behavior shipped in **1.12.0** lives inside the snap release: a **self-send warning** on send confirmation, the **filled PSBT** in the `signPsbt` confirmation UI, and a new **`createMany`** account use case. Manual testing should cover Bitcoin account flows and send/`signPsbt` confirmations after rebuild.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b21e0224ac4fb30769a77c5453baeebcce7b48b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->