### PR TITLE
ci: fix dev script exit code on failure

### DIFF
--- a/development/generate-beta-commit.js
+++ b/development/generate-beta-commit.js
@@ -3,7 +3,10 @@ const { promises: fs } = require('fs');
 const exec = promisify(require('child_process').exec);
 const VERSION = require('../package.json').version;
 
-start().catch(console.error);
+start().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
 
 async function start() {
   let betaVersion;

--- a/development/metamaskbot-build-announce/index.test.ts
+++ b/development/metamaskbot-build-announce/index.test.ts
@@ -75,11 +75,13 @@ function configureMocks(): void {
 describe('start() entry point', () => {
   let warnSpy: jest.SpyInstance;
   let errorSpy: jest.SpyInstance;
+  let processExitSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.resetModules();
     warnSpy = jest.spyOn(console, 'warn').mockImplementation();
     errorSpy = jest.spyOn(console, 'error').mockImplementation();
+    processExitSpy = jest.spyOn(process, 'exit').mockImplementation();
     configureMocks();
   });
 
@@ -103,7 +105,7 @@ describe('start() entry point', () => {
     expect(getMocks().utils.postCommentWithMetamaskBot).not.toHaveBeenCalled();
   });
 
-  it('invokes console.error when required env vars are missing', async () => {
+  it('exits with error when required env vars are missing', async () => {
     setEnv({ HOST_URL: undefined });
 
     // eslint-disable-next-line @typescript-eslint/no-require-imports
@@ -117,6 +119,7 @@ describe('start() entry point', () => {
         ),
       }),
     );
+    expect(processExitSpy).toHaveBeenCalledWith(1);
   });
 
   it('calls postCommentWithMetamaskBot with assembled comment body', async () => {

--- a/development/metamaskbot-build-announce/index.ts
+++ b/development/metamaskbot-build-announce/index.ts
@@ -5,7 +5,10 @@ import { buildPerformanceBenchmarksSection } from './performance-benchmarks';
 import { buildTestPlanSection } from './test-plan';
 import { buildSectionWithFallback, postCommentWithMetamaskBot } from './utils';
 
-start().catch(console.error);
+start().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});
 
 async function start(): Promise<void> {
   const {


### PR DESCRIPTION
## **Description**

Two development scripts were setting an exit code of zero upon failure, giving a false impression that the script succeeded. They have been updated to use an exit code of 1 upon failure.

## **Changelog**

CHANGELOG entry: N/A

## **Related issues**

Example here: https://github.com/MetaMask/metamask-extension/actions/runs/27353684566/job/80830567013

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small error-handling change in dev/CI helper scripts only; no product runtime or security paths affected.
> 
> **Overview**
> Fixes **false-green CI** for two development entry scripts by exiting with code **1** when `start()` rejects, instead of only logging via `.catch(console.error)` (which leaves Node’s exit code at 0).
> 
> **`generate-beta-commit.js`** and **`metamaskbot-build-announce/index.ts`** now use an explicit catch that logs the error and calls `process.exit(1)`. The build-announce test suite mocks `process.exit` and asserts exit **1** when required env vars are missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 645d83edb04329694a33ad23fee354f31fefcf4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->