### PR TITLE
fix: #42683: [Bug]: When global balance is hidden, the Perps balance is still displayed

### DIFF
--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx
@@ -41,6 +41,16 @@ const mockStore = configureStore({
   },
 });
 
+const mockPrivacyModeStore = configureStore({
+  metamask: {
+    ...mockState.metamask,
+    preferences: {
+      ...mockState.metamask.preferences,
+      privacyMode: true,
+    },
+  },
+});
+
 describe('invokePerpsBalanceAction', () => {
   it('logs when callback returns a rejected promise', async () => {
     const consoleErrorSpy = jest
@@ -85,6 +95,27 @@ describe('PerpsBalanceDropdown', () => {
     renderWithProvider(<PerpsBalanceDropdown />, mockStore);
 
     expect(screen.getByText('$15,250')).toBeInTheDocument();
+  });
+
+  it('masks the total balance when privacy mode is enabled', () => {
+    renderWithProvider(<PerpsBalanceDropdown />, mockPrivacyModeStore);
+
+    expect(screen.queryByText('$15,250')).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId('perps-balance-dropdown-balance'),
+    ).toHaveTextContent('••••••');
+  });
+
+  it('masks the unrealized P&L when privacy mode is enabled', () => {
+    renderWithProvider(
+      <PerpsBalanceDropdown hasPositions />,
+      mockPrivacyModeStore,
+    );
+
+    expect(screen.queryByText(/\+\$375/u)).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId('perps-balance-dropdown-pnl'),
+    ).toHaveTextContent('••••••');
   });
 
   it('renders loading skeleton when account data is still loading', () => {

--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx
@@ -113,9 +113,9 @@ describe('PerpsBalanceDropdown', () => {
     );
 
     expect(screen.queryByText(/\+\$375/u)).not.toBeInTheDocument();
-    expect(
-      screen.getByTestId('perps-balance-dropdown-pnl'),
-    ).toHaveTextContent('••••••');
+    expect(screen.getByTestId('perps-balance-dropdown-pnl')).toHaveTextContent(
+      '••••••',
+    );
   });
 
   it('renders loading skeleton when account data is still loading', () => {

--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
 import {
   twMerge,
   TextVariant,
@@ -20,12 +21,16 @@ import {
   formatPerpsFiat,
   PRICE_RANGES_MINIMAL_VIEW,
 } from '../../../../../shared/lib/perps-formatters';
+import { getPrivacyMode } from '../../../../selectors';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { useFormatters } from '../../../../hooks/useFormatters';
 import { usePerpsEligibility } from '../../../../hooks/perps';
 import { usePerpsLiveAccount } from '../../../../hooks/perps/stream';
 import { PerpsGeoBlockModal } from '../perps-geo-block-modal';
 import { PerpsControlBarSkeleton } from '../perps-skeletons';
+
+/** Masked balance shown when the global hide-balance preference is enabled. Mirrors SensitiveTextLength.Short (6 bullets). */
+const HIDDEN_BALANCE = '••••••';
 
 /** Handler from perps triggers (e.g. deposit / withdraw); may return a Promise. */
 export type PerpsBalanceActionHandler = () => void | Promise<unknown>;
@@ -73,6 +78,7 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
   onWithdraw,
 }) => {
   const t = useI18nContext();
+  const privacyMode = useSelector(getPrivacyMode);
   const { account, isInitialLoading } = usePerpsLiveAccount();
   const { formatPercentWithMinThreshold } = useFormatters();
   const { isEligible } = usePerpsEligibility();
@@ -180,9 +186,11 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
               gap={2}
             >
               <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
-                {formatPerpsFiat(accountValue, {
-                  ranges: PRICE_RANGES_MINIMAL_VIEW,
-                })}
+                {privacyMode
+                  ? HIDDEN_BALANCE
+                  : formatPerpsFiat(accountValue, {
+                      ranges: PRICE_RANGES_MINIMAL_VIEW,
+                    })}
               </Text>
               <Icon
                 name={isDropdownOpen ? IconName.ArrowUp : IconName.ArrowDown}
@@ -240,7 +248,9 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
             fontWeight={FontWeight.Medium}
             color={isProfit ? TextColor.SuccessDefault : TextColor.ErrorDefault}
           >
-            {formattedPnl} ({formattedRoe})
+            {privacyMode
+              ? HIDDEN_BALANCE
+              : `${formattedPnl} (${formattedRoe})`}
           </Text>
         </Box>
       )}

--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
@@ -248,9 +248,7 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
             fontWeight={FontWeight.Medium}
             color={isProfit ? TextColor.SuccessDefault : TextColor.ErrorDefault}
           >
-            {privacyMode
-              ? HIDDEN_BALANCE
-              : `${formattedPnl} (${formattedRoe})`}
+            {privacyMode ? HIDDEN_BALANCE : `${formattedPnl} (${formattedRoe})`}
           </Text>
         </Box>
       )}

--- a/ui/components/app/perps/perps-market-balance-actions/perps-market-balance-actions.test.tsx
+++ b/ui/components/app/perps/perps-market-balance-actions/perps-market-balance-actions.test.tsx
@@ -39,6 +39,16 @@ const mockStore = configureStore({
   },
 });
 
+const mockPrivacyModeStore = configureStore({
+  metamask: {
+    ...mockState.metamask,
+    preferences: {
+      ...mockState.metamask.preferences,
+      privacyMode: true,
+    },
+  },
+});
+
 describe('PerpsMarketBalanceActions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -58,6 +68,26 @@ describe('PerpsMarketBalanceActions', () => {
     expect(
       screen.getByTestId('perps-balance-actions-add-funds'),
     ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('perps-balance-actions-total'),
+    ).toHaveTextContent('$15,250.00');
+  });
+
+  it('masks the balances when privacy mode is enabled', () => {
+    renderWithProvider(
+      <PerpsMarketBalanceActions showActionButtons />,
+      mockPrivacyModeStore,
+    );
+
+    expect(
+      screen.queryByText('$15,250.00'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId('perps-balance-actions-total'),
+    ).toHaveTextContent('••••••');
+    expect(
+      screen.getByTestId('perps-balance-actions-available'),
+    ).toHaveTextContent('••••••');
   });
 
   it('calls onAddFunds when eligible', () => {

--- a/ui/components/app/perps/perps-market-balance-actions/perps-market-balance-actions.test.tsx
+++ b/ui/components/app/perps/perps-market-balance-actions/perps-market-balance-actions.test.tsx
@@ -68,9 +68,9 @@ describe('PerpsMarketBalanceActions', () => {
     expect(
       screen.getByTestId('perps-balance-actions-add-funds'),
     ).toBeInTheDocument();
-    expect(
-      screen.getByTestId('perps-balance-actions-total'),
-    ).toHaveTextContent('$15,250.00');
+    expect(screen.getByTestId('perps-balance-actions-total')).toHaveTextContent(
+      '$15,250.00',
+    );
   });
 
   it('masks the balances when privacy mode is enabled', () => {
@@ -79,12 +79,10 @@ describe('PerpsMarketBalanceActions', () => {
       mockPrivacyModeStore,
     );
 
-    expect(
-      screen.queryByText('$15,250.00'),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.getByTestId('perps-balance-actions-total'),
-    ).toHaveTextContent('••••••');
+    expect(screen.queryByText('$15,250.00')).not.toBeInTheDocument();
+    expect(screen.getByTestId('perps-balance-actions-total')).toHaveTextContent(
+      '••••••',
+    );
     expect(
       screen.getByTestId('perps-balance-actions-available'),
     ).toHaveTextContent('••••••');

--- a/ui/components/app/perps/perps-market-balance-actions/perps-market-balance-actions.tsx
+++ b/ui/components/app/perps/perps-market-balance-actions/perps-market-balance-actions.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useState } from 'react';
+import { useSelector } from 'react-redux';
 import {
   Box,
   Button,
@@ -18,6 +19,7 @@ import {
   PERPS_EVENT_VALUE,
 } from '../../../../../shared/constants/perps-events';
 import { MetaMetricsEventName } from '../../../../../shared/constants/metametrics';
+import { getPrivacyMode } from '../../../../selectors';
 import {
   usePerpsEligibility,
   usePerpsEventTracking,
@@ -31,6 +33,9 @@ import {
   type PerpsBalanceActionHandler,
 } from '../perps-balance-dropdown';
 import { PerpsGeoBlockModal } from '../perps-geo-block-modal';
+
+/** Masked balance shown when the global hide-balance preference is enabled. Mirrors SensitiveTextLength.Short (6 bullets). */
+const HIDDEN_BALANCE = '••••••';
 
 type PerpsMarketBalanceActionsProps = {
   /** Whether to show the action buttons (Add funds, Withdraw) */
@@ -53,6 +58,7 @@ const PerpsMarketBalanceActions = ({
   onLearnMore,
 }: PerpsMarketBalanceActionsProps) => {
   const t = useI18nContext();
+  const privacyMode = useSelector(getPrivacyMode);
   const { track } = usePerpsEventTracking();
   const { formatCurrency } = useFormatters();
   const { account } = usePerpsLiveAccount();
@@ -198,7 +204,7 @@ const PerpsMarketBalanceActions = ({
         fontWeight={FontWeight.Medium}
         data-testid="perps-balance-actions-total"
       >
-        {formatCurrency(accountValue, 'USD')}
+        {privacyMode ? HIDDEN_BALANCE : formatCurrency(accountValue, 'USD')}
       </Text>
 
       {/* Available Balance */}
@@ -208,7 +214,9 @@ const PerpsMarketBalanceActions = ({
           color={TextColor.TextAlternative}
           data-testid="perps-balance-actions-available"
         >
-          {formatCurrency(parseFloat(availableBalance), 'USD')}{' '}
+          {privacyMode
+            ? HIDDEN_BALANCE
+            : formatCurrency(parseFloat(availableBalance), 'USD')}{' '}
           {t('perpsAvailable').toLowerCase()}
         </Text>
       </Box>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When a user hid their global balance from the wallet home, the Perps tab still showed real fiat figures: the total balance and unrealized P&L in the balance dropdown, and the account value and available balance on the market detail page. The Perps balance components rendered formatted currency without ever consulting the privacy-mode preference, so they stayed visible while every other balance surface was masked.

This change wires the existing `getPrivacyMode` selector into `PerpsBalanceDropdown` and `PerpsMarketBalanceActions` and, when privacy mode is on, swaps the formatted values for a 6-bullet mask string that mirrors the `SensitiveTextLength.Short` convention used elsewhere in the app. Non-balance labels (Total balance, available) remain visible, matching the mobile behavior.

## **Changelog**

CHANGELOG entry: Fixed Perps balances remaining visible when the global balance is hidden; the Perps total balance, P&L, and available balance are now masked along with the rest of the wallet.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/42683

## **Manual testing steps**

1. Check out this branch and load the extension.
2. On the wallet home, click the total balance to hide it (enable privacy mode).
3. Open the Perps tab and confirm the total balance and unrealized P&L now show bullet masks instead of dollar amounts.
4. Open a Perps market detail page and confirm the account value and available balance are also masked.
5. Click the balance again to unhide it and confirm the real Perps figures return.
6. Run the colocated tests: `yarn jest ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx ui/components/app/perps/perps-market-balance-actions/perps-market-balance-actions.test.tsx`.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- AEP_SCREENSHOTS_START -->
<details open><summary>perps-tab-balance-masked-privacy-mode-1780548790528.png</summary>

<img alt="perps-tab-balance-masked-privacy-mode-1780548790528.png" src="https://diner-expulsion-catapult.ngrok-free.dev/v1/runs/12ee1f5f-1313-46a2-8d32-b8c93502ae3a/artifacts/perps-tab-balance-masked-privacy-mode-1780548790528.png" width="420" />

[Open full-size image](https://diner-expulsion-catapult.ngrok-free.dev/v1/runs/12ee1f5f-1313-46a2-8d32-b8c93502ae3a/artifacts/perps-tab-balance-masked-privacy-mode-1780548790528.png)

</details>

<!-- AEP_SCREENSHOTS_END -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- AEP_VISUAL_VALIDATION_START -->
## AEP Visual Validation

**✅ Passed**

Evidence proves the primary PR behavior: with privacy mode enabled via the issue's real repro step (clicking the home balance, verified by a cdp Redux read-back of privacyMode=true), the home Perps tab's perps-balance-dropdown-balance rende…

<details><summary>Validation details</summary>

Visual validation passed: Evidence proves the primary PR behavior: with privacy mode enabled via the issue's real repro step (clicking the home balance, verified by a cdp Redux read-back of privacyMode=true), the home Perps tab's perps-balance-dropdown-balance renders 'Total balance••••••' (get-text confirmed), masking the value while keeping the label, with a screenshot and clean shutdown. However coverage is partial: the second changed component (perps-market-balance-actions.tsx) and the 'unrealized P&L' masking named in the target behavior were never exercised, and there is no control case showing a real fiat figure being hidden (account data was never injected), so the bullets could not be conclusively distinguished from an empty/placeholder render. Approve with medium confidence.

**metamask-mm-visual-validation** — passed. Visually validated PR #43186 fix for issue #42683: when global balance is hidden (privacy mode), the Perps tab balance is now masked. Launched the default pre-onboarded wallet, unlocked, confirmed the Perps tab (account-overview__perps-tab) was present (the fixture's remoteFeatureFlags.perpsEnabledVersion is already enabled and satisfied by the build version). Reproduced the issue's exact 'hide global balance by clicking on it' step by clicking the home balance, which flipped metamask.preferences.privacyMode to true (verified via mm cdp Redux read). Opened the Perps tab; perps-balance-dropdown-balance rendered 'Total balance••••••' (get-text confirmed), i.e. the total balance is masked with the 6-bullet string while the 'Total balance' label remains visible. No real fiat figure ($15,250 or similar) appears in the Perps balance header (the dollar values shown are market prices in the Explore section, not the user's balance). This matches the target behavior and the mobile hide-balance convention.

</details>

Run `12ee1f5f-1313-46a2-8d32-b8c93502ae3a` · [LangSmith trace](https://smith.langchain.com/o/09df0f02-e7c8-47f9-b00a-9e4757168f81/projects/p/metamask-aep)
<!-- AEP_VISUAL_VALIDATION_END -->
