### PR TITLE
fix: flaky test Vault Corruption

### DIFF
--- a/test/e2e/page-objects/flows/vault-corruption.flow.ts
+++ b/test/e2e/page-objects/flows/vault-corruption.flow.ts
@@ -62,6 +62,54 @@ export const simpleReloadScript = `
 `;
 
 /**
+ * Script to read the encrypted vault from the IndexedDB backup database.
+ * Resolves with the encrypted vault string, or `null` if it isn't present yet.
+ */
+const readBackupVaultScript = `
+  const callback = arguments[arguments.length - 1];
+  const request = globalThis.indexedDB.open('metamask-backup', 1);
+  request.onupgradeneeded = () => {
+    const db = request.result;
+    if (!db.objectStoreNames.contains('store')) {
+      db.createObjectStore('store');
+    }
+  };
+  request.onsuccess = () => {
+    const db = request.result;
+    const transaction = db.transaction('store', 'readonly');
+    const store = transaction.objectStore('store');
+    const getRequest = store.get('KeyringController');
+    getRequest.onsuccess = () => {
+      const keyringController = getRequest.result;
+      callback(keyringController?.vault ?? null);
+    };
+    getRequest.onerror = () => callback(null);
+  };
+  request.onerror = () => callback(null);
+`;
+
+/**
+ * Waits for the encrypted vault to be written to the IndexedDB backup database.
+ *
+ * The backup write is asynchronous and debounced, so without this guard the
+ * corruption flow can break `storage.local` and reload the extension before the
+ * backup has been committed.
+ *
+ * @param driver - The WebDriver instance. Must currently be on an extension page
+ * (e.g. the login page) so the script can access the extension's IndexedDB.
+ * @param timeoutMs - How long to wait for the backup.
+ */
+export async function waitForBackupVault(
+  driver: Driver,
+  timeoutMs = 10000,
+): Promise<void> {
+  await driver.wait(async () => {
+    const backupVault = await driver.executeAsyncScript(readBackupVaultScript);
+    return Boolean(backupVault);
+  }, timeoutMs);
+}
+
+/**
  * Onboards a new wallet, then executes a script.
  *
  * This flow:
@@ -110,6 +158,9 @@ export async function onboardThenExecuteScript(
     waitForSync: false,
   });
   await lockAndWaitForLoginPage(driver);
+
+  // Ensure backup is in IndexedDB otherwise the Extension may restart with no backup to recover from.
+  await waitForBackupVault(driver);
 
   // use the home page to destroy the vault
   await driver.executeAsyncScript(script);

--- a/test/e2e/page-objects/flows/vault-corruption.flow.ts
+++ b/test/e2e/page-objects/flows/vault-corruption.flow.ts
@@ -64,8 +64,11 @@ export const simpleReloadScript = `
 /**
  * Script to read the encrypted vault from the IndexedDB backup database.
  * Resolves with the encrypted vault string, or `null` if it isn't present yet.
+ *
+ * Must be run via `executeAsyncScript` on an extension page (e.g. the login or
+ * home page) so it can access the extension's IndexedDB.
  */
-const readBackupVaultScript = `
+export const getBackupVaultScript = `
   const callback = arguments[arguments.length - 1];
   const request = globalThis.indexedDB.open('metamask-backup', 1);
   request.onupgradeneeded = () => {
@@ -89,6 +92,19 @@ const readBackupVaultScript = `
 `;
 
 /**
+ * Reads the encrypted vault from the IndexedDB backup database.
+ *
+ * @param driver - The WebDriver instance. Must currently be on an extension page
+ * (e.g. the login or home page) so the script can access the extension's IndexedDB.
+ * @returns The encrypted vault string, or `null` if it isn't present.
+ */
+export async function getBackupVault(driver: Driver): Promise<string | null> {
+  return (await driver.executeAsyncScript(getBackupVaultScript)) as
+    | string
+    | null;
+}
+
+/**
  * Waits for the encrypted vault to be written to the IndexedDB backup database.
  *
  * The backup write is asynchronous and debounced, so without this guard the
@@ -104,7 +120,7 @@ export async function waitForBackupVault(
   timeoutMs = 10000,
 ): Promise<void> {
   await driver.wait(async () => {
-    const backupVault = await driver.executeAsyncScript(readBackupVaultScript);
+    const backupVault = await getBackupVault(driver);
     return Boolean(backupVault);
   }, timeoutMs);
 }

--- a/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
+++ b/test/e2e/tests/vault-corruption/vault-corruption.spec.ts
@@ -9,6 +9,7 @@ import {
   completeVaultRecoveryOnboardingFlow,
 } from '../../page-objects/flows/onboarding.flow';
 import {
+  getBackupVault,
   getFirstAddress,
   onboardThenTriggerCorruptionFlow,
 } from '../../page-objects/flows/vault-corruption.flow';
@@ -55,32 +56,6 @@ describe('Vault Corruption', function () {
   const breakPrimaryDatabaseOnlyScript = createCorruptionScript(
     reloadAndCallbackScript,
   );
-
-  /**
-   * Script to retrieve the encrypted vault from the backup database.
-   */
-  const getBackupVaultScript = `
-    const callback = arguments[arguments.length - 1];
-    const request = globalThis.indexedDB.open('metamask-backup', 1);
-    request.onupgradeneeded = () => {
-      const db = request.result;
-      if (!db.objectStoreNames.contains('store')) {
-        db.createObjectStore('store');
-      }
-    };
-    request.onsuccess = () => {
-      const db = request.result;
-      const transaction = db.transaction('store', 'readonly');
-      const store = transaction.objectStore('store');
-      const getRequest = store.get('KeyringController');
-      getRequest.onsuccess = () => {
-        const keyringController = getRequest.result;
-        callback(keyringController?.vault ?? null);
-      };
-      getRequest.onerror = () => callback(null);
-    };
-    request.onerror = () => callback(null);
-  `;
 
   async function mockSentryMissingVaultError(
     mockServer: MockttpServer,
@@ -189,8 +164,7 @@ describe('Vault Corruption', function () {
           },
         );
 
-        const backupVault =
-          await driver.executeAsyncScript(getBackupVaultScript);
+        const backupVault = await getBackupVault(driver);
         assert.ok(backupVault, 'Expected backup vault to exist');
 
         await driver.wait(async () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Ensure backup is in IndexedDB otherwise the Extension may restart with no backup to recover from.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to e2e helpers and flow timing; no production wallet or backup behavior is modified.
> 
> **Overview**
> **Fixes flaky Vault Corruption e2e tests** by waiting for the encrypted vault to land in the `metamask-backup` IndexedDB before the corruption script runs.
> 
> Backup writes are **async and debounced**, so the shared onboarding/corruption flow could null `KeyringController` and reload the extension before a backup existed—recovery tests then failed intermittently. `onboardThenExecuteScript` now calls **`waitForBackupVault`** (polls via **`getBackupVault`**) after lock and before executing the corruption script.
> 
> The IndexedDB read script and **`getBackupVault`** helper were **moved from** `vault-corruption.spec.ts` **into** `vault-corruption.flow.ts` so the spec and flow reuse the same logic; the Sentry test still asserts on the backup vault using the shared helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa3bea842336fb279357b15bd9e527fff7f1c6c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->