### PR TITLE
refactor(analytics): migrate onboarding-flow to analytics selectors

### DIFF
--- a/test/e2e/tests/onboarding/onboarding.spec.ts
+++ b/test/e2e/tests/onboarding/onboarding.spec.ts
@@ -328,8 +328,9 @@ describe('MetaMask onboarding', function () {
             seedPhraseBackedUp: null,
           })
           .withMetaMetricsController({
-            participateInMetaMetrics: null,
-            metaMetricsId: null,
+            completedMetaMetricsOnboarding: false,
+            optedIn: false,
+            analyticsId: null,
           })
           .build(),
         title: this.test?.fullTitle(),

--- a/ui/hooks/subscription/useSubscription.ts
+++ b/ui/hooks/subscription/useSubscription.ts
@@ -69,7 +69,7 @@ import { CONFIRM_TRANSACTION_ROUTE } from '../../helpers/constants/routes';
 import { getInternalAccountBySelectedAccountGroupAndCaip } from '../../selectors/multichain-accounts/account-tree';
 import {
   getMetaMaskHdKeyrings,
-  getMetaMetricsId,
+  getAnalyticsId,
   getModalTypeForShieldEntryModal,
   getUnapprovedConfirmations,
   getUpdatedAndSortedAccountsWithCaipAccountId,
@@ -735,7 +735,7 @@ export const useHandleSubscriptionSupportAction = () => {
   const version = process.env.METAMASK_VERSION as string;
   const sessionData = useSelector(selectSessionData);
   const profileId = sessionData?.profile?.profileId;
-  const metaMetricsId = useSelector(getMetaMetricsId);
+  const analyticsId = useSelector(getAnalyticsId);
   const { customerId: shieldCustomerId } = useUserSubscriptions();
 
   const handleClickContactSupport = useCallback(() => {
@@ -744,8 +744,8 @@ export const useHandleSubscriptionSupportAction = () => {
     if (profileId) {
       url.searchParams.append('metamask_profile_id', profileId);
     }
-    if (metaMetricsId) {
-      url.searchParams.append('metamask_metametrics_id', metaMetricsId);
+    if (analyticsId) {
+      url.searchParams.append('metamask_metametrics_id', analyticsId);
     }
     if (shieldCustomerId) {
       url.searchParams.append('shield_id', shieldCustomerId);
@@ -754,7 +754,7 @@ export const useHandleSubscriptionSupportAction = () => {
     const supportLinkWithUserId = url.toString();
 
     openWindow(supportLinkWithUserId);
-  }, [version, profileId, metaMetricsId, shieldCustomerId]);
+  }, [version, profileId, analyticsId, shieldCustomerId]);
 
   return {
     handleClickContactSupport,

--- a/ui/pages/onboarding-flow/create-password/create-password.test.tsx
+++ b/ui/pages/onboarding-flow/create-password/create-password.test.tsx
@@ -91,7 +91,8 @@ describe('Onboarding Create Password', () => {
         metamask: {
           ...initializedMockState.metamask,
           firstTimeFlowType: FirstTimeFlowType.import,
-          participateInMetaMetrics: null,
+          completedMetaMetricsOnboarding: false,
+          optedIn: false,
           passkeyRecord: null,
         },
       };
@@ -117,7 +118,8 @@ describe('Onboarding Create Password', () => {
         metamask: {
           ...initializedMockState.metamask,
           firstTimeFlowType: FirstTimeFlowType.import,
-          participateInMetaMetrics: null,
+          completedMetaMetricsOnboarding: false,
+          optedIn: false,
           passkeyRecord: {
             credentialId: 'cred',
             derivationMethod: 'prf',
@@ -148,7 +150,8 @@ describe('Onboarding Create Password', () => {
         metamask: {
           ...initializedMockState.metamask,
           firstTimeFlowType: FirstTimeFlowType.import,
-          participateInMetaMetrics: true,
+          completedMetaMetricsOnboarding: true,
+          optedIn: true,
           passkeyRecord: {
             credentialId: 'cred',
             derivationMethod: 'prf',

--- a/ui/pages/onboarding-flow/create-password/create-password.tsx
+++ b/ui/pages/onboarding-flow/create-password/create-password.tsx
@@ -14,10 +14,10 @@ import {
 } from '../../../helpers/constants/routes';
 import {
   getFirstTimeFlowType,
-  getMetaMetricsId,
-  getParticipateInMetaMetrics,
+  getAnalyticsId,
+  getCompletedMetaMetricsOnboarding,
+  getOptedIn,
   getIsSocialLoginFlow,
-  getIsParticipateInMetaMetricsSet,
   getIsPasskeyFeatureAvailable,
   getAccountTypeForOnboardingMetrics,
 } from '../../../selectors';
@@ -77,20 +77,18 @@ export default function CreatePassword({
   const isPasskeyFeatureAvailable = useSelector(getIsPasskeyFeatureAvailable);
   const isWalletResetInProgress = useSelector(getIsWalletResetInProgress);
 
-  const participateInMetaMetrics = useSelector(getParticipateInMetaMetrics);
-  const isParticipateInMetaMetricsSet = useSelector(
-    getIsParticipateInMetaMetricsSet,
+  const isOptedIn = useSelector(getOptedIn);
+  const completedMetaMetricsOnboarding = useSelector(
+    getCompletedMetaMetricsOnboarding,
   );
-  const metametricsId = useSelector(getMetaMetricsId);
+  const analyticsId = useSelector(getAnalyticsId);
   const accountTypeForMetrics = useSelector(getAccountTypeForOnboardingMetrics);
-  const base64MetametricsId = Buffer.from(metametricsId ?? '').toString(
-    'base64',
-  );
+  const base64AnalyticsId = Buffer.from(analyticsId ?? '').toString('base64');
   const shouldInjectMetametricsIframe = Boolean(
-    participateInMetaMetrics && base64MetametricsId,
+    completedMetaMetricsOnboarding && isOptedIn && base64AnalyticsId,
   );
   const analyticsIframeQuery = {
-    mmi: base64MetametricsId,
+    mmi: base64AnalyticsId,
     env: 'production',
   };
   const urlSearchParams = new URLSearchParams(analyticsIframeQuery);
@@ -133,7 +131,7 @@ export default function CreatePassword({
           navigate(ONBOARDING_COMPLETION_ROUTE, { replace: true });
         } else {
           navigate(
-            isParticipateInMetaMetricsSet
+            completedMetaMetricsOnboarding
               ? ONBOARDING_COMPLETION_ROUTE
               : ONBOARDING_METAMETRICS,
             { replace: true },
@@ -156,7 +154,7 @@ export default function CreatePassword({
     firstTimeFlowType,
     newAccountCreationInProgress,
     secretRecoveryPhrase,
-    isParticipateInMetaMetricsSet,
+    completedMetaMetricsOnboarding,
     isWalletResetInProgress,
     isPasskeyFeatureAvailable,
   ]);

--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.tsx
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.tsx
@@ -37,7 +37,7 @@ import {
   getBackupAndSyncOnboardingToggleState,
   getExternalServicesOnboardingToggleState,
   getFirstTimeFlowType,
-  getParticipateInMetaMetrics,
+  getOptedIn,
   getDeferredDeepLink,
   getAccountTypeForOnboardingMetrics,
 } from '../../../selectors';
@@ -94,7 +94,7 @@ export default function CreationSuccessful() {
   const firstTimeFlowType = useSelector(getFirstTimeFlowType);
   const isSidePanelEnabled = useSidePanelEnabled();
   const isOnboardingCompleted = useSelector(getCompletedOnboarding);
-  const participateInMetaMetrics = useSelector(getParticipateInMetaMetrics);
+  const isOptedIn = useSelector(getOptedIn);
   const accountTypeForMetrics = useSelector(getAccountTypeForOnboardingMetrics);
   const deferredDeepLink: DeferredDeepLink | null =
     useSelector(getDeferredDeepLink);
@@ -307,7 +307,7 @@ export default function CreationSuccessful() {
       // before onboarding completion, we track the MetricsOptIn/Out event
       trackEvent({
         category: MetaMetricsEventCategory.Onboarding,
-        event: participateInMetaMetrics
+        event: isOptedIn
           ? MetaMetricsEventName.MetricsOptIn
           : MetaMetricsEventName.MetricsOptOut,
         properties: {
@@ -374,7 +374,7 @@ export default function CreationSuccessful() {
     isFromSettingsSecurity,
     firstTimeFlowType,
     trackEvent,
-    participateInMetaMetrics,
+    isOptedIn,
     handleOnDoneNavigation,
     isResetWalletInProgress,
     accountTypeForMetrics,

--- a/ui/pages/onboarding-flow/download-app/download-app.test.tsx
+++ b/ui/pages/onboarding-flow/download-app/download-app.test.tsx
@@ -23,7 +23,8 @@ jest.mock('react-router-dom', () => {
 type StateOverrides = {
   metamask: {
     isBackupAndSyncEnabled?: boolean;
-    participateInMetaMetrics?: boolean;
+    optedIn?: boolean;
+    completedMetaMetricsOnboarding?: boolean;
     isSignedIn?: boolean;
     useExternalServices?: boolean;
     internalAccounts?: {
@@ -55,7 +56,8 @@ type StateOverrides = {
 const initialState: StateOverrides = {
   metamask: {
     isBackupAndSyncEnabled: false,
-    participateInMetaMetrics: true,
+    completedMetaMetricsOnboarding: true,
+    optedIn: true,
     isSignedIn: false,
     useExternalServices: true,
     internalAccounts: {

--- a/ui/pages/onboarding-flow/metametrics/metametrics.test.tsx
+++ b/ui/pages/onboarding-flow/metametrics/metametrics.test.tsx
@@ -46,7 +46,8 @@ describe('Onboarding Metametrics Component', () => {
   const mockState = {
     metamask: {
       firstTimeFlowType: FirstTimeFlowType.create,
-      participateInMetaMetrics: null,
+      completedMetaMetricsOnboarding: false,
+      optedIn: false,
       internalAccounts: {
         accounts: {},
         selectedAccount: '',

--- a/ui/pages/onboarding-flow/metametrics/metametrics.tsx
+++ b/ui/pages/onboarding-flow/metametrics/metametrics.tsx
@@ -25,8 +25,8 @@ import {
   getDataCollectionForMarketing,
   getFirstTimeFlowType,
   getFirstTimeFlowTypeRouteAfterMetaMetricsOptIn,
-  getIsParticipateInMetaMetricsSet,
-  getParticipateInMetaMetrics,
+  getCompletedMetaMetricsOnboarding,
+  getOptedIn,
 } from '../../../selectors';
 import { getCurrentKeyring } from '../../../../shared/lib/selectors/keyring';
 
@@ -126,10 +126,10 @@ export default function OnboardingMetametrics() {
 
   const firstTimeFlowType = useSelector(getFirstTimeFlowType);
 
-  const participateInMetaMetricsSet = useSelector(
-    getIsParticipateInMetaMetricsSet,
+  const completedMetaMetricsOnboarding = useSelector(
+    getCompletedMetaMetricsOnboarding,
   );
-  const participateInMetaMetrics = useSelector(getParticipateInMetaMetrics);
+  const isOptedIn = useSelector(getOptedIn);
   const dataCollectionForMarketing = useSelector(getDataCollectionForMarketing);
   const [
     isParticipateInMetaMetricsChecked,
@@ -144,17 +144,13 @@ export default function OnboardingMetametrics() {
   const marketingCheckboxRef = useRef<{ toggle: () => void } | null>(null);
 
   useEffect(() => {
-    if (participateInMetaMetricsSet) {
-      setIsParticipateInMetaMetricsChecked(participateInMetaMetrics === true);
+    if (completedMetaMetricsOnboarding) {
+      setIsParticipateInMetaMetricsChecked(isOptedIn);
     }
     if (dataCollectionForMarketing) {
       setIsDataCollectionForMarketingChecked(dataCollectionForMarketing);
     }
-  }, [
-    participateInMetaMetricsSet,
-    participateInMetaMetrics,
-    dataCollectionForMarketing,
-  ]);
+  }, [completedMetaMetricsOnboarding, isOptedIn, dataCollectionForMarketing]);
 
   const currentKeyring = useSelector(getCurrentKeyring);
 

--- a/ui/pages/onboarding-flow/onboarding-flow-switch/onboarding-flow-switch.tsx
+++ b/ui/pages/onboarding-flow/onboarding-flow-switch/onboarding-flow-switch.tsx
@@ -22,7 +22,7 @@ import { PLATFORM_FIREFOX } from '../../../../shared/constants/app';
 import { getBrowserName } from '../../../../shared/lib/browser-runtime.utils';
 import {
   getFirstTimeFlowType,
-  getIsParticipateInMetaMetricsSet,
+  getCompletedMetaMetricsOnboarding,
   getIsSocialLoginFlow,
   getIsSocialLoginUserAuthenticated,
 } from '../../../selectors';
@@ -48,8 +48,8 @@ export default function OnboardingFlowSwitch() {
   const firstTimeFlowType = useSelector(getFirstTimeFlowType);
   const isSocialLoginFlow = useSelector(getIsSocialLoginFlow);
   const isUnlocked = useSelector(getIsUnlocked);
-  const isParticipateInMetaMetricsSet = useSelector(
-    getIsParticipateInMetaMetricsSet,
+  const completedMetaMetricsOnboarding = useSelector(
+    getCompletedMetaMetricsOnboarding,
   );
 
   if (completedOnboarding) {
@@ -60,7 +60,7 @@ export default function OnboardingFlowSwitch() {
     return (
       <Navigate
         to={
-          isParticipateInMetaMetricsSet
+          completedMetaMetricsOnboarding
             ? ONBOARDING_COMPLETION_ROUTE
             : ONBOARDING_METAMETRICS
         }

--- a/ui/pages/onboarding-flow/setup-passkey/setup-passkey.tsx
+++ b/ui/pages/onboarding-flow/setup-passkey/setup-passkey.tsx
@@ -9,7 +9,7 @@ import {
 import {
   getAccountTypeForOnboardingMetrics,
   getFirstTimeFlowType,
-  getIsParticipateInMetaMetricsSet,
+  getCompletedMetaMetricsOnboarding,
 } from '../../../selectors';
 import SetupPasskeyContent from '../../../components/app/setup-passkey-content';
 import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
@@ -23,8 +23,8 @@ import { getBrowserName } from '../../../../shared/lib/browser-runtime.utils';
 export default function SetupPasskey() {
   const navigate = useNavigate();
   const firstTimeFlowType = useSelector(getFirstTimeFlowType);
-  const isParticipateInMetaMetricsSet = useSelector(
-    getIsParticipateInMetaMetricsSet,
+  const completedMetaMetricsOnboarding = useSelector(
+    getCompletedMetaMetricsOnboarding,
   );
 
   const handleNext = useCallback(() => {
@@ -38,7 +38,7 @@ export default function SetupPasskey() {
       if (isFirefox) {
         nextRoute = ONBOARDING_COMPLETION_ROUTE;
       } else {
-        nextRoute = isParticipateInMetaMetricsSet
+        nextRoute = completedMetaMetricsOnboarding
           ? ONBOARDING_COMPLETION_ROUTE
           : ONBOARDING_METAMETRICS;
       }
@@ -47,7 +47,7 @@ export default function SetupPasskey() {
     }
 
     navigate(nextRoute, { replace: true });
-  }, [firstTimeFlowType, navigate, isParticipateInMetaMetricsSet]);
+  }, [firstTimeFlowType, navigate, completedMetaMetricsOnboarding]);
 
   return <SetupPasskeyContent onNext={handleNext} />;
 }

--- a/ui/pages/onboarding-flow/welcome/welcome.test.tsx
+++ b/ui/pages/onboarding-flow/welcome/welcome.test.tsx
@@ -85,7 +85,7 @@ describe('Welcome Page', () => {
         accounts: {},
         selectedAccount: '',
       },
-      metaMetricsId: '0x00000000',
+      analyticsId: '0x00000000',
     },
   };
   const mockStore = configureMockStore([thunk])(mockState);

--- a/ui/pages/onboarding-flow/welcome/welcome.tsx
+++ b/ui/pages/onboarding-flow/welcome/welcome.tsx
@@ -30,7 +30,7 @@ import {
 import {
   getAccountTypeForOnboardingMetrics,
   getFirstTimeFlowType,
-  getIsParticipateInMetaMetricsSet,
+  getCompletedMetaMetricsOnboarding,
   getIsPasskeyFeatureAvailable,
   getIsSocialLoginFlow,
 } from '../../../selectors';
@@ -108,8 +108,8 @@ export default function OnboardingWelcome() {
   const firstTimeFlowType = useSelector(getFirstTimeFlowType);
   const isWalletResetInProgress = useSelector(getIsWalletResetInProgress);
   const isSocialLoginFLow = useSelector(getIsSocialLoginFlow);
-  const isParticipateInMetaMetricsSet = useSelector(
-    getIsParticipateInMetaMetricsSet,
+  const completedMetaMetricsOnboarding = useSelector(
+    getCompletedMetaMetricsOnboarding,
   );
   const isPasskeyFeatureAvailable = useSelector(getIsPasskeyFeatureAvailable);
   const accountTypeForMetrics = useSelector(getAccountTypeForOnboardingMetrics);
@@ -157,7 +157,7 @@ export default function OnboardingWelcome() {
         firstTimeFlowType === FirstTimeFlowType.restore
       ) {
         navigate(
-          isParticipateInMetaMetricsSet
+          completedMetaMetricsOnboarding
             ? ONBOARDING_COMPLETION_ROUTE
             : ONBOARDING_METAMETRICS,
           { replace: true },
@@ -191,7 +191,7 @@ export default function OnboardingWelcome() {
     navigate,
     firstTimeFlowType,
     newAccountCreationInProgress,
-    isParticipateInMetaMetricsSet,
+    completedMetaMetricsOnboarding,
     getIsUserAuthenticatedWithSocialLogin,
     isFireFox,
     isWalletResetInProgress,


### PR DESCRIPTION
## **Description**

Part 3 of the Analytics Phase B split (supersedes monolithic #43406).

**Owner:** @MetaMask/web3auth

**Reason:** Onboarding and subscription flows still read legacy metrics selectors.

**Solution:** Migrate onboarding-flow pages/tests, `useSubscription.ts`, and onboarding E2E to `getOptedIn`, `getCompletedMetaMetricsOnboarding`, and `getAnalyticsId`.

**Depends on:** #43430

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of https://github.com/MetaMask/MetaMask-planning/issues/7331

## **Manual testing steps**

1. Run `yarn start` and complete create-wallet and import-wallet onboarding flows
2. Verify metrics opt-in and opt-out during onboarding
3. Run `yarn build:test` then `yarn test:e2e:single test/e2e/tests/onboarding/onboarding.spec.ts --browser=chrome`

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
