### PR TITLE
chore: bump lavamoat webpack cp-13.34.1

### DIFF
--- a/lavamoat/webpack/build/policy.json
+++ b/lavamoat/webpack/build/policy.json
@@ -321,6 +321,7 @@
         "depcheck>@babel/parser": true,
         "@lavamoat/webpack>@lavamoat/aa": true,
         "browserify>browser-resolve": true,
+        "@lavamoat/webpack>json-stable-stringify": true,
         "@lavamoat/webpack>lavamoat-core": true,
         "webpack": true
       }

--- a/package.json
+++ b/package.json
@@ -321,7 +321,7 @@
     "@keystonehq/bc-ur-registry-eth": "^0.22.1",
     "@lavamoat/lavadome-react": "0.0.20",
     "@lavamoat/snow": "^2.0.4",
-    "@lavamoat/webpack": "2.2.0",
+    "@lavamoat/webpack": "2.2.3",
     "@ledgerhq/errors": "^6.21.0",
     "@ledgerhq/hw-app-eth": "^6.42.0",
     "@ledgerhq/hw-transport": "^6.31.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -487,7 +487,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:7.29.2, @babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.23.0, @babel/parser@npm:^7.24.4, @babel/parser@npm:^7.26.7, @babel/parser@npm:^7.27.3, @babel/parser@npm:^7.28.6, @babel/parser@npm:^7.29.0, @babel/parser@npm:^7.29.2":
+"@babel/parser@npm:7.29.3":
+  version: 7.29.3
+  resolution: "@babel/parser@npm:7.29.3"
+  dependencies:
+    "@babel/types": "npm:^7.29.0"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10/10e8f34e0fdaa495b9db8be71f4eb29b16d8a57e0818c1bb1c4084015b0383803fd77812ed41597760cbf3d9ab3ae9f4af54f39ff5e5d8e081ba43593232f0ca
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.23.0, @babel/parser@npm:^7.24.4, @babel/parser@npm:^7.26.7, @babel/parser@npm:^7.27.3, @babel/parser@npm:^7.28.6, @babel/parser@npm:^7.29.0, @babel/parser@npm:^7.29.2":
   version: 7.29.2
   resolution: "@babel/parser@npm:7.29.2"
   dependencies:
@@ -5048,20 +5059,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@lavamoat/webpack@npm:2.2.0":
-  version: 2.2.0
-  resolution: "@lavamoat/webpack@npm:2.2.0"
+"@lavamoat/webpack@npm:2.2.3":
+  version: 2.2.3
+  resolution: "@lavamoat/webpack@npm:2.2.3"
   dependencies:
-    "@babel/parser": "npm:7.29.2"
+    "@babel/parser": "npm:7.29.3"
     "@lavamoat/aa": "npm:^5.0.1"
     "@lavamoat/types": "npm:^1.0.1"
     browser-resolve: "npm:2.0.0"
     json-stable-stringify: "npm:1.3.0"
-    lavamoat-core: "npm:^18.0.2"
+    lavamoat-core: "npm:^18.0.4"
     ses: "npm:1.15.0"
   peerDependencies:
     webpack: ^5.80.2
-  checksum: 10/71c4dea975cd3191f31eceec70aa52b30155ba7b87dde1ca556330947955f7fcff8b9bc454c789bb482da870362bf87d29c4f5fce067dd15046d82be1aa2122a
+  checksum: 10/9f2e7cc12860c14c056b873bf97fd4f633019244f13a15429f6778bc5db0e08b0a419f618008382d64b52aa670c1446cde368252ad13d438d43acd075c3edd69
   languageName: node
   linkType: hard
 
@@ -32013,18 +32024,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lavamoat-core@npm:^18.0.2":
-  version: 18.0.2
-  resolution: "lavamoat-core@npm:18.0.2"
+"lavamoat-core@npm:^18.0.4":
+  version: 18.0.4
+  resolution: "lavamoat-core@npm:18.0.4"
   dependencies:
     "@babel/types": "npm:7.29.0"
     "@lavamoat/types": "npm:^1.0.1"
     json-stable-stringify: "npm:1.3.0"
-    lavamoat-tofu: "npm:^9.0.1"
+    lavamoat-tofu: "npm:^9.0.2"
     ses: "npm:1.15.0"
   bin:
     lavamoat-sort-policy: src/policy-sort-cli.js
-  checksum: 10/3a0114a65421ed32d9087de3a908865c453dbef4236e1ead1e4cf8cd1676ac4236b200526317fa1c7378804d946e80aee68fa0ba4f40323cf32eb78b9a582811
+  checksum: 10/28eee28b61275c349ab9d846e7d58f5a03499de2ea120448d463243217b4e6345cb7df902e72fdd331148b486229091bf9bd56939aa3d284bf811fb2e28c36fb
   languageName: node
   linkType: hard
 
@@ -32044,11 +32055,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lavamoat-tofu@npm:^9.0.1":
-  version: 9.0.1
-  resolution: "lavamoat-tofu@npm:9.0.1"
+"lavamoat-tofu@npm:^9.0.2":
+  version: 9.0.2
+  resolution: "lavamoat-tofu@npm:9.0.2"
   dependencies:
-    "@babel/parser": "npm:7.29.2"
+    "@babel/parser": "npm:7.29.3"
     "@babel/traverse": "npm:7.29.0"
     "@babel/types": "npm:7.29.0"
     "@lavamoat/types": "npm:^1.0.1"
@@ -32056,7 +32067,7 @@ __metadata:
     type-fest: "npm:4.41.0"
   peerDependencies:
     lavamoat-core: ">15.4.0"
-  checksum: 10/ec323dd154bd42159a05c47ffe3dff6568166edde6a366ea9de33caf4a6ce58d0b777cf717e60634da7d40e2cbc2e824611fb07229608d839e2f343b93c6f0cb
+  checksum: 10/b80fc9961c91922e2f0cef8cdf6235258770af37ad0972029d91bfdef424534408b13b7987058902fe416e64a5e7cbbb4e84ab3756709c2753383d7eeeb88071
   languageName: node
   linkType: hard
 
@@ -33166,7 +33177,7 @@ __metadata:
     "@lavamoat/lavadome-react": "npm:0.0.20"
     "@lavamoat/lavapack": "npm:^7.0.22"
     "@lavamoat/snow": "npm:^2.0.4"
-    "@lavamoat/webpack": "npm:2.2.0"
+    "@lavamoat/webpack": "npm:2.2.3"
     "@ledgerhq/errors": "npm:^6.21.0"
     "@ledgerhq/hw-app-eth": "npm:^6.42.0"
     "@ledgerhq/hw-transport": "npm:^6.31.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -487,7 +487,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/parser@npm:7.29.3":
+"@babel/parser@npm:7.29.3, @babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.23.0, @babel/parser@npm:^7.24.4, @babel/parser@npm:^7.26.7, @babel/parser@npm:^7.27.3, @babel/parser@npm:^7.28.6, @babel/parser@npm:^7.29.0, @babel/parser@npm:^7.29.2":
   version: 7.29.3
   resolution: "@babel/parser@npm:7.29.3"
   dependencies:
@@ -495,17 +495,6 @@ __metadata:
   bin:
     parser: ./bin/babel-parser.js
   checksum: 10/10e8f34e0fdaa495b9db8be71f4eb29b16d8a57e0818c1bb1c4084015b0383803fd77812ed41597760cbf3d9ab3ae9f4af54f39ff5e5d8e081ba43593232f0ca
-  languageName: node
-  linkType: hard
-
-"@babel/parser@npm:^7.1.0, @babel/parser@npm:^7.14.7, @babel/parser@npm:^7.20.7, @babel/parser@npm:^7.23.0, @babel/parser@npm:^7.24.4, @babel/parser@npm:^7.26.7, @babel/parser@npm:^7.27.3, @babel/parser@npm:^7.28.6, @babel/parser@npm:^7.29.0, @babel/parser@npm:^7.29.2":
-  version: 7.29.2
-  resolution: "@babel/parser@npm:7.29.2"
-  dependencies:
-    "@babel/types": "npm:^7.29.0"
-  bin:
-    parser: ./bin/babel-parser.js
-  checksum: 10/45d050bf75aa5194b3255f156173e8553d615ff5a2434674cc4a10cdc7c261931befb8618c996a1c449b87f0ef32a3407879af2ac967d95dc7b4fdbae7037efa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Bumps `@lavamoat/webpack` from `2.2.0` to `2.2.3` in `package.json`. The `yarn.lock` is refreshed to pick up the transitive updates (`lavamoat-core`, `lavamoat-tofu`, and a `@babel/parser` entry for those packages).

This keeps the LavaMoat build tooling up to date. No application or webpack config source changes — only dependency versions.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: null

## **Manual testing steps**

1. Build the extension and verify the build completes successfully.

## **Screenshots/Recordings**

Not applicable

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only change to LavaMoat build tooling; risk is mainly that extension/webpack LavaMoat builds must still pass after the bump.
> 
> **Overview**
> Bumps **`@lavamoat/webpack`** from **2.2.0** to **2.2.3** and refreshes **`yarn.lock`** so the LavaMoat webpack toolchain picks up **`lavamoat-core` 18.0.4**, **`lavamoat-tofu` 9.0.2**, and a matching **`@babel/parser` 7.29.3** on those dependency paths.
> 
> The webpack LavaMoat **`policy.json`** is updated to allow **`@lavamoat/webpack>json-stable-stringify`** as a dependency of the **`@lavamoat/webpack`** policy entry—no extension runtime or webpack config source changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2929bb8f7b1934c6ef6fece3481d012250f275d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->