### PR TITLE
fix(perps): limit PNL to 2 decimal places in close all positions modal cp-13.35.0

### DIFF
--- a/ui/components/app/perps/close-position/close-all-positions-modal.test.tsx
+++ b/ui/components/app/perps/close-position/close-all-positions-modal.test.tsx
@@ -14,30 +14,23 @@ jest.mock('../../../../store/background-connection', () => ({
 
 jest.mock('../../../../../shared/lib/perps-formatters', () => ({
   PRICE_RANGES_UNIVERSAL: [],
-  formatPerpsFiat: (value: number | string) => {
+  formatPerpsFiat: (
+    value: number | string,
+    options?: { minimumDecimals?: number; maximumDecimals?: number },
+  ) => {
     const amount = Number(value);
+    const minDec = options?.minimumDecimals ?? 0;
+    const maxDec = options?.maximumDecimals ?? 6;
     return `$${amount
       .toLocaleString('en-US', {
-        minimumFractionDigits: 0,
-        maximumFractionDigits: 6,
+        minimumFractionDigits: minDec,
+        maximumFractionDigits: maxDec,
       })
       .replace(/(\.\d*?[1-9])0+$/u, '$1')
       .replace(/\.0+$/u, '')}`;
   },
 }));
 
-jest.mock('../utils/formatPerpsDisplayPrice', () => ({
-  formatPerpsFiatUniversal: (value: number | string) => {
-    const amount = Number(value);
-    return `$${amount
-      .toLocaleString('en-US', {
-        minimumFractionDigits: 0,
-        maximumFractionDigits: 6,
-      })
-      .replace(/(\.\d*?[1-9])0+$/u, '$1')
-      .replace(/\.0+$/u, '')}`;
-  },
-}));
 
 const mockStore = configureStore({
   metamask: {

--- a/ui/components/app/perps/close-position/close-all-positions-modal.test.tsx
+++ b/ui/components/app/perps/close-position/close-all-positions-modal.test.tsx
@@ -31,7 +31,6 @@ jest.mock('../../../../../shared/lib/perps-formatters', () => ({
   },
 }));
 
-
 const mockStore = configureStore({
   metamask: {
     ...mockState.metamask,

--- a/ui/components/app/perps/close-position/close-all-positions-modal.tsx
+++ b/ui/components/app/perps/close-position/close-all-positions-modal.tsx
@@ -21,7 +21,6 @@ import {
   formatPerpsFiat,
   PRICE_RANGES_UNIVERSAL,
 } from '../../../../../shared/lib/perps-formatters';
-import { formatPerpsFiatUniversal } from '../utils/formatPerpsDisplayPrice';
 import { PERPS_FALLBACK_FEE_RATES } from '../../../../../shared/constants/perps';
 import {
   Modal,
@@ -270,9 +269,10 @@ export const CloseAllPositionsModal: React.FC<CloseAllPositionsModalProps> = ({
                       >
                         <span>
                           {totalUnrealizedPnl >= 0 ? '+' : '-'}
-                          {formatPerpsFiatUniversal(
-                            Math.abs(totalUnrealizedPnl),
-                          )}
+                          {formatPerpsFiat(Math.abs(totalUnrealizedPnl), {
+                            minimumDecimals: 2,
+                            maximumDecimals: 2,
+                          })}
                         </span>
                       </Text>,
                     ])}


### PR DESCRIPTION
## **Description**

The PNL value in the "Close All Positions" modal was formatted using `formatPerpsFiatUniversal`, which delegates to `PRICE_RANGES_UNIVERSAL`. That config allows up to 4–6 decimal places depending on value magnitude (e.g., values between $10–$100 show up to 4 decimals, values $0.01–$10 show up to 6 decimals).

This change switches the PNL display to use `formatPerpsFiat` with explicit `minimumDecimals: 2` and `maximumDecimals: 2`, capping PNL to 2 decimal places. This is consistent with how `formatPnl` formats PNL values elsewhere in the codebase.

## **Changelog**

CHANGELOG entry: Fixed PNL display in the Close All Positions modal to show a maximum of 2 decimal places

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2852

## **Manual testing steps**

Feature: Close All Positions modal PNL formatting

Scenario: PNL displays with 2 decimal places
  Given the user has open perps positions with unrealized PNL
  When the user opens the "Close All Positions" modal
  Then the PNL value (e.g., "+$12.34" or "-$5.67") is shown with exactly 2 decimal places
  And PNL values are not shown with more than 2 decimal places (e.g., not "+$12.3456")
## **Screenshots/Recordings**
### **Before**
https://consensyssoftware.atlassian.net/browse/TAT-2852?focusedCommentId=428853
### **After**
<img width="356" height="370" alt="Screenshot 2026-06-10 at 11 41 10" src="https://github.com/user-attachments/assets/2aab7176-0ce2-400f-a679-5106f69e3ee4" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only formatting change in one modal; no auth, fees calculation, or submission logic touched.
> 
> **Overview**
> The **Close All Positions** modal no longer formats total unrealized PNL with `formatPerpsFiatUniversal` (variable 4–6 decimals via `PRICE_RANGES_UNIVERSAL`). It now uses shared `formatPerpsFiat` with **`minimumDecimals: 2`** and **`maximumDecimals: 2`**, so values like `+$12.34` / `-$5.67` always show two fractional digits—aligned with `formatPnl` on the single-position close flow.
> 
> Tests drop the `formatPerpsDisplayPrice` mock and extend the `formatPerpsFiat` jest mock to honor optional decimal options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96fdd5a521ed64306de0cd41350daf02ec924f51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->