### PR TITLE
feat(confirmations): update MM Pay token picker layout to match mobile

### DIFF
--- a/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -156,6 +156,7 @@ export const CustomAmountInfo = React.memo(
         >
           {children}
         </CenterContainer>
+        <AlertMessage />
         {overrideBottomContent ?? (
           <BottomContainer
             amountFiat={amountFiat}
@@ -291,7 +292,6 @@ function BottomContainer({
       gap={2}
       paddingBottom={4}
     >
-      <AlertMessage />
       {disablePay !== true && hasTokens && <PayWithRow />}
       {isResultReady && !hideResults && (
         <>

--- a/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
+++ b/ui/pages/confirmations/components/info/custom-amount-info/custom-amount-info.tsx
@@ -1,6 +1,5 @@
 import React, { ReactNode, useCallback } from 'react';
 import type { TransactionMeta } from '@metamask/transaction-controller';
-import { TransactionType } from '@metamask/transaction-controller';
 import { Box, Text } from '../../../../../components/component-library';
 import {
   Display,
@@ -157,7 +156,13 @@ export const CustomAmountInfo = React.memo(
         >
           {children}
         </CenterContainer>
-        {overrideBottomContent ?? <BottomContainer amountFiat={amountFiat} />}
+        {overrideBottomContent ?? (
+          <BottomContainer
+            amountFiat={amountFiat}
+            disablePay={disablePay}
+            hasTokens={hasTokens}
+          />
+        )}
       </Box>
     );
   },
@@ -172,6 +177,7 @@ export function CustomAmountInfoSkeleton() {
       data-testid="custom-amount-info-skeleton"
     >
       <CenterContainerSkeleton />
+      <PayWithRowSkeleton />
     </Box>
   );
 }
@@ -235,16 +241,12 @@ function CenterContainer({
             <PayTokenAmount amountHuman={amountHuman} disabled={!hasTokens} />
           )}
           {children}
-          {disablePay !== true && hasTokens && (
-            <PayWithRow variant={ConfirmInfoRowSize.Small} />
-          )}
         </Box>
       )}
 
       {hasTokens && hasMax && (
         <PercentageButtons onPercentageClick={onPercentageClick} />
       )}
-      <AlertMessage />
     </Box>
   );
 }
@@ -260,31 +262,27 @@ function CenterContainerSkeleton() {
       style={{ flex: 1 }}
     >
       <CustomAmountSkeleton />
-      <Box
-        display={Display.Flex}
-        flexDirection={FlexDirection.Column}
-        alignItems={AlignItems.center}
-        gap={2}
-      >
-        <PayTokenAmountSkeleton />
-        <PayWithRowSkeleton />
-      </Box>
+      <PayTokenAmountSkeleton />
       <PercentageButtonsSkeleton />
     </Box>
   );
 }
 
-function BottomContainer({ amountFiat }: { amountFiat: string }) {
+function BottomContainer({
+  amountFiat,
+  disablePay,
+  hasTokens,
+}: {
+  amountFiat: string;
+  disablePay?: boolean;
+  hasTokens: boolean;
+}) {
   const t = useI18nContext();
   const isResultReady = useIsResultReady();
   const { hideResults } = useTransactionCustomAmountAlerts();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
 
   const isPerpsWithdraw = isPerpsWithdrawTransaction(currentConfirmation);
-
-  if (!isResultReady || hideResults) {
-    return null;
-  }
 
   return (
     <Box
@@ -293,20 +291,26 @@ function BottomContainer({ amountFiat }: { amountFiat: string }) {
       gap={2}
       paddingBottom={4}
     >
-      <BridgeFeeRow
-        variant={ConfirmInfoRowSize.Small}
-        tooltipDescription={
-          isPerpsWithdraw ? t('perpsWithdrawTooltip') : undefined
-        }
-      />
-      <BridgeTimeRow rowVariant={ConfirmInfoRowSize.Small} />
-      {isPerpsWithdraw ? (
-        <ReceiveRow
-          inputAmountUsd={amountFiat}
-          variant={ConfirmInfoRowSize.Small}
-        />
-      ) : (
-        <TotalRow variant={ConfirmInfoRowSize.Small} />
+      <AlertMessage />
+      {disablePay !== true && hasTokens && <PayWithRow />}
+      {isResultReady && !hideResults && (
+        <>
+          <BridgeFeeRow
+            variant={ConfirmInfoRowSize.Small}
+            tooltipDescription={
+              isPerpsWithdraw ? t('perpsWithdrawTooltip') : undefined
+            }
+          />
+          <BridgeTimeRow rowVariant={ConfirmInfoRowSize.Small} />
+          {isPerpsWithdraw ? (
+            <ReceiveRow
+              inputAmountUsd={amountFiat}
+              variant={ConfirmInfoRowSize.Small}
+            />
+          ) : (
+            <TotalRow variant={ConfirmInfoRowSize.Small} />
+          )}
+        </>
       )}
     </Box>
   );

--- a/ui/pages/confirmations/components/info/musd-conversion-info/musd-override-content.tsx
+++ b/ui/pages/confirmations/components/info/musd-conversion-info/musd-override-content.tsx
@@ -18,6 +18,7 @@ import {
 import { useTransactionPayAvailableTokens } from '../../../hooks/pay/useTransactionPayAvailableTokens';
 import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
 import {
+  ConfirmInfoRowSize,
   PayWithRow,
   PayWithRowSkeleton,
 } from '../../rows/pay-with-row/pay-with-row';
@@ -61,7 +62,7 @@ export const MusdOverrideContent = ({
         />
       )}
       {hasTokens && payToken ? (
-        <PayWithRow />
+        <PayWithRow variant={ConfirmInfoRowSize.Small} />
       ) : (
         <PayWithRowSkeleton />
       )}

--- a/ui/pages/confirmations/components/info/musd-conversion-info/musd-override-content.tsx
+++ b/ui/pages/confirmations/components/info/musd-conversion-info/musd-override-content.tsx
@@ -18,7 +18,6 @@ import {
 import { useTransactionPayAvailableTokens } from '../../../hooks/pay/useTransactionPayAvailableTokens';
 import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToken';
 import {
-  ConfirmInfoRowSize,
   PayWithRow,
   PayWithRowSkeleton,
 } from '../../rows/pay-with-row/pay-with-row';
@@ -62,7 +61,7 @@ export const MusdOverrideContent = ({
         />
       )}
       {hasTokens && payToken ? (
-        <PayWithRow variant={ConfirmInfoRowSize.Small} />
+        <PayWithRow />
       ) : (
         <PayWithRowSkeleton />
       )}

--- a/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
@@ -317,7 +317,6 @@ describe('PayWithRow', () => {
       expect(screen.queryByTestId('pay-with-arrow')).not.toBeInTheDocument();
     });
   });
-
 });
 
 describe('PayWithRowSkeleton', () => {

--- a/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
@@ -10,19 +10,13 @@ import { useSendTokens } from '../../../hooks/send/useSendTokens';
 import { useConfirmContext } from '../../../context/confirm';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0021): route-isolation backlog
 import { isHardwareAccount } from '../../../../multichain-accounts/account-details/account-type-utils';
-import { useFiatFormatter } from '../../../../../hooks/useFiatFormatter';
-import {
-  PayWithRow,
-  PayWithRowSkeleton,
-  ConfirmInfoRowSize,
-} from './pay-with-row';
+import { PayWithRow, PayWithRowSkeleton } from './pay-with-row';
 
 jest.mock('../../../hooks/pay/useTransactionPayToken');
 jest.mock('../../../hooks/pay/useTransactionPayData');
 jest.mock('../../../hooks/send/useSendTokens');
 jest.mock('../../../context/confirm');
 jest.mock('../../../../multichain-accounts/account-details/account-type-utils');
-jest.mock('../../../../../hooks/useFiatFormatter');
 
 jest.mock(
   '../../../../../components/app/alert-system/contexts/alertMetricsContext',
@@ -142,14 +136,9 @@ describe('PayWithRow', () => {
   const useSendTokensMock = jest.mocked(useSendTokens);
   const useConfirmContextMock = jest.mocked(useConfirmContext);
   const isHardwareAccountMock = jest.mocked(isHardwareAccount);
-  const useFiatFormatterMock = jest.mocked(useFiatFormatter);
 
   beforeEach(() => {
     jest.resetAllMocks();
-
-    useFiatFormatterMock.mockReturnValue(
-      (value: number) => `$${value.toFixed(2)}`,
-    );
 
     useSendTokensMock.mockReturnValue([]);
     useTransactionPayRequiredTokensMock.mockReturnValue([]);
@@ -329,75 +318,6 @@ describe('PayWithRow', () => {
     });
   });
 
-  describe('Small variant (pill)', () => {
-    it('renders pill container', () => {
-      const store = mockStore(getMockState());
-      renderWithProvider(
-        <PayWithRow variant={ConfirmInfoRowSize.Small} />,
-        store,
-      );
-
-      expect(screen.getByTestId('pay-with-row')).toBeInTheDocument();
-    });
-
-    it('formats balance in USD regardless of user currency', () => {
-      const store = mockStore(getMockState());
-      renderWithProvider(
-        <PayWithRow variant={ConfirmInfoRowSize.Small} />,
-        store,
-      );
-
-      expect(useFiatFormatterMock).toHaveBeenCalledWith({
-        overrideCurrency: 'usd',
-      });
-    });
-
-    it('renders balance display', () => {
-      const store = mockStore(getMockState());
-      renderWithProvider(
-        <PayWithRow variant={ConfirmInfoRowSize.Small} />,
-        store,
-      );
-
-      expect(screen.getByTestId('pay-with-balance')).toHaveTextContent(
-        '$150.00',
-      );
-    });
-
-    it('renders pay with text inside symbol text', () => {
-      const store = mockStore(getMockState());
-      renderWithProvider(
-        <PayWithRow variant={ConfirmInfoRowSize.Small} />,
-        store,
-      );
-
-      expect(screen.getByTestId('pay-with-symbol')).toHaveTextContent(
-        'Pay with ETH',
-      );
-    });
-
-    it('shows arrow icon when editable', () => {
-      const store = mockStore(getMockState());
-      renderWithProvider(
-        <PayWithRow variant={ConfirmInfoRowSize.Small} />,
-        store,
-      );
-
-      expect(screen.getByTestId('pay-with-arrow')).toBeInTheDocument();
-    });
-
-    it('hides arrow icon for hardware account', () => {
-      isHardwareAccountMock.mockReturnValue(true);
-
-      const store = mockStore(getMockState());
-      renderWithProvider(
-        <PayWithRow variant={ConfirmInfoRowSize.Small} />,
-        store,
-      );
-
-      expect(screen.queryByTestId('pay-with-arrow')).not.toBeInTheDocument();
-    });
-  });
 });
 
 describe('PayWithRowSkeleton', () => {

--- a/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -1,8 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useState } from 'react';
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { useSelector } from 'react-redux';
-import { BigNumber } from 'bignumber.js';
 import { isPerpsWithdrawTransaction } from '../../../../../../shared/lib/transactions.utils';
 
 import {
@@ -22,13 +21,9 @@ import {
   BorderRadius,
   Display,
   FlexDirection,
-  IconColor,
   JustifyContent,
-  TextColor,
-  TextVariant,
 } from '../../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
-import { useFiatFormatter } from '../../../../../hooks/useFiatFormatter';
 import { getInternalAccountByAddress } from '../../../../../selectors/accounts';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0021): route-isolation backlog
 import { isHardwareAccount } from '../../../../multichain-accounts/account-details/account-type-utils';
@@ -37,8 +32,6 @@ import { useTransactionPayToken } from '../../../hooks/pay/useTransactionPayToke
 import { useTransactionPayRequiredTokens } from '../../../hooks/pay/useTransactionPayData';
 import { PayWithModal } from '../../modals/pay-with-modal';
 import { TokenIcon } from '../../token-icon';
-
-export { ConfirmInfoRowSize };
 
 type PayWithRowContentProps = {
   displayToken: {
@@ -53,13 +46,7 @@ type PayWithRowContentProps = {
   isPerpsWithdraw: boolean;
 };
 
-type PayWithRowPillProps = PayWithRowContentProps & {
-  balanceUsdFormatted: string;
-};
-
-export type PayWithRowProps = {
-  variant?: ConfirmInfoRowSize;
-};
+export type PayWithRowProps = Record<string, never>;
 
 export const PayWithRowSkeleton = () => {
   return (
@@ -84,13 +71,10 @@ export const PayWithRowSkeleton = () => {
   );
 };
 
-export function PayWithRow({
-  variant = ConfirmInfoRowSize.Default,
-}: PayWithRowProps) {
+export function PayWithRow() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { payToken } = useTransactionPayToken();
   const requiredTokens = useTransactionPayRequiredTokens();
-  const fiatFormatter = useFiatFormatter({ overrideCurrency: 'usd' });
 
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const from = currentConfirmation?.txParams?.from;
@@ -117,12 +101,6 @@ export function PayWithRow({
   const displayToken =
     payToken ?? (isPerpsWithdraw ? undefined : firstRequiredToken);
 
-  const balanceUsdFormatted = useMemo(
-    () =>
-      fiatFormatter(new BigNumber(displayToken?.balanceUsd ?? '0').toNumber()),
-    [fiatFormatter, displayToken?.balanceUsd],
-  );
-
   if (!displayToken?.chainId) {
     if (isPerpsWithdraw) {
       return <PayWithRowSkeleton />;
@@ -130,37 +108,24 @@ export function PayWithRow({
     return null;
   }
 
-  const contentProps: PayWithRowContentProps = {
-    displayToken: {
-      chainId: displayToken.chainId,
-      address: displayToken.address,
-      symbol: displayToken.symbol,
-      balanceUsd: displayToken.balanceUsd,
-    },
-    canEdit,
-    from,
-    onOpenModal: handleOpenModal,
-    isPerpsWithdraw,
-  };
-
-  const isSmall = variant === ConfirmInfoRowSize.Small;
-
   return (
     <>
       {isModalOpen && (
         <PayWithModal isOpen={isModalOpen} onClose={handleCloseModal} />
       )}
-      {isSmall ? (
-        <PayWithRowPill
-          {...contentProps}
-          balanceUsdFormatted={balanceUsdFormatted}
-        />
-      ) : (
-        <PayWithRowInline
-          {...contentProps}
-          ownerId={currentConfirmation?.id ?? ''}
-        />
-      )}
+      <PayWithRowInline
+        displayToken={{
+          chainId: displayToken.chainId,
+          address: displayToken.address,
+          symbol: displayToken.symbol,
+          balanceUsd: displayToken.balanceUsd,
+        }}
+        canEdit={canEdit}
+        from={from}
+        onOpenModal={handleOpenModal}
+        isPerpsWithdraw={isPerpsWithdraw}
+        ownerId={currentConfirmation?.id ?? ''}
+      />
     </>
   );
 }
@@ -181,7 +146,7 @@ function PayWithRowInline({
       ownerId={ownerId}
       data-testid="pay-with-row"
       label={isPerpsWithdraw ? t('withdrawTo') : t('payWith')}
-      rowVariant={ConfirmInfoRowSize.Default}
+      rowVariant={ConfirmInfoRowSize.Small}
     >
       <Box
         data-testid="pay-with-pill"
@@ -225,62 +190,4 @@ function PayWithRowInline({
   );
 }
 
-function PayWithRowPill({
-  displayToken,
-  balanceUsdFormatted,
-  canEdit,
-  from,
-  onOpenModal,
-  isPerpsWithdraw,
-}: PayWithRowPillProps) {
-  const t = useI18nContext();
 
-  return (
-    <Box
-      data-testid="pay-with-row"
-      onClick={canEdit ? onOpenModal : undefined}
-      backgroundColor={BackgroundColor.backgroundAlternative}
-      borderRadius={BorderRadius.pill}
-      display={Display.Flex}
-      flexDirection={FlexDirection.Row}
-      alignItems={AlignItems.center}
-      justifyContent={JustifyContent.center}
-      gap={3}
-      paddingTop={2}
-      paddingBottom={2}
-      paddingLeft={2}
-      paddingRight={4}
-      style={{
-        cursor: canEdit ? 'pointer' : 'default',
-      }}
-    >
-      <TokenIcon
-        chainId={displayToken.chainId as `0x${string}`}
-        tokenAddress={displayToken.address as `0x${string}`}
-        symbol={displayToken.symbol}
-      />
-      <Text
-        variant={TextVariant.bodyMdMedium}
-        color={TextColor.textDefault}
-        data-testid="pay-with-symbol"
-      >
-        {`${isPerpsWithdraw ? t('withdrawTo') : t('payWith')} ${displayToken.symbol}`}
-      </Text>
-      <Text
-        variant={TextVariant.bodyMdMedium}
-        color={TextColor.textAlternative}
-        data-testid="pay-with-balance"
-      >
-        {balanceUsdFormatted}
-      </Text>
-      {canEdit && from && (
-        <Icon
-          data-testid="pay-with-arrow"
-          name={IconName.ArrowDown}
-          size={IconSize.Sm}
-          color={IconColor.iconAlternative}
-        />
-      )}
-    </Box>
-  );
-}

--- a/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -33,6 +33,8 @@ import { useTransactionPayRequiredTokens } from '../../../hooks/pay/useTransacti
 import { PayWithModal } from '../../modals/pay-with-modal';
 import { TokenIcon } from '../../token-icon';
 
+export { ConfirmInfoRowSize };
+
 type PayWithRowContentProps = {
   displayToken: {
     chainId: string;
@@ -46,7 +48,9 @@ type PayWithRowContentProps = {
   isPerpsWithdraw: boolean;
 };
 
-export type PayWithRowProps = Record<string, never>;
+export type PayWithRowProps = {
+  variant?: ConfirmInfoRowSize;
+};
 
 export const PayWithRowSkeleton = () => {
   return (
@@ -71,7 +75,9 @@ export const PayWithRowSkeleton = () => {
   );
 };
 
-export function PayWithRow() {
+export function PayWithRow({
+  variant = ConfirmInfoRowSize.Small,
+}: PayWithRowProps = {}) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { payToken } = useTransactionPayToken();
   const requiredTokens = useTransactionPayRequiredTokens();
@@ -125,6 +131,7 @@ export function PayWithRow() {
         onOpenModal={handleOpenModal}
         isPerpsWithdraw={isPerpsWithdraw}
         ownerId={currentConfirmation?.id ?? ''}
+        rowVariant={variant}
       />
     </>
   );
@@ -137,7 +144,11 @@ function PayWithRowInline({
   onOpenModal,
   ownerId,
   isPerpsWithdraw,
-}: PayWithRowContentProps & { ownerId: string }) {
+  rowVariant,
+}: PayWithRowContentProps & {
+  ownerId: string;
+  rowVariant: ConfirmInfoRowSize;
+}) {
   const t = useI18nContext();
 
   return (
@@ -146,7 +157,7 @@ function PayWithRowInline({
       ownerId={ownerId}
       data-testid="pay-with-row"
       label={isPerpsWithdraw ? t('withdrawTo') : t('payWith')}
-      rowVariant={ConfirmInfoRowSize.Small}
+      rowVariant={rowVariant}
     >
       <Box
         data-testid="pay-with-pill"
@@ -189,5 +200,3 @@ function PayWithRowInline({
     </ConfirmInfoAlertRow>
   );
 }
-
-


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The MM Pay token picker on extension used a centered pill layout (`Pay with USDC · $750.00`) with error messages displayed below it. Mobile has already moved to an inline row layout with errors shown above the token picker, matching the updated Figma designs.

This PR restructures the `CustomAmountInfo` layout to match mobile:

- **Alert messages** now render above the token picker and quote card rows (previously below the percentage buttons)
- **PayWithRow** moves from the centered input area into the bottom quote card section alongside fee/time/total rows
- **PayWithRowPill** (the old centered pill variant) is removed — only the inline row style remains
- The `variant` prop on `PayWithRow` is removed since all consumers now use the same inline layout

These changes affect all flows using `CustomAmountInfo`: Perps Deposit, Perps Withdraw, and mUSD Conversion.


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Updated MM Pay token picker to use inline row layout with error messages shown above the payment details


## **Related issues**

Fixes:  https://consensyssoftware.atlassian.net/browse/CONF-1183

## **Manual testing steps**

1. Open the extension and navigate to a Perps Deposit flow (or trigger via developer tools)
2. Verify the token picker renders as an inline row (`Pay with` label on the left, token + arrow on the right) below the amount input area, alongside the fee rows
3. Enter an amount that triggers a validation error — verify the error message appears **above** the token picker row, not below the percentage buttons
4. Navigate to a Perps Withdraw flow — verify the "Receive" row renders inline with no extra vertical margins
5. Navigate to an mUSD Conversion flow — verify the PayWithRow renders inline


## **Screenshots/Recordings**

[Screencast from 2026-06-08 14-02-01.webm](https://github.com/user-attachments/assets/4eb25d3d-6523-4fab-a538-309758f5b2d6)


<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Confirmation-screen layout and component restructuring only; no changes to transaction signing, auth, or payment execution logic.
> 
> **Overview**
> Restructures **MM Pay** `CustomAmountInfo` to align extension confirmations with mobile/Figma: validation **alerts sit above** the bottom quote section, and **`PayWithRow` moves out of the centered amount area** into `BottomContainer` with bridge fee/time/total (or receive) rows.
> 
> **`PayWithRow`** drops the standalone centered **pill** layout (`PayWithRowPill`, USD balance in the pill, `useFiatFormatter`) and always renders the **inline** `ConfirmInfoAlertRow` style; default row size is **`Small`**. Loading skeletons follow the new placement (pay-with skeleton at the bottom, not under the amount). Fee rows still gate on quote readiness; the pay-with row can show even when quotes are not ready yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce8a0e85e70fb3bb88fc5dd69ce4b7719cc4405b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->