### PR TITLE
ci: Replace tokens in `identify-codeowners` and `update-lavamoat-policies` workflows

### DIFF
--- a/.github/workflows/identify-codeowners.yml
+++ b/.github/workflows/identify-codeowners.yml
@@ -28,7 +28,6 @@ jobs:
     environment: pr-comment
     steps:
       - name: Get token
-        if: ${{ steps.is-cross-repo.outputs.IS_CROSS_REPO_PR == 'false' }}
         id: token
         uses: MetaMask/github-tools/.github/actions/get-token@v1
         with:

--- a/.github/workflows/identify-codeowners.yml
+++ b/.github/workflows/identify-codeowners.yml
@@ -27,6 +27,17 @@ jobs:
     timeout-minutes: 30
     environment: pr-comment
     steps:
+      - name: Get token
+        if: ${{ steps.is-cross-repo.outputs.IS_CROSS_REPO_PR == 'false' }}
+        id: token
+        uses: MetaMask/github-tools/.github/actions/get-token@v1
+        with:
+          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
+          permissions: |
+            actions: read
+            contents: write
+            pull_requests: write
+
       - name: Checkout .github/ directory
         uses: actions/checkout@v6
         with:
@@ -45,5 +56,5 @@ jobs:
 
       - name: Identify codeowners
         env:
-          PR_COMMENT_TOKEN: ${{ secrets.PR_COMMENT_TOKEN }}
+          PR_COMMENT_TOKEN: ${{ steps.token.outputs.token }}
         run: node ./.github/scripts/identify-codeowners.mts

--- a/.github/workflows/identify-codeowners.yml
+++ b/.github/workflows/identify-codeowners.yml
@@ -26,6 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: pr-comment
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Get token
         id: token

--- a/.github/workflows/update-lavamoat-policies.yml
+++ b/.github/workflows/update-lavamoat-policies.yml
@@ -156,6 +156,8 @@ jobs:
 
       - name: Checkout pull request
         if: ${{ env.VALIDATION_FAILED == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: gh pr checkout "${PR_NUMBER}"
 
       - name: Download policy diffs from CI

--- a/.github/workflows/update-lavamoat-policies.yml
+++ b/.github/workflows/update-lavamoat-policies.yml
@@ -21,6 +21,7 @@ jobs:
       COMMENT_ID: ${{ github.event.comment.id }}
     permissions:
       contents: read
+      pull-requests: read
       id-token: write
     outputs:
       IS_CROSS_REPO_PR: ${{ steps.is-cross-repo.outputs.IS_CROSS_REPO_PR }}
@@ -33,6 +34,8 @@ jobs:
     steps:
       - name: Determine whether this PR is cross-repo
         id: is-cross-repo
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: echo "IS_CROSS_REPO_PR=$(gh pr view "${PR_NUMBER}" --repo "${REPO}" --json isCrossRepository --jq '.isCrossRepository')" >> "$GITHUB_OUTPUT"
 
       - name: Get token

--- a/.github/workflows/update-lavamoat-policies.yml
+++ b/.github/workflows/update-lavamoat-policies.yml
@@ -16,7 +16,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     env:
-      GITHUB_TOKEN: ${{ secrets.LAVAMOAT_UPDATE_TOKEN }}
       REPO: ${{ github.repository }}
       PR_NUMBER: ${{ github.event.issue.number }}
       COMMENT_ID: ${{ github.event.comment.id }}
@@ -33,8 +32,21 @@ jobs:
         id: is-cross-repo
         run: echo "IS_CROSS_REPO_PR=$(gh pr view "${PR_NUMBER}" --repo "${REPO}" --json isCrossRepository --jq '.isCrossRepository')" >> "$GITHUB_OUTPUT"
 
+      - name: Get token
+        if: ${{ steps.is-cross-repo.outputs.IS_CROSS_REPO_PR == 'false' }}
+        id: token
+        uses: MetaMask/github-tools/.github/actions/get-token@v1
+        with:
+          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
+          permissions: |
+            actions: read
+            contents: read
+            pull_requests: write
+
       - name: React to the comment
         if: ${{ steps.is-cross-repo.outputs.IS_CROSS_REPO_PR == 'false' }}
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           gh api \
             --method POST \
@@ -46,6 +58,8 @@ jobs:
       - name: Find CI run for PR head commit
         if: ${{ steps.is-cross-repo.outputs.IS_CROSS_REPO_PR == 'false' }}
         id: find-ci-run
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           HEAD_SHA=$(gh pr view "${PR_NUMBER}" --repo "${REPO}" --json headRefOid --jq '.headRefOid')
           echo "Looking for main.yml run for commit ${HEAD_SHA}..."
@@ -108,7 +122,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:
-      GITHUB_TOKEN: ${{ secrets.LAVAMOAT_UPDATE_TOKEN }}
       REPO: ${{ github.repository }}
       PR_NUMBER: ${{ github.event.issue.number }}
       RUN_ID: ${{ needs.prepare.outputs.RUN_ID }}
@@ -119,11 +132,21 @@ jobs:
       FAILED_JOBS: ${{ needs.prepare.outputs.FAILED_JOBS }}
       ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
     steps:
+      - name: Get token
+        id: token
+        uses: MetaMask/github-tools/.github/actions/get-token@v1
+        with:
+          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
+          permissions: |
+            actions: read
+            contents: write
+            pull_requests: write
+
       - name: Checkout repository
         if: ${{ env.VALIDATION_FAILED == 'true' }}
         uses: actions/checkout@v6
         with:
-          token: ${{ secrets.LAVAMOAT_UPDATE_TOKEN }}
+          token: ${{ steps.token.outputs.token }}
 
       - name: Checkout pull request
         if: ${{ env.VALIDATION_FAILED == 'true' }}
@@ -137,7 +160,7 @@ jobs:
           pattern: lavamoat-policy-diff-*
           merge-multiple: true
           run-id: ${{ env.RUN_ID }}
-          github-token: ${{ secrets.LAVAMOAT_UPDATE_TOKEN }}
+          github-token: ${{ steps.token.outputs.token }}
 
       - name: Check for policy diffs
         if: ${{ !cancelled() }}
@@ -162,6 +185,8 @@ jobs:
 
       - name: Compare policy changes
         if: ${{ steps.check-diffs.outputs.HAS_DIFFS == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           BASE_REF=$(gh pr view "${PR_NUMBER}" --json baseRefName --jq .baseRefName)
           git fetch origin "${BASE_REF}"
@@ -192,35 +217,49 @@ jobs:
 
       - name: Post comment (policies updated)
         if: ${{ steps.check-diffs.outputs.HAS_DIFFS == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           echo -e 'Policies updated.  \n👀 Please review the diff for suspicious new powers.  \n\n> [!TIP]  \n> Follow the policy review process outlined in the [LavaMoat Policy Review Process doc](https://github.com/MetaMask/metamask-extension/blob/main/docs/lavamoat-policy-review-process.md) before expecting an approval from Policy Reviewers.  \n🧠 Learn how to read policy diffs: https://lavamoat.github.io/guides/policy-diff/#what-to-look-for-when-reviewing-a-policy-diff \n\n' | cat - does_diff_diff.txt | gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body-file -
 
       - name: Post comment (no CI run found)
         if: ${{ needs.prepare.result == 'success' && env.NO_CI_RUN == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "No CI run found for this commit. Please wait for CI to start and retry \`@metamaskbot update-policies\`."
 
       - name: Post comment (validation still running)
         if: ${{ needs.prepare.result == 'success' && env.VALIDATION_PENDING == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "LavaMoat validation is still running. Please retry \`@metamaskbot update-policies\` after CI validation completes."
 
       - name: Post comment (validation failed but no diffs available)
         if: ${{ !cancelled() && env.VALIDATION_FAILED == 'true' && steps.check-diffs.outputs.HAS_DIFFS != 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           printf 'LavaMoat validation failed but no policy diffs were produced (the validation job may have crashed before generating diffs).\n\nFailed jobs:\n%s' "$FAILED_JOBS" | gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body-file -
 
       - name: Post comment (validation skipped)
         if: ${{ needs.prepare.result == 'success' && env.VALIDATION_SKIPPED == 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "LavaMoat validation was skipped in CI. Policies were not checked for this commit."
 
       - name: Post comment (no policy changes)
         if: ${{ needs.prepare.result == 'success' && env.RUN_ID && env.VALIDATION_FAILED != 'true' && !env.VALIDATION_PENDING && env.VALIDATION_SKIPPED != 'true' }}
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "No policy changes"
 
       - name: Post comment if the update failed
         if: ${{ (failure() && !(env.VALIDATION_FAILED == 'true' && steps.check-diffs.outputs.HAS_DIFFS != 'true')) || needs.prepare.result == 'failure' }}
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
         run: |
           gh pr comment "${PR_NUMBER}" --repo "${REPO}" --body "Policy update failed. You can [review the logs or retry the policy update here](${ACTION_RUN_URL})"

--- a/.github/workflows/update-lavamoat-policies.yml
+++ b/.github/workflows/update-lavamoat-policies.yml
@@ -19,6 +19,9 @@ jobs:
       REPO: ${{ github.repository }}
       PR_NUMBER: ${{ github.event.issue.number }}
       COMMENT_ID: ${{ github.event.comment.id }}
+    permissions:
+      contents: read
+      id-token: write
     outputs:
       IS_CROSS_REPO_PR: ${{ steps.is-cross-repo.outputs.IS_CROSS_REPO_PR }}
       RUN_ID: ${{ steps.find-ci-run.outputs.RUN_ID }}
@@ -131,6 +134,9 @@ jobs:
       VALIDATION_FAILED: ${{ needs.prepare.outputs.VALIDATION_FAILED }}
       FAILED_JOBS: ${{ needs.prepare.outputs.FAILED_JOBS }}
       ACTION_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Get token
         id: token


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This replaces tokens in the `identify-codeowners` and `update-lavamoat-policies` workflows.

- `identify-codeowners` has a Patroll token, which is unreliable.
- `update-lavamoat-policies` is using a `metamaskbot` PAT which is invalidated.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how GitHub API and git push credentials are obtained for PR comments and automated policy commits; misconfiguration of token exchange or permissions could break bot automation or over-scope access.
> 
> **Overview**
> Replaces long-lived GitHub PATs in two automation workflows with **OIDC-based tokens** from `MetaMask/github-tools` `get-token@v1` and `${{ vars.TOKEN_EXCHANGE_URL }}`.
> 
> In **`identify-codeowners`**, `PR_COMMENT_TOKEN` now comes from the exchanged token (with `contents`/`pull_requests` write) instead of `secrets.PR_COMMENT_TOKEN`; the job adds `id-token: write` and scoped `permissions`.
> 
> In **`update-lavamoat-policies`**, job-level `GITHUB_TOKEN` / `LAVAMOAT_UPDATE_TOKEN` usage is removed: `prepare` still uses `GITHUB_TOKEN` only for the cross-repo check; other `gh` steps, checkout, artifact download, and commits use the exchanged token with per-job permission blocks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5343ce245ed0b171122751b83a550bd252881b7a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->