### PR TITLE
test: revert

### DIFF
--- a/test/e2e/feature-flags/feature-flag-registry.ts
+++ b/test/e2e/feature-flags/feature-flag-registry.ts
@@ -66,7 +66,7 @@ export type FeatureFlagRegistryEntry = {
  * Remote flag values are stored in the exact format returned by the production
  * client-config API, so they can be served directly by mock-e2e.js.
  *
- * Production defaults last synced: 2026-06-02
+ * Production defaults last synced: 2026-04-14
  * Source: https://client-config.api.cx.metamask.io/v1/flags?client=extension&distribution=main&environment=prod
  */
 export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
@@ -193,7 +193,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     name: 'additionalNetworksBlacklist',
     type: FeatureFlagType.Remote,
     inProd: true,
-    productionDefault: ['0x1079'],
+    productionDefault: [],
     status: FeatureFlagStatus.Active,
   },
 
@@ -255,14 +255,9 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     productionDefault: {
       versions: {
         '13.15.0': {
-          enabled: false,
           featureVersion: null,
           minimumVersion: null,
-        },
-        '13.33.0': {
-          enabled: true,
-          featureVersion: '1',
-          minimumVersion: '13.33.0',
+          enabled: false,
         },
       },
     },
@@ -614,294 +609,6 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      contracts: {
-        '0x8f': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Monad',
-            signature:
-              '0x12d31e58c92cdc29dac8af0405883b3b0ee44156d7fdf5c3c2ffa4138f2461cc20e7f8625431dbd24bb784407d1a1d9bdb75b191a6cf127eac68b67d13bd11e41c',
-          },
-        ],
-        '0x152': [
-          {
-            name: 'Cronos Testnet',
-            signature:
-              '0x8fec0190a311f6ba5dc9df8d76fef3673e6c4081c087f779bca7e3247bb40a5070d393d29c6b268deb3fa231a138b7914b25395cd6dec0fdf4b2b7701975e78b1c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x61': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'BNB Testnet',
-            signature:
-              '0x80aaf42c70b0b9efdf26e38ced69fce70f6b4f5496e7e59888819c14fb16290301ad049299d99e3650fa1a616a87bb80eb52ae9f02ddd8b53dd6b983275d0eb61b',
-          },
-        ],
-        '0x3909': [
-          {
-            name: 'Sonic Testnet',
-            signature:
-              '0xc092cc0bcf804f95eb659d281c00586bc72018a242d66fefacdc33a990faf99478c368612277cbbf72aee4a10b7ace6d8666f2c8c4fece9daada40cb360190631b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x13fb': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Citrea Testnet',
-            signature:
-              '0xf9e4aa35fc098468212352c2b9662022f9565bd713ca66e634c804f9820b5e0c266d710afba58aed00e5b7e24134dd9b52e2e331076de745137531a6d245a7521b',
-          },
-        ],
-        '0xaa36a7': [
-          {
-            signature:
-              '0x1aba1c0dafadab6663efdd6086764a9b9fa5ab5c002e88ebae85edea162fbc425c398b2b93afdc036503f12361c05a7ff0b409ee523d5277e0b4d0a840679e591c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Sepolia - Official',
-          },
-          {
-            name: 'Sepolia - Testing',
-            signature:
-              '0x016cf109489c415ba28e695eb3cb06ac46689c5c49e2aba101d7ec2f68c890282563b324f5c8df5e0536994451825aa235438b7346e8c18b4e64161d990781891c',
-            address: '0xCd8D6C5554e209Fbb0deC797C6293cf7eAE13454',
-          },
-        ],
-        '0xa4ec': [
-          {
-            name: 'Celo Mainnet',
-            signature:
-              '0x1421ea4d014170a4fc5d0559f267974f4aa095a6e6047b107eff1807afa425774775f796a52a90b767810eade3b5919087bb361651a7b8f4f9679f1f46adb60e1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x2105': [
-          {
-            name: 'Base',
-            signature:
-              '0xbdddd2e925cf2cc7e148d3c11b02c917995fba8f3a3dc0b73c0059d029feca88014e723b8a32b2310a60c5b1cc17dfb3ae180b5a39f1d3264f985314b9168e0a1c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x14a34': [
-          {
-            name: 'Base Sepolia',
-            signature:
-              '0xaed94ac035e745629423c547200eb2411fd7194d832a6b4cf459d3e3d34a6b62124e88640a0bf623146bdef63b0ce1c8797bd2a6c8357fab86c8be466744f55d1c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x88bb0': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Hoodi Testnet',
-            signature:
-              '0x23de8eb645a65b08721e5d2194063acead5f5f818474b7884ae767c7aaf9bb9b22233ab92684bc41087f8509e945d96083124ae1919a9357f2ae65267df4f0e21b',
-          },
-        ],
-        '0x66eee': [
-          {
-            name: 'Arbitrum Sepolia',
-            signature:
-              '0x6fdb53ecf8f575b85ff9895277b1f8e11349970fbb42225fe41587a072bbcef43e8d54303c4e1aa38d44cae9ba2c8bf825e9e138176d6b09a729cd82a14356cf1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x1012': [
-          {
-            signature:
-              '0x6818c8c50d25e23dd3810758f3fc45d41c5444bec8fe0983660387414fab00366f6d8a0462b2e8985c16cdff5898d6bf9787e255b1a668d083728b448a5c3f641c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Citrea',
-          },
-        ],
-        '0x82': [
-          {
-            signature:
-              '0x54c423b1af4abbd1fb226e260dddba757acbcd8881e6b55b842c6b839874fa3f0e2f77685389ad5c28e096f12ef22557cebf6a77f6064baa071453a445a4c7d51c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Unichain Mainnet',
-          },
-        ],
-        '0x138de': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Berachain',
-            signature:
-              '0x2c2037ddedcdfb9b7d8ea7c546259eef371a86b0e3610192eb15ece0114c59d86134791cd9e9df4208bbbdc83776d80b30b1fea6bf1a05bb072575217492497a1b',
-          },
-        ],
-        '0xe708': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Linea',
-            signature:
-              '0x8bad472a54f1be8adbcce8badc512045a467d64aa2affce55eb6ecb9b6eda8a142eee478bc99a81580ff52d5daea857eb9e482e457b1e121c0574191e01ec9f21c',
-          },
-        ],
-        '0x515': [
-          {
-            signature:
-              '0x64487330691a05700a2321ee1db4092adce9590e7aded6e489df024838ecec734c935d182f74883818cb7659d5c784163573afdf8221252fa68d960cbe1c312f1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Unichain Sepolia',
-          },
-        ],
-        '0x18c6': [
-          {
-            name: 'MegaEth Testnet',
-            signature:
-              '0x6743135a8dfc8f58133d827b4997bc5316c8eb92883d2704a30b1d8a7bf494ce226b523e5f85a681eb5de8349c9564e62d389876d0e5fe5cc06fb9412d9d1cb61b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0xaa37dc': [
-          {
-            name: 'Optimism Sepolia',
-            signature:
-              '0xa60cab833af6a8aa2dcc80d5e12d9e1566edb6cdf51c38e7cf43d441dac561007f05643e73e6b00107e18dbf15de98aae14192306276e92d654f62bd7c3023241c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x530': [
-          {
-            name: 'Sei Testnet',
-            signature:
-              '0x91135fcd7bfb9e2456c227ff12905128c3854db36775278d47b96c3c669f730c4063e3a62d94884617769bbad2868f35d725cb3b611d9bd1231bceb5967724711c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0xaa044c': [
-          {
-            signature:
-              '0x1590458cdfa10225e4fe734ed44deec95ac1887c877e63deb5ad35b41025c9ef2f33666cdd2c189b1999a78072ab9f8f122d93a52eaf12687fb2ff5b74d8de9f1c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Celo Sepolia',
-          },
-        ],
-        '0x1': [
-          {
-            signature:
-              '0xffb37facfedf12f1e98b56203de1c855391b791a20ee361234c546f4b50eb11853283cfc311419049f0325ad0a806ec232cc519073e3b5d4ad59ff331964d2e71b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Mainnet',
-          },
-        ],
-        '0x19': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Cronos',
-            signature:
-              '0xa1856ef8c948b0a5204da687d53231848de2a585def9faac05c23c47412615dc476db943010164356b1d2ca8a8a66a8b0ae2d30c11b6b2aaf1cca116f0a333761c',
-          },
-        ],
-        '0x38': [
-          {
-            signature:
-              '0x28ae371904b3ba71344e426c8de0e2cee0b8529a9510c059b412671655881ad646b8cf544342a5f8e0753eda83221e14e3c9dae5435417401f5fee8ee1d63dce1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'BNB',
-          },
-        ],
-        '0xa4b1': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Arbitrum One',
-            signature:
-              '0xc3be82057efec197d92b0cbb7cef9d50dba0345646524687a3ae7235a8fcb1706ba79f197d45fcf4c6cfb5808ef70258c5f6bb29b7e3553a4b9660692eb5e81d1b',
-          },
-        ],
-        '0x92': [
-          {
-            signature:
-              '0x9f2a94332f2b71bff8a772053f47dbb65e26e5286341be0a3c55270d5549351f1dddb7566be0619b0150d42d540b0847cb0acbd0ab118ff608a40a18400834711b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Sonic Mainnet',
-          },
-        ],
-        '0x138c5': [
-          {
-            signature:
-              '0x66940bcb2c4b95ec2c1c1024fee1e3a8e51c8f072a52a9f0252a793604c8a6ba58ac3153d4dd041873d33eec349450c4a9acd51ddaed117bee448ed7a388208c1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Berachain Testnet',
-          },
-        ],
-        '0xa4ba': [
-          {
-            name: 'Arbitrum Nova',
-            signature:
-              '0x818898e7f90f2f1f47dc7bec74dd683dfcc11efc7025d81f57644d366a3d9e442edb789731045ccb5ba89ee0d84bb517194bb9a097b152922bbd39ffd022ff421c',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x13882': [
-          {
-            name: 'Polygon Amoy Testnet',
-            signature:
-              '0x472bb78ebb6686ddf0bb2e75265e1f4266cd050f8b498e88f97e9380afd8bfbd169c4d3221ec8845cb81ba7e9ddb7de9b819a15617803e20aee2aaa07664b6c81b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x89': [
-          {
-            signature:
-              '0x302aa2d59940e88f35d2fa140fe6a1e9dc682218a444a7fb2d88f007fbe7792b2b8d615f5ae1e4f184533a02c47d8ac0f6ba3f591679295dff93c65095c0f03d1b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Polygon',
-          },
-        ],
-        '0x531': [
-          {
-            name: 'Sei Mainnet',
-            signature:
-              '0xde089fc9af662bc4b0f873e4dc79760f6c3539f6f1cf32d9bc46baccf86ebae070a9062436f29ee86d04cc55699b27579f657922a2292ec2f1c5170d587917401b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x64': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Gnosis',
-            signature:
-              '0xd0cfc2959c866e5218faf675f852e0c7021a454064e509d40256c5bec395e300381c19dcbec2e921b2f6d7d9a925a39dee8ea2e8dd8f595633b8dc333d91f1af1b',
-          },
-        ],
-        '0xa': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Optimism',
-            signature:
-              '0x60e12ffc04e098bd26a897ed2a974e4e255fc6db3b052fe3a2647372bfbac76f096bf5236510ddc217e12b802e08617cc27292d69ca51b0467ba91c6df74cd7b1c',
-          },
-        ],
-        '0x27d8': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Chiado',
-            signature:
-              '0x0ff531d6afcc191c3b3bdffc1596d9ce8d1d52fa500ea2097c0823820a66f97963b88b646d4d4edbc0f781127d7985b87132d89c62c3cb4ad42848ce289645fa1b',
-          },
-        ],
-        '0x1079': [
-          {
-            name: 'Tempo',
-            signature:
-              '0x810496170fb570d0d976c58273ad4a423252bac1f2e10c8a63adbbbfc4e79d2c5d894bae20c28e90a577338e68506138ac6dea142a1e80a31c0c2dd2999efa651b',
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-          },
-        ],
-        '0x279f': [
-          {
-            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
-            name: 'Monad Testnet',
-            signature:
-              '0x85ec60e9dbac6404b66803b5abace8517ce1325bb6391b7d1ff8ec4433bbe62f4363031873a11ed79364290e196a47830fc36346a9aaf2e44518c1101496983c1b',
-          },
-        ],
-      },
       supportedChains: [
         '0x1',
         '0x1012',
@@ -934,11 +641,308 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
         '0xa4b1',
         '0xa4ba',
         '0xa4ec',
+        '0xa5bf',
         '0xaa044c',
         '0xaa36a7',
         '0xaa37dc',
         '0xe708',
       ],
+      contracts: {
+        '0x82': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Unichain Mainnet',
+            signature:
+              '0x54c423b1af4abbd1fb226e260dddba757acbcd8881e6b55b842c6b839874fa3f0e2f77685389ad5c28e096f12ef22557cebf6a77f6064baa071453a445a4c7d51c',
+          },
+        ],
+        '0x1012': [
+          {
+            name: 'Citrea',
+            signature:
+              '0x6818c8c50d25e23dd3810758f3fc45d41c5444bec8fe0983660387414fab00366f6d8a0462b2e8985c16cdff5898d6bf9787e255b1a668d083728b448a5c3f641c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0xa4ba': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Arbitrum Nova',
+            signature:
+              '0x818898e7f90f2f1f47dc7bec74dd683dfcc11efc7025d81f57644d366a3d9e442edb789731045ccb5ba89ee0d84bb517194bb9a097b152922bbd39ffd022ff421c',
+          },
+        ],
+        '0x3909': [
+          {
+            name: 'Sonic Testnet',
+            signature:
+              '0xc092cc0bcf804f95eb659d281c00586bc72018a242d66fefacdc33a990faf99478c368612277cbbf72aee4a10b7ace6d8666f2c8c4fece9daada40cb360190631b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x38': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'BNB',
+            signature:
+              '0x28ae371904b3ba71344e426c8de0e2cee0b8529a9510c059b412671655881ad646b8cf544342a5f8e0753eda83221e14e3c9dae5435417401f5fee8ee1d63dce1b',
+          },
+        ],
+        '0x138c5': [
+          {
+            name: 'Berachain Testnet',
+            signature:
+              '0x66940bcb2c4b95ec2c1c1024fee1e3a8e51c8f072a52a9f0252a793604c8a6ba58ac3153d4dd041873d33eec349450c4a9acd51ddaed117bee448ed7a388208c1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x1079': [
+          {
+            name: 'Tempo',
+            signature:
+              '0x810496170fb570d0d976c58273ad4a423252bac1f2e10c8a63adbbbfc4e79d2c5d894bae20c28e90a577338e68506138ac6dea142a1e80a31c0c2dd2999efa651b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x89': [
+          {
+            name: 'Polygon',
+            signature:
+              '0x302aa2d59940e88f35d2fa140fe6a1e9dc682218a444a7fb2d88f007fbe7792b2b8d615f5ae1e4f184533a02c47d8ac0f6ba3f591679295dff93c65095c0f03d1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0xa': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Optimism',
+            signature:
+              '0x60e12ffc04e098bd26a897ed2a974e4e255fc6db3b052fe3a2647372bfbac76f096bf5236510ddc217e12b802e08617cc27292d69ca51b0467ba91c6df74cd7b1c',
+          },
+        ],
+        '0x531': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Sei Mainnet',
+            signature:
+              '0xde089fc9af662bc4b0f873e4dc79760f6c3539f6f1cf32d9bc46baccf86ebae070a9062436f29ee86d04cc55699b27579f657922a2292ec2f1c5170d587917401b',
+          },
+        ],
+        '0x14a34': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Base Sepolia',
+            signature:
+              '0xaed94ac035e745629423c547200eb2411fd7194d832a6b4cf459d3e3d34a6b62124e88640a0bf623146bdef63b0ce1c8797bd2a6c8357fab86c8be466744f55d1c',
+          },
+        ],
+        '0x13fb': [
+          {
+            name: 'Citrea Testnet',
+            signature:
+              '0xf9e4aa35fc098468212352c2b9662022f9565bd713ca66e634c804f9820b5e0c266d710afba58aed00e5b7e24134dd9b52e2e331076de745137531a6d245a7521b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x138de': [
+          {
+            signature:
+              '0x2c2037ddedcdfb9b7d8ea7c546259eef371a86b0e3610192eb15ece0114c59d86134791cd9e9df4208bbbdc83776d80b30b1fea6bf1a05bb072575217492497a1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Berachain',
+          },
+        ],
+        '0x8f': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Monad',
+            signature:
+              '0x12d31e58c92cdc29dac8af0405883b3b0ee44156d7fdf5c3c2ffa4138f2461cc20e7f8625431dbd24bb784407d1a1d9bdb75b191a6cf127eac68b67d13bd11e41c',
+          },
+        ],
+        '0x18c6': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'MegaEth Testnet',
+            signature:
+              '0x6743135a8dfc8f58133d827b4997bc5316c8eb92883d2704a30b1d8a7bf494ce226b523e5f85a681eb5de8349c9564e62d389876d0e5fe5cc06fb9412d9d1cb61b',
+          },
+        ],
+        '0x88bb0': [
+          {
+            signature:
+              '0x23de8eb645a65b08721e5d2194063acead5f5f818474b7884ae767c7aaf9bb9b22233ab92684bc41087f8509e945d96083124ae1919a9357f2ae65267df4f0e21b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Hoodi Testnet',
+          },
+        ],
+        '0xa4b1': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Arbitrum One',
+            signature:
+              '0xc3be82057efec197d92b0cbb7cef9d50dba0345646524687a3ae7235a8fcb1706ba79f197d45fcf4c6cfb5808ef70258c5f6bb29b7e3553a4b9660692eb5e81d1b',
+          },
+        ],
+        '0x1': [
+          {
+            signature:
+              '0xffb37facfedf12f1e98b56203de1c855391b791a20ee361234c546f4b50eb11853283cfc311419049f0325ad0a806ec232cc519073e3b5d4ad59ff331964d2e71b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Mainnet',
+          },
+        ],
+        '0x279f': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Monad Testnet',
+            signature:
+              '0x85ec60e9dbac6404b66803b5abace8517ce1325bb6391b7d1ff8ec4433bbe62f4363031873a11ed79364290e196a47830fc36346a9aaf2e44518c1101496983c1b',
+          },
+        ],
+        '0x19': [
+          {
+            signature:
+              '0xa1856ef8c948b0a5204da687d53231848de2a585def9faac05c23c47412615dc476db943010164356b1d2ca8a8a66a8b0ae2d30c11b6b2aaf1cca116f0a333761c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Cronos',
+          },
+        ],
+        '0xaa37dc': [
+          {
+            signature:
+              '0xa60cab833af6a8aa2dcc80d5e12d9e1566edb6cdf51c38e7cf43d441dac561007f05643e73e6b00107e18dbf15de98aae14192306276e92d654f62bd7c3023241c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Optimism Sepolia',
+          },
+        ],
+        '0x515': [
+          {
+            name: 'Unichain Sepolia',
+            signature:
+              '0x64487330691a05700a2321ee1db4092adce9590e7aded6e489df024838ecec734c935d182f74883818cb7659d5c784163573afdf8221252fa68d960cbe1c312f1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x92': [
+          {
+            name: 'Sonic Mainnet',
+            signature:
+              '0x9f2a94332f2b71bff8a772053f47dbb65e26e5286341be0a3c55270d5549351f1dddb7566be0619b0150d42d540b0847cb0acbd0ab118ff608a40a18400834711b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x64': [
+          {
+            signature:
+              '0xd0cfc2959c866e5218faf675f852e0c7021a454064e509d40256c5bec395e300381c19dcbec2e921b2f6d7d9a925a39dee8ea2e8dd8f595633b8dc333d91f1af1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Gnosis',
+          },
+        ],
+        '0xe708': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Linea',
+            signature:
+              '0x8bad472a54f1be8adbcce8badc512045a467d64aa2affce55eb6ecb9b6eda8a142eee478bc99a81580ff52d5daea857eb9e482e457b1e121c0574191e01ec9f21c',
+          },
+        ],
+        '0x61': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'BNB Testnet',
+            signature:
+              '0x80aaf42c70b0b9efdf26e38ced69fce70f6b4f5496e7e59888819c14fb16290301ad049299d99e3650fa1a616a87bb80eb52ae9f02ddd8b53dd6b983275d0eb61b',
+          },
+        ],
+        '0x66eee': [
+          {
+            name: 'Arbitrum Sepolia',
+            signature:
+              '0x6fdb53ecf8f575b85ff9895277b1f8e11349970fbb42225fe41587a072bbcef43e8d54303c4e1aa38d44cae9ba2c8bf825e9e138176d6b09a729cd82a14356cf1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x152': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Cronos Testnet',
+            signature:
+              '0x8fec0190a311f6ba5dc9df8d76fef3673e6c4081c087f779bca7e3247bb40a5070d393d29c6b268deb3fa231a138b7914b25395cd6dec0fdf4b2b7701975e78b1c',
+          },
+        ],
+        '0xaa36a7': [
+          {
+            name: 'Sepolia - Official',
+            signature:
+              '0x1aba1c0dafadab6663efdd6086764a9b9fa5ab5c002e88ebae85edea162fbc425c398b2b93afdc036503f12361c05a7ff0b409ee523d5277e0b4d0a840679e591c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+          {
+            address: '0xCd8D6C5554e209Fbb0deC797C6293cf7eAE13454',
+            name: 'Sepolia - Testing',
+            signature:
+              '0x016cf109489c415ba28e695eb3cb06ac46689c5c49e2aba101d7ec2f68c890282563b324f5c8df5e0536994451825aa235438b7346e8c18b4e64161d990781891c',
+          },
+        ],
+        '0x2105': [
+          {
+            signature:
+              '0xbdddd2e925cf2cc7e148d3c11b02c917995fba8f3a3dc0b73c0059d029feca88014e723b8a32b2310a60c5b1cc17dfb3ae180b5a39f1d3264f985314b9168e0a1c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Base',
+          },
+        ],
+        '0xa5bf': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Tempo Testnet',
+            signature:
+              '0x2413338e5c47c56853195d1870988d721ec502c78e54fe5b98468a401538b942237a2769461ffbfa8269936bf309243d5b0d69f7114938653469c4d8225715ee1c',
+          },
+        ],
+        '0xaa044c': [
+          {
+            name: 'Celo Sepolia',
+            signature:
+              '0x1590458cdfa10225e4fe734ed44deec95ac1887c877e63deb5ad35b41025c9ef2f33666cdd2c189b1999a78072ab9f8f122d93a52eaf12687fb2ff5b74d8de9f1c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x13882': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Polygon Amoy Testnet',
+            signature:
+              '0x472bb78ebb6686ddf0bb2e75265e1f4266cd050f8b498e88f97e9380afd8bfbd169c4d3221ec8845cb81ba7e9ddb7de9b819a15617803e20aee2aaa07664b6c81b',
+          },
+        ],
+        '0x27d8': [
+          {
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+            name: 'Chiado',
+            signature:
+              '0x0ff531d6afcc191c3b3bdffc1596d9ce8d1d52fa500ea2097c0823820a66f97963b88b646d4d4edbc0f781127d7985b87132d89c62c3cb4ad42848ce289645fa1b',
+          },
+        ],
+        '0xa4ec': [
+          {
+            name: 'Celo Mainnet',
+            signature:
+              '0x1421ea4d014170a4fc5d0559f267974f4aa095a6e6047b107eff1807afa425774775f796a52a90b767810eade3b5919087bb361651a7b8f4f9679f1f46adb60e1b',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+        '0x530': [
+          {
+            name: 'Sei Testnet',
+            signature:
+              '0x91135fcd7bfb9e2456c227ff12905128c3854db36775278d47b96c3c669f730c4063e3a62d94884617769bbad2868f35d725cb3b611d9bd1231bceb5967724711c',
+            address: '0x63c0c19a282a1B52b07dD5a65b58948A07DAE32B',
+          },
+        ],
+      },
     },
     status: FeatureFlagStatus.Active,
   },
@@ -969,7 +973,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      pollingIntervalMs: 86400000,
+      useBackendWebSocketService: true,
     },
     status: FeatureFlagStatus.Active,
   },
@@ -1947,67 +1951,67 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      '0x144': {
-        extensionActive: false,
-        sentinelUrl: 'https://tx-sentinel-zksync-mainnet.api.cx.metamask.io',
-      },
-      '0x2105': {
-        sentinelUrl: 'https://tx-sentinel-base-mainnet.api.cx.metamask.io',
-        extensionActive: true,
-        gaslessBridgeWith7702Enabled: true,
-      },
-      '0xa': {
-        extensionActive: false,
-        sentinelUrl: 'https://tx-sentinel-optimism-mainnet.api.cx.metamask.io',
-      },
       '0xa86a': {
         extensionActive: false,
         sentinelUrl: 'https://tx-sentinel-avalanche-mainnet.api.cx.metamask.io',
       },
-      '0x8f': {
-        sentinelUrl: 'https://tx-sentinel-monad-mainnet.api.cx.metamask.io',
+      '0x2105': {
+        extensionActive: true,
+        gaslessBridgeWith7702Enabled: true,
+        sentinelUrl: 'https://tx-sentinel-base-mainnet.api.cx.metamask.io',
+      },
+      '0xe708': {
+        sentinelUrl: 'https://tx-sentinel-linea-mainnet.api.cx.metamask.io',
+        extensionActive: true,
+        gaslessBridgeWith7702Enabled: false,
+      },
+      '0x89': {
+        extensionActive: true,
+        gaslessBridgeWith7702Enabled: true,
+        sentinelUrl: 'https://tx-sentinel-polygon-mainnet.api.cx.metamask.io',
+      },
+      '0x1': {
+        maxDeadline: 160,
+        sentinelUrl: 'https://tx-sentinel-ethereum-mainnet.api.cx.metamask.io',
+        expectedDeadline: 45,
+        extensionActive: true,
+        gaslessBridgeWith7702Enabled: false,
+      },
+      '0xa4b1': {
+        gaslessBridgeWith7702Enabled: true,
+        sentinelUrl: 'https://tx-sentinel-arbitrum-mainnet.api.cx.metamask.io',
+        extensionActive: true,
+      },
+      default: {
+        maxDeadline: 150,
+        batchStatusPollingInterval: 1000,
+        expectedDeadline: 45,
         extensionActive: false,
+        extensionReturnTxHashAsap: true,
+        extensionReturnTxHashAsapBatch: true,
+        extensionSkipSmartTransactionStatusPage: false,
+        gaslessBridgeWith7702Enabled: false,
       },
       '0x531': {
         sentinelUrl: 'https://tx-sentinel-sei-mainnet.api.cx.metamask.io',
         extensionActive: false,
       },
-      '0x89': {
-        gaslessBridgeWith7702Enabled: true,
-        sentinelUrl: 'https://tx-sentinel-polygon-mainnet.api.cx.metamask.io',
-        extensionActive: true,
-      },
-      '0xe708': {
-        extensionActive: true,
-        gaslessBridgeWith7702Enabled: true,
-        sentinelUrl: 'https://tx-sentinel-linea-mainnet.api.cx.metamask.io',
-      },
-      default: {
-        extensionReturnTxHashAsap: true,
-        extensionReturnTxHashAsapBatch: true,
-        extensionSkipSmartTransactionStatusPage: false,
-        gaslessBridgeWith7702Enabled: false,
-        maxDeadline: 150,
-        batchStatusPollingInterval: 1000,
-        expectedDeadline: 45,
+      '0x144': {
+        sentinelUrl: 'https://tx-sentinel-zksync-mainnet.api.cx.metamask.io',
         extensionActive: false,
+      },
+      '0xa': {
+        extensionActive: false,
+        sentinelUrl: 'https://tx-sentinel-optimism-mainnet.api.cx.metamask.io',
       },
       '0x38': {
         extensionActive: true,
         gaslessBridgeWith7702Enabled: false,
         sentinelUrl: 'https://tx-sentinel-bsc-mainnet.api.cx.metamask.io',
       },
-      '0x1': {
-        extensionActive: true,
-        gaslessBridgeWith7702Enabled: false,
-        maxDeadline: 160,
-        sentinelUrl: 'https://tx-sentinel-ethereum-mainnet.api.cx.metamask.io',
-        expectedDeadline: 45,
-      },
-      '0xa4b1': {
-        sentinelUrl: 'https://tx-sentinel-arbitrum-mainnet.api.cx.metamask.io',
-        extensionActive: true,
-        gaslessBridgeWith7702Enabled: true,
+      '0x8f': {
+        extensionActive: false,
+        sentinelUrl: 'https://tx-sentinel-monad-mainnet.api.cx.metamask.io',
       },
     },
     status: FeatureFlagStatus.Active,
@@ -2109,8 +2113,8 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
+      minimumVersion: '0.0.0',
       enabled: true,
-      minimumVersion: '13.32.0',
     },
     status: FeatureFlagStatus.Active,
   },
@@ -2128,8 +2132,8 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      enabled: true,
-      minimumVersion: '13.28.0',
+      enabled: false,
+      minimumVersion: '0.0.0',
     },
     status: FeatureFlagStatus.Active,
   },
@@ -2169,7 +2173,16 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     name: 'coreExtensionUxCeux1024AbtestReferralUi',
     type: FeatureFlagType.Remote,
     inProd: true,
-    productionDefault: [],
+    productionDefault: [
+      {
+        name: 'control',
+        scope: { type: 'threshold', value: 1 },
+      },
+      {
+        name: 'treatment',
+        scope: { type: 'threshold', value: 0 },
+      },
+    ],
     status: FeatureFlagStatus.Active,
   },
 
@@ -2185,10 +2198,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     name: 'extensionUxNetworkManagement',
     type: FeatureFlagType.Remote,
     inProd: true,
-    productionDefault: {
-      enabled: false,
-      minimumVersion: '13.33.0',
-    },
+    productionDefault: false,
     status: FeatureFlagStatus.Active,
   },
 
@@ -2196,10 +2206,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     name: 'extensionUxTokenManagementFilter',
     type: FeatureFlagType.Remote,
     inProd: true,
-    productionDefault: {
-      minimumVersion: '13.33.0',
-      enabled: true,
-    },
+    productionDefault: false,
     status: FeatureFlagStatus.Active,
   },
 
@@ -2247,8 +2254,8 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      minimumVersion: '13.30.0',
-      enabled: true,
+      enabled: false,
+      minimumVersion: '13.15.0',
     },
     status: FeatureFlagStatus.Active,
   },
@@ -2257,7 +2264,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     name: 'perpsHip3AllowlistMarkets',
     type: FeatureFlagType.Remote,
     inProd: true,
-    productionDefault: '',
+    productionDefault: 'xyz:*',
     status: FeatureFlagStatus.Active,
   },
 
@@ -2284,8 +2291,8 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      minimumVersion: '13.32.0',
-      enabled: true,
+      enabled: false,
+      minimumVersion: '0.0.0',
     },
     status: FeatureFlagStatus.Active,
   },
@@ -2295,8 +2302,8 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      enabled: true,
-      minimumVersion: '13.32.0',
+      enabled: false,
+      minimumVersion: '0.0.0',
     },
     status: FeatureFlagStatus.Active,
   },
@@ -2384,85 +2391,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      attemptsMax: 4,
-      allowedPredictWithdrawTokens: {
-        '0x1': [
-          '0x0000000000000000000000000000000000000000',
-          '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
-        ],
-        '0x38': [
-          '0x0000000000000000000000000000000000000000',
-          '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d',
-        ],
-        '0x89': [
-          '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174',
-          '0x0000000000000000000000000000000000000000',
-          '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619',
-        ],
-      },
-      relayFallbackGas: {
-        max: '1500001',
-        estimate: '900001',
-      },
-      slippageTokens: {
-        '0xa4b1': {
-          '0x0000000000000000000000000000000000000000': 0.005,
-          '0x82aF49447D8a07e3bd95BD0d56f35241523fBab1': 0.005,
-          '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9': 0.005,
-          '0xaf88d065e77c8cC2239327C5EDb3A432268e5831': 0.005,
-        },
-        '0xe708': {
-          '0xe5D7C2a44FfDDf6b295A15c148167daaAf5Cf34f': 0.005,
-          '0x0000000000000000000000000000000000000000': 0.005,
-          '0x176211869cA2b568f2A7D4EE941E073a821EE1ff': 0.005,
-          '0xA219439258ca9da29E9Cc4cE5596924745e12B93': 0.005,
-          '0xacA92E438df0B2401fF60dA7E4337B687a2435DA': 0.005,
-        },
-        '0x1': {
-          '0x0000000000000000000000000000000000000000': 0.005,
-          '0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599': 0.005,
-          '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48': 0.005,
-          '0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2': 0.005,
-          '0xacA92E438df0B2401fF60dA7E4337B687a2435DA': 0.005,
-          '0xdAC17F958D2ee523a2206206994597C13D831ec7': 0.005,
-        },
-        '0x2105': {
-          '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913': 0.005,
-          '0xfde4C96c8593536E31F229EA8f37b2ADa2699bb2': 0.005,
-          '0x0000000000000000000000000000000000000000': 0.005,
-          '0x4200000000000000000000000000000000000006': 0.005,
-        },
-        '0x38': {
-          '0x0555E30da8f98308EdB960aa94C0Db47230d2B9c': 0.005,
-          '0x2170Ed0880ac9A755fd29B2688956BD959F933F8': 0.005,
-          '0x55d398326f99059fF775485246999027B3197955': 0.005,
-          '0x8AC76a51cc950d9822D68b83fE1Ad97B32Cd580d': 0.005,
-          '0x0000000000000000000000000000000000000000': 0.005,
-        },
-        '0x89': {
-          '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359': 0.005,
-          '0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619': 0.005,
-          '0xc2132D05D31c914a87C6611C10748AEb04B58e8F': 0.005,
-          '0x0000000000000000000000000000000000001010': 0.005,
-          '0x2791Bca1f2de4661ED88A30C99A7a9449Aa84174': 0.005,
-        },
-      },
-      bufferSubsequent: 0.05,
-      bufferInitial: 0.015,
-      bufferStep: 0.015,
-      perpsWithdrawAnyToken: false,
-      payStrategies: {
-        relay: {
-          enabled: true,
-          gaslessEnabled: false,
-        },
-      },
-      slippage: 0.02,
-      predictWithdrawAnyToken: true,
-      relayExecuteUrl: 'https://intents.api.cx.metamask.io/relay/execute',
-      relayQuoteUrl: 'https://intents.api.cx.metamask.io/relay/quote',
-      strategyOrder: ['relay'],
-      relayDisabledGasStationChains: [],
+      name: 'empty',
     },
     status: FeatureFlagStatus.Active,
   },
@@ -2486,7 +2415,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     productionDefault: {
       rc: true,
       versions: {
-        '13.33.0': {
+        '13.32.0': {
           default: {
             enabled: true,
             tokens: {},
@@ -2495,11 +2424,6 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
             perpsWithdraw: {
               enabled: true,
               tokens: {
-                '0xa4b1': [
-                  '0x0000000000000000000000000000000000000000',
-                  '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
-                  '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9',
-                ],
                 '0xe708': [
                   '0x0000000000000000000000000000000000000000',
                   '0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
@@ -2524,6 +2448,11 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
                   '0x0000000000000000000000000000000000001010',
                   '0x3c499c542cEF5E3811e1192ce70d8cC03d5c3359',
                   '0xc2132d05d31c914a87c6611c10748aeb04b58e8f',
+                ],
+                '0xa4b1': [
+                  '0x0000000000000000000000000000000000000000',
+                  '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+                  '0xFd086bC7CD5C481DCC9C85ebE478A1C0b69FCbb9',
                 ],
               },
             },
@@ -2572,8 +2501,8 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
+      minimumVersion: '13.26.0',
       enabled: true,
-      minimumVersion: '13.27.0',
     },
     status: FeatureFlagStatus.Active,
   },
@@ -2642,7 +2571,7 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     type: FeatureFlagType.Remote,
     inProd: true,
     productionDefault: {
-      blockedRegions: ['BE', 'US', 'CA-ON', 'GB', 'CU', 'IR', 'KP', 'SY'],
+      blockedRegions: ['BE', 'US', 'CA-ON', 'GB'],
     },
     status: FeatureFlagStatus.Active,
   },

--- a/test/e2e/fixtures/default-fixture.json
+++ b/test/e2e/fixtures/default-fixture.json
@@ -352,9 +352,24 @@
     },
     "CurrencyController": {
       "currencyRates": {
+        "BNB": {
+          "conversionDate": null,
+          "conversionRate": null,
+          "usdConversionRate": null
+        },
         "ETH": {
           "conversionDate": null,
           "conversionRate": 1700,
+          "usdConversionRate": null
+        },
+        "MON": {
+          "conversionDate": null,
+          "conversionRate": null,
+          "usdConversionRate": null
+        },
+        "POL": {
+          "conversionDate": null,
+          "conversionRate": null,
           "usdConversionRate": null
         }
       },
@@ -1124,36 +1139,7 @@
       }
     },
     "RewardsController": {
-      "rewardsAccounts": {
-        "bip122:000000000019d6689c085ae165831e93:bc1qg6whd6pc0cguh6gpp3ewujm53hv32ta9hdp252": {
-          "account": "bip122:000000000019d6689c085ae165831e93:bc1qg6whd6pc0cguh6gpp3ewujm53hv32ta9hdp252",
-          "lastFreshOptInStatusCheck": 1780567256841,
-          "lastPerpsDiscountRateFetched": null,
-          "perpsFeeDiscount": null,
-          "subscriptionId": null
-        },
-        "eip155:0:0x5cfe73b6021e818b776b421b1c4db2474086a7e1": {
-          "account": "eip155:0:0x5cfe73b6021e818b776b421b1c4db2474086a7e1",
-          "lastFreshOptInStatusCheck": 1780567256847,
-          "lastPerpsDiscountRateFetched": null,
-          "perpsFeeDiscount": null,
-          "subscriptionId": null
-        },
-        "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:4tE76eixEgyJDrdykdWJR1XBkzUk4cLMvqjR2xVJUxer": {
-          "account": "solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:4tE76eixEgyJDrdykdWJR1XBkzUk4cLMvqjR2xVJUxer",
-          "lastFreshOptInStatusCheck": 1780567256848,
-          "lastPerpsDiscountRateFetched": null,
-          "perpsFeeDiscount": null,
-          "subscriptionId": null
-        },
-        "tron:728126428:TJ3QZbBREK1Xybe1jf4nR9Attb8i54vGS3": {
-          "account": "tron:728126428:TJ3QZbBREK1Xybe1jf4nR9Attb8i54vGS3",
-          "lastFreshOptInStatusCheck": 1780567256841,
-          "lastPerpsDiscountRateFetched": null,
-          "perpsFeeDiscount": null,
-          "subscriptionId": null
-        }
-      },
+      "rewardsAccounts": {},
       "rewardsActiveAccount": null,
       "rewardsPointsEstimateHistory": [],
       "rewardsSeasonStatuses": {},
@@ -1232,7 +1218,15 @@
     },
     "TokenRatesController": {
       "marketData": {
-        "0x539": {}
+        "0x1": {},
+        "0x2105": {},
+        "0x38": {},
+        "0x539": {},
+        "0x89": {},
+        "0x8f": {},
+        "0xa": {},
+        "0xa4b1": {},
+        "0xe708": {}
       }
     },
     "TokensController": {

--- a/test/e2e/fixtures/fixture-validation.ts
+++ b/test/e2e/fixtures/fixture-validation.ts
@@ -113,10 +113,6 @@ const getFixtureIgnoredKeys = (): string[] => [
   'data.KeyringController.vault',
   // PerpsController is conditionally included in build via PERPS_ENABLED env var
   'data.PerpsController',
-  'data.RewardsController.rewardsAccounts.bip122:000000000019d6689c085ae165831e93:bc1qg6whd6pc0cguh6gpp3ewujm53hv32ta9hdp252.lastFreshOptInStatusCheck',
-  'data.RewardsController.rewardsAccounts.eip155:0:0x5cfe73b6021e818b776b421b1c4db2474086a7e1.lastFreshOptInStatusCheck',
-  'data.RewardsController.rewardsAccounts.solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:4tE76eixEgyJDrdykdWJR1XBkzUk4cLMvqjR2xVJUxer.lastFreshOptInStatusCheck',
-  'data.RewardsController.rewardsAccounts.tron:728126428:TJ3QZbBREK1Xybe1jf4nR9Attb8i54vGS3.lastFreshOptInStatusCheck',
 ];
 
 /**

--- a/test/e2e/mock-e2e.js
+++ b/test/e2e/mock-e2e.js
@@ -266,13 +266,6 @@ async function setupMocking(
       };
     });
 
-  // Rewards API
-  await server
-    .forPost('https://rewards.uat-api.cx.metamask.io/public/rewards/ois')
-    .thenCallback(() => {
-      return { statusCode: 200, json: { ois: [], sids: [] } };
-    });
-
   // User Profile Lineage
   await server
     .forGet('https://authentication.api.cx.metamask.io/api/v2/profile/lineage')

--- a/test/e2e/tests/account/snap-account-signatures-and-disconnects.spec.ts
+++ b/test/e2e/tests/account/snap-account-signatures-and-disconnects.spec.ts
@@ -14,10 +14,7 @@ import {
   signTypedDataV3WithSnapAccount,
   signTypedDataV4WithSnapAccount,
 } from '../../page-objects/flows/sign.flow';
-import {
-  mockSnapSimpleKeyringAndSite,
-  SNAP_SIMPLE_KEYRING_E2E_MANIFEST_FLAGS,
-} from './snap-keyring-site-mocks';
+import { mockSnapSimpleKeyringAndSite } from './snap-keyring-site-mocks';
 
 describe('Snap Account Signatures and Disconnects', function (this: Suite) {
   it('can connect to the Test Dapp, then #signTypedDataV3, disconnect then connect, then #signTypedDataV4 (async flow approve)', async function () {
@@ -30,9 +27,13 @@ describe('Snap Account Signatures and Disconnects', function (this: Suite) {
         fixtures: new FixtureBuilderV2()
           .withSnapsPrivacyWarningAlreadyShown()
           .build(),
-        manifestFlags: SNAP_SIMPLE_KEYRING_E2E_MANIFEST_FLAGS,
-        testSpecificMock: (mockServer: Mockttp) =>
-          mockSnapSimpleKeyringAndSite(mockServer, 8081),
+        testSpecificMock: async (mockServer: Mockttp) => {
+          const snapMocks = await mockSnapSimpleKeyringAndSite(
+            mockServer,
+            8081,
+          );
+          return snapMocks;
+        },
         title: this.test?.fullTitle(),
       },
       async ({ driver }: { driver: Driver }) => {
@@ -46,7 +47,7 @@ describe('Snap Account Signatures and Disconnects', function (this: Suite) {
           WINDOW_TITLES.ExtensionInFullScreenView,
         );
         const headerNavbar = new HeaderNavbar(driver);
-        // BUG #37591 - With BIP44 the account name is not retained.
+        // BUG #37591 - With BIP44 the account mame is not retained.
         await headerNavbar.checkAccountLabel('Snap Account 1');
 
         // Open the Test Dapp and connect

--- a/test/e2e/tests/account/snap-account-signatures.spec.ts
+++ b/test/e2e/tests/account/snap-account-signatures.spec.ts
@@ -4,7 +4,9 @@ import { Driver } from '../../webdriver/driver';
 import { DAPP_PATH, WINDOW_TITLES } from '../../constants';
 import { withFixtures } from '../../helpers';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
+import ExperimentalSettings from '../../page-objects/pages/settings/experimental-settings';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
+import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import SnapSimpleKeyringPage from '../../page-objects/pages/snap-simple-keyring-page';
 import TestDapp from '../../page-objects/pages/test-dapp';
 import { installSnapSimpleKeyring } from '../../page-objects/flows/snap-simple-keyring.flow';
@@ -17,10 +19,7 @@ import {
   signTypedDataV4WithSnapAccount,
   signTypedDataWithSnapAccount,
 } from '../../page-objects/flows/sign.flow';
-import {
-  mockSnapSimpleKeyringAndSite,
-  SNAP_SIMPLE_KEYRING_E2E_MANIFEST_FLAGS,
-} from './snap-keyring-site-mocks';
+import { mockSnapSimpleKeyringAndSite } from './snap-keyring-site-mocks';
 
 describe('Snap Account Signatures', function (this: Suite) {
   this.timeout(500000); // This test is very long, so we need an unusually high timeout
@@ -41,9 +40,13 @@ describe('Snap Account Signatures', function (this: Suite) {
           fixtures: new FixtureBuilderV2()
             .withSnapsPrivacyWarningAlreadyShown()
             .build(),
-          manifestFlags: SNAP_SIMPLE_KEYRING_E2E_MANIFEST_FLAGS,
-          testSpecificMock: (mockServer: Mockttp) =>
-            mockSnapSimpleKeyringAndSite(mockServer, 8081),
+          testSpecificMock: async (mockServer: Mockttp) => {
+            const snapMocks = await mockSnapSimpleKeyringAndSite(
+              mockServer,
+              8081,
+            );
+            return snapMocks;
+          },
           title,
         },
         async ({ driver }: { driver: Driver }) => {
@@ -54,12 +57,22 @@ describe('Snap Account Signatures', function (this: Suite) {
           const snapSimpleKeyringPage = new SnapSimpleKeyringPage(driver);
           const newPublicKey = await snapSimpleKeyringPage.createNewAccount();
 
+          // Check snap account is displayed after adding the snap account.
           await driver.switchToWindowWithTitle(
             WINDOW_TITLES.ExtensionInFullScreenView,
           );
           const headerNavbar = new HeaderNavbar(driver);
-          // BUG #37591 - With BIP44 the account name is not retained.
+          // BUG #37591 - With BIP44 the account mame is not retained.
           await headerNavbar.checkAccountLabel('Snap Account 1');
+
+          // Navigate to experimental settings and disable redesigned signature.
+          await headerNavbar.openSettingsPage();
+          const settingsPage = new SettingsPage(driver);
+          await settingsPage.checkPageIsLoaded();
+          await settingsPage.goToExperimentalSettings();
+
+          const experimentalSettings = new ExperimentalSettings(driver);
+          await experimentalSettings.checkPageIsLoaded();
 
           // Connect the SSK account
           const testDapp = new TestDapp(driver);

--- a/test/e2e/tests/account/snap-keyring-site-mocks.ts
+++ b/test/e2e/tests/account/snap-keyring-site-mocks.ts
@@ -1,14 +1,6 @@
 import { Mockttp } from 'mockttp';
 import { mockSimpleKeyringSnap } from '../../mock-response-data/snaps/snap-binary-mocks';
 
-/** Disables rewards flags that add background work during snap account E2E setup. */
-export const SNAP_SIMPLE_KEYRING_E2E_MANIFEST_FLAGS = {
-  remoteFeatureFlags: {
-    rewardsEnabled: { enabled: false, minimumVersion: '13.32.0' },
-    rewardsOnboardingEnabled: { enabled: false, minimumVersion: '13.32.0' },
-  },
-};
-
 export async function serveSnapKeyRingFromLocalhost(
   mockServer: Mockttp,
   port: number = 8080,
@@ -51,8 +43,8 @@ export async function mockSnapSimpleKeyringAndSite(
   mockServer: Mockttp,
   port: number = 8080,
 ) {
-  return [
-    await mockSimpleKeyringSnap(mockServer),
-    await serveSnapKeyRingFromLocalhost(mockServer, port),
-  ];
+  const simpleKeyring = await mockSimpleKeyringSnap(mockServer);
+  const siteProxy = await serveSnapKeyRingFromLocalhost(mockServer, port);
+
+  return [simpleKeyring, siteProxy];
 }

--- a/test/e2e/tests/confirmations/helpers.ts
+++ b/test/e2e/tests/confirmations/helpers.ts
@@ -52,11 +52,6 @@ export function withTransactionEnvelopeTypeFixtures(
           : {},
       ...(smartContract && { smartContract }),
       testSpecificMock: combinedMocks,
-      manifestFlags: {
-        remoteFeatureFlags: {
-          extensionUxTokenManagementFilter: false,
-        },
-      },
       title,
     },
     testFunction,

--- a/test/e2e/tests/confirmations/transactions/erc20-approve-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/erc20-approve-redesign.spec.ts
@@ -28,11 +28,6 @@ describe('Confirmation Redesign ERC20 Approve Component', function () {
           smartContract,
           testSpecificMock: mocks,
           title: this.test?.fullTitle(),
-          manifestFlags: {
-            remoteFeatureFlags: {
-              extensionUxTokenManagementFilter: false,
-            },
-          },
         },
         async ({
           driver,

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -127,9 +127,24 @@
   "CronjobController": { "events": "object" },
   "CurrencyController": {
     "currencyRates": {
+      "BNB": {
+        "conversionDate": null,
+        "conversionRate": null,
+        "usdConversionRate": null
+      },
       "ETH": {
         "conversionDate": "object",
         "conversionRate": 1700,
+        "usdConversionRate": null
+      },
+      "MON": {
+        "conversionDate": "object",
+        "conversionRate": null,
+        "usdConversionRate": null
+      },
+      "POL": {
+        "conversionDate": null,
+        "conversionRate": null,
         "usdConversionRate": null
       }
     },

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -121,9 +121,24 @@
     "coverageResults": "object",
     "cryptocurrencies": ["btc", "sol"],
     "currencyRates": {
+      "BNB": {
+        "conversionDate": null,
+        "conversionRate": null,
+        "usdConversionRate": null
+      },
       "ETH": {
         "conversionDate": "object",
         "conversionRate": 1700,
+        "usdConversionRate": null
+      },
+      "MON": {
+        "conversionDate": "object",
+        "conversionRate": null,
+        "usdConversionRate": null
+      },
+      "POL": {
+        "conversionDate": null,
+        "conversionRate": null,
         "usdConversionRate": null
       }
     },

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-background-state.json
@@ -75,9 +75,24 @@
     },
     "CurrencyController": {
       "currencyRates": {
+        "BNB": {
+          "conversionDate": null,
+          "conversionRate": null,
+          "usdConversionRate": null
+        },
         "ETH": {
           "conversionDate": "object",
           "conversionRate": 1700,
+          "usdConversionRate": null
+        },
+        "MON": {
+          "conversionDate": "object",
+          "conversionRate": null,
+          "usdConversionRate": null
+        },
+        "POL": {
+          "conversionDate": null,
+          "conversionRate": null,
           "usdConversionRate": null
         }
       },

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -82,9 +82,24 @@
     },
     "CurrencyController": {
       "currencyRates": {
+        "BNB": {
+          "conversionDate": null,
+          "conversionRate": null,
+          "usdConversionRate": null
+        },
         "ETH": {
           "conversionDate": "object",
           "conversionRate": 1700,
+          "usdConversionRate": null
+        },
+        "MON": {
+          "conversionDate": "object",
+          "conversionRate": null,
+          "usdConversionRate": null
+        },
+        "POL": {
+          "conversionDate": null,
+          "conversionRate": null,
           "usdConversionRate": null
         }
       },

--- a/test/e2e/tests/multichain/asset-list.spec.ts
+++ b/test/e2e/tests/multichain/asset-list.spec.ts
@@ -95,11 +95,6 @@ function buildFixtures(title: string) {
     smartContract: SMART_CONTRACTS.HST,
     title,
     testSpecificMock: mockSetup,
-    manifestFlags: {
-      remoteFeatureFlags: {
-        extensionUxTokenManagementFilter: false,
-      },
-    },
   };
 }
 

--- a/test/e2e/tests/perps/perps-fixture-config.ts
+++ b/test/e2e/tests/perps/perps-fixture-config.ts
@@ -207,8 +207,6 @@ export function getPerpsGeoBlockConfig(title?: string) {
         // eslint-disable-next-line @typescript-eslint/naming-convention
         confirmations_pay_post_quote:
           PERPS_ELIGIBLE_REMOTE_FEATURE_FLAGS.confirmations_pay_post_quote,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        confirmations_pay: { name: 'empty' },
         perpsPerpTradingGeoBlockedCountriesV2: { blockedRegions: ['US'] },
       });
       await server
@@ -255,8 +253,6 @@ async function mockEligibleFeatureFlags(server: Mockttp): Promise<void> {
     // eslint-disable-next-line @typescript-eslint/naming-convention
     confirmations_pay_post_quote:
       PERPS_ELIGIBLE_REMOTE_FEATURE_FLAGS.confirmations_pay_post_quote,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    confirmations_pay: { name: 'empty' },
     perpsPerpTradingGeoBlockedCountriesV2: { blockedRegions: [] },
   });
   await server

--- a/test/e2e/tests/send/send-erc20-gas.spec.ts
+++ b/test/e2e/tests/send/send-erc20-gas.spec.ts
@@ -40,11 +40,6 @@ describe('Send ERC20 - Gas Customization', function () {
         smartContract,
         title: this.test?.fullTitle(),
         testSpecificMock: mocks,
-        manifestFlags: {
-          remoteFeatureFlags: {
-            extensionUxTokenManagementFilter: false,
-          },
-        },
       },
       async ({ driver }) => {
         await login(driver);
@@ -115,11 +110,6 @@ describe('Send ERC20 - Gas Customization', function () {
         smartContract,
         title: this.test?.fullTitle(),
         testSpecificMock: mocks,
-        manifestFlags: {
-          remoteFeatureFlags: {
-            extensionUxTokenManagementFilter: false,
-          },
-        },
       },
       async ({ driver, contractRegistry, localNodes }) => {
         const contractAddress =
@@ -192,11 +182,6 @@ describe('Send ERC20 - Gas Customization', function () {
         smartContract,
         title: this.test?.fullTitle(),
         testSpecificMock: mocks,
-        manifestFlags: {
-          remoteFeatureFlags: {
-            extensionUxTokenManagementFilter: false,
-          },
-        },
       },
       async ({ driver, contractRegistry, localNodes }) => {
         const contractAddress =

--- a/test/e2e/tests/send/send-erc20-mainnet.spec.ts
+++ b/test/e2e/tests/send/send-erc20-mainnet.spec.ts
@@ -89,11 +89,6 @@ describe('Send ERC20 - Mainnet', function () {
           .build(),
         title: this.test?.fullTitle(),
         testSpecificMock: mockSpotPriceV3ForDai,
-        manifestFlags: {
-          remoteFeatureFlags: {
-            extensionUxTokenManagementFilter: false,
-          },
-        },
         localNodeOptions: [
           {
             type: 'anvil',

--- a/test/e2e/tests/send/send-erc20-to-contract.spec.ts
+++ b/test/e2e/tests/send/send-erc20-to-contract.spec.ts
@@ -40,11 +40,6 @@ describe('Send ERC20 - Contract Warning', function () {
         smartContract,
         title: this.test?.fullTitle(),
         testSpecificMock: mocks,
-        manifestFlags: {
-          remoteFeatureFlags: {
-            extensionUxTokenManagementFilter: false,
-          },
-        },
       },
       async ({ driver, contractRegistry, localNodes }) => {
         const contractAddress: string =

--- a/test/e2e/tests/settings/hide-token-without-balance.spec.ts
+++ b/test/e2e/tests/settings/hide-token-without-balance.spec.ts
@@ -20,11 +20,6 @@ describe('Hide tokens without balance', function (this: Suite) {
         fixtures: new FixtureBuilderV2().build(),
         title: this.test?.fullTitle(),
         smartContract,
-        manifestFlags: {
-          remoteFeatureFlags: {
-            extensionUxTokenManagementFilter: false,
-          },
-        },
       },
       async ({ driver, localNodes }) => {
         await login(driver, { localNode: localNodes[0] });

--- a/test/e2e/tests/settings/state-logs.json
+++ b/test/e2e/tests/settings/state-logs.json
@@ -668,9 +668,19 @@
     "coverageResults": {},
     "cryptocurrencies": ["string"],
     "currencyRates": {
-      "*": {
+      "BNB": {
+        "conversionDate": "null",
+        "conversionRate": "null",
+        "usdConversionRate": "null"
+      },
+      "ETH": {
         "conversionDate": "null",
         "conversionRate": "number",
+        "usdConversionRate": "null"
+      },
+      "POL": {
+        "conversionDate": "null",
+        "conversionRate": "null",
         "usdConversionRate": "null"
       }
     },
@@ -1062,7 +1072,14 @@
     "lastWithdrawResult": "null",
     "manageInstitutionalWallets": "boolean",
     "marketData": {
-      "*": {}
+      "0x1": {},
+      "0x2105": {},
+      "0x38": {},
+      "0x539": {},
+      "0x89": {},
+      "0xa": {},
+      "0xa4b1": {},
+      "0xe708": {}
     },
     "marketFilterPreferences": {
       "optionId": "string",
@@ -1299,15 +1316,7 @@
     },
     "localOverrides": {},
     "location": "string",
-    "rewardsAccounts": {
-      "*": {
-        "account": "string",
-        "lastFreshOptInStatusCheck": "number",
-        "lastPerpsDiscountRateFetched": "null",
-        "perpsFeeDiscount": "null",
-        "subscriptionId": "null"
-      }
-    },
+    "rewardsAccounts": {},
     "rewardsActiveAccount": "null",
     "rewardsPointsEstimateHistory": [],
     "rewardsSeasons": {},

--- a/test/e2e/tests/smart-transactions/mocks.ts
+++ b/test/e2e/tests/smart-transactions/mocks.ts
@@ -527,16 +527,6 @@ export async function mockSmartTransactionRequests(mockServer: MockttpServer) {
     )
     .once()
     .thenJson(200, { uuid: STX_UUID, txHashes: [TRANSACTION_HASH] });
-
-  await mockServer
-    .forPost(`${TX_SENTINEL_URL}/v1/networks/1/submitTransactions`)
-    .once()
-    .thenCallback(() => {
-      return {
-        statusCode: 200,
-        json: { uuid: STX_UUID, txHashes: [TRANSACTION_HASH] },
-      };
-    });
 }
 
 export async function mockChooseGasFeeTokenRequests(mockServer: MockttpServer) {
@@ -573,13 +563,6 @@ export async function mockChooseGasFeeTokenRequests(mockServer: MockttpServer) {
     )
     .once()
     .thenJson(200, { uuid: STX_UUID });
-
-  await mockServer
-    .forPost(`${TX_SENTINEL_URL}/v1/networks/1/submitTransactions`)
-    .once()
-    .thenCallback(() => {
-      return { statusCode: 200, json: { uuid: STX_UUID } };
-    });
 }
 
 /**
@@ -721,16 +704,6 @@ export async function mockGasIncludedTransactionRequests(
     )
     .once()
     .thenJson(200, { uuid: STX_UUID, txHashes: [TRANSACTION_HASH] });
-
-  await mockServer
-    .forPost(`${TX_SENTINEL_URL}/v1/networks/1/submitTransactions`)
-    .once()
-    .thenCallback(() => {
-      return {
-        statusCode: 200,
-        json: { uuid: STX_UUID, txHashes: [TRANSACTION_HASH] },
-      };
-    });
 }
 
 export async function mockSmartTransactionBatchRequests(
@@ -757,13 +730,6 @@ export async function mockSmartTransactionBatchRequests(
     )
     .once()
     .thenJson(submitStatusCode, submitResponse);
-
-  await mockServer
-    .forPost(`${TX_SENTINEL_URL}/v1/networks/1/submitTransactions`)
-    .once()
-    .thenCallback(() => {
-      return { statusCode: submitStatusCode, json: submitResponse };
-    });
 
   for (const transactionHash of transactionHashes) {
     await mockServer
@@ -798,38 +764,16 @@ export async function mockSmartTransactionRequestsBase(
     .thenJson(200, GET_FEES_RESPONSE);
 
   await mockServer
-    .forPost(`${TX_SENTINEL_URL}/v1/networks/1/getFees`)
-    .thenCallback(() => {
-      return { statusCode: 200, json: GET_FEES_RESPONSE };
-    });
-
-  await mockServer
     .forGet('https://transaction.api.cx.metamask.io/networks/1/batchStatus')
     .withQuery({ uuids: STX_UUID })
     .once()
     .thenJson(200, GET_BATCH_STATUS_RESPONSE_PENDING);
 
   await mockServer
-    .forGet(`${TX_SENTINEL_URL}/v1/networks/1/batchStatus`)
-    .withQuery({ uuids: STX_UUID })
-    .once()
-    .thenCallback(() => {
-      return { statusCode: 200, json: GET_BATCH_STATUS_RESPONSE_PENDING };
-    });
-
-  await mockServer
     .forGet('https://transaction.api.cx.metamask.io/networks/1/batchStatus')
     .withQuery({ uuids: STX_UUID })
     .once()
     .thenJson(200, GET_BATCH_STATUS_RESPONSE_SUCCESS);
-
-  await mockServer
-    .forGet(`${TX_SENTINEL_URL}/v1/networks/1/batchStatus`)
-    .withQuery({ uuids: STX_UUID })
-    .once()
-    .thenCallback(() => {
-      return { statusCode: 200, json: GET_BATCH_STATUS_RESPONSE_SUCCESS };
-    });
 
   await mockServer
     .forJsonRpcRequest({

--- a/test/e2e/tests/tokens/add-token-using-search.spec.ts
+++ b/test/e2e/tests/tokens/add-token-using-search.spec.ts
@@ -217,11 +217,6 @@ describe('Add existing token using search', function () {
         localNodeOptions: {
           chainId: parseInt(CHAIN_IDS.BSC, 16),
         },
-        manifestFlags: {
-          remoteFeatureFlags: {
-            extensionUxTokenManagementFilter: false,
-          },
-        },
         title: this.test?.fullTitle(),
         testSpecificMock: mockBscApis,
       },

--- a/test/e2e/tests/tokens/import-tokens.spec.ts
+++ b/test/e2e/tests/tokens/import-tokens.spec.ts
@@ -548,11 +548,6 @@ describe('Import flow', function () {
           .build(),
         title: this.test?.fullTitle(),
         testSpecificMock: importTokensTestMock,
-        manifestFlags: {
-          remoteFeatureFlags: {
-            extensionUxTokenManagementFilter: false,
-          },
-        },
       },
       async ({ driver }) => {
         await login(driver, { validateBalance: false });
@@ -684,11 +679,6 @@ describe('Import flow', function () {
           .build(),
         title: this.test?.fullTitle(),
         testSpecificMock: importTokensTestMock,
-        manifestFlags: {
-          remoteFeatureFlags: {
-            extensionUxTokenManagementFilter: false,
-          },
-        },
       },
       async ({ driver }) => {
         await login(driver, { validateBalance: false });

--- a/test/e2e/tests/tokens/token-details.spec.ts
+++ b/test/e2e/tests/tokens/token-details.spec.ts
@@ -26,11 +26,6 @@ describe('Token Details', function () {
       .withSelectedNetwork(NETWORK_CLIENT_ID.MAINNET)
       .withEnabledNetworks({ eip155: { [chainId]: true } })
       .build(),
-    manifestFlags: {
-      remoteFeatureFlags: {
-        extensionUxTokenManagementFilter: false,
-      },
-    },
     localNodeOptions: {
       chainId: parseInt(chainId, 16),
     },

--- a/test/e2e/tests/tokens/token-list-storage-service.spec.ts
+++ b/test/e2e/tests/tokens/token-list-storage-service.spec.ts
@@ -50,11 +50,6 @@ describe('Token List via StorageService', function () {
         localNodeOptions: {
           chainId: parseInt(chainId, 16),
         },
-        manifestFlags: {
-          remoteFeatureFlags: {
-            extensionUxTokenManagementFilter: false,
-          },
-        },
         title: (this as Context).test?.fullTitle(),
         testSpecificMock: async (mockServer: Mockttp) => [
           // Price API

--- a/test/e2e/tests/tokens/token-list.spec.ts
+++ b/test/e2e/tests/tokens/token-list.spec.ts
@@ -29,11 +29,6 @@ describe('Token List', function () {
     localNodeOptions: {
       chainId: parseInt(chainId, 16),
     },
-    manifestFlags: {
-      remoteFeatureFlags: {
-        extensionUxTokenManagementFilter: false,
-      },
-    },
   };
 
   it('should not show percentage increase for an ERC20 token without prices available', async function () {

--- a/test/e2e/tests/tokens/token-sort.spec.ts
+++ b/test/e2e/tests/tokens/token-sort.spec.ts
@@ -45,11 +45,6 @@ describe('Token List Sorting', function () {
       {
         ...testFixtures,
         title: (this as Context).test?.fullTitle(),
-        manifestFlags: {
-          remoteFeatureFlags: {
-            extensionUxTokenManagementFilter: false,
-          },
-        },
         testSpecificMock: mockCustomTokenImport,
       },
       async ({ driver }: { driver: Driver }) => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to E2E fixtures, mocks, and registry snapshots with no production extension logic; main risk is CI flakiness if prod flag defaults no longer match what specific tests expect.
> 
> **Overview**
> Reverts recent E2E and fixture drift by **resyncing** `feature-flag-registry.ts` production defaults (sync date **2026-04-14**) and aligning default wallet state with slimmer rewards data and broader currency/token rate scaffolding.
> 
> **Feature flags:** Turns off or simplifies several prod defaults that tests had been overriding—e.g. `rewardsEnabled` / onboarding, `extensionUxTokenManagementFilter`, `extensionUxNetworkManagement`, `assetsUnifyState` (drops the `13.33.0` rollout), `additionalNetworksBlacklist` (empty), `confirmations_pay` (placeholder `empty`), incoming tx polling → **`useBackendWebSocketService`**, and tighter perps geo blocks. EIP-7702 and smart-transaction network entries are reshuffled to match current client-config.
> 
> **Fixtures & mocks:** `default-fixture.json` clears `RewardsController.rewardsAccounts`, adds BNB/MON/POL currency slots, expands `TokenRatesController.marketData` chains, and updates metrics/state-log snapshots. **`mock-e2e.js`** drops the rewards OIS mock. **Smart-transaction** mocks stop duplicating tx-sentinel `submitTransactions` / `getFees` / `batchStatus` paths.
> 
> **Specs:** Removes per-test `manifestFlags` (especially `extensionUxTokenManagementFilter: false`) now covered by registry defaults; snap signature tests open **Experimental** settings instead of custom rewards manifest flags; perps fixtures no longer force `confirmations_pay: { name: 'empty' }`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f43fb2a91c6c8125d42faf83ff316828c39a6508. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->