### PR TITLE
test(analytics): migrate confirmations and PPOM metrics E2E

### DIFF
--- a/test/e2e/tests/confirmations/helpers.ts
+++ b/test/e2e/tests/confirmations/helpers.ts
@@ -5,7 +5,7 @@ import { MockedEndpoint, Mockttp } from '../../mock-e2e';
 import { SMART_CONTRACTS } from '../../seeder/smart-contracts';
 import { Driver } from '../../webdriver/driver';
 import Confirmation from '../../page-objects/pages/confirmations/confirmation';
-import { MOCK_META_METRICS_ID } from '../../constants';
+import { MOCK_ANALYTICS_ID } from '../../constants';
 import { mockDialogSnap } from '../../mock-response-data/snaps/snap-binary-mocks';
 
 export const DECODING_E2E_API_URL =
@@ -42,8 +42,9 @@ export function withTransactionEnvelopeTypeFixtures(
       fixtures: new FixtureBuilderV2()
         .withPermissionControllerConnectedToTestDapp()
         .withMetaMetricsController({
-          metaMetricsId: MOCK_META_METRICS_ID,
-          participateInMetaMetrics: true,
+          analyticsId: MOCK_ANALYTICS_ID,
+          completedMetaMetricsOnboarding: true,
+          optedIn: true,
         })
         .build(),
       localNodeOptions:
@@ -79,8 +80,9 @@ export function withSignatureFixtures(
       fixtures: new FixtureBuilderV2()
         .withPermissionControllerConnectedToTestDapp()
         .withMetaMetricsController({
-          metaMetricsId: MOCK_META_METRICS_ID,
-          participateInMetaMetrics: true,
+          analyticsId: MOCK_ANALYTICS_ID,
+          completedMetaMetricsOnboarding: true,
+          optedIn: true,
         })
         .build(),
       testSpecificMock: mocks,

--- a/test/e2e/tests/confirmations/navigation.spec.ts
+++ b/test/e2e/tests/confirmations/navigation.spec.ts
@@ -12,7 +12,7 @@ import TransactionConfirmation from '../../page-objects/pages/confirmations/tran
 import {
   DAPP_ONE_URL,
   DAPP_PATH,
-  MOCK_META_METRICS_ID,
+  MOCK_ANALYTICS_ID,
   WINDOW_TITLES,
 } from '../../constants';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
@@ -124,8 +124,9 @@ describe('Confirmation Navigation', function (this: Suite) {
           .withPermissionControllerConnectedToTestDapp()
           .withSnapsPrivacyWarningAlreadyShown()
           .withMetaMetricsController({
-            metaMetricsId: MOCK_META_METRICS_ID,
-            participateInMetaMetrics: true,
+            analyticsId: MOCK_ANALYTICS_ID,
+            completedMetaMetricsOnboarding: true,
+            optedIn: true,
           })
           .build(),
         testSpecificMock: mockDialogSnap,

--- a/test/e2e/tests/confirmations/transactions/metrics.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/metrics.spec.ts
@@ -6,7 +6,7 @@ import {
   TransactionMetaMetricsEvent,
 } from '../../../../../shared/constants/transaction';
 import { Driver } from '../../../webdriver/driver';
-import { MOCK_META_METRICS_ID, WINDOW_TITLES } from '../../../constants';
+import { MOCK_ANALYTICS_ID, WINDOW_TITLES } from '../../../constants';
 import TestDapp from '../../../page-objects/pages/test-dapp';
 import FixtureBuilderV2 from '../../../fixtures/fixture-builder-v2';
 import { withFixtures, getEventPayloads } from '../../../helpers';
@@ -31,8 +31,9 @@ describe('Metrics', function () {
         fixtures: new FixtureBuilderV2()
           .withPermissionControllerConnectedToTestDapp()
           .withMetaMetricsController({
-            metaMetricsId: MOCK_META_METRICS_ID,
-            participateInMetaMetrics: true,
+            analyticsId: MOCK_ANALYTICS_ID,
+            completedMetaMetricsOnboarding: true,
+            optedIn: true,
           })
           .build(),
         title: this.test?.fullTitle(),

--- a/test/e2e/tests/ppom/ppom-blockaid-alert-metrics.spec.js
+++ b/test/e2e/tests/ppom/ppom-blockaid-alert-metrics.spec.js
@@ -6,11 +6,11 @@ const { withFixtures, getEventPayloads } = require('../../helpers');
 const { login } = require('../../page-objects/flows/login.flow');
 const {
   DAPP_URL_LOCALHOST,
+  MOCK_ANALYTICS_ID,
   NETWORK_CLIENT_ID,
   WINDOW_TITLES,
 } = require('../../constants');
 const { mockServerJsonRpc } = require('./mocks/mock-server-json-rpc');
-const { MOCK_META_METRICS_ID } = require('./constants');
 
 const selectedAddress = '0x5cfe73b6021e818b776b421b1c4db2474086a7e1';
 const selectedAddressWithoutPrefix = '5cfe73b6021e818b776b421b1c4db2474086a7e1';
@@ -271,8 +271,9 @@ describe('Confirmation Security Alert - Blockaid', function () {
             },
           })
           .withMetaMetricsController({
-            metaMetricsId: MOCK_META_METRICS_ID,
-            participateInMetaMetrics: true,
+            analyticsId: MOCK_ANALYTICS_ID,
+            completedMetaMetricsOnboarding: true,
+            optedIn: true,
           })
           .build(),
         title: this.test.fullTitle(),
@@ -325,7 +326,7 @@ describe('Confirmation Security Alert - Blockaid', function () {
             ppom_debug_traceCall_count: 3,
             ppom_eth_call_count: 1,
           },
-          userId: MOCK_META_METRICS_ID,
+          userId: MOCK_ANALYTICS_ID,
           type: 'track',
         };
 
@@ -359,7 +360,7 @@ describe('Confirmation Security Alert - Blockaid', function () {
             ppom_eth_call_count: 1,
             ppom_debug_traceCall_count: 1,
           },
-          userId: MOCK_META_METRICS_ID,
+          userId: MOCK_ANALYTICS_ID,
           type: 'track',
         };
 

--- a/test/e2e/tests/ppom/ppom-blockaid-toggle-metrics.spec.ts
+++ b/test/e2e/tests/ppom/ppom-blockaid-toggle-metrics.spec.ts
@@ -2,7 +2,7 @@ import { strict as assert } from 'assert';
 import { Mockttp } from 'mockttp';
 import { login } from '../../page-objects/flows/login.flow';
 import { withFixtures, getEventPayloads } from '../../helpers';
-import { MOCK_META_METRICS_ID, NETWORK_CLIENT_ID } from '../../constants';
+import { MOCK_ANALYTICS_ID, NETWORK_CLIENT_ID } from '../../constants';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import SettingsPage from '../../page-objects/pages/settings/settings-page';
@@ -71,8 +71,9 @@ describe('PPOM Blockaid Alert - Metrics', function () {
             chainIds: [1],
           })
           .withMetaMetricsController({
-            metaMetricsId: MOCK_META_METRICS_ID,
-            participateInMetaMetrics: true,
+            analyticsId: MOCK_ANALYTICS_ID,
+            completedMetaMetricsOnboarding: true,
+            optedIn: true,
           })
           .build(),
         title: this.test?.fullTitle(),
@@ -112,7 +113,7 @@ describe('PPOM Blockaid Alert - Metrics', function () {
             blockaid_alerts_enabled: true,
             category: 'Settings',
           },
-          userId: MOCK_META_METRICS_ID,
+          userId: MOCK_ANALYTICS_ID,
           type: 'track',
         };
         const matchToggleOnEvent = {
@@ -134,7 +135,7 @@ describe('PPOM Blockaid Alert - Metrics', function () {
             blockaid_alerts_enabled: false,
             category: 'Settings',
           },
-          userId: MOCK_META_METRICS_ID,
+          userId: MOCK_ANALYTICS_ID,
           type: 'track',
         };
         const matchToggleOffEvent = {


### PR DESCRIPTION
## **Description**

Part 12 of the Analytics Phase B split (supersedes monolithic #43406).

**Owner:** @MetaMask/confirmations

**Reason:** Confirmations and PPOM metrics E2E specs still use legacy metrics fixture fields.

**Solution:** Update confirmations and PPOM metrics E2E specs for canonical analytics fields.

**Depends on:** #43430

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of https://github.com/MetaMask/MetaMask-planning/issues/7331

## **Manual testing steps**

1. Run `yarn build:test`
2. Run confirmations and PPOM metrics E2E specs affected by this change

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
