### PR TITLE
fix(perps): allow withdraw when a non-EVM network is selected

### DIFF
--- a/ui/components/app/perps/hooks/usePerpsWithdrawNavigation.test.ts
+++ b/ui/components/app/perps/hooks/usePerpsWithdrawNavigation.test.ts
@@ -8,7 +8,7 @@ import {
   PERPS_WITHDRAW_ROUTE,
 } from '../../../../helpers/constants/routes';
 import { ConfirmationLoader } from '../../../../pages/confirmations/hooks/useConfirmationNavigation';
-import { getSelectedInternalAccount } from '../../../../../shared/lib/selectors/accounts';
+import { getSelectedEvmInternalAccount } from '../../../../selectors';
 import { createPerpsWithdrawTransaction } from './createPerpsWithdrawTransaction';
 import { usePerpsWithdrawNavigation } from './usePerpsWithdrawNavigation';
 
@@ -19,8 +19,9 @@ jest.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
 }));
 
-jest.mock('../../../../../shared/lib/selectors/accounts', () => ({
-  getSelectedInternalAccount: jest.fn(),
+jest.mock('../../../../selectors', () => ({
+  ...jest.requireActual('../../../../selectors'),
+  getSelectedEvmInternalAccount: jest.fn(),
 }));
 
 jest.mock(
@@ -36,7 +37,9 @@ jest.mock('./createPerpsWithdrawTransaction', () => ({
   createPerpsWithdrawTransaction: jest.fn(),
 }));
 
-const getSelectedInternalAccountMock = jest.mocked(getSelectedInternalAccount);
+const getSelectedEvmInternalAccountMock = jest.mocked(
+  getSelectedEvmInternalAccount,
+);
 const mockCreatePerpsWithdrawTransaction = jest.mocked(
   createPerpsWithdrawTransaction,
 );
@@ -100,7 +103,7 @@ function renderUsePerpsWithdrawNavigation(
 describe('usePerpsWithdrawNavigation', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    getSelectedInternalAccountMock.mockReturnValue({
+    getSelectedEvmInternalAccountMock.mockReturnValue({
       address: MOCK_ACCOUNT_ADDRESS,
     } as never);
     mockCreatePerpsWithdrawTransaction.mockResolvedValue({
@@ -248,7 +251,7 @@ describe('usePerpsWithdrawNavigation', () => {
   });
 
   it('returns null when there is no selected account', async () => {
-    getSelectedInternalAccountMock.mockReturnValue(undefined as never);
+    getSelectedEvmInternalAccountMock.mockReturnValue(undefined as never);
 
     const { result } = renderUsePerpsWithdrawNavigation(
       () => usePerpsWithdrawNavigation(),

--- a/ui/components/app/perps/hooks/usePerpsWithdrawNavigation.ts
+++ b/ui/components/app/perps/hooks/usePerpsWithdrawNavigation.ts
@@ -4,8 +4,8 @@ import { useLocation, useNavigate } from 'react-router-dom';
 import { TransactionType } from '@metamask/transaction-controller';
 import type { Hex } from '@metamask/utils';
 
-import { getSelectedInternalAccount } from '../../../../../shared/lib/selectors/accounts';
 import type { RemoteFeatureFlagsState } from '../../../../../shared/lib/selectors/remote-feature-flags';
+import { getSelectedEvmInternalAccount } from '../../../../selectors';
 import {
   CONFIRM_TRANSACTION_ROUTE,
   PERPS_WITHDRAW_ROUTE,
@@ -47,7 +47,9 @@ export function usePerpsWithdrawNavigation(
   const { navigateOnTrigger = true, onNavigated } = options;
   const navigate = useNavigate();
   const location = useLocation();
-  const selectedAccount = useSelector(getSelectedInternalAccount);
+  // Perps withdraws settle to the EVM account, so resolve it directly instead
+  // of the globally selected account, which may be non-EVM (Solana, BTC, Tron).
+  const selectedAccount = useSelector(getSelectedEvmInternalAccount);
   const isConfirmationFlowEnabled = useSelector(
     (state: RemoteFeatureFlagsState) =>
       selectPayQuoteConfig(state, TransactionType.perpsWithdraw).enabled ===


### PR DESCRIPTION
## **Description**

On the Perps tab, opening **Total balance → Withdraw** did nothing when a non-EVM network (Solana, Bitcoin, Tron) was selected.

The withdraw entrypoint resolved the recipient via `getSelectedInternalAccount`, which returns the globally selected account. With a non-EVM network active, that's a non-EVM address, which was then passed to `createPerpsWithdrawTransaction` as the `Hex` `from`/`to` for an Arbitrum ERC-20 transfer shell. `addTransaction` rejected and the error was only logged, so the button appeared to do nothing.

This change resolves the EVM account directly via `getSelectedEvmInternalAccount`, so the Perps withdraw flow always builds against the EVM account regardless of the selected non-EVM network. Withdraw eligibility is driven by the supported withdraw tokens, not the active network.

## **Changelog**

CHANGELOG entry: Fixed the Perps withdraw button doing nothing when a non-EVM network (Solana, Bitcoin, Tron) was selected

## **Related issues**

Fixes: [CONF-1475](https://consensyssoftware.atlassian.net/browse/CONF-1475)

## **Manual testing steps**

1. Select a non-EVM network (e.g. Solana) with a funded Perps (HyperLiquid) balance on your EVM account.
2. Go to the **Perps** tab → click **Total balance** → **Withdraw**.
3. Confirm the withdraw flow now opens (custom-amount confirmation when `confirmations_pay_post_quote.perpsWithdraw.enabled`, otherwise the legacy `/perps/withdraw` route).
4. Repeat with Bitcoin/Tron selected, and verify it still works with an EVM network selected.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[CONF-1475]: https://consensyssoftware.atlassian.net/browse/CONF-1475?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped change to Perps withdraw navigation account resolution; existing EVM-only behavior is preserved when an EVM network is selected.
> 
> **Overview**
> Fixes **Perps withdraw** appearing dead when the user has a **non-EVM network** (Solana, Bitcoin, Tron) selected.
> 
> `usePerpsWithdrawNavigation` now reads the recipient via **`getSelectedEvmInternalAccount`** instead of **`getSelectedInternalAccount`**, so withdraw always uses the EVM address that Perps settlements expect. The hook tests were updated to mock the new selector.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 65bad05a399171d53d2d71af5a8706afd89605ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->