### PR TITLE
test: fix flaky test `Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx should queue signTypedData tx after eth_sendTransaction confirmation and signTypedData confirmation should target the correct network after eth_sendTransaction is confirmed`

### DIFF
--- a/test/e2e/page-objects/pages/confirmations/transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/transaction-confirmation.ts
@@ -133,6 +133,11 @@ class TransactionConfirmation extends Confirmation {
   private readonly enforcedSimulationsToggleUnchecked: RawLocator =
     '[data-testid="enforced-simulations-toggle-input"]:not(:checked)';
 
+  private readonly reviewAlertButton: RawLocator = {
+    tag: 'span',
+    text: 'Review alert',
+  };
+
   private readonly simulationDetailsLayout: RawLocator =
     '[data-testid="simulation-details-layout"]';
 
@@ -682,6 +687,13 @@ class TransactionConfirmation extends Confirmation {
       text: fiatFee,
     });
     console.log('Send fees validation successful');
+  }
+
+  async waitForReviewAlertToDisappear(): Promise<void> {
+    // We need a guard because the review alert may not be present immediately
+    await this.driver.assertElementNotPresent(this.reviewAlertButton, {
+      waitAtLeastGuard: 2000,
+    });
   }
 }
 

--- a/test/e2e/page-objects/pages/confirmations/transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/transaction-confirmation.ts
@@ -134,7 +134,7 @@ class TransactionConfirmation extends Confirmation {
     '[data-testid="enforced-simulations-toggle-input"]:not(:checked)';
 
   private readonly reviewAlertButton: RawLocator = {
-    tag: 'span',
+    tag: 'button',
     text: 'Review alert',
   };
 

--- a/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.ts
+++ b/test/e2e/tests/request-queuing/dapp1-send-dapp2-signTypedData.spec.ts
@@ -132,6 +132,8 @@ describe('Request Queuing Dapp 1, Switch Tx -> Dapp 2 Send Tx', function () {
         // Check correct network on the send confirmation.
         await transactionConfirmation.checkNetworkIsDisplayed('Localhost 7777');
 
+        // The Review Alert appears while the balance is not yet loaded
+        await transactionConfirmation.waitForReviewAlertToDisappear();
         await transactionConfirmation.clickFooterConfirmButton();
 
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The spec is flaky because we have 1 tx and 1 signature queued in the popup.
We click on Confirm tx, however, the footer behaves like this
1. it appears the Confirm button enabled --> you can click on it
2. after some time, it appears the Review alert text in the button and it's disabled --> this happens because it needs to load the balance and see if the account has balance to pay the fees (until the balance is not loaded, that will remain -- given this is not the selected network but another one, it takes more time - we cannot ensure this on home after login as usual)
3. after some time, the balance is loaded, then the Review alert disappears as the account has balance

So there is a race condition, if we happen to click on step 1, then the dialog won't be closed as the step number 2 will happen and then 3 and we'll see the tx remained opened.
If we happen to click after step 1, then the clickElement will wait step 2 and then step. 3 and the click will take effect so the test passes.


The fix is to assert that the Review alert is not there, with a guard, so we ensure we enter directly in step 2, and wait for that to disappear) then the click will always take effect


https://github.com/user-attachments/assets/d8041193-f58a-4e31-a8e4-0a707ff9dfb3



## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
5. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only page object and spec changes; no production wallet or confirmation logic is modified.
> 
> **Overview**
> Stabilizes the **request queuing** E2E flow where a send confirmation is confirmed while a second dapp’s `signTypedData` is queued.
> 
> The `TransactionConfirmation` page object gains a **Review alert** locator and `waitForReviewAlertToDisappear()`, which waits (with a short guard) until that alert is gone—matching UI behavior when balance/simulation data is still loading. The `dapp1-send-dapp2-signTypedData` spec calls this **before** confirming the send, so the test no longer races the alert and flakes on confirm.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 846db7046e846b3ab3290da339e951badf8ef05f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->