### PR TITLE
feat: Add QR error handling for invalid transaction signature

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -7,12 +7,6 @@
     "message": "Das Laden dauert länger als gewöhnlich.",
     "description": "First line of the message that is shown when the initial loading of the MetaMask UI takes a very long time."
   },
-  "QRHardwareInvalidTransactionTitle": {
-    "message": "Fehler"
-  },
-  "QRHardwareMismatchedSignId": {
-    "message": "Inkongruente Transaktionsdaten. Bitte überprüfen Sie die Transaktionsdetails."
-  },
   "QRHardwarePubkeyAccountOutOfRange": {
     "message": "Keine weiteren Konten. Wenn Sie auf ein Konto zugreifen möchten, das unten nicht aufgelistet ist, verbinden Sie bitte erneut Ihr Hardware-Wallet und wählen Sie dieses."
   },

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -7,12 +7,6 @@
     "message": "Η φόρτωση διαρκεί περισσότερο από το συνηθισμένο.",
     "description": "First line of the message that is shown when the initial loading of the MetaMask UI takes a very long time."
   },
-  "QRHardwareInvalidTransactionTitle": {
-    "message": "Σφάλμα"
-  },
-  "QRHardwareMismatchedSignId": {
-    "message": "Μη συμβατά δεδομένα συναλλαγών. Ελέγξτε τις λεπτομέρειες της συναλλαγής."
-  },
   "QRHardwarePubkeyAccountOutOfRange": {
     "message": "Δεν υπάρχουν άλλοι λογαριασμοί. Αν θέλετε να αποκτήσετε πρόσβαση σε έναν άλλο λογαριασμό που δεν περιλαμβάνεται στην παρακάτω λίστα, παρακαλούμε συνδέστε ξανά το πορτοφόλι υλικού σας και επιλέξτε το."
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -7,12 +7,6 @@
     "message": "Loading is taking longer than usual.",
     "description": "First line of the message that is shown when the initial loading of the MetaMask UI takes a very long time."
   },
-  "QRHardwareInvalidTransactionTitle": {
-    "message": "Error"
-  },
-  "QRHardwareMismatchedSignId": {
-    "message": "Incongruent transaction data. Please check the transaction details."
-  },
   "QRHardwarePubkeyAccountOutOfRange": {
     "message": "No more accounts. If you would like to access another account unlisted below, please reconnect your hardware wallet and select it."
   },
@@ -7826,6 +7820,14 @@
   "qrCameraAccessNeededTitle": {
     "message": "Camera access needed",
     "description": "Title when the camera permission dialog was dismissed without a choice."
+  },
+  "qrErrorMismatchedTransactionBody": {
+    "message": "This QR code is for a different transaction. Cancel and try again, making sure to scan the QR code shown in MetaMask with your hardware wallet first.",
+    "description": "Body text when a signature QR belongs to a previous transaction."
+  },
+  "qrErrorMismatchedTransactionTitle": {
+    "message": "Wrong QR code",
+    "description": "Title shown when a signature QR belongs to a different transaction."
   },
   "qrErrorNonUrPairingBody": {
     "message": "Go back to your hardware wallet and find the option to share or export your accounts, choose MetaMask, then scan the QR code.",

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -7,12 +7,6 @@
     "message": "Loading is taking longer than usual.",
     "description": "First line of the message that is shown when the initial loading of the MetaMask UI takes a very long time."
   },
-  "QRHardwareInvalidTransactionTitle": {
-    "message": "Error"
-  },
-  "QRHardwareMismatchedSignId": {
-    "message": "Incongruent transaction data. Please check the transaction details."
-  },
   "QRHardwarePubkeyAccountOutOfRange": {
     "message": "No more accounts. If you would like to access another account unlisted below, please reconnect your hardware wallet and select it."
   },
@@ -7826,6 +7820,14 @@
   "qrCameraAccessNeededTitle": {
     "message": "Camera access needed",
     "description": "Title when the camera permission dialog was dismissed without a choice."
+  },
+  "qrErrorMismatchedTransactionBody": {
+    "message": "This QR code is for a different transaction. Cancel and try again, making sure to scan the QR code shown in MetaMask with your hardware wallet first.",
+    "description": "Body text when a signature QR belongs to a previous transaction."
+  },
+  "qrErrorMismatchedTransactionTitle": {
+    "message": "Wrong QR code",
+    "description": "Title shown when a signature QR belongs to a different transaction."
   },
   "qrErrorNonUrPairingBody": {
     "message": "Go back to your hardware wallet and find the option to share or export your accounts, choose MetaMask, then scan the QR code.",

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -7,12 +7,6 @@
     "message": "La carga está tardando más de lo habitual.",
     "description": "First line of the message that is shown when the initial loading of the MetaMask UI takes a very long time."
   },
-  "QRHardwareInvalidTransactionTitle": {
-    "message": "Error"
-  },
-  "QRHardwareMismatchedSignId": {
-    "message": "Datos de transacción incongruentes. Compruebe los detalles."
-  },
   "QRHardwarePubkeyAccountOutOfRange": {
     "message": "No hay más cuentas. Para acceder a otra cuenta que no figura en la lista, vuelva a conectar su monedero físico y selecciónela."
   },

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -7,12 +7,6 @@
     "message": "Le chargement prend plus de temps que d’habitude.",
     "description": "First line of the message that is shown when the initial loading of the MetaMask UI takes a very long time."
   },
-  "QRHardwareInvalidTransactionTitle": {
-    "message": "Erreur"
-  },
-  "QRHardwareMismatchedSignId": {
-    "message": "Données de transaction incompatibles. Veuillez vérifier les détails de la transaction."
-  },
   "QRHardwarePubkeyAccountOutOfRange": {
     "message": "Il n’y a plus de comptes. Si vous souhaitez accéder à un autre compte non répertorié ci-dessous, veuillez reconnecter votre portefeuille matériel et le sélectionner."
   },

--- a/app/_locales/ga/messages.json
+++ b/app/_locales/ga/messages.json
@@ -7,12 +7,6 @@
     "message": "Tá an luchtú ag glacadh níos faide ná mar is gnách.",
     "description": "First line of the message that is shown when the initial loading of the MetaMask UI takes a very long time."
   },
-  "QRHardwareInvalidTransactionTitle": {
-    "message": "Earráid"
-  },
-  "QRHardwareMismatchedSignId": {
-    "message": "Sonraí idirbhirt neamhréireach. Seiceáil sonraí an idirbhirt le do thoil."
-  },
   "QRHardwarePubkeyAccountOutOfRange": {
     "message": "Níl aon chuntais eile ann. Más mian leat rochtain a fháil ar chuntas eile nach bhfuil liostaithe thíos, athcheangail do sparán crua-earraí agus roghnaigh é."
   },

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -7,12 +7,6 @@
     "message": "लोडिंग सामान्य से अधिक समय ले रही है।",
     "description": "First line of the message that is shown when the initial loading of the MetaMask UI takes a very long time."
   },
-  "QRHardwareInvalidTransactionTitle": {
-    "message": "गड़बड़ी"
-  },
-  "QRHardwareMismatchedSignId": {
-    "message": "असंगत ट्रांसेक्शन डेटा। कृपया ट्रांसेक्शन की जानकारी की जांच करें।"
-  },
   "QRHardwarePubkeyAccountOutOfRange": {
     "message": "कोई और अकाउंट नहीं। यदि आप नीचे अलिस्टेड किसी अन्य अकाउंट तक पहुंचना चाहते हैं, तो कृपया अपने hardware wallet को फिर से कनेक्ट करें और उसे चुनें।"
   },

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -7,12 +7,6 @@
     "message": "Pemuatan memerlukan waktu lebih lama dari biasanya.",
     "description": "First line of the message that is shown when the initial loading of the MetaMask UI takes a very long time."
   },
-  "QRHardwareInvalidTransactionTitle": {
-    "message": "Kesalahan"
-  },
-  "QRHardwareMismatchedSignId": {
-    "message": "Data transaksi tidak sesuai. Harap periksa detail transaksi."
-  },
   "QRHardwarePubkeyAccountOutOfRange": {
     "message": "Tidak ada akun lainnya. Jika Anda ingin mengakses akun lain yang tidak terdaftar di bawah ini, harap hubungkan kembali dompet perangkat keras Anda dan pilih."
   },

--- a/app/_locales/it/messages.json
+++ b/app/_locales/it/messages.json
@@ -1,10 +1,4 @@
 {
-  "QRHardwareInvalidTransactionTitle": {
-    "message": "Errore"
-  },
-  "QRHardwareMismatchedSignId": {
-    "message": "Dati incongruenti. Controlla i dati della transazione."
-  },
   "QRHardwarePubkeyAccountOutOfRange": {
     "message": "Non ci sono altri account. Se desideri accedere a un altro account non elencato di seguito, ricollega il tuo portafoglio hardware e selezionalo."
   },

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -7,12 +7,6 @@
     "message": "読み込みに通常より時間がかかっています。",
     "description": "First line of the message that is shown when the initial loading of the MetaMask UI takes a very long time."
   },
-  "QRHardwareInvalidTransactionTitle": {
-    "message": "エラー"
-  },
-  "QRHardwareMismatchedSignId": {
-    "message": "トランザクションデータが一致していません。トランザクションの詳細を確認してください。"
-  },
   "QRHardwarePubkeyAccountOutOfRange": {
     "message": "他にアカウントはありません。以下のリストにない別のアカウントにアクセスする場合は、ハードウェアウォレットを接続しなおして選択してください。"
   },

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -7,12 +7,6 @@
     "message": "로딩이 평소보다 오래 걸립니다.",
     "description": "First line of the message that is shown when the initial loading of the MetaMask UI takes a very long time."
   },
-  "QRHardwareInvalidTransactionTitle": {
-    "message": "오류"
-  },
-  "QRHardwareMismatchedSignId": {
-    "message": "일치하지 않는 트랜잭션 데이터. 트랜잭션 세부 정보를 확인하세요."
-  },
   "QRHardwarePubkeyAccountOutOfRange": {
     "message": "더 이상 계정이 없습니다. 아래 목록에 없는 다른 계정에 액세스하려면 하드웨어 지갑을 다시 연결하고 선택하세요."
   },

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -7,12 +7,6 @@
     "message": "O carregamento está demorando mais que o normal.",
     "description": "First line of the message that is shown when the initial loading of the MetaMask UI takes a very long time."
   },
-  "QRHardwareInvalidTransactionTitle": {
-    "message": "Erro"
-  },
-  "QRHardwareMismatchedSignId": {
-    "message": "Os dados da transação são inconsistentes. Verifique os detalhes da transação."
-  },
   "QRHardwarePubkeyAccountOutOfRange": {
     "message": "Não há mais contas. Se você gostaria de acessar outra conta não listada abaixo, reconecte sua carteira de hardware e selecione-a."
   },

--- a/app/_locales/pt_BR/messages.json
+++ b/app/_locales/pt_BR/messages.json
@@ -1,10 +1,4 @@
 {
-  "QRHardwareInvalidTransactionTitle": {
-    "message": "Erro"
-  },
-  "QRHardwareMismatchedSignId": {
-    "message": "Os dados da transação são inconsistentes. Verifique os detalhes da transação."
-  },
   "QRHardwarePubkeyAccountOutOfRange": {
     "message": "Não há mais contas. Se você gostaria de acessar outra conta não listada abaixo, reconecte sua carteira de hardware e selecione-a."
   },

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -7,12 +7,6 @@
     "message": "Загрузка занимает больше времени, чем обычно.",
     "description": "First line of the message that is shown when the initial loading of the MetaMask UI takes a very long time."
   },
-  "QRHardwareInvalidTransactionTitle": {
-    "message": "Ошибка"
-  },
-  "QRHardwareMismatchedSignId": {
-    "message": "Несоответствующие данные транзакции. Проверьте ее реквизиты."
-  },
   "QRHardwarePubkeyAccountOutOfRange": {
     "message": "Больше нет счетов. Если вы хотите получить доступ к другому счету, не указанному ниже, повторно подключите аппаратный кошелек и выберите его."
   },

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -7,12 +7,6 @@
     "message": "Masyadong matagal ang paglo-load kaysa sa karaniwan.",
     "description": "First line of the message that is shown when the initial loading of the MetaMask UI takes a very long time."
   },
-  "QRHardwareInvalidTransactionTitle": {
-    "message": "Error"
-  },
-  "QRHardwareMismatchedSignId": {
-    "message": "Hindi tugmang data ng transaksyon. Pakisuri ang mga detalye ng transaksyon."
-  },
   "QRHardwarePubkeyAccountOutOfRange": {
     "message": "Wala nang mga account. Kung gusto mong mag-access ng iba pang account na hindi nakalista sa ibaba, pakikonektang muli ang wallet na hardware mo at piliin ito."
   },

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -7,12 +7,6 @@
     "message": "Yükleme her zamankinden daha uzun sürüyor.",
     "description": "First line of the message that is shown when the initial loading of the MetaMask UI takes a very long time."
   },
-  "QRHardwareInvalidTransactionTitle": {
-    "message": "Hata"
-  },
-  "QRHardwareMismatchedSignId": {
-    "message": "Uyumsuz işlem verisi. Lütfen işlem ayrıntılarını kontrol edin."
-  },
   "QRHardwarePubkeyAccountOutOfRange": {
     "message": "Başka hesap yok. Aşağıda listelenmeyen başka bir hesaba erişmek istiyorsanız lütfen donanım cüzdanınızı yeniden bağlayın ve seçin."
   },

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -7,12 +7,6 @@
     "message": "Thời gian tải lâu hơn bình thường.",
     "description": "First line of the message that is shown when the initial loading of the MetaMask UI takes a very long time."
   },
-  "QRHardwareInvalidTransactionTitle": {
-    "message": "Lỗi"
-  },
-  "QRHardwareMismatchedSignId": {
-    "message": "Dữ liệu giao dịch không đồng nhất. Vui lòng kiểm tra chi tiết giao dịch."
-  },
   "QRHardwarePubkeyAccountOutOfRange": {
     "message": "Không còn tài khoản nào. Nếu bạn muốn truy cập một tài khoản khác không được liệt kê bên dưới, vui lòng kết nối lại với ví cứng và chọn tài khoản đó."
   },

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -7,12 +7,6 @@
     "message": "加载时间比平时长。",
     "description": "First line of the message that is shown when the initial loading of the MetaMask UI takes a very long time."
   },
-  "QRHardwareInvalidTransactionTitle": {
-    "message": "错误"
-  },
-  "QRHardwareMismatchedSignId": {
-    "message": "不一致的交易数据。请查看交易详情。"
-  },
   "QRHardwarePubkeyAccountOutOfRange": {
     "message": "暂无更多账户。若想访问下方未列出的其他账户，请重新连接您的硬件钱包并选择它。"
   },

--- a/ui/components/app/qr-hardware-popover/base-qr-reader/base-qr-reader.test.tsx
+++ b/ui/components/app/qr-hardware-popover/base-qr-reader/base-qr-reader.test.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect } from 'react';
 import { act, render, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
+import { URDecoder } from '@ngraveio/bc-ur';
 import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import WebcamUtils from '../../../../helpers/utils/webcam-utils';
 import {
@@ -13,13 +14,23 @@ import {
   ENVIRONMENT_TYPE_FULLSCREEN,
   ENVIRONMENT_TYPE_POPUP,
 } from '../../../../../shared/constants/app';
-import { MetaMetricsEventName } from '../../../../../shared/constants/metametrics';
+import {
+  MetaMetricsEventName,
+  MetaMetricsHardwareWalletDeviceType,
+} from '../../../../../shared/constants/metametrics';
 import { getEnvironmentType } from '../../../../../shared/lib/environment-type';
 import { CameraPermissionState } from '../../../../contexts/hardware-wallets/constants';
 import EnhancedQrReader from '../enhanced-qr-reader';
+import { QrErrorFlowContext } from '../qr-error-content';
+import {
+  QrMismatchedTransactionError,
+  ScanErrorCategory,
+} from '../qr-utils/qr-utils';
 import {
   DOMExceptionName,
   PAIRING_EXPECTED_UR_TYPES,
+  SIGNING_EXPECTED_UR_TYPES,
+  UrType,
   WebcamErrorType,
   type BaseQrReaderProps,
 } from './base-qr-reader.types';
@@ -45,6 +56,13 @@ jest.mock('../../../../helpers/utils/webcam-utils');
 
 jest.mock('../enhanced-qr-reader');
 
+jest.mock('@ngraveio/bc-ur', () => ({
+  ...jest.requireActual('@ngraveio/bc-ur'),
+  // The real delegation is (re)installed in `beforeEach` so that per-test
+  // overrides do not leak between tests.
+  URDecoder: jest.fn(),
+}));
+
 const mockGetEnvironmentType = jest.mocked(getEnvironmentType);
 const mockGetChromiumExtensionCameraSiteSettingsUrl = jest.mocked(
   getChromiumExtensionCameraSiteSettingsUrl,
@@ -54,6 +72,7 @@ const mockGetMozExtensionOriginForDisplay = jest.mocked(
   getMozExtensionOriginForDisplay,
 );
 const mockEnhancedQrReader = jest.mocked(EnhancedQrReader);
+const mockURDecoder = jest.mocked(URDecoder);
 
 const mockCheckStatus = jest.mocked(WebcamUtils.checkStatus);
 const mockQueryCameraPermission = jest.mocked(
@@ -67,7 +86,8 @@ const mockStream = {
 };
 
 /**
- * Sets up `WebcamUtils` mocks for the happy path: fullscreen, prompt permission, stream OK.
+ * Sets up `WebcamUtils` mocks for the success path with fullscreen, prompt
+ * permission, and a working video stream.
  */
 function setupWebcamUtilsSuccess() {
   mockCheckStatus.mockResolvedValue({
@@ -96,6 +116,14 @@ describe('BaseQrReader', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockURDecoder.mockImplementation(
+      (...args: ConstructorParameters<typeof URDecoder>) =>
+        new (
+          jest.requireActual(
+            '@ngraveio/bc-ur',
+          ) as typeof import('@ngraveio/bc-ur')
+        ).URDecoder(...args),
+    );
     mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_FULLSCREEN);
     // @ts-expect-error mocking platform
     global.platform = {
@@ -782,6 +810,85 @@ describe('BaseQrReader', () => {
     expect(
       screen.getByTestId('qr-error-nonUrQrCode-signing'),
     ).toBeInTheDocument();
+  });
+
+  it('renders QrErrorContent when handleSuccess rejects with mismatched transaction', async () => {
+    setupWebcamUtilsSuccess();
+    const mockInstance = {
+      isComplete: jest
+        .fn()
+        .mockReturnValueOnce(false)
+        .mockReturnValueOnce(true),
+      isError: jest.fn().mockReturnValue(false),
+      receivePart: jest.fn(),
+      estimatedPercentComplete: jest.fn().mockReturnValue(1),
+      resultUR: jest.fn().mockReturnValue({ type: UrType.EthSignature }),
+    };
+    mockURDecoder.mockImplementation(
+      () => mockInstance as unknown as URDecoder,
+    );
+
+    mockEnhancedQrReader.mockImplementation((({
+      onFrame,
+    }: {
+      onFrame: (data: string) => void;
+    }) => {
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      useEffect(() => {
+        onFrame(`ur:${UrType.EthSignature}/mock-frame`);
+      }, [onFrame]);
+      return null;
+    }) as unknown as typeof EnhancedQrReader);
+
+    const handleSuccess = jest
+      .fn()
+      .mockRejectedValue(new QrMismatchedTransactionError());
+
+    const mockTrackEvent = jest.fn().mockResolvedValue(undefined);
+
+    await act(async () => {
+      renderWithProvider(
+        <BaseQrReader
+          {...defaultProps}
+          isReadingWallet={false}
+          expectedUrTypes={SIGNING_EXPECTED_UR_TYPES}
+          handleSuccess={handleSuccess}
+        />,
+        undefined,
+        '/',
+        render,
+        () => mockTrackEvent,
+      );
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('qr-error-mismatchedTransaction-signing'),
+      ).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(messages.qrErrorMismatchedTransactionTitle.message),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(messages.qrErrorMismatchedTransactionBody.message),
+    ).toBeInTheDocument();
+    expect(defaultProps.setErrorActive).toHaveBeenCalledWith(true);
+
+    const scanFailed = mockTrackEvent.mock.calls.filter(
+      (call: unknown[]) =>
+        (call[0] as { event: string }).event ===
+        MetaMetricsEventName.QrHardwareScanFailed,
+    );
+    expect(scanFailed).toHaveLength(1);
+    expect(scanFailed[0][0].properties).toStrictEqual({
+      // eslint-disable-next-line @typescript-eslint/naming-convention -- Segment analytics payload keys use snake_case
+      device_type: MetaMetricsHardwareWalletDeviceType.QrHardware,
+      // eslint-disable-next-line @typescript-eslint/naming-convention -- Segment analytics payload keys use snake_case
+      error_category: ScanErrorCategory.MismatchedSignId,
+      // eslint-disable-next-line @typescript-eslint/naming-convention -- Segment analytics payload keys use snake_case
+      is_ur_format: true,
+      flow: QrErrorFlowContext.Signing,
+    });
   });
 
   // ---- Cancel & Try Again on error UI ------------------------------------

--- a/ui/components/app/qr-hardware-popover/base-qr-reader/base-qr-reader.tsx
+++ b/ui/components/app/qr-hardware-popover/base-qr-reader/base-qr-reader.tsx
@@ -269,8 +269,6 @@ const BaseQrReader = ({
     if (error.type === WebcamErrorType.NoWebcamFound) {
       title = t('noWebcamFoundTitle');
       message = t('noWebcamFound');
-    } else if (error.message === t('QRHardwareMismatchedSignId')) {
-      message = t('QRHardwareMismatchedSignId');
     } else {
       title = t('generalCameraErrorTitle');
       message = t('generalCameraError');

--- a/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.stories.tsx
+++ b/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.stories.tsx
@@ -19,6 +19,7 @@ Presentational component for QR scan error states during hardware wallet pairing
 - **NonUrQrCode** (State 3) - scanned data is not a UR code. Copy differs between pairing and signing.
 - **WrongUrType** (State 4) - valid UR, but the type is wrong for this flow. Copy differs between pairing and signing.
 - **UrDecodeError** (State 5) - the UR decoder encountered an error. Copy is universal (same for pairing and signing).
+- **MismatchedTransaction** (State 6) - signature QR belongs to a different transaction. Copy is universal (signing flow only).
 
 **Buttons**
 - **Learn more** (secondary) - opens the MetaMask support article.
@@ -45,6 +46,7 @@ Presentational component for QR scan error states during hardware wallet pairing
         QrErrorType.NonUrQrCode,
         QrErrorType.WrongUrType,
         QrErrorType.UrDecodeError,
+        QrErrorType.MismatchedTransaction,
       ],
       description: 'Which QR scan error state to display.',
     },
@@ -111,6 +113,16 @@ export const UrDecodeError: Story = {
   args: {
     errorType: QrErrorType.UrDecodeError,
     flowContext: QrErrorFlowContext.Pairing,
+    onTryAgain: () => undefined,
+  },
+};
+
+/** State 6 - Signature QR belongs to a different transaction. */
+export const MismatchedTransaction: Story = {
+  name: 'State 6: Mismatched Transaction',
+  args: {
+    errorType: QrErrorType.MismatchedTransaction,
+    flowContext: QrErrorFlowContext.Signing,
     onTryAgain: () => undefined,
   },
 };

--- a/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.test.tsx
+++ b/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.test.tsx
@@ -111,4 +111,24 @@ describe('QrErrorContent', () => {
 
     expect(onTryAgain).not.toHaveBeenCalled();
   });
+
+  it('renders mismatched transaction copy in the signing flow', () => {
+    renderWithLocalization(
+      <QrErrorContent
+        errorType={QrErrorType.MismatchedTransaction}
+        flowContext={QrErrorFlowContext.Signing}
+        onTryAgain={jest.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByTestId('qr-error-mismatchedTransaction-signing'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(messages.qrErrorMismatchedTransactionTitle.message),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(messages.qrErrorMismatchedTransactionBody.message),
+    ).toBeInTheDocument();
+  });
 });

--- a/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.types.ts
+++ b/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.types.ts
@@ -4,11 +4,13 @@
  * - `NonUrQrCode` - scanned data does not start with `ur:`.
  * - `WrongUrType` - valid UR whose type does not match the current flow.
  * - `UrDecodeError` - the UR decoder failed to reassemble frames.
+ * - `MismatchedTransaction` - the signature QR belongs to a different transaction.
  */
 export const QrErrorType = {
   NonUrQrCode: 'nonUrQrCode',
   WrongUrType: 'wrongUrType',
   UrDecodeError: 'urDecodeError',
+  MismatchedTransaction: 'mismatchedTransaction',
 } as const;
 
 export type QrErrorType = (typeof QrErrorType)[keyof typeof QrErrorType];

--- a/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.utils.test.ts
+++ b/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.utils.test.ts
@@ -65,7 +65,7 @@ describe('qr-error-content utils', () => {
       expect(mockT).toHaveBeenCalledWith('qrErrorUrDecodeBody');
     });
 
-    it('returns the same universal copy for UrDecodeError + Signing', () => {
+    it('returns universal title and body for UrDecodeError + Signing', () => {
       resolveErrorCopy(
         QrErrorType.UrDecodeError,
         QrErrorFlowContext.Signing,
@@ -74,6 +74,17 @@ describe('qr-error-content utils', () => {
 
       expect(mockT).toHaveBeenCalledWith('qrErrorUrDecodeTitle');
       expect(mockT).toHaveBeenCalledWith('qrErrorUrDecodeBody');
+    });
+
+    it('returns mismatched transaction copy for MismatchedTransaction', () => {
+      resolveErrorCopy(
+        QrErrorType.MismatchedTransaction,
+        QrErrorFlowContext.Signing,
+        mockT,
+      );
+
+      expect(mockT).toHaveBeenCalledWith('qrErrorMismatchedTransactionTitle');
+      expect(mockT).toHaveBeenCalledWith('qrErrorMismatchedTransactionBody');
     });
 
     it('falls back to UR decode copy for unrecognised error types', () => {
@@ -111,6 +122,7 @@ describe('qr-error-content utils', () => {
         QrErrorType.NonUrQrCode,
         QrErrorType.WrongUrType,
         QrErrorType.UrDecodeError,
+        QrErrorType.MismatchedTransaction,
       ];
       const allFlows = [QrErrorFlowContext.Pairing, QrErrorFlowContext.Signing];
 
@@ -149,6 +161,15 @@ describe('qr-error-content utils', () => {
       expect(
         rootTestId(QrErrorType.UrDecodeError, QrErrorFlowContext.Signing),
       ).toBe('qr-error-urDecodeError-signing');
+    });
+
+    it('reflects the MismatchedTransaction error type', () => {
+      expect(
+        rootTestId(
+          QrErrorType.MismatchedTransaction,
+          QrErrorFlowContext.Signing,
+        ),
+      ).toBe('qr-error-mismatchedTransaction-signing');
     });
   });
 });

--- a/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.utils.ts
+++ b/ui/components/app/qr-hardware-popover/qr-error-content/qr-error-content.utils.ts
@@ -42,6 +42,11 @@ export function resolveErrorCopy(
           ? t('qrErrorWrongUrTypePairingBody')
           : t('qrErrorWrongUrTypeSigningBody'),
       };
+    case QrErrorType.MismatchedTransaction:
+      return {
+        title: t('qrErrorMismatchedTransactionTitle'),
+        body: t('qrErrorMismatchedTransactionBody'),
+      };
     case QrErrorType.UrDecodeError:
     default:
       return {

--- a/ui/components/app/qr-hardware-popover/qr-hardware-sign-request/qr-reader/qr-reader.test.tsx
+++ b/ui/components/app/qr-hardware-popover/qr-hardware-sign-request/qr-reader/qr-reader.test.tsx
@@ -4,12 +4,12 @@ import type { UR } from '@ngraveio/bc-ur';
 import { ETHSignature } from '@keystonehq/bc-ur-registry-eth';
 import * as uuid from 'uuid';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
-import { tEn } from '../../../../../../test/lib/i18n-helpers';
 import {
   UrType,
   SIGNING_EXPECTED_UR_TYPES,
   type BaseQrReaderProps,
 } from '../../base-qr-reader';
+import { QrMismatchedTransactionError } from '../../qr-utils/qr-utils';
 import type { QrReaderProps } from './qr-reader.types';
 import QrReader from './qr-reader';
 
@@ -138,7 +138,7 @@ describe('QrReader', () => {
       });
     });
 
-    it('throws and sets error title when requestId does not match', async () => {
+    it('throws QrMismatchedTransactionError when requestId does not match', async () => {
       mockUr = buildMockUr();
 
       mockFromCBOR.mockReturnValue({
@@ -151,16 +151,11 @@ describe('QrReader', () => {
       await screen.getByTestId('base-qr-reader-success').click();
 
       await waitFor(() => {
-        expect(defaultProps.setErrorTitle).toHaveBeenCalledWith(
-          tEn('QRHardwareInvalidTransactionTitle'),
-        );
+        expect(defaultProps.setErrorTitle).not.toHaveBeenCalled();
         expect(defaultProps.submitQRHardwareSignature).not.toHaveBeenCalled();
       });
 
-      expect(mockLastReaderError).toBeDefined();
-      expect(mockLastReaderError?.message).toBe(
-        tEn('QRHardwareMismatchedSignId'),
-      );
+      expect(mockLastReaderError).toBeInstanceOf(QrMismatchedTransactionError);
     });
   });
 

--- a/ui/components/app/qr-hardware-popover/qr-hardware-sign-request/qr-reader/qr-reader.tsx
+++ b/ui/components/app/qr-hardware-popover/qr-hardware-sign-request/qr-reader/qr-reader.tsx
@@ -6,7 +6,7 @@ import BaseQrReader, {
   CBOR_ENCODING,
   SIGNING_EXPECTED_UR_TYPES,
 } from '../../base-qr-reader';
-import { useI18nContext } from '../../../../../hooks/useI18nContext';
+import { QrMismatchedTransactionError } from '../../qr-utils/qr-utils';
 import type { QrReaderProps } from './qr-reader.types';
 
 /**
@@ -30,8 +30,6 @@ const QrReader = ({
   setErrorTitle,
   setErrorActive,
 }: QrReaderProps) => {
-  const t = useI18nContext();
-
   const handleSuccess = useCallback(
     async (ur: UR) => {
       const ethSignature = ETHSignature.fromCBOR(ur.cbor);
@@ -39,8 +37,7 @@ const QrReader = ({
       const signId = uuid.stringify(buffer as Uint8Array);
 
       if (signId !== requestId) {
-        setErrorTitle(t('QRHardwareInvalidTransactionTitle'));
-        throw new Error(t('QRHardwareMismatchedSignId'));
+        throw new QrMismatchedTransactionError();
       }
 
       return await submitQRHardwareSignature({
@@ -48,7 +45,7 @@ const QrReader = ({
         cbor: ur.cbor.toString(CBOR_ENCODING),
       });
     },
-    [submitQRHardwareSignature, requestId, setErrorTitle, t],
+    [submitQRHardwareSignature, requestId],
   );
 
   return (

--- a/ui/components/app/qr-hardware-popover/qr-hooks/decoder-lifecycle/useDecoderLifecycle.test.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/decoder-lifecycle/useDecoderLifecycle.test.ts
@@ -5,8 +5,12 @@ import {
   UrType,
   PAIRING_EXPECTED_UR_TYPES,
   SIGNING_EXPECTED_UR_TYPES,
+  type BaseQrReaderProps,
 } from '../../base-qr-reader';
-import { ScanErrorCategory } from '../../qr-utils/qr-utils';
+import {
+  ScanErrorCategory,
+  QrMismatchedTransactionError,
+} from '../../qr-utils/qr-utils';
 import type { DecoderCallbacks } from '../qr-hooks.types';
 import { useDecoderLifecycle } from './useDecoderLifecycle';
 
@@ -26,16 +30,68 @@ jest.mock('@ngraveio/bc-ur', () => {
 
 const mockURDecoder = jest.mocked(URDecoder);
 
+/**
+ * The subset of the `URDecoder` surface that {@link useDecoderLifecycle} uses.
+ */
+type MockDecoder = {
+  isComplete: jest.Mock<boolean, []>;
+  isError: jest.Mock<boolean, []>;
+  receivePart: jest.Mock<void, [string]>;
+  estimatedPercentComplete: jest.Mock<number, []>;
+  resultUR: jest.Mock<{ type: string }, []>;
+};
+
+/**
+ * Builds a `URDecoder` mock with inert defaults that tests can override.
+ *
+ * @param overrides - Mock methods to replace the defaults with.
+ * @returns A decoder mock.
+ */
+function buildDecoderMock(overrides: Partial<MockDecoder> = {}): MockDecoder {
+  return {
+    isComplete: jest.fn().mockReturnValue(false),
+    isError: jest.fn().mockReturnValue(false),
+    receivePart: jest.fn(),
+    estimatedPercentComplete: jest.fn().mockReturnValue(0),
+    resultUR: jest.fn(),
+    ...overrides,
+  };
+}
+
+/**
+ * Builds a decoder mock that reports incomplete on the first frame and complete
+ * on the second, returning a UR of the given type.
+ *
+ * @param resultType - UR type returned by `resultUR()`.
+ * @returns A decoder mock that completes on the next frame.
+ */
+function buildCompletingDecoderMock(resultType: string): MockDecoder {
+  return buildDecoderMock({
+    isComplete: jest.fn().mockReturnValueOnce(false).mockReturnValueOnce(true),
+    estimatedPercentComplete: jest.fn().mockReturnValue(1),
+    resultUR: jest.fn().mockReturnValue({ type: resultType }),
+  });
+}
+
+/**
+ * Registers the URDecoder constructor mock to return the given instance.
+ *
+ * @param instance - The decoder mock to return on construction.
+ */
+function setDecoderInstance(instance: MockDecoder): void {
+  mockURDecoder.mockImplementation(() => instance as unknown as URDecoder);
+}
+
 describe('useDecoderLifecycle', () => {
   const mockHandleSuccess = jest.fn().mockResolvedValue(undefined);
   const mockSetScanProgress = jest.fn();
   const mockSetScanError = jest.fn();
   const mockSetError = jest.fn();
 
-  const defaultProps: {
-    handleSuccess: typeof mockHandleSuccess;
-    expectedUrTypes: readonly string[];
-  } = {
+  const defaultProps: Pick<
+    BaseQrReaderProps,
+    'handleSuccess' | 'expectedUrTypes'
+  > = {
     handleSuccess: mockHandleSuccess,
     expectedUrTypes: PAIRING_EXPECTED_UR_TYPES,
   };
@@ -103,16 +159,10 @@ describe('useDecoderLifecycle', () => {
     });
 
     it('feeds data into the decoder and updates progress', () => {
-      const mockInstance = {
-        isComplete: jest.fn().mockReturnValue(false),
-        isError: jest.fn().mockReturnValue(false),
-        receivePart: jest.fn(),
+      const decoder = buildDecoderMock({
         estimatedPercentComplete: jest.fn().mockReturnValue(0.5),
-        resultUR: jest.fn(),
-      };
-      mockURDecoder.mockImplementation(
-        () => mockInstance as unknown as URDecoder,
-      );
+      });
+      setDecoderInstance(decoder);
 
       const { result } = renderDecoderHook();
 
@@ -120,27 +170,15 @@ describe('useDecoderLifecycle', () => {
         result.current.handleScan('UR:CRYPTO-HDKEY/1-2/some-data');
       });
 
-      expect(mockInstance.receivePart).toHaveBeenCalledWith(
+      expect(decoder.receivePart).toHaveBeenCalledWith(
         'UR:CRYPTO-HDKEY/1-2/some-data',
       );
       expect(mockSetScanProgress).toHaveBeenCalledWith(0.5);
     });
 
     it('calls handleSuccess when decoder completes', () => {
-      const mockResult = { type: UrType.CryptoHdkey };
-      const mockInstance = {
-        isComplete: jest
-          .fn()
-          .mockReturnValueOnce(false)
-          .mockReturnValueOnce(true),
-        isError: jest.fn().mockReturnValue(false),
-        receivePart: jest.fn(),
-        estimatedPercentComplete: jest.fn().mockReturnValue(1),
-        resultUR: jest.fn().mockReturnValue(mockResult),
-      };
-      mockURDecoder.mockImplementation(
-        () => mockInstance as unknown as URDecoder,
-      );
+      const decoder = buildCompletingDecoderMock(UrType.CryptoHdkey);
+      setDecoderInstance(decoder);
 
       const { result } = renderDecoderHook();
 
@@ -148,7 +186,9 @@ describe('useDecoderLifecycle', () => {
         result.current.handleScan('final-frame');
       });
 
-      expect(mockHandleSuccess).toHaveBeenCalledWith(mockResult);
+      expect(mockHandleSuccess).toHaveBeenCalledWith({
+        type: UrType.CryptoHdkey,
+      });
     });
 
     it('does not update progress when decoder completes immediately', () => {
@@ -178,16 +218,10 @@ describe('useDecoderLifecycle', () => {
     });
 
     it('does not process data when decoder is already complete', () => {
-      const mockInstance = {
+      const decoder = buildDecoderMock({
         isComplete: jest.fn().mockReturnValue(true),
-        isError: jest.fn().mockReturnValue(false),
-        receivePart: jest.fn(),
-        estimatedPercentComplete: jest.fn(),
-        resultUR: jest.fn(),
-      };
-      mockURDecoder.mockImplementation(
-        () => mockInstance as unknown as URDecoder,
-      );
+      });
+      setDecoderInstance(decoder);
 
       const { result } = renderDecoderHook();
 
@@ -195,23 +229,11 @@ describe('useDecoderLifecycle', () => {
         result.current.handleScan('extra-frame');
       });
 
-      expect(mockInstance.receivePart).not.toHaveBeenCalled();
+      expect(decoder.receivePart).not.toHaveBeenCalled();
     });
 
     it('classifies as WrongUrType when decoded UR does not match expected pairing types', () => {
-      const mockInstance = {
-        isComplete: jest
-          .fn()
-          .mockReturnValueOnce(false)
-          .mockReturnValueOnce(true),
-        isError: jest.fn().mockReturnValue(false),
-        receivePart: jest.fn(),
-        estimatedPercentComplete: jest.fn().mockReturnValue(1),
-        resultUR: jest.fn().mockReturnValue({ type: UrType.EthSignature }),
-      };
-      mockURDecoder.mockImplementation(
-        () => mockInstance as unknown as URDecoder,
-      );
+      setDecoderInstance(buildCompletingDecoderMock(UrType.EthSignature));
 
       const { result } = renderDecoderHook({
         ...defaultProps,
@@ -231,19 +253,7 @@ describe('useDecoderLifecycle', () => {
     });
 
     it('classifies as WrongUrType when decoded UR does not match expected signing types', () => {
-      const mockInstance = {
-        isComplete: jest
-          .fn()
-          .mockReturnValueOnce(false)
-          .mockReturnValueOnce(true),
-        isError: jest.fn().mockReturnValue(false),
-        receivePart: jest.fn(),
-        estimatedPercentComplete: jest.fn().mockReturnValue(1),
-        resultUR: jest.fn().mockReturnValue({ type: UrType.CryptoHdkey }),
-      };
-      mockURDecoder.mockImplementation(
-        () => mockInstance as unknown as URDecoder,
-      );
+      setDecoderInstance(buildCompletingDecoderMock(UrType.CryptoHdkey));
 
       const { result } = renderDecoderHook({
         ...defaultProps,
@@ -262,54 +272,16 @@ describe('useDecoderLifecycle', () => {
       expect(mockHandleSuccess).not.toHaveBeenCalled();
     });
 
-    it('classifies non-UR data as NonUrQrScanned with pairing types', () => {
-      const mockInstance = {
-        isComplete: jest.fn().mockReturnValue(false),
-        isError: jest.fn().mockReturnValue(false),
-        receivePart: jest.fn().mockImplementation(() => {
-          throw new Error('invalid payload');
+    it('classifies a thrown non-UR payload as NonUrQrScanned', () => {
+      setDecoderInstance(
+        buildDecoderMock({
+          receivePart: jest.fn().mockImplementation(() => {
+            throw new Error('invalid payload');
+          }),
         }),
-        estimatedPercentComplete: jest.fn(),
-        resultUR: jest.fn(),
-      };
-      mockURDecoder.mockImplementation(
-        () => mockInstance as unknown as URDecoder,
       );
 
-      const { result } = renderDecoderHook({
-        ...defaultProps,
-        expectedUrTypes: PAIRING_EXPECTED_UR_TYPES,
-      });
-
-      act(() => {
-        result.current.handleScan('bad-data');
-      });
-
-      expect(mockSetScanError).toHaveBeenCalledWith({
-        category: ScanErrorCategory.NonUrQrScanned,
-        isUrFormat: false,
-      });
-      expect(mockHandleSuccess).not.toHaveBeenCalled();
-    });
-
-    it('classifies non-UR data as NonUrQrScanned with signing types', () => {
-      const mockInstance = {
-        isComplete: jest.fn().mockReturnValue(false),
-        isError: jest.fn().mockReturnValue(false),
-        receivePart: jest.fn().mockImplementation(() => {
-          throw new Error('invalid payload');
-        }),
-        estimatedPercentComplete: jest.fn(),
-        resultUR: jest.fn(),
-      };
-      mockURDecoder.mockImplementation(
-        () => mockInstance as unknown as URDecoder,
-      );
-
-      const { result } = renderDecoderHook({
-        ...defaultProps,
-        expectedUrTypes: SIGNING_EXPECTED_UR_TYPES,
-      });
+      const { result } = renderDecoderHook();
 
       act(() => {
         result.current.handleScan('bad-data');
@@ -323,17 +295,12 @@ describe('useDecoderLifecycle', () => {
     });
 
     it('classifies UR-formatted data that throws as ScanException with isUrFormat true', () => {
-      const mockInstance = {
-        isComplete: jest.fn().mockReturnValue(false),
-        isError: jest.fn().mockReturnValue(false),
-        receivePart: jest.fn().mockImplementation(() => {
-          throw new Error('cbor decode failure');
+      setDecoderInstance(
+        buildDecoderMock({
+          receivePart: jest.fn().mockImplementation(() => {
+            throw new Error('cbor decode failure');
+          }),
         }),
-        estimatedPercentComplete: jest.fn(),
-        resultUR: jest.fn(),
-      };
-      mockURDecoder.mockImplementation(
-        () => mockInstance as unknown as URDecoder,
       );
 
       const { result } = renderDecoderHook();
@@ -407,15 +374,11 @@ describe('useDecoderLifecycle', () => {
     });
 
     it('classifies as UrDecodeError when decoder enters error state', () => {
-      const mockInstance = {
-        isComplete: jest.fn().mockReturnValue(false),
-        isError: jest.fn().mockReturnValue(true),
-        receivePart: jest.fn(),
-        estimatedPercentComplete: jest.fn().mockReturnValue(0.99),
-        resultUR: jest.fn(),
-      };
-      mockURDecoder.mockImplementation(
-        () => mockInstance as unknown as URDecoder,
+      setDecoderInstance(
+        buildDecoderMock({
+          isError: jest.fn().mockReturnValue(true),
+          estimatedPercentComplete: jest.fn().mockReturnValue(0.99),
+        }),
       );
 
       const { result } = renderDecoderHook();
@@ -431,26 +394,13 @@ describe('useDecoderLifecycle', () => {
       expect(mockHandleSuccess).not.toHaveBeenCalled();
     });
 
-    it('calls setError when handleSuccess rejects', async () => {
+    it('routes a generic handleSuccess rejection to setError', async () => {
       const rejectError = new Error('processing failed');
-      const mockInstance = {
-        isComplete: jest
-          .fn()
-          .mockReturnValueOnce(false)
-          .mockReturnValueOnce(true),
-        isError: jest.fn().mockReturnValue(false),
-        receivePart: jest.fn(),
-        estimatedPercentComplete: jest.fn().mockReturnValue(1),
-        resultUR: jest.fn().mockReturnValue({ type: UrType.CryptoHdkey }),
-      };
-      mockURDecoder.mockImplementation(
-        () => mockInstance as unknown as URDecoder,
-      );
+      setDecoderInstance(buildCompletingDecoderMock(UrType.CryptoHdkey));
 
-      const failingHandleSuccess = jest.fn().mockRejectedValue(rejectError);
       const { result } = renderDecoderHook({
         ...defaultProps,
-        handleSuccess: failingHandleSuccess,
+        handleSuccess: jest.fn().mockRejectedValue(rejectError),
       });
 
       act(() => {
@@ -459,21 +409,55 @@ describe('useDecoderLifecycle', () => {
 
       await new Promise(process.nextTick);
       expect(mockSetError).toHaveBeenCalledWith(rejectError);
+      expect(mockSetScanError).not.toHaveBeenCalled();
+    });
+
+    it('routes a QrMismatchedTransactionError rejection to setScanError', async () => {
+      setDecoderInstance(buildCompletingDecoderMock(UrType.EthSignature));
+
+      const { result } = renderDecoderHook({
+        ...defaultProps,
+        handleSuccess: jest
+          .fn()
+          .mockRejectedValue(new QrMismatchedTransactionError()),
+        expectedUrTypes: SIGNING_EXPECTED_UR_TYPES,
+      });
+
+      act(() => {
+        result.current.handleScan('final-frame');
+      });
+
+      await new Promise(process.nextTick);
+      expect(mockSetScanError).toHaveBeenCalledWith({
+        category: ScanErrorCategory.MismatchedSignId,
+        isUrFormat: true,
+      });
+      expect(mockSetError).not.toHaveBeenCalled();
+    });
+
+    it('routes a plain Error sharing the mismatch message to setError, not setScanError', async () => {
+      setDecoderInstance(buildCompletingDecoderMock(UrType.EthSignature));
+
+      const lookalikeError = new Error('QrMismatchedTransactionError');
+      const { result } = renderDecoderHook({
+        ...defaultProps,
+        handleSuccess: jest.fn().mockRejectedValue(lookalikeError),
+        expectedUrTypes: SIGNING_EXPECTED_UR_TYPES,
+      });
+
+      act(() => {
+        result.current.handleScan('final-frame');
+      });
+
+      await new Promise(process.nextTick);
+      expect(mockSetError).toHaveBeenCalledWith(lookalikeError);
+      expect(mockSetScanError).not.toHaveBeenCalled();
     });
   });
 
   describe('lazy decoder initialization', () => {
     it('constructs URDecoder only once across multiple handleScan calls', () => {
-      const mockInstance = {
-        isComplete: jest.fn().mockReturnValue(false),
-        isError: jest.fn().mockReturnValue(false),
-        receivePart: jest.fn(),
-        estimatedPercentComplete: jest.fn().mockReturnValue(0),
-        resultUR: jest.fn(),
-      };
-      mockURDecoder.mockImplementation(
-        () => mockInstance as unknown as URDecoder,
-      );
+      setDecoderInstance(buildDecoderMock());
 
       const { result } = renderDecoderHook();
 
@@ -487,16 +471,7 @@ describe('useDecoderLifecycle', () => {
     });
 
     it('does not construct URDecoder until first handleScan call', () => {
-      mockURDecoder.mockImplementation(
-        () =>
-          ({
-            isComplete: jest.fn().mockReturnValue(false),
-            isError: jest.fn().mockReturnValue(false),
-            receivePart: jest.fn(),
-            estimatedPercentComplete: jest.fn().mockReturnValue(0),
-            resultUR: jest.fn(),
-          }) as unknown as URDecoder,
-      );
+      setDecoderInstance(buildDecoderMock());
 
       renderDecoderHook();
 
@@ -516,20 +491,11 @@ describe('useDecoderLifecycle', () => {
     });
 
     it('creates a fresh decoder so subsequent scans start from scratch', () => {
-      const completedInstance = {
+      const completedInstance = buildDecoderMock({
         isComplete: jest.fn().mockReturnValue(true),
-        isError: jest.fn().mockReturnValue(false),
-        receivePart: jest.fn(),
         estimatedPercentComplete: jest.fn().mockReturnValue(1),
-        resultUR: jest.fn(),
-      };
-      const freshInstance = {
-        isComplete: jest.fn().mockReturnValue(false),
-        isError: jest.fn().mockReturnValue(false),
-        receivePart: jest.fn(),
-        estimatedPercentComplete: jest.fn().mockReturnValue(0),
-        resultUR: jest.fn(),
-      };
+      });
+      const freshInstance = buildDecoderMock();
 
       mockURDecoder
         .mockImplementationOnce(() => completedInstance as unknown as URDecoder)
@@ -555,20 +521,14 @@ describe('useDecoderLifecycle', () => {
 
   describe('multi-frame scanning', () => {
     it('accumulates progress across multiple scan calls', () => {
-      const mockInstance = {
-        isComplete: jest.fn().mockReturnValue(false),
-        isError: jest.fn().mockReturnValue(false),
-        receivePart: jest.fn(),
+      const decoder = buildDecoderMock({
         estimatedPercentComplete: jest
           .fn()
           .mockReturnValueOnce(0.25)
           .mockReturnValueOnce(0.5)
           .mockReturnValueOnce(0.75),
-        resultUR: jest.fn(),
-      };
-      mockURDecoder.mockImplementation(
-        () => mockInstance as unknown as URDecoder,
-      );
+      });
+      setDecoderInstance(decoder);
 
       const { result } = renderDecoderHook();
 
@@ -578,7 +538,7 @@ describe('useDecoderLifecycle', () => {
         result.current.handleScan('frame-3');
       });
 
-      expect(mockInstance.receivePart).toHaveBeenCalledTimes(3);
+      expect(decoder.receivePart).toHaveBeenCalledTimes(3);
       expect(mockSetScanProgress).toHaveBeenCalledWith(0.25);
       expect(mockSetScanProgress).toHaveBeenCalledWith(0.5);
       expect(mockSetScanProgress).toHaveBeenCalledWith(0.75);

--- a/ui/components/app/qr-hardware-popover/qr-hooks/decoder-lifecycle/useDecoderLifecycle.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/decoder-lifecycle/useDecoderLifecycle.ts
@@ -5,7 +5,11 @@ import type {
   BaseQrReaderProps,
   WebcamError,
 } from '../../base-qr-reader/base-qr-reader.types';
-import { classifyScanResult, ScanErrorCategory } from '../../qr-utils/qr-utils';
+import {
+  classifyScanResult,
+  isQrMismatchedTransactionError,
+  ScanErrorCategory,
+} from '../../qr-utils/qr-utils';
 import type { DecoderCallbacks } from '../qr-hooks.types';
 
 /**
@@ -107,10 +111,16 @@ export function useDecoderLifecycle(
             return;
           }
 
-          handleSuccess(result).catch((successError: WebcamError) =>
-            setError(successError),
-          );
-          return;
+          handleSuccess(result).catch((successError: unknown) => {
+            if (isQrMismatchedTransactionError(successError)) {
+              setScanError({
+                category: ScanErrorCategory.MismatchedSignId,
+                isUrFormat: true,
+              });
+              return;
+            }
+            setError(successError as WebcamError);
+          });
         }
 
         // Progress is only updated for incomplete multi-frame scans.

--- a/ui/components/app/qr-hardware-popover/qr-hooks/decoder-lifecycle/useDecoderLifecycle.ts
+++ b/ui/components/app/qr-hardware-popover/qr-hooks/decoder-lifecycle/useDecoderLifecycle.ts
@@ -121,6 +121,7 @@ export function useDecoderLifecycle(
             }
             setError(successError as WebcamError);
           });
+          return;
         }
 
         // Progress is only updated for incomplete multi-frame scans.

--- a/ui/components/app/qr-hardware-popover/qr-utils/qr-utils.test.ts
+++ b/ui/components/app/qr-hardware-popover/qr-utils/qr-utils.test.ts
@@ -5,6 +5,8 @@ import {
 import { QrErrorType } from '../qr-error-content';
 import {
   classifyScanResult,
+  isQrMismatchedTransactionError,
+  QrMismatchedTransactionError,
   scanCategoryToQrErrorType,
   ScanErrorCategory,
   type ScanClassificationInput,
@@ -472,6 +474,12 @@ describe('scanCategoryToQrErrorType', () => {
     );
   });
 
+  it('maps MismatchedSignId to MismatchedTransaction', () => {
+    expect(scanCategoryToQrErrorType(ScanErrorCategory.MismatchedSignId)).toBe(
+      QrErrorType.MismatchedTransaction,
+    );
+  });
+
   it('falls back to UrDecodeError for unknown categories', () => {
     const unknownCategory = 'future_category' as never;
     expect(scanCategoryToQrErrorType(unknownCategory)).toBe(
@@ -515,5 +523,32 @@ describe('ScanErrorClassification type discrimination', () => {
       expect(result.rawMessage).toBe('crash');
       expect(typeof result.isUrFormat).toBe('boolean');
     }
+  });
+});
+
+describe('QrMismatchedTransactionError', () => {
+  it('extends Error so it can flow through generic error handling', () => {
+    expect(new QrMismatchedTransactionError()).toBeInstanceOf(Error);
+  });
+
+  it('is detected by isQrMismatchedTransactionError', () => {
+    expect(
+      isQrMismatchedTransactionError(new QrMismatchedTransactionError()),
+    ).toBe(true);
+  });
+
+  it('does not detect a plain Error sharing the same message', () => {
+    // Guard must rely on the instance, not the message string, so a
+    // look-alike error is still routed through the generic error path.
+    expect(
+      isQrMismatchedTransactionError(new Error('QrMismatchedTransactionError')),
+    ).toBe(false);
+  });
+
+  it('does not detect unrelated errors or non-error values', () => {
+    expect(isQrMismatchedTransactionError(new Error('other'))).toBe(false);
+    expect(isQrMismatchedTransactionError('not-an-error')).toBe(false);
+    expect(isQrMismatchedTransactionError(null)).toBe(false);
+    expect(isQrMismatchedTransactionError(undefined)).toBe(false);
   });
 });

--- a/ui/components/app/qr-hardware-popover/qr-utils/qr-utils.ts
+++ b/ui/components/app/qr-hardware-popover/qr-utils/qr-utils.ts
@@ -8,12 +8,14 @@ import { extractMessageFromUnknownError } from '../../../../contexts/hardware-wa
  * - `WrongUrType` - valid UR whose type does not match the current flow.
  * - `UrDecodeError` - the UR decoder failed to reassemble frames.
  * - `ScanException` - an unexpected runtime exception during processing.
+ * - `MismatchedSignId` - the signature QR request ID does not match the pending transaction.
  */
 export const ScanErrorCategory = {
   NonUrQrScanned: 'non_ur_qr_scanned',
   WrongUrType: 'wrong_ur_type',
   UrDecodeError: 'ur_decode_error',
   ScanException: 'scan_exception',
+  MismatchedSignId: 'mismatched_sign_id',
 } as const;
 
 export type ScanErrorCategory =
@@ -35,7 +37,30 @@ export type ScanErrorClassification =
       category: typeof ScanErrorCategory.ScanException;
       isUrFormat: boolean;
       rawMessage: string;
-    };
+    }
+  | { category: typeof ScanErrorCategory.MismatchedSignId; isUrFormat: true };
+
+/**
+ * Thrown when a scanned signature QR belongs to a different transaction.
+ */
+export class QrMismatchedTransactionError extends Error {
+  constructor() {
+    super('QrMismatchedTransactionError');
+    this.name = 'QrMismatchedTransactionError';
+  }
+}
+
+/**
+ * Type guard for {@link QrMismatchedTransactionError}.
+ *
+ * @param error - Unknown rejection from `handleSuccess`.
+ * @returns True when the error represents a mismatched signing request ID.
+ */
+export function isQrMismatchedTransactionError(
+  error: unknown,
+): error is QrMismatchedTransactionError {
+  return error instanceof QrMismatchedTransactionError;
+}
 
 /**
  * Input for {@link classifyScanResult}. Callers populate only the fields
@@ -142,6 +167,8 @@ export function scanCategoryToQrErrorType(
     case ScanErrorCategory.UrDecodeError:
     case ScanErrorCategory.ScanException:
       return QrErrorType.UrDecodeError;
+    case ScanErrorCategory.MismatchedSignId:
+      return QrErrorType.MismatchedTransaction;
     default:
       return QrErrorType.UrDecodeError;
   }


### PR DESCRIPTION
## **Description**
This PR adds proper error handling within the QR hardware wallet scan errors group when transaction signature is mismatched.

There are some minor refactoring changes related to the changes introduced, mostly within the test files.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Add QR error handling for invalid transaction signature

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1890

## **Manual testing steps**
1. Start a new transaction using QR hardware wallet.
2. Scan QR and keep it on your device's screen.
3. Cancel transaction.
4. Start new transaction.
5. Do not scan new QR.
6. Try to use QR that is already on your device which you generated for signing the previous transaction.
7. Observe the edge case and verify that everything is shown as expected.
8. Make sure that error title and error message are correct and as expected.
9. Make sure that we're using new modal for error handling for QR hardware wallets.

## **Screenshots/Recordings**

### **Before**
<img width="419" height="360" alt="image" src="https://github.com/user-attachments/assets/e5f6d913-363f-4cb0-88f3-f3b247129b56" />

### **After**

#### --- Chrome ---
<img width="1095" height="993" alt="Screenshot 2026-06-11 at 12 36 58" src="https://github.com/user-attachments/assets/910f4b10-43f0-49f4-985c-bcd4c9e5fc78" />

#### --- Firefox ---
<img width="1095" height="993" alt="Screenshot 2026-06-11 at 12 39 07" src="https://github.com/user-attachments/assets/bd339566-a5b2-41e9-a17b-fa2ef03dcc3a" />

## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Signing still rejects mismatched request IDs; only error routing and user-facing copy changed, with broad test coverage and no change to successful submit paths.
> 
> **Overview**
> When a QR hardware wallet signature’s request ID does not match the pending transaction, the flow now surfaces a dedicated **“Wrong QR code”** state in the shared `QrErrorContent` UI instead of the older generic error popover.
> 
> Signing validation throws `QrMismatchedTransactionError`; `useDecoderLifecycle` maps that to `ScanErrorCategory.MismatchedSignId` so analytics and the structured scan-error path stay consistent with other QR errors. Legacy `QRHardwareMismatchedSignId` / `QRHardwareInvalidTransactionTitle` strings are removed in favor of `qrErrorMismatchedTransactionTitle` and `qrErrorMismatchedTransactionBody` (added for English locales in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52b7fcd020ebf7f2f32752aa27c5fb87b916e14c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->