### PR TITLE
feat: Add MetaMetrics event tracking for QR scan errors

### DIFF
--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -1173,6 +1173,7 @@ export enum MetaMetricsEventName {
   HardwareWalletRecoverySuccessModalViewed = 'Hardware Wallet Recovery Success Modal Viewed',
   HardwareWalletRecoveryCtaClicked = 'Hardware Wallet Recovery CTA Clicked',
   HardwareWalletRecoveryRepairCtaClicked = 'Hardware Wallet Recovery Repair CTA Clicked',
+  QrHardwareScanFailed = 'QR Hardware Scan Failed',
   ViewportSwitched = 'Viewport Switched',
   // Rewards
   RewardsOptInStarted = 'REWARDS_OPT_IN_STARTED',

--- a/ui/components/app/qr-hardware-popover/base-qr-reader/base-qr-reader-utils.test.ts
+++ b/ui/components/app/qr-hardware-popover/base-qr-reader/base-qr-reader-utils.test.ts
@@ -182,6 +182,7 @@ describe('base-qr-reader-utils', () => {
         QrErrorFlowContext.Pairing,
       );
       expect(properties).toStrictEqual({
+        device_type: MetaMetricsHardwareWalletDeviceType.QrHardware,
         error_category: 'non_ur_qr_scanned',
         is_ur_format: false,
         flow: 'pairing',
@@ -199,6 +200,7 @@ describe('base-qr-reader-utils', () => {
         QrErrorFlowContext.Pairing,
       );
       expect(properties).toStrictEqual({
+        device_type: MetaMetricsHardwareWalletDeviceType.QrHardware,
         error_category: 'wrong_ur_type',
         is_ur_format: true,
         flow: 'pairing',
@@ -217,6 +219,7 @@ describe('base-qr-reader-utils', () => {
         QrErrorFlowContext.Signing,
       );
       expect(properties).toStrictEqual({
+        device_type: MetaMetricsHardwareWalletDeviceType.QrHardware,
         error_category: 'scan_exception',
         is_ur_format: true,
         flow: 'signing',
@@ -234,6 +237,7 @@ describe('base-qr-reader-utils', () => {
         QrErrorFlowContext.Signing,
       );
       expect(properties).toStrictEqual({
+        device_type: MetaMetricsHardwareWalletDeviceType.QrHardware,
         error_category: 'ur_decode_error',
         is_ur_format: true,
         flow: 'signing',

--- a/ui/components/app/qr-hardware-popover/base-qr-reader/base-qr-reader-utils.test.ts
+++ b/ui/components/app/qr-hardware-popover/base-qr-reader/base-qr-reader-utils.test.ts
@@ -8,11 +8,17 @@ import {
   MetaMetricsHardwareWalletRecoveryLocation,
 } from '../../../../../shared/constants/metametrics';
 import { HARDWARE_WALLET_RECOVERY_SEGMENT_PAYLOAD_KEYS } from '../../../../../shared/lib/hardware-wallet-recovery-metrics';
+import { QrErrorFlowContext } from '../qr-error-content';
+import {
+  ScanErrorCategory,
+  type ScanErrorClassification,
+} from '../qr-utils/qr-utils';
 import { CameraReadyState } from './base-qr-reader.types';
 import {
   cameraReadyStateToErrorCode,
   createQrCameraSyntheticError,
   buildQrCameraRecoveryTrackEventArgs,
+  buildQrScanFailedTrackEventArgs,
 } from './base-qr-reader-utils';
 
 describe('base-qr-reader-utils', () => {
@@ -149,6 +155,114 @@ describe('base-qr-reader-utils', () => {
       expect(successArgs.event).toBe(
         MetaMetricsEventName.HardwareWalletRecoverySuccessModalViewed,
       );
+    });
+  });
+
+  describe('buildQrScanFailedTrackEventArgs', () => {
+    it('returns QrHardwareScanFailed event with Accounts category', () => {
+      const classification: ScanErrorClassification = {
+        category: ScanErrorCategory.NonUrQrScanned,
+        isUrFormat: false,
+      };
+      const args = buildQrScanFailedTrackEventArgs(
+        classification,
+        QrErrorFlowContext.Pairing,
+      );
+      expect(args.event).toBe(MetaMetricsEventName.QrHardwareScanFailed);
+      expect(args.category).toBe(MetaMetricsEventCategory.Accounts);
+    });
+
+    it('includes error_category, is_ur_format, and flow for non_ur_qr_scanned', () => {
+      const classification: ScanErrorClassification = {
+        category: ScanErrorCategory.NonUrQrScanned,
+        isUrFormat: false,
+      };
+      const { properties } = buildQrScanFailedTrackEventArgs(
+        classification,
+        QrErrorFlowContext.Pairing,
+      );
+      expect(properties).toStrictEqual({
+        error_category: 'non_ur_qr_scanned',
+        is_ur_format: false,
+        flow: 'pairing',
+      });
+    });
+
+    it('includes received_ur_type only for wrong_ur_type', () => {
+      const classification: ScanErrorClassification = {
+        category: ScanErrorCategory.WrongUrType,
+        isUrFormat: true,
+        receivedUrType: 'eth-signature',
+      };
+      const { properties } = buildQrScanFailedTrackEventArgs(
+        classification,
+        QrErrorFlowContext.Pairing,
+      );
+      expect(properties).toStrictEqual({
+        error_category: 'wrong_ur_type',
+        is_ur_format: true,
+        flow: 'pairing',
+        received_ur_type: 'eth-signature',
+      });
+    });
+
+    it('includes raw_message only for scan_exception', () => {
+      const classification: ScanErrorClassification = {
+        category: ScanErrorCategory.ScanException,
+        isUrFormat: true,
+        rawMessage: 'cbor decode failure',
+      };
+      const { properties } = buildQrScanFailedTrackEventArgs(
+        classification,
+        QrErrorFlowContext.Signing,
+      );
+      expect(properties).toStrictEqual({
+        error_category: 'scan_exception',
+        is_ur_format: true,
+        flow: 'signing',
+        raw_message: 'cbor decode failure',
+      });
+    });
+
+    it('includes only base properties for ur_decode_error', () => {
+      const classification: ScanErrorClassification = {
+        category: ScanErrorCategory.UrDecodeError,
+        isUrFormat: true,
+      };
+      const { properties } = buildQrScanFailedTrackEventArgs(
+        classification,
+        QrErrorFlowContext.Signing,
+      );
+      expect(properties).toStrictEqual({
+        error_category: 'ur_decode_error',
+        is_ur_format: true,
+        flow: 'signing',
+      });
+    });
+
+    it('is_ur_format is boolean for every category', () => {
+      const categories: ScanErrorClassification[] = [
+        { category: ScanErrorCategory.NonUrQrScanned, isUrFormat: false },
+        {
+          category: ScanErrorCategory.WrongUrType,
+          isUrFormat: true,
+          receivedUrType: 'crypto-hdkey',
+        },
+        { category: ScanErrorCategory.UrDecodeError, isUrFormat: true },
+        {
+          category: ScanErrorCategory.ScanException,
+          isUrFormat: true,
+          rawMessage: 'error',
+        },
+      ];
+
+      for (const classification of categories) {
+        const { properties } = buildQrScanFailedTrackEventArgs(
+          classification,
+          QrErrorFlowContext.Pairing,
+        );
+        expect(typeof properties.is_ur_format).toBe('boolean');
+      }
     });
   });
 });

--- a/ui/components/app/qr-hardware-popover/base-qr-reader/base-qr-reader-utils.ts
+++ b/ui/components/app/qr-hardware-popover/base-qr-reader/base-qr-reader-utils.ts
@@ -113,6 +113,8 @@ export function buildQrScanFailedTrackEventArgs(
 } {
   const properties: Record<string, Json> = {
     // eslint-disable-next-line @typescript-eslint/naming-convention -- Segment analytics payload keys use snake_case
+    device_type: MetaMetricsHardwareWalletDeviceType.QrHardware,
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- Segment analytics payload keys use snake_case
     error_category: classification.category,
     // eslint-disable-next-line @typescript-eslint/naming-convention -- Segment analytics payload keys use snake_case
     is_ur_format: classification.isUrFormat,

--- a/ui/components/app/qr-hardware-popover/base-qr-reader/base-qr-reader-utils.ts
+++ b/ui/components/app/qr-hardware-popover/base-qr-reader/base-qr-reader-utils.ts
@@ -112,16 +112,20 @@ export function buildQrScanFailedTrackEventArgs(
   properties: Record<string, Json>;
 } {
   const properties: Record<string, Json> = {
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- Segment analytics payload keys use snake_case
     error_category: classification.category,
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- Segment analytics payload keys use snake_case
     is_ur_format: classification.isUrFormat,
     flow,
   };
 
   if (classification.category === ScanErrorCategory.WrongUrType) {
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- Segment analytics payload keys use snake_case
     properties.received_ur_type = classification.receivedUrType;
   }
 
   if (classification.category === ScanErrorCategory.ScanException) {
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- Segment analytics payload keys use snake_case
     properties.raw_message = classification.rawMessage;
   }
 

--- a/ui/components/app/qr-hardware-popover/base-qr-reader/base-qr-reader-utils.ts
+++ b/ui/components/app/qr-hardware-popover/base-qr-reader/base-qr-reader-utils.ts
@@ -14,6 +14,11 @@ import {
   createHardwareWalletError,
   HardwareWalletType,
 } from '../../../../contexts/hardware-wallets';
+import type { QrErrorFlowContext } from '../qr-error-content';
+import {
+  ScanErrorCategory,
+  type ScanErrorClassification,
+} from '../qr-utils/qr-utils';
 import {
   CameraReadyState,
   type CameraReadyStateValue,
@@ -84,5 +89,45 @@ export function buildQrCameraRecoveryTrackEventArgs(
       errorTypeViewCount,
       error: syntheticError,
     }),
+  };
+}
+
+/**
+ * Builds a complete `trackEvent` argument for a QR scan-failed event.
+ *
+ * Every category includes `error_category`, `is_ur_format`, and `flow`.
+ * `received_ur_type` is added for `wrong_ur_type`; `raw_message` is added
+ * for `scan_exception`.
+ *
+ * @param classification - The structured scan error from {@link classifyScanResult}.
+ * @param flow - Whether the scan occurred during pairing or signing.
+ * @returns A ready-to-use `trackEvent` argument.
+ */
+export function buildQrScanFailedTrackEventArgs(
+  classification: ScanErrorClassification,
+  flow: QrErrorFlowContext,
+): {
+  category: MetaMetricsEventCategory;
+  event: MetaMetricsEventName;
+  properties: Record<string, Json>;
+} {
+  const properties: Record<string, Json> = {
+    error_category: classification.category,
+    is_ur_format: classification.isUrFormat,
+    flow,
+  };
+
+  if (classification.category === ScanErrorCategory.WrongUrType) {
+    properties.received_ur_type = classification.receivedUrType;
+  }
+
+  if (classification.category === ScanErrorCategory.ScanException) {
+    properties.raw_message = classification.rawMessage;
+  }
+
+  return {
+    category: MetaMetricsEventCategory.Accounts,
+    event: MetaMetricsEventName.QrHardwareScanFailed,
+    properties,
   };
 }

--- a/ui/components/app/qr-hardware-popover/base-qr-reader/base-qr-reader.test.tsx
+++ b/ui/components/app/qr-hardware-popover/base-qr-reader/base-qr-reader.test.tsx
@@ -1133,6 +1133,8 @@ describe('BaseQrReader', () => {
       expect(scanFailed).toHaveLength(1);
       expect(scanFailed[0][0].properties).toStrictEqual({
         // eslint-disable-next-line @typescript-eslint/naming-convention -- Segment analytics payload keys use snake_case
+        device_type: 'QR Hardware',
+        // eslint-disable-next-line @typescript-eslint/naming-convention -- Segment analytics payload keys use snake_case
         error_category: 'non_ur_qr_scanned',
         // eslint-disable-next-line @typescript-eslint/naming-convention -- Segment analytics payload keys use snake_case
         is_ur_format: false,

--- a/ui/components/app/qr-hardware-popover/base-qr-reader/base-qr-reader.test.tsx
+++ b/ui/components/app/qr-hardware-popover/base-qr-reader/base-qr-reader.test.tsx
@@ -1104,5 +1104,69 @@ describe('BaseQrReader', () => {
       ).toBeInTheDocument();
       expect(mockTrackEvent).not.toHaveBeenCalled();
     });
+
+    // ---- QR scan-failed tracking ------------------------------------------
+
+    it('fires QrHardwareScanFailed with non_ur_qr_scanned for pairing flow', async () => {
+      setupWebcamUtilsSuccess();
+      mockEnhancedQrReader.mockImplementation((({
+        onFrame,
+      }: {
+        onFrame: (data: string) => void;
+      }) => {
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        useEffect(() => {
+          onFrame('not-a-valid-ur-payload');
+        }, [onFrame]);
+        return null;
+      }) as unknown as typeof EnhancedQrReader);
+
+      await act(async () => {
+        renderWithMetrics(
+          <BaseQrReader {...defaultProps} isReadingWallet />,
+        );
+      });
+
+      const scanFailed = mockTrackEvent.mock.calls.filter(
+        (call: unknown[]) =>
+          (call[0] as { event: string }).event ===
+          MetaMetricsEventName.QrHardwareScanFailed,
+      );
+      expect(scanFailed).toHaveLength(1);
+      expect(scanFailed[0][0].properties).toStrictEqual({
+        error_category: 'non_ur_qr_scanned',
+        is_ur_format: false,
+        flow: 'pairing',
+      });
+    });
+
+    it('fires QrHardwareScanFailed with non_ur_qr_scanned for signing flow', async () => {
+      setupWebcamUtilsSuccess();
+      mockEnhancedQrReader.mockImplementation((({
+        onFrame,
+      }: {
+        onFrame: (data: string) => void;
+      }) => {
+        // eslint-disable-next-line react-hooks/rules-of-hooks
+        useEffect(() => {
+          onFrame('not-a-valid-ur-payload');
+        }, [onFrame]);
+        return null;
+      }) as unknown as typeof EnhancedQrReader);
+
+      await act(async () => {
+        renderWithMetrics(
+          <BaseQrReader {...defaultProps} isReadingWallet={false} />,
+        );
+      });
+
+      const scanFailed = mockTrackEvent.mock.calls.filter(
+        (call: unknown[]) =>
+          (call[0] as { event: string }).event ===
+          MetaMetricsEventName.QrHardwareScanFailed,
+      );
+      expect(scanFailed).toHaveLength(1);
+      expect(scanFailed[0][0].properties.flow).toBe('signing');
+    });
   });
 });

--- a/ui/components/app/qr-hardware-popover/base-qr-reader/base-qr-reader.test.tsx
+++ b/ui/components/app/qr-hardware-popover/base-qr-reader/base-qr-reader.test.tsx
@@ -1122,9 +1122,7 @@ describe('BaseQrReader', () => {
       }) as unknown as typeof EnhancedQrReader);
 
       await act(async () => {
-        renderWithMetrics(
-          <BaseQrReader {...defaultProps} isReadingWallet />,
-        );
+        renderWithMetrics(<BaseQrReader {...defaultProps} isReadingWallet />);
       });
 
       const scanFailed = mockTrackEvent.mock.calls.filter(
@@ -1134,7 +1132,9 @@ describe('BaseQrReader', () => {
       );
       expect(scanFailed).toHaveLength(1);
       expect(scanFailed[0][0].properties).toStrictEqual({
+        // eslint-disable-next-line @typescript-eslint/naming-convention -- Segment analytics payload keys use snake_case
         error_category: 'non_ur_qr_scanned',
+        // eslint-disable-next-line @typescript-eslint/naming-convention -- Segment analytics payload keys use snake_case
         is_ur_format: false,
         flow: 'pairing',
       });

--- a/ui/components/app/qr-hardware-popover/base-qr-reader/base-qr-reader.tsx
+++ b/ui/components/app/qr-hardware-popover/base-qr-reader/base-qr-reader.tsx
@@ -180,10 +180,14 @@ const BaseQrReader = ({
 
   // ---- QR scan-failed tracking --------------------------------------------
 
+  // Guards against duplicate events when trackEvent is recreated by context changes.
+  const lastTrackedScanErrorRef = useRef<typeof scanError>(null);
+
   useEffect(() => {
-    if (!scanError) {
+    if (!scanError || scanError === lastTrackedScanErrorRef.current) {
       return;
     }
+    lastTrackedScanErrorRef.current = scanError;
     const flow = isReadingWallet
       ? QrErrorFlowContext.Pairing
       : QrErrorFlowContext.Signing;

--- a/ui/components/app/qr-hardware-popover/base-qr-reader/base-qr-reader.tsx
+++ b/ui/components/app/qr-hardware-popover/base-qr-reader/base-qr-reader.tsx
@@ -32,6 +32,7 @@ import EnhancedQrReader from '../enhanced-qr-reader';
 import {
   cameraReadyStateToErrorCode,
   buildQrCameraRecoveryTrackEventArgs,
+  buildQrScanFailedTrackEventArgs,
 } from './base-qr-reader-utils';
 import {
   CameraReadyState,
@@ -176,6 +177,18 @@ const BaseQrReader = ({
       ),
     );
   }, [readyState, trackEvent]);
+
+  // ---- QR scan-failed tracking --------------------------------------------
+
+  useEffect(() => {
+    if (!scanError) {
+      return;
+    }
+    const flow = isReadingWallet
+      ? QrErrorFlowContext.Pairing
+      : QrErrorFlowContext.Signing;
+    trackEvent(buildQrScanFailedTrackEventArgs(scanError, flow));
+  }, [scanError, isReadingWallet, trackEvent]);
 
   // ---- Decoder lifecycle --------------------------------------------------
 

--- a/ui/components/app/qr-hardware-popover/qr-hooks/decoder-lifecycle/useDecoderLifecycle.test.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/decoder-lifecycle/useDecoderLifecycle.test.ts
@@ -1,5 +1,6 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import { URDecoder } from '@ngraveio/bc-ur';
+import log from 'loglevel';
 import {
   UrType,
   PAIRING_EXPECTED_UR_TYPES,
@@ -297,6 +298,62 @@ describe('useDecoderLifecycle', () => {
         rawMessage: 'cbor decode failure',
       });
       expect(mockHandleSuccess).not.toHaveBeenCalled();
+    });
+
+    it('calls log.warn with the raw exception for ScanException errors', () => {
+      const warnSpy = jest.spyOn(log, 'warn').mockImplementation();
+      const thrownError = new Error('cbor decode failure');
+      const mockInstance = {
+        isComplete: jest.fn().mockReturnValue(false),
+        isError: jest.fn().mockReturnValue(false),
+        receivePart: jest.fn().mockImplementation(() => {
+          throw thrownError;
+        }),
+        estimatedPercentComplete: jest.fn(),
+        resultUR: jest.fn(),
+      };
+      mockURDecoder.mockImplementation(
+        () => mockInstance as unknown as URDecoder,
+      );
+
+      const { result } = renderDecoderHook();
+
+      act(() => {
+        result.current.handleScan('ur:crypto-hdkey/corrupted-data');
+      });
+
+      expect(warnSpy).toHaveBeenCalledWith('QR scan exception', thrownError);
+      warnSpy.mockRestore();
+    });
+
+    it('does not call log.warn for NonUrQrScanned errors', () => {
+      const warnSpy = jest.spyOn(log, 'warn').mockImplementation();
+      const mockInstance = {
+        isComplete: jest.fn().mockReturnValue(false),
+        isError: jest.fn().mockReturnValue(false),
+        receivePart: jest.fn().mockImplementation(() => {
+          throw new Error('invalid payload');
+        }),
+        estimatedPercentComplete: jest.fn(),
+        resultUR: jest.fn(),
+      };
+      mockURDecoder.mockImplementation(
+        () => mockInstance as unknown as URDecoder,
+      );
+
+      const { result } = renderDecoderHook();
+
+      act(() => {
+        result.current.handleScan('bad-data');
+      });
+
+      expect(mockSetScanError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: ScanErrorCategory.NonUrQrScanned,
+        }),
+      );
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
     });
 
     it('classifies as UrDecodeError when decoder enters error state', () => {

--- a/ui/components/app/qr-hardware-popover/qr-hooks/decoder-lifecycle/useDecoderLifecycle.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/decoder-lifecycle/useDecoderLifecycle.ts
@@ -1,10 +1,11 @@
 import { useCallback, useRef } from 'react';
 import { URDecoder } from '@ngraveio/bc-ur';
+import log from 'loglevel';
 import type {
   BaseQrReaderProps,
   WebcamError,
 } from '../../base-qr-reader/base-qr-reader.types';
-import { classifyScanResult } from '../../qr-utils/qr-utils';
+import { classifyScanResult, ScanErrorCategory } from '../../qr-utils/qr-utils';
 import type { DecoderCallbacks } from '../qr-hooks.types';
 
 /**
@@ -109,6 +110,9 @@ export function useDecoderLifecycle(
         });
 
         if (detectedError) {
+          if (detectedError.category === ScanErrorCategory.ScanException) {
+            log.warn('QR scan exception', exception);
+          }
           setScanError(detectedError);
         }
       }


### PR DESCRIPTION
## **Description**
This PR adds MetaMetrics event tracking for QR scan errors.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->
CHANGELOG entry: null

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1770

## **Manual testing steps**
1. Run local Segment server and look for intercepted events
2. Try to scan invalid QR codes on Pairing and Signing flows.
3. Make sure that proper events are logged (sent to Segment)

## **Screenshots/Recordings**
### **Before**
No UI changes. Nothing to show here.

### **After**
No UI changes. Nothing to show here.

### **Intercepted events**
<img width="508" height="396" alt="Screenshot 2026-06-09 at 18 27 32" src="https://github.com/user-attachments/assets/cae80a06-a8f2-4265-bbd5-d872265c1f04" />
<img width="508" height="396" alt="Screenshot 2026-06-09 at 18 29 02" src="https://github.com/user-attachments/assets/be1bfe64-c46e-411a-bf22-f98a959f3fa5" />
<img width="508" height="402" alt="Screenshot 2026-06-09 at 18 34 31" src="https://github.com/user-attachments/assets/106ab828-80d1-4910-a649-a33c2ff96a68" />

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only instrumentation on existing scan-error paths; no auth or transaction logic changes. Scan-exception raw messages may appear in Segment properties for debugging.
> 
> **Overview**
> Adds **MetaMetrics** tracking when QR hardware wallet scans fail, via a new **`QrHardwareScanFailed`** event and **`buildQrScanFailedTrackEventArgs`**, which sends Accounts-category payloads with **`error_category`**, **`is_ur_format`**, **`flow`** (pairing vs signing), and optional **`received_ur_type`** or **`raw_message`** depending on the classification.
> 
> **`BaseQrReader`** fires that event in a **`useEffect`** when **`scanError`** is set, with a ref guard so the same error object is not tracked twice if **`trackEvent`** changes.
> 
> **`useDecoderLifecycle`** logs **`log.warn('QR scan exception', …)`** only for **`ScanException`** categories, not for benign non-UR scans. Unit and integration tests cover the builder, decoder logging, and pairing/signing tracking.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8225a2df51c5b2816cda7594ff3ef65405d69e3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->