### PR TITLE
test: pin geckodriver to 0.36.0 (temporarily) cp-13.35.0

### DIFF
--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -139,25 +139,6 @@ jobs:
           name: ${{ env.JOB_NAME }}
           path: ./previous-test-results/
 
-      # TEMPORARY: pin geckodriver to 0.36.0 for Firefox e2e runs.
-      # geckodriver 0.37.0 (released 2026-06-03) regresses the temporary-addon
-      # dapp-connection flow in Firefox (the dapp can't detect the wallet),
-      # failing every dapp test. Selenium Manager otherwise auto-floats to the
-      # latest driver, which is why this broke with no repo change. Remove this
-      # step once a fixed geckodriver release is verified.
-      # See: https://github.com/mozilla/geckodriver/releases/tag/v0.37.0
-      - name: Pin geckodriver 0.36.0 (Firefox only)
-        if: ${{ contains(inputs.test-command, 'firefox') }}
-        run: |
-          GECKO_VERSION=0.36.0
-          GECKO_DIR="$RUNNER_TEMP/geckodriver-${GECKO_VERSION}"
-          mkdir -p "$GECKO_DIR"
-          curl -fsSL "https://github.com/mozilla/geckodriver/releases/download/v${GECKO_VERSION}/geckodriver-v${GECKO_VERSION}-linux64.tar.gz" \
-            | tar -xz -C "$GECKO_DIR"
-          chmod +x "$GECKO_DIR/geckodriver"
-          echo "GECKODRIVER_PATH=$GECKO_DIR/geckodriver" >> "$GITHUB_ENV"
-          "$GECKO_DIR/geckodriver" --version
-
       - name: Run E2E tests
         timeout-minutes: ${{ inputs.test-timeout-minutes }}
         run: ${{ inputs.test-command }} --retries 1

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -139,6 +139,25 @@ jobs:
           name: ${{ env.JOB_NAME }}
           path: ./previous-test-results/
 
+      # TEMPORARY: pin geckodriver to 0.36.0 for Firefox e2e runs.
+      # geckodriver 0.37.0 (released 2026-06-03) regresses the temporary-addon
+      # dapp-connection flow in Firefox (the dapp can't detect the wallet),
+      # failing every dapp test. Selenium Manager otherwise auto-floats to the
+      # latest driver, which is why this broke with no repo change. Remove this
+      # step once a fixed geckodriver release is verified.
+      # See: https://github.com/mozilla/geckodriver/releases/tag/v0.37.0
+      - name: Pin geckodriver 0.36.0 (Firefox only)
+        if: ${{ contains(inputs.test-command, 'firefox') }}
+        run: |
+          GECKO_VERSION=0.36.0
+          GECKO_DIR="$RUNNER_TEMP/geckodriver-${GECKO_VERSION}"
+          mkdir -p "$GECKO_DIR"
+          curl -fsSL "https://github.com/mozilla/geckodriver/releases/download/v${GECKO_VERSION}/geckodriver-v${GECKO_VERSION}-linux64.tar.gz" \
+            | tar -xz -C "$GECKO_DIR"
+          chmod +x "$GECKO_DIR/geckodriver"
+          echo "GECKODRIVER_PATH=$GECKO_DIR/geckodriver" >> "$GITHUB_ENV"
+          "$GECKO_DIR/geckodriver" --version
+
       - name: Run E2E tests
         timeout-minutes: ${{ inputs.test-timeout-minutes }}
         run: ${{ inputs.test-command }} --retries 1

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -139,6 +139,24 @@ jobs:
           name: ${{ env.JOB_NAME }}
           path: ./previous-test-results/
 
+      # geckodriver 0.37.0 breaks some e2e tests as the dapp can't detect the wallet.
+      # We pin the version as a temporary patch until migration to Playwright (in progress)
+      # This sets GECKODRIVER_PATH, which `test/e2e/webdriver/firefox.js` reads
+      # first; the firefox.js fallback handles local runs. Remove this step (and
+      # the firefox.js pin) once a fixed geckodriver release is verified.
+      # See: https://github.com/mozilla/geckodriver/releases/tag/v0.37.0
+      - name: Pin geckodriver 0.36.0 (Firefox only)
+        if: ${{ contains(inputs.test-command, 'firefox') }}
+        run: |
+          GECKO_VERSION=0.36.0
+          GECKO_DIR="$RUNNER_TEMP/geckodriver-${GECKO_VERSION}"
+          mkdir -p "$GECKO_DIR"
+          curl -fsSL "https://github.com/mozilla/geckodriver/releases/download/v${GECKO_VERSION}/geckodriver-v${GECKO_VERSION}-linux64.tar.gz" \
+            | tar -xz -C "$GECKO_DIR"
+          chmod +x "$GECKO_DIR/geckodriver"
+          echo "GECKODRIVER_PATH=$GECKO_DIR/geckodriver" >> "$GITHUB_ENV"
+          "$GECKO_DIR/geckodriver" --version
+
       - name: Run E2E tests
         timeout-minutes: ${{ inputs.test-timeout-minutes }}
         run: ${{ inputs.test-command }} --retries 1

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -1,3 +1,4 @@
+const { execFileSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -11,6 +12,75 @@ const firefox = require('selenium-webdriver/firefox');
 const { retry } = require('../../../development/lib/retry');
 const { isHeadless } = require('../../helpers/env');
 const { getOrBuildXpi } = require('../helpers/xpi');
+
+// geckodriver 0.37.0 breaks some e2e tests as the dapp can't detect the wallet.
+// We pin the version as a temporary patch until migration to Playwright (in progress)
+// See: https://github.com/mozilla/geckodriver/releases/tag/v0.37.0
+const PINNED_GECKODRIVER_VERSION = '0.36.0';
+
+/**
+ * Resolve the geckodriver binary to use.
+ *
+ * Resolution order:
+ * 1. `GECKODRIVER_PATH` env var, if set (manual override, e.g. to test a
+ *    different driver version).
+ * 2. The pinned {@link PINNED_GECKODRIVER_VERSION}, resolved (and downloaded +
+ *    cached cross-platform) via the `selenium-manager` binary that ships with
+ *    `selenium-webdriver`. This is the default for both local and CI runs, so
+ *    no env var or extra CI setup is required.
+ * 3. `undefined` on failure, so Selenium Manager falls back to its default
+ *    auto-resolution rather than hard-failing.
+ *
+ * @returns {string|undefined} Absolute path to the geckodriver binary, or
+ * `undefined` to defer to Selenium Manager's default resolution.
+ */
+function resolveGeckodriverPath() {
+  if (process.env.GECKODRIVER_PATH) {
+    return process.env.GECKODRIVER_PATH;
+  }
+
+  try {
+    const platform =
+      // eslint-disable-next-line no-nested-ternary
+      process.platform === 'darwin'
+        ? 'macos'
+        : process.platform === 'win32'
+          ? 'windows'
+          : 'linux';
+    const binName =
+      process.platform === 'win32'
+        ? 'selenium-manager.exe'
+        : 'selenium-manager';
+    const seleniumManager = path.join(
+      path.dirname(require.resolve('selenium-webdriver')),
+      'bin',
+      platform,
+      binName,
+    );
+
+    const output = execFileSync(
+      seleniumManager,
+      [
+        '--driver',
+        'geckodriver',
+        '--driver-version',
+        PINNED_GECKODRIVER_VERSION,
+        '--output',
+        'json',
+      ],
+      { encoding: 'utf8' },
+    );
+
+    const { result } = JSON.parse(output);
+    return result?.driver_path || undefined;
+  } catch (error) {
+    console.warn(
+      `Could not resolve pinned geckodriver ${PINNED_GECKODRIVER_VERSION}; ` +
+        `falling back to Selenium Manager's default driver resolution. ${error}`,
+    );
+    return undefined;
+  }
+}
 
 /**
  * The prefix for temporary Firefox profiles. All Firefox profiles used for e2e tests
@@ -84,14 +154,9 @@ class FirefoxDriver {
 
     // For cases where Firefox is installed as snap (Linux)
     const FF_SNAP_GECKO_PATH = '/snap/bin/geckodriver';
-    // `GECKODRIVER_PATH` lets us pin an explicit geckodriver binary instead of
-    // letting Selenium Manager auto-resolve (and silently float to) the latest
-    // release. This is currently used to pin 0.36.0, since geckodriver 0.37.0
-    // regresses the Firefox temporary-addon dapp-connection flow. When unset,
-    // behaviour is unchanged (Selenium Manager resolves the driver).
     const service = process.env.FIREFOX_SNAP
       ? new firefox.ServiceBuilder(FF_SNAP_GECKO_PATH)
-      : new firefox.ServiceBuilder(process.env.GECKODRIVER_PATH || undefined);
+      : new firefox.ServiceBuilder(resolveGeckodriverPath());
 
     if (port) {
       service.setPort(port);

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -22,12 +22,13 @@ const PINNED_GECKODRIVER_VERSION = '0.36.0';
  * Resolve the geckodriver binary to use.
  *
  * Resolution order:
- * 1. `GECKODRIVER_PATH` env var, if set (manual override, e.g. to test a
- *    different driver version).
+ * 1. `GECKODRIVER_PATH` env var, if set. CI sets this explicitly via the
+ *    "Pin geckodriver" step in `.github/workflows/run-e2e.yml` (also usable as
+ *    a manual override to test a different driver version).
  * 2. The pinned {@link PINNED_GECKODRIVER_VERSION}, resolved (and downloaded +
  *    cached cross-platform) via the `selenium-manager` binary that ships with
- *    `selenium-webdriver`. This is the default for both local and CI runs, so
- *    no env var or extra CI setup is required.
+ *    `selenium-webdriver`. This is the fallback that fixes local runs without
+ *    requiring any env var.
  * 3. `undefined` on failure, so Selenium Manager falls back to its default
  *    auto-resolution rather than hard-failing.
  *

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -84,9 +84,14 @@ class FirefoxDriver {
 
     // For cases where Firefox is installed as snap (Linux)
     const FF_SNAP_GECKO_PATH = '/snap/bin/geckodriver';
+    // `GECKODRIVER_PATH` lets us pin an explicit geckodriver binary instead of
+    // letting Selenium Manager auto-resolve (and silently float to) the latest
+    // release. This is currently used to pin 0.36.0, since geckodriver 0.37.0
+    // regresses the Firefox temporary-addon dapp-connection flow. When unset,
+    // behaviour is unchanged (Selenium Manager resolves the driver).
     const service = process.env.FIREFOX_SNAP
       ? new firefox.ServiceBuilder(FF_SNAP_GECKO_PATH)
-      : new firefox.ServiceBuilder();
+      : new firefox.ServiceBuilder(process.env.GECKODRIVER_PATH || undefined);
 
     if (port) {
       service.setPort(port);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Some Firefox tests got broken. It seems geckodriver version updated to 0.37.0 and broke the MetaMask <-> Dapp connections in our e2e tests.
We now pin the version to the previous working one.

This is a temporary patch, that will be removed altogether once the Playwright migration is finalized (currently in progress), as we won't be using geckodriver anymore and we'll be using pinned Firefox and pw versions to be 100% deterministic and upgrade manually via code changes.




<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run a failing spec and see it passes now ` ENABLE_MV3=false yarn test:e2e:single test/e2e/tests/mm-connect/dapp-connection-control-bar-network-picker.spec.ts --leave-running=true --browser=firefox`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test infrastructure only; no production extension behavior changes, with graceful fallback if pinned driver resolution fails.
> 
> **Overview**
> Firefox Selenium e2e runs now **pin geckodriver to 0.36.0** because **0.37.0** breaks MetaMask–dapp wallet detection in tests. A new **`resolveGeckodriverPath()`** picks the driver via **`GECKODRIVER_PATH`**, then **`selenium-manager`** (bundled with `selenium-webdriver`) for the pinned version on local and CI, with a warn-and-fallback to default Selenium Manager resolution on failure.
> 
> **`FirefoxDriver.build`** wires that path into **`firefox.ServiceBuilder`** for non-snap Firefox; **`FIREFOX_SNAP`** still uses the snap geckodriver binary. Intended as a temporary workaround until Playwright migration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27e51ed887f3b43a018cd43c37463a261b82d01a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->