### PR TITLE
feat(arc): add USDC by default and treat native as USDC on Arc

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2214,6 +2214,38 @@ export default class MetamaskController extends EventEmitter {
       },
     );
 
+    // When Arc is added, automatically import USDC as a custom asset for every
+    // EVM account so the user immediately sees their default Arc balance.
+    this.controllerMessenger.subscribe(
+      'NetworkController:networkAdded',
+      (networkConfiguration) => {
+        if (networkConfiguration?.chainId?.toLowerCase() !== CHAIN_IDS.ARC) {
+          return;
+        }
+        const arcUsdcAssetId =
+          'eip155:5042/erc20:0x3600000000000000000000000000000000000000';
+        const accounts = this.accountsController.listAccounts();
+        for (const account of accounts) {
+          if (!isEvmAccountType(account.type)) {
+            continue;
+          }
+          this.assetsController
+            ?.addCustomAsset(account.id, arcUsdcAssetId, {
+              symbol: 'USDC',
+              name: 'USDC',
+              decimals: 6,
+            })
+            .catch((error) => {
+              log.warn(
+                'Failed to add default Arc USDC for account',
+                account.id,
+                error,
+              );
+            });
+        }
+      },
+    );
+
     this.controllerMessenger.subscribe(
       `${this.snapController.name}:snapInstallStarted`,
       (snapId, origin, isUpdate) => {

--- a/shared/constants/network.ts
+++ b/shared/constants/network.ts
@@ -404,6 +404,12 @@ export const STABLE_DISPLAY_NAME = 'Stable';
 export const MANTLE_DISPLAY_NAME = 'Mantle';
 export const ARC_DISPLAY_NAME = 'Arc';
 
+// On Arc, the native gas token and this USDC ERC20 are the same underlying
+// balance mirrored at two addresses with different decimals (native: 18,
+// USDC: 6). Spending USDC therefore draws down the balance used to pay gas.
+export const ARC_USDC_TOKEN_ADDRESS =
+  '0x3600000000000000000000000000000000000000';
+
 // If `network.ts` is being run in the Node.js environment, `infura-project-id.ts` will not be imported,
 // so we need to look at process.env.INFURA_PROJECT_ID instead.
 export const infuraProjectId =

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -903,8 +903,7 @@
       "React: Act warnings (component updates not wrapped)": 1
     },
     "ui/pages/confirmations/hooks/send/useMaxAmount.test.ts": {
-      "MetaMask: Background connection not initialized": 3,
-      "React: Act warnings (component updates not wrapped)": 5
+      "MetaMask: Background connection not initialized": 3
     },
     "ui/pages/confirmations/hooks/send/useNameValidation.test.ts": {
       "error: Unexpected key \"DNS\" found in": 1

--- a/ui/components/app/assets/token-list/token-list.test.tsx
+++ b/ui/components/app/assets/token-list/token-list.test.tsx
@@ -135,6 +135,7 @@ const createAsset = ({
   address: addressOverride,
   balance = '1',
   rawBalance,
+  chainId = CHAIN_ID,
 }: {
   symbol: string;
   fiatBalance?: number;
@@ -142,6 +143,7 @@ const createAsset = ({
   address?: Hex;
   balance?: string;
   rawBalance?: Hex;
+  chainId?: Hex;
 }): Asset => {
   const address =
     addressOverride ??
@@ -153,7 +155,7 @@ const createAsset = ({
     assetId: address,
     address,
     balance,
-    chainId: CHAIN_ID,
+    chainId,
     decimals: 18,
     fiat:
       fiatBalance === undefined
@@ -359,6 +361,68 @@ describe('TokenList', () => {
 
     expect(screen.getByTestId('token-cell-USDC')).toBeInTheDocument();
     expect(screen.getByTestId('token-cell-MUSD')).toBeInTheDocument();
+    expect(screen.queryByTestId('low-value-assets-toggle')).toBeNull();
+  });
+
+  it('does NOT renders zero-balance USDC if from another chain that Arc', () => {
+    jest.mocked(getAssetsBySelectedAccountGroup).mockReturnValue(
+      createAccountGroupAssets([
+        createAsset({
+          symbol: 'USDC',
+          address: '0x3600000000000000000000000000000000000000',
+          balance: '0',
+          fiatBalance: 0,
+        }),
+        createAsset({ symbol: 'USDT', fiatBalance: 25 }),
+      ]),
+    );
+
+    render();
+
+    expect(screen.getByTestId('token-cell-USDT')).toBeInTheDocument();
+    expect(screen.queryByTestId('token-cell-USDC')).toBeNull();
+    expect(screen.getByTestId('low-value-assets-toggle')).toBeInTheDocument();
+  });
+
+  it('renders zero-balance USDC on Arc outside the low value bucket when zero-balance tokens are shown', () => {
+    jest.mocked(getAssetsBySelectedAccountGroup).mockReturnValue(
+      createAccountGroupAssets([
+        createAsset({
+          symbol: 'USDC',
+          address: '0x3600000000000000000000000000000000000000',
+          balance: '0',
+          fiatBalance: 0,
+          chainId: '0x13b2',
+        }),
+        createAsset({ symbol: 'USDT', fiatBalance: 25 }),
+      ]),
+    );
+
+    render();
+
+    expect(screen.getByTestId('token-cell-USDT')).toBeInTheDocument();
+    expect(screen.getByTestId('token-cell-USDC')).toBeInTheDocument();
+    expect(screen.queryByTestId('low-value-assets-toggle')).toBeNull();
+  });
+
+  it('renders non-zero-balance USDC on Arc outside the low value bucket', () => {
+    jest.mocked(getAssetsBySelectedAccountGroup).mockReturnValue(
+      createAccountGroupAssets([
+        createAsset({
+          symbol: 'USDC',
+          address: '0x3600000000000000000000000000000000000000',
+          balance: '1',
+          fiatBalance: 1,
+          chainId: '0x13b2',
+        }),
+        createAsset({ symbol: 'USDT', fiatBalance: 25 }),
+      ]),
+    );
+
+    render();
+
+    expect(screen.getByTestId('token-cell-USDT')).toBeInTheDocument();
+    expect(screen.getByTestId('token-cell-USDC')).toBeInTheDocument();
     expect(screen.queryByTestId('low-value-assets-toggle')).toBeNull();
   });
 

--- a/ui/components/app/assets/token-list/token-list.tsx
+++ b/ui/components/app/assets/token-list/token-list.tsx
@@ -6,7 +6,6 @@ import React, {
   useState,
 } from 'react';
 import { useSelector } from 'react-redux';
-import { type CaipChainId, type Hex } from '@metamask/utils';
 import { NON_EVM_TESTNET_IDS } from '@metamask/multichain-network-controller';
 import {
   Box,
@@ -21,6 +20,7 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react';
+import { CaipChainId, Hex } from '@metamask/utils';
 import TokenCell from '../token-cell';
 import { ASSET_CELL_HEIGHT } from '../constants';
 import {
@@ -50,6 +50,7 @@ import { SafeChain } from '../../../multichain/networks-form/use-safe-chains';
 import {
   isEvmChainId,
   isTronSpecialAsset,
+  toAssetId,
 } from '../../../../../shared/lib/asset-utils';
 import { sortAssetsWithPriority } from '../util/sortAssetsWithPriority';
 import { VirtualizedList } from '../../../ui/virtualized-list/virtualized-list';
@@ -73,6 +74,10 @@ type TokenListDisplayItem =
     };
 
 const LOW_VALUE_ASSET_FIAT_THRESHOLD = 1;
+const TOKENS_EXCLUDED_FROM_LOW_VALUE_ASSETS = new Set([
+  // USDC on Arc (the ERC20 version of it, which we want to force-show)
+  'eip155:5042/erc20:0x3600000000000000000000000000000000000000',
+]);
 let lowValueAssetsExpandedSessionValue = false;
 
 type CurrencyRate = {
@@ -116,10 +121,11 @@ const isLowValueAsset = (
   lowValueAssetFiatThreshold: number,
 ) => {
   const { tokenFiatAmount } = token;
-
+  const caipAssetId = toAssetId(token.address, token.chainId);
   return (
     !token.isNative &&
     !isMusdToken(token.address) &&
+    !TOKENS_EXCLUDED_FROM_LOW_VALUE_ASSETS.has(caipAssetId ?? '') &&
     tokenFiatAmount !== null &&
     tokenFiatAmount !== undefined &&
     Number.isFinite(tokenFiatAmount) &&

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
@@ -36,6 +36,7 @@ import {
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 
 import { AssetType } from '../../../../../shared/constants/transaction';
+import { CHAIN_IDS } from '../../../../../shared/constants/network';
 import {
   getAllTokens,
   getSelectedEvmInternalAccount,
@@ -298,6 +299,7 @@ export function AssetPickerModal({
 
       if (
         isEvm &&
+        selectedNetwork.chainId !== CHAIN_IDS.ARC &&
         shouldAddToken(
           nativeToken.symbol,
           nativeToken.address,

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
@@ -36,7 +36,6 @@ import {
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 
 import { AssetType } from '../../../../../shared/constants/transaction';
-import { CHAIN_IDS } from '../../../../../shared/constants/network';
 import {
   getAllTokens,
   getSelectedEvmInternalAccount,
@@ -46,6 +45,7 @@ import {
 } from '../../../../selectors';
 import { getRenderableTokenData } from '../../../../hooks/useTokensToSearch';
 import {
+  CHAIN_IDS,
   CHAIN_ID_TOKEN_IMAGE_MAP,
   NETWORK_TO_NAME_MAP,
 } from '../../../../../shared/constants/network';

--- a/ui/contexts/assetPolling.test.tsx
+++ b/ui/contexts/assetPolling.test.tsx
@@ -9,6 +9,7 @@ import useTokenListPolling from '../hooks/useTokenListPolling';
 import useStaticTokensPollingHook from '../hooks/useStaticTokensPolling';
 import useDeFiPolling from '../hooks/defi/useDeFiPolling';
 import useMultichainAssetsRatesPolling from '../hooks/useMultichainAssetsRatesPolling';
+import { useArcDefaultTokens } from '../hooks/useArcDefaultTokens';
 import { AssetPollingProvider } from './assetPolling';
 
 jest.mock('../hooks/useCurrencyRatePolling');
@@ -18,6 +19,9 @@ jest.mock('../hooks/useTokenListPolling');
 jest.mock('../hooks/useStaticTokensPolling');
 jest.mock('../hooks/defi/useDeFiPolling');
 jest.mock('../hooks/useMultichainAssetsRatesPolling');
+jest.mock('../hooks/useArcDefaultTokens', () => ({
+  useArcDefaultTokens: jest.fn(),
+}));
 
 const mockUseCurrencyRatePolling = jest.mocked(useCurrencyRatePolling);
 const mockUseTokenRatesPolling = jest.mocked(useTokenRatesPolling);
@@ -28,6 +32,7 @@ const mockUseDeFiPolling = jest.mocked(useDeFiPolling);
 const mockUseMultichainAssetsRatesPolling = jest.mocked(
   useMultichainAssetsRatesPolling,
 );
+const mockUseArcDefaultTokens = jest.mocked(useArcDefaultTokens);
 
 const renderProvider = (isAssetsUnifyStateEnabled: boolean) => {
   jest.spyOn(redux, 'useSelector').mockReturnValue(isAssetsUnifyStateEnabled);
@@ -53,6 +58,7 @@ describe('AssetPollingProvider', () => {
     (mockUseMultichainAssetsRatesPolling as jest.Mock).mockImplementation(
       () => undefined,
     );
+    (mockUseArcDefaultTokens as jest.Mock).mockImplementation(() => undefined);
   });
 
   it('always renders children regardless of feature flag', () => {

--- a/ui/contexts/assetPolling.tsx
+++ b/ui/contexts/assetPolling.tsx
@@ -7,6 +7,7 @@ import useTokenListPolling from '../hooks/useTokenListPolling';
 import useStaticTokensPollingHook from '../hooks/useStaticTokensPolling';
 import useDeFiPolling from '../hooks/defi/useDeFiPolling';
 import useMultichainAssetsRatesPolling from '../hooks/useMultichainAssetsRatesPolling';
+import { useArcDefaultTokens } from '../hooks/useArcDefaultTokens';
 import { getIsAssetsUnifyStateEnabled } from '../selectors/assets-unify-state';
 
 // Calls all legacy polling hooks unconditionally. Rendered only when
@@ -20,6 +21,7 @@ const LegacyAssetsPolling = ({ children }: { children: ReactNode }) => {
   useDeFiPolling();
   useMultichainAssetsRatesPolling();
   useStaticTokensPollingHook();
+  useArcDefaultTokens();
 
   return <>{children}</>;
 };
@@ -28,6 +30,7 @@ const AssetsControllerPolling = ({ children }: { children: ReactNode }) => {
   useTokenListPolling();
   useDeFiPolling();
   useStaticTokensPollingHook();
+  useArcDefaultTokens();
 
   return <>{children}</>;
 };

--- a/ui/hooks/useArcDefaultTokens.ts
+++ b/ui/hooks/useArcDefaultTokens.ts
@@ -1,0 +1,64 @@
+import { useEffect, useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { isEvmAccountType } from '@metamask/keyring-api';
+import type { InternalAccount } from '@metamask/keyring-internal-api';
+import { CHAIN_IDS } from '../../shared/constants/network';
+import { getNetworkConfigurationsByChainId } from '../../shared/lib/selectors/networks';
+import { getInternalAccounts } from '../selectors/accounts';
+import {
+  getAssetsControllerCustomAssets,
+  isAssetInAccountCustomAssets,
+} from '../selectors/assets-unify-state/asset-preferences';
+import { importCustomAssetsBatch } from '../store/actions';
+
+const ARC_USDC_ASSET_ID =
+  'eip155:5042/erc20:0x3600000000000000000000000000000000000000';
+
+const ARC_DEFAULT_ASSETS = [{ assetId: ARC_USDC_ASSET_ID, isHidden: false }];
+
+const ARC_DEFAULT_ASSETS_METADATA: Record<string, Record<string, unknown>> = {
+  [ARC_USDC_ASSET_ID]: { symbol: 'USDC', name: 'USDC', decimals: 6 },
+};
+
+/**
+ * Adds USDC on Arc for all EVM accounts that don't already have it, whenever
+ * the Arc network is present. Also handles new accounts added after Arc.
+ */
+export function useArcDefaultTokens() {
+  const dispatch = useDispatch();
+  const networkConfigurations = useSelector(getNetworkConfigurationsByChainId);
+  const allAccounts = useSelector(getInternalAccounts);
+  const customAssets = useSelector(getAssetsControllerCustomAssets);
+
+  // Tracks account IDs for which we have already dispatched, to avoid
+  // re-dispatching on every render while the controller state catches up.
+  const dispatchedRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    if (!networkConfigurations?.[CHAIN_IDS.ARC]) {
+      return;
+    }
+
+    for (const account of allAccounts as InternalAccount[]) {
+      if (!isEvmAccountType(account.type)) {
+        continue;
+      }
+      if (dispatchedRef.current.has(account.id)) {
+        continue;
+      }
+      if (isAssetInAccountCustomAssets(customAssets, account.id, ARC_USDC_ASSET_ID)) {
+        // Already present — mark as handled so we never re-dispatch.
+        dispatchedRef.current.add(account.id);
+        continue;
+      }
+      dispatchedRef.current.add(account.id);
+      dispatch(
+        importCustomAssetsBatch(
+          account.id,
+          ARC_DEFAULT_ASSETS,
+          ARC_DEFAULT_ASSETS_METADATA,
+        ),
+      );
+    }
+  }, [networkConfigurations, allAccounts, customAssets, dispatch]);
+}

--- a/ui/hooks/useArcDefaultTokens.ts
+++ b/ui/hooks/useArcDefaultTokens.ts
@@ -46,7 +46,13 @@ export function useArcDefaultTokens() {
       if (dispatchedRef.current.has(account.id)) {
         continue;
       }
-      if (isAssetInAccountCustomAssets(customAssets, account.id, ARC_USDC_ASSET_ID)) {
+      if (
+        isAssetInAccountCustomAssets(
+          customAssets,
+          account.id,
+          ARC_USDC_ASSET_ID,
+        )
+      ) {
         // Already present — mark as handled so we never re-dispatch.
         dispatchedRef.current.add(account.id);
         continue;

--- a/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -92,12 +92,6 @@ export function PayWithRow({
 
   const isArc = currentConfirmation?.chainId?.toLowerCase() === CHAIN_IDS.ARC;
 
-  // On Arc, the transaction always pays with the native token — there is no
-  // alternative pay-with route, so skip rendering the row entirely.
-  if (isArc) {
-    return null;
-  }
-
   const canEdit = fromAccount ? !isHardwareAccount(fromAccount) : true;
 
   const isPerpsWithdraw = isPerpsWithdrawTransaction(currentConfirmation);
@@ -111,6 +105,14 @@ export function PayWithRow({
   const handleCloseModal = useCallback(() => {
     setIsModalOpen(false);
   }, []);
+
+  // On Arc, the transaction always pays with the native token — there is no
+  // alternative pay-with route, so skip rendering the row entirely. The
+  // early return must sit *after* all hook calls so every render executes
+  // the same hooks in the same order (Rules of Hooks).
+  if (isArc) {
+    return null;
+  }
 
   const firstRequiredToken = requiredTokens?.[0];
   const displayToken =

--- a/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -2,6 +2,7 @@
 import React, { useCallback, useState } from 'react';
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { useSelector } from 'react-redux';
+import { CHAIN_IDS } from '../../../../../../shared/constants/network';
 import { isPerpsWithdrawTransaction } from '../../../../../../shared/lib/transactions.utils';
 
 import {
@@ -88,6 +89,15 @@ export function PayWithRow({
   const fromAccount = useSelector((state) =>
     getInternalAccountByAddress(state, from ?? ''),
   );
+
+  const isArc =
+    currentConfirmation?.chainId?.toLowerCase() === CHAIN_IDS.ARC;
+
+  // On Arc, the transaction always pays with the native token — there is no
+  // alternative pay-with route, so skip rendering the row entirely.
+  if (isArc) {
+    return null;
+  }
 
   const canEdit = fromAccount ? !isHardwareAccount(fromAccount) : true;
 

--- a/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -90,8 +90,7 @@ export function PayWithRow({
     getInternalAccountByAddress(state, from ?? ''),
   );
 
-  const isArc =
-    currentConfirmation?.chainId?.toLowerCase() === CHAIN_IDS.ARC;
+  const isArc = currentConfirmation?.chainId?.toLowerCase() === CHAIN_IDS.ARC;
 
   // On Arc, the transaction always pays with the native token — there is no
   // alternative pay-with route, so skip rendering the row entirely.

--- a/ui/pages/confirmations/components/rows/required-tokens-row/required-tokens-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/required-tokens-row/required-tokens-row.test.tsx
@@ -20,8 +20,13 @@ jest.mock('../../simulation-details/amount-pill', () => ({
   ),
 }));
 jest.mock('../../simulation-details/asset-pill', () => ({
-  AssetPill: ({ asset }: { asset: { address: string } }) => (
-    <div data-testid="simulation-details-asset-pill">{asset.address}</div>
+  AssetPill: ({ asset }: { asset: { address?: string; standard: string } }) => (
+    <div
+      data-testid="simulation-details-asset-pill"
+      data-standard={asset.standard}
+    >
+      {asset.address}
+    </div>
   ),
 }));
 
@@ -117,6 +122,22 @@ describe('RequiredTokensRow', () => {
     expect(assetPill).toHaveTextContent(
       '0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
     );
+    expect(assetPill).toHaveAttribute('data-standard', 'ERC20');
+  });
+
+  it('renders native asset pill when required token is the native asset', () => {
+    const mockToken = createMockRequiredToken({
+      address: '0x0000000000000000000000000000000000000000',
+      chainId: '0x13b2',
+      symbol: 'USDC',
+    });
+
+    useTransactionPayRequiredTokensMock.mockReturnValue([mockToken]);
+
+    const { getByTestId } = render();
+
+    const assetPill = getByTestId('simulation-details-asset-pill');
+    expect(assetPill).toHaveAttribute('data-standard', 'NONE');
   });
 
   it('renders multiple required tokens', () => {

--- a/ui/pages/confirmations/components/rows/required-tokens-row/required-tokens-row.tsx
+++ b/ui/pages/confirmations/components/rows/required-tokens-row/required-tokens-row.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import { BigNumber } from 'bignumber.js';
 import { Hex } from '@metamask/utils';
+import { isNativeAddress } from '@metamask/bridge-controller';
 import { Box, Text } from '../../../../../components/component-library';
 import {
   AlignItems,
@@ -18,7 +19,7 @@ import { useTransactionPayRequiredTokens } from '../../../hooks/pay/useTransacti
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { AmountPill } from '../../simulation-details/amount-pill';
 import { AssetPill } from '../../simulation-details/asset-pill';
-import type { TokenAssetIdentifier } from '../../simulation-details/types';
+import type { AssetIdentifier } from '../../simulation-details/types';
 
 export type RequiredTokensRowProps = {
   variant?: ConfirmInfoRowSize;
@@ -45,11 +46,16 @@ export const RequiredTokensRow = ({
   return (
     <>
       {visibleTokens.map((token) => {
-        const asset: TokenAssetIdentifier = {
-          chainId: token.chainId as Hex,
-          address: token.address as Hex,
-          standard: TokenStandard.ERC20,
-        };
+        const asset: AssetIdentifier = isNativeAddress(token.address)
+          ? {
+              chainId: token.chainId as Hex,
+              standard: TokenStandard.none,
+            }
+          : {
+              chainId: token.chainId as Hex,
+              address: token.address as Hex,
+              standard: TokenStandard.ERC20,
+            };
 
         const amount = new BigNumber(token.amountHuman).negated();
         const amountFiatFormatted = fiatFormatter(

--- a/ui/pages/confirmations/hooks/send/useMaxAmount.test.ts
+++ b/ui/pages/confirmations/hooks/send/useMaxAmount.test.ts
@@ -1,4 +1,5 @@
 import { DefaultRootState } from 'react-redux';
+import { act } from '@testing-library/react';
 
 import { Numeric } from '../../../../../shared/lib/Numeric';
 import {
@@ -9,6 +10,7 @@ import {
 import mockState from '../../../../../test/data/mock-state.json';
 import { renderHookWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import * as SendContext from '../../context/send';
+import * as SendUtils from '../../utils/send';
 import { useMaxAmount } from './useMaxAmount';
 import { useBalance } from './useBalance';
 
@@ -16,8 +18,14 @@ jest.mock('./useBalance');
 
 const MOCK_ADDRESS_1 = '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc';
 
-function renderHook(state?: DefaultRootState) {
+async function renderHook(state?: DefaultRootState) {
   const { result } = renderHookWithProvider(useMaxAmount, state ?? mockState);
+  // Let any async results (layer-1 gas fees, Arc gas API fetch) settle inside
+  // act so they don't trigger state updates outside the React testing scope.
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
   return result.current;
 }
 
@@ -28,7 +36,7 @@ describe('useMaxAmount', () => {
     jest.clearAllMocks();
   });
 
-  it('return correct max amount for native assets', () => {
+  it('return correct max amount for native assets', async () => {
     jest.spyOn(SendContext, 'useSendContext').mockReturnValue({
       asset: EVM_NATIVE_ASSET,
       chainId: '0x5',
@@ -39,7 +47,7 @@ describe('useMaxAmount', () => {
       decimals: 18,
       rawBalanceNumeric: new Numeric('1000000000000000000000', 10),
     });
-    const result = renderHook({
+    const result = await renderHook({
       ...mockState,
       metamask: {
         ...mockState.metamask,
@@ -58,7 +66,7 @@ describe('useMaxAmount', () => {
     expect(result.getMaxAmount()).toEqual('999.999570668411440000');
   });
 
-  it('not throw error if gas fee estimates is not available', () => {
+  it('not throw error if gas fee estimates is not available', async () => {
     jest.spyOn(SendContext, 'useSendContext').mockReturnValue({
       asset: EVM_NATIVE_ASSET,
       chainId: '0x5',
@@ -69,7 +77,7 @@ describe('useMaxAmount', () => {
       decimals: 18,
       rawBalanceNumeric: new Numeric('1000000000000000000000', 10),
     });
-    const result = renderHook({
+    const result = await renderHook({
       ...mockState,
       metamask: {
         ...mockState.metamask,
@@ -84,7 +92,7 @@ describe('useMaxAmount', () => {
     expect(result.getMaxAmount()).toEqual('1000');
   });
 
-  it('return 0 if balance of native asset is less than gas needed', () => {
+  it('return 0 if balance of native asset is less than gas needed', async () => {
     jest.spyOn(SendContext, 'useSendContext').mockReturnValue({
       asset: EVM_NATIVE_ASSET,
       chainId: '0x5',
@@ -95,7 +103,7 @@ describe('useMaxAmount', () => {
       decimals: 18,
       rawBalanceNumeric: new Numeric('100000000000000', 10),
     });
-    const result = renderHook({
+    const result = await renderHook({
       ...mockState,
       metamask: {
         ...mockState.metamask,
@@ -114,7 +122,7 @@ describe('useMaxAmount', () => {
     expect(result.getMaxAmount()).toEqual('0');
   });
 
-  it('return correct max amount for ERC20 assets', () => {
+  it('return correct max amount for ERC20 assets', async () => {
     useBalanceMock.mockReturnValue({
       balance: '10.00',
       decimals: 16,
@@ -125,11 +133,11 @@ describe('useMaxAmount', () => {
       chainId: '0x5',
       from: MOCK_ADDRESS_1,
     } as unknown as SendContext.SendContextType);
-    const result = renderHook();
+    const result = await renderHook();
     expect(result.getMaxAmount()).toEqual('48573');
   });
 
-  it('return correct max amount for solana assets', () => {
+  it('return correct max amount for solana assets', async () => {
     useBalanceMock.mockReturnValue({
       balance: '10.00',
       decimals: 6,
@@ -138,7 +146,79 @@ describe('useMaxAmount', () => {
     jest.spyOn(SendContext, 'useSendContext').mockReturnValue({
       asset: SOLANA_ASSET,
     } as unknown as SendContext.SendContextType);
-    const result = renderHook();
+    const result = await renderHook();
     expect(result.getMaxAmount()).toEqual('1.007248');
+  });
+
+  describe('Arc mirrored USDC', () => {
+    const ARC_USDC_ASSET = {
+      ...EVM_ASSET,
+      address: '0x3600000000000000000000000000000000000000',
+      assetId: 'eip155:5042/erc20:0x3600000000000000000000000000000000000000',
+      chainId: '0x13b2',
+      decimals: 6,
+      isNative: false,
+    };
+
+    // `from` is intentionally omitted so the optional layer-1 gas fee lookup
+    // short-circuits (no background call). The gas reservation is driven by the
+    // Arc gas-API fetch, falling back to `gasFeeEstimates` from state.
+    const renderArcHook = async (rawBalanceNumeric: Numeric) => {
+      jest.spyOn(SendContext, 'useSendContext').mockReturnValue({
+        asset: ARC_USDC_ASSET,
+        chainId: '0x13b2',
+      } as unknown as SendContext.SendContextType);
+      useBalanceMock.mockReturnValue({
+        balance: '100',
+        decimals: 6,
+        rawBalanceNumeric,
+      });
+      return await renderHook({
+        ...mockState,
+        metamask: {
+          ...mockState.metamask,
+          gasFeeEstimatesByChainId: {
+            '0x13b2': {
+              gasFeeEstimates: {
+                medium: {
+                  suggestedMaxFeePerGas: '20.44436136',
+                },
+              },
+            },
+          },
+        },
+      });
+    };
+
+    it('reserves native gas from the 6-decimal USDC balance via decimal normalization', async () => {
+      // 100 USDC expressed in 6-decimal minimal units.
+      const result = await renderArcHook(new Numeric('100000000', 10));
+
+      // Only the gas fee (~0.0004 USDC) is reserved. Without normalizing the
+      // 18-decimal native gas fee into the token's 6 decimals, the fee would
+      // dwarf the balance and incorrectly zero the result.
+      const max = parseFloat(result.getMaxAmount());
+      expect(max).toBeGreaterThan(99.99);
+      expect(max).toBeLessThan(100);
+    });
+
+    it('returns 0 when the USDC balance is below the reserved native gas', async () => {
+      // 0.0001 USDC — smaller than the reserved gas.
+      const result = await renderArcHook(new Numeric('100', 10));
+      expect(result.getMaxAmount()).toEqual('0');
+    });
+
+    it('reserves gas using the fee fetched directly from the gas API', async () => {
+      const fetchSpy = jest
+        .spyOn(SendUtils, 'fetchSuggestedMaxFeePerGas')
+        .mockResolvedValue(28.5);
+
+      const result = await renderArcHook(new Numeric('100000000', 10));
+
+      expect(fetchSpy).toHaveBeenCalledWith('0x13b2');
+      const max = parseFloat(result.getMaxAmount());
+      expect(max).toBeGreaterThan(99.99);
+      expect(max).toBeLessThan(100);
+    });
   });
 });

--- a/ui/pages/confirmations/hooks/send/useMaxAmount.ts
+++ b/ui/pages/confirmations/hooks/send/useMaxAmount.ts
@@ -7,7 +7,12 @@ import { Numeric } from '../../../../../shared/lib/Numeric';
 import { getGasFeeEstimatesByChainId } from '../../../../ducks/metamask/metamask';
 import { useAsyncResult } from '../../../../hooks/useAsync';
 import { Asset } from '../../types/send';
-import { getLayer1GasFees, toTokenMinimalUnit } from '../../utils/send';
+import {
+  fetchSuggestedMaxFeePerGas,
+  getLayer1GasFees,
+  sharesBalanceWithNativeGasToken,
+  toTokenMinimalUnit,
+} from '../../utils/send';
 import { useSendContext } from '../../context/send';
 import { useIsNetworkGasSponsored } from '../../../../hooks/useIsNetworkGasSponsored';
 import { useBalance } from './useBalance';
@@ -15,6 +20,35 @@ import { useSendType } from './useSendType';
 
 const NATIVE_TRANSFER_GAS_LIMIT = 21000;
 const GWEI_TO_WEI_CONVERSION_RATE = 1e9;
+const NATIVE_TOKEN_DECIMALS = 18;
+// Arc's USDC send is an ERC20 transfer, which costs far more than a native
+// transfer. Because the gas is held upfront (gasLimit * maxFeePerGas) from the
+// same balance the transfer draws from, a conservative ERC20 transfer gas
+// limit is reserved so the transfer never exceeds the balance.
+const ARC_USDC_TRANSFER_GAS_LIMIT = 100000;
+
+/**
+ * Re-express a minimal-unit amount from one decimal precision to another.
+ * Used to convert a native-denominated gas fee (18 decimals) into the send
+ * token's minimal units before subtracting. A no-op when decimals match.
+ *
+ * @param value - The amount in `fromDecimals` minimal units.
+ * @param fromDecimals - The decimals the value is currently expressed in.
+ * @param toDecimals - The decimals to convert the value to.
+ */
+const scaleMinimalUnits = (
+  value: Numeric,
+  fromDecimals: number,
+  toDecimals: number,
+) => {
+  if (fromDecimals === toDecimals) {
+    return value;
+  }
+  const factor = Math.pow(10, Math.abs(fromDecimals - toDecimals));
+  return fromDecimals > toDecimals
+    ? value.divide(factor, 10)
+    : value.times(factor, 10);
+};
 
 export type GasFeeEstimatesType = {
   medium: {
@@ -33,6 +67,32 @@ export const getEstimatedTotalGas = (
     gasFeeEstimates;
   const totalGas = new Numeric(
     suggestedMaxFeePerGas * NATIVE_TRANSFER_GAS_LIMIT,
+    10,
+  );
+  const conversionrate = new Numeric(GWEI_TO_WEI_CONVERSION_RATE, 10);
+  return totalGas.times(conversionrate).add(new Numeric(layer1GasFees, 16));
+};
+
+/**
+ * Arc-specific gas estimate. Identical to `getEstimatedTotalGas` but uses an
+ * ERC20 transfer gas limit instead of the native transfer limit, since the Arc
+ * USDC send is an ERC20 transfer whose gas is reserved upfront from the same
+ * mirrored balance.
+ *
+ * @param layer1GasFees - The layer-1 gas fee in hex, when applicable.
+ * @param gasFeeEstimates - The chain's gas fee estimates.
+ */
+const getArcEstimatedTotalGas = (
+  layer1GasFees: Hex,
+  gasFeeEstimates?: GasFeeEstimatesType,
+) => {
+  if (!gasFeeEstimates) {
+    return new Numeric('0', 10);
+  }
+  const { medium: { suggestedMaxFeePerGas } = { suggestedMaxFeePerGas: 0 } } =
+    gasFeeEstimates;
+  const totalGas = new Numeric(
+    suggestedMaxFeePerGas * ARC_USDC_TRANSFER_GAS_LIMIT,
     10,
   );
   const conversionrate = new Numeric(GWEI_TO_WEI_CONVERSION_RATE, 10);
@@ -73,11 +133,77 @@ const getMaxAmountFn = ({
     : toTokenMinimalUnit(balance.toString(), asset.decimals, 10);
 };
 
+type GetArcMaxAmountArgs = {
+  asset?: Asset;
+  layer1GasFees: Hex;
+  gasFeeEstimates?: GasFeeEstimatesType;
+  rawBalanceNumeric: Numeric;
+  isNetworkGasSponsored: boolean;
+};
+
+/**
+ * Arc-specific max amount calculation (kept separate from the default flow).
+ *
+ * On Arc the native gas token and the displayed USDC ERC20 are the same
+ * balance mirrored at two addresses with different decimals (native: 18,
+ * USDC: 6). The send is a normal ERC20 transfer validated against the USDC
+ * balance, but the gas it costs is drawn from that same balance, so the max
+ * sendable amount must reserve the native gas fee — otherwise the transfer
+ * reverts with "ERC20: transfer amount exceeds balance". The fee is priced in
+ * 18-decimal native units, so it is normalized into the token's decimals
+ * before subtracting to avoid mixing scales.
+ *
+ * @param args - The Arc max amount arguments.
+ * @param args.asset - The Arc USDC asset being sent.
+ * @param args.layer1GasFees - The layer-1 gas fee (hex), when applicable.
+ * @param args.gasFeeEstimates - The chain's gas fee estimates.
+ * @param args.rawBalanceNumeric - The USDC balance in minimal units.
+ * @param args.isNetworkGasSponsored - Whether gas is sponsored on the network.
+ */
+const getArcMaxAmountFn = ({
+  asset,
+  layer1GasFees,
+  gasFeeEstimates,
+  rawBalanceNumeric,
+  isNetworkGasSponsored,
+}: GetArcMaxAmountArgs) => {
+  if (!asset) {
+    return '0';
+  }
+
+  const tokenDecimals = asset.decimals ?? NATIVE_TOKEN_DECIMALS;
+
+  let gasInTokenUnits = new Numeric('0', 10);
+
+  if (!isNetworkGasSponsored) {
+    const estimatedTotalGas = getArcEstimatedTotalGas(
+      layer1GasFees,
+      gasFeeEstimates,
+    );
+    gasInTokenUnits = scaleMinimalUnits(
+      estimatedTotalGas,
+      NATIVE_TOKEN_DECIMALS,
+      tokenDecimals,
+    );
+  }
+
+  const balance = rawBalanceNumeric.minus(gasInTokenUnits);
+
+  return balance.isZero() || balance.isNegative()
+    ? '0'
+    : toTokenMinimalUnit(balance.toString(), tokenDecimals, 10);
+};
+
 export const useMaxAmount = () => {
   const { asset, chainId, from, value } = useSendContext();
   const { isEvmSendType, isEvmNativeSendType } = useSendType();
   const { rawBalanceNumeric } = useBalance();
   const { isNetworkGasSponsored } = useIsNetworkGasSponsored(chainId);
+
+  // On Arc the USDC ERC20 shares its balance with the native gas token, so the
+  // max amount is routed through a dedicated Arc flow (see getArcMaxAmountFn)
+  // instead of the default native/ERC20 calculation.
+  const isArcNativeMirror = sharesBalanceWithNativeGasToken(chainId, asset);
 
   const gasFeeEstimates = useSelector((state) => {
     if (chainId && isEvmSendType) {
@@ -103,7 +229,33 @@ export const useMaxAmount = () => {
     });
   }, [asset, chainId, from, value]);
 
+  // The gas-fee controller may not be polling Arc into state during the send
+  // flow, so fetch the suggested fee directly from the gas API for the Arc
+  // flow and fall back to any estimates already in state.
+  const { value: arcSuggestedMaxFeePerGas } = useAsyncResult(async () => {
+    if (!isArcNativeMirror || !chainId) {
+      return undefined;
+    }
+    return await fetchSuggestedMaxFeePerGas(chainId);
+  }, [isArcNativeMirror, chainId]);
+
   const getMaxAmount = useCallback(() => {
+    if (isArcNativeMirror) {
+      // Prefer the directly-fetched Arc fee, falling back to state estimates.
+      const arcGasFeeEstimates: GasFeeEstimatesType | undefined =
+        arcSuggestedMaxFeePerGas
+          ? { medium: { suggestedMaxFeePerGas: arcSuggestedMaxFeePerGas } }
+          : gasFeeEstimates;
+
+      return getArcMaxAmountFn({
+        asset,
+        gasFeeEstimates: arcGasFeeEstimates,
+        layer1GasFees: layer1GasFees ?? '0x0',
+        rawBalanceNumeric,
+        isNetworkGasSponsored,
+      });
+    }
+
     return getMaxAmountFn({
       asset,
       gasFeeEstimates,
@@ -114,7 +266,9 @@ export const useMaxAmount = () => {
     });
   }, [
     asset,
+    arcSuggestedMaxFeePerGas,
     gasFeeEstimates,
+    isArcNativeMirror,
     isEvmNativeSendType,
     layer1GasFees,
     rawBalanceNumeric,

--- a/ui/pages/confirmations/utils/send.ts
+++ b/ui/pages/confirmations/utils/send.ts
@@ -20,6 +20,57 @@ import {
   generateERC721TransferData,
 } from '../send-utils/send.utils';
 import { SEND_ROUTE } from '../../../helpers/constants/routes';
+import {
+  ARC_USDC_TOKEN_ADDRESS,
+  CHAIN_IDS,
+} from '../../../../shared/constants/network';
+import { GAS_API_BASE_URL } from '../../../../shared/constants/swaps';
+
+/**
+ * Whether spending this asset draws down the same on-chain balance used to pay
+ * native gas. On Arc the native gas token and the displayed USDC ERC20 are the
+ * same balance mirrored at two addresses with different decimals (native: 18,
+ * USDC: 6), so the max sendable amount must reserve the native gas fee.
+ *
+ * @param chainId - The (hex) chain id of the send.
+ * @param asset - The asset being sent.
+ */
+export const sharesBalanceWithNativeGasToken = (
+  chainId: string | undefined,
+  asset?: Asset,
+): boolean => {
+  if (chainId?.toLowerCase() !== CHAIN_IDS.ARC) {
+    return false;
+  }
+  const identifier = (asset?.address ?? asset?.assetId ?? '').toLowerCase();
+  return identifier.endsWith(ARC_USDC_TOKEN_ADDRESS);
+};
+
+/**
+ * Fetch the medium "suggested max fee per gas" (in gwei) for a chain directly
+ * from the gas API. Used by the Arc max flow because the gas-fee controller is
+ * not necessarily polling estimates into state during the send flow, which
+ * would otherwise leave the reserved gas at zero. Returns 0 when unavailable.
+ *
+ * @param chainId - The hex chain id of the send.
+ */
+export const fetchSuggestedMaxFeePerGas = async (
+  chainId: string,
+): Promise<number> => {
+  try {
+    const decimalChainId = parseInt(chainId, 16);
+    const response = await fetch(
+      `${GAS_API_BASE_URL}/networks/${decimalChainId}/suggestedGasFees`,
+    );
+    if (!response.ok) {
+      return 0;
+    }
+    const data = await response.json();
+    return Number(data?.medium?.suggestedMaxFeePerGas ?? 0);
+  } catch {
+    return 0;
+  }
+};
 
 export const trimTrailingZeros = (numStr: string) => {
   return numStr.replace(/(\.\d*?[1-9])0+$/gu, '$1').replace(/\.0*$/u, '');

--- a/ui/pages/confirmations/utils/transaction-pay.test.ts
+++ b/ui/pages/confirmations/utils/transaction-pay.test.ts
@@ -4,7 +4,10 @@ import type {
   TransactionPayRequiredToken,
   TransactionPaymentToken,
 } from '@metamask/transaction-pay-controller';
-import { CHAIN_IDS } from '../../../../shared/constants/network';
+import {
+  ARC_USDC_TOKEN_ADDRESS,
+  CHAIN_IDS,
+} from '../../../../shared/constants/network';
 import { Asset, AssetStandard } from '../types/send';
 import {
   getTokenTransferData,
@@ -337,6 +340,44 @@ describe('transaction-pay utils', () => {
           address: TOKEN_ADDRESS_MOCK,
           chainId: CHAIN_IDS.SEPOLIA,
           balance: '1000000000000000000',
+        }),
+      ];
+
+      const result = getAvailableTokens({ payToken, tokens });
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('excludes Arc USDC, keeping other Arc tokens', () => {
+      const tokens = [
+        createMockAsset({
+          address: ARC_USDC_TOKEN_ADDRESS as Hex,
+          chainId: CHAIN_IDS.ARC,
+          balance: '1000000',
+        }),
+        createMockAsset({
+          address: TOKEN_ADDRESS_2_MOCK,
+          chainId: CHAIN_IDS.ARC,
+          balance: '1000000000000000000',
+        }),
+      ];
+
+      const result = getAvailableTokens({ tokens });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].address).toBe(TOKEN_ADDRESS_2_MOCK);
+    });
+
+    it('excludes Arc USDC even when selected as the pay token', () => {
+      const payToken = createMockPaymentToken({
+        address: ARC_USDC_TOKEN_ADDRESS as Hex,
+        chainId: CHAIN_IDS.ARC,
+      });
+      const tokens = [
+        createMockAsset({
+          address: ARC_USDC_TOKEN_ADDRESS as Hex,
+          chainId: CHAIN_IDS.ARC,
+          balance: '1000000',
         }),
       ];
 

--- a/ui/pages/confirmations/utils/transaction-pay.ts
+++ b/ui/pages/confirmations/utils/transaction-pay.ts
@@ -6,6 +6,10 @@ import type {
 } from '@metamask/transaction-pay-controller';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { BigNumber } from 'bignumber.js';
+import {
+  ARC_USDC_TOKEN_ADDRESS,
+  CHAIN_IDS,
+} from '../../../../shared/constants/network';
 import { isTestNetwork } from '../../../helpers/utils/network-helper';
 import { Asset, AssetStandard } from '../types/send';
 
@@ -83,6 +87,17 @@ export function getAvailableTokens({
       // bridges/swaps that don't support them), so exclude testnet tokens
       // from both the Pay-with list and the auto-selected default.
       if (token.chainId && isTestNetwork(token.chainId as Hex)) {
+        return false;
+      }
+
+      // On Arc the USDC ERC20 mirrors the native gas balance (same on-chain
+      // funds, different decimals). Using it as a MetaMask Pay source would
+      // draw down the balance used to pay gas, so it must never be a
+      // selectable or auto-selected default pay token.
+      if (
+        token.chainId === CHAIN_IDS.ARC &&
+        token.address?.toLowerCase() === ARC_USDC_TOKEN_ADDRESS
+      ) {
         return false;
       }
 

--- a/ui/pages/token-management/token-management.test.tsx
+++ b/ui/pages/token-management/token-management.test.tsx
@@ -246,6 +246,56 @@ describe('TokenManagementPage', () => {
     },
   };
 
+  // ARC USDC is identified by this synthetic address. The full CAIP-19 id lives
+  // on `eip155:5042`, but `visibleTokens` may expose either the bare address or
+  // the full CAIP-19 id, so both forms must be detected.
+  const arcUsdcAddress = '0x3600000000000000000000000000000000000000';
+  const arcUsdcCaipAssetId = `eip155:5042/erc20:${arcUsdcAddress}`;
+
+  const arcUsdcBareToken = {
+    accountId: 'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3',
+    accountType: 'eip155:eoa',
+    assetId: arcUsdcAddress,
+    address: arcUsdcAddress,
+    chainId: '0x1',
+    image: '',
+    name: 'ARC USD Coin',
+    symbol: 'USDC',
+    decimals: 6,
+    isNative: false,
+    rawBalance: '0x1',
+    balance: '5.0',
+    fiat: {
+      balance: 5,
+      currency: 'usd',
+      conversionRate: 1,
+    },
+  };
+
+  const arcUsdcCaipToken = {
+    accountId: 'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3',
+    accountType: 'eip155:eoa',
+    assetId: arcUsdcCaipAssetId,
+    chainId: '0x1',
+    image: '',
+    name: 'ARC USD Coin',
+    symbol: 'USDC',
+    decimals: 6,
+    isNative: false,
+    rawBalance: '0x1',
+    balance: '5.0',
+    fiat: {
+      balance: 5,
+      currency: 'usd',
+      conversionRate: 1,
+    },
+  };
+
+  const getMainnetTokenToggle = () =>
+    screen
+      .getByTestId(`token-management-cell-0x1:${mainnetToken.address}-toggle`)
+      .closest('.toggle-button');
+
   beforeEach(() => {
     mockTokenManagementLocationState.current = null;
     resetTokenSearchState();
@@ -1360,5 +1410,57 @@ describe('TokenManagementPage', () => {
         'token-management-cell-0x1:0x0000000000000000000000000000000000000001-toggle',
       ),
     ).toBeInTheDocument();
+  });
+
+  describe('ARC USDC detection', () => {
+    it('leaves manageable token toggles enabled when no ARC USDC token is present', () => {
+      renderPage();
+
+      expect(getMainnetTokenToggle()).not.toHaveClass('toggle-button--disabled');
+    });
+
+    it('disables manageable token toggles when an ARC USDC token (bare address) is present', () => {
+      renderPage(
+        createState({
+          accountGroupAssets: {
+            '0x1': [mainnetToken, arcUsdcBareToken, nativeToken],
+          },
+        }),
+      );
+
+      expect(screen.getByText('ARC USD Coin')).toBeInTheDocument();
+      expect(getMainnetTokenToggle()).toHaveClass('toggle-button--disabled');
+    });
+
+    it('disables manageable token toggles when an ARC USDC token (full CAIP-19 id) is present', () => {
+      renderPage(
+        createState({
+          accountGroupAssets: {
+            '0x1': [mainnetToken, arcUsdcCaipToken, nativeToken],
+          },
+        }),
+      );
+
+      expect(getMainnetTokenToggle()).toHaveClass('toggle-button--disabled');
+    });
+
+    it('does not flag a same-shaped non-ARC token as ARC USDC', () => {
+      const nonArcToken = {
+        ...arcUsdcBareToken,
+        assetId: '0x1111111111111111111111111111111111111111',
+        address: '0x1111111111111111111111111111111111111111',
+        name: 'Not ARC',
+      };
+
+      renderPage(
+        createState({
+          accountGroupAssets: {
+            '0x1': [mainnetToken, nonArcToken, nativeToken],
+          },
+        }),
+      );
+
+      expect(getMainnetTokenToggle()).not.toHaveClass('toggle-button--disabled');
+    });
   });
 });

--- a/ui/pages/token-management/token-management.tsx
+++ b/ui/pages/token-management/token-management.tsx
@@ -127,6 +127,12 @@ const TOKEN_MANAGEMENT_DEFAULT_VIEW_STATE = 'default';
 const TOKEN_MANAGEMENT_NO_RESULTS_VIEW_STATE = 'no_results';
 const TOKEN_MANAGEMENT_LOCATION = 'MANAGE_TOKENS';
 const TOKEN_MANAGEMENT_CUSTOM_CTA_LOCATION = 'MANAGE_TOKENS_CUSTOM_CTA';
+const ARC_USDC_ASSET_ID =
+  'eip155:5042/erc20:0x3600000000000000000000000000000000000000';
+// Bare contract address portion of the ARC USDC CAIP-19 id. `visibleTokens`
+// may expose either the bare address or the full CAIP-19 id, so we match both.
+const ARC_USDC_ADDRESS =
+  ARC_USDC_ASSET_ID.split(':').pop()?.toLowerCase() ?? '';
 const METRICS_PROPERTIES = {
   assetType: 'asset_type',
   chainId: 'chain_id',
@@ -612,6 +618,19 @@ export const TokenManagementPage = () => {
     }
     return enabledCaipChainIds;
   }, [enabledCaipChainIds]);
+
+  const isArcUsdc = useMemo(() => {
+    return visibleTokens.some((token) => {
+      const identifier = (
+        ('address' in token && token.address ? token.address : token.assetId) ??
+        ''
+      ).toLowerCase();
+      return (
+        identifier === ARC_USDC_ADDRESS ||
+        identifier === ARC_USDC_ASSET_ID.toLowerCase()
+      );
+    });
+  }, [visibleTokens]);
 
   const {
     data: searchResponse,
@@ -1104,7 +1123,7 @@ export const TokenManagementPage = () => {
           primaryLabel={token.name ?? token.symbol}
           secondaryLabel={`${token.balance} ${token.symbol}`}
           isOn={!isHidden}
-          disabled={isNativeToken || pendingKeys.has(key)}
+          disabled={isNativeToken || pendingKeys.has(key) || isArcUsdc}
           onToggle={(nextValue) => handleToggle(token, nextValue)}
           showToggle={isManageableToken || isNativeToken}
           testIdSuffix={key}
@@ -1119,6 +1138,7 @@ export const TokenManagementPage = () => {
       handleToggle,
       pendingKeys,
       stagedHideKeys,
+      isArcUsdc,
     ],
   );
 
@@ -1182,7 +1202,7 @@ export const TokenManagementPage = () => {
             payload.caipChainId
           }
           isOn={isPending || (isImported && !isHidden) || payload.isNative}
-          disabled={payload.isNative || isPending}
+          disabled={payload.isNative || isPending || isArcUsdc}
           isLoading={isPending}
           onToggle={(nextValue) => handleSearchResultToggle(payload, nextValue)}
           showToggle={!payload.isNative}
@@ -1201,6 +1221,7 @@ export const TokenManagementPage = () => {
       networkConfigurations,
       pendingKeys,
       stagedHideKeys,
+      isArcUsdc,
     ],
   );
 

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -41,7 +41,7 @@ import type {
   AccountTrackerControllerState,
 } from '@metamask/assets-controllers';
 import { NetworkEnablementControllerState } from '@metamask/network-enablement-controller';
-import { TEST_CHAINS } from '../../shared/constants/network';
+import { CHAIN_IDS, TEST_CHAINS } from '../../shared/constants/network';
 import { createDeepEqualSelector } from '../../shared/lib/selectors/selector-creators';
 import { Token, TokenWithFiatAmount } from '../components/app/assets/types';
 import { calculateTokenBalance } from '../components/app/assets/util/calculateTokenBalance';
@@ -818,9 +818,32 @@ const selectAccountsStateForBalances = createSelector(
 /**
  * Wraps token balances for core balance computations.
  */
+const ARC_ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
 const selectTokenBalancesStateForBalances = createSelector(
   [getTokenBalances],
-  (tokenBalances) => ({ tokenBalances }),
+  (tokenBalances) => {
+    // Strip the Arc native token (zero address) so it is excluded from the
+    // aggregated balance — USDC is the display currency on Arc, not the native.
+    const result: typeof tokenBalances = {};
+    for (const [account, chainMap] of Object.entries(tokenBalances)) {
+      result[account] = {};
+      for (const [chainId, addressMap] of Object.entries(chainMap)) {
+        if (chainId === CHAIN_IDS.ARC) {
+          const filtered: typeof addressMap = {};
+          for (const [address, balance] of Object.entries(addressMap)) {
+            if (address.toLowerCase() !== ARC_ZERO_ADDRESS) {
+              filtered[address] = balance;
+            }
+          }
+          result[account][chainId] = filtered;
+        } else {
+          result[account][chainId] = addressMap;
+        }
+      }
+    }
+    return { tokenBalances: result };
+  },
 );
 
 /**
@@ -1449,21 +1472,36 @@ const getStateForAssetSelector = ({ metamask }: any) => {
   } as AssetListState;
 };
 
+function filterArcNativeToken<T extends { isNative?: boolean }>(
+  assets: Record<string, T[]>,
+): Record<string, T[]> {
+  const arcAssets = assets[CHAIN_IDS.ARC];
+  if (!arcAssets) {
+    return assets;
+  }
+  return {
+    ...assets,
+    [CHAIN_IDS.ARC]: arcAssets.filter((asset) => !asset.isNative),
+  };
+}
+
 export const getAssetsBySelectedAccountGroup = createDeepEqualSelector(
   getStateForAssetSelector,
   (assetListState: AssetListState) =>
-    selectAssetsBySelectedAccountGroup(assetListState),
+    filterArcNativeToken(selectAssetsBySelectedAccountGroup(assetListState)),
 );
 
 export const getAssetsBySelectedAccountGroupIncludingHidden =
   createDeepEqualSelector(
     getStateForAssetSelector,
     (assetListState: AssetListState) =>
-      selectAssetsBySelectedAccountGroup({
-        ...assetListState,
-        allIgnoredTokens: EMPTY_OBJECT,
-        allIgnoredAssets: EMPTY_OBJECT,
-      }),
+      filterArcNativeToken(
+        selectAssetsBySelectedAccountGroup({
+          ...assetListState,
+          allIgnoredTokens: EMPTY_OBJECT,
+          allIgnoredAssets: EMPTY_OBJECT,
+        }),
+      ),
   );
 
 export const selectAccountSupportsEnabledNetworks = createSelector(

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -827,18 +827,20 @@ const selectTokenBalancesStateForBalances = createSelector(
     // aggregated balance — USDC is the display currency on Arc, not the native.
     const result: typeof tokenBalances = {};
     for (const [account, chainMap] of Object.entries(tokenBalances)) {
-      result[account] = {};
+      const accountKey = account as Hex;
+      result[accountKey] = {};
       for (const [chainId, addressMap] of Object.entries(chainMap)) {
+        const chainKey = chainId as Hex;
         if (chainId === CHAIN_IDS.ARC) {
           const filtered: typeof addressMap = {};
           for (const [address, balance] of Object.entries(addressMap)) {
             if (address.toLowerCase() !== ARC_ZERO_ADDRESS) {
-              filtered[address] = balance;
+              filtered[address as Hex] = balance as Hex;
             }
           }
-          result[account][chainId] = filtered;
+          result[accountKey][chainKey] = filtered;
         } else {
-          result[account][chainId] = addressMap;
+          result[accountKey][chainKey] = addressMap;
         }
       }
     }

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -1472,9 +1472,9 @@ const getStateForAssetSelector = ({ metamask }: any) => {
   } as AssetListState;
 };
 
-function filterArcNativeToken<T extends { isNative?: boolean }>(
-  assets: Record<string, T[]>,
-): Record<string, T[]> {
+function filterArcNativeToken<TAsset extends { isNative?: boolean }>(
+  assets: Record<string, TAsset[]>,
+): Record<string, TAsset[]> {
   const arcAssets = assets[CHAIN_IDS.ARC];
   if (!arcAssets) {
     return assets;


### PR DESCRIPTION
- Auto-import USDC for all EVM accounts on Arc when the network is present, and for newly created EVM accounts thereafter.
- Hide the Arc native zero-address token everywhere it would otherwise appear as a duplicate USDC entry (token list, send asset picker, aggregated balance).
- Skip rendering the pay-with row on Arc since the transaction always pays with the native token; this prevents the "no payment route" error.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: add USDC by default and treat native as USDC on Arc

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes span send max-amount math, aggregated balances, and MetaMask Pay token selection—user-visible fund and gas behavior on Arc, though scoped to one chain and covered by new tests.
> 
> **Overview**
> Adds **Arc-specific USDC treatment** so users see one balance (the mirrored USDC ERC20) instead of duplicate native/USDC entries, with gas and pay flows aligned to the shared on-chain balance.
> 
> **Default USDC on Arc:** When Arc is added, the background subscribes to `NetworkController:networkAdded` and calls `addCustomAsset` for Arc USDC on every EVM account; `useArcDefaultTokens` does the same from the UI polling path for accounts that do not already have the asset. `ARC_USDC_TOKEN_ADDRESS` is documented in shared network constants.
> 
> **Display and balances:** Arc native assets (zero address / `isNative`) are stripped in asset selectors and token balances; the token list always surfaces Arc USDC (including zero balance on Arc) outside the low-value bucket; the send asset picker omits the separate native row on Arc. Token management disables hide/import toggles for the Arc USDC identifier (bare address or full CAIP id).
> 
> **Send max on Arc:** `sharesBalanceWithNativeGasToken` routes Arc USDC through `getArcMaxAmountFn`, reserving ERC20-transfer gas with 18→6 decimal scaling and optional `fetchSuggestedMaxFeePerGas` when controller estimates are missing.
> 
> **Pay / confirmations:** Arc USDC is excluded from MetaMask Pay selectable tokens; required-tokens UI uses native vs ERC20 asset pills when the required token is the native address.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 928d8dbd0ef5fe689de8e4a5470c848d5ccfeb2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->