### PR TITLE
fix: stale swap status cp-13.35.0

### DIFF
--- a/ui/selectors/activity.ts
+++ b/ui/selectors/activity.ts
@@ -4,7 +4,7 @@ import {
   TransactionType,
   type TransactionMeta,
 } from '@metamask/transaction-controller';
-import { StatusTypes } from '@metamask/bridge-controller';
+import { isCrossChain, StatusTypes } from '@metamask/bridge-controller';
 import type { BridgeHistoryItem } from '@metamask/bridge-status-controller';
 import type { TransactionPayControllerState } from '@metamask/transaction-pay-controller';
 import type { Transaction as KeyringTransaction } from '@metamask/keyring-api';
@@ -27,6 +27,7 @@ import { toAssetId } from '../../shared/lib/asset-utils';
 import { mapKeyringTransaction } from '../../shared/lib/activity/adapters/keyring-transaction';
 import { mapLocalTransaction } from '../../shared/lib/activity/adapters/local-transaction';
 import { isProtectedByEnforcedSimulations } from '../pages/confirmations/utils/confirm';
+import { Status } from '../../shared/lib/activity/types';
 import { enrichLocalMusdClaimActivity } from './activity/enrich-local-musd-claim';
 import { getAssetsMetadata } from './assets';
 import {
@@ -281,20 +282,32 @@ function getSwapTokens(bridgeHistoryItem?: BridgeHistoryItem) {
   };
 }
 
-function getBridgeActivityStatus(bridgeHistoryItem?: BridgeHistoryItem) {
-  if (bridgeHistoryItem?.status.status === StatusTypes.FAILED) {
-    return 'failed' as const;
+function getBridgeActivityStatus(
+  bridgeHistoryItem?: BridgeHistoryItem,
+): Status | undefined {
+  if (!bridgeHistoryItem) {
+    return undefined;
   }
 
-  if (bridgeHistoryItem?.status.status === StatusTypes.COMPLETE) {
-    return 'success' as const;
+  const {
+    quote,
+    status: { status },
+  } = bridgeHistoryItem;
+
+  if (status === StatusTypes.FAILED) {
+    return 'failed';
+  }
+
+  if (status === StatusTypes.COMPLETE) {
+    return 'success';
   }
 
   if (
-    bridgeHistoryItem?.status.status === StatusTypes.PENDING ||
-    bridgeHistoryItem?.status.status === StatusTypes.SUBMITTED
+    // Same-chain swaps can leave bridge status pending after the local tx confirms
+    isCrossChain(quote.srcChainId, quote.destChainId) &&
+    (status === StatusTypes.PENDING || status === StatusTypes.SUBMITTED)
   ) {
-    return 'pending' as const;
+    return 'pending';
   }
 
   return undefined;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Stale swap (bridge) state that can sometimes result in incorrect activity list item status

Note: Activity redesign is behind a feature flag

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to bridge-derived activity status for swap/bridge list items; no auth or transaction submission logic.
> 
> **Overview**
> Fixes activity list items for **same-chain swaps** showing **pending** after the on-chain transaction has already confirmed.
> 
> `getBridgeActivityStatus` in `activity.ts` no longer maps bridge history `PENDING`/`SUBMITTED` to activity `pending` unless `isCrossChain(quote.srcChainId, quote.destChainId)` is true. When bridge status is stale on same-chain swaps, the mapper falls back to **local transaction status** instead of overriding with bridge state. The helper also returns `undefined` when there is no bridge history item and uses the shared `Status` type.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cef0ad070611c6c86db970a9559ada7d54df3cfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->