### PR TITLE
chore: update CLA allowlist to include metamask-aep bot

### DIFF
--- a/.github/scripts/check-template-and-add-labels.mts
+++ b/.github/scripts/check-template-and-add-labels.mts
@@ -35,6 +35,7 @@ const knownBots = [
   'runway-github',
   'cursor',
   'copilot-swe-agent',
+  'metamask-aep',
 ];
 
 // GitHub App / bot logins that cannot be resolved as User in GraphQL (user(login:) returns null).

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,6 +27,6 @@ jobs:
           url-to-cladocument: 'https://metamask.io/cla'
           # This branch can't have protections, commits are made directly to the specified branch.
           branch: 'cla-signatures'
-          allowlist: 'dependabot[bot],metamaskbot,metamaskbotv2[bot],crowdin-bot,runway-github[bot],cursoragent,Copilot'
+          allowlist: 'dependabot[bot],metamaskbot,metamaskbotv2[bot],crowdin-bot,runway-github[bot],cursoragent,Copilot,metamask-aep[bot]'
           allow-organization-members: true
           blockchain-storage-flag: false


### PR DESCRIPTION
## **Description**

Adds `metamask-aep[bot]` to the CLA Signature Bot allowlist in `.github/workflows/cla.yml`.

The AI tiger team has built a Slack-approved agent that automatically fixes bugs and opens PRs under the `metamask-aep[bot]` account. Because this is an automation account that cannot sign the Contributor License Agreement, its PRs are currently blocked by the CLA Signature Bot check. Allowlisting it treats it like our other exempt automation accounts (e.g. `dependabot[bot]`, `metamaskbot`, `crowdin-bot`, `runway-github[bot]`, `cursoragent`, `Copilot`) so its PRs are no longer blocked on the CLA check.

## **Changelog**

CHANGELOG entry: chore: Adds `metamask-aep[bot]` to the CLA Signature Bot allowlist in `.github/workflows/cla.yml`.

## **Related issues**

Fixes:

## **Manual testing steps**

This change only affects CI. To verify:
1. Have a PR opened by the `metamask-aep[bot]` account.
2. Confirm the `CLA Signature Bot` check passes (does not request a CLA signature) for that PR.

## **Screenshots/Recordings**

### **Before**

CLA Signature Bot blocks PRs opened by `metamask-aep[bot]`, requesting a CLA signature it cannot provide.

### **After**

CLA Signature Bot treats `metamask-aep[bot]` as an exempt automation account; its PRs pass the check.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI configuration only; no application, auth, or data-path changes.
> 
> **Overview**
> Treats **`metamask-aep`** as an internal automation account so its PRs are not blocked by CLA or mis-labeled as external.
> 
> **`.github/workflows/cla.yml`** adds `metamask-aep[bot]` to the CLA Signature Bot **allowlist**, alongside other bots that cannot sign the CLA.
> 
> **`.github/scripts/check-template-and-add-labels.mts`** adds `metamask-aep` to **`knownBots`**, so issues/PRs from that actor skip bot template checks and are not tagged as external contributors when org membership cannot be verified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5edd17d1f9d5d962e41ba7525aca41f8bf8dd88. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->