### PR TITLE
fix: #42683: [Bug]: When global balance is hidden, the Perps balance is still displayed

### DIFF
--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx
@@ -41,6 +41,16 @@ const mockStore = configureStore({
   },
 });
 
+const mockPrivacyModeStore = configureStore({
+  metamask: {
+    ...mockState.metamask,
+    preferences: {
+      ...mockState.metamask.preferences,
+      privacyMode: true,
+    },
+  },
+});
+
 describe('invokePerpsBalanceAction', () => {
   it('logs when callback returns a rejected promise', async () => {
     const consoleErrorSpy = jest
@@ -232,6 +242,33 @@ describe('PerpsBalanceDropdown', () => {
 
     expect(screen.getByText(/42\.00%/u)).toBeInTheDocument();
     expect(screen.queryByText(/1\.00%/u)).not.toBeInTheDocument();
+  });
+
+  describe('when global balance privacy mode is enabled', () => {
+    it('masks the total balance instead of showing the formatted amount', () => {
+      renderWithProvider(<PerpsBalanceDropdown />, mockPrivacyModeStore);
+
+      expect(screen.queryByText('$15,250')).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId('perps-balance-dropdown-balance'),
+      ).toHaveTextContent('••••••');
+      // Label remains visible
+      expect(screen.getByText(/total balance/iu)).toBeInTheDocument();
+    });
+
+    it('masks the unrealized P&L while keeping the label visible', () => {
+      renderWithProvider(
+        <PerpsBalanceDropdown hasPositions />,
+        mockPrivacyModeStore,
+      );
+
+      expect(screen.queryByText(/\+\$375/u)).not.toBeInTheDocument();
+      expect(screen.queryByText(/7\.32%/u)).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId('perps-balance-dropdown-pnl'),
+      ).toHaveTextContent('••••••');
+      expect(screen.getByText(/unrealized p&l/iu)).toBeInTheDocument();
+    });
   });
 
   describe('geo-blocking', () => {

--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
 import {
   twMerge,
   TextVariant,
@@ -24,8 +25,12 @@ import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { useFormatters } from '../../../../hooks/useFormatters';
 import { usePerpsEligibility } from '../../../../hooks/perps';
 import { usePerpsLiveAccount } from '../../../../hooks/perps/stream';
+import { getPrivacyMode } from '../../../../selectors';
 import { PerpsGeoBlockModal } from '../perps-geo-block-modal';
 import { PerpsControlBarSkeleton } from '../perps-skeletons';
+
+/** Mask shown in place of fiat amounts when the global balance privacy mode is on. */
+const HIDDEN_BALANCE = '••••••';
 
 /** Handler from perps triggers (e.g. deposit / withdraw); may return a Promise. */
 export type PerpsBalanceActionHandler = () => void | Promise<unknown>;
@@ -76,6 +81,7 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
   const { account, isInitialLoading } = usePerpsLiveAccount();
   const { formatPercentWithMinThreshold } = useFormatters();
   const { isEligible } = usePerpsEligibility();
+  const privacyMode = useSelector(getPrivacyMode);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isGeoBlockModalOpen, setIsGeoBlockModalOpen] = useState(false);
 
@@ -180,9 +186,11 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
               gap={2}
             >
               <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
-                {formatPerpsFiat(accountValue, {
-                  ranges: PRICE_RANGES_MINIMAL_VIEW,
-                })}
+                {privacyMode
+                  ? HIDDEN_BALANCE
+                  : formatPerpsFiat(accountValue, {
+                      ranges: PRICE_RANGES_MINIMAL_VIEW,
+                    })}
               </Text>
               <Icon
                 name={isDropdownOpen ? IconName.ArrowUp : IconName.ArrowDown}
@@ -240,7 +248,9 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
             fontWeight={FontWeight.Medium}
             color={isProfit ? TextColor.SuccessDefault : TextColor.ErrorDefault}
           >
-            {formattedPnl} ({formattedRoe})
+            {privacyMode
+              ? HIDDEN_BALANCE
+              : `${formattedPnl} (${formattedRoe})`}
           </Text>
         </Box>
       )}

--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
@@ -248,9 +248,7 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
             fontWeight={FontWeight.Medium}
             color={isProfit ? TextColor.SuccessDefault : TextColor.ErrorDefault}
           >
-            {privacyMode
-              ? HIDDEN_BALANCE
-              : `${formattedPnl} (${formattedRoe})`}
+            {privacyMode ? HIDDEN_BALANCE : `${formattedPnl} (${formattedRoe})`}
           </Text>
         </Box>
       )}

--- a/ui/components/app/perps/perps-market-balance-actions/perps-market-balance-actions.test.tsx
+++ b/ui/components/app/perps/perps-market-balance-actions/perps-market-balance-actions.test.tsx
@@ -39,6 +39,16 @@ const mockStore = configureStore({
   },
 });
 
+const mockPrivacyModeStore = configureStore({
+  metamask: {
+    ...mockState.metamask,
+    preferences: {
+      ...mockState.metamask.preferences,
+      privacyMode: true,
+    },
+  },
+});
+
 describe('PerpsMarketBalanceActions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -69,6 +79,31 @@ describe('PerpsMarketBalanceActions', () => {
 
     fireEvent.click(screen.getByTestId('perps-balance-actions-add-funds'));
     expect(onAddFunds).toHaveBeenCalledTimes(1);
+  });
+
+  describe('when global balance privacy mode is enabled', () => {
+    it('masks the account value and available balance while keeping actions visible', () => {
+      renderWithProvider(
+        <PerpsMarketBalanceActions showActionButtons />,
+        mockPrivacyModeStore,
+      );
+
+      expect(
+        screen.getByTestId('perps-balance-actions-total'),
+      ).toHaveTextContent('••••••');
+      expect(
+        screen.getByTestId('perps-balance-actions-available'),
+      ).toHaveTextContent('••••••');
+      expect(
+        screen.getByTestId('perps-balance-actions-available'),
+      ).toHaveTextContent(/available/iu);
+      expect(
+        screen.queryByText(/\$[\d,]/u),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId('perps-balance-actions-add-funds'),
+      ).toBeInTheDocument();
+    });
   });
 
   describe('geo-blocking', () => {

--- a/ui/components/app/perps/perps-market-balance-actions/perps-market-balance-actions.test.tsx
+++ b/ui/components/app/perps/perps-market-balance-actions/perps-market-balance-actions.test.tsx
@@ -97,9 +97,7 @@ describe('PerpsMarketBalanceActions', () => {
       expect(
         screen.getByTestId('perps-balance-actions-available'),
       ).toHaveTextContent(/available/iu);
-      expect(
-        screen.queryByText(/\$[\d,]/u),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText(/\$[\d,]/u)).not.toBeInTheDocument();
       expect(
         screen.getByTestId('perps-balance-actions-add-funds'),
       ).toBeInTheDocument();

--- a/ui/components/app/perps/perps-market-balance-actions/perps-market-balance-actions.tsx
+++ b/ui/components/app/perps/perps-market-balance-actions/perps-market-balance-actions.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from 'react';
+import { useSelector } from 'react-redux';
 import {
   Box,
   Button,
@@ -26,11 +27,15 @@ import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { useFormatters } from '../../../../hooks/useFormatters';
 import { usePerpsLiveAccount } from '../../../../hooks/perps/stream';
 import { getTradeableBalance } from '../../../../hooks/perps/getTradeableBalance';
+import { getPrivacyMode } from '../../../../selectors';
 import {
   invokePerpsBalanceAction,
   type PerpsBalanceActionHandler,
 } from '../perps-balance-dropdown';
 import { PerpsGeoBlockModal } from '../perps-geo-block-modal';
+
+/** Mask shown in place of fiat amounts when the global balance privacy mode is on. */
+const HIDDEN_BALANCE = '••••••';
 
 type PerpsMarketBalanceActionsProps = {
   /** Whether to show the action buttons (Add funds, Withdraw) */
@@ -57,6 +62,7 @@ const PerpsMarketBalanceActions = ({
   const { formatCurrency } = useFormatters();
   const { account } = usePerpsLiveAccount();
   const { isEligible } = usePerpsEligibility();
+  const privacyMode = useSelector(getPrivacyMode);
   const [isGeoBlockModalOpen, setIsGeoBlockModalOpen] = useState(false);
 
   // Use account data or defaults
@@ -198,7 +204,7 @@ const PerpsMarketBalanceActions = ({
         fontWeight={FontWeight.Medium}
         data-testid="perps-balance-actions-total"
       >
-        {formatCurrency(accountValue, 'USD')}
+        {privacyMode ? HIDDEN_BALANCE : formatCurrency(accountValue, 'USD')}
       </Text>
 
       {/* Available Balance */}
@@ -208,7 +214,9 @@ const PerpsMarketBalanceActions = ({
           color={TextColor.TextAlternative}
           data-testid="perps-balance-actions-available"
         >
-          {formatCurrency(parseFloat(availableBalance), 'USD')}{' '}
+          {privacyMode
+            ? HIDDEN_BALANCE
+            : formatCurrency(parseFloat(availableBalance), 'USD')}{' '}
           {t('perpsAvailable').toLowerCase()}
         </Text>
       </Box>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When a user hides their global balance (the hide-balance / privacy toggle), the Perps balances continued to display real fiat amounts, leaking information the user expected to be hidden. The Perps balance header (PerpsBalanceDropdown) and the market detail balance (PerpsMarketBalanceActions) rendered formatted fiat values directly and never consulted the global privacy preference.

Both components now read the existing getPrivacyMode selector via useSelector and render a bullet mask in place of the fiat amounts when privacy mode is active: the total balance and unrealized P&L in perps-balance-dropdown.tsx, and the account value and available balance in perps-market-balance-actions.tsx. Labels such as "Total balance", "Unrealized P&L", and "available" remain visible, consistent with how the rest of the wallet masks balances.

## **Changelog**

CHANGELOG entry: Fixed Perps balances not being hidden when the global balance privacy toggle is enabled.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/42683

## **Manual testing steps**

1. Check out this branch and load the extension.
2. On the wallet home, click the balance to hide it (enable privacy mode).
3. Open the Perps tab and confirm the total balance and unrealized P&L are masked with bullets instead of showing fiat amounts.
4. Open a Perps market detail page and confirm the account value and available balance are also masked while labels and action buttons remain visible.
5. Toggle the global balance back on and confirm the Perps amounts reappear.
6. Run the targeted tests: yarn jest ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx ui/components/app/perps/perps-market-balance-actions/perps-market-balance-actions.test.tsx

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- AEP_SCREENSHOTS_START -->
<details open><summary>perps-balance-masked-privacy-mode-1780537326042.png</summary>

<img alt="perps-balance-masked-privacy-mode-1780537326042.png" src="https://diner-expulsion-catapult.ngrok-free.dev/v1/runs/9d08fa54-2417-4e5b-b36d-d22f61ffa8db/artifacts/perps-balance-masked-privacy-mode-1780537326042.png" width="420" />

[Open full-size image](https://diner-expulsion-catapult.ngrok-free.dev/v1/runs/9d08fa54-2417-4e5b-b36d-d22f61ffa8db/artifacts/perps-balance-masked-privacy-mode-1780537326042.png)

</details>

<!-- AEP_SCREENSHOTS_END -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- AEP_VISUAL_VALIDATION_START -->
## AEP Visual Validation

**✅ Passed**

The evidence proves the core PR behavior for PerpsBalanceDropdown: with global privacy mode enabled, perps-balance-dropdown-balance changed from 'Total balance$0' (fiat path) to 'Total balance••••••' (masked) while the 'Total balance' label…

<details><summary>Validation details</summary>

Visual validation passed: The evidence proves the core PR behavior for PerpsBalanceDropdown: with global privacy mode enabled, perps-balance-dropdown-balance changed from 'Total balance$0' (fiat path) to 'Total balance••••••' (masked) while the 'Total balance' label stayed visible, and live Redux state confirmed preferences.privacyMode=true. The before/after textual contrast is strong evidence that the new getPrivacyMode masking branch actually toggles. Approval is held at medium confidence because (1) one of the four changed files, perps-market-balance-actions.tsx, was never exercised or asserted, and (2) the masked value was the empty-account $0 rather than a non-zero fiat figure, and screenshot pixels were not directly inspected (judged from textual observations plus a 55KB PNG artifact).

**metamask-mm-visual-validation** — passed. PR #43183 adds getPrivacyMode masking to PerpsBalanceDropdown (and PerpsMarketBalanceActions). Validated visually: launched the default pre-onboarded fixture, unlocked, opened the Perps tab (account-overview__perps-tab, enabled by default), enabled global privacy mode through the real UI toggle (eth-overview__primary-currency -> setPrivacyMode), and confirmed perps-balance-dropdown-balance renders 'Total balance••••••' with no fiat figure while the 'Total balance' label stays visible. Live Redux state confirmed metamask.preferences.privacyMode=true. Screenshot captured after the masked state was visible.

</details>

Run `9d08fa54-2417-4e5b-b36d-d22f61ffa8db` · [LangSmith trace](https://smith.langchain.com/o/09df0f02-e7c8-47f9-b00a-9e4757168f81/projects/p/metamask-aep)
<!-- AEP_VISUAL_VALIDATION_END -->
