### PR TITLE
feat: Skeleton migration (perps scope)

### DIFF
--- a/ui/components/app/perps/perps-fiat-hero-amount-input/perps-fiat-hero-amount-input.tsx
+++ b/ui/components/app/perps/perps-fiat-hero-amount-input/perps-fiat-hero-amount-input.tsx
@@ -10,7 +10,7 @@ import {
   TextColor,
   twMerge,
 } from '@metamask/design-system-react';
-import { Skeleton } from '../../../component-library/skeleton';
+import { Skeleton } from '@metamask/design-system-react';
 import { getCurrencySymbol } from '../../../../helpers/utils/common.util';
 import type { PerpsFiatHeroAmountInputProps } from './perps-fiat-hero-amount-input.types';
 

--- a/ui/components/app/perps/perps-fiat-hero-amount-input/perps-fiat-hero-amount-input.tsx
+++ b/ui/components/app/perps/perps-fiat-hero-amount-input/perps-fiat-hero-amount-input.tsx
@@ -9,8 +9,8 @@ import {
   TextAlign,
   TextColor,
   twMerge,
+  Skeleton,
 } from '@metamask/design-system-react';
-import { Skeleton } from '@metamask/design-system-react';
 import { getCurrencySymbol } from '../../../../helpers/utils/common.util';
 import type { PerpsFiatHeroAmountInputProps } from './perps-fiat-hero-amount-input.types';
 

--- a/ui/components/app/perps/perps-market-recent-activity/perps-market-recent-activity.test.tsx
+++ b/ui/components/app/perps/perps-market-recent-activity/perps-market-recent-activity.test.tsx
@@ -87,7 +87,7 @@ describe('PerpsMarketRecentActivity', () => {
         mockStore,
       );
 
-      const skeletons = container.querySelectorAll('.mm-skeleton');
+      const skeletons = container.querySelectorAll('[data-testid="perps-recent-activity-skeleton"]');
       expect(skeletons.length).toBe(3);
     });
 

--- a/ui/components/app/perps/perps-market-recent-activity/perps-market-recent-activity.test.tsx
+++ b/ui/components/app/perps/perps-market-recent-activity/perps-market-recent-activity.test.tsx
@@ -87,7 +87,9 @@ describe('PerpsMarketRecentActivity', () => {
         mockStore,
       );
 
-      const skeletons = container.querySelectorAll('[data-testid="perps-recent-activity-skeleton"]');
+      const skeletons = container.querySelectorAll(
+        '[data-testid="perps-recent-activity-skeleton"]',
+      );
       expect(skeletons.length).toBe(3);
     });
 

--- a/ui/components/app/perps/perps-market-recent-activity/perps-market-recent-activity.tsx
+++ b/ui/components/app/perps/perps-market-recent-activity/perps-market-recent-activity.tsx
@@ -31,7 +31,7 @@ const RecentActivitySkeleton: React.FC = () => (
     className="overflow-hidden rounded-xl"
   >
     {SKELETON_ITEMS.map((i) => (
-      <Skeleton key={i} className="h-[72px] w-full rounded-none" />
+      <Skeleton key={i} className="h-[72px] w-full rounded-none" data-testid="perps-recent-activity-skeleton" />
     ))}
   </Box>
 );

--- a/ui/components/app/perps/perps-market-recent-activity/perps-market-recent-activity.tsx
+++ b/ui/components/app/perps/perps-market-recent-activity/perps-market-recent-activity.tsx
@@ -11,6 +11,7 @@ import {
   IconName,
   IconSize,
   IconColor,
+  Skeleton,
 } from '@metamask/design-system-react';
 import { useNavigate } from 'react-router-dom';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
@@ -20,7 +21,6 @@ import { TransactionCard } from '../transaction-card';
 import { PERPS_CONSTANTS } from '../constants';
 import { PERPS_EVENT_VALUE } from '../../../../../shared/constants/perps-events';
 import { PERPS_ACTIVITY_ROUTE } from '../../../../helpers/constants/routes';
-import { Skeleton } from '@metamask/design-system-react';
 import type { PerpsTransaction } from '../types';
 
 const SKELETON_ITEMS = [1, 2, 3];
@@ -31,7 +31,11 @@ const RecentActivitySkeleton: React.FC = () => (
     className="overflow-hidden rounded-xl"
   >
     {SKELETON_ITEMS.map((i) => (
-      <Skeleton key={i} className="h-[72px] w-full rounded-none" data-testid="perps-recent-activity-skeleton" />
+      <Skeleton
+        key={i}
+        className="h-[72px] w-full rounded-none"
+        data-testid="perps-recent-activity-skeleton"
+      />
     ))}
   </Box>
 );

--- a/ui/components/app/perps/perps-market-recent-activity/perps-market-recent-activity.tsx
+++ b/ui/components/app/perps/perps-market-recent-activity/perps-market-recent-activity.tsx
@@ -20,7 +20,7 @@ import { TransactionCard } from '../transaction-card';
 import { PERPS_CONSTANTS } from '../constants';
 import { PERPS_EVENT_VALUE } from '../../../../../shared/constants/perps-events';
 import { PERPS_ACTIVITY_ROUTE } from '../../../../helpers/constants/routes';
-import { Skeleton } from '../../../component-library/skeleton';
+import { Skeleton } from '@metamask/design-system-react';
 import type { PerpsTransaction } from '../types';
 
 const SKELETON_ITEMS = [1, 2, 3];

--- a/ui/components/app/perps/perps-recent-activity/perps-recent-activity.tsx
+++ b/ui/components/app/perps/perps-recent-activity/perps-recent-activity.tsx
@@ -13,6 +13,7 @@ import {
   IconName,
   IconSize,
   IconColor,
+  Skeleton,
 } from '@metamask/design-system-react';
 import { useNavigate } from 'react-router-dom';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
@@ -20,8 +21,6 @@ import { TransactionCard } from '../transaction-card';
 import { PERPS_RECENT_ACTIVITY_MAX_TRANSACTIONS } from '../../../../../shared/constants/perps';
 import { PERPS_EVENT_VALUE } from '../../../../../shared/constants/perps-events';
 import { PERPS_ACTIVITY_ROUTE } from '../../../../helpers/constants/routes';
-import { BorderRadius } from '../../../../helpers/constants/design-system';
-import { Skeleton } from '../../../component-library/skeleton';
 import { PerpsCardSkeleton } from '../perps-skeletons/perps-card-skeleton';
 import type { PerpsTransaction } from '../types';
 
@@ -84,8 +83,8 @@ export const PerpsRecentActivity: React.FC<PerpsRecentActivityProps> = ({
           paddingTop={3}
           paddingBottom={3}
         >
-          <Skeleton className="h-5 w-36" borderRadius={BorderRadius.SM} />
-          <Skeleton className="h-4 w-14" borderRadius={BorderRadius.SM} />
+          <Skeleton className="h-5 w-36 rounded" />
+          <Skeleton className="h-4 w-14 rounded" />
         </Box>
         <Box flexDirection={BoxFlexDirection.Column}>
           {[1, 2, 3].map((cardIndex) => (

--- a/ui/components/app/perps/perps-skeletons/perps-activity-page-skeleton.tsx
+++ b/ui/components/app/perps/perps-skeletons/perps-activity-page-skeleton.tsx
@@ -1,8 +1,5 @@
 import React from 'react';
-import { Box, BoxFlexDirection } from '@metamask/design-system-react';
-
-import { Skeleton } from '../../../component-library/skeleton';
-import { BorderRadius } from '../../../../helpers/constants/design-system';
+import { Box, BoxFlexDirection, Skeleton } from '@metamask/design-system-react';
 import { PerpsCardSkeleton } from './perps-card-skeleton';
 
 /**
@@ -17,7 +14,7 @@ export const PerpsActivityPageSkeleton: React.FC = () => {
     >
       {/* Filter Dropdown Skeleton */}
       <Box paddingLeft={4} paddingRight={4} paddingBottom={4}>
-        <Skeleton className="h-10 w-full" borderRadius={BorderRadius.MD} />
+        <Skeleton className="h-10 w-full rounded-md" />
       </Box>
 
       {/* Date groups with transaction cards */}

--- a/ui/components/app/perps/perps-skeletons/perps-balance-actions-skeleton.tsx
+++ b/ui/components/app/perps/perps-skeletons/perps-balance-actions-skeleton.tsx
@@ -1,8 +1,5 @@
 import React from 'react';
-import { Box, BoxFlexDirection } from '@metamask/design-system-react';
-
-import { Skeleton } from '../../../component-library/skeleton';
-import { BorderRadius } from '../../../../helpers/constants/design-system';
+import { Box, BoxFlexDirection, Skeleton } from '@metamask/design-system-react';
 
 /**
  * PerpsBalanceActionsSkeleton component displays a loading skeleton for the balance actions
@@ -24,8 +21,8 @@ export const PerpsBalanceActionsSkeleton: React.FC = () => {
 
       {/* Action Buttons Skeleton */}
       <Box flexDirection={BoxFlexDirection.Row} gap={3} marginTop={4}>
-        <Skeleton className="h-12 flex-1" borderRadius={BorderRadius.LG} />
-        <Skeleton className="h-12 flex-1" borderRadius={BorderRadius.LG} />
+        <Skeleton className="h-12 flex-1 rounded-lg" />
+        <Skeleton className="h-12 flex-1 rounded-lg" />
       </Box>
     </Box>
   );

--- a/ui/components/app/perps/perps-skeletons/perps-card-skeleton.tsx
+++ b/ui/components/app/perps/perps-skeletons/perps-card-skeleton.tsx
@@ -3,10 +3,8 @@ import {
   Box,
   BoxFlexDirection,
   BoxAlignItems,
+  Skeleton,
 } from '@metamask/design-system-react';
-
-import { Skeleton } from '../../../component-library/skeleton';
-import { BorderRadius } from '../../../../helpers/constants/design-system';
 
 /**
  * PerpsCardSkeleton component displays a loading skeleton for position/order/market cards
@@ -22,7 +20,7 @@ export const PerpsCardSkeleton: React.FC = () => {
       data-testid="perps-card-skeleton"
     >
       {/* Token Logo Skeleton - matches AvatarTokenSize.Md (32px) */}
-      <Skeleton className="h-8 w-8 shrink-0" borderRadius={BorderRadius.pill} />
+      <Skeleton className="h-8 w-8 shrink-0 rounded-full" />
 
       {/* Left side: Symbol and info */}
       <Box

--- a/ui/components/app/perps/perps-skeletons/perps-control-bar-skeleton.tsx
+++ b/ui/components/app/perps/perps-skeletons/perps-control-bar-skeleton.tsx
@@ -4,10 +4,8 @@ import {
   BoxFlexDirection,
   BoxJustifyContent,
   BoxAlignItems,
+  Skeleton,
 } from '@metamask/design-system-react';
-
-import { Skeleton } from '../../../component-library/skeleton';
-import { BorderRadius } from '../../../../helpers/constants/design-system';
 
 /**
  * PerpsControlBarSkeleton component displays a loading skeleton for the control bar
@@ -36,7 +34,7 @@ export const PerpsControlBarSkeleton: React.FC = () => {
           gap={2}
         >
           <Skeleton className="h-4 w-20" />
-          <Skeleton className="h-4 w-4" borderRadius={BorderRadius.SM} />
+          <Skeleton className="h-4 w-4 rounded" />
         </Box>
       </Box>
     </Box>

--- a/ui/components/app/perps/perps-skeletons/perps-detail-page-skeleton.tsx
+++ b/ui/components/app/perps/perps-skeletons/perps-detail-page-skeleton.tsx
@@ -8,10 +8,8 @@ import {
   IconName,
   IconSize,
   IconColor,
+  Skeleton,
 } from '@metamask/design-system-react';
-
-import { Skeleton } from '../../../component-library/skeleton';
-import { BorderRadius } from '../../../../helpers/constants/design-system';
 
 /**
  * PerpsDetailPageSkeleton component displays a loading skeleton for the market detail page
@@ -43,10 +41,7 @@ export const PerpsDetailPageSkeleton: React.FC = () => {
         </Box>
 
         {/* Token Logo Skeleton */}
-        <Skeleton
-          className="h-10 w-10 shrink-0"
-          borderRadius={BorderRadius.pill}
-        />
+        <Skeleton className="h-10 w-10 shrink-0 rounded-full" />
 
         {/* Header Content Skeleton */}
         <Box flexDirection={BoxFlexDirection.Column} gap={1}>
@@ -76,7 +71,7 @@ export const PerpsDetailPageSkeleton: React.FC = () => {
 
       {/* Chart Skeleton */}
       <Box paddingLeft={4} paddingRight={4}>
-        <Skeleton className="h-[250px] w-full" borderRadius={BorderRadius.LG} />
+        <Skeleton className="h-[250px] w-full rounded-lg" />
       </Box>
 
       {/* Period Selector Skeleton */}
@@ -89,11 +84,7 @@ export const PerpsDetailPageSkeleton: React.FC = () => {
         paddingRight={4}
       >
         {['1m', '5m', '15m', '1h', '4h', '1d'].map((period) => (
-          <Skeleton
-            key={period}
-            className="h-8 w-10"
-            borderRadius={BorderRadius.MD}
-          />
+          <Skeleton key={period} className="h-8 w-10 rounded-md" />
         ))}
       </Box>
 
@@ -140,10 +131,7 @@ export const PerpsDetailPageSkeleton: React.FC = () => {
               alignItems={BoxAlignItems.Center}
               gap={4}
             >
-              <Skeleton
-                className="h-8 w-8 shrink-0"
-                borderRadius={BorderRadius.pill}
-              />
+              <Skeleton className="h-8 w-8 shrink-0 rounded-full" />
               <Box
                 flexDirection={BoxFlexDirection.Column}
                 alignItems={BoxAlignItems.Start}
@@ -181,8 +169,8 @@ export const PerpsDetailPageSkeleton: React.FC = () => {
         paddingBottom={4}
       >
         <Box flexDirection={BoxFlexDirection.Row} gap={3}>
-          <Skeleton className="h-12 flex-1" borderRadius={BorderRadius.LG} />
-          <Skeleton className="h-12 flex-1" borderRadius={BorderRadius.LG} />
+          <Skeleton className="h-12 flex-1 rounded-lg" />
+          <Skeleton className="h-12 flex-1 rounded-lg" />
         </Box>
       </Box>
     </Box>

--- a/ui/components/app/perps/perps-skeletons/perps-home-card-skeleton.tsx
+++ b/ui/components/app/perps/perps-skeletons/perps-home-card-skeleton.tsx
@@ -3,10 +3,8 @@ import {
   Box,
   BoxFlexDirection,
   BoxAlignItems,
+  Skeleton,
 } from '@metamask/design-system-react';
-
-import { Skeleton } from '../../../component-library/skeleton';
-import { BorderRadius } from '../../../../helpers/constants/design-system';
 
 /**
  * PerpsHomeCardSkeleton component displays a loading skeleton for home page list items
@@ -22,7 +20,7 @@ export const PerpsHomeCardSkeleton: React.FC = () => {
       data-testid="perps-home-card-skeleton"
     >
       {/* Token Logo Skeleton - matches AvatarTokenSize.Md (32px) */}
-      <Skeleton className="h-8 w-8 shrink-0" borderRadius={BorderRadius.pill} />
+      <Skeleton className="h-8 w-8 shrink-0 rounded-full" />
 
       {/* Left side: Symbol and info */}
       <Box

--- a/ui/components/app/perps/perps-skeletons/perps-section-skeleton.tsx
+++ b/ui/components/app/perps/perps-skeletons/perps-section-skeleton.tsx
@@ -5,7 +5,7 @@ import {
   BoxAlignItems,
 } from '@metamask/design-system-react';
 
-import { Skeleton } from '../../../component-library/skeleton';
+import { Skeleton } from '@metamask/design-system-react';
 import { PerpsCardSkeleton } from './perps-card-skeleton';
 import { PerpsStartTradeCtaSkeleton } from './perps-start-trade-cta-skeleton';
 

--- a/ui/components/app/perps/perps-skeletons/perps-section-skeleton.tsx
+++ b/ui/components/app/perps/perps-skeletons/perps-section-skeleton.tsx
@@ -3,9 +3,9 @@ import {
   Box,
   BoxFlexDirection,
   BoxAlignItems,
+  Skeleton,
 } from '@metamask/design-system-react';
 
-import { Skeleton } from '@metamask/design-system-react';
 import { PerpsCardSkeleton } from './perps-card-skeleton';
 import { PerpsStartTradeCtaSkeleton } from './perps-start-trade-cta-skeleton';
 

--- a/ui/components/app/perps/perps-skeletons/perps-start-trade-cta-skeleton.tsx
+++ b/ui/components/app/perps/perps-skeletons/perps-start-trade-cta-skeleton.tsx
@@ -3,10 +3,8 @@ import {
   Box,
   BoxFlexDirection,
   BoxAlignItems,
+  Skeleton,
 } from '@metamask/design-system-react';
-
-import { Skeleton } from '../../../component-library/skeleton';
-import { BorderRadius } from '../../../../helpers/constants/design-system';
 
 /**
  * PerpsStartTradeCtaSkeleton displays a loading skeleton for the Start a new trade CTA
@@ -22,7 +20,7 @@ export const PerpsStartTradeCtaSkeleton: React.FC = () => {
       data-testid="perps-start-trade-cta-skeleton"
     >
       {/* Icon circle - matches StartTradeCta (h-8 w-8) */}
-      <Skeleton className="h-8 w-8 shrink-0" borderRadius={BorderRadius.pill} />
+      <Skeleton className="h-8 w-8 shrink-0 rounded-full" />
       <Skeleton className="h-4 w-36" />
     </Box>
   );

--- a/ui/components/app/perps/perps-token-logo/perps-token-logo.tsx
+++ b/ui/components/app/perps/perps-token-logo/perps-token-logo.tsx
@@ -2,11 +2,10 @@ import React, { useMemo, useState, useEffect } from 'react';
 import {
   AvatarToken,
   AvatarTokenSize,
+  Skeleton,
   twMerge,
 } from '@metamask/design-system-react';
 import { getDisplaySymbol, getAssetIconUrls } from '../utils';
-import { Skeleton } from '../../../component-library/skeleton';
-import { BorderRadius } from '../../../../helpers/constants/design-system';
 import { useTheme } from '../../../../hooks/useTheme';
 import { ThemeType } from '../../../../../shared/constants/preferences';
 import {
@@ -112,8 +111,7 @@ export const PerpsTokenLogo: React.FC<PerpsTokenLogoProps> = ({
   if (isResolving) {
     return (
       <Skeleton
-        className={`shrink-0 ${AVATAR_SIZE_CLASS[size]} ${className ?? ''}`}
-        borderRadius={BorderRadius.full}
+        className={`shrink-0 rounded-full ${AVATAR_SIZE_CLASS[size]} ${className ?? ''}`}
         data-testid={`perps-token-logo-${sanitizedSymbol}`}
       />
     );

--- a/ui/pages/perps/market-list/components/market-row-skeleton/market-row-skeleton.tsx
+++ b/ui/pages/perps/market-list/components/market-row-skeleton/market-row-skeleton.tsx
@@ -4,10 +4,9 @@ import {
   BoxBackgroundColor,
   BoxFlexDirection,
   BoxAlignItems,
+  Skeleton,
 } from '@metamask/design-system-react';
 
-import { Skeleton } from '../../../../../components/component-library/skeleton';
-import { BorderRadius } from '../../../../../helpers/constants/design-system';
 
 /**
  * MarketRowSkeleton component displays a loading skeleton for market rows
@@ -24,10 +23,7 @@ export const MarketRowSkeleton: React.FC = () => {
       data-testid="market-row-skeleton"
     >
       {/* Token Logo Skeleton */}
-      <Skeleton
-        className="h-10 w-10 shrink-0"
-        borderRadius={BorderRadius.pill}
-      />
+      <Skeleton className="h-10 w-10 shrink-0 rounded-full" />
 
       {/* Left side: Symbol and metric */}
       <Box

--- a/ui/pages/perps/market-list/components/market-row-skeleton/market-row-skeleton.tsx
+++ b/ui/pages/perps/market-list/components/market-row-skeleton/market-row-skeleton.tsx
@@ -7,7 +7,6 @@ import {
   Skeleton,
 } from '@metamask/design-system-react';
 
-
 /**
  * MarketRowSkeleton component displays a loading skeleton for market rows
  * Matches the layout of MarketRow for smooth loading transitions

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -30,6 +30,7 @@ import {
   Button,
   ButtonVariant,
   ButtonSize,
+  Skeleton,
 } from '@metamask/design-system-react';
 import { brandColor } from '@metamask/design-tokens';
 import type { PriceUpdate } from '@metamask/perps-controller';
@@ -101,7 +102,6 @@ import {
   normalizeMarketDetailsOrders,
 } from '../../components/app/perps/utils/orderUtils';
 import { PerpsDetailPageSkeleton } from '../../components/app/perps/perps-skeletons';
-import { Skeleton } from '@metamask/design-system-react';
 import { Popover, PopoverPosition } from '../../components/component-library';
 import { useFormatters } from '../../hooks/useFormatters';
 import { EditMarginModal } from '../../components/app/perps/edit-margin';
@@ -1000,9 +1000,7 @@ const PerpsMarketDetailPage: React.FC = () => {
   // or the live chart once data is available.
   const renderChartContent = () => {
     if (isCandleLoading && !candleData) {
-      return (
-        <Skeleton className="h-[250px] w-full rounded-lg" />
-      );
+      return <Skeleton className="h-[250px] w-full rounded-lg" />;
     }
 
     if (candleError && !candleData) {

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -101,7 +101,7 @@ import {
   normalizeMarketDetailsOrders,
 } from '../../components/app/perps/utils/orderUtils';
 import { PerpsDetailPageSkeleton } from '../../components/app/perps/perps-skeletons';
-import { Skeleton } from '../../components/component-library/skeleton';
+import { Skeleton } from '@metamask/design-system-react';
 import { Popover, PopoverPosition } from '../../components/component-library';
 import { useFormatters } from '../../hooks/useFormatters';
 import { EditMarginModal } from '../../components/app/perps/edit-margin';
@@ -117,7 +117,6 @@ import {
   usePerpsToast,
 } from '../../components/app/perps/perps-toast';
 import Tooltip from '../../components/ui/tooltip';
-import { BorderRadius } from '../../helpers/constants/design-system';
 import type { MetaMaskReduxState } from '../../store/store';
 import { MetaMetricsEventName } from '../../../shared/constants/metametrics';
 import {
@@ -1002,7 +1001,7 @@ const PerpsMarketDetailPage: React.FC = () => {
   const renderChartContent = () => {
     if (isCandleLoading && !candleData) {
       return (
-        <Skeleton className="h-[250px] w-full" borderRadius={BorderRadius.LG} />
+        <Skeleton className="h-[250px] w-full rounded-lg" />
       );
     }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Use `Skeleton` from DSR.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-727

## **Manual testing steps**

1. Check `Skeleton` on affected pages
2. Make sure there is no visual regressions

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="474" height="854" alt="image" src="https://github.com/user-attachments/assets/14dd7281-c837-48be-9547-5f46e768b135" />

### **After**

<img width="476" height="856" alt="image" src="https://github.com/user-attachments/assets/3331f347-8ee1-42d3-8a13-8e75df9833ec" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only design-system swap across perps loading states; no trading, auth, or data-path changes.
> 
> **Overview**
> Migrates **Perps** loading placeholders from the extension **component-library** `Skeleton` to **`Skeleton` from `@metamask/design-system-react`**, aligning perps with the design system (DSYS-727).
> 
> Touches hero amount input, recent-activity UIs, token logo loading state, market list row skeleton, market detail chart placeholder, and the shared perps skeleton components (activity page, cards, detail page, balance actions, etc.). **`borderRadius={BorderRadius.*}`** on skeletons is replaced with Tailwind rounding classes (`rounded`, `rounded-md`, `rounded-lg`, `rounded-full`). Unused **`BorderRadius`** imports are dropped where they only served skeletons.
> 
> **Tests:** `perps-market-recent-activity` loading assertion now targets **`data-testid="perps-recent-activity-skeleton"`** instead of `.mm-skeleton`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 205ee9c14ff801a81e3e5edd40014198ea36a9ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->