### PR TITLE
chore: remove legacy zkSync RPC URL from fixtures and Storybook

### DIFF
--- a/app/scripts/fixtures/with-networks.js
+++ b/app/scripts/fixtures/with-networks.js
@@ -125,7 +125,7 @@ export const FIXTURES_NETWORKS = {
     },
     zkSync: {
       id: 'zkSync',
-      rpcUrl: 'https://mainnet.era.zksync.io',
+      rpcUrl: `https://zksync-mainnet.infura.io/v3/${infuraProjectId}`,
       chainId: CHAIN_IDS.ZKSYNC_ERA,
       ticker: CURRENCY_SYMBOLS.ETH,
       nickname: ZK_SYNC_ERA_DISPLAY_NAME,

--- a/ui/components/multichain/network-list-menu/popular-network-list/PopularNetworkList.stories.js
+++ b/ui/components/multichain/network-list-menu/popular-network-list/PopularNetworkList.stories.js
@@ -36,7 +36,7 @@ const customNetworkStore = configureStore({
         'test-networkConfigurationId-2': {
           chainId: CHAIN_IDS.ZKSYNC_ERA,
           nickname: ZK_SYNC_ERA_DISPLAY_NAME,
-          rpcUrl: `https://mainnet.era.zksync.io`,
+          rpcUrl: `https://zksync-mainnet.infura.io/v3`,
           ticker: CURRENCY_SYMBOLS.ETH,
           rpcPrefs: {
             blockExplorerUrl: 'https://explorer.zksync.io/',


### PR DESCRIPTION
## **Description**

Follow up to #43407. Replaces the public `https://mainnet.era.zksync.io` URL with the Infura URL in two non production files that were missed in the original PR:

- `app/scripts/fixtures/with-networks.js` (e2e fixture builder)
- `ui/components/multichain/network-list-menu/popular-network-list/PopularNetworkList.stories.js` (Storybook demo)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. `yarn storybook` and open `Components/PopularNetworkList`. zkSync entry shows the Infura URL.
2. Run an e2e test that uses `FIXTURES_NETWORKS.zkSync` from `with-networks.js` and confirm it loads.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and Storybook fixture updates only; no production network or auth logic changes.
> 
> **Overview**
> Follow-up to the zkSync RPC migration: **zkSync Era** network config in the e2e fixture builder (`with-networks.js`) and the **PopularNetworkList** Storybook store now use the Infura endpoint (`zksync-mainnet.infura.io/v3`) instead of the public `mainnet.era.zksync.io` URL, matching other networks in those files.
> 
> No production RPC wiring changes; the privacy snapshot allowlist is unchanged so pre-migration users are not affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ca79f97a6e4021f9f2dbb5833fb4bb20279205eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->