### PR TITLE
feat(perps): ADR58 POC ETH debug banner (DO NOT MERGE)

### DIFF
--- a/ui/components/app/perps/perps-view.tsx
+++ b/ui/components/app/perps/perps-view.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  BoxBackgroundColor,
   BoxFlexDirection,
   Text,
   TextVariant,
@@ -289,6 +290,10 @@ export const PerpsView = () => {
   }, [isEligible, applyOrdersSnapshot, orders.length, t]);
 
   const hasPositions = positions.length > 0;
+  // ADR58 POC (DO NOT MERGE): detect an open ETH perps position to gate the debug banner
+  const hasEthPosition = positions.some(
+    (position) => position.symbol === 'ETH',
+  );
   // Only the single-position view can mirror a card-level RoE; for zero or
   // multiple positions, summary RoE remains the account aggregate.
   const singlePosition = positions.length === 1 ? positions[0] : undefined;
@@ -368,6 +373,20 @@ export const PerpsView = () => {
         <Text variant={TextVariant.BodySm} color={TextColor.ErrorDefault}>
           {batchActionError}
         </Text>
+      ) : null}
+
+      {/* ADR58 POC (DO NOT MERGE): debug banner shown above positions when an open ETH position exists */}
+      {process.env.METAMASK_DEBUG && hasEthPosition ? (
+        <Box
+          backgroundColor={BoxBackgroundColor.ErrorDefault}
+          padding={2}
+          paddingInline={4}
+          data-testid="adr58-eth-banner"
+        >
+          <Text variant={TextVariant.BodyMd} color={TextColor.OverlayInverse}>
+            ADR58 POC: ETH POSITION DETECTED
+          </Text>
+        </Box>
       ) : null}
 
       <PerpsPositionsOrders


### PR DESCRIPTION
## **Description**

**DO NOT MERGE** — ADR-58 recipe validation demo for [TAT-3216](https://consensyssoftware.atlassian.net/browse/TAT-3216).

This adds a debug-only Perps banner on Extension when the selected account has an open ETH position.

| Area | Detail |
| --- | --- |
| Change | Show `ADR58 POC: ETH POSITION DETECTED` above the Perps positions list. |
| Gate | `METAMASK_DEBUG` only (`yarn start` / dev builds). |
| File | `ui/components/app/perps/perps-view.tsx` |
| Purpose | Demonstrate recipe-based visual verification with executable evidence. |

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TAT-3216](https://consensyssoftware.atlassian.net/browse/TAT-3216)

## **Manual testing steps**

1. Build with `yarn start`.
2. Open Perps home (`#/?tab=perps`) with no open ETH position → banner absent.
3. Open a small ETH position → red banner appears above positions with exact copy.
4. Close ETH position → banner disappears.

## **Screenshots/Recordings**

<table>
<tr><td colspan="2"><strong>AC1/AC2 — ETH-position banner behavior</strong><br/>No open ETH position keeps the banner hidden; an open ETH position shows the debug banner above positions.</td></tr>
<tr>
<td align="center" width="50%"><em>No ETH position</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-artifacts/main/evidence/tat-3216-feat-adr58-eth-debug-banner-0529/01-ac1-no-eth-banner.png" alt="AC1: Perps home with no ETH banner" width="400" /></td>
<td align="center" width="50%"><em>Open ETH position</em><br/><img src="https://raw.githubusercontent.com/abretonc7s/mm-extension-artifacts/main/evidence/tat-3216-feat-adr58-eth-debug-banner-0529/02-ac2-eth-banner.png" alt="AC2: Perps home with ETH debug banner" width="400" /></td>
</tr>
</table>

## **Validation Recipe**

Recipe run passed **13/13 nodes** in **9.1s**.

| Claim | Proof | Evidence |
| --- | --- | --- |
| Banner absent without open ETH position | Recipe state + screenshot | `01-ac1-no-eth-banner.png` |
| Banner visible with open ETH position | Recipe state + screenshot | `02-ac2-eth-banner.png` |
| Banner copy is exact | Recipe assertion | `ADR58 POC: ETH POSITION DETECTED` |

```bash
metamask-recipe run temp/tasks/mms-recipe-dev/20260605T052931Z-tat-3216/artifacts/recipe.json \
  --adapter extension \
  --artifacts-dir temp/tasks/mms-recipe-dev/20260605T052931Z-tat-3216/artifacts/run \
  --project-root . \
  --cdp-port 6661
```

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TAT-3216]: https://consensyssoftware.atlassian.net/browse/TAT-3216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TAT-3216]: https://consensyssoftware.atlassian.net/browse/TAT-3216?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ