### PR TITLE
fix: migrate zkSync Era default RPC to Infura

### DIFF
--- a/app/scripts/migrations/213.test.ts
+++ b/app/scripts/migrations/213.test.ts
@@ -174,6 +174,26 @@ describe(`migration #${version}`, () => {
     expect(changed.size).toBe(0);
   });
 
+  it('is a no-op when zkSync own Infura is the only Infura (self should not satisfy the gate)', async () => {
+    const state = buildState({
+      [ZKSYNC_CHAIN_ID]: {
+        rpcEndpoints: [
+          { url: ZKSYNC_LEGACY_URL, type: 'custom' },
+          {
+            url: `https://zksync-mainnet.infura.io/v3/${infuraProjectId}`,
+            type: 'infura',
+          },
+        ],
+        defaultRpcEndpointIndex: 1,
+      },
+      '0x1': customDefault('https://my-alchemy-key.alchemy.com'),
+    });
+    const changed = new Set<string>();
+    await migrate(state, changed);
+    expect(zksyncEndpoints(state)[0].url).toEqual(ZKSYNC_LEGACY_URL);
+    expect(changed.size).toBe(0);
+  });
+
   it('preserves non-url fields on the rewritten endpoint', async () => {
     const state = buildState({
       [ZKSYNC_CHAIN_ID]: {

--- a/app/scripts/migrations/213.test.ts
+++ b/app/scripts/migrations/213.test.ts
@@ -1,0 +1,204 @@
+import { CHAIN_IDS, infuraProjectId } from '../../../shared/constants/network';
+import migrate, { version } from './213';
+
+const ZKSYNC_CHAIN_ID = CHAIN_IDS.ZKSYNC_ERA;
+const ZKSYNC_LEGACY_URL = 'https://mainnet.era.zksync.io';
+const ZKSYNC_INFURA_URL = `https://zksync-mainnet.infura.io/v3/${infuraProjectId}`;
+
+const zksyncEndpoints = (state: { data: Record<string, unknown> }) => {
+  const networkController = state.data.NetworkController as {
+    networkConfigurationsByChainId: Record<
+      string,
+      { rpcEndpoints: { url: string; type: string }[] }
+    >;
+  };
+  return networkController.networkConfigurationsByChainId[ZKSYNC_CHAIN_ID]
+    .rpcEndpoints;
+};
+
+const buildState = (
+  configsByChainId: Record<string, unknown>,
+): { meta: { version: number }; data: Record<string, unknown> } => ({
+  meta: { version: version - 1 },
+  data: {
+    NetworkController: {
+      selectedNetworkClientId: 'x',
+      networkConfigurationsByChainId: configsByChainId,
+    },
+  },
+});
+
+const infuraDefault = (url: string) => ({
+  rpcEndpoints: [{ url, type: 'infura' }],
+  defaultRpcEndpointIndex: 0,
+});
+
+const customDefault = (url: string) => ({
+  rpcEndpoints: [{ url, type: 'custom' }],
+  defaultRpcEndpointIndex: 0,
+});
+
+describe(`migration #${version}`, () => {
+  it('bumps the state version', async () => {
+    const state = { meta: { version: version - 1 }, data: {} };
+    await migrate(state, new Set());
+    expect(state.meta.version).toBe(version);
+  });
+
+  it('skips silently when NetworkController state is missing', async () => {
+    const state = { meta: { version: version - 1 }, data: {} };
+    const changed = new Set<string>();
+    await expect(migrate(state, changed)).resolves.toBeUndefined();
+    expect(state.meta.version).toBe(version);
+    expect(changed.size).toBe(0);
+  });
+
+  it('is a no-op when no Infura RPC endpoints are used elsewhere', async () => {
+    const state = buildState({
+      '0x1': customDefault('https://custom.rpc'),
+    });
+    const before = JSON.parse(JSON.stringify(state.data));
+    const changed = new Set<string>();
+    await migrate(state, changed);
+    expect(state.data).toEqual(before);
+    expect(changed.size).toBe(0);
+  });
+
+  it('is a no-op when zkSync Era is not configured', async () => {
+    const state = buildState({
+      '0x1': infuraDefault(`https://mainnet.infura.io/v3/${infuraProjectId}`),
+    });
+    const before = JSON.parse(JSON.stringify(state.data));
+    const changed = new Set<string>();
+    await migrate(state, changed);
+    expect(state.data).toEqual(before);
+    expect(changed.size).toBe(0);
+  });
+
+  it('rewrites the zkSync default URL when the user relies on Infura elsewhere', async () => {
+    const state = buildState({
+      [ZKSYNC_CHAIN_ID]: customDefault(ZKSYNC_LEGACY_URL),
+      '0x1': infuraDefault(`https://mainnet.infura.io/v3/${infuraProjectId}`),
+    });
+    const changed = new Set<string>();
+    await migrate(state, changed);
+    expect(zksyncEndpoints(state)[0].url).toEqual(ZKSYNC_INFURA_URL);
+    expect(changed.has('NetworkController')).toBe(true);
+  });
+
+  it('leaves a user-customised zkSync URL untouched', async () => {
+    const state = buildState({
+      [ZKSYNC_CHAIN_ID]: customDefault('https://other.rpc'),
+      '0x1': infuraDefault(`https://mainnet.infura.io/v3/${infuraProjectId}`),
+    });
+    const changed = new Set<string>();
+    await migrate(state, changed);
+    expect(zksyncEndpoints(state)[0].url).toEqual('https://other.rpc');
+    expect(changed.size).toBe(0);
+  });
+
+  it('keeps defaultRpcEndpointIndex unchanged when rewriting', async () => {
+    const state = buildState({
+      [ZKSYNC_CHAIN_ID]: customDefault(ZKSYNC_LEGACY_URL),
+      '0x1': infuraDefault(`https://mainnet.infura.io/v3/${infuraProjectId}`),
+    });
+    await migrate(state, new Set());
+    const networkController = state.data.NetworkController as {
+      networkConfigurationsByChainId: Record<
+        string,
+        { defaultRpcEndpointIndex: number }
+      >;
+    };
+    expect(
+      networkController.networkConfigurationsByChainId[ZKSYNC_CHAIN_ID]
+        .defaultRpcEndpointIndex,
+    ).toBe(0);
+  });
+
+  it('is a no-op when Linea Mainnet is the only Infura network', async () => {
+    const state = buildState({
+      [ZKSYNC_CHAIN_ID]: customDefault(ZKSYNC_LEGACY_URL),
+      '0x1': customDefault('https://custom.rpc'),
+      '0xe708': infuraDefault(
+        `https://linea-mainnet.infura.io/v3/${infuraProjectId}`,
+      ),
+    });
+    const changed = new Set<string>();
+    await migrate(state, changed);
+    expect(zksyncEndpoints(state)[0].url).toEqual(ZKSYNC_LEGACY_URL);
+    expect(changed.size).toBe(0);
+  });
+
+  it('preserves other endpoints when rewriting the zkSync default URL', async () => {
+    const state = buildState({
+      [ZKSYNC_CHAIN_ID]: {
+        rpcEndpoints: [
+          { url: ZKSYNC_LEGACY_URL, type: 'custom' },
+          { url: 'https://user.custom.zksync.rpc', type: 'custom' },
+        ],
+        defaultRpcEndpointIndex: 0,
+      },
+      '0x1': infuraDefault(`https://mainnet.infura.io/v3/${infuraProjectId}`),
+    });
+    const changed = new Set<string>();
+    await migrate(state, changed);
+    const endpoints = zksyncEndpoints(state);
+    expect(endpoints).toHaveLength(2);
+    expect(endpoints[0].url).toEqual(ZKSYNC_INFURA_URL);
+    expect(endpoints[1].url).toEqual('https://user.custom.zksync.rpc');
+    expect(changed.has('NetworkController')).toBe(true);
+  });
+
+  it('is a no-op when zkSync is at the legacy URL but no Infura elsewhere', async () => {
+    const state = buildState({
+      [ZKSYNC_CHAIN_ID]: customDefault(ZKSYNC_LEGACY_URL),
+      '0x1': customDefault('https://custom.rpc'),
+    });
+    const changed = new Set<string>();
+    await migrate(state, changed);
+    expect(zksyncEndpoints(state)[0].url).toEqual(ZKSYNC_LEGACY_URL);
+    expect(changed.size).toBe(0);
+  });
+
+  it('is a no-op when Sepolia is the only Infura network (testnets are excluded)', async () => {
+    const state = buildState({
+      [ZKSYNC_CHAIN_ID]: customDefault(ZKSYNC_LEGACY_URL),
+      '0x1': customDefault('https://custom.rpc'),
+      '0xaa36a7': infuraDefault(
+        `https://sepolia.infura.io/v3/${infuraProjectId}`,
+      ),
+    });
+    const changed = new Set<string>();
+    await migrate(state, changed);
+    expect(zksyncEndpoints(state)[0].url).toEqual(ZKSYNC_LEGACY_URL);
+    expect(changed.size).toBe(0);
+  });
+
+  it('preserves non-url fields on the rewritten endpoint', async () => {
+    const state = buildState({
+      [ZKSYNC_CHAIN_ID]: {
+        rpcEndpoints: [
+          {
+            url: ZKSYNC_LEGACY_URL,
+            type: 'custom',
+            name: 'zkSync Era',
+            networkClientId: 'zksync-era-client',
+            failoverUrls: ['https://failover.zksync.rpc'],
+          },
+        ],
+        defaultRpcEndpointIndex: 0,
+      },
+      '0x1': infuraDefault(`https://mainnet.infura.io/v3/${infuraProjectId}`),
+    });
+    const changed = new Set<string>();
+    await migrate(state, changed);
+    expect(zksyncEndpoints(state)[0]).toStrictEqual({
+      url: ZKSYNC_INFURA_URL,
+      type: 'custom',
+      name: 'zkSync Era',
+      networkClientId: 'zksync-era-client',
+      failoverUrls: ['https://failover.zksync.rpc'],
+    });
+    expect(changed.has('NetworkController')).toBe(true);
+  });
+});

--- a/app/scripts/migrations/213.ts
+++ b/app/scripts/migrations/213.ts
@@ -98,7 +98,11 @@ function userReliesOnInfura(
   return Object.entries(networkConfigurationsByChainId)
     .filter(
       ([chainId]) =>
-        ![...infuraChainIdsTestNets, CHAIN_IDS.LINEA_MAINNET].includes(chainId),
+        ![
+          ...infuraChainIdsTestNets,
+          CHAIN_IDS.LINEA_MAINNET,
+          CHAIN_IDS.ZKSYNC_ERA,
+        ].includes(chainId),
     )
     .some(([, networkConfig]) => {
       if (

--- a/app/scripts/migrations/213.ts
+++ b/app/scripts/migrations/213.ts
@@ -1,0 +1,132 @@
+import { getErrorMessage, hasProperty, isObject } from '@metamask/utils';
+import { RpcEndpointType } from '@metamask/network-controller';
+import { captureException } from '../../../shared/lib/sentry';
+import {
+  allowedInfuraHosts,
+  CHAIN_IDS,
+  infuraChainIdsTestNets,
+  infuraProjectId,
+} from '../../../shared/constants/network';
+import type { Migrate } from './types';
+
+export const version = 213;
+
+const ZKSYNC_LEGACY_URL = 'https://mainnet.era.zksync.io';
+const ZKSYNC_INFURA_URL = `https://zksync-mainnet.infura.io/v3/${infuraProjectId}`;
+
+/**
+ * Migration 213: replace the public zkSync Era RPC endpoint
+ * (`https://mainnet.era.zksync.io`) with the Infura endpoint on existing user
+ * installs, but only when the user already relies on Infura elsewhere in
+ * their network config (excluding testnets and Linea Mainnet, which ship as
+ * Infura by default for everyone).
+ *
+ * - Users without zkSync Era configured: no-op.
+ * - Users who customized the zkSync URL away from the public endpoint: no-op.
+ * - Users with no Infura defaults anywhere else: no-op.
+ *
+ * @param versionedData - Versioned MetaMask extension state, exactly what we
+ * persist to disk.
+ * @param localChangedControllers - A set of controller keys that have been
+ * changed by the migration.
+ */
+export const migrate = (async (versionedData, localChangedControllers) => {
+  versionedData.meta.version = version;
+
+  const data = versionedData.data as Record<string, unknown>;
+
+  try {
+    transformState(data, localChangedControllers);
+  } catch (error) {
+    console.error(error);
+    captureException(
+      new Error(`Migration #${version}: ${getErrorMessage(error)}`),
+    );
+  }
+}) satisfies Migrate;
+
+export default migrate;
+
+function transformState(
+  state: Record<string, unknown>,
+  localChangedControllers: Set<string>,
+) {
+  if (
+    !hasProperty(state, 'NetworkController') ||
+    !isObject(state.NetworkController) ||
+    !hasProperty(state.NetworkController, 'networkConfigurationsByChainId') ||
+    !isObject(state.NetworkController.networkConfigurationsByChainId)
+  ) {
+    return;
+  }
+
+  const { networkConfigurationsByChainId } = state.NetworkController;
+
+  if (!userReliesOnInfura(networkConfigurationsByChainId)) {
+    return;
+  }
+
+  const zksyncNetworkConfig =
+    networkConfigurationsByChainId[CHAIN_IDS.ZKSYNC_ERA];
+  if (!isObject(zksyncNetworkConfig)) {
+    return;
+  }
+
+  const { rpcEndpoints } = zksyncNetworkConfig;
+  if (!Array.isArray(rpcEndpoints)) {
+    return;
+  }
+
+  const index = rpcEndpoints.findIndex(
+    (endpoint) => isObject(endpoint) && endpoint.url === ZKSYNC_LEGACY_URL,
+  );
+
+  if (index === -1) {
+    return;
+  }
+
+  rpcEndpoints[index] = {
+    ...rpcEndpoints[index],
+    url: ZKSYNC_INFURA_URL,
+  };
+  localChangedControllers.add('NetworkController');
+}
+
+function userReliesOnInfura(
+  networkConfigurationsByChainId: Record<string, unknown>,
+): boolean {
+  return Object.entries(networkConfigurationsByChainId)
+    .filter(
+      ([chainId]) =>
+        ![...infuraChainIdsTestNets, CHAIN_IDS.LINEA_MAINNET].includes(chainId),
+    )
+    .some(([, networkConfig]) => {
+      if (
+        !isObject(networkConfig) ||
+        !Array.isArray(networkConfig.rpcEndpoints) ||
+        typeof networkConfig.defaultRpcEndpointIndex !== 'number'
+      ) {
+        return false;
+      }
+
+      const defaultRpcEndpoint =
+        networkConfig.rpcEndpoints[networkConfig.defaultRpcEndpointIndex];
+
+      if (
+        !isObject(defaultRpcEndpoint) ||
+        typeof defaultRpcEndpoint.url !== 'string'
+      ) {
+        return false;
+      }
+
+      try {
+        const urlHost = new URL(defaultRpcEndpoint.url).host;
+        return (
+          defaultRpcEndpoint.type === RpcEndpointType.Infura ||
+          allowedInfuraHosts.includes(urlHost)
+        );
+      } catch {
+        return false;
+      }
+    });
+}

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -248,6 +248,7 @@ const migrations = [
   require('./210'),
   require('./211'),
   require('./212'),
+  require('./213'),
 ];
 
 export default migrations;

--- a/shared/constants/network.test.ts
+++ b/shared/constants/network.test.ts
@@ -86,11 +86,11 @@ describe('NetworkConstants', () => {
       expect(polygonRpc.rpcEndpoints[0].url).toContain('infura.io');
     });
 
-    it('zkSync Era entry should not use Infura', () => {
+    it('zkSync Era entry should use Infura', () => {
       const [zksyncEraRpc] = FEATURED_RPCS.filter(
         (rpc) => rpc.chainId === CHAIN_IDS.ZKSYNC_ERA,
       );
-      expect(zksyncEraRpc.rpcEndpoints[0].url).not.toContain('infura.io');
+      expect(zksyncEraRpc.rpcEndpoints[0].url).toContain('infura.io');
     });
 
     it('base entry should use Infura', () => {

--- a/shared/constants/network.ts
+++ b/shared/constants/network.ts
@@ -1653,7 +1653,7 @@ export const FEATURED_RPCS: AddNetworkFields[] = [
     nativeCurrency: CURRENCY_SYMBOLS.ETH,
     rpcEndpoints: [
       {
-        url: `https://mainnet.era.zksync.io`,
+        url: `https://zksync-mainnet.infura.io/v3/${infuraProjectId}`,
         failoverUrls: [],
         type: RpcEndpointType.Custom,
       },

--- a/test/e2e/fixtures/default-fixture.json
+++ b/test/e2e/fixtures/default-fixture.json
@@ -174,7 +174,7 @@
       "announcements": {}
     },
     "AppMetadataController": {
-      "currentMigrationVersion": 212,
+      "currentMigrationVersion": 213,
       "firstTimeInfo": {},
       "previousAppVersion": "",
       "previousMigrationVersion": 0
@@ -1260,6 +1260,6 @@
   },
   "meta": {
     "storageKind": "split",
-    "version": 212
+    "version": 213
   }
 }

--- a/test/e2e/fixtures/onboarding-fixture.json
+++ b/test/e2e/fixtures/onboarding-fixture.json
@@ -35,7 +35,7 @@
       "announcements": {}
     },
     "AppMetadataController": {
-      "currentMigrationVersion": 212,
+      "currentMigrationVersion": 213,
       "firstTimeInfo": {
         "date": 0,
         "version": "13.17.0"
@@ -2274,6 +2274,6 @@
   },
   "meta": {
     "storageKind": "split",
-    "version": 212
+    "version": 213
   }
 }

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -299,5 +299,5 @@
     },
     "config": "object"
   },
-  "meta": { "storageKind": "split", "version": 212 }
+  "meta": { "storageKind": "split", "version": 213 }
 }


### PR DESCRIPTION
## **Description**

Routes zkSync Era through Infura by default. Updates the `FEATURED_RPCS` entry for zkSync Era from `https://mainnet.era.zksync.io` to `https://zksync-mainnet.infura.io/v3/{infuraProjectId}`, and adds migration 213 to update existing users.

The migration only rewrites the stored zkSync default URL when:
1. The user's stored zkSync default is still `https://mainnet.era.zksync.io` (custom user-set URLs are preserved), and
2. The user appears to still rely on Infura elsewhere in their network config — i.e. at least one of their other configured networks (excluding testnets and Linea Mainnet, which ship as Infura by default for everyone) has an Infura default RPC. This avoids overriding users who have deliberately moved off Infura.

## **Changelog**

CHANGELOG entry: Routed the default zkSync Era RPC through Infura for improved performance and reliability.

## **Related issues**

Fixes:

## **Manual testing steps**

1. On `main`: `yarn start`, load the build into Chrome, open zkSync Era and confirm the RPC URL is `https://mainnet.era.zksync.io`.
2. Switch to this branch and `yarn start` again (state is preserved).
3. zkSync Era RPC URL should now be the Infura endpoint.
4. Repeat with Ethereum Mainnet's default RPC swapped to a non-Infura custom URL before step 2 — zkSync Era URL should remain unchanged.
5. Fresh profile on this branch — zkSync Era should appear with the Infura URL from the start.

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

<img width="565" height="827" alt="Screenshot 2026-06-10 at 19 04 17" src="https://github.com/user-attachments/assets/204eb67d-239c-4aa3-b0e8-92ce51f7b382" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Persisted network RPC URLs change on upgrade for a subset of users, which can affect connectivity if Infura is blocked or misconfigured, but logic is gated and does not touch keys or transactions signing.
> 
> **Overview**
> **zkSync Era** now defaults to Infura instead of the public `mainnet.era.zksync.io` endpoint. The `FEATURED_RPCS` entry is updated so new installs get `zksync-mainnet.infura.io`, and **migration 213** rewrites stored `NetworkController` RPC URLs for upgrades when the user still has the legacy zkSync URL and appears to use Infura on at least one other mainnet (testnets, Linea, and zkSync itself do not count toward that gate). Custom zkSync RPCs and users who moved off Infura elsewhere are left unchanged.
> 
> Migration registration, broad unit tests for the gate and rewrite behavior, the zkSync Infura assertion in `network.test.ts`, and e2e fixture/meta version **213** updates accompany the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2992d3e91f2cf781d0895293db0300de53b855c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->