### PR TITLE
feat: use Skeleton (core extensions UX)

### DIFF
--- a/ui/components/app/wallet-overview/__snapshots__/aggregated-percentage-overview.test.tsx.snap
+++ b/ui/components/app/wallet-overview/__snapshots__/aggregated-percentage-overview.test.tsx.snap
@@ -57,29 +57,39 @@ exports[`AggregatedMultichainPercentageOverview render renders correctly with po
 exports[`AggregatedMultichainPercentageOverview render renders correctly with zero values 1`] = `
 <div>
   <div
-    class="mm-box mm-skeleton mm-box--background-color-icon-alternative mm-box--rounded-sm"
+    aria-hidden="true"
+    class="relative overflow-hidden rounded"
   >
     <div
-      class="flex"
+      aria-hidden="true"
+      class="pointer-events-none absolute inset-0 rounded bg-icon-alternative motion-safe:animate-skeleton-pulse"
+    />
+    <div
+      aria-hidden="true"
+      class="pointer-events-none invisible relative z-10"
     >
-      <p
-        class="mm-box mm-text mm-text--body-md-medium mm-text--ellipsis mm-box--color-text-alternative"
-        data-testid="aggregated-value-change"
-        style="white-space: pre;"
+      <div
+        class="flex"
       >
-        +
-        $0.00
-         
-      </p>
-      <p
-        class="mm-box mm-text mm-text--body-md-medium mm-text--ellipsis mm-box--color-text-alternative"
-        data-testid="aggregated-percentage-change"
-      >
-        (
-        +
-        0.00%
-        )
-      </p>
+        <p
+          class="mm-box mm-text mm-text--body-md-medium mm-text--ellipsis mm-box--color-text-alternative"
+          data-testid="aggregated-value-change"
+          style="white-space: pre;"
+        >
+          +
+          $0.00
+           
+        </p>
+        <p
+          class="mm-box mm-text mm-text--body-md-medium mm-text--ellipsis mm-box--color-text-alternative"
+          data-testid="aggregated-percentage-change"
+        >
+          (
+          +
+          0.00%
+          )
+        </p>
+      </div>
     </div>
   </div>
 </div>
@@ -88,24 +98,34 @@ exports[`AggregatedMultichainPercentageOverview render renders correctly with ze
 exports[`AggregatedPercentageOverview render renders correctly 1`] = `
 <div>
   <div
-    class="mm-box mm-skeleton mm-box--background-color-icon-alternative mm-box--rounded-sm"
+    aria-hidden="true"
+    class="relative overflow-hidden rounded"
   >
     <div
-      class="flex gap-1"
+      aria-hidden="true"
+      class="pointer-events-none absolute inset-0 rounded bg-icon-alternative motion-safe:animate-skeleton-pulse"
+    />
+    <div
+      aria-hidden="true"
+      class="pointer-events-none invisible relative z-10"
     >
-      <p
-        class="mm-box mm-text mm-text--body-md-medium mm-text--ellipsis mm-box--color-text-alternative"
-        data-testid="aggregated-value-change"
-        style="white-space: pre;"
+      <div
+        class="flex gap-1"
       >
-        +$0.00
-      </p>
-      <p
-        class="mm-box mm-text mm-text--body-md-medium mm-text--ellipsis mm-box--color-text-alternative"
-        data-testid="aggregated-percentage-change"
-      >
-        (+0.00%)
-      </p>
+        <p
+          class="mm-box mm-text mm-text--body-md-medium mm-text--ellipsis mm-box--color-text-alternative"
+          data-testid="aggregated-value-change"
+          style="white-space: pre;"
+        >
+          +$0.00
+        </p>
+        <p
+          class="mm-box mm-text mm-text--body-md-medium mm-text--ellipsis mm-box--color-text-alternative"
+          data-testid="aggregated-percentage-change"
+        >
+          (+0.00%)
+        </p>
+      </div>
     </div>
   </div>
 </div>

--- a/ui/components/app/wallet-overview/aggregated-percentage-overview-cross-chains.tsx
+++ b/ui/components/app/wallet-overview/aggregated-percentage-overview-cross-chains.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import { toChecksumAddress } from 'ethereumjs-util';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { Hex } from '@metamask/utils';
-import { Box } from '@metamask/design-system-react';
+import { Box , Skeleton } from '@metamask/design-system-react';
 import {
   getSelectedAccount,
   getShouldHideZeroBalanceTokens,
@@ -28,7 +28,6 @@ import { SensitiveText } from '../../component-library';
 import { getCalculatedTokenAmount1dAgo } from '../../../helpers/utils/util';
 import { useAccountTotalCrossChainFiatBalance } from '../../../hooks/useAccountTotalCrossChainFiatBalance';
 import { useGetFormattedTokensPerChain } from '../../../hooks/useGetFormattedTokensPerChain';
-import { Skeleton } from '@metamask/design-system-react';
 import { isZeroAmount } from '../../../helpers/utils/number-utils';
 import { TokenWithBalance } from '../../multichain/asset-picker-amount/asset-picker-modal/types';
 

--- a/ui/components/app/wallet-overview/aggregated-percentage-overview-cross-chains.tsx
+++ b/ui/components/app/wallet-overview/aggregated-percentage-overview-cross-chains.tsx
@@ -4,7 +4,7 @@ import { useSelector } from 'react-redux';
 import { toChecksumAddress } from 'ethereumjs-util';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { Hex } from '@metamask/utils';
-import { Box , Skeleton } from '@metamask/design-system-react';
+import { Box, Skeleton } from '@metamask/design-system-react';
 import {
   getSelectedAccount,
   getShouldHideZeroBalanceTokens,

--- a/ui/components/app/wallet-overview/aggregated-percentage-overview-cross-chains.tsx
+++ b/ui/components/app/wallet-overview/aggregated-percentage-overview-cross-chains.tsx
@@ -28,7 +28,7 @@ import { SensitiveText } from '../../component-library';
 import { getCalculatedTokenAmount1dAgo } from '../../../helpers/utils/util';
 import { useAccountTotalCrossChainFiatBalance } from '../../../hooks/useAccountTotalCrossChainFiatBalance';
 import { useGetFormattedTokensPerChain } from '../../../hooks/useGetFormattedTokensPerChain';
-import { Skeleton } from '../../component-library/skeleton';
+import { Skeleton } from '@metamask/design-system-react';
 import { isZeroAmount } from '../../../helpers/utils/number-utils';
 import { TokenWithBalance } from '../../multichain/asset-picker-amount/asset-picker-modal/types';
 
@@ -162,7 +162,7 @@ export const AggregatedPercentageOverviewCrossChains = ({
 
   return (
     <Skeleton
-      isLoading={
+      hideChildren={
         !anyEnabledNetworksAreAvailable &&
         isZeroAmount(formattedAmountChangeCrossChains)
       }

--- a/ui/components/app/wallet-overview/aggregated-percentage-overview.tsx
+++ b/ui/components/app/wallet-overview/aggregated-percentage-overview.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { toChecksumAddress } from 'ethereumjs-util';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
-import { Box } from '@metamask/design-system-react';
+import { Box , Skeleton } from '@metamask/design-system-react';
 import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
 import {
   getSelectedAccount,
@@ -29,7 +29,6 @@ import { getHistoricalMultichainAggregatedBalance } from '../../../selectors/ass
 import { formatWithThreshold } from '../assets/util/formatWithThreshold';
 import { useFormatters } from '../../../hooks/useFormatters';
 import { isZeroAmount } from '../../../helpers/utils/number-utils';
-import { Skeleton } from '@metamask/design-system-react';
 
 // core already has this exported type but its not yet available in this version
 // todo remove this and use core type once available
@@ -124,7 +123,9 @@ export const AggregatedPercentageOverview = ({
 
   return (
     <Skeleton
-      hideChildren={!anyEnabledNetworksAreAvailable && isZeroAmount(amountChange)}
+      hideChildren={
+        !anyEnabledNetworksAreAvailable && isZeroAmount(amountChange)
+      }
     >
       <Box className="flex gap-1">
         <SensitiveText

--- a/ui/components/app/wallet-overview/aggregated-percentage-overview.tsx
+++ b/ui/components/app/wallet-overview/aggregated-percentage-overview.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { toChecksumAddress } from 'ethereumjs-util';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
-import { Box , Skeleton } from '@metamask/design-system-react';
+import { Box, Skeleton } from '@metamask/design-system-react';
 import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
 import {
   getSelectedAccount,

--- a/ui/components/app/wallet-overview/aggregated-percentage-overview.tsx
+++ b/ui/components/app/wallet-overview/aggregated-percentage-overview.tsx
@@ -29,7 +29,7 @@ import { getHistoricalMultichainAggregatedBalance } from '../../../selectors/ass
 import { formatWithThreshold } from '../assets/util/formatWithThreshold';
 import { useFormatters } from '../../../hooks/useFormatters';
 import { isZeroAmount } from '../../../helpers/utils/number-utils';
-import { Skeleton } from '../../component-library/skeleton';
+import { Skeleton } from '@metamask/design-system-react';
 
 // core already has this exported type but its not yet available in this version
 // todo remove this and use core type once available
@@ -124,7 +124,7 @@ export const AggregatedPercentageOverview = ({
 
   return (
     <Skeleton
-      isLoading={!anyEnabledNetworksAreAvailable && isZeroAmount(amountChange)}
+      hideChildren={!anyEnabledNetworksAreAvailable && isZeroAmount(amountChange)}
     >
       <Box className="flex gap-1">
         <SensitiveText
@@ -212,7 +212,7 @@ export const AggregatedMultichainPercentageOverview = ({
 
   return (
     <Skeleton
-      isLoading={
+      hideChildren={
         !anyEnabledNetworksAreAvailable && isZeroAmount(singleDayAmountChange)
       }
     >

--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -6,7 +6,7 @@ import { CaipChainId } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 
 import { InternalAccount } from '@metamask/keyring-internal-api';
-import { Box } from '@metamask/design-system-react';
+import { Box , Skeleton } from '@metamask/design-system-react';
 import { ButtonLink, IconName } from '../../component-library';
 import { TextVariant } from '../../../helpers/constants/design-system';
 import { getPortfolioUrl } from '../../../helpers/utils/portfolio';
@@ -49,7 +49,6 @@ import { useAccountTotalCrossChainFiatBalance } from '../../../hooks/useAccountT
 import { useGetFormattedTokensPerChain } from '../../../hooks/useGetFormattedTokensPerChain';
 import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
 import { useRewardsModal } from '../../../hooks/rewards/useRewardsModal';
-import { Skeleton } from '@metamask/design-system-react';
 import { isZeroAmount } from '../../../helpers/utils/number-utils';
 import { BalanceEmptyState } from '../balance-empty-state';
 import { selectAccountGroupBalanceForEmptyState } from '../../../selectors/assets';

--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -6,7 +6,7 @@ import { CaipChainId } from '@metamask/utils';
 import type { Hex } from '@metamask/utils';
 
 import { InternalAccount } from '@metamask/keyring-internal-api';
-import { Box , Skeleton } from '@metamask/design-system-react';
+import { Box, Skeleton } from '@metamask/design-system-react';
 import { ButtonLink, IconName } from '../../component-library';
 import { TextVariant } from '../../../helpers/constants/design-system';
 import { getPortfolioUrl } from '../../../helpers/utils/portfolio';

--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -49,7 +49,7 @@ import { useAccountTotalCrossChainFiatBalance } from '../../../hooks/useAccountT
 import { useGetFormattedTokensPerChain } from '../../../hooks/useGetFormattedTokensPerChain';
 import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
 import { useRewardsModal } from '../../../hooks/rewards/useRewardsModal';
-import { Skeleton } from '../../component-library/skeleton';
+import { Skeleton } from '@metamask/design-system-react';
 import { isZeroAmount } from '../../../helpers/utils/number-utils';
 import { BalanceEmptyState } from '../balance-empty-state';
 import { selectAccountGroupBalanceForEmptyState } from '../../../selectors/assets';
@@ -144,10 +144,10 @@ export const LegacyAggregatedBalance = ({
 
   return (
     <Skeleton
-      isLoading={
+      hideChildren={
         !anyEnabledNetworksAreAvailable && isZeroAmount(balanceToDisplay)
       }
-      marginBottom={1}
+      className="mb-1"
     >
       <UserPreferencedCurrencyDisplay
         style={{ display: 'contents' }}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Use `Skeleton` from DSR.

> [!NOTE]
> This is a dead code - this is not used in app anymore. I just added it to Home rendering to capture screenshots.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-727

## **Manual testing steps**

1. Add `LegacyAggregatedBalance` rendering
2. Make sure there is no visual changes

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="486" height="856" alt="image" src="https://github.com/user-attachments/assets/91edebb5-6847-4a44-be17-20481eaa3046" />

### **After**

<img width="492" height="852" alt="image" src="https://github.com/user-attachments/assets/8e20b080-7c35-4dc7-8921-bbedbaae7d1e" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only swap of skeleton component and prop naming in legacy wallet overview paths; no auth, data, or transaction logic changes.
> 
> **Overview**
> Wallet overview loading placeholders now use **`Skeleton` from `@metamask/design-system-react`** instead of the component-library skeleton.
> 
> In **`aggregated-percentage-overview`**, **`aggregated-percentage-overview-cross-chains`**, and **`LegacyAggregatedBalance` in `coin-overview`**, the prop is renamed from **`isLoading`** to **`hideChildren`** with the same condition (no enabled networks and zero balance/change). **`coin-overview`** also swaps **`marginBottom={1}`** for **`className="mb-1"`** on that skeleton.
> 
> Jest snapshots for the percentage overview tests were updated to match the DSR skeleton DOM (pulse overlay, `aria-hidden`, invisible content wrapper).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 635c3ea674a8e0094e7cd3437df640ac421d9d5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->