### PR TITLE
feat: updated Swaps network filter and ff changes for send network filter

### DIFF
--- a/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
@@ -70,6 +70,7 @@ type NetworkRowProps = {
   iconSrc?: string | IconName;
   chainId?: string;
   selected?: boolean;
+  disabled?: boolean;
   endIconName?: IconName;
   onClick: () => void;
   testId: string;
@@ -81,6 +82,7 @@ export type NetworkSelectionItem = {
   iconSrc?: string | IconName;
   chainId?: string;
   selected?: boolean;
+  disabled?: boolean;
   endIconName?: IconName;
   onClick: () => void;
   testId: string;
@@ -97,6 +99,7 @@ type NetworkSelectionModalProps = {
   onClose: () => void;
   title: React.ReactNode;
   sections: NetworkSelectionSection[];
+  'data-testid'?: string;
   topItem?: NetworkSelectionItem;
   footerButton?: {
     label: React.ReactNode;
@@ -128,6 +131,7 @@ const HomeNetworkFilterRow = ({
   iconSrc,
   chainId,
   selected = false,
+  disabled = false,
   endIconName,
   onClick,
   testId,
@@ -139,6 +143,7 @@ const HomeNetworkFilterRow = ({
         iconSrc={isIconName(iconSrc) ? (iconSrc as string) : iconSrc}
         chainId={chainId}
         selected={selected}
+        disabled={disabled}
         onClick={onClick}
         focus={false}
         endAccessory={
@@ -159,6 +164,7 @@ export const NetworkSelectionModal = ({
   sections,
   topItem,
   footerButton,
+  'data-testid': dataTestId,
 }: NetworkSelectionModalProps) => {
   return (
     <Modal
@@ -166,6 +172,7 @@ export const NetworkSelectionModal = ({
       onClose={onClose}
       isClosedOnOutsideClick
       isClosedOnEscapeKey
+      data-testid={dataTestId}
     >
       <ModalOverlay />
       {isOpen ? (
@@ -220,6 +227,9 @@ export const NetworkSelectionModal = ({
                   />
                 )}
               </button>
+            ) : null}
+            {topItem && sections.length > 0 ? (
+              <hr className="mx-4 mt-2 w-[calc(100%-32px)] border-0 border-t border-border-muted" />
             ) : null}
             {sections.map((section, index) => (
               <Box key={section.key} className="flex flex-col">

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/__snapshots__/asset-picker-modal-network.test.tsx.snap
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/__snapshots__/asset-picker-modal-network.test.tsx.snap
@@ -133,6 +133,11 @@ exports[`AssetPickerModalNetwork should not show selected network when network p
             <div
               class="mm-box flex flex-col mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
             >
+              <p
+                class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default px-4 pb-2 pt-4"
+              >
+                Default networks
+              </p>
               <div
                 class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
                 data-testid="network-list-item-0x1"
@@ -305,6 +310,11 @@ exports[`AssetPickerModalNetwork should use passed in network as default when ne
             <div
               class="mm-box flex flex-col mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
             >
+              <p
+                class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default px-4 pb-2 pt-4"
+              >
+                Default networks
+              </p>
               <div
                 class="mm-box multichain-network-list-item multichain-network-list-item--selected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-background-muted"
                 data-testid="network-list-item-0x1"

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/__snapshots__/asset-picker-modal-network.test.tsx.snap
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/__snapshots__/asset-picker-modal-network.test.tsx.snap
@@ -57,8 +57,7 @@ exports[`AssetPickerModalNetwork renders modal with no network list by default 1
             </div>
           </header>
           <div
-            class="mm-box multichain-asset-picker__network-list mm-box--display-flex mm-box--flex-direction-column"
-            style="min-height: 0; overflow-y: auto;"
+            class="mm-box mm-modal-body multichain-asset-picker__network-list flex min-h-0 flex-1 flex-col overflow-auto mm-box--padding-right-0 mm-box--padding-left-0"
           />
         </section>
       </div>
@@ -129,11 +128,10 @@ exports[`AssetPickerModalNetwork should not show selected network when network p
             </div>
           </header>
           <div
-            class="mm-box multichain-asset-picker__network-list mm-box--display-flex mm-box--flex-direction-column"
-            style="min-height: 0; overflow-y: auto;"
+            class="mm-box mm-modal-body multichain-asset-picker__network-list flex min-h-0 flex-1 flex-col overflow-auto mm-box--padding-right-0 mm-box--padding-left-0"
           >
             <div
-              class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
+              class="mm-box flex flex-col mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
             >
               <div
                 class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
@@ -302,11 +300,10 @@ exports[`AssetPickerModalNetwork should use passed in network as default when ne
             </div>
           </header>
           <div
-            class="mm-box multichain-asset-picker__network-list mm-box--display-flex mm-box--flex-direction-column"
-            style="min-height: 0; overflow-y: auto;"
+            class="mm-box mm-modal-body multichain-asset-picker__network-list flex min-h-0 flex-1 flex-col overflow-auto mm-box--padding-right-0 mm-box--padding-left-0"
           >
             <div
-              class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
+              class="mm-box flex flex-col mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
             >
               <div
                 class="mm-box multichain-network-list-item multichain-network-list-item--selected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-background-muted"

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-network.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-network.tsx
@@ -7,6 +7,12 @@ import {
 } from '@metamask/network-controller';
 import type { CaipChainId } from '@metamask/utils';
 import {
+  FontWeight,
+  Text as DsText,
+  TextColor as DsTextColor,
+  TextVariant as DsTextVariant,
+} from '@metamask/design-system-react';
+import {
   Display,
   FlexDirection,
   BlockSize,
@@ -20,6 +26,7 @@ import {
   ModalOverlay,
   ModalContent,
   ModalHeader,
+  ModalBody,
   Modal,
   Box,
   ButtonLink,
@@ -174,6 +181,8 @@ export const AssetPickerModalNetwork = ({
     <Modal
       isOpen={isOpen}
       onClose={onClose}
+      isClosedOnEscapeKey
+      isClosedOnOutsideClick
       className="multichain-asset-picker__network-modal"
     >
       <ModalOverlay />
@@ -235,28 +244,31 @@ export const AssetPickerModalNetwork = ({
             </ButtonLink>
           </Box>
         )}
-        <Box
-          className="multichain-asset-picker__network-list"
-          display={Display.Flex}
-          flexDirection={FlexDirection.Column}
-          style={{ minHeight: 0, overflowY: 'auto' }}
+        <ModalBody
+          paddingLeft={0}
+          paddingRight={0}
+          className="multichain-asset-picker__network-list flex min-h-0 flex-1 flex-col overflow-auto"
         >
-          {networkSections.map((section) => (
+          {networkSections.map((section, index) => (
             <Box
               key={section.key}
               display={Display.Flex}
               flexDirection={FlexDirection.Column}
               width={BlockSize.Full}
+              className="flex flex-col"
             >
+              {index > 0 ? (
+                <hr className="mx-4 mt-2 w-[calc(100%-32px)] border-0 border-t border-border-muted" />
+              ) : null}
               {section.titleKey ? (
-                <Text
-                  variant={TextVariant.bodyMd}
-                  color={TextColor.textAlternative}
-                  padding={4}
-                  paddingBottom={2}
+                <DsText
+                  variant={DsTextVariant.BodyMd}
+                  color={DsTextColor.TextAlternative}
+                  fontWeight={FontWeight.Medium}
+                  className="px-4 pb-2 pt-4"
                 >
                   {t(section.titleKey)}
-                </Text>
+                </DsText>
               ) : null}
               {section.items.map((networkConfig) => {
                 const { name, chainId } = networkConfig;
@@ -312,7 +324,7 @@ export const AssetPickerModalNetwork = ({
               })}
             </Box>
           ))}
-        </Box>
+        </ModalBody>
       </ModalContent>
     </Modal>
   );

--- a/ui/helpers/utils/network-sections.test.ts
+++ b/ui/helpers/utils/network-sections.test.ts
@@ -1,0 +1,27 @@
+import { getNetworkSections } from './network-sections';
+
+describe('getNetworkSections', () => {
+  it('assigns section titles even when only one section is present', () => {
+    const sections = getNetworkSections([
+      { chainId: '0x1', name: 'Ethereum' },
+      { chainId: '0xa', name: 'Optimism' },
+    ]);
+
+    expect(sections).toHaveLength(1);
+    expect(sections[0].titleKey).toBe('defaultNetworks');
+  });
+
+  it('groups networks into multiple sections with titles', () => {
+    const sections = getNetworkSections([
+      { chainId: '0x1', name: 'Ethereum' },
+      {
+        chainId: 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        name: 'Solana',
+      },
+    ]);
+
+    expect(sections).toHaveLength(2);
+    expect(sections[0].titleKey).toBe('defaultNetworks');
+    expect(sections[1].titleKey).toBe('customNetworks');
+  });
+});

--- a/ui/helpers/utils/network-sections.ts
+++ b/ui/helpers/utils/network-sections.ts
@@ -75,11 +75,9 @@ export function getNetworkSections<TNetwork extends { chainId: string }>(
       .sort(compareFn),
   })).filter(({ items }) => items.length > 0);
 
-  const showHeaders = groupedSections.length > 1;
-
   return groupedSections.map(({ key, items }) => ({
     key,
-    titleKey: showHeaders ? SECTION_TITLE_KEY[key] : undefined,
+    titleKey: SECTION_TITLE_KEY[key],
     items,
   }));
 }

--- a/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
+++ b/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
@@ -2,357 +2,434 @@
 
 exports[`BridgeInputGroup should render destination networks 1`] = `
 <div
-  class="mm-box mm-popover mm-popover--open mm-popover--reference-hidden bridge-network-list-popover mm-box--margin-inline-3 mm-box--padding-4 mm-box--background-color-background-subsection mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
-  data-popper-escaped="true"
-  data-popper-placement="top"
-  data-popper-reference-hidden="true"
+  class="mm-modal"
   data-testid="bridge-network-picker-popover"
-  role="dialog"
-  style="position: absolute; left: 0px; top: 0px; width: calc(100% - 24px); padding: 0px; height: 90%; max-height: 90%; display: flex; flex-direction: column; overflow: scroll; bottom: 0px; transform: translate(0px, -12px);"
 >
   <div
-    class="mm-box multichain-network-list-item multichain-network-list-item--selected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-background-muted"
-    data-testid="network-list-item-undefined"
+    aria-hidden="true"
+    class="mm-box mm-modal-overlay mm-box--width-full mm-box--height-full mm-box--background-color-overlay-default"
+  />
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+  <div
+    data-focus-lock-disabled="false"
   >
     <div
-      class="mm-box mm-box--margin-top-1"
+      class="mm-box mm-modal-content mm-box--padding-top-4 mm-box--sm:padding-top-8 mm-box--md:padding-top-12 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--sm:padding-bottom-8 mm-box--md:padding-bottom-12 mm-box--padding-left-4 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-flex-start mm-box--width-screen mm-box--height-screen"
     >
-      <div
-        class="inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full h-8 w-8 bg-muted"
-        color="text-primary-default"
+      <section
+        aria-modal="true"
+        class="mm-box mm-modal-content__dialog mm-modal-content__dialog--size-sm overflow-hidden mm-box--padding-0 mm-box--padding-top-4 mm-box--padding-bottom-4 mm-box--display-flex mm-box--flex-direction-column mm-box--width-full mm-box--background-color-background-default mm-box--rounded-lg"
+        role="dialog"
       >
-        <svg
-          class="inline-block w-5 h-5 text-primary-default"
-          fill="currentColor"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 22q-2.05 0-3.875-.787c-1.825-.788-2.28-1.242-3.187-2.15s-1.625-1.971-2.15-3.188S2 13.367 2 12q0-2.075.788-3.887c.788-1.812 1.241-2.267 2.15-3.175s1.97-1.625 3.187-2.15S10.633 2 12 2q2.075 0 3.888.788c1.812.788 2.266 1.241 3.174 2.15s1.625 1.966 2.15 3.175S22 10.617 22 12q0 2.05-.787 3.875c-.788 1.825-1.242 2.28-2.15 3.188s-1.967 1.625-3.175 2.15S13.383 22 12 22m0-2.05q.65-.9 1.125-1.875c.475-.975.575-1.342.775-2.075h-3.8q.3 1.1.775 2.075c.475.975.692 1.275 1.125 1.875m-2.6-.4q-.45-.825-.787-1.712A11.6 11.6 0 0 1 8.05 16H5.1q.725 1.25 1.813 2.175C8 19.1 8.467 19.25 9.4 19.55m5.2 0q1.4-.45 2.488-1.375c1.088-.925 1.329-1.342 1.812-2.175h-2.95q-.225.95-.562 1.838c-.337.887-.488 1.162-.788 1.712M4.25 14h3.4q-.075-.5-.112-.987C7.5 12.525 7.5 12.35 7.5 12a13 13 0 0 1 .15-2h-3.4q-.125.5-.187.988C4 11.476 4 11.65 4 12a8 8 0 0 0 .25 2m5.4 0h4.7q.075-.5.113-.987c.038-.488.037-.663.037-1.013a13 13 0 0 0-.15-2h-4.7q-.075.5-.112.988C9.5 11.476 9.5 11.65 9.5 12a13 13 0 0 0 .15 2m6.7 0h3.4q.125-.5.188-.987C20 12.525 20 12.35 20 12a8 8 0 0 0-.25-2h-3.4q.075.5.113.988c.038.488.037.662.037 1.012a13 13 0 0 1-.15 2m-.4-6h2.95q-.725-1.25-1.812-2.175C16 4.9 15.533 4.75 14.6 4.45q.45.824.788 1.713c.338.888.412 1.204.562 1.837M10.1 8h3.8q-.3-1.1-.775-2.075C12.65 4.95 12.433 4.65 12 4.05q-.65.9-1.125 1.875C10.4 6.9 10.3 7.267 10.1 8m-5 0h2.95q.225-.95.563-1.837C8.95 5.275 9.1 5 9.4 4.45Q8 4.9 6.913 5.825C5.826 6.75 5.583 7.167 5.1 8"
-          />
-        </svg>
-      </div>
-    </div>
-    <div
-      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
-    >
-      A
-    </div>
-    <div
-      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
-      style="overflow: hidden;"
-    >
-      <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
-        data-testid="All networks"
-      >
-        <div
-          class="multichain-network-list-item__tooltip"
+        <header
+          class="mm-box mm-header-base mm-modal-header mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--justify-content-space-between"
         >
           <div
-            class=""
-            style="display: inline;"
-            tabindex="0"
-            title=""
+            class="mm-box mm-box--width-full"
+          >
+            <h4
+              class="mm-box mm-text mm-text--heading-sm mm-text--text-align-center mm-box--color-text-default"
+            >
+              Select network
+            </h4>
+          </div>
+          <div
+            class="mm-box mm-box--display-flex mm-box--justify-content-flex-end"
+            style="min-width: 0px;"
+          >
+            <button
+              aria-label="Close"
+              class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
+            >
+              <span
+                class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                style="mask-image: url('./images/icons/close.svg');"
+              />
+            </button>
+          </div>
+        </header>
+        <div
+          class="flex flex-col max-h-[calc(100vh-168px)] overflow-y-auto"
+        >
+          <button
+            class="flex min-h-16 w-full cursor-pointer items-center justify-between border-0 p-4 text-left hover:bg-hover bg-muted"
+            data-testid="bridge-network-picker-popover-all-networks"
+            type="button"
+          >
+            <div
+              class="flex min-w-0 items-center gap-3"
+            >
+              <span
+                class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                style="mask-image: url('./images/icons/global.svg');"
+              />
+              <p
+                class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default truncate"
+              >
+                All networks
+              </p>
+            </div>
+            <span
+              class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+              style="mask-image: url('./images/icons/check.svg');"
+            />
+          </button>
+          <div
+            class="flex flex-col"
           >
             <p
-              class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
-              tabindex="0"
+              class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default px-4 py-2"
             >
-              All networks
+              Default networks
             </p>
+            <div
+              class=""
+              data-testid="bridge-network-picker-popover-item-eip155:1"
+            >
+              <div
+                class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
+                data-testid="network-list-item-eip155:1"
+              >
+                <div
+                  class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+                >
+                  <img
+                    alt="Ethereum logo"
+                    class="mm-avatar-network__network-image"
+                    src="./images/eth_logo.svg"
+                  />
+                </div>
+                <div
+                  class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
+                  style="overflow: hidden;"
+                >
+                  <div
+                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
+                    data-testid="Ethereum"
+                  >
+                    <div
+                      class="multichain-network-list-item__tooltip"
+                    >
+                      <div
+                        class=""
+                        style="display: inline;"
+                        tabindex="0"
+                        title=""
+                      >
+                        <p
+                          class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
+                          tabindex="0"
+                        >
+                          Ethereum
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class=""
+              data-testid="bridge-network-picker-popover-item-eip155:10"
+            >
+              <div
+                class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
+                data-testid="network-list-item-eip155:10"
+              >
+                <div
+                  class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+                >
+                  <img
+                    alt="OP logo"
+                    class="mm-avatar-network__network-image"
+                    src="./images/optimism.svg"
+                  />
+                </div>
+                <div
+                  class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
+                  style="overflow: hidden;"
+                >
+                  <div
+                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
+                    data-testid="OP"
+                  >
+                    <div
+                      class="multichain-network-list-item__tooltip"
+                    >
+                      <div
+                        class=""
+                        style="display: inline;"
+                        tabindex="0"
+                        title=""
+                      >
+                        <p
+                          class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
+                          tabindex="0"
+                        >
+                          OP
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class=""
+              data-testid="bridge-network-picker-popover-item-eip155:137"
+            >
+              <div
+                class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
+                data-testid="network-list-item-eip155:137"
+              >
+                <div
+                  class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+                >
+                  <img
+                    alt="Polygon logo"
+                    class="mm-avatar-network__network-image"
+                    src="./images/pol-token.svg"
+                  />
+                </div>
+                <div
+                  class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
+                  style="overflow: hidden;"
+                >
+                  <div
+                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
+                    data-testid="Polygon"
+                  >
+                    <div
+                      class="multichain-network-list-item__tooltip"
+                    >
+                      <div
+                        class=""
+                        style="display: inline;"
+                        tabindex="0"
+                        title=""
+                      >
+                        <p
+                          class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
+                          tabindex="0"
+                        >
+                          Polygon
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class=""
+              data-testid="bridge-network-picker-popover-item-eip155:56"
+            >
+              <div
+                class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
+                data-testid="network-list-item-eip155:56"
+              >
+                <div
+                  class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+                >
+                  <img
+                    alt="BNB Chain logo"
+                    class="mm-avatar-network__network-image"
+                    src="./images/bnb.svg"
+                  />
+                </div>
+                <div
+                  class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
+                  style="overflow: hidden;"
+                >
+                  <div
+                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
+                    data-testid="BNB Chain"
+                  >
+                    <div
+                      class="multichain-network-list-item__tooltip"
+                    >
+                      <div
+                        class=""
+                        style="display: inline;"
+                        tabindex="0"
+                        title=""
+                      >
+                        <p
+                          class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
+                          tabindex="0"
+                        >
+                          BNB Chain
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="flex flex-col"
+          >
+            <hr
+              class="mx-4 mt-2 w-[calc(100%-32px)] border-0 border-t border-border-muted"
+            />
+            <p
+              class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default px-4 py-2"
+            >
+              Custom networks
+            </p>
+            <div
+              class=""
+              data-testid="bridge-network-picker-popover-item-solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+            >
+              <div
+                class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
+                data-testid="network-list-item-solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+              >
+                <div
+                  class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+                >
+                  <img
+                    alt="Solana logo"
+                    class="mm-avatar-network__network-image"
+                    src="./images/solana-logo.svg"
+                  />
+                </div>
+                <div
+                  class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
+                  style="overflow: hidden;"
+                >
+                  <div
+                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
+                    data-testid="Solana"
+                  >
+                    <div
+                      class="multichain-network-list-item__tooltip"
+                    >
+                      <div
+                        class=""
+                        style="display: inline;"
+                        tabindex="0"
+                        title=""
+                      >
+                        <p
+                          class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
+                          tabindex="0"
+                        >
+                          Solana
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class=""
+              data-testid="bridge-network-picker-popover-item-bip122:000000000019d6689c085ae165831e93"
+            >
+              <div
+                class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
+                data-testid="network-list-item-bip122:000000000019d6689c085ae165831e93"
+              >
+                <div
+                  class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+                >
+                  <img
+                    alt="Bitcoin logo"
+                    class="mm-avatar-network__network-image"
+                    src="./images/bitcoin-logo.svg"
+                  />
+                </div>
+                <div
+                  class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
+                  style="overflow: hidden;"
+                >
+                  <div
+                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
+                    data-testid="Bitcoin"
+                  >
+                    <div
+                      class="multichain-network-list-item__tooltip"
+                    >
+                      <div
+                        class=""
+                        style="display: inline;"
+                        tabindex="0"
+                        title=""
+                      >
+                        <p
+                          class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
+                          tabindex="0"
+                        >
+                          Bitcoin
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class=""
+              data-testid="bridge-network-picker-popover-item-tron:728126428"
+            >
+              <div
+                class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
+                data-testid="network-list-item-tron:728126428"
+              >
+                <div
+                  class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+                >
+                  <img
+                    alt="Tron logo"
+                    class="mm-avatar-network__network-image"
+                    src="./images/tron-logo.svg"
+                  />
+                </div>
+                <div
+                  class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
+                  style="overflow: hidden;"
+                >
+                  <div
+                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
+                    data-testid="Tron"
+                  >
+                    <div
+                      class="multichain-network-list-item__tooltip"
+                    >
+                      <div
+                        class=""
+                        style="display: inline;"
+                        tabindex="0"
+                        title=""
+                      >
+                        <p
+                          class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
+                          tabindex="0"
+                        >
+                          Tron
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
-      </div>
+      </section>
     </div>
   </div>
   <div
-    class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
-    data-testid="network-list-item-solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
-  >
-    <div
-      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
-    >
-      <img
-        alt="Solana logo"
-        class="mm-avatar-network__network-image"
-        src="./images/solana-logo.svg"
-      />
-    </div>
-    <div
-      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
-      style="overflow: hidden;"
-    >
-      <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
-        data-testid="Solana"
-      >
-        <div
-          class="multichain-network-list-item__tooltip"
-        >
-          <div
-            class=""
-            style="display: inline;"
-            tabindex="0"
-            title=""
-          >
-            <p
-              class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
-              tabindex="0"
-            >
-              Solana
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
-    data-testid="network-list-item-bip122:000000000019d6689c085ae165831e93"
-  >
-    <div
-      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
-    >
-      <img
-        alt="Bitcoin logo"
-        class="mm-avatar-network__network-image"
-        src="./images/bitcoin-logo.svg"
-      />
-    </div>
-    <div
-      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
-      style="overflow: hidden;"
-    >
-      <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
-        data-testid="Bitcoin"
-      >
-        <div
-          class="multichain-network-list-item__tooltip"
-        >
-          <div
-            class=""
-            style="display: inline;"
-            tabindex="0"
-            title=""
-          >
-            <p
-              class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
-              tabindex="0"
-            >
-              Bitcoin
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
-    data-testid="network-list-item-eip155:1"
-  >
-    <div
-      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
-    >
-      <img
-        alt="Ethereum logo"
-        class="mm-avatar-network__network-image"
-        src="./images/eth_logo.svg"
-      />
-    </div>
-    <div
-      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
-      style="overflow: hidden;"
-    >
-      <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
-        data-testid="Ethereum"
-      >
-        <div
-          class="multichain-network-list-item__tooltip"
-        >
-          <div
-            class=""
-            style="display: inline;"
-            tabindex="0"
-            title=""
-          >
-            <p
-              class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
-              tabindex="0"
-            >
-              Ethereum
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
-    data-testid="network-list-item-eip155:10"
-  >
-    <div
-      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
-    >
-      <img
-        alt="OP logo"
-        class="mm-avatar-network__network-image"
-        src="./images/optimism.svg"
-      />
-    </div>
-    <div
-      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
-      style="overflow: hidden;"
-    >
-      <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
-        data-testid="OP"
-      >
-        <div
-          class="multichain-network-list-item__tooltip"
-        >
-          <div
-            class=""
-            style="display: inline;"
-            tabindex="0"
-            title=""
-          >
-            <p
-              class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
-              tabindex="0"
-            >
-              OP
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
-    data-testid="network-list-item-eip155:137"
-  >
-    <div
-      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
-    >
-      <img
-        alt="Polygon logo"
-        class="mm-avatar-network__network-image"
-        src="./images/pol-token.svg"
-      />
-    </div>
-    <div
-      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
-      style="overflow: hidden;"
-    >
-      <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
-        data-testid="Polygon"
-      >
-        <div
-          class="multichain-network-list-item__tooltip"
-        >
-          <div
-            class=""
-            style="display: inline;"
-            tabindex="0"
-            title=""
-          >
-            <p
-              class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
-              tabindex="0"
-            >
-              Polygon
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
-    data-testid="network-list-item-eip155:56"
-  >
-    <div
-      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
-    >
-      <img
-        alt="BNB Chain logo"
-        class="mm-avatar-network__network-image"
-        src="./images/bnb.svg"
-      />
-    </div>
-    <div
-      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
-      style="overflow: hidden;"
-    >
-      <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
-        data-testid="BNB Chain"
-      >
-        <div
-          class="multichain-network-list-item__tooltip"
-        >
-          <div
-            class=""
-            style="display: inline;"
-            tabindex="0"
-            title=""
-          >
-            <p
-              class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
-              tabindex="0"
-            >
-              BNB Chain
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
-    data-testid="network-list-item-tron:728126428"
-  >
-    <div
-      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
-    >
-      <img
-        alt="Tron logo"
-        class="mm-avatar-network__network-image"
-        src="./images/tron-logo.svg"
-      />
-    </div>
-    <div
-      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
-      style="overflow: hidden;"
-    >
-      <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
-        data-testid="Tron"
-      >
-        <div
-          class="multichain-network-list-item__tooltip"
-        >
-          <div
-            class=""
-            style="display: inline;"
-            tabindex="0"
-            title=""
-          >
-            <p
-              class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
-              tabindex="0"
-            >
-              Tron
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
 </div>
 `;
 
@@ -411,316 +488,388 @@ exports[`BridgeInputGroup should render popular tokens 2`] = `
 
 exports[`BridgeInputGroup should render source networks 1`] = `
 <div
-  class="mm-box mm-popover mm-popover--open mm-popover--reference-hidden bridge-network-list-popover mm-box--margin-inline-3 mm-box--padding-4 mm-box--background-color-background-subsection mm-box--rounded-xl mm-box--border-color-border-muted box--border-style-solid box--border-width-1"
-  data-popper-escaped="true"
-  data-popper-placement="top"
-  data-popper-reference-hidden="true"
+  class="mm-modal"
   data-testid="bridge-network-picker-popover"
-  role="dialog"
-  style="position: absolute; left: 0px; top: 0px; width: calc(100% - 24px); padding: 0px; height: 90%; max-height: 90%; display: flex; flex-direction: column; overflow: scroll; bottom: 0px; transform: translate(0px, -12px);"
 >
   <div
-    class="mm-box multichain-network-list-item multichain-network-list-item--selected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-background-muted"
-    data-testid="network-list-item-undefined"
+    aria-hidden="true"
+    class="mm-box mm-modal-overlay mm-box--width-full mm-box--height-full mm-box--background-color-overlay-default"
+  />
+  <div
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
+  <div
+    data-focus-lock-disabled="false"
   >
     <div
-      class="mm-box mm-box--margin-top-1"
+      class="mm-box mm-modal-content mm-box--padding-top-4 mm-box--sm:padding-top-8 mm-box--md:padding-top-12 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--sm:padding-bottom-8 mm-box--md:padding-bottom-12 mm-box--padding-left-4 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-flex-start mm-box--width-screen mm-box--height-screen"
     >
-      <div
-        class="inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full h-8 w-8 bg-muted"
-        color="text-primary-default"
+      <section
+        aria-modal="true"
+        class="mm-box mm-modal-content__dialog mm-modal-content__dialog--size-sm overflow-hidden mm-box--padding-0 mm-box--padding-top-4 mm-box--padding-bottom-4 mm-box--display-flex mm-box--flex-direction-column mm-box--width-full mm-box--background-color-background-default mm-box--rounded-lg"
+        role="dialog"
       >
-        <svg
-          class="inline-block w-5 h-5 text-primary-default"
-          fill="currentColor"
-          viewBox="0 0 24 24"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M12 22q-2.05 0-3.875-.787c-1.825-.788-2.28-1.242-3.187-2.15s-1.625-1.971-2.15-3.188S2 13.367 2 12q0-2.075.788-3.887c.788-1.812 1.241-2.267 2.15-3.175s1.97-1.625 3.187-2.15S10.633 2 12 2q2.075 0 3.888.788c1.812.788 2.266 1.241 3.174 2.15s1.625 1.966 2.15 3.175S22 10.617 22 12q0 2.05-.787 3.875c-.788 1.825-1.242 2.28-2.15 3.188s-1.967 1.625-3.175 2.15S13.383 22 12 22m0-2.05q.65-.9 1.125-1.875c.475-.975.575-1.342.775-2.075h-3.8q.3 1.1.775 2.075c.475.975.692 1.275 1.125 1.875m-2.6-.4q-.45-.825-.787-1.712A11.6 11.6 0 0 1 8.05 16H5.1q.725 1.25 1.813 2.175C8 19.1 8.467 19.25 9.4 19.55m5.2 0q1.4-.45 2.488-1.375c1.088-.925 1.329-1.342 1.812-2.175h-2.95q-.225.95-.562 1.838c-.337.887-.488 1.162-.788 1.712M4.25 14h3.4q-.075-.5-.112-.987C7.5 12.525 7.5 12.35 7.5 12a13 13 0 0 1 .15-2h-3.4q-.125.5-.187.988C4 11.476 4 11.65 4 12a8 8 0 0 0 .25 2m5.4 0h4.7q.075-.5.113-.987c.038-.488.037-.663.037-1.013a13 13 0 0 0-.15-2h-4.7q-.075.5-.112.988C9.5 11.476 9.5 11.65 9.5 12a13 13 0 0 0 .15 2m6.7 0h3.4q.125-.5.188-.987C20 12.525 20 12.35 20 12a8 8 0 0 0-.25-2h-3.4q.075.5.113.988c.038.488.037.662.037 1.012a13 13 0 0 1-.15 2m-.4-6h2.95q-.725-1.25-1.812-2.175C16 4.9 15.533 4.75 14.6 4.45q.45.824.788 1.713c.338.888.412 1.204.562 1.837M10.1 8h3.8q-.3-1.1-.775-2.075C12.65 4.95 12.433 4.65 12 4.05q-.65.9-1.125 1.875C10.4 6.9 10.3 7.267 10.1 8m-5 0h2.95q.225-.95.563-1.837C8.95 5.275 9.1 5 9.4 4.45Q8 4.9 6.913 5.825C5.826 6.75 5.583 7.167 5.1 8"
-          />
-        </svg>
-      </div>
-    </div>
-    <div
-      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
-    >
-      A
-    </div>
-    <div
-      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
-      style="overflow: hidden;"
-    >
-      <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
-        data-testid="All networks"
-      >
-        <div
-          class="multichain-network-list-item__tooltip"
+        <header
+          class="mm-box mm-header-base mm-modal-header mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--justify-content-space-between"
         >
           <div
-            class=""
-            style="display: inline;"
-            tabindex="0"
-            title=""
+            class="mm-box mm-box--width-full"
+          >
+            <h4
+              class="mm-box mm-text mm-text--heading-sm mm-text--text-align-center mm-box--color-text-default"
+            >
+              Select network
+            </h4>
+          </div>
+          <div
+            class="mm-box mm-box--display-flex mm-box--justify-content-flex-end"
+            style="min-width: 0px;"
+          >
+            <button
+              aria-label="Close"
+              class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
+            >
+              <span
+                class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                style="mask-image: url('./images/icons/close.svg');"
+              />
+            </button>
+          </div>
+        </header>
+        <div
+          class="flex flex-col max-h-[calc(100vh-168px)] overflow-y-auto"
+        >
+          <button
+            class="flex min-h-16 w-full cursor-pointer items-center justify-between border-0 p-4 text-left hover:bg-hover bg-muted"
+            data-testid="bridge-network-picker-popover-all-networks"
+            type="button"
+          >
+            <div
+              class="flex min-w-0 items-center gap-3"
+            >
+              <span
+                class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                style="mask-image: url('./images/icons/global.svg');"
+              />
+              <p
+                class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default truncate"
+              >
+                All networks
+              </p>
+            </div>
+            <span
+              class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+              style="mask-image: url('./images/icons/check.svg');"
+            />
+          </button>
+          <div
+            class="flex flex-col"
           >
             <p
-              class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
-              tabindex="0"
+              class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default px-4 py-2"
             >
-              All networks
+              Default networks
             </p>
+            <div
+              class=""
+              data-testid="bridge-network-picker-popover-item-eip155:1"
+            >
+              <div
+                class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
+                data-testid="network-list-item-eip155:1"
+              >
+                <div
+                  class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+                >
+                  <img
+                    alt="Ethereum logo"
+                    class="mm-avatar-network__network-image"
+                    src="./images/eth_logo.svg"
+                  />
+                </div>
+                <div
+                  class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
+                  style="overflow: hidden;"
+                >
+                  <div
+                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
+                    data-testid="Ethereum"
+                  >
+                    <div
+                      class="multichain-network-list-item__tooltip"
+                    >
+                      <div
+                        class=""
+                        style="display: inline;"
+                        tabindex="0"
+                        title=""
+                      >
+                        <p
+                          class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
+                          tabindex="0"
+                        >
+                          Ethereum
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class=""
+              data-testid="bridge-network-picker-popover-item-eip155:10"
+            >
+              <div
+                class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
+                data-testid="network-list-item-eip155:10"
+              >
+                <div
+                  class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+                >
+                  <img
+                    alt="OP logo"
+                    class="mm-avatar-network__network-image"
+                    src="./images/optimism.svg"
+                  />
+                </div>
+                <div
+                  class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
+                  style="overflow: hidden;"
+                >
+                  <div
+                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
+                    data-testid="OP"
+                  >
+                    <div
+                      class="multichain-network-list-item__tooltip"
+                    >
+                      <div
+                        class=""
+                        style="display: inline;"
+                        tabindex="0"
+                        title=""
+                      >
+                        <p
+                          class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
+                          tabindex="0"
+                        >
+                          OP
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class=""
+              data-testid="bridge-network-picker-popover-item-eip155:137"
+            >
+              <div
+                class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
+                data-testid="network-list-item-eip155:137"
+              >
+                <div
+                  class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+                >
+                  <img
+                    alt="Polygon logo"
+                    class="mm-avatar-network__network-image"
+                    src="./images/pol-token.svg"
+                  />
+                </div>
+                <div
+                  class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
+                  style="overflow: hidden;"
+                >
+                  <div
+                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
+                    data-testid="Polygon"
+                  >
+                    <div
+                      class="multichain-network-list-item__tooltip"
+                    >
+                      <div
+                        class=""
+                        style="display: inline;"
+                        tabindex="0"
+                        title=""
+                      >
+                        <p
+                          class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
+                          tabindex="0"
+                        >
+                          Polygon
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class=""
+              data-testid="bridge-network-picker-popover-item-eip155:56"
+            >
+              <div
+                class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
+                data-testid="network-list-item-eip155:56"
+              >
+                <div
+                  class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+                >
+                  <img
+                    alt="BNB Chain logo"
+                    class="mm-avatar-network__network-image"
+                    src="./images/bnb.svg"
+                  />
+                </div>
+                <div
+                  class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
+                  style="overflow: hidden;"
+                >
+                  <div
+                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
+                    data-testid="BNB Chain"
+                  >
+                    <div
+                      class="multichain-network-list-item__tooltip"
+                    >
+                      <div
+                        class=""
+                        style="display: inline;"
+                        tabindex="0"
+                        title=""
+                      >
+                        <p
+                          class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
+                          tabindex="0"
+                        >
+                          BNB Chain
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+          <div
+            class="flex flex-col"
+          >
+            <hr
+              class="mx-4 mt-2 w-[calc(100%-32px)] border-0 border-t border-border-muted"
+            />
+            <p
+              class="text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default px-4 py-2"
+            >
+              Custom networks
+            </p>
+            <div
+              class=""
+              data-testid="bridge-network-picker-popover-item-solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+            >
+              <div
+                class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
+                data-testid="network-list-item-solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
+              >
+                <div
+                  class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+                >
+                  <img
+                    alt="Solana logo"
+                    class="mm-avatar-network__network-image"
+                    src="./images/solana-logo.svg"
+                  />
+                </div>
+                <div
+                  class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
+                  style="overflow: hidden;"
+                >
+                  <div
+                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
+                    data-testid="Solana"
+                  >
+                    <div
+                      class="multichain-network-list-item__tooltip"
+                    >
+                      <div
+                        class=""
+                        style="display: inline;"
+                        tabindex="0"
+                        title=""
+                      >
+                        <p
+                          class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
+                          tabindex="0"
+                        >
+                          Solana
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div
+              class=""
+              data-testid="bridge-network-picker-popover-item-bip122:000000000019d6689c085ae165831e93"
+            >
+              <div
+                class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
+                data-testid="network-list-item-bip122:000000000019d6689c085ae165831e93"
+              >
+                <div
+                  class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+                >
+                  <img
+                    alt="Bitcoin logo"
+                    class="mm-avatar-network__network-image"
+                    src="./images/bitcoin-logo.svg"
+                  />
+                </div>
+                <div
+                  class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
+                  style="overflow: hidden;"
+                >
+                  <div
+                    class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
+                    data-testid="Bitcoin"
+                  >
+                    <div
+                      class="multichain-network-list-item__tooltip"
+                    >
+                      <div
+                        class=""
+                        style="display: inline;"
+                        tabindex="0"
+                        title=""
+                      >
+                        <p
+                          class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
+                          tabindex="0"
+                        >
+                          Bitcoin
+                        </p>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
           </div>
         </div>
-      </div>
+      </section>
     </div>
   </div>
   <div
-    class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
-    data-testid="network-list-item-solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp"
-  >
-    <div
-      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
-    >
-      <img
-        alt="Solana logo"
-        class="mm-avatar-network__network-image"
-        src="./images/solana-logo.svg"
-      />
-    </div>
-    <div
-      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
-      style="overflow: hidden;"
-    >
-      <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
-        data-testid="Solana"
-      >
-        <div
-          class="multichain-network-list-item__tooltip"
-        >
-          <div
-            class=""
-            style="display: inline;"
-            tabindex="0"
-            title=""
-          >
-            <p
-              class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
-              tabindex="0"
-            >
-              Solana
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
-    data-testid="network-list-item-bip122:000000000019d6689c085ae165831e93"
-  >
-    <div
-      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
-    >
-      <img
-        alt="Bitcoin logo"
-        class="mm-avatar-network__network-image"
-        src="./images/bitcoin-logo.svg"
-      />
-    </div>
-    <div
-      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
-      style="overflow: hidden;"
-    >
-      <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
-        data-testid="Bitcoin"
-      >
-        <div
-          class="multichain-network-list-item__tooltip"
-        >
-          <div
-            class=""
-            style="display: inline;"
-            tabindex="0"
-            title=""
-          >
-            <p
-              class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
-              tabindex="0"
-            >
-              Bitcoin
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
-    data-testid="network-list-item-eip155:1"
-  >
-    <div
-      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
-    >
-      <img
-        alt="Ethereum logo"
-        class="mm-avatar-network__network-image"
-        src="./images/eth_logo.svg"
-      />
-    </div>
-    <div
-      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
-      style="overflow: hidden;"
-    >
-      <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
-        data-testid="Ethereum"
-      >
-        <div
-          class="multichain-network-list-item__tooltip"
-        >
-          <div
-            class=""
-            style="display: inline;"
-            tabindex="0"
-            title=""
-          >
-            <p
-              class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
-              tabindex="0"
-            >
-              Ethereum
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
-    data-testid="network-list-item-eip155:10"
-  >
-    <div
-      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
-    >
-      <img
-        alt="OP logo"
-        class="mm-avatar-network__network-image"
-        src="./images/optimism.svg"
-      />
-    </div>
-    <div
-      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
-      style="overflow: hidden;"
-    >
-      <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
-        data-testid="OP"
-      >
-        <div
-          class="multichain-network-list-item__tooltip"
-        >
-          <div
-            class=""
-            style="display: inline;"
-            tabindex="0"
-            title=""
-          >
-            <p
-              class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
-              tabindex="0"
-            >
-              OP
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
-    data-testid="network-list-item-eip155:137"
-  >
-    <div
-      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
-    >
-      <img
-        alt="Polygon logo"
-        class="mm-avatar-network__network-image"
-        src="./images/pol-token.svg"
-      />
-    </div>
-    <div
-      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
-      style="overflow: hidden;"
-    >
-      <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
-        data-testid="Polygon"
-      >
-        <div
-          class="multichain-network-list-item__tooltip"
-        >
-          <div
-            class=""
-            style="display: inline;"
-            tabindex="0"
-            title=""
-          >
-            <p
-              class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
-              tabindex="0"
-            >
-              Polygon
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <div
-    class="mm-box multichain-network-list-item multichain-network-list-item--deselected mm-box--padding-top-4 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--gap-4 mm-box--justify-content-space-between mm-box--align-items-center mm-box--width-full mm-box--background-color-transparent"
-    data-testid="network-list-item-eip155:56"
-  >
-    <div
-      class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
-    >
-      <img
-        alt="BNB Chain logo"
-        class="mm-avatar-network__network-image"
-        src="./images/bnb.svg"
-      />
-    </div>
-    <div
-      class="mm-box mm-box--display-flex mm-box--flex-direction-column mm-box--justify-content-flex-start mm-box--align-items-flex-start mm-box--width-full"
-      style="overflow: hidden;"
-    >
-      <div
-        class="mm-box mm-box--display-flex mm-box--gap-2 mm-box--flex-direction-row mm-box--align-items-center mm-box--width-full"
-        data-testid="BNB Chain"
-      >
-        <div
-          class="multichain-network-list-item__tooltip"
-        >
-          <div
-            class=""
-            style="display: inline;"
-            tabindex="0"
-            title=""
-          >
-            <p
-              class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
-              tabindex="0"
-            >
-              BNB Chain
-            </p>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
+    data-focus-guard="true"
+    style="width: 1px; height: 0px; padding: 0px; overflow: hidden; position: fixed; top: 1px; left: 1px;"
+    tabindex="0"
+  />
 </div>
 `;
 

--- a/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
+++ b/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
@@ -78,6 +78,9 @@ exports[`BridgeInputGroup should render destination networks 1`] = `
               style="mask-image: url('./images/icons/check.svg');"
             />
           </button>
+          <hr
+            class="mx-4 mt-2 w-[calc(100%-32px)] border-0 border-t border-border-muted"
+          />
           <div
             class="flex flex-col"
           >
@@ -564,6 +567,9 @@ exports[`BridgeInputGroup should render source networks 1`] = `
               style="mask-image: url('./images/icons/check.svg');"
             />
           </button>
+          <hr
+            class="mx-4 mt-2 w-[calc(100%-32px)] border-0 border-t border-border-muted"
+          />
           <div
             class="flex flex-col"
           >

--- a/ui/pages/bridge/prepare/bridge-input-group.test.tsx
+++ b/ui/pages/bridge/prepare/bridge-input-group.test.tsx
@@ -3,7 +3,7 @@ import {
   RequestStatus,
   formatChainIdToCaip,
 } from '@metamask/bridge-controller';
-import { act, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, screen, waitFor } from '@testing-library/react';
 import { userEvent } from '@testing-library/user-event';
 import { CaipAssetType } from '@metamask/utils';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
@@ -378,7 +378,7 @@ describe('BridgeInputGroup', () => {
       undefined,
       getFromChains,
       false,
-      { expectedDefaultToken: 'ETH', expectedNetworkCount: 7 },
+      { expectedDefaultToken: 'ETH', expectedNetworkCount: 6 },
     ],
     [
       'destination',
@@ -390,7 +390,7 @@ describe('BridgeInputGroup', () => {
       },
       getToChains,
       true,
-      { expectedDefaultToken: 'mUSD', expectedNetworkCount: 8 },
+      { expectedDefaultToken: 'mUSD', expectedNetworkCount: 7 },
     ],
   ])(
     'should render %s networks',
@@ -416,6 +416,7 @@ describe('BridgeInputGroup', () => {
           enabledNetworkMap,
         },
         featureFlagOverrides: {
+          extensionUxNetworkManagement: true,
           bridgeConfig: {
             chainRanking: [
               { chainId: MultichainNetworks.SOLANA },
@@ -457,17 +458,21 @@ describe('BridgeInputGroup', () => {
       });
 
       expect(networkPickerPopover).toMatchSnapshot();
-      expect(
-        networkPickerPopover.getElementsByTagName('p').length,
-      ).toStrictEqual(expectedNetworkCount);
 
-      await act(async () => {
-        await userEvent.click(
-          networkPickerPopover.getElementsByTagName('p')[1],
-        );
-      });
+      const networkItems = screen.getAllByTestId(
+        /bridge-network-picker-popover-item-/u,
+      );
+      expect(networkItems).toHaveLength(expectedNetworkCount);
+
+      fireEvent.click(
+        screen.getByTestId(
+          'network-list-item-solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
+        ),
+      );
       await waitFor(() => {
-        expect(networkPickerPopover).not.toBeVisible();
+        expect(
+          screen.queryByTestId('bridge-network-picker-popover'),
+        ).not.toBeInTheDocument();
         expect(mockUsePopularTokens.mock.lastCall).toStrictEqual([
           expect.objectContaining({
             accountGroupId: 'entropy:01K2FF18CTTXJYD34R78X4N1N1/0',

--- a/ui/pages/bridge/prepare/components/bridge-asset-picker/index.tsx
+++ b/ui/pages/bridge/prepare/components/bridge-asset-picker/index.tsx
@@ -13,6 +13,7 @@ import {
   IconSize,
 } from '@metamask/design-system-react';
 import { type CaipChainId } from '@metamask/utils';
+import { getIsNetworkManagementEnabled } from '../../../../../selectors/multichain/feature-flags';
 import {
   BRIDGE_CHAIN_ID_TO_NETWORK_IMAGE_MAP,
   NETWORK_TO_SHORT_NETWORK_NAME_MAP,
@@ -75,6 +76,7 @@ export const BridgeAssetPicker = ({
   );
 
   const t = useI18nContext();
+  const isNetworkManagementEnabled = useSelector(getIsNetworkManagementEnabled);
   const { isStockToken, isTokenTradingOpen } = useRWAToken();
   const [showMarketClosedModal, setShowMarketClosedModal] = useState(false);
   const closeFromMarketCloseRef = useRef(false);
@@ -203,7 +205,11 @@ export const BridgeAssetPicker = ({
               style={{ minHeight: 32 }}
             />
             <NetworkPicker
-              buttonElement={networkPickerButtonRef.current}
+              buttonElement={
+                isNetworkManagementEnabled
+                  ? undefined
+                  : networkPickerButtonRef.current
+              }
               isOpen={isNetworkPickerOpen}
               chains={chains}
               selectedChainId={selectedChainId}
@@ -248,7 +254,7 @@ export const BridgeAssetPicker = ({
               }
             />
 
-            {!isNetworkPickerOpen && (
+            {isNetworkManagementEnabled || !isNetworkPickerOpen ? (
               <BridgeAssetList
                 accountGroupId={accountGroup?.id}
                 chainIds={chainIdsSet}
@@ -269,7 +275,7 @@ export const BridgeAssetPicker = ({
                 }}
                 {...assetListProps}
               />
-            )}
+            ) : null}
           </ModalBody>
         </ModalContent>
       </Modal>

--- a/ui/pages/bridge/prepare/components/bridge-asset-picker/network-picker.stories.tsx
+++ b/ui/pages/bridge/prepare/components/bridge-asset-picker/network-picker.stories.tsx
@@ -48,9 +48,9 @@ export const NetworkPickerStory = () => {
         }))}
         selectedChainId={'eip155:1'}
         onNetworkChange={() => {}}
-        buttonElement={null}
         isOpen={true}
         onClose={() => {}}
+        testId="bridge-network-picker-story"
       />
     )
   );

--- a/ui/pages/bridge/prepare/components/bridge-asset-picker/network-picker.tsx
+++ b/ui/pages/bridge/prepare/components/bridge-asset-picker/network-picker.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import {
   AvatarIcon,
   AvatarIconSize,
@@ -7,12 +8,18 @@ import {
 } from '@metamask/design-system-react';
 import { type CaipChainId } from '@metamask/utils';
 import { BRIDGE_CHAIN_ID_TO_NETWORK_IMAGE_MAP } from '../../../../../../shared/constants/bridge';
-import {
+import { IconName as ComponentIconName ,
   Popover,
   PopoverRole,
 } from '../../../../../components/component-library';
-import { NetworkListItem } from '../../../../../components/multichain';
+import { NetworkListItem } from '../../../../../components/multichain/network-list-item';
+import {
+  NetworkSelectionModal,
+  type NetworkSelectionSection,
+} from '../../../../../components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
+import { getNetworkSections } from '../../../../../helpers/utils/network-sections';
+import { getIsNetworkManagementEnabled } from '../../../../../selectors/multichain/feature-flags';
 import {
   BackgroundColor,
   BorderRadius,
@@ -32,12 +39,66 @@ export const NetworkPicker = ({
   selectedChainId: CaipChainId | null;
   disabledChainId?: CaipChainId;
   onNetworkChange: (chainId: CaipChainId | null) => void;
-  buttonElement: HTMLElement | null;
+  buttonElement?: HTMLElement | null;
   isOpen: boolean;
   onClose: () => void;
   testId: string;
 }) => {
   const t = useI18nContext();
+  const isNetworkManagementEnabled = useSelector(getIsNetworkManagementEnabled);
+
+  const networkSections = useMemo(() => getNetworkSections(chains), [chains]);
+
+  const sections = useMemo<NetworkSelectionSection[]>(
+    () =>
+      networkSections.map((section) => ({
+        key: section.key,
+        title: section.titleKey ? t(section.titleKey) : undefined,
+        items: section.items.map(({ chainId, name }) => ({
+          key: chainId,
+          chainId,
+          name,
+          iconSrc: BRIDGE_CHAIN_ID_TO_NETWORK_IMAGE_MAP[chainId],
+          selected: selectedChainId === chainId,
+          disabled: disabledChainId === chainId,
+          onClick: () => {
+            if (disabledChainId === chainId) {
+              return;
+            }
+            onNetworkChange(chainId);
+          },
+          testId: `${testId}-item-${chainId}`,
+        })),
+      })),
+    [
+      disabledChainId,
+      networkSections,
+      onNetworkChange,
+      selectedChainId,
+      t,
+      testId,
+    ],
+  );
+
+  if (isNetworkManagementEnabled) {
+    return (
+      <NetworkSelectionModal
+        isOpen={isOpen}
+        onClose={onClose}
+        title={t('bridgeSelectNetwork')}
+        data-testid={testId}
+        topItem={{
+          key: 'all-networks',
+          name: t('allNetworks'),
+          iconSrc: ComponentIconName.Global,
+          selected: !selectedChainId,
+          onClick: () => onNetworkChange(null),
+          testId: `${testId}-all-networks`,
+        }}
+        sections={sections}
+      />
+    );
+  }
 
   return (
     <Popover

--- a/ui/pages/bridge/prepare/components/bridge-asset-picker/network-picker.tsx
+++ b/ui/pages/bridge/prepare/components/bridge-asset-picker/network-picker.tsx
@@ -8,7 +8,8 @@ import {
 } from '@metamask/design-system-react';
 import { type CaipChainId } from '@metamask/utils';
 import { BRIDGE_CHAIN_ID_TO_NETWORK_IMAGE_MAP } from '../../../../../../shared/constants/bridge';
-import { IconName as ComponentIconName ,
+import {
+  IconName as ComponentIconName,
   Popover,
   PopoverRole,
 } from '../../../../../components/component-library';

--- a/ui/pages/confirmations/components/send/network-filter/network-filter.tsx
+++ b/ui/pages/confirmations/components/send/network-filter/network-filter.tsx
@@ -276,13 +276,19 @@ export const NetworkFilter = ({
                 onClick={() => handleNetworkSelection(null)}
                 focus={false}
               />
-              {networkSections.map((section) => (
+              {networkSections.length > 0 ? (
+                <hr className="mx-4 mt-2 w-[calc(100%-32px)] border-0 border-t border-border-muted" />
+              ) : null}
+              {networkSections.map((section, index) => (
                 <Box
                   key={section.key}
                   display={Display.Flex}
                   flexDirection={FlexDirection.Column}
                   width={BlockSize.Full}
                 >
+                  {index > 0 ? (
+                    <hr className="mx-4 mt-2 w-[calc(100%-32px)] border-0 border-t border-border-muted" />
+                  ) : null}
                   {section.titleKey ? (
                     <Text
                       paddingLeft={4}

--- a/ui/pages/contacts/components/contact-networks.tsx
+++ b/ui/pages/contacts/components/contact-networks.tsx
@@ -107,12 +107,15 @@ export const ContactNetworks = ({
           flexDirection={BoxFlexDirection.Column}
           className="flex min-h-0 w-full flex-1 flex-col overflow-auto"
         >
-          {networkSections.map((section) => (
+          {networkSections.map((section, index) => (
             <Box
               key={section.key}
               flexDirection={BoxFlexDirection.Column}
               className="flex w-full flex-col"
             >
+              {index > 0 ? (
+                <hr className="mx-4 mt-2 w-[calc(100%-32px)] border-0 border-t border-border-muted" />
+              ) : null}
               {section.titleKey ? (
                 <Text
                   variant={TextVariant.BodyMd}


### PR DESCRIPTION
This PR is to:
Update Swaps network filter as per new [design](https://www.figma.com/design/02ZwGYSaQG0Gd6zjxH1ANA/existing-network-selectors?node-id=146-3341)
Update FF fence in send flow

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: added design changes for swaps filter

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run extension with `getIsNetworkManagementEnabled` set to true
2. The new Swap filter should match the design file
3. No functionality change

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

Uploading Screen Recording 2026-06-11 at 11.50.38 AM.mov…



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-visible network selection in swap/bridge flows changes UI and interaction (modal vs popover) when the feature flag is on; selection logic is reused but regression risk spans multiple flows.
> 
> **Overview**
> Aligns **swap/bridge** and related network pickers with the new network-selector design when **`getIsNetworkManagementEnabled`** is on.
> 
> **Bridge swap network filter:** With the flag enabled, the bridge asset picker’s network chooser switches from a **popover** to the shared **`NetworkSelectionModal`** (header, “All networks” row, **Default** / **Custom** sections, muted dividers). The asset list stays visible while the network modal is open; the popover anchor is only used when the flag is off.
> 
> **Shared building blocks:** **`NetworkSelectionModal`** gains optional **`disabled`** rows, root **`data-testid`**, and an **`<hr>`** after the top item when sections follow. **`getNetworkSections`** always sets section **`titleKey`** (e.g. “Default networks”) even for a single section—previously headers were hidden unless multiple sections existed.
> 
> **Other pickers:** Asset-picker network modal uses **`ModalBody`**, design-system section labels, section dividers, and outside/escape dismiss. Send network filter and contacts network modals get the same divider pattern between “All networks” and sections.
> 
> Tests and snapshots reflect the modal markup and per-section network item counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23c58815c4c567399ed7b3a4c3babcb5dbbd0796. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->