### PR TITLE
test: fix flaky test `Change wallet password` and `Unlock wallet` and refactor using POM practices

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -895,7 +895,6 @@ module.exports = {
         'test/e2e/page-objects/pages/settings/about-page.ts',
         'test/e2e/page-objects/pages/settings/advanced-settings.ts',
         'test/e2e/page-objects/pages/settings/backup-and-sync-settings.ts',
-        'test/e2e/page-objects/pages/settings/change-password-page.ts',
         'test/e2e/page-objects/pages/settings/contacts-settings.ts',
         'test/e2e/page-objects/pages/settings/experimental-settings.ts',
         'test/e2e/page-objects/pages/settings/notifications-settings-page.ts',

--- a/test/e2e/flask/create-watch-account.spec.ts
+++ b/test/e2e/flask/create-watch-account.spec.ts
@@ -11,6 +11,7 @@ import HeaderNavbar from '../page-objects/pages/header-navbar';
 import HomePage from '../page-objects/pages/home/homepage';
 import SettingsPage from '../page-objects/pages/settings/settings-page';
 import { login } from '../page-objects/flows/login.flow';
+import { closeSettings } from '../page-objects/flows/settings.flow';
 import { watchEoaAddress } from '../page-objects/flows/watch-account.flow';
 
 const ACCOUNT_1 = '0x5CfE73b6021E818B776b421B1c4Db2474086a7e1';
@@ -303,7 +304,7 @@ describe.skip('Account-watcher snap', function (this: Suite) {
             'Toggle should be off by default',
           );
           await experimentalSettings.toggleWatchAccount();
-          await settingsPage.clickBackButton();
+          await closeSettings(driver);
 
           // verify the 'Watch and Ethereum account (Beta)' option is available
           await homePage.checkPageIsLoaded();
@@ -336,7 +337,7 @@ describe.skip('Account-watcher snap', function (this: Suite) {
           const experimentalSettings = new ExperimentalSettings(driver);
           await experimentalSettings.checkPageIsLoaded();
           await experimentalSettings.toggleWatchAccount();
-          await settingsPage.clickBackButton();
+          await closeSettings(driver);
 
           // verify the 'Watch and Ethereum account (Beta)' option is available
           await homePage.checkPageIsLoaded();
@@ -355,7 +356,7 @@ describe.skip('Account-watcher snap', function (this: Suite) {
           await settingsPage.goToExperimentalSettings();
           await experimentalSettings.checkPageIsLoaded();
           await experimentalSettings.toggleWatchAccount();
-          await settingsPage.clickBackButton();
+          await closeSettings(driver);
 
           // verify the 'Watch and Ethereum account (Beta)' option is not available
           await homePage.checkPageIsLoaded();

--- a/test/e2e/flask/snaps/preinstalled-example.spec.ts
+++ b/test/e2e/flask/snaps/preinstalled-example.spec.ts
@@ -3,6 +3,7 @@ import { Mockttp } from 'mockttp';
 import { Driver } from '../../webdriver/driver';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { login } from '../../page-objects/flows/login.flow';
+import { closeSettings } from '../../page-objects/flows/settings.flow';
 import {
   DAPP_PATH,
   MOCK_META_METRICS_ID,
@@ -67,7 +68,6 @@ describe('Preinstalled example Snap', function () {
       },
       async ({ driver }: { driver: Driver }) => {
         await login(driver);
-        const settingsPage = new SettingsPage(driver);
         const preInstalledExample = new PreinstalledExampleSettings(driver);
         await navigateToPreInstalledExample(driver);
 
@@ -77,7 +77,7 @@ describe('Preinstalled example Snap', function () {
         await preInstalledExample.checkIsToggleOn();
         await preInstalledExample.checkSelectedRadioOption('option2');
         await preInstalledExample.checkSelectedDropdownOption('option2');
-        await settingsPage.clickBackButton();
+        await closeSettings(driver);
 
         // Navigate to `test-snaps` page, we don't need to connect because the Snap uses
         // initialConnections to pre-approve the dapp.

--- a/test/e2e/page-objects/flows/settings.flow.ts
+++ b/test/e2e/page-objects/flows/settings.flow.ts
@@ -97,8 +97,6 @@ export async function changePasswordAndLockWallet(
   // before the new password is persisted.
   await driver.delay(3_000);
 
-  await changePasswordPage.closePasswordChangedToast();
-
   const settingsPage = new SettingsPage(driver);
   await settingsPage.clickBackButton();
 

--- a/test/e2e/page-objects/flows/settings.flow.ts
+++ b/test/e2e/page-objects/flows/settings.flow.ts
@@ -18,7 +18,7 @@ import { lockAndWaitForLoginPage } from './login.flow';
  */
 export const closeSettings = async (driver: Driver): Promise<void> => {
   const settingsPage = new SettingsPage(driver);
-  await settingsPage.clickBackButton();
+  await settingsPage.closeSettings();
 
   const headerNavbar = new HeaderNavbar(driver);
   await headerNavbar.clickDrawerBackButton();

--- a/test/e2e/page-objects/flows/settings.flow.ts
+++ b/test/e2e/page-objects/flows/settings.flow.ts
@@ -5,6 +5,8 @@ import PreferencesAndDisplaySettings from '../pages/settings/preferences-and-dis
 import SelectNetwork from '../pages/dialog/select-network';
 import HeaderNavbar from '../pages/header-navbar';
 import PrivacySettings from '../pages/settings/privacy-settings';
+import ChangePasswordPage from '../pages/settings/change-password-page';
+import { lockAndWaitForLoginPage } from './login.flow';
 
 /**
  * Enable test networks (testnets) from Settings → Networks (opens the network
@@ -56,4 +58,49 @@ export async function navigateToSecurityAndPassword(
   await settingsPage.goToSecurityAndPasswordSettings();
   const privacySettings = new PrivacySettings(driver);
   await privacySettings.checkSecurityAndPasswordPageIsLoaded();
+}
+
+/**
+ * Change the wallet password from Settings → Security & Privacy, then lock the
+ * wallet and wait for the login page.
+ *
+ * @param driver - The WebDriver instance
+ * @param currentPassword - The current wallet password
+ * @param newPassword - The new wallet password
+ * @param isSocialLogin - Whether the user is a social login user (shows an
+ * additional password change warning that must be confirmed)
+ */
+export async function changePasswordAndLockWallet(
+  driver: Driver,
+  currentPassword: string,
+  newPassword: string,
+  isSocialLogin: boolean = false,
+): Promise<void> {
+  await navigateToSecurityAndPassword(driver);
+
+  const privacySettings = new PrivacySettings(driver);
+  await privacySettings.openChangePassword();
+
+  const changePasswordPage = new ChangePasswordPage(driver);
+  await changePasswordPage.checkPageIsLoaded();
+
+  await changePasswordPage.confirmCurrentPassword(currentPassword);
+
+  await changePasswordPage.changePassword(newPassword);
+  if (isSocialLogin) {
+    await changePasswordPage.checkPasswordChangedWarning();
+    await changePasswordPage.confirmChangePasswordWarning();
+  }
+
+  // Password change triggers an async vault re-encryption. No UI element
+  // reliably signals completion, so a brief delay avoids navigating away
+  // before the new password is persisted.
+  await driver.delay(3_000);
+
+  await changePasswordPage.closePasswordChangedToast();
+
+  const settingsPage = new SettingsPage(driver);
+  await settingsPage.clickBackButton();
+
+  await lockAndWaitForLoginPage(driver);
 }

--- a/test/e2e/page-objects/flows/settings.flow.ts
+++ b/test/e2e/page-objects/flows/settings.flow.ts
@@ -9,6 +9,22 @@ import ChangePasswordPage from '../pages/settings/change-password-page';
 import { lockAndWaitForLoginPage } from './login.flow';
 
 /**
+ * Close the Settings page and return to the wallet home.
+ *
+ * Clicking the Settings back button returns to home with the account drawer
+ * still open, so this also closes the drawer via the navbar back button.
+ *
+ * @param driver - The WebDriver instance
+ */
+export const closeSettings = async (driver: Driver): Promise<void> => {
+  const settingsPage = new SettingsPage(driver);
+  await settingsPage.clickBackButton();
+
+  const headerNavbar = new HeaderNavbar(driver);
+  await headerNavbar.clickDrawerBackButton();
+};
+
+/**
  * Enable test networks (testnets) from Settings → Networks (opens the network
  * list menu; toggles "Show test networks").
  *
@@ -45,7 +61,7 @@ export const enableNativeTokenAsMainBalance = async (
   await assetsSettings.checkAssetsPageIsLoaded();
   await assetsSettings.toggleShowNativeTokenAsMainBalance();
 
-  await settingsPage.clickBackButton();
+  await closeSettings(driver);
 };
 
 export async function navigateToSecurityAndPassword(
@@ -95,10 +111,9 @@ export async function changePasswordAndLockWallet(
   // Password change triggers an async vault re-encryption. No UI element
   // reliably signals completion, so a brief delay avoids navigating away
   // before the new password is persisted.
-  await driver.delay(3_000);
+  await driver.delay(2_000);
 
-  const settingsPage = new SettingsPage(driver);
-  await settingsPage.clickBackButton();
+  await closeSettings(driver);
 
   await lockAndWaitForLoginPage(driver);
 }

--- a/test/e2e/page-objects/pages/settings/change-password-page.ts
+++ b/test/e2e/page-objects/pages/settings/change-password-page.ts
@@ -3,49 +3,34 @@ import { Driver } from '../../../webdriver/driver';
 export default class ChangePasswordPage {
   private readonly driver: Driver;
 
-  private readonly currentPasswordInput =
-    '[data-testid="verify-current-password-input"]';
-
-  private readonly verifyCurrentPasswordButton =
-    '[data-testid="verify-current-password-button"]';
-
-  private readonly newPasswordInput = '[data-testid="change-password-input"]';
-
   private readonly confirmNewPasswordInput =
     '[data-testid="change-password-confirm-input"]';
 
-  private readonly passwordTerms = '[data-testid="change-password-terms"]';
+  private readonly confirmWarningButton =
+    '[data-testid="change-password-warning-confirm"]';
 
-  private readonly saveButton = '[data-testid="change-password-button"]';
+  private readonly currentPasswordInput =
+    '[data-testid="verify-current-password-input"]';
+
+  private readonly newPasswordInput = '[data-testid="change-password-input"]';
+
+  private readonly passwordChangedToastCloseButton =
+    'button[aria-label="Close"]';
 
   private readonly passwordChangedWarning = {
     text: 'Changing your password here will lock MetaMask on other devices you’re using. You’ll need to log in again with your new password.',
     css: 'p',
   };
 
-  private readonly confirmWarningButton =
-    '[data-testid="change-password-warning-confirm"]';
+  private readonly passwordTerms = '[data-testid="change-password-terms"]';
+
+  private readonly saveButton = '[data-testid="change-password-button"]';
+
+  private readonly verifyCurrentPasswordButton =
+    '[data-testid="verify-current-password-button"]';
 
   constructor(driver: Driver) {
     this.driver = driver;
-  }
-
-  async checkPageIsLoaded(): Promise<void> {
-    console.log('Check change password page is loaded');
-    await this.driver.waitForSelector(this.currentPasswordInput);
-  }
-
-  async waitForPasskeyVerificationToComplete(): Promise<void> {
-    console.log(
-      'Waiting for passkey verification to complete and new password form to appear',
-    );
-    await this.driver.waitForSelector(this.newPasswordInput);
-  }
-
-  async confirmCurrentPassword(password: string): Promise<void> {
-    console.log('Confirm current password');
-    await this.driver.fill(this.currentPasswordInput, password);
-    await this.driver.clickElement(this.verifyCurrentPasswordButton);
   }
 
   async changePassword(newPassword: string): Promise<void> {
@@ -56,13 +41,41 @@ export default class ChangePasswordPage {
     await this.driver.clickElement(this.saveButton);
   }
 
+  async checkPageIsLoaded(): Promise<void> {
+    console.log('Check change password page is loaded');
+    await this.driver.waitForSelector(this.currentPasswordInput);
+  }
+
   async checkPasswordChangedWarning(): Promise<void> {
     console.log('Check password changed warning');
     await this.driver.waitForSelector(this.passwordChangedWarning);
   }
 
+  async closePasswordChangedToast(): Promise<void> {
+    console.log(
+      'Close password changed toast if displayed (transient element)',
+    );
+    await this.driver.clickElementSafe(
+      this.passwordChangedToastCloseButton,
+      5000,
+    );
+  }
+
   async confirmChangePasswordWarning(): Promise<void> {
     console.log('Confirm change password warning');
-    await this.driver.clickElement(this.confirmWarningButton);
+    await this.driver.clickElementAndWaitToDisappear(this.confirmWarningButton);
+  }
+
+  async confirmCurrentPassword(password: string): Promise<void> {
+    console.log('Confirm current password');
+    await this.driver.fill(this.currentPasswordInput, password);
+    await this.driver.clickElement(this.verifyCurrentPasswordButton);
+  }
+
+  async waitForPasskeyVerificationToComplete(): Promise<void> {
+    console.log(
+      'Waiting for passkey verification to complete and new password form to appear',
+    );
+    await this.driver.waitForSelector(this.newPasswordInput);
   }
 }

--- a/test/e2e/page-objects/pages/settings/change-password-page.ts
+++ b/test/e2e/page-objects/pages/settings/change-password-page.ts
@@ -1,8 +1,6 @@
 import { Driver } from '../../../webdriver/driver';
 
 export default class ChangePasswordPage {
-  private readonly driver: Driver;
-
   private readonly confirmNewPasswordInput =
     '[data-testid="change-password-confirm-input"]';
 
@@ -11,6 +9,8 @@ export default class ChangePasswordPage {
 
   private readonly currentPasswordInput =
     '[data-testid="verify-current-password-input"]';
+
+  private readonly driver: Driver;
 
   private readonly newPasswordInput = '[data-testid="change-password-input"]';
 

--- a/test/e2e/page-objects/pages/settings/change-password-page.ts
+++ b/test/e2e/page-objects/pages/settings/change-password-page.ts
@@ -14,9 +14,6 @@ export default class ChangePasswordPage {
 
   private readonly newPasswordInput = '[data-testid="change-password-input"]';
 
-  private readonly passwordChangedToastCloseButton =
-    'button[aria-label="Close"]';
-
   private readonly passwordChangedWarning = {
     text: 'Changing your password here will lock MetaMask on other devices you’re using. You’ll need to log in again with your new password.',
     css: 'p',
@@ -49,16 +46,6 @@ export default class ChangePasswordPage {
   async checkPasswordChangedWarning(): Promise<void> {
     console.log('Check password changed warning');
     await this.driver.waitForSelector(this.passwordChangedWarning);
-  }
-
-  async closePasswordChangedToast(): Promise<void> {
-    console.log(
-      'Close password changed toast if displayed (transient element)',
-    );
-    await this.driver.clickElementSafe(
-      this.passwordChangedToastCloseButton,
-      5000,
-    );
   }
 
   async confirmChangePasswordWarning(): Promise<void> {

--- a/test/e2e/page-objects/pages/settings/settings-page.ts
+++ b/test/e2e/page-objects/pages/settings/settings-page.ts
@@ -1,5 +1,4 @@
-import HomePage from '../home/homepage';
-import { Driver } from '../../../webdriver/driver';
+import { Driver, PAGES } from '../../../webdriver/driver';
 
 class SettingsPage {
   private readonly driver: Driver;
@@ -115,7 +114,7 @@ class SettingsPage {
    * waits for the home page. Kept E2E-local to avoid importing `ui` routes.
    */
   async clickBackButton(): Promise<void> {
-    await this.driver.navigate();
+    await this.driver.navigate(PAGES.HOME, { waitForControllers: false });
   }
 
   async waitForTransactionShieldButtonReady(): Promise<void> {

--- a/test/e2e/page-objects/pages/settings/settings-page.ts
+++ b/test/e2e/page-objects/pages/settings/settings-page.ts
@@ -118,7 +118,7 @@ class SettingsPage {
    */
   async clickBackButton(): Promise<void> {
     await this.driver.clickElement(this.backButton);
-    await this.driver.clickElementAndWaitToDisappear(this.backButton);
+    await this.driver.clickElementSafe(this.backButton);
   }
 
   async waitForTransactionShieldButtonReady(): Promise<void> {

--- a/test/e2e/page-objects/pages/settings/settings-page.ts
+++ b/test/e2e/page-objects/pages/settings/settings-page.ts
@@ -115,10 +115,7 @@ class SettingsPage {
    * waits for the home page. Kept E2E-local to avoid importing `ui` routes.
    */
   async clickBackButton(): Promise<void> {
-    await this.driver.executeScript(
-      `window.location.hash = ${JSON.stringify('/')}`,
-    );
-    await new HomePage(this.driver).checkPageIsLoaded();
+    await this.driver.navigate();
   }
 
   async waitForTransactionShieldButtonReady(): Promise<void> {

--- a/test/e2e/page-objects/pages/settings/settings-page.ts
+++ b/test/e2e/page-objects/pages/settings/settings-page.ts
@@ -12,7 +12,7 @@ class SettingsPage {
     '[data-testid="settings-tab-item-assets"]';
 
   private readonly backButton = {
-    testId: 'settings-header-back-button'
+    testId: 'settings-header-back-button',
   };
 
   private readonly developerToolsSettingsButton =
@@ -95,30 +95,40 @@ class SettingsPage {
 
   async checkPageIsLoaded(): Promise<void> {
     console.log('Check settings page is loaded');
-    await this.driver.wait(async () => {
-      return await this.isOnSettingsPage();
-    });
+    await this.driver.waitForSelector(this.settingsPageFullscreenRoot);
   }
 
-  async hasElement(
-    locator: string | { css?: string; text?: string; tag?: string },
-  ) {
-    const elements = await this.driver.findElements(locator);
-    return elements.length > 0;
+  async isOnSettingsPage(): Promise<boolean> {
+    const currentUrl = await this.driver.getCurrentUrl();
+    return currentUrl.includes('settings');
   }
 
-  async isOnSettingsPage() {
-    return await this.hasElement(this.settingsPageFullscreenRoot);
+  /**
+   * Click the Settings back button once. The back button only navigates one
+   * level up, so a single click may not fully close Settings when on a nested
+   * page. Use closeSettings to fully exit the Settings page.
+   */
+  async clickBackButton(): Promise<void> {
+    await this.driver.clickElementSafe(this.backButton);
   }
 
   /**
    * Close the Settings page and return to the wallet home with the navbar open.
-   * 2 clicks are required to fully close the settings due to UI issue.
-   * Use closeSettings to perform the full flow of closing settings AND navbar.
+   *
+   * The back button only navigates one level up, so when we are on a nested
+   * settings page (e.g. not Preferences) it must be clicked several times to
+   * fully close Settings. Click it while we are still on a Settings page, up to
+   * a few times, stopping as soon as we have left it.
    */
-  async clickBackButton(): Promise<void> {
-    await this.driver.clickElement(this.backButton);
-    await this.driver.clickElementSafe(this.backButton);
+  async closeSettings(): Promise<void> {
+    const maxAttempts = 5;
+    for (let attempt = 0; attempt < maxAttempts; attempt++) {
+      if (!(await this.isOnSettingsPage())) {
+        return;
+      }
+      await this.clickBackButton();
+      await this.driver.delay(1000);
+    }
   }
 
   async waitForTransactionShieldButtonReady(): Promise<void> {

--- a/test/e2e/page-objects/pages/settings/settings-page.ts
+++ b/test/e2e/page-objects/pages/settings/settings-page.ts
@@ -11,7 +11,9 @@ class SettingsPage {
   private readonly assetsSettingsButton =
     '[data-testid="settings-tab-item-assets"]';
 
-  private readonly backButton = 'button[aria-label="Back"]';
+  private readonly backButton = {
+    testId: 'settings-header-back-button'
+  };
 
   private readonly developerToolsSettingsButton =
     '[data-testid="settings-tab-item-developer-tools"]';
@@ -111,11 +113,12 @@ class SettingsPage {
 
   /**
    * Close the Settings page and return to the wallet home with the navbar open.
+   * 2 clicks are required to fully close the settings due to UI issue.
    * Use closeSettings to perform the full flow of closing settings AND navbar.
    */
   async clickBackButton(): Promise<void> {
     await this.driver.clickElement(this.backButton);
-    await this.driver.clickElementSafe(this.backButton);
+    await this.driver.clickElementAndWaitToDisappear(this.backButton);
   }
 
   async waitForTransactionShieldButtonReady(): Promise<void> {

--- a/test/e2e/page-objects/pages/settings/settings-page.ts
+++ b/test/e2e/page-objects/pages/settings/settings-page.ts
@@ -1,4 +1,4 @@
-import { Driver, PAGES } from '../../../webdriver/driver';
+import { Driver } from '../../../webdriver/driver';
 
 class SettingsPage {
   private readonly driver: Driver;
@@ -10,6 +10,8 @@ class SettingsPage {
 
   private readonly assetsSettingsButton =
     '[data-testid="settings-tab-item-assets"]';
+
+  private readonly backButton = 'button[aria-label="Back"]';
 
   private readonly developerToolsSettingsButton =
     '[data-testid="settings-tab-item-developer-tools"]';
@@ -39,8 +41,6 @@ class SettingsPage {
 
   private readonly searchButton =
     '[data-testid="settings-header-search-button"]';
-
-  private readonly settingsPageRoot = '[data-testid="settings-root"]';
 
   private readonly settingsPageFullscreenRoot =
     '[data-testid="settings-tab-bar-grouped"]';
@@ -110,11 +110,12 @@ class SettingsPage {
   }
 
   /**
-   * Navigates to wallet home (`/` — same path as app `DEFAULT_ROUTE`) and
-   * waits for the home page. Kept E2E-local to avoid importing `ui` routes.
+   * Close the Settings page and return to the wallet home with the navbar open.
+   * Use closeSettings to perform the full flow of closing settings AND navbar.
    */
   async clickBackButton(): Promise<void> {
-    await this.driver.navigate(PAGES.HOME, { waitForControllers: false });
+    await this.driver.clickElement(this.backButton);
+    await this.driver.clickElementSafe(this.backButton);
   }
 
   async waitForTransactionShieldButtonReady(): Promise<void> {

--- a/test/e2e/snaps/test-snap-get-locale.spec.ts
+++ b/test/e2e/snaps/test-snap-get-locale.spec.ts
@@ -1,10 +1,10 @@
 import { Driver } from '../webdriver/driver';
 import { TestSnaps } from '../page-objects/pages/test-snaps';
 import HomePage from '../page-objects/pages/home/homepage';
-import SettingsPage from '../page-objects/pages/settings/settings-page';
 import PreferencesAndDisplaySettings from '../page-objects/pages/settings/preferences-and-display-settings';
 import FixtureBuilderV2 from '../fixtures/fixture-builder-v2';
 import { login } from '../page-objects/flows/login.flow';
+import { closeSettings } from '../page-objects/flows/settings.flow';
 import { openTestSnapClickButtonAndInstall } from '../page-objects/flows/install-test-snap.flow';
 import { withFixtures } from '../helpers';
 import { mockLocalizationSnap } from '../mock-response-data/snaps/snap-binary-mocks';
@@ -56,8 +56,7 @@ describe('Test Snap Get Locale', function () {
         await preferencesAndDisplaySettings.changeLanguage('Dansk');
 
         await preferencesAndDisplaySettings.assertLoadingOverlayNotPresent();
-        const settingsPage = new SettingsPage(driver);
-        await settingsPage.clickBackButton();
+        await closeSettings(driver);
 
         await homePage.headerNavbar.openSnapListPage();
         await driver.waitForSelector({

--- a/test/e2e/tests/account/snap-account-settings.spec.ts
+++ b/test/e2e/tests/account/snap-account-settings.spec.ts
@@ -7,6 +7,7 @@ import ExperimentalSettings from '../../page-objects/pages/settings/experimental
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import { login } from '../../page-objects/flows/login.flow';
+import { closeSettings } from '../../page-objects/flows/settings.flow';
 
 describe('Add snap account experimental settings', function (this: Suite) {
   it('switch "Enable Add account snap" to on', async function () {
@@ -36,7 +37,7 @@ describe('Add snap account experimental settings', function (this: Suite) {
         const experimentalSettings = new ExperimentalSettings(driver);
         await experimentalSettings.checkPageIsLoaded();
         await experimentalSettings.toggleAddAccountSnap();
-        await settingsPage.clickBackButton();
+        await closeSettings(driver);
         // Make sure the "Add account Snap" button is visible.
         await headerNavbar.openAccountMenu();
         await accountListPage.addMultichainWallet();

--- a/test/e2e/tests/account/unlock-wallet.spec.ts
+++ b/test/e2e/tests/account/unlock-wallet.spec.ts
@@ -51,7 +51,7 @@ describe('Unlock wallet - ', function () {
     );
   });
 
-  it('should show connections removed modal when max key chain length is reached for social account', async function () {
+  it('should show connections removed modal when max key chain length is reached for social account TEST', async function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilderV2({ onboarding: true }).build(),

--- a/test/e2e/tests/account/unlock-wallet.spec.ts
+++ b/test/e2e/tests/account/unlock-wallet.spec.ts
@@ -11,6 +11,7 @@ import {
   lockAndWaitForPasskeyUnlockPage,
   login,
 } from '../../page-objects/flows/login.flow';
+import { closeSettings } from '../../page-objects/flows/settings.flow';
 import { MOCK_GOOGLE_ACCOUNT, WALLET_PASSWORD } from '../../constants';
 import { OAuthMockttpService } from '../../helpers/seedless-onboarding/mocks';
 import {
@@ -51,7 +52,7 @@ describe('Unlock wallet - ', function () {
     );
   });
 
-  it('should show connections removed modal when max key chain length is reached for social account TEST', async function () {
+  it('should show connections removed modal when max key chain length is reached for social account', async function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilderV2({ onboarding: true }).build(),
@@ -95,7 +96,7 @@ describe('Unlock wallet - ', function () {
         // Wait for the password change to be applied to the social login user
         await driver.delay(2_000);
 
-        await settingsPage.clickBackButton();
+        await closeSettings(driver);
 
         await lockAndWaitForLoginPage(driver);
         const loginPage = new LoginPage(driver);

--- a/test/e2e/tests/identity/contact-syncing/backup-and-sync-settings.spec.ts
+++ b/test/e2e/tests/identity/contact-syncing/backup-and-sync-settings.spec.ts
@@ -13,6 +13,7 @@ import ContactsSettings from '../../../page-objects/pages/settings/contacts-sett
 import SettingsPage from '../../../page-objects/pages/settings/settings-page';
 import BackupAndSyncSettings from '../../../page-objects/pages/settings/backup-and-sync-settings';
 import { login } from '../../../page-objects/flows/login.flow';
+import { closeSettings } from '../../../page-objects/flows/settings.flow';
 import { skipOnFirefox } from '../helpers';
 import { arrangeContactSyncingTestUtils } from './helpers';
 
@@ -123,7 +124,7 @@ describe('Contact Syncing - Backup and Sync Settings', function () {
             );
 
           // Add a new contact via UI (like the account syncing test does)
-          await settingsPage.clickBackButton();
+          await closeSettings(driver);
           await header.openContactsPage();
           const contactsSettings = new ContactsSettings(driver);
           await contactsSettings.checkPageIsLoaded();
@@ -266,7 +267,7 @@ describe('Contact Syncing - Backup and Sync Settings', function () {
             );
 
           // Add a new contact via UI to test that syncing works when enabled
-          await settingsPage.clickBackButton();
+          await closeSettings(driver);
           await header.openContactsPage();
           const contactsSettings = new ContactsSettings(driver);
           await contactsSettings.checkPageIsLoaded();

--- a/test/e2e/tests/metrics/delete-metametrics-data.spec.ts
+++ b/test/e2e/tests/metrics/delete-metametrics-data.spec.ts
@@ -5,6 +5,7 @@ import { MOCK_META_METRICS_ID } from '../../constants';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { getEventPayloads, withFixtures } from '../../helpers';
 import { login } from '../../page-objects/flows/login.flow';
+import { closeSettings } from '../../page-objects/flows/settings.flow';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import HomePage from '../../page-objects/pages/home/homepage';
 import PrivacySettings from '../../page-objects/pages/settings/privacy-settings';
@@ -121,7 +122,7 @@ describe('Delete MetaMetrics Data', function (this: Suite) {
           environment_type: 'fullscreen',
         });
 
-        await settingsPage.clickBackButton();
+        await closeSettings(driver);
         await new HomePage(driver).checkPageIsLoaded();
         await headerNavbar.openSettingsPage();
         await settingsPage.checkPageIsLoaded();

--- a/test/e2e/tests/multichain/aggregated-balances.spec.ts
+++ b/test/e2e/tests/multichain/aggregated-balances.spec.ts
@@ -4,6 +4,7 @@ import { Driver } from '../../webdriver/driver';
 import { withFixtures } from '../../helpers';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { login } from '../../page-objects/flows/login.flow';
+import { closeSettings } from '../../page-objects/flows/settings.flow';
 import { SMART_CONTRACTS } from '../../seeder/smart-contracts';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import HomePage from '../../page-objects/pages/home/homepage';
@@ -76,7 +77,7 @@ describe('Multichain Aggregated Balances', function (this: Suite) {
         console.log('Step 3: Enable fiat balance display in settings');
         await headerNavbar.openSettingsPage();
         await settingsPage.toggleBalanceSetting();
-        await settingsPage.clickBackButton();
+        await closeSettings(driver);
 
         console.log('Step 4: Verify main balance on homepage and account menu');
         await homepage.checkExpectedBalanceIsDisplayed(
@@ -108,7 +109,7 @@ describe('Multichain Aggregated Balances', function (this: Suite) {
         await settingsPage.toggleBalanceSetting();
         await settingsPage.goToDeveloperOptions();
         await settingsPage.toggleShowFiatOnTestnets();
-        await settingsPage.clickBackButton();
+        await closeSettings(driver);
 
         console.log('Step 8: Verify USD balance on Sepolia network');
         await homepage.checkExpectedBalanceIsDisplayed(

--- a/test/e2e/tests/multichain/all-permissions-page.spec.ts
+++ b/test/e2e/tests/multichain/all-permissions-page.spec.ts
@@ -13,6 +13,7 @@ import PermissionListPage from '../../page-objects/pages/permission/permission-l
 import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import TestDapp from '../../page-objects/pages/test-dapp';
 import { login } from '../../page-objects/flows/login.flow';
+import { closeSettings } from '../../page-objects/flows/settings.flow';
 import { connectAccountToTestDapp } from '../../page-objects/flows/test-dapp.flow';
 
 describe('Permissions Page', function () {
@@ -68,7 +69,7 @@ describe('Permissions Page', function () {
 
         const experimentalSettings = new ExperimentalSettings(driver);
         await experimentalSettings.checkPageIsLoaded();
-        await settingsPage.clickBackButton();
+        await closeSettings(driver);
 
         // go to homepage and check site permissions
         await new Homepage(driver).checkPageIsLoaded();

--- a/test/e2e/tests/network/popular-network.spec.ts
+++ b/test/e2e/tests/network/popular-network.spec.ts
@@ -13,6 +13,7 @@ import SelectNetwork from '../../page-objects/pages/dialog/select-network';
 import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import PrivacySettings from '../../page-objects/pages/settings/privacy-settings';
 import { login } from '../../page-objects/flows/login.flow';
+import { closeSettings } from '../../page-objects/flows/settings.flow';
 
 const MOCK_CHAINLIST_RESPONSE = [
   {
@@ -230,7 +231,7 @@ describe('Popular Networks', function (this: Suite) {
         const privacySettings = new PrivacySettings(driver);
         await privacySettings.checkPageIsLoaded();
         await privacySettings.toggleNetworkDetailsCheck();
-        await settingsPage.clickBackButton();
+        await closeSettings(driver);
 
         // return to the home screen
         const homepage = new Homepage(driver);

--- a/test/e2e/tests/seedless-onboarding/refresh-auth-tokens.spec.ts
+++ b/test/e2e/tests/seedless-onboarding/refresh-auth-tokens.spec.ts
@@ -9,6 +9,7 @@ import { Driver } from '../../webdriver/driver';
 import HomePage from '../../page-objects/pages/home/homepage';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import { lockAndWaitForLoginPage } from '../../page-objects/flows/login.flow';
+import { closeSettings } from '../../page-objects/flows/settings.flow';
 import { AuthServer } from '../../helpers/seedless-onboarding/constants';
 import LoginPage from '../../page-objects/pages/login-page';
 import SettingsPage from '../../page-objects/pages/settings/settings-page';
@@ -93,7 +94,7 @@ describe('Refresh Auth Tokens (Seedless Onboarding)', function () {
         assert.strictEqual(authServiceTokenRequests.length, 2);
 
         // close the settings page
-        await settingsPage.clickBackButton();
+        await closeSettings(driver);
 
         // Lock the wallet and wait for login page
         await lockAndWaitForLoginPage(driver);

--- a/test/e2e/tests/settings/about-metamask-ui-validation.spec.ts
+++ b/test/e2e/tests/settings/about-metamask-ui-validation.spec.ts
@@ -8,6 +8,7 @@ import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import HomePage from '../../page-objects/pages/home/homepage';
 import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import { login } from '../../page-objects/flows/login.flow';
+import { closeSettings } from '../../page-objects/flows/settings.flow';
 
 // Test case to validate the view in the "About" - MetaMask.
 describe('Setting - About MetaMask :', function (this: Suite) {
@@ -34,7 +35,7 @@ describe('Setting - About MetaMask :', function (this: Suite) {
         await aboutPage.checkMetaMaskVersionNumber(version);
 
         // click on `close` button
-        await settingsPage.clickBackButton();
+        await closeSettings(driver);
 
         // wait for home page and validate the balance
         const homePage = new HomePage(driver);

--- a/test/e2e/tests/settings/account-token-list.spec.ts
+++ b/test/e2e/tests/settings/account-token-list.spec.ts
@@ -10,6 +10,7 @@ import HomePage from '../../page-objects/pages/home/homepage';
 import { switchToNetworkFromNetworkSelect } from '../../page-objects/flows/network.flow';
 import { getMockAssetsPrice } from '../tokens/utils/mocks';
 import { login } from '../../page-objects/flows/login.flow';
+import { closeSettings } from '../../page-objects/flows/settings.flow';
 
 const infuraSepoliaUrl =
   'https://sepolia.infura.io/v3/00000000000000000000000000000000';
@@ -141,7 +142,7 @@ describe('Settings', function () {
         const settingsPage = new SettingsPage(driver);
         await settingsPage.checkPageIsLoaded();
         await settingsPage.toggleBalanceSetting();
-        await settingsPage.clickBackButton();
+        await closeSettings(driver);
         await homePage.checkExpectedBalanceIsDisplayed('25', 'SepoliaETH');
       },
     );

--- a/test/e2e/tests/settings/change-password.spec.ts
+++ b/test/e2e/tests/settings/change-password.spec.ts
@@ -2,7 +2,6 @@ import { Mockttp } from 'mockttp';
 import { Browser } from 'selenium-webdriver';
 import { withFixtures } from '../../helpers';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
-import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import ChangePasswordPage from '../../page-objects/pages/settings/change-password-page';
 import PrivacySettings from '../../page-objects/pages/settings/privacy-settings';
 import LoginPage from '../../page-objects/pages/login-page';
@@ -18,6 +17,7 @@ import {
 } from '../../page-objects/flows/login.flow';
 import {
   changePasswordAndLockWallet,
+  closeSettings,
   navigateToSecurityAndPassword,
 } from '../../page-objects/flows/settings.flow';
 import { OAuthMockttpService } from '../../helpers/seedless-onboarding/mocks';
@@ -170,8 +170,7 @@ describe('Change wallet password', function () {
         // before the new password is persisted.
         await driver.delay(2_000);
 
-        const settingsPage = new SettingsPage(driver);
-        await settingsPage.clickBackButton();
+        await closeSettings(driver);
 
         await lockAndWaitForPasskeyUnlockPage(driver);
 

--- a/test/e2e/tests/settings/change-password.spec.ts
+++ b/test/e2e/tests/settings/change-password.spec.ts
@@ -13,48 +13,17 @@ import {
   importWalletWithSocialLoginOnboardingFlow,
 } from '../../page-objects/flows/onboarding.flow';
 import {
-  lockAndWaitForLoginPage,
   lockAndWaitForPasskeyUnlockPage,
   login,
 } from '../../page-objects/flows/login.flow';
-import { navigateToSecurityAndPassword } from '../../page-objects/flows/settings.flow';
+import {
+  changePasswordAndLockWallet,
+  navigateToSecurityAndPassword,
+} from '../../page-objects/flows/settings.flow';
 import { OAuthMockttpService } from '../../helpers/seedless-onboarding/mocks';
 import { Driver } from '../../webdriver/driver';
 import { MOCK_GOOGLE_ACCOUNT, WALLET_PASSWORD } from '../../constants';
 import { DUMMY_PASSKEY_RECORD } from '../../webdriver/virtual-authenticator';
-
-async function doPasswordChangeAndLockWallet(
-  driver: Driver,
-  currentPassword: string,
-  newPassword: string,
-  isSocialLogin: boolean = false,
-) {
-  await navigateToSecurityAndPassword(driver);
-
-  const privacySettings = new PrivacySettings(driver);
-  await privacySettings.openChangePassword();
-
-  const changePasswordPage = new ChangePasswordPage(driver);
-  await changePasswordPage.checkPageIsLoaded();
-
-  await changePasswordPage.confirmCurrentPassword(currentPassword);
-
-  await changePasswordPage.changePassword(newPassword);
-  if (isSocialLogin) {
-    await changePasswordPage.checkPasswordChangedWarning();
-    await changePasswordPage.confirmChangePasswordWarning();
-  }
-
-  // Password change triggers an async vault re-encryption. No UI element
-  // reliably signals completion, so a brief delay avoids navigating away
-  // before the new password is persisted.
-  await driver.delay(2_000);
-
-  const settingsPage = new SettingsPage(driver);
-  await settingsPage.clickBackButton();
-
-  await lockAndWaitForLoginPage(driver);
-}
 
 describe('Change wallet password', function () {
   const OLD_PASSWORD = WALLET_PASSWORD;
@@ -75,7 +44,7 @@ describe('Change wallet password', function () {
         const homePage = new HomePage(driver);
         await homePage.checkPageIsLoaded();
 
-        await doPasswordChangeAndLockWallet(driver, OLD_PASSWORD, NEW_PASSWORD);
+        await changePasswordAndLockWallet(driver, OLD_PASSWORD, NEW_PASSWORD);
 
         const loginPage = new LoginPage(driver);
 
@@ -111,8 +80,9 @@ describe('Change wallet password', function () {
 
         const homePage = new HomePage(driver);
         await homePage.checkPageIsLoaded();
+        await homePage.waitForNonEvmAccountsLoaded();
 
-        await doPasswordChangeAndLockWallet(
+        await changePasswordAndLockWallet(
           driver,
           OLD_PASSWORD,
           NEW_PASSWORD,
@@ -151,7 +121,7 @@ describe('Change wallet password', function () {
       async ({ driver }: { driver: Driver }) => {
         await login(driver, { ignorePasskeyUnlock: true });
 
-        await doPasswordChangeAndLockWallet(
+        await changePasswordAndLockWallet(
           driver,
           OLD_PASSWORD,
           PASSKEY_NEW_PASSWORD,

--- a/test/e2e/tests/settings/clear-activity.spec.ts
+++ b/test/e2e/tests/settings/clear-activity.spec.ts
@@ -5,6 +5,7 @@ import ActivityList from '../../page-objects/pages/home/activity-list';
 import HomePage from '../../page-objects/pages/home/homepage';
 import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import { login } from '../../page-objects/flows/login.flow';
+import { closeSettings } from '../../page-objects/flows/settings.flow';
 
 describe('Clear account activity', function (this: Suite) {
   // /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -39,7 +40,7 @@ describe('Clear account activity', function (this: Suite) {
         await settingsPage.goToDeveloperOptions();
         await settingsPage.clickDeveloperOptionsDeleteActivityAndNonceData();
         await settingsPage.confirmDeleteActivityAndNonceModal();
-        await settingsPage.clickBackButton();
+        await closeSettings(driver);
 
         await activityList.checkNoTxInActivity();
       },

--- a/test/e2e/tests/settings/hide-token-without-balance.spec.ts
+++ b/test/e2e/tests/settings/hide-token-without-balance.spec.ts
@@ -5,8 +5,8 @@ import { SMART_CONTRACTS } from '../../seeder/smart-contracts';
 import AssetListPage from '../../page-objects/pages/home/asset-list';
 import AssetsSettingsPage from '../../page-objects/pages/settings/assets-settings-page';
 import HomePage from '../../page-objects/pages/home/homepage';
-import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import { login } from '../../page-objects/flows/login.flow';
+import { closeSettings } from '../../page-objects/flows/settings.flow';
 
 describe('Hide tokens without balance', function (this: Suite) {
   // /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -47,8 +47,7 @@ describe('Hide tokens without balance', function (this: Suite) {
         const assetsSettings = new AssetsSettingsPage(driver);
         await assetsSettings.checkAssetsPageIsLoaded();
         await assetsSettings.toggleHideTokensWithoutBalance();
-        const settingsPage = new SettingsPage(driver);
-        await settingsPage.clickBackButton();
+        await closeSettings(driver);
 
         // Check that tokens with zero balances are hidden, tokens with non-zero balances remain visible
         await new HomePage(driver).checkPageIsLoaded();

--- a/test/e2e/tests/settings/ipfs-toggle.spec.ts
+++ b/test/e2e/tests/settings/ipfs-toggle.spec.ts
@@ -9,6 +9,7 @@ import NftListPage from '../../page-objects/pages/home/nft-list';
 import PrivacySettings from '../../page-objects/pages/settings/privacy-settings';
 import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import { login } from '../../page-objects/flows/login.flow';
+import { closeSettings } from '../../page-objects/flows/settings.flow';
 
 async function mockIPFSRequest(mockServer: MockttpServer) {
   return [
@@ -42,7 +43,7 @@ describe('Settings', function () {
         await privacySettings.checkPageIsLoaded();
         await privacySettings.goToThirdPartyApisSettings();
         await privacySettings.toggleIpfsGateway();
-        await settingsPage.clickBackButton();
+        await closeSettings(driver);
         const homePage = new Homepage(driver);
         await homePage.checkPageIsLoaded();
 

--- a/test/e2e/tests/settings/passkey-settings.spec.ts
+++ b/test/e2e/tests/settings/passkey-settings.spec.ts
@@ -5,14 +5,16 @@ import { Driver } from '../../webdriver/driver';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import HomePage from '../../page-objects/pages/home/homepage';
 import LoginPage from '../../page-objects/pages/login-page';
-import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import PrivacySettings from '../../page-objects/pages/settings/privacy-settings';
 import { completeOnboardingWithPasskey } from '../../page-objects/flows/onboarding.flow';
 import {
   lockAndWaitForLoginPage,
   login,
 } from '../../page-objects/flows/login.flow';
-import { navigateToSecurityAndPassword } from '../../page-objects/flows/settings.flow';
+import {
+  closeSettings,
+  navigateToSecurityAndPassword,
+} from '../../page-objects/flows/settings.flow';
 import { DUMMY_PASSKEY_RECORD } from '../../webdriver/virtual-authenticator';
 
 describe('Passkey settings', function () {
@@ -45,8 +47,7 @@ describe('Passkey settings', function () {
 
         await privacySettings.checkSecurityAndPasswordPageIsLoaded();
 
-        const settingsPage = new SettingsPage(driver);
-        await settingsPage.clickBackButton();
+        await closeSettings(driver);
 
         await lockAndWaitForLoginPage(driver);
 

--- a/test/e2e/tests/settings/preferences-and-display-language.spec.ts
+++ b/test/e2e/tests/settings/preferences-and-display-language.spec.ts
@@ -8,6 +8,7 @@ import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import Homepage from '../../page-objects/pages/home/homepage';
 import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import { login } from '../../page-objects/flows/login.flow';
+import { closeSettings } from '../../page-objects/flows/settings.flow';
 import ar from '../../../../app/_locales/ar/messages.json';
 import da from '../../../../app/_locales/da/messages.json';
 import de from '../../../../app/_locales/de/messages.json';
@@ -150,8 +151,7 @@ describe('Settings - Preferences and display', function (this: Suite) {
         );
         assert.equal(isLanguageLabelChanged, true, 'Language did not change');
 
-        const settingsPage = new SettingsPage(driver);
-        await settingsPage.clickBackButton();
+        await closeSettings(driver);
 
         const homepage = new Homepage(driver);
         await homepage.checkPageIsLoaded();
@@ -189,8 +189,7 @@ describe('Settings - Preferences and display', function (this: Suite) {
         );
         assert.equal(isLabelTextChanged, true, 'Language did not change');
 
-        const settingsPage = new SettingsPage(driver);
-        await settingsPage.clickBackButton();
+        await closeSettings(driver);
         const homepage = new Homepage(driver);
         await homepage.checkPageIsLoaded();
         await homepage.checkExpectedBalanceIsDisplayed();
@@ -226,7 +225,7 @@ describe('Settings - Preferences and display', function (this: Suite) {
         await preferencesAndDisplaySettings.changeLanguage('العربية');
 
         const settingsPage = new SettingsPage(driver);
-        await settingsPage.clickBackButton();
+        await closeSettings(driver);
         await new HeaderNavbar(driver).openSettingsPage();
         await settingsPage.checkPageIsLoaded();
 

--- a/test/e2e/tests/settings/show-default-address.spec.ts
+++ b/test/e2e/tests/settings/show-default-address.spec.ts
@@ -3,8 +3,8 @@ import { withFixtures } from '../../helpers';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import PreferencesAndDisplaySettings from '../../page-objects/pages/settings/preferences-and-display-settings';
 import HomePage from '../../page-objects/pages/home/homepage';
-import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import { login } from '../../page-objects/flows/login.flow';
+import { closeSettings } from '../../page-objects/flows/settings.flow';
 
 const SHOW_DEFAULT_ADDRESS_FLAG = {
   remoteFeatureFlags: { extensionUxDefaultAddressVersioned: true },
@@ -69,8 +69,7 @@ describe('Show default address', function (this: Suite) {
         );
         await preferencesAndDisplaySettings.checkPageIsLoaded();
         await preferencesAndDisplaySettings.toggleShowDefaultAddress();
-        const settingsPage = new SettingsPage(driver);
-        await settingsPage.clickBackButton();
+        await closeSettings(driver);
 
         // Check on home page that default address is not present
         await homePage.checkPageIsLoaded();

--- a/test/e2e/tests/settings/show-native-as-main-balance.spec.ts
+++ b/test/e2e/tests/settings/show-native-as-main-balance.spec.ts
@@ -7,6 +7,7 @@ import HomePage from '../../page-objects/pages/home/homepage';
 import PreferencesAndDisplaySettings from '../../page-objects/pages/settings/preferences-and-display-settings';
 import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import { login } from '../../page-objects/flows/login.flow';
+import { closeSettings } from '../../page-objects/flows/settings.flow';
 
 async function mockPriceApi(mockServer: Mockttp) {
   const spotPricesMockEth = await mockServer
@@ -94,7 +95,7 @@ describe('Settings: Show native token as main balance', function () {
         await settingsPage.goToAssetsSettings();
         await assetsSettings.checkAssetsPageIsLoaded();
         await assetsSettings.toggleShowNativeTokenAsMainBalance();
-        await settingsPage.clickBackButton();
+        await closeSettings(driver);
 
         // assert amount displayed
         const assetListPage = new AssetListPage(driver);
@@ -128,12 +129,12 @@ describe('Settings: Show native token as main balance', function () {
         await settingsPage.goToAssetsSettings();
         await assetsSettings.checkAssetsPageIsLoaded();
         await assetsSettings.toggleShowNativeTokenAsMainBalance();
-        await settingsPage.clickBackButton();
+        await closeSettings(driver);
 
         // go to setting and back to home page and make sure popover is not shown again
         await homePage.headerNavbar.openSettingsPage();
         await settingsPage.checkPageIsLoaded();
-        await settingsPage.clickBackButton();
+        await closeSettings(driver);
         await homePage.checkPageIsLoaded();
       },
     );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

I found that the clickBackButton from settings had a workaround (instead of a click) because sometimes the click 'takes no effect' and we remain in Settibngs, so that method was using a script to go Home. This method was flaky.

The reason of this behaviour is that the back button from settings not necessarily closes the settings page, if we are more than 1 level up of the pages (if we are not on the Preference page, but on another one -- see video below).

The workaraound has now been removed:
- we have a new method called closeSettings in the settings page class: this method adds a loop where it clicks the back button and if we are still in settings (one level down) we click it again.
- we have a flow for closing the settings AND the navbar, as if this is not done, the navbar remains open, breaking several tests. Before this didn't happen as we navigated to the home route with the drawer closed, but now is needed. This represents the user actions

Some other changes:
- moved a function from a spec file to a flow file
- reordered a page object class and removed it from the excluded lint rule list for alphabetical order

https://github.com/user-attachments/assets/b4f48cd7-d725-45bc-8e21-db303d287b1d


Extra note: tests where run with the e2e quality gate. After that I needed to fix lint, so that's why I added the skip quality gate, as changed files already run extra times. See full e2e run here https://github.com/MetaMask/metamask-extension/actions/runs/27195671725/job/80286845407?pr=43355

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: unblocks ci and as well fixes this refactor task https://consensyssoftware.atlassian.net/browse/MMQA-1919

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to E2E page objects, flows, and specs; no production wallet or auth logic is modified.
> 
> **Overview**
> Replaces flaky settings exit behavior in E2E tests with a **realistic navigation flow** instead of forcing home via `window.location.hash`.
> 
> **`SettingsPage`** no longer jumps to `/` on “back.” **`closeSettings()`** repeatedly clicks the settings header back control (up to five times) until the URL is no longer on settings, which fixes nested settings pages where one back click only pops one level. **`settings.flow`** adds **`closeSettings(driver)`** to run that loop and then **`clickDrawerBackButton()`** so the account drawer is not left open (a common failure after leaving settings).
> 
> Specs that used **`clickBackButton()`** or inline password-change helpers now call **`closeSettings`** and **`changePasswordAndLockWallet`** from **`settings.flow`**. **`change-password.spec`** drops its local helper in favor of the shared flow; social-login case adds **`waitForNonEvmAccountsLoaded`**. **`ChangePasswordPage`** is reordered for page-object lint rules and **`confirmChangePasswordWarning`** waits for the modal to disappear.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d358d4e6f227340413f3bace08d639df24154722. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->