### PR TITLE
feat(deep-links): add QR code support for prediction markets and rewards

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -3081,6 +3081,12 @@
   "decryptRequest": {
     "message": "Decrypt request"
   },
+  "deepLinkQrPredictDescription": {
+    "message": "To access MetaMask Prediction Markets, scan the QR code with your mobile device."
+  },
+  "deepLinkQrPredictTitle": {
+    "message": "Open Prediction Markets on mobile"
+  },
   "deepLink_Caution": {
     "message": "Proceed with caution"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -3081,6 +3081,12 @@
   "decryptRequest": {
     "message": "Decrypt request"
   },
+  "deepLinkQrPredictDescription": {
+    "message": "To access MetaMask Prediction Markets, scan the QR code with your mobile device."
+  },
+  "deepLinkQrPredictTitle": {
+    "message": "Open Prediction Markets on mobile"
+  },
   "deepLink_Caution": {
     "message": "Proceed with caution"
   },

--- a/shared/lib/deep-links/parse.test.ts
+++ b/shared/lib/deep-links/parse.test.ts
@@ -2,7 +2,7 @@ import log from 'loglevel';
 import { parse } from './parse';
 import { VALID, INVALID, MISSING, verify } from './verify';
 import { type Route, routes } from './routes';
-import { SIG_PARAM } from './constants';
+import { SIG_PARAM, SIG_PARAMS_PARAM } from './constants';
 
 const mockVerify = verify as jest.MockedFunction<typeof verify>;
 const mockRoutes = routes as jest.Mocked<Map<string, Route>>;
@@ -190,6 +190,27 @@ describe('parse', () => {
     // because it is not listed in `sig_params`
     expect(mockHandler).toHaveBeenCalledWith(
       new URLSearchParams([['value', '123']]),
+    );
+  });
+
+  it('passes original query parameters to routes that opt in', async () => {
+    mockRoutes.set('/test', {
+      handler: mockHandler,
+      handlerSearchParams: 'original',
+    } as unknown as Route);
+    mockVerify.mockResolvedValue(VALID);
+
+    const urlStr =
+      `https://example.com/test?marketId=30615&${SIG_PARAMS_PARAM}=marketId` +
+      `&${SIG_PARAM}=signature&utm_source=twitter&_hsenc=value&attributionId=attr`;
+
+    await parse(new URL(urlStr));
+
+    expect(mockHandler).toHaveBeenCalledWith(
+      new URLSearchParams(
+        `marketId=30615&${SIG_PARAMS_PARAM}=marketId&${SIG_PARAM}=signature` +
+          '&utm_source=twitter&_hsenc=value&attributionId=attr',
+      ),
     );
   });
 });

--- a/shared/lib/deep-links/parse.ts
+++ b/shared/lib/deep-links/parse.ts
@@ -36,10 +36,17 @@ export async function parse<Options extends ParseOptions = { verify: true }>(
   let destination: Destination;
   try {
     const canonicalUrl = new URL(canonicalize(url));
+    const canonicalSearchParams = new URLSearchParams(canonicalUrl.searchParams);
     // canonicalize does not remove sig_params, as it is needed for verification
-    // but we do not want to pass it to the route handler, so we remove it
-    canonicalUrl.searchParams.delete(SIG_PARAMS_PARAM);
-    destination = route.handler(canonicalUrl.searchParams);
+    // but canonical route handlers should not receive it.
+    canonicalSearchParams.delete(SIG_PARAMS_PARAM);
+
+    const handlerSearchParams =
+      route.handlerSearchParams === 'original'
+        ? new URLSearchParams(url.searchParams)
+        : canonicalSearchParams;
+
+    destination = route.handler(handlerSearchParams);
   } catch (error) {
     // tab may have closed in the meantime, the searchParams may have
     // been rejected by the handler, etc.

--- a/shared/lib/deep-links/parse.ts
+++ b/shared/lib/deep-links/parse.ts
@@ -36,7 +36,9 @@ export async function parse<Options extends ParseOptions = { verify: true }>(
   let destination: Destination;
   try {
     const canonicalUrl = new URL(canonicalize(url));
-    const canonicalSearchParams = new URLSearchParams(canonicalUrl.searchParams);
+    const canonicalSearchParams = new URLSearchParams(
+      canonicalUrl.searchParams,
+    );
     // canonicalize does not remove sig_params, as it is needed for verification
     // but canonical route handlers should not receive it.
     canonicalSearchParams.delete(SIG_PARAMS_PARAM);

--- a/shared/lib/deep-links/routes/home.ts
+++ b/shared/lib/deep-links/routes/home.ts
@@ -1,7 +1,22 @@
+import { DEEP_LINK_HOST } from '../constants';
 import { DEFAULT_ROUTE, Route } from './route';
+import type { Destination } from './route';
+
+export const DEEP_LINK_ORIGIN = `https://${DEEP_LINK_HOST}`;
 
 export enum HomeQueryParams {
   OpenNetworkSelector = 'openNetworkSelector',
+  PredictDeeplinkUrl = 'predictDeeplinkUrl',
+}
+
+export function createHomeQrCodeDestination(
+  queryParam: HomeQueryParams.PredictDeeplinkUrl,
+  deeplinkUrl: string,
+): Destination {
+  return {
+    path: DEFAULT_ROUTE,
+    query: new URLSearchParams({ [queryParam]: deeplinkUrl }),
+  };
 }
 
 export const home = new Route({

--- a/shared/lib/deep-links/routes/predict.test.ts
+++ b/shared/lib/deep-links/routes/predict.test.ts
@@ -1,0 +1,27 @@
+import { predict } from './predict';
+import { HomeQueryParams } from './home';
+import { DEFAULT_ROUTE } from './route';
+
+describe('predict deep link route', () => {
+  it('uses original query parameters in the QR deeplink', () => {
+    expect(predict.handlerSearchParams).toBe('original');
+  });
+
+  it('opens the default route with QR modal params and preserves every query parameter in the encoded deeplink', () => {
+    const params = new URLSearchParams(
+      'marketId=30615&sig_params=marketId&sig=signature&utm_source=twitter&_hsenc=value&attributionId=attr',
+    );
+
+    const destination = predict.handler(params);
+
+    expect(destination).toHaveProperty('path');
+    expect((destination as { path: string }).path).toBe(DEFAULT_ROUTE);
+    expect(
+      (destination as { query: URLSearchParams }).query.get(
+        HomeQueryParams.PredictDeeplinkUrl,
+      ),
+    ).toBe(
+      'https://link.metamask.io/predict?marketId=30615&sig_params=marketId&sig=signature&utm_source=twitter&_hsenc=value&attributionId=attr',
+    );
+  });
+});

--- a/shared/lib/deep-links/routes/predict.ts
+++ b/shared/lib/deep-links/routes/predict.ts
@@ -1,14 +1,21 @@
-import { BaseUrl } from '../../../constants/urls';
+import {
+  DEEP_LINK_ORIGIN,
+  createHomeQrCodeDestination,
+  HomeQueryParams,
+} from './home';
 import { Route } from './route';
 
 export const predict = new Route({
   pathname: '/predict',
   getTitle: (_: URLSearchParams) => 'deepLink_thePredictPage',
+  handlerSearchParams: 'original',
   handler: function handler(params: URLSearchParams) {
-    const predictUrl = new URL('/prediction-markets', BaseUrl.MetaMask);
-    params.forEach((value, key) => predictUrl.searchParams.append(key, value));
-    return {
-      redirectTo: predictUrl,
-    };
+    const deeplinkUrl = new URL('/predict', DEEP_LINK_ORIGIN);
+    params.forEach((value, key) => deeplinkUrl.searchParams.append(key, value));
+
+    return createHomeQrCodeDestination(
+      HomeQueryParams.PredictDeeplinkUrl,
+      deeplinkUrl.toString(),
+    );
   },
 });

--- a/shared/lib/deep-links/routes/rewards.test.ts
+++ b/shared/lib/deep-links/routes/rewards.test.ts
@@ -1,0 +1,27 @@
+import { rewards } from './rewards';
+
+describe('rewards deep link route', () => {
+  it('has the correct pathname', () => {
+    expect(rewards.pathname).toBe('/rewards');
+  });
+
+  it('returns the correct title key', () => {
+    expect(rewards.getTitle(new URLSearchParams())).toBe(
+      'deepLink_theRewardsPage',
+    );
+  });
+
+  it('returns the /rewards route and preserves query parameters', () => {
+    const params = new URLSearchParams(
+      'referral=ABC123&sig_params=referral&sig=signature&utm_source=twitter&_hsenc=value&attributionId=attr',
+    );
+
+    const destination = rewards.handler(params);
+
+    expect(destination).toHaveProperty('path');
+    expect((destination as { path: string }).path).toBe('/rewards');
+    expect((destination as { query: URLSearchParams }).query.toString()).toBe(
+      params.toString(),
+    );
+  });
+});

--- a/shared/lib/deep-links/routes/route.test.ts
+++ b/shared/lib/deep-links/routes/route.test.ts
@@ -33,6 +33,15 @@ describe('Route', () => {
     expect(route.handler).toBe(mockHandler);
   });
 
+  it('defaults handlerSearchParams to canonical', () => {
+    expect(route.handlerSearchParams).toBe('canonical');
+  });
+
+  it('assigns handlerSearchParams from options', () => {
+    route = new Route({ ...options, handlerSearchParams: 'original' });
+    expect(route.handlerSearchParams).toBe('original');
+  });
+
   it('should call getTitle with URLSearchParams', () => {
     const params = new URLSearchParams({ foo: 'bar' });
     route.getTitle(params);

--- a/shared/lib/deep-links/routes/route.ts
+++ b/shared/lib/deep-links/routes/route.ts
@@ -31,6 +31,8 @@ export type Destination =
       redirectTo: URL;
     };
 
+export type HandlerSearchParams = 'canonical' | 'original';
+
 export type RouteOptions = {
   /**
    * The pathname of the route.
@@ -48,6 +50,11 @@ export type RouteOptions = {
    * @throws if the handler fails to process the params
    */
   handler: (params: URLSearchParams) => Destination;
+  /**
+   * Controls which search params are passed to the route handler.
+   * Defaults to canonical params, which removes unsigned params for signed links.
+   */
+  handlerSearchParams?: HandlerSearchParams;
 };
 
 export const SWAP_ROUTE = `${CROSS_CHAIN_SWAP_ROUTE}${PREPARE_SWAP_ROUTE}`;
@@ -73,9 +80,15 @@ export class Route {
    */
   public readonly handler: RouteOptions['handler'];
 
+  /**
+   * @see {@link RouteOptions.handlerSearchParams}
+   */
+  public readonly handlerSearchParams: HandlerSearchParams;
+
   constructor(options: RouteOptions) {
     this.pathname = options.pathname.toLowerCase();
     this.getTitle = options.getTitle;
     this.handler = options.handler;
+    this.handlerSearchParams = options.handlerSearchParams ?? 'canonical';
   }
 }

--- a/shared/lib/deep-links/utils.test.ts
+++ b/shared/lib/deep-links/utils.test.ts
@@ -1,4 +1,7 @@
-import { getDeferredDeepLinkRoute, buildInterstitialRoute } from './utils';
+import {
+  getDeferredDeepLinkRoute,
+  buildInterstitialRoute,
+} from './utils';
 import { DeferredDeepLinkRouteType } from './types';
 import * as parseModule from './parse';
 import { VALID, MISSING, INVALID } from './verify';

--- a/shared/lib/deep-links/utils.test.ts
+++ b/shared/lib/deep-links/utils.test.ts
@@ -1,7 +1,4 @@
-import {
-  getDeferredDeepLinkRoute,
-  buildInterstitialRoute,
-} from './utils';
+import { getDeferredDeepLinkRoute, buildInterstitialRoute } from './utils';
 import { DeferredDeepLinkRouteType } from './types';
 import * as parseModule from './parse';
 import { VALID, MISSING, INVALID } from './verify';

--- a/test/e2e/tests/deep-link/helpers.ts
+++ b/test/e2e/tests/deep-link/helpers.ts
@@ -312,10 +312,6 @@ export const mockRewardsApi = async (server: Mockttp): Promise<void> => {
 export const REDIRECT_ROUTES = [
   { route: '/buy', expectedUrl: `${BaseUrl.Portfolio}/buy` },
   { route: '/card-onboarding', expectedUrl: `${BaseUrl.MetaMask}/card` },
-  {
-    route: '/predict',
-    expectedUrl: `${BaseUrl.MetaMask}/prediction-markets`,
-  },
 ] as const;
 
 export function getHashParams(url: URL) {

--- a/ui/components/app/deeplink-qr-code/deeplink-qr-code.tsx
+++ b/ui/components/app/deeplink-qr-code/deeplink-qr-code.tsx
@@ -1,0 +1,83 @@
+import React, { useMemo } from 'react';
+import {
+  Box,
+  Text,
+  TextVariant,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '@metamask/design-system-react';
+import qrCode from 'qrcode-generator';
+import { ModalBody } from '../../component-library/modal-body/modal-body';
+
+export type DeeplinkQRCodeProps = {
+  title: string;
+  description: string;
+  data: string;
+  onDone: () => void;
+  doneLabel: string;
+  testId: string;
+};
+
+export const QRCodeImage = ({ data }: { data: string }) => {
+  const qrMarkup = useMemo(() => {
+    const qrImage = qrCode(0, 'M');
+    qrImage.addData(data);
+    qrImage.make();
+    return qrImage.createTableTag(5, 16);
+  }, [data]);
+
+  return (
+    <Box className="qr-code__wrapper my-2">
+      <Box
+        data-testid="qr-code-image"
+        className="qr-code__image"
+        dangerouslySetInnerHTML={{
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          __html: qrMarkup,
+        }}
+      />
+      <Box className="qr-code__logo">
+        <img src="images/logo/metamask-fox.svg" alt="Logo" />
+      </Box>
+    </Box>
+  );
+};
+
+export function DeeplinkQRCode({
+  title,
+  description,
+  data,
+  onDone,
+  doneLabel,
+  testId,
+}: DeeplinkQRCodeProps) {
+  return (
+    <ModalBody
+      className="w-full h-full pt-8 pb-4 flex flex-col"
+      data-testid={testId}
+    >
+      <Box className="flex flex-1 flex-col items-center justify-center gap-4">
+        <Text variant={TextVariant.HeadingSm} className="text-center">
+          {title}
+        </Text>
+        <Text
+          variant={TextVariant.BodyMd}
+          className="text-center text-alternative"
+        >
+          {description}
+        </Text>
+        <QRCodeImage data={data} />
+        <Button
+          variant={ButtonVariant.Primary}
+          size={ButtonSize.Lg}
+          onClick={onDone}
+          className="w-full my-2"
+        >
+          {doneLabel}
+        </Button>
+      </Box>
+    </ModalBody>
+  );
+}

--- a/ui/components/app/deeplink-qr-code/index.ts
+++ b/ui/components/app/deeplink-qr-code/index.ts
@@ -1,0 +1,2 @@
+export { DeeplinkQRCode, QRCodeImage } from './deeplink-qr-code';
+export type { DeeplinkQRCodeProps } from './deeplink-qr-code';

--- a/ui/components/app/rewards/RewardsQRCode.tsx
+++ b/ui/components/app/rewards/RewardsQRCode.tsx
@@ -1,13 +1,4 @@
 import React, { useCallback } from 'react';
-import {
-  Box,
-  Text,
-  TextVariant,
-  Button,
-  ButtonSize,
-  ButtonVariant,
-} from '@metamask/design-system-react';
-import qrCode from 'qrcode-generator';
 import { useDispatch, useSelector } from 'react-redux';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
@@ -16,31 +7,8 @@ import {
   setRewardsDeeplinkUrl,
 } from '../../../ducks/rewards';
 import { selectRewardsDeeplinkUrl } from '../../../ducks/rewards/selectors';
-import { ModalBody } from '../../component-library/modal-body/modal-body';
+import { DeeplinkQRCode } from '../deeplink-qr-code';
 import { REWARDS_DEEPLINK_BASE_URL } from './utils/constants';
-
-const QrCodeView = ({ data }: { data: string }) => {
-  const qrImage = qrCode(0, 'M');
-  qrImage.addData(data);
-  qrImage.make();
-
-  return (
-    <Box className="qr-code__wrapper my-2">
-      <Box
-        data-testid="qr-code-image"
-        className="qr-code__image"
-        dangerouslySetInnerHTML={{
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          __html: qrImage.createTableTag(5, 16),
-        }}
-      />
-      <Box className="qr-code__logo">
-        <img src="images/logo/metamask-fox.svg" alt="Logo" />
-      </Box>
-    </Box>
-  );
-};
 
 // eslint-disable-next-line @typescript-eslint/naming-convention
 export default function RewardsQRCode() {
@@ -57,30 +25,13 @@ export default function RewardsQRCode() {
   const dataToEncode = rewardsDeeplinkUrl ?? REWARDS_DEEPLINK_BASE_URL;
 
   return (
-    <ModalBody
-      className="w-full h-full pt-8 pb-4 flex flex-col"
-      data-testid="rewards-onboarding-qrcode-container"
-    >
-      <Box className="flex flex-1 flex-col items-center justify-center gap-4">
-        <Text variant={TextVariant.HeadingSm} className="text-center">
-          {t('rewardsQRCodeTitle')}
-        </Text>
-        <Text
-          variant={TextVariant.BodyMd}
-          className="text-center text-alternative"
-        >
-          {t('rewardsQRCodeDescription')}
-        </Text>
-        <QrCodeView data={dataToEncode} />
-        <Button
-          variant={ButtonVariant.Primary}
-          size={ButtonSize.Lg}
-          onClick={handleClose}
-          className="w-full my-2"
-        >
-          {t('done')}
-        </Button>
-      </Box>
-    </ModalBody>
+    <DeeplinkQRCode
+      title={t('rewardsQRCodeTitle')}
+      description={t('rewardsQRCodeDescription')}
+      data={dataToEncode}
+      onDone={handleClose}
+      doneLabel={t('done')}
+      testId="rewards-onboarding-qrcode-container"
+    />
   );
 }

--- a/ui/pages/home/HomeDeepLinkActions.test.tsx
+++ b/ui/pages/home/HomeDeepLinkActions.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import { renderHook } from '@testing-library/react-hooks';
 import mockState from '../../../test/data/mock-state.json';
 import configureStore from '../../store/store';
@@ -178,4 +178,47 @@ describe('HomeDeepLinkActions', () => {
       expectedAction();
     },
   );
+
+  it('notifies Home to show the predict QR code for a predict deeplink URL', async () => {
+    const deeplinkUrl =
+      'https://link.metamask.io/predict?marketId=30615&sig_params=marketId&sig=signature&utm_source=twitter';
+    const onQrCodeDeepLink = jest.fn();
+    const { Wrapper } = createWrapper({
+      pathname: DEFAULT_ROUTE,
+      search: `?${new URLSearchParams({
+        [HomeQueryParams.PredictDeeplinkUrl]: deeplinkUrl,
+      }).toString()}`,
+      isNetworkMenuOpen: false,
+    });
+
+    render(<HomeDeepLinkActions onQrCodeDeepLink={onQrCodeDeepLink} />, {
+      wrapper: Wrapper,
+    });
+
+    await waitFor(() => {
+      expect(onQrCodeDeepLink).toHaveBeenCalledWith({
+        deeplinkUrl,
+        descriptionKey: 'deepLinkQrPredictDescription',
+        titleKey: 'deepLinkQrPredictTitle',
+      });
+    });
+  });
+
+  it('ignores predict QR deeplink params that do not point to /predict', () => {
+    const onQrCodeDeepLink = jest.fn();
+    const { Wrapper } = createWrapper({
+      pathname: DEFAULT_ROUTE,
+      search: `?${new URLSearchParams({
+        [HomeQueryParams.PredictDeeplinkUrl]:
+          'https://link.metamask.io/rewards?referral=ABC123',
+      }).toString()}`,
+      isNetworkMenuOpen: false,
+    });
+
+    render(<HomeDeepLinkActions onQrCodeDeepLink={onQrCodeDeepLink} />, {
+      wrapper: Wrapper,
+    });
+
+    expect(onQrCodeDeepLink).not.toHaveBeenCalled();
+  });
 });

--- a/ui/pages/home/HomeDeepLinkActions.tsx
+++ b/ui/pages/home/HomeDeepLinkActions.tsx
@@ -1,15 +1,45 @@
-import { memo, useCallback, useEffect, useMemo } from 'react';
+import { FC, memo, useCallback, useEffect, useMemo } from 'react';
 import { useLocation, useSearchParams } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { DEFAULT_ROUTE } from '../../helpers/constants/routes';
 import { selectIsNetworkMenuOpen } from '../../selectors';
 import { toggleNetworkMenu } from '../../store/actions';
-import { HomeQueryParams } from '../../../shared/lib/deep-links/routes/home';
+import {
+  DEEP_LINK_ORIGIN,
+  HomeQueryParams,
+} from '../../../shared/lib/deep-links/routes/home';
+
+export type HomeDeepLinkQrCode = {
+  deeplinkUrl: string;
+  descriptionKey: string;
+  titleKey: string;
+};
+
+type HomeDeepLinkActionsProps = {
+  onQrCodeDeepLink?: (qrCode: HomeDeepLinkQrCode) => void;
+};
+
+function isDeepLinkUrlForPath(urlString: string | undefined, pathname: string) {
+  if (!urlString) {
+    return false;
+  }
+
+  try {
+    const url = new URL(urlString);
+    return url.origin === DEEP_LINK_ORIGIN && url.pathname === pathname;
+  } catch {
+    return false;
+  }
+}
 
 /**
  * Reusable hook to handle deep link actions for the home route.
+ * @param options0
+ * @param options0.onQrCodeDeepLink
  */
-export const useHomeDeepLinkEffects = () => {
+export const useHomeDeepLinkEffects = ({
+  onQrCodeDeepLink,
+}: HomeDeepLinkActionsProps = {}) => {
   const { pathname } = useLocation();
   const isHomeRoute = pathname === DEFAULT_ROUTE;
 
@@ -23,17 +53,36 @@ export const useHomeDeepLinkEffects = () => {
     }
   }, [dispatch, isNetworkMenuOpen]);
 
+  const openPredictQrCodeModal = useCallback(
+    (deeplinkUrl: string) => {
+      onQrCodeDeepLink?.({
+        deeplinkUrl,
+        descriptionKey: 'deepLinkQrPredictDescription',
+        titleKey: 'deepLinkQrPredictTitle',
+      });
+    },
+    [onQrCodeDeepLink],
+  );
+
   const deepLinkHandlers: Record<
     HomeQueryParams,
-    { isValidParam: (param?: string) => boolean; action: () => void }
+    {
+      isValidParam: (param?: string) => boolean;
+      action: (param: string) => void;
+    }
   > = useMemo(
     () => ({
       [HomeQueryParams.OpenNetworkSelector]: {
         isValidParam: (param?: string) => param?.toLowerCase() === 'true',
         action: openNetworkSelectorModal,
       },
+      [HomeQueryParams.PredictDeeplinkUrl]: {
+        isValidParam: (param?: string) =>
+          isDeepLinkUrlForPath(param, '/predict'),
+        action: openPredictQrCodeModal,
+      },
     }),
-    [openNetworkSelectorModal],
+    [openNetworkSelectorModal, openPredictQrCodeModal],
   );
 
   const clearDeepLinkParams = useCallback(() => {
@@ -46,8 +95,8 @@ export const useHomeDeepLinkEffects = () => {
   }, [setSearchParams, deepLinkHandlers]);
 
   const handleDeepLinkAction = useCallback(
-    (action: () => void) => {
-      action();
+    (action: (param: string) => void, param: string) => {
+      action(param);
       clearDeepLinkParams();
     },
     [clearDeepLinkParams],
@@ -61,7 +110,7 @@ export const useHomeDeepLinkEffects = () => {
     for (const [key, value] of searchParams.entries()) {
       const deepLink = deepLinkHandlers[key as HomeQueryParams];
       if (deepLink?.isValidParam(value)) {
-        handleDeepLinkAction(deepLink.action);
+        handleDeepLinkAction(deepLink.action, value);
         break;
       }
     }
@@ -72,7 +121,7 @@ export const useHomeDeepLinkEffects = () => {
  * Ghost component that manages the useHomeDeepLinkEffects
  * Can be used in non-functional components (that cannot use hooks)
  */
-export const HomeDeepLinkActions = memo(() => {
-  useHomeDeepLinkEffects();
+export const HomeDeepLinkActions = memo((props: HomeDeepLinkActionsProps) => {
+  useHomeDeepLinkEffects(props);
   return null;
 });

--- a/ui/pages/home/HomeDeepLinkActions.tsx
+++ b/ui/pages/home/HomeDeepLinkActions.tsx
@@ -1,4 +1,4 @@
-import { FC, memo, useCallback, useEffect, useMemo } from 'react';
+import { memo, useCallback, useEffect, useMemo } from 'react';
 import { useLocation, useSearchParams } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { DEFAULT_ROUTE } from '../../helpers/constants/routes';
@@ -121,7 +121,9 @@ export const useHomeDeepLinkEffects = ({
  * Ghost component that manages the useHomeDeepLinkEffects
  * Can be used in non-functional components (that cannot use hooks)
  */
-export const HomeDeepLinkActions = memo((props: HomeDeepLinkActionsProps) => {
-  useHomeDeepLinkEffects(props);
-  return null;
-});
+export const HomeDeepLinkActions = memo(
+  ({ onQrCodeDeepLink }: HomeDeepLinkActionsProps) => {
+    useHomeDeepLinkEffects({ onQrCodeDeepLink });
+    return null;
+  },
+);

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -42,6 +42,7 @@ import {
   Modal,
   ModalBody,
   ModalContent,
+  ModalContentSize,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
@@ -64,6 +65,7 @@ import PasswordOutdatedModal from '../../components/app/password-outdated-modal'
 import ShieldEntryModal from '../../components/app/shield-entry-modal';
 import RewardsModal from '../../components/app/rewards/onboarding/RewardsModal';
 import { Pna25Modal } from '../../components/app/modals/pna25-modal';
+import { DeeplinkQRCode } from '../../components/app/deeplink-qr-code';
 import { isBeta, isFlask, isMain } from '../../../shared/lib/build-types';
 import BetaAndFlaskHomeFooter from './beta-and-flask-home-footer.component';
 import { HomeDeepLinkActions } from './HomeDeepLinkActions';
@@ -169,6 +171,7 @@ export default class Home extends PureComponent {
 
   state = {
     canShowBlockageNotification: true,
+    deepLinkQrCode: null,
     notificationClosing: false,
     shouldEvaluateCohortEligibility: true,
   };
@@ -423,6 +426,14 @@ export default class Home extends PureComponent {
   onOutdatedBrowserWarningClose = () => {
     const { setOutdatedBrowserWarningLastShown } = this.props;
     setOutdatedBrowserWarningLastShown(new Date().getTime());
+  };
+
+  showDeepLinkQrCode = (deepLinkQrCode) => {
+    this.setState({ deepLinkQrCode });
+  };
+
+  hideDeepLinkQrCode = () => {
+    this.setState({ deepLinkQrCode: null });
   };
 
   renderNotifications() {
@@ -800,6 +811,8 @@ export default class Home extends PureComponent {
   };
 
   render() {
+    const { t } = this.context;
+    const { deepLinkQrCode } = this.state;
     const {
       useExternalServices,
       setBasicFunctionalityModalOpen,
@@ -860,7 +873,18 @@ export default class Home extends PureComponent {
       !displayUpdateModal &&
       !isSeedlessPasswordOutdated &&
       !showShieldEntryModal &&
-      !showRecoveryPhrase;
+      !showRecoveryPhrase &&
+      !deepLinkQrCode;
+
+    const showDeepLinkQrCodeModal =
+      canSeeModals &&
+      !showTermsOfUse &&
+      !showMultiRpcEditModal &&
+      !displayUpdateModal &&
+      !isSeedlessPasswordOutdated &&
+      !showShieldEntryModal &&
+      !showRecoveryPhrase &&
+      Boolean(deepLinkQrCode);
 
     const showPna25ModalComponent =
       showPna25Modal &&
@@ -871,7 +895,8 @@ export default class Home extends PureComponent {
       !isSeedlessPasswordOutdated &&
       !showShieldEntryModal &&
       !showRecoveryPhrase &&
-      !rewardsModalOpen;
+      !rewardsModalOpen &&
+      !deepLinkQrCode;
 
     const { location } = this.props;
 
@@ -913,6 +938,49 @@ export default class Home extends PureComponent {
           ) : null}
           {showShieldEntryModal && <ShieldEntryModal />}
           {showRewardsModal && <RewardsModal />}
+          {showDeepLinkQrCodeModal ? (
+            <Modal
+              data-testid="deeplink-qrcode-modal"
+              isOpen={true}
+              onClose={this.hideDeepLinkQrCode}
+            >
+              <ModalOverlay />
+              <ModalContent
+                alignItems={AlignItems.center}
+                justifyContent={JustifyContent.center}
+                size={ModalContentSize.Md}
+                modalDialogProps={{
+                  paddingTop: 0,
+                  paddingBottom: 0,
+                  style: {
+                    height: 'auto',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                  },
+                }}
+              >
+                <ModalHeader
+                  closeButtonProps={{
+                    className: 'absolute z-10',
+                    style: {
+                      top: '24px',
+                      right: '12px',
+                    },
+                  }}
+                  paddingBottom={0}
+                  onClose={this.hideDeepLinkQrCode}
+                />
+                <DeeplinkQRCode
+                  title={t(deepLinkQrCode.titleKey)}
+                  description={t(deepLinkQrCode.descriptionKey)}
+                  data={deepLinkQrCode.deeplinkUrl}
+                  onDone={this.hideDeepLinkQrCode}
+                  doneLabel={t('done')}
+                  testId="deeplink-qrcode-container"
+                />
+              </ModalContent>
+            </Modal>
+          ) : null}
           {showPna25ModalComponent && <Pna25Modal />}
           {isPopup && !connectedStatusPopoverHasBeenShown
             ? this.renderPopover()
@@ -933,7 +1001,7 @@ export default class Home extends PureComponent {
         </div>
 
         {/* Ghost component that manages the useHomeDeepLinkEffects */}
-        <HomeDeepLinkActions />
+        <HomeDeepLinkActions onQrCodeDeepLink={this.showDeepLinkQrCode} />
       </ScrollContainer>
     );
   }

--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -941,7 +941,7 @@ export default class Home extends PureComponent {
           {showDeepLinkQrCodeModal ? (
             <Modal
               data-testid="deeplink-qrcode-modal"
-              isOpen={true}
+              isOpen
               onClose={this.hideDeepLinkQrCode}
             >
               <ModalOverlay />


### PR DESCRIPTION
## **Description**

**Context:** The extension intercepts https://link.metamask.io/predict deeplinks and rewrites the URL before sending users to https://metamask.io/prediction-markets. When sig_params is present, it only keeps the params listed there and drops the rest, including sig, UTMs, _hsenc, etc. 

/predict deeplinks on desktop extension no longer redirect to the web prediction-markets page. They route to Home and open a QR modal so users can continue on mobile with the full link.metamask.io/predict URL (including sig, UTMs, and other params that signed-link canonicalization used to drop).

Deep link routing adds handlerSearchParams (canonical vs original) so routes like predict can receive the raw query string while verification still uses canonical params. createHomeQrCodeDestination and HomeQueryParams.PredictDeeplinkUrl wire the encoded deeplink into Home; HomeDeepLinkActions validates the URL origin/path and triggers the modal. A shared DeeplinkQRCode component replaces duplicated QR UI in rewards and powers the new Home modal, with new i18n strings for the predict copy.

## **Changelog**

CHANGELOG entry:

## **Related issues**

Fixes: GE-223, GE-225

## **Manual testing steps**

1. Build and run extension in a test/dev environment.
2. Open a `/predict` deeplink ([signed](https://link.metamask.io/predict?marketId=30615&sig_params=marketId&sig=v8C_9bzBNrKmeVh7lVaN48-hrd9JQRTylD9-eaLEmSMIvBdROEi9ElQjoX5mF_6y9tUIUNAobj5Qm9KhrpKHIA) and [unsigned](https://link.metamask.io/predict?marketId=30615&utm_source=twitter) variants) and verify:
   - it resolves to Home,
   - a QR modal is shown,
   - the QR payload is a `link.metamask.io/predict` URL containing expected params.
3. Open a `/rewards` deeplink and verify it follows rewards flow behavior (including onboarding/rewards-specific branching), not the predict QR path.


## **Screenshots/Recordings**

### **Before**

<img width="1681" height="1153" alt="Screenshot 2026-06-08 at 16 51 45" src="https://github.com/user-attachments/assets/155aa307-1ce3-4c40-8bda-aa84baaa6c83" />

### **After**

<img width="1378" height="773" alt="Screenshot 2026-06-08 at 16 51 18" src="https://github.com/user-attachments/assets/23cc8a3f-7019-425a-b519-e1d46b19df2e" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deep-link parsing and `/predict` destination behavior (no longer a web redirect); incorrect URL validation or param handling could break signed/attribution links, but scope is limited to predict QR flow with tests.
> 
> **Overview**
> **`/predict` deeplinks on desktop extension no longer redirect to the web prediction-markets page.** They route to Home and open a QR modal so users can continue on mobile with the full `link.metamask.io/predict` URL (including `sig`, UTMs, and other params that signed-link canonicalization used to drop).
> 
> Deep link routing adds **`handlerSearchParams`** (`canonical` vs `original`) so routes like **`predict`** can receive the **raw query string** while verification still uses canonical params. **`createHomeQrCodeDestination`** and **`HomeQueryParams.PredictDeeplinkUrl`** wire the encoded deeplink into Home; **`HomeDeepLinkActions`** validates the URL origin/path and triggers the modal. A shared **`DeeplinkQRCode`** component replaces duplicated QR UI in rewards and powers the new Home modal, with new i18n strings for the predict copy.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b450fc69ed8a8c9d1c3c8b86baaacc75b36ddc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->