### PR TITLE
Migrate Icon and IconName to @metamask/design-system-react in home.component

### DIFF
--- a/ui/pages/home/home.component.js
+++ b/ui/pages/home/home.component.js
@@ -36,9 +36,7 @@ import { SECOND } from '../../../shared/constants/time';
 import {
   ButtonIcon,
   ButtonIconSize,
-  IconName,
   Box,
-  Icon,
   Modal,
   ModalBody,
   ModalContent,
@@ -46,6 +44,7 @@ import {
   ModalHeader,
   ModalOverlay,
 } from '../../components/component-library';
+import { Icon, IconName } from '@metamask/design-system-react';
 import MultiRpcEditModal from '../../components/app/multi-rpc-edit-modal/multi-rpc-edit-modal';
 import UpdateModal from '../../components/app/update-modal/update-modal';
 import {
@@ -568,7 +567,7 @@ export default class Home extends PureComponent {
           onAutoHide={onAutoHide}
           message={
             <Box display={Display.InlineFlex}>
-              <Icon name={IconName.Danger} marginRight={1} />
+              <Icon name={IconName.Danger} className="mr-1" />
               <Text variant={TextVariant.BodySm} asChild>
                 <h6>{t('importTokensError')}</h6>
               </Text>


### PR DESCRIPTION
## **Description**

Migrated `Icon` and `IconName` imports from `../../components/component-library` to `@metamask/design-system-react` in `ui/pages/home/home.component.js`.

Also replaced deprecated `marginRight={1}` prop with Tailwind class `className="mr-1"` on the Icon component.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of #43340

## **Manual testing steps**

1. The Icon here only shows up when a token import fails, so it's hard to trigger manually in a dev environment.
2. Since it's not reachable through normal flows, I'm using the diff as evidence instead — the change from marginRight={1} to className="mr-1" is straightforward and shouldn't cause any visual regression.

## **Screenshots/Recordings**

<img width="1403" height="635" alt="截屏2026-06-08 18 11 16" src="https://github.com/user-attachments/assets/fb1a70f6-b4c1-4db0-9618-1d5db2da02ca" />

**Unreachable UI Evidence:**
The migrated `Icon` component is only rendered when `newTokensImportedError` prop is non-empty (line 562), which requires a failed token import to trigger:

<img width="622" height="76" alt="截屏2026-06-08 19 32 59" src="https://github.com/user-attachments/assets/1d686724-1d4d-4655-bf22-e436099cab7a" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
