### PR TITLE
test(analytics): update snaps E2E for analytics fixtures

### DIFF
--- a/test/e2e/flask/snaps/preinstalled-example.spec.ts
+++ b/test/e2e/flask/snaps/preinstalled-example.spec.ts
@@ -4,11 +4,7 @@ import { Driver } from '../../webdriver/driver';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { login } from '../../page-objects/flows/login.flow';
 import { closeSettings } from '../../page-objects/flows/settings.flow';
-import {
-  DAPP_PATH,
-  MOCK_META_METRICS_ID,
-  WINDOW_TITLES,
-} from '../../constants';
+import { DAPP_PATH, MOCK_ANALYTICS_ID, WINDOW_TITLES } from '../../constants';
 import { withFixtures, sentryRegEx } from '../../helpers';
 import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import PreinstalledExampleSettings from '../../page-objects/pages/settings/preinstalled-example-settings';
@@ -138,8 +134,9 @@ describe('Preinstalled example Snap', function () {
         },
         fixtures: new FixtureBuilderV2()
           .withMetaMetricsController({
-            metaMetricsId: MOCK_META_METRICS_ID,
-            participateInMetaMetrics: true,
+            analyticsId: MOCK_ANALYTICS_ID,
+            completedMetaMetricsOnboarding: true,
+            optedIn: true,
           })
           .build(),
         title: this.test?.fullTitle(),
@@ -190,8 +187,9 @@ describe('Preinstalled example Snap', function () {
         },
         fixtures: new FixtureBuilderV2()
           .withMetaMetricsController({
-            metaMetricsId: MOCK_META_METRICS_ID,
-            participateInMetaMetrics: true,
+            analyticsId: MOCK_ANALYTICS_ID,
+            completedMetaMetricsOnboarding: true,
+            optedIn: true,
           })
           .build(),
         title: this.test?.fullTitle(),
@@ -238,8 +236,9 @@ describe('Preinstalled example Snap', function () {
         },
         fixtures: new FixtureBuilderV2()
           .withMetaMetricsController({
-            metaMetricsId: MOCK_META_METRICS_ID,
-            participateInMetaMetrics: true,
+            analyticsId: MOCK_ANALYTICS_ID,
+            completedMetaMetricsOnboarding: true,
+            optedIn: true,
           })
           .build(),
         title: this.test?.fullTitle(),

--- a/test/e2e/snaps/test-snap-installed.spec.ts
+++ b/test/e2e/snaps/test-snap-installed.spec.ts
@@ -60,8 +60,9 @@ describe('Test Snap installed', function () {
         },
         fixtures: new FixtureBuilderV2()
           .withMetaMetricsController({
-            metaMetricsId: 'fake-metrics-id',
-            participateInMetaMetrics: true,
+            analyticsId: 'fake-metrics-id',
+            completedMetaMetricsOnboarding: true,
+            optedIn: true,
           })
           .withSnapsPrivacyWarningAlreadyShown()
           .build(),

--- a/test/e2e/snaps/test-snap-metrics.spec.ts
+++ b/test/e2e/snaps/test-snap-metrics.spec.ts
@@ -5,7 +5,7 @@ import { Driver } from '../webdriver/driver';
 import { getEventPayloads, withFixtures } from '../helpers';
 import FixtureBuilderV2 from '../fixtures/fixture-builder-v2';
 import {
-  MOCK_META_METRICS_ID,
+  MOCK_ANALYTICS_ID,
   DAPP_PATH,
   DAPP_URL,
   WINDOW_TITLES,
@@ -148,8 +148,9 @@ describe('Test Snap Metrics', function () {
         },
         fixtures: new FixtureBuilderV2()
           .withMetaMetricsController({
-            metaMetricsId: MOCK_META_METRICS_ID,
-            participateInMetaMetrics: true,
+            analyticsId: MOCK_ANALYTICS_ID,
+            completedMetaMetricsOnboarding: true,
+            optedIn: true,
           })
           .withSnapsPrivacyWarningAlreadyShown()
           .build(),
@@ -230,8 +231,9 @@ describe('Test Snap Metrics', function () {
         },
         fixtures: new FixtureBuilderV2()
           .withMetaMetricsController({
-            metaMetricsId: MOCK_META_METRICS_ID,
-            participateInMetaMetrics: true,
+            analyticsId: MOCK_ANALYTICS_ID,
+            completedMetaMetricsOnboarding: true,
+            optedIn: true,
           })
           .withSnapsPrivacyWarningAlreadyShown()
           .build(),
@@ -304,8 +306,9 @@ describe('Test Snap Metrics', function () {
         },
         fixtures: new FixtureBuilderV2()
           .withMetaMetricsController({
-            metaMetricsId: MOCK_META_METRICS_ID,
-            participateInMetaMetrics: true,
+            analyticsId: MOCK_ANALYTICS_ID,
+            completedMetaMetricsOnboarding: true,
+            optedIn: true,
           })
           .withSnapsPrivacyWarningAlreadyShown()
           .build(),
@@ -375,8 +378,9 @@ describe('Test Snap Metrics', function () {
         },
         fixtures: new FixtureBuilderV2()
           .withMetaMetricsController({
-            metaMetricsId: MOCK_META_METRICS_ID,
-            participateInMetaMetrics: true,
+            analyticsId: MOCK_ANALYTICS_ID,
+            completedMetaMetricsOnboarding: true,
+            optedIn: true,
           })
           .withSnapsPrivacyWarningAlreadyShown()
           .build(),
@@ -444,8 +448,9 @@ describe('Test Snap Metrics', function () {
         },
         fixtures: new FixtureBuilderV2()
           .withMetaMetricsController({
-            metaMetricsId: MOCK_META_METRICS_ID,
-            participateInMetaMetrics: true,
+            analyticsId: MOCK_ANALYTICS_ID,
+            completedMetaMetricsOnboarding: true,
+            optedIn: true,
           })
           .withSnapsPrivacyWarningAlreadyShown()
           .build(),
@@ -526,8 +531,9 @@ describe('Test Snap Metrics', function () {
         },
         fixtures: new FixtureBuilderV2()
           .withMetaMetricsController({
-            metaMetricsId: MOCK_META_METRICS_ID,
-            participateInMetaMetrics: true,
+            analyticsId: MOCK_ANALYTICS_ID,
+            completedMetaMetricsOnboarding: true,
+            optedIn: true,
           })
           .withSnapsPrivacyWarningAlreadyShown()
           .build(),
@@ -610,8 +616,9 @@ describe('Test Snap Metrics', function () {
         },
         fixtures: new FixtureBuilderV2()
           .withMetaMetricsController({
-            metaMetricsId: MOCK_META_METRICS_ID,
-            participateInMetaMetrics: true,
+            analyticsId: MOCK_ANALYTICS_ID,
+            completedMetaMetricsOnboarding: true,
+            optedIn: true,
           })
           .withSnapsPrivacyWarningAlreadyShown()
           .build(),


### PR DESCRIPTION
## **Description**

Part 9 of the Analytics Phase B split (supersedes monolithic #43406).

**Owner:** @MetaMask/core-platform

**Reason:** Snaps E2E specs still use legacy metrics fixture fields.

**Solution:** Update snaps E2E specs for canonical analytics fixture fields.

**Depends on:** #43430

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of https://github.com/MetaMask/MetaMask-planning/issues/7331

## **Manual testing steps**

1. Run `yarn build:test`
2. Run snaps E2E specs affected by this change

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
