### PR TITLE
fix: handle scientific notation in parseBalanceWithDecimals to prevent BigInt crash cp-13.34.1

### DIFF
--- a/shared/lib/selectors/assets-migration.test.ts
+++ b/shared/lib/selectors/assets-migration.test.ts
@@ -317,6 +317,105 @@ describe('getAccountTrackerControllerAccountsByChainId', () => {
       // 1.23456 with 2 decimals → truncated to 1.23 → 123
       expect(result['0x1'][mockAccountAddressChecksummed].balance).toBe('0x7b');
     });
+
+    it('does not crash when amount is in scientific notation (e.g. "1e-18")', () => {
+      const state = {
+        metamask: {
+          ...enabledFlags,
+          accountsByChainId: {},
+          assetsInfo: {
+            [nativeEthAssetId]: { type: 'native', decimals: 18 },
+          },
+          assetsBalance: {
+            [mockAccountId]: {
+              [nativeEthAssetId]: { amount: '1e-18' },
+            },
+          },
+          internalAccounts: {
+            accounts: {
+              [mockAccountId]: {
+                id: mockAccountId,
+                address: mockAccountAddressLowercase,
+                type: 'eip155:eoa',
+              },
+            },
+          },
+        },
+      };
+
+      // Should not throw — 1e-18 ETH = 1 wei = 0x1
+      expect(() =>
+        getAccountTrackerControllerAccountsByChainId(state),
+      ).not.toThrow();
+      const result = getAccountTrackerControllerAccountsByChainId(state);
+      expect(result['0x1'][mockAccountAddressChecksummed].balance).toBe('0x1');
+    });
+
+    it('does not crash when amount has absurd scientific notation exponent (e.g. "1e-18000000000000000000")', () => {
+      const state = {
+        metamask: {
+          ...enabledFlags,
+          accountsByChainId: {},
+          assetsInfo: {
+            [nativeEthAssetId]: { type: 'native', decimals: 18 },
+          },
+          assetsBalance: {
+            [mockAccountId]: {
+              [nativeEthAssetId]: { amount: '1e-18000000000000000000' },
+            },
+          },
+          internalAccounts: {
+            accounts: {
+              [mockAccountId]: {
+                id: mockAccountId,
+                address: mockAccountAddressLowercase,
+                type: 'eip155:eoa',
+              },
+            },
+          },
+        },
+      };
+
+      // Should not throw — value is sub-unit, rounds to 0x0
+      expect(() =>
+        getAccountTrackerControllerAccountsByChainId(state),
+      ).not.toThrow();
+      const result = getAccountTrackerControllerAccountsByChainId(state);
+      expect(result['0x1'][mockAccountAddressChecksummed].balance).toBe('0x0');
+    });
+
+    it('correctly parses positive scientific notation (e.g. "1.5e2" with 2 decimals)', () => {
+      const state = {
+        metamask: {
+          ...enabledFlags,
+          accountsByChainId: {},
+          assetsInfo: {
+            [nativeEthAssetId]: { type: 'native', decimals: 2 },
+          },
+          assetsBalance: {
+            [mockAccountId]: {
+              [nativeEthAssetId]: { amount: '1.5e2' },
+            },
+          },
+          internalAccounts: {
+            accounts: {
+              [mockAccountId]: {
+                id: mockAccountId,
+                address: mockAccountAddressLowercase,
+                type: 'eip155:eoa',
+              },
+            },
+          },
+        },
+      };
+
+      // 1.5e2 = 150 human-readable, with 2 decimals → 15000 base units = 0x3a98
+      expect(() =>
+        getAccountTrackerControllerAccountsByChainId(state),
+      ).not.toThrow();
+      const result = getAccountTrackerControllerAccountsByChainId(state);
+      expect(result['0x1'][mockAccountAddressChecksummed].balance).toBe('0x3a98');
+    });
   });
 });
 

--- a/shared/lib/selectors/assets-migration.test.ts
+++ b/shared/lib/selectors/assets-migration.test.ts
@@ -1,11 +1,11 @@
-import { getNativeAssetForChainId } from "@metamask/bridge-controller";
-import { toChecksumHexAddress } from "@metamask/controller-utils";
-import type { CaipAssetType, Hex } from "@metamask/utils";
+import { getNativeAssetForChainId } from '@metamask/bridge-controller';
+import { toChecksumHexAddress } from '@metamask/controller-utils';
+import type { CaipAssetType, Hex } from '@metamask/utils';
 import {
   ASSETS_UNIFY_STATE_FLAG,
   ASSETS_UNIFY_STATE_VERSION_1,
-} from "../assets-unify-state/remote-feature-flag";
-import { getIsAssetsUnifiedStateIncludedInBuild } from "../environment";
+} from '../assets-unify-state/remote-feature-flag';
+import { getIsAssetsUnifiedStateIncludedInBuild } from '../environment';
 import {
   getAccountTrackerControllerAccountsByChainId,
   getTokensControllerAllTokens,
@@ -21,45 +21,57 @@ import {
   getMultichainAssetsRatesControllerConversionRates,
   getRatesControllerRates,
   getRatesControllerFiatCurrency,
-} from "./assets-migration";
+} from './assets-migration';
 
 // Opt out of the global `isAssetsUnifyStateFeatureEnabled` mock (see test/jest/setup.js)
 // and provide the pure flag-evaluation logic without the IN_TEST bypass
 // (test/helpers/setup-helper.js sets process.env.IN_TEST=true for all unit tests,
 // so using jest.requireActual here would make the function always return true,
 // breaking all "when disabled" test cases).
-jest.mock("../assets-unify-state/remote-feature-flag", () => ({
-  ...jest.requireActual("../assets-unify-state/remote-feature-flag"),
+jest.mock('../assets-unify-state/remote-feature-flag', () => ({
+  ...jest.requireActual('../assets-unify-state/remote-feature-flag'),
   isAssetsUnifyStateFeatureEnabled: jest.fn(
     (
-      featureFlag: { enabled: boolean; featureVersion: string } | undefined | null,
+      featureFlag:
+        | { enabled: boolean; featureVersion: string }
+        | undefined
+        | null,
       featureVersion: string,
-    ) => Boolean(featureFlag?.enabled) && featureFlag?.featureVersion === featureVersion,
+    ) =>
+      Boolean(featureFlag?.enabled) &&
+      featureFlag?.featureVersion === featureVersion,
   ),
 }));
 
-jest.mock("../environment", () => ({
-  ...jest.requireActual("../environment"),
+jest.mock('../environment', () => ({
+  ...jest.requireActual('../environment'),
   getIsAssetsUnifiedStateIncludedInBuild: jest.fn(() => true),
 }));
 
-const mockAccountId = "mock-account-id-1";
-const mockAccountId2 = "mock-account-id-2";
+const mockAccountId = 'mock-account-id-1';
+const mockAccountId2 = 'mock-account-id-2';
 
-const mockAccountAddressLowercase: Hex = "0xd8da6bf26964af9d7eed9e03e53415d37aa96045";
-const mockAccountAddressChecksummed = toChecksumHexAddress(mockAccountAddressLowercase) as Hex;
+const mockAccountAddressLowercase: Hex =
+  '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
+const mockAccountAddressChecksummed = toChecksumHexAddress(
+  mockAccountAddressLowercase,
+) as Hex;
 
-const nativeEthAssetId = "eip155:1/slip44:60";
-const erc20AssetAddressLowercase: Hex = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
-const erc20AssetAddressChecksummed = toChecksumHexAddress(erc20AssetAddressLowercase) as Hex;
+const nativeEthAssetId = 'eip155:1/slip44:60';
+const erc20AssetAddressLowercase: Hex =
+  '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
+const erc20AssetAddressChecksummed = toChecksumHexAddress(
+  erc20AssetAddressLowercase,
+) as Hex;
 const erc20AssetId = `eip155:1/erc20:${erc20AssetAddressLowercase}`;
 const solanaTokenAssetId =
-  "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
+  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
 
-const nativePolygonAssetId = "eip155:137/slip44:966";
-const bitcoinNativeAssetId = "bip122:000000000019d6689c085ae165831e93/slip44:0";
-const mockAccountId3 = "mock-account-id-3";
-const mockAccountAddressLowercase2: Hex = "0x1234567890abcdef1234567890abcdef12345678";
+const nativePolygonAssetId = 'eip155:137/slip44:966';
+const bitcoinNativeAssetId = 'bip122:000000000019d6689c085ae165831e93/slip44:0';
+const mockAccountId3 = 'mock-account-id-3';
+const mockAccountAddressLowercase2: Hex =
+  '0x1234567890abcdef1234567890abcdef12345678';
 const enabledFlags = {
   remoteFeatureFlags: {
     [ASSETS_UNIFY_STATE_FLAG]: {
@@ -71,8 +83,8 @@ const enabledFlags = {
 
 function makeMockPrice(overrides: Partial<Record<string, unknown>> = {}) {
   return {
-    assetPriceType: "fungible",
-    id: "mock-price",
+    assetPriceType: 'fungible',
+    id: 'mock-price',
     price: 1,
     lastUpdated: 1700000000000,
     marketCap: 0,
@@ -96,9 +108,9 @@ function makeMockPrice(overrides: Partial<Record<string, unknown>> = {}) {
   };
 }
 
-describe("getAccountTrackerControllerAccountsByChainId", () => {
-  describe("when assets unify state feature is enabled (happy path)", () => {
-    it("derives accountsByChainId from new state structure", () => {
+describe('getAccountTrackerControllerAccountsByChainId', () => {
+  describe('when assets unify state feature is enabled (happy path)', () => {
+    it('derives accountsByChainId from new state structure', () => {
       const state = {
         metamask: {
           remoteFeatureFlags: {
@@ -109,13 +121,13 @@ describe("getAccountTrackerControllerAccountsByChainId", () => {
           },
           accountsByChainId: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: "native", decimals: 18 },
-            [erc20AssetId]: { type: "erc20", decimals: 6 },
+            [nativeEthAssetId]: { type: 'native', decimals: 18 },
+            [erc20AssetId]: { type: 'erc20', decimals: 6 },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: "1.23456789" },
-              [erc20AssetId]: { amount: "1" },
+              [nativeEthAssetId]: { amount: '1.23456789' },
+              [erc20AssetId]: { amount: '1' },
             },
           },
           internalAccounts: {
@@ -123,11 +135,11 @@ describe("getAccountTrackerControllerAccountsByChainId", () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: "eip155:eoa",
+                type: 'eip155:eoa',
               },
               [mockAccountId2]: {
                 id: mockAccountId2,
-                type: "solana:data-account",
+                type: 'solana:data-account',
               },
             },
           },
@@ -136,29 +148,29 @@ describe("getAccountTrackerControllerAccountsByChainId", () => {
       const result = getAccountTrackerControllerAccountsByChainId(state);
 
       expect(result).toStrictEqual({
-        "0x1": {
+        '0x1': {
           [mockAccountAddressChecksummed]: {
-            balance: "0x112210f4768db400", // 1234567890000000000
+            balance: '0x112210f4768db400', // 1234567890000000000
           },
         },
       });
     });
   });
 
-  describe("edge cases when enabled", () => {
-    it("handles multiple chains for the same EVM account", () => {
+  describe('edge cases when enabled', () => {
+    it('handles multiple chains for the same EVM account', () => {
       const state = {
         metamask: {
           ...enabledFlags,
           accountsByChainId: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: "native", decimals: 18 },
-            [nativePolygonAssetId]: { type: "native", decimals: 18 },
+            [nativeEthAssetId]: { type: 'native', decimals: 18 },
+            [nativePolygonAssetId]: { type: 'native', decimals: 18 },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: "1" },
-              [nativePolygonAssetId]: { amount: "2" },
+              [nativeEthAssetId]: { amount: '1' },
+              [nativePolygonAssetId]: { amount: '2' },
             },
           },
           internalAccounts: {
@@ -166,7 +178,7 @@ describe("getAccountTrackerControllerAccountsByChainId", () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: "eip155:eoa",
+                type: 'eip155:eoa',
               },
             },
           },
@@ -174,23 +186,23 @@ describe("getAccountTrackerControllerAccountsByChainId", () => {
       };
       const result = getAccountTrackerControllerAccountsByChainId(state);
 
-      expect(result["0x1"]).toBeDefined();
-      expect(result["0x89"]).toBeDefined();
+      expect(result['0x1']).toBeDefined();
+      expect(result['0x89']).toBeDefined();
       expect(Object.keys(result)).toHaveLength(2);
     });
 
-    it("handles balance with 0 decimals", () => {
-      const zeroDecNativeId = "eip155:42/slip44:60";
+    it('handles balance with 0 decimals', () => {
+      const zeroDecNativeId = 'eip155:42/slip44:60';
       const state = {
         metamask: {
           ...enabledFlags,
           accountsByChainId: {},
           assetsInfo: {
-            [zeroDecNativeId]: { type: "native", decimals: 0 },
+            [zeroDecNativeId]: { type: 'native', decimals: 0 },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [zeroDecNativeId]: { amount: "42" },
+              [zeroDecNativeId]: { amount: '42' },
             },
           },
           internalAccounts: {
@@ -198,7 +210,7 @@ describe("getAccountTrackerControllerAccountsByChainId", () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: "eip155:eoa",
+                type: 'eip155:eoa',
               },
             },
           },
@@ -206,22 +218,25 @@ describe("getAccountTrackerControllerAccountsByChainId", () => {
       };
       const result = getAccountTrackerControllerAccountsByChainId(state);
 
-      expect(result["0x2a"][mockAccountAddressChecksummed].balance).toBe("0x2a");
+      expect(result['0x2a'][mockAccountAddressChecksummed].balance).toBe(
+        '0x2a',
+      );
     });
 
-    it("skips balance entries without metadata in assetsInfo", () => {
-      const unknownAssetId = "eip155:1/erc20:0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    it('skips balance entries without metadata in assetsInfo', () => {
+      const unknownAssetId =
+        'eip155:1/erc20:0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
       const state = {
         metamask: {
           ...enabledFlags,
           accountsByChainId: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: "native", decimals: 18 },
+            [nativeEthAssetId]: { type: 'native', decimals: 18 },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: "1" },
-              [unknownAssetId]: { amount: "500" },
+              [nativeEthAssetId]: { amount: '1' },
+              [unknownAssetId]: { amount: '500' },
             },
           },
           internalAccounts: {
@@ -229,7 +244,7 @@ describe("getAccountTrackerControllerAccountsByChainId", () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: "eip155:eoa",
+                type: 'eip155:eoa',
               },
             },
           },
@@ -237,22 +252,22 @@ describe("getAccountTrackerControllerAccountsByChainId", () => {
       };
       const result = getAccountTrackerControllerAccountsByChainId(state);
 
-      expect(Object.keys(result)).toStrictEqual(["0x1"]);
+      expect(Object.keys(result)).toStrictEqual(['0x1']);
     });
 
-    it("skips non-native assets (ERC-20) from accountsByChainId", () => {
+    it('skips non-native assets (ERC-20) from accountsByChainId', () => {
       const state = {
         metamask: {
           ...enabledFlags,
           accountsByChainId: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: "native", decimals: 18 },
-            [erc20AssetId]: { type: "erc20", decimals: 6 },
+            [nativeEthAssetId]: { type: 'native', decimals: 18 },
+            [erc20AssetId]: { type: 'erc20', decimals: 6 },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: "5" },
-              [erc20AssetId]: { amount: "1000" },
+              [nativeEthAssetId]: { amount: '5' },
+              [erc20AssetId]: { amount: '1000' },
             },
           },
           internalAccounts: {
@@ -260,7 +275,7 @@ describe("getAccountTrackerControllerAccountsByChainId", () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: "eip155:eoa",
+                type: 'eip155:eoa',
               },
             },
           },
@@ -268,20 +283,22 @@ describe("getAccountTrackerControllerAccountsByChainId", () => {
       };
       const result = getAccountTrackerControllerAccountsByChainId(state);
 
-      expect(Object.keys(result["0x1"])).toStrictEqual([mockAccountAddressChecksummed]);
+      expect(Object.keys(result['0x1'])).toStrictEqual([
+        mockAccountAddressChecksummed,
+      ]);
     });
 
-    it("truncates fractional digits exceeding decimals in parseBalanceWithDecimals", () => {
+    it('truncates fractional digits exceeding decimals in parseBalanceWithDecimals', () => {
       const state = {
         metamask: {
           ...enabledFlags,
           accountsByChainId: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: "native", decimals: 2 },
+            [nativeEthAssetId]: { type: 'native', decimals: 2 },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: "1.23456" },
+              [nativeEthAssetId]: { amount: '1.23456' },
             },
           },
           internalAccounts: {
@@ -289,7 +306,7 @@ describe("getAccountTrackerControllerAccountsByChainId", () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: "eip155:eoa",
+                type: 'eip155:eoa',
               },
             },
           },
@@ -298,7 +315,7 @@ describe("getAccountTrackerControllerAccountsByChainId", () => {
       const result = getAccountTrackerControllerAccountsByChainId(state);
 
       // 1.23456 with 2 decimals → truncated to 1.23 → 123
-      expect(result["0x1"][mockAccountAddressChecksummed].balance).toBe("0x7b");
+      expect(result['0x1'][mockAccountAddressChecksummed].balance).toBe('0x7b');
     });
 
     it('does not crash when amount is in scientific notation (e.g. "1e-18")', () => {
@@ -307,11 +324,11 @@ describe("getAccountTrackerControllerAccountsByChainId", () => {
           ...enabledFlags,
           accountsByChainId: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: "native", decimals: 18 },
+            [nativeEthAssetId]: { type: 'native', decimals: 18 },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: "1e-18" },
+              [nativeEthAssetId]: { amount: '1e-18' },
             },
           },
           internalAccounts: {
@@ -319,7 +336,7 @@ describe("getAccountTrackerControllerAccountsByChainId", () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: "eip155:eoa",
+                type: 'eip155:eoa',
               },
             },
           },
@@ -327,9 +344,11 @@ describe("getAccountTrackerControllerAccountsByChainId", () => {
       };
 
       // Should not throw — 1e-18 ETH = 1 wei = 0x1
-      expect(() => getAccountTrackerControllerAccountsByChainId(state)).not.toThrow();
+      expect(() =>
+        getAccountTrackerControllerAccountsByChainId(state),
+      ).not.toThrow();
       const result = getAccountTrackerControllerAccountsByChainId(state);
-      expect(result["0x1"][mockAccountAddressChecksummed].balance).toBe("0x1");
+      expect(result['0x1'][mockAccountAddressChecksummed].balance).toBe('0x1');
     });
 
     it('does not crash when amount has absurd scientific notation exponent (e.g. "1e-18000000000000000000")', () => {
@@ -338,11 +357,11 @@ describe("getAccountTrackerControllerAccountsByChainId", () => {
           ...enabledFlags,
           accountsByChainId: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: "native", decimals: 18 },
+            [nativeEthAssetId]: { type: 'native', decimals: 18 },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: "1e-18000000000000000000" },
+              [nativeEthAssetId]: { amount: '1e-18000000000000000000' },
             },
           },
           internalAccounts: {
@@ -350,7 +369,7 @@ describe("getAccountTrackerControllerAccountsByChainId", () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: "eip155:eoa",
+                type: 'eip155:eoa',
               },
             },
           },
@@ -358,9 +377,11 @@ describe("getAccountTrackerControllerAccountsByChainId", () => {
       };
 
       // Should not throw — value is sub-unit, rounds to 0x0
-      expect(() => getAccountTrackerControllerAccountsByChainId(state)).not.toThrow();
+      expect(() =>
+        getAccountTrackerControllerAccountsByChainId(state),
+      ).not.toThrow();
       const result = getAccountTrackerControllerAccountsByChainId(state);
-      expect(result["0x1"][mockAccountAddressChecksummed].balance).toBe("0x0");
+      expect(result['0x1'][mockAccountAddressChecksummed].balance).toBe('0x0');
     });
 
     it('correctly parses positive scientific notation (e.g. "1.5e2" with 2 decimals)', () => {
@@ -369,11 +390,11 @@ describe("getAccountTrackerControllerAccountsByChainId", () => {
           ...enabledFlags,
           accountsByChainId: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: "native", decimals: 2 },
+            [nativeEthAssetId]: { type: 'native', decimals: 2 },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: "1.5e2" },
+              [nativeEthAssetId]: { amount: '1.5e2' },
             },
           },
           internalAccounts: {
@@ -381,7 +402,7 @@ describe("getAccountTrackerControllerAccountsByChainId", () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: "eip155:eoa",
+                type: 'eip155:eoa',
               },
             },
           },
@@ -389,24 +410,28 @@ describe("getAccountTrackerControllerAccountsByChainId", () => {
       };
 
       // 1.5e2 = 150 human-readable, with 2 decimals → 15000 base units = 0x3a98
-      expect(() => getAccountTrackerControllerAccountsByChainId(state)).not.toThrow();
+      expect(() =>
+        getAccountTrackerControllerAccountsByChainId(state),
+      ).not.toThrow();
       const result = getAccountTrackerControllerAccountsByChainId(state);
-      expect(result["0x1"][mockAccountAddressChecksummed].balance).toBe("0x3a98");
+      expect(result['0x1'][mockAccountAddressChecksummed].balance).toBe(
+        '0x3a98',
+      );
     });
   });
 });
 
-describe("getTokensControllerAllTokens", () => {
-  describe("when assets unify state feature is disabled", () => {
-    it("returns allTokens from state unchanged", () => {
+describe('getTokensControllerAllTokens', () => {
+  describe('when assets unify state feature is disabled', () => {
+    it('returns allTokens from state unchanged', () => {
       const legacyAllTokens = {
-        "0x1": {
+        '0x1': {
           [mockAccountAddressLowercase]: [
             {
               address: erc20AssetAddressLowercase,
-              symbol: "USDC",
+              symbol: 'USDC',
               decimals: 6,
-              name: "USD Coin",
+              name: 'USD Coin',
             },
           ],
         },
@@ -424,8 +449,8 @@ describe("getTokensControllerAllTokens", () => {
     });
   });
 
-  describe("when assets unify state feature is enabled (happy path)", () => {
-    it("derives allTokens from new state structure", () => {
+  describe('when assets unify state feature is enabled (happy path)', () => {
+    it('derives allTokens from new state structure', () => {
       const state = {
         metamask: {
           remoteFeatureFlags: {
@@ -437,18 +462,18 @@ describe("getTokensControllerAllTokens", () => {
           allTokens: {},
           allIgnoredTokens: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: "native", decimals: 18 },
+            [nativeEthAssetId]: { type: 'native', decimals: 18 },
             [erc20AssetId]: {
-              type: "erc20",
+              type: 'erc20',
               decimals: 6,
-              symbol: "USDC",
-              name: "USD Coin",
+              symbol: 'USDC',
+              name: 'USD Coin',
             },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: "1" },
-              [erc20AssetId]: { amount: "1000000" },
+              [nativeEthAssetId]: { amount: '1' },
+              [erc20AssetId]: { amount: '1000000' },
             },
           },
           customAssets: {},
@@ -457,11 +482,11 @@ describe("getTokensControllerAllTokens", () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: "eip155:eoa",
+                type: 'eip155:eoa',
               },
               [mockAccountId2]: {
                 id: mockAccountId2,
-                type: "solana:data-account",
+                type: 'solana:data-account',
               },
             },
           },
@@ -470,13 +495,13 @@ describe("getTokensControllerAllTokens", () => {
       const result = getTokensControllerAllTokens(state);
 
       expect(result).toStrictEqual({
-        "0x1": {
+        '0x1': {
           [mockAccountAddressLowercase]: [
             {
               address: erc20AssetAddressChecksummed,
-              symbol: "USDC",
+              symbol: 'USDC',
               decimals: 6,
-              name: "USD Coin",
+              name: 'USD Coin',
               image: undefined,
             },
           ],
@@ -485,8 +510,8 @@ describe("getTokensControllerAllTokens", () => {
     });
   });
 
-  describe("edge cases when enabled", () => {
-    it("includes tokens from customAssets not present in assetsBalance", () => {
+  describe('edge cases when enabled', () => {
+    it('includes tokens from customAssets not present in assetsBalance', () => {
       const state = {
         metamask: {
           ...enabledFlags,
@@ -494,11 +519,11 @@ describe("getTokensControllerAllTokens", () => {
           allIgnoredTokens: {},
           assetsInfo: {
             [erc20AssetId]: {
-              type: "erc20",
+              type: 'erc20',
               decimals: 6,
-              symbol: "USDC",
-              name: "USD Coin",
-              image: "https://example.com/usdc.png",
+              symbol: 'USDC',
+              name: 'USD Coin',
+              image: 'https://example.com/usdc.png',
             },
           },
           assetsBalance: {},
@@ -510,7 +535,7 @@ describe("getTokensControllerAllTokens", () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: "eip155:eoa",
+                type: 'eip155:eoa',
               },
             },
           },
@@ -518,18 +543,18 @@ describe("getTokensControllerAllTokens", () => {
       };
       const result = getTokensControllerAllTokens(state);
 
-      expect(result["0x1"][mockAccountAddressLowercase]).toStrictEqual([
+      expect(result['0x1'][mockAccountAddressLowercase]).toStrictEqual([
         {
           address: erc20AssetAddressChecksummed,
-          symbol: "USDC",
+          symbol: 'USDC',
           decimals: 6,
-          name: "USD Coin",
-          image: "https://example.com/usdc.png",
+          name: 'USD Coin',
+          image: 'https://example.com/usdc.png',
         },
       ]);
     });
 
-    it("deduplicates tokens present in both assetsBalance and customAssets", () => {
+    it('deduplicates tokens present in both assetsBalance and customAssets', () => {
       const state = {
         metamask: {
           ...enabledFlags,
@@ -537,15 +562,15 @@ describe("getTokensControllerAllTokens", () => {
           allIgnoredTokens: {},
           assetsInfo: {
             [erc20AssetId]: {
-              type: "erc20",
+              type: 'erc20',
               decimals: 6,
-              symbol: "USDC",
-              name: "USD Coin",
+              symbol: 'USDC',
+              name: 'USD Coin',
             },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [erc20AssetId]: { amount: "1" },
+              [erc20AssetId]: { amount: '1' },
             },
           },
           customAssets: {
@@ -556,7 +581,7 @@ describe("getTokensControllerAllTokens", () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: "eip155:eoa",
+                type: 'eip155:eoa',
               },
             },
           },
@@ -564,12 +589,12 @@ describe("getTokensControllerAllTokens", () => {
       };
       const result = getTokensControllerAllTokens(state);
 
-      expect(result["0x1"][mockAccountAddressLowercase]).toHaveLength(1);
+      expect(result['0x1'][mockAccountAddressLowercase]).toHaveLength(1);
     });
 
-    it("skips assets with no metadata in assetsInfo", () => {
+    it('skips assets with no metadata in assetsInfo', () => {
       const unknownAssetId =
-        "eip155:1/erc20:0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" as CaipAssetType;
+        'eip155:1/erc20:0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' as CaipAssetType;
       const state = {
         metamask: {
           ...enabledFlags,
@@ -578,7 +603,7 @@ describe("getTokensControllerAllTokens", () => {
           assetsInfo: {},
           assetsBalance: {
             [mockAccountId]: {
-              [unknownAssetId]: { amount: "1" },
+              [unknownAssetId]: { amount: '1' },
             },
           },
           customAssets: {},
@@ -587,7 +612,7 @@ describe("getTokensControllerAllTokens", () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: "eip155:eoa",
+                type: 'eip155:eoa',
               },
             },
           },
@@ -598,7 +623,7 @@ describe("getTokensControllerAllTokens", () => {
       expect(result).toStrictEqual({});
     });
 
-    it("skips native assets from allTokens (only ERC-20s)", () => {
+    it('skips native assets from allTokens (only ERC-20s)', () => {
       const state = {
         metamask: {
           ...enabledFlags,
@@ -606,15 +631,15 @@ describe("getTokensControllerAllTokens", () => {
           allIgnoredTokens: {},
           assetsInfo: {
             [nativeEthAssetId]: {
-              type: "native",
+              type: 'native',
               decimals: 18,
-              symbol: "ETH",
-              name: "Ether",
+              symbol: 'ETH',
+              name: 'Ether',
             },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: "1" },
+              [nativeEthAssetId]: { amount: '1' },
             },
           },
           customAssets: {},
@@ -623,7 +648,7 @@ describe("getTokensControllerAllTokens", () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: "eip155:eoa",
+                type: 'eip155:eoa',
               },
             },
           },
@@ -636,11 +661,11 @@ describe("getTokensControllerAllTokens", () => {
   });
 });
 
-describe("getTokensControllerAllIgnoredTokens", () => {
-  describe("when assets unify state feature is disabled", () => {
-    it("returns allIgnoredTokens from state unchanged", () => {
+describe('getTokensControllerAllIgnoredTokens', () => {
+  describe('when assets unify state feature is disabled', () => {
+    it('returns allIgnoredTokens from state unchanged', () => {
       const legacyAllIgnoredTokens = {
-        "0x1": {
+        '0x1': {
           [mockAccountAddressLowercase]: [erc20AssetAddressLowercase],
         },
       };
@@ -657,8 +682,8 @@ describe("getTokensControllerAllIgnoredTokens", () => {
     });
   });
 
-  describe("when assets unify state feature is enabled (happy path)", () => {
-    it("derives allIgnoredTokens from new state structure", () => {
+  describe('when assets unify state feature is enabled (happy path)', () => {
+    it('derives allIgnoredTokens from new state structure', () => {
       const state = {
         metamask: {
           remoteFeatureFlags: {
@@ -678,11 +703,11 @@ describe("getTokensControllerAllIgnoredTokens", () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: "eip155:eoa",
+                type: 'eip155:eoa',
               },
               [mockAccountId2]: {
                 id: mockAccountId2,
-                type: "solana:data-account",
+                type: 'solana:data-account',
               },
             },
           },
@@ -691,15 +716,15 @@ describe("getTokensControllerAllIgnoredTokens", () => {
       const result = getTokensControllerAllIgnoredTokens(state);
 
       expect(result).toStrictEqual({
-        "0x1": {
+        '0x1': {
           [mockAccountAddressLowercase]: [erc20AssetAddressLowercase],
         },
       });
     });
   });
 
-  describe("edge cases when enabled", () => {
-    it("skips preferences with hidden set to false", () => {
+  describe('edge cases when enabled', () => {
+    it('skips preferences with hidden set to false', () => {
       const state = {
         metamask: {
           ...enabledFlags,
@@ -714,7 +739,7 @@ describe("getTokensControllerAllIgnoredTokens", () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: "eip155:eoa",
+                type: 'eip155:eoa',
               },
             },
           },
@@ -725,7 +750,7 @@ describe("getTokensControllerAllIgnoredTokens", () => {
       expect(result).toStrictEqual({});
     });
 
-    it("applies hidden tokens to all EVM accounts", () => {
+    it('applies hidden tokens to all EVM accounts', () => {
       const state = {
         metamask: {
           ...enabledFlags,
@@ -739,16 +764,16 @@ describe("getTokensControllerAllIgnoredTokens", () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: "eip155:eoa",
+                type: 'eip155:eoa',
               },
               [mockAccountId3]: {
                 id: mockAccountId3,
                 address: mockAccountAddressLowercase2,
-                type: "eip155:eoa",
+                type: 'eip155:eoa',
               },
               [mockAccountId2]: {
                 id: mockAccountId2,
-                type: "solana:data-account",
+                type: 'solana:data-account',
               },
             },
           },
@@ -756,17 +781,17 @@ describe("getTokensControllerAllIgnoredTokens", () => {
       };
       const result = getTokensControllerAllIgnoredTokens(state);
 
-      expect(result["0x1"][mockAccountAddressLowercase]).toStrictEqual([
+      expect(result['0x1'][mockAccountAddressLowercase]).toStrictEqual([
         erc20AssetAddressLowercase,
       ]);
-      expect(result["0x1"][mockAccountAddressLowercase2]).toStrictEqual([
+      expect(result['0x1'][mockAccountAddressLowercase2]).toStrictEqual([
         erc20AssetAddressLowercase,
       ]);
     });
   });
 });
 
-describe("getTokenBalancesControllerTokenBalances", () => {
+describe('getTokenBalancesControllerTokenBalances', () => {
   const enabledFeatureFlags = {
     [ASSETS_UNIFY_STATE_FLAG]: {
       enabled: true,
@@ -779,21 +804,21 @@ describe("getTokenBalancesControllerTokenBalances", () => {
       [mockAccountId]: {
         id: mockAccountId,
         address: mockAccountAddressLowercase,
-        type: "eip155:eoa",
+        type: 'eip155:eoa',
       },
       [mockAccountId2]: {
         id: mockAccountId2,
-        type: "solana:data-account",
+        type: 'solana:data-account',
       },
     },
   };
 
-  describe("when assets unify state feature is disabled", () => {
-    it("returns tokenBalances from state unchanged", () => {
+  describe('when assets unify state feature is disabled', () => {
+    it('returns tokenBalances from state unchanged', () => {
       const legacyTokenBalances = {
         [mockAccountAddressLowercase]: {
-          "0x1": {
-            [erc20AssetAddressChecksummed]: "0xf4240" as const,
+          '0x1': {
+            [erc20AssetAddressChecksummed]: '0xf4240' as const,
           },
         },
       };
@@ -809,20 +834,20 @@ describe("getTokenBalancesControllerTokenBalances", () => {
     });
   });
 
-  describe("when assets unify state feature is enabled (happy path)", () => {
-    it("derives tokenBalances from new state structure", () => {
+  describe('when assets unify state feature is enabled (happy path)', () => {
+    it('derives tokenBalances from new state structure', () => {
       const state = {
         metamask: {
           remoteFeatureFlags: enabledFeatureFlags,
           tokenBalances: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: "native", decimals: 18 },
-            [erc20AssetId]: { type: "erc20", decimals: 6 },
+            [nativeEthAssetId]: { type: 'native', decimals: 18 },
+            [erc20AssetId]: { type: 'erc20', decimals: 6 },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: "1.23456789" },
-              [erc20AssetId]: { amount: "1" },
+              [nativeEthAssetId]: { amount: '1.23456789' },
+              [erc20AssetId]: { amount: '1' },
             },
           },
           customAssets: {},
@@ -831,21 +856,24 @@ describe("getTokenBalancesControllerTokenBalances", () => {
       };
       const result = getTokenBalancesControllerTokenBalances(state);
 
-      const nativeAddress = getNativeAssetForChainId("0x1").address;
+      const nativeAddress = getNativeAssetForChainId('0x1').address;
       expect(result).toStrictEqual({
         [mockAccountAddressLowercase]: {
-          "0x1": {
-            [nativeAddress]: "0x112210f4768db400", // 1.23456789 ETH (18 decimals)
-            [erc20AssetAddressChecksummed]: "0xf4240", // 1 USDC (6 decimals)
+          '0x1': {
+            [nativeAddress]: '0x112210f4768db400', // 1.23456789 ETH (18 decimals)
+            [erc20AssetAddressChecksummed]: '0xf4240', // 1 USDC (6 decimals)
           },
         },
       });
     });
 
-    it("adds zero-balance placeholder for custom EVM token not yet in assetsBalance", () => {
-      const customTokenAddress: Hex = "0x4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8";
+    it('adds zero-balance placeholder for custom EVM token not yet in assetsBalance', () => {
+      const customTokenAddress: Hex =
+        '0x4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8';
       const customTokenAssetId = `eip155:1/erc20:${customTokenAddress}`;
-      const customTokenAddressChecksummed = toChecksumHexAddress(customTokenAddress) as Hex;
+      const customTokenAddressChecksummed = toChecksumHexAddress(
+        customTokenAddress,
+      ) as Hex;
 
       const state = {
         metamask: {
@@ -853,10 +881,10 @@ describe("getTokenBalancesControllerTokenBalances", () => {
           tokenBalances: {},
           assetsInfo: {
             [customTokenAssetId]: {
-              type: "erc20",
+              type: 'erc20',
               decimals: 18,
-              symbol: "aEthWETH",
-              name: "Aave Ethereum WETH",
+              symbol: 'aEthWETH',
+              name: 'Aave Ethereum WETH',
             },
           },
           assetsBalance: {},
@@ -870,24 +898,24 @@ describe("getTokenBalancesControllerTokenBalances", () => {
 
       expect(result).toStrictEqual({
         [mockAccountAddressLowercase]: {
-          "0x1": {
-            [customTokenAddressChecksummed]: "0x0",
+          '0x1': {
+            [customTokenAddressChecksummed]: '0x0',
           },
         },
       });
     });
 
-    it("does not overwrite real balance with zero placeholder", () => {
+    it('does not overwrite real balance with zero placeholder', () => {
       const state = {
         metamask: {
           remoteFeatureFlags: enabledFeatureFlags,
           tokenBalances: {},
           assetsInfo: {
-            [erc20AssetId]: { type: "erc20", decimals: 6 },
+            [erc20AssetId]: { type: 'erc20', decimals: 6 },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [erc20AssetId]: { amount: "1" },
+              [erc20AssetId]: { amount: '1' },
             },
           },
           customAssets: {
@@ -898,21 +926,21 @@ describe("getTokenBalancesControllerTokenBalances", () => {
       };
       const result = getTokenBalancesControllerTokenBalances(state);
 
-      expect(result[mockAccountAddressLowercase]["0x1"]).toStrictEqual({
-        [erc20AssetAddressChecksummed]: "0xf4240", // real balance, not 0x0
+      expect(result[mockAccountAddressLowercase]['0x1']).toStrictEqual({
+        [erc20AssetAddressChecksummed]: '0xf4240', // real balance, not 0x0
       });
     });
 
-    it("skips custom non-EVM tokens", () => {
+    it('skips custom non-EVM tokens', () => {
       const state = {
         metamask: {
           remoteFeatureFlags: enabledFeatureFlags,
           tokenBalances: {},
           assetsInfo: {
             [solanaTokenAssetId]: {
-              type: "token",
+              type: 'token',
               decimals: 6,
-              symbol: "USDC",
+              symbol: 'USDC',
             },
           },
           assetsBalance: {},
@@ -928,20 +956,21 @@ describe("getTokenBalancesControllerTokenBalances", () => {
     });
   });
 
-  describe("edge cases when enabled", () => {
-    it("skips balance entries without metadata in assetsInfo", () => {
-      const unknownAssetId = "eip155:1/erc20:0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+  describe('edge cases when enabled', () => {
+    it('skips balance entries without metadata in assetsInfo', () => {
+      const unknownAssetId =
+        'eip155:1/erc20:0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
       const state = {
         metamask: {
           ...enabledFlags,
           tokenBalances: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: "native", decimals: 18 },
+            [nativeEthAssetId]: { type: 'native', decimals: 18 },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: "1" },
-              [unknownAssetId]: { amount: "999" },
+              [nativeEthAssetId]: { amount: '1' },
+              [unknownAssetId]: { amount: '999' },
             },
           },
           internalAccounts: {
@@ -949,7 +978,7 @@ describe("getTokenBalancesControllerTokenBalances", () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: "eip155:eoa",
+                type: 'eip155:eoa',
               },
             },
           },
@@ -957,26 +986,26 @@ describe("getTokenBalancesControllerTokenBalances", () => {
       };
       const result = getTokenBalancesControllerTokenBalances(state);
 
-      const nativeAddress = getNativeAssetForChainId("0x1").address;
-      expect(Object.keys(result[mockAccountAddressLowercase]["0x1"])).toStrictEqual([
-        nativeAddress,
-      ]);
+      const nativeAddress = getNativeAssetForChainId('0x1').address;
+      expect(
+        Object.keys(result[mockAccountAddressLowercase]['0x1']),
+      ).toStrictEqual([nativeAddress]);
     });
 
-    it("handles multiple EVM accounts", () => {
+    it('handles multiple EVM accounts', () => {
       const state = {
         metamask: {
           ...enabledFlags,
           tokenBalances: {},
           assetsInfo: {
-            [erc20AssetId]: { type: "erc20", decimals: 6 },
+            [erc20AssetId]: { type: 'erc20', decimals: 6 },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [erc20AssetId]: { amount: "10" },
+              [erc20AssetId]: { amount: '10' },
             },
             [mockAccountId3]: {
-              [erc20AssetId]: { amount: "20" },
+              [erc20AssetId]: { amount: '20' },
             },
           },
           internalAccounts: {
@@ -984,12 +1013,12 @@ describe("getTokenBalancesControllerTokenBalances", () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: "eip155:eoa",
+                type: 'eip155:eoa',
               },
               [mockAccountId3]: {
                 id: mockAccountId3,
                 address: mockAccountAddressLowercase2,
-                type: "eip155:eoa",
+                type: 'eip155:eoa',
               },
             },
           },
@@ -999,19 +1028,23 @@ describe("getTokenBalancesControllerTokenBalances", () => {
 
       expect(result[mockAccountAddressLowercase]).toBeDefined();
       expect(result[mockAccountAddressLowercase2]).toBeDefined();
-      expect(result[mockAccountAddressLowercase]["0x1"][erc20AssetAddressChecksummed]).toBe(
-        "0x989680",
-      ); // 10 * 10^6
-      expect(result[mockAccountAddressLowercase2]["0x1"][erc20AssetAddressChecksummed]).toBe(
-        "0x1312d00",
-      ); // 20 * 10^6
+      expect(
+        result[mockAccountAddressLowercase]['0x1'][
+          erc20AssetAddressChecksummed
+        ],
+      ).toBe('0x989680'); // 10 * 10^6
+      expect(
+        result[mockAccountAddressLowercase2]['0x1'][
+          erc20AssetAddressChecksummed
+        ],
+      ).toBe('0x1312d00'); // 20 * 10^6
     });
   });
 });
 
-describe("getMultiChainAssetsControllerAccountsAssets", () => {
-  describe("when assets unify state feature is disabled", () => {
-    it("returns accountsAssets from state unchanged", () => {
+describe('getMultiChainAssetsControllerAccountsAssets', () => {
+  describe('when assets unify state feature is disabled', () => {
+    it('returns accountsAssets from state unchanged', () => {
       const legacyAccountsAssets = {
         [mockAccountId2]: [solanaTokenAssetId] as CaipAssetType[],
       };
@@ -1027,8 +1060,8 @@ describe("getMultiChainAssetsControllerAccountsAssets", () => {
     });
   });
 
-  describe("when assets unify state feature is enabled (happy path)", () => {
-    it("derives accountsAssets from new state structure for non-EVM accounts only", () => {
+  describe('when assets unify state feature is enabled (happy path)', () => {
+    it('derives accountsAssets from new state structure for non-EVM accounts only', () => {
       const state = {
         metamask: {
           remoteFeatureFlags: {
@@ -1040,11 +1073,11 @@ describe("getMultiChainAssetsControllerAccountsAssets", () => {
           accountsAssets: {},
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: "1" },
-              [erc20AssetId]: { amount: "1" },
+              [nativeEthAssetId]: { amount: '1' },
+              [erc20AssetId]: { amount: '1' },
             },
             [mockAccountId2]: {
-              [solanaTokenAssetId]: { amount: "100" },
+              [solanaTokenAssetId]: { amount: '100' },
             },
           },
           customAssets: {},
@@ -1053,11 +1086,11 @@ describe("getMultiChainAssetsControllerAccountsAssets", () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: "eip155:eoa",
+                type: 'eip155:eoa',
               },
               [mockAccountId2]: {
                 id: mockAccountId2,
-                type: "solana:data-account",
+                type: 'solana:data-account',
               },
             },
           },
@@ -1071,27 +1104,30 @@ describe("getMultiChainAssetsControllerAccountsAssets", () => {
     });
   });
 
-  describe("edge cases when enabled", () => {
-    it("merges and deduplicates assetsBalance and customAssets", () => {
+  describe('edge cases when enabled', () => {
+    it('merges and deduplicates assetsBalance and customAssets', () => {
       const extraSolAssetId =
-        "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:So11111111111111111111111111111111111111112" as CaipAssetType;
+        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:So11111111111111111111111111111111111111112' as CaipAssetType;
       const state = {
         metamask: {
           ...enabledFlags,
           accountsAssets: {},
           assetsBalance: {
             [mockAccountId2]: {
-              [solanaTokenAssetId]: { amount: "100" },
+              [solanaTokenAssetId]: { amount: '100' },
             },
           },
           customAssets: {
-            [mockAccountId2]: [solanaTokenAssetId as CaipAssetType, extraSolAssetId],
+            [mockAccountId2]: [
+              solanaTokenAssetId as CaipAssetType,
+              extraSolAssetId,
+            ],
           },
           internalAccounts: {
             accounts: {
               [mockAccountId2]: {
                 id: mockAccountId2,
-                type: "solana:data-account",
+                type: 'solana:data-account',
               },
             },
           },
@@ -1104,15 +1140,15 @@ describe("getMultiChainAssetsControllerAccountsAssets", () => {
       expect(result[mockAccountId2]).toContain(extraSolAssetId);
     });
 
-    it("filters out EIP155 assets for non-EVM accounts", () => {
+    it('filters out EIP155 assets for non-EVM accounts', () => {
       const state = {
         metamask: {
           ...enabledFlags,
           accountsAssets: {},
           assetsBalance: {
             [mockAccountId2]: {
-              [nativeEthAssetId]: { amount: "1" },
-              [solanaTokenAssetId]: { amount: "100" },
+              [nativeEthAssetId]: { amount: '1' },
+              [solanaTokenAssetId]: { amount: '100' },
             },
           },
           customAssets: {},
@@ -1120,7 +1156,7 @@ describe("getMultiChainAssetsControllerAccountsAssets", () => {
             accounts: {
               [mockAccountId2]: {
                 id: mockAccountId2,
-                type: "solana:data-account",
+                type: 'solana:data-account',
               },
             },
           },
@@ -1131,14 +1167,14 @@ describe("getMultiChainAssetsControllerAccountsAssets", () => {
       expect(result[mockAccountId2]).toStrictEqual([solanaTokenAssetId]);
     });
 
-    it("returns empty array when non-EVM account has only EIP155 assets", () => {
+    it('returns empty array when non-EVM account has only EIP155 assets', () => {
       const state = {
         metamask: {
           ...enabledFlags,
           accountsAssets: {},
           assetsBalance: {
             [mockAccountId2]: {
-              [nativeEthAssetId]: { amount: "1" },
+              [nativeEthAssetId]: { amount: '1' },
             },
           },
           customAssets: {},
@@ -1146,7 +1182,7 @@ describe("getMultiChainAssetsControllerAccountsAssets", () => {
             accounts: {
               [mockAccountId2]: {
                 id: mockAccountId2,
-                type: "solana:data-account",
+                type: 'solana:data-account',
               },
             },
           },
@@ -1159,16 +1195,16 @@ describe("getMultiChainAssetsControllerAccountsAssets", () => {
   });
 });
 
-describe("getMultiChainAssetsControllerAssetsMetadata", () => {
-  describe("when assets unify state feature is disabled", () => {
-    it("returns assetsMetadata from state unchanged", () => {
+describe('getMultiChainAssetsControllerAssetsMetadata', () => {
+  describe('when assets unify state feature is disabled', () => {
+    it('returns assetsMetadata from state unchanged', () => {
       const legacyAssetsMetadata = {
         [solanaTokenAssetId]: {
           fungible: true as const,
-          iconUrl: "https://example.com/sol.png",
-          units: [{ decimals: 6, symbol: "USDC", name: "USD Coin" }],
-          symbol: "USDC",
-          name: "USD Coin",
+          iconUrl: 'https://example.com/sol.png',
+          units: [{ decimals: 6, symbol: 'USDC', name: 'USD Coin' }],
+          symbol: 'USDC',
+          name: 'USD Coin',
         },
       };
       const state = {
@@ -1183,8 +1219,8 @@ describe("getMultiChainAssetsControllerAssetsMetadata", () => {
     });
   });
 
-  describe("when assets unify state feature is enabled (happy path)", () => {
-    it("derives assetsMetadata from assetsInfo for non-EIP155 assets only", () => {
+  describe('when assets unify state feature is enabled (happy path)', () => {
+    it('derives assetsMetadata from assetsInfo for non-EIP155 assets only', () => {
       const state = {
         metamask: {
           remoteFeatureFlags: {
@@ -1195,19 +1231,19 @@ describe("getMultiChainAssetsControllerAssetsMetadata", () => {
           },
           assetsMetadata: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: "native", decimals: 18 },
+            [nativeEthAssetId]: { type: 'native', decimals: 18 },
             [erc20AssetId]: {
-              type: "erc20",
+              type: 'erc20',
               decimals: 6,
-              symbol: "USDC",
-              name: "USD Coin",
+              symbol: 'USDC',
+              name: 'USD Coin',
             },
             [solanaTokenAssetId]: {
-              type: "token",
+              type: 'token',
               decimals: 6,
-              symbol: "USDC",
-              name: "USD Coin",
-              image: "https://example.com/sol-usdc.png",
+              symbol: 'USDC',
+              name: 'USD Coin',
+              image: 'https://example.com/sol-usdc.png',
             },
           },
         },
@@ -1217,59 +1253,59 @@ describe("getMultiChainAssetsControllerAssetsMetadata", () => {
       expect(result).toStrictEqual({
         [solanaTokenAssetId]: {
           fungible: true,
-          iconUrl: "https://example.com/sol-usdc.png",
+          iconUrl: 'https://example.com/sol-usdc.png',
           units: [
             {
               decimals: 6,
-              symbol: "USDC",
-              name: "USD Coin",
+              symbol: 'USDC',
+              name: 'USD Coin',
             },
           ],
-          symbol: "USDC",
-          name: "USD Coin",
+          symbol: 'USDC',
+          name: 'USD Coin',
         },
       });
     });
   });
 
-  describe("edge cases when enabled", () => {
-    it("defaults iconUrl to empty string when image is undefined", () => {
+  describe('edge cases when enabled', () => {
+    it('defaults iconUrl to empty string when image is undefined', () => {
       const state = {
         metamask: {
           ...enabledFlags,
           assetsMetadata: {},
           assetsInfo: {
             [solanaTokenAssetId]: {
-              type: "token",
+              type: 'token',
               decimals: 9,
-              symbol: "SOL",
-              name: "Solana",
+              symbol: 'SOL',
+              name: 'Solana',
             },
           },
         },
       };
       const result = getMultiChainAssetsControllerAssetsMetadata(state);
 
-      expect(result[solanaTokenAssetId as CaipAssetType].iconUrl).toBe("");
+      expect(result[solanaTokenAssetId as CaipAssetType].iconUrl).toBe('');
     });
 
-    it("excludes EIP155 assets from multichain metadata", () => {
+    it('excludes EIP155 assets from multichain metadata', () => {
       const state = {
         metamask: {
           ...enabledFlags,
           assetsMetadata: {},
           assetsInfo: {
             [nativeEthAssetId]: {
-              type: "native",
+              type: 'native',
               decimals: 18,
-              symbol: "ETH",
-              name: "Ether",
+              symbol: 'ETH',
+              name: 'Ether',
             },
             [erc20AssetId]: {
-              type: "erc20",
+              type: 'erc20',
               decimals: 6,
-              symbol: "USDC",
-              name: "USD Coin",
+              symbol: 'USDC',
+              name: 'USD Coin',
             },
           },
         },
@@ -1281,9 +1317,9 @@ describe("getMultiChainAssetsControllerAssetsMetadata", () => {
   });
 });
 
-describe("getMultiChainAssetsControllerAllIgnoredAssets", () => {
-  describe("when assets unify state feature is disabled", () => {
-    it("returns allIgnoredAssets from state unchanged", () => {
+describe('getMultiChainAssetsControllerAllIgnoredAssets', () => {
+  describe('when assets unify state feature is disabled', () => {
+    it('returns allIgnoredAssets from state unchanged', () => {
       const legacyAllIgnoredAssets = {
         [mockAccountId2]: [solanaTokenAssetId] as CaipAssetType[],
       };
@@ -1299,8 +1335,8 @@ describe("getMultiChainAssetsControllerAllIgnoredAssets", () => {
     });
   });
 
-  describe("when assets unify state feature is enabled (happy path)", () => {
-    it("derives allIgnoredAssets from assetPreferences for non-EVM accounts only", () => {
+  describe('when assets unify state feature is enabled (happy path)', () => {
+    it('derives allIgnoredAssets from assetPreferences for non-EVM accounts only', () => {
       const state = {
         metamask: {
           remoteFeatureFlags: {
@@ -1319,11 +1355,11 @@ describe("getMultiChainAssetsControllerAllIgnoredAssets", () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: "eip155:eoa",
+                type: 'eip155:eoa',
               },
               [mockAccountId2]: {
                 id: mockAccountId2,
-                type: "solana:data-account",
+                type: 'solana:data-account',
               },
             },
           },
@@ -1337,8 +1373,8 @@ describe("getMultiChainAssetsControllerAllIgnoredAssets", () => {
     });
   });
 
-  describe("edge cases when enabled", () => {
-    it("skips preferences with hidden set to false", () => {
+  describe('edge cases when enabled', () => {
+    it('skips preferences with hidden set to false', () => {
       const state = {
         metamask: {
           ...enabledFlags,
@@ -1350,7 +1386,7 @@ describe("getMultiChainAssetsControllerAllIgnoredAssets", () => {
             accounts: {
               [mockAccountId2]: {
                 id: mockAccountId2,
-                type: "solana:data-account",
+                type: 'solana:data-account',
               },
             },
           },
@@ -1361,7 +1397,7 @@ describe("getMultiChainAssetsControllerAllIgnoredAssets", () => {
       expect(result[mockAccountId2]).toStrictEqual([]);
     });
 
-    it("skips EIP155 assets from ignored assets list", () => {
+    it('skips EIP155 assets from ignored assets list', () => {
       const state = {
         metamask: {
           ...enabledFlags,
@@ -1373,7 +1409,7 @@ describe("getMultiChainAssetsControllerAllIgnoredAssets", () => {
             accounts: {
               [mockAccountId2]: {
                 id: mockAccountId2,
-                type: "solana:data-account",
+                type: 'solana:data-account',
               },
             },
           },
@@ -1384,7 +1420,7 @@ describe("getMultiChainAssetsControllerAllIgnoredAssets", () => {
       expect(result[mockAccountId2]).toStrictEqual([]);
     });
 
-    it("skips EVM accounts entirely", () => {
+    it('skips EVM accounts entirely', () => {
       const state = {
         metamask: {
           ...enabledFlags,
@@ -1397,7 +1433,7 @@ describe("getMultiChainAssetsControllerAllIgnoredAssets", () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: "eip155:eoa",
+                type: 'eip155:eoa',
               },
             },
           },
@@ -1410,12 +1446,12 @@ describe("getMultiChainAssetsControllerAllIgnoredAssets", () => {
   });
 });
 
-describe("getMultiChainBalancesControllerBalances", () => {
-  describe("when assets unify state feature is disabled", () => {
-    it("returns balances from state unchanged", () => {
+describe('getMultiChainBalancesControllerBalances', () => {
+  describe('when assets unify state feature is disabled', () => {
+    it('returns balances from state unchanged', () => {
       const legacyBalances = {
         [mockAccountId2]: {
-          [solanaTokenAssetId]: { amount: "100", unit: "USDC" },
+          [solanaTokenAssetId]: { amount: '100', unit: 'USDC' },
         },
       };
       const state = {
@@ -1430,8 +1466,8 @@ describe("getMultiChainBalancesControllerBalances", () => {
     });
   });
 
-  describe("when assets unify state feature is enabled (happy path)", () => {
-    it("derives balances from new state structure for non-EVM accounts only", () => {
+  describe('when assets unify state feature is enabled (happy path)', () => {
+    it('derives balances from new state structure for non-EVM accounts only', () => {
       const state = {
         metamask: {
           remoteFeatureFlags: {
@@ -1442,21 +1478,21 @@ describe("getMultiChainBalancesControllerBalances", () => {
           },
           balances: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: "native", decimals: 18 },
-            [erc20AssetId]: { type: "erc20", decimals: 6, symbol: "USDC" },
+            [nativeEthAssetId]: { type: 'native', decimals: 18 },
+            [erc20AssetId]: { type: 'erc20', decimals: 6, symbol: 'USDC' },
             [solanaTokenAssetId]: {
-              type: "token",
+              type: 'token',
               decimals: 6,
-              symbol: "USDC",
+              symbol: 'USDC',
             },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: "1" },
-              [erc20AssetId]: { amount: "1" },
+              [nativeEthAssetId]: { amount: '1' },
+              [erc20AssetId]: { amount: '1' },
             },
             [mockAccountId2]: {
-              [solanaTokenAssetId]: { amount: "250.5" },
+              [solanaTokenAssetId]: { amount: '250.5' },
             },
           },
           internalAccounts: {
@@ -1464,11 +1500,11 @@ describe("getMultiChainBalancesControllerBalances", () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: "eip155:eoa",
+                type: 'eip155:eoa',
               },
               [mockAccountId2]: {
                 id: mockAccountId2,
-                type: "solana:data-account",
+                type: 'solana:data-account',
               },
             },
           },
@@ -1478,17 +1514,17 @@ describe("getMultiChainBalancesControllerBalances", () => {
 
       expect(result).toStrictEqual({
         [mockAccountId2]: {
-          [solanaTokenAssetId]: { amount: "250.5", unit: "USDC" },
+          [solanaTokenAssetId]: { amount: '250.5', unit: 'USDC' },
         },
       });
     });
   });
 });
 
-describe("getCurrencyRateControllerCurrentCurrency", () => {
-  describe("when assets unify state feature is disabled", () => {
-    it("returns currentCurrency from state unchanged", () => {
-      const legacyCurrentCurrency = "eur";
+describe('getCurrencyRateControllerCurrentCurrency', () => {
+  describe('when assets unify state feature is disabled', () => {
+    it('returns currentCurrency from state unchanged', () => {
+      const legacyCurrentCurrency = 'eur';
       const state = {
         metamask: {
           currentCurrency: legacyCurrentCurrency,
@@ -1500,8 +1536,8 @@ describe("getCurrencyRateControllerCurrentCurrency", () => {
     });
   });
 
-  describe("when assets unify state feature is enabled", () => {
-    it("returns selectedCurrency from new state", () => {
+  describe('when assets unify state feature is enabled', () => {
+    it('returns selectedCurrency from new state', () => {
       const state = {
         metamask: {
           remoteFeatureFlags: {
@@ -1510,20 +1546,20 @@ describe("getCurrencyRateControllerCurrentCurrency", () => {
               featureVersion: ASSETS_UNIFY_STATE_VERSION_1,
             },
           },
-          currentCurrency: "eur",
-          selectedCurrency: "usd",
+          currentCurrency: 'eur',
+          selectedCurrency: 'usd',
         },
       };
       const result = getCurrencyRateControllerCurrentCurrency(state);
 
-      expect(result).toBe("usd");
+      expect(result).toBe('usd');
     });
   });
 });
 
-describe("getCurrencyRateControllerCurrencyRates", () => {
-  describe("when assets unify state feature is disabled", () => {
-    it("returns currencyRates from state unchanged", () => {
+describe('getCurrencyRateControllerCurrencyRates', () => {
+  describe('when assets unify state feature is disabled', () => {
+    it('returns currencyRates from state unchanged', () => {
       const legacyCurrencyRates = {
         ETH: {
           conversionDate: 1000,
@@ -1543,10 +1579,10 @@ describe("getCurrencyRateControllerCurrencyRates", () => {
     });
   });
 
-  describe("when assets unify state feature is enabled (happy path)", () => {
-    it("derives currencyRates from assetsInfo and assetsPrice for native EVM assets", () => {
+  describe('when assets unify state feature is enabled (happy path)', () => {
+    it('derives currencyRates from assetsInfo and assetsPrice for native EVM assets', () => {
       const lastUpdated = 1700000000000; // ms
-      const mockNonFungibleAssetId = "eip155:137/slip44:987654321";
+      const mockNonFungibleAssetId = 'eip155:137/slip44:987654321';
       const state = {
         metamask: {
           remoteFeatureFlags: {
@@ -1555,25 +1591,25 @@ describe("getCurrencyRateControllerCurrencyRates", () => {
               featureVersion: ASSETS_UNIFY_STATE_VERSION_1,
             },
           },
-          currentCurrency: "eur",
-          selectedCurrency: "eur",
+          currentCurrency: 'eur',
+          selectedCurrency: 'eur',
           currencyRates: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: "native", symbol: "ETH", decimals: 18 },
+            [nativeEthAssetId]: { type: 'native', symbol: 'ETH', decimals: 18 },
             [erc20AssetId]: {
-              type: "erc20",
-              symbol: "USDC",
+              type: 'erc20',
+              symbol: 'USDC',
               decimals: 6,
             },
             [mockNonFungibleAssetId]: {
-              type: "something",
-              symbol: "SMT",
+              type: 'something',
+              symbol: 'SMT',
             },
           },
           assetsPrice: {
             [nativeEthAssetId]: {
-              assetPriceType: "fungible",
-              id: "eth-price",
+              assetPriceType: 'fungible',
+              id: 'eth-price',
               price: 2500,
               usdPrice: 3000,
               lastUpdated,
@@ -1596,8 +1632,8 @@ describe("getCurrencyRateControllerCurrencyRates", () => {
               pricePercentChange1y: 30,
             },
             [mockNonFungibleAssetId]: {
-              assetPriceType: "something",
-              id: "smt-price",
+              assetPriceType: 'something',
+              id: 'smt-price',
               price: 0.5,
               lastUpdated,
             },
@@ -1617,14 +1653,14 @@ describe("getCurrencyRateControllerCurrencyRates", () => {
   });
 });
 
-describe("getTokenRatesControllerMarketData", () => {
-  describe("when assets unify state feature is disabled", () => {
-    it("returns marketData from state unchanged", () => {
+describe('getTokenRatesControllerMarketData', () => {
+  describe('when assets unify state feature is disabled', () => {
+    it('returns marketData from state unchanged', () => {
       const legacyMarketData = {
-        "0x1": {
+        '0x1': {
           [erc20AssetAddressChecksummed]: {
             tokenAddress: erc20AssetAddressChecksummed,
-            currency: "ETH",
+            currency: 'ETH',
             price: 1,
             marketCap: 0,
             allTimeHigh: 0,
@@ -1658,8 +1694,8 @@ describe("getTokenRatesControllerMarketData", () => {
     });
   });
 
-  describe("when assets unify state feature is enabled (happy path)", () => {
-    it("derives marketData from assetsPrice with prices converted to native currency", () => {
+  describe('when assets unify state feature is enabled (happy path)', () => {
+    it('derives marketData from assetsPrice with prices converted to native currency', () => {
       const lastUpdated = 1700000000000;
       const ethPriceInUsd = 2000;
       const usdcPriceInUsd = 1;
@@ -1672,21 +1708,21 @@ describe("getTokenRatesControllerMarketData", () => {
             },
           },
           marketData: {},
-          currentCurrency: "usd",
-          selectedCurrency: "usd",
+          currentCurrency: 'usd',
+          selectedCurrency: 'usd',
           currencyRates: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: "native", symbol: "ETH", decimals: 18 },
+            [nativeEthAssetId]: { type: 'native', symbol: 'ETH', decimals: 18 },
             [erc20AssetId]: {
-              type: "erc20",
-              symbol: "USDC",
+              type: 'erc20',
+              symbol: 'USDC',
               decimals: 6,
             },
           },
           assetsPrice: {
             [nativeEthAssetId]: {
-              assetPriceType: "fungible",
-              id: "eth-price",
+              assetPriceType: 'fungible',
+              id: 'eth-price',
               price: ethPriceInUsd,
               usdPrice: ethPriceInUsd,
               lastUpdated,
@@ -1709,8 +1745,8 @@ describe("getTokenRatesControllerMarketData", () => {
               pricePercentChange1y: 30,
             },
             [erc20AssetId]: {
-              assetPriceType: "fungible",
-              id: "usdc-price",
+              assetPriceType: 'fungible',
+              id: 'usdc-price',
               price: usdcPriceInUsd,
               usdPrice: usdcPriceInUsd,
               lastUpdated,
@@ -1734,115 +1770,118 @@ describe("getTokenRatesControllerMarketData", () => {
             },
           },
           networkConfigurationsByChainId: {
-            "0x1": { nativeCurrency: "ETH" },
+            '0x1': { nativeCurrency: 'ETH' },
           },
         },
       };
       const result = getTokenRatesControllerMarketData(state);
 
       // ETH native rate is 2000 USD; USDC price 1 USD -> 1/2000 ETH
-      const marketData = result["0x1"][erc20AssetAddressChecksummed];
+      const marketData = result['0x1'][erc20AssetAddressChecksummed];
       expect(marketData.price).toBe(usdcPriceInUsd / ethPriceInUsd);
-      expect(marketData.currency).toBe("ETH");
+      expect(marketData.currency).toBe('ETH');
       expect(marketData.tokenAddress).toBe(erc20AssetAddressChecksummed);
     });
   });
 
-  describe("edge cases when enabled", () => {
-    it("skips non-EIP155 assets from marketData", () => {
+  describe('edge cases when enabled', () => {
+    it('skips non-EIP155 assets from marketData', () => {
       const state = {
         metamask: {
           ...enabledFlags,
           marketData: {},
-          currentCurrency: "usd",
-          selectedCurrency: "usd",
+          currentCurrency: 'usd',
+          selectedCurrency: 'usd',
           currencyRates: {},
           assetsInfo: {
             [nativeEthAssetId]: {
-              type: "native",
-              symbol: "ETH",
+              type: 'native',
+              symbol: 'ETH',
               decimals: 18,
             },
             [solanaTokenAssetId]: {
-              type: "token",
-              symbol: "USDC",
+              type: 'token',
+              symbol: 'USDC',
               decimals: 6,
             },
           },
           assetsPrice: {
-            [nativeEthAssetId]: makeMockPrice({ id: "eth", price: 2000 }),
+            [nativeEthAssetId]: makeMockPrice({ id: 'eth', price: 2000 }),
             [solanaTokenAssetId]: makeMockPrice({
-              id: "sol-usdc",
+              id: 'sol-usdc',
               price: 1,
             }),
           },
           networkConfigurationsByChainId: {
-            "0x1": { nativeCurrency: "ETH" },
+            '0x1': { nativeCurrency: 'ETH' },
           },
         },
       };
       const result = getTokenRatesControllerMarketData(state);
 
-      expect(result["0x1"]).toBeDefined();
-      expect(Object.keys(result).every((key) => key.startsWith("0x"))).toBe(true);
+      expect(result['0x1']).toBeDefined();
+      expect(Object.keys(result).every((key) => key.startsWith('0x'))).toBe(
+        true,
+      );
     });
 
-    it("skips assets without metadata in assetsInfo", () => {
-      const unknownAssetId = "eip155:1/erc20:0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+    it('skips assets without metadata in assetsInfo', () => {
+      const unknownAssetId =
+        'eip155:1/erc20:0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
       const state = {
         metamask: {
           ...enabledFlags,
           marketData: {},
-          currentCurrency: "usd",
-          selectedCurrency: "usd",
+          currentCurrency: 'usd',
+          selectedCurrency: 'usd',
           currencyRates: {},
           assetsInfo: {
             [nativeEthAssetId]: {
-              type: "native",
-              symbol: "ETH",
+              type: 'native',
+              symbol: 'ETH',
               decimals: 18,
             },
           },
           assetsPrice: {
             [nativeEthAssetId]: makeMockPrice({
-              id: "eth",
+              id: 'eth',
               price: 2000,
             }),
             [unknownAssetId]: makeMockPrice({
-              id: "unknown",
+              id: 'unknown',
               price: 42,
             }),
           },
           networkConfigurationsByChainId: {
-            "0x1": { nativeCurrency: "ETH" },
+            '0x1': { nativeCurrency: 'ETH' },
           },
         },
       };
       const result = getTokenRatesControllerMarketData(state);
 
-      expect(Object.keys(result["0x1"])).toHaveLength(1);
+      expect(Object.keys(result['0x1'])).toHaveLength(1);
     });
 
-    it("skips assets when native currency conversion rate is unavailable", () => {
+    it('skips assets when native currency conversion rate is unavailable', () => {
       const state = {
         metamask: {
           ...enabledFlags,
           marketData: {},
-          currentCurrency: "usd",
-          selectedCurrency: "usd",
+          currentCurrency: 'usd',
+          selectedCurrency: 'usd',
           currencyRates: {},
           assetsInfo: {
             [erc20AssetId]: {
-              type: "erc20",
-              symbol: "USDC",
+              type: 'erc20',
+              symbol: 'USDC',
               decimals: 6,
             },
           },
           assetsPrice: {
-            [erc20AssetId]: makeMockPrice({ id: "usdc", price: 1 }),
+            [erc20AssetId]: makeMockPrice({ id: 'usdc', price: 1 }),
           },
           networkConfigurationsByChainId: {
-            "0x1": { nativeCurrency: "ETH" },
+            '0x1': { nativeCurrency: 'ETH' },
           },
         },
       };
@@ -1851,62 +1890,64 @@ describe("getTokenRatesControllerMarketData", () => {
       expect(result).toStrictEqual({});
     });
 
-    it("places native slip44 asset at getNativeTokenAddress", () => {
-      const nativeTokenAddress = "0x0000000000000000000000000000000000000000";
+    it('places native slip44 asset at getNativeTokenAddress', () => {
+      const nativeTokenAddress = '0x0000000000000000000000000000000000000000';
       const state = {
         metamask: {
           ...enabledFlags,
           marketData: {},
-          currentCurrency: "usd",
-          selectedCurrency: "usd",
+          currentCurrency: 'usd',
+          selectedCurrency: 'usd',
           currencyRates: {},
           assetsInfo: {
             [nativeEthAssetId]: {
-              type: "native",
-              symbol: "ETH",
+              type: 'native',
+              symbol: 'ETH',
               decimals: 18,
             },
           },
           assetsPrice: {
-            [nativeEthAssetId]: makeMockPrice({ id: "eth", price: 2000 }),
+            [nativeEthAssetId]: makeMockPrice({ id: 'eth', price: 2000 }),
           },
           networkConfigurationsByChainId: {
-            "0x1": { nativeCurrency: "ETH" },
+            '0x1': { nativeCurrency: 'ETH' },
           },
         },
       };
       const result = getTokenRatesControllerMarketData(state);
 
-      expect(result["0x1"][nativeTokenAddress]).toBeDefined();
-      expect(result["0x1"][nativeTokenAddress].tokenAddress).toBe(nativeTokenAddress);
-      expect(result["0x1"][nativeTokenAddress].price).toBe(1);
+      expect(result['0x1'][nativeTokenAddress]).toBeDefined();
+      expect(result['0x1'][nativeTokenAddress].tokenAddress).toBe(
+        nativeTokenAddress,
+      );
+      expect(result['0x1'][nativeTokenAddress].price).toBe(1);
     });
 
-    it("converts all price fields to native currency denomination", () => {
+    it('converts all price fields to native currency denomination', () => {
       const ethPrice = 2500;
       const state = {
         metamask: {
           ...enabledFlags,
           marketData: {},
-          currentCurrency: "usd",
-          selectedCurrency: "usd",
+          currentCurrency: 'usd',
+          selectedCurrency: 'usd',
           currencyRates: {},
           assetsInfo: {
             [nativeEthAssetId]: {
-              type: "native",
-              symbol: "ETH",
+              type: 'native',
+              symbol: 'ETH',
               decimals: 18,
             },
             [erc20AssetId]: {
-              type: "erc20",
-              symbol: "USDC",
+              type: 'erc20',
+              symbol: 'USDC',
               decimals: 6,
             },
           },
           assetsPrice: {
-            [nativeEthAssetId]: makeMockPrice({ id: "eth", price: ethPrice }),
+            [nativeEthAssetId]: makeMockPrice({ id: 'eth', price: ethPrice }),
             [erc20AssetId]: makeMockPrice({
-              id: "usdc",
+              id: 'usdc',
               price: 1,
               marketCap: 30e9,
               allTimeHigh: 1.1,
@@ -1919,12 +1960,12 @@ describe("getTokenRatesControllerMarketData", () => {
             }),
           },
           networkConfigurationsByChainId: {
-            "0x1": { nativeCurrency: "ETH" },
+            '0x1': { nativeCurrency: 'ETH' },
           },
         },
       };
       const result = getTokenRatesControllerMarketData(state);
-      const md = result["0x1"][erc20AssetAddressChecksummed];
+      const md = result['0x1'][erc20AssetAddressChecksummed];
 
       expect(md.price).toBe(1 / ethPrice);
       expect(md.marketCap).toBe(30e9 / ethPrice);
@@ -1938,64 +1979,65 @@ describe("getTokenRatesControllerMarketData", () => {
       expect(md.circulatingSupply).toBe(30e9);
     });
 
-    it("does not use slip44 fallback for ERC-20 assets missing from assetsInfo", () => {
+    it('does not use slip44 fallback for ERC-20 assets missing from assetsInfo', () => {
       const ethPrice = 2000;
-      const nativeTokenAddress = "0x0000000000000000000000000000000000000000";
-      const orphanErc20AssetId = "eip155:1/erc20:0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
+      const nativeTokenAddress = '0x0000000000000000000000000000000000000000';
+      const orphanErc20AssetId =
+        'eip155:1/erc20:0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
       const state = {
         metamask: {
           ...enabledFlags,
           marketData: {},
-          currentCurrency: "usd",
-          selectedCurrency: "usd",
+          currentCurrency: 'usd',
+          selectedCurrency: 'usd',
           currencyRates: {},
           assetsInfo: {
             [nativeEthAssetId]: {
-              type: "native",
-              symbol: "ETH",
+              type: 'native',
+              symbol: 'ETH',
               decimals: 18,
             },
           },
           assetsPrice: {
-            [nativeEthAssetId]: makeMockPrice({ id: "eth", price: ethPrice }),
+            [nativeEthAssetId]: makeMockPrice({ id: 'eth', price: ethPrice }),
             [orphanErc20AssetId]: makeMockPrice({
-              id: "orphan",
+              id: 'orphan',
               price: 999,
             }),
           },
           networkConfigurationsByChainId: {
-            "0x1": { nativeCurrency: "ETH" },
+            '0x1': { nativeCurrency: 'ETH' },
           },
         },
       };
       const result = getTokenRatesControllerMarketData(state);
 
       // The native entry should still be the native price, not overwritten
-      expect(result["0x1"][nativeTokenAddress].price).toBe(1);
+      expect(result['0x1'][nativeTokenAddress].price).toBe(1);
       // The orphan ERC-20 should be skipped entirely (no metadata)
       const checksumOrphan = toChecksumHexAddress(
-        "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+        '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
       ) as Hex;
-      expect(result["0x1"][checksumOrphan]).toBeUndefined();
+      expect(result['0x1'][checksumOrphan]).toBeUndefined();
     });
   });
 });
 
-describe("getMultichainAssetsRatesControllerConversionRates", () => {
-  describe("when assets unify state feature is disabled", () => {
-    it("returns conversionRates from state unchanged", () => {
+describe('getMultichainAssetsRatesControllerConversionRates', () => {
+  describe('when assets unify state feature is disabled', () => {
+    it('returns conversionRates from state unchanged', () => {
       const legacyConversionRates = {
         [solanaTokenAssetId]: {
-          rate: "1",
+          rate: '1',
           conversionTime: 1700000000000,
           expirationTime: undefined,
           marketData: {
             fungible: true as const,
-            allTimeHigh: "1.1",
-            allTimeLow: "0.9",
-            circulatingSupply: "1000000",
-            marketCap: "1000000",
-            totalVolume: "500000",
+            allTimeHigh: '1.1',
+            allTimeLow: '0.9',
+            circulatingSupply: '1000000',
+            marketCap: '1000000',
+            totalVolume: '500000',
             pricePercentChange: {
               PT1H: 0,
               P1D: 0,
@@ -2020,8 +2062,8 @@ describe("getMultichainAssetsRatesControllerConversionRates", () => {
     });
   });
 
-  describe("when assets unify state feature is enabled (happy path)", () => {
-    it("derives conversionRates from assetsPrice for non-EVM assets only", () => {
+  describe('when assets unify state feature is enabled (happy path)', () => {
+    it('derives conversionRates from assetsPrice for non-EVM assets only', () => {
       const lastUpdated = 1700000000000;
       const state = {
         metamask: {
@@ -2034,8 +2076,8 @@ describe("getMultichainAssetsRatesControllerConversionRates", () => {
           conversionRates: {},
           assetsPrice: {
             [nativeEthAssetId]: {
-              assetPriceType: "fungible",
-              id: "eth-price",
+              assetPriceType: 'fungible',
+              id: 'eth-price',
               price: 2000,
               usdPrice: 2000,
               lastUpdated,
@@ -2058,8 +2100,8 @@ describe("getMultichainAssetsRatesControllerConversionRates", () => {
               pricePercentChange1y: 30,
             },
             [solanaTokenAssetId]: {
-              assetPriceType: "fungible",
-              id: "sol-usdc-price",
+              assetPriceType: 'fungible',
+              id: 'sol-usdc-price',
               price: 1.02,
               usdPrice: 1.02,
               lastUpdated,
@@ -2088,16 +2130,16 @@ describe("getMultichainAssetsRatesControllerConversionRates", () => {
 
       expect(result[nativeEthAssetId]).toBeUndefined();
       expect(result[solanaTokenAssetId]).toStrictEqual({
-        rate: "1.02",
+        rate: '1.02',
         conversionTime: lastUpdated,
         expirationTime: undefined,
         marketData: {
           fungible: true,
-          allTimeHigh: "1.1",
-          allTimeLow: "0.95",
-          circulatingSupply: "30000000000",
-          marketCap: "30000000000",
-          totalVolume: "100000000000",
+          allTimeHigh: '1.1',
+          allTimeLow: '0.95',
+          circulatingSupply: '30000000000',
+          marketCap: '30000000000',
+          totalVolume: '100000000000',
           pricePercentChange: {
             PT1H: 0.1,
             P1D: 0.5,
@@ -2112,15 +2154,15 @@ describe("getMultichainAssetsRatesControllerConversionRates", () => {
     });
   });
 
-  describe("edge cases when enabled", () => {
-    it("returns empty result when only EVM assets exist in assetsPrice", () => {
+  describe('edge cases when enabled', () => {
+    it('returns empty result when only EVM assets exist in assetsPrice', () => {
       const state = {
         metamask: {
           ...enabledFlags,
           conversionRates: {},
           assetsPrice: {
-            [nativeEthAssetId]: makeMockPrice({ id: "eth", price: 2000 }),
-            [erc20AssetId]: makeMockPrice({ id: "usdc", price: 1 }),
+            [nativeEthAssetId]: makeMockPrice({ id: 'eth', price: 2000 }),
+            [erc20AssetId]: makeMockPrice({ id: 'usdc', price: 1 }),
           },
         },
       };
@@ -2129,7 +2171,7 @@ describe("getMultichainAssetsRatesControllerConversionRates", () => {
       expect(result).toStrictEqual({});
     });
 
-    it("converts all market data fields to strings", () => {
+    it('converts all market data fields to strings', () => {
       const lastUpdated = 1700000000000;
       const state = {
         metamask: {
@@ -2137,7 +2179,7 @@ describe("getMultichainAssetsRatesControllerConversionRates", () => {
           conversionRates: {},
           assetsPrice: {
             [solanaTokenAssetId]: makeMockPrice({
-              id: "sol-usdc",
+              id: 'sol-usdc',
               price: 1.5,
               lastUpdated,
               allTimeHigh: 2.0,
@@ -2152,17 +2194,17 @@ describe("getMultichainAssetsRatesControllerConversionRates", () => {
       const result = getMultichainAssetsRatesControllerConversionRates(state);
 
       const entry = result[solanaTokenAssetId];
-      expect(entry.rate).toBe("1.5");
+      expect(entry.rate).toBe('1.5');
       expect(entry.conversionTime).toBe(lastUpdated);
       expect(entry.expirationTime).toBeUndefined();
-      expect(entry.marketData?.allTimeHigh).toBe("2");
-      expect(entry.marketData?.allTimeLow).toBe("0.8");
-      expect(entry.marketData?.circulatingSupply).toBe("1000000000");
-      expect(entry.marketData?.marketCap).toBe("1500000000");
-      expect(entry.marketData?.totalVolume).toBe("500000000");
+      expect(entry.marketData?.allTimeHigh).toBe('2');
+      expect(entry.marketData?.allTimeLow).toBe('0.8');
+      expect(entry.marketData?.circulatingSupply).toBe('1000000000');
+      expect(entry.marketData?.marketCap).toBe('1500000000');
+      expect(entry.marketData?.totalVolume).toBe('500000000');
     });
 
-    it("handles empty assetsPrice", () => {
+    it('handles empty assetsPrice', () => {
       const state = {
         metamask: {
           ...enabledFlags,
@@ -2177,11 +2219,12 @@ describe("getMultichainAssetsRatesControllerConversionRates", () => {
   });
 });
 
-describe("getRatesControllerRates", () => {
-  const solanaNativeAssetId = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501";
+describe('getRatesControllerRates', () => {
+  const solanaNativeAssetId =
+    'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501';
 
-  describe("when assets unify state feature is disabled", () => {
-    it("returns rates from state unchanged", () => {
+  describe('when assets unify state feature is disabled', () => {
+    it('returns rates from state unchanged', () => {
       const legacyRates = {
         btc: {
           conversionDate: 1700000000000,
@@ -2206,8 +2249,8 @@ describe("getRatesControllerRates", () => {
     });
   });
 
-  describe("when assets unify state feature is enabled (happy path)", () => {
-    it("derives rates from assetsInfo and assetsPrice for non-EVM native assets", () => {
+  describe('when assets unify state feature is enabled (happy path)', () => {
+    it('derives rates from assetsInfo and assetsPrice for non-EVM native assets', () => {
       const lastUpdated = 1700000000000;
       const state = {
         metamask: {
@@ -2215,36 +2258,36 @@ describe("getRatesControllerRates", () => {
           rates: {},
           assetsInfo: {
             [nativeEthAssetId]: {
-              type: "native",
-              symbol: "ETH",
+              type: 'native',
+              symbol: 'ETH',
               decimals: 18,
             },
             [bitcoinNativeAssetId]: {
-              type: "native",
-              symbol: "BTC",
+              type: 'native',
+              symbol: 'BTC',
               decimals: 8,
             },
             [solanaNativeAssetId]: {
-              type: "native",
-              symbol: "SOL",
+              type: 'native',
+              symbol: 'SOL',
               decimals: 9,
             },
           },
           assetsPrice: {
             [nativeEthAssetId]: makeMockPrice({
-              id: "eth",
+              id: 'eth',
               price: 2000,
               usdPrice: 2000,
               lastUpdated,
             }),
             [bitcoinNativeAssetId]: makeMockPrice({
-              id: "btc",
+              id: 'btc',
               price: 71052.43,
               usdPrice: 71052.43,
               lastUpdated,
             }),
             [solanaNativeAssetId]: makeMockPrice({
-              id: "sol",
+              id: 'sol',
               price: 91.69,
               usdPrice: 91.69,
               lastUpdated,
@@ -2271,47 +2314,47 @@ describe("getRatesControllerRates", () => {
   });
 });
 
-describe("getRatesControllerFiatCurrency", () => {
-  describe("when assets unify state feature is disabled", () => {
-    it("returns fiatCurrency from state unchanged", () => {
+describe('getRatesControllerFiatCurrency', () => {
+  describe('when assets unify state feature is disabled', () => {
+    it('returns fiatCurrency from state unchanged', () => {
       const state = {
         metamask: {
-          fiatCurrency: "eur",
+          fiatCurrency: 'eur',
         },
       };
       const result = getRatesControllerFiatCurrency(state);
 
-      expect(result).toBe("eur");
+      expect(result).toBe('eur');
     });
   });
 
-  describe("when assets unify state feature is enabled", () => {
-    it("returns selectedCurrency from new state", () => {
+  describe('when assets unify state feature is enabled', () => {
+    it('returns selectedCurrency from new state', () => {
       const state = {
         metamask: {
           ...enabledFlags,
-          fiatCurrency: "eur",
-          selectedCurrency: "usd",
+          fiatCurrency: 'eur',
+          selectedCurrency: 'usd',
         },
       };
       const result = getRatesControllerFiatCurrency(state);
 
-      expect(result).toBe("usd");
+      expect(result).toBe('usd');
     });
   });
 });
 
-describe("getIsAssetsUnifiedStateIncludedInBuild compile-time gate", () => {
+describe('getIsAssetsUnifiedStateIncludedInBuild compile-time gate', () => {
   afterEach(() => {
     jest.mocked(getIsAssetsUnifiedStateIncludedInBuild).mockReturnValue(true);
   });
 
-  it("returns legacy accountsByChainId when the build excludes unified state even if the remote flag is enabled", () => {
+  it('returns legacy accountsByChainId when the build excludes unified state even if the remote flag is enabled', () => {
     jest.mocked(getIsAssetsUnifiedStateIncludedInBuild).mockReturnValue(false);
     const legacyAccountsByChainId = {
-      "0x1": {
+      '0x1': {
         [mockAccountAddressChecksummed]: {
-          balance: "0xabc" as const,
+          balance: '0xabc' as const,
         },
       },
     };
@@ -2321,15 +2364,15 @@ describe("getIsAssetsUnifiedStateIncludedInBuild compile-time gate", () => {
         // the object so this test does not reuse a cached `true` from earlier examples.
         remoteFeatureFlags: {
           ...enabledFlags.remoteFeatureFlags,
-          compileTimeGateCacheBust: "accountsByChainId",
+          compileTimeGateCacheBust: 'accountsByChainId',
         },
         accountsByChainId: legacyAccountsByChainId,
         assetsInfo: {
-          [nativeEthAssetId]: { type: "native", decimals: 18 },
+          [nativeEthAssetId]: { type: 'native', decimals: 18 },
         },
         assetsBalance: {
           [mockAccountId]: {
-            [nativeEthAssetId]: { amount: "999" },
+            [nativeEthAssetId]: { amount: '999' },
           },
         },
         internalAccounts: {
@@ -2337,13 +2380,15 @@ describe("getIsAssetsUnifiedStateIncludedInBuild compile-time gate", () => {
             [mockAccountId]: {
               id: mockAccountId,
               address: mockAccountAddressLowercase,
-              type: "eip155:eoa",
+              type: 'eip155:eoa',
             },
           },
         },
       },
     };
 
-    expect(getAccountTrackerControllerAccountsByChainId(state)).toBe(legacyAccountsByChainId);
+    expect(getAccountTrackerControllerAccountsByChainId(state)).toBe(
+      legacyAccountsByChainId,
+    );
   });
 });

--- a/shared/lib/selectors/assets-migration.test.ts
+++ b/shared/lib/selectors/assets-migration.test.ts
@@ -1,11 +1,11 @@
-import { getNativeAssetForChainId } from '@metamask/bridge-controller';
-import { toChecksumHexAddress } from '@metamask/controller-utils';
-import type { CaipAssetType, Hex } from '@metamask/utils';
+import { getNativeAssetForChainId } from "@metamask/bridge-controller";
+import { toChecksumHexAddress } from "@metamask/controller-utils";
+import type { CaipAssetType, Hex } from "@metamask/utils";
 import {
   ASSETS_UNIFY_STATE_FLAG,
   ASSETS_UNIFY_STATE_VERSION_1,
-} from '../assets-unify-state/remote-feature-flag';
-import { getIsAssetsUnifiedStateIncludedInBuild } from '../environment';
+} from "../assets-unify-state/remote-feature-flag";
+import { getIsAssetsUnifiedStateIncludedInBuild } from "../environment";
 import {
   getAccountTrackerControllerAccountsByChainId,
   getTokensControllerAllTokens,
@@ -21,57 +21,45 @@ import {
   getMultichainAssetsRatesControllerConversionRates,
   getRatesControllerRates,
   getRatesControllerFiatCurrency,
-} from './assets-migration';
+} from "./assets-migration";
 
 // Opt out of the global `isAssetsUnifyStateFeatureEnabled` mock (see test/jest/setup.js)
 // and provide the pure flag-evaluation logic without the IN_TEST bypass
 // (test/helpers/setup-helper.js sets process.env.IN_TEST=true for all unit tests,
 // so using jest.requireActual here would make the function always return true,
 // breaking all "when disabled" test cases).
-jest.mock('../assets-unify-state/remote-feature-flag', () => ({
-  ...jest.requireActual('../assets-unify-state/remote-feature-flag'),
+jest.mock("../assets-unify-state/remote-feature-flag", () => ({
+  ...jest.requireActual("../assets-unify-state/remote-feature-flag"),
   isAssetsUnifyStateFeatureEnabled: jest.fn(
     (
-      featureFlag:
-        | { enabled: boolean; featureVersion: string }
-        | undefined
-        | null,
+      featureFlag: { enabled: boolean; featureVersion: string } | undefined | null,
       featureVersion: string,
-    ) =>
-      Boolean(featureFlag?.enabled) &&
-      featureFlag?.featureVersion === featureVersion,
+    ) => Boolean(featureFlag?.enabled) && featureFlag?.featureVersion === featureVersion,
   ),
 }));
 
-jest.mock('../environment', () => ({
-  ...jest.requireActual('../environment'),
+jest.mock("../environment", () => ({
+  ...jest.requireActual("../environment"),
   getIsAssetsUnifiedStateIncludedInBuild: jest.fn(() => true),
 }));
 
-const mockAccountId = 'mock-account-id-1';
-const mockAccountId2 = 'mock-account-id-2';
+const mockAccountId = "mock-account-id-1";
+const mockAccountId2 = "mock-account-id-2";
 
-const mockAccountAddressLowercase: Hex =
-  '0xd8da6bf26964af9d7eed9e03e53415d37aa96045';
-const mockAccountAddressChecksummed = toChecksumHexAddress(
-  mockAccountAddressLowercase,
-) as Hex;
+const mockAccountAddressLowercase: Hex = "0xd8da6bf26964af9d7eed9e03e53415d37aa96045";
+const mockAccountAddressChecksummed = toChecksumHexAddress(mockAccountAddressLowercase) as Hex;
 
-const nativeEthAssetId = 'eip155:1/slip44:60';
-const erc20AssetAddressLowercase: Hex =
-  '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
-const erc20AssetAddressChecksummed = toChecksumHexAddress(
-  erc20AssetAddressLowercase,
-) as Hex;
+const nativeEthAssetId = "eip155:1/slip44:60";
+const erc20AssetAddressLowercase: Hex = "0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48";
+const erc20AssetAddressChecksummed = toChecksumHexAddress(erc20AssetAddressLowercase) as Hex;
 const erc20AssetId = `eip155:1/erc20:${erc20AssetAddressLowercase}`;
 const solanaTokenAssetId =
-  'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';
+  "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v";
 
-const nativePolygonAssetId = 'eip155:137/slip44:966';
-const bitcoinNativeAssetId = 'bip122:000000000019d6689c085ae165831e93/slip44:0';
-const mockAccountId3 = 'mock-account-id-3';
-const mockAccountAddressLowercase2: Hex =
-  '0x1234567890abcdef1234567890abcdef12345678';
+const nativePolygonAssetId = "eip155:137/slip44:966";
+const bitcoinNativeAssetId = "bip122:000000000019d6689c085ae165831e93/slip44:0";
+const mockAccountId3 = "mock-account-id-3";
+const mockAccountAddressLowercase2: Hex = "0x1234567890abcdef1234567890abcdef12345678";
 const enabledFlags = {
   remoteFeatureFlags: {
     [ASSETS_UNIFY_STATE_FLAG]: {
@@ -83,8 +71,8 @@ const enabledFlags = {
 
 function makeMockPrice(overrides: Partial<Record<string, unknown>> = {}) {
   return {
-    assetPriceType: 'fungible',
-    id: 'mock-price',
+    assetPriceType: "fungible",
+    id: "mock-price",
     price: 1,
     lastUpdated: 1700000000000,
     marketCap: 0,
@@ -108,9 +96,9 @@ function makeMockPrice(overrides: Partial<Record<string, unknown>> = {}) {
   };
 }
 
-describe('getAccountTrackerControllerAccountsByChainId', () => {
-  describe('when assets unify state feature is enabled (happy path)', () => {
-    it('derives accountsByChainId from new state structure', () => {
+describe("getAccountTrackerControllerAccountsByChainId", () => {
+  describe("when assets unify state feature is enabled (happy path)", () => {
+    it("derives accountsByChainId from new state structure", () => {
       const state = {
         metamask: {
           remoteFeatureFlags: {
@@ -121,13 +109,13 @@ describe('getAccountTrackerControllerAccountsByChainId', () => {
           },
           accountsByChainId: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: 'native', decimals: 18 },
-            [erc20AssetId]: { type: 'erc20', decimals: 6 },
+            [nativeEthAssetId]: { type: "native", decimals: 18 },
+            [erc20AssetId]: { type: "erc20", decimals: 6 },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: '1.23456789' },
-              [erc20AssetId]: { amount: '1' },
+              [nativeEthAssetId]: { amount: "1.23456789" },
+              [erc20AssetId]: { amount: "1" },
             },
           },
           internalAccounts: {
@@ -135,11 +123,11 @@ describe('getAccountTrackerControllerAccountsByChainId', () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: 'eip155:eoa',
+                type: "eip155:eoa",
               },
               [mockAccountId2]: {
                 id: mockAccountId2,
-                type: 'solana:data-account',
+                type: "solana:data-account",
               },
             },
           },
@@ -148,29 +136,29 @@ describe('getAccountTrackerControllerAccountsByChainId', () => {
       const result = getAccountTrackerControllerAccountsByChainId(state);
 
       expect(result).toStrictEqual({
-        '0x1': {
+        "0x1": {
           [mockAccountAddressChecksummed]: {
-            balance: '0x112210f4768db400', // 1234567890000000000
+            balance: "0x112210f4768db400", // 1234567890000000000
           },
         },
       });
     });
   });
 
-  describe('edge cases when enabled', () => {
-    it('handles multiple chains for the same EVM account', () => {
+  describe("edge cases when enabled", () => {
+    it("handles multiple chains for the same EVM account", () => {
       const state = {
         metamask: {
           ...enabledFlags,
           accountsByChainId: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: 'native', decimals: 18 },
-            [nativePolygonAssetId]: { type: 'native', decimals: 18 },
+            [nativeEthAssetId]: { type: "native", decimals: 18 },
+            [nativePolygonAssetId]: { type: "native", decimals: 18 },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: '1' },
-              [nativePolygonAssetId]: { amount: '2' },
+              [nativeEthAssetId]: { amount: "1" },
+              [nativePolygonAssetId]: { amount: "2" },
             },
           },
           internalAccounts: {
@@ -178,7 +166,7 @@ describe('getAccountTrackerControllerAccountsByChainId', () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: 'eip155:eoa',
+                type: "eip155:eoa",
               },
             },
           },
@@ -186,23 +174,23 @@ describe('getAccountTrackerControllerAccountsByChainId', () => {
       };
       const result = getAccountTrackerControllerAccountsByChainId(state);
 
-      expect(result['0x1']).toBeDefined();
-      expect(result['0x89']).toBeDefined();
+      expect(result["0x1"]).toBeDefined();
+      expect(result["0x89"]).toBeDefined();
       expect(Object.keys(result)).toHaveLength(2);
     });
 
-    it('handles balance with 0 decimals', () => {
-      const zeroDecNativeId = 'eip155:42/slip44:60';
+    it("handles balance with 0 decimals", () => {
+      const zeroDecNativeId = "eip155:42/slip44:60";
       const state = {
         metamask: {
           ...enabledFlags,
           accountsByChainId: {},
           assetsInfo: {
-            [zeroDecNativeId]: { type: 'native', decimals: 0 },
+            [zeroDecNativeId]: { type: "native", decimals: 0 },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [zeroDecNativeId]: { amount: '42' },
+              [zeroDecNativeId]: { amount: "42" },
             },
           },
           internalAccounts: {
@@ -210,7 +198,7 @@ describe('getAccountTrackerControllerAccountsByChainId', () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: 'eip155:eoa',
+                type: "eip155:eoa",
               },
             },
           },
@@ -218,25 +206,22 @@ describe('getAccountTrackerControllerAccountsByChainId', () => {
       };
       const result = getAccountTrackerControllerAccountsByChainId(state);
 
-      expect(result['0x2a'][mockAccountAddressChecksummed].balance).toBe(
-        '0x2a',
-      );
+      expect(result["0x2a"][mockAccountAddressChecksummed].balance).toBe("0x2a");
     });
 
-    it('skips balance entries without metadata in assetsInfo', () => {
-      const unknownAssetId =
-        'eip155:1/erc20:0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+    it("skips balance entries without metadata in assetsInfo", () => {
+      const unknownAssetId = "eip155:1/erc20:0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
       const state = {
         metamask: {
           ...enabledFlags,
           accountsByChainId: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: 'native', decimals: 18 },
+            [nativeEthAssetId]: { type: "native", decimals: 18 },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: '1' },
-              [unknownAssetId]: { amount: '500' },
+              [nativeEthAssetId]: { amount: "1" },
+              [unknownAssetId]: { amount: "500" },
             },
           },
           internalAccounts: {
@@ -244,7 +229,7 @@ describe('getAccountTrackerControllerAccountsByChainId', () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: 'eip155:eoa',
+                type: "eip155:eoa",
               },
             },
           },
@@ -252,22 +237,22 @@ describe('getAccountTrackerControllerAccountsByChainId', () => {
       };
       const result = getAccountTrackerControllerAccountsByChainId(state);
 
-      expect(Object.keys(result)).toStrictEqual(['0x1']);
+      expect(Object.keys(result)).toStrictEqual(["0x1"]);
     });
 
-    it('skips non-native assets (ERC-20) from accountsByChainId', () => {
+    it("skips non-native assets (ERC-20) from accountsByChainId", () => {
       const state = {
         metamask: {
           ...enabledFlags,
           accountsByChainId: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: 'native', decimals: 18 },
-            [erc20AssetId]: { type: 'erc20', decimals: 6 },
+            [nativeEthAssetId]: { type: "native", decimals: 18 },
+            [erc20AssetId]: { type: "erc20", decimals: 6 },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: '5' },
-              [erc20AssetId]: { amount: '1000' },
+              [nativeEthAssetId]: { amount: "5" },
+              [erc20AssetId]: { amount: "1000" },
             },
           },
           internalAccounts: {
@@ -275,7 +260,7 @@ describe('getAccountTrackerControllerAccountsByChainId', () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: 'eip155:eoa',
+                type: "eip155:eoa",
               },
             },
           },
@@ -283,22 +268,20 @@ describe('getAccountTrackerControllerAccountsByChainId', () => {
       };
       const result = getAccountTrackerControllerAccountsByChainId(state);
 
-      expect(Object.keys(result['0x1'])).toStrictEqual([
-        mockAccountAddressChecksummed,
-      ]);
+      expect(Object.keys(result["0x1"])).toStrictEqual([mockAccountAddressChecksummed]);
     });
 
-    it('truncates fractional digits exceeding decimals in parseBalanceWithDecimals', () => {
+    it("truncates fractional digits exceeding decimals in parseBalanceWithDecimals", () => {
       const state = {
         metamask: {
           ...enabledFlags,
           accountsByChainId: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: 'native', decimals: 2 },
+            [nativeEthAssetId]: { type: "native", decimals: 2 },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: '1.23456' },
+              [nativeEthAssetId]: { amount: "1.23456" },
             },
           },
           internalAccounts: {
@@ -306,7 +289,7 @@ describe('getAccountTrackerControllerAccountsByChainId', () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: 'eip155:eoa',
+                type: "eip155:eoa",
               },
             },
           },
@@ -315,7 +298,7 @@ describe('getAccountTrackerControllerAccountsByChainId', () => {
       const result = getAccountTrackerControllerAccountsByChainId(state);
 
       // 1.23456 with 2 decimals → truncated to 1.23 → 123
-      expect(result['0x1'][mockAccountAddressChecksummed].balance).toBe('0x7b');
+      expect(result["0x1"][mockAccountAddressChecksummed].balance).toBe("0x7b");
     });
 
     it('does not crash when amount is in scientific notation (e.g. "1e-18")', () => {
@@ -324,11 +307,11 @@ describe('getAccountTrackerControllerAccountsByChainId', () => {
           ...enabledFlags,
           accountsByChainId: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: 'native', decimals: 18 },
+            [nativeEthAssetId]: { type: "native", decimals: 18 },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: '1e-18' },
+              [nativeEthAssetId]: { amount: "1e-18" },
             },
           },
           internalAccounts: {
@@ -336,7 +319,7 @@ describe('getAccountTrackerControllerAccountsByChainId', () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: 'eip155:eoa',
+                type: "eip155:eoa",
               },
             },
           },
@@ -344,11 +327,9 @@ describe('getAccountTrackerControllerAccountsByChainId', () => {
       };
 
       // Should not throw — 1e-18 ETH = 1 wei = 0x1
-      expect(() =>
-        getAccountTrackerControllerAccountsByChainId(state),
-      ).not.toThrow();
+      expect(() => getAccountTrackerControllerAccountsByChainId(state)).not.toThrow();
       const result = getAccountTrackerControllerAccountsByChainId(state);
-      expect(result['0x1'][mockAccountAddressChecksummed].balance).toBe('0x1');
+      expect(result["0x1"][mockAccountAddressChecksummed].balance).toBe("0x1");
     });
 
     it('does not crash when amount has absurd scientific notation exponent (e.g. "1e-18000000000000000000")', () => {
@@ -357,11 +338,11 @@ describe('getAccountTrackerControllerAccountsByChainId', () => {
           ...enabledFlags,
           accountsByChainId: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: 'native', decimals: 18 },
+            [nativeEthAssetId]: { type: "native", decimals: 18 },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: '1e-18000000000000000000' },
+              [nativeEthAssetId]: { amount: "1e-18000000000000000000" },
             },
           },
           internalAccounts: {
@@ -369,7 +350,7 @@ describe('getAccountTrackerControllerAccountsByChainId', () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: 'eip155:eoa',
+                type: "eip155:eoa",
               },
             },
           },
@@ -377,11 +358,9 @@ describe('getAccountTrackerControllerAccountsByChainId', () => {
       };
 
       // Should not throw — value is sub-unit, rounds to 0x0
-      expect(() =>
-        getAccountTrackerControllerAccountsByChainId(state),
-      ).not.toThrow();
+      expect(() => getAccountTrackerControllerAccountsByChainId(state)).not.toThrow();
       const result = getAccountTrackerControllerAccountsByChainId(state);
-      expect(result['0x1'][mockAccountAddressChecksummed].balance).toBe('0x0');
+      expect(result["0x1"][mockAccountAddressChecksummed].balance).toBe("0x0");
     });
 
     it('correctly parses positive scientific notation (e.g. "1.5e2" with 2 decimals)', () => {
@@ -390,11 +369,11 @@ describe('getAccountTrackerControllerAccountsByChainId', () => {
           ...enabledFlags,
           accountsByChainId: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: 'native', decimals: 2 },
+            [nativeEthAssetId]: { type: "native", decimals: 2 },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: '1.5e2' },
+              [nativeEthAssetId]: { amount: "1.5e2" },
             },
           },
           internalAccounts: {
@@ -402,7 +381,7 @@ describe('getAccountTrackerControllerAccountsByChainId', () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: 'eip155:eoa',
+                type: "eip155:eoa",
               },
             },
           },
@@ -410,26 +389,24 @@ describe('getAccountTrackerControllerAccountsByChainId', () => {
       };
 
       // 1.5e2 = 150 human-readable, with 2 decimals → 15000 base units = 0x3a98
-      expect(() =>
-        getAccountTrackerControllerAccountsByChainId(state),
-      ).not.toThrow();
+      expect(() => getAccountTrackerControllerAccountsByChainId(state)).not.toThrow();
       const result = getAccountTrackerControllerAccountsByChainId(state);
-      expect(result['0x1'][mockAccountAddressChecksummed].balance).toBe('0x3a98');
+      expect(result["0x1"][mockAccountAddressChecksummed].balance).toBe("0x3a98");
     });
   });
 });
 
-describe('getTokensControllerAllTokens', () => {
-  describe('when assets unify state feature is disabled', () => {
-    it('returns allTokens from state unchanged', () => {
+describe("getTokensControllerAllTokens", () => {
+  describe("when assets unify state feature is disabled", () => {
+    it("returns allTokens from state unchanged", () => {
       const legacyAllTokens = {
-        '0x1': {
+        "0x1": {
           [mockAccountAddressLowercase]: [
             {
               address: erc20AssetAddressLowercase,
-              symbol: 'USDC',
+              symbol: "USDC",
               decimals: 6,
-              name: 'USD Coin',
+              name: "USD Coin",
             },
           ],
         },
@@ -447,8 +424,8 @@ describe('getTokensControllerAllTokens', () => {
     });
   });
 
-  describe('when assets unify state feature is enabled (happy path)', () => {
-    it('derives allTokens from new state structure', () => {
+  describe("when assets unify state feature is enabled (happy path)", () => {
+    it("derives allTokens from new state structure", () => {
       const state = {
         metamask: {
           remoteFeatureFlags: {
@@ -460,18 +437,18 @@ describe('getTokensControllerAllTokens', () => {
           allTokens: {},
           allIgnoredTokens: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: 'native', decimals: 18 },
+            [nativeEthAssetId]: { type: "native", decimals: 18 },
             [erc20AssetId]: {
-              type: 'erc20',
+              type: "erc20",
               decimals: 6,
-              symbol: 'USDC',
-              name: 'USD Coin',
+              symbol: "USDC",
+              name: "USD Coin",
             },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: '1' },
-              [erc20AssetId]: { amount: '1000000' },
+              [nativeEthAssetId]: { amount: "1" },
+              [erc20AssetId]: { amount: "1000000" },
             },
           },
           customAssets: {},
@@ -480,11 +457,11 @@ describe('getTokensControllerAllTokens', () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: 'eip155:eoa',
+                type: "eip155:eoa",
               },
               [mockAccountId2]: {
                 id: mockAccountId2,
-                type: 'solana:data-account',
+                type: "solana:data-account",
               },
             },
           },
@@ -493,13 +470,13 @@ describe('getTokensControllerAllTokens', () => {
       const result = getTokensControllerAllTokens(state);
 
       expect(result).toStrictEqual({
-        '0x1': {
+        "0x1": {
           [mockAccountAddressLowercase]: [
             {
               address: erc20AssetAddressChecksummed,
-              symbol: 'USDC',
+              symbol: "USDC",
               decimals: 6,
-              name: 'USD Coin',
+              name: "USD Coin",
               image: undefined,
             },
           ],
@@ -508,8 +485,8 @@ describe('getTokensControllerAllTokens', () => {
     });
   });
 
-  describe('edge cases when enabled', () => {
-    it('includes tokens from customAssets not present in assetsBalance', () => {
+  describe("edge cases when enabled", () => {
+    it("includes tokens from customAssets not present in assetsBalance", () => {
       const state = {
         metamask: {
           ...enabledFlags,
@@ -517,11 +494,11 @@ describe('getTokensControllerAllTokens', () => {
           allIgnoredTokens: {},
           assetsInfo: {
             [erc20AssetId]: {
-              type: 'erc20',
+              type: "erc20",
               decimals: 6,
-              symbol: 'USDC',
-              name: 'USD Coin',
-              image: 'https://example.com/usdc.png',
+              symbol: "USDC",
+              name: "USD Coin",
+              image: "https://example.com/usdc.png",
             },
           },
           assetsBalance: {},
@@ -533,7 +510,7 @@ describe('getTokensControllerAllTokens', () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: 'eip155:eoa',
+                type: "eip155:eoa",
               },
             },
           },
@@ -541,18 +518,18 @@ describe('getTokensControllerAllTokens', () => {
       };
       const result = getTokensControllerAllTokens(state);
 
-      expect(result['0x1'][mockAccountAddressLowercase]).toStrictEqual([
+      expect(result["0x1"][mockAccountAddressLowercase]).toStrictEqual([
         {
           address: erc20AssetAddressChecksummed,
-          symbol: 'USDC',
+          symbol: "USDC",
           decimals: 6,
-          name: 'USD Coin',
-          image: 'https://example.com/usdc.png',
+          name: "USD Coin",
+          image: "https://example.com/usdc.png",
         },
       ]);
     });
 
-    it('deduplicates tokens present in both assetsBalance and customAssets', () => {
+    it("deduplicates tokens present in both assetsBalance and customAssets", () => {
       const state = {
         metamask: {
           ...enabledFlags,
@@ -560,15 +537,15 @@ describe('getTokensControllerAllTokens', () => {
           allIgnoredTokens: {},
           assetsInfo: {
             [erc20AssetId]: {
-              type: 'erc20',
+              type: "erc20",
               decimals: 6,
-              symbol: 'USDC',
-              name: 'USD Coin',
+              symbol: "USDC",
+              name: "USD Coin",
             },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [erc20AssetId]: { amount: '1' },
+              [erc20AssetId]: { amount: "1" },
             },
           },
           customAssets: {
@@ -579,7 +556,7 @@ describe('getTokensControllerAllTokens', () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: 'eip155:eoa',
+                type: "eip155:eoa",
               },
             },
           },
@@ -587,12 +564,12 @@ describe('getTokensControllerAllTokens', () => {
       };
       const result = getTokensControllerAllTokens(state);
 
-      expect(result['0x1'][mockAccountAddressLowercase]).toHaveLength(1);
+      expect(result["0x1"][mockAccountAddressLowercase]).toHaveLength(1);
     });
 
-    it('skips assets with no metadata in assetsInfo', () => {
+    it("skips assets with no metadata in assetsInfo", () => {
       const unknownAssetId =
-        'eip155:1/erc20:0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef' as CaipAssetType;
+        "eip155:1/erc20:0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" as CaipAssetType;
       const state = {
         metamask: {
           ...enabledFlags,
@@ -601,7 +578,7 @@ describe('getTokensControllerAllTokens', () => {
           assetsInfo: {},
           assetsBalance: {
             [mockAccountId]: {
-              [unknownAssetId]: { amount: '1' },
+              [unknownAssetId]: { amount: "1" },
             },
           },
           customAssets: {},
@@ -610,7 +587,7 @@ describe('getTokensControllerAllTokens', () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: 'eip155:eoa',
+                type: "eip155:eoa",
               },
             },
           },
@@ -621,7 +598,7 @@ describe('getTokensControllerAllTokens', () => {
       expect(result).toStrictEqual({});
     });
 
-    it('skips native assets from allTokens (only ERC-20s)', () => {
+    it("skips native assets from allTokens (only ERC-20s)", () => {
       const state = {
         metamask: {
           ...enabledFlags,
@@ -629,15 +606,15 @@ describe('getTokensControllerAllTokens', () => {
           allIgnoredTokens: {},
           assetsInfo: {
             [nativeEthAssetId]: {
-              type: 'native',
+              type: "native",
               decimals: 18,
-              symbol: 'ETH',
-              name: 'Ether',
+              symbol: "ETH",
+              name: "Ether",
             },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: '1' },
+              [nativeEthAssetId]: { amount: "1" },
             },
           },
           customAssets: {},
@@ -646,7 +623,7 @@ describe('getTokensControllerAllTokens', () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: 'eip155:eoa',
+                type: "eip155:eoa",
               },
             },
           },
@@ -659,11 +636,11 @@ describe('getTokensControllerAllTokens', () => {
   });
 });
 
-describe('getTokensControllerAllIgnoredTokens', () => {
-  describe('when assets unify state feature is disabled', () => {
-    it('returns allIgnoredTokens from state unchanged', () => {
+describe("getTokensControllerAllIgnoredTokens", () => {
+  describe("when assets unify state feature is disabled", () => {
+    it("returns allIgnoredTokens from state unchanged", () => {
       const legacyAllIgnoredTokens = {
-        '0x1': {
+        "0x1": {
           [mockAccountAddressLowercase]: [erc20AssetAddressLowercase],
         },
       };
@@ -680,8 +657,8 @@ describe('getTokensControllerAllIgnoredTokens', () => {
     });
   });
 
-  describe('when assets unify state feature is enabled (happy path)', () => {
-    it('derives allIgnoredTokens from new state structure', () => {
+  describe("when assets unify state feature is enabled (happy path)", () => {
+    it("derives allIgnoredTokens from new state structure", () => {
       const state = {
         metamask: {
           remoteFeatureFlags: {
@@ -701,11 +678,11 @@ describe('getTokensControllerAllIgnoredTokens', () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: 'eip155:eoa',
+                type: "eip155:eoa",
               },
               [mockAccountId2]: {
                 id: mockAccountId2,
-                type: 'solana:data-account',
+                type: "solana:data-account",
               },
             },
           },
@@ -714,15 +691,15 @@ describe('getTokensControllerAllIgnoredTokens', () => {
       const result = getTokensControllerAllIgnoredTokens(state);
 
       expect(result).toStrictEqual({
-        '0x1': {
+        "0x1": {
           [mockAccountAddressLowercase]: [erc20AssetAddressLowercase],
         },
       });
     });
   });
 
-  describe('edge cases when enabled', () => {
-    it('skips preferences with hidden set to false', () => {
+  describe("edge cases when enabled", () => {
+    it("skips preferences with hidden set to false", () => {
       const state = {
         metamask: {
           ...enabledFlags,
@@ -737,7 +714,7 @@ describe('getTokensControllerAllIgnoredTokens', () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: 'eip155:eoa',
+                type: "eip155:eoa",
               },
             },
           },
@@ -748,7 +725,7 @@ describe('getTokensControllerAllIgnoredTokens', () => {
       expect(result).toStrictEqual({});
     });
 
-    it('applies hidden tokens to all EVM accounts', () => {
+    it("applies hidden tokens to all EVM accounts", () => {
       const state = {
         metamask: {
           ...enabledFlags,
@@ -762,16 +739,16 @@ describe('getTokensControllerAllIgnoredTokens', () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: 'eip155:eoa',
+                type: "eip155:eoa",
               },
               [mockAccountId3]: {
                 id: mockAccountId3,
                 address: mockAccountAddressLowercase2,
-                type: 'eip155:eoa',
+                type: "eip155:eoa",
               },
               [mockAccountId2]: {
                 id: mockAccountId2,
-                type: 'solana:data-account',
+                type: "solana:data-account",
               },
             },
           },
@@ -779,17 +756,17 @@ describe('getTokensControllerAllIgnoredTokens', () => {
       };
       const result = getTokensControllerAllIgnoredTokens(state);
 
-      expect(result['0x1'][mockAccountAddressLowercase]).toStrictEqual([
+      expect(result["0x1"][mockAccountAddressLowercase]).toStrictEqual([
         erc20AssetAddressLowercase,
       ]);
-      expect(result['0x1'][mockAccountAddressLowercase2]).toStrictEqual([
+      expect(result["0x1"][mockAccountAddressLowercase2]).toStrictEqual([
         erc20AssetAddressLowercase,
       ]);
     });
   });
 });
 
-describe('getTokenBalancesControllerTokenBalances', () => {
+describe("getTokenBalancesControllerTokenBalances", () => {
   const enabledFeatureFlags = {
     [ASSETS_UNIFY_STATE_FLAG]: {
       enabled: true,
@@ -802,21 +779,21 @@ describe('getTokenBalancesControllerTokenBalances', () => {
       [mockAccountId]: {
         id: mockAccountId,
         address: mockAccountAddressLowercase,
-        type: 'eip155:eoa',
+        type: "eip155:eoa",
       },
       [mockAccountId2]: {
         id: mockAccountId2,
-        type: 'solana:data-account',
+        type: "solana:data-account",
       },
     },
   };
 
-  describe('when assets unify state feature is disabled', () => {
-    it('returns tokenBalances from state unchanged', () => {
+  describe("when assets unify state feature is disabled", () => {
+    it("returns tokenBalances from state unchanged", () => {
       const legacyTokenBalances = {
         [mockAccountAddressLowercase]: {
-          '0x1': {
-            [erc20AssetAddressChecksummed]: '0xf4240' as const,
+          "0x1": {
+            [erc20AssetAddressChecksummed]: "0xf4240" as const,
           },
         },
       };
@@ -832,20 +809,20 @@ describe('getTokenBalancesControllerTokenBalances', () => {
     });
   });
 
-  describe('when assets unify state feature is enabled (happy path)', () => {
-    it('derives tokenBalances from new state structure', () => {
+  describe("when assets unify state feature is enabled (happy path)", () => {
+    it("derives tokenBalances from new state structure", () => {
       const state = {
         metamask: {
           remoteFeatureFlags: enabledFeatureFlags,
           tokenBalances: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: 'native', decimals: 18 },
-            [erc20AssetId]: { type: 'erc20', decimals: 6 },
+            [nativeEthAssetId]: { type: "native", decimals: 18 },
+            [erc20AssetId]: { type: "erc20", decimals: 6 },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: '1.23456789' },
-              [erc20AssetId]: { amount: '1' },
+              [nativeEthAssetId]: { amount: "1.23456789" },
+              [erc20AssetId]: { amount: "1" },
             },
           },
           customAssets: {},
@@ -854,24 +831,21 @@ describe('getTokenBalancesControllerTokenBalances', () => {
       };
       const result = getTokenBalancesControllerTokenBalances(state);
 
-      const nativeAddress = getNativeAssetForChainId('0x1').address;
+      const nativeAddress = getNativeAssetForChainId("0x1").address;
       expect(result).toStrictEqual({
         [mockAccountAddressLowercase]: {
-          '0x1': {
-            [nativeAddress]: '0x112210f4768db400', // 1.23456789 ETH (18 decimals)
-            [erc20AssetAddressChecksummed]: '0xf4240', // 1 USDC (6 decimals)
+          "0x1": {
+            [nativeAddress]: "0x112210f4768db400", // 1.23456789 ETH (18 decimals)
+            [erc20AssetAddressChecksummed]: "0xf4240", // 1 USDC (6 decimals)
           },
         },
       });
     });
 
-    it('adds zero-balance placeholder for custom EVM token not yet in assetsBalance', () => {
-      const customTokenAddress: Hex =
-        '0x4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8';
+    it("adds zero-balance placeholder for custom EVM token not yet in assetsBalance", () => {
+      const customTokenAddress: Hex = "0x4d5f47fa6a74757f35c14fd3a6ef8e3c9bc514e8";
       const customTokenAssetId = `eip155:1/erc20:${customTokenAddress}`;
-      const customTokenAddressChecksummed = toChecksumHexAddress(
-        customTokenAddress,
-      ) as Hex;
+      const customTokenAddressChecksummed = toChecksumHexAddress(customTokenAddress) as Hex;
 
       const state = {
         metamask: {
@@ -879,10 +853,10 @@ describe('getTokenBalancesControllerTokenBalances', () => {
           tokenBalances: {},
           assetsInfo: {
             [customTokenAssetId]: {
-              type: 'erc20',
+              type: "erc20",
               decimals: 18,
-              symbol: 'aEthWETH',
-              name: 'Aave Ethereum WETH',
+              symbol: "aEthWETH",
+              name: "Aave Ethereum WETH",
             },
           },
           assetsBalance: {},
@@ -896,24 +870,24 @@ describe('getTokenBalancesControllerTokenBalances', () => {
 
       expect(result).toStrictEqual({
         [mockAccountAddressLowercase]: {
-          '0x1': {
-            [customTokenAddressChecksummed]: '0x0',
+          "0x1": {
+            [customTokenAddressChecksummed]: "0x0",
           },
         },
       });
     });
 
-    it('does not overwrite real balance with zero placeholder', () => {
+    it("does not overwrite real balance with zero placeholder", () => {
       const state = {
         metamask: {
           remoteFeatureFlags: enabledFeatureFlags,
           tokenBalances: {},
           assetsInfo: {
-            [erc20AssetId]: { type: 'erc20', decimals: 6 },
+            [erc20AssetId]: { type: "erc20", decimals: 6 },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [erc20AssetId]: { amount: '1' },
+              [erc20AssetId]: { amount: "1" },
             },
           },
           customAssets: {
@@ -924,21 +898,21 @@ describe('getTokenBalancesControllerTokenBalances', () => {
       };
       const result = getTokenBalancesControllerTokenBalances(state);
 
-      expect(result[mockAccountAddressLowercase]['0x1']).toStrictEqual({
-        [erc20AssetAddressChecksummed]: '0xf4240', // real balance, not 0x0
+      expect(result[mockAccountAddressLowercase]["0x1"]).toStrictEqual({
+        [erc20AssetAddressChecksummed]: "0xf4240", // real balance, not 0x0
       });
     });
 
-    it('skips custom non-EVM tokens', () => {
+    it("skips custom non-EVM tokens", () => {
       const state = {
         metamask: {
           remoteFeatureFlags: enabledFeatureFlags,
           tokenBalances: {},
           assetsInfo: {
             [solanaTokenAssetId]: {
-              type: 'token',
+              type: "token",
               decimals: 6,
-              symbol: 'USDC',
+              symbol: "USDC",
             },
           },
           assetsBalance: {},
@@ -954,21 +928,20 @@ describe('getTokenBalancesControllerTokenBalances', () => {
     });
   });
 
-  describe('edge cases when enabled', () => {
-    it('skips balance entries without metadata in assetsInfo', () => {
-      const unknownAssetId =
-        'eip155:1/erc20:0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+  describe("edge cases when enabled", () => {
+    it("skips balance entries without metadata in assetsInfo", () => {
+      const unknownAssetId = "eip155:1/erc20:0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
       const state = {
         metamask: {
           ...enabledFlags,
           tokenBalances: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: 'native', decimals: 18 },
+            [nativeEthAssetId]: { type: "native", decimals: 18 },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: '1' },
-              [unknownAssetId]: { amount: '999' },
+              [nativeEthAssetId]: { amount: "1" },
+              [unknownAssetId]: { amount: "999" },
             },
           },
           internalAccounts: {
@@ -976,7 +949,7 @@ describe('getTokenBalancesControllerTokenBalances', () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: 'eip155:eoa',
+                type: "eip155:eoa",
               },
             },
           },
@@ -984,26 +957,26 @@ describe('getTokenBalancesControllerTokenBalances', () => {
       };
       const result = getTokenBalancesControllerTokenBalances(state);
 
-      const nativeAddress = getNativeAssetForChainId('0x1').address;
-      expect(
-        Object.keys(result[mockAccountAddressLowercase]['0x1']),
-      ).toStrictEqual([nativeAddress]);
+      const nativeAddress = getNativeAssetForChainId("0x1").address;
+      expect(Object.keys(result[mockAccountAddressLowercase]["0x1"])).toStrictEqual([
+        nativeAddress,
+      ]);
     });
 
-    it('handles multiple EVM accounts', () => {
+    it("handles multiple EVM accounts", () => {
       const state = {
         metamask: {
           ...enabledFlags,
           tokenBalances: {},
           assetsInfo: {
-            [erc20AssetId]: { type: 'erc20', decimals: 6 },
+            [erc20AssetId]: { type: "erc20", decimals: 6 },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [erc20AssetId]: { amount: '10' },
+              [erc20AssetId]: { amount: "10" },
             },
             [mockAccountId3]: {
-              [erc20AssetId]: { amount: '20' },
+              [erc20AssetId]: { amount: "20" },
             },
           },
           internalAccounts: {
@@ -1011,12 +984,12 @@ describe('getTokenBalancesControllerTokenBalances', () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: 'eip155:eoa',
+                type: "eip155:eoa",
               },
               [mockAccountId3]: {
                 id: mockAccountId3,
                 address: mockAccountAddressLowercase2,
-                type: 'eip155:eoa',
+                type: "eip155:eoa",
               },
             },
           },
@@ -1026,23 +999,19 @@ describe('getTokenBalancesControllerTokenBalances', () => {
 
       expect(result[mockAccountAddressLowercase]).toBeDefined();
       expect(result[mockAccountAddressLowercase2]).toBeDefined();
-      expect(
-        result[mockAccountAddressLowercase]['0x1'][
-          erc20AssetAddressChecksummed
-        ],
-      ).toBe('0x989680'); // 10 * 10^6
-      expect(
-        result[mockAccountAddressLowercase2]['0x1'][
-          erc20AssetAddressChecksummed
-        ],
-      ).toBe('0x1312d00'); // 20 * 10^6
+      expect(result[mockAccountAddressLowercase]["0x1"][erc20AssetAddressChecksummed]).toBe(
+        "0x989680",
+      ); // 10 * 10^6
+      expect(result[mockAccountAddressLowercase2]["0x1"][erc20AssetAddressChecksummed]).toBe(
+        "0x1312d00",
+      ); // 20 * 10^6
     });
   });
 });
 
-describe('getMultiChainAssetsControllerAccountsAssets', () => {
-  describe('when assets unify state feature is disabled', () => {
-    it('returns accountsAssets from state unchanged', () => {
+describe("getMultiChainAssetsControllerAccountsAssets", () => {
+  describe("when assets unify state feature is disabled", () => {
+    it("returns accountsAssets from state unchanged", () => {
       const legacyAccountsAssets = {
         [mockAccountId2]: [solanaTokenAssetId] as CaipAssetType[],
       };
@@ -1058,8 +1027,8 @@ describe('getMultiChainAssetsControllerAccountsAssets', () => {
     });
   });
 
-  describe('when assets unify state feature is enabled (happy path)', () => {
-    it('derives accountsAssets from new state structure for non-EVM accounts only', () => {
+  describe("when assets unify state feature is enabled (happy path)", () => {
+    it("derives accountsAssets from new state structure for non-EVM accounts only", () => {
       const state = {
         metamask: {
           remoteFeatureFlags: {
@@ -1071,11 +1040,11 @@ describe('getMultiChainAssetsControllerAccountsAssets', () => {
           accountsAssets: {},
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: '1' },
-              [erc20AssetId]: { amount: '1' },
+              [nativeEthAssetId]: { amount: "1" },
+              [erc20AssetId]: { amount: "1" },
             },
             [mockAccountId2]: {
-              [solanaTokenAssetId]: { amount: '100' },
+              [solanaTokenAssetId]: { amount: "100" },
             },
           },
           customAssets: {},
@@ -1084,11 +1053,11 @@ describe('getMultiChainAssetsControllerAccountsAssets', () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: 'eip155:eoa',
+                type: "eip155:eoa",
               },
               [mockAccountId2]: {
                 id: mockAccountId2,
-                type: 'solana:data-account',
+                type: "solana:data-account",
               },
             },
           },
@@ -1102,30 +1071,27 @@ describe('getMultiChainAssetsControllerAccountsAssets', () => {
     });
   });
 
-  describe('edge cases when enabled', () => {
-    it('merges and deduplicates assetsBalance and customAssets', () => {
+  describe("edge cases when enabled", () => {
+    it("merges and deduplicates assetsBalance and customAssets", () => {
       const extraSolAssetId =
-        'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:So11111111111111111111111111111111111111112' as CaipAssetType;
+        "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:So11111111111111111111111111111111111111112" as CaipAssetType;
       const state = {
         metamask: {
           ...enabledFlags,
           accountsAssets: {},
           assetsBalance: {
             [mockAccountId2]: {
-              [solanaTokenAssetId]: { amount: '100' },
+              [solanaTokenAssetId]: { amount: "100" },
             },
           },
           customAssets: {
-            [mockAccountId2]: [
-              solanaTokenAssetId as CaipAssetType,
-              extraSolAssetId,
-            ],
+            [mockAccountId2]: [solanaTokenAssetId as CaipAssetType, extraSolAssetId],
           },
           internalAccounts: {
             accounts: {
               [mockAccountId2]: {
                 id: mockAccountId2,
-                type: 'solana:data-account',
+                type: "solana:data-account",
               },
             },
           },
@@ -1138,15 +1104,15 @@ describe('getMultiChainAssetsControllerAccountsAssets', () => {
       expect(result[mockAccountId2]).toContain(extraSolAssetId);
     });
 
-    it('filters out EIP155 assets for non-EVM accounts', () => {
+    it("filters out EIP155 assets for non-EVM accounts", () => {
       const state = {
         metamask: {
           ...enabledFlags,
           accountsAssets: {},
           assetsBalance: {
             [mockAccountId2]: {
-              [nativeEthAssetId]: { amount: '1' },
-              [solanaTokenAssetId]: { amount: '100' },
+              [nativeEthAssetId]: { amount: "1" },
+              [solanaTokenAssetId]: { amount: "100" },
             },
           },
           customAssets: {},
@@ -1154,7 +1120,7 @@ describe('getMultiChainAssetsControllerAccountsAssets', () => {
             accounts: {
               [mockAccountId2]: {
                 id: mockAccountId2,
-                type: 'solana:data-account',
+                type: "solana:data-account",
               },
             },
           },
@@ -1165,14 +1131,14 @@ describe('getMultiChainAssetsControllerAccountsAssets', () => {
       expect(result[mockAccountId2]).toStrictEqual([solanaTokenAssetId]);
     });
 
-    it('returns empty array when non-EVM account has only EIP155 assets', () => {
+    it("returns empty array when non-EVM account has only EIP155 assets", () => {
       const state = {
         metamask: {
           ...enabledFlags,
           accountsAssets: {},
           assetsBalance: {
             [mockAccountId2]: {
-              [nativeEthAssetId]: { amount: '1' },
+              [nativeEthAssetId]: { amount: "1" },
             },
           },
           customAssets: {},
@@ -1180,7 +1146,7 @@ describe('getMultiChainAssetsControllerAccountsAssets', () => {
             accounts: {
               [mockAccountId2]: {
                 id: mockAccountId2,
-                type: 'solana:data-account',
+                type: "solana:data-account",
               },
             },
           },
@@ -1193,16 +1159,16 @@ describe('getMultiChainAssetsControllerAccountsAssets', () => {
   });
 });
 
-describe('getMultiChainAssetsControllerAssetsMetadata', () => {
-  describe('when assets unify state feature is disabled', () => {
-    it('returns assetsMetadata from state unchanged', () => {
+describe("getMultiChainAssetsControllerAssetsMetadata", () => {
+  describe("when assets unify state feature is disabled", () => {
+    it("returns assetsMetadata from state unchanged", () => {
       const legacyAssetsMetadata = {
         [solanaTokenAssetId]: {
           fungible: true as const,
-          iconUrl: 'https://example.com/sol.png',
-          units: [{ decimals: 6, symbol: 'USDC', name: 'USD Coin' }],
-          symbol: 'USDC',
-          name: 'USD Coin',
+          iconUrl: "https://example.com/sol.png",
+          units: [{ decimals: 6, symbol: "USDC", name: "USD Coin" }],
+          symbol: "USDC",
+          name: "USD Coin",
         },
       };
       const state = {
@@ -1217,8 +1183,8 @@ describe('getMultiChainAssetsControllerAssetsMetadata', () => {
     });
   });
 
-  describe('when assets unify state feature is enabled (happy path)', () => {
-    it('derives assetsMetadata from assetsInfo for non-EIP155 assets only', () => {
+  describe("when assets unify state feature is enabled (happy path)", () => {
+    it("derives assetsMetadata from assetsInfo for non-EIP155 assets only", () => {
       const state = {
         metamask: {
           remoteFeatureFlags: {
@@ -1229,19 +1195,19 @@ describe('getMultiChainAssetsControllerAssetsMetadata', () => {
           },
           assetsMetadata: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: 'native', decimals: 18 },
+            [nativeEthAssetId]: { type: "native", decimals: 18 },
             [erc20AssetId]: {
-              type: 'erc20',
+              type: "erc20",
               decimals: 6,
-              symbol: 'USDC',
-              name: 'USD Coin',
+              symbol: "USDC",
+              name: "USD Coin",
             },
             [solanaTokenAssetId]: {
-              type: 'token',
+              type: "token",
               decimals: 6,
-              symbol: 'USDC',
-              name: 'USD Coin',
-              image: 'https://example.com/sol-usdc.png',
+              symbol: "USDC",
+              name: "USD Coin",
+              image: "https://example.com/sol-usdc.png",
             },
           },
         },
@@ -1251,59 +1217,59 @@ describe('getMultiChainAssetsControllerAssetsMetadata', () => {
       expect(result).toStrictEqual({
         [solanaTokenAssetId]: {
           fungible: true,
-          iconUrl: 'https://example.com/sol-usdc.png',
+          iconUrl: "https://example.com/sol-usdc.png",
           units: [
             {
               decimals: 6,
-              symbol: 'USDC',
-              name: 'USD Coin',
+              symbol: "USDC",
+              name: "USD Coin",
             },
           ],
-          symbol: 'USDC',
-          name: 'USD Coin',
+          symbol: "USDC",
+          name: "USD Coin",
         },
       });
     });
   });
 
-  describe('edge cases when enabled', () => {
-    it('defaults iconUrl to empty string when image is undefined', () => {
+  describe("edge cases when enabled", () => {
+    it("defaults iconUrl to empty string when image is undefined", () => {
       const state = {
         metamask: {
           ...enabledFlags,
           assetsMetadata: {},
           assetsInfo: {
             [solanaTokenAssetId]: {
-              type: 'token',
+              type: "token",
               decimals: 9,
-              symbol: 'SOL',
-              name: 'Solana',
+              symbol: "SOL",
+              name: "Solana",
             },
           },
         },
       };
       const result = getMultiChainAssetsControllerAssetsMetadata(state);
 
-      expect(result[solanaTokenAssetId as CaipAssetType].iconUrl).toBe('');
+      expect(result[solanaTokenAssetId as CaipAssetType].iconUrl).toBe("");
     });
 
-    it('excludes EIP155 assets from multichain metadata', () => {
+    it("excludes EIP155 assets from multichain metadata", () => {
       const state = {
         metamask: {
           ...enabledFlags,
           assetsMetadata: {},
           assetsInfo: {
             [nativeEthAssetId]: {
-              type: 'native',
+              type: "native",
               decimals: 18,
-              symbol: 'ETH',
-              name: 'Ether',
+              symbol: "ETH",
+              name: "Ether",
             },
             [erc20AssetId]: {
-              type: 'erc20',
+              type: "erc20",
               decimals: 6,
-              symbol: 'USDC',
-              name: 'USD Coin',
+              symbol: "USDC",
+              name: "USD Coin",
             },
           },
         },
@@ -1315,9 +1281,9 @@ describe('getMultiChainAssetsControllerAssetsMetadata', () => {
   });
 });
 
-describe('getMultiChainAssetsControllerAllIgnoredAssets', () => {
-  describe('when assets unify state feature is disabled', () => {
-    it('returns allIgnoredAssets from state unchanged', () => {
+describe("getMultiChainAssetsControllerAllIgnoredAssets", () => {
+  describe("when assets unify state feature is disabled", () => {
+    it("returns allIgnoredAssets from state unchanged", () => {
       const legacyAllIgnoredAssets = {
         [mockAccountId2]: [solanaTokenAssetId] as CaipAssetType[],
       };
@@ -1333,8 +1299,8 @@ describe('getMultiChainAssetsControllerAllIgnoredAssets', () => {
     });
   });
 
-  describe('when assets unify state feature is enabled (happy path)', () => {
-    it('derives allIgnoredAssets from assetPreferences for non-EVM accounts only', () => {
+  describe("when assets unify state feature is enabled (happy path)", () => {
+    it("derives allIgnoredAssets from assetPreferences for non-EVM accounts only", () => {
       const state = {
         metamask: {
           remoteFeatureFlags: {
@@ -1353,11 +1319,11 @@ describe('getMultiChainAssetsControllerAllIgnoredAssets', () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: 'eip155:eoa',
+                type: "eip155:eoa",
               },
               [mockAccountId2]: {
                 id: mockAccountId2,
-                type: 'solana:data-account',
+                type: "solana:data-account",
               },
             },
           },
@@ -1371,8 +1337,8 @@ describe('getMultiChainAssetsControllerAllIgnoredAssets', () => {
     });
   });
 
-  describe('edge cases when enabled', () => {
-    it('skips preferences with hidden set to false', () => {
+  describe("edge cases when enabled", () => {
+    it("skips preferences with hidden set to false", () => {
       const state = {
         metamask: {
           ...enabledFlags,
@@ -1384,7 +1350,7 @@ describe('getMultiChainAssetsControllerAllIgnoredAssets', () => {
             accounts: {
               [mockAccountId2]: {
                 id: mockAccountId2,
-                type: 'solana:data-account',
+                type: "solana:data-account",
               },
             },
           },
@@ -1395,7 +1361,7 @@ describe('getMultiChainAssetsControllerAllIgnoredAssets', () => {
       expect(result[mockAccountId2]).toStrictEqual([]);
     });
 
-    it('skips EIP155 assets from ignored assets list', () => {
+    it("skips EIP155 assets from ignored assets list", () => {
       const state = {
         metamask: {
           ...enabledFlags,
@@ -1407,7 +1373,7 @@ describe('getMultiChainAssetsControllerAllIgnoredAssets', () => {
             accounts: {
               [mockAccountId2]: {
                 id: mockAccountId2,
-                type: 'solana:data-account',
+                type: "solana:data-account",
               },
             },
           },
@@ -1418,7 +1384,7 @@ describe('getMultiChainAssetsControllerAllIgnoredAssets', () => {
       expect(result[mockAccountId2]).toStrictEqual([]);
     });
 
-    it('skips EVM accounts entirely', () => {
+    it("skips EVM accounts entirely", () => {
       const state = {
         metamask: {
           ...enabledFlags,
@@ -1431,7 +1397,7 @@ describe('getMultiChainAssetsControllerAllIgnoredAssets', () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: 'eip155:eoa',
+                type: "eip155:eoa",
               },
             },
           },
@@ -1444,12 +1410,12 @@ describe('getMultiChainAssetsControllerAllIgnoredAssets', () => {
   });
 });
 
-describe('getMultiChainBalancesControllerBalances', () => {
-  describe('when assets unify state feature is disabled', () => {
-    it('returns balances from state unchanged', () => {
+describe("getMultiChainBalancesControllerBalances", () => {
+  describe("when assets unify state feature is disabled", () => {
+    it("returns balances from state unchanged", () => {
       const legacyBalances = {
         [mockAccountId2]: {
-          [solanaTokenAssetId]: { amount: '100', unit: 'USDC' },
+          [solanaTokenAssetId]: { amount: "100", unit: "USDC" },
         },
       };
       const state = {
@@ -1464,8 +1430,8 @@ describe('getMultiChainBalancesControllerBalances', () => {
     });
   });
 
-  describe('when assets unify state feature is enabled (happy path)', () => {
-    it('derives balances from new state structure for non-EVM accounts only', () => {
+  describe("when assets unify state feature is enabled (happy path)", () => {
+    it("derives balances from new state structure for non-EVM accounts only", () => {
       const state = {
         metamask: {
           remoteFeatureFlags: {
@@ -1476,21 +1442,21 @@ describe('getMultiChainBalancesControllerBalances', () => {
           },
           balances: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: 'native', decimals: 18 },
-            [erc20AssetId]: { type: 'erc20', decimals: 6, symbol: 'USDC' },
+            [nativeEthAssetId]: { type: "native", decimals: 18 },
+            [erc20AssetId]: { type: "erc20", decimals: 6, symbol: "USDC" },
             [solanaTokenAssetId]: {
-              type: 'token',
+              type: "token",
               decimals: 6,
-              symbol: 'USDC',
+              symbol: "USDC",
             },
           },
           assetsBalance: {
             [mockAccountId]: {
-              [nativeEthAssetId]: { amount: '1' },
-              [erc20AssetId]: { amount: '1' },
+              [nativeEthAssetId]: { amount: "1" },
+              [erc20AssetId]: { amount: "1" },
             },
             [mockAccountId2]: {
-              [solanaTokenAssetId]: { amount: '250.5' },
+              [solanaTokenAssetId]: { amount: "250.5" },
             },
           },
           internalAccounts: {
@@ -1498,11 +1464,11 @@ describe('getMultiChainBalancesControllerBalances', () => {
               [mockAccountId]: {
                 id: mockAccountId,
                 address: mockAccountAddressLowercase,
-                type: 'eip155:eoa',
+                type: "eip155:eoa",
               },
               [mockAccountId2]: {
                 id: mockAccountId2,
-                type: 'solana:data-account',
+                type: "solana:data-account",
               },
             },
           },
@@ -1512,17 +1478,17 @@ describe('getMultiChainBalancesControllerBalances', () => {
 
       expect(result).toStrictEqual({
         [mockAccountId2]: {
-          [solanaTokenAssetId]: { amount: '250.5', unit: 'USDC' },
+          [solanaTokenAssetId]: { amount: "250.5", unit: "USDC" },
         },
       });
     });
   });
 });
 
-describe('getCurrencyRateControllerCurrentCurrency', () => {
-  describe('when assets unify state feature is disabled', () => {
-    it('returns currentCurrency from state unchanged', () => {
-      const legacyCurrentCurrency = 'eur';
+describe("getCurrencyRateControllerCurrentCurrency", () => {
+  describe("when assets unify state feature is disabled", () => {
+    it("returns currentCurrency from state unchanged", () => {
+      const legacyCurrentCurrency = "eur";
       const state = {
         metamask: {
           currentCurrency: legacyCurrentCurrency,
@@ -1534,8 +1500,8 @@ describe('getCurrencyRateControllerCurrentCurrency', () => {
     });
   });
 
-  describe('when assets unify state feature is enabled', () => {
-    it('returns selectedCurrency from new state', () => {
+  describe("when assets unify state feature is enabled", () => {
+    it("returns selectedCurrency from new state", () => {
       const state = {
         metamask: {
           remoteFeatureFlags: {
@@ -1544,20 +1510,20 @@ describe('getCurrencyRateControllerCurrentCurrency', () => {
               featureVersion: ASSETS_UNIFY_STATE_VERSION_1,
             },
           },
-          currentCurrency: 'eur',
-          selectedCurrency: 'usd',
+          currentCurrency: "eur",
+          selectedCurrency: "usd",
         },
       };
       const result = getCurrencyRateControllerCurrentCurrency(state);
 
-      expect(result).toBe('usd');
+      expect(result).toBe("usd");
     });
   });
 });
 
-describe('getCurrencyRateControllerCurrencyRates', () => {
-  describe('when assets unify state feature is disabled', () => {
-    it('returns currencyRates from state unchanged', () => {
+describe("getCurrencyRateControllerCurrencyRates", () => {
+  describe("when assets unify state feature is disabled", () => {
+    it("returns currencyRates from state unchanged", () => {
       const legacyCurrencyRates = {
         ETH: {
           conversionDate: 1000,
@@ -1577,10 +1543,10 @@ describe('getCurrencyRateControllerCurrencyRates', () => {
     });
   });
 
-  describe('when assets unify state feature is enabled (happy path)', () => {
-    it('derives currencyRates from assetsInfo and assetsPrice for native EVM assets', () => {
+  describe("when assets unify state feature is enabled (happy path)", () => {
+    it("derives currencyRates from assetsInfo and assetsPrice for native EVM assets", () => {
       const lastUpdated = 1700000000000; // ms
-      const mockNonFungibleAssetId = 'eip155:137/slip44:987654321';
+      const mockNonFungibleAssetId = "eip155:137/slip44:987654321";
       const state = {
         metamask: {
           remoteFeatureFlags: {
@@ -1589,25 +1555,25 @@ describe('getCurrencyRateControllerCurrencyRates', () => {
               featureVersion: ASSETS_UNIFY_STATE_VERSION_1,
             },
           },
-          currentCurrency: 'eur',
-          selectedCurrency: 'eur',
+          currentCurrency: "eur",
+          selectedCurrency: "eur",
           currencyRates: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: 'native', symbol: 'ETH', decimals: 18 },
+            [nativeEthAssetId]: { type: "native", symbol: "ETH", decimals: 18 },
             [erc20AssetId]: {
-              type: 'erc20',
-              symbol: 'USDC',
+              type: "erc20",
+              symbol: "USDC",
               decimals: 6,
             },
             [mockNonFungibleAssetId]: {
-              type: 'something',
-              symbol: 'SMT',
+              type: "something",
+              symbol: "SMT",
             },
           },
           assetsPrice: {
             [nativeEthAssetId]: {
-              assetPriceType: 'fungible',
-              id: 'eth-price',
+              assetPriceType: "fungible",
+              id: "eth-price",
               price: 2500,
               usdPrice: 3000,
               lastUpdated,
@@ -1630,8 +1596,8 @@ describe('getCurrencyRateControllerCurrencyRates', () => {
               pricePercentChange1y: 30,
             },
             [mockNonFungibleAssetId]: {
-              assetPriceType: 'something',
-              id: 'smt-price',
+              assetPriceType: "something",
+              id: "smt-price",
               price: 0.5,
               lastUpdated,
             },
@@ -1651,14 +1617,14 @@ describe('getCurrencyRateControllerCurrencyRates', () => {
   });
 });
 
-describe('getTokenRatesControllerMarketData', () => {
-  describe('when assets unify state feature is disabled', () => {
-    it('returns marketData from state unchanged', () => {
+describe("getTokenRatesControllerMarketData", () => {
+  describe("when assets unify state feature is disabled", () => {
+    it("returns marketData from state unchanged", () => {
       const legacyMarketData = {
-        '0x1': {
+        "0x1": {
           [erc20AssetAddressChecksummed]: {
             tokenAddress: erc20AssetAddressChecksummed,
-            currency: 'ETH',
+            currency: "ETH",
             price: 1,
             marketCap: 0,
             allTimeHigh: 0,
@@ -1692,8 +1658,8 @@ describe('getTokenRatesControllerMarketData', () => {
     });
   });
 
-  describe('when assets unify state feature is enabled (happy path)', () => {
-    it('derives marketData from assetsPrice with prices converted to native currency', () => {
+  describe("when assets unify state feature is enabled (happy path)", () => {
+    it("derives marketData from assetsPrice with prices converted to native currency", () => {
       const lastUpdated = 1700000000000;
       const ethPriceInUsd = 2000;
       const usdcPriceInUsd = 1;
@@ -1706,21 +1672,21 @@ describe('getTokenRatesControllerMarketData', () => {
             },
           },
           marketData: {},
-          currentCurrency: 'usd',
-          selectedCurrency: 'usd',
+          currentCurrency: "usd",
+          selectedCurrency: "usd",
           currencyRates: {},
           assetsInfo: {
-            [nativeEthAssetId]: { type: 'native', symbol: 'ETH', decimals: 18 },
+            [nativeEthAssetId]: { type: "native", symbol: "ETH", decimals: 18 },
             [erc20AssetId]: {
-              type: 'erc20',
-              symbol: 'USDC',
+              type: "erc20",
+              symbol: "USDC",
               decimals: 6,
             },
           },
           assetsPrice: {
             [nativeEthAssetId]: {
-              assetPriceType: 'fungible',
-              id: 'eth-price',
+              assetPriceType: "fungible",
+              id: "eth-price",
               price: ethPriceInUsd,
               usdPrice: ethPriceInUsd,
               lastUpdated,
@@ -1743,8 +1709,8 @@ describe('getTokenRatesControllerMarketData', () => {
               pricePercentChange1y: 30,
             },
             [erc20AssetId]: {
-              assetPriceType: 'fungible',
-              id: 'usdc-price',
+              assetPriceType: "fungible",
+              id: "usdc-price",
               price: usdcPriceInUsd,
               usdPrice: usdcPriceInUsd,
               lastUpdated,
@@ -1768,118 +1734,115 @@ describe('getTokenRatesControllerMarketData', () => {
             },
           },
           networkConfigurationsByChainId: {
-            '0x1': { nativeCurrency: 'ETH' },
+            "0x1": { nativeCurrency: "ETH" },
           },
         },
       };
       const result = getTokenRatesControllerMarketData(state);
 
       // ETH native rate is 2000 USD; USDC price 1 USD -> 1/2000 ETH
-      const marketData = result['0x1'][erc20AssetAddressChecksummed];
+      const marketData = result["0x1"][erc20AssetAddressChecksummed];
       expect(marketData.price).toBe(usdcPriceInUsd / ethPriceInUsd);
-      expect(marketData.currency).toBe('ETH');
+      expect(marketData.currency).toBe("ETH");
       expect(marketData.tokenAddress).toBe(erc20AssetAddressChecksummed);
     });
   });
 
-  describe('edge cases when enabled', () => {
-    it('skips non-EIP155 assets from marketData', () => {
+  describe("edge cases when enabled", () => {
+    it("skips non-EIP155 assets from marketData", () => {
       const state = {
         metamask: {
           ...enabledFlags,
           marketData: {},
-          currentCurrency: 'usd',
-          selectedCurrency: 'usd',
+          currentCurrency: "usd",
+          selectedCurrency: "usd",
           currencyRates: {},
           assetsInfo: {
             [nativeEthAssetId]: {
-              type: 'native',
-              symbol: 'ETH',
+              type: "native",
+              symbol: "ETH",
               decimals: 18,
             },
             [solanaTokenAssetId]: {
-              type: 'token',
-              symbol: 'USDC',
+              type: "token",
+              symbol: "USDC",
               decimals: 6,
             },
           },
           assetsPrice: {
-            [nativeEthAssetId]: makeMockPrice({ id: 'eth', price: 2000 }),
+            [nativeEthAssetId]: makeMockPrice({ id: "eth", price: 2000 }),
             [solanaTokenAssetId]: makeMockPrice({
-              id: 'sol-usdc',
+              id: "sol-usdc",
               price: 1,
             }),
           },
           networkConfigurationsByChainId: {
-            '0x1': { nativeCurrency: 'ETH' },
+            "0x1": { nativeCurrency: "ETH" },
           },
         },
       };
       const result = getTokenRatesControllerMarketData(state);
 
-      expect(result['0x1']).toBeDefined();
-      expect(Object.keys(result).every((key) => key.startsWith('0x'))).toBe(
-        true,
-      );
+      expect(result["0x1"]).toBeDefined();
+      expect(Object.keys(result).every((key) => key.startsWith("0x"))).toBe(true);
     });
 
-    it('skips assets without metadata in assetsInfo', () => {
-      const unknownAssetId =
-        'eip155:1/erc20:0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+    it("skips assets without metadata in assetsInfo", () => {
+      const unknownAssetId = "eip155:1/erc20:0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
       const state = {
         metamask: {
           ...enabledFlags,
           marketData: {},
-          currentCurrency: 'usd',
-          selectedCurrency: 'usd',
+          currentCurrency: "usd",
+          selectedCurrency: "usd",
           currencyRates: {},
           assetsInfo: {
             [nativeEthAssetId]: {
-              type: 'native',
-              symbol: 'ETH',
+              type: "native",
+              symbol: "ETH",
               decimals: 18,
             },
           },
           assetsPrice: {
             [nativeEthAssetId]: makeMockPrice({
-              id: 'eth',
+              id: "eth",
               price: 2000,
             }),
             [unknownAssetId]: makeMockPrice({
-              id: 'unknown',
+              id: "unknown",
               price: 42,
             }),
           },
           networkConfigurationsByChainId: {
-            '0x1': { nativeCurrency: 'ETH' },
+            "0x1": { nativeCurrency: "ETH" },
           },
         },
       };
       const result = getTokenRatesControllerMarketData(state);
 
-      expect(Object.keys(result['0x1'])).toHaveLength(1);
+      expect(Object.keys(result["0x1"])).toHaveLength(1);
     });
 
-    it('skips assets when native currency conversion rate is unavailable', () => {
+    it("skips assets when native currency conversion rate is unavailable", () => {
       const state = {
         metamask: {
           ...enabledFlags,
           marketData: {},
-          currentCurrency: 'usd',
-          selectedCurrency: 'usd',
+          currentCurrency: "usd",
+          selectedCurrency: "usd",
           currencyRates: {},
           assetsInfo: {
             [erc20AssetId]: {
-              type: 'erc20',
-              symbol: 'USDC',
+              type: "erc20",
+              symbol: "USDC",
               decimals: 6,
             },
           },
           assetsPrice: {
-            [erc20AssetId]: makeMockPrice({ id: 'usdc', price: 1 }),
+            [erc20AssetId]: makeMockPrice({ id: "usdc", price: 1 }),
           },
           networkConfigurationsByChainId: {
-            '0x1': { nativeCurrency: 'ETH' },
+            "0x1": { nativeCurrency: "ETH" },
           },
         },
       };
@@ -1888,64 +1851,62 @@ describe('getTokenRatesControllerMarketData', () => {
       expect(result).toStrictEqual({});
     });
 
-    it('places native slip44 asset at getNativeTokenAddress', () => {
-      const nativeTokenAddress = '0x0000000000000000000000000000000000000000';
+    it("places native slip44 asset at getNativeTokenAddress", () => {
+      const nativeTokenAddress = "0x0000000000000000000000000000000000000000";
       const state = {
         metamask: {
           ...enabledFlags,
           marketData: {},
-          currentCurrency: 'usd',
-          selectedCurrency: 'usd',
+          currentCurrency: "usd",
+          selectedCurrency: "usd",
           currencyRates: {},
           assetsInfo: {
             [nativeEthAssetId]: {
-              type: 'native',
-              symbol: 'ETH',
+              type: "native",
+              symbol: "ETH",
               decimals: 18,
             },
           },
           assetsPrice: {
-            [nativeEthAssetId]: makeMockPrice({ id: 'eth', price: 2000 }),
+            [nativeEthAssetId]: makeMockPrice({ id: "eth", price: 2000 }),
           },
           networkConfigurationsByChainId: {
-            '0x1': { nativeCurrency: 'ETH' },
+            "0x1": { nativeCurrency: "ETH" },
           },
         },
       };
       const result = getTokenRatesControllerMarketData(state);
 
-      expect(result['0x1'][nativeTokenAddress]).toBeDefined();
-      expect(result['0x1'][nativeTokenAddress].tokenAddress).toBe(
-        nativeTokenAddress,
-      );
-      expect(result['0x1'][nativeTokenAddress].price).toBe(1);
+      expect(result["0x1"][nativeTokenAddress]).toBeDefined();
+      expect(result["0x1"][nativeTokenAddress].tokenAddress).toBe(nativeTokenAddress);
+      expect(result["0x1"][nativeTokenAddress].price).toBe(1);
     });
 
-    it('converts all price fields to native currency denomination', () => {
+    it("converts all price fields to native currency denomination", () => {
       const ethPrice = 2500;
       const state = {
         metamask: {
           ...enabledFlags,
           marketData: {},
-          currentCurrency: 'usd',
-          selectedCurrency: 'usd',
+          currentCurrency: "usd",
+          selectedCurrency: "usd",
           currencyRates: {},
           assetsInfo: {
             [nativeEthAssetId]: {
-              type: 'native',
-              symbol: 'ETH',
+              type: "native",
+              symbol: "ETH",
               decimals: 18,
             },
             [erc20AssetId]: {
-              type: 'erc20',
-              symbol: 'USDC',
+              type: "erc20",
+              symbol: "USDC",
               decimals: 6,
             },
           },
           assetsPrice: {
-            [nativeEthAssetId]: makeMockPrice({ id: 'eth', price: ethPrice }),
+            [nativeEthAssetId]: makeMockPrice({ id: "eth", price: ethPrice }),
             [erc20AssetId]: makeMockPrice({
-              id: 'usdc',
+              id: "usdc",
               price: 1,
               marketCap: 30e9,
               allTimeHigh: 1.1,
@@ -1958,12 +1919,12 @@ describe('getTokenRatesControllerMarketData', () => {
             }),
           },
           networkConfigurationsByChainId: {
-            '0x1': { nativeCurrency: 'ETH' },
+            "0x1": { nativeCurrency: "ETH" },
           },
         },
       };
       const result = getTokenRatesControllerMarketData(state);
-      const md = result['0x1'][erc20AssetAddressChecksummed];
+      const md = result["0x1"][erc20AssetAddressChecksummed];
 
       expect(md.price).toBe(1 / ethPrice);
       expect(md.marketCap).toBe(30e9 / ethPrice);
@@ -1977,65 +1938,64 @@ describe('getTokenRatesControllerMarketData', () => {
       expect(md.circulatingSupply).toBe(30e9);
     });
 
-    it('does not use slip44 fallback for ERC-20 assets missing from assetsInfo', () => {
+    it("does not use slip44 fallback for ERC-20 assets missing from assetsInfo", () => {
       const ethPrice = 2000;
-      const nativeTokenAddress = '0x0000000000000000000000000000000000000000';
-      const orphanErc20AssetId =
-        'eip155:1/erc20:0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+      const nativeTokenAddress = "0x0000000000000000000000000000000000000000";
+      const orphanErc20AssetId = "eip155:1/erc20:0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef";
       const state = {
         metamask: {
           ...enabledFlags,
           marketData: {},
-          currentCurrency: 'usd',
-          selectedCurrency: 'usd',
+          currentCurrency: "usd",
+          selectedCurrency: "usd",
           currencyRates: {},
           assetsInfo: {
             [nativeEthAssetId]: {
-              type: 'native',
-              symbol: 'ETH',
+              type: "native",
+              symbol: "ETH",
               decimals: 18,
             },
           },
           assetsPrice: {
-            [nativeEthAssetId]: makeMockPrice({ id: 'eth', price: ethPrice }),
+            [nativeEthAssetId]: makeMockPrice({ id: "eth", price: ethPrice }),
             [orphanErc20AssetId]: makeMockPrice({
-              id: 'orphan',
+              id: "orphan",
               price: 999,
             }),
           },
           networkConfigurationsByChainId: {
-            '0x1': { nativeCurrency: 'ETH' },
+            "0x1": { nativeCurrency: "ETH" },
           },
         },
       };
       const result = getTokenRatesControllerMarketData(state);
 
       // The native entry should still be the native price, not overwritten
-      expect(result['0x1'][nativeTokenAddress].price).toBe(1);
+      expect(result["0x1"][nativeTokenAddress].price).toBe(1);
       // The orphan ERC-20 should be skipped entirely (no metadata)
       const checksumOrphan = toChecksumHexAddress(
-        '0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+        "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
       ) as Hex;
-      expect(result['0x1'][checksumOrphan]).toBeUndefined();
+      expect(result["0x1"][checksumOrphan]).toBeUndefined();
     });
   });
 });
 
-describe('getMultichainAssetsRatesControllerConversionRates', () => {
-  describe('when assets unify state feature is disabled', () => {
-    it('returns conversionRates from state unchanged', () => {
+describe("getMultichainAssetsRatesControllerConversionRates", () => {
+  describe("when assets unify state feature is disabled", () => {
+    it("returns conversionRates from state unchanged", () => {
       const legacyConversionRates = {
         [solanaTokenAssetId]: {
-          rate: '1',
+          rate: "1",
           conversionTime: 1700000000000,
           expirationTime: undefined,
           marketData: {
             fungible: true as const,
-            allTimeHigh: '1.1',
-            allTimeLow: '0.9',
-            circulatingSupply: '1000000',
-            marketCap: '1000000',
-            totalVolume: '500000',
+            allTimeHigh: "1.1",
+            allTimeLow: "0.9",
+            circulatingSupply: "1000000",
+            marketCap: "1000000",
+            totalVolume: "500000",
             pricePercentChange: {
               PT1H: 0,
               P1D: 0,
@@ -2060,8 +2020,8 @@ describe('getMultichainAssetsRatesControllerConversionRates', () => {
     });
   });
 
-  describe('when assets unify state feature is enabled (happy path)', () => {
-    it('derives conversionRates from assetsPrice for non-EVM assets only', () => {
+  describe("when assets unify state feature is enabled (happy path)", () => {
+    it("derives conversionRates from assetsPrice for non-EVM assets only", () => {
       const lastUpdated = 1700000000000;
       const state = {
         metamask: {
@@ -2074,8 +2034,8 @@ describe('getMultichainAssetsRatesControllerConversionRates', () => {
           conversionRates: {},
           assetsPrice: {
             [nativeEthAssetId]: {
-              assetPriceType: 'fungible',
-              id: 'eth-price',
+              assetPriceType: "fungible",
+              id: "eth-price",
               price: 2000,
               usdPrice: 2000,
               lastUpdated,
@@ -2098,8 +2058,8 @@ describe('getMultichainAssetsRatesControllerConversionRates', () => {
               pricePercentChange1y: 30,
             },
             [solanaTokenAssetId]: {
-              assetPriceType: 'fungible',
-              id: 'sol-usdc-price',
+              assetPriceType: "fungible",
+              id: "sol-usdc-price",
               price: 1.02,
               usdPrice: 1.02,
               lastUpdated,
@@ -2128,16 +2088,16 @@ describe('getMultichainAssetsRatesControllerConversionRates', () => {
 
       expect(result[nativeEthAssetId]).toBeUndefined();
       expect(result[solanaTokenAssetId]).toStrictEqual({
-        rate: '1.02',
+        rate: "1.02",
         conversionTime: lastUpdated,
         expirationTime: undefined,
         marketData: {
           fungible: true,
-          allTimeHigh: '1.1',
-          allTimeLow: '0.95',
-          circulatingSupply: '30000000000',
-          marketCap: '30000000000',
-          totalVolume: '100000000000',
+          allTimeHigh: "1.1",
+          allTimeLow: "0.95",
+          circulatingSupply: "30000000000",
+          marketCap: "30000000000",
+          totalVolume: "100000000000",
           pricePercentChange: {
             PT1H: 0.1,
             P1D: 0.5,
@@ -2152,15 +2112,15 @@ describe('getMultichainAssetsRatesControllerConversionRates', () => {
     });
   });
 
-  describe('edge cases when enabled', () => {
-    it('returns empty result when only EVM assets exist in assetsPrice', () => {
+  describe("edge cases when enabled", () => {
+    it("returns empty result when only EVM assets exist in assetsPrice", () => {
       const state = {
         metamask: {
           ...enabledFlags,
           conversionRates: {},
           assetsPrice: {
-            [nativeEthAssetId]: makeMockPrice({ id: 'eth', price: 2000 }),
-            [erc20AssetId]: makeMockPrice({ id: 'usdc', price: 1 }),
+            [nativeEthAssetId]: makeMockPrice({ id: "eth", price: 2000 }),
+            [erc20AssetId]: makeMockPrice({ id: "usdc", price: 1 }),
           },
         },
       };
@@ -2169,7 +2129,7 @@ describe('getMultichainAssetsRatesControllerConversionRates', () => {
       expect(result).toStrictEqual({});
     });
 
-    it('converts all market data fields to strings', () => {
+    it("converts all market data fields to strings", () => {
       const lastUpdated = 1700000000000;
       const state = {
         metamask: {
@@ -2177,7 +2137,7 @@ describe('getMultichainAssetsRatesControllerConversionRates', () => {
           conversionRates: {},
           assetsPrice: {
             [solanaTokenAssetId]: makeMockPrice({
-              id: 'sol-usdc',
+              id: "sol-usdc",
               price: 1.5,
               lastUpdated,
               allTimeHigh: 2.0,
@@ -2192,17 +2152,17 @@ describe('getMultichainAssetsRatesControllerConversionRates', () => {
       const result = getMultichainAssetsRatesControllerConversionRates(state);
 
       const entry = result[solanaTokenAssetId];
-      expect(entry.rate).toBe('1.5');
+      expect(entry.rate).toBe("1.5");
       expect(entry.conversionTime).toBe(lastUpdated);
       expect(entry.expirationTime).toBeUndefined();
-      expect(entry.marketData?.allTimeHigh).toBe('2');
-      expect(entry.marketData?.allTimeLow).toBe('0.8');
-      expect(entry.marketData?.circulatingSupply).toBe('1000000000');
-      expect(entry.marketData?.marketCap).toBe('1500000000');
-      expect(entry.marketData?.totalVolume).toBe('500000000');
+      expect(entry.marketData?.allTimeHigh).toBe("2");
+      expect(entry.marketData?.allTimeLow).toBe("0.8");
+      expect(entry.marketData?.circulatingSupply).toBe("1000000000");
+      expect(entry.marketData?.marketCap).toBe("1500000000");
+      expect(entry.marketData?.totalVolume).toBe("500000000");
     });
 
-    it('handles empty assetsPrice', () => {
+    it("handles empty assetsPrice", () => {
       const state = {
         metamask: {
           ...enabledFlags,
@@ -2217,12 +2177,11 @@ describe('getMultichainAssetsRatesControllerConversionRates', () => {
   });
 });
 
-describe('getRatesControllerRates', () => {
-  const solanaNativeAssetId =
-    'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501';
+describe("getRatesControllerRates", () => {
+  const solanaNativeAssetId = "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501";
 
-  describe('when assets unify state feature is disabled', () => {
-    it('returns rates from state unchanged', () => {
+  describe("when assets unify state feature is disabled", () => {
+    it("returns rates from state unchanged", () => {
       const legacyRates = {
         btc: {
           conversionDate: 1700000000000,
@@ -2247,8 +2206,8 @@ describe('getRatesControllerRates', () => {
     });
   });
 
-  describe('when assets unify state feature is enabled (happy path)', () => {
-    it('derives rates from assetsInfo and assetsPrice for non-EVM native assets', () => {
+  describe("when assets unify state feature is enabled (happy path)", () => {
+    it("derives rates from assetsInfo and assetsPrice for non-EVM native assets", () => {
       const lastUpdated = 1700000000000;
       const state = {
         metamask: {
@@ -2256,36 +2215,36 @@ describe('getRatesControllerRates', () => {
           rates: {},
           assetsInfo: {
             [nativeEthAssetId]: {
-              type: 'native',
-              symbol: 'ETH',
+              type: "native",
+              symbol: "ETH",
               decimals: 18,
             },
             [bitcoinNativeAssetId]: {
-              type: 'native',
-              symbol: 'BTC',
+              type: "native",
+              symbol: "BTC",
               decimals: 8,
             },
             [solanaNativeAssetId]: {
-              type: 'native',
-              symbol: 'SOL',
+              type: "native",
+              symbol: "SOL",
               decimals: 9,
             },
           },
           assetsPrice: {
             [nativeEthAssetId]: makeMockPrice({
-              id: 'eth',
+              id: "eth",
               price: 2000,
               usdPrice: 2000,
               lastUpdated,
             }),
             [bitcoinNativeAssetId]: makeMockPrice({
-              id: 'btc',
+              id: "btc",
               price: 71052.43,
               usdPrice: 71052.43,
               lastUpdated,
             }),
             [solanaNativeAssetId]: makeMockPrice({
-              id: 'sol',
+              id: "sol",
               price: 91.69,
               usdPrice: 91.69,
               lastUpdated,
@@ -2312,47 +2271,47 @@ describe('getRatesControllerRates', () => {
   });
 });
 
-describe('getRatesControllerFiatCurrency', () => {
-  describe('when assets unify state feature is disabled', () => {
-    it('returns fiatCurrency from state unchanged', () => {
+describe("getRatesControllerFiatCurrency", () => {
+  describe("when assets unify state feature is disabled", () => {
+    it("returns fiatCurrency from state unchanged", () => {
       const state = {
         metamask: {
-          fiatCurrency: 'eur',
+          fiatCurrency: "eur",
         },
       };
       const result = getRatesControllerFiatCurrency(state);
 
-      expect(result).toBe('eur');
+      expect(result).toBe("eur");
     });
   });
 
-  describe('when assets unify state feature is enabled', () => {
-    it('returns selectedCurrency from new state', () => {
+  describe("when assets unify state feature is enabled", () => {
+    it("returns selectedCurrency from new state", () => {
       const state = {
         metamask: {
           ...enabledFlags,
-          fiatCurrency: 'eur',
-          selectedCurrency: 'usd',
+          fiatCurrency: "eur",
+          selectedCurrency: "usd",
         },
       };
       const result = getRatesControllerFiatCurrency(state);
 
-      expect(result).toBe('usd');
+      expect(result).toBe("usd");
     });
   });
 });
 
-describe('getIsAssetsUnifiedStateIncludedInBuild compile-time gate', () => {
+describe("getIsAssetsUnifiedStateIncludedInBuild compile-time gate", () => {
   afterEach(() => {
     jest.mocked(getIsAssetsUnifiedStateIncludedInBuild).mockReturnValue(true);
   });
 
-  it('returns legacy accountsByChainId when the build excludes unified state even if the remote flag is enabled', () => {
+  it("returns legacy accountsByChainId when the build excludes unified state even if the remote flag is enabled", () => {
     jest.mocked(getIsAssetsUnifiedStateIncludedInBuild).mockReturnValue(false);
     const legacyAccountsByChainId = {
-      '0x1': {
+      "0x1": {
         [mockAccountAddressChecksummed]: {
-          balance: '0xabc' as const,
+          balance: "0xabc" as const,
         },
       },
     };
@@ -2362,15 +2321,15 @@ describe('getIsAssetsUnifiedStateIncludedInBuild compile-time gate', () => {
         // the object so this test does not reuse a cached `true` from earlier examples.
         remoteFeatureFlags: {
           ...enabledFlags.remoteFeatureFlags,
-          compileTimeGateCacheBust: 'accountsByChainId',
+          compileTimeGateCacheBust: "accountsByChainId",
         },
         accountsByChainId: legacyAccountsByChainId,
         assetsInfo: {
-          [nativeEthAssetId]: { type: 'native', decimals: 18 },
+          [nativeEthAssetId]: { type: "native", decimals: 18 },
         },
         assetsBalance: {
           [mockAccountId]: {
-            [nativeEthAssetId]: { amount: '999' },
+            [nativeEthAssetId]: { amount: "999" },
           },
         },
         internalAccounts: {
@@ -2378,15 +2337,13 @@ describe('getIsAssetsUnifiedStateIncludedInBuild compile-time gate', () => {
             [mockAccountId]: {
               id: mockAccountId,
               address: mockAccountAddressLowercase,
-              type: 'eip155:eoa',
+              type: "eip155:eoa",
             },
           },
         },
       },
     };
 
-    expect(getAccountTrackerControllerAccountsByChainId(state)).toBe(
-      legacyAccountsByChainId,
-    );
+    expect(getAccountTrackerControllerAccountsByChainId(state)).toBe(legacyAccountsByChainId);
   });
 });

--- a/shared/lib/selectors/assets-migration.ts
+++ b/shared/lib/selectors/assets-migration.ts
@@ -945,10 +945,57 @@ export const getRatesControllerFiatCurrency = createDeepEqualSelector(
   },
 ) as unknown as ControllerStateSelector<RatesControllerState, 'fiatCurrency'>;
 
+
+/**
+ * Converts a scientific notation balance string (e.g. "1e-18") to its raw
+ * base-unit bigint representation given the token's decimal precision.
+ * Sub-unit values are truncated toward zero (e.g. "1e-19" with 18 decimals
+ * yields 0n). Returns 0n for any string that is not valid scientific notation.
+ *
+ * @param balanceString - The balance in scientific notation (e.g. "1e-18").
+ * @param decimals - The token's decimal precision.
+ * @returns The raw base-unit value as a bigint.
+ */
+function parseScientificNotationBalance(
+  balanceString: string,
+  decimals: number,
+): bigint {
+  const match = balanceString.match(/^([+-]?\d+(?:\.\d+)?)[eE]([+-]?\d+)$/u);
+  if (!match) {
+    return 0n;
+  }
+
+  const [, coefficient, rawExponent] = match;
+  const exponent = parseInt(rawExponent, 10);
+  const isNegative = coefficient.startsWith('-');
+  const absCoefficient = coefficient.replace(/^[+-]/u, '');
+  const [coefInt, coefFrac = ''] = absCoefficient.split('.');
+  const coefDigits = coefInt + coefFrac;
+  const finalExponent = exponent + decimals - coefFrac.length;
+
+  let result: bigint;
+  if (finalExponent >= 0) {
+    result = BigInt(coefDigits) * 10n ** BigInt(finalExponent);
+  } else {
+    // Fractional base units are truncated by keeping only the leading digits.
+    const digitsToKeep = coefDigits.length + finalExponent;
+    result = digitsToKeep <= 0 ? 0n : BigInt(coefDigits.slice(0, digitsToKeep));
+  }
+
+  return isNegative ? -result : result;
+}
+
 function parseBalanceWithDecimals(
   balanceString: string,
   decimals: number,
 ): Hex {
+  // Scientific notation (e.g. "1e-18") cannot be split on "." correctly —
+  // handle it separately before the normal fixed-point path.
+  if (balanceString.includes('e') || balanceString.includes('E')) {
+    const raw = parseScientificNotationBalance(balanceString, decimals);
+    return bigIntToHex(raw < 0n ? 0n : raw);
+  }
+
   const [integerPart, fractionalPart = ''] = balanceString.split('.');
 
   if (decimals === 0) {

--- a/shared/lib/selectors/assets-migration.ts
+++ b/shared/lib/selectors/assets-migration.ts
@@ -4,12 +4,9 @@ import {
   Hex,
   bigIntToHex,
   KnownCaipNamespace,
-} from '@metamask/utils';
-import { toChecksumHexAddress } from '@metamask/controller-utils';
-import {
-  AssetsControllerState,
-  FungibleAssetPrice,
-} from '@metamask/assets-controller';
+} from "@metamask/utils";
+import { toChecksumHexAddress } from "@metamask/controller-utils";
+import { AssetsControllerState, FungibleAssetPrice } from "@metamask/assets-controller";
 import {
   AccountTrackerControllerState,
   MultichainAssetsControllerState,
@@ -23,21 +20,21 @@ import {
   MarketDataDetails,
   TokenRatesControllerState,
   RatesControllerState,
-} from '@metamask/assets-controllers';
-import { AccountsControllerState } from '@metamask/accounts-controller';
-import { isEvmAccountType } from '@metamask/keyring-api';
-import { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-flag-controller';
-import { NetworkState } from '@metamask/network-controller';
-import { decimalToPrefixedHex } from '../conversion.utils';
+} from "@metamask/assets-controllers";
+import { AccountsControllerState } from "@metamask/accounts-controller";
+import { isEvmAccountType } from "@metamask/keyring-api";
+import { RemoteFeatureFlagControllerState } from "@metamask/remote-feature-flag-controller";
+import { NetworkState } from "@metamask/network-controller";
+import { decimalToPrefixedHex } from "../conversion.utils";
 import {
   ASSETS_UNIFY_STATE_FLAG,
   ASSETS_UNIFY_STATE_VERSION_1,
   isAssetsUnifyStateFeatureEnabled,
   type AssetsUnifyStateFeatureFlag,
-} from '../assets-unify-state/remote-feature-flag';
-import { getIsAssetsUnifiedStateIncludedInBuild } from '../environment';
-import { AssetType } from '../../constants/transaction';
-import { createDeepEqualSelector } from './selector-creators';
+} from "../assets-unify-state/remote-feature-flag";
+import { getIsAssetsUnifiedStateIncludedInBuild } from "../environment";
+import { AssetType } from "../../constants/transaction";
+import { createDeepEqualSelector } from "./selector-creators";
 
 // Old state controllers and fields status
 //
@@ -82,9 +79,7 @@ import { createDeepEqualSelector } from './selector-creators';
 type ControllerStateSelector<
   InputState extends Record<string, unknown>,
   ResultField extends keyof InputState,
-> = (state: {
-  metamask: Pick<InputState, ResultField>;
-}) => InputState[ResultField];
+> = (state: { metamask: Pick<InputState, ResultField> }) => InputState[ResultField];
 
 const getIsAssetsUnifyStateEnabled = createDeepEqualSelector(
   [
@@ -99,96 +94,81 @@ const getIsAssetsUnifyStateEnabled = createDeepEqualSelector(
       | AssetsUnifyStateFeatureFlag
       | undefined;
 
-    return isAssetsUnifyStateFeatureEnabled(
-      featureFlag,
-      ASSETS_UNIFY_STATE_VERSION_1,
-    );
+    return isAssetsUnifyStateFeatureEnabled(featureFlag, ASSETS_UNIFY_STATE_VERSION_1);
   },
 );
 
 // ChainId (hex) -> AccountAddress (hex checksummed) -> Balance (hex)
-export const getAccountTrackerControllerAccountsByChainId =
-  createDeepEqualSelector(
-    [
-      getIsAssetsUnifyStateEnabled,
-      (state: {
-        metamask: Pick<AccountTrackerControllerState, 'accountsByChainId'>;
-      }) => state.metamask?.accountsByChainId ?? {},
-      (state: { metamask: Pick<AssetsControllerState, 'assetsBalance'> }) =>
-        state.metamask?.assetsBalance ?? {},
-      (state: { metamask: Pick<AssetsControllerState, 'assetsInfo'> }) =>
-        state.metamask?.assetsInfo ?? {},
-      (state: {
-        metamask: Pick<AccountsControllerState, 'internalAccounts'>;
-      }) => state.metamask?.internalAccounts?.accounts ?? {},
-    ],
-    (
-      isAssetsUnifyStateEnabled,
-      accountsByChainId,
-      assetsBalance,
-      assetsInfo,
-      internalAccountsById,
-    ) => {
-      if (!isAssetsUnifyStateEnabled) {
-        return accountsByChainId;
+export const getAccountTrackerControllerAccountsByChainId = createDeepEqualSelector(
+  [
+    getIsAssetsUnifyStateEnabled,
+    (state: { metamask: Pick<AccountTrackerControllerState, "accountsByChainId"> }) =>
+      state.metamask?.accountsByChainId ?? {},
+    (state: { metamask: Pick<AssetsControllerState, "assetsBalance"> }) =>
+      state.metamask?.assetsBalance ?? {},
+    (state: { metamask: Pick<AssetsControllerState, "assetsInfo"> }) =>
+      state.metamask?.assetsInfo ?? {},
+    (state: { metamask: Pick<AccountsControllerState, "internalAccounts"> }) =>
+      state.metamask?.internalAccounts?.accounts ?? {},
+  ],
+  (
+    isAssetsUnifyStateEnabled,
+    accountsByChainId,
+    assetsBalance,
+    assetsInfo,
+    internalAccountsById,
+  ) => {
+    if (!isAssetsUnifyStateEnabled) {
+      return accountsByChainId;
+    }
+
+    const result: AccountTrackerControllerState["accountsByChainId"] = {};
+
+    for (const [accountId, accountBalances] of Object.entries(assetsBalance)) {
+      const internalAccount = internalAccountsById[accountId];
+      if (!internalAccount || !isEvmAccountType(internalAccount.type)) {
+        continue;
       }
 
-      const result: AccountTrackerControllerState['accountsByChainId'] = {};
+      const checksummedAddress = toChecksumHexAddress(internalAccount.address);
 
-      for (const [accountId, accountBalances] of Object.entries(
-        assetsBalance,
-      )) {
-        const internalAccount = internalAccountsById[accountId];
-        if (!internalAccount || !isEvmAccountType(internalAccount.type)) {
+      for (const [assetId, balanceData] of Object.entries(accountBalances)) {
+        const metadata = assetsInfo[assetId];
+        if (metadata?.type !== "native") {
           continue;
         }
 
-        const checksummedAddress = toChecksumHexAddress(
-          internalAccount.address,
-        );
+        const { chain: parsedChain } = parseCaipAssetType(assetId as CaipAssetType);
 
-        for (const [assetId, balanceData] of Object.entries(accountBalances)) {
-          const metadata = assetsInfo[assetId];
-          if (metadata?.type !== 'native') {
-            continue;
-          }
+        // No need to check if the chain is EVM, we already filtered out non-EVM accounts
+        const hexChainId = decimalToPrefixedHex(parsedChain.reference);
+        const amount = balanceData?.amount ?? "0";
 
-          const { chain: parsedChain } = parseCaipAssetType(
-            assetId as CaipAssetType,
-          );
-
-          // No need to check if the chain is EVM, we already filtered out non-EVM accounts
-          const hexChainId = decimalToPrefixedHex(parsedChain.reference);
-          const amount = balanceData?.amount ?? '0';
-
-          result[hexChainId] ??= {};
-          result[hexChainId][checksummedAddress] = {
-            // TODO: Use raw value from state when available
-            balance: parseBalanceWithDecimals(amount, metadata.decimals),
-          };
-        }
+        result[hexChainId] ??= {};
+        result[hexChainId][checksummedAddress] = {
+          // TODO: Use raw value from state when available
+          balance: parseBalanceWithDecimals(amount, metadata.decimals),
+        };
       }
+    }
 
-      return result;
-    },
-  ) as unknown as ControllerStateSelector<
-    AccountTrackerControllerState,
-    'accountsByChainId'
-  >;
+    return result;
+  },
+) as unknown as ControllerStateSelector<AccountTrackerControllerState, "accountsByChainId">;
 
 // ChainId (hex) -> AccountAddress (hex lowercase) -> Array of Tokens
 export const getTokensControllerAllTokens = createDeepEqualSelector(
   [
     getIsAssetsUnifyStateEnabled,
-    (state: { metamask: Pick<TokensControllerState, 'allTokens'> }) =>
+    (state: { metamask: Pick<TokensControllerState, "allTokens"> }) =>
       state.metamask?.allTokens ?? {},
-    (state: { metamask: Pick<AssetsControllerState, 'assetsInfo'> }) =>
+    (state: { metamask: Pick<AssetsControllerState, "assetsInfo"> }) =>
       state.metamask?.assetsInfo ?? {},
-    (state: { metamask: Pick<AssetsControllerState, 'assetsBalance'> }) =>
+    (state: { metamask: Pick<AssetsControllerState, "assetsBalance"> }) =>
       state.metamask?.assetsBalance ?? {},
-    (state: { metamask: Pick<AssetsControllerState, 'customAssets'> }) =>
+    (state: { metamask: Pick<AssetsControllerState, "customAssets"> }) =>
       state.metamask?.customAssets ?? {},
-    (state: { metamask: Pick<AccountsControllerState, 'internalAccounts'> }) =>
+    (state: { metamask: Pick<AccountsControllerState, "internalAccounts"> }) =>
       state.metamask?.internalAccounts?.accounts ?? {},
   ],
   (
@@ -203,23 +183,17 @@ export const getTokensControllerAllTokens = createDeepEqualSelector(
       return allTokens;
     }
 
-    const result: TokensControllerState['allTokens'] = {};
+    const result: TokensControllerState["allTokens"] = {};
 
     // Merge assetsBalance and customAssets: accountId -> assetId[]
     const allAssets = Object.fromEntries(
-      [
-        ...new Set([
-          ...Object.keys(assetsBalance),
-          ...Object.keys(customAssets),
-        ]),
-      ].map((accountId) => {
-        const fromBalance = Object.keys(assetsBalance[accountId] ?? {});
-        const fromCustom = customAssets[accountId] ?? [];
-        return [
-          accountId,
-          [...new Set([...fromBalance, ...fromCustom])] as CaipAssetType[],
-        ];
-      }),
+      [...new Set([...Object.keys(assetsBalance), ...Object.keys(customAssets)])].map(
+        (accountId) => {
+          const fromBalance = Object.keys(assetsBalance[accountId] ?? {});
+          const fromCustom = customAssets[accountId] ?? [];
+          return [accountId, [...new Set([...fromBalance, ...fromCustom])] as CaipAssetType[]];
+        },
+      ),
     );
 
     for (const [accountId, assetIds] of Object.entries(allAssets)) {
@@ -230,7 +204,7 @@ export const getTokensControllerAllTokens = createDeepEqualSelector(
 
       for (const assetId of assetIds) {
         const metadata = assetsInfo[assetId];
-        if (!metadata || metadata.type === 'native') {
+        if (!metadata || metadata.type === "native") {
           continue;
         }
 
@@ -256,30 +230,25 @@ export const getTokensControllerAllTokens = createDeepEqualSelector(
 
     return result;
   },
-) as unknown as ControllerStateSelector<TokensControllerState, 'allTokens'>;
+) as unknown as ControllerStateSelector<TokensControllerState, "allTokens">;
 
 // ChainId (hex) -> AccountAddress (hex lowercase) -> Array of TokenAddress (hex lowercase)
 export const getTokensControllerAllIgnoredTokens = createDeepEqualSelector(
   [
     getIsAssetsUnifyStateEnabled,
-    (state: { metamask: Pick<TokensControllerState, 'allIgnoredTokens'> }) =>
+    (state: { metamask: Pick<TokensControllerState, "allIgnoredTokens"> }) =>
       state.metamask?.allIgnoredTokens ?? {},
-    (state: { metamask: Pick<AssetsControllerState, 'assetPreferences'> }) =>
+    (state: { metamask: Pick<AssetsControllerState, "assetPreferences"> }) =>
       state.metamask?.assetPreferences ?? {},
-    (state: { metamask: Pick<AccountsControllerState, 'internalAccounts'> }) =>
+    (state: { metamask: Pick<AccountsControllerState, "internalAccounts"> }) =>
       state.metamask?.internalAccounts?.accounts ?? {},
   ],
-  (
-    isAssetsUnifyStateEnabled,
-    allIgnoredTokens,
-    assetPreferences,
-    internalAccountsById,
-  ) => {
+  (isAssetsUnifyStateEnabled, allIgnoredTokens, assetPreferences, internalAccountsById) => {
     if (!isAssetsUnifyStateEnabled) {
       return allIgnoredTokens;
     }
 
-    const result: TokensControllerState['allIgnoredTokens'] = {};
+    const result: TokensControllerState["allIgnoredTokens"] = {};
 
     for (const [assetId, { hidden }] of Object.entries(assetPreferences)) {
       if (!hidden) {
@@ -301,33 +270,27 @@ export const getTokensControllerAllIgnoredTokens = createDeepEqualSelector(
 
         result[hexChainId] ??= {};
         result[hexChainId][internalAccount.address] ??= [];
-        result[hexChainId][internalAccount.address].push(
-          assetType.assetReference,
-        );
+        result[hexChainId][internalAccount.address].push(assetType.assetReference);
       }
     }
 
     return result;
   },
-) as unknown as ControllerStateSelector<
-  TokensControllerState,
-  'allIgnoredTokens'
->;
+) as unknown as ControllerStateSelector<TokensControllerState, "allIgnoredTokens">;
 
 // AcountAddress (hex lowercase) -> ChainId (hex) -> TokenAddress (hex checksummed) -> Balance (hex)
 export const getTokenBalancesControllerTokenBalances = createDeepEqualSelector(
   [
     getIsAssetsUnifyStateEnabled,
-    (state: {
-      metamask: Pick<TokenBalancesControllerState, 'tokenBalances'>;
-    }) => state.metamask?.tokenBalances ?? {},
-    (state: { metamask: Pick<AssetsControllerState, 'assetsInfo'> }) =>
+    (state: { metamask: Pick<TokenBalancesControllerState, "tokenBalances"> }) =>
+      state.metamask?.tokenBalances ?? {},
+    (state: { metamask: Pick<AssetsControllerState, "assetsInfo"> }) =>
       state.metamask?.assetsInfo ?? {},
-    (state: { metamask: Pick<AssetsControllerState, 'assetsBalance'> }) =>
+    (state: { metamask: Pick<AssetsControllerState, "assetsBalance"> }) =>
       state.metamask?.assetsBalance ?? {},
-    (state: { metamask: Pick<AssetsControllerState, 'customAssets'> }) =>
+    (state: { metamask: Pick<AssetsControllerState, "customAssets"> }) =>
       state.metamask?.customAssets ?? {},
-    (state: { metamask: Pick<AccountsControllerState, 'internalAccounts'> }) =>
+    (state: { metamask: Pick<AccountsControllerState, "internalAccounts"> }) =>
       state.metamask?.internalAccounts?.accounts ?? {},
   ],
   (
@@ -342,7 +305,7 @@ export const getTokenBalancesControllerTokenBalances = createDeepEqualSelector(
       return tokenBalances;
     }
 
-    const result: TokenBalancesControllerState['tokenBalances'] = {};
+    const result: TokenBalancesControllerState["tokenBalances"] = {};
     for (const [accountId, chainIdBalances] of Object.entries(assetsBalance)) {
       const internalAccount = internalAccountsById[accountId];
       if (!internalAccount || !isEvmAccountType(internalAccount.type)) {
@@ -362,9 +325,7 @@ export const getTokenBalancesControllerTokenBalances = createDeepEqualSelector(
 
         const hexChainId = decimalToPrefixedHex(assetType.chain.reference);
         const assetAddress = toChecksumHexAddress(
-          metadata.type === 'native'
-            ? getNativeTokenAddress(hexChainId)
-            : assetType.assetReference,
+          metadata.type === "native" ? getNativeTokenAddress(hexChainId) : assetType.assetReference,
         ) as Hex;
 
         result[accountAddress][hexChainId] ??= {};
@@ -393,7 +354,7 @@ export const getTokenBalancesControllerTokenBalances = createDeepEqualSelector(
         }
 
         const metadata = assetsInfo[assetId];
-        if (!metadata || metadata.type === 'native') {
+        if (!metadata || metadata.type === "native") {
           continue;
         }
 
@@ -404,224 +365,186 @@ export const getTokenBalancesControllerTokenBalances = createDeepEqualSelector(
         }
 
         const hexChainId = decimalToPrefixedHex(assetType.chain.reference);
-        const assetAddress = toChecksumHexAddress(
-          assetType.assetReference,
-        ) as Hex;
+        const assetAddress = toChecksumHexAddress(assetType.assetReference) as Hex;
 
         if (!result[accountAddress]?.[hexChainId]?.[assetAddress]) {
           result[accountAddress][hexChainId] ??= {};
-          result[accountAddress][hexChainId][assetAddress] =
-            parseBalanceWithDecimals('0', metadata.decimals);
+          result[accountAddress][hexChainId][assetAddress] = parseBalanceWithDecimals(
+            "0",
+            metadata.decimals,
+          );
         }
       }
     }
 
     return result;
   },
-) as unknown as ControllerStateSelector<
-  TokenBalancesControllerState,
-  'tokenBalances'
->;
+) as unknown as ControllerStateSelector<TokenBalancesControllerState, "tokenBalances">;
 
 // AccountId -> Array of AssetIds
-export const getMultiChainAssetsControllerAccountsAssets =
-  createDeepEqualSelector(
-    [
-      getIsAssetsUnifyStateEnabled,
-      (state: {
-        metamask: Pick<MultichainAssetsControllerState, 'accountsAssets'>;
-      }) => state.metamask?.accountsAssets ?? {},
-      (state: { metamask: Pick<AssetsControllerState, 'assetsBalance'> }) =>
-        state.metamask?.assetsBalance ?? {},
-      (state: { metamask: Pick<AssetsControllerState, 'customAssets'> }) =>
-        state.metamask?.customAssets ?? {},
-      (state: {
-        metamask: Pick<AccountsControllerState, 'internalAccounts'>;
-      }) => state.metamask?.internalAccounts?.accounts ?? {},
-    ],
-    (
-      isAssetsUnifyStateEnabled,
-      accountsAssets,
-      assetsBalance,
-      customAssets,
-      internalAccountsById,
-    ) => {
-      if (!isAssetsUnifyStateEnabled) {
-        return accountsAssets;
-      }
+export const getMultiChainAssetsControllerAccountsAssets = createDeepEqualSelector(
+  [
+    getIsAssetsUnifyStateEnabled,
+    (state: { metamask: Pick<MultichainAssetsControllerState, "accountsAssets"> }) =>
+      state.metamask?.accountsAssets ?? {},
+    (state: { metamask: Pick<AssetsControllerState, "assetsBalance"> }) =>
+      state.metamask?.assetsBalance ?? {},
+    (state: { metamask: Pick<AssetsControllerState, "customAssets"> }) =>
+      state.metamask?.customAssets ?? {},
+    (state: { metamask: Pick<AccountsControllerState, "internalAccounts"> }) =>
+      state.metamask?.internalAccounts?.accounts ?? {},
+  ],
+  (
+    isAssetsUnifyStateEnabled,
+    accountsAssets,
+    assetsBalance,
+    customAssets,
+    internalAccountsById,
+  ) => {
+    if (!isAssetsUnifyStateEnabled) {
+      return accountsAssets;
+    }
 
-      const result: MultichainAssetsControllerState['accountsAssets'] = {};
+    const result: MultichainAssetsControllerState["accountsAssets"] = {};
 
-      // Merge assetsBalance and customAssets: accountId -> assetId[]
-      const allAssets = Object.fromEntries(
-        [
-          ...new Set([
-            ...Object.keys(assetsBalance),
-            ...Object.keys(customAssets),
-          ]),
-        ].map((accountId) => {
+    // Merge assetsBalance and customAssets: accountId -> assetId[]
+    const allAssets = Object.fromEntries(
+      [...new Set([...Object.keys(assetsBalance), ...Object.keys(customAssets)])].map(
+        (accountId) => {
           const fromBalance = Object.keys(assetsBalance[accountId] ?? {});
           const fromCustom = customAssets[accountId] ?? [];
-          return [
-            accountId,
-            [...new Set([...fromBalance, ...fromCustom])] as CaipAssetType[],
-          ];
-        }),
-      );
+          return [accountId, [...new Set([...fromBalance, ...fromCustom])] as CaipAssetType[]];
+        },
+      ),
+    );
 
-      for (const [accountId, assetIds] of Object.entries(allAssets)) {
-        const internalAccount = internalAccountsById[accountId];
-        if (!internalAccount || isEvmAccountType(internalAccount.type)) {
+    for (const [accountId, assetIds] of Object.entries(allAssets)) {
+      const internalAccount = internalAccountsById[accountId];
+      if (!internalAccount || isEvmAccountType(internalAccount.type)) {
+        continue;
+      }
+
+      result[accountId] = [];
+
+      for (const assetId of assetIds) {
+        const assetType = parseCaipAssetType(assetId);
+        if (assetType.chain.namespace === KnownCaipNamespace.Eip155) {
           continue;
         }
 
-        result[accountId] = [];
-
-        for (const assetId of assetIds) {
-          const assetType = parseCaipAssetType(assetId);
-          if (assetType.chain.namespace === KnownCaipNamespace.Eip155) {
-            continue;
-          }
-
-          result[accountId].push(assetId);
-        }
+        result[accountId].push(assetId);
       }
+    }
 
-      return result;
-    },
-  ) as unknown as ControllerStateSelector<
-    MultichainAssetsControllerState,
-    'accountsAssets'
-  >;
+    return result;
+  },
+) as unknown as ControllerStateSelector<MultichainAssetsControllerState, "accountsAssets">;
 
 // TODO There are issues with the new image url not matching the one in assetsMetadata iconUrl
 // AssetId -> AssetMetadata
-export const getMultiChainAssetsControllerAssetsMetadata =
-  createDeepEqualSelector(
-    [
-      getIsAssetsUnifyStateEnabled,
-      (state: {
-        metamask: Pick<MultichainAssetsControllerState, 'assetsMetadata'>;
-      }) => state.metamask?.assetsMetadata ?? {},
-      (state: { metamask: Pick<AssetsControllerState, 'assetsInfo'> }) =>
-        state.metamask?.assetsInfo ?? {},
-    ],
-    (isAssetsUnifyStateEnabled, assetsMetadata, assetsInfo) => {
-      if (!isAssetsUnifyStateEnabled) {
-        return assetsMetadata;
+export const getMultiChainAssetsControllerAssetsMetadata = createDeepEqualSelector(
+  [
+    getIsAssetsUnifyStateEnabled,
+    (state: { metamask: Pick<MultichainAssetsControllerState, "assetsMetadata"> }) =>
+      state.metamask?.assetsMetadata ?? {},
+    (state: { metamask: Pick<AssetsControllerState, "assetsInfo"> }) =>
+      state.metamask?.assetsInfo ?? {},
+  ],
+  (isAssetsUnifyStateEnabled, assetsMetadata, assetsInfo) => {
+    if (!isAssetsUnifyStateEnabled) {
+      return assetsMetadata;
+    }
+
+    const result: MultichainAssetsControllerState["assetsMetadata"] = {};
+
+    for (const [assetId, metadata] of Object.entries(assetsInfo)) {
+      const assetType = parseCaipAssetType(assetId as CaipAssetType);
+      if (assetType.chain.namespace === KnownCaipNamespace.Eip155) {
+        continue;
       }
 
-      const result: MultichainAssetsControllerState['assetsMetadata'] = {};
+      result[assetId as CaipAssetType] = {
+        fungible: true,
+        iconUrl: metadata.image ?? "",
+        units: [
+          {
+            decimals: metadata.decimals,
+            symbol: metadata.symbol,
+            name: metadata.name,
+          },
+        ],
+        symbol: metadata.symbol,
+        name: metadata.name,
+      };
+    }
 
-      for (const [assetId, metadata] of Object.entries(assetsInfo)) {
+    return result;
+  },
+) as unknown as ControllerStateSelector<MultichainAssetsControllerState, "assetsMetadata">;
+
+// AccountId -> Array of AssetIds
+export const getMultiChainAssetsControllerAllIgnoredAssets = createDeepEqualSelector(
+  [
+    getIsAssetsUnifyStateEnabled,
+    (state: { metamask: Pick<MultichainAssetsControllerState, "allIgnoredAssets"> }) =>
+      state.metamask?.allIgnoredAssets ?? {},
+    (state: { metamask: Pick<AssetsControllerState, "assetPreferences"> }) =>
+      state.metamask?.assetPreferences ?? {},
+    (state: { metamask: Pick<AccountsControllerState, "internalAccounts"> }) =>
+      state.metamask?.internalAccounts?.accounts ?? {},
+  ],
+  (isAssetsUnifyStateEnabled, allIgnoredAssets, assetPreferences, internalAccountsById) => {
+    if (!isAssetsUnifyStateEnabled) {
+      return allIgnoredAssets;
+    }
+
+    const result: MultichainAssetsControllerState["allIgnoredAssets"] = {};
+
+    for (const accountId of Object.keys(internalAccountsById)) {
+      const internalAccount = internalAccountsById[accountId];
+      if (!internalAccount || isEvmAccountType(internalAccount.type)) {
+        continue;
+      }
+
+      result[accountId] = [];
+
+      for (const [assetId, { hidden }] of Object.entries(assetPreferences)) {
+        if (!hidden) {
+          continue;
+        }
+
         const assetType = parseCaipAssetType(assetId as CaipAssetType);
         if (assetType.chain.namespace === KnownCaipNamespace.Eip155) {
           continue;
         }
 
-        result[assetId as CaipAssetType] = {
-          fungible: true,
-          iconUrl: metadata.image ?? '',
-          units: [
-            {
-              decimals: metadata.decimals,
-              symbol: metadata.symbol,
-              name: metadata.name,
-            },
-          ],
-          symbol: metadata.symbol,
-          name: metadata.name,
-        };
+        result[accountId].push(assetId as CaipAssetType);
       }
+    }
 
-      return result;
-    },
-  ) as unknown as ControllerStateSelector<
-    MultichainAssetsControllerState,
-    'assetsMetadata'
-  >;
-
-// AccountId -> Array of AssetIds
-export const getMultiChainAssetsControllerAllIgnoredAssets =
-  createDeepEqualSelector(
-    [
-      getIsAssetsUnifyStateEnabled,
-      (state: {
-        metamask: Pick<MultichainAssetsControllerState, 'allIgnoredAssets'>;
-      }) => state.metamask?.allIgnoredAssets ?? {},
-      (state: { metamask: Pick<AssetsControllerState, 'assetPreferences'> }) =>
-        state.metamask?.assetPreferences ?? {},
-      (state: {
-        metamask: Pick<AccountsControllerState, 'internalAccounts'>;
-      }) => state.metamask?.internalAccounts?.accounts ?? {},
-    ],
-    (
-      isAssetsUnifyStateEnabled,
-      allIgnoredAssets,
-      assetPreferences,
-      internalAccountsById,
-    ) => {
-      if (!isAssetsUnifyStateEnabled) {
-        return allIgnoredAssets;
-      }
-
-      const result: MultichainAssetsControllerState['allIgnoredAssets'] = {};
-
-      for (const accountId of Object.keys(internalAccountsById)) {
-        const internalAccount = internalAccountsById[accountId];
-        if (!internalAccount || isEvmAccountType(internalAccount.type)) {
-          continue;
-        }
-
-        result[accountId] = [];
-
-        for (const [assetId, { hidden }] of Object.entries(assetPreferences)) {
-          if (!hidden) {
-            continue;
-          }
-
-          const assetType = parseCaipAssetType(assetId as CaipAssetType);
-          if (assetType.chain.namespace === KnownCaipNamespace.Eip155) {
-            continue;
-          }
-
-          result[accountId].push(assetId as CaipAssetType);
-        }
-      }
-
-      return result;
-    },
-  ) as unknown as ControllerStateSelector<
-    MultichainAssetsControllerState,
-    'allIgnoredAssets'
-  >;
+    return result;
+  },
+) as unknown as ControllerStateSelector<MultichainAssetsControllerState, "allIgnoredAssets">;
 
 // AccountId -> AssetId -> Balance (amount + unit)
 export const getMultiChainBalancesControllerBalances = createDeepEqualSelector(
   [
     getIsAssetsUnifyStateEnabled,
-    (state: {
-      metamask: Pick<MultichainBalancesControllerState, 'balances'>;
-    }) => state.metamask?.balances ?? {},
-    (state: { metamask: Pick<AssetsControllerState, 'assetsBalance'> }) =>
+    (state: { metamask: Pick<MultichainBalancesControllerState, "balances"> }) =>
+      state.metamask?.balances ?? {},
+    (state: { metamask: Pick<AssetsControllerState, "assetsBalance"> }) =>
       state.metamask?.assetsBalance ?? {},
-    (state: { metamask: Pick<AssetsControllerState, 'assetsInfo'> }) =>
+    (state: { metamask: Pick<AssetsControllerState, "assetsInfo"> }) =>
       state.metamask?.assetsInfo ?? {},
-    (state: { metamask: Pick<AccountsControllerState, 'internalAccounts'> }) =>
+    (state: { metamask: Pick<AccountsControllerState, "internalAccounts"> }) =>
       state.metamask?.internalAccounts?.accounts ?? {},
   ],
-  (
-    isAssetsUnifyStateEnabled,
-    balances,
-    assetsBalance,
-    assetsInfo,
-    internalAccountsById,
-  ) => {
+  (isAssetsUnifyStateEnabled, balances, assetsBalance, assetsInfo, internalAccountsById) => {
     if (!isAssetsUnifyStateEnabled) {
       return balances;
     }
 
-    const result: MultichainBalancesControllerState['balances'] = {};
+    const result: MultichainBalancesControllerState["balances"] = {};
 
     for (const [accountId, chainIdBalances] of Object.entries(assetsBalance)) {
       const internalAccount = internalAccountsById[accountId];
@@ -635,10 +558,7 @@ export const getMultiChainBalancesControllerBalances = createDeepEqualSelector(
         const assetType = parseCaipAssetType(assetId as CaipAssetType);
         const metadata = assetsInfo[assetId];
 
-        if (
-          !metadata ||
-          assetType.chain.namespace === KnownCaipNamespace.Eip155
-        ) {
+        if (!metadata || assetType.chain.namespace === KnownCaipNamespace.Eip155) {
           continue;
         }
 
@@ -651,17 +571,13 @@ export const getMultiChainBalancesControllerBalances = createDeepEqualSelector(
 
     return result;
   },
-) as unknown as ControllerStateSelector<
-  MultichainBalancesControllerState,
-  'balances'
->;
+) as unknown as ControllerStateSelector<MultichainBalancesControllerState, "balances">;
 
 export const getCurrencyRateControllerCurrentCurrency = createDeepEqualSelector(
   [
     getIsAssetsUnifyStateEnabled,
     (state: { metamask: CurrencyRateState }) => state.metamask?.currentCurrency,
-    (state: { metamask: AssetsControllerState }) =>
-      state.metamask?.selectedCurrency,
+    (state: { metamask: AssetsControllerState }) => state.metamask?.selectedCurrency,
   ],
   (isAssetsUnifyStateEnabled, currentCurrency, selectedCurrency) => {
     if (!isAssetsUnifyStateEnabled) {
@@ -670,29 +586,26 @@ export const getCurrencyRateControllerCurrentCurrency = createDeepEqualSelector(
 
     return selectedCurrency;
   },
-) as unknown as ControllerStateSelector<CurrencyRateState, 'currentCurrency'>;
+) as unknown as ControllerStateSelector<CurrencyRateState, "currentCurrency">;
 
 // Native Symbol -> Rates (conversionRate, usdConversionRate, conversionDate)
 export const getCurrencyRateControllerCurrencyRates = createDeepEqualSelector(
   [
     getIsAssetsUnifyStateEnabled,
-    (state: { metamask: CurrencyRateState }) =>
-      state.metamask?.currencyRates ?? {},
-    (state: { metamask: AssetsControllerState }) =>
-      state.metamask?.assetsInfo ?? {},
-    (state: { metamask: AssetsControllerState }) =>
-      state.metamask?.assetsPrice ?? {},
+    (state: { metamask: CurrencyRateState }) => state.metamask?.currencyRates ?? {},
+    (state: { metamask: AssetsControllerState }) => state.metamask?.assetsInfo ?? {},
+    (state: { metamask: AssetsControllerState }) => state.metamask?.assetsPrice ?? {},
   ],
   (isAssetsUnifyStateEnabled, currencyRates, assetsInfo, assetsPrice) => {
     if (!isAssetsUnifyStateEnabled) {
       return currencyRates;
     }
 
-    const result: CurrencyRateState['currencyRates'] = {};
+    const result: CurrencyRateState["currencyRates"] = {};
 
     // Sorting just to ensure that we process mainnet (eip155:1) first
-    for (const [assetId, metadata] of Object.entries(assetsInfo).toSorted(
-      (a, b) => a[0].localeCompare(b[0]),
+    for (const [assetId, metadata] of Object.entries(assetsInfo).toSorted((a, b) =>
+      a[0].localeCompare(b[0]),
     )) {
       // Skip if we already have an entry for this symbol
       if (result[metadata.symbol]) {
@@ -702,16 +615,13 @@ export const getCurrencyRateControllerCurrencyRates = createDeepEqualSelector(
       const assetType = parseCaipAssetType(assetId as CaipAssetType);
 
       // Skip if not a native asset or not evm
-      if (
-        metadata.type !== 'native' ||
-        assetType.chain.namespace !== KnownCaipNamespace.Eip155
-      ) {
+      if (metadata.type !== "native" || assetType.chain.namespace !== KnownCaipNamespace.Eip155) {
         continue;
       }
 
       const price = assetsPrice[assetId];
 
-      if (price?.assetPriceType !== 'fungible') {
+      if (price?.assetPriceType !== "fungible") {
         continue;
       }
 
@@ -724,21 +634,17 @@ export const getCurrencyRateControllerCurrencyRates = createDeepEqualSelector(
 
     return result;
   },
-) as unknown as ControllerStateSelector<CurrencyRateState, 'currencyRates'>;
+) as unknown as ControllerStateSelector<CurrencyRateState, "currencyRates">;
 
 // ChainId (hex) -> TokenAddress (hex checksummed) -> MarketData
 export const getTokenRatesControllerMarketData = createDeepEqualSelector(
   [
     getIsAssetsUnifyStateEnabled,
-    (state: { metamask: TokenRatesControllerState }) =>
-      state.metamask?.marketData ?? {},
-    (state: { metamask: AssetsControllerState }) =>
-      state.metamask?.assetsPrice ?? {},
-    (state: { metamask: AssetsControllerState }) =>
-      state.metamask?.assetsInfo ?? {},
+    (state: { metamask: TokenRatesControllerState }) => state.metamask?.marketData ?? {},
+    (state: { metamask: AssetsControllerState }) => state.metamask?.assetsPrice ?? {},
+    (state: { metamask: AssetsControllerState }) => state.metamask?.assetsInfo ?? {},
     getCurrencyRateControllerCurrencyRates,
-    (state: { metamask: NetworkState }) =>
-      state.metamask?.networkConfigurationsByChainId ?? {},
+    (state: { metamask: NetworkState }) => state.metamask?.networkConfigurationsByChainId ?? {},
   ],
   (
     isAssetsUnifyStateEnabled,
@@ -752,7 +658,7 @@ export const getTokenRatesControllerMarketData = createDeepEqualSelector(
       return marketData;
     }
 
-    const result: TokenRatesControllerState['marketData'] = {};
+    const result: TokenRatesControllerState["marketData"] = {};
 
     for (const [assetId, price] of Object.entries(assetsPrice) as [
       CaipAssetType,
@@ -771,17 +677,13 @@ export const getTokenRatesControllerMarketData = createDeepEqualSelector(
 
       const hexChainId = decimalToPrefixedHex(assetType.chain.reference);
       const nativeAssetSymbol =
-        networkConfigurationsByChainId[hexChainId]?.nativeCurrency ??
-        AssetType.native;
+        networkConfigurationsByChainId[hexChainId]?.nativeCurrency ?? AssetType.native;
 
       const assetAddress = toChecksumHexAddress(
-        metadata.type === 'native'
-          ? getNativeTokenAddress(hexChainId)
-          : assetType.assetReference,
+        metadata.type === "native" ? getNativeTokenAddress(hexChainId) : assetType.assetReference,
       ) as Hex;
 
-      const nativeCurrencyRate =
-        currencyRates[nativeAssetSymbol]?.conversionRate;
+      const nativeCurrencyRate = currencyRates[nativeAssetSymbol]?.conversionRate;
       if (!nativeCurrencyRate) {
         continue;
       }
@@ -820,83 +722,72 @@ export const getTokenRatesControllerMarketData = createDeepEqualSelector(
 
     return result;
   },
-) as unknown as ControllerStateSelector<
-  TokenRatesControllerState,
-  'marketData'
->;
+) as unknown as ControllerStateSelector<TokenRatesControllerState, "marketData">;
 
-export const getMultichainAssetsRatesControllerConversionRates =
-  createDeepEqualSelector(
-    [
-      getIsAssetsUnifyStateEnabled,
-      (state: { metamask: MultichainAssetsRatesControllerState }) =>
-        state.metamask.conversionRates ?? {},
-      (state: { metamask: AssetsControllerState }) =>
-        state.metamask.assetsPrice ?? {},
-    ],
-    (isAssetsUnifyStateEnabled, conversionRates, assetsPrice) => {
-      if (!isAssetsUnifyStateEnabled) {
-        return conversionRates;
+export const getMultichainAssetsRatesControllerConversionRates = createDeepEqualSelector(
+  [
+    getIsAssetsUnifyStateEnabled,
+    (state: { metamask: MultichainAssetsRatesControllerState }) =>
+      state.metamask.conversionRates ?? {},
+    (state: { metamask: AssetsControllerState }) => state.metamask.assetsPrice ?? {},
+  ],
+  (isAssetsUnifyStateEnabled, conversionRates, assetsPrice) => {
+    if (!isAssetsUnifyStateEnabled) {
+      return conversionRates;
+    }
+
+    const result: MultichainAssetsRatesControllerState["conversionRates"] = {};
+
+    for (const [assetId, assetPrice] of Object.entries(assetsPrice) as [
+      CaipAssetType,
+      FungibleAssetPrice, // TODO: A type discriminator to AssetPrice is needed to be added to avoid this cast, but it is safe for now
+    ][]) {
+      const assetType = parseCaipAssetType(assetId);
+      if (assetType.chain.namespace === KnownCaipNamespace.Eip155) {
+        continue;
       }
 
-      const result: MultichainAssetsRatesControllerState['conversionRates'] =
-        {};
-
-      for (const [assetId, assetPrice] of Object.entries(assetsPrice) as [
-        CaipAssetType,
-        FungibleAssetPrice, // TODO: A type discriminator to AssetPrice is needed to be added to avoid this cast, but it is safe for now
-      ][]) {
-        const assetType = parseCaipAssetType(assetId);
-        if (assetType.chain.namespace === KnownCaipNamespace.Eip155) {
-          continue;
-        }
-
-        result[assetId] = {
-          rate: `${assetPrice.price}`,
-          conversionTime: assetPrice.lastUpdated,
-          expirationTime: undefined,
-          marketData: {
-            fungible: true,
-            allTimeHigh: `${assetPrice.allTimeHigh}`,
-            allTimeLow: `${assetPrice.allTimeLow}`,
-            circulatingSupply: `${assetPrice.circulatingSupply}`,
-            marketCap: `${assetPrice.marketCap}`,
-            totalVolume: `${assetPrice.totalVolume}`,
-            pricePercentChange: {
-              PT1H: assetPrice.pricePercentChange1h as number,
-              P1D: assetPrice.pricePercentChange1d as number,
-              P7D: assetPrice.pricePercentChange7d as number,
-              P14D: assetPrice.pricePercentChange14d as number,
-              P30D: assetPrice.pricePercentChange30d as number,
-              P200D: assetPrice.pricePercentChange200d as number,
-              P1Y: assetPrice.pricePercentChange1y as number,
-            },
+      result[assetId] = {
+        rate: `${assetPrice.price}`,
+        conversionTime: assetPrice.lastUpdated,
+        expirationTime: undefined,
+        marketData: {
+          fungible: true,
+          allTimeHigh: `${assetPrice.allTimeHigh}`,
+          allTimeLow: `${assetPrice.allTimeLow}`,
+          circulatingSupply: `${assetPrice.circulatingSupply}`,
+          marketCap: `${assetPrice.marketCap}`,
+          totalVolume: `${assetPrice.totalVolume}`,
+          pricePercentChange: {
+            PT1H: assetPrice.pricePercentChange1h as number,
+            P1D: assetPrice.pricePercentChange1d as number,
+            P7D: assetPrice.pricePercentChange7d as number,
+            P14D: assetPrice.pricePercentChange14d as number,
+            P30D: assetPrice.pricePercentChange30d as number,
+            P200D: assetPrice.pricePercentChange200d as number,
+            P1Y: assetPrice.pricePercentChange1y as number,
           },
-        };
-      }
+        },
+      };
+    }
 
-      return result;
-    },
-  ) as unknown as ControllerStateSelector<
-    MultichainAssetsRatesControllerState,
-    'conversionRates'
-  >;
+    return result;
+  },
+) as unknown as ControllerStateSelector<MultichainAssetsRatesControllerState, "conversionRates">;
 
 export const getRatesControllerRates = createDeepEqualSelector(
   [
     getIsAssetsUnifyStateEnabled,
     (state: { metamask: RatesControllerState }) => state.metamask.rates ?? {},
-    (state: { metamask: AssetsControllerState }) =>
-      state.metamask?.assetsInfo ?? {},
-    (state: { metamask: AssetsControllerState }) =>
-      state.metamask?.assetsPrice ?? {},
+    (state: { metamask: AssetsControllerState }) => state.metamask?.assetsInfo ?? {},
+    (state: { metamask: AssetsControllerState }) => state.metamask?.assetsPrice ?? {},
   ],
   (isAssetsUnifyStateEnabled, rates, assetsInfo, assetsPrice) => {
     if (!isAssetsUnifyStateEnabled) {
       return rates;
     }
 
-    const result: RatesControllerState['rates'] = {};
+    const result: RatesControllerState["rates"] = {};
 
     for (const [assetId, metadata] of Object.entries(assetsInfo)) {
       const symbol = metadata.symbol.toLowerCase();
@@ -911,9 +802,9 @@ export const getRatesControllerRates = createDeepEqualSelector(
 
       // Skip if not a native asset, if evm or if not fungible
       if (
-        metadata.type !== 'native' ||
+        metadata.type !== "native" ||
         assetType.chain.namespace === KnownCaipNamespace.Eip155 ||
-        price?.assetPriceType !== 'fungible'
+        price?.assetPriceType !== "fungible"
       ) {
         continue;
       }
@@ -927,14 +818,13 @@ export const getRatesControllerRates = createDeepEqualSelector(
 
     return result;
   },
-) as unknown as ControllerStateSelector<RatesControllerState, 'rates'>;
+) as unknown as ControllerStateSelector<RatesControllerState, "rates">;
 
 export const getRatesControllerFiatCurrency = createDeepEqualSelector(
   [
     getIsAssetsUnifyStateEnabled,
     (state: { metamask: RatesControllerState }) => state.metamask.fiatCurrency,
-    (state: { metamask: AssetsControllerState }) =>
-      state.metamask.selectedCurrency,
+    (state: { metamask: AssetsControllerState }) => state.metamask.selectedCurrency,
   ],
   (isAssetsUnifyStateEnabled, fiatCurrency, selectedCurrency) => {
     if (!isAssetsUnifyStateEnabled) {
@@ -943,8 +833,7 @@ export const getRatesControllerFiatCurrency = createDeepEqualSelector(
 
     return selectedCurrency;
   },
-) as unknown as ControllerStateSelector<RatesControllerState, 'fiatCurrency'>;
-
+) as unknown as ControllerStateSelector<RatesControllerState, "fiatCurrency">;
 
 /**
  * Converts a scientific notation balance string (e.g. "1e-18") to its raw
@@ -956,10 +845,7 @@ export const getRatesControllerFiatCurrency = createDeepEqualSelector(
  * @param decimals - The token's decimal precision.
  * @returns The raw base-unit value as a bigint.
  */
-function parseScientificNotationBalance(
-  balanceString: string,
-  decimals: number,
-): bigint {
+function parseScientificNotationBalance(balanceString: string, decimals: number): bigint {
   const match = balanceString.match(/^([+-]?\d+(?:\.\d+)?)[eE]([+-]?\d+)$/u);
   if (!match) {
     return 0n;
@@ -967,9 +853,9 @@ function parseScientificNotationBalance(
 
   const [, coefficient, rawExponent] = match;
   const exponent = parseInt(rawExponent, 10);
-  const isNegative = coefficient.startsWith('-');
-  const absCoefficient = coefficient.replace(/^[+-]/u, '');
-  const [coefInt, coefFrac = ''] = absCoefficient.split('.');
+  const isNegative = coefficient.startsWith("-");
+  const absCoefficient = coefficient.replace(/^[+-]/u, "");
+  const [coefInt, coefFrac = ""] = absCoefficient.split(".");
   const coefDigits = coefInt + coefFrac;
   const finalExponent = exponent + decimals - coefFrac.length;
 
@@ -985,34 +871,25 @@ function parseScientificNotationBalance(
   return isNegative ? -result : result;
 }
 
-function parseBalanceWithDecimals(
-  balanceString: string,
-  decimals: number,
-): Hex {
+function parseBalanceWithDecimals(balanceString: string, decimals: number): Hex {
   // Scientific notation (e.g. "1e-18") cannot be split on "." correctly —
   // handle it separately before the normal fixed-point path.
-  if (balanceString.includes('e') || balanceString.includes('E')) {
+  if (balanceString.includes("e") || balanceString.includes("E")) {
     const raw = parseScientificNotationBalance(balanceString, decimals);
     return bigIntToHex(raw < 0n ? 0n : raw);
   }
 
-  const [integerPart, fractionalPart = ''] = balanceString.split('.');
+  const [integerPart, fractionalPart = ""] = balanceString.split(".");
 
   if (decimals === 0) {
     return bigIntToHex(BigInt(integerPart));
   }
 
   if (fractionalPart.length >= decimals) {
-    return bigIntToHex(
-      BigInt(`${integerPart}${fractionalPart.slice(0, decimals)}`),
-    );
+    return bigIntToHex(BigInt(`${integerPart}${fractionalPart.slice(0, decimals)}`));
   }
 
   return bigIntToHex(
-    BigInt(
-      `${integerPart}${fractionalPart}${'0'.repeat(
-        decimals - fractionalPart.length,
-      )}`,
-    ),
+    BigInt(`${integerPart}${fractionalPart}${"0".repeat(decimals - fractionalPart.length)}`),
   );
 }

--- a/shared/lib/selectors/assets-migration.ts
+++ b/shared/lib/selectors/assets-migration.ts
@@ -4,9 +4,12 @@ import {
   Hex,
   bigIntToHex,
   KnownCaipNamespace,
-} from "@metamask/utils";
-import { toChecksumHexAddress } from "@metamask/controller-utils";
-import { AssetsControllerState, FungibleAssetPrice } from "@metamask/assets-controller";
+} from '@metamask/utils';
+import { toChecksumHexAddress } from '@metamask/controller-utils';
+import {
+  AssetsControllerState,
+  FungibleAssetPrice,
+} from '@metamask/assets-controller';
 import {
   AccountTrackerControllerState,
   MultichainAssetsControllerState,
@@ -20,21 +23,21 @@ import {
   MarketDataDetails,
   TokenRatesControllerState,
   RatesControllerState,
-} from "@metamask/assets-controllers";
-import { AccountsControllerState } from "@metamask/accounts-controller";
-import { isEvmAccountType } from "@metamask/keyring-api";
-import { RemoteFeatureFlagControllerState } from "@metamask/remote-feature-flag-controller";
-import { NetworkState } from "@metamask/network-controller";
-import { decimalToPrefixedHex } from "../conversion.utils";
+} from '@metamask/assets-controllers';
+import { AccountsControllerState } from '@metamask/accounts-controller';
+import { isEvmAccountType } from '@metamask/keyring-api';
+import { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-flag-controller';
+import { NetworkState } from '@metamask/network-controller';
+import { decimalToPrefixedHex } from '../conversion.utils';
 import {
   ASSETS_UNIFY_STATE_FLAG,
   ASSETS_UNIFY_STATE_VERSION_1,
   isAssetsUnifyStateFeatureEnabled,
   type AssetsUnifyStateFeatureFlag,
-} from "../assets-unify-state/remote-feature-flag";
-import { getIsAssetsUnifiedStateIncludedInBuild } from "../environment";
-import { AssetType } from "../../constants/transaction";
-import { createDeepEqualSelector } from "./selector-creators";
+} from '../assets-unify-state/remote-feature-flag';
+import { getIsAssetsUnifiedStateIncludedInBuild } from '../environment';
+import { AssetType } from '../../constants/transaction';
+import { createDeepEqualSelector } from './selector-creators';
 
 // Old state controllers and fields status
 //
@@ -79,7 +82,9 @@ import { createDeepEqualSelector } from "./selector-creators";
 type ControllerStateSelector<
   InputState extends Record<string, unknown>,
   ResultField extends keyof InputState,
-> = (state: { metamask: Pick<InputState, ResultField> }) => InputState[ResultField];
+> = (state: {
+  metamask: Pick<InputState, ResultField>;
+}) => InputState[ResultField];
 
 const getIsAssetsUnifyStateEnabled = createDeepEqualSelector(
   [
@@ -94,81 +99,96 @@ const getIsAssetsUnifyStateEnabled = createDeepEqualSelector(
       | AssetsUnifyStateFeatureFlag
       | undefined;
 
-    return isAssetsUnifyStateFeatureEnabled(featureFlag, ASSETS_UNIFY_STATE_VERSION_1);
+    return isAssetsUnifyStateFeatureEnabled(
+      featureFlag,
+      ASSETS_UNIFY_STATE_VERSION_1,
+    );
   },
 );
 
 // ChainId (hex) -> AccountAddress (hex checksummed) -> Balance (hex)
-export const getAccountTrackerControllerAccountsByChainId = createDeepEqualSelector(
-  [
-    getIsAssetsUnifyStateEnabled,
-    (state: { metamask: Pick<AccountTrackerControllerState, "accountsByChainId"> }) =>
-      state.metamask?.accountsByChainId ?? {},
-    (state: { metamask: Pick<AssetsControllerState, "assetsBalance"> }) =>
-      state.metamask?.assetsBalance ?? {},
-    (state: { metamask: Pick<AssetsControllerState, "assetsInfo"> }) =>
-      state.metamask?.assetsInfo ?? {},
-    (state: { metamask: Pick<AccountsControllerState, "internalAccounts"> }) =>
-      state.metamask?.internalAccounts?.accounts ?? {},
-  ],
-  (
-    isAssetsUnifyStateEnabled,
-    accountsByChainId,
-    assetsBalance,
-    assetsInfo,
-    internalAccountsById,
-  ) => {
-    if (!isAssetsUnifyStateEnabled) {
-      return accountsByChainId;
-    }
-
-    const result: AccountTrackerControllerState["accountsByChainId"] = {};
-
-    for (const [accountId, accountBalances] of Object.entries(assetsBalance)) {
-      const internalAccount = internalAccountsById[accountId];
-      if (!internalAccount || !isEvmAccountType(internalAccount.type)) {
-        continue;
+export const getAccountTrackerControllerAccountsByChainId =
+  createDeepEqualSelector(
+    [
+      getIsAssetsUnifyStateEnabled,
+      (state: {
+        metamask: Pick<AccountTrackerControllerState, 'accountsByChainId'>;
+      }) => state.metamask?.accountsByChainId ?? {},
+      (state: { metamask: Pick<AssetsControllerState, 'assetsBalance'> }) =>
+        state.metamask?.assetsBalance ?? {},
+      (state: { metamask: Pick<AssetsControllerState, 'assetsInfo'> }) =>
+        state.metamask?.assetsInfo ?? {},
+      (state: {
+        metamask: Pick<AccountsControllerState, 'internalAccounts'>;
+      }) => state.metamask?.internalAccounts?.accounts ?? {},
+    ],
+    (
+      isAssetsUnifyStateEnabled,
+      accountsByChainId,
+      assetsBalance,
+      assetsInfo,
+      internalAccountsById,
+    ) => {
+      if (!isAssetsUnifyStateEnabled) {
+        return accountsByChainId;
       }
 
-      const checksummedAddress = toChecksumHexAddress(internalAccount.address);
+      const result: AccountTrackerControllerState['accountsByChainId'] = {};
 
-      for (const [assetId, balanceData] of Object.entries(accountBalances)) {
-        const metadata = assetsInfo[assetId];
-        if (metadata?.type !== "native") {
+      for (const [accountId, accountBalances] of Object.entries(
+        assetsBalance,
+      )) {
+        const internalAccount = internalAccountsById[accountId];
+        if (!internalAccount || !isEvmAccountType(internalAccount.type)) {
           continue;
         }
 
-        const { chain: parsedChain } = parseCaipAssetType(assetId as CaipAssetType);
+        const checksummedAddress = toChecksumHexAddress(
+          internalAccount.address,
+        );
 
-        // No need to check if the chain is EVM, we already filtered out non-EVM accounts
-        const hexChainId = decimalToPrefixedHex(parsedChain.reference);
-        const amount = balanceData?.amount ?? "0";
+        for (const [assetId, balanceData] of Object.entries(accountBalances)) {
+          const metadata = assetsInfo[assetId];
+          if (metadata?.type !== 'native') {
+            continue;
+          }
 
-        result[hexChainId] ??= {};
-        result[hexChainId][checksummedAddress] = {
-          // TODO: Use raw value from state when available
-          balance: parseBalanceWithDecimals(amount, metadata.decimals),
-        };
+          const { chain: parsedChain } = parseCaipAssetType(
+            assetId as CaipAssetType,
+          );
+
+          // No need to check if the chain is EVM, we already filtered out non-EVM accounts
+          const hexChainId = decimalToPrefixedHex(parsedChain.reference);
+          const amount = balanceData?.amount ?? '0';
+
+          result[hexChainId] ??= {};
+          result[hexChainId][checksummedAddress] = {
+            // TODO: Use raw value from state when available
+            balance: parseBalanceWithDecimals(amount, metadata.decimals),
+          };
+        }
       }
-    }
 
-    return result;
-  },
-) as unknown as ControllerStateSelector<AccountTrackerControllerState, "accountsByChainId">;
+      return result;
+    },
+  ) as unknown as ControllerStateSelector<
+    AccountTrackerControllerState,
+    'accountsByChainId'
+  >;
 
 // ChainId (hex) -> AccountAddress (hex lowercase) -> Array of Tokens
 export const getTokensControllerAllTokens = createDeepEqualSelector(
   [
     getIsAssetsUnifyStateEnabled,
-    (state: { metamask: Pick<TokensControllerState, "allTokens"> }) =>
+    (state: { metamask: Pick<TokensControllerState, 'allTokens'> }) =>
       state.metamask?.allTokens ?? {},
-    (state: { metamask: Pick<AssetsControllerState, "assetsInfo"> }) =>
+    (state: { metamask: Pick<AssetsControllerState, 'assetsInfo'> }) =>
       state.metamask?.assetsInfo ?? {},
-    (state: { metamask: Pick<AssetsControllerState, "assetsBalance"> }) =>
+    (state: { metamask: Pick<AssetsControllerState, 'assetsBalance'> }) =>
       state.metamask?.assetsBalance ?? {},
-    (state: { metamask: Pick<AssetsControllerState, "customAssets"> }) =>
+    (state: { metamask: Pick<AssetsControllerState, 'customAssets'> }) =>
       state.metamask?.customAssets ?? {},
-    (state: { metamask: Pick<AccountsControllerState, "internalAccounts"> }) =>
+    (state: { metamask: Pick<AccountsControllerState, 'internalAccounts'> }) =>
       state.metamask?.internalAccounts?.accounts ?? {},
   ],
   (
@@ -183,17 +203,23 @@ export const getTokensControllerAllTokens = createDeepEqualSelector(
       return allTokens;
     }
 
-    const result: TokensControllerState["allTokens"] = {};
+    const result: TokensControllerState['allTokens'] = {};
 
     // Merge assetsBalance and customAssets: accountId -> assetId[]
     const allAssets = Object.fromEntries(
-      [...new Set([...Object.keys(assetsBalance), ...Object.keys(customAssets)])].map(
-        (accountId) => {
-          const fromBalance = Object.keys(assetsBalance[accountId] ?? {});
-          const fromCustom = customAssets[accountId] ?? [];
-          return [accountId, [...new Set([...fromBalance, ...fromCustom])] as CaipAssetType[]];
-        },
-      ),
+      [
+        ...new Set([
+          ...Object.keys(assetsBalance),
+          ...Object.keys(customAssets),
+        ]),
+      ].map((accountId) => {
+        const fromBalance = Object.keys(assetsBalance[accountId] ?? {});
+        const fromCustom = customAssets[accountId] ?? [];
+        return [
+          accountId,
+          [...new Set([...fromBalance, ...fromCustom])] as CaipAssetType[],
+        ];
+      }),
     );
 
     for (const [accountId, assetIds] of Object.entries(allAssets)) {
@@ -204,7 +230,7 @@ export const getTokensControllerAllTokens = createDeepEqualSelector(
 
       for (const assetId of assetIds) {
         const metadata = assetsInfo[assetId];
-        if (!metadata || metadata.type === "native") {
+        if (!metadata || metadata.type === 'native') {
           continue;
         }
 
@@ -230,25 +256,30 @@ export const getTokensControllerAllTokens = createDeepEqualSelector(
 
     return result;
   },
-) as unknown as ControllerStateSelector<TokensControllerState, "allTokens">;
+) as unknown as ControllerStateSelector<TokensControllerState, 'allTokens'>;
 
 // ChainId (hex) -> AccountAddress (hex lowercase) -> Array of TokenAddress (hex lowercase)
 export const getTokensControllerAllIgnoredTokens = createDeepEqualSelector(
   [
     getIsAssetsUnifyStateEnabled,
-    (state: { metamask: Pick<TokensControllerState, "allIgnoredTokens"> }) =>
+    (state: { metamask: Pick<TokensControllerState, 'allIgnoredTokens'> }) =>
       state.metamask?.allIgnoredTokens ?? {},
-    (state: { metamask: Pick<AssetsControllerState, "assetPreferences"> }) =>
+    (state: { metamask: Pick<AssetsControllerState, 'assetPreferences'> }) =>
       state.metamask?.assetPreferences ?? {},
-    (state: { metamask: Pick<AccountsControllerState, "internalAccounts"> }) =>
+    (state: { metamask: Pick<AccountsControllerState, 'internalAccounts'> }) =>
       state.metamask?.internalAccounts?.accounts ?? {},
   ],
-  (isAssetsUnifyStateEnabled, allIgnoredTokens, assetPreferences, internalAccountsById) => {
+  (
+    isAssetsUnifyStateEnabled,
+    allIgnoredTokens,
+    assetPreferences,
+    internalAccountsById,
+  ) => {
     if (!isAssetsUnifyStateEnabled) {
       return allIgnoredTokens;
     }
 
-    const result: TokensControllerState["allIgnoredTokens"] = {};
+    const result: TokensControllerState['allIgnoredTokens'] = {};
 
     for (const [assetId, { hidden }] of Object.entries(assetPreferences)) {
       if (!hidden) {
@@ -270,27 +301,33 @@ export const getTokensControllerAllIgnoredTokens = createDeepEqualSelector(
 
         result[hexChainId] ??= {};
         result[hexChainId][internalAccount.address] ??= [];
-        result[hexChainId][internalAccount.address].push(assetType.assetReference);
+        result[hexChainId][internalAccount.address].push(
+          assetType.assetReference,
+        );
       }
     }
 
     return result;
   },
-) as unknown as ControllerStateSelector<TokensControllerState, "allIgnoredTokens">;
+) as unknown as ControllerStateSelector<
+  TokensControllerState,
+  'allIgnoredTokens'
+>;
 
 // AcountAddress (hex lowercase) -> ChainId (hex) -> TokenAddress (hex checksummed) -> Balance (hex)
 export const getTokenBalancesControllerTokenBalances = createDeepEqualSelector(
   [
     getIsAssetsUnifyStateEnabled,
-    (state: { metamask: Pick<TokenBalancesControllerState, "tokenBalances"> }) =>
-      state.metamask?.tokenBalances ?? {},
-    (state: { metamask: Pick<AssetsControllerState, "assetsInfo"> }) =>
+    (state: {
+      metamask: Pick<TokenBalancesControllerState, 'tokenBalances'>;
+    }) => state.metamask?.tokenBalances ?? {},
+    (state: { metamask: Pick<AssetsControllerState, 'assetsInfo'> }) =>
       state.metamask?.assetsInfo ?? {},
-    (state: { metamask: Pick<AssetsControllerState, "assetsBalance"> }) =>
+    (state: { metamask: Pick<AssetsControllerState, 'assetsBalance'> }) =>
       state.metamask?.assetsBalance ?? {},
-    (state: { metamask: Pick<AssetsControllerState, "customAssets"> }) =>
+    (state: { metamask: Pick<AssetsControllerState, 'customAssets'> }) =>
       state.metamask?.customAssets ?? {},
-    (state: { metamask: Pick<AccountsControllerState, "internalAccounts"> }) =>
+    (state: { metamask: Pick<AccountsControllerState, 'internalAccounts'> }) =>
       state.metamask?.internalAccounts?.accounts ?? {},
   ],
   (
@@ -305,7 +342,7 @@ export const getTokenBalancesControllerTokenBalances = createDeepEqualSelector(
       return tokenBalances;
     }
 
-    const result: TokenBalancesControllerState["tokenBalances"] = {};
+    const result: TokenBalancesControllerState['tokenBalances'] = {};
     for (const [accountId, chainIdBalances] of Object.entries(assetsBalance)) {
       const internalAccount = internalAccountsById[accountId];
       if (!internalAccount || !isEvmAccountType(internalAccount.type)) {
@@ -325,7 +362,9 @@ export const getTokenBalancesControllerTokenBalances = createDeepEqualSelector(
 
         const hexChainId = decimalToPrefixedHex(assetType.chain.reference);
         const assetAddress = toChecksumHexAddress(
-          metadata.type === "native" ? getNativeTokenAddress(hexChainId) : assetType.assetReference,
+          metadata.type === 'native'
+            ? getNativeTokenAddress(hexChainId)
+            : assetType.assetReference,
         ) as Hex;
 
         result[accountAddress][hexChainId] ??= {};
@@ -354,7 +393,7 @@ export const getTokenBalancesControllerTokenBalances = createDeepEqualSelector(
         }
 
         const metadata = assetsInfo[assetId];
-        if (!metadata || metadata.type === "native") {
+        if (!metadata || metadata.type === 'native') {
           continue;
         }
 
@@ -365,186 +404,224 @@ export const getTokenBalancesControllerTokenBalances = createDeepEqualSelector(
         }
 
         const hexChainId = decimalToPrefixedHex(assetType.chain.reference);
-        const assetAddress = toChecksumHexAddress(assetType.assetReference) as Hex;
+        const assetAddress = toChecksumHexAddress(
+          assetType.assetReference,
+        ) as Hex;
 
         if (!result[accountAddress]?.[hexChainId]?.[assetAddress]) {
           result[accountAddress][hexChainId] ??= {};
-          result[accountAddress][hexChainId][assetAddress] = parseBalanceWithDecimals(
-            "0",
-            metadata.decimals,
-          );
+          result[accountAddress][hexChainId][assetAddress] =
+            parseBalanceWithDecimals('0', metadata.decimals);
         }
       }
     }
 
     return result;
   },
-) as unknown as ControllerStateSelector<TokenBalancesControllerState, "tokenBalances">;
+) as unknown as ControllerStateSelector<
+  TokenBalancesControllerState,
+  'tokenBalances'
+>;
 
 // AccountId -> Array of AssetIds
-export const getMultiChainAssetsControllerAccountsAssets = createDeepEqualSelector(
-  [
-    getIsAssetsUnifyStateEnabled,
-    (state: { metamask: Pick<MultichainAssetsControllerState, "accountsAssets"> }) =>
-      state.metamask?.accountsAssets ?? {},
-    (state: { metamask: Pick<AssetsControllerState, "assetsBalance"> }) =>
-      state.metamask?.assetsBalance ?? {},
-    (state: { metamask: Pick<AssetsControllerState, "customAssets"> }) =>
-      state.metamask?.customAssets ?? {},
-    (state: { metamask: Pick<AccountsControllerState, "internalAccounts"> }) =>
-      state.metamask?.internalAccounts?.accounts ?? {},
-  ],
-  (
-    isAssetsUnifyStateEnabled,
-    accountsAssets,
-    assetsBalance,
-    customAssets,
-    internalAccountsById,
-  ) => {
-    if (!isAssetsUnifyStateEnabled) {
-      return accountsAssets;
-    }
-
-    const result: MultichainAssetsControllerState["accountsAssets"] = {};
-
-    // Merge assetsBalance and customAssets: accountId -> assetId[]
-    const allAssets = Object.fromEntries(
-      [...new Set([...Object.keys(assetsBalance), ...Object.keys(customAssets)])].map(
-        (accountId) => {
-          const fromBalance = Object.keys(assetsBalance[accountId] ?? {});
-          const fromCustom = customAssets[accountId] ?? [];
-          return [accountId, [...new Set([...fromBalance, ...fromCustom])] as CaipAssetType[]];
-        },
-      ),
-    );
-
-    for (const [accountId, assetIds] of Object.entries(allAssets)) {
-      const internalAccount = internalAccountsById[accountId];
-      if (!internalAccount || isEvmAccountType(internalAccount.type)) {
-        continue;
+export const getMultiChainAssetsControllerAccountsAssets =
+  createDeepEqualSelector(
+    [
+      getIsAssetsUnifyStateEnabled,
+      (state: {
+        metamask: Pick<MultichainAssetsControllerState, 'accountsAssets'>;
+      }) => state.metamask?.accountsAssets ?? {},
+      (state: { metamask: Pick<AssetsControllerState, 'assetsBalance'> }) =>
+        state.metamask?.assetsBalance ?? {},
+      (state: { metamask: Pick<AssetsControllerState, 'customAssets'> }) =>
+        state.metamask?.customAssets ?? {},
+      (state: {
+        metamask: Pick<AccountsControllerState, 'internalAccounts'>;
+      }) => state.metamask?.internalAccounts?.accounts ?? {},
+    ],
+    (
+      isAssetsUnifyStateEnabled,
+      accountsAssets,
+      assetsBalance,
+      customAssets,
+      internalAccountsById,
+    ) => {
+      if (!isAssetsUnifyStateEnabled) {
+        return accountsAssets;
       }
 
-      result[accountId] = [];
+      const result: MultichainAssetsControllerState['accountsAssets'] = {};
 
-      for (const assetId of assetIds) {
-        const assetType = parseCaipAssetType(assetId);
-        if (assetType.chain.namespace === KnownCaipNamespace.Eip155) {
+      // Merge assetsBalance and customAssets: accountId -> assetId[]
+      const allAssets = Object.fromEntries(
+        [
+          ...new Set([
+            ...Object.keys(assetsBalance),
+            ...Object.keys(customAssets),
+          ]),
+        ].map((accountId) => {
+          const fromBalance = Object.keys(assetsBalance[accountId] ?? {});
+          const fromCustom = customAssets[accountId] ?? [];
+          return [
+            accountId,
+            [...new Set([...fromBalance, ...fromCustom])] as CaipAssetType[],
+          ];
+        }),
+      );
+
+      for (const [accountId, assetIds] of Object.entries(allAssets)) {
+        const internalAccount = internalAccountsById[accountId];
+        if (!internalAccount || isEvmAccountType(internalAccount.type)) {
           continue;
         }
 
-        result[accountId].push(assetId);
-      }
-    }
+        result[accountId] = [];
 
-    return result;
-  },
-) as unknown as ControllerStateSelector<MultichainAssetsControllerState, "accountsAssets">;
+        for (const assetId of assetIds) {
+          const assetType = parseCaipAssetType(assetId);
+          if (assetType.chain.namespace === KnownCaipNamespace.Eip155) {
+            continue;
+          }
+
+          result[accountId].push(assetId);
+        }
+      }
+
+      return result;
+    },
+  ) as unknown as ControllerStateSelector<
+    MultichainAssetsControllerState,
+    'accountsAssets'
+  >;
 
 // TODO There are issues with the new image url not matching the one in assetsMetadata iconUrl
 // AssetId -> AssetMetadata
-export const getMultiChainAssetsControllerAssetsMetadata = createDeepEqualSelector(
-  [
-    getIsAssetsUnifyStateEnabled,
-    (state: { metamask: Pick<MultichainAssetsControllerState, "assetsMetadata"> }) =>
-      state.metamask?.assetsMetadata ?? {},
-    (state: { metamask: Pick<AssetsControllerState, "assetsInfo"> }) =>
-      state.metamask?.assetsInfo ?? {},
-  ],
-  (isAssetsUnifyStateEnabled, assetsMetadata, assetsInfo) => {
-    if (!isAssetsUnifyStateEnabled) {
-      return assetsMetadata;
-    }
-
-    const result: MultichainAssetsControllerState["assetsMetadata"] = {};
-
-    for (const [assetId, metadata] of Object.entries(assetsInfo)) {
-      const assetType = parseCaipAssetType(assetId as CaipAssetType);
-      if (assetType.chain.namespace === KnownCaipNamespace.Eip155) {
-        continue;
+export const getMultiChainAssetsControllerAssetsMetadata =
+  createDeepEqualSelector(
+    [
+      getIsAssetsUnifyStateEnabled,
+      (state: {
+        metamask: Pick<MultichainAssetsControllerState, 'assetsMetadata'>;
+      }) => state.metamask?.assetsMetadata ?? {},
+      (state: { metamask: Pick<AssetsControllerState, 'assetsInfo'> }) =>
+        state.metamask?.assetsInfo ?? {},
+    ],
+    (isAssetsUnifyStateEnabled, assetsMetadata, assetsInfo) => {
+      if (!isAssetsUnifyStateEnabled) {
+        return assetsMetadata;
       }
 
-      result[assetId as CaipAssetType] = {
-        fungible: true,
-        iconUrl: metadata.image ?? "",
-        units: [
-          {
-            decimals: metadata.decimals,
-            symbol: metadata.symbol,
-            name: metadata.name,
-          },
-        ],
-        symbol: metadata.symbol,
-        name: metadata.name,
-      };
-    }
+      const result: MultichainAssetsControllerState['assetsMetadata'] = {};
 
-    return result;
-  },
-) as unknown as ControllerStateSelector<MultichainAssetsControllerState, "assetsMetadata">;
-
-// AccountId -> Array of AssetIds
-export const getMultiChainAssetsControllerAllIgnoredAssets = createDeepEqualSelector(
-  [
-    getIsAssetsUnifyStateEnabled,
-    (state: { metamask: Pick<MultichainAssetsControllerState, "allIgnoredAssets"> }) =>
-      state.metamask?.allIgnoredAssets ?? {},
-    (state: { metamask: Pick<AssetsControllerState, "assetPreferences"> }) =>
-      state.metamask?.assetPreferences ?? {},
-    (state: { metamask: Pick<AccountsControllerState, "internalAccounts"> }) =>
-      state.metamask?.internalAccounts?.accounts ?? {},
-  ],
-  (isAssetsUnifyStateEnabled, allIgnoredAssets, assetPreferences, internalAccountsById) => {
-    if (!isAssetsUnifyStateEnabled) {
-      return allIgnoredAssets;
-    }
-
-    const result: MultichainAssetsControllerState["allIgnoredAssets"] = {};
-
-    for (const accountId of Object.keys(internalAccountsById)) {
-      const internalAccount = internalAccountsById[accountId];
-      if (!internalAccount || isEvmAccountType(internalAccount.type)) {
-        continue;
-      }
-
-      result[accountId] = [];
-
-      for (const [assetId, { hidden }] of Object.entries(assetPreferences)) {
-        if (!hidden) {
-          continue;
-        }
-
+      for (const [assetId, metadata] of Object.entries(assetsInfo)) {
         const assetType = parseCaipAssetType(assetId as CaipAssetType);
         if (assetType.chain.namespace === KnownCaipNamespace.Eip155) {
           continue;
         }
 
-        result[accountId].push(assetId as CaipAssetType);
+        result[assetId as CaipAssetType] = {
+          fungible: true,
+          iconUrl: metadata.image ?? '',
+          units: [
+            {
+              decimals: metadata.decimals,
+              symbol: metadata.symbol,
+              name: metadata.name,
+            },
+          ],
+          symbol: metadata.symbol,
+          name: metadata.name,
+        };
       }
-    }
 
-    return result;
-  },
-) as unknown as ControllerStateSelector<MultichainAssetsControllerState, "allIgnoredAssets">;
+      return result;
+    },
+  ) as unknown as ControllerStateSelector<
+    MultichainAssetsControllerState,
+    'assetsMetadata'
+  >;
+
+// AccountId -> Array of AssetIds
+export const getMultiChainAssetsControllerAllIgnoredAssets =
+  createDeepEqualSelector(
+    [
+      getIsAssetsUnifyStateEnabled,
+      (state: {
+        metamask: Pick<MultichainAssetsControllerState, 'allIgnoredAssets'>;
+      }) => state.metamask?.allIgnoredAssets ?? {},
+      (state: { metamask: Pick<AssetsControllerState, 'assetPreferences'> }) =>
+        state.metamask?.assetPreferences ?? {},
+      (state: {
+        metamask: Pick<AccountsControllerState, 'internalAccounts'>;
+      }) => state.metamask?.internalAccounts?.accounts ?? {},
+    ],
+    (
+      isAssetsUnifyStateEnabled,
+      allIgnoredAssets,
+      assetPreferences,
+      internalAccountsById,
+    ) => {
+      if (!isAssetsUnifyStateEnabled) {
+        return allIgnoredAssets;
+      }
+
+      const result: MultichainAssetsControllerState['allIgnoredAssets'] = {};
+
+      for (const accountId of Object.keys(internalAccountsById)) {
+        const internalAccount = internalAccountsById[accountId];
+        if (!internalAccount || isEvmAccountType(internalAccount.type)) {
+          continue;
+        }
+
+        result[accountId] = [];
+
+        for (const [assetId, { hidden }] of Object.entries(assetPreferences)) {
+          if (!hidden) {
+            continue;
+          }
+
+          const assetType = parseCaipAssetType(assetId as CaipAssetType);
+          if (assetType.chain.namespace === KnownCaipNamespace.Eip155) {
+            continue;
+          }
+
+          result[accountId].push(assetId as CaipAssetType);
+        }
+      }
+
+      return result;
+    },
+  ) as unknown as ControllerStateSelector<
+    MultichainAssetsControllerState,
+    'allIgnoredAssets'
+  >;
 
 // AccountId -> AssetId -> Balance (amount + unit)
 export const getMultiChainBalancesControllerBalances = createDeepEqualSelector(
   [
     getIsAssetsUnifyStateEnabled,
-    (state: { metamask: Pick<MultichainBalancesControllerState, "balances"> }) =>
-      state.metamask?.balances ?? {},
-    (state: { metamask: Pick<AssetsControllerState, "assetsBalance"> }) =>
+    (state: {
+      metamask: Pick<MultichainBalancesControllerState, 'balances'>;
+    }) => state.metamask?.balances ?? {},
+    (state: { metamask: Pick<AssetsControllerState, 'assetsBalance'> }) =>
       state.metamask?.assetsBalance ?? {},
-    (state: { metamask: Pick<AssetsControllerState, "assetsInfo"> }) =>
+    (state: { metamask: Pick<AssetsControllerState, 'assetsInfo'> }) =>
       state.metamask?.assetsInfo ?? {},
-    (state: { metamask: Pick<AccountsControllerState, "internalAccounts"> }) =>
+    (state: { metamask: Pick<AccountsControllerState, 'internalAccounts'> }) =>
       state.metamask?.internalAccounts?.accounts ?? {},
   ],
-  (isAssetsUnifyStateEnabled, balances, assetsBalance, assetsInfo, internalAccountsById) => {
+  (
+    isAssetsUnifyStateEnabled,
+    balances,
+    assetsBalance,
+    assetsInfo,
+    internalAccountsById,
+  ) => {
     if (!isAssetsUnifyStateEnabled) {
       return balances;
     }
 
-    const result: MultichainBalancesControllerState["balances"] = {};
+    const result: MultichainBalancesControllerState['balances'] = {};
 
     for (const [accountId, chainIdBalances] of Object.entries(assetsBalance)) {
       const internalAccount = internalAccountsById[accountId];
@@ -558,7 +635,10 @@ export const getMultiChainBalancesControllerBalances = createDeepEqualSelector(
         const assetType = parseCaipAssetType(assetId as CaipAssetType);
         const metadata = assetsInfo[assetId];
 
-        if (!metadata || assetType.chain.namespace === KnownCaipNamespace.Eip155) {
+        if (
+          !metadata ||
+          assetType.chain.namespace === KnownCaipNamespace.Eip155
+        ) {
           continue;
         }
 
@@ -571,13 +651,17 @@ export const getMultiChainBalancesControllerBalances = createDeepEqualSelector(
 
     return result;
   },
-) as unknown as ControllerStateSelector<MultichainBalancesControllerState, "balances">;
+) as unknown as ControllerStateSelector<
+  MultichainBalancesControllerState,
+  'balances'
+>;
 
 export const getCurrencyRateControllerCurrentCurrency = createDeepEqualSelector(
   [
     getIsAssetsUnifyStateEnabled,
     (state: { metamask: CurrencyRateState }) => state.metamask?.currentCurrency,
-    (state: { metamask: AssetsControllerState }) => state.metamask?.selectedCurrency,
+    (state: { metamask: AssetsControllerState }) =>
+      state.metamask?.selectedCurrency,
   ],
   (isAssetsUnifyStateEnabled, currentCurrency, selectedCurrency) => {
     if (!isAssetsUnifyStateEnabled) {
@@ -586,26 +670,29 @@ export const getCurrencyRateControllerCurrentCurrency = createDeepEqualSelector(
 
     return selectedCurrency;
   },
-) as unknown as ControllerStateSelector<CurrencyRateState, "currentCurrency">;
+) as unknown as ControllerStateSelector<CurrencyRateState, 'currentCurrency'>;
 
 // Native Symbol -> Rates (conversionRate, usdConversionRate, conversionDate)
 export const getCurrencyRateControllerCurrencyRates = createDeepEqualSelector(
   [
     getIsAssetsUnifyStateEnabled,
-    (state: { metamask: CurrencyRateState }) => state.metamask?.currencyRates ?? {},
-    (state: { metamask: AssetsControllerState }) => state.metamask?.assetsInfo ?? {},
-    (state: { metamask: AssetsControllerState }) => state.metamask?.assetsPrice ?? {},
+    (state: { metamask: CurrencyRateState }) =>
+      state.metamask?.currencyRates ?? {},
+    (state: { metamask: AssetsControllerState }) =>
+      state.metamask?.assetsInfo ?? {},
+    (state: { metamask: AssetsControllerState }) =>
+      state.metamask?.assetsPrice ?? {},
   ],
   (isAssetsUnifyStateEnabled, currencyRates, assetsInfo, assetsPrice) => {
     if (!isAssetsUnifyStateEnabled) {
       return currencyRates;
     }
 
-    const result: CurrencyRateState["currencyRates"] = {};
+    const result: CurrencyRateState['currencyRates'] = {};
 
     // Sorting just to ensure that we process mainnet (eip155:1) first
-    for (const [assetId, metadata] of Object.entries(assetsInfo).toSorted((a, b) =>
-      a[0].localeCompare(b[0]),
+    for (const [assetId, metadata] of Object.entries(assetsInfo).toSorted(
+      (a, b) => a[0].localeCompare(b[0]),
     )) {
       // Skip if we already have an entry for this symbol
       if (result[metadata.symbol]) {
@@ -615,13 +702,16 @@ export const getCurrencyRateControllerCurrencyRates = createDeepEqualSelector(
       const assetType = parseCaipAssetType(assetId as CaipAssetType);
 
       // Skip if not a native asset or not evm
-      if (metadata.type !== "native" || assetType.chain.namespace !== KnownCaipNamespace.Eip155) {
+      if (
+        metadata.type !== 'native' ||
+        assetType.chain.namespace !== KnownCaipNamespace.Eip155
+      ) {
         continue;
       }
 
       const price = assetsPrice[assetId];
 
-      if (price?.assetPriceType !== "fungible") {
+      if (price?.assetPriceType !== 'fungible') {
         continue;
       }
 
@@ -634,17 +724,21 @@ export const getCurrencyRateControllerCurrencyRates = createDeepEqualSelector(
 
     return result;
   },
-) as unknown as ControllerStateSelector<CurrencyRateState, "currencyRates">;
+) as unknown as ControllerStateSelector<CurrencyRateState, 'currencyRates'>;
 
 // ChainId (hex) -> TokenAddress (hex checksummed) -> MarketData
 export const getTokenRatesControllerMarketData = createDeepEqualSelector(
   [
     getIsAssetsUnifyStateEnabled,
-    (state: { metamask: TokenRatesControllerState }) => state.metamask?.marketData ?? {},
-    (state: { metamask: AssetsControllerState }) => state.metamask?.assetsPrice ?? {},
-    (state: { metamask: AssetsControllerState }) => state.metamask?.assetsInfo ?? {},
+    (state: { metamask: TokenRatesControllerState }) =>
+      state.metamask?.marketData ?? {},
+    (state: { metamask: AssetsControllerState }) =>
+      state.metamask?.assetsPrice ?? {},
+    (state: { metamask: AssetsControllerState }) =>
+      state.metamask?.assetsInfo ?? {},
     getCurrencyRateControllerCurrencyRates,
-    (state: { metamask: NetworkState }) => state.metamask?.networkConfigurationsByChainId ?? {},
+    (state: { metamask: NetworkState }) =>
+      state.metamask?.networkConfigurationsByChainId ?? {},
   ],
   (
     isAssetsUnifyStateEnabled,
@@ -658,7 +752,7 @@ export const getTokenRatesControllerMarketData = createDeepEqualSelector(
       return marketData;
     }
 
-    const result: TokenRatesControllerState["marketData"] = {};
+    const result: TokenRatesControllerState['marketData'] = {};
 
     for (const [assetId, price] of Object.entries(assetsPrice) as [
       CaipAssetType,
@@ -677,13 +771,17 @@ export const getTokenRatesControllerMarketData = createDeepEqualSelector(
 
       const hexChainId = decimalToPrefixedHex(assetType.chain.reference);
       const nativeAssetSymbol =
-        networkConfigurationsByChainId[hexChainId]?.nativeCurrency ?? AssetType.native;
+        networkConfigurationsByChainId[hexChainId]?.nativeCurrency ??
+        AssetType.native;
 
       const assetAddress = toChecksumHexAddress(
-        metadata.type === "native" ? getNativeTokenAddress(hexChainId) : assetType.assetReference,
+        metadata.type === 'native'
+          ? getNativeTokenAddress(hexChainId)
+          : assetType.assetReference,
       ) as Hex;
 
-      const nativeCurrencyRate = currencyRates[nativeAssetSymbol]?.conversionRate;
+      const nativeCurrencyRate =
+        currencyRates[nativeAssetSymbol]?.conversionRate;
       if (!nativeCurrencyRate) {
         continue;
       }
@@ -722,72 +820,83 @@ export const getTokenRatesControllerMarketData = createDeepEqualSelector(
 
     return result;
   },
-) as unknown as ControllerStateSelector<TokenRatesControllerState, "marketData">;
+) as unknown as ControllerStateSelector<
+  TokenRatesControllerState,
+  'marketData'
+>;
 
-export const getMultichainAssetsRatesControllerConversionRates = createDeepEqualSelector(
-  [
-    getIsAssetsUnifyStateEnabled,
-    (state: { metamask: MultichainAssetsRatesControllerState }) =>
-      state.metamask.conversionRates ?? {},
-    (state: { metamask: AssetsControllerState }) => state.metamask.assetsPrice ?? {},
-  ],
-  (isAssetsUnifyStateEnabled, conversionRates, assetsPrice) => {
-    if (!isAssetsUnifyStateEnabled) {
-      return conversionRates;
-    }
-
-    const result: MultichainAssetsRatesControllerState["conversionRates"] = {};
-
-    for (const [assetId, assetPrice] of Object.entries(assetsPrice) as [
-      CaipAssetType,
-      FungibleAssetPrice, // TODO: A type discriminator to AssetPrice is needed to be added to avoid this cast, but it is safe for now
-    ][]) {
-      const assetType = parseCaipAssetType(assetId);
-      if (assetType.chain.namespace === KnownCaipNamespace.Eip155) {
-        continue;
+export const getMultichainAssetsRatesControllerConversionRates =
+  createDeepEqualSelector(
+    [
+      getIsAssetsUnifyStateEnabled,
+      (state: { metamask: MultichainAssetsRatesControllerState }) =>
+        state.metamask.conversionRates ?? {},
+      (state: { metamask: AssetsControllerState }) =>
+        state.metamask.assetsPrice ?? {},
+    ],
+    (isAssetsUnifyStateEnabled, conversionRates, assetsPrice) => {
+      if (!isAssetsUnifyStateEnabled) {
+        return conversionRates;
       }
 
-      result[assetId] = {
-        rate: `${assetPrice.price}`,
-        conversionTime: assetPrice.lastUpdated,
-        expirationTime: undefined,
-        marketData: {
-          fungible: true,
-          allTimeHigh: `${assetPrice.allTimeHigh}`,
-          allTimeLow: `${assetPrice.allTimeLow}`,
-          circulatingSupply: `${assetPrice.circulatingSupply}`,
-          marketCap: `${assetPrice.marketCap}`,
-          totalVolume: `${assetPrice.totalVolume}`,
-          pricePercentChange: {
-            PT1H: assetPrice.pricePercentChange1h as number,
-            P1D: assetPrice.pricePercentChange1d as number,
-            P7D: assetPrice.pricePercentChange7d as number,
-            P14D: assetPrice.pricePercentChange14d as number,
-            P30D: assetPrice.pricePercentChange30d as number,
-            P200D: assetPrice.pricePercentChange200d as number,
-            P1Y: assetPrice.pricePercentChange1y as number,
-          },
-        },
-      };
-    }
+      const result: MultichainAssetsRatesControllerState['conversionRates'] =
+        {};
 
-    return result;
-  },
-) as unknown as ControllerStateSelector<MultichainAssetsRatesControllerState, "conversionRates">;
+      for (const [assetId, assetPrice] of Object.entries(assetsPrice) as [
+        CaipAssetType,
+        FungibleAssetPrice, // TODO: A type discriminator to AssetPrice is needed to be added to avoid this cast, but it is safe for now
+      ][]) {
+        const assetType = parseCaipAssetType(assetId);
+        if (assetType.chain.namespace === KnownCaipNamespace.Eip155) {
+          continue;
+        }
+
+        result[assetId] = {
+          rate: `${assetPrice.price}`,
+          conversionTime: assetPrice.lastUpdated,
+          expirationTime: undefined,
+          marketData: {
+            fungible: true,
+            allTimeHigh: `${assetPrice.allTimeHigh}`,
+            allTimeLow: `${assetPrice.allTimeLow}`,
+            circulatingSupply: `${assetPrice.circulatingSupply}`,
+            marketCap: `${assetPrice.marketCap}`,
+            totalVolume: `${assetPrice.totalVolume}`,
+            pricePercentChange: {
+              PT1H: assetPrice.pricePercentChange1h as number,
+              P1D: assetPrice.pricePercentChange1d as number,
+              P7D: assetPrice.pricePercentChange7d as number,
+              P14D: assetPrice.pricePercentChange14d as number,
+              P30D: assetPrice.pricePercentChange30d as number,
+              P200D: assetPrice.pricePercentChange200d as number,
+              P1Y: assetPrice.pricePercentChange1y as number,
+            },
+          },
+        };
+      }
+
+      return result;
+    },
+  ) as unknown as ControllerStateSelector<
+    MultichainAssetsRatesControllerState,
+    'conversionRates'
+  >;
 
 export const getRatesControllerRates = createDeepEqualSelector(
   [
     getIsAssetsUnifyStateEnabled,
     (state: { metamask: RatesControllerState }) => state.metamask.rates ?? {},
-    (state: { metamask: AssetsControllerState }) => state.metamask?.assetsInfo ?? {},
-    (state: { metamask: AssetsControllerState }) => state.metamask?.assetsPrice ?? {},
+    (state: { metamask: AssetsControllerState }) =>
+      state.metamask?.assetsInfo ?? {},
+    (state: { metamask: AssetsControllerState }) =>
+      state.metamask?.assetsPrice ?? {},
   ],
   (isAssetsUnifyStateEnabled, rates, assetsInfo, assetsPrice) => {
     if (!isAssetsUnifyStateEnabled) {
       return rates;
     }
 
-    const result: RatesControllerState["rates"] = {};
+    const result: RatesControllerState['rates'] = {};
 
     for (const [assetId, metadata] of Object.entries(assetsInfo)) {
       const symbol = metadata.symbol.toLowerCase();
@@ -802,9 +911,9 @@ export const getRatesControllerRates = createDeepEqualSelector(
 
       // Skip if not a native asset, if evm or if not fungible
       if (
-        metadata.type !== "native" ||
+        metadata.type !== 'native' ||
         assetType.chain.namespace === KnownCaipNamespace.Eip155 ||
-        price?.assetPriceType !== "fungible"
+        price?.assetPriceType !== 'fungible'
       ) {
         continue;
       }
@@ -818,13 +927,14 @@ export const getRatesControllerRates = createDeepEqualSelector(
 
     return result;
   },
-) as unknown as ControllerStateSelector<RatesControllerState, "rates">;
+) as unknown as ControllerStateSelector<RatesControllerState, 'rates'>;
 
 export const getRatesControllerFiatCurrency = createDeepEqualSelector(
   [
     getIsAssetsUnifyStateEnabled,
     (state: { metamask: RatesControllerState }) => state.metamask.fiatCurrency,
-    (state: { metamask: AssetsControllerState }) => state.metamask.selectedCurrency,
+    (state: { metamask: AssetsControllerState }) =>
+      state.metamask.selectedCurrency,
   ],
   (isAssetsUnifyStateEnabled, fiatCurrency, selectedCurrency) => {
     if (!isAssetsUnifyStateEnabled) {
@@ -833,7 +943,7 @@ export const getRatesControllerFiatCurrency = createDeepEqualSelector(
 
     return selectedCurrency;
   },
-) as unknown as ControllerStateSelector<RatesControllerState, "fiatCurrency">;
+) as unknown as ControllerStateSelector<RatesControllerState, 'fiatCurrency'>;
 
 /**
  * Converts a scientific notation balance string (e.g. "1e-18") to its raw
@@ -845,7 +955,10 @@ export const getRatesControllerFiatCurrency = createDeepEqualSelector(
  * @param decimals - The token's decimal precision.
  * @returns The raw base-unit value as a bigint.
  */
-function parseScientificNotationBalance(balanceString: string, decimals: number): bigint {
+function parseScientificNotationBalance(
+  balanceString: string,
+  decimals: number,
+): bigint {
   const match = balanceString.match(/^([+-]?\d+(?:\.\d+)?)[eE]([+-]?\d+)$/u);
   if (!match) {
     return 0n;
@@ -853,9 +966,9 @@ function parseScientificNotationBalance(balanceString: string, decimals: number)
 
   const [, coefficient, rawExponent] = match;
   const exponent = parseInt(rawExponent, 10);
-  const isNegative = coefficient.startsWith("-");
-  const absCoefficient = coefficient.replace(/^[+-]/u, "");
-  const [coefInt, coefFrac = ""] = absCoefficient.split(".");
+  const isNegative = coefficient.startsWith('-');
+  const absCoefficient = coefficient.replace(/^[+-]/u, '');
+  const [coefInt, coefFrac = ''] = absCoefficient.split('.');
   const coefDigits = coefInt + coefFrac;
   const finalExponent = exponent + decimals - coefFrac.length;
 
@@ -871,25 +984,32 @@ function parseScientificNotationBalance(balanceString: string, decimals: number)
   return isNegative ? -result : result;
 }
 
-function parseBalanceWithDecimals(balanceString: string, decimals: number): Hex {
+function parseBalanceWithDecimals(
+  balanceString: string,
+  decimals: number,
+): Hex {
   // Scientific notation (e.g. "1e-18") cannot be split on "." correctly —
   // handle it separately before the normal fixed-point path.
-  if (balanceString.includes("e") || balanceString.includes("E")) {
+  if (balanceString.includes('e') || balanceString.includes('E')) {
     const raw = parseScientificNotationBalance(balanceString, decimals);
     return bigIntToHex(raw < 0n ? 0n : raw);
   }
 
-  const [integerPart, fractionalPart = ""] = balanceString.split(".");
+  const [integerPart, fractionalPart = ''] = balanceString.split('.');
 
   if (decimals === 0) {
     return bigIntToHex(BigInt(integerPart));
   }
 
   if (fractionalPart.length >= decimals) {
-    return bigIntToHex(BigInt(`${integerPart}${fractionalPart.slice(0, decimals)}`));
+    return bigIntToHex(
+      BigInt(`${integerPart}${fractionalPart.slice(0, decimals)}`),
+    );
   }
 
   return bigIntToHex(
-    BigInt(`${integerPart}${fractionalPart}${"0".repeat(decimals - fractionalPart.length)}`),
+    BigInt(
+      `${integerPart}${fractionalPart}${'0'.repeat(decimals - fractionalPart.length)}`,
+    ),
   );
 }


### PR DESCRIPTION
When BackendWebsocketDataSource stores a very small balance (e.g. 1 wei with 18 decimals), BigNumber.js .toFixed() returns scientific notation like "1e-18". The existing parseBalanceWithDecimals splits on "." which fails for scientific notation, producing strings like "1e-18000000000000000000" that crash BigInt() with SyntaxError.

Adds parseScientificNotationBalance to correctly convert scientific notation strings to base-unit bigints before the normal fixed-point path.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: handle scientific notation in parseBalanceWithDecimals to prevent BigInt crash

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how native and token hex balances are derived for the assets-unify migration path; wrong parsing would show incorrect balances, though scope is limited and covered by new tests.
> 
> **Overview**
> Fixes **`BigInt` crashes** when unified asset balance strings arrive in **scientific notation** (e.g. `"1e-18"` from very small amounts), which the old decimal-splitting logic mangled into invalid strings.
> 
> Adds **`parseScientificNotationBalance`** and branches **`parseBalanceWithDecimals`** on `e`/`E` before the fixed-point path, converting to base units with **truncation toward zero** and **clamping negatives to `0x0`**. Selector tests cover tiny balances, huge exponents, and positive forms like `"1.5e2"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfbb13fd247a927874089de30b0beee055037ad3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->