### PR TITLE
feat: add optimizations to QR code scanning process

### DIFF
--- a/ui/components/app/qr-hardware-popover/enhanced-qr-reader/enhanced-qr-reader.test.tsx
+++ b/ui/components/app/qr-hardware-popover/enhanced-qr-reader/enhanced-qr-reader.test.tsx
@@ -10,7 +10,11 @@ jest.mock('@zxing/browser', () => ({
 
 jest.mock('@zxing/library', () => ({
   BarcodeFormat: { QR_CODE: 'QR_CODE' },
-  DecodeHintType: { POSSIBLE_FORMATS: 'POSSIBLE_FORMATS' },
+  DecodeHintType: {
+    POSSIBLE_FORMATS: 'POSSIBLE_FORMATS',
+    TRY_HARDER: 'TRY_HARDER',
+    CHARACTER_SET: 'CHARACTER_SET',
+  },
 }));
 
 const MockBrowserQRCodeReader = BrowserQRCodeReader as jest.MockedClass<
@@ -18,17 +22,17 @@ const MockBrowserQRCodeReader = BrowserQRCodeReader as jest.MockedClass<
 >;
 
 describe('EnhancedQrReader', () => {
-  let mockDecodeFromVideoDevice: jest.Mock;
+  let mockDecodeFromConstraints: jest.Mock;
   let mockControls: { stop: jest.Mock };
 
   beforeEach(() => {
     mockControls = { stop: jest.fn() };
-    mockDecodeFromVideoDevice = jest.fn().mockResolvedValue(mockControls);
+    mockDecodeFromConstraints = jest.fn().mockResolvedValue(mockControls);
 
     MockBrowserQRCodeReader.mockImplementation(
       () =>
         ({
-          decodeFromVideoDevice: mockDecodeFromVideoDevice,
+          decodeFromConstraints: mockDecodeFromConstraints,
         }) as unknown as BrowserQRCodeReader,
     );
   });
@@ -62,23 +66,38 @@ describe('EnhancedQrReader', () => {
   });
 
   describe('QR reader initialization', () => {
-    it('configures BrowserQRCodeReader with scan interval options', () => {
+    it('configures BrowserQRCodeReader with optimized scan intervals', () => {
       render(<EnhancedQrReader onFrame={jest.fn()} />);
 
       expect(MockBrowserQRCodeReader).toHaveBeenCalledWith(
         expect.any(Map),
         expect.objectContaining({
-          delayBetweenScanAttempts: 100,
-          delayBetweenScanSuccess: 100,
+          delayBetweenScanAttempts: 80,
+          delayBetweenScanSuccess: 50,
         }),
       );
     });
 
-    it('starts decoding from the video element ref', () => {
+    it('enables TRY_HARDER and CHARACTER_SET decode hints', () => {
       render(<EnhancedQrReader onFrame={jest.fn()} />);
 
-      expect(mockDecodeFromVideoDevice).toHaveBeenCalledWith(
-        undefined,
+      const [hintsArg] = MockBrowserQRCodeReader.mock.calls[0] ?? [];
+      const hints = hintsArg as unknown as Map<string, unknown>;
+      expect(hints.get('TRY_HARDER')).toBe(true);
+      expect(hints.get('CHARACTER_SET')).toBe('UTF-8');
+    });
+
+    it('starts decoding with HD video constraints', () => {
+      render(<EnhancedQrReader onFrame={jest.fn()} />);
+
+      expect(mockDecodeFromConstraints).toHaveBeenCalledWith(
+        expect.objectContaining({
+          audio: false,
+          video: expect.objectContaining({
+            width: { min: 640, ideal: 1280 },
+            height: { min: 480, ideal: 720 },
+          }),
+        }),
         expect.any(HTMLVideoElement),
         expect.any(Function),
       );
@@ -88,8 +107,8 @@ describe('EnhancedQrReader', () => {
   describe('onFrame callback', () => {
     it('invokes onFrame with decoded text on successful scan', () => {
       const onFrame = jest.fn();
-      mockDecodeFromVideoDevice.mockImplementation(
-        (_device, _elem, callback) => {
+      mockDecodeFromConstraints.mockImplementation(
+        (_constraints, _elem, callback) => {
           callback({ getText: () => 'decoded-payload' });
           return Promise.resolve(mockControls);
         },
@@ -102,8 +121,8 @@ describe('EnhancedQrReader', () => {
 
     it('does not invoke onFrame when result is undefined', () => {
       const onFrame = jest.fn();
-      mockDecodeFromVideoDevice.mockImplementation(
-        (_device, _elem, callback) => {
+      mockDecodeFromConstraints.mockImplementation(
+        (_constraints, _elem, callback) => {
           callback(undefined);
           return Promise.resolve(mockControls);
         },
@@ -129,7 +148,7 @@ describe('EnhancedQrReader', () => {
     });
 
     it('handles gracefully when controls resolve to undefined', async () => {
-      mockDecodeFromVideoDevice.mockResolvedValue(undefined);
+      mockDecodeFromConstraints.mockResolvedValue(undefined);
 
       const { unmount } = render(<EnhancedQrReader onFrame={jest.fn()} />);
 
@@ -144,7 +163,7 @@ describe('EnhancedQrReader', () => {
 
     it('logs rejection instead of throwing when cleanup fails', async () => {
       const logDebugSpy = jest.spyOn(log, 'debug');
-      mockDecodeFromVideoDevice.mockRejectedValue(new Error('cleanup failed'));
+      mockDecodeFromConstraints.mockRejectedValue(new Error('cleanup failed'));
 
       const { unmount } = render(<EnhancedQrReader onFrame={jest.fn()} />);
 

--- a/ui/components/app/qr-hardware-popover/enhanced-qr-reader/enhanced-qr-reader.test.tsx
+++ b/ui/components/app/qr-hardware-popover/enhanced-qr-reader/enhanced-qr-reader.test.tsx
@@ -94,8 +94,8 @@ describe('EnhancedQrReader', () => {
         expect.objectContaining({
           audio: false,
           video: expect.objectContaining({
-            width: { min: 640, ideal: 1280 },
-            height: { min: 480, ideal: 720 },
+            width: { ideal: 1280 },
+            height: { ideal: 720 },
           }),
         }),
         expect.any(HTMLVideoElement),

--- a/ui/components/app/qr-hardware-popover/enhanced-qr-reader/enhanced-qr-reader.tsx
+++ b/ui/components/app/qr-hardware-popover/enhanced-qr-reader/enhanced-qr-reader.tsx
@@ -14,14 +14,13 @@ const SCAN_ATTEMPT_DELAY_MS = MILLISECOND * 80;
 // animated multi-part UR QR codes are captured faster.
 const SCAN_SUCCESS_DELAY_MS = MILLISECOND * 50;
 
-// Video constraints requesting HD resolution for clearer QR detection.
-// The `ideal` values let the browser negotiate the best available
-// resolution without failing if the camera cannot reach 720p.
+// Request HD resolution for clearer QR detection. Uses `ideal` rather
+// than `min` so cameras that cannot deliver 720p still work.
 const VIDEO_CONSTRAINTS: MediaStreamConstraints = {
   audio: false,
   video: {
-    width: { min: 640, ideal: 1280 },
-    height: { min: 480, ideal: 720 },
+    width: { ideal: 1280 },
+    height: { ideal: 720 },
   },
 };
 
@@ -86,6 +85,10 @@ const EnhancedQrReader = ({ onFrame }: EnhancedQrReaderProps) => {
         }
       },
     );
+
+    // Prevent unhandled rejection if the stream fails to start (e.g.
+    // camera disconnected between the permission probe and here).
+    promise.catch(log.debug);
 
     return () => {
       promise.then((controls) => controls?.stop()).catch(log.debug);

--- a/ui/components/app/qr-hardware-popover/enhanced-qr-reader/enhanced-qr-reader.tsx
+++ b/ui/components/app/qr-hardware-popover/enhanced-qr-reader/enhanced-qr-reader.tsx
@@ -6,8 +6,24 @@ import { MILLISECOND } from '../../../../../shared/constants/time';
 import Spinner from '../../../ui/spinner';
 import type { EnhancedQrReaderProps } from './enhanced-qr-reader.types';
 
-// Delay between ZXing scan attempts and successes to avoid CPU thrashing.
-const SCAN_INTERVAL_MS = MILLISECOND * 100;
+// Delay after a failed decode attempt. Kept moderate to prevent CPU
+// thrashing while still retrying promptly.
+const SCAN_ATTEMPT_DELAY_MS = MILLISECOND * 80;
+
+// Delay after a successful decoding. Lower than the attempt delay so
+// animated multi-part UR QR codes are captured faster.
+const SCAN_SUCCESS_DELAY_MS = MILLISECOND * 50;
+
+// Video constraints requesting HD resolution for clearer QR detection.
+// The `ideal` values let the browser negotiate the best available
+// resolution without failing if the camera cannot reach 720p.
+const VIDEO_CONSTRAINTS: MediaStreamConstraints = {
+  audio: false,
+  video: {
+    width: { min: 640, ideal: 1280 },
+    height: { min: 480, ideal: 720 },
+  },
+};
 
 /**
  * Continuous QR code scanner using ZXing.
@@ -27,9 +43,13 @@ const EnhancedQrReader = ({ onFrame }: EnhancedQrReaderProps) => {
   const codeReader = useMemo(() => {
     const hints = new Map();
     hints.set(DecodeHintType.POSSIBLE_FORMATS, [BarcodeFormat.QR_CODE]);
+    // Multi-pass detection for blurry or angled frames.
+    hints.set(DecodeHintType.TRY_HARDER, true);
+    // Explicit encoding to avoid heuristic guessing across platforms.
+    hints.set(DecodeHintType.CHARACTER_SET, 'UTF-8');
     return new BrowserQRCodeReader(hints, {
-      delayBetweenScanAttempts: SCAN_INTERVAL_MS,
-      delayBetweenScanSuccess: SCAN_INTERVAL_MS,
+      delayBetweenScanAttempts: SCAN_ATTEMPT_DELAY_MS,
+      delayBetweenScanSuccess: SCAN_SUCCESS_DELAY_MS,
     });
   }, []);
 
@@ -49,16 +69,16 @@ const EnhancedQrReader = ({ onFrame }: EnhancedQrReaderProps) => {
     };
   }, []);
 
-  // Starts the camera stream and continuous QR decoding.
-  // Cleanup stops the stream when the component unmounts or deps change.
+  // Starts the camera stream with explicit resolution constraints and
+  // continuous QR decoding. Cleanup stops the stream on unmounting.
   useEffect(() => {
     const videoElem = videoRef.current;
     if (!videoElem) {
       return undefined;
     }
 
-    const promise = codeReader.decodeFromVideoDevice(
-      undefined,
+    const promise = codeReader.decodeFromConstraints(
+      VIDEO_CONSTRAINTS,
       videoElem,
       (result) => {
         if (result) {
@@ -79,6 +99,8 @@ const EnhancedQrReader = ({ onFrame }: EnhancedQrReaderProps) => {
         style={{
           display: canPlay ? 'block' : 'none',
           width: '100%',
+          aspectRatio: '1',
+          objectFit: 'cover',
           filter: 'blur(4px)',
         }}
       />

--- a/ui/components/app/qr-hardware-popover/qr-hooks/decoder-lifecycle/useDecoderLifecycle.test.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/decoder-lifecycle/useDecoderLifecycle.test.ts
@@ -77,6 +77,30 @@ describe('useDecoderLifecycle', () => {
       expect(mockSetScanProgress).not.toHaveBeenCalled();
     });
 
+    it('skips processing when receiving the same frame content twice', () => {
+      const mockInstance = {
+        isComplete: jest.fn().mockReturnValue(false),
+        isError: jest.fn().mockReturnValue(false),
+        receivePart: jest.fn(),
+        estimatedPercentComplete: jest.fn().mockReturnValue(0.25),
+        resultUR: jest.fn(),
+      };
+      mockURDecoder.mockImplementation(
+        () => mockInstance as unknown as URDecoder,
+      );
+
+      const { result } = renderDecoderHook();
+
+      act(() => {
+        result.current.handleScan('ur:crypto-hdkey/frame-1');
+        result.current.handleScan('ur:crypto-hdkey/frame-1');
+        result.current.handleScan('ur:crypto-hdkey/frame-1');
+      });
+
+      expect(mockInstance.receivePart).toHaveBeenCalledTimes(1);
+      expect(mockSetScanProgress).toHaveBeenCalledTimes(1);
+    });
+
     it('feeds data into the decoder and updates progress', () => {
       const mockInstance = {
         isComplete: jest.fn().mockReturnValue(false),
@@ -124,6 +148,32 @@ describe('useDecoderLifecycle', () => {
       });
 
       expect(mockHandleSuccess).toHaveBeenCalledWith(mockResult);
+    });
+
+    it('does not update progress when decoder completes immediately', () => {
+      const mockResult = { type: UrType.CryptoHdkey };
+      const mockInstance = {
+        isComplete: jest
+          .fn()
+          .mockReturnValueOnce(false)
+          .mockReturnValueOnce(true),
+        isError: jest.fn().mockReturnValue(false),
+        receivePart: jest.fn(),
+        estimatedPercentComplete: jest.fn().mockReturnValue(1),
+        resultUR: jest.fn().mockReturnValue(mockResult),
+      };
+      mockURDecoder.mockImplementation(
+        () => mockInstance as unknown as URDecoder,
+      );
+
+      const { result } = renderDecoderHook();
+
+      act(() => {
+        result.current.handleScan('single-frame-qr');
+      });
+
+      expect(mockHandleSuccess).toHaveBeenCalledWith(mockResult);
+      expect(mockSetScanProgress).not.toHaveBeenCalled();
     });
 
     it('does not process data when decoder is already complete', () => {

--- a/ui/components/app/qr-hardware-popover/qr-hooks/decoder-lifecycle/useDecoderLifecycle.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/decoder-lifecycle/useDecoderLifecycle.ts
@@ -69,9 +69,17 @@ export function useDecoderLifecycle(
         if (!data || decoder.isComplete()) {
           return;
         }
+
+        // Between animation frame transitions the camera may decode the
+        // same content multiple times. Skipping duplicates avoids
+        // redundant fountain-code work and unnecessary state updates.
+        if (data === lastScannedTextRef.current) {
+          return;
+        }
         lastScannedTextRef.current = data;
+
         decoder.receivePart(data);
-        setScanProgress(decoder.estimatedPercentComplete());
+
         // Fountain decoding can fail silently (e.g. checksum mismatch) without
         // throwing. Detect this before checking isComplete so the error is surfaced.
         if (decoder.isError()) {
@@ -84,6 +92,7 @@ export function useDecoderLifecycle(
           }
           return;
         }
+
         if (decoder.isComplete()) {
           const result = decoder.resultUR();
 
@@ -100,7 +109,13 @@ export function useDecoderLifecycle(
           handleSuccess(result).catch((successError: WebcamError) =>
             setError(successError),
           );
+          return;
         }
+
+        // Progress is only updated for incomplete multi-frame scans.
+        // Single-frame QR codes complete immediately above, avoiding a
+        // needless state update and React re-render.
+        setScanProgress(decoder.estimatedPercentComplete());
       } catch (exception) {
         const detectedError = classifyScanResult({
           text: lastScannedTextRef.current ?? undefined,


### PR DESCRIPTION
## **Description**
This PR adds optimizations for QR code scanning which we're using in QR hardware wallet flows.

### Noticeable scanning improvements after manual testing
- Faster scanning of simpler QR codes.
- Faster scanning from more distance (when QR device is more far away from the camera).
- Faster scanning and error identification for multi QR.

### Additional notes:
#### For scanning to be quick and successful:
- Screen needs to be clean.
- Screen needs to be bright (increase brightness).
- QR code must be in fullscreen mode with white background.

#### Sources of interference that are still problematic:
- Very bad angle of a device while scanning.
- Large reflections on screen due to unique lighting of the surrounding environment.
- Very small, but complex QR code (not in fullscreen)
- Low brightness of the screen.
- Fingerprints on the screen combined with reflections.

#### Conclusion
While the QR scanning is improved, and is more robust and quicker, we still need to educate users about the scanning process and conditions.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1851

## **Manual testing steps**
1. Try scanning valid and invalid QR codes within the "Pairing" flow.
2. Try scanning valid and invalid QR codes within the "Signing" flow.
3. Make sure everything works as expected.
4. Make sure that there are no regressions.
5. Make sure that scanning performance has improved.

## **Screenshots/Recordings**
### **Before**
No UI changes. Nothing to show here.

### **After**
No UI changes. Nothing to show here.

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to QR reader tuning and scan-loop efficiency in the hardware popover; behavior is covered by updated unit tests with no auth or transaction logic touched.
> 
> **Overview**
> **Improves QR hardware wallet scanning** by tuning the camera reader and reducing redundant UR decoding work.
> 
> `EnhancedQrReader` now starts the stream via **`decodeFromConstraints`** with **720p ideal** resolution, adds ZXing **`TRY_HARDER`** and **UTF-8** hints, and uses **faster scan intervals** (80ms between attempts, 50ms after success). Stream start failures are **caught** so they do not surface as unhandled rejections, and the preview uses a **square aspect ratio** with **`object-fit: cover`**.
> 
> `useDecoderLifecycle` **ignores consecutive identical QR payloads** so animated UR frames are not fed to the decoder repeatedly, and it **skips progress updates** when a scan completes in one frame. Tests cover the new reader settings and decoder behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db86a0b5104d6d23af754c376efe4f5320307a2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->