### PR TITLE
refactor: consolidate confirmations developer options

### DIFF
--- a/ui/pages/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.tsx
+++ b/ui/pages/confirmations/components/developer/confirmations-developer-options/confirmations-developer-options.tsx
@@ -1,7 +1,11 @@
 import React from 'react';
 
-import { Text } from '../../../../../components/component-library';
-import { TextColor } from '../../../../../helpers/constants/design-system';
+import { Box, Text } from '../../../../../components/component-library';
+import {
+  Display,
+  FlexWrap,
+  TextColor,
+} from '../../../../../helpers/constants/design-system';
 import { MusdConversionButton } from '../musd-conversion-button';
 import { PerpsDepositButton } from '../perps-deposit-button';
 import { PerpsWithdrawButton } from '../perps-withdraw-button';
@@ -20,13 +24,20 @@ export const ConfirmationsDeveloperOptions = () => {
         color={TextColor.textAlternative}
         paddingTop={4}
       >
-        Example Confirmations
+        Test Confirmations
       </Text>
-      <div className="settings-page__content-padded">
-        <MusdConversionButton />
+      <Box
+        display={Display.Flex}
+        flexWrap={FlexWrap.Wrap}
+        gap={2}
+        paddingLeft={4}
+        paddingRight={4}
+        paddingTop={4}
+      >
         <PerpsDepositButton />
         <PerpsWithdrawButton />
-      </div>
+        <MusdConversionButton />
+      </Box>
     </>
   );
 };

--- a/ui/pages/confirmations/components/developer/developer-button/developer-button.tsx
+++ b/ui/pages/confirmations/components/developer/developer-button/developer-button.tsx
@@ -1,77 +1,30 @@
 import React from 'react';
 
 import {
-  Box,
   Button,
+  ButtonSize,
   ButtonVariant,
-  Icon,
-  IconName,
-  IconSize,
 } from '../../../../../components/component-library';
-import {
-  IconColor,
-  Display,
-  FlexDirection,
-  JustifyContent,
-  AlignItems,
-} from '../../../../../helpers/constants/design-system';
 
 export type DeveloperButtonProps = {
-  buttonLabel: string;
-  description: string;
   disabled?: boolean;
-  hasTriggered?: boolean;
   onPress: () => void;
   title: string;
 };
 
 export const DeveloperButton = ({
-  buttonLabel,
-  description,
   disabled,
-  hasTriggered,
   onPress,
   title,
 }: DeveloperButtonProps) => {
   return (
-    <Box
-      className="settings-page__content-row"
-      display={Display.Flex}
-      flexDirection={FlexDirection.Row}
-      justifyContent={JustifyContent.spaceBetween}
-      gap={4}
+    <Button
+      variant={ButtonVariant.Primary}
+      size={ButtonSize.Sm}
+      onClick={onPress}
+      disabled={disabled}
     >
-      <div className="settings-page__content-item">
-        <span>{title}</span>
-        <div className="settings-page__content-description">{description}</div>
-      </div>
-
-      <div className="settings-page__content-item-col">
-        <Button
-          variant={ButtonVariant.Primary}
-          onClick={onPress}
-          disabled={disabled}
-        >
-          {buttonLabel}
-        </Button>
-      </div>
-      <div className="settings-page__content-item-col">
-        <Box
-          display={Display.Flex}
-          alignItems={AlignItems.center}
-          paddingLeft={2}
-          paddingRight={2}
-          style={{ height: '40px', width: '40px' }}
-        >
-          <Icon
-            className="settings-page-developer-options__icon-check"
-            name={IconName.Check}
-            color={IconColor.successDefault}
-            size={IconSize.Lg}
-            hidden={!hasTriggered}
-          />
-        </Box>
-      </div>
-    </Box>
+      {title}
+    </Button>
   );
 };

--- a/ui/pages/confirmations/components/developer/musd-conversion-button/musd-conversion-button.tsx
+++ b/ui/pages/confirmations/components/developer/musd-conversion-button/musd-conversion-button.tsx
@@ -19,7 +19,6 @@ import { generateERC20TransferData } from '../utils';
 export const MusdConversionButton = () => {
   const { navigateToTransaction } = useConfirmationNavigation();
   const selectedAccount = useSelector(getSelectedInternalAccount);
-  const [hasTriggered, setHasTriggered] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
   const handleTrigger = useCallback(async () => {
@@ -54,8 +53,6 @@ export const MusdConversionButton = () => {
         },
       );
 
-      setHasTriggered(true);
-
       navigateToTransaction(txMeta.id, {
         loader: ConfirmationLoader.CustomAmount,
       });
@@ -69,10 +66,7 @@ export const MusdConversionButton = () => {
   return (
     <DeveloperButton
       title="MUSD Conversion"
-      description="Triggers a MUSD conversion confirmation."
-      buttonLabel={isLoading ? 'Loading...' : 'Trigger'}
       onPress={handleTrigger}
-      hasTriggered={hasTriggered}
       disabled={isLoading}
     />
   );

--- a/ui/pages/confirmations/components/developer/perps-deposit-button/perps-deposit-button.tsx
+++ b/ui/pages/confirmations/components/developer/perps-deposit-button/perps-deposit-button.tsx
@@ -23,7 +23,6 @@ import { generateERC20TransferData } from '../utils';
 export const PerpsDepositButton = () => {
   const { navigateToTransaction } = useConfirmationNavigation();
   const selectedAccount = useSelector(getSelectedInternalAccount);
-  const [hasTriggered, setHasTriggered] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
   const handleTrigger = useCallback(async () => {
@@ -58,8 +57,6 @@ export const PerpsDepositButton = () => {
         },
       );
 
-      setHasTriggered(true);
-
       navigateToTransaction(txMeta.id, {
         loader: ConfirmationLoader.CustomAmount,
       });
@@ -73,10 +70,7 @@ export const PerpsDepositButton = () => {
   return (
     <DeveloperButton
       title="Perps Deposit"
-      description="Triggers a Perps deposit confirmation."
-      buttonLabel={isLoading ? 'Loading...' : 'Trigger'}
       onPress={handleTrigger}
-      hasTriggered={hasTriggered}
       disabled={isLoading}
     />
   );

--- a/ui/pages/confirmations/components/developer/perps-withdraw-button/perps-withdraw-button.test.tsx
+++ b/ui/pages/confirmations/components/developer/perps-withdraw-button/perps-withdraw-button.test.tsx
@@ -1,36 +1,41 @@
-import React from "react";
-import { Provider } from "react-redux";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
-import mockState from "../../../../../../test/data/mock-state.json";
-import { createPerpsWithdrawTransaction } from "../../../../../components/app/perps/hooks/createPerpsWithdrawTransaction";
-import { getSelectedInternalAccount } from "../../../../../../shared/lib/selectors/accounts";
+import React from 'react';
+import { Provider } from 'react-redux';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import mockState from '../../../../../../test/data/mock-state.json';
+import { createPerpsWithdrawTransaction } from '../../../../../components/app/perps/hooks/createPerpsWithdrawTransaction';
+import { getSelectedInternalAccount } from '../../../../../../shared/lib/selectors/accounts';
 import {
   ConfirmationLoader,
   useConfirmationNavigation,
-} from "../../../hooks/useConfirmationNavigation";
-import { PerpsWithdrawButton } from "./perps-withdraw-button";
+} from '../../../hooks/useConfirmationNavigation';
+import { PerpsWithdrawButton } from './perps-withdraw-button';
 
-jest.mock("../../../../../components/app/perps/hooks/createPerpsWithdrawTransaction", () => ({
-  createPerpsWithdrawTransaction: jest.fn(),
-}));
+jest.mock(
+  '../../../../../components/app/perps/hooks/createPerpsWithdrawTransaction',
+  () => ({
+    createPerpsWithdrawTransaction: jest.fn(),
+  }),
+);
 
-jest.mock("../../../../../../shared/lib/selectors/accounts", () => ({
+jest.mock('../../../../../../shared/lib/selectors/accounts', () => ({
   getSelectedInternalAccount: jest.fn(),
 }));
 
-jest.mock("../../../hooks/useConfirmationNavigation", () => ({
+jest.mock('../../../hooks/useConfirmationNavigation', () => ({
   ConfirmationLoader: {
-    CustomAmount: "customAmount",
+    CustomAmount: 'customAmount',
   },
   useConfirmationNavigation: jest.fn(),
 }));
 
-const createPerpsWithdrawTransactionMock = jest.mocked(createPerpsWithdrawTransaction);
+const createPerpsWithdrawTransactionMock = jest.mocked(
+  createPerpsWithdrawTransaction,
+);
 const getSelectedInternalAccountMock = jest.mocked(getSelectedInternalAccount);
 const useConfirmationNavigationMock = jest.mocked(useConfirmationNavigation);
 
-const MOCK_ACCOUNT_ADDRESS = "0x1234567890123456789012345678901234567890";
-const MOCK_TX_ID = "withdraw-tx-id";
+const MOCK_ACCOUNT_ADDRESS = '0x1234567890123456789012345678901234567890';
+const MOCK_TX_ID = 'withdraw-tx-id';
 
 function createMockStore() {
   return {
@@ -48,7 +53,7 @@ function renderButton() {
   );
 }
 
-describe("PerpsWithdrawButton", () => {
+describe('PerpsWithdrawButton', () => {
   const navigateToTransactionMock = jest.fn();
   const navigateToTransactionsMock = jest.fn();
 
@@ -67,16 +72,18 @@ describe("PerpsWithdrawButton", () => {
     } as never);
   });
 
-  it("renders the Perps Withdraw developer button", () => {
+  it('renders the Perps Withdraw developer button', () => {
     renderButton();
 
-    expect(screen.getByRole("button", { name: "Perps Withdraw" })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: 'Perps Withdraw' }),
+    ).toBeInTheDocument();
   });
 
-  it("creates a perpsWithdraw transaction on Arbitrum and navigates to it", async () => {
+  it('creates a perpsWithdraw transaction on Arbitrum and navigates to it', async () => {
     renderButton();
 
-    fireEvent.click(screen.getByRole("button", { name: "Perps Withdraw" }));
+    fireEvent.click(screen.getByRole('button', { name: 'Perps Withdraw' }));
 
     await waitFor(() => {
       expect(createPerpsWithdrawTransactionMock).toHaveBeenCalledTimes(1);
@@ -91,13 +98,15 @@ describe("PerpsWithdrawButton", () => {
     });
   });
 
-  it("does not create a transaction when there is no selected account", () => {
+  it('does not create a transaction when there is no selected account', () => {
     getSelectedInternalAccountMock.mockReturnValue(undefined as never);
-    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+    const consoleErrorSpy = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
 
     renderButton();
 
-    fireEvent.click(screen.getByRole("button", { name: "Perps Withdraw" }));
+    fireEvent.click(screen.getByRole('button', { name: 'Perps Withdraw' }));
 
     expect(createPerpsWithdrawTransactionMock).not.toHaveBeenCalled();
     expect(navigateToTransactionMock).not.toHaveBeenCalled();

--- a/ui/pages/confirmations/components/developer/perps-withdraw-button/perps-withdraw-button.test.tsx
+++ b/ui/pages/confirmations/components/developer/perps-withdraw-button/perps-withdraw-button.test.tsx
@@ -75,17 +75,13 @@ describe('PerpsWithdrawButton', () => {
   it('renders the Perps Withdraw developer button', () => {
     renderButton();
 
-    expect(screen.getByText('Perps Withdraw')).toBeInTheDocument();
-    expect(
-      screen.getByText('Triggers a Perps withdraw confirmation.'),
-    ).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Trigger' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Perps Withdraw' })).toBeInTheDocument();
   });
 
   it('creates a perpsWithdraw transaction on Arbitrum and navigates to it', async () => {
     renderButton();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Trigger' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Perps Withdraw' }));
 
     await waitFor(() => {
       expect(createPerpsWithdrawTransactionMock).toHaveBeenCalledTimes(1);
@@ -108,7 +104,7 @@ describe('PerpsWithdrawButton', () => {
 
     renderButton();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Trigger' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Perps Withdraw' }));
 
     expect(createPerpsWithdrawTransactionMock).not.toHaveBeenCalled();
     expect(navigateToTransactionMock).not.toHaveBeenCalled();

--- a/ui/pages/confirmations/components/developer/perps-withdraw-button/perps-withdraw-button.test.tsx
+++ b/ui/pages/confirmations/components/developer/perps-withdraw-button/perps-withdraw-button.test.tsx
@@ -1,41 +1,36 @@
-import React from 'react';
-import { Provider } from 'react-redux';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import mockState from '../../../../../../test/data/mock-state.json';
-import { createPerpsWithdrawTransaction } from '../../../../../components/app/perps/hooks/createPerpsWithdrawTransaction';
-import { getSelectedInternalAccount } from '../../../../../../shared/lib/selectors/accounts';
+import React from "react";
+import { Provider } from "react-redux";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import mockState from "../../../../../../test/data/mock-state.json";
+import { createPerpsWithdrawTransaction } from "../../../../../components/app/perps/hooks/createPerpsWithdrawTransaction";
+import { getSelectedInternalAccount } from "../../../../../../shared/lib/selectors/accounts";
 import {
   ConfirmationLoader,
   useConfirmationNavigation,
-} from '../../../hooks/useConfirmationNavigation';
-import { PerpsWithdrawButton } from './perps-withdraw-button';
+} from "../../../hooks/useConfirmationNavigation";
+import { PerpsWithdrawButton } from "./perps-withdraw-button";
 
-jest.mock(
-  '../../../../../components/app/perps/hooks/createPerpsWithdrawTransaction',
-  () => ({
-    createPerpsWithdrawTransaction: jest.fn(),
-  }),
-);
+jest.mock("../../../../../components/app/perps/hooks/createPerpsWithdrawTransaction", () => ({
+  createPerpsWithdrawTransaction: jest.fn(),
+}));
 
-jest.mock('../../../../../../shared/lib/selectors/accounts', () => ({
+jest.mock("../../../../../../shared/lib/selectors/accounts", () => ({
   getSelectedInternalAccount: jest.fn(),
 }));
 
-jest.mock('../../../hooks/useConfirmationNavigation', () => ({
+jest.mock("../../../hooks/useConfirmationNavigation", () => ({
   ConfirmationLoader: {
-    CustomAmount: 'customAmount',
+    CustomAmount: "customAmount",
   },
   useConfirmationNavigation: jest.fn(),
 }));
 
-const createPerpsWithdrawTransactionMock = jest.mocked(
-  createPerpsWithdrawTransaction,
-);
+const createPerpsWithdrawTransactionMock = jest.mocked(createPerpsWithdrawTransaction);
 const getSelectedInternalAccountMock = jest.mocked(getSelectedInternalAccount);
 const useConfirmationNavigationMock = jest.mocked(useConfirmationNavigation);
 
-const MOCK_ACCOUNT_ADDRESS = '0x1234567890123456789012345678901234567890';
-const MOCK_TX_ID = 'withdraw-tx-id';
+const MOCK_ACCOUNT_ADDRESS = "0x1234567890123456789012345678901234567890";
+const MOCK_TX_ID = "withdraw-tx-id";
 
 function createMockStore() {
   return {
@@ -53,7 +48,7 @@ function renderButton() {
   );
 }
 
-describe('PerpsWithdrawButton', () => {
+describe("PerpsWithdrawButton", () => {
   const navigateToTransactionMock = jest.fn();
   const navigateToTransactionsMock = jest.fn();
 
@@ -72,16 +67,16 @@ describe('PerpsWithdrawButton', () => {
     } as never);
   });
 
-  it('renders the Perps Withdraw developer button', () => {
+  it("renders the Perps Withdraw developer button", () => {
     renderButton();
 
-    expect(screen.getByRole('button', { name: 'Perps Withdraw' })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Perps Withdraw" })).toBeInTheDocument();
   });
 
-  it('creates a perpsWithdraw transaction on Arbitrum and navigates to it', async () => {
+  it("creates a perpsWithdraw transaction on Arbitrum and navigates to it", async () => {
     renderButton();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Perps Withdraw' }));
+    fireEvent.click(screen.getByRole("button", { name: "Perps Withdraw" }));
 
     await waitFor(() => {
       expect(createPerpsWithdrawTransactionMock).toHaveBeenCalledTimes(1);
@@ -96,15 +91,13 @@ describe('PerpsWithdrawButton', () => {
     });
   });
 
-  it('does not create a transaction when there is no selected account', () => {
+  it("does not create a transaction when there is no selected account", () => {
     getSelectedInternalAccountMock.mockReturnValue(undefined as never);
-    const consoleErrorSpy = jest
-      .spyOn(console, 'error')
-      .mockImplementation(() => undefined);
+    const consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
 
     renderButton();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Perps Withdraw' }));
+    fireEvent.click(screen.getByRole("button", { name: "Perps Withdraw" }));
 
     expect(createPerpsWithdrawTransactionMock).not.toHaveBeenCalled();
     expect(navigateToTransactionMock).not.toHaveBeenCalled();

--- a/ui/pages/confirmations/components/developer/perps-withdraw-button/perps-withdraw-button.tsx
+++ b/ui/pages/confirmations/components/developer/perps-withdraw-button/perps-withdraw-button.tsx
@@ -13,7 +13,6 @@ import {
 export const PerpsWithdrawButton = () => {
   const { navigateToTransaction } = useConfirmationNavigation();
   const selectedAccount = useSelector(getSelectedInternalAccount);
-  const [hasTriggered, setHasTriggered] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
   const handleTrigger = useCallback(async () => {
@@ -29,8 +28,6 @@ export const PerpsWithdrawButton = () => {
         accountAddress: selectedAccount.address as Hex,
       });
 
-      setHasTriggered(true);
-
       navigateToTransaction(transactionId, {
         loader: ConfirmationLoader.CustomAmount,
       });
@@ -44,10 +41,7 @@ export const PerpsWithdrawButton = () => {
   return (
     <DeveloperButton
       title="Perps Withdraw"
-      description="Triggers a Perps withdraw confirmation."
-      buttonLabel={isLoading ? 'Loading...' : 'Trigger'}
       onPress={handleTrigger}
-      hasTriggered={hasTriggered}
       disabled={isLoading}
     />
   );

--- a/ui/pages/settings/debug-tab/debug-content/__snapshots__/debug-content.test.tsx.snap
+++ b/ui/pages/settings/debug-tab/debug-content/__snapshots__/debug-content.test.tsx.snap
@@ -606,128 +606,26 @@ exports[`Develop options tab should match snapshot 1`] = `
     <p
       class="mm-box mm-text settings-page__security-tab-sub-header mm-text--body-md mm-box--padding-top-4 mm-box--color-text-alternative"
     >
-      Example Confirmations
+      Test Confirmations
     </p>
     <div
-      class="settings-page__content-padded"
+      class="mm-box mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-2 mm-box--flex-wrap-wrap"
     >
-      <div
-        class="mm-box settings-page__content-row mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
+      <button
+        class="mm-box mm-text mm-button-base mm-button-base--size-sm mm-button-primary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-inverse mm-box--background-color-icon-default mm-box--rounded-xl"
       >
-        <div
-          class="settings-page__content-item"
-        >
-          <span>
-            MUSD Conversion
-          </span>
-          <div
-            class="settings-page__content-description"
-          >
-            Triggers a MUSD conversion confirmation.
-          </div>
-        </div>
-        <div
-          class="settings-page__content-item-col"
-        >
-          <button
-            class="mm-box mm-text mm-button-base mm-button-base--size-md mm-button-primary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-inverse mm-box--background-color-icon-default mm-box--rounded-xl"
-          >
-            Trigger
-          </button>
-        </div>
-        <div
-          class="settings-page__content-item-col"
-        >
-          <div
-            class="mm-box mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--align-items-center"
-            style="height: 40px; width: 40px;"
-          >
-            <span
-              class="mm-box settings-page-developer-options__icon-check mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-success-default"
-              hidden=""
-              style="mask-image: url('./images/icons/check.svg');"
-            />
-          </div>
-        </div>
-      </div>
-      <div
-        class="mm-box settings-page__content-row mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
+        Perps Deposit
+      </button>
+      <button
+        class="mm-box mm-text mm-button-base mm-button-base--size-sm mm-button-primary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-inverse mm-box--background-color-icon-default mm-box--rounded-xl"
       >
-        <div
-          class="settings-page__content-item"
-        >
-          <span>
-            Perps Deposit
-          </span>
-          <div
-            class="settings-page__content-description"
-          >
-            Triggers a Perps deposit confirmation.
-          </div>
-        </div>
-        <div
-          class="settings-page__content-item-col"
-        >
-          <button
-            class="mm-box mm-text mm-button-base mm-button-base--size-md mm-button-primary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-inverse mm-box--background-color-icon-default mm-box--rounded-xl"
-          >
-            Trigger
-          </button>
-        </div>
-        <div
-          class="settings-page__content-item-col"
-        >
-          <div
-            class="mm-box mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--align-items-center"
-            style="height: 40px; width: 40px;"
-          >
-            <span
-              class="mm-box settings-page-developer-options__icon-check mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-success-default"
-              hidden=""
-              style="mask-image: url('./images/icons/check.svg');"
-            />
-          </div>
-        </div>
-      </div>
-      <div
-        class="mm-box settings-page__content-row mm-box--display-flex mm-box--gap-4 mm-box--flex-direction-row mm-box--justify-content-space-between"
+        Perps Withdraw
+      </button>
+      <button
+        class="mm-box mm-text mm-button-base mm-button-base--size-sm mm-button-primary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-inverse mm-box--background-color-icon-default mm-box--rounded-xl"
       >
-        <div
-          class="settings-page__content-item"
-        >
-          <span>
-            Perps Withdraw
-          </span>
-          <div
-            class="settings-page__content-description"
-          >
-            Triggers a Perps withdraw confirmation.
-          </div>
-        </div>
-        <div
-          class="settings-page__content-item-col"
-        >
-          <button
-            class="mm-box mm-text mm-button-base mm-button-base--size-md mm-button-primary mm-text--body-md-medium mm-box--padding-0 mm-box--padding-right-4 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-inverse mm-box--background-color-icon-default mm-box--rounded-xl"
-          >
-            Trigger
-          </button>
-        </div>
-        <div
-          class="settings-page__content-item-col"
-        >
-          <div
-            class="mm-box mm-box--padding-right-2 mm-box--padding-left-2 mm-box--display-flex mm-box--align-items-center"
-            style="height: 40px; width: 40px;"
-          >
-            <span
-              class="mm-box settings-page-developer-options__icon-check mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-success-default"
-              hidden=""
-              style="mask-image: url('./images/icons/check.svg');"
-            />
-          </div>
-        </div>
-      </div>
+        MUSD Conversion
+      </button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## **Description**

The confirmations section of the developer options settings page previously rendered each trigger as a verbose row — title, description text, primary button, and a check icon — matching the Sentry test button pattern. Since these buttons have no meaningful description text, that layout added unnecessary visual weight.

This PR replaces the row layout with a compact flex-wrap flow of primary buttons, removes the redundant `hasTriggered` state and associated props (navigation happens immediately on trigger), and reorders the buttons to Perps Deposit → Perps Withdraw → MUSD Conversion.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

## **Manual testing steps**

1. Open Settings → Developer Options
2. Scroll to the Confirmations section
3. Verify the three buttons (Perps Deposit, Perps Withdraw, MUSD Conversion) render inline in a flow layout
4. Verify each button still triggers its respective confirmation flow

## **Screenshots/Recordings**

### **Before**

<img width="326" height="472" alt="Before" src="https://github.com/user-attachments/assets/306262d0-d1ce-4dd3-908b-797080f29c55" />

### **After**


<!-- AEP_SCREENSHOTS_START -->
- after-validation-1780933333945.png: run://e3bfd0f9-fe28-4610-9e7f-f087e4c62657/artifacts/after-validation-1780933333945.png
<!-- AEP_SCREENSHOTS_END -->
<img width="338" height="172" alt="After" src="https://github.com/user-attachments/assets/aab73fc1-c2d3-4a29-a844-9c3da9285088" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Developer-only settings UI and test snapshot updates; transaction trigger logic is unchanged aside from removing unused state.
> 
> **Overview**
> The **Confirmations** block on Developer Options is simplified from full settings rows to a compact **Test Confirmations** strip of small primary buttons in a flex-wrap layout (order: Perps Deposit, Perps Withdraw, MUSD Conversion).
> 
> `DeveloperButton` is reduced to a labeled `Button` only—descriptions, separate “Trigger” labels, loading text on the button, and success check icons are removed. The per-flow `hasTriggered` state is dropped because navigation happens right after each trigger. Tests and the debug-tab snapshot match the new button-only UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e19dd62df13fd0af8e11fa29ce65839c77a3ed6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- AEP_VISUAL_VALIDATION_START -->
## AEP Visual Validation

**✅ Passed**

All eight planned assertions are satisfied by multi-layer CLI evidence.

<details><summary>Validation details</summary>

Visual validation passed: All eight planned assertions are satisfied by multi-layer CLI evidence. The debug settings page `/settings/debug` now renders a "Test Confirmations" sub-header (old "Example Confirmations" string is absent from the rebuilt bundle) followed by exactly three compact primary buttons — "Perps Deposit", "Perps Withdraw", "MUSD Conversion" — in the correct order (a11y tree nodes e29/e30/e31). Zero "Trigger" button labels, zero description text, and zero check/success icon nodes were found in the a11y tree or CDP text scan. A fresh `yarn build:test` rebuild was correctly performed after detecting a stale Jun-4 build, and post-rebuild grep confirmed the label change in dist/chrome/ui-18.js. Screenshot artifact `after-validation-1780933333945.png` (107 KB) was captured with the Confirmations section scrolled into viewport. The PR diff-stated flex-wrap Box layout replacing the old per-row padded wrapper is consistent with the a11y node count and absence of the old CSS class. Evidence conclusively covers the intended refactor.

**metamask-mm-visual-validation** — passed. PR #43264 validated successfully. The Settings → Debug tab Confirmations section now renders with: (1) "Test Confirmations" sub-header (was "Example Confirmations"), (2) three compact small primary buttons — "Perps Deposit", "Perps Withdraw", "MUSD Conversion" — in a flex-wrap row, (3) no description text, (4) no "Trigger" button labels, and (5) no check/success icons. All eight assertions passed. A rebuild was required as the checked-out build predated the PR source changes.

</details>

Run `e3bfd0f9-fe28-4610-9e7f-f087e4c62657`
<!-- AEP_VISUAL_VALIDATION_END -->
