### PR TITLE
feat: updated API for token management list cp-13.35.0

### DIFF
--- a/shared/lib/token-search/token-search-api.test.ts
+++ b/shared/lib/token-search/token-search-api.test.ts
@@ -130,9 +130,64 @@ describe('browseTokens', () => {
     jest.restoreAllMocks();
   });
 
-  it('uses token search with a blank query and preserves network pagination', async () => {
-    const payload = {
+  it('fetches chain assets with occurrences and merges paginated results', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({
+          data: [
+            {
+              assetId: 'eip155:1/erc20:0xaaa',
+              symbol: 'AAA',
+              decimals: 18,
+              name: 'Alpha',
+            },
+          ],
+          count: 1,
+          totalCount: 10,
+          pageInfo: { hasNextPage: true, endCursor: 'eth-cursor' },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({
+          data: [
+            {
+              assetId:
+                'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
+              symbol: 'USDC',
+              decimals: 6,
+              name: 'USD Coin',
+            },
+          ],
+          count: 1,
+          totalCount: 20,
+          pageInfo: { hasNextPage: false, endCursor: '' },
+        }),
+      });
+    global.fetch = fetchMock as unknown as typeof global.fetch;
+
+    const response = await browseTokens({
+      networks: ['eip155:1', 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
+      first: 25,
+      after: JSON.stringify({
+        'eip155:1': 'MA==',
+      }),
+    });
+
+    expect(response).toStrictEqual({
       data: [
+        {
+          assetId: 'eip155:1/erc20:0xaaa',
+          symbol: 'AAA',
+          decimals: 18,
+          name: 'Alpha',
+        },
         {
           assetId:
             'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v',
@@ -141,29 +196,23 @@ describe('browseTokens', () => {
           name: 'USD Coin',
         },
       ],
-      count: 1,
-      totalCount: 30_947,
-      pageInfo: { hasNextPage: true, endCursor: 'MjQ=' },
-    };
-    const fetchMock = jest.fn().mockResolvedValue({
-      ok: true,
-      status: 200,
-      statusText: 'OK',
-      json: async () => payload,
+      count: 2,
+      totalCount: 30,
+      pageInfo: {
+        hasNextPage: true,
+        endCursor: JSON.stringify({
+          'eip155:1': 'eth-cursor',
+        }),
+      },
     });
-    global.fetch = fetchMock as unknown as typeof global.fetch;
-
-    const response = await browseTokens({
-      networks: ['eip155:1', 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
-      first: 25,
-      after: 'MA==',
-    });
-
-    expect(response).toStrictEqual(payload);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
     const [url] = fetchMock.mock.calls[0];
     expect(url).toBe(
-      'https://token.api.cx.metamask.io/tokens/search?query=+&networks=eip155%3A1%2Csolana%3A5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp&first=25&after=MA%3D%3D',
+      'https://tokens.api.cx.metamask.io/v3/chains/eip155:1/assets?first=25&occurrenceFloor=3&after=MA%3D%3D',
+    );
+    const [secondUrl] = fetchMock.mock.calls[1];
+    expect(secondUrl).toBe(
+      'https://tokens.api.cx.metamask.io/v3/chains/solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/assets?first=25&occurrenceFloor=3',
     );
   });
 
@@ -176,7 +225,69 @@ describe('browseTokens', () => {
     }) as unknown as typeof global.fetch;
 
     await expect(browseTokens({ networks: ['eip155:1'] })).rejects.toThrow(
-      /Token search failed: 500/u,
+      /Token browse failed: 500/u,
     );
+  });
+
+  it('keeps successful chain results when some browse requests fail with 400', async () => {
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        json: async () => ({
+          data: [
+            {
+              assetId: 'eip155:1/erc20:0xaaa',
+              symbol: 'AAA',
+              decimals: 18,
+              name: 'Alpha',
+            },
+          ],
+          count: 1,
+          totalCount: 1,
+          pageInfo: { hasNextPage: false, endCursor: '' },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 400,
+        statusText: 'Bad Request',
+        json: async () => ({}),
+      });
+    global.fetch = fetchMock as unknown as typeof global.fetch;
+
+    await expect(
+      browseTokens({
+        networks: ['eip155:1', 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp'],
+        first: 25,
+      }),
+    ).resolves.toStrictEqual({
+      data: [
+        {
+          assetId: 'eip155:1/erc20:0xaaa',
+          symbol: 'AAA',
+          decimals: 18,
+          name: 'Alpha',
+        },
+      ],
+      count: 1,
+      totalCount: 1,
+      pageInfo: { hasNextPage: false, endCursor: '' },
+    });
+  });
+
+  it('returns an empty page when no networks are provided', async () => {
+    const fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof global.fetch;
+
+    await expect(browseTokens({})).resolves.toStrictEqual({
+      data: [],
+      count: 0,
+      totalCount: 0,
+      pageInfo: { hasNextPage: false, endCursor: '' },
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
   });
 });

--- a/shared/lib/token-search/token-search-api.test.ts
+++ b/shared/lib/token-search/token-search-api.test.ts
@@ -130,7 +130,7 @@ describe('browseTokens', () => {
     jest.restoreAllMocks();
   });
 
-  it('fetches chain assets with occurrences and merges paginated results', async () => {
+  it('applies occurrence floor only to EVM chains and merges paginated results', async () => {
     const fetchMock = jest
       .fn()
       .mockResolvedValueOnce({
@@ -212,7 +212,7 @@ describe('browseTokens', () => {
     );
     const [secondUrl] = fetchMock.mock.calls[1];
     expect(secondUrl).toBe(
-      'https://tokens.api.cx.metamask.io/v3/chains/solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/assets?first=25&occurrenceFloor=3',
+      'https://tokens.api.cx.metamask.io/v3/chains/solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/assets?first=25',
     );
   });
 

--- a/shared/lib/token-search/token-search-api.ts
+++ b/shared/lib/token-search/token-search-api.ts
@@ -2,8 +2,8 @@ import getFetchWithTimeout from '../fetch-with-timeout';
 import { TEN_SECONDS_IN_MILLISECONDS } from '../transactions-controller-utils';
 
 const TOKEN_SEARCH_BASE_URL = 'https://token.api.cx.metamask.io';
-// A single-space query is the API browse mode and still returns cursor pages.
-const TOKEN_BROWSE_QUERY = ' ';
+const TOKEN_V3_BASE_URL = 'https://tokens.api.cx.metamask.io';
+const DEFAULT_BROWSE_OCCURRENCE_FLOOR = 3;
 
 export type TokenSearchResult = {
   assetId: string;
@@ -36,6 +36,15 @@ export type SearchTokensOptions = {
 };
 
 export type BrowseTokensOptions = Omit<SearchTokensOptions, 'query'>;
+
+type ChainAssetsResponse = {
+  data?: TokenSearchResult[];
+  count?: number;
+  totalCount?: number;
+  pageInfo?: Partial<TokenSearchPageInfo>;
+};
+
+type BrowseCursorState = Record<string, string | undefined>;
 
 export const buildTokenSearchQueryString = (
   options: Omit<SearchTokensOptions, 'signal'>,
@@ -79,17 +88,32 @@ const fetchTokenSearch = async (
   return (await response.json()) as TokenSearchResponse;
 };
 
+const getEmptyTokenSearchResponse = (): TokenSearchResponse => ({
+  data: [],
+  count: 0,
+  totalCount: 0,
+  pageInfo: { hasNextPage: false, endCursor: '' },
+});
+
+const parseBrowseCursorState = (cursor?: string): BrowseCursorState => {
+  if (!cursor) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(cursor) as BrowseCursorState;
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+};
+
 export const searchTokens = async (
   options: SearchTokensOptions,
 ): Promise<TokenSearchResponse> => {
   const trimmedQuery = options.query.trim();
   if (!trimmedQuery) {
-    return {
-      data: [],
-      count: 0,
-      totalCount: 0,
-      pageInfo: { hasNextPage: false, endCursor: '' },
-    };
+    return getEmptyTokenSearchResponse();
   }
 
   return fetchTokenSearch({
@@ -100,8 +124,92 @@ export const searchTokens = async (
 
 export const browseTokens = async (
   options: BrowseTokensOptions,
-): Promise<TokenSearchResponse> =>
-  fetchTokenSearch({
-    ...options,
-    query: TOKEN_BROWSE_QUERY,
-  });
+): Promise<TokenSearchResponse> => {
+  if (!options.networks || options.networks.length === 0) {
+    return getEmptyTokenSearchResponse();
+  }
+
+  const fetchWithTimeout = getFetchWithTimeout(TEN_SECONDS_IN_MILLISECONDS);
+  const cursorState = parseBrowseCursorState(options.after);
+
+  const settledResponses = await Promise.allSettled(
+    options.networks.map(async (chainId) => {
+      const url = new URL(
+        `${TOKEN_V3_BASE_URL}/v3/chains/${chainId}/assets`,
+      );
+      if (typeof options.first === 'number') {
+        url.searchParams.set('first', String(options.first));
+      }
+      url.searchParams.set(
+        'occurrenceFloor',
+        String(DEFAULT_BROWSE_OCCURRENCE_FLOOR),
+      );
+
+      const chainCursor = cursorState[chainId];
+      if (chainCursor) {
+        url.searchParams.set('after', chainCursor);
+      }
+
+      const response = await fetchWithTimeout(url.toString(), {
+        method: 'GET',
+        headers: { 'X-Client-Id': 'extension' },
+        signal: options.signal,
+      });
+
+      if (!response.ok) {
+        throw new Error(
+          `Token browse failed: ${response.status} ${response.statusText}`,
+        );
+      }
+
+      return [chainId, (await response.json()) as ChainAssetsResponse] as const;
+    }),
+  );
+
+  const responses = settledResponses
+    .filter(
+      (
+        response,
+      ): response is PromiseFulfilledResult<
+        readonly [string, ChainAssetsResponse]
+      > => response.status === 'fulfilled',
+    )
+    .map((response) => response.value);
+
+  if (responses.length === 0) {
+    const firstRejected = settledResponses.find(
+      (response): response is PromiseRejectedResult =>
+        response.status === 'rejected',
+    );
+    if (firstRejected) {
+      throw firstRejected.reason;
+    }
+
+    return getEmptyTokenSearchResponse();
+  }
+
+  const data = responses.flatMap(([, response]) => response.data ?? []);
+  const totalCount = responses.reduce(
+    (sum, [, response]) => sum + (response.totalCount ?? response.count ?? 0),
+    0,
+  );
+
+  const nextCursorState = Object.fromEntries(
+    responses
+      .filter(([, response]) => response.pageInfo?.hasNextPage)
+      .map(([chainId, response]) => [chainId, response.pageInfo?.endCursor]),
+  );
+
+  return {
+    data,
+    count: data.length,
+    totalCount,
+    pageInfo: {
+      hasNextPage: Object.keys(nextCursorState).length > 0,
+      endCursor:
+        Object.keys(nextCursorState).length > 0
+          ? JSON.stringify(nextCursorState)
+          : '',
+    },
+  };
+};

--- a/shared/lib/token-search/token-search-api.ts
+++ b/shared/lib/token-search/token-search-api.ts
@@ -135,9 +135,7 @@ export const browseTokens = async (
 
   const settledResponses = await Promise.allSettled(
     options.networks.map(async (chainId) => {
-      const url = new URL(
-        `${TOKEN_V3_BASE_URL}/v3/chains/${chainId}/assets`,
-      );
+      const url = new URL(`${TOKEN_V3_BASE_URL}/v3/chains/${chainId}/assets`);
       if (typeof options.first === 'number') {
         url.searchParams.set('first', String(options.first));
       }

--- a/shared/lib/token-search/token-search-api.ts
+++ b/shared/lib/token-search/token-search-api.ts
@@ -4,6 +4,7 @@ import { TEN_SECONDS_IN_MILLISECONDS } from '../transactions-controller-utils';
 const TOKEN_SEARCH_BASE_URL = 'https://token.api.cx.metamask.io';
 const TOKEN_V3_BASE_URL = 'https://tokens.api.cx.metamask.io';
 const DEFAULT_BROWSE_OCCURRENCE_FLOOR = 3;
+const EVM_CHAIN_NAMESPACE = 'eip155:';
 
 export type TokenSearchResult = {
   assetId: string;
@@ -140,10 +141,12 @@ export const browseTokens = async (
       if (typeof options.first === 'number') {
         url.searchParams.set('first', String(options.first));
       }
-      url.searchParams.set(
-        'occurrenceFloor',
-        String(DEFAULT_BROWSE_OCCURRENCE_FLOOR),
-      );
+      if (chainId.startsWith(EVM_CHAIN_NAMESPACE)) {
+        url.searchParams.set(
+          'occurrenceFloor',
+          String(DEFAULT_BROWSE_OCCURRENCE_FLOOR),
+        );
+      }
 
       const chainCursor = cursorState[chainId];
       if (chainCursor) {

--- a/ui/pages/token-management/token-management.test.tsx
+++ b/ui/pages/token-management/token-management.test.tsx
@@ -485,7 +485,7 @@ describe('TokenManagementPage', () => {
     ).toBeInTheDocument();
   });
 
-  it('enables API browse results when the page opens for EVM and non-EVM networks', () => {
+  it('enables API browse results for EVM and non-EVM networks when the page opens', () => {
     renderPage(
       createState({
         enabledNetworkMap: {
@@ -500,6 +500,25 @@ describe('TokenManagementPage', () => {
         query: '',
         enableTokenBrowse: true,
         networks: ['eip155:1', solanaChainId],
+      }),
+    );
+  });
+
+  it('uses enabled CAIP chain ids directly for empty-query browse', () => {
+    renderPage(
+      createState({
+        enabledNetworkMap: {
+          eip155: { '0x1': true, '0x89': true, '0x5': true },
+        },
+      }),
+    );
+
+    const { calls } = mockTokenSearch.spy.mock;
+    expect(calls[calls.length - 1][0]).toEqual(
+      expect.objectContaining({
+        query: '',
+        enableTokenBrowse: true,
+        networks: ['eip155:1', 'eip155:137', 'eip155:5'],
       }),
     );
   });
@@ -1250,6 +1269,24 @@ describe('TokenManagementPage', () => {
     fireEvent.change(screen.getByTestId('token-management-search-input'), {
       target: { value: 'usdc' },
     });
+
+    expect(
+      screen.getByTestId('token-management-search-error'),
+    ).toBeInTheDocument();
+  });
+
+  it('surfaces a friendly error message when the browse request fails and there are no local tokens', () => {
+    setTokenSearchState({ error: new Error('boom') });
+    renderPage(
+      createState({
+        enabledNetworks: {
+          '0x1': true,
+        },
+        accountGroupAssets: {
+          '0x1': [],
+        },
+      }),
+    );
 
     expect(
       screen.getByTestId('token-management-search-error'),

--- a/ui/pages/token-management/token-management.tsx
+++ b/ui/pages/token-management/token-management.tsx
@@ -1515,7 +1515,10 @@ export const TokenManagementPage = () => {
         }}
       >
         {hasQuery && isSearching && !hasResults ? loadingState : null}
-        {!hasQuery && !isSearchFetching && searchError && tokenListItems.length === 0
+        {!hasQuery &&
+        !isSearchFetching &&
+        searchError &&
+        tokenListItems.length === 0
           ? searchErrorState
           : null}
         {hasQuery && !isSearching && searchError && !hasResults

--- a/ui/pages/token-management/token-management.tsx
+++ b/ui/pages/token-management/token-management.tsx
@@ -33,7 +33,6 @@ import {
   type CaipChainId,
   type Hex,
 } from '@metamask/utils';
-import { formatChainIdToCaip } from '@metamask/bridge-controller';
 import { ERC20 } from '@metamask/controller-utils';
 
 import { TokenManagementCell } from '../../components/multichain/token-management-cell';
@@ -51,6 +50,7 @@ import {
   getEnabledNetworksByNamespace,
   getIsEvmMultichainNetworkSelected,
   getSelectedMultichainNetworkConfiguration,
+  selectEnabledNetworksAsCaipChainIds,
 } from '../../selectors/multichain/networks';
 import { getNetworkConfigurationsByChainId } from '../../../shared/lib/selectors/networks';
 import {
@@ -215,11 +215,6 @@ const normalizeToHexChainId = (chainId: string): string => {
     ? `0x${decimalChainId.toString(16)}`.toLowerCase()
     : chainId.toLowerCase();
 };
-
-const normalizeToCaipChainId = (chainId: string): CaipChainId =>
-  chainId.startsWith('0x')
-    ? formatChainIdToCaip(chainId as Hex)
-    : (chainId as CaipChainId);
 
 const getTokenAddressKey = (chainId: string, address: string) =>
   `${normalizeToHexChainId(chainId)}:${address.toLowerCase()}`;
@@ -484,6 +479,7 @@ export const TokenManagementPage = () => {
       return {} as Record<string, boolean>;
     }
   });
+  const enabledCaipChainIds = useSelector(selectEnabledNetworksAsCaipChainIds);
   const networkConfigurations = useSelector(getNetworkConfigurationsByChainId);
   const allMultichainNetworkConfigurations = useSelector(
     getAllMultichainNetworkConfigurations,
@@ -611,11 +607,11 @@ export const TokenManagementPage = () => {
   const tokenSearchQuery = hasQuery ? debouncedSearchQuery : '';
 
   const searchNetworks = useMemo(() => {
-    if (allEnabledNetworksForAllNamespaces.length === 0) {
+    if (enabledCaipChainIds.length === 0) {
       return undefined;
     }
-    return allEnabledNetworksForAllNamespaces.map(normalizeToCaipChainId);
-  }, [allEnabledNetworksForAllNamespaces]);
+    return enabledCaipChainIds;
+  }, [enabledCaipChainIds]);
 
   const {
     data: searchResponse,
@@ -648,7 +644,7 @@ export const TokenManagementPage = () => {
   const isSearching =
     isWaitingForDebounce ||
     (hasQuery && debouncedSearchQuery.length > 0 && isSearchFetching);
-  const searchError = hasQuery ? searchQueryError : null;
+  const searchError = searchQueryError;
 
   const importedEvmTokensByChain = useMemo(() => {
     const map = new Map<string, Set<string>>();
@@ -1440,7 +1436,7 @@ export const TokenManagementPage = () => {
 
   const shouldShowTokenList = hasQuery
     ? hasResults || (!isSearching && !searchError)
-    : tokenListItems.length > 0 || !isSearchFetching;
+    : tokenListItems.length > 0 || (!isSearchFetching && !searchError);
 
   const startAccessory = (
     <Link to={DEFAULT_ROUTE} aria-label={t('back')} onClick={handleBack}>
@@ -1519,6 +1515,9 @@ export const TokenManagementPage = () => {
         }}
       >
         {hasQuery && isSearching && !hasResults ? loadingState : null}
+        {!hasQuery && !isSearchFetching && searchError && tokenListItems.length === 0
+          ? searchErrorState
+          : null}
         {hasQuery && !isSearching && searchError && !hasResults
           ? searchErrorState
           : null}


### PR DESCRIPTION
This PR is to update the API on token management page to fetch the list of tokens. 
API endpoint `v3/chains/chainId/assets
`
Search API will stay same, it's just to update assets list

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: updated token list API

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run extension
2. Go to Token Management Page
3. Everything should stay same, both imported and non imported tokens should be listed
4. Switch to Arc network, check the five tokens are listed on token management page
NOTE: Token not rendered on home page is being handled by assets

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the external browse data source and pagination contract (multi-fetch + JSON cursors), which can affect which tokens appear and how infinite scroll behaves across EVM and non-EVM networks.
> 
> **Overview**
> Switches **token browse** on Token Management from the legacy token-search “blank query” flow to the **tokens v3** `chains/{chainId}/assets` API, while **typed search** still uses the existing search endpoint.
> 
> `browseTokens` now issues **one request per enabled CAIP chain**, merges results, and tracks pagination with a **JSON cursor keyed by chain** (only chains with a next page are included). **EVM** chains get `occurrenceFloor=3`; **non-EVM** chains do not. **Partial failure** is tolerated: if some chains return 400, successful chains still return data; if every chain fails, the first error is thrown. **No networks** yields an empty response without calling fetch.
> 
> The Token Management page wires browse to **`selectEnabledNetworksAsCaipChainIds`** instead of locally converting hex chain IDs, and **browse failures** are surfaced in the UI when the list is empty (not only when the user has typed a search query).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c180a938f1e3acec4f189964655c0dd60f45add4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->