### PR TITLE
chore: abort requests that hang instead of letting stall in e2e reports

### DIFF
--- a/.github/scripts/create-e2e-test-report.mts
+++ b/.github/scripts/create-e2e-test-report.mts
@@ -33,7 +33,24 @@ async function main() {
     GITHUB_ACTIONS: process.env.GITHUB_ACTIONS === 'true',
   };
 
-  const github = new Octokit({ auth: env.GITHUB_TOKEN });
+  // Abort individual GitHub API requests that hang instead of letting them
+  // stall the whole job until the workflow-level timeout. When a request times
+  // out it surfaces as an error that callers already handle gracefully.
+  const REQUEST_TIMEOUT_MS = Number(process.env.REQUEST_TIMEOUT_MS) || 30_000;
+
+  const github = new Octokit({
+    auth: env.GITHUB_TOKEN,
+    request: {
+      fetch: (
+        url: Parameters<typeof fetch>[0],
+        options: Parameters<typeof fetch>[1] = {},
+      ) =>
+        fetch(url, {
+          ...options,
+          signal: options.signal ?? AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        }),
+    },
+  });
 
   const jobsCache: { [runId: number]: Job[] } = {};
 

--- a/.github/scripts/create-e2e-test-report.mts
+++ b/.github/scripts/create-e2e-test-report.mts
@@ -36,7 +36,7 @@ async function main() {
   // Abort individual GitHub API requests that hang instead of letting them
   // stall the whole job until the workflow-level timeout. When a request times
   // out it surfaces as an error that callers already handle gracefully.
-  const REQUEST_TIMEOUT_MS = Number(process.env.REQUEST_TIMEOUT_MS) || 30_000;
+  const REQUEST_TIMEOUT_MS = 30_000;
 
   const github = new Octokit({
     auth: env.GITHUB_TOKEN,

--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -196,6 +196,7 @@ jobs:
       - test-e2e-chrome-api-specs-webpack
       - test-e2e-chrome-api-specs-multichain-webpack
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     if: ${{ !cancelled() }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The firefox create e2e report job hanged and stayed 30mins until it was cancelled (default timeout).
This wait time is too long an unnecessary. The gitbub api requests had not timeout, so a stalled request never throws, and it remains waiting until the workflow timeout reaches to the limit (30mins in firefox, none in chrome).

Now we have bounded requests which abort after 30s
Also added `timeout-minutes: 30` to the chrome job as it didn't have one at the workflow level, to keep parity with firefox.


https://github.com/MetaMask/metamask-extension/actions/runs/26885765863/job/79366946547?pr=43161

<img width="2608" height="1012" alt="image" src="https://github.com/user-attachments/assets/3201015f-b1e2-41b5-8ec3-668188d35f06" />


e2e-firefox<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only reporting script and workflow limits; no runtime product or auth/data paths.
> 
> **Overview**
> Improves reliability of the Chrome E2E **report** job when GitHub API calls hang.
> 
> `create-e2e-test-report.mts` now wires Octokit with a custom `fetch` that applies a **30s** `AbortSignal.timeout` on each request (unless a signal is already set), so a stuck API call fails fast instead of blocking until the workflow times out. Timeouts/errors still flow through existing handlers (e.g. `getJobs` returns `[]` on failure).
> 
> The `test-e2e-chrome-report` job in `e2e-chrome.yml` gets an explicit **`timeout-minutes: 30`** cap as a backstop for the whole report step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 539340dc02ac799823f721ffbba275fd8fcaf16d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->