### PR TITLE
fix: #42683: [Bug]: When global balance is hidden, the Perps balance is still displayed

### DIFF
--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx
@@ -41,6 +41,16 @@ const mockStore = configureStore({
   },
 });
 
+const mockPrivacyModeStore = configureStore({
+  metamask: {
+    ...mockState.metamask,
+    preferences: {
+      ...mockState.metamask.preferences,
+      privacyMode: true,
+    },
+  },
+});
+
 describe('invokePerpsBalanceAction', () => {
   it('logs when callback returns a rejected promise', async () => {
     const consoleErrorSpy = jest
@@ -85,6 +95,23 @@ describe('PerpsBalanceDropdown', () => {
     renderWithProvider(<PerpsBalanceDropdown />, mockStore);
 
     expect(screen.getByText('$15,250')).toBeInTheDocument();
+  });
+
+  it('masks the total balance when privacy mode is enabled', () => {
+    renderWithProvider(<PerpsBalanceDropdown />, mockPrivacyModeStore);
+
+    expect(screen.queryByText('$15,250')).not.toBeInTheDocument();
+    expect(screen.getByText(/•+/u)).toBeInTheDocument();
+  });
+
+  it('masks the unrealized P&L when privacy mode is enabled', () => {
+    renderWithProvider(
+      <PerpsBalanceDropdown hasPositions />,
+      mockPrivacyModeStore,
+    );
+
+    expect(screen.queryByText(/\+\$375/u)).not.toBeInTheDocument();
+    expect(screen.queryByText(/7\.32%/u)).not.toBeInTheDocument();
   });
 
   it('renders loading skeleton when account data is still loading', () => {

--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
 import {
   twMerge,
   TextVariant,
@@ -12,10 +13,18 @@ import {
   BoxFlexDirection,
   BoxJustifyContent,
   BoxAlignItems,
-  FontWeight,
   ButtonBase,
 } from '@metamask/design-system-react';
 import type { Position } from '@metamask/perps-controller';
+import {
+  SensitiveText,
+  SensitiveTextLength,
+} from '../../../component-library';
+import {
+  TextVariant as LegacyTextVariant,
+  TextColor as LegacyTextColor,
+} from '../../../../helpers/constants/design-system';
+import { getPrivacyMode } from '../../../../selectors';
 import {
   formatPerpsFiat,
   PRICE_RANGES_MINIMAL_VIEW,
@@ -73,6 +82,7 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
   onWithdraw,
 }) => {
   const t = useI18nContext();
+  const privacyMode = useSelector(getPrivacyMode);
   const { account, isInitialLoading } = usePerpsLiveAccount();
   const { formatPercentWithMinThreshold } = useFormatters();
   const { isEligible } = usePerpsEligibility();
@@ -179,11 +189,15 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
               alignItems={BoxAlignItems.Center}
               gap={2}
             >
-              <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
+              <SensitiveText
+                variant={LegacyTextVariant.bodySmMedium}
+                isHidden={privacyMode}
+                length={SensitiveTextLength.Medium}
+              >
                 {formatPerpsFiat(accountValue, {
                   ranges: PRICE_RANGES_MINIMAL_VIEW,
                 })}
-              </Text>
+              </SensitiveText>
               <Icon
                 name={isDropdownOpen ? IconName.ArrowUp : IconName.ArrowDown}
                 size={IconSize.Xs}
@@ -235,13 +249,18 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
           <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
             {t('perpsUnrealizedPnl')}
           </Text>
-          <Text
-            variant={TextVariant.BodySm}
-            fontWeight={FontWeight.Medium}
-            color={isProfit ? TextColor.SuccessDefault : TextColor.ErrorDefault}
+          <SensitiveText
+            variant={LegacyTextVariant.bodySmMedium}
+            color={
+              isProfit
+                ? LegacyTextColor.successDefault
+                : LegacyTextColor.errorDefault
+            }
+            isHidden={privacyMode}
+            length={SensitiveTextLength.Medium}
           >
             {formattedPnl} ({formattedRoe})
-          </Text>
+          </SensitiveText>
         </Box>
       )}
       <PerpsGeoBlockModal

--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
@@ -16,10 +16,7 @@ import {
   ButtonBase,
 } from '@metamask/design-system-react';
 import type { Position } from '@metamask/perps-controller';
-import {
-  SensitiveText,
-  SensitiveTextLength,
-} from '../../../component-library';
+import { SensitiveText, SensitiveTextLength } from '../../../component-library';
 import {
   TextVariant as LegacyTextVariant,
   TextColor as LegacyTextColor,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When a user enables the global "hide balance" privacy setting, the Perps tab still displayed the real total balance and unrealized P&L figures, unlike every other balance surface in the app and unlike mobile. The cause was that PerpsBalanceDropdown rendered those values in unconditional design-system Text elements and never read the privacyMode preference.

This change reads privacyMode via the existing getPrivacyMode selector in ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx and renders the total balance and P&L values through the canonical SensitiveText component with isHidden={privacyMode}, mirroring how token-list-item and aggregated-balance mask fiat figures. The static labels and chevron are left untouched. The legacy TextVariant/TextColor enums are aliased so SensitiveText keeps the existing BodySm medium-weight styling and success/error colors without shadowing the design-system-react identifiers used elsewhere in the file.

## **Changelog**

CHANGELOG entry: Fixed the Perps balance and unrealized P&L not being hidden when the global balance privacy setting is enabled.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/42683

## **Manual testing steps**

1. Check out this branch locally and open the extension.
2. On the wallet home screen, click the total balance to hide it (enable privacy mode).
3. Open the Perps tab and confirm the total balance shown in the balance dropdown is masked with dots instead of the dollar amount.
4. With an open position, confirm the unrealized P&L row is also masked.
5. Click the balance again to unhide it and confirm the Perps balance and P&L values reappear.
6. Run the unit tests: yarn jest ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- AEP_SCREENSHOTS_START -->
<details open><summary>perps-balance-hidden-privacy-mode-1781152876296.png</summary>

<img alt="perps-balance-hidden-privacy-mode-1781152876296.png" src="https://diner-expulsion-catapult.ngrok-free.dev/v1/runs/dfd166f8-b4e5-469e-bfdf-e93fb3ccddf1/artifacts/perps-balance-hidden-privacy-mode-1781152876296.png" width="420" />

[Open full-size image](https://diner-expulsion-catapult.ngrok-free.dev/v1/runs/dfd166f8-b4e5-469e-bfdf-e93fb3ccddf1/artifacts/perps-balance-hidden-privacy-mode-1781152876296.png)

</details>

<!-- AEP_SCREENSHOTS_END -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- AEP_VISUAL_VALIDATION_START -->
## AEP Visual Validation

**✅ Passed**

The evidence credibly proves the PR's target behavior.

<details><summary>Validation details</summary>

Visual validation passed: The evidence credibly proves the PR's target behavior. The validation enabled global privacy mode (privacyMode=true confirmed via CDP), opened the Perps tab where perps-balance-dropdown rendered (not the skeleton), and injected a confirmed non-zero perps account snapshot (totalBalance 15250.00, unrealizedPnl 375.00, returnOnEquity 7.32) plus one open position into the in-memory PerpsStreamManager. The get_text observations directly show the figures masked while static labels remain visible: perps-balance-dropdown-balance = 'Total balance•••••••••' (no $15,250) and perps-balance-dropdown-pnl = 'Unrealized P&L•••••••••' (no +$375 (7.32%)), with chevron and labels intact. All four planned assertions are supported by textual CLI output, not just zero exit codes. Confidence is held at medium because screenshot pixels are not directly available for inspection and no negative control (privacy mode OFF revealing the real $15,250/$375 against the same injected data) was captured, so masking is inferred from the masked state plus targeted label-vs-figure contrast rather than a side-by-side before/after.

**metamask-mm-visual-validation** — passed. Validated PR #43185: the Perps balance dropdown masks figures under global privacy mode while keeping static labels and chevron visible. Launched the default pre-onboarded wallet, unlocked, and enabled global privacy mode by clicking the home total balance (testid eth-overview__primary-currency; the home prefix differs from the planned coin-overview__ but the same handleSensitiveToggle ran and privacyMode=true was confirmed via CDP). Opened the Perps tab where perps-balance-dropdown rendered (not perps-control-bar-skeleton). The balance/P&L come from the in-memory PerpsStreamManager, not Redux, so I located the singleton via a React-fiber walk (found it inside a useEffect deps array, account channel name confirmed), disconnected the live sources for the account and positions channels, and pushData'd a non-zero account snapshot (totalBalance 15250.00, unrealizedPnl 375.00, returnOnEquity 7.32) plus one open ETH position so hasPositions became true. After injection: perps-balance-dropdown-balance read 'Total balance•••••••••' (no $15,250) and perps-balance-dropdown-pnl read 'Unrealized P&L•••••••••' (no +$375 (7.32%)), with the chevron and both static labels still present. All four assertions met. Screenshot captured.

</details>

Run `dfd166f8-b4e5-469e-bfdf-e93fb3ccddf1` · [LangSmith trace](https://smith.langchain.com/o/09df0f02-e7c8-47f9-b00a-9e4757168f81/projects/p/metamask-aep)
<!-- AEP_VISUAL_VALIDATION_END -->
