### PR TITLE
fix: updated swap modal handling

### DIFF
--- a/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
@@ -419,10 +419,7 @@ const HomeNetworkFilterModalContent = ({
       });
     }
 
-    if (
-      (showTestnets || process.env.METAMASK_DEBUG) &&
-      testNetworks.length > 0
-    ) {
+    if (showTestnets && testNetworks.length > 0) {
       nextSections.push({
         key: 'test-networks',
         title: t('testnets'),

--- a/ui/pages/bridge/prepare/bridge-input-group.test.tsx
+++ b/ui/pages/bridge/prepare/bridge-input-group.test.tsx
@@ -464,12 +464,17 @@ describe('BridgeInputGroup', () => {
       );
       expect(networkItems).toHaveLength(expectedNetworkCount);
 
-      fireEvent.click(
-        screen.getByTestId(
-          'network-list-item-solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
-        ),
+      const solanaNetworkItem = screen.getByTestId(
+        'network-list-item-solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp',
       );
+      // `mousedown` reproduces the real-browser sequence: the asset picker's
+      // outside-click handler runs on `mousedown` (before `click`) and must not
+      // close the asset picker when selecting a network.
+      fireEvent.mouseDown(solanaNetworkItem);
+      fireEvent.click(solanaNetworkItem);
       await waitFor(() => {
+        // The asset picker stays open; only the network picker closes.
+        expect(getByTestId('bridge-asset-picker-modal')).toBeVisible();
         expect(
           screen.queryByTestId('bridge-network-picker-popover'),
         ).not.toBeInTheDocument();

--- a/ui/pages/bridge/prepare/components/bridge-asset-picker/index.tsx
+++ b/ui/pages/bridge/prepare/components/bridge-asset-picker/index.tsx
@@ -83,6 +83,16 @@ export const BridgeAssetPicker = ({
 
   const networkPickerButtonRef = useRef<HTMLButtonElement>(null);
   const [isNetworkPickerOpen, setIsNetworkPickerOpen] = useState(false);
+  // Mirrors `isNetworkPickerOpen` for the asset picker's outside-click handler.
+  // `ModalContent` registers its document `mousedown` listener once on mount,
+  // so it captures a stale `isClosedOnOutsideClick`. Selecting a network in the
+  // nested network modal fires `mousedown` before `click`, which would close the
+  // asset picker before the selection applies. Reading this ref in `handleClose`
+  // lets us ignore that close while the network picker is open.
+  const isNetworkPickerOpenRef = useRef(false);
+  useEffect(() => {
+    isNetworkPickerOpenRef.current = isNetworkPickerOpen;
+  }, [isNetworkPickerOpen]);
   // This is the network that the user has selected from the dropdown
   const [selectedChainId, setSelectedChainId] = useState<CaipChainId | null>(
     null,
@@ -127,6 +137,12 @@ export const BridgeAssetPicker = ({
   }, [isOpen]);
 
   const handleClose = useCallback(() => {
+    // Ignore close attempts (e.g. the parent modal's stale outside-click
+    // handler) while the network picker is open. The network picker manages
+    // its own close, so the asset picker should stay open underneath it.
+    if (isNetworkPickerOpenRef.current) {
+      return;
+    }
     if (closeFromMarketCloseRef.current) {
       closeFromMarketCloseRef.current = false;
       return;


### PR DESCRIPTION
When we click on the network filter in swaps page, it should redirect the user back to token list page. This PR enables that behaviour

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: asset picker network

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to Swaps flow
2. Click on asset picker, switch network
3. After network switch, user should be redirected to asset picker modal
4. After selecting asset, user should be redirected back to swaps page

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/db824ff2-e37e-4833-9feb-dda2634e059c



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized modal close-guard and a small home filter visibility tweak; bridge tests cover the network-selection path.
> 
> **Overview**
> Fixes **bridge/swap asset picker** closing when users pick a network from the nested network picker. **`BridgeAssetPicker`** keeps a ref synced with `isNetworkPickerOpen` and **bails out of `handleClose`** while that picker is open, so document **`mousedown`** outside-click handling (which can see a stale closure from **`ModalContent`**) does not dismiss the token list before the network choice applies.
> 
> **`bridge-input-group` tests** now fire **`mousedown` then `click`** on a network row and assert the asset picker modal stays visible while only the network popover closes.
> 
> **Home network filter modal** shows the testnets section only when **`showTestnets`** is enabled—drops the **`METAMASK_DEBUG`** override that previously exposed test networks in that UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c5b2fb4921e1b42e41e0ccac24e66bdb7d515f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->