### PR TITLE
fix: exclude ondo assets by name from batch sell

### DIFF
--- a/shared/constants/batch-sell.ts
+++ b/shared/constants/batch-sell.ts
@@ -13,3 +13,5 @@ export const BATCH_SELL_SUPPORTED_CHAIN_IDS = new Set([
   toEvmCaipChainId(CHAIN_IDS.ARBITRUM),
   toEvmCaipChainId(CHAIN_IDS.POLYGON),
 ]);
+
+export const ONDO_TOKENIZED_TOKEN_NAME = 'Ondo Tokenized';

--- a/ui/ducks/batch-sell/selectors.test.ts
+++ b/ui/ducks/batch-sell/selectors.test.ts
@@ -522,6 +522,60 @@ describe('batch-sell selectors', () => {
       expect(result[0].symbol).toBe('ETH');
     });
 
+    it('filters out tokens whose name includes "Ondo Tokenized"', () => {
+      const ONDO_ASSET_ID =
+        `${CAIP_MAINNET}/erc20:0xBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBbBb` as CaipChainId;
+      const ONDO_BRIDGE_TOKEN = {
+        assetId: ONDO_ASSET_ID,
+        chainId: CAIP_MAINNET,
+        symbol: 'OUSG',
+        name: 'Ondo Tokenized Short-Term US Government Bond Fund',
+        decimals: 18,
+        balance: '5',
+        tokenFiatAmount: 500,
+        iconUrl: undefined,
+      };
+      mockGetBridgeAssetsByAssetId.mockReturnValue({
+        [ETH_ASSET_ID.toLowerCase()]: ETH_BRIDGE_TOKEN,
+        [ONDO_ASSET_ID.toLowerCase()]: ONDO_BRIDGE_TOKEN,
+      } as never);
+
+      const result = getAvailableBatchSellSwapAssetsForNetwork(
+        buildState(),
+        CAIP_MAINNET,
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].symbol).toBe('ETH');
+    });
+
+    it('does not filter out tokens whose name only partially resembles "Ondo Tokenized"', () => {
+      const OTHER_ASSET_ID =
+        `${CAIP_MAINNET}/erc20:0xCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCcCc` as CaipChainId;
+      const OTHER_BRIDGE_TOKEN = {
+        assetId: OTHER_ASSET_ID,
+        chainId: CAIP_MAINNET,
+        symbol: 'ONDO',
+        name: 'Ondo Finance',
+        decimals: 18,
+        balance: '10',
+        tokenFiatAmount: 100,
+        iconUrl: undefined,
+      };
+      mockGetBridgeAssetsByAssetId.mockReturnValue({
+        [ETH_ASSET_ID.toLowerCase()]: ETH_BRIDGE_TOKEN,
+        [OTHER_ASSET_ID.toLowerCase()]: OTHER_BRIDGE_TOKEN,
+      } as never);
+
+      const result = getAvailableBatchSellSwapAssetsForNetwork(
+        buildState(),
+        CAIP_MAINNET,
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result.map((a) => a.symbol)).toContain('ONDO');
+    });
+
     it('populates tokenFiatPrice and percentageChange from marketData for EVM native asset', () => {
       mockGetBridgeAssetsByAssetId.mockReturnValue({
         [ETH_ASSET_ID.toLowerCase()]: ETH_BRIDGE_TOKEN,

--- a/ui/ducks/batch-sell/selectors.ts
+++ b/ui/ducks/batch-sell/selectors.ts
@@ -47,7 +47,10 @@ import { getSelectedAccountGroup } from '../../selectors/multichain-accounts/acc
 import { QuoteValidationErrors, type BridgeToken } from '../bridge/types';
 import { createDeepEqualSelector } from '../../../shared/lib/selectors/selector-creators';
 import { isHardwareWallet } from '../../../shared/lib/selectors/keyring';
-import { BATCH_SELL_SUPPORTED_CHAIN_IDS } from '../../../shared/constants/batch-sell';
+import {
+  BATCH_SELL_SUPPORTED_CHAIN_IDS,
+  ONDO_TOKENIZED_TOKEN_NAME,
+} from '../../../shared/constants/batch-sell';
 import { isStockRWAToken } from '../../pages/bridge/hooks/useRWAToken';
 import { BatchSellAsset } from './types';
 
@@ -252,7 +255,10 @@ export const getAvailableBatchSellSwapAssetsForNetwork = createSelector(
         if (stablecoinSet.has(asset.assetId.toLowerCase())) {
           return false;
         }
-        if (isStockRWAToken(asset)) {
+        if (
+          isStockRWAToken(asset) ||
+          asset.name?.includes(ONDO_TOKENIZED_TOKEN_NAME)
+        ) {
           return false;
         }
         return true;


### PR DESCRIPTION
## **Description**

Ondo Finance issues tokenized real-world asset tokens whose names begin with `"Ondo Tokenized"` (e.g. *Ondo Tokenized Short-Term US Government Bond Fund*). These are regulated instruments that should not be available as swap sources in the Batch Sell flow, the same way stock-RWA tokens are excluded today.

This PR adds a name-based guard to `getAvailableBatchSellSwapAssetsForNetwork` that filters out any asset whose `name` contains the `"Ondo Tokenized"` prefix, and exports the string as the named constant `ONDO_TOKENIZED_TOKEN_NAME` from `shared/constants/batch-sell.ts` so it is easy to discover and reuse.

1. **What is the reason for the change?** Tokenized Ondo assets are regulated RWA instruments and must not appear in the Batch Sell asset picker as sellable tokens.
2. **What is the improvement/solution?** `getAvailableBatchSellSwapAssetsForNetwork` now checks `asset.name?.includes(ONDO_TOKENIZED_TOKEN_NAME)` in addition to the existing `isStockRWAToken` guard, and the constant is centralised in `shared/constants/batch-sell.ts`.

## **Changelog**

CHANGELOG entry: exclude Ondo assets from batch sell select screen

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4586

## **Manual testing steps**

1. Open the Batch Sell flow on a network that has Ondo Tokenized tokens in the wallet (e.g. Ethereum Mainnet with OUSG).
2. Open the "Sell" asset picker.
3. Confirm that tokens whose name starts with "Ondo Tokenized" do **not** appear in the list.
4. Confirm that regular Ondo Finance tokens (e.g. `ONDO` governance token) **do** appear, as only the "Ondo Tokenized" prefix is blocked.
5. Confirm that stock-RWA tokens (e.g. tokenised equities) are still filtered as before.

## **Screenshots/Recordings**

<!--
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow product filter on Batch Sell asset selection with unit tests; no auth, payments, or swap execution logic changes.
> 
> **Overview**
> Batch Sell no longer lists **Ondo tokenized RWA** instruments as sellable swap sources. `getAvailableBatchSellSwapAssetsForNetwork` now drops assets whose `name` contains the shared constant **`ONDO_TOKENIZED_TOKEN_NAME`** (`"Ondo Tokenized"`), using the same exclusion path as stock RWA tokens.
> 
> The substring check is intentional: names like *Ondo Tokenized Short-Term US Government Bond Fund* are blocked, while unrelated names such as *Ondo Finance* remain eligible. Selector tests cover both behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 179953f052f1e89bc6d3ed61a96ea49a679eb624. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->