### PR TITLE
fix: scope webpack `BUNDLE_` env prefix to avoid collisions

### DIFF
--- a/development/webpack/utils/cli.ts
+++ b/development/webpack/utils/cli.ts
@@ -22,7 +22,7 @@ import {
   resolveAutoThreads,
 } from './loaders/threadLoader';
 
-const ENV_PREFIX = 'BUNDLE';
+const ENV_PREFIX = 'BUNDLE_';
 const addFeat = 'addFeature' as const;
 const omitFeat = 'omitFeature' as const;
 type YargsOptionsMap = { [key: string]: YargsOptions };
@@ -370,7 +370,7 @@ function getCli<T extends YargsOptionsMap = Options>(options: T, name: string) {
     })
     // enable ENV parsing, which allows the user to specify webpack options via
     // environment variables prefixed with `BUNDLE_`
-    // TODO: choose a better name than `BUNDLE` (it looks like `MM` is already being used in CI for ✨something✨)
+    // TODO: choose a better name than `BUNDLE_` (it looks like `MM` is already being used in CI for ✨something✨)
     .env(ENV_PREFIX)
     // TODO: enable completion once https://github.com/yargs/yargs/pull/2422 is released.
     // enable the `completion` command, which outputs a bash completion script


### PR DESCRIPTION
## **Description**

Running `yarn webpack` from a VS Code integrated terminal can fail with:

> `Unknown argument: dDebugpyPath`

**Root cause:** the webpack CLI parses environment variables via yargs `.env(ENV_PREFIX)` together with `.strict()`. yargs matches env vars using `envVar.startsWith(prefix)` and then strips `prefix.length` characters — it does **not** require a separator after the prefix. With `ENV_PREFIX = 'BUNDLE'`, the VS Code Python Debugger extension (`ms-python.debugpy`) injects `BUNDLED_DEBUGPY_PATH` into every integrated terminal via a global environment variable collection (the "configless debug" feature, [vscode-python-debugger#557](https://github.com/microsoft/vscode-python-debugger/pull/557)). yargs sees that variable, strips `BUNDLE` → `D_DEBUGPY_PATH`, camelCases it to `dDebugpyPath`, and `.strict()` aborts because it is not a known option.

This is a binary env-var collision, which is why it appears to break "out of nowhere" with no code changes: it triggers as soon as the debugpy extension (which injects the variable globally) is present in the environment that runs `yarn webpack`.

**Fix:** include the trailing underscore in the prefix (`BUNDLE_`). yargs then requires the separator, so `BUNDLED_DEBUGPY_PATH` no longer matches (index 6 is `D`, not `_`), while every documented `BUNDLE_*` option parses identically — the `substring`/camelCase results are unchanged (`BUNDLE_MINIFY` → `minify`, `BUNDLE_BROWSER` → `browser`, ...).

## **Changelog**

CHANGELOG entry: null

<!-- Dev-tooling change only; not end-user facing. -->

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. In VS Code with the Python Debugger extension (`ms-python.debugpy`) installed, open an integrated terminal and confirm the injected variable is present: `echo $BUNDLED_DEBUGPY_PATH` (non-empty).
2. On `main`: `yarn webpack --help` → fails with `Unknown argument: dDebugpyPath`.
3. On this branch: `yarn webpack --help` → exits cleanly (exit 0).
4. Confirm documented env options still work, e.g. `BUNDLE_MINIFY=true yarn webpack --dry-run`.

## **Screenshots/Recordings**

N/A — CLI behavior change.

### **Before**

`yarn webpack` → `Unknown argument: dDebugpyPath`

### **After**

`yarn webpack` runs normally.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
