### PR TITLE
feat: optimize e2e test report job id

### DIFF
--- a/.github/scripts/create-e2e-test-report.mts
+++ b/.github/scripts/create-e2e-test-report.mts
@@ -12,14 +12,8 @@ import {
   normalizeTestPath,
   XML,
 } from './shared/utils.mts';
-import type { Endpoints } from '@octokit/types';
-
-type Job =
-  Endpoints['GET /repos/{owner}/{repo}/actions/runs/{run_id}/jobs']['response']['data']['jobs'][number];
 
 async function main() {
-  const { Octokit } = await import('octokit');
-
   const env = {
     OWNER: process.env.OWNER || 'metamask',
     REPOSITORY: process.env.REPOSITORY || 'metamask-extension',
@@ -29,43 +23,8 @@ async function main() {
     TEST_RESULTS_PATH: process.env.TEST_RESULTS_PATH || 'test/test-results/e2e',
     TEST_RUNS_PATH:
       process.env.TEST_RUNS_PATH || 'test/test-results/test-runs.json',
-    GITHUB_TOKEN: process.env.GITHUB_TOKEN!,
     GITHUB_ACTIONS: process.env.GITHUB_ACTIONS === 'true',
   };
-
-  const github = new Octokit({ auth: env.GITHUB_TOKEN });
-
-  const jobsCache: { [runId: number]: Job[] } = {};
-
-  async function getJobs(runId: number) {
-    if (!runId) {
-      return [];
-    } else if (jobsCache[runId]) {
-      return jobsCache[runId];
-    } else {
-      try {
-        const jobs = await github.paginate(
-          github.rest.actions.listJobsForWorkflowRun,
-          {
-            owner: env.OWNER,
-            repo: env.REPOSITORY,
-            run_id: runId,
-            per_page: 100,
-          },
-        );
-        jobsCache[runId] = jobs;
-        return jobsCache[runId];
-      } catch (error) {
-        return [];
-      }
-    }
-  }
-
-  async function getJobId(runId: number, jobName: string) {
-    const jobs = await getJobs(runId);
-    const job = jobs.find((job) => job.name.endsWith(jobName));
-    return job?.id;
-  }
 
   let summary = '';
   const core = env.GITHUB_ACTIONS
@@ -104,12 +63,14 @@ async function main() {
         const jobName = suite.properties?.[0].property?.[0]?.$.value
           ? `${suite.properties?.[0].property?.[0]?.$.value}`
           : '';
-        const runId = suite.properties?.[0].property?.[1]?.$.value
+        const jobId = suite.properties?.[0].property?.[1]?.$.value
           ? +suite.properties?.[0].property?.[1]?.$.value
           : 0;
-        const jobId = (await getJobId(runId, jobName)) ?? 0;
-        const prNumber = suite.properties?.[0].property?.[2]?.$.value
+        const runId = suite.properties?.[0].property?.[2]?.$.value
           ? +suite.properties?.[0].property?.[2]?.$.value
+          : 0;
+        const prNumber = suite.properties?.[0].property?.[3]?.$.value
+          ? +suite.properties?.[0].property?.[3]?.$.value
           : 0;
 
         const testSuite: TestSuite = {

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -144,7 +144,7 @@ jobs:
         run: ${{ inputs.test-command }} --retries 1
         env:
           # The properties are picked up by mocha-junit-reporter and added to the XML test results
-          PROPERTIES: 'JOB_NAME:${{ env.JOB_NAME }},RUN_ID:${{ env.RUN_ID }},PR_NUMBER:${{ env.PR_NUMBER }}'
+          PROPERTIES: 'JOB_NAME:${{ env.JOB_NAME }},JOB_ID:${{ job.check_run_id }},RUN_ID:${{ env.RUN_ID }},PR_NUMBER:${{ env.PR_NUMBER }}'
           # On re-run, pass the path to previous results to run only failed tests
           PREVIOUS_RESULTS_PATH: ${{ steps.download-previous-results.outcome == 'success' && './previous-test-results/test/test-results/e2e' || '' }}
 

--- a/package.json
+++ b/package.json
@@ -586,7 +586,6 @@
     "@noble/ciphers": "^1.3.0",
     "@noble/curves": "^1.9.2",
     "@octokit/rest": "^22.0.1",
-    "@octokit/types": "^16.0.0",
     "@open-rpc/meta-schema": "^1.14.6",
     "@open-rpc/mock-server": "^1.7.5",
     "@open-rpc/schema-utils-js": "^2.0.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -33550,7 +33550,6 @@ __metadata:
     "@noble/curves": "npm:^1.9.2"
     "@noble/hashes": "npm:^1.3.3"
     "@octokit/rest": "npm:^22.0.1"
-    "@octokit/types": "npm:^16.0.0"
     "@open-rpc/meta-schema": "npm:^1.14.6"
     "@open-rpc/mock-server": "npm:^1.7.5"
     "@open-rpc/schema-utils-js": "npm:^2.0.5"


### PR DESCRIPTION
## **Description**

This PR optimizes how the E2E test report resolves the GitHub Actions **job id**.

Previously, `.github/scripts/create-e2e-test-report.mts` resolved the numeric job id at report-generation time by calling the GitHub REST API (`listJobsForWorkflowRun`) and matching the job by name. That required an authenticated Octokit client (`GITHUB_TOKEN`), pagination, an in-memory cache, and an extra network round-trip per run that could fail or rate-limit.

The job id is already known inside the workflow, so we now emit it directly into the JUnit XML via `mocha-junit-reporter`'s `PROPERTIES`, alongside the existing `JOB_NAME`, `RUN_ID`, and `PR_NUMBER`. The report script reads `JOB_ID` straight from the XML — exactly like the other values — and all the GitHub API machinery is removed.

**Changes**

- **`.github/workflows/run-e2e.yml`**: add `JOB_ID:${{ job.check_run_id }}` to the `PROPERTIES` env so the numeric job id is written into each test suite's XML.
- **`.github/scripts/create-e2e-test-report.mts`**:
  - Read `JOB_ID` from the XML properties (index `1`); shift `RUN_ID` → index `2` and `PR_NUMBER` → index `3` to match the new property order.
  - Remove the `octokit` / `@octokit/types` imports, the `Octokit` client, the `GITHUB_TOKEN` env, the `Job` type, and the `getJobs` / `getJobId` helpers + jobs cache.

The failed-test summary links (`/actions/runs/{runId}/job/{jobId}`) keep working as before, but without the API lookup.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

This is a CI-only change; verify via the E2E workflow:

1. Open/trigger a PR that runs the E2E suites (`run-e2e`).
2. After the run, open the E2E job summary and confirm the test report renders correctly.
3. For any failed test, confirm the `Job: <name>` link is present and resolves to the correct job page (`/actions/runs/<run_id>/job/<job_id>`), confirming `job.check_run_id` produced the right numeric id.
4. Confirm the report step no longer needs `GITHUB_TOKEN` and makes no Actions API calls.

## **Screenshots/Recordings**

N/A — CI tooling change with no UI impact.

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only reporting change; no app runtime, auth, or user data paths affected.
> 
> **Overview**
> E2E test summaries no longer look up the GitHub Actions **job id** via the REST API at report time. The workflow now writes **`JOB_ID`** (from `job.check_run_id`) into JUnit XML through `mocha-junit-reporter`'s `PROPERTIES`, alongside `JOB_NAME`, `RUN_ID`, and `PR_NUMBER`.
> 
> **`create-e2e-test-report.mts`** reads `JOB_ID` from the XML (property index 1), shifts `RUN_ID` and `PR_NUMBER` to indices 2 and 3, and drops the Octokit client, `GITHUB_TOKEN`, pagination/cache, and `getJobs` / `getJobId` helpers. **`@octokit/types`** is removed from devDependencies. Failed-test **Job** links should behave the same without extra API calls or token use in the report step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d22c5ba33962ed2b86024934a654b20c6987966. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

