### PR TITLE
fix(sidepanel): avoid leaving popup + side panel both open on view toggle

### DIFF
--- a/ui/store/actions.toggle-default-view.test.ts
+++ b/ui/store/actions.toggle-default-view.test.ts
@@ -1,0 +1,176 @@
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import browser from 'webextension-polyfill';
+import {
+  ENVIRONMENT_TYPE_POPUP,
+  ENVIRONMENT_TYPE_SIDEPANEL,
+} from '../../shared/constants/app';
+import { getEnvironmentType } from '../../shared/lib/environment-type';
+import { getIsSidePanelFeatureEnabled } from '../../shared/lib/environment';
+import { setBackgroundConnection } from './background-connection';
+import { toggleDefaultView } from './actions';
+
+jest.mock('webextension-polyfill', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  __esModule: true,
+  default: {
+    tabs: {
+      query: jest.fn(),
+    },
+    sidePanel: {
+      open: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../../shared/lib/environment-type', () => ({
+  ...jest.requireActual('../../shared/lib/environment-type'),
+  getEnvironmentType: jest.fn(),
+}));
+
+jest.mock('../../shared/lib/environment', () => ({
+  ...jest.requireActual('../../shared/lib/environment'),
+  getIsSidePanelFeatureEnabled: jest.fn(),
+}));
+
+const mockGetEnvironmentType = jest.mocked(getEnvironmentType);
+const mockGetIsSidePanelFeatureEnabled = jest.mocked(
+  getIsSidePanelFeatureEnabled,
+);
+
+const browserMock = browser as unknown as {
+  tabs: { query: jest.Mock };
+  sidePanel: { open: jest.Mock };
+};
+
+const middleware = [thunk];
+const mockStore = configureStore(middleware);
+
+/**
+ * Reads the `(preference, value)` pairs passed to the background `setPreference`
+ * RPC, ignoring the trailing trace-context argument that may be appended.
+ *
+ * @param setPreferenceMock - The mocked background `setPreference` method.
+ */
+function setPreferenceCalls(setPreferenceMock: jest.Mock) {
+  return setPreferenceMock.mock.calls.map((args) => [args[0], args[1]]);
+}
+
+describe('toggleDefaultView', () => {
+  let setPreferenceBackground: jest.Mock;
+  let closeSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    setPreferenceBackground = jest.fn().mockResolvedValue({});
+    setBackgroundConnection({
+      setPreference: setPreferenceBackground,
+    } as never);
+
+    closeSpy = jest.spyOn(window, 'close').mockImplementation(() => undefined);
+
+    mockGetIsSidePanelFeatureEnabled.mockReturnValue(true);
+    browserMock.tabs.query.mockResolvedValue([{ windowId: 1 }]);
+    browserMock.sidePanel.open.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    closeSpy.mockRestore();
+  });
+
+  it('does nothing when the side panel feature is disabled', async () => {
+    mockGetIsSidePanelFeatureEnabled.mockReturnValue(false);
+    mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_POPUP);
+    const store = mockStore();
+
+    await store.dispatch(toggleDefaultView());
+
+    expect(browserMock.sidePanel.open).not.toHaveBeenCalled();
+    expect(setPreferenceBackground).not.toHaveBeenCalled();
+    expect(closeSpy).not.toHaveBeenCalled();
+  });
+
+  describe('from side panel to popup', () => {
+    it('persists the preference as false and closes the side panel window', async () => {
+      mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_SIDEPANEL);
+      const store = mockStore();
+
+      await store.dispatch(toggleDefaultView());
+
+      expect(setPreferenceCalls(setPreferenceBackground)).toContainEqual([
+        'useSidePanelAsDefault',
+        false,
+      ]);
+      expect(browserMock.sidePanel.open).not.toHaveBeenCalled();
+      expect(closeSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe('from popup to side panel', () => {
+    it('opens the side panel, persists the preference as true, and closes the popup', async () => {
+      mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_POPUP);
+      const store = mockStore();
+
+      await store.dispatch(toggleDefaultView());
+
+      expect(browserMock.sidePanel.open).toHaveBeenCalledWith({ windowId: 1 });
+      expect(setPreferenceCalls(setPreferenceBackground)).toContainEqual([
+        'useSidePanelAsDefault',
+        true,
+      ]);
+      expect(closeSpy).toHaveBeenCalled();
+    });
+
+    // Regression test for https://github.com/MetaMask/metamask-extension/issues/43060
+    // The previous implementation gated success on a single `chrome.runtime.getContexts`
+    // probe 500ms after opening. After a side panel -> popup -> side panel round-trip that
+    // probe races with context teardown/setup and could report no context even though the
+    // panel opened, leaving both the popup and side panel open and the preference unchanged.
+    it('persists the preference and closes the popup without probing side panel contexts', async () => {
+      const getContextsSpy = jest.fn().mockResolvedValue([]);
+      // @ts-expect-error chrome is not typed on the test global
+      global.chrome = { runtime: { getContexts: getContextsSpy } };
+      mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_POPUP);
+      const store = mockStore();
+
+      await store.dispatch(toggleDefaultView());
+
+      expect(getContextsSpy).not.toHaveBeenCalled();
+      expect(setPreferenceCalls(setPreferenceBackground)).toContainEqual([
+        'useSidePanelAsDefault',
+        true,
+      ]);
+      expect(closeSpy).toHaveBeenCalled();
+    });
+
+    it('stays in popup view and does not persist the preference when opening the side panel fails', async () => {
+      browserMock.sidePanel.open.mockRejectedValue(
+        new Error('side panel unavailable'),
+      );
+      mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_POPUP);
+      const store = mockStore();
+
+      await store.dispatch(toggleDefaultView());
+
+      expect(browserMock.sidePanel.open).toHaveBeenCalledWith({ windowId: 1 });
+      expect(setPreferenceCalls(setPreferenceBackground)).not.toContainEqual([
+        'useSidePanelAsDefault',
+        true,
+      ]);
+      expect(closeSpy).not.toHaveBeenCalled();
+    });
+
+    it('does nothing when there is no active window to open the side panel in', async () => {
+      browserMock.tabs.query.mockResolvedValue([]);
+      mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_POPUP);
+      const store = mockStore();
+
+      await store.dispatch(toggleDefaultView());
+
+      expect(browserMock.sidePanel.open).not.toHaveBeenCalled();
+      expect(setPreferenceBackground).not.toHaveBeenCalled();
+      expect(closeSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/ui/store/actions.toggle-default-view.test.ts
+++ b/ui/store/actions.toggle-default-view.test.ts
@@ -44,7 +44,8 @@ const browserMock = browser as unknown as {
 };
 
 const middleware = [thunk];
-const mockStore = configureStore(middleware);
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const mockStore = configureStore<any>(middleware);
 
 /**
  * Reads the `(preference, value)` pairs passed to the background `setPreference`
@@ -84,7 +85,7 @@ describe('toggleDefaultView', () => {
     mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_POPUP);
     const store = mockStore();
 
-    await store.dispatch(toggleDefaultView());
+    await store.dispatch(toggleDefaultView() as never);
 
     expect(browserMock.sidePanel.open).not.toHaveBeenCalled();
     expect(setPreferenceBackground).not.toHaveBeenCalled();
@@ -96,7 +97,7 @@ describe('toggleDefaultView', () => {
       mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_SIDEPANEL);
       const store = mockStore();
 
-      await store.dispatch(toggleDefaultView());
+      await store.dispatch(toggleDefaultView() as never);
 
       expect(setPreferenceCalls(setPreferenceBackground)).toContainEqual([
         'useSidePanelAsDefault',
@@ -112,7 +113,7 @@ describe('toggleDefaultView', () => {
       mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_POPUP);
       const store = mockStore();
 
-      await store.dispatch(toggleDefaultView());
+      await store.dispatch(toggleDefaultView() as never);
 
       expect(browserMock.sidePanel.open).toHaveBeenCalledWith({ windowId: 1 });
       expect(setPreferenceCalls(setPreferenceBackground)).toContainEqual([
@@ -134,7 +135,7 @@ describe('toggleDefaultView', () => {
       mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_POPUP);
       const store = mockStore();
 
-      await store.dispatch(toggleDefaultView());
+      await store.dispatch(toggleDefaultView() as never);
 
       expect(getContextsSpy).not.toHaveBeenCalled();
       expect(setPreferenceCalls(setPreferenceBackground)).toContainEqual([
@@ -151,7 +152,7 @@ describe('toggleDefaultView', () => {
       mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_POPUP);
       const store = mockStore();
 
-      await store.dispatch(toggleDefaultView());
+      await store.dispatch(toggleDefaultView() as never);
 
       expect(browserMock.sidePanel.open).toHaveBeenCalledWith({ windowId: 1 });
       expect(setPreferenceCalls(setPreferenceBackground)).not.toContainEqual([
@@ -166,7 +167,7 @@ describe('toggleDefaultView', () => {
       mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_POPUP);
       const store = mockStore();
 
-      await store.dispatch(toggleDefaultView());
+      await store.dispatch(toggleDefaultView() as never);
 
       expect(browserMock.sidePanel.open).not.toHaveBeenCalled();
       expect(setPreferenceBackground).not.toHaveBeenCalled();

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -4506,7 +4506,10 @@ export function toggleDefaultView(): ThunkAction<
           await browserWithSidePanel.sidePanel.open({ windowId });
         } catch (error) {
           // Nothing was opened, so the popup stays and state is consistent.
-          log.error('Side panel failed to open; remaining in popup view', error);
+          log.error(
+            'Side panel failed to open; remaining in popup view',
+            error,
+          );
           return;
         }
 

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -4488,23 +4488,33 @@ export function toggleDefaultView(): ThunkAction<
           currentWindow: true,
         });
 
-        if (tabs && tabs.length > 0 && tabs[0].windowId) {
-          await browserWithSidePanel.sidePanel.open({
-            windowId: tabs[0].windowId,
-          });
-          await new Promise((resolve) => setTimeout(resolve, 500));
-
-          const contexts = await chrome.runtime.getContexts({
-            contextTypes: ['SIDE_PANEL' as chrome.runtime.ContextType],
-          });
-
-          if (!contexts || contexts.length === 0) {
-            return;
-          }
-
-          await dispatch(setUseSidePanelAsDefault(true));
-          window.close();
+        const windowId = tabs?.[0]?.windowId;
+        if (!windowId) {
+          return;
         }
+
+        // `sidePanel.open()` rejects on browsers where the API exists but is
+        // non-functional (e.g. Arc), which is our signal that the switch
+        // failed. We intentionally avoid probing `chrome.runtime.getContexts`
+        // as a success gate: that probe races with side panel context
+        // teardown/setup (most notably right after a side panel -> popup ->
+        // side panel round-trip) and can report no context even when the panel
+        // opened. A false negative there used to leave the panel open, skip
+        // closing the popup, and skip persisting the preference, leaving both
+        // surfaces open and the next launch defaulting back to the popup.
+        try {
+          await browserWithSidePanel.sidePanel.open({ windowId });
+        } catch (error) {
+          // Nothing was opened, so the popup stays and state is consistent.
+          log.error('Side panel failed to open; remaining in popup view', error);
+          return;
+        }
+
+        // Persist the preference before closing the popup so a reopen always
+        // honors the side panel choice and the background toolbar-behavior
+        // subscription flips to open-on-click.
+        await dispatch(setUseSidePanelAsDefault(true));
+        window.close();
       }
     } catch (error) {
       log.error('Error toggling default view:', error);


### PR DESCRIPTION
## **Description**

When a user switched the extension view from **side panel → popup → side panel**, closing and reopening MetaMask would incorrectly open the **popup**, and in some cases left **both the popup and the side panel open at the same time**.

**Root cause:** the popup → side panel path in `toggleDefaultView` (`ui/store/actions.ts`) gated success on a single `chrome.runtime.getContexts({ contextTypes: ['SIDE_PANEL'] })` probe taken 500ms after calling `sidePanel.open()`. That probe is racy — immediately after a side panel → popup round-trip, the previous side panel context teardown races with the new panel's setup, so the probe frequently reported **no** context even though the panel had opened. On that false negative the function did a bare early `return` *after* the panel was already open, which:

- left the freshly-opened **side panel open**,
- skipped `window.close()`, so the **popup stayed open** (both surfaces visible), and
- skipped persisting `useSidePanelAsDefault = true`, so the **next launch defaulted back to popup**.

**Fix:** success is now determined by whether `sidePanel.open()` resolves (it rejects on browsers where the API exists but is non-functional, e.g. Arc) instead of the flaky context probe. The preference is persisted whenever the panel opens, and there is no longer any path that leaves both surfaces open — either the panel opened (persist preference + close popup) or it didn't (return, popup stays).

Added a dedicated, colocated test file (`ui/store/actions.toggle-default-view.test.ts`) covering the toggle in both directions, the Arc/open-failure path, the no-window guard, and a regression test asserting the preference is persisted and the popup closes **without** probing side panel contexts.

## **Changelog**

CHANGELOG entry: Fixed a bug where switching the extension between side panel and popup view and back could reopen MetaMask in the popup, sometimes leaving both the side panel and popup open at the same time

## **Related issues**

Fixes: #43060

## **Manual testing steps**

1. Use a Chromium-based browser (Chrome/Edge/Brave) with the side panel feature enabled.
2. Open MetaMask in the side panel.
3. Open the global menu and choose **Switch to Popup**.
4. Open the global menu again and choose **Switch to Side Panel**.
5. Close MetaMask, then click the toolbar icon to reopen it.
6. Verify MetaMask reopens in the **side panel** (not the popup), and that the popup and side panel are never open simultaneously.

## **Screenshots/Recordings**

### **Before**

<!-- [recording showing reopen in popup / both surfaces open] -->

### **After**

<!-- [recording showing reopen consistently in the side panel] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-facing extension UI launch behavior and preference persistence, but scope is limited to `toggleDefaultView` with added regression tests.
> 
> **Overview**
> Fixes **popup ↔ side panel** toggling so a round-trip no longer leaves **both surfaces open** or fails to save the default view (#43060).
> 
> In `toggleDefaultView`, the popup → side panel path **drops** the 500ms wait and **`chrome.runtime.getContexts` success check**, which could falsely report no side panel context right after teardown/setup. Success is now **`sidePanel.open()` resolving** (rejections are caught and logged, popup stays open, preference unchanged). On success, **`useSidePanelAsDefault`** is persisted **before** `window.close()`.
> 
> Adds **`actions.toggle-default-view.test.ts`** covering disabled feature, both toggle directions, open failure, missing window, and a regression test that **`getContexts` is never called**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d857c0fbb91afdf4bd141c60d4590e0a00063e70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->