### PR TITLE
refactor(analytics): migrate platform misc UI and cross-domain E2E

### DIFF
--- a/test/e2e/tests/account/unlock-wallet.spec.ts
+++ b/test/e2e/tests/account/unlock-wallet.spec.ts
@@ -107,7 +107,8 @@ describe('Unlock wallet - ', function () {
 
         if (process.env.SELENIUM_BROWSER === Browser.FIREFOX) {
           await onboardingMetricsFlow(driver, {
-            participateInMetaMetrics: false,
+            completedMetaMetricsOnboarding: true,
+            optedIn: false,
             dataCollectionForMarketing: false,
           });
         }

--- a/test/e2e/tests/port-stream-chunking/port-stream-chunking.spec.ts
+++ b/test/e2e/tests/port-stream-chunking/port-stream-chunking.spec.ts
@@ -9,7 +9,7 @@ import {
 import { getEventPayloads, withFixtures } from '../../helpers';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import HomePage from '../../page-objects/pages/home/homepage';
-import { MOCK_META_METRICS_ID } from '../../constants';
+import { MOCK_ANALYTICS_ID } from '../../constants';
 import { PAGES } from '../../webdriver/driver';
 import LoginPage from '../../page-objects/pages/login-page';
 
@@ -63,8 +63,9 @@ describe('Port Stream Chunking', function () {
         fixtures: new FixtureBuilderV2()
           .withTransactionController({ transactions: largeTransactions })
           .withMetaMetricsController({
-            metaMetricsId: MOCK_META_METRICS_ID,
-            participateInMetaMetrics: true,
+            analyticsId: MOCK_ANALYTICS_ID,
+            completedMetaMetricsOnboarding: true,
+            optedIn: true,
           })
           .build(),
         title: this.test?.fullTitle(),

--- a/test/e2e/tests/portfolio/portfolio-site.spec.ts
+++ b/test/e2e/tests/portfolio/portfolio-site.spec.ts
@@ -1,6 +1,6 @@
 import { MockttpServer } from 'mockttp';
 import { withFixtures } from '../../helpers';
-import { MOCK_META_METRICS_ID } from '../../constants';
+import { MOCK_ANALYTICS_ID } from '../../constants';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { emptyHtmlPage } from '../../mock-e2e';
 import HomePage from '../../page-objects/pages/home/homepage';
@@ -13,7 +13,7 @@ describe('Portfolio site', function () {
       .forGet('https://app.metamask.io/explore/tokens')
       .withQuery({
         metamaskEntry: 'ext_portfolio_button',
-        metametricsId: MOCK_META_METRICS_ID,
+        metametricsId: MOCK_ANALYTICS_ID,
         metricsEnabled: 'true',
         marketingEnabled: 'false',
       })
@@ -31,8 +31,9 @@ describe('Portfolio site', function () {
         dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilderV2()
           .withMetaMetricsController({
-            metaMetricsId: MOCK_META_METRICS_ID,
-            participateInMetaMetrics: true,
+            analyticsId: MOCK_ANALYTICS_ID,
+            completedMetaMetricsOnboarding: true,
+            optedIn: true,
           })
           .build(),
         title: this.test?.fullTitle(),
@@ -45,7 +46,7 @@ describe('Portfolio site', function () {
 
         // Verify site
         await driver.waitForUrl({
-          url: `https://app.metamask.io/explore/tokens?metamaskEntry=ext_portfolio_button&metametricsId=${MOCK_META_METRICS_ID}&metricsEnabled=true&marketingEnabled=false`,
+          url: `https://app.metamask.io/explore/tokens?metamaskEntry=ext_portfolio_button&metametricsId=${MOCK_ANALYTICS_ID}&metricsEnabled=true&marketingEnabled=false`,
         });
         await new MockedPage(driver).checkDisplayedMessage(
           'Empty page by MetaMask',

--- a/test/e2e/tests/profile-metrics/profile-metrics.spec.ts
+++ b/test/e2e/tests/profile-metrics/profile-metrics.spec.ts
@@ -134,7 +134,8 @@ describe('Profile Metrics', function () {
         {
           fixtures: new FixtureBuilderV2()
             .withMetaMetricsController({
-              participateInMetaMetrics: true,
+              completedMetaMetricsOnboarding: true,
+              optedIn: true,
             })
             .build(),
           testSpecificMock: async (server: Mockttp) => [
@@ -173,7 +174,8 @@ describe('Profile Metrics', function () {
         {
           fixtures: new FixtureBuilderV2()
             .withMetaMetricsController({
-              participateInMetaMetrics: true,
+              completedMetaMetricsOnboarding: true,
+              optedIn: true,
             })
             .build(),
           testSpecificMock: async (server: Mockttp) => [
@@ -230,54 +232,59 @@ describe('Profile Metrics', function () {
   [
     {
       title: 'when MetaMetrics is disabled',
-      participateInMetaMetrics: false,
+      completedMetaMetricsOnboarding: true,
+      optedIn: false,
       pna25Acknowledged: true,
     },
     {
       title: 'when the user has not acknowledged the privacy change',
-      participateInMetaMetrics: true,
+      completedMetaMetricsOnboarding: true,
+      optedIn: true,
       pna25Acknowledged: false,
     },
-  ].forEach(({ title, participateInMetaMetrics, pna25Acknowledged }) => {
-    describe(title, function () {
-      it('does not send existing accounts to the API on wallet unlock', async function () {
-        await withFixtures(
-          {
-            fixtures: new FixtureBuilderV2()
-              .withMetaMetricsController({
-                participateInMetaMetrics,
-              })
-              .withAppStateController({
-                pna25Acknowledged,
-              })
-              .build(),
-            testSpecificMock: async (server: Mockttp) => [
-              await mockAuthService(server),
-              await mockRemoteFeatureFlags()(server),
-            ],
-            title: this.test?.fullTitle(),
-          },
-          async ({
-            driver,
-            mockedEndpoint,
-          }: {
-            driver: Driver;
-            mockedEndpoint: MockedEndpoint[];
-          }) => {
-            await login(driver);
+  ].forEach(
+    ({ title, optedIn, completedMetaMetricsOnboarding, pna25Acknowledged }) => {
+      describe(title, function () {
+        it('does not send existing accounts to the API on wallet unlock', async function () {
+          await withFixtures(
+            {
+              fixtures: new FixtureBuilderV2()
+                .withMetaMetricsController({
+                  optedIn,
+                  completedMetaMetricsOnboarding,
+                })
+                .withAppStateController({
+                  pna25Acknowledged,
+                })
+                .build(),
+              testSpecificMock: async (server: Mockttp) => [
+                await mockAuthService(server),
+                await mockRemoteFeatureFlags()(server),
+              ],
+              title: this.test?.fullTitle(),
+            },
+            async ({
+              driver,
+              mockedEndpoint,
+            }: {
+              driver: Driver;
+              mockedEndpoint: MockedEndpoint[];
+            }) => {
+              await login(driver);
 
-            await driver.delay(5000);
+              await driver.delay(5000);
 
-            const [authCall] = mockedEndpoint;
-            const requests = await authCall.getSeenRequests();
-            assert.equal(
-              requests.length,
-              0,
-              'Expected no requests to the auth API.',
-            );
-          },
-        );
+              const [authCall] = mockedEndpoint;
+              const requests = await authCall.getSeenRequests();
+              assert.equal(
+                requests.length,
+                0,
+                'Expected no requests to the auth API.',
+              );
+            },
+          );
+        });
       });
-    });
-  });
+    },
+  );
 });

--- a/test/e2e/tests/remote-feature-flag/remote-feature-flag.spec.ts
+++ b/test/e2e/tests/remote-feature-flag/remote-feature-flag.spec.ts
@@ -9,7 +9,7 @@ import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import DeveloperOptionsPage from '../../page-objects/pages/debug-page';
 import {
   MOCK_CUSTOMIZED_REMOTE_FEATURE_FLAGS,
-  MOCK_META_METRICS_ID,
+  MOCK_ANALYTICS_ID,
   MOCK_REMOTE_FEATURE_FLAGS_RESPONSE,
 } from '../../constants';
 import { type MockedEndpoint, Mockttp } from '../../mock-e2e';
@@ -60,8 +60,9 @@ describe('Remote feature flag', function (this: Suite) {
       {
         fixtures: new FixtureBuilderV2()
           .withMetaMetricsController({
-            metaMetricsId: MOCK_META_METRICS_ID,
-            participateInMetaMetrics: true,
+            analyticsId: MOCK_ANALYTICS_ID,
+            completedMetaMetricsOnboarding: true,
+            optedIn: true,
           })
           .build(),
         title: this.test?.fullTitle(),
@@ -110,8 +111,9 @@ describe('Remote feature flag', function (this: Suite) {
       {
         fixtures: new FixtureBuilderV2()
           .withMetaMetricsController({
-            metaMetricsId: MOCK_META_METRICS_ID,
-            participateInMetaMetrics: true,
+            analyticsId: MOCK_ANALYTICS_ID,
+            completedMetaMetricsOnboarding: true,
+            optedIn: true,
           })
           .build(),
         manifestFlags: {

--- a/test/e2e/tests/survey/survey.spec.ts
+++ b/test/e2e/tests/survey/survey.spec.ts
@@ -1,6 +1,6 @@
 import { MockttpServer } from 'mockttp';
 import { ACCOUNTS_PROD_API_BASE_URL } from '../../../../shared/constants/accounts';
-import { MOCK_META_METRICS_ID } from '../../constants';
+import { MOCK_ANALYTICS_ID } from '../../constants';
 import { withFixtures } from '../../helpers';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import Homepage from '../../page-objects/pages/home/homepage';
@@ -9,7 +9,7 @@ import { login } from '../../page-objects/flows/login.flow';
 async function mockSurveys(mockServer: MockttpServer) {
   await mockServer
     .forGet(
-      `${ACCOUNTS_PROD_API_BASE_URL}/v1/users/${MOCK_META_METRICS_ID}/surveys`,
+      `${ACCOUNTS_PROD_API_BASE_URL}/v1/users/${MOCK_ANALYTICS_ID}/surveys`,
     )
     // We need to mock this request twice because of a bug on the wallet side (#33604)
     .twice()
@@ -29,7 +29,7 @@ async function mockSurveys(mockServer: MockttpServer) {
     });
   await mockServer
     .forGet(
-      `${ACCOUNTS_PROD_API_BASE_URL}/v1/users/${MOCK_META_METRICS_ID}/surveys`,
+      `${ACCOUNTS_PROD_API_BASE_URL}/v1/users/${MOCK_ANALYTICS_ID}/surveys`,
     )
     .once()
     .thenCallback(() => {
@@ -55,8 +55,9 @@ describe('Test Survey', function () {
         dappOptions: { numberOfTestDapps: 1 },
         fixtures: new FixtureBuilderV2()
           .withMetaMetricsController({
-            metaMetricsId: MOCK_META_METRICS_ID,
-            participateInMetaMetrics: true,
+            analyticsId: MOCK_ANALYTICS_ID,
+            completedMetaMetricsOnboarding: true,
+            optedIn: true,
           })
           .build(),
         testSpecificMock: mockSurveys,

--- a/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
+++ b/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
@@ -160,7 +160,8 @@ describe('Vault Corruption', function () {
           driver,
           breakPrimaryDatabaseOnlyScript,
           {
-            participateInMetaMetrics: true,
+            completedMetaMetricsOnboarding: true,
+            optedIn: true,
           },
         );
 

--- a/ui/components/app/modals/pna25-modal/pna25-modal.stories.tsx
+++ b/ui/components/app/modals/pna25-modal/pna25-modal.stories.tsx
@@ -7,7 +7,8 @@ import Pna25Modal from './pna25-modal';
 const storeMock = configureStore({
   metamask: {
     completedOnboarding: true,
-    participateInMetaMetrics: true,
+    optedIn: true,
+    completedMetaMetricsOnboarding: true,
     pna25Acknowledged: false,
   },
 });

--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -28,8 +28,9 @@ import {
   getIsTokenNetworkFilterEqualCurrentNetwork,
   getChainIdsToPoll,
   getDataCollectionForMarketing,
-  getMetaMetricsId,
-  getParticipateInMetaMetrics,
+  getAnalyticsId,
+  getCompletedMetaMetricsOnboarding,
+  getOptedIn,
   getEnabledNetworksByNamespace,
   selectAnyEnabledNetworksAreAvailable,
 } from '../../../selectors';
@@ -187,8 +188,12 @@ export const CoinOverview = ({
 
   const { trackEvent } = useContext(MetaMetricsContext);
 
-  const metaMetricsId = useSelector(getMetaMetricsId);
-  const isMetaMetricsEnabled = useSelector(getParticipateInMetaMetrics);
+  const analyticsId = useSelector(getAnalyticsId);
+  const completedMetaMetricsOnboarding = useSelector(
+    getCompletedMetaMetricsOnboarding,
+  );
+  const isOptedIn = useSelector(getOptedIn);
+  const isMetaMetricsEnabled = completedMetaMetricsOnboarding && isOptedIn;
   const isMarketingEnabled = useSelector(getDataCollectionForMarketing);
 
   const dispatch = useDispatch();
@@ -223,7 +228,7 @@ export const CoinOverview = ({
     const url = getPortfolioUrl(
       'explore/tokens',
       'ext_portfolio_button',
-      metaMetricsId,
+      analyticsId,
       isMetaMetricsEnabled === true,
       isMarketingEnabled === true,
     );
@@ -236,7 +241,7 @@ export const CoinOverview = ({
         text: 'Portfolio',
       },
     });
-  }, [isMarketingEnabled, isMetaMetricsEnabled, metaMetricsId, trackEvent]);
+  }, [isMarketingEnabled, isMetaMetricsEnabled, analyticsId, trackEvent]);
 
   const handleReceiveOnClick = useCallback(() => {
     trace({ name: TraceName.ReceiveModal });

--- a/ui/components/app/wallet-overview/non-evm-overview.test.tsx
+++ b/ui/components/app/wallet-overview/non-evm-overview.test.tsx
@@ -81,7 +81,7 @@ const BTC_OVERVIEW_SWAP = 'coin-overview-swap';
 const BTC_OVERVIEW_SEND = 'coin-overview-send';
 const BTC_OVERVIEW_PRIMARY_CURRENCY = 'coin-overview__primary-currency';
 
-const mockMetaMetricsId = 'deadbeef';
+const mockAnalyticsId = 'deadbeef';
 const mockNonEvmBalance = '1';
 const mockNonEvmAccount = {
   address: 'bc1qwl8399fz829uqvqly9tcatgrgtwp3udnhxfq4k',
@@ -191,7 +191,7 @@ const mockMetamaskStore = {
   // selected account
   completedOnboarding: true,
   // Used when clicking on some buttons
-  metaMetricsId: mockMetaMetricsId,
+  analyticsId: mockAnalyticsId,
   // Override state if provided
   multichainNetworkConfigurationsByChainId:
     AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS,

--- a/ui/components/ui/survey-toast/survey-toast.tsx
+++ b/ui/components/ui/survey-toast/survey-toast.tsx
@@ -11,8 +11,9 @@ import {
 import {
   getLastViewedUserSurvey,
   getUseExternalServices,
-  getMetaMetricsId,
-  getParticipateInMetaMetrics,
+  getAnalyticsId,
+  getCompletedMetaMetricsOnboarding,
+  getOptedIn,
 } from '../../../selectors';
 import { getSelectedInternalAccount } from '../../../../shared/lib/selectors/accounts';
 import { ACCOUNTS_API_BASE_URL } from '../../../../shared/constants/accounts';
@@ -34,18 +35,22 @@ export function SurveyToast() {
   const dispatch = useDispatch();
   const { trackEvent } = useContext(MetaMetricsContext);
   const lastViewedUserSurvey = useSelector(getLastViewedUserSurvey);
-  const participateInMetaMetrics = useSelector(getParticipateInMetaMetrics);
+  const isOptedIn = useSelector(getOptedIn);
+  const completedMetaMetricsOnboarding = useSelector(
+    getCompletedMetaMetricsOnboarding,
+  );
   const basicFunctionality = useSelector(getUseExternalServices);
   const internalAccount = useSelector(getSelectedInternalAccount);
-  const metaMetricsId = useSelector(getMetaMetricsId);
+  const analyticsId = useSelector(getAnalyticsId);
+  const isMetaMetricsEnabled = completedMetaMetricsOnboarding && isOptedIn;
 
   const surveyUrl = useMemo(
-    () => `${ACCOUNTS_API_BASE_URL}/v1/users/${metaMetricsId}/surveys`,
-    [metaMetricsId],
+    () => `${ACCOUNTS_API_BASE_URL}/v1/users/${analyticsId}/surveys`,
+    [analyticsId],
   );
 
   useEffect(() => {
-    if (!basicFunctionality || !metaMetricsId || !participateInMetaMetrics) {
+    if (!basicFunctionality || !analyticsId || !isMetaMetricsEnabled) {
       return undefined;
     }
 
@@ -79,7 +84,7 @@ export function SurveyToast() {
         setSurvey(_survey);
       } catch (error: unknown) {
         if (error instanceof Error && error.name !== 'AbortError') {
-          console.error('Failed to fetch survey:', metaMetricsId, error);
+          console.error('Failed to fetch survey:', analyticsId, error);
         }
       }
     };
@@ -93,7 +98,8 @@ export function SurveyToast() {
     internalAccount?.address,
     lastViewedUserSurvey,
     basicFunctionality,
-    metaMetricsId,
+    analyticsId,
+    isMetaMetricsEnabled,
     dispatch,
   ]);
 
@@ -117,7 +123,7 @@ export function SurveyToast() {
   }
 
   function trackAction(response: 'accept' | 'deny') {
-    if (!participateInMetaMetrics || !survey) {
+    if (!isMetaMetricsEnabled || !survey) {
       return;
     }
 

--- a/ui/helpers/utils/portfolio.js
+++ b/ui/helpers/utils/portfolio.js
@@ -1,7 +1,7 @@
 export function getPortfolioUrl(
   endpoint = '',
   metamaskEntry = '',
-  metaMetricsId = '',
+  analyticsId = '',
   metricsEnabled = false,
   marketingEnabled = false,
   accountAddress,
@@ -11,7 +11,7 @@ export function getPortfolioUrl(
   const url = new URL(endpoint, baseUrl);
 
   url.searchParams.append('metamaskEntry', metamaskEntry);
-  url.searchParams.append('metametricsId', metaMetricsId);
+  url.searchParams.append('metametricsId', analyticsId);
 
   // Append privacy preferences for metrics + marketing on user navigation to Portfolio
   url.searchParams.append('metricsEnabled', String(metricsEnabled));

--- a/ui/pages/asset/components/asset-page.tsx
+++ b/ui/pages/asset/components/asset-page.tsx
@@ -62,8 +62,9 @@ import {
   getDataCollectionForMarketing,
   getIsBridgeChain,
   getIsSwapsChain,
-  getMetaMetricsId,
-  getParticipateInMetaMetrics,
+  getAnalyticsId,
+  getCompletedMetaMetricsOnboarding,
+  getOptedIn,
   getShowFiatInTestnets,
 } from '../../../selectors';
 import {
@@ -164,9 +165,13 @@ const AssetPage = ({
   const showFiat =
     shouldShowFiat && (isMainnet || (isTestnet && showFiatInTestnets));
 
-  const isMetaMetricsEnabled = useSelector(getParticipateInMetaMetrics);
+  const completedMetaMetricsOnboarding = useSelector(
+    getCompletedMetaMetricsOnboarding,
+  );
+  const isOptedIn = useSelector(getOptedIn);
+  const isMetaMetricsEnabled = completedMetaMetricsOnboarding && isOptedIn;
   const isMarketingEnabled = useSelector(getDataCollectionForMarketing);
-  const metaMetricsId = useSelector(getMetaMetricsId);
+  const analyticsId = useSelector(getAnalyticsId);
 
   let address =
     (() => {
@@ -208,7 +213,7 @@ const AssetPage = ({
       getPortfolioUrl(
         '',
         'asset_page',
-        metaMetricsId,
+        analyticsId,
         isMetaMetricsEnabled === true,
         isMarketingEnabled === true,
         selectedAccount.address,
@@ -218,7 +223,7 @@ const AssetPage = ({
       selectedAccount.address,
       isMarketingEnabled,
       isMetaMetricsEnabled,
-      metaMetricsId,
+      analyticsId,
     ],
   );
 

--- a/ui/pages/batch-sell/pages/select/components/batch-sell-empty-select-tokens.test.tsx
+++ b/ui/pages/batch-sell/pages/select/components/batch-sell-empty-select-tokens.test.tsx
@@ -22,8 +22,9 @@ jest.mock('../../../../../hooks/useTheme', () => ({
 }));
 
 jest.mock('../../../../../selectors', () => ({
-  getMetaMetricsId: jest.fn(),
-  getParticipateInMetaMetrics: jest.fn(),
+  getAnalyticsId: jest.fn(),
+  getCompletedMetaMetricsOnboarding: jest.fn(),
+  getOptedIn: jest.fn(),
   getDataCollectionForMarketing: jest.fn(),
 }));
 
@@ -38,19 +39,22 @@ jest.mock('../../../../../helpers/utils/portfolio', () => ({
 const mockUseSelector = jest.mocked(useSelector);
 const mockGetPortfolioUrl = jest.mocked(getPortfolioUrl);
 
-// Seed the three useSelector calls in component order:
-// 1. getMetaMetricsId
-// 2. getParticipateInMetaMetrics
-// 3. getDataCollectionForMarketing
+// Seed the useSelector calls in component order:
+// 1. getAnalyticsId
+// 2. getCompletedMetaMetricsOnboarding
+// 3. getOptedIn
+// 4. getDataCollectionForMarketing
 function seedSelectors({
-  metaMetricsId = 'mock-metrics-id',
-  isMetaMetricsEnabled = true,
+  analyticsId = 'mock-metrics-id',
+  completedMetaMetricsOnboarding = true,
+  isOptedIn = true,
   isMarketingEnabled = false,
 } = {}) {
   mockUseSelector.mockReset();
   mockUseSelector
-    .mockReturnValueOnce(metaMetricsId as never)
-    .mockReturnValueOnce(isMetaMetricsEnabled as never)
+    .mockReturnValueOnce(analyticsId as never)
+    .mockReturnValueOnce(completedMetaMetricsOnboarding as never)
+    .mockReturnValueOnce(isOptedIn as never)
     .mockReturnValueOnce(isMarketingEnabled as never);
 }
 
@@ -124,8 +128,9 @@ describe('BatchSellEmptySelectTokens', () => {
 
     it('passes the correct arguments to getPortfolioUrl', () => {
       seedSelectors({
-        metaMetricsId: 'test-id',
-        isMetaMetricsEnabled: true,
+        analyticsId: 'test-id',
+        completedMetaMetricsOnboarding: true,
+        isOptedIn: true,
         isMarketingEnabled: true,
       });
 
@@ -143,8 +148,9 @@ describe('BatchSellEmptySelectTokens', () => {
 
     it('passes updated selector values when they change between renders', () => {
       seedSelectors({
-        metaMetricsId: 'id-a',
-        isMetaMetricsEnabled: false,
+        analyticsId: 'id-a',
+        completedMetaMetricsOnboarding: true,
+        isOptedIn: false,
         isMarketingEnabled: false,
       });
       const { unmount } = render(<BatchSellEmptySelectTokens />);
@@ -162,8 +168,9 @@ describe('BatchSellEmptySelectTokens', () => {
       jest.clearAllMocks();
 
       seedSelectors({
-        metaMetricsId: 'id-b',
-        isMetaMetricsEnabled: true,
+        analyticsId: 'id-b',
+        completedMetaMetricsOnboarding: true,
+        isOptedIn: true,
         isMarketingEnabled: true,
       });
       render(<BatchSellEmptySelectTokens />);

--- a/ui/pages/batch-sell/pages/select/components/batch-sell-empty-select-tokens.tsx
+++ b/ui/pages/batch-sell/pages/select/components/batch-sell-empty-select-tokens.tsx
@@ -16,8 +16,9 @@ import { ThemeType } from '../../../../../../shared/constants/preferences';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { useTheme } from '../../../../../hooks/useTheme';
 import {
-  getMetaMetricsId,
-  getParticipateInMetaMetrics,
+  getAnalyticsId,
+  getCompletedMetaMetricsOnboarding,
+  getOptedIn,
   getDataCollectionForMarketing,
 } from '../../../../../selectors';
 import { getPortfolioUrl } from '../../../../../helpers/utils/portfolio';
@@ -25,8 +26,12 @@ import { getPortfolioUrl } from '../../../../../helpers/utils/portfolio';
 export const BatchSellEmptySelectTokens = () => {
   const t = useI18nContext();
   const theme = useTheme();
-  const metaMetricsId = useSelector(getMetaMetricsId);
-  const isMetaMetricsEnabled = useSelector(getParticipateInMetaMetrics);
+  const analyticsId = useSelector(getAnalyticsId);
+  const completedMetaMetricsOnboarding = useSelector(
+    getCompletedMetaMetricsOnboarding,
+  );
+  const isOptedIn = useSelector(getOptedIn);
+  const isMetaMetricsEnabled = completedMetaMetricsOnboarding && isOptedIn;
   const isMarketingEnabled = useSelector(getDataCollectionForMarketing);
 
   const defiIcon =
@@ -38,12 +43,12 @@ export const BatchSellEmptySelectTokens = () => {
     const url = getPortfolioUrl(
       'explore/tokens',
       'ext_batch_sell_empty',
-      metaMetricsId,
+      analyticsId,
       isMetaMetricsEnabled ?? undefined,
       isMarketingEnabled,
     );
     globalThis.platform.openTab({ url });
-  }, [metaMetricsId, isMetaMetricsEnabled, isMarketingEnabled]);
+  }, [analyticsId, isMetaMetricsEnabled, isMarketingEnabled]);
 
   return (
     <Box

--- a/ui/pages/error-page/error-component.test.tsx
+++ b/ui/pages/error-page/error-component.test.tsx
@@ -7,7 +7,7 @@ import configureMockState from 'redux-mock-store';
 import { renderWithProvider } from '../../../test/lib/render-helpers-navigate';
 import { useI18nContext } from '../../hooks/useI18nContext';
 import { MetaMetricsContext } from '../../contexts/metametrics';
-import { getParticipateInMetaMetrics } from '../../selectors';
+import { getCompletedMetaMetricsOnboarding, getOptedIn } from '../../selectors';
 import { getMessage } from '../../helpers/utils/i18n-helper';
 import { enLocale as messages } from '../../../test/lib/i18n-helpers';
 import { getUserSubscriptions } from '../../selectors/subscription';
@@ -50,7 +50,10 @@ describe('ErrorPage', () => {
 
   beforeEach(() => {
     useSelectorMock.mockImplementation((selector) => {
-      if (selector === getParticipateInMetaMetrics) {
+      if (selector === getCompletedMetaMetricsOnboarding) {
+        return true;
+      }
+      if (selector === getOptedIn) {
         return true;
       }
       if (selector === getUserSubscriptions) {
@@ -140,7 +143,10 @@ describe('ErrorPage', () => {
 
   it('should render not sentry user feedback option when metrics is not opted in', () => {
     useSelectorMock.mockImplementation((selector) => {
-      if (selector === getParticipateInMetaMetrics) {
+      if (selector === getCompletedMetaMetricsOnboarding) {
+        return true;
+      }
+      if (selector === getOptedIn) {
         return false;
       }
       return undefined;

--- a/ui/pages/error-page/error-page.component.tsx
+++ b/ui/pages/error-page/error-page.component.tsx
@@ -8,7 +8,7 @@ import {
   BoxFlexDirection,
   BoxJustifyContent,
 } from '@metamask/design-system-react';
-import { getParticipateInMetaMetrics } from '../../selectors';
+import { getCompletedMetaMetricsOnboarding, getOptedIn } from '../../selectors';
 import { useI18nContext } from '../../hooks/useI18nContext';
 import {
   BannerAlert,
@@ -53,7 +53,11 @@ type ErrorPageProps = {
 
 const ErrorPage = ({ error }: ErrorPageProps) => {
   const t = useI18nContext();
-  const isMetaMetricsEnabled = useSelector(getParticipateInMetaMetrics);
+  const completedMetaMetricsOnboarding = useSelector(
+    getCompletedMetaMetricsOnboarding,
+  );
+  const isOptedIn = useSelector(getOptedIn);
+  const isMetaMetricsEnabled = completedMetaMetricsOnboarding && isOptedIn;
 
   const [feedbackMessage, setFeedbackMessage] = useState('');
   const [isFeedbackModalOpen, setIsFeedbackModalOpen] = useState(false);

--- a/ui/pages/unlock-page/unlock-page.stories.tsx
+++ b/ui/pages/unlock-page/unlock-page.stories.tsx
@@ -40,7 +40,8 @@ DefaultStory.storyName = 'Default';
 
 DefaultStory.args = {
   forceUpdateMetamaskState: () => ({
-    participateInMetaMetrics: true,
+    optedIn: true,
+    completedMetaMetricsOnboarding: true,
   }),
   passkeyAutoUnlockSuppressed: false,
   mustDeferPasskeyToBrowserTab: false,


### PR DESCRIPTION
## **Description**

Part 13 of the Analytics Phase B split (supersedes monolithic #43406).

**Owner:** Extension Platform

**Reason:** Cross-cutting UI and E2E consumers still reference legacy metrics selectors.

**Solution:** Migrate error page, portfolio helper, survey toast, batch-sell, coin-overview, and cross-domain E2E specs to canonical analytics selectors.

**Depends on:** #43430

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of https://github.com/MetaMask/MetaMask-planning/issues/7331

## **Manual testing steps**

1. Run `yarn start` and verify portfolio/discover URL params with metrics on and off
2. Run `yarn build:test`
3. Run profile-metrics, survey, and vault-corruption E2E specs affected by this change

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
