### PR TITLE
build: patch LavaMoat webpack runtime ordering

### DIFF
--- a/.yarn/patches/@lavamoat-webpack-npm-2.2.0-e4dc53d83c.patch
+++ b/.yarn/patches/@lavamoat-webpack-npm-2.2.0-e4dc53d83c.patch
@@ -1,0 +1,95 @@
+diff --git a/src/runtime/runtimeBuilder.js b/src/runtime/runtimeBuilder.js
+index 6cd3bd57d781919212d1bdc85e3719d2a98fc689..48673cd31a480919968845b693e835ff13a23efa 100644
+--- a/src/runtime/runtimeBuilder.js
++++ b/src/runtime/runtimeBuilder.js
+@@ -41,6 +41,56 @@ class VirtualRuntimeModule extends RuntimeModule {
+   }
+ }
+ 
++/**
++ * Compare runtime IDs in a stable way without changing their types.
++ *
++ * @param {string | number} a
++ * @param {string | number} b
++ * @returns {number}
++ */
++const compareIds = (a, b) => {
++  const typeA = typeof a
++  const typeB = typeof b
++  if (typeA !== typeB) {
++    return typeA < typeB ? -1 : 1
++  }
++  if (typeof a === 'number' && typeof b === 'number') {
++    return a - b
++  }
++  const stringA = String(a)
++  const stringB = String(b)
++  if (stringA < stringB) {
++    return -1
++  }
++  if (stringA > stringB) {
++    return 1
++  }
++  return 0
++}
++
++/**
++ * @template {string | number} T
++ * @param {T[]} ids
++ * @returns {T[]}
++ */
++const sortedIds = (ids) => [...ids].sort(compareIds)
++
++/**
++ * @param {[string, (string | number)[]][]} identifiersForModuleIds
++ * @returns {[string, (string | number)[]][]}
++ */
++const sortedIdentifierMap = (identifiersForModuleIds) =>
++  identifiersForModuleIds
++    .map(([resourceId, moduleIds]) =>
++      /** @type {[string, (string | number)[]]} */ ([
++        resourceId,
++        sortedIds(moduleIds),
++      ])
++    )
++    .sort(([resourceIdA], [resourceIdB]) =>
++      compareIds(resourceIdA, resourceIdB)
++    )
++
+ /** @import {LavaMoatPluginOptions, LavaMoatChunkRuntimeConfiguration} from '../buildtime/types' */
+ /** @import {LavaMoatPolicy} from '@lavamoat/types' */
+ /** @import {RuntimeFragment} from './assemble.js' */
+@@ -190,31 +240,31 @@ const LOCKDOWN_SHIMS = [];`
+         // a mapping used to look up resource ids by module id
+         {
+           name: 'idmap',
+-          data: identifiersForModuleIds,
++          data: sortedIdentifierMap(identifiersForModuleIds),
+           json: true,
+         },
+         // list of ids of modules to skip in policy enforcement
+         {
+           name: 'unenforceable',
+           data: unenforceableModuleIds,
+           json: true,
+         },
+         // list of known context modules
+         {
+           name: 'ctxm',
+           data: contextModuleIds || null,
+           json: true,
+         },
+         // known chunk ids
+         {
+           name: 'kch',
+-          data: chunkIds,
++          data: sortedIds(chunkIds),
+           json: true,
+         },
+         // a record of module ids that are externals and need to be enforced as builtins
+         {
+           name: 'externals',
+           data: externals || null,
+           json: true,
+         },
+         // options to turn on scuttling

--- a/package.json
+++ b/package.json
@@ -320,7 +320,7 @@
     "@keystonehq/bc-ur-registry-eth": "^0.22.1",
     "@lavamoat/lavadome-react": "0.0.20",
     "@lavamoat/snow": "^2.0.4",
-    "@lavamoat/webpack": "2.2.0",
+    "@lavamoat/webpack": "patch:@lavamoat/webpack@npm%3A2.2.0#~/.yarn/patches/@lavamoat-webpack-npm-2.2.0-e4dc53d83c.patch",
     "@ledgerhq/errors": "^6.21.0",
     "@ledgerhq/hw-app-eth": "^6.42.0",
     "@ledgerhq/hw-transport": "^6.31.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5065,6 +5065,23 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@lavamoat/webpack@patch:@lavamoat/webpack@npm%3A2.2.0#~/.yarn/patches/@lavamoat-webpack-npm-2.2.0-e4dc53d83c.patch":
+  version: 2.2.0
+  resolution: "@lavamoat/webpack@patch:@lavamoat/webpack@npm%3A2.2.0#~/.yarn/patches/@lavamoat-webpack-npm-2.2.0-e4dc53d83c.patch::version=2.2.0&hash=372cbb"
+  dependencies:
+    "@babel/parser": "npm:7.29.2"
+    "@lavamoat/aa": "npm:^5.0.1"
+    "@lavamoat/types": "npm:^1.0.1"
+    browser-resolve: "npm:2.0.0"
+    json-stable-stringify: "npm:1.3.0"
+    lavamoat-core: "npm:^18.0.2"
+    ses: "npm:1.15.0"
+  peerDependencies:
+    webpack: ^5.80.2
+  checksum: 10/0f13eb12f9a7c5b7d62e781979c263141ee0d3dcc9f82fc9395e3c12c4e3ec4be1968fabff2890f9132058bc6ec427b9214962ac57837f5513c79eceaa3ba03e
+  languageName: node
+  linkType: hard
+
 "@ledgerhq/cryptoassets-evm-signatures@npm:^13.5.2":
   version: 13.5.2
   resolution: "@ledgerhq/cryptoassets-evm-signatures@npm:13.5.2"
@@ -33437,7 +33454,7 @@ __metadata:
     "@lavamoat/lavadome-react": "npm:0.0.20"
     "@lavamoat/lavapack": "npm:^7.0.22"
     "@lavamoat/snow": "npm:^2.0.4"
-    "@lavamoat/webpack": "npm:2.2.0"
+    "@lavamoat/webpack": "patch:@lavamoat/webpack@npm%3A2.2.0#~/.yarn/patches/@lavamoat-webpack-npm-2.2.0-e4dc53d83c.patch"
     "@ledgerhq/errors": "npm:^6.21.0"
     "@ledgerhq/hw-app-eth": "npm:^6.42.0"
     "@ledgerhq/hw-transport": "npm:^6.31.0"


### PR DESCRIPTION
## **Description**

Adds a local Yarn patch for `@lavamoat/webpack@2.2.0` that sorts the runtime-embedded lookup data tied to the observed nondeterministic webpack output:

- `idmap` resource/module ID entries, including each resource's module ID list
- `kch` known chunk IDs

This keeps the local MetaMask patch focused on the fields that affect the reproducibility issue we observed, without broadening it to runtime fields that were not part of the local nondeterminism.

This is intended as the local MetaMask patch while the equivalent fix is upstreamed to LavaMoat.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. `yarn install --immutable`
2. `yarn lint:changed:fix`
3. `yarn lint:lockfile:dedupe`
4. `yarn allow-scripts auto`
5. `yarn webpack:tsc`
6. `node -c node_modules/@lavamoat/webpack/src/runtime/runtimeBuilder.js`
7. Direct runtime-builder stability check: emitted `stable` for equivalent unsorted `idmap` and `chunkIds` inputs

Policy and attribution notes:

- `yarn allow-scripts auto` reported no changes necessary.
- `yarn attributions:generate` was run earlier, but generated broad unrelated attribution churn for this same-version patch; those generated files were not included.
- `yarn lavamoat:auto` was attempted earlier, but local policy-only builds failed because `INFURA_PROJECT_ID` is not set; no partial policy files were left in the branch.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
