### PR TITLE
fix(ramps): keep buy enabled for unsupported networks

### DIFF
--- a/ui/components/app/modals/add-funds-modal/add-funds-modal.test.tsx
+++ b/ui/components/app/modals/add-funds-modal/add-funds-modal.test.tsx
@@ -45,4 +45,32 @@ describe('Add funds modal Component', () => {
 
     expect(container).toMatchSnapshot();
   });
+
+  it('enables the buy crypto button when the chain is not in buyable chains', () => {
+    const storeWithUnsupportedChain = configureMockStore()({
+      ...defaultState,
+      ramps: {
+        buyableChains: [{ chainId: 1, active: true }],
+      },
+    });
+
+    const { getByTestId } = renderWithProvider(
+      <AddFundsModal
+        onClose={jest.fn()}
+        token={{
+          address: '0x0',
+          decimals: 18,
+          symbol: 'USDC',
+          conversionRate: {
+            usd: '1',
+          },
+        }}
+        chainId={CHAIN_IDS.SEPOLIA}
+        payerAddress="0x0"
+      />,
+      storeWithUnsupportedChain,
+    );
+
+    expect(getByTestId('add-funds-modal-buy-crypto-button')).toBeEnabled();
+  });
 });

--- a/ui/components/app/modals/add-funds-modal/add-funds-modal.tsx
+++ b/ui/components/app/modals/add-funds-modal/add-funds-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useMemo, useState } from 'react';
+import React, { useCallback, useContext, useState } from 'react';
 import {
   Box,
   Icon,
@@ -8,7 +8,6 @@ import {
   Text,
   TextVariant,
 } from '@metamask/design-system-react';
-import { useSelector } from 'react-redux';
 import { TokenPaymentInfo } from '@metamask/subscription-controller';
 import { Hex } from '@metamask/utils';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
@@ -19,7 +18,6 @@ import {
   ModalHeader,
   ModalOverlay,
 } from '../../../component-library';
-import { getBuyableChains } from '../../../../ducks/ramps';
 import useRamps from '../../../../hooks/ramps/useRamps/useRamps';
 import { ReceiveModal } from '../../../multichain/receive-modal';
 import useBridging from '../../../../hooks/bridge/useBridging';
@@ -29,8 +27,6 @@ import {
   MetaMetricsSwapsEventSource,
 } from '../../../../../shared/constants/metametrics';
 import { MetaMetricsContext } from '../../../../contexts/metametrics';
-import { hexToDecimal } from '../../../../../shared/lib/conversion.utils';
-import { AggregatorNetwork } from '../../../../ducks/ramps/types';
 import { trace, TraceName } from '../../../../../shared/lib/trace';
 
 const AddFundsModal = ({
@@ -48,21 +44,9 @@ const AddFundsModal = ({
   const { openBuyCryptoInPdapp } = useRamps();
   const { trackEvent } = useContext(MetaMetricsContext);
 
-  const buyableChains = useSelector(getBuyableChains);
-
   const { openBridgeExperience } = useBridging();
 
   const [showReceiveModal, setShowReceiveModal] = useState(false);
-
-  const isBuyableChain = useMemo(() => {
-    if (!chainId) {
-      return false;
-    }
-    return buyableChains.some(
-      (network: AggregatorNetwork) =>
-        String(network.chainId) === hexToDecimal(chainId),
-    );
-  }, [buyableChains, chainId]);
 
   const handleBuyAndSellOnClick = useCallback(() => {
     openBuyCryptoInPdapp();
@@ -160,7 +144,6 @@ const AddFundsModal = ({
             label: t('addFundsModalBuyCrypto'),
             iconName: IconName.Add,
             onClick: handleBuyAndSellOnClick,
-            disabled: !isBuyableChain,
           })}
           {buttonRow({
             id: 'add-funds-modal-receive-crypto-button',

--- a/ui/components/app/wallet-overview/coin-buttons.stories.js
+++ b/ui/components/app/wallet-overview/coin-buttons.stories.js
@@ -13,7 +13,6 @@ export default {
     isSwapsChain: true,
     isSigningEnabled: true,
     isBridgeChain: true,
-    isBuyableChain: true,
     defaultSwapsToken: {
       symbol: 'ETH',
       name: 'Ether',

--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -198,7 +198,6 @@ type CoinButtonsProps = {
   trackingLocation: string;
   isSwapsChain: boolean;
   isSigningEnabled: boolean;
-  isBuyableChain: boolean;
   classPrefix?: string;
   /** When true, disables the send button for non-EVM chains (used on asset page) */
   disableSendForNonEvm?: boolean;
@@ -210,7 +209,6 @@ const CoinButtons = ({
   trackingLocation,
   isSwapsChain,
   isSigningEnabled,
-  isBuyableChain,
   classPrefix = 'coin',
   disableSendForNonEvm = false,
 }: CoinButtonsProps) => {
@@ -266,7 +264,6 @@ const CoinButtons = ({
   const isEvmAsset = isEvmChainId(normalizedChainId);
 
   const buttonTooltips = {
-    buyButton: [{ condition: !isBuyableChain, message: '' }],
     sendButton: [
       { condition: !isSigningEnabled, message: 'methodNotSupported' },
       {
@@ -505,14 +502,10 @@ const CoinButtons = ({
             size={IconSizeLegacy.Md}
           />
         }
-        disabled={!isBuyableChain}
         data-testid={`${classPrefix}-overview-buy`}
         label={t('buy')}
         onClick={handleBuyAndSellOnClick}
         width={BlockSize.Full}
-        tooltipRender={(contents: React.ReactElement) =>
-          generateTooltip('buyButton', contents)
-        }
       />
       <IconButton
         className={`${classPrefix}-overview__button`}

--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -65,7 +65,6 @@ export type CoinOverviewProps = {
   classPrefix?: string;
   chainId: CaipChainId | Hex;
   isBridgeChain: boolean;
-  isBuyableChain: boolean;
   isSwapsChain: boolean;
   isSigningEnabled: boolean;
 };
@@ -179,7 +178,6 @@ export const CoinOverview = ({
   classPrefix = 'coin',
   chainId,
   isBridgeChain,
-  isBuyableChain,
   isSwapsChain,
   isSigningEnabled,
 }: CoinOverviewProps) => {
@@ -338,7 +336,6 @@ export const CoinOverview = ({
             isSwapsChain,
             isSigningEnabled,
             isBridgeChain,
-            isBuyableChain,
             classPrefix,
           }}
         />

--- a/ui/components/app/wallet-overview/eth-overview.js
+++ b/ui/components/app/wallet-overview/eth-overview.js
@@ -11,12 +11,10 @@ import {
   getIsBridgeChain,
 } from '../../../selectors';
 import { getSelectedInternalAccount } from '../../../../shared/lib/selectors/accounts';
-import { getIsNativeTokenBuyable } from '../../../ducks/ramps';
 import { CoinOverview } from './coin-overview';
 
 const EthOverview = ({ className }) => {
   const isBridgeChain = useSelector(getIsBridgeChain);
-  const isBuyableChain = useSelector(getIsNativeTokenBuyable);
   const balanceIsCached = useSelector(isBalanceCached);
   const chainId = useSelector(getCurrentChainId);
   const balance = useSelector(getSelectedAccountCachedBalance);
@@ -39,7 +37,6 @@ const EthOverview = ({ className }) => {
       isSigningEnabled={isSigningEnabled}
       isSwapsChain={isSwapsChain}
       isBridgeChain={isBridgeChain}
-      isBuyableChain={isBuyableChain}
     />
   );
 };

--- a/ui/components/app/wallet-overview/eth-overview.test.js
+++ b/ui/components/app/wallet-overview/eth-overview.test.js
@@ -411,7 +411,7 @@ describe('EthOverview', () => {
       expect(buyButton).toBeInTheDocument();
     });
 
-    it('should have the Buy native token button disabled if chain id is not part of supported buyable chains', () => {
+    it('enables the Buy native token button if chain id is not part of supported buyable chains', async () => {
       const mockedStoreWithUnbuyableChainId = {
         ...mockStore,
         metamask: {
@@ -434,7 +434,18 @@ describe('EthOverview', () => {
       );
       const buyButton = queryByTestId(ETH_OVERVIEW_BUY);
       expect(buyButton).toBeInTheDocument();
-      expect(buyButton).toBeDisabled();
+      expect(buyButton).not.toBeDisabled();
+
+      fireEvent.click(buyButton);
+      expect(openTabSpy).toHaveBeenCalledTimes(1);
+
+      await waitFor(() =>
+        expect(openTabSpy).toHaveBeenCalledWith({
+          url: expect.stringContaining(
+            `/buy?metamaskEntry=ext_buy_sell_button`,
+          ),
+        }),
+      );
     });
 
     it('should have the Buy native token enabled if chain id is part of supported buyable chains', () => {

--- a/ui/components/app/wallet-overview/non-evm-overview.test.tsx
+++ b/ui/components/app/wallet-overview/non-evm-overview.test.tsx
@@ -325,7 +325,7 @@ describe('NonEvmOverview', () => {
     expect(buyButton).toBeInTheDocument();
   });
 
-  it('"Buy & Sell" button is disabled if BTC is not buyable and SOL is not buyable', () => {
+  it('"Buy & Sell" button is enabled if BTC is not buyable and SOL is not buyable', () => {
     const { queryByTestId } = renderWithProvider(
       <NonEvmOverview />,
       getStore(),
@@ -333,7 +333,7 @@ describe('NonEvmOverview', () => {
     const buyButton = queryByTestId(BUY_BUTTON);
 
     expect(buyButton).toBeInTheDocument();
-    expect(buyButton).toBeDisabled();
+    expect(buyButton).not.toBeDisabled();
   });
 
   it('"Buy & Sell" button is enabled if BTC is buyable', () => {

--- a/ui/components/app/wallet-overview/non-evm-overview.tsx
+++ b/ui/components/app/wallet-overview/non-evm-overview.tsx
@@ -3,7 +3,6 @@ import { useSelector } from 'react-redux';
 import { getMultichainSelectedAccountCachedBalance } from '../../../selectors/multichain';
 import { getSelectedMultichainNetworkConfiguration } from '../../../selectors/multichain/networks';
 
-import { getIsNativeTokenBuyable } from '../../../ducks/ramps';
 import { getIsSwapsChain, getIsBridgeChain } from '../../../selectors';
 import { getSelectedInternalAccount } from '../../../../shared/lib/selectors/accounts';
 import { CoinOverview } from './coin-overview';
@@ -16,7 +15,6 @@ const NonEvmOverview = ({ className }: NonEvmOverviewProps) => {
   const { chainId } = useSelector(getSelectedMultichainNetworkConfiguration);
   const balance = useSelector(getMultichainSelectedAccountCachedBalance);
   const account = useSelector(getSelectedInternalAccount);
-  const isNativeTokenBuyable = useSelector(getIsNativeTokenBuyable);
 
   let isSwapsChain = false;
   let isBridgeChain = false;
@@ -34,7 +32,6 @@ const NonEvmOverview = ({ className }: NonEvmOverviewProps) => {
       isSigningEnabled={true}
       isSwapsChain={isSwapsChain}
       isBridgeChain={isBridgeChain}
-      isBuyableChain={isNativeTokenBuyable}
     />
   );
 };

--- a/ui/pages/asset/components/asset-page.test.tsx
+++ b/ui/pages/asset/components/asset-page.test.tsx
@@ -406,7 +406,7 @@ describe('AssetPage', () => {
     expect(buyButton).toBeEnabled();
   });
 
-  it('should disable the buy button on unsupported chains', () => {
+  it('enables the buy button on unsupported chains', async () => {
     const { queryByTestId } = renderWithProvider(
       <AssetPage asset={token} optionsButton={null} />,
       configureMockStore([thunk])({
@@ -419,7 +419,16 @@ describe('AssetPage', () => {
     );
     const buyButton = queryByTestId('token-overview-buy');
     expect(buyButton).toBeInTheDocument();
-    expect(buyButton).toBeDisabled();
+    expect(buyButton).not.toBeDisabled();
+
+    fireEvent.click(buyButton as HTMLElement);
+    expect(openTabSpy).toHaveBeenCalledTimes(1);
+
+    await waitFor(() =>
+      expect(openTabSpy).toHaveBeenCalledWith({
+        url: expect.stringContaining(`/buy?metamaskEntry=ext_buy_sell_button`),
+      }),
+    );
   });
 
   it('should open the buy crypto URL for a buyable chain ID', async () => {

--- a/ui/pages/asset/components/asset-page.tsx
+++ b/ui/pages/asset/components/asset-page.tsx
@@ -53,7 +53,6 @@ import { AddressCopyButton } from '../../../components/multichain';
 // eslint-disable-next-line import-x/no-restricted-paths
 import { ActivityList as ActivityListV3 } from '../../activity/activity-list';
 import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
-import { getIsNativeTokenBuyable } from '../../../ducks/ramps';
 import { getPortfolioUrl } from '../../../helpers/utils/portfolio';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
@@ -115,7 +114,6 @@ const AssetPage = ({
   const t = useI18nContext();
   const navigate = useNavigate();
   const currency = useSelector(getCurrentCurrency);
-  const isBuyableChain = useSelector(getIsNativeTokenBuyable);
   const isEvm = isEvmChainId(asset.chainId);
   // TODO BIP44 Refactor: This selector does not work with BIP44 enabled, pass the information in the asset object
   const nativeAssetType = useSelector(getMultichainNativeAssetType);
@@ -346,7 +344,6 @@ const AssetPage = ({
             {...{
               account: selectedAccount,
               trackingLocation: 'asset-page',
-              isBuyableChain,
               isSigningEnabled,
               isSwapsChain,
               isBridgeChain,

--- a/ui/pages/asset/components/token-buttons.tsx
+++ b/ui/pages/asset/components/token-buttons.tsx
@@ -23,7 +23,6 @@ import {
   IconName,
   IconSize,
 } from '../../../components/component-library';
-import { getIsNativeTokenBuyable } from '../../../ducks/ramps';
 
 import { Asset } from '../types/asset';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0021): route-isolation backlog
@@ -53,7 +52,6 @@ const TokenButtons = ({
 
   const currentChainId = token.chainId;
 
-  const isBuyableChain = useSelector(getIsNativeTokenBuyable);
   const { openBuyCryptoInPdapp } = useRamps();
   const { openBridgeExperience } = useBridging();
 
@@ -138,9 +136,7 @@ const TokenButtons = ({
         label={t('buy')}
         data-testid="token-overview-buy"
         onClick={handleBuyAndSellOnClick}
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        disabled={token.isERC721 || !isBuyableChain}
+        disabled={token.isERC721}
       />
 
       {shouldShowSendButton ? (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Removes the stale ramps buyable-chain gating that disabled Buy buttons when the selected/current chain is not in `buyableChains`. This keeps Buy enabled for token-filter and token-specific contexts, matching the current behavior expected for token-specific network filtering and Swaps.

Updated the wallet overview, token asset page, and add-funds modal Buy CTAs to remain enabled while preserving unrelated Send/Swap disabled states.

## **Changelog**

CHANGELOG entry: Fixed a bug that disabled Buy buttons when an unsupported network was selected.

## **Related issues**

Fixes: TRAM-371301

## **Manual testing steps**

1. Run the extension and open the wallet home page.
2. Select or filter to a network that is not supported by ramps buyable chains.
3. Verify the Buy button remains enabled and opens the Buy experience.
4. Open a token details page for a token on the unsupported network.
5. Verify the Buy button remains enabled and opens the Buy experience.
6. From a shield/add-funds flow, open the Add funds modal for an unsupported chain.
7. Verify the Buy crypto row remains enabled.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91822897-8816-4bfa-941e-9402abc518a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91822897-8816-4bfa-941e-9402abc518a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

