### PR TITLE
chore: fix typo in test description

### DIFF
--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -2906,7 +2906,7 @@ describe('Actions', () => {
       expect(setShowHoldToReveal).toHaveBeenCalledWith(true);
     });
 
-    it('returns invalidPassword error when password validation failes', async () => {
+    it('returns invalidPassword error when password validation fails', async () => {
       const store = mockStore();
       const verifyPasswordStub = sinon.stub().rejects(new Error('error'));
       background.getApi.returns({


### PR DESCRIPTION
## **Description**

This typo was accidentally introduced in #42728, thanks @ccharly for finding it.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to a test name; no runtime or behavioral impact.
> 
> **Overview**
> Corrects a typo in the **`#exportAccount`** test in `actions.test.js`: the case title now says password validation **fails** instead of **failes**.
> 
> No production or test logic changes—only the `it(...)` description string.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a2fd7f6328c41684d778ee92ba15aa23a525494. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->