### PR TITLE
refactor(ai-pr-risk-analysis): add checks permission and remove redundant GH_TOKEN

### DIFF
--- a/.github/workflows/ai-pr-risk-analysis.yml
+++ b/.github/workflows/ai-pr-risk-analysis.yml
@@ -24,6 +24,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
+      checks: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -39,8 +40,6 @@ jobs:
 
       - name: Run AI PR Analysis
         uses: ./.ai-analyzer-action
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           mode: pr-risk-analysis
           add-comment: false


### PR DESCRIPTION
## **Description**

The AI PR risk analysis workflow needs the same CI hardening applied in [MetaMask/metamask-mobile#31199](https://github.com/MetaMask/metamask-mobile/pull/31199).

This change:

- Adds `checks: write` permission so the MetaMask ai-analyzer action can create or update GitHub Check runs
- Drops the redundant `GH_TOKEN` env var on the **Run AI PR Analysis** step; authentication remains via the action's `github-token` input

No application, auth, or runtime behavior is modified — CI workflow only.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Refs: N/A — CI workflow hardening for AI PR risk analysis; mirrors metamask-mobile#31199.

## **Manual testing steps**

N/A — workflow-only change. Verified by inspection of `.github/workflows/ai-pr-risk-analysis.yml` diff:

- `checks: write` added under job permissions
- duplicate `GH_TOKEN` env removed from the ai-analyzer step

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change with no application, auth, or runtime impact; aligns permissions with ai-analyzer check publishing needs.
> 
> **Overview**
> Hardens the **AI PR risk analysis** GitHub Actions workflow so the MetaMask `ai-analyzer` action can publish Check runs and uses a single token path for GitHub API access.
> 
> The `analyze` job now grants **`checks: write`** alongside existing `contents: read` and `pull-requests: write`. The **Run AI PR Analysis** step no longer sets a duplicate **`GH_TOKEN`** env var; authentication is only via the action’s **`github-token`** input (`secrets.GITHUB_TOKEN`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 790fa686f7aa34099818d7112665fc5826d3ee25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->