### PR TITLE
chore: fix update-fixture script when build is skipped

### DIFF
--- a/.github/workflows/get-requirements.yml
+++ b/.github/workflows/get-requirements.yml
@@ -452,6 +452,32 @@ jobs:
             });
             core.info(`Posted build-source-hash: ${process.env.BUILD_HASH}`);
 
+      # Publish the canonical run that holds the builds for this commit — this
+      # run when builds are fresh, or the donor run when builds are reused — as a
+      # commit status on the PR head. Out-of-band workflows (e.g.
+      # update-e2e-fixtures.yml) read this to locate build artifacts without
+      # re-deriving the reuse lookup. Best-effort, like the build-source-hash
+      # status above.
+      - name: Post builds-from-run commit status
+        if: ${{ steps.compute-build-hash.outputs.build-hash }}
+        continue-on-error: true
+        uses: actions/github-script@v8
+        env:
+          BUILDS_FROM_RUN: ${{ steps.find-reusable-builds.outputs.builds-from-run || env.RUN_ID }}
+          HEAD_COMMIT_HASH: ${{ env.HEAD_COMMIT_HASH }}
+        with:
+          script: |
+            await github.rest.repos.createCommitStatus({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              sha: process.env.HEAD_COMMIT_HASH,
+              state: 'success',
+              context: 'builds-from-run',
+              description: process.env.BUILDS_FROM_RUN,
+              target_url: `${process.env.GITHUB_SERVER_URL}/${context.repo.owner}/${context.repo.repo}/actions/runs/${process.env.BUILDS_FROM_RUN}`,
+            });
+            core.info(`Posted builds-from-run: ${process.env.BUILDS_FROM_RUN}`);
+
       - id: filter
         if: ${{ steps.check-skip-merge-queue.outputs.up-to-date != 'true' }}
         uses: dorny/paths-filter@9d7afb8d214ad99e78fbd4247752c4caed2b6e4c

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -84,47 +84,140 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.FIXTURE_UPDATE_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
 
-      - name: Find and download dist artifact
+      # The build-reuse feature skips the build jobs on a PR's Main run
+      # when its build-source hash matches a prior run (commonly a `main` run).
+      # In that case the artifact does NOT exist on the PR branch's own run,
+      # so we mirror the build-reuse lookup: find the donor run by matching
+      # the `build-source-hash` commit status, searching the PR branch first
+      # and then the base branch.
+      - name: Find dist artifact run
+        id: find-dist
+        uses: actions/github-script@v8
+        env:
+          PR_NUMBER: ${{ github.event.issue.number }}
+        with:
+          github-token: ${{ secrets.FIXTURE_UPDATE_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo;
+            const ARTIFACT_NAME = 'build-dist-webpack';
+            const prNumber = parseInt(process.env.PR_NUMBER, 10);
+            const { stdout: headOut } = await exec.getExecOutput('git', ['rev-parse', 'HEAD'], { silent: true });
+            const headSha = headOut.trim();
+
+            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
+            const branch = pr.head.ref;
+            const baseBranch = pr.base.ref;
+            core.info(`PR #${prNumber} HEAD: ${headSha} (branch '${branch}' -> base '${baseBranch}')`);
+
+            async function runHasArtifact(runId) {
+              const artifacts = await github.paginate(
+                github.rest.actions.listWorkflowRunArtifacts,
+                { owner, repo, run_id: runId, per_page: 100 },
+              );
+              return artifacts.some((a) => a.name === ARTIFACT_NAME);
+            }
+
+            async function buildHashForSha(sha) {
+              const { data: { statuses } } = await github.rest.repos.getCombinedStatusForRef({
+                owner, repo, ref: sha, per_page: 100,
+              });
+              return statuses.find((s) => s.context === 'build-source-hash')?.description;
+            }
+
+            // The build-dist-webpack job runs via the reusable run-build.yml,
+            // so it appears as 'build-dist-webpack / build-dist-webpack'.
+            async function distBuildJob(runId) {
+              const jobs = await github.paginate(
+                github.rest.actions.listJobsForWorkflowRun,
+                { owner, repo, run_id: runId, per_page: 100 },
+              );
+              return jobs.find((j) => j.name.includes(ARTIFACT_NAME));
+            }
+
+            // 1. Locate the PR branch's own Main run for the current HEAD commit.
+            const { data: { workflow_runs: branchRuns } } = await github.rest.actions.listWorkflowRuns({
+              owner, repo, workflow_id: 'main.yml', branch, per_page: 10,
+            });
+            const headRun = branchRuns.find((r) => r.head_sha === headSha);
+            if (!headRun) {
+              core.setFailed(`No 'Main' workflow run found for the PR HEAD commit ${headSha} on branch '${branch}'. Ensure the Main workflow has run for the latest commit on this branch.`);
+              return;
+            }
+            core.info(`Found branch run ${headRun.id} (status: ${headRun.status}, conclusion: ${headRun.conclusion ?? ''})`);
+
+            // Fast path: the artifact is already available on the branch run.
+            if (await runHasArtifact(headRun.id)) {
+              core.info(`-> Using '${ARTIFACT_NAME}' from branch run ${headRun.id}`);
+              core.setOutput('run-id', String(headRun.id));
+              return;
+            }
+
+            // No artifact on the branch run yet — determine why before falling back.
+            const buildJob = await distBuildJob(headRun.id);
+            const reused = buildJob?.conclusion === 'skipped';
+
+            if (!reused) {
+              // Builds are fresh on this run, so the artifact must originate here.
+              // Fail fast with an actionable message rather than searching for a
+              // donor that cannot exist (a fresh build means no prior run matched).
+              if (!buildJob || buildJob.status !== 'completed') {
+                core.setFailed(`The '${ARTIFACT_NAME}' build is still in progress for commit ${headSha} (run ${headRun.id}). Re-run '@metamaskbot update-e2e-fixture' once the Main workflow's build has completed.`);
+              } else if (buildJob.conclusion !== 'success') {
+                core.setFailed(`The '${ARTIFACT_NAME}' build ${buildJob.conclusion} for commit ${headSha} (run ${headRun.id}). Fix the build and re-run '@metamaskbot update-e2e-fixture'.`);
+              } else {
+                core.setFailed(`The '${ARTIFACT_NAME}' build succeeded for commit ${headSha} (run ${headRun.id}) but its artifact is unavailable (it may have expired). Re-run the Main workflow on this branch, then '@metamaskbot update-e2e-fixture'.`);
+              }
+              return;
+            }
+
+            // 2. Builds were reused (the build job was skipped): find the donor
+            //    run by matching the build-source hash, mirroring get-requirements.yml.
+            core.info(`Branch run ${headRun.id} reused builds (build job skipped). Locating the donor run...`);
+            const buildHash = await buildHashForSha(headSha);
+            if (!buildHash) {
+              core.setFailed(`Builds were reused for commit ${headSha} but no 'build-source-hash' commit status was found, so the donor run cannot be located.`);
+              return;
+            }
+            core.info(`PR build-source-hash: ${buildHash}`);
+
+            async function findDonor(searchBranch) {
+              core.info(`Searching '${searchBranch}' for a run matching build hash ${buildHash}...`);
+              const { data: { workflow_runs } } = await github.rest.actions.listWorkflowRuns({
+                owner, repo, workflow_id: 'main.yml', branch: searchBranch, per_page: 20,
+              });
+              const allowed = new Set(['completed', 'in_progress']);
+              for (const run of workflow_runs) {
+                if (!allowed.has(run.status)) continue;
+                if ((await buildHashForSha(run.head_sha)) !== buildHash) continue;
+                if (await runHasArtifact(run.id)) {
+                  core.info(`-> Found donor run ${run.id} (SHA: ${run.head_sha})`);
+                  return String(run.id);
+                }
+              }
+              return null;
+            }
+
+            let donorId = await findDonor(branch);
+            if (!donorId && baseBranch !== branch) {
+              donorId = await findDonor(baseBranch);
+            }
+
+            if (!donorId) {
+              core.setFailed(`Builds were reused for commit ${headSha}, but no run with a matching build-source-hash (${buildHash}) and a '${ARTIFACT_NAME}' artifact was found on '${branch}' or '${baseBranch}'. The donor run's artifact may have expired — re-run the Main workflow on this branch to rebuild.`);
+              return;
+            }
+            core.setOutput('run-id', donorId);
+
+      - name: Download dist artifact
         run: |
-          COMMIT_SHA_FULL=$(git rev-parse HEAD)
-
-          # Get the most recent run for the Main workflow on this branch
-          RUN_INFO=$(gh run list --workflow "Main" --branch "${BRANCH}" --json databaseId,status,conclusion,headSha --limit 1 --jq 'first')
-
-          if [ -z "$RUN_INFO" ] || [ "$RUN_INFO" = "null" ]; then
-            echo "::error::No 'Main' workflow run found for branch ${BRANCH}"
-            exit 1
-          fi
-
-          RUN_ID=$(echo "$RUN_INFO" | jq -r '.databaseId')
-          RUN_STATUS=$(echo "$RUN_INFO" | jq -r '.status')
-          RUN_CONCLUSION=$(echo "$RUN_INFO" | jq -r '.conclusion')
-          RUN_HEAD_SHA=$(echo "$RUN_INFO" | jq -r '.headSha')
-
-          echo "Found run ${RUN_ID} with status: ${RUN_STATUS}, conclusion: ${RUN_CONCLUSION}, headSha: ${RUN_HEAD_SHA}"
-          echo "Current PR HEAD commit: ${COMMIT_SHA_FULL}"
-
-          if [ "${RUN_HEAD_SHA}" != "${COMMIT_SHA_FULL}" ]; then
-            echo "::error::The latest 'Main' workflow run (commit ${RUN_HEAD_SHA}) does not match the current PR HEAD (commit ${COMMIT_SHA_FULL}). Please ensure the Main workflow has run for the latest commit on this branch."
-            exit 1
-          fi
-
-          if [ "${RUN_STATUS}" != "completed" ]; then
-            echo "::notice::The latest 'Main' workflow run is still in progress (status: ${RUN_STATUS}). Attempting to download the dist artifact anyway."
-          elif [ "${RUN_CONCLUSION}" != "success" ]; then
-            echo "::warning::The latest 'Main' workflow run concluded with '${RUN_CONCLUSION}'. The build artifact may still be available, proceeding with download attempt."
-          fi
-
-          echo "Attempting to download dist artifact..."
-
+          echo "Attempting to download dist artifact from run ${RUN_ID}..."
           if ! gh run download "${RUN_ID}" -n build-dist-webpack -D build-dist-webpack; then
-            echo "::error::Failed to download the 'build-dist-webpack' artifact. The build job may not have completed yet, or may have failed. Please ensure the build-dist-webpack job has completed successfully."
+            echo "::error::Failed to download the 'build-dist-webpack' artifact from run ${RUN_ID}. The build job may not have completed yet, or may have failed. Please ensure the build-dist-webpack job has completed successfully."
             exit 1
           fi
-
           echo "Successfully downloaded dist artifact."
         env:
-          BRANCH: ${{ steps.branch.outputs.BRANCH }}
+          RUN_ID: ${{ steps.find-dist.outputs.run-id }}
           GITHUB_TOKEN: ${{ secrets.FIXTURE_UPDATE_TOKEN }}
 
       - name: Cache dist artifact

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -84,129 +84,35 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.FIXTURE_UPDATE_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
 
-      # The build-reuse feature skips the build jobs on a PR's Main run
-      # when its build-source hash matches a prior run (commonly a `main` run).
-      # In that case the artifact does NOT exist on the PR branch's own run,
-      # so we mirror the build-reuse lookup: find the donor run by matching
-      # the `build-source-hash` commit status, searching the PR branch first
-      # and then the base branch.
+      # The build-reuse feature skips the build jobs on a PR's Main run when its
+      # build-source hash matches a prior run (commonly a `main` run); in that
+      # case the artifact lives on the donor run, not the PR's own run.
+      # get-requirements.yml publishes the canonical run that holds the builds
+      # (this run for fresh builds, the donor run when reused) as a
+      # `builds-from-run` commit status on the PR head, so we just read it.
       - name: Find dist artifact run
         id: find-dist
         uses: actions/github-script@v8
-        env:
-          PR_NUMBER: ${{ github.event.issue.number }}
         with:
           github-token: ${{ secrets.FIXTURE_UPDATE_TOKEN }}
           script: |
             const { owner, repo } = context.repo;
-            const ARTIFACT_NAME = 'build-dist-webpack';
-            const prNumber = parseInt(process.env.PR_NUMBER, 10);
             const { stdout: headOut } = await exec.getExecOutput('git', ['rev-parse', 'HEAD'], { silent: true });
             const headSha = headOut.trim();
 
-            const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: prNumber });
-            const branch = pr.head.ref;
-            const baseBranch = pr.base.ref;
-            core.info(`PR #${prNumber} HEAD: ${headSha} (branch '${branch}' -> base '${baseBranch}')`);
-
-            async function runHasArtifact(runId) {
-              const artifacts = await github.paginate(
-                github.rest.actions.listWorkflowRunArtifacts,
-                { owner, repo, run_id: runId, per_page: 100 },
-              );
-              return artifacts.some((a) => a.name === ARTIFACT_NAME);
-            }
-
-            async function buildHashForSha(sha) {
-              const { data: { statuses } } = await github.rest.repos.getCombinedStatusForRef({
-                owner, repo, ref: sha, per_page: 100,
-              });
-              return statuses.find((s) => s.context === 'build-source-hash')?.description;
-            }
-
-            // The build-dist-webpack job runs via the reusable run-build.yml,
-            // so it appears as 'build-dist-webpack / build-dist-webpack'.
-            async function distBuildJob(runId) {
-              const jobs = await github.paginate(
-                github.rest.actions.listJobsForWorkflowRun,
-                { owner, repo, run_id: runId, per_page: 100 },
-              );
-              return jobs.find((j) => j.name.includes(ARTIFACT_NAME));
-            }
-
-            // 1. Locate the PR branch's own Main run for the current HEAD commit.
-            const { data: { workflow_runs: branchRuns } } = await github.rest.actions.listWorkflowRuns({
-              owner, repo, workflow_id: 'main.yml', branch, per_page: 10,
+            // getCombinedStatusForRef de-duplicates to the most recent status
+            // per context, so a single page is sufficient.
+            const { data: { statuses } } = await github.rest.repos.getCombinedStatusForRef({
+              owner, repo, ref: headSha, per_page: 100,
             });
-            const headRun = branchRuns.find((r) => r.head_sha === headSha);
-            if (!headRun) {
-              core.setFailed(`No 'Main' workflow run found for the PR HEAD commit ${headSha} on branch '${branch}'. Ensure the Main workflow has run for the latest commit on this branch.`);
+            const buildsFromRun = statuses.find((s) => s.context === 'builds-from-run')?.description;
+
+            if (!buildsFromRun) {
+              core.setFailed(`No 'builds-from-run' commit status found on ${headSha}. This commit's Main run may predate the build-reuse pointer, or its best-effort status post failed. Re-run the Main workflow on this branch, then '@metamaskbot update-e2e-fixture'.`);
               return;
             }
-            core.info(`Found branch run ${headRun.id} (status: ${headRun.status}, conclusion: ${headRun.conclusion ?? ''})`);
-
-            // Fast path: the artifact is already available on the branch run.
-            if (await runHasArtifact(headRun.id)) {
-              core.info(`-> Using '${ARTIFACT_NAME}' from branch run ${headRun.id}`);
-              core.setOutput('run-id', String(headRun.id));
-              return;
-            }
-
-            // No artifact on the branch run yet — determine why before falling back.
-            const buildJob = await distBuildJob(headRun.id);
-            const reused = buildJob?.conclusion === 'skipped';
-
-            if (!reused) {
-              // Builds are fresh on this run, so the artifact must originate here.
-              // Fail fast with an actionable message rather than searching for a
-              // donor that cannot exist (a fresh build means no prior run matched).
-              if (!buildJob || buildJob.status !== 'completed') {
-                core.setFailed(`The '${ARTIFACT_NAME}' build is still in progress for commit ${headSha} (run ${headRun.id}). Re-run '@metamaskbot update-e2e-fixture' once the Main workflow's build has completed.`);
-              } else if (buildJob.conclusion !== 'success') {
-                core.setFailed(`The '${ARTIFACT_NAME}' build ${buildJob.conclusion} for commit ${headSha} (run ${headRun.id}). Fix the build and re-run '@metamaskbot update-e2e-fixture'.`);
-              } else {
-                core.setFailed(`The '${ARTIFACT_NAME}' build succeeded for commit ${headSha} (run ${headRun.id}) but its artifact is unavailable (it may have expired). Re-run the Main workflow on this branch, then '@metamaskbot update-e2e-fixture'.`);
-              }
-              return;
-            }
-
-            // 2. Builds were reused (the build job was skipped): find the donor
-            //    run by matching the build-source hash, mirroring get-requirements.yml.
-            core.info(`Branch run ${headRun.id} reused builds (build job skipped). Locating the donor run...`);
-            const buildHash = await buildHashForSha(headSha);
-            if (!buildHash) {
-              core.setFailed(`Builds were reused for commit ${headSha} but no 'build-source-hash' commit status was found, so the donor run cannot be located.`);
-              return;
-            }
-            core.info(`PR build-source-hash: ${buildHash}`);
-
-            async function findDonor(searchBranch) {
-              core.info(`Searching '${searchBranch}' for a run matching build hash ${buildHash}...`);
-              const { data: { workflow_runs } } = await github.rest.actions.listWorkflowRuns({
-                owner, repo, workflow_id: 'main.yml', branch: searchBranch, per_page: 20,
-              });
-              const allowed = new Set(['completed', 'in_progress']);
-              for (const run of workflow_runs) {
-                if (!allowed.has(run.status)) continue;
-                if ((await buildHashForSha(run.head_sha)) !== buildHash) continue;
-                if (await runHasArtifact(run.id)) {
-                  core.info(`-> Found donor run ${run.id} (SHA: ${run.head_sha})`);
-                  return String(run.id);
-                }
-              }
-              return null;
-            }
-
-            let donorId = await findDonor(branch);
-            if (!donorId && baseBranch !== branch) {
-              donorId = await findDonor(baseBranch);
-            }
-
-            if (!donorId) {
-              core.setFailed(`Builds were reused for commit ${headSha}, but no run with a matching build-source-hash (${buildHash}) and a '${ARTIFACT_NAME}' artifact was found on '${branch}' or '${baseBranch}'. The donor run's artifact may have expired — re-run the Main workflow on this branch to rebuild.`);
-              return;
-            }
-            core.setOutput('run-id', donorId);
+            core.info(`-> builds-from-run: ${buildsFromRun}`);
+            core.setOutput('run-id', buildsFromRun);
 
       - name: Download dist artifact
         run: |


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The metamaskbot update-fixture script relies on the dist build from the branch in order to update the fixtures with the latest state.
Recently a cache build functionality was added in order to grab the build from main under some circumstances. When this happens the update-fixture script fails, as it never finds the artifact.

See example of failure:

https://github.com/MetaMask/metamask-extension/actions/runs/26883982483/job/79300793423

<img width="1273" height="278" alt="image" src="https://github.com/user-attachments/assets/2c51917e-6730-483f-9220-a93bbe1dd2c3" />

This PR fixes the script by publishing the `builds-from-run` commit status on the PR head (the current run on fresh builds or the donor when reused). This way we now read this on the `update-e2e-fixtures.yml` and download from that run.
Consider:
- if the build job is being run but not yet finished (artifact not present), the command will fail at the donwload step with the message, mentioning to re-run again once build is there --> this is the same as it was before. 
- the PRs already opened (before this merged) which try to use the update-e2e-fixture in a comment, will still fail, so they need to update with main.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Fork the extension repo
2. Add this changes and merge them
3. Create a test PR with a change in a test file (no app change)
4. Wait for ci 
5. Add comment `@metamaskbot update-e2e-fixture`
6. Job starts and succeeds to find the build 


See a commit was made, builds were skipped, then I added the comment, and the builds are effectively find
(it fails the test step because once the wallet is openede, I don't have all envars setup in my fork, but that's expected)

https://github.com/seaona/metamask-extension/actions/runs/28178317127/job/83460855167  

<img width="634" height="228" alt="image" src="https://github.com/user-attachments/assets/5fec1f45-657c-4267-96a8-ae5c3a6bf6a3" />




## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow changes with no application or secrets logic changes; artifact lookup is explicit with a clear failure path when the status is absent.
> 
> **Overview**
> Fixes **`@metamaskbot update-e2e-fixture`** when Main **skips build jobs** because build-reuse pulled artifacts from another run (often **`main`**). The bot used to download **`build-dist-webpack`** from the PR branch’s latest Main run, which has no artifact when builds were skipped.
> 
> **`get-requirements.yml`** now posts a best-effort commit status **`builds-from-run`** on the PR head with the run ID that actually holds the builds (current run or donor run), alongside the existing **`build-source-hash`** status.
> 
> **`update-e2e-fixtures.yml`** reads that status via **`getCombinedStatusForRef`** and downloads from the published run ID instead of inferring from the branch’s latest Main run. If the status is missing (old Main run or failed post), it fails with guidance to re-run Main and retry the bot command.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e2552ca3d725c4010ee561b239816affafd5104. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->