### PR TITLE
test: re-enable e2e tests `account-hide-unhide.spec.ts` and `account-pin-unpin.spec.ts`

### DIFF
--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -9,102 +9,113 @@ import SettingsPage from './settings/settings-page';
 class AccountListPage {
   private readonly driver: Driver;
 
-  private readonly accountDetailsTab = {
-    text: 'Account details',
-    tag: 'button',
-  };
-
   private readonly accountListBalance =
     '[data-testid="first-currency-display"]';
-
-  private readonly accountListItem =
-    '.multichain-account-menu-popover__list--menu-item';
-
-  private readonly accountMenuButton =
-    '[data-testid="account-list-menu-details"]';
 
   private readonly accountPageBalance = '[data-testid="balance-display"]';
 
   private readonly accountValueAndSuffix =
     '[data-testid="account-value-and-suffix"]';
 
+  private readonly accountListItem =
+    '.multichain-account-menu-popover__list--menu-item';
+
+  private readonly multichainAccountListItem = '.multichain-account-cell';
+
+  private readonly walletHeader =
+    '[data-testid="multichain-account-tree-wallet-header"]';
+
+  private readonly accountMenuButton =
+    '[data-testid="account-list-menu-details"]';
+
+  private readonly accountDetailsTab = {
+    text: 'Account details',
+    tag: 'button',
+  };
+
+  private readonly multichainAccountOptionsMenuButton =
+    '[data-testid="multichain-account-cell-end-accessory"]';
+
   private readonly addHardwareWalletButton =
     '[data-testid="choose-wallet-type-hardware-wallet"]';
+
+  private readonly chooseWalletTypeWatchEthereumAccountButton =
+    '[data-testid="choose-wallet-type-watch-ethereum-account"]';
 
   private readonly addingAccountMessage = {
     text: 'Adding account...',
     tag: 'p',
   };
 
-  private readonly addMultichainAccountButton =
-    '[data-testid="add-multichain-account-button"]';
-
-  private readonly addMultichainWalletButton =
-    '[data-testid="account-list-add-wallet-button"]';
-
   private readonly addSnapAccountButton =
     '[data-testid="choose-wallet-type-snap-account"]';
 
-  private readonly chooseWalletTypeBackButton = '[data-testid="back-button"]';
-
-  private readonly chooseWalletTypeWatchEthereumAccountButton =
-    '[data-testid="choose-wallet-type-watch-ethereum-account"]';
+  private readonly walletDetailsButton = {
+    text: 'Details',
+    tag: 'button',
+  };
 
   private readonly closeAccountModalButton =
     'header button[aria-label="Close"]';
 
+  private readonly chooseWalletTypeBackButton = '[data-testid="back-button"]';
+
   private readonly closeMultichainAccountsPageButton =
     '.multichain-page-header button[aria-label="Back"]';
 
-  private readonly currentSelectedAccount =
-    '.multichain-account-list-item--selected';
+  private readonly addMultichainWalletButton =
+    '[data-testid="account-list-add-wallet-button"]';
 
-  private readonly exportSrpButton = {
-    text: 'Show Secret Recovery Phrase',
-    tag: 'button',
-  };
-
-  private readonly hiddenAccountOptionsMenuButton =
-    '.multichain-account-menu-popover__list--menu-item-hidden-account [data-testid="account-list-item-menu-button"]';
-
-  private readonly hiddenAccountsList = '[data-testid="multichain-account-tree-hidden-header"]';
-
-  private readonly hideAccountButton =
-    '[data-testid="multichain-account-menu-item-hideAccount"]';
-
-  private readonly importAccountConfirmButton =
-    '[data-testid="import-account-confirm-button"]';
-
-  private readonly importAccountDropdownOption = '.dropdown__select';
+  private readonly importWalletFromMultichainWalletModalButton =
+    '[data-testid="choose-wallet-type-import-wallet"]';
 
   private readonly importAccountFromMultichainWalletModalButton =
     '[data-testid="choose-wallet-type-import-account"]';
 
-  private readonly importAccountJsonFileInput =
-    'input[data-testid="file-input"]';
+  private readonly multichainAccountMenuItem =
+    '.multichain-account-cell-menu-item';
+
+  private readonly multichainAccountNameInput =
+    '[data-testid="account-name-input"] input';
+
+  private readonly multichainAccountNameInputConfirmButton =
+    '.mm-button-base[aria-label="Confirm"]';
+
+  private readonly addMultichainAccountButton =
+    '[data-testid="add-multichain-account-button"]';
+
+  private readonly currentSelectedAccount =
+    '.multichain-account-list-item--selected';
+
+  private readonly hiddenAccountOptionsMenuButton =
+    '.multichain-account-menu-popover__list--menu-item-hidden-account [data-testid="account-list-item-menu-button"]';
+
+  private readonly hiddenAccountsList =
+    '[data-testid="multichain-account-tree-hidden-header"]';
+
+  private readonly hideAccountButton =
+    '[data-testid="multichain-account-menu-item-hideAccount"]';
+
+  private readonly unhideAccountButton =
+    '[data-testid="multichain-account-menu-item-showAccount"]';
+
+  private readonly importAccountConfirmButton =
+    '[data-testid="import-account-confirm-button"]';
+
+  private readonly importAccountPrivateKeyInput = '#private-key-box';
+
+  private readonly importAccountDropdownOption = '.dropdown__select';
 
   private readonly importAccountJsonFileOption = {
     text: 'JSON File',
     tag: 'option',
   };
 
+  private readonly importAccountJsonFileInput =
+    'input[data-testid="file-input"]';
+
   private readonly importAccountJsonPasswordInput =
     'input[id="json-password-box"]';
-
-  private readonly importAccountPrivateKeyInput = '#private-key-box';
-
-  private readonly importSrpConfirmButton = {
-    text: 'Continue',
-    tag: 'span',
-  };
-
-  private readonly importSrpInput =
-    '[data-testid="srp-input-import__srp-note"]';
-
-  private readonly importWalletFromMultichainWalletModalButton =
-    '[data-testid="choose-wallet-type-import-wallet"]';
-
-  private readonly multichainAccountListItem = '.multichain-account-cell';
 
   private readonly multichainAccountMenuAddresses = {
     tag: 'p',
@@ -121,9 +132,6 @@ class AccountListPage {
     text: 'Hide account',
   };
 
-  private readonly multichainAccountMenuItem =
-    '.multichain-account-cell-menu-item';
-
   private readonly multichainAccountMenuPin = {
     tag: 'p',
     text: 'Pin to top',
@@ -134,19 +142,14 @@ class AccountListPage {
     text: 'Rename',
   };
 
-  private readonly multichainAccountNameInput =
-    '[data-testid="account-name-input"] input';
-
-  private readonly multichainAccountNameInputConfirmButton =
-    '.mm-button-base[aria-label="Confirm"]';
-
-  private readonly multichainAccountOptionsMenuButton =
-    '[data-testid="multichain-account-cell-end-accessory"]';
-
-  private readonly pinnedHeader = '[data-testid="multichain-account-tree-pinned-header"]';
-
   private readonly pinAccountButton =
     '[data-testid="multichain-account-menu-item-pinToTop"]';
+
+  private readonly unpinAccountButton =
+    '[data-testid="multichain-account-menu-item-unpin"]';
+
+  private readonly pinnedHeader =
+    '[data-testid="multichain-account-tree-pinned-header"]';
 
   private readonly removeAccountButton =
     '[data-testid="account-list-menu-remove"]';
@@ -166,29 +169,6 @@ class AccountListPage {
     tag: 'button',
   };
 
-  private readonly syncingMessage = {
-    text: 'Syncing...',
-    tag: 'p',
-  };
-
-  private readonly unhideAccountButton = '[data-testid="multichain-account-menu-item-showAccount"]';
-
-  private readonly unpinAccountButton =
-    '[data-testid="multichain-account-menu-item-unpin"]';
-
-  private readonly viewAccountOnExplorerButton = {
-    text: 'View on explorer',
-    tag: 'p',
-  };
-
-  private readonly walletDetailsButton = {
-    text: 'Details',
-    tag: 'button',
-  };
-
-  private readonly walletHeader =
-    '[data-testid="multichain-account-tree-wallet-header"]';
-
   private readonly watchAccountAddressInput =
     'input#address-input[type="text"]';
 
@@ -202,8 +182,51 @@ class AccountListPage {
     tag: 'h4',
   };
 
+  private readonly importSrpInput =
+    '[data-testid="srp-input-import__srp-note"]';
+
+  private readonly importSrpConfirmButton = {
+    text: 'Continue',
+    tag: 'span',
+  };
+
+  private readonly exportSrpButton = {
+    text: 'Show Secret Recovery Phrase',
+    tag: 'button',
+  };
+
+  private readonly viewAccountOnExplorerButton = {
+    text: 'View on explorer',
+    tag: 'p',
+  };
+
+  private readonly syncingMessage = {
+    text: 'Syncing...',
+    tag: 'p',
+  };
+
   constructor(driver: Driver) {
     this.driver = driver;
+  }
+
+  async checkPageIsLoaded(
+    timeout: number = 10000,
+    { waitForSync = true }: { waitForSync?: boolean } = {},
+  ): Promise<void> {
+    try {
+      await this.driver.waitForMultipleSelectors(
+        [this.addMultichainAccountButton, this.addMultichainWalletButton],
+        { timeout },
+      );
+    } catch (e) {
+      console.log('Timeout while waiting for account list to be loaded', e);
+      throw e;
+    }
+
+    if (waitForSync) {
+      await this.waitUntilSyncingIsCompleted();
+    }
+    console.log('Account list is loaded');
   }
 
   /**
@@ -240,47 +263,6 @@ class AccountListPage {
   }
 
   /**
-   * Adds a new multichain account.
-   *
-   * @param options - Options for creating the multichain account
-   * @param options.srpIndex - Optional SRP index for the new account
-   */
-  async addMultichainAccount(options?: { srpIndex?: number }): Promise<void> {
-    console.log(`Adding new multichain account`);
-    await this.waitUntilSyncingIsCompleted();
-    const buttonIndex = options?.srpIndex ?? 0;
-    const expectedCount = buttonIndex + 1;
-    let createMultichainAccountButtons: Awaited<
-      ReturnType<typeof this.driver.findElements>
-    > = [];
-    await this.driver.waitUntil(
-      async () => {
-        createMultichainAccountButtons = await this.driver.findElements(
-          this.addMultichainAccountButton,
-        );
-        return createMultichainAccountButtons.length >= expectedCount;
-      },
-      { timeout: 10000, interval: 500 },
-    );
-    await createMultichainAccountButtons[buttonIndex].click();
-
-    // Wait for the account creation to complete by waiting for loading state to finish
-    // The button shows "Adding account..." during loading and "Add account" when done
-    await this.driver.assertElementNotPresent({
-      css: this.addMultichainAccountButton,
-      text: 'Adding account...',
-    });
-  }
-
-  /**
-   * Adds a new multichain wallet.
-   */
-  async addMultichainWallet(): Promise<void> {
-    console.log(`Adding new multichain wallet`);
-    await this.driver.clickElement(this.addMultichainWalletButton);
-  }
-
-  /**
    * Import a new account with a private key.
    *
    * @param privateKey - Private key of the account
@@ -311,420 +293,11 @@ class AccountListPage {
   }
 
   /**
-   * Change the label of a multichain account.
-   *
-   * @param newLabel - The new label for the multichain account
+   * Adds a new multichain wallet.
    */
-  async changeMultichainAccountLabel(newLabel: string): Promise<void> {
-    console.log(
-      `Account details modal opened, changing multichain account label to: ${newLabel}`,
-    );
-    await this.driver.clickElement(this.multichainAccountNameInput);
-    await this.driver.fill(this.multichainAccountNameInput, newLabel);
-    await this.driver.clickElement(
-      this.multichainAccountNameInputConfirmButton,
-    );
-  }
-
-  /**
-   * Checks that the account balance is displayed in the account list.
-   *
-   * @param expectedBalance - The expected balance to check.
-   */
-  async checkAccountBalanceDisplayed(expectedBalance: string): Promise<void> {
-    console.log(
-      `Check that account balance ${expectedBalance} is displayed in account list`,
-    );
-    await this.driver.waitForSelector({
-      css: this.accountListBalance,
-      text: expectedBalance,
-    });
-  }
-
-  /**
-   * Verifies that account balance is private.
-   *
-   */
-  async checkAccountBalanceIsPrivate(): Promise<void> {
-    console.log(`Verify that account balance is private`);
-    await this.driver.waitForSelector({
-      css: this.accountPageBalance,
-      text: '••••••',
-    });
-  }
-
-  async checkAccountBelongsToSrp(
-    accountName: string,
-    srpIndex: number,
-  ): Promise<void> {
-    console.log(`Check that current account is an imported account`);
-    await new HeaderNavbar(this.driver).openSettingsPage();
-    const settingsPage = new SettingsPage(this.driver);
-    await settingsPage.checkPageIsLoaded();
-    await settingsPage.goToSecurityAndPasswordSettings();
-
-    const privacySettings = new PrivacySettings(this.driver);
-    await privacySettings.checkSecurityAndPasswordPageIsLoaded();
-    await privacySettings.openSrpList();
-
-    if (srpIndex === 0) {
-      throw new Error('SRP index must be > 0');
-    }
-
-    const selectedSrp = await this.driver.waitForSelector({
-      css: '.select-srp__container',
-      text: `Secret Recovery Phrase ${srpIndex}`,
-    });
-    const showAccountsButton = await this.driver.waitForSelector(
-      `[data-testid="srp-list-show-accounts-${srpIndex - 1}"]`,
-    );
-    await showAccountsButton.click();
-
-    await this.driver.findNestedElement(selectedSrp, {
-      text: accountName,
-      tag: 'p',
-    });
-  }
-
-  async checkAccountDisplayedInAccountList(
-    expectedLabel: string = 'Account',
-  ): Promise<void> {
-    console.log(
-      `Check that account label ${expectedLabel} is displayed in account list`,
-    );
-    await this.driver.waitForSelector({
-      css: this.accountListItem,
-      text: expectedLabel,
-    });
-  }
-
-  /**
-   * Checks that the account with the specified label is not displayed in the account list.
-   *
-   * @param expectedLabel - The label of the account that should not be displayed.
-   */
-  async checkAccountIsNotDisplayedInAccountList(
-    expectedLabel: string,
-  ): Promise<void> {
-    console.log(
-      `Check that account label ${expectedLabel} is not displayed in account list`,
-    );
-    await this.driver.assertElementNotPresent({
-      css: this.accountListItem,
-      text: expectedLabel,
-    });
-  }
-
-  async checkAccountIsPinned(): Promise<void> {
-    console.log(`Check that account is pinned`);
-    await this.driver.waitForSelector(this.pinnedHeader);
-  }
-
-  async checkAccountIsUnpinned(): Promise<void> {
-    console.log(`Check that account is unpinned`);
-    await this.driver.assertElementNotPresent(this.pinnedHeader);
-  }
-
-  async checkAccountNameIsDisplayed(accountName: string): Promise<void> {
-    console.log(`Check that account name ${accountName} is displayed`);
-    await this.driver.waitForSelector({
-      text: accountName,
-      tag: 'p',
-    });
-  }
-
-  async checkAccountNameIsDisplayedUnderWallet(
-    accountName: string,
-    walletName: string,
-  ): Promise<void> {
-    console.log(
-      `Check that account name ${accountName} is displayed under wallet ${walletName}`,
-    );
-    const walletHeader = await this.driver.waitForSelector({
-      css: this.walletHeader,
-      text: walletName,
-    });
-    // VirtualizedList wraps each item in a div, so the header and account rows are not direct
-    // siblings—each is the only child of its wrapper div. Go to the header's parent (the wrapper),
-    // then to that parent's first following sibling (the next item's wrapper), and find the account name inside it.
-    // Use . (string value) instead of text() so we match the element that contains the text in any descendant.
-    await this.driver.findNestedElement(walletHeader, {
-      xpath: `../following-sibling::*[1]//*[contains(., ${quoteXPathText(accountName)})]`,
-    });
-  }
-
-  async checkAccountNotDisplayedInAccountList(
-    expectedLabel: string = 'Account',
-  ): Promise<void> {
-    console.log(
-      `Check that account label ${expectedLabel} is not displayed in account list`,
-    );
-    await this.driver.assertElementNotPresent({
-      css: this.accountListItem,
-      text: expectedLabel,
-    });
-  }
-
-  /**
-   * Checks that the account value and suffix is displayed in the account list.
-   *
-   * @param expectedValueAndSuffix - The expected value and suffix to check.
-   */
-  async checkAccountValueAndSuffixDisplayed(
-    expectedValueAndSuffix: string,
-  ): Promise<void> {
-    console.log(
-      `Check that account value and suffix ${expectedValueAndSuffix} is displayed in account list`,
-    );
-    await this.driver.findElement(this.accountValueAndSuffix, 5000);
-    await this.driver.waitForSelector(
-      {
-        css: this.accountValueAndSuffix,
-        text: expectedValueAndSuffix,
-      },
-      {
-        timeout: 20000,
-      },
-    );
-  }
-
-  async checkAddAccountSnapButtonIsDisplayed(): Promise<void> {
-    console.log('Check add account snap button is displayed');
-    await this.driver.waitForSelector(this.addSnapAccountButton);
-  }
-
-  async checkAddAccountSnapButtonNotPresent(): Promise<void> {
-    console.log('Check add account snap button is not present');
-    await this.driver.assertElementNotPresent(this.addSnapAccountButton);
-  }
-
-  async checkAddWalletButtonIsDisplayed(): Promise<void> {
-    console.log('Check add wallet button is displayed');
-    await this.driver.waitForSelector(this.addMultichainWalletButton);
-  }
-
-  /**
-   * Checks that the watch ethereum account option is displayed in the choose wallet type page.
-   *
-   * @param expectedAvailability - Whether the watch ethereum account option is expected to be displayed.
-   */
-  async checkAddWatchAccountAvailable(
-    expectedAvailability: boolean,
-  ): Promise<void> {
-    console.log(
-      `Check watch ethereum account option is ${
-        expectedAvailability ? 'displayed ' : 'not displayed'
-      }`,
-    );
+  async addMultichainWallet(): Promise<void> {
+    console.log(`Adding new multichain wallet`);
     await this.driver.clickElement(this.addMultichainWalletButton);
-    if (expectedAvailability) {
-      await this.driver.waitForSelector(
-        this.chooseWalletTypeWatchEthereumAccountButton,
-      );
-    } else {
-      await this.driver.assertElementNotPresent(
-        this.chooseWalletTypeWatchEthereumAccountButton,
-      );
-    }
-  }
-
-  async checkCurrentAccountIsImported(): Promise<void> {
-    console.log(`Check that current account is an imported account`);
-    await this.driver.waitForSelector({
-      css: this.currentSelectedAccount,
-      text: 'Imported',
-    });
-  }
-
-  async checkHiddenAccountsListExists(): Promise<void> {
-    console.log(`Check that hidden accounts list is displayed in account list`);
-    await this.driver.waitForSelector(this.hiddenAccountsList);
-  }
-
-  /**
-   * Checks that the account balance is displayed on the multichain account list page
-   * for a specific account, optionally scoped under a specific wallet.
-   *
-   * When only one wallet exists the wallet header is not rendered, so omit
-   * the `wallet` param and the lookup falls back to finding the account cell
-   * directly by account name.
-   *
-   * @param options - The wallet, account, and balance to check.
-   * @param options.balance - The expected balance to check.
-   * @param options.wallet - The wallet name. Only pass when multiple wallets are present.
-   * @param options.account - The account name (default: 'Account 1').
-   */
-  async checkMultichainAccountBalanceDisplayed({
-    balance,
-    wallet,
-    account = 'Account 1',
-  }: {
-    balance: string;
-    wallet?: string;
-    account?: string;
-  }): Promise<void> {
-    console.log(
-      `Check that multichain account balance ${balance} is displayed for ${account}${wallet ? ` under ${wallet}` : ''}`,
-    );
-
-    if (wallet) {
-      // Multiple wallets: scope the search to accounts under the specified wallet header.
-      const walletHeader = await this.driver.waitForSelector({
-        css: this.walletHeader,
-        text: wallet,
-      });
-      await this.driver.findNestedElement(walletHeader, {
-        xpath: `../following-sibling::*[preceding-sibling::*[.//*[@data-testid='multichain-account-tree-wallet-header']][1]//*[@data-testid='multichain-account-tree-wallet-header' and contains(., ${quoteXPathText(wallet)})]]//*[contains(@class, 'multichain-account-cell') and .//*[contains(@class, 'multichain-account-cell__account-name') and contains(text(), ${quoteXPathText(account)})]]//*[@data-testid='balance-display' and contains(text(), ${quoteXPathText(balance)})]`,
-      });
-    } else {
-      // Single wallet (no wallet header rendered): find the account cell directly.
-      const accountCell = await this.driver.waitForSelector({
-        css: this.multichainAccountListItem,
-        text: account,
-      });
-      await this.driver.findNestedElement(accountCell, {
-        xpath: `.//*[@data-testid='balance-display' and contains(text(), ${quoteXPathText(balance)})]`,
-      });
-    }
-  }
-
-  async checkMultiChainAccountMenuIsDisplayed(): Promise<void> {
-    console.log(`Check that multichain account menu is displayed`);
-    await this.driver.waitForMultipleSelectors([
-      this.multichainAccountMenuAddresses,
-      this.multichainAccountMenuDetails,
-      this.multichainAccountMenuHide,
-      this.multichainAccountMenuRename,
-      this.multichainAccountMenuPin,
-    ]);
-  }
-
-  /**
-   * Checks that the multichain account label is displayed on the multichain account list page.
-   *
-   * @param expectedLabel - The expected label to check.
-   */
-  async checkMultichainAccountNameDisplayed(
-    expectedLabel: string = 'Account',
-  ): Promise<void> {
-    console.log(
-      `Check that multichain account label ${expectedLabel} is displayed on account list page`,
-    );
-    await this.driver.waitForSelector({
-      css: this.multichainAccountListItem,
-      text: expectedLabel,
-    });
-  }
-
-  /**
-   * Verifies number of accounts currently showing in the accounts menu.
-   *
-   * @param expectedNumberOfAccounts - The expected number of accounts showing.
-   * @param accountType - Optional account type to filter by. If not provided, counts all accounts.
-   */
-  async checkNumberOfAvailableAccounts(
-    expectedNumberOfAccounts: number,
-    accountType?: ACCOUNT_TYPE,
-  ): Promise<void> {
-    console.log(
-      `Verify the number of ${
-        accountType ? ACCOUNT_TYPE[accountType] : 'all'
-      } accounts in the account menu is: ${expectedNumberOfAccounts}`,
-    );
-
-    await this.driver.waitForSelector(this.accountListItem);
-    await this.driver.wait(async () => {
-      const internalAccounts = await this.driver.findElements(
-        this.accountListItem,
-      );
-
-      let filteredAccounts = internalAccounts;
-      if (accountType !== undefined) {
-        // Filter accounts based on type
-        filteredAccounts = await Promise.all(
-          internalAccounts.map(async (account) => {
-            const accountText = await account.getText();
-            switch (accountType) {
-              case ACCOUNT_TYPE.Ethereum:
-                return (
-                  !accountText.includes('Bitcoin') &&
-                  !accountText.includes('Solana')
-                );
-              case ACCOUNT_TYPE.Bitcoin:
-                return accountText.includes('Bitcoin');
-              case ACCOUNT_TYPE.Solana:
-                return accountText.includes('Solana');
-              default:
-                return true;
-            }
-          }),
-        ).then((results) =>
-          internalAccounts.filter((_, index) => results[index]),
-        );
-      }
-
-      const isValid = filteredAccounts.length === expectedNumberOfAccounts;
-      console.log(
-        `Number of ${
-          accountType ? ACCOUNT_TYPE[accountType] : 'all'
-        } accounts: ${
-          filteredAccounts.length
-        } is equal to ${expectedNumberOfAccounts}? ${isValid}`,
-      );
-      return isValid;
-    });
-  }
-
-  async checkPageIsLoaded(
-    timeout: number = 10000,
-    { waitForSync = true }: { waitForSync?: boolean } = {},
-  ): Promise<void> {
-    try {
-      await this.driver.waitForMultipleSelectors(
-        [this.addMultichainAccountButton, this.addMultichainWalletButton],
-        { timeout },
-      );
-    } catch (e) {
-      console.log('Timeout while waiting for account list to be loaded', e);
-      throw e;
-    }
-
-    if (waitForSync) {
-      await this.waitUntilSyncingIsCompleted();
-    }
-    console.log('Account list is loaded');
-  }
-
-  /**
-   * Check that the remove account button is not displayed in the account options menu for the specified account.
-   *
-   * @param accountLabel - The label of the account to check.
-   */
-  async checkRemoveAccountButtonIsNotDisplayed(
-    accountLabel: string,
-  ): Promise<void> {
-    console.log(
-      `Check that remove account button is not displayed in account options menu for account ${accountLabel} in account list`,
-    );
-    await this.openAccountOptionsInAccountList(accountLabel);
-    await this.driver.assertElementNotPresent(this.removeAccountButton);
-  }
-
-  async checkWalletDetailsButtonIsDisplayed(): Promise<void> {
-    console.log('Check wallet details button is displayed');
-    await this.driver.waitForSelector(this.walletDetailsButton);
-  }
-
-  async checkWalletDisplayedInAccountListMenu(
-    expectedLabel: string = 'Wallet',
-  ): Promise<void> {
-    console.log(
-      `Check that wallet label ${expectedLabel} is displayed in account list menu`,
-    );
-    await this.driver.waitForSelector({
-      css: this.walletHeader,
-      text: expectedLabel,
-    });
   }
 
   /**
@@ -737,22 +310,45 @@ class AccountListPage {
   }
 
   /**
-   * Click a multichain account menu item.
-   *
-   * @param item - The menu item to click (e.g., 'Account details', 'Rename', 'Addresses')
+   * Waiting until syncing is completed.
    */
-  async clickMultichainAccountMenuItem(
-    item: 'Account details' | 'Rename' | 'Addresses',
-  ): Promise<void> {
-    console.log(`Click multichain account menu item ${item}`);
-    await this.driver.clickElement(
-      `${this.multichainAccountMenuItem}[aria-label="${item}"]`,
-    );
+  async waitUntilSyncingIsCompleted(): Promise<void> {
+    console.log(`Check that account syncing not displayed in account list`);
+    await this.checkAddWalletButtonIsDisplayed();
+    await this.driver.assertElementNotPresent(this.syncingMessage);
   }
 
-  async clickWalletDetailsButton(): Promise<void> {
-    console.log('Click wallet details button');
-    await this.driver.clickElement(this.walletDetailsButton);
+  /**
+   * Adds a new multichain account.
+   *
+   * @param options - Options for creating the multichain account
+   * @param options.srpIndex - Optional SRP index for the new account
+   */
+  async addMultichainAccount(options?: { srpIndex?: number }): Promise<void> {
+    console.log(`Adding new multichain account`);
+    await this.waitUntilSyncingIsCompleted();
+    const buttonIndex = options?.srpIndex ?? 0;
+    const expectedCount = buttonIndex + 1;
+    let createMultichainAccountButtons: Awaited<
+      ReturnType<typeof this.driver.findElements>
+    > = [];
+    await this.driver.waitUntil(
+      async () => {
+        createMultichainAccountButtons = await this.driver.findElements(
+          this.addMultichainAccountButton,
+        );
+        return createMultichainAccountButtons.length >= expectedCount;
+      },
+      { timeout: 10000, interval: 500 },
+    );
+    await createMultichainAccountButtons[buttonIndex].click();
+
+    // Wait for the account creation to complete by waiting for loading state to finish
+    // The button shows "Adding account..." during loading and "Add account" when done
+    await this.driver.assertElementNotPresent({
+      css: this.addMultichainAccountButton,
+      text: 'Adding account...',
+    });
   }
 
   async closeAccountModal(): Promise<void> {
@@ -827,6 +423,62 @@ class AccountListPage {
   }
 
   /**
+   * Open the multichain account menu for the specified account.
+   *
+   * @param options - Options for opening the multichain account menu
+   * @param options.accountLabel - The label of the account to open the menu for
+   * @param options.srpIndex - Optional SRP index if there are multiple SRPs
+   */
+  async openMultichainAccountMenu(options: {
+    accountLabel: string;
+    srpIndex?: number;
+  }): Promise<void> {
+    console.log(
+      `Open multichain account menu in account list for account ${options.accountLabel}`,
+    );
+    // To ensure no pending Create Account action is in progress
+    await this.driver.assertElementNotPresent(this.addingAccountMessage, {
+      waitAtLeastGuard: largeDelayMs,
+    });
+
+    const multichainAccountMenuIcons = await this.driver.findElements(
+      `${this.multichainAccountOptionsMenuButton}[aria-label="${options.accountLabel} options"]`,
+    );
+
+    await multichainAccountMenuIcons[options.srpIndex ?? 0].click();
+  }
+
+  /**
+   * Click a multichain account menu item.
+   *
+   * @param item - The menu item to click (e.g., 'Account details', 'Rename', 'Addresses')
+   */
+  async clickMultichainAccountMenuItem(
+    item: 'Account details' | 'Rename' | 'Addresses',
+  ): Promise<void> {
+    console.log(`Click multichain account menu item ${item}`);
+    await this.driver.clickElement(
+      `${this.multichainAccountMenuItem}[aria-label="${item}"]`,
+    );
+  }
+
+  /**
+   * Change the label of a multichain account.
+   *
+   * @param newLabel - The new label for the multichain account
+   */
+  async changeMultichainAccountLabel(newLabel: string): Promise<void> {
+    console.log(
+      `Account details modal opened, changing multichain account label to: ${newLabel}`,
+    );
+    await this.driver.clickElement(this.multichainAccountNameInput);
+    await this.driver.fill(this.multichainAccountNameInput, newLabel);
+    await this.driver.clickElement(
+      this.multichainAccountNameInputConfirmButton,
+    );
+  }
+
+  /**
    * Open the account options menu for the specified account.
    *
    * @param accountLabel - The label of the account to open the options menu for.
@@ -837,6 +489,42 @@ class AccountListPage {
     );
     await this.driver.clickElement(
       `button[data-testid="account-list-item-menu-button"][aria-label="${accountLabel} Options"]`,
+    );
+  }
+
+  /**
+   * View the account on explorer for the specified account in account list.
+   *
+   * @param accountLabel - The label of the account to view on explorer.
+   */
+  async viewAccountOnExplorer(accountLabel: string): Promise<void> {
+    console.log(
+      `View account on explorer in account list for account ${accountLabel}`,
+    );
+    await this.openAccountOptionsInAccountList(accountLabel);
+    await this.driver.clickElement(this.viewAccountOnExplorerButton);
+  }
+
+  /**
+   * Checks that the account value and suffix is displayed in the account list.
+   *
+   * @param expectedValueAndSuffix - The expected value and suffix to check.
+   */
+  async checkAccountValueAndSuffixDisplayed(
+    expectedValueAndSuffix: string,
+  ): Promise<void> {
+    console.log(
+      `Check that account value and suffix ${expectedValueAndSuffix} is displayed in account list`,
+    );
+    await this.driver.findElement(this.accountValueAndSuffix, 5000);
+    await this.driver.waitForSelector(
+      {
+        css: this.accountValueAndSuffix,
+        text: expectedValueAndSuffix,
+      },
+      {
+        timeout: 20000,
+      },
     );
   }
 
@@ -863,32 +551,6 @@ class AccountListPage {
   async openHiddenAccountsList(): Promise<void> {
     console.log(`Open hidden accounts option menu`);
     await this.driver.clickElement(this.hiddenAccountsList);
-  }
-
-  /**
-   * Open the multichain account menu for the specified account.
-   *
-   * @param options - Options for opening the multichain account menu
-   * @param options.accountLabel - The label of the account to open the menu for
-   * @param options.srpIndex - Optional SRP index if there are multiple SRPs
-   */
-  async openMultichainAccountMenu(options: {
-    accountLabel: string;
-    srpIndex?: number;
-  }): Promise<void> {
-    console.log(
-      `Open multichain account menu in account list for account ${options.accountLabel}`,
-    );
-    // To ensure no pending Create Account action is in progress
-    await this.driver.assertElementNotPresent(this.addingAccountMessage, {
-      waitAtLeastGuard: largeDelayMs,
-    });
-
-    const multichainAccountMenuIcons = await this.driver.findElements(
-      `${this.multichainAccountOptionsMenuButton}[aria-label="${options.accountLabel} options"]`,
-    );
-
-    await multichainAccountMenuIcons[options.srpIndex ?? 0].click();
   }
 
   async pinAccount(): Promise<void> {
@@ -920,32 +582,6 @@ class AccountListPage {
     }
   }
 
-  async selectAccount(accountLabel: string): Promise<void> {
-    console.log(`Select account with label ${accountLabel} in account list`);
-    await this.driver.clickElement({
-      text: accountLabel,
-    });
-    console.log(`Account with label ${accountLabel} selected`);
-  }
-
-  async startExportSrpForAccount(accountLabel: string): Promise<void> {
-    console.log(`Exporting SRP for account ${accountLabel}`);
-    await this.openAccountDetailsModal(accountLabel);
-    await this.driver.delay(500);
-    await this.driver.clickElement(this.exportSrpButton);
-  }
-
-  async startImportSecretPhrase(srp: string): Promise<void> {
-    console.log(`Importing ${srp.split(' ').length} word srp`);
-
-    await this.driver.clickElement(this.addMultichainWalletButton);
-    await this.driver.clickElement(
-      this.importWalletFromMultichainWalletModalButton,
-    );
-    await this.driver.pasteIntoField(this.importSrpInput, srp);
-    await this.driver.clickElement(this.importSrpConfirmButton);
-  }
-
   async switchToAccount(expectedLabel: string): Promise<void> {
     console.log(
       `Switch to account with label ${expectedLabel} in account list`,
@@ -969,25 +605,392 @@ class AccountListPage {
   }
 
   /**
-   * View the account on explorer for the specified account in account list.
+   * Checks that the account balance is displayed in the account list.
    *
-   * @param accountLabel - The label of the account to view on explorer.
+   * @param expectedBalance - The expected balance to check.
    */
-  async viewAccountOnExplorer(accountLabel: string): Promise<void> {
+  async checkAccountBalanceDisplayed(expectedBalance: string): Promise<void> {
     console.log(
-      `View account on explorer in account list for account ${accountLabel}`,
+      `Check that account balance ${expectedBalance} is displayed in account list`,
     );
-    await this.openAccountOptionsInAccountList(accountLabel);
-    await this.driver.clickElement(this.viewAccountOnExplorerButton);
+    await this.driver.waitForSelector({
+      css: this.accountListBalance,
+      text: expectedBalance,
+    });
   }
 
   /**
-   * Waiting until syncing is completed.
+   * Checks that the account balance is displayed on the multichain account list page
+   * for a specific account, optionally scoped under a specific wallet.
+   *
+   * When only one wallet exists the wallet header is not rendered, so omit
+   * the `wallet` param and the lookup falls back to finding the account cell
+   * directly by account name.
+   *
+   * @param options - The wallet, account, and balance to check.
+   * @param options.balance - The expected balance to check.
+   * @param options.wallet - The wallet name. Only pass when multiple wallets are present.
+   * @param options.account - The account name (default: 'Account 1').
    */
-  async waitUntilSyncingIsCompleted(): Promise<void> {
-    console.log(`Check that account syncing not displayed in account list`);
-    await this.checkAddWalletButtonIsDisplayed();
-    await this.driver.assertElementNotPresent(this.syncingMessage);
+  async checkMultichainAccountBalanceDisplayed({
+    balance,
+    wallet,
+    account = 'Account 1',
+  }: {
+    balance: string;
+    wallet?: string;
+    account?: string;
+  }): Promise<void> {
+    console.log(
+      `Check that multichain account balance ${balance} is displayed for ${account}${wallet ? ` under ${wallet}` : ''}`,
+    );
+
+    if (wallet) {
+      // Multiple wallets: scope the search to accounts under the specified wallet header.
+      const walletHeader = await this.driver.waitForSelector({
+        css: this.walletHeader,
+        text: wallet,
+      });
+      await this.driver.findNestedElement(walletHeader, {
+        xpath: `../following-sibling::*[preceding-sibling::*[.//*[@data-testid='multichain-account-tree-wallet-header']][1]//*[@data-testid='multichain-account-tree-wallet-header' and contains(., ${quoteXPathText(wallet)})]]//*[contains(@class, 'multichain-account-cell') and .//*[contains(@class, 'multichain-account-cell__account-name') and contains(text(), ${quoteXPathText(account)})]]//*[@data-testid='balance-display' and contains(text(), ${quoteXPathText(balance)})]`,
+      });
+    } else {
+      // Single wallet (no wallet header rendered): find the account cell directly.
+      const accountCell = await this.driver.waitForSelector({
+        css: this.multichainAccountListItem,
+        text: account,
+      });
+      await this.driver.findNestedElement(accountCell, {
+        xpath: `.//*[@data-testid='balance-display' and contains(text(), ${quoteXPathText(balance)})]`,
+      });
+    }
+  }
+
+  async checkAccountDisplayedInAccountList(
+    expectedLabel: string = 'Account',
+  ): Promise<void> {
+    console.log(
+      `Check that account label ${expectedLabel} is displayed in account list`,
+    );
+    await this.driver.waitForSelector({
+      css: this.accountListItem,
+      text: expectedLabel,
+    });
+  }
+
+  /**
+   * Checks that the multichain account label is displayed on the multichain account list page.
+   *
+   * @param expectedLabel - The expected label to check.
+   */
+  async checkMultichainAccountNameDisplayed(
+    expectedLabel: string = 'Account',
+  ): Promise<void> {
+    console.log(
+      `Check that multichain account label ${expectedLabel} is displayed on account list page`,
+    );
+    await this.driver.waitForSelector({
+      css: this.multichainAccountListItem,
+      text: expectedLabel,
+    });
+  }
+
+  async checkWalletDisplayedInAccountListMenu(
+    expectedLabel: string = 'Wallet',
+  ): Promise<void> {
+    console.log(
+      `Check that wallet label ${expectedLabel} is displayed in account list menu`,
+    );
+    await this.driver.waitForSelector({
+      css: this.walletHeader,
+      text: expectedLabel,
+    });
+  }
+
+  async checkWalletDetailsButtonIsDisplayed(): Promise<void> {
+    console.log('Check wallet details button is displayed');
+    await this.driver.waitForSelector(this.walletDetailsButton);
+  }
+
+  async checkAddWalletButtonIsDisplayed(): Promise<void> {
+    console.log('Check add wallet button is displayed');
+    await this.driver.waitForSelector(this.addMultichainWalletButton);
+  }
+
+  async clickWalletDetailsButton(): Promise<void> {
+    console.log('Click wallet details button');
+    await this.driver.clickElement(this.walletDetailsButton);
+  }
+
+  async checkAccountNotDisplayedInAccountList(
+    expectedLabel: string = 'Account',
+  ): Promise<void> {
+    console.log(
+      `Check that account label ${expectedLabel} is not displayed in account list`,
+    );
+    await this.driver.assertElementNotPresent({
+      css: this.accountListItem,
+      text: expectedLabel,
+    });
+  }
+
+  /**
+   * Checks that the account with the specified label is not displayed in the account list.
+   *
+   * @param expectedLabel - The label of the account that should not be displayed.
+   */
+  async checkAccountIsNotDisplayedInAccountList(
+    expectedLabel: string,
+  ): Promise<void> {
+    console.log(
+      `Check that account label ${expectedLabel} is not displayed in account list`,
+    );
+    await this.driver.assertElementNotPresent({
+      css: this.accountListItem,
+      text: expectedLabel,
+    });
+  }
+
+  async checkAccountIsPinned(): Promise<void> {
+    console.log(`Check that account is pinned`);
+    await this.driver.waitForSelector(this.pinnedHeader);
+  }
+
+  async checkAccountIsUnpinned(): Promise<void> {
+    console.log(`Check that account is unpinned`);
+    await this.driver.assertElementNotPresent(this.pinnedHeader);
+  }
+
+  async checkAddAccountSnapButtonIsDisplayed(): Promise<void> {
+    console.log('Check add account snap button is displayed');
+    await this.driver.waitForSelector(this.addSnapAccountButton);
+  }
+
+  async checkAddAccountSnapButtonNotPresent(): Promise<void> {
+    console.log('Check add account snap button is not present');
+    await this.driver.assertElementNotPresent(this.addSnapAccountButton);
+  }
+
+  /**
+   * Checks that the watch ethereum account option is displayed in the choose wallet type page.
+   *
+   * @param expectedAvailability - Whether the watch ethereum account option is expected to be displayed.
+   */
+  async checkAddWatchAccountAvailable(
+    expectedAvailability: boolean,
+  ): Promise<void> {
+    console.log(
+      `Check watch ethereum account option is ${
+        expectedAvailability ? 'displayed ' : 'not displayed'
+      }`,
+    );
+    await this.driver.clickElement(this.addMultichainWalletButton);
+    if (expectedAvailability) {
+      await this.driver.waitForSelector(
+        this.chooseWalletTypeWatchEthereumAccountButton,
+      );
+    } else {
+      await this.driver.assertElementNotPresent(
+        this.chooseWalletTypeWatchEthereumAccountButton,
+      );
+    }
+  }
+
+  /**
+   * Verifies that account balance is private.
+   *
+   */
+  async checkAccountBalanceIsPrivate(): Promise<void> {
+    console.log(`Verify that account balance is private`);
+    await this.driver.waitForSelector({
+      css: this.accountPageBalance,
+      text: '••••••',
+    });
+  }
+
+  async checkCurrentAccountIsImported(): Promise<void> {
+    console.log(`Check that current account is an imported account`);
+    await this.driver.waitForSelector({
+      css: this.currentSelectedAccount,
+      text: 'Imported',
+    });
+  }
+
+  async checkHiddenAccountsListExists(): Promise<void> {
+    console.log(`Check that hidden accounts list is displayed in account list`);
+    await this.driver.waitForSelector(this.hiddenAccountsList);
+  }
+
+  async checkMultiChainAccountMenuIsDisplayed(): Promise<void> {
+    console.log(`Check that multichain account menu is displayed`);
+    await this.driver.waitForMultipleSelectors([
+      this.multichainAccountMenuAddresses,
+      this.multichainAccountMenuDetails,
+      this.multichainAccountMenuHide,
+      this.multichainAccountMenuRename,
+      this.multichainAccountMenuPin,
+    ]);
+  }
+
+  /**
+   * Verifies number of accounts currently showing in the accounts menu.
+   *
+   * @param expectedNumberOfAccounts - The expected number of accounts showing.
+   * @param accountType - Optional account type to filter by. If not provided, counts all accounts.
+   */
+  async checkNumberOfAvailableAccounts(
+    expectedNumberOfAccounts: number,
+    accountType?: ACCOUNT_TYPE,
+  ): Promise<void> {
+    console.log(
+      `Verify the number of ${
+        accountType ? ACCOUNT_TYPE[accountType] : 'all'
+      } accounts in the account menu is: ${expectedNumberOfAccounts}`,
+    );
+
+    await this.driver.waitForSelector(this.accountListItem);
+    await this.driver.wait(async () => {
+      const internalAccounts = await this.driver.findElements(
+        this.accountListItem,
+      );
+
+      let filteredAccounts = internalAccounts;
+      if (accountType !== undefined) {
+        // Filter accounts based on type
+        filteredAccounts = await Promise.all(
+          internalAccounts.map(async (account) => {
+            const accountText = await account.getText();
+            switch (accountType) {
+              case ACCOUNT_TYPE.Ethereum:
+                return (
+                  !accountText.includes('Bitcoin') &&
+                  !accountText.includes('Solana')
+                );
+              case ACCOUNT_TYPE.Bitcoin:
+                return accountText.includes('Bitcoin');
+              case ACCOUNT_TYPE.Solana:
+                return accountText.includes('Solana');
+              default:
+                return true;
+            }
+          }),
+        ).then((results) =>
+          internalAccounts.filter((_, index) => results[index]),
+        );
+      }
+
+      const isValid = filteredAccounts.length === expectedNumberOfAccounts;
+      console.log(
+        `Number of ${
+          accountType ? ACCOUNT_TYPE[accountType] : 'all'
+        } accounts: ${
+          filteredAccounts.length
+        } is equal to ${expectedNumberOfAccounts}? ${isValid}`,
+      );
+      return isValid;
+    });
+  }
+
+  /**
+   * Check that the remove account button is not displayed in the account options menu for the specified account.
+   *
+   * @param accountLabel - The label of the account to check.
+   */
+  async checkRemoveAccountButtonIsNotDisplayed(
+    accountLabel: string,
+  ): Promise<void> {
+    console.log(
+      `Check that remove account button is not displayed in account options menu for account ${accountLabel} in account list`,
+    );
+    await this.openAccountOptionsInAccountList(accountLabel);
+    await this.driver.assertElementNotPresent(this.removeAccountButton);
+  }
+
+  async selectAccount(accountLabel: string): Promise<void> {
+    console.log(`Select account with label ${accountLabel} in account list`);
+    await this.driver.clickElement({
+      text: accountLabel,
+    });
+    console.log(`Account with label ${accountLabel} selected`);
+  }
+
+  async startImportSecretPhrase(srp: string): Promise<void> {
+    console.log(`Importing ${srp.split(' ').length} word srp`);
+
+    await this.driver.clickElement(this.addMultichainWalletButton);
+    await this.driver.clickElement(
+      this.importWalletFromMultichainWalletModalButton,
+    );
+    await this.driver.pasteIntoField(this.importSrpInput, srp);
+    await this.driver.clickElement(this.importSrpConfirmButton);
+  }
+
+  async startExportSrpForAccount(accountLabel: string): Promise<void> {
+    console.log(`Exporting SRP for account ${accountLabel}`);
+    await this.openAccountDetailsModal(accountLabel);
+    await this.driver.delay(500);
+    await this.driver.clickElement(this.exportSrpButton);
+  }
+
+  async checkAccountBelongsToSrp(
+    accountName: string,
+    srpIndex: number,
+  ): Promise<void> {
+    console.log(`Check that current account is an imported account`);
+    await new HeaderNavbar(this.driver).openSettingsPage();
+    const settingsPage = new SettingsPage(this.driver);
+    await settingsPage.checkPageIsLoaded();
+    await settingsPage.goToSecurityAndPasswordSettings();
+
+    const privacySettings = new PrivacySettings(this.driver);
+    await privacySettings.checkSecurityAndPasswordPageIsLoaded();
+    await privacySettings.openSrpList();
+
+    if (srpIndex === 0) {
+      throw new Error('SRP index must be > 0');
+    }
+
+    const selectedSrp = await this.driver.waitForSelector({
+      css: '.select-srp__container',
+      text: `Secret Recovery Phrase ${srpIndex}`,
+    });
+    const showAccountsButton = await this.driver.waitForSelector(
+      `[data-testid="srp-list-show-accounts-${srpIndex - 1}"]`,
+    );
+    await showAccountsButton.click();
+
+    await this.driver.findNestedElement(selectedSrp, {
+      text: accountName,
+      tag: 'p',
+    });
+  }
+
+  async checkAccountNameIsDisplayed(accountName: string): Promise<void> {
+    console.log(`Check that account name ${accountName} is displayed`);
+    await this.driver.waitForSelector({
+      text: accountName,
+      tag: 'p',
+    });
+  }
+
+  async checkAccountNameIsDisplayedUnderWallet(
+    accountName: string,
+    walletName: string,
+  ): Promise<void> {
+    console.log(
+      `Check that account name ${accountName} is displayed under wallet ${walletName}`,
+    );
+    const walletHeader = await this.driver.waitForSelector({
+      css: this.walletHeader,
+      text: walletName,
+    });
+    // VirtualizedList wraps each item in a div, so the header and account rows are not direct
+    // siblings—each is the only child of its wrapper div. Go to the header's parent (the wrapper),
+    // then to that parent's first following sibling (the next item's wrapper), and find the account name inside it.
+    // Use . (string value) instead of text() so we match the element that contains the text in any descendant.
+    await this.driver.findNestedElement(walletHeader, {
+      xpath: `../following-sibling::*[1]//*[contains(., ${quoteXPathText(accountName)})]`,
+    });
   }
 }
 

--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -9,115 +9,102 @@ import SettingsPage from './settings/settings-page';
 class AccountListPage {
   private readonly driver: Driver;
 
-  private readonly accountListAddressItem =
-    '[data-testid="account-list-address"]';
+  private readonly accountDetailsTab = {
+    text: 'Account details',
+    tag: 'button',
+  };
 
   private readonly accountListBalance =
     '[data-testid="first-currency-display"]';
+
+  private readonly accountListItem =
+    '.multichain-account-menu-popover__list--menu-item';
+
+  private readonly accountMenuButton =
+    '[data-testid="account-list-menu-details"]';
 
   private readonly accountPageBalance = '[data-testid="balance-display"]';
 
   private readonly accountValueAndSuffix =
     '[data-testid="account-value-and-suffix"]';
 
-  private readonly accountListItem =
-    '.multichain-account-menu-popover__list--menu-item';
-
-  private readonly multichainAccountListItem = '.multichain-account-cell';
-
-  private readonly walletHeader =
-    '[data-testid="multichain-account-tree-wallet-header"]';
-
-  private readonly accountMenuButton =
-    '[data-testid="account-list-menu-details"]';
-
-  private readonly accountDetailsTab = {
-    text: 'Account details',
-    tag: 'button',
-  };
-
-  private readonly accountOptionsMenuButton =
-    '[data-testid="account-list-item-menu-button"]';
-
-  private readonly multichainAccountOptionsMenuButton =
-    '[data-testid="multichain-account-cell-end-accessory"]';
-
   private readonly addHardwareWalletButton =
     '[data-testid="choose-wallet-type-hardware-wallet"]';
-
-  private readonly chooseWalletTypeWatchEthereumAccountButton =
-    '[data-testid="choose-wallet-type-watch-ethereum-account"]';
 
   private readonly addingAccountMessage = {
     text: 'Adding account...',
     tag: 'p',
   };
 
-  private readonly addSnapAccountButton =
-    '[data-testid="choose-wallet-type-snap-account"]';
-
-  private readonly walletDetailsButton = {
-    text: 'Details',
-    tag: 'button',
-  };
-
-  private readonly closeAccountModalButton =
-    'header button[aria-label="Close"]';
-
-  private readonly chooseWalletTypeBackButton = '[data-testid="back-button"]';
-
-  private readonly closeMultichainAccountsPageButton =
-    '.multichain-page-header button[aria-label="Back"]';
+  private readonly addMultichainAccountButton =
+    '[data-testid="add-multichain-account-button"]';
 
   private readonly addMultichainWalletButton =
     '[data-testid="account-list-add-wallet-button"]';
 
-  private readonly importWalletFromMultichainWalletModalButton =
-    '[data-testid="choose-wallet-type-import-wallet"]';
+  private readonly addSnapAccountButton =
+    '[data-testid="choose-wallet-type-snap-account"]';
 
-  private readonly importAccountFromMultichainWalletModalButton =
-    '[data-testid="choose-wallet-type-import-account"]';
+  private readonly chooseWalletTypeBackButton = '[data-testid="back-button"]';
 
-  private readonly multichainAccountMenuItem =
-    '.multichain-account-cell-menu-item';
+  private readonly chooseWalletTypeWatchEthereumAccountButton =
+    '[data-testid="choose-wallet-type-watch-ethereum-account"]';
 
-  private readonly multichainAccountNameInput =
-    '[data-testid="account-name-input"] input';
+  private readonly closeAccountModalButton =
+    'header button[aria-label="Close"]';
 
-  private readonly multichainAccountNameInputConfirmButton =
-    '.mm-button-base[aria-label="Confirm"]';
-
-  private readonly addMultichainAccountButton =
-    '[data-testid="add-multichain-account-button"]';
+  private readonly closeMultichainAccountsPageButton =
+    '.multichain-page-header button[aria-label="Back"]';
 
   private readonly currentSelectedAccount =
     '.multichain-account-list-item--selected';
 
+  private readonly exportSrpButton = {
+    text: 'Show Secret Recovery Phrase',
+    tag: 'button',
+  };
+
   private readonly hiddenAccountOptionsMenuButton =
     '.multichain-account-menu-popover__list--menu-item-hidden-account [data-testid="account-list-item-menu-button"]';
 
-  private readonly hiddenAccountsList = '[data-testid="hidden-accounts-list"]';
+  private readonly hiddenAccountsList = '[data-testid="multichain-account-tree-hidden-header"]';
 
-  private readonly hideUnhideAccountButton =
-    '[data-testid="account-list-menu-hide"]';
+  private readonly hideAccountButton =
+    '[data-testid="multichain-account-menu-item-hideAccount"]';
 
   private readonly importAccountConfirmButton =
     '[data-testid="import-account-confirm-button"]';
 
-  private readonly importAccountPrivateKeyInput = '#private-key-box';
-
   private readonly importAccountDropdownOption = '.dropdown__select';
+
+  private readonly importAccountFromMultichainWalletModalButton =
+    '[data-testid="choose-wallet-type-import-account"]';
+
+  private readonly importAccountJsonFileInput =
+    'input[data-testid="file-input"]';
 
   private readonly importAccountJsonFileOption = {
     text: 'JSON File',
     tag: 'option',
   };
 
-  private readonly importAccountJsonFileInput =
-    'input[data-testid="file-input"]';
-
   private readonly importAccountJsonPasswordInput =
     'input[id="json-password-box"]';
+
+  private readonly importAccountPrivateKeyInput = '#private-key-box';
+
+  private readonly importSrpConfirmButton = {
+    text: 'Continue',
+    tag: 'span',
+  };
+
+  private readonly importSrpInput =
+    '[data-testid="srp-input-import__srp-note"]';
+
+  private readonly importWalletFromMultichainWalletModalButton =
+    '[data-testid="choose-wallet-type-import-wallet"]';
+
+  private readonly multichainAccountListItem = '.multichain-account-cell';
 
   private readonly multichainAccountMenuAddresses = {
     tag: 'p',
@@ -134,6 +121,9 @@ class AccountListPage {
     text: 'Hide account',
   };
 
+  private readonly multichainAccountMenuItem =
+    '.multichain-account-cell-menu-item';
+
   private readonly multichainAccountMenuPin = {
     tag: 'p',
     text: 'Pin to top',
@@ -144,10 +134,19 @@ class AccountListPage {
     text: 'Rename',
   };
 
-  private readonly pinUnpinAccountButton =
-    '[data-testid="account-list-menu-pin"]';
+  private readonly multichainAccountNameInput =
+    '[data-testid="account-name-input"] input';
 
-  private readonly pinnedIcon = '[data-testid="account-pinned-icon"]';
+  private readonly multichainAccountNameInputConfirmButton =
+    '.mm-button-base[aria-label="Confirm"]';
+
+  private readonly multichainAccountOptionsMenuButton =
+    '[data-testid="multichain-account-cell-end-accessory"]';
+
+  private readonly pinnedHeader = '[data-testid="multichain-account-tree-pinned-header"]';
+
+  private readonly pinAccountButton =
+    '[data-testid="multichain-account-menu-item-pinToTop"]';
 
   private readonly removeAccountButton =
     '[data-testid="account-list-menu-remove"]';
@@ -167,6 +166,29 @@ class AccountListPage {
     tag: 'button',
   };
 
+  private readonly syncingMessage = {
+    text: 'Syncing...',
+    tag: 'p',
+  };
+
+  private readonly unhideAccountButton = '[data-testid="multichain-account-menu-item-showAccount"]';
+
+  private readonly unpinAccountButton =
+    '[data-testid="multichain-account-menu-item-unpin"]';
+
+  private readonly viewAccountOnExplorerButton = {
+    text: 'View on explorer',
+    tag: 'p',
+  };
+
+  private readonly walletDetailsButton = {
+    text: 'Details',
+    tag: 'button',
+  };
+
+  private readonly walletHeader =
+    '[data-testid="multichain-account-tree-wallet-header"]';
+
   private readonly watchAccountAddressInput =
     'input#address-input[type="text"]';
 
@@ -180,61 +202,8 @@ class AccountListPage {
     tag: 'h4',
   };
 
-  private readonly importSrpInput =
-    '[data-testid="srp-input-import__srp-note"]';
-
-  private readonly importSrpConfirmButton = {
-    text: 'Continue',
-    tag: 'span',
-  };
-
-  private readonly exportSrpButton = {
-    text: 'Show Secret Recovery Phrase',
-    tag: 'button',
-  };
-
-  private readonly srpListTitle = {
-    text: 'Select Secret Recovery Phrase',
-    tag: 'label',
-  };
-
-  private readonly viewAccountOnExplorerButton = {
-    text: 'View on explorer',
-    tag: 'p',
-  };
-
-  private readonly addAccountButton = {
-    text: 'Add account',
-    tag: 'p',
-  };
-
-  private readonly syncingMessage = {
-    text: 'Syncing...',
-    tag: 'p',
-  };
-
   constructor(driver: Driver) {
     this.driver = driver;
-  }
-
-  async checkPageIsLoaded(
-    timeout: number = 10000,
-    { waitForSync = true }: { waitForSync?: boolean } = {},
-  ): Promise<void> {
-    try {
-      await this.driver.waitForMultipleSelectors(
-        [this.addMultichainAccountButton, this.addMultichainWalletButton],
-        { timeout },
-      );
-    } catch (e) {
-      console.log('Timeout while waiting for account list to be loaded', e);
-      throw e;
-    }
-
-    if (waitForSync) {
-      await this.waitUntilSyncingIsCompleted();
-    }
-    console.log('Account list is loaded');
   }
 
   /**
@@ -271,62 +240,6 @@ class AccountListPage {
   }
 
   /**
-   * Import a new account with a private key.
-   *
-   * @param privateKey - Private key of the account
-   * @param expectedErrorMessage - Expected error message if the import should fail
-   */
-  async addNewImportedAccount(
-    privateKey: string,
-    expectedErrorMessage?: string,
-  ): Promise<void> {
-    console.log(`Adding new imported account`);
-    await this.driver.clickElement(this.addMultichainWalletButton);
-    await this.driver.clickElement(
-      this.importAccountFromMultichainWalletModalButton,
-    );
-    await this.driver.fill(this.importAccountPrivateKeyInput, privateKey);
-    if (expectedErrorMessage) {
-      await this.driver.clickElement(this.importAccountConfirmButton);
-      await this.driver.waitForSelector({
-        css: '.mm-help-text',
-        text: expectedErrorMessage,
-      });
-    } else {
-      await this.driver.clickElementAndWaitToDisappear(
-        this.importAccountConfirmButton,
-      );
-      await this.closeChooseWalletTypePage();
-    }
-  }
-
-  /**
-   * Adds a new multichain wallet.
-   */
-  async addMultichainWallet(): Promise<void> {
-    console.log(`Adding new multichain wallet`);
-    await this.driver.clickElement(this.addMultichainWalletButton);
-  }
-
-  /**
-   * Import a wallet.
-   */
-  async clickImportWallet(): Promise<void> {
-    await this.driver.clickElement(
-      this.importWalletFromMultichainWalletModalButton,
-    );
-  }
-
-  /**
-   * Waiting until syncing is completed.
-   */
-  async waitUntilSyncingIsCompleted(): Promise<void> {
-    console.log(`Check that account syncing not displayed in account list`);
-    await this.checkAddWalletButtonIsDisplayed();
-    await this.driver.assertElementNotPresent(this.syncingMessage);
-  }
-
-  /**
    * Adds a new multichain account.
    *
    * @param options - Options for creating the multichain account
@@ -359,114 +272,42 @@ class AccountListPage {
     });
   }
 
-  async closeAccountModal(): Promise<void> {
-    console.log(`Close account modal in account list`);
-    await this.driver.clickElementAndWaitToDisappear(
-      this.closeAccountModalButton,
-    );
-  }
-
-  async closeChooseWalletTypePage(): Promise<void> {
-    console.log(`Navigate back from choose wallet type page`);
-    await this.driver.clickElement(this.chooseWalletTypeBackButton);
-  }
-
-  async closeMultichainAccountsPage(): Promise<void> {
-    console.log(`Close multichain accounts page`);
-    await this.driver.clickElementAndWaitToDisappear(
-      this.closeMultichainAccountsPageButton,
-    );
-  }
-
-  async hideAccount(): Promise<void> {
-    console.log(`Hide account in account list`);
-    await this.driver.clickElement(this.hideUnhideAccountButton);
+  /**
+   * Adds a new multichain wallet.
+   */
+  async addMultichainWallet(): Promise<void> {
+    console.log(`Adding new multichain wallet`);
+    await this.driver.clickElement(this.addMultichainWalletButton);
   }
 
   /**
-   * Import an account with a JSON file.
+   * Import a new account with a private key.
    *
-   * @param jsonFilePath - Path to the JSON file to import
-   * @param password - Password for the imported account
+   * @param privateKey - Private key of the account
+   * @param expectedErrorMessage - Expected error message if the import should fail
    */
-  async importAccountWithJsonFile(
-    jsonFilePath: string,
-    password: string,
+  async addNewImportedAccount(
+    privateKey: string,
+    expectedErrorMessage?: string,
   ): Promise<void> {
     console.log(`Adding new imported account`);
     await this.driver.clickElement(this.addMultichainWalletButton);
     await this.driver.clickElement(
       this.importAccountFromMultichainWalletModalButton,
     );
-    await this.driver.clickElement(this.importAccountDropdownOption);
-    await this.driver.clickElement(this.importAccountJsonFileOption);
-
-    const fileInput = await this.driver.findElement(
-      this.importAccountJsonFileInput,
-    );
-    await fileInput.sendKeys(jsonFilePath);
-    await this.driver.fill(this.importAccountJsonPasswordInput, password);
-    // needed to mitigate a race condition with the state update
-    // there is no condition we can wait for in the UI
-    await this.driver.delay(largeDelayMs);
-    await this.driver.clickElementAndWaitToDisappear(
-      this.importAccountConfirmButton,
-    );
-    await this.closeChooseWalletTypePage();
-  }
-
-  /**
-   * Open the account details modal for the specified account in account list.
-   *
-   * @param accountLabel - The label of the account to open the details modal for.
-   */
-  async openAccountDetailsModal(accountLabel: string): Promise<void> {
-    console.log(
-      `Open account details modal in account list for account ${accountLabel}`,
-    );
-    await this.openAccountOptionsInAccountList(accountLabel);
-    await this.driver.clickElement(this.accountMenuButton);
-    await this.driver.clickElementSafe(this.accountDetailsTab);
-  }
-
-  /**
-   * Open the multichain account menu for the specified account.
-   *
-   * @param options - Options for opening the multichain account menu
-   * @param options.accountLabel - The label of the account to open the menu for
-   * @param options.srpIndex - Optional SRP index if there are multiple SRPs
-   */
-  async openMultichainAccountMenu(options: {
-    accountLabel: string;
-    srpIndex?: number;
-  }): Promise<void> {
-    console.log(
-      `Open multichain account menu in account list for account ${options.accountLabel}`,
-    );
-    // To ensure no pending Create Account action is in progress
-    await this.driver.assertElementNotPresent(this.addingAccountMessage, {
-      waitAtLeastGuard: largeDelayMs,
-    });
-
-    const multichainAccountMenuIcons = await this.driver.findElements(
-      `${this.multichainAccountOptionsMenuButton}[aria-label="${options.accountLabel} options"]`,
-    );
-
-    await multichainAccountMenuIcons[options.srpIndex ?? 0].click();
-  }
-
-  /**
-   * Click a multichain account menu item.
-   *
-   * @param item - The menu item to click (e.g., 'Account details', 'Rename', 'Addresses')
-   */
-  async clickMultichainAccountMenuItem(
-    item: 'Account details' | 'Rename' | 'Addresses',
-  ): Promise<void> {
-    console.log(`Click multichain account menu item ${item}`);
-    await this.driver.clickElement(
-      `${this.multichainAccountMenuItem}[aria-label="${item}"]`,
-    );
+    await this.driver.fill(this.importAccountPrivateKeyInput, privateKey);
+    if (expectedErrorMessage) {
+      await this.driver.clickElement(this.importAccountConfirmButton);
+      await this.driver.waitForSelector({
+        css: '.mm-help-text',
+        text: expectedErrorMessage,
+      });
+    } else {
+      await this.driver.clickElementAndWaitToDisappear(
+        this.importAccountConfirmButton,
+      );
+      await this.closeChooseWalletTypePage();
+    }
   }
 
   /**
@@ -486,30 +327,142 @@ class AccountListPage {
   }
 
   /**
-   * Open the account options menu for the specified account.
+   * Checks that the account balance is displayed in the account list.
    *
-   * @param accountLabel - The label of the account to open the options menu for.
+   * @param expectedBalance - The expected balance to check.
    */
-  async openAccountOptionsInAccountList(accountLabel: string): Promise<void> {
+  async checkAccountBalanceDisplayed(expectedBalance: string): Promise<void> {
     console.log(
-      `Open account options in account list for account ${accountLabel}`,
+      `Check that account balance ${expectedBalance} is displayed in account list`,
     );
-    await this.driver.clickElement(
-      `button[data-testid="account-list-item-menu-button"][aria-label="${accountLabel} Options"]`,
-    );
+    await this.driver.waitForSelector({
+      css: this.accountListBalance,
+      text: expectedBalance,
+    });
   }
 
   /**
-   * View the account on explorer for the specified account in account list.
+   * Verifies that account balance is private.
    *
-   * @param accountLabel - The label of the account to view on explorer.
    */
-  async viewAccountOnExplorer(accountLabel: string): Promise<void> {
-    console.log(
-      `View account on explorer in account list for account ${accountLabel}`,
+  async checkAccountBalanceIsPrivate(): Promise<void> {
+    console.log(`Verify that account balance is private`);
+    await this.driver.waitForSelector({
+      css: this.accountPageBalance,
+      text: '••••••',
+    });
+  }
+
+  async checkAccountBelongsToSrp(
+    accountName: string,
+    srpIndex: number,
+  ): Promise<void> {
+    console.log(`Check that current account is an imported account`);
+    await new HeaderNavbar(this.driver).openSettingsPage();
+    const settingsPage = new SettingsPage(this.driver);
+    await settingsPage.checkPageIsLoaded();
+    await settingsPage.goToSecurityAndPasswordSettings();
+
+    const privacySettings = new PrivacySettings(this.driver);
+    await privacySettings.checkSecurityAndPasswordPageIsLoaded();
+    await privacySettings.openSrpList();
+
+    if (srpIndex === 0) {
+      throw new Error('SRP index must be > 0');
+    }
+
+    const selectedSrp = await this.driver.waitForSelector({
+      css: '.select-srp__container',
+      text: `Secret Recovery Phrase ${srpIndex}`,
+    });
+    const showAccountsButton = await this.driver.waitForSelector(
+      `[data-testid="srp-list-show-accounts-${srpIndex - 1}"]`,
     );
-    await this.openAccountOptionsInAccountList(accountLabel);
-    await this.driver.clickElement(this.viewAccountOnExplorerButton);
+    await showAccountsButton.click();
+
+    await this.driver.findNestedElement(selectedSrp, {
+      text: accountName,
+      tag: 'p',
+    });
+  }
+
+  async checkAccountDisplayedInAccountList(
+    expectedLabel: string = 'Account',
+  ): Promise<void> {
+    console.log(
+      `Check that account label ${expectedLabel} is displayed in account list`,
+    );
+    await this.driver.waitForSelector({
+      css: this.accountListItem,
+      text: expectedLabel,
+    });
+  }
+
+  /**
+   * Checks that the account with the specified label is not displayed in the account list.
+   *
+   * @param expectedLabel - The label of the account that should not be displayed.
+   */
+  async checkAccountIsNotDisplayedInAccountList(
+    expectedLabel: string,
+  ): Promise<void> {
+    console.log(
+      `Check that account label ${expectedLabel} is not displayed in account list`,
+    );
+    await this.driver.assertElementNotPresent({
+      css: this.accountListItem,
+      text: expectedLabel,
+    });
+  }
+
+  async checkAccountIsPinned(): Promise<void> {
+    console.log(`Check that account is pinned`);
+    await this.driver.waitForSelector(this.pinnedHeader);
+  }
+
+  async checkAccountIsUnpinned(): Promise<void> {
+    console.log(`Check that account is unpinned`);
+    await this.driver.assertElementNotPresent(this.pinnedHeader);
+  }
+
+  async checkAccountNameIsDisplayed(accountName: string): Promise<void> {
+    console.log(`Check that account name ${accountName} is displayed`);
+    await this.driver.waitForSelector({
+      text: accountName,
+      tag: 'p',
+    });
+  }
+
+  async checkAccountNameIsDisplayedUnderWallet(
+    accountName: string,
+    walletName: string,
+  ): Promise<void> {
+    console.log(
+      `Check that account name ${accountName} is displayed under wallet ${walletName}`,
+    );
+    const walletHeader = await this.driver.waitForSelector({
+      css: this.walletHeader,
+      text: walletName,
+    });
+    // VirtualizedList wraps each item in a div, so the header and account rows are not direct
+    // siblings—each is the only child of its wrapper div. Go to the header's parent (the wrapper),
+    // then to that parent's first following sibling (the next item's wrapper), and find the account name inside it.
+    // Use . (string value) instead of text() so we match the element that contains the text in any descendant.
+    await this.driver.findNestedElement(walletHeader, {
+      xpath: `../following-sibling::*[1]//*[contains(., ${quoteXPathText(accountName)})]`,
+    });
+  }
+
+  async checkAccountNotDisplayedInAccountList(
+    expectedLabel: string = 'Account',
+  ): Promise<void> {
+    console.log(
+      `Check that account label ${expectedLabel} is not displayed in account list`,
+    );
+    await this.driver.assertElementNotPresent({
+      css: this.accountListItem,
+      text: expectedLabel,
+    });
   }
 
   /**
@@ -535,92 +488,57 @@ class AccountListPage {
     );
   }
 
-  async openAccountOptionsMenu(): Promise<void> {
-    console.log(`Open account option menu`);
-    await this.driver.waitForSelector(this.accountListItem);
-    await this.driver.clickElement(this.accountOptionsMenuButton);
+  async checkAddAccountSnapButtonIsDisplayed(): Promise<void> {
+    console.log('Check add account snap button is displayed');
+    await this.driver.waitForSelector(this.addSnapAccountButton);
   }
 
-  async openConnectHardwareWalletModal(): Promise<void> {
-    console.log(`Open connect hardware wallet modal`);
-    await this.driver.clickElement(this.addMultichainWalletButton);
-    await this.driver.clickElement(this.addHardwareWalletButton);
-    // This delay is needed to mitigate an existing bug
-    // See https://github.com/metamask/metamask-extension/issues/25851
-    await this.driver.delay(largeDelayMs);
+  async checkAddAccountSnapButtonNotPresent(): Promise<void> {
+    console.log('Check add account snap button is not present');
+    await this.driver.assertElementNotPresent(this.addSnapAccountButton);
   }
 
-  async openHiddenAccountOptions(): Promise<void> {
-    console.log(`Open hidden accounts options menu`);
-    await this.driver.clickElement(this.hiddenAccountOptionsMenuButton);
-  }
-
-  async openHiddenAccountsList(): Promise<void> {
-    console.log(`Open hidden accounts option menu`);
-    await this.driver.clickElement(this.hiddenAccountsList);
-  }
-
-  async pinAccount(): Promise<void> {
-    console.log(`Pin account in account list`);
-    await this.driver.clickElement(this.pinUnpinAccountButton);
+  async checkAddWalletButtonIsDisplayed(): Promise<void> {
+    console.log('Check add wallet button is displayed');
+    await this.driver.waitForSelector(this.addMultichainWalletButton);
   }
 
   /**
-   * Remove the specified account from the account list.
+   * Checks that the watch ethereum account option is displayed in the choose wallet type page.
    *
-   * @param accountLabel - The label of the account to remove.
-   * @param confirmRemoval - Whether to confirm the removal of the account. Defaults to true.
+   * @param expectedAvailability - Whether the watch ethereum account option is expected to be displayed.
    */
-  async removeAccount(
-    accountLabel: string,
-    confirmRemoval: boolean = true,
+  async checkAddWatchAccountAvailable(
+    expectedAvailability: boolean,
   ): Promise<void> {
-    console.log(`Remove account in account list`);
-    await this.openAccountOptionsInAccountList(accountLabel);
-    await this.driver.clickElement(this.removeAccountButton);
-    await this.driver.waitForSelector(this.removeAccountMessage);
-    if (confirmRemoval) {
-      console.log('Confirm removal of account');
-      await this.driver.clickElement(this.removeAccountConfirmButton);
+    console.log(
+      `Check watch ethereum account option is ${
+        expectedAvailability ? 'displayed ' : 'not displayed'
+      }`,
+    );
+    await this.driver.clickElement(this.addMultichainWalletButton);
+    if (expectedAvailability) {
+      await this.driver.waitForSelector(
+        this.chooseWalletTypeWatchEthereumAccountButton,
+      );
     } else {
-      console.log('Click nevermind button to cancel account removal');
-      await this.driver.clickElement(this.removeAccountNevermindButton);
+      await this.driver.assertElementNotPresent(
+        this.chooseWalletTypeWatchEthereumAccountButton,
+      );
     }
   }
 
-  async switchToAccount(expectedLabel: string): Promise<void> {
-    console.log(
-      `Switch to account with label ${expectedLabel} in account list`,
-    );
-    await this.driver.clickElement({
-      css: this.accountListItem,
-      text: expectedLabel,
-    });
-  }
-
-  async unhideAccount(): Promise<void> {
-    console.log(`Unhide account in account list`);
-    await this.driver.clickElement(this.hideUnhideAccountButton);
-  }
-
-  async unpinAccount(): Promise<void> {
-    console.log(`Unpin account in account list`);
-    await this.driver.clickElement(this.pinUnpinAccountButton);
-  }
-
-  /**
-   * Checks that the account balance is displayed in the account list.
-   *
-   * @param expectedBalance - The expected balance to check.
-   */
-  async checkAccountBalanceDisplayed(expectedBalance: string): Promise<void> {
-    console.log(
-      `Check that account balance ${expectedBalance} is displayed in account list`,
-    );
+  async checkCurrentAccountIsImported(): Promise<void> {
+    console.log(`Check that current account is an imported account`);
     await this.driver.waitForSelector({
-      css: this.accountListBalance,
-      text: expectedBalance,
+      css: this.currentSelectedAccount,
+      text: 'Imported',
     });
+  }
+
+  async checkHiddenAccountsListExists(): Promise<void> {
+    console.log(`Check that hidden accounts list is displayed in account list`);
+    await this.driver.waitForSelector(this.hiddenAccountsList);
   }
 
   /**
@@ -670,16 +588,15 @@ class AccountListPage {
     }
   }
 
-  async checkAccountDisplayedInAccountList(
-    expectedLabel: string = 'Account',
-  ): Promise<void> {
-    console.log(
-      `Check that account label ${expectedLabel} is displayed in account list`,
-    );
-    await this.driver.waitForSelector({
-      css: this.accountListItem,
-      text: expectedLabel,
-    });
+  async checkMultiChainAccountMenuIsDisplayed(): Promise<void> {
+    console.log(`Check that multichain account menu is displayed`);
+    await this.driver.waitForMultipleSelectors([
+      this.multichainAccountMenuAddresses,
+      this.multichainAccountMenuDetails,
+      this.multichainAccountMenuHide,
+      this.multichainAccountMenuRename,
+      this.multichainAccountMenuPin,
+    ]);
   }
 
   /**
@@ -697,143 +614,6 @@ class AccountListPage {
       css: this.multichainAccountListItem,
       text: expectedLabel,
     });
-  }
-
-  async checkWalletDisplayedInAccountListMenu(
-    expectedLabel: string = 'Wallet',
-  ): Promise<void> {
-    console.log(
-      `Check that wallet label ${expectedLabel} is displayed in account list menu`,
-    );
-    await this.driver.waitForSelector({
-      css: this.walletHeader,
-      text: expectedLabel,
-    });
-  }
-
-  async checkWalletDetailsButtonIsDisplayed(): Promise<void> {
-    console.log('Check wallet details button is displayed');
-    await this.driver.waitForSelector(this.walletDetailsButton);
-  }
-
-  async checkAddWalletButtonIsDisplayed(): Promise<void> {
-    console.log('Check add wallet button is displayed');
-    await this.driver.waitForSelector(this.addMultichainWalletButton);
-  }
-
-  async clickWalletDetailsButton(): Promise<void> {
-    console.log('Click wallet details button');
-    await this.driver.clickElement(this.walletDetailsButton);
-  }
-
-  async checkAccountNotDisplayedInAccountList(
-    expectedLabel: string = 'Account',
-  ): Promise<void> {
-    console.log(
-      `Check that account label ${expectedLabel} is not displayed in account list`,
-    );
-    await this.driver.assertElementNotPresent({
-      css: this.accountListItem,
-      text: expectedLabel,
-    });
-  }
-
-  /**
-   * Checks that the account with the specified label is not displayed in the account list.
-   *
-   * @param expectedLabel - The label of the account that should not be displayed.
-   */
-  async checkAccountIsNotDisplayedInAccountList(
-    expectedLabel: string,
-  ): Promise<void> {
-    console.log(
-      `Check that account label ${expectedLabel} is not displayed in account list`,
-    );
-    await this.driver.assertElementNotPresent({
-      css: this.accountListItem,
-      text: expectedLabel,
-    });
-  }
-
-  async checkAccountIsPinned(): Promise<void> {
-    console.log(`Check that account is pinned`);
-    await this.driver.waitForSelector(this.pinnedIcon);
-  }
-
-  async checkAccountIsUnpinned(): Promise<void> {
-    console.log(`Check that account is unpinned`);
-    await this.driver.assertElementNotPresent(this.pinnedIcon);
-  }
-
-  async checkAddAccountSnapButtonIsDisplayed(): Promise<void> {
-    console.log('Check add account snap button is displayed');
-    await this.driver.waitForSelector(this.addSnapAccountButton);
-  }
-
-  async checkAddAccountSnapButtonNotPresent(): Promise<void> {
-    console.log('Check add account snap button is not present');
-    await this.driver.assertElementNotPresent(this.addSnapAccountButton);
-  }
-
-  /**
-   * Checks that the watch ethereum account option is displayed in the choose wallet type page.
-   *
-   * @param expectedAvailability - Whether the watch ethereum account option is expected to be displayed.
-   */
-  async checkAddWatchAccountAvailable(
-    expectedAvailability: boolean,
-  ): Promise<void> {
-    console.log(
-      `Check watch ethereum account option is ${
-        expectedAvailability ? 'displayed ' : 'not displayed'
-      }`,
-    );
-    await this.driver.clickElement(this.addMultichainWalletButton);
-    if (expectedAvailability) {
-      await this.driver.waitForSelector(
-        this.chooseWalletTypeWatchEthereumAccountButton,
-      );
-    } else {
-      await this.driver.assertElementNotPresent(
-        this.chooseWalletTypeWatchEthereumAccountButton,
-      );
-    }
-  }
-
-  /**
-   * Verifies that account balance is private.
-   *
-   */
-  async checkAccountBalanceIsPrivate(): Promise<void> {
-    console.log(`Verify that account balance is private`);
-    await this.driver.waitForSelector({
-      css: this.accountPageBalance,
-      text: '••••••',
-    });
-  }
-
-  async checkCurrentAccountIsImported(): Promise<void> {
-    console.log(`Check that current account is an imported account`);
-    await this.driver.waitForSelector({
-      css: this.currentSelectedAccount,
-      text: 'Imported',
-    });
-  }
-
-  async checkHiddenAccountsListExists(): Promise<void> {
-    console.log(`Check that hidden accounts list is displayed in account list`);
-    await this.driver.waitForSelector(this.hiddenAccountsList);
-  }
-
-  async checkMultiChainAccountMenuIsDisplayed(): Promise<void> {
-    console.log(`Check that multichain account menu is displayed`);
-    await this.driver.waitForMultipleSelectors([
-      this.multichainAccountMenuAddresses,
-      this.multichainAccountMenuDetails,
-      this.multichainAccountMenuHide,
-      this.multichainAccountMenuRename,
-      this.multichainAccountMenuPin,
-    ]);
   }
 
   /**
@@ -895,6 +675,26 @@ class AccountListPage {
     });
   }
 
+  async checkPageIsLoaded(
+    timeout: number = 10000,
+    { waitForSync = true }: { waitForSync?: boolean } = {},
+  ): Promise<void> {
+    try {
+      await this.driver.waitForMultipleSelectors(
+        [this.addMultichainAccountButton, this.addMultichainWalletButton],
+        { timeout },
+      );
+    } catch (e) {
+      console.log('Timeout while waiting for account list to be loaded', e);
+      throw e;
+    }
+
+    if (waitForSync) {
+      await this.waitUntilSyncingIsCompleted();
+    }
+    console.log('Account list is loaded');
+  }
+
   /**
    * Check that the remove account button is not displayed in the account options menu for the specified account.
    *
@@ -910,12 +710,229 @@ class AccountListPage {
     await this.driver.assertElementNotPresent(this.removeAccountButton);
   }
 
+  async checkWalletDetailsButtonIsDisplayed(): Promise<void> {
+    console.log('Check wallet details button is displayed');
+    await this.driver.waitForSelector(this.walletDetailsButton);
+  }
+
+  async checkWalletDisplayedInAccountListMenu(
+    expectedLabel: string = 'Wallet',
+  ): Promise<void> {
+    console.log(
+      `Check that wallet label ${expectedLabel} is displayed in account list menu`,
+    );
+    await this.driver.waitForSelector({
+      css: this.walletHeader,
+      text: expectedLabel,
+    });
+  }
+
+  /**
+   * Import a wallet.
+   */
+  async clickImportWallet(): Promise<void> {
+    await this.driver.clickElement(
+      this.importWalletFromMultichainWalletModalButton,
+    );
+  }
+
+  /**
+   * Click a multichain account menu item.
+   *
+   * @param item - The menu item to click (e.g., 'Account details', 'Rename', 'Addresses')
+   */
+  async clickMultichainAccountMenuItem(
+    item: 'Account details' | 'Rename' | 'Addresses',
+  ): Promise<void> {
+    console.log(`Click multichain account menu item ${item}`);
+    await this.driver.clickElement(
+      `${this.multichainAccountMenuItem}[aria-label="${item}"]`,
+    );
+  }
+
+  async clickWalletDetailsButton(): Promise<void> {
+    console.log('Click wallet details button');
+    await this.driver.clickElement(this.walletDetailsButton);
+  }
+
+  async closeAccountModal(): Promise<void> {
+    console.log(`Close account modal in account list`);
+    await this.driver.clickElementAndWaitToDisappear(
+      this.closeAccountModalButton,
+    );
+  }
+
+  async closeChooseWalletTypePage(): Promise<void> {
+    console.log(`Navigate back from choose wallet type page`);
+    await this.driver.clickElement(this.chooseWalletTypeBackButton);
+  }
+
+  async closeMultichainAccountsPage(): Promise<void> {
+    console.log(`Close multichain accounts page`);
+    await this.driver.clickElementAndWaitToDisappear(
+      this.closeMultichainAccountsPageButton,
+    );
+  }
+
+  async hideAccount(): Promise<void> {
+    console.log(`Hide account in account list`);
+    await this.openAccountOptionsMenu();
+    await this.driver.clickElement(this.hideAccountButton);
+  }
+
+  /**
+   * Import an account with a JSON file.
+   *
+   * @param jsonFilePath - Path to the JSON file to import
+   * @param password - Password for the imported account
+   */
+  async importAccountWithJsonFile(
+    jsonFilePath: string,
+    password: string,
+  ): Promise<void> {
+    console.log(`Adding new imported account`);
+    await this.driver.clickElement(this.addMultichainWalletButton);
+    await this.driver.clickElement(
+      this.importAccountFromMultichainWalletModalButton,
+    );
+    await this.driver.clickElement(this.importAccountDropdownOption);
+    await this.driver.clickElement(this.importAccountJsonFileOption);
+
+    const fileInput = await this.driver.findElement(
+      this.importAccountJsonFileInput,
+    );
+    await fileInput.sendKeys(jsonFilePath);
+    await this.driver.fill(this.importAccountJsonPasswordInput, password);
+    // needed to mitigate a race condition with the state update
+    // there is no condition we can wait for in the UI
+    await this.driver.delay(largeDelayMs);
+    await this.driver.clickElementAndWaitToDisappear(
+      this.importAccountConfirmButton,
+    );
+    await this.closeChooseWalletTypePage();
+  }
+
+  /**
+   * Open the account details modal for the specified account in account list.
+   *
+   * @param accountLabel - The label of the account to open the details modal for.
+   */
+  async openAccountDetailsModal(accountLabel: string): Promise<void> {
+    console.log(
+      `Open account details modal in account list for account ${accountLabel}`,
+    );
+    await this.openAccountOptionsInAccountList(accountLabel);
+    await this.driver.clickElement(this.accountMenuButton);
+    await this.driver.clickElementSafe(this.accountDetailsTab);
+  }
+
+  /**
+   * Open the account options menu for the specified account.
+   *
+   * @param accountLabel - The label of the account to open the options menu for.
+   */
+  async openAccountOptionsInAccountList(accountLabel: string): Promise<void> {
+    console.log(
+      `Open account options in account list for account ${accountLabel}`,
+    );
+    await this.driver.clickElement(
+      `button[data-testid="account-list-item-menu-button"][aria-label="${accountLabel} Options"]`,
+    );
+  }
+
+  async openAccountOptionsMenu(): Promise<void> {
+    console.log(`Open account option menu`);
+    await this.driver.waitForSelector(this.accountListItem);
+    await this.driver.clickElement(this.multichainAccountOptionsMenuButton);
+  }
+
+  async openConnectHardwareWalletModal(): Promise<void> {
+    console.log(`Open connect hardware wallet modal`);
+    await this.driver.clickElement(this.addMultichainWalletButton);
+    await this.driver.clickElement(this.addHardwareWalletButton);
+    // This delay is needed to mitigate an existing bug
+    // See https://github.com/metamask/metamask-extension/issues/25851
+    await this.driver.delay(largeDelayMs);
+  }
+
+  async openHiddenAccountOptions(): Promise<void> {
+    console.log(`Open hidden accounts options menu`);
+    await this.driver.clickElement(this.hiddenAccountOptionsMenuButton);
+  }
+
+  async openHiddenAccountsList(): Promise<void> {
+    console.log(`Open hidden accounts option menu`);
+    await this.driver.clickElement(this.hiddenAccountsList);
+  }
+
+  /**
+   * Open the multichain account menu for the specified account.
+   *
+   * @param options - Options for opening the multichain account menu
+   * @param options.accountLabel - The label of the account to open the menu for
+   * @param options.srpIndex - Optional SRP index if there are multiple SRPs
+   */
+  async openMultichainAccountMenu(options: {
+    accountLabel: string;
+    srpIndex?: number;
+  }): Promise<void> {
+    console.log(
+      `Open multichain account menu in account list for account ${options.accountLabel}`,
+    );
+    // To ensure no pending Create Account action is in progress
+    await this.driver.assertElementNotPresent(this.addingAccountMessage, {
+      waitAtLeastGuard: largeDelayMs,
+    });
+
+    const multichainAccountMenuIcons = await this.driver.findElements(
+      `${this.multichainAccountOptionsMenuButton}[aria-label="${options.accountLabel} options"]`,
+    );
+
+    await multichainAccountMenuIcons[options.srpIndex ?? 0].click();
+  }
+
+  async pinAccount(): Promise<void> {
+    console.log(`Pin account in account list`);
+    await this.openAccountOptionsMenu();
+    await this.driver.clickElement(this.pinAccountButton);
+  }
+
+  /**
+   * Remove the specified account from the account list.
+   *
+   * @param accountLabel - The label of the account to remove.
+   * @param confirmRemoval - Whether to confirm the removal of the account. Defaults to true.
+   */
+  async removeAccount(
+    accountLabel: string,
+    confirmRemoval: boolean = true,
+  ): Promise<void> {
+    console.log(`Remove account in account list`);
+    await this.openAccountOptionsInAccountList(accountLabel);
+    await this.driver.clickElement(this.removeAccountButton);
+    await this.driver.waitForSelector(this.removeAccountMessage);
+    if (confirmRemoval) {
+      console.log('Confirm removal of account');
+      await this.driver.clickElement(this.removeAccountConfirmButton);
+    } else {
+      console.log('Click nevermind button to cancel account removal');
+      await this.driver.clickElement(this.removeAccountNevermindButton);
+    }
+  }
+
   async selectAccount(accountLabel: string): Promise<void> {
     console.log(`Select account with label ${accountLabel} in account list`);
     await this.driver.clickElement({
       text: accountLabel,
     });
     console.log(`Account with label ${accountLabel} selected`);
+  }
+
+  async startExportSrpForAccount(accountLabel: string): Promise<void> {
+    console.log(`Exporting SRP for account ${accountLabel}`);
+    await this.openAccountDetailsModal(accountLabel);
+    await this.driver.delay(500);
+    await this.driver.clickElement(this.exportSrpButton);
   }
 
   async startImportSecretPhrase(srp: string): Promise<void> {
@@ -929,72 +946,48 @@ class AccountListPage {
     await this.driver.clickElement(this.importSrpConfirmButton);
   }
 
-  async startExportSrpForAccount(accountLabel: string): Promise<void> {
-    console.log(`Exporting SRP for account ${accountLabel}`);
-    await this.openAccountDetailsModal(accountLabel);
-    await this.driver.delay(500);
-    await this.driver.clickElement(this.exportSrpButton);
-  }
-
-  async checkAccountBelongsToSrp(
-    accountName: string,
-    srpIndex: number,
-  ): Promise<void> {
-    console.log(`Check that current account is an imported account`);
-    await new HeaderNavbar(this.driver).openSettingsPage();
-    const settingsPage = new SettingsPage(this.driver);
-    await settingsPage.checkPageIsLoaded();
-    await settingsPage.goToSecurityAndPasswordSettings();
-
-    const privacySettings = new PrivacySettings(this.driver);
-    await privacySettings.checkSecurityAndPasswordPageIsLoaded();
-    await privacySettings.openSrpList();
-
-    if (srpIndex === 0) {
-      throw new Error('SRP index must be > 0');
-    }
-
-    const selectedSrp = await this.driver.waitForSelector({
-      css: '.select-srp__container',
-      text: `Secret Recovery Phrase ${srpIndex}`,
-    });
-    const showAccountsButton = await this.driver.waitForSelector(
-      `[data-testid="srp-list-show-accounts-${srpIndex - 1}"]`,
-    );
-    await showAccountsButton.click();
-
-    await this.driver.findNestedElement(selectedSrp, {
-      text: accountName,
-      tag: 'p',
-    });
-  }
-
-  async checkAccountNameIsDisplayed(accountName: string): Promise<void> {
-    console.log(`Check that account name ${accountName} is displayed`);
-    await this.driver.waitForSelector({
-      text: accountName,
-      tag: 'p',
-    });
-  }
-
-  async checkAccountNameIsDisplayedUnderWallet(
-    accountName: string,
-    walletName: string,
-  ): Promise<void> {
+  async switchToAccount(expectedLabel: string): Promise<void> {
     console.log(
-      `Check that account name ${accountName} is displayed under wallet ${walletName}`,
+      `Switch to account with label ${expectedLabel} in account list`,
     );
-    const walletHeader = await this.driver.waitForSelector({
-      css: this.walletHeader,
-      text: walletName,
+    await this.driver.clickElement({
+      css: this.accountListItem,
+      text: expectedLabel,
     });
-    // VirtualizedList wraps each item in a div, so the header and account rows are not direct
-    // siblings—each is the only child of its wrapper div. Go to the header's parent (the wrapper),
-    // then to that parent's first following sibling (the next item's wrapper), and find the account name inside it.
-    // Use . (string value) instead of text() so we match the element that contains the text in any descendant.
-    await this.driver.findNestedElement(walletHeader, {
-      xpath: `../following-sibling::*[1]//*[contains(., ${quoteXPathText(accountName)})]`,
-    });
+  }
+
+  async unhideAccount(): Promise<void> {
+    console.log(`Unhide account in account list`);
+    await this.openAccountOptionsMenu();
+    await this.driver.clickElement(this.unhideAccountButton);
+  }
+
+  async unpinAccount(): Promise<void> {
+    console.log(`Unpin account in account list`);
+    await this.openAccountOptionsMenu();
+    await this.driver.clickElement(this.unpinAccountButton);
+  }
+
+  /**
+   * View the account on explorer for the specified account in account list.
+   *
+   * @param accountLabel - The label of the account to view on explorer.
+   */
+  async viewAccountOnExplorer(accountLabel: string): Promise<void> {
+    console.log(
+      `View account on explorer in account list for account ${accountLabel}`,
+    );
+    await this.openAccountOptionsInAccountList(accountLabel);
+    await this.driver.clickElement(this.viewAccountOnExplorerButton);
+  }
+
+  /**
+   * Waiting until syncing is completed.
+   */
+  async waitUntilSyncingIsCompleted(): Promise<void> {
+    console.log(`Check that account syncing not displayed in account list`);
+    await this.checkAddWalletButtonIsDisplayed();
+    await this.driver.assertElementNotPresent(this.syncingMessage);
   }
 }
 

--- a/test/e2e/tests/account/account-hide-unhide.spec.ts
+++ b/test/e2e/tests/account/account-hide-unhide.spec.ts
@@ -7,8 +7,7 @@ import AccountListPage from '../../page-objects/pages/account-list-page';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
 
 // Hide/unhide is not available in BIP44 stage 2
-// eslint-disable-next-line
-describe.skip('Account list - hide/unhide functionality', function (this: Suite) {
+describe('Account list - hide/unhide functionality', function (this: Suite) {
   it('hide and unhide account by clicking hide and unhide button', async function () {
     await withFixtures(
       {
@@ -22,13 +21,11 @@ describe.skip('Account list - hide/unhide functionality', function (this: Suite)
         // hide account
         const accountListPage = new AccountListPage(driver);
         await accountListPage.checkPageIsLoaded();
-        await accountListPage.openAccountOptionsMenu();
         await accountListPage.hideAccount();
         await accountListPage.checkHiddenAccountsListExists();
 
         // unhide account
         await accountListPage.openHiddenAccountsList();
-        await accountListPage.openHiddenAccountOptions();
         await accountListPage.unhideAccount();
         await accountListPage.checkAccountDisplayedInAccountList();
       },

--- a/test/e2e/tests/account/account-pin-unpin.spec.ts
+++ b/test/e2e/tests/account/account-pin-unpin.spec.ts
@@ -7,8 +7,7 @@ import AccountListPage from '../../page-objects/pages/account-list-page';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
 
 // Pin/unpin is not available in BIP44 stage 2
-// eslint-disable-next-line
-describe.skip('Account list - pin/unpin functionality', function (this: Suite) {
+describe('Account list - pin/unpin functionality', function (this: Suite) {
   it('pin and unpin account by clicking the pin/unpin button', async function () {
     await withFixtures(
       {
@@ -22,12 +21,10 @@ describe.skip('Account list - pin/unpin functionality', function (this: Suite) {
         // pin account
         const accountListPage = new AccountListPage(driver);
         await accountListPage.checkPageIsLoaded();
-        await accountListPage.openAccountOptionsMenu();
         await accountListPage.pinAccount();
         await accountListPage.checkAccountIsPinned();
 
         // unpin account
-        await accountListPage.openAccountOptionsMenu();
         await accountListPage.unpinAccount();
         await accountListPage.checkAccountIsUnpinned();
       },
@@ -47,19 +44,16 @@ describe.skip('Account list - pin/unpin functionality', function (this: Suite) {
         // pin account
         const accountListPage = new AccountListPage(driver);
         await accountListPage.checkPageIsLoaded();
-        await accountListPage.openAccountOptionsMenu();
         await accountListPage.pinAccount();
         await accountListPage.checkAccountIsPinned();
 
         // hide the same account and check the account is unpinned automatically
-        await accountListPage.openAccountOptionsMenu();
         await accountListPage.hideAccount();
         await accountListPage.checkHiddenAccountsListExists();
         await accountListPage.checkAccountIsUnpinned();
 
         // unhide the same account and check the account is still unpinned
         await accountListPage.openHiddenAccountsList();
-        await accountListPage.openHiddenAccountOptions();
         await accountListPage.unhideAccount();
         await accountListPage.checkAccountDisplayedInAccountList();
         await accountListPage.checkAccountIsUnpinned();


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Re-enables 2 disabled spec files, due to old selectors and methods.
Updates the page object accordingly.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-1854 and https://consensyssoftware.atlassian.net/browse/MMQA-1856

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to E2E page objects and specs; no application or wallet logic is modified.
> 
> **Overview**
> Re-enables **account hide/unhide** and **pin/unpin** E2E suites by removing `describe.skip` and aligning flows with the multichain account list UI.
> 
> The `AccountListPage` object is updated to use multichain `data-testid`s (options menu on `multichain-account-cell-end-accessory`, hide/show/pin/unpin menu items, hidden and pinned section headers). **Hide, unhide, pin, and unpin** helpers now open the account options menu before clicking the action, and pinned state is asserted via the **pinned tree header** instead of a per-account icon. Specs drop redundant manual menu steps that those helpers now cover.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a41dc13505a0d78a27d5b52b9d2aef7c27396f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->