### PR TITLE
fix(sentry): cp-13.34.0 Restore and expand filtering of high-volume fetch spans with low diagnostic value

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -303,16 +303,25 @@ export function beforeBreadcrumb() {
  * @returns {boolean} Whether to create a span for the request.
  */
 export function shouldCreateSpanForRequest(url) {
-  // Do not create spans for outgoing requests to a 'sentry.io' domain.
-  if (/^https?:\/\/(?:[\w\d.@-]+\.)?sentry\.io(?:\/|$)/u.test(url)) {
+  // Do not create spans for outgoing requests to telemetry domains
+  // ('sentry.io' and 'segment.io'). These are reporting endpoints, so
+  // tracing them adds high-volume spans with no diagnostic value.
+  if (
+    /^https?:\/\/(?:[\w\d.@-]+\.)?(?:sentry|segment)\.io(?:\/|$)/u.test(url)
+  ) {
     return false;
   }
-  // Block span creation on fetches for preinstalled snap manifest and locale files.
-  // Snap manifests are fetched on every MV3 SW restart,
-  // and locale files are fetched on every popup open.
-  // These are high volume, local file reads with no diagnostic value.
-  // TODO: Consider blocking all local extension file fetches.
-  if (/^(?:chrome|moz)-extension:\/\/[^/]+\/(?:snaps|_locales)\//u.test(url)) {
+  // Block span creation on ALL local extension file fetches.
+  // PR #41526 originally narrowed this to preinstalled snap manifests
+  // (fetched on every MV3 SW restart) and locale files (fetched on every
+  // popup open) under the `/snaps/` and `/_locales/` paths, but left a TODO
+  // to block all local extension fetches. This completes that TODO: the
+  // dominant remaining offenders are root-level content-hashed
+  // `chrome-extension://<id>/<hash>.json` preinstalled-snap bundles emitted
+  // by webpack as `asset/resource` (see app/scripts/constants/snaps.ts),
+  // which sit at the extension root and slipped past the old regex.
+  // These are all high-volume local file reads with no diagnostic value.
+  if (/^(?:chrome|moz)-extension:\/\//u.test(url)) {
     return false;
   }
   // Create spans for all other requests.

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -297,7 +297,12 @@ export function beforeBreadcrumb() {
 
 /**
  * Returns whether a span should be created for a given request URL.
- * Filters out Sentry domain requests and local extension file fetches.
+ *
+ * Filters out high-volume fetches with no per-request diagnostic value:
+ * telemetry endpoints (sentry.io, segment.io), static config files re-fetched on
+ * a constant poll cadence (chainid.network, acl.execution.metamask.io), and local
+ * extension reads (snap manifests / locale files, and content-hashed
+ * preinstalled-snap `<hash>.json` bundles). All other requests are traced.
  *
  * @param {string} url - The request URL.
  * @returns {boolean} Whether to create a span for the request.

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -311,17 +311,20 @@ export function shouldCreateSpanForRequest(url) {
   ) {
     return false;
   }
-  // Block span creation on ALL local extension file fetches.
-  // PR #41526 originally narrowed this to preinstalled snap manifests
-  // (fetched on every MV3 SW restart) and locale files (fetched on every
-  // popup open) under the `/snaps/` and `/_locales/` paths, but left a TODO
-  // to block all local extension fetches. This completes that TODO: the
-  // dominant remaining offenders are root-level content-hashed
-  // `chrome-extension://<id>/<hash>.json` preinstalled-snap bundles emitted
-  // by webpack as `asset/resource` (see app/scripts/constants/snaps.ts),
-  // which sit at the extension root and slipped past the old regex.
-  // These are all high-volume local file reads with no diagnostic value.
-  if (/^(?:chrome|moz)-extension:\/\//u.test(url)) {
+  // Block span creation on high-volume local extension file reads that have no
+  // diagnostic value:
+  // - Preinstalled snap manifests (fetched on every MV3 SW restart) and locale
+  //   files (fetched on every popup open), under `/snaps/` and `/_locales/`
+  //   (PR #41526).
+  // - Root-level content-hashed `chrome-extension://<id>/<hash>.json`
+  //   preinstalled-snap bundles emitted by webpack `asset/resource` (see
+  //   app/scripts/constants/snaps.ts). They sit at the extension root, so they
+  //   slipped past the #41526 regex. Scoped to hashed `.json` filenames so other
+  //   local extension fetches still get spans.
+  if (
+    /^(?:chrome|moz)-extension:\/\/[^/]+\/(?:snaps|_locales)\//u.test(url) ||
+    /^(?:chrome|moz)-extension:\/\/[^/]+\/[0-9a-f]{8,}\.json$/u.test(url)
+  ) {
     return false;
   }
   // Create spans for all other requests.

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -311,19 +311,15 @@ export function shouldCreateSpanForRequest(url) {
   ) {
     return false;
   }
-  // Block span creation on high-volume local extension file reads that have no
-  // diagnostic value:
-  // - Preinstalled snap manifests (fetched on every MV3 SW restart) and locale
-  //   files (fetched on every popup open), under `/snaps/` and `/_locales/`
-  //   (PR #41526).
-  // - Root-level content-hashed `chrome-extension://<id>/<hash>.json`
-  //   preinstalled-snap bundles emitted by webpack `asset/resource` (see
-  //   app/scripts/constants/snaps.ts). They sit at the extension root, so they
-  //   slipped past the #41526 regex. Scoped to hashed `.json` filenames so other
-  //   local extension fetches still get spans.
+  // Skip spans for high-volume local extension reads with no diagnostic value:
+  // snap manifests and locale files (under `/snaps/` and `/_locales/`, read on
+  // every SW restart / popup open) and the content-hashed preinstalled-snap
+  // bundles webpack emits at the extension root (`<hash>.json`, see
+  // app/scripts/constants/snaps.ts). Other local fetches keep their spans.
   if (
-    /^(?:chrome|moz)-extension:\/\/[^/]+\/(?:snaps|_locales)\//u.test(url) ||
-    /^(?:chrome|moz)-extension:\/\/[^/]+\/[0-9a-f]{8,}\.json$/u.test(url)
+    /^(?:chrome|moz)-extension:\/\/[^/]+\/(?:(?:snaps|_locales)\/|[0-9a-f]{8,}\.json$)/u.test(
+      url,
+    )
   ) {
     return false;
   }

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -303,11 +303,14 @@ export function beforeBreadcrumb() {
  * @returns {boolean} Whether to create a span for the request.
  */
 export function shouldCreateSpanForRequest(url) {
-  // Do not create spans for outgoing requests to telemetry domains
-  // ('sentry.io' and 'segment.io'). These are reporting endpoints, so
-  // tracing them adds high-volume spans with no diagnostic value.
+  // Do not create spans for high-volume remote fetches with no per-request
+  // diagnostic value: telemetry endpoints (sentry.io, segment.io) and static
+  // config files re-fetched on a constant poll cadence (chainid.network chain
+  // registry; acl.execution.metamask.io PPOM allowlist registry/signature).
   if (
-    /^https?:\/\/(?:[\w\d.@-]+\.)?(?:sentry|segment)\.io(?:\/|$)/u.test(url)
+    /^https?:\/\/(?:[\w\d.@-]+\.)?(?:sentry\.io|segment\.io|chainid\.network|acl\.execution\.metamask\.io)(?:\/|$)/u.test(
+      url,
+    )
   ) {
     return false;
   }

--- a/app/scripts/lib/setupSentry.test.js
+++ b/app/scripts/lib/setupSentry.test.js
@@ -186,6 +186,28 @@ describe('Setup Sentry', () => {
       ).toStrictEqual(false);
     });
 
+    it('should return false for root content-hashed json fetches (preinstalled snap bundles)', () => {
+      // These are the webpack `asset/resource` preinstalled-snap bundles that
+      // sit at the extension root and slipped past the old `/snaps/` regex.
+      expect(
+        shouldCreateSpanForRequest('chrome-extension://abc/deadbeef.json'),
+      ).toStrictEqual(false);
+      expect(
+        shouldCreateSpanForRequest('moz-extension://abc/deadbeef.json'),
+      ).toStrictEqual(false);
+    });
+
+    it('should return false for all other local extension file fetches', () => {
+      expect(
+        shouldCreateSpanForRequest('chrome-extension://abc/home.html'),
+      ).toStrictEqual(false);
+      expect(
+        shouldCreateSpanForRequest(
+          'chrome-extension://abcdefg/scripts/ppom-validator.wasm',
+        ),
+      ).toStrictEqual(false);
+    });
+
     it('should return false for sentry.io domains', () => {
       expect(
         shouldCreateSpanForRequest('https://sentry.io/api/123'),
@@ -195,15 +217,10 @@ describe('Setup Sentry', () => {
       ).toStrictEqual(false);
     });
 
-    it('should return true for other local extension file fetches', () => {
+    it('should return false for segment.io domains', () => {
       expect(
-        shouldCreateSpanForRequest(
-          'chrome-extension://abcdefg/scripts/ppom-validator.wasm',
-        ),
-      ).toStrictEqual(true);
-      expect(
-        shouldCreateSpanForRequest('chrome-extension://abcdefg/home.html'),
-      ).toStrictEqual(true);
+        shouldCreateSpanForRequest('https://api.segment.io/v1/batch'),
+      ).toStrictEqual(false);
     });
 
     it('should return true for external API URLs', () => {
@@ -212,6 +229,9 @@ describe('Setup Sentry', () => {
       ).toStrictEqual(true);
       expect(
         shouldCreateSpanForRequest('https://api.coingecko.com/v3/simple/price'),
+      ).toStrictEqual(true);
+      expect(
+        shouldCreateSpanForRequest('https://example.com/foo'),
       ).toStrictEqual(true);
     });
   });

--- a/app/scripts/lib/setupSentry.test.js
+++ b/app/scripts/lib/setupSentry.test.js
@@ -229,6 +229,22 @@ describe('Setup Sentry', () => {
       ).toStrictEqual(false);
     });
 
+    it('should return false for static config domains', () => {
+      expect(
+        shouldCreateSpanForRequest('https://chainid.network/chains.json'),
+      ).toStrictEqual(false);
+      expect(
+        shouldCreateSpanForRequest(
+          'https://acl.execution.metamask.io/latest/registry.json',
+        ),
+      ).toStrictEqual(false);
+      expect(
+        shouldCreateSpanForRequest(
+          'https://acl.execution.metamask.io/latest/signature.json',
+        ),
+      ).toStrictEqual(false);
+    });
+
     it('should return true for external API URLs', () => {
       expect(
         shouldCreateSpanForRequest('https://mainnet.infura.io/v3/abc'),
@@ -238,6 +254,16 @@ describe('Setup Sentry', () => {
       ).toStrictEqual(true);
       expect(
         shouldCreateSpanForRequest('https://example.com/foo'),
+      ).toStrictEqual(true);
+      // Other cx.metamask.io APIs are real calls — still traced (only the static
+      // `acl.execution.metamask.io` config is excluded, not all of metamask.io).
+      expect(
+        shouldCreateSpanForRequest(
+          'https://accounts.api.cx.metamask.io/v2/supportedNetworks',
+        ),
+      ).toStrictEqual(true);
+      expect(
+        shouldCreateSpanForRequest('https://token.api.cx.metamask.io/tokens/1'),
       ).toStrictEqual(true);
     });
   });

--- a/app/scripts/lib/setupSentry.test.js
+++ b/app/scripts/lib/setupSentry.test.js
@@ -197,15 +197,21 @@ describe('Setup Sentry', () => {
       ).toStrictEqual(false);
     });
 
-    it('should return false for all other local extension file fetches', () => {
+    it('should return true for other local extension file fetches (only hashed json is blocked)', () => {
+      // Non-hashed local fetches still get spans — the block is scoped to the
+      // content-hashed preinstalled-snap bundles, not all local files.
       expect(
         shouldCreateSpanForRequest('chrome-extension://abc/home.html'),
-      ).toStrictEqual(false);
+      ).toStrictEqual(true);
       expect(
         shouldCreateSpanForRequest(
           'chrome-extension://abcdefg/scripts/ppom-validator.wasm',
         ),
-      ).toStrictEqual(false);
+      ).toStrictEqual(true);
+      // A non-hex-named root json (e.g. a config file) is also still traced.
+      expect(
+        shouldCreateSpanForRequest('chrome-extension://abc/manifest.json'),
+      ).toStrictEqual(true);
     });
 
     it('should return false for sentry.io domains', () => {


### PR DESCRIPTION
## **Description**

The MV3 service worker's network calls are auto-instrumented as `http.client` spans under one long-lived `/service-worker.js` root transaction — ~70M spans/24h on 13.33.0, the single top span producer (distinct from the assets-controller spike tracked in #43226 / #43234). 

- The largest avoidable chunk is ~20M+/24h of **preinstalled-snap bundles** which were previously filtered out by #41526, but are now emitted by webpack at the extension root with content-hashed names, requiring a new filter regex. This commit adds a **targeted** exclusion in `shouldCreateSpanForRequest` for those root-level content-hashed `<hash>.json` files.
- This commit also adds `segment.io`, `chainid.network`, `acl.execution.metamask.io` to the no-span domain list. 

Together this removes ~23M+/24h of zero-diagnostic-value spans on builds carrying it. The remaining `/service-worker.js` `http.client` volume (infura RPC + config polls) is left as a follow-up in #43235.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #43235

## **Manual testing steps**

1. Confirm `shouldCreateSpanForRequest('chrome-extension://<id>/deadbeef.json')` (content-hashed) returns `false`.
2. Confirm `shouldCreateSpanForRequest('chrome-extension://<id>/home.html')` returns `true` — non-hashed local fetches are still traced.
3. Confirm `shouldCreateSpanForRequest('https://api.segment.io/v1/batch')` returns `false`, a normal request (`https://example.com/foo`) returns `true`, and the existing `/snaps/`, `/_locales/`, and `sentry.io` exclusions still hold.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability.
- [x] I’ve included tests if applicable.
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable.
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change to which HTTP requests get Sentry spans; no auth, transaction, or user-data logic is modified, with behavior covered by unit tests.
> 
> **Overview**
> Expands **`shouldCreateSpanForRequest`** so Sentry’s browser tracing integration skips more high-volume **`http.client`** spans that add little per-request signal in the MV3 service worker.
> 
> **Remote:** The no-span host list now includes **`segment.io`**, **`chainid.network`**, and **`acl.execution.metamask.io`** (with existing **`sentry.io`**), covering telemetry and repeatedly polled static config (chain registry, PPOM ACL registry/signature).
> 
> **Local:** Extension fetches still skip **`/snaps/`** and **`/_locales/`**, and now also skip root-level **content-hashed** **`<hex>.json`** bundles (preinstalled snap webpack assets that no longer live under **`/snaps/`**). Other local URLs (e.g. **`home.html`**, **`manifest.json`**, WASM) still get spans.
> 
> Tests document the new cases and clarify that only **`acl.execution.metamask.io`** is excluded among MetaMask hosts—not all **`*.metamask.io`** APIs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7981d6f8a6e8e18bd30e285b7c7dbe76bb2ada3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->