### PR TITLE
fix: token list font size cp-13.35.0

### DIFF
--- a/ui/components/app/assets/token-cell/__snapshots__/token-cell.test.tsx.snap
+++ b/ui/components/app/assets/token-cell/__snapshots__/token-cell.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`Token Cell should match snapshot 1`] = `
             </p>
           </div>
           <p
-            class="mm-box mm-text text-s-body-md @compact:text-s-body-sm mm-text--body-md mm-text--text-align-end mm-box--color-text-alternative"
+            class="mm-box mm-text mm-text--body-sm-medium mm-text--text-align-end mm-box--color-text-alternative"
             data-testid="multichain-token-list-item-value"
           >
             5 TEST

--- a/ui/components/app/assets/token-cell/cells/token-cell-primary-display.tsx
+++ b/ui/components/app/assets/token-cell/cells/token-cell-primary-display.tsx
@@ -4,6 +4,7 @@ import { Skeleton } from '@metamask/design-system-react';
 import {
   TextAlign,
   TextColor,
+  TextVariant,
 } from '../../../../../helpers/constants/design-system';
 import {
   SensitiveText,
@@ -35,7 +36,7 @@ export const TokenCellPrimaryDisplay = React.memo(
         <SensitiveText
           data-testid="multichain-token-list-item-value"
           color={TextColor.textAlternative}
-          className="text-s-body-md @compact:text-s-body-sm"
+          variant={TextVariant.bodySmMedium}
           textAlign={TextAlign.End}
           isHidden={privacyMode}
           length={SensitiveTextLength.Short}

--- a/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
+++ b/ui/pages/asset/components/__snapshots__/asset-page.test.tsx.snap
@@ -318,7 +318,7 @@ exports[`AssetPage should render a native asset 1`] = `
                 </p>
               </div>
               <p
-                class="mm-box mm-text text-s-body-md @compact:text-s-body-sm mm-text--body-md mm-text--text-align-end mm-box--color-text-alternative"
+                class="mm-box mm-text mm-text--body-sm-medium mm-text--text-align-end mm-box--color-text-alternative"
                 data-testid="multichain-token-list-item-value"
               >
                 0 TEST
@@ -660,7 +660,7 @@ exports[`AssetPage should render an ERC20 asset without prices 1`] = `
                 </p>
               </div>
               <p
-                class="mm-box mm-text text-s-body-md @compact:text-s-body-sm mm-text--body-md mm-text--text-align-end mm-box--color-text-alternative"
+                class="mm-box mm-text mm-text--body-sm-medium mm-text--text-align-end mm-box--color-text-alternative"
                 data-testid="multichain-token-list-item-value"
               >
                 0 TEST
@@ -1081,7 +1081,7 @@ exports[`AssetPage should render an ERC20 token with prices 1`] = `
                 </p>
               </div>
               <p
-                class="mm-box mm-text text-s-body-md @compact:text-s-body-sm mm-text--body-md mm-text--text-align-end mm-box--color-text-alternative"
+                class="mm-box mm-text mm-text--body-sm-medium mm-text--text-align-end mm-box--color-text-alternative"
                 data-testid="multichain-token-list-item-value"
               >
                 0 TEST

--- a/ui/pages/defi/components/__snapshots__/defi-details-page.test.tsx.snap
+++ b/ui/pages/defi/components/__snapshots__/defi-details-page.test.tsx.snap
@@ -159,7 +159,7 @@ exports[`DeFiDetailsPage renders defi asset page 1`] = `
                     </p>
                   </div>
                   <p
-                    class="mm-box mm-text text-s-body-md @compact:text-s-body-sm mm-text--body-md mm-text--text-align-end mm-box--color-text-alternative"
+                    class="mm-box mm-text mm-text--body-sm-medium mm-text--text-align-end mm-box--color-text-alternative"
                     data-testid="multichain-token-list-item-value"
                   >
                     10 Liquid staked Ether 2.0


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Reverts the 2nd-line token font size that was adjusted in this [PR](https://github.com/MetaMask/metamask-extension/pull/43184)

This element was already on small size and didn't need adjustment

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Tokens list

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic typography only on token list balance text; no logic, auth, or data changes.
> 
> **Overview**
> Reverts the **second-line token balance** typography on multichain token list rows (the `multichain-token-list-item-value` quantity, e.g. `5 TEST`) to the smaller style that existed before a recent sizing change.
> 
> In `TokenCellPrimaryDisplay`, styling moves from responsive Tailwind classes (`text-s-body-md` / `@compact:text-s-body-sm`) to the design-system **`TextVariant.bodySmMedium`** on `SensitiveText`. Jest snapshots for token cell, asset page, and DeFi details page are updated to match the restored `mm-text--body-sm-medium` output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06c28dc379038191ae6b6f1a967297eafd87805d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->