### PR TITLE
test: fix flaky test Monad Network Connection Tests should connect dapp to Monad Testnet and verify MON network and tokens

### DIFF
--- a/test/e2e/tests/network/network-connection.spec.ts
+++ b/test/e2e/tests/network/network-connection.spec.ts
@@ -32,7 +32,7 @@ const networkConfigs: NetworkConfig[] = [
   },
   {
     name: 'MegaETH Testnet',
-    tokenSymbol: 'ETH',
+    tokenSymbol: 'MegaETH',
     fixtureMethod: (builder) =>
       builder.withSelectedNetwork(NETWORK_CLIENT_ID.MEGAETH_TESTNET_V2),
     testTitle: 'MegaETH Network Connection Tests',
@@ -81,7 +81,9 @@ networkConfigs.forEach((config) => {
           title: this.test?.fullTitle(),
         },
         async ({ driver }: { driver: Driver }) => {
-          await login(driver, { validateBalance: false });
+          await login(driver, {
+            expectedBalance: `25 ${config.tokenSymbol}`,
+          });
 
           const assetListPage = new AssetListPage(driver);
           await driver.switchToWindowWithTitle(

--- a/test/e2e/tests/network/network-connection.spec.ts
+++ b/test/e2e/tests/network/network-connection.spec.ts
@@ -81,7 +81,7 @@ networkConfigs.forEach((config) => {
           title: this.test?.fullTitle(),
         },
         async ({ driver }: { driver: Driver }) => {
-          await login(driver);
+          await login(driver, { validateBalance: false });
 
           const assetListPage = new AssetListPage(driver);
           await driver.switchToWindowWithTitle(


### PR DESCRIPTION


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The `login()` default balance check times out waiting for "25" on Monad Testnet, which shows 0 MON 

The fix passes `validateBalance: false to login()`, since this test is about verifying dapp connectivity and network interactions. Token presence is already confirmed separately via `assetListPage.checkTokenExistsInList`.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<img width="1366" height="682" alt="test-failure-screenshot-1" src="https://github.com/user-attachments/assets/e4b9336f-31a4-430e-99d7-8ad75fcfbe95" />


### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to e2e network connection specs; no production or security impact.
> 
> **Overview**
> Stabilizes the parameterized **network connection** e2e suite by aligning post-login balance checks with each network’s native token instead of the default **25 ETH** assertion.
> 
> `login()` now receives `expectedBalance: \`25 ${config.tokenSymbol}\`` so the homepage wait matches **MON**, **MegaETH**, and **SEI** fixtures. **MegaETH Testnet**’s `tokenSymbol` is corrected from `ETH` to `MegaETH` so the balance string and token list checks stay consistent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fe36e4b108e25bdc8db9d4562bd080737d6d39a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->