### PR TITLE
refactor: replace modal focus story constants with enums

### DIFF
--- a/ui/components/component-library/modal-focus/modal-focus.stories.tsx
+++ b/ui/components/component-library/modal-focus/modal-focus.stories.tsx
@@ -5,8 +5,8 @@ import Box from '../../ui/box';
 
 import {
   BorderColor,
-  DISPLAY,
-  FLEX_DIRECTION,
+  Display,
+  FlexDirection,
 } from '../../../helpers/constants/design-system';
 
 import { ModalFocus } from './modal-focus';
@@ -44,8 +44,8 @@ const Template: ComponentStory<typeof ModalFocus> = (args) => {
           <Box
             padding={4}
             borderColor={BorderColor.borderDefault}
-            display={DISPLAY.FLEX}
-            flexDirection={FLEX_DIRECTION.COLUMN}
+            display={Display.Flex}
+            flexDirection={FlexDirection.Column}
             gap={4}
           >
             {args.children}
@@ -79,8 +79,8 @@ export const InitialFocusRef = (args) => {
           <Box
             padding={4}
             borderColor={BorderColor.borderDefault}
-            display={DISPLAY.FLEX}
-            flexDirection={FLEX_DIRECTION.COLUMN}
+            display={Display.Flex}
+            flexDirection={FlexDirection.Column}
             gap={4}
           >
             <input />
@@ -103,7 +103,7 @@ export const FinalFocusRef = (args) => {
   const [open, setOpen] = React.useState(false);
   return (
     <>
-      <Box display={DISPLAY.FLEX} gap={4}>
+      <Box display={Display.Flex} gap={4}>
         <button onClick={() => setOpen(true)}>Open</button>
         <input placeholder="Focus will return here" ref={ref} />
       </Box>
@@ -112,8 +112,8 @@ export const FinalFocusRef = (args) => {
           <Box
             padding={4}
             borderColor={BorderColor.borderDefault}
-            display={DISPLAY.FLEX}
-            flexDirection={FLEX_DIRECTION.COLUMN}
+            display={Display.Flex}
+            flexDirection={FlexDirection.Column}
             gap={4}
           >
             <p>Focus will be returned to the input once closed</p>
@@ -138,8 +138,8 @@ export const RestoreFocus = (args) => {
           <Box
             padding={4}
             borderColor={BorderColor.borderDefault}
-            display={DISPLAY.FLEX}
-            flexDirection={FLEX_DIRECTION.COLUMN}
+            display={Display.Flex}
+            flexDirection={FlexDirection.Column}
             gap={4}
           >
             <p>Focus will be restored to the open button once closed</p>


### PR DESCRIPTION
## **Description**

Replaces deprecated design-system constants in the ModalFocus Storybook example:

- `DISPLAY.FLEX` -> `Display.Flex`
- `FLEX_DIRECTION.COLUMN` -> `FlexDirection.Column`

The change is intentionally scoped to `ui/components/component-library/modal-focus/modal-focus.stories.tsx` for #18714.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #18714

## **Manual testing steps**

1. Review the ModalFocus story source.
2. Confirm deprecated `DISPLAY` / `FLEX_DIRECTION` constants are no longer used in `modal-focus.stories.tsx`.
3. Run `yarn lint:changed`.

<!--
## **Screenshots/Recordings**

Not applicable: source-only Storybook constant refactor.
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## Validation performed

- `npx -y -p node@24 corepack yarn lint:changed:fix`
- `npx -y -p node@24 corepack yarn lint:changed`
- `git diff --check`
- Static check: no `DISPLAY` / `FLEX_DIRECTION` remains in `ui/components/component-library/modal-focus/modal-focus.stories.tsx`; `Display.Flex=5`, `FlexDirection.Column=4`.
