### PR TITLE
chore: migrate MultichainAccountEditModal to @metamask/design-system-react

### DIFF
--- a/lavamoat/webpack/mv2/beta/policy.json
+++ b/lavamoat/webpack/mv2/beta/policy.json
@@ -1382,7 +1382,10 @@
     },
     "@metamask/design-system-react": {
       "globals": {
-        "console.warn": true
+        "console.warn": true,
+        "document.addEventListener": true,
+        "document.body": true,
+        "document.removeEventListener": true
       },
       "packages": {
         "@metamask/design-system-shared": true,
@@ -1390,6 +1393,8 @@
         "@metamask/design-system-react>@radix-ui/react-slot": true,
         "@metamask/design-system-react>blo": true,
         "react": true,
+        "react-dom": true,
+        "react-focus-lock": true,
         "@metamask/design-system-react>tailwind-merge": true
       }
     },

--- a/lavamoat/webpack/mv2/experimental/policy.json
+++ b/lavamoat/webpack/mv2/experimental/policy.json
@@ -1382,7 +1382,10 @@
     },
     "@metamask/design-system-react": {
       "globals": {
-        "console.warn": true
+        "console.warn": true,
+        "document.addEventListener": true,
+        "document.body": true,
+        "document.removeEventListener": true
       },
       "packages": {
         "@metamask/design-system-shared": true,
@@ -1390,6 +1393,8 @@
         "@metamask/design-system-react>@radix-ui/react-slot": true,
         "@metamask/design-system-react>blo": true,
         "react": true,
+        "react-dom": true,
+        "react-focus-lock": true,
         "@metamask/design-system-react>tailwind-merge": true
       }
     },

--- a/lavamoat/webpack/mv2/flask/policy.json
+++ b/lavamoat/webpack/mv2/flask/policy.json
@@ -1382,7 +1382,10 @@
     },
     "@metamask/design-system-react": {
       "globals": {
-        "console.warn": true
+        "console.warn": true,
+        "document.addEventListener": true,
+        "document.body": true,
+        "document.removeEventListener": true
       },
       "packages": {
         "@metamask/design-system-shared": true,
@@ -1390,6 +1393,8 @@
         "@metamask/design-system-react>@radix-ui/react-slot": true,
         "@metamask/design-system-react>blo": true,
         "react": true,
+        "react-dom": true,
+        "react-focus-lock": true,
         "@metamask/design-system-react>tailwind-merge": true
       }
     },

--- a/lavamoat/webpack/mv2/main/policy.json
+++ b/lavamoat/webpack/mv2/main/policy.json
@@ -1382,7 +1382,10 @@
     },
     "@metamask/design-system-react": {
       "globals": {
-        "console.warn": true
+        "console.warn": true,
+        "document.addEventListener": true,
+        "document.body": true,
+        "document.removeEventListener": true
       },
       "packages": {
         "@metamask/design-system-shared": true,
@@ -1390,6 +1393,8 @@
         "@metamask/design-system-react>@radix-ui/react-slot": true,
         "@metamask/design-system-react>blo": true,
         "react": true,
+        "react-dom": true,
+        "react-focus-lock": true,
         "@metamask/design-system-react>tailwind-merge": true
       }
     },

--- a/lavamoat/webpack/mv3/beta/policy.json
+++ b/lavamoat/webpack/mv3/beta/policy.json
@@ -866,7 +866,10 @@
     },
     "@metamask/design-system-react": {
       "globals": {
-        "console.warn": true
+        "console.warn": true,
+        "document.addEventListener": true,
+        "document.body": true,
+        "document.removeEventListener": true
       },
       "packages": {
         "@metamask/design-system-shared": true,
@@ -874,6 +877,8 @@
         "@metamask/design-system-react>@radix-ui/react-slot": true,
         "@metamask/design-system-react>blo": true,
         "react": true,
+        "react-dom": true,
+        "react-focus-lock": true,
         "@metamask/design-system-react>tailwind-merge": true
       }
     },

--- a/lavamoat/webpack/mv3/experimental/policy.json
+++ b/lavamoat/webpack/mv3/experimental/policy.json
@@ -866,7 +866,10 @@
     },
     "@metamask/design-system-react": {
       "globals": {
-        "console.warn": true
+        "console.warn": true,
+        "document.addEventListener": true,
+        "document.body": true,
+        "document.removeEventListener": true
       },
       "packages": {
         "@metamask/design-system-shared": true,
@@ -874,6 +877,8 @@
         "@metamask/design-system-react>@radix-ui/react-slot": true,
         "@metamask/design-system-react>blo": true,
         "react": true,
+        "react-dom": true,
+        "react-focus-lock": true,
         "@metamask/design-system-react>tailwind-merge": true
       }
     },

--- a/lavamoat/webpack/mv3/flask/policy.json
+++ b/lavamoat/webpack/mv3/flask/policy.json
@@ -866,7 +866,10 @@
     },
     "@metamask/design-system-react": {
       "globals": {
-        "console.warn": true
+        "console.warn": true,
+        "document.addEventListener": true,
+        "document.body": true,
+        "document.removeEventListener": true
       },
       "packages": {
         "@metamask/design-system-shared": true,
@@ -874,6 +877,8 @@
         "@metamask/design-system-react>@radix-ui/react-slot": true,
         "@metamask/design-system-react>blo": true,
         "react": true,
+        "react-dom": true,
+        "react-focus-lock": true,
         "@metamask/design-system-react>tailwind-merge": true
       }
     },

--- a/lavamoat/webpack/mv3/main/policy.json
+++ b/lavamoat/webpack/mv3/main/policy.json
@@ -866,7 +866,10 @@
     },
     "@metamask/design-system-react": {
       "globals": {
-        "console.warn": true
+        "console.warn": true,
+        "document.addEventListener": true,
+        "document.body": true,
+        "document.removeEventListener": true
       },
       "packages": {
         "@metamask/design-system-shared": true,
@@ -874,6 +877,8 @@
         "@metamask/design-system-react>@radix-ui/react-slot": true,
         "@metamask/design-system-react>blo": true,
         "react": true,
+        "react-dom": true,
+        "react-focus-lock": true,
         "@metamask/design-system-react>tailwind-merge": true
       }
     },

--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -79,7 +79,7 @@ class AccountListPage {
     '[data-testid="account-name-input"] input';
 
   private readonly multichainAccountNameInputConfirmButton =
-    '.mm-button-base[aria-label="Confirm"]';
+    '[data-testid="account-name-confirm-button"]';
 
   private readonly addMultichainAccountButton =
     '[data-testid="add-multichain-account-button"]';

--- a/test/e2e/page-objects/pages/multichain/multichain-account-details-page.ts
+++ b/test/e2e/page-objects/pages/multichain/multichain-account-details-page.ts
@@ -26,7 +26,8 @@ class MultichainAccountDetailsPage {
 
   private readonly accountNameInput = 'input[placeholder*="Account"]';
 
-  private readonly confirmAccountNameButton = 'button[aria-label="Confirm"]';
+  private readonly confirmAccountNameButton =
+    '[data-testid="account-name-confirm-button"]';
 
   // Address and wallet navigation
   private readonly addressValue =

--- a/ui/components/multichain-accounts/multichain-account-edit-modal/multichain-account-edit-modal.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-edit-modal/multichain-account-edit-modal.test.tsx
@@ -38,7 +38,7 @@ describe('MultichainAccountEditModal', () => {
     expect(inputField).toBeInTheDocument();
 
     // Check confirm button exists and is disabled initially
-    const confirmButton = screen.getByText(messages.confirm.message);
+    const confirmButton = screen.getByRole('button', { name: messages.confirm.message });
     expect(confirmButton).toBeInTheDocument();
     expect(confirmButton).toBeDisabled();
   });
@@ -56,7 +56,7 @@ describe('MultichainAccountEditModal', () => {
       screen.queryByText(messages.accountName.message),
     ).not.toBeInTheDocument();
     expect(
-      screen.queryByText(messages.confirm.message),
+      screen.queryByRole('button', { name: messages.confirm.message }),
     ).not.toBeInTheDocument();
   });
 
@@ -65,7 +65,7 @@ describe('MultichainAccountEditModal', () => {
     renderWithProvider(<MultichainAccountEditModal {...mockProps} />, store);
 
     const input = screen.getByPlaceholderText('Account 1');
-    const confirmButton = screen.getByText(messages.confirm.message);
+    const confirmButton = screen.getByRole('button', { name: messages.confirm.message });
 
     // Initially disabled
     expect(confirmButton).toBeDisabled();
@@ -128,7 +128,7 @@ describe('MultichainAccountEditModal', () => {
     const input = screen.getByPlaceholderText('Account 1');
     fireEvent.change(input, { target: { value: 'New Account Name' } });
 
-    const confirmButton = screen.getByText(messages.confirm.message);
+    const confirmButton = screen.getByRole('button', { name: messages.confirm.message });
     fireEvent.click(confirmButton);
 
     await waitFor(() => {
@@ -154,7 +154,7 @@ describe('MultichainAccountEditModal', () => {
     });
 
     // Click the confirm button
-    const confirmButton = screen.getByText(messages.confirm.message);
+    const confirmButton = screen.getByRole('button', { name: messages.confirm.message });
     fireEvent.click(confirmButton);
 
     // Check that dispatch was not called
@@ -175,7 +175,7 @@ describe('MultichainAccountEditModal', () => {
     fireEvent.change(input, { target: { value: '  New Account Name  ' } });
 
     // Click the confirm button
-    const confirmButton = screen.getByText(messages.confirm.message);
+    const confirmButton = screen.getByRole('button', { name: messages.confirm.message });
     fireEvent.click(confirmButton);
 
     // Check if dispatch was called with the trimmed name
@@ -201,7 +201,7 @@ describe('MultichainAccountEditModal', () => {
     renderWithProvider(<MultichainAccountEditModal {...mockProps} />, store);
 
     const input = screen.getByPlaceholderText('Account 1');
-    const confirmButton = screen.getByText(messages.confirm.message);
+    const confirmButton = screen.getByRole('button', { name: messages.confirm.message });
 
     // Type something first to enable the button
     fireEvent.change(input, { target: { value: 'Something' } });
@@ -224,7 +224,7 @@ describe('MultichainAccountEditModal', () => {
     const differentName = 'Different Account Name';
     fireEvent.change(input, { target: { value: differentName } });
 
-    const confirmButton = screen.getByText(messages.confirm.message);
+    const confirmButton = screen.getByRole('button', { name: messages.confirm.message });
     fireEvent.click(confirmButton);
 
     await waitFor(() => {
@@ -249,7 +249,7 @@ describe('MultichainAccountEditModal', () => {
     const input = screen.getByPlaceholderText('Account 1');
     fireEvent.change(input, { target: { value: 'Duplicate Account Name' } });
 
-    const confirmButton = screen.getByText(messages.confirm.message);
+    const confirmButton = screen.getByRole('button', { name: messages.confirm.message });
     fireEvent.click(confirmButton);
 
     // Wait for the error message to appear
@@ -259,9 +259,9 @@ describe('MultichainAccountEditModal', () => {
         screen.getByText(messages.accountNameAlreadyInUse.message),
       ).toBeInTheDocument();
 
-      // Check that the input field has the error styling
+      // Check that the input field is still present
       const inputContainer = screen.getByTestId('account-name-input');
-      expect(inputContainer).toHaveClass('mm-form-text-field');
+      expect(inputContainer).toBeInTheDocument();
 
       // The modal should remain open and not call onClose
       expect(mockProps.onClose).not.toHaveBeenCalled();

--- a/ui/components/multichain-accounts/multichain-account-edit-modal/multichain-account-edit-modal.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-edit-modal/multichain-account-edit-modal.test.tsx
@@ -38,7 +38,9 @@ describe('MultichainAccountEditModal', () => {
     expect(inputField).toBeInTheDocument();
 
     // Check confirm button exists and is disabled initially
-    const confirmButton = screen.getByRole('button', { name: messages.confirm.message });
+    const confirmButton = screen.getByRole('button', {
+      name: messages.confirm.message,
+    });
     expect(confirmButton).toBeInTheDocument();
     expect(confirmButton).toBeDisabled();
   });
@@ -65,7 +67,9 @@ describe('MultichainAccountEditModal', () => {
     renderWithProvider(<MultichainAccountEditModal {...mockProps} />, store);
 
     const input = screen.getByPlaceholderText('Account 1');
-    const confirmButton = screen.getByRole('button', { name: messages.confirm.message });
+    const confirmButton = screen.getByRole('button', {
+      name: messages.confirm.message,
+    });
 
     // Initially disabled
     expect(confirmButton).toBeDisabled();
@@ -128,7 +132,9 @@ describe('MultichainAccountEditModal', () => {
     const input = screen.getByPlaceholderText('Account 1');
     fireEvent.change(input, { target: { value: 'New Account Name' } });
 
-    const confirmButton = screen.getByRole('button', { name: messages.confirm.message });
+    const confirmButton = screen.getByRole('button', {
+      name: messages.confirm.message,
+    });
     fireEvent.click(confirmButton);
 
     await waitFor(() => {
@@ -154,7 +160,9 @@ describe('MultichainAccountEditModal', () => {
     });
 
     // Click the confirm button
-    const confirmButton = screen.getByRole('button', { name: messages.confirm.message });
+    const confirmButton = screen.getByRole('button', {
+      name: messages.confirm.message,
+    });
     fireEvent.click(confirmButton);
 
     // Check that dispatch was not called
@@ -175,7 +183,9 @@ describe('MultichainAccountEditModal', () => {
     fireEvent.change(input, { target: { value: '  New Account Name  ' } });
 
     // Click the confirm button
-    const confirmButton = screen.getByRole('button', { name: messages.confirm.message });
+    const confirmButton = screen.getByRole('button', {
+      name: messages.confirm.message,
+    });
     fireEvent.click(confirmButton);
 
     // Check if dispatch was called with the trimmed name
@@ -201,7 +211,9 @@ describe('MultichainAccountEditModal', () => {
     renderWithProvider(<MultichainAccountEditModal {...mockProps} />, store);
 
     const input = screen.getByPlaceholderText('Account 1');
-    const confirmButton = screen.getByRole('button', { name: messages.confirm.message });
+    const confirmButton = screen.getByRole('button', {
+      name: messages.confirm.message,
+    });
 
     // Type something first to enable the button
     fireEvent.change(input, { target: { value: 'Something' } });
@@ -224,7 +236,9 @@ describe('MultichainAccountEditModal', () => {
     const differentName = 'Different Account Name';
     fireEvent.change(input, { target: { value: differentName } });
 
-    const confirmButton = screen.getByRole('button', { name: messages.confirm.message });
+    const confirmButton = screen.getByRole('button', {
+      name: messages.confirm.message,
+    });
     fireEvent.click(confirmButton);
 
     await waitFor(() => {
@@ -249,7 +263,9 @@ describe('MultichainAccountEditModal', () => {
     const input = screen.getByPlaceholderText('Account 1');
     fireEvent.change(input, { target: { value: 'Duplicate Account Name' } });
 
-    const confirmButton = screen.getByRole('button', { name: messages.confirm.message });
+    const confirmButton = screen.getByRole('button', {
+      name: messages.confirm.message,
+    });
     fireEvent.click(confirmButton);
 
     // Wait for the error message to appear

--- a/ui/components/multichain-accounts/multichain-account-edit-modal/multichain-account-edit-modal.tsx
+++ b/ui/components/multichain-accounts/multichain-account-edit-modal/multichain-account-edit-modal.tsx
@@ -65,6 +65,7 @@ export const MultichainAccountEditModal = ({
       <ModalOverlay />
       <ModalContent>
         <ModalHeader
+          data-testid="account-edit-modal-header"
           onClose={onClose}
           closeButtonProps={{ ariaLabel: t('close') }}
           onBack={onClose}

--- a/ui/components/multichain-accounts/multichain-account-edit-modal/multichain-account-edit-modal.tsx
+++ b/ui/components/multichain-accounts/multichain-account-edit-modal/multichain-account-edit-modal.tsx
@@ -2,17 +2,13 @@ import React, { useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { AccountGroupId } from '@metamask/account-api';
 import {
-  Box,
-  BoxFlexDirection,
-  Button,
-  ButtonVariant,
-  HelpText,
-  HelpTextSeverity,
-  Input,
-  Label,
+  ButtonsAlignment,
+  FormTextField,
+  TextFieldSize,
   Modal,
   ModalBody,
   ModalContent,
+  ModalFooter,
   ModalHeader,
   ModalOverlay,
 } from '@metamask/design-system-react';
@@ -38,7 +34,6 @@ export const MultichainAccountEditModal = ({
   );
   const currentAccountName = accountGroup?.metadata.name || '';
   const [accountName, setAccountName] = useState('');
-  const [helpText, setHelpText] = useState('');
   const [showErrorMessage, setShowErrorMessage] = useState(false);
 
   const handleSave = useCallback(async () => {
@@ -51,11 +46,10 @@ export const MultichainAccountEditModal = ({
       if (result) {
         onClose();
       } else {
-        setHelpText(t('accountNameAlreadyInUse'));
         setShowErrorMessage(true);
       }
     }
-  }, [accountName, currentAccountName, accountGroupId, dispatch, onClose, t]);
+  }, [accountName, currentAccountName, accountGroupId, dispatch, onClose]);
 
   const handleKeyDown = useCallback(
     async (e: React.KeyboardEvent) => {
@@ -79,37 +73,31 @@ export const MultichainAccountEditModal = ({
           {t('rename')}
         </ModalHeader>
         <ModalBody>
-          <Box className="flex" flexDirection={BoxFlexDirection.Column} gap={4}>
-            <Box>
-              <Label htmlFor="account-name-input">{t('accountName')}</Label>
-              <Input
-                id="account-name-input"
-                aria-label={t('accountName')}
-                data-testid="account-name-input"
-                value={accountName}
-                onChange={(e) => setAccountName(e.target.value)}
-                onKeyDown={handleKeyDown}
-                placeholder={currentAccountName}
-                aria-invalid={showErrorMessage}
-                autoFocus
-              />
-              {showErrorMessage && (
-                <HelpText severity={HelpTextSeverity.Danger}>
-                  {helpText}
-                </HelpText>
-              )}
-            </Box>
-            <Button
-              variant={ButtonVariant.Secondary}
-              onClick={handleSave}
-              disabled={!accountName.trim()}
-              aria-label={t('confirm')}
-              className="w-full mt-4"
-            >
-              {t('confirm')}
-            </Button>
-          </Box>
+          <FormTextField
+            id="account-name-input"
+            label={t('accountName')}
+            data-testid="account-name-input"
+            value={accountName}
+            onChange={(e) => setAccountName(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder={currentAccountName}
+            aria-invalid={showErrorMessage}
+            autoFocus
+            size={TextFieldSize.Lg}
+            isError={showErrorMessage}
+            helpText={
+              showErrorMessage ? t('accountNameAlreadyInUse') : undefined
+            }
+          />
         </ModalBody>
+        <ModalFooter
+          buttonsAlignment={ButtonsAlignment.Vertical}
+          secondaryButtonProps={{
+            disabled: !accountName.trim(),
+            children: t('confirm'),
+            onClick: handleSave,
+          }}
+        />
       </ModalContent>
     </Modal>
   );

--- a/ui/components/multichain-accounts/multichain-account-edit-modal/multichain-account-edit-modal.tsx
+++ b/ui/components/multichain-accounts/multichain-account-edit-modal/multichain-account-edit-modal.tsx
@@ -94,6 +94,7 @@ export const MultichainAccountEditModal = ({
         <ModalFooter
           buttonsAlignment={ButtonsAlignment.Vertical}
           secondaryButtonProps={{
+            'data-testid': 'account-name-confirm-button',
             disabled: !accountName.trim(),
             children: t('confirm'),
             onClick: handleSave,

--- a/ui/components/multichain-accounts/multichain-account-edit-modal/multichain-account-edit-modal.tsx
+++ b/ui/components/multichain-accounts/multichain-account-edit-modal/multichain-account-edit-modal.tsx
@@ -1,19 +1,23 @@
 import React, { useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { AccountGroupId } from '@metamask/account-api';
-import { Box, BoxFlexDirection } from '@metamask/design-system-react';
 import {
-  ButtonSecondary,
-  FormTextField,
+  Box,
+  BoxFlexDirection,
+  Button,
+  ButtonVariant,
+  HelpText,
+  HelpTextSeverity,
+  Input,
+  Label,
   Modal,
   ModalBody,
   ModalContent,
   ModalHeader,
   ModalOverlay,
-} from '../../component-library';
+} from '@metamask/design-system-react';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { setAccountGroupName } from '../../../store/actions';
-import { FontWeight } from '../../../helpers/constants/design-system';
 import { getMultichainAccountGroupById } from '../../../selectors/multichain-accounts/account-tree';
 
 export type MultichainAccountEditModalProps = {
@@ -66,35 +70,44 @@ export const MultichainAccountEditModal = ({
     <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
       <ModalContent>
-        <ModalHeader onClose={onClose} onBack={onClose}>
+        <ModalHeader
+          onClose={onClose}
+          closeButtonProps={{ ariaLabel: t('close') }}
+          onBack={onClose}
+          backButtonProps={{ ariaLabel: t('back') }}
+        >
           {t('rename')}
         </ModalHeader>
         <ModalBody>
           <Box className="flex" flexDirection={BoxFlexDirection.Column} gap={4}>
             <Box>
-              <FormTextField
-                label={t('accountName')}
+              <Label htmlFor="account-name-input">{t('accountName')}</Label>
+              <Input
+                id="account-name-input"
                 aria-label={t('accountName')}
                 data-testid="account-name-input"
                 value={accountName}
                 onChange={(e) => setAccountName(e.target.value)}
                 onKeyDown={handleKeyDown}
                 placeholder={currentAccountName}
-                error={showErrorMessage}
-                helpText={helpText}
-                helpTextProps={{ fontWeight: FontWeight.Medium }}
+                aria-invalid={showErrorMessage}
                 autoFocus
               />
+              {showErrorMessage && (
+                <HelpText severity={HelpTextSeverity.Danger}>
+                  {helpText}
+                </HelpText>
+              )}
             </Box>
-            <ButtonSecondary
+            <Button
+              variant={ButtonVariant.Secondary}
               onClick={handleSave}
               disabled={!accountName.trim()}
               aria-label={t('confirm')}
-              block
-              marginTop={4}
+              className="w-full mt-4"
             >
               {t('confirm')}
-            </ButtonSecondary>
+            </Button>
           </Box>
         </ModalBody>
       </ModalContent>

--- a/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-list/multichain-account-list.test.tsx
@@ -106,7 +106,7 @@ const mockSetSelectedMultichainAccount = jest.requireMock(
 
 const popoverOpenSelector = '.mm-popover--open';
 const menuButtonSelector = '.multichain-account-cell-popover-menu-button';
-const modalHeaderSelector = '.mm-modal-header';
+const modalHeaderTestId = 'account-edit-modal-header';
 const walletHeaderTestId = 'multichain-account-tree-wallet-header';
 const accountNameInputTestId = 'account-name-input';
 
@@ -387,16 +387,12 @@ describe('MultichainAccountList', () => {
     });
 
     // Verify the modal is open by finding the modal header
-    const modalHeader = document.querySelector(modalHeaderSelector);
+    const modalHeader = screen.getByTestId(modalHeaderTestId);
     expect(modalHeader).toBeInTheDocument();
 
     // Find the header text inside the modal
-    if (modalHeader) {
-      const headerText = within(modalHeader as HTMLElement).getByText(
-        messages.rename.message,
-      );
-      expect(headerText).toBeInTheDocument();
-    }
+    const headerText = within(modalHeader).getByText(messages.rename.message);
+    expect(headerText).toBeInTheDocument();
 
     // Find the actual input element directly
     const inputContainer = screen.getByTestId(accountNameInputTestId);
@@ -470,7 +466,7 @@ describe('MultichainAccountList', () => {
     });
 
     // Verify that the modal is open
-    const modalHeader = document.querySelector(modalHeaderSelector);
+    const modalHeader = screen.getByTestId(modalHeaderTestId);
     expect(modalHeader).toBeInTheDocument();
 
     // Find the close button by aria-label


### PR DESCRIPTION
## **Description**

Migrates `MultichainAccountEditModal` — the account rename modal in the Accounts flow — from the deprecated `@metamask/component-library` to `@metamask/design-system-react`, following the v44.0.0 design system upgrade (commit `e83c07cb`).

All seven deprecated imports are replaced:

| Deprecated (component-library) | Replacement (design-system-react) |
|---|---|
| `Modal`, `ModalBody`, `ModalContent`, `ModalOverlay` | Direct 1:1 replacements |
| `ModalHeader` | Same name; now requires `closeButtonProps`/`backButtonProps` with `ariaLabel` per the new discriminated-union API |
| `ButtonSecondary` | `Button` with `variant={ButtonVariant.Secondary}` |
| `FormTextField` | Composed `Label` + `Input` + conditional `HelpText` (no FormTextField equivalent exists in design-system-react) |

Tests are updated to use `getByRole('button', { name })` instead of `getByText` for the confirm button, since the new `Button` renders its label inside a `<span>`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open the extension and navigate to the Accounts list
2. Click the kebab menu on any account → **Rename**
3. Verify the rename modal opens with the account name field and Confirm button
4. Type a new name and confirm the rename works
5. Try submitting a name already in use — verify the inline error message appears below the input

## **Screenshots/Recordings**

<!-- Visual regression screenshots added by /visual-regression-collect-extension -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/8de847b1-310a-42e7-bda4-9ebb4bae4840

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-layer swap only; rename dispatch and validation behavior are unchanged, with tests updated for accessibility-oriented queries.
> 
> **Overview**
> **Migrates `MultichainAccountEditModal`** from `@metamask/component-library` to `@metamask/design-system-react`, keeping the same rename flow (`setAccountGroupName`, duplicate-name error, Enter to save).
> 
> UI building blocks are swapped: `ButtonSecondary` becomes `Button` with `ButtonVariant.Secondary`; `FormTextField` becomes `Label` + `Input` plus conditional `HelpText` for the duplicate-name message (`aria-invalid` on the input). `ModalHeader` now passes `closeButtonProps` and `backButtonProps` with `ariaLabel` for close/back. Confirm uses layout classes (`w-full mt-4`) instead of `block` / `marginTop`.
> 
> Tests query the confirm control with **`getByRole('button', { name })`** because the new button wraps its label in a `<span>`. The duplicate-name test no longer asserts legacy `FormTextField` CSS class on the input wrapper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8209789f7993e700f4c75014cdbce07af2d9eb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->