### PR TITLE
ci: remove used optional workflow secret

### DIFF
--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -15,8 +15,6 @@ on:
         type: string
         description: The matrix for the E2E jobs
     secrets:
-      PR_COMMENT_TOKEN:
-        required: false
       INFURA_PROJECT_ID:
         required: false
 


### PR DESCRIPTION
## **Description**

Remove the `PR_COMMENT_TOKEN` secret from `e2e-chrome.yml`, which has been unused since #39197

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI metadata-only change with no runtime or application impact; E2E jobs in this workflow did not consume the removed secret.
> 
> **Overview**
> Removes the optional `PR_COMMENT_TOKEN` entry from the `workflow_call` secrets block in **E2E Chrome** (`.github/workflows/e2e-chrome.yml`). Callers no longer declare or forward that secret for this reusable workflow; **`INFURA_PROJECT_ID`** remains the only declared secret.
> 
> This is workflow-definition cleanup only—no job steps, commands, or secret forwarding in this file are changed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de3cd1f7127f19033cd96f84213335d9ec9fdee3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->