### PR TITLE
refactor(analytics): migrate assets defi empty state metrics

### DIFF
--- a/ui/components/app/assets/defi-list/cells/defi-empty-state.tsx
+++ b/ui/components/app/assets/defi-list/cells/defi-empty-state.tsx
@@ -12,8 +12,9 @@ import {
 } from '../../../../../../shared/constants/metametrics';
 import {
   getDataCollectionForMarketing,
-  getMetaMetricsId,
-  getParticipateInMetaMetrics,
+  getAnalyticsId,
+  getCompletedMetaMetricsOnboarding,
+  getOptedIn,
 } from '../../../../../selectors';
 
 export const DeFiEmptyStateMessage = () => {
@@ -21,15 +22,19 @@ export const DeFiEmptyStateMessage = () => {
   const theme = useTheme();
   const { trackEvent } = useContext(MetaMetricsContext);
 
-  const metaMetricsId = useSelector(getMetaMetricsId);
-  const isMetaMetricsEnabled = useSelector(getParticipateInMetaMetrics);
+  const analyticsId = useSelector(getAnalyticsId);
+  const completedMetaMetricsOnboarding = useSelector(
+    getCompletedMetaMetricsOnboarding,
+  );
+  const isOptedIn = useSelector(getOptedIn);
+  const isMetaMetricsEnabled = completedMetaMetricsOnboarding && isOptedIn;
   const isMarketingEnabled = useSelector(getDataCollectionForMarketing);
 
   const handleExploreDefi = useCallback(() => {
     const url = getPortfolioUrl(
       'explore/tokens',
       'ext_defi_empty_state_button',
-      metaMetricsId,
+      analyticsId,
       isMetaMetricsEnabled === true,
       isMarketingEnabled === true,
     );
@@ -42,7 +47,7 @@ export const DeFiEmptyStateMessage = () => {
         text: 'Explore DeFi',
       },
     });
-  }, [isMarketingEnabled, isMetaMetricsEnabled, metaMetricsId, trackEvent]);
+  }, [isMarketingEnabled, isMetaMetricsEnabled, analyticsId, trackEvent]);
 
   const defiIcon =
     theme === ThemeType.dark


### PR DESCRIPTION
## **Description**

Part 8 of the Analytics Phase B split (supersedes monolithic #43406).

**Owner:** @MetaMask/metamask-assets

**Reason:** Defi empty state still uses legacy metrics selectors.

**Solution:** Update `defi-empty-state.tsx` to use canonical analytics selectors.

**Depends on:** #43430

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of https://github.com/MetaMask/MetaMask-planning/issues/7331

## **Manual testing steps**

1. Run `yarn start` and verify defi empty state renders and links work with metrics enabled and disabled

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
