### PR TITLE
ci: make the report jobs fail gracefully

### DIFF
--- a/.github/scripts/create-e2e-test-report.mts
+++ b/.github/scripts/create-e2e-test-report.mts
@@ -1,3 +1,4 @@
+import type { Endpoints } from '@octokit/types';
 import * as fs from 'fs/promises';
 import path from 'path';
 import type {
@@ -10,12 +11,17 @@ import {
   consoleBold,
   formatTime,
   normalizeTestPath,
+  withTimeout,
   XML,
 } from './shared/utils.mts';
-import type { Endpoints } from '@octokit/types';
 
 type Job =
   Endpoints['GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs']['response']['data']['jobs'][number];
+
+// Maximum time to wait for the GitHub jobs API for a single workflow run.
+// If exceeded, the lookup is abandoned and the report is generated without
+// job-link enrichment for that run.
+const JOBS_LOOKUP_TIMEOUT_MS = 30_000;
 
 async function main() {
   const { Octokit } = await import('octokit');
@@ -35,29 +41,45 @@ async function main() {
 
   const github = new Octokit({ auth: env.GITHUB_TOKEN });
 
+  // Successful lookups are cached. Failed lookups are recorded in
+  // failedRunIds so we don't retry (and re-warn) for the same runId, and so
+  // the final summary can list everything that was skipped.
   const jobsCache: { [runId: number]: Job[] } = {};
+  const failedRunIds = new Map<number, string>();
 
   async function getJobs(runId: number) {
     if (!runId) {
       return [];
-    } else if (jobsCache[runId]) {
+    }
+    if (jobsCache[runId]) {
       return jobsCache[runId];
-    } else {
-      try {
-        const jobs = await github.paginate(
-          github.rest.actions.listJobsForWorkflowRun,
-          {
-            owner: env.OWNER,
-            repo: env.REPOSITORY,
-            run_id: runId,
-            per_page: 100,
-          },
-        );
-        jobsCache[runId] = jobs;
-        return jobsCache[runId];
-      } catch (error) {
-        return [];
-      }
+    }
+    if (failedRunIds.has(runId)) {
+      return [];
+    }
+    try {
+      const jobs = await withTimeout(
+        github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+          owner: env.OWNER,
+          repo: env.REPOSITORY,
+          run_id: runId,
+          per_page: 100,
+        }),
+        JOBS_LOOKUP_TIMEOUT_MS,
+        `listJobsForWorkflowRun(runId=${runId})`,
+      );
+      jobsCache[runId] = jobs;
+      return jobsCache[runId];
+    } catch (error) {
+      // Best-effort: degrade to no job-link enrichment for this runId rather
+      // than failing report generation. Returning [] makes downstream code
+      // emit the report without "Job: [name](url)" lines for affected suites.
+      const reason = error instanceof Error ? error.message : String(error);
+      failedRunIds.set(runId, reason);
+      console.warn(
+        `⚠️ Skipping job-link enrichment for runId=${runId}: ${reason}`,
+      );
+      return [];
     }
   }
 
@@ -87,13 +109,36 @@ async function main() {
     const testRuns: TestRun[] = [];
     const filenames = await fs.readdir(env.TEST_RESULTS_PATH);
 
-    for (const filename of filenames) {
-      const file = await fs.readFile(
-        path.join(env.TEST_RESULTS_PATH, filename),
-        'utf8',
-      );
-      const results = await XML.parse(file);
+    // Three-phase structure so that a slow GitHub jobs API can't serialize
+    // N timeouts back-to-back and exceed the workflow step's overall budget.
+    // Phase 1: parse every XML in parallel.
+    const parsedFiles = await Promise.all(
+      filenames.map(async (filename) => {
+        const file = await fs.readFile(
+          path.join(env.TEST_RESULTS_PATH, filename),
+          'utf8',
+        );
+        return XML.parse(file);
+      }),
+    );
 
+    // Phase 2: collect every unique runId referenced by any suite, then
+    // prefetch their jobs concurrently. Worst-case wall time becomes ~one
+    // timeout regardless of how many runIds, instead of N × timeout.
+    const uniqueRunIds = new Set<number>();
+    for (const results of parsedFiles) {
+      for (const suite of results.testsuites.testsuite || []) {
+        const runId = suite.properties?.[0].property?.[1]?.$.value
+          ? +suite.properties?.[0].property?.[1]?.$.value
+          : 0;
+        if (runId) uniqueRunIds.add(runId);
+      }
+    }
+    await Promise.all([...uniqueRunIds].map((id) => getJobs(id)));
+
+    // Phase 3: build the report. getJobId() below now hits jobsCache (or
+    // failedRunIds) synchronously and never makes a network call.
+    for (const results of parsedFiles) {
       for (const suite of results.testsuites.testsuite || []) {
         if (!suite.testcase || !suite.$.file) continue;
         const tests = +suite.$.tests;
@@ -336,6 +381,14 @@ async function main() {
 
     await core.summary.write();
     await fs.writeFile(env.TEST_RUNS_PATH, JSON.stringify(testRuns, null, 2));
+
+    if (failedRunIds.size > 0) {
+      console.warn(
+        `⚠️ Job-link enrichment was skipped for ${failedRunIds.size} workflow run(s): ${[
+          ...failedRunIds.keys(),
+        ].join(', ')}`,
+      );
+    }
   } catch (error) {
     core.setFailed(`Error creating the test report: ${error}`);
   }

--- a/.github/scripts/shared/utils.mts
+++ b/.github/scripts/shared/utils.mts
@@ -118,3 +118,32 @@ export function consoleBold(str: string): string {
     .replaceAll('<strong>', '\x1b[1m')
     .replaceAll('</strong>', '\x1b[0m');
 }
+
+/**
+ * Race a promise against a timeout. The timer is always cleared in `finally`
+ * so it does not keep the Node process alive. The rejection error includes
+ * the operation label to aid diagnosis.
+ */
+export async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  operation: string,
+): Promise<T> {
+  let timer: ReturnType<typeof globalThis.setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<T>((_, reject) => {
+        timer = globalThis.setTimeout(() => {
+          reject(
+            new Error(
+              `Timed out after ${timeoutMs}ms waiting for ${operation}`,
+            ),
+          );
+        }, timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) globalThis.clearTimeout(timer);
+  }
+}

--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -196,6 +196,7 @@ jobs:
       - test-e2e-chrome-api-specs-webpack
       - test-e2e-chrome-api-specs-multichain-webpack
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: ${{ !cancelled() }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/e2e-firefox.yml
+++ b/.github/workflows/e2e-firefox.yml
@@ -110,7 +110,7 @@ jobs:
       - test-e2e-firefox-flask-webpack
       - test-e2e-firefox-dist-webpack
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 5
     if: ${{ !cancelled() }}
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## **Description**

We had a problem where sometimes the `test-e2e-chrome-report` and `test-e2e-firefox-report` would hang until they timed out at 30 minutes.  This PR fixes that in several ways:

1. **Job level timeout** — shortened to 5 minutes, just in case everything else goes wrong
2. **Bounded the Octokit call** — Added a new `withTimeout()` so the individual calls to the GitHub API are time-bound
3. **Best-effort degradation** — on timeout/error, `getJobs` caches an empty array, records the runId + reason in `failedRunIds`, and returns `[]`. The renderer's existing `suite.job.id && suite.job.runId` guard then drops just the per-suite "Job: [link]" line; the rest of the report still renders.
4. **Parallel three-phase restructure** — parse all XML files → collect unique runIds across all suites → `Promise.all` prefetch via `getJobs`. Worst-case wall time is ~30s regardless of how many runIds there are, instead of N × 30s sequential.

Deliberately degraded output is tested in this run https://github.com/MetaMask/metamask-extension/actions/runs/26931106011.  When the call fails, it leaves out the job links that normally look like this:

> #### Job: [test-e2e-chrome-webpack (12)](https://example.com)


## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only CI reporting scripts and workflow timeouts; test results still aggregate, with optional job links dropped on API errors.
> 
> **Overview**
> Makes E2E **report** jobs resilient when GitHub Actions job lookups are slow or fail, so summaries still publish without blocking the whole workflow.
> 
> `create-e2e-test-report.mts` now wraps `listJobsForWorkflowRun` in a **30s** `withTimeout`, records failed `runId`s instead of retrying, and **prefetches** unique run jobs in parallel after parsing XML (so wall time is ~one timeout, not N). On failure it still writes the report but omits per-suite **Job:** links and logs warnings. A shared `withTimeout` helper was added in `utils.mts`.
> 
> Chrome and Firefox report jobs get an explicit **5 minute** job timeout (Firefox was **30** minutes before).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc371d039b43b0f0dc5e96f4d15af696543afb1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->