### PR TITLE
feat: removed round border from hover state in global menu

### DIFF
--- a/ui/components/multichain/global-menu/global-menu-list.tsx
+++ b/ui/components/multichain/global-menu/global-menu-list.tsx
@@ -116,6 +116,7 @@ export const GlobalMenuList = ({
                 disabled={item.disabled}
                 showInfoDot={item.showInfoDot}
                 subtitle={item.subtitle}
+                className="first:rounded-t-none last:rounded-b-none"
                 data-testid={item.id}
               >
                 {renderMenuItemContent(item.label, item.badge, showChevron)}


### PR DESCRIPTION
This PR is to remove round borders from hover state in global menu

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to global menu, check the hover state doesn't have round border

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1056" height="382" alt="Screenshot 2026-06-11 at 11 08 41 AM" src="https://github.com/user-attachments/assets/9c90a1fb-f3f1-4978-8584-fd6f30f562f5" />

### **After**

<img width="1128" height="314" alt="Screenshot 2026-06-11 at 11 08 57 AM" src="https://github.com/user-attachments/assets/0c8160b3-7b5c-4ee3-ae4f-37429bdd026c" />



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS class on global menu list items with no logic or data changes.
> 
> **Overview**
> **Global menu list items** now pass `className="first:rounded-t-none last:rounded-b-none"` on each `MenuItem` in `global-menu-list.tsx`, so the first and last row in a section lose corner radius on the top and bottom respectively.
> 
> That keeps hover (and related) backgrounds square at the section edges instead of showing rounded caps on stacked items inside the menu.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b89295b745b068b40690c3c4559bdd8a2f9c417a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->