### PR TITLE
test: fix flaky `Trezor Hardware can create an ERC20 token`

### DIFF
--- a/test/e2e/tests/hardware-wallets/trezor/trezor-erc20.spec.ts
+++ b/test/e2e/tests/hardware-wallets/trezor/trezor-erc20.spec.ts
@@ -13,6 +13,7 @@ import ActivityListPage from '../../../page-objects/pages/home/activity-list';
 import AssetListPage from '../../../page-objects/pages/home/asset-list';
 import TransactionConfirmation from '../../../page-objects/pages/confirmations/transaction-confirmation';
 import { SMART_CONTRACTS } from '../../../seeder/smart-contracts';
+import { mockEmptyPrices } from '../../tokens/utils/mocks';
 
 describe('Trezor Hardware', function (this: Suite) {
   it('can create an ERC20 token', async function () {
@@ -25,6 +26,7 @@ describe('Trezor Hardware', function (this: Suite) {
             account: KNOWN_PUBLIC_KEY_ADDRESSES[0].address,
           })
           .build(),
+        testSpecificMock: mockEmptyPrices,
         title: this.test?.fullTitle(),
       },
       async ({ driver, localNodes }) => {
@@ -77,6 +79,7 @@ describe('Trezor Hardware', function (this: Suite) {
           })
 
           .build(),
+        testSpecificMock: mockEmptyPrices,
         title: this.test?.fullTitle(),
         smartContract: [
           {
@@ -140,6 +143,7 @@ describe('Trezor Hardware', function (this: Suite) {
             account: KNOWN_PUBLIC_KEY_ADDRESSES[0].address,
           })
           .build(),
+        testSpecificMock: mockEmptyPrices,
         title: this.test?.fullTitle(),
         smartContract: [
           {
@@ -196,6 +200,7 @@ describe('Trezor Hardware', function (this: Suite) {
             account: KNOWN_PUBLIC_KEY_ADDRESSES[0].address,
           })
           .build(),
+        testSpecificMock: mockEmptyPrices,
         title: this.test?.fullTitle(),
         smartContract: [
           {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Add missing mock

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2e test-only change with no production code paths affected.
> 
> **Overview**
> Stabilizes Trezor hardware-wallet ERC20 e2e tests by stubbing token price APIs during fixture setup.
> 
> Each of the four cases in `trezor-erc20.spec.ts` (create, transfer, approve, increase allowance) now passes `testSpecificMock: mockEmptyPrices` into `withFixtures`, matching the existing pattern in `ledger-erc20.spec.ts`. That keeps price-dependent UI (e.g. login balance checks) from failing when live or flaky price data is returned.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1003b7aa886910071935a759954c241ec236c8a1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->