### PR TITLE
chore: change comment_pr_token to be managed by token-exchange-service

### DIFF
--- a/.github/workflows/e2e-chrome.yml
+++ b/.github/workflows/e2e-chrome.yml
@@ -15,8 +15,6 @@ on:
         type: string
         description: The matrix for the E2E jobs
     secrets:
-      PR_COMMENT_TOKEN:
-        required: false
       INFURA_PROJECT_ID:
         required: false
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -617,7 +617,6 @@ jobs:
       builds-from-run: ${{ needs.get-requirements.outputs.builds-from-run }}
       builds-from-sha: ${{ needs.get-requirements.outputs.builds-from-sha }}
     secrets:
-      PR_COMMENT_TOKEN: ${{ secrets.PR_COMMENT_TOKEN }}
       E2E_OPENAI_API_KEY: ${{ secrets.E2E_OPENAI_API_KEY }}
       E2E_CLAUDE_API_KEY: ${{ secrets.E2E_CLAUDE_API_KEY }}
       E2E_GEMINI_API_KEY: ${{ secrets.E2E_GEMINI_API_KEY }}

--- a/.github/workflows/publish-prerelease.yml
+++ b/.github/workflows/publish-prerelease.yml
@@ -3,8 +3,6 @@ name: Publish prerelease
 on:
   workflow_call:
     secrets:
-      PR_COMMENT_TOKEN:
-        required: true
       E2E_OPENAI_API_KEY:
         required: false
       E2E_CLAUDE_API_KEY:
@@ -109,8 +107,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: pr-comment
+    permissions:
+      contents: read
+      id-token: write
     env:
-      PR_COMMENT_TOKEN: ${{ secrets.PR_COMMENT_TOKEN }}
       OWNER: ${{ github.repository_owner }}
       REPOSITORY: ${{ github.event.repository.name }}
       RUN_ID: ${{ github.run_id }}
@@ -188,6 +188,17 @@ jobs:
             echo "EOF"
           } >> "${GITHUB_ENV}"
 
+      - name: Get token
+        id: token
+        if: ${{ env.PR_NUMBER && vars.AWS_CLOUDFRONT_URL }}
+        uses: MetaMask/github-tools/.github/actions/get-token@v1
+        with:
+          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
+          permissions: |
+            pull_requests: write
+
       - name: Publish prerelease
-        if: ${{ env.PR_NUMBER && env.PR_COMMENT_TOKEN && vars.AWS_CLOUDFRONT_URL }}
+        if: ${{ env.PR_NUMBER && steps.token.outputs.token && vars.AWS_CLOUDFRONT_URL }}
+        env:
+          PR_COMMENT_TOKEN: ${{ steps.token.outputs.token }}
         run: yarn tsx ./development/metamaskbot-build-announce/index.ts


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
This pull request brings COMMENT_PR_TOKEN to be returned by the token-exchange-service. 
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how CI obtains GitHub tokens for PR comments; misconfiguration could break prerelease bot comments without affecting the extension runtime.
> 
> **Overview**
> **PR comment auth for prerelease announcements** now comes from the token-exchange service instead of a long-lived `PR_COMMENT_TOKEN` repository secret.
> 
> `publish-prerelease` drops the `PR_COMMENT_TOKEN` workflow secret and job-level env wiring. The `publish-prerelease` job adds `id-token: write`, runs **Get token** via `MetaMask/github-tools/.github/actions/get-token@v1` (`TOKEN_EXCHANGE_URL`, `pull_requests: write`), and only runs the announce script when that step returns a token—setting `PR_COMMENT_TOKEN` from `steps.token.outputs.token` for `metamaskbot-build-announce`.
> 
> **Callers** no longer pass `PR_COMMENT_TOKEN` into `publish-prerelease` (`main.yml`) or declare it on `e2e-chrome.yml` / `publish-prerelease.yml` `workflow_call` secrets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97549550ecf9310729dd411c6caa3556a944b13f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->