### PR TITLE
fix: #42683: [Bug]: When global balance is hidden, the Perps balance is still displayed

### DIFF
--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx
@@ -234,6 +234,26 @@ describe('PerpsBalanceDropdown', () => {
     expect(screen.queryByText(/1\.00%/u)).not.toBeInTheDocument();
   });
 
+  it('hides balance and P&L when privacyMode is true', () => {
+    const privacyModeStore = configureStore({
+      metamask: {
+        ...mockState.metamask,
+        preferences: {
+          ...mockState.metamask.preferences,
+          privacyMode: true,
+        },
+      },
+    });
+
+    renderWithProvider(
+      <PerpsBalanceDropdown hasPositions />,
+      privacyModeStore,
+    );
+
+    expect(screen.queryByText('$15,250')).not.toBeInTheDocument();
+    expect(screen.queryByText(/\+\$375/u)).not.toBeInTheDocument();
+  });
+
   describe('geo-blocking', () => {
     it('shows geo-block modal and does not call onAddFunds when user is not eligible', () => {
       mockUsePerpsEligibility.mockReturnValue({ isEligible: false });

--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
 import {
   twMerge,
   TextVariant,
@@ -24,6 +25,11 @@ import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { useFormatters } from '../../../../hooks/useFormatters';
 import { usePerpsEligibility } from '../../../../hooks/perps';
 import { usePerpsLiveAccount } from '../../../../hooks/perps/stream';
+import {
+  SensitiveText,
+  SensitiveTextLength,
+} from '../../../component-library';
+import { getPrivacyMode } from '../../../../selectors';
 import { PerpsGeoBlockModal } from '../perps-geo-block-modal';
 import { PerpsControlBarSkeleton } from '../perps-skeletons';
 
@@ -76,6 +82,7 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
   const { account, isInitialLoading } = usePerpsLiveAccount();
   const { formatPercentWithMinThreshold } = useFormatters();
   const { isEligible } = usePerpsEligibility();
+  const privacyMode = useSelector(getPrivacyMode);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isGeoBlockModalOpen, setIsGeoBlockModalOpen] = useState(false);
 
@@ -179,11 +186,16 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
               alignItems={BoxAlignItems.Center}
               gap={2}
             >
-              <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
+              <SensitiveText
+                variant={TextVariant.BodySm}
+                fontWeight={FontWeight.Medium}
+                isHidden={privacyMode}
+                length={SensitiveTextLength.Medium}
+              >
                 {formatPerpsFiat(accountValue, {
                   ranges: PRICE_RANGES_MINIMAL_VIEW,
                 })}
-              </Text>
+              </SensitiveText>
               <Icon
                 name={isDropdownOpen ? IconName.ArrowUp : IconName.ArrowDown}
                 size={IconSize.Xs}
@@ -235,13 +247,15 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
           <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
             {t('perpsUnrealizedPnl')}
           </Text>
-          <Text
+          <SensitiveText
             variant={TextVariant.BodySm}
             fontWeight={FontWeight.Medium}
             color={isProfit ? TextColor.SuccessDefault : TextColor.ErrorDefault}
+            isHidden={privacyMode}
+            length={SensitiveTextLength.Medium}
           >
             {formattedPnl} ({formattedRoe})
-          </Text>
+          </SensitiveText>
         </Box>
       )}
       <PerpsGeoBlockModal


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When a user hides their global balance by clicking the eye icon, the Perps tab continued to show the total balance and unrealised P&L in plain text. The root cause was that `PerpsBalanceDropdown` rendered both money values with ordinary `Text` components and never read the `privacyMode` preference from the Redux store.

The fix adds `useSelector(getPrivacyMode)` to the component and replaces the two `Text` nodes that render `accountValue` and `formattedPnl / formattedRoe` with `SensitiveText isHidden={privacyMode}`, following the same pattern used in `defi-details-page.tsx`. When `privacyMode` is true, `SensitiveText` renders a row of asterisks instead of the numeric value, consistent with behaviour everywhere else in the extension and on mobile.

## **Changelog**

CHANGELOG entry: Fixed Perps balance and unrealised P&L being visible when global balance is hidden

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/42683

## **Manual testing steps**

1. Install the extension locally and unlock your wallet.
2. Click the balance amount on the home screen to enable privacy mode (eye icon turns off, balances show asterisks).
3. Navigate to the Perps tab.
4. Confirm the total balance field and the unrealised P&L / RoE field both display asterisks instead of dollar amounts.
5. Click the balance amount again to disable privacy mode.
6. Confirm the Perps balance and P&L values are now visible again.
7. Run the unit tests for the changed component: `yarn jest ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.