### PR TITLE
refactor: migrate multichain-accounts permissions pages

### DIFF
--- a/test/e2e/page-objects/flows/snap-permission.flow.ts
+++ b/test/e2e/page-objects/flows/snap-permission.flow.ts
@@ -66,9 +66,11 @@ export async function completeSnapInstallSwitchToTestSnap(driver: Driver) {
 export async function approveAccount(driver: Driver) {
   await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
+  // Use `contains(., 'Connect')` (the button's full string value) rather than
+  // `contains(text(), 'Connect')` so the selector still matches design-system
+  // buttons, which render their label inside a nested `<span>`.
   await driver.clickElement({
-    text: 'Connect',
-    tag: 'button',
+    xpath: "//button[contains(., 'Connect')]",
   });
 
   await driver.waitForSelector({

--- a/ui/components/multichain-accounts/permissions/multichain-edit-accounts-page/multichain-edit-accounts-page.tsx
+++ b/ui/components/multichain-accounts/permissions/multichain-edit-accounts-page/multichain-edit-accounts-page.tsx
@@ -2,14 +2,15 @@ import React, { useCallback, useContext, useMemo, useState } from 'react';
 import { AccountGroupId, AccountWalletId } from '@metamask/account-api';
 import { useSelector } from 'react-redux';
 import classnames from 'clsx';
-import { useI18nContext } from '../../../../hooks/useI18nContext';
 import {
   IconName,
   ButtonIcon,
   ButtonIconSize,
-  ButtonSecondary,
-  ButtonSecondarySize,
-} from '../../../component-library';
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '@metamask/design-system-react';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
 
 import {
   BackgroundColor,
@@ -170,20 +171,21 @@ export const MultichainEditAccountsPage = ({
         />
       </ScrollContainer>
       <Footer className="multichain-edit-accounts-page__footer">
-        <ButtonSecondary
+        <Button
           data-testid="connect-more-accounts-button"
           onClick={handleConnect}
-          size={ButtonSecondarySize.Lg}
+          variant={ButtonVariant.Secondary}
+          size={ButtonSize.Lg}
           // Allow 0 accounts selected for existing Snaps and non-Snaps revoke flows,
           // but require at least 1 account for initial Snaps permission requests
-          disabled={
+          isDisabled={
             selectedAccountGroups.length === 0 &&
             snapsPermissionsRequestType === SnapsPermissionsRequestType.Initial
           }
-          block
+          isFullWidth
         >
           {confirmButtonText ?? t('connect')}
-        </ButtonSecondary>
+        </Button>
       </Footer>
     </Page>
   );

--- a/ui/components/multichain-accounts/permissions/multichain-edit-networks-page/multichain-edit-networks-page.tsx
+++ b/ui/components/multichain-accounts/permissions/multichain-edit-networks-page/multichain-edit-networks-page.tsx
@@ -5,25 +5,26 @@ import {
   BoxAlignItems,
   BoxFlexDirection,
   BoxJustifyContent,
-} from '@metamask/design-system-react';
-import { useI18nContext } from '../../../../hooks/useI18nContext';
-import {
-  IconName,
+  Button,
   ButtonIcon,
   ButtonIconSize,
+  ButtonSize,
+  ButtonVariant,
   Checkbox,
-  IconSize,
-  ButtonPrimary,
-  ButtonPrimarySize,
-  Text,
+  FontWeight,
   Icon,
-} from '../../../component-library';
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
 
 import {
   BackgroundColor,
-  IconColor,
-  TextColor,
-  TextVariant,
+  TextVariant as LegacyTextVariant,
 } from '../../../../helpers/constants/design-system';
 import {
   MetaMetricsEventCategory,
@@ -101,7 +102,7 @@ export const MultichainEditNetworksPage = ({
     >
       <Header
         textProps={{
-          variant: TextVariant.headingSm,
+          variant: LegacyTextVariant.headingSm,
         }}
         startAccessory={
           <ButtonIcon
@@ -122,11 +123,13 @@ export const MultichainEditNetworksPage = ({
       >
         <Box padding={4}>
           <Checkbox
+            id="edit-networks-select-all"
             label={t('selectAll')}
-            isChecked={checked}
-            gap={4}
-            onClick={() => (allAreSelected ? deselectAll() : selectAll())}
-            isIndeterminate={isIndeterminate}
+            isSelected={checked || isIndeterminate}
+            onChange={() => (allAreSelected ? deselectAll() : selectAll())}
+            checkedIconProps={
+              isIndeterminate ? { name: IconName.MinusBold } : undefined
+            }
           />
         </Box>
         {nonTestNetworks.map((network) => (
@@ -139,13 +142,18 @@ export const MultichainEditNetworksPage = ({
             }}
             startAccessory={
               <Checkbox
-                isChecked={selectedChainIds.includes(network.caipChainId)}
+                id={`edit-networks-checkbox-${network.caipChainId}`}
+                isSelected={selectedChainIds.includes(network.caipChainId)}
+                onChange={() => handleNetworkClick(network.caipChainId)}
+                onClick={(event) => event.stopPropagation()}
               />
             }
           />
         ))}
         <Box padding={4}>
-          <Text variant={TextVariant.bodyMdMedium}>{t('testnets')}</Text>
+          <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+            {t('testnets')}
+          </Text>
         </Box>
         {testNetworks.map((network) => (
           <NetworkListItem
@@ -157,7 +165,10 @@ export const MultichainEditNetworksPage = ({
             }}
             startAccessory={
               <Checkbox
-                isChecked={selectedChainIds.includes(network.caipChainId)}
+                id={`edit-networks-checkbox-${network.caipChainId}`}
+                isSelected={selectedChainIds.includes(network.caipChainId)}
+                onChange={() => handleNetworkClick(network.caipChainId)}
+                onClick={(event) => event.stopPropagation()}
               />
             }
             showEndAccessory={false}
@@ -181,13 +192,13 @@ export const MultichainEditNetworksPage = ({
               <Icon
                 name={IconName.Danger}
                 size={IconSize.Sm}
-                color={IconColor.errorDefault}
+                color={IconColor.ErrorDefault}
               />
-              <Text variant={TextVariant.bodySm} color={TextColor.errorDefault}>
+              <Text variant={TextVariant.BodySm} color={TextColor.ErrorDefault}>
                 {t('disconnectMessage')}
               </Text>
             </Box>
-            <ButtonPrimary
+            <Button
               data-testid="disconnect-chains-button"
               onClick={() => {
                 onSubmit(selectedChainIds);
@@ -212,25 +223,27 @@ export const MultichainEditNetworksPage = ({
                 });
                 onClose();
               }}
-              size={ButtonPrimarySize.Lg}
-              block
-              danger
+              variant={ButtonVariant.Primary}
+              size={ButtonSize.Lg}
+              isFullWidth
+              isDanger
             >
               {t('disconnect')}
-            </ButtonPrimary>
+            </Button>
           </Box>
         ) : (
-          <ButtonPrimary
+          <Button
             data-testid="connect-more-chains-button"
             onClick={() => {
               onSubmit(selectedChainIds);
               onClose();
             }}
-            size={ButtonPrimarySize.Lg}
-            block
+            variant={ButtonVariant.Primary}
+            size={ButtonSize.Lg}
+            isFullWidth
           >
             {t('update')}
-          </ButtonPrimary>
+          </Button>
         )}
       </Footer>
     </Page>

--- a/ui/components/multichain-accounts/permissions/permission-review-page/multichain-review-permissions-page.tsx
+++ b/ui/components/multichain-accounts/permissions/permission-review-page/multichain-review-permissions-page.tsx
@@ -8,9 +8,15 @@ import {
 } from '@metamask/chain-agnostic-permission';
 import log from 'loglevel';
 import {
+  AvatarFavicon,
+  AvatarFaviconSize,
   Box,
   BoxAlignItems,
   BoxFlexDirection,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  IconName,
 } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { getAllNetworkConfigurationsByCaipChainId } from '../../../../../shared/lib/selectors/networks';
@@ -28,16 +34,6 @@ import {
   setPermittedAccounts,
   setPermittedChains,
 } from '../../../../store/actions';
-import {
-  AvatarFavicon,
-  AvatarFaviconSize,
-  Button,
-  ButtonPrimary,
-  ButtonPrimarySize,
-  ButtonSize,
-  ButtonVariant,
-  IconName,
-} from '../../../component-library';
 import { ToastContainer, Toast } from '../../../multichain/toast/toast';
 import { NoConnectionContent } from '../../../multichain/pages/connections/components/no-connection';
 import { Content, Footer, Page } from '../../../multichain/pages/page';
@@ -449,10 +445,10 @@ export const MultichainReviewPermissions = () => {
                 ) : null}
                 <Button
                   size={ButtonSize.Lg}
-                  block
+                  isFullWidth
                   variant={ButtonVariant.Secondary}
                   startIconName={IconName.Logout}
-                  danger
+                  isDanger
                   onClick={handleDisconnectClick}
                   data-test-id="disconnect-all"
                 >
@@ -462,16 +458,17 @@ export const MultichainReviewPermissions = () => {
             ) : (
               <>
                 {connectedAccountGroups.length > 0 ? (
-                  <ButtonPrimary
-                    size={ButtonPrimarySize.Lg}
-                    block
+                  <Button
+                    variant={ButtonVariant.Primary}
+                    size={ButtonSize.Lg}
+                    isFullWidth
                     data-test-id="no-connections-button"
                     // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
                     // eslint-disable-next-line @typescript-eslint/no-misused-promises
                     onClick={requestAccountsAndChainPermissions}
                   >
                     {t('connectAccounts')}
-                  </ButtonPrimary>
+                  </Button>
                 ) : null}
               </>
             )}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Migrated 3 permissions pages from the legacy `component-library` to `@metamask/design-system-react`:

- `multichain-edit-accounts-page.tsx`
- `multichain-edit-networks-page.tsx`
- `multichain-review-permissions-page.tsx`

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1879

## **Manual testing steps**

Check the UI/UX in the permission screens when connecting to a dapp

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Chrome**

https://github.com/user-attachments/assets/c2173dac-5ca8-4c8c-9099-928704d559fc

### **Firefox**

https://github.com/user-attachments/assets/fa7686bb-af52-4af3-bf1f-f9f6384d018c

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dapp/Snap permission connection flows (account and network selection) with component API changes; risk is mainly UI regressions rather than permission logic changes.
> 
> **Overview**
> Moves three multichain **permissions** screens (`edit accounts`, `edit networks`, `review permissions`) off legacy `component-library` controls onto **`@metamask/design-system-react`**.
> 
> **Buttons** on those pages now use design-system `Button` with `variant` / `size`, and props **`isDisabled`**, **`isFullWidth`**, and **`isDanger`** instead of the old `disabled`, `block`, and `danger` APIs. **Edit networks** also switches **checkboxes** to the design-system API (`isSelected`, `onChange`, explicit `id`s, indeterminate via `checkedIconProps`) and aligns **text/icon** tokens with design-system enums.
> 
> **E2E:** `approveAccount` in `snap-permission.flow.ts` clicks **Connect** via XPath `//button[contains(., 'Connect')]` so tests still find the label when design-system buttons wrap it in a nested `<span>`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08e6dbd796a18510c286709c4a54ebe983687416. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->