### PR TITLE
fix: ensure stringied numeric values are numeric in token details page cp-13.35.0

### DIFF
--- a/shared/lib/selectors/assets-migration.test.ts
+++ b/shared/lib/selectors/assets-migration.test.ts
@@ -2204,6 +2204,34 @@ describe('getMultichainAssetsRatesControllerConversionRates', () => {
       expect(entry.marketData?.totalVolume).toBe('500000000');
     });
 
+    it('omits non-finite market data fields instead of stringifying them', () => {
+      const state = {
+        metamask: {
+          ...enabledFlags,
+          conversionRates: {},
+          assetsPrice: {
+            [solanaTokenAssetId]: makeMockPrice({
+              id: 'sol-usdc',
+              price: 1.5,
+              allTimeHigh: null,
+              allTimeLow: undefined,
+              circulatingSupply: NaN,
+              marketCap: null,
+              totalVolume: Infinity,
+            }),
+          },
+        },
+      };
+      const result = getMultichainAssetsRatesControllerConversionRates(state);
+
+      const { marketData } = result[solanaTokenAssetId];
+      expect(marketData?.allTimeHigh).toBeUndefined();
+      expect(marketData?.allTimeLow).toBeUndefined();
+      expect(marketData?.circulatingSupply).toBeUndefined();
+      expect(marketData?.marketCap).toBeUndefined();
+      expect(marketData?.totalVolume).toBeUndefined();
+    });
+
     it('handles empty assetsPrice', () => {
       const state = {
         metamask: {

--- a/shared/lib/selectors/assets-migration.ts
+++ b/shared/lib/selectors/assets-migration.ts
@@ -857,11 +857,21 @@ export const getMultichainAssetsRatesControllerConversionRates =
           expirationTime: undefined,
           marketData: {
             fungible: true,
-            allTimeHigh: `${assetPrice.allTimeHigh}`,
-            allTimeLow: `${assetPrice.allTimeLow}`,
-            circulatingSupply: `${assetPrice.circulatingSupply}`,
-            marketCap: `${assetPrice.marketCap}`,
-            totalVolume: `${assetPrice.totalVolume}`,
+            allTimeHigh: Number.isFinite(assetPrice.allTimeHigh)
+              ? `${assetPrice.allTimeHigh}`
+              : undefined,
+            allTimeLow: Number.isFinite(assetPrice.allTimeLow)
+              ? `${assetPrice.allTimeLow}`
+              : undefined,
+            circulatingSupply: Number.isFinite(assetPrice.circulatingSupply)
+              ? `${assetPrice.circulatingSupply}`
+              : undefined,
+            marketCap: Number.isFinite(assetPrice.marketCap)
+              ? `${assetPrice.marketCap}`
+              : undefined,
+            totalVolume: Number.isFinite(assetPrice.totalVolume)
+              ? `${assetPrice.totalVolume}`
+              : undefined,
             pricePercentChange: {
               PT1H: assetPrice.pricePercentChange1h as number,
               P1D: assetPrice.pricePercentChange1d as number,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Some non-numeric values in the token details page are being stringified, which is causing an issue when converting to BigInteger.

<img width="1962" height="914" alt="image" src="https://github.com/user-attachments/assets/7a48a7f8-ddfe-431c-8222-0a0425df535b" />


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed issue with token market non-numeric values being stringified.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/43389

## **Manual testing steps**

1. Import Solana token JBxEqfH8vzyUCXmWvTesN41ccbxoaESXxuJG9LFWpump
2. Access the asset details page

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small selector change with tests; only affects display/mapping of optional market stats for non-EVM assets when unify state is enabled.
> 
> **Overview**
> Fixes multichain token **market data** on the asset details page when price API fields are missing or invalid.
> 
> In `getMultichainAssetsRatesControllerConversionRates`, **allTimeHigh**, **allTimeLow**, **circulatingSupply**, **marketCap**, and **totalVolume** are now stringified only when `Number.isFinite` is true; otherwise the field is **`undefined`** instead of values like `"null"`, `"NaN"`, or `"Infinity"` that broke downstream **BigInteger** parsing.
> 
> A unit test covers `null`, `undefined`, `NaN`, and `Infinity` inputs for those fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a073152510f5d83d06ff8f6c08fce91524ec00b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->