### PR TITLE
refactor(analytics): migrate bridge metrics test utilities

### DIFF
--- a/test/e2e/tests/bridge/bridge-test-utils.ts
+++ b/test/e2e/tests/bridge/bridge-test-utils.ts
@@ -14,7 +14,7 @@ import { SMART_CONTRACTS } from '../../seeder/smart-contracts';
 import { Driver } from '../../webdriver/driver';
 import BridgeQuotePage from '../../page-objects/pages/bridge/quote-page';
 
-import { MOCK_META_METRICS_ID } from '../../constants';
+import { MOCK_ANALYTICS_ID } from '../../constants';
 import { getEventPayloads } from '../../helpers';
 import { mockSegment } from '../metrics/mocks/segment';
 import {
@@ -1287,8 +1287,9 @@ export const getBridgeFixtures = ({
   const fixtureBuilder = new FixtureBuilderV2()
     .withNetworkRpcUrlOnLocalhost('0x1')
     .withMetaMetricsController({
-      metaMetricsId: MOCK_META_METRICS_ID,
-      participateInMetaMetrics: true,
+      analyticsId: MOCK_ANALYTICS_ID,
+      completedMetaMetricsOnboarding: true,
+      optedIn: true,
     })
     .withCurrencyController(MOCK_CURRENCY_RATES)
     .withTokensController({

--- a/ui/hooks/bridge/useBridging.test.ts
+++ b/ui/hooks/bridge/useBridging.test.ts
@@ -38,7 +38,7 @@ jest.mock('react-redux', () => ({
 
 const resetInputFieldsSpy = jest.spyOn(bridgeActions, 'resetInputFields');
 
-const MOCK_METAMETRICS_ID = '0xtestMetaMetricsId';
+const MOCK_ANALYTICS_ID = '0xtestMetaMetricsId';
 const BRIDGE_PREPARE_PATH = `${CROSS_CHAIN_SWAP_ROUTE}${PREPARE_SWAP_ROUTE}`;
 
 const renderUseBridging = (mockStoreState: object, pathname?: string) =>
@@ -144,7 +144,7 @@ describe('useBridging', () => {
           createBridgeMockStore({
             metamaskStateOverrides: {
               useExternalServices: true,
-              metaMetricsId: MOCK_METAMETRICS_ID,
+              analyticsId: MOCK_ANALYTICS_ID,
               enabledNetworkMap: {
                 eip155: {
                   '1': true,
@@ -241,7 +241,7 @@ describe('useBridging', () => {
         createBridgeMockStore({
           metamaskStateOverrides: {
             useExternalServices: true,
-            metaMetricsId: MOCK_METAMETRICS_ID,
+            analyticsId: MOCK_ANALYTICS_ID,
             enabledNetworkMap: {
               eip155: { '1': true, '10': true, '56': true },
             },
@@ -294,7 +294,7 @@ describe('useBridging', () => {
         createBridgeMockStore({
           metamaskStateOverrides: {
             useExternalServices: true,
-            metaMetricsId: MOCK_METAMETRICS_ID,
+            analyticsId: MOCK_ANALYTICS_ID,
             enabledNetworkMap: {
               eip155: { '1': true, '10': true, '56': true },
             },
@@ -479,7 +479,7 @@ describe('useBridging', () => {
                 { chainId: CHAIN_IDS.BSC },
                 { chainId: CHAIN_IDS.OPTIMISM },
               ),
-              metaMetricsId: MOCK_METAMETRICS_ID,
+              analyticsId: MOCK_ANALYTICS_ID,
               enabledNetworkMap: {
                 eip155: {
                   '10': true,


### PR DESCRIPTION
## **Description**

Part 6 of the Analytics Phase B split (supersedes monolithic #43406).

**Owner:** @MetaMask/swaps-engineers

**Reason:** Bridge test utilities still use legacy metrics fixture fields.

**Solution:** Update bridge unit test and E2E test utils for canonical analytics fields.

**Depends on:** #43430

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of https://github.com/MetaMask/MetaMask-planning/issues/7331

## **Manual testing steps**

1. Run `yarn test:unit ui/hooks/bridge/useBridging.test.ts`

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
