### PR TITLE
test: skip perps withdraw tests with new confirmation page due to timeout enabling form

### DIFF
--- a/test/e2e/tests/perps/perps-withdraw.spec.ts
+++ b/test/e2e/tests/perps/perps-withdraw.spec.ts
@@ -153,7 +153,9 @@ describe('Perps Withdraw', function (this: Suite) {
     );
   });
 
-  it('submits a valid withdrawal from the confirmation flow', async function () {
+  // The fill form takes very long to be enabled in the new withdraw page causing the test to fail
+  // To re-enable back once the issue is fixed
+  it.skip('submits a valid withdrawal from the confirmation flow', async function () {
     await withFixtures(
       {
         ...withdrawConfirmationFixtures(this.test?.fullTitle()),
@@ -172,7 +174,9 @@ describe('Perps Withdraw', function (this: Suite) {
     );
   });
 
-  it('blocks withdrawal amounts above the Perps available balance', async function () {
+  // The fill form takes very long to be enabled in the new withdraw page causing the test to fail
+  // To re-enable back once the issue is fixed
+  it.skip('blocks withdrawal amounts above the Perps available balance', async function () {
     await withFixtures(
       {
         ...withdrawConfirmationFixtures(this.test?.fullTitle()),

--- a/test/e2e/tests/perps/perps-withdraw.spec.ts
+++ b/test/e2e/tests/perps/perps-withdraw.spec.ts
@@ -155,6 +155,7 @@ describe('Perps Withdraw', function (this: Suite) {
 
   // The fill form takes very long to be enabled in the new withdraw page causing the test to fail
   // To re-enable back once the issue is fixed
+  // eslint-disable-next-line mocha/no-skipped-tests
   it.skip('submits a valid withdrawal from the confirmation flow', async function () {
     await withFixtures(
       {
@@ -176,6 +177,7 @@ describe('Perps Withdraw', function (this: Suite) {
 
   // The fill form takes very long to be enabled in the new withdraw page causing the test to fail
   // To re-enable back once the issue is fixed
+  // eslint-disable-next-line mocha/no-skipped-tests
   it.skip('blocks withdrawal amounts above the Perps available balance', async function () {
     await withFixtures(
       {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The fill withdraw form takes too long to be enabled, causing the new perps withdraw tests to timeout.

The issue should be investigated and sorted out before re-enabling, as it's blocking our ci

https://github.com/user-attachments/assets/64e885b5-0443-4d6c-92ee-029e4f9c901b


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code; reduces E2E coverage for the new withdraw confirmation path until re-enabled.
> 
> **Overview**
> **Temporarily skips two Perps withdraw confirmation E2E tests** in `perps-withdraw.spec.ts` so CI stays green while the new confirmation flow is investigated.
> 
> The skipped cases cover a **successful withdrawal** through the confirmation UI and **insufficient-funds validation** when the amount exceeds available balance. Comments note the amount field stays disabled too long on the new withdraw page, which causes timeouts; `eslint-disable-next-line mocha/no-skipped-tests` is added for each `it.skip`. **Legacy withdraw page tests are unchanged** and still run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8fb894e92b3642890fd37039eb1a60ccf8c60b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->