### PR TITLE
fix: received activity classification

### DIFF
--- a/shared/lib/activity/adapters/api-evm-transactions.test.ts
+++ b/shared/lib/activity/adapters/api-evm-transactions.test.ts
@@ -63,6 +63,40 @@ describe('mapEvmTransactions', () => {
     });
   });
 
+  it('maps an ERC-20 transfer with an incidental receive transfer to a Send activity', () => {
+    const transaction =
+      apiResponses.lineaAaveUsdcSendWithRebaseCredit as unknown as V1TransactionByHashResponse;
+    const aaveLineaUsdc = transaction.to;
+    const senderAddress = transaction.from;
+    const recipientAddress = transaction.valueTransfers?.[1]?.to;
+
+    const item = mapApiEvmTransactions({
+      subjectAddress: senderAddress,
+      transaction,
+    });
+    const activity = { ...item };
+    delete activity.raw;
+
+    expect(activity).toMatchObject({
+      type: 'send',
+      chainId: 'eip155:59144',
+      status: 'success',
+      timestamp: 1778074371000,
+      data: {
+        from: senderAddress,
+        to: recipientAddress,
+        hash: transaction.hash,
+        token: {
+          direction: 'out',
+          amount: '419402',
+          decimals: 6,
+          symbol: 'aLinUSDC',
+          assetId: toAssetId(aaveLineaUsdc, 'eip155:59144'),
+        },
+      },
+    });
+  });
+
   it('maps a native value contract call without method data to a Send activity', () => {
     const transaction = {
       hash: '0x64d2f26c261178252fcad9dbb665cf40337b827a582066553dd6634eaeea9f0a',

--- a/shared/lib/activity/adapters/api-evm-transactions.ts
+++ b/shared/lib/activity/adapters/api-evm-transactions.ts
@@ -185,7 +185,7 @@ export function mapApiEvmTransactions({
     hasNativeTransferWithoutMethod
   ) {
     const isReceive =
-      Boolean(receivedTransfer) ||
+      Boolean(receivedTransfer && !sentTransfer) ||
       (equalsIgnoreCase(transaction.to, subjectAddress) &&
         !equalsIgnoreCase(transaction.from, subjectAddress));
 

--- a/shared/lib/activity/adapters/fixtures/api-responses.ts
+++ b/shared/lib/activity/adapters/fixtures/api-responses.ts
@@ -46,4 +46,58 @@ export const apiResponses = {
     readable: 'Unidentified Transaction',
     readableExtended: 'Unidentified Transaction',
   },
+  // ERC-20 send where the API also reports a small incoming rebase credit from
+  // the zero address (Aave aToken). The adapter should still classify as send.
+  lineaAaveUsdcSendWithRebaseCredit: {
+    hash: '0xdbd832950b40d6242f99176e8f263473670e6a39ddb00580dfcda67772cc6aae',
+    timestamp: '2026-05-06T13:32:51.000Z',
+    chainId: 59144,
+    accountId: 'eip155:59144:0x699e414873f56c7bb60e54ad63d3bb7b283874df',
+    blockNumber: 30529877,
+    blockHash:
+      '0xdc81c3e6834e5697830aa6cb4bc68ea744f38d72718e080f948c9c2c8d17fb51',
+    gas: 120484,
+    gasUsed: 118377,
+    gasPrice: '50000011',
+    effectiveGasPrice: '50000011',
+    nonce: 43,
+    cumulativeGasUsed: 139377,
+    methodId: '0xa9059cbb',
+    value: '0',
+    to: '0x374d7860c4f2f604de0191298dd393703cce84f3',
+    from: '0x699e414873f56c7bb60e54ad63d3bb7b283874df',
+    isError: false,
+    valueTransfers: [
+      {
+        from: '0x0000000000000000000000000000000000000000',
+        to: '0x699e414873f56c7bb60e54ad63d3bb7b283874df',
+        amount: '13344',
+        decimal: 6,
+        contractAddress: '0x374d7860c4f2f604de0191298dd393703cce84f3',
+        symbol: 'aLinUSDC',
+        name: 'Aave Linea USDC',
+        transferType: 'erc20',
+        iconUrl:
+          'https://static.cx.metamask.io/api/v1/tokenIcons/59144/0x374d7860c4f2f604de0191298dd393703cce84f3.png',
+      },
+      {
+        from: '0x699e414873f56c7bb60e54ad63d3bb7b283874df',
+        to: '0xed8799cd90c48f62d0b4f1bb00876b03f0b71c91',
+        amount: '419402',
+        decimal: 6,
+        contractAddress: '0x374d7860c4f2f604de0191298dd393703cce84f3',
+        symbol: 'aLinUSDC',
+        name: 'Aave Linea USDC',
+        transferType: 'erc20',
+        iconUrl:
+          'https://static.cx.metamask.io/api/v1/tokenIcons/59144/0x374d7860c4f2f604de0191298dd393703cce84f3.png',
+      },
+    ],
+    logs: [],
+    transactionProtocol: 'ERC_20',
+    transactionCategory: 'TRANSFER',
+    transactionType: 'ERC_20_TRANSFER',
+    readable: 'Sent aLinUSDC',
+    readableExtended: 'Sent 0.4194 aLinUSDC',
+  },
 };


### PR DESCRIPTION


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Only classify as receive when the subject has an incoming transfer and no outgoing transfer in the same transaction.
 
Note: Activity redesign hasn't rolled out yet

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

Activity redesign hasn't rolled out yet

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow classification tweak in the activity adapter with a targeted test; activity redesign is not rolled out yet.
> 
> **Overview**
> Fixes EVM activity mapping when the Accounts API lists **both** an outgoing and an incoming value transfer for the same account (e.g. Aave aToken sends with a small rebase credit from the zero address).
> 
> In `mapApiEvmTransactions`, **receive** is no longer inferred from `receivedTransfer` alone when the user also has a **sent** leg; those txs classify as **send** and use the outbound transfer for amount and counterparty.
> 
> Adds a Linea Aave aLinUSDC fixture and a test that expects **send** with the main outbound amount, not **receive** on the incidental credit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b96bda9dc8308797b57fc87242dc88433732a649. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->