### PR TITLE
refactor(analytics): migrate ramp portfolio URL builder

### DIFF
--- a/ui/hooks/ramps/useRamps/useRamps.ts
+++ b/ui/hooks/ramps/useRamps/useRamps.ts
@@ -5,8 +5,9 @@ import { ChainId } from '../../../../shared/constants/network';
 import { getCurrentChainId } from '../../../../shared/lib/selectors/networks';
 import {
   getDataCollectionForMarketing,
-  getMetaMetricsId,
-  getParticipateInMetaMetrics,
+  getAnalyticsId,
+  getCompletedMetaMetricsOnboarding,
+  getOptedIn,
 } from '../../../selectors';
 import { isEvmChainId } from '../../../../shared/lib/asset-utils';
 
@@ -29,8 +30,12 @@ const useRamps = (
   metamaskEntry: RampsMetaMaskEntry = RampsMetaMaskEntry.BuySellButton,
 ): IUseRamps => {
   const chainId = useSelector(getCurrentChainId);
-  const metaMetricsId = useSelector(getMetaMetricsId);
-  const isMetaMetricsEnabled = useSelector(getParticipateInMetaMetrics);
+  const analyticsId = useSelector(getAnalyticsId);
+  const completedMetaMetricsOnboarding = useSelector(
+    getCompletedMetaMetricsOnboarding,
+  );
+  const isOptedIn = useSelector(getOptedIn);
+  const isMetaMetricsEnabled = completedMetaMetricsOnboarding && isOptedIn;
   const isMarketingEnabled = useSelector(getDataCollectionForMarketing);
 
   const getBuyURI = useCallback(
@@ -47,8 +52,8 @@ const useRamps = (
         }
 
         params.set('chainId', numericChainId);
-        if (metaMetricsId) {
-          params.set('metametricsId', metaMetricsId);
+        if (analyticsId) {
+          params.set('metametricsId', analyticsId);
         }
         params.set('metricsEnabled', String(isMetaMetricsEnabled === true));
         if (isMarketingEnabled) {
@@ -62,7 +67,7 @@ const useRamps = (
         return `${DEFAULT_PORTFOLIO_URL}/buy`;
       }
     },
-    [isMarketingEnabled, isMetaMetricsEnabled, metaMetricsId, metamaskEntry],
+    [isMarketingEnabled, isMetaMetricsEnabled, analyticsId, metamaskEntry],
   );
 
   const openBuyCryptoInPdapp = useCallback(


### PR DESCRIPTION
## **Description**

Part 7 of the Analytics Phase B split (supersedes monolithic #43406).

**Owner:** @MetaMask/ramp

**Reason:** Ramp portfolio URL builder still reads legacy metrics selectors.

**Solution:** Update `useRamps.ts` to use canonical analytics selectors.

**Depends on:** #43430

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of https://github.com/MetaMask/MetaMask-planning/issues/7331

## **Manual testing steps**

1. Run `yarn start` and verify ramp/buy flows build portfolio URLs with correct metrics params

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
