### PR TITLE
feat: container-based responsive text

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 const { brandColor } = require('@metamask/design-tokens');
+const plugin = require('tailwindcss/plugin');
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
@@ -25,5 +26,9 @@ module.exports = {
     fontSize: {}, // This removes all default Tailwind font sizes. We want to rely on the design system font sizes and enforce use of the Text component
     extend: {},
   },
-  plugins: [],
+  plugins: [
+    plugin(({ addVariant }) => {
+      addVariant('@compact', '@container (max-width: 399px)');
+    }),
+  ],
 };

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -28,7 +28,7 @@ module.exports = {
   },
   plugins: [
     plugin(({ addVariant }) => {
-      addVariant('@compact', '@container (max-width: 399px)');
+      addVariant('@compact', '@container list-item (max-width: 399px)');
     }),
   ],
 };

--- a/ui/components/app/assets/asset-list/cells/asset-title.tsx
+++ b/ui/components/app/assets/asset-list/cells/asset-title.tsx
@@ -18,9 +18,9 @@ export const AssetCellTitle = ({ title }: AssetCellTitleProps) => {
   return (
     <Text
       fontWeight={FontWeight.Medium}
+      className="text-s-body-md @compact:text-s-body-sm"
       ellipsis
       data-testid="multichain-token-list-item-token-name"
-      className="text-s-body-md @compact:text-s-body-sm"
     >
       {networkTitleOverrides(t as TranslateFunction, { title })}
     </Text>

--- a/ui/components/app/assets/asset-list/cells/asset-title.tsx
+++ b/ui/components/app/assets/asset-list/cells/asset-title.tsx
@@ -1,8 +1,5 @@
 import React from 'react';
-import {
-  FontWeight,
-  TextVariant,
-} from '../../../../../helpers/constants/design-system';
+import { FontWeight } from '../../../../../helpers/constants/design-system';
 import { Text } from '../../../../component-library';
 import {
   TranslateFunction,
@@ -21,9 +18,9 @@ export const AssetCellTitle = ({ title }: AssetCellTitleProps) => {
   return (
     <Text
       fontWeight={FontWeight.Medium}
-      variant={TextVariant.bodyMd}
       ellipsis
       data-testid="multichain-token-list-item-token-name"
+      className="text-s-body-md @compact:text-s-body-sm"
     >
       {networkTitleOverrides(t as TranslateFunction, { title })}
     </Text>

--- a/ui/components/app/assets/asset-list/cells/generic-asset-cell-layout.tsx
+++ b/ui/components/app/assets/asset-list/cells/generic-asset-cell-layout.tsx
@@ -29,7 +29,7 @@ export default function GenericAssetCellLayout({
     <Box
       flexDirection={BoxFlexDirection.Row}
       gap={4}
-      className="flex h-full w-full [container-type:inline-size]"
+      className="flex h-full w-full [container-name:list-item] [container-type:inline-size]"
     >
       <Box asChild>
         <a

--- a/ui/components/app/assets/asset-list/cells/generic-asset-cell-layout.tsx
+++ b/ui/components/app/assets/asset-list/cells/generic-asset-cell-layout.tsx
@@ -29,7 +29,7 @@ export default function GenericAssetCellLayout({
     <Box
       flexDirection={BoxFlexDirection.Row}
       gap={4}
-      className="flex h-full w-full"
+      className="flex h-full w-full [container-type:inline-size]"
     >
       <Box asChild>
         <a

--- a/ui/components/app/assets/defi-list/cells/defi-grouped-symbol-cell.tsx
+++ b/ui/components/app/assets/defi-list/cells/defi-grouped-symbol-cell.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-  TextVariant,
   TextAlign,
   TextColor,
 } from '../../../../../helpers/constants/design-system';
@@ -41,11 +40,11 @@ export function DeFiSymbolGroup({
   return (
     <SensitiveText
       color={TextColor.textAlternative}
-      variant={TextVariant.bodySmMedium}
       textAlign={TextAlign.End}
       data-testid="defi-list-symbol-group"
       isHidden={privacyMode}
       length={SensitiveTextLength.Medium}
+      className="text-s-body-md @compact:text-s-body-sm"
     >
       {symbolGroup}
     </SensitiveText>

--- a/ui/components/app/assets/defi-list/cells/defi-grouped-symbol-cell.tsx
+++ b/ui/components/app/assets/defi-list/cells/defi-grouped-symbol-cell.tsx
@@ -40,11 +40,11 @@ export function DeFiSymbolGroup({
   return (
     <SensitiveText
       color={TextColor.textAlternative}
+      className="text-s-body-md @compact:text-s-body-sm"
       textAlign={TextAlign.End}
       data-testid="defi-list-symbol-group"
       isHidden={privacyMode}
       length={SensitiveTextLength.Medium}
-      className="text-s-body-md @compact:text-s-body-sm"
     >
       {symbolGroup}
     </SensitiveText>

--- a/ui/components/app/assets/defi-list/cells/defi-protocol-cell.tsx
+++ b/ui/components/app/assets/defi-list/cells/defi-protocol-cell.tsx
@@ -2,7 +2,6 @@ import React, { useContext } from 'react';
 import { useSelector } from 'react-redux';
 import GenericAssetCellLayout from '../../asset-list/cells/generic-asset-cell-layout';
 import { getPreferences } from '../../../../../../shared/lib/selectors/preferences';
-import { TextVariant } from '../../../../../helpers/constants/design-system';
 import { SensitiveText } from '../../../../component-library';
 import { AvatarType } from '../../../../multichain/avatar-group/avatar-group.types';
 import { AssetCellBadge } from '../../asset-list/cells/asset-cell-badge';
@@ -63,9 +62,9 @@ export default function DefiProtocolCell({
       headerLeftDisplay={<AssetCellTitle title={position.title} />}
       headerRightDisplay={
         <SensitiveText
-          variant={TextVariant.bodyMdMedium}
           isHidden={privacyMode}
           data-testid="defi-list-market-value"
+          className="text-s-body-md @compact:text-s-body-sm"
         >
           {position.marketValue}
         </SensitiveText>

--- a/ui/components/app/assets/defi-list/cells/defi-protocol-cell.tsx
+++ b/ui/components/app/assets/defi-list/cells/defi-protocol-cell.tsx
@@ -62,9 +62,9 @@ export default function DefiProtocolCell({
       headerLeftDisplay={<AssetCellTitle title={position.title} />}
       headerRightDisplay={
         <SensitiveText
+          className="text-s-body-md @compact:text-s-body-sm"
           isHidden={privacyMode}
           data-testid="defi-list-market-value"
-          className="text-s-body-md @compact:text-s-body-sm"
         >
           {position.marketValue}
         </SensitiveText>

--- a/ui/components/app/assets/token-cell/__snapshots__/token-cell.test.tsx.snap
+++ b/ui/components/app/assets/token-cell/__snapshots__/token-cell.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Token Cell should match snapshot 1`] = `
 <div>
   <div
-    class="flex-row gap-4 flex h-full w-full"
+    class="flex-row gap-4 flex h-full w-full [container-type:inline-size]"
   >
     <a
       class="flex w-full flex-row py-2 px-4 hover:bg-hover cursor-pointer"
@@ -47,14 +47,14 @@ exports[`Token Cell should match snapshot 1`] = `
             class="flex flex-row gap-2 min-w-0"
           >
             <p
-              class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--ellipsis mm-box--color-text-default"
+              class="mm-box mm-text text-s-body-md @compact:text-s-body-sm mm-text--body-md mm-text--font-weight-medium mm-text--ellipsis mm-box--color-text-default"
               data-testid="multichain-token-list-item-token-name"
             >
               TEST
             </p>
           </div>
           <p
-            class="mm-box mm-text mm-text--body-sm mm-text--font-weight-normal mm-text--text-align-end mm-box--color-text-default"
+            class="mm-box mm-text text-s-body-sm @compact:text-s-body-sm mm-text--body-md mm-text--font-weight-normal mm-text--text-align-end mm-box--color-text-default"
             data-testid="multichain-token-list-item-secondary-value"
             style="white-space: nowrap; padding-inline-start: 8px;"
           >
@@ -75,7 +75,7 @@ exports[`Token Cell should match snapshot 1`] = `
             </p>
           </div>
           <p
-            class="mm-box mm-text mm-text--body-sm-medium mm-text--text-align-end mm-box--color-text-alternative"
+            class="mm-box mm-text text-s-body-md @compact:text-s-body-sm mm-text--body-md mm-text--text-align-end mm-box--color-text-alternative"
             data-testid="multichain-token-list-item-value"
           >
             5 TEST

--- a/ui/components/app/assets/token-cell/__snapshots__/token-cell.test.tsx.snap
+++ b/ui/components/app/assets/token-cell/__snapshots__/token-cell.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Token Cell should match snapshot 1`] = `
 <div>
   <div
-    class="flex-row gap-4 flex h-full w-full [container-type:inline-size]"
+    class="flex-row gap-4 flex h-full w-full [container-name:list-item] [container-type:inline-size]"
   >
     <a
       class="flex w-full flex-row py-2 px-4 hover:bg-hover cursor-pointer"

--- a/ui/components/app/assets/token-cell/cells/token-cell-primary-display.tsx
+++ b/ui/components/app/assets/token-cell/cells/token-cell-primary-display.tsx
@@ -35,10 +35,10 @@ export const TokenCellPrimaryDisplay = React.memo(
         <SensitiveText
           data-testid="multichain-token-list-item-value"
           color={TextColor.textAlternative}
+          className="text-s-body-md @compact:text-s-body-sm"
           textAlign={TextAlign.End}
           isHidden={privacyMode}
           length={SensitiveTextLength.Short}
-          className="text-s-body-md @compact:text-s-body-sm"
         >
           {formatTokenQuantity(Number(token.balance ?? 0), token.symbol)}
         </SensitiveText>

--- a/ui/components/app/assets/token-cell/cells/token-cell-primary-display.tsx
+++ b/ui/components/app/assets/token-cell/cells/token-cell-primary-display.tsx
@@ -4,7 +4,6 @@ import { Skeleton } from '@metamask/design-system-react';
 import {
   TextAlign,
   TextColor,
-  TextVariant,
 } from '../../../../../helpers/constants/design-system';
 import {
   SensitiveText,
@@ -36,10 +35,10 @@ export const TokenCellPrimaryDisplay = React.memo(
         <SensitiveText
           data-testid="multichain-token-list-item-value"
           color={TextColor.textAlternative}
-          variant={TextVariant.bodySmMedium}
           textAlign={TextAlign.End}
           isHidden={privacyMode}
           length={SensitiveTextLength.Short}
+          className="text-s-body-md @compact:text-s-body-sm"
         >
           {formatTokenQuantity(Number(token.balance ?? 0), token.symbol)}
         </SensitiveText>

--- a/ui/components/app/assets/token-cell/cells/token-cell-secondary-display.tsx
+++ b/ui/components/app/assets/token-cell/cells/token-cell-secondary-display.tsx
@@ -95,16 +95,16 @@ export const TokenCellSecondaryDisplay = React.memo(
       >
         <SensitiveText
           fontWeight={token.secondary ? FontWeight.Medium : FontWeight.Normal}
+          className={cn(
+            token.secondary ? 'text-s-body-md' : 'text-s-body-sm',
+            '@compact:text-s-body-sm',
+          )}
           textAlign={TextAlign.End}
           data-testid="multichain-token-list-item-secondary-value"
           ellipsis={token.isStakeable}
           isHidden={privacyMode}
           length={SensitiveTextLength.Medium}
           style={secondaryDisplayStyle}
-          className={cn(
-            token.secondary ? 'text-s-body-md' : 'text-s-body-sm',
-            '@compact:text-s-body-sm',
-          )}
         >
           {secondaryDisplayText}
         </SensitiveText>

--- a/ui/components/app/assets/token-cell/cells/token-cell-secondary-display.tsx
+++ b/ui/components/app/assets/token-cell/cells/token-cell-secondary-display.tsx
@@ -1,12 +1,12 @@
 import React, { CSSProperties } from 'react';
 import { useSelector } from 'react-redux';
+import cn from 'clsx';
 import { Skeleton } from '@metamask/design-system-react';
 import {
   BackgroundColor,
   FontWeight,
   IconColor,
   TextAlign,
-  TextVariant,
 } from '../../../../../helpers/constants/design-system';
 import {
   ButtonIcon,
@@ -95,13 +95,16 @@ export const TokenCellSecondaryDisplay = React.memo(
       >
         <SensitiveText
           fontWeight={token.secondary ? FontWeight.Medium : FontWeight.Normal}
-          variant={token.secondary ? TextVariant.bodyMd : TextVariant.bodySm}
           textAlign={TextAlign.End}
           data-testid="multichain-token-list-item-secondary-value"
           ellipsis={token.isStakeable}
           isHidden={privacyMode}
           length={SensitiveTextLength.Medium}
           style={secondaryDisplayStyle}
+          className={cn(
+            token.secondary ? 'text-s-body-md' : 'text-s-body-sm',
+            '@compact:text-s-body-sm',
+          )}
         >
           {secondaryDisplayText}
         </SensitiveText>

--- a/ui/components/app/multichain-bridge-transaction-list-item/multichain-bridge-transaction-list-item.tsx
+++ b/ui/components/app/multichain-bridge-transaction-list-item/multichain-bridge-transaction-list-item.tsx
@@ -157,14 +157,13 @@ const MultichainBridgeTransactionListItem = ({
       rightContent={
         <>
           <Text
-            className="activity-list-item__primary-currency"
+            className="activity-list-item__primary-currency text-s-body-md @compact:text-s-body-sm"
             color={TextColor.textDefault}
             data-testid="transaction-list-item-primary-currency"
             ellipsis
             fontWeight={FontWeight.Medium}
             textAlign={TextAlign.Right}
             title="Primary Currency"
-            variant={TextVariant.bodyMdMedium}
           >
             {(() => {
               if (sourceAsset?.fungible) {

--- a/ui/components/app/perps/order-card/order-card.tsx
+++ b/ui/components/app/perps/order-card/order-card.tsx
@@ -92,6 +92,7 @@ export const OrderCard = ({
         baseStyles,
         heightStyle,
         variantStyles,
+        '[container-name:list-item] [container-type:inline-size]',
       )}
       isFullWidth
       onClick={handleClick}
@@ -113,14 +114,24 @@ export const OrderCard = ({
         {isTriggerBasedOrder ? (
           // TP/SL: render label directly in the column so it wraps freely.
           // The symbol is redundant here — it appears after the size below.
-          <Text fontWeight={FontWeight.Medium}>{formatOrderLabel(order)}</Text>
+          <Text
+            fontWeight={FontWeight.Medium}
+            className="text-s-body-md @compact:text-s-body-sm"
+          >
+            {formatOrderLabel(order)}
+          </Text>
         ) : (
           <Box
             flexDirection={BoxFlexDirection.Row}
             alignItems={BoxAlignItems.Center}
             gap={1}
           >
-            <Text fontWeight={FontWeight.Medium}>{displayName}</Text>
+            <Text
+              fontWeight={FontWeight.Medium}
+              className="text-s-body-md @compact:text-s-body-sm"
+            >
+              {displayName}
+            </Text>
             <Text
               variant={TextVariant.BodySm}
               color={TextColor.TextAlternative}
@@ -140,7 +151,10 @@ export const OrderCard = ({
         alignItems={BoxAlignItems.End}
         gap={1}
       >
-        <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
+        <Text
+          fontWeight={FontWeight.Medium}
+          className="text-s-body-md @compact:text-s-body-sm"
+        >
           {orderValueUsd ?? t('perpsMarket')}
         </Text>
         {isTriggerBasedOrder && orderValueUsd && (

--- a/ui/components/app/perps/perps-market-card/perps-market-card.tsx
+++ b/ui/components/app/perps/perps-market-card/perps-market-card.tsx
@@ -19,7 +19,7 @@ import {
 } from '../utils';
 
 const CARD_STYLES =
-  'justify-start rounded-none min-w-0 h-[62px] gap-4 text-left cursor-pointer bg-default pt-2 pb-2 px-4 hover:bg-hover active:bg-pressed';
+  'justify-start rounded-none min-w-0 h-[62px] gap-4 text-left cursor-pointer bg-default pt-2 pb-2 px-4 hover:bg-hover active:bg-pressed [container-name:list-item] [container-type:inline-size]';
 
 export type PerpsMarketCardProps = {
   symbol: string;
@@ -63,7 +63,12 @@ export const PerpsMarketCard = ({
         alignItems={BoxAlignItems.Start}
         gap={1}
       >
-        <Text fontWeight={FontWeight.Medium}>{displayName}</Text>
+        <Text
+          fontWeight={FontWeight.Medium}
+          className="text-s-body-md @compact:text-s-body-sm"
+        >
+          {displayName}
+        </Text>
         {volume ? (
           <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
             {volume}
@@ -76,7 +81,10 @@ export const PerpsMarketCard = ({
         alignItems={BoxAlignItems.End}
         gap={1}
       >
-        <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
+        <Text
+          fontWeight={FontWeight.Medium}
+          className="text-s-body-md @compact:text-s-body-sm"
+        >
           {price}
         </Text>
         <Text

--- a/ui/components/app/perps/position-card/position-card.tsx
+++ b/ui/components/app/perps/position-card/position-card.tsx
@@ -68,6 +68,7 @@ export const PositionCard = ({ position, onClick }: PositionCardProps) => {
         'gap-4 text-left cursor-pointer',
         'bg-default pt-2 pb-2 px-4 h-[62px]',
         'hover:bg-hover active:bg-pressed',
+        '[container-name:list-item] [container-type:inline-size]',
       )}
       isFullWidth
       onClick={handleClick}
@@ -92,7 +93,12 @@ export const PositionCard = ({ position, onClick }: PositionCardProps) => {
           alignItems={BoxAlignItems.Center}
           gap={1}
         >
-          <Text fontWeight={FontWeight.Medium}>{displayName}</Text>
+          <Text
+            fontWeight={FontWeight.Medium}
+            className="text-s-body-md @compact:text-s-body-sm"
+          >
+            {displayName}
+          </Text>
           <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
             {position.leverage.value}x {direction}
           </Text>
@@ -109,7 +115,10 @@ export const PositionCard = ({ position, onClick }: PositionCardProps) => {
         alignItems={BoxAlignItems.End}
         gap={1}
       >
-        <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
+        <Text
+          fontWeight={FontWeight.Medium}
+          className="text-s-body-md @compact:text-s-body-sm"
+        >
           {formatPerpsFiatMinimal(parseFloat(position.positionValue))}
         </Text>
         <Box

--- a/ui/components/app/perps/transaction-card/transaction-card.tsx
+++ b/ui/components/app/perps/transaction-card/transaction-card.tsx
@@ -157,7 +157,12 @@ export const TransactionCard = ({
           alignItems={BoxAlignItems.Center}
           gap={2}
         >
-          <Text fontWeight={FontWeight.Medium}>{transaction.title}</Text>
+          <Text
+            fontWeight={FontWeight.Medium}
+            className="text-s-body-md @compact:text-s-body-sm"
+          >
+            {transaction.title}
+          </Text>
           {!(isClickable && hasInteractiveBadge) && (
             <PerpsFillTag transaction={transaction} screenName={screenName} />
           )}
@@ -174,9 +179,9 @@ export const TransactionCard = ({
         gap={1}
       >
         <Text
-          variant={TextVariant.BodySm}
           fontWeight={FontWeight.Medium}
           color={amountDisplay.color}
+          className="text-s-body-md @compact:text-s-body-sm"
         >
           {amountDisplay.text}
         </Text>
@@ -186,6 +191,7 @@ export const TransactionCard = ({
 
   const sharedClassName = twMerge(
     'gap-4 px-4 py-3',
+    '[container-name:list-item] [container-type:inline-size]',
     variantStyles,
     showTopBorder && 'border-t border-background-default',
   );
@@ -196,6 +202,7 @@ export const TransactionCard = ({
         flexDirection={BoxFlexDirection.Row}
         alignItems={BoxAlignItems.Center}
         className={twMerge(
+          '[container-name:list-item] [container-type:inline-size]',
           variantStyles,
           showTopBorder && 'border-t border-background-default',
         )}

--- a/ui/components/multichain/activity-list-item/__snapshots__/activity-list-item.test.js.snap
+++ b/ui/components/multichain/activity-list-item/__snapshots__/activity-list-item.test.js.snap
@@ -20,7 +20,7 @@ exports[`ActivityListItem should match snapshot with no props 1`] = `
             class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--align-items-center"
           >
             <p
-              class="mm-box mm-text mm-text--body-md-medium mm-text--font-weight-medium mm-text--ellipsis mm-text--text-align-left mm-box--color-text-default"
+              class="mm-box mm-text text-s-body-md @compact:text-s-body-sm mm-text--body-md-medium mm-text--font-weight-medium mm-text--ellipsis mm-text--text-align-left mm-box--color-text-default"
               data-testid="activity-list-item-action"
             />
           </div>
@@ -66,14 +66,14 @@ exports[`ActivityListItem should match snapshot with props 1`] = `
             class="mm-box mm-box--display-flex mm-box--flex-direction-row mm-box--align-items-center"
           >
             <p
-              class="mm-box mm-text mm-text--body-md-medium mm-text--font-weight-medium mm-text--ellipsis mm-text--text-align-left mm-box--color-text-default"
+              class="mm-box mm-text text-s-body-md @compact:text-s-body-sm mm-text--body-md-medium mm-text--font-weight-medium mm-text--ellipsis mm-text--text-align-left mm-box--color-text-default"
               data-testid="activity-list-item-action"
             >
               Hello World
             </p>
           </div>
           <div
-            class="mm-box mm-text mm-text--body-sm-medium mm-text--ellipsis mm-text--text-align-left mm-box--color-text-default"
+            class="mm-box mm-text text-s-body-md @compact:text-s-body-sm mm-text--body-sm-medium mm-text--ellipsis mm-text--text-align-left mm-box--color-text-default"
           >
             <p>
               I am a list item

--- a/ui/components/multichain/activity-list-item/activity-list-item.js
+++ b/ui/components/multichain/activity-list-item/activity-list-item.js
@@ -93,6 +93,7 @@ export const ActivityListItem = ({
                 variant={TextVariant.bodyMdMedium}
                 fontWeight={FontWeight.Medium}
                 data-testid="activity-list-item-action"
+                className="text-s-body-md @compact:text-s-body-sm"
               >
                 {title}
               </Text>
@@ -103,6 +104,7 @@ export const ActivityListItem = ({
                 ellipsis
                 textAlign={TextAlign.Left}
                 variant={TextVariant.bodySmMedium}
+                className="text-s-body-md @compact:text-s-body-sm"
               >
                 {subtitle}
               </Text>

--- a/ui/components/multichain/activity-v2/activity-list-item.tsx
+++ b/ui/components/multichain/activity-v2/activity-list-item.tsx
@@ -64,7 +64,7 @@ export const ActivityListItem = ({ transaction, onClick }: Props) => {
         {/* Left side - Action and Details */}
         <div className="flex-1 min-w-0">
           <Text
-            className="font-medium truncate"
+            className="font-medium truncate text-s-body-md @compact:text-s-body-sm"
             data-testid="activity-list-item-action"
           >
             {title}
@@ -90,7 +90,7 @@ export const ActivityListItem = ({ transaction, onClick }: Props) => {
         <div className="flex flex-col items-end">
           {amount && token && (
             <Text
-              className="font-medium"
+              className="font-medium text-s-body-md @compact:text-s-body-sm"
               data-testid="transaction-list-item-primary-currency"
             >
               {formatTokenAmount(amount, token.symbol)}

--- a/ui/components/multichain/activity-v2/activity-list.tsx
+++ b/ui/components/multichain/activity-v2/activity-list.tsx
@@ -271,7 +271,7 @@ export const ActivityList = ({ filter }: Props) => {
               return (
                 <div
                   key={String(virtualItem.key)}
-                  className="absolute top-0 left-0 w-full"
+                  className="absolute top-0 left-0 w-full [container-type:inline-size]"
                   data-index={virtualItem.index}
                   ref={(node) => {
                     virtualizer.measureElement(node);

--- a/ui/components/multichain/activity-v2/activity-list.tsx
+++ b/ui/components/multichain/activity-v2/activity-list.tsx
@@ -271,7 +271,7 @@ export const ActivityList = ({ filter }: Props) => {
               return (
                 <div
                   key={String(virtualItem.key)}
-                  className="absolute top-0 left-0 w-full [container-type:inline-size]"
+                  className="absolute top-0 left-0 w-full [container-name:list-item] [container-type:inline-size]"
                   data-index={virtualItem.index}
                   ref={(node) => {
                     virtualizer.measureElement(node);

--- a/ui/components/multichain/activity-v2/non-evm-activity-list-item.tsx
+++ b/ui/components/multichain/activity-v2/non-evm-activity-list-item.tsx
@@ -91,7 +91,7 @@ export const NonEvmActivityListItem = ({ transaction, onClick }: Props) => {
       // @ts-expect-error: React 18 ReactElement.key is Key|null, incompatible with @types/prop-types ReactNodeLike
       rightContent={
         <Text
-          className="activity-list-item__primary-currency"
+          className="activity-list-item__primary-currency text-s-body-md @compact:text-s-body-sm"
           data-testid="transaction-list-item-primary-currency"
           ellipsis
         >

--- a/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
+++ b/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
@@ -220,7 +220,7 @@ exports[`AssetPage should render a native asset 1`] = `
         Your balance
       </h4>
       <div
-        class="flex-row gap-4 flex h-full w-full"
+        class="flex-row gap-4 flex h-full w-full [container-type:inline-size]"
       >
         <a
           class="flex w-full flex-row py-2 px-4 "
@@ -264,7 +264,7 @@ exports[`AssetPage should render a native asset 1`] = `
                 class="flex flex-row gap-2 min-w-0"
               >
                 <p
-                  class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--ellipsis mm-box--color-text-default"
+                  class="mm-box mm-text text-s-body-md @compact:text-s-body-sm mm-text--body-md mm-text--font-weight-medium mm-text--ellipsis mm-box--color-text-default"
                   data-testid="multichain-token-list-item-token-name"
                 >
                   TEST
@@ -297,7 +297,7 @@ exports[`AssetPage should render a native asset 1`] = `
                 </button>
               </div>
               <p
-                class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--ellipsis mm-text--text-align-end mm-box--color-text-default"
+                class="mm-box mm-text text-s-body-md @compact:text-s-body-sm mm-text--body-md mm-text--font-weight-medium mm-text--ellipsis mm-text--text-align-end mm-box--color-text-default"
                 data-testid="multichain-token-list-item-secondary-value"
                 style="white-space: nowrap; padding-inline-start: 8px;"
               >
@@ -318,7 +318,7 @@ exports[`AssetPage should render a native asset 1`] = `
                 </p>
               </div>
               <p
-                class="mm-box mm-text mm-text--body-sm-medium mm-text--text-align-end mm-box--color-text-alternative"
+                class="mm-box mm-text text-s-body-md @compact:text-s-body-sm mm-text--body-md mm-text--text-align-end mm-box--color-text-alternative"
                 data-testid="multichain-token-list-item-value"
               >
                 0 TEST
@@ -588,7 +588,7 @@ exports[`AssetPage should render an ERC20 asset without prices 1`] = `
         Your balance
       </h4>
       <div
-        class="flex-row gap-4 flex h-full w-full"
+        class="flex-row gap-4 flex h-full w-full [container-type:inline-size]"
       >
         <a
           class="flex w-full flex-row py-2 px-4 "
@@ -632,14 +632,14 @@ exports[`AssetPage should render an ERC20 asset without prices 1`] = `
                 class="flex flex-row gap-2 min-w-0"
               >
                 <p
-                  class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--ellipsis mm-box--color-text-default"
+                  class="mm-box mm-text text-s-body-md @compact:text-s-body-sm mm-text--body-md mm-text--font-weight-medium mm-text--ellipsis mm-box--color-text-default"
                   data-testid="multichain-token-list-item-token-name"
                 >
                   TEST
                 </p>
               </div>
               <p
-                class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--text-align-end mm-box--color-text-default"
+                class="mm-box mm-text text-s-body-md @compact:text-s-body-sm mm-text--body-md mm-text--font-weight-medium mm-text--text-align-end mm-box--color-text-default"
                 data-testid="multichain-token-list-item-secondary-value"
                 style="white-space: nowrap; padding-inline-start: 8px;"
               >
@@ -660,7 +660,7 @@ exports[`AssetPage should render an ERC20 asset without prices 1`] = `
                 </p>
               </div>
               <p
-                class="mm-box mm-text mm-text--body-sm-medium mm-text--text-align-end mm-box--color-text-alternative"
+                class="mm-box mm-text text-s-body-md @compact:text-s-body-sm mm-text--body-md mm-text--text-align-end mm-box--color-text-alternative"
                 data-testid="multichain-token-list-item-value"
               >
                 0 TEST
@@ -1009,7 +1009,7 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
         Your balance
       </h4>
       <div
-        class="flex-row gap-4 flex h-full w-full"
+        class="flex-row gap-4 flex h-full w-full [container-type:inline-size]"
       >
         <a
           class="flex w-full flex-row py-2 px-4 "
@@ -1053,14 +1053,14 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
                 class="flex flex-row gap-2 min-w-0"
               >
                 <p
-                  class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--ellipsis mm-box--color-text-default"
+                  class="mm-box mm-text text-s-body-md @compact:text-s-body-sm mm-text--body-md mm-text--font-weight-medium mm-text--ellipsis mm-box--color-text-default"
                   data-testid="multichain-token-list-item-token-name"
                 >
                   TEST
                 </p>
               </div>
               <p
-                class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--text-align-end mm-box--color-text-default"
+                class="mm-box mm-text text-s-body-md @compact:text-s-body-sm mm-text--body-md mm-text--font-weight-medium mm-text--text-align-end mm-box--color-text-default"
                 data-testid="multichain-token-list-item-secondary-value"
                 style="white-space: nowrap; padding-inline-start: 8px;"
               >
@@ -1081,7 +1081,7 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
                 </p>
               </div>
               <p
-                class="mm-box mm-text mm-text--body-sm-medium mm-text--text-align-end mm-box--color-text-alternative"
+                class="mm-box mm-text text-s-body-md @compact:text-s-body-sm mm-text--body-md mm-text--text-align-end mm-box--color-text-alternative"
                 data-testid="multichain-token-list-item-value"
               >
                 0 TEST

--- a/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
+++ b/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
@@ -220,7 +220,7 @@ exports[`AssetPage should render a native asset 1`] = `
         Your balance
       </h4>
       <div
-        class="flex-row gap-4 flex h-full w-full [container-type:inline-size]"
+        class="flex-row gap-4 flex h-full w-full [container-name:list-item] [container-type:inline-size]"
       >
         <a
           class="flex w-full flex-row py-2 px-4 "
@@ -588,7 +588,7 @@ exports[`AssetPage should render an ERC20 asset without prices 1`] = `
         Your balance
       </h4>
       <div
-        class="flex-row gap-4 flex h-full w-full [container-type:inline-size]"
+        class="flex-row gap-4 flex h-full w-full [container-name:list-item] [container-type:inline-size]"
       >
         <a
           class="flex w-full flex-row py-2 px-4 "
@@ -1009,7 +1009,7 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
         Your balance
       </h4>
       <div
-        class="flex-row gap-4 flex h-full w-full [container-type:inline-size]"
+        class="flex-row gap-4 flex h-full w-full [container-name:list-item] [container-type:inline-size]"
       >
         <a
           class="flex w-full flex-row py-2 px-4 "

--- a/ui/pages/defi/components/__snapshots__/defi-details-page.test.tsx.snap
+++ b/ui/pages/defi/components/__snapshots__/defi-details-page.test.tsx.snap
@@ -87,7 +87,7 @@ exports[`DeFiDetailsPage renders defi asset page 1`] = `
             Staked
           </p>
           <div
-            class="flex-row gap-4 flex h-full w-full"
+            class="flex-row gap-4 flex h-full w-full [container-type:inline-size]"
           >
             <a
               class="flex w-full flex-row py-2 px-4 "
@@ -131,14 +131,14 @@ exports[`DeFiDetailsPage renders defi asset page 1`] = `
                     class="flex flex-row gap-2 min-w-0"
                   >
                     <p
-                      class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--ellipsis mm-box--color-text-default"
+                      class="mm-box mm-text text-s-body-md @compact:text-s-body-sm mm-text--body-md mm-text--font-weight-medium mm-text--ellipsis mm-box--color-text-default"
                       data-testid="multichain-token-list-item-token-name"
                     >
                       Liquid staked Ether 2.0
                     </p>
                   </div>
                   <p
-                    class="mm-box mm-text mm-text--body-md mm-text--font-weight-medium mm-text--text-align-end mm-box--color-text-default"
+                    class="mm-box mm-text text-s-body-md @compact:text-s-body-sm mm-text--body-md mm-text--font-weight-medium mm-text--text-align-end mm-box--color-text-default"
                     data-testid="multichain-token-list-item-secondary-value"
                     style="white-space: nowrap; padding-inline-start: 8px;"
                   >
@@ -159,7 +159,7 @@ exports[`DeFiDetailsPage renders defi asset page 1`] = `
                     </p>
                   </div>
                   <p
-                    class="mm-box mm-text mm-text--body-sm-medium mm-text--text-align-end mm-box--color-text-alternative"
+                    class="mm-box mm-text text-s-body-md @compact:text-s-body-sm mm-text--body-md mm-text--text-align-end mm-box--color-text-alternative"
                     data-testid="multichain-token-list-item-value"
                   >
                     10 Liquid staked Ether 2.0

--- a/ui/pages/defi/components/__snapshots__/defi-details-page.test.tsx.snap
+++ b/ui/pages/defi/components/__snapshots__/defi-details-page.test.tsx.snap
@@ -87,7 +87,7 @@ exports[`DeFiDetailsPage renders defi asset page 1`] = `
             Staked
           </p>
           <div
-            class="flex-row gap-4 flex h-full w-full [container-type:inline-size]"
+            class="flex-row gap-4 flex h-full w-full [container-name:list-item] [container-type:inline-size]"
           >
             <a
               class="flex w-full flex-row py-2 px-4 "


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Container-based responsive typography for activity, token. defi and perps list items
- Adds a "compact" container query (width < 400px)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: feat: container-based responsive text
## **Related issues**

Fixes:

## **Manual testing steps**

1. Open sidebar (Chrome)
2. Adjust sidebar below 400px wide


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/a7e08cf3-9d80-4dff-8bb4-1a79100d65ac



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only typography and Tailwind variant changes across list UIs; no auth, transactions, or data-handling logic.
> 
> **Overview**
> Adds **container-query–based typography** so list rows shrink text when the row is narrower than 400px, instead of relying only on viewport breakpoints.
> 
> **Tailwind** registers a custom `@compact` variant (`@container list-item (max-width: 399px)`). Row shells are marked as inline-size containers named `list-item` (shared asset cell layout, virtualized activity rows, Perps cards, etc.).
> 
> **UI** applies `text-s-body-md` with `@compact:text-s-body-sm` on primary labels and amounts across token/DeFi cells, legacy and v2 activity items, bridge activity, and Perps market/order/position/transaction cards. Some `Text`/`SensitiveText` usage drops `TextVariant` in favor of these classes (secondary fiat display uses `clsx` for base size + compact override).
> 
> Snapshot tests reflect the new classes on rendered markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c164cf66125b156c18e383c88d54cbb73e0ca27c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->