### PR TITLE
feat: Skeleton migration (web3auth scope)

### DIFF
--- a/ui/pages/shield/transaction-shield/components/button-row.tsx
+++ b/ui/pages/shield/transaction-shield/components/button-row.tsx
@@ -11,9 +11,8 @@ import {
   Text,
   TextVariant,
   twMerge,
+  Skeleton,
 } from '@metamask/design-system-react';
-import { BorderRadius } from '../../../../helpers/constants/design-system';
-import { Skeleton } from '../../../../components/component-library/skeleton';
 
 type ButtonRowProps = {
   title: string;
@@ -101,7 +100,7 @@ const ButtonRow = ({
             <Skeleton
               width={40}
               height={40}
-              borderRadius={BorderRadius.full}
+              className="rounded-full"
               style={{ flexShrink: 0 }}
             />
           ) : (

--- a/ui/pages/shield/transaction-shield/components/membership-header.tsx
+++ b/ui/pages/shield/transaction-shield/components/membership-header.tsx
@@ -7,11 +7,11 @@ import {
   Text,
   TextColor,
   TextVariant,
+  Skeleton,
 } from '@metamask/design-system-react';
 import classnames from 'clsx';
 import { ThemeType } from '../../../../../shared/constants/preferences';
 import { useTheme } from '../../../../hooks/useTheme';
-import { Skeleton } from '../../../../components/component-library/skeleton';
 import {
   BackgroundColor,
   BorderRadius,

--- a/ui/pages/shield/transaction-shield/transaction-shield.tsx
+++ b/ui/pages/shield/transaction-shield/transaction-shield.tsx
@@ -21,10 +21,10 @@ import {
   TextButton,
   TextColor,
   TextVariant,
+  Skeleton,
 } from '@metamask/design-system-react';
 import { useDispatch, useSelector } from 'react-redux';
 import log from 'loglevel';
-import { Skeleton } from '../../../components/component-library/skeleton';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   useShieldRewards,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Use `Skeleton` from DSR.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-727

## **Manual testing steps**

1. Check `TransactionsShield` page
2. Be sure there is no visual regressions

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="481" height="460" alt="image" src="https://github.com/user-attachments/assets/774d4ad8-0459-4253-b8c2-2f7f887921a2" />

### **After**

<img width="477" height="476" alt="image" src="https://github.com/user-attachments/assets/776d2e86-d64d-4fb1-800f-7684d32e47b6" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only loading skeleton swap on the Transaction Shield page with no logic or data-path changes.
> 
> **Overview**
> Migrates Transaction Shield loading placeholders from the extension **component-library** `Skeleton` to **`Skeleton` from `@metamask/design-system-react`** (DSR), aligned with DSYS-727.
> 
> **`button-row`**, **`membership-header`**, and **`transaction-shield`** now import DSR `Skeleton` only. In **`button-row`**, the circular avatar placeholder uses `className="rounded-full"` instead of the old `BorderRadius.full` prop.
> 
> Loading behavior and dimensions are unchanged; this is an import/API swap for design-system consistency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec7ed04171302838f603ab286c7a727d0e0a6fba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->