### PR TITLE
test: fix flaky test `Address Book Sends to an address book entry on a different network`

### DIFF
--- a/test/e2e/tests/settings/address-book.spec.ts
+++ b/test/e2e/tests/settings/address-book.spec.ts
@@ -109,7 +109,9 @@ describe('Address Book', function (this: Suite) {
           amount: '2',
         });
 
-        await new TransactionConfirmation(driver).clickFooterConfirmButton();
+        const confirmation = new TransactionConfirmation(driver);
+        await confirmation.waitForReviewAlertToDisappear();
+        await confirmation.clickFooterConfirmButton();
 
         // Select Linea to check the Activity list
         const networkSelector = new NetworkManager(driver);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This spec is flaky because we are performing a send on a network not being the default one.
In this case, the balance is not yet loaded leading to the Review alert being displayed on the button, because it 'has no balance' until the balance is loaded.

Waiting for the balance after login (as usually) doesn't fix it because the send happens in a different network and needs a bit of time until the balance is loaded for that network.

Now we'll wait until the Review alert disappears to then click on Confirm. Otherwise it can happen that the Confirm is clicked (as it briefly appears first) but then nothing happens as the page is re-rendered with the review alert button change
<img width="780" height="493" alt="image" src="https://github.com/user-attachments/assets/6af517d8-02a6-4f32-9cdf-5b79427c40df" />


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code impact.
> 
> **Overview**
> Stabilizes the e2e test **Sends to an address book entry on a different network** by waiting for the transaction confirmation **review alert** to clear before clicking confirm.
> 
> The flow now reuses `TransactionConfirmation.waitForReviewAlertToDisappear()` (same pattern as other send flows) so the test does not confirm while the UI still shows the review state tied to balance loading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3051af8b58ee5ba124f0f13d8e5e4b9d830716f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->