### PR TITLE
fix(assets-controller): update patch to add reconciliation/self-healing metadata cp-13.35.0

### DIFF
--- a/.yarn/patches/@metamask-assets-controller-npm-8.3.2-f205cdbfee.patch
+++ b/.yarn/patches/@metamask-assets-controller-npm-8.3.2-f205cdbfee.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/AssetsController.cjs b/dist/AssetsController.cjs
-index 7869c149db4678616dd467723a686b722629ec96..2745120fa5ab3014e64cc18529e6a9dceb5473d8 100644
+index 7869c149db4678616dd467723a686b722629ec96..6a27b9953164fea3352a3f17246aad9e93a1b475 100644
 --- a/dist/AssetsController.cjs
 +++ b/dist/AssetsController.cjs
 @@ -13,7 +13,7 @@ var __classPrivateFieldSet = (this && this.__classPrivateFieldSet) || function (
@@ -62,13 +62,16 @@ index 7869c149db4678616dd467723a686b722629ec96..2745120fa5ab3014e64cc18529e6a9dc
  }, _AssetsController_resolveNativeAssetIds = function _AssetsController_resolveNativeAssetIds(chains) {
      const nativeAssetMap = __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_getNativeAssetMap).call(this);
      const ids = [];
-@@ -1405,6 +1417,22 @@ async function _AssetsController_executeMiddlewares(sources, request, initialRes
+@@ -1405,6 +1417,25 @@ async function _AssetsController_executeMiddlewares(sources, request, initialRes
                      }
                  }
              }
 +            // Reconcile & self-heal stale asset "types" (e.g. erc20 -> native)
-+            // Important to dynamically update as we start receiving new chain native token changes
-+            const assetsInfoAssetIdsSet = new Set(Object.keys(response.assetsInfo ?? {}));
++            // using IDs from new response assetInfo and assetBalance
++            const assetsInfoAssetIdsSet = new Set([
++                ...Object.keys(normalizedResponse.assetsInfo ?? {}),
++                ...Object.values(normalizedResponse.assetsBalance ?? {}).flatMap((accountBalances) => Object.keys(accountBalances)),
++            ]);
 +            for (const assetId of assetsInfoAssetIdsSet) {
 +                const entry = metadata[assetId];
 +                if (!entry) {
@@ -85,7 +88,7 @@ index 7869c149db4678616dd467723a686b722629ec96..2745120fa5ab3014e64cc18529e6a9dc
              if (normalizedResponse.assetsBalance) {
                  for (const [accountId, accountBalances] of Object.entries(normalizedResponse.assetsBalance)) {
                      const previousBalances = previousState.assetsBalance[accountId] ?? {};
-@@ -1887,7 +1915,7 @@ async function _AssetsController_executeMiddlewares(sources, request, initialRes
+@@ -1887,7 +1918,7 @@ async function _AssetsController_executeMiddlewares(sources, request, initialRes
          }
      }
      return result;
@@ -95,7 +98,7 @@ index 7869c149db4678616dd467723a686b722629ec96..2745120fa5ab3014e64cc18529e6a9dc
  // EVENT HANDLERS
  // ============================================================================
 diff --git a/dist/AssetsController.mjs b/dist/AssetsController.mjs
-index 7552c96a765368243d30f099187c739b88c838c2..e914a5d59331d2312136f525b7dff9cd967af8bb 100644
+index 7552c96a765368243d30f099187c739b88c838c2..2ee3f81f5a58fd6502f0858bb98982e55a8b1ef5 100644
 --- a/dist/AssetsController.mjs
 +++ b/dist/AssetsController.mjs
 @@ -9,7 +9,7 @@ var __classPrivateFieldSet = (this && this.__classPrivateFieldSet) || function (
@@ -158,13 +161,16 @@ index 7552c96a765368243d30f099187c739b88c838c2..e914a5d59331d2312136f525b7dff9cd
  }, _AssetsController_resolveNativeAssetIds = function _AssetsController_resolveNativeAssetIds(chains) {
      const nativeAssetMap = __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_getNativeAssetMap).call(this);
      const ids = [];
-@@ -1398,6 +1410,22 @@ async function _AssetsController_executeMiddlewares(sources, request, initialRes
+@@ -1398,6 +1410,25 @@ async function _AssetsController_executeMiddlewares(sources, request, initialRes
                      }
                  }
              }
 +            // Reconcile & self-heal stale asset "types" (e.g. erc20 -> native)
-+            // Important to dynamically update as we start receiving new chain native token changes
-+            const assetsInfoAssetIdsSet = new Set(Object.keys(response.assetsInfo ?? {}));
++            // using IDs from new response assetInfo and assetBalance
++            const assetsInfoAssetIdsSet = new Set([
++                ...Object.keys(normalizedResponse.assetsInfo ?? {}),
++                ...Object.values(normalizedResponse.assetsBalance ?? {}).flatMap((accountBalances) => Object.keys(accountBalances)),
++            ]);
 +            for (const assetId of assetsInfoAssetIdsSet) {
 +                const entry = metadata[assetId];
 +                if (!entry) {
@@ -181,7 +187,7 @@ index 7552c96a765368243d30f099187c739b88c838c2..e914a5d59331d2312136f525b7dff9cd
              if (normalizedResponse.assetsBalance) {
                  for (const [accountId, accountBalances] of Object.entries(normalizedResponse.assetsBalance)) {
                      const previousBalances = previousState.assetsBalance[accountId] ?? {};
-@@ -1880,7 +1908,7 @@ async function _AssetsController_executeMiddlewares(sources, request, initialRes
+@@ -1880,7 +1911,7 @@ async function _AssetsController_executeMiddlewares(sources, request, initialRes
          }
      }
      return result;

--- a/.yarn/patches/@metamask-assets-controller-npm-8.3.2-f205cdbfee.patch
+++ b/.yarn/patches/@metamask-assets-controller-npm-8.3.2-f205cdbfee.patch
@@ -1,5 +1,5 @@
 diff --git a/dist/AssetsController.cjs b/dist/AssetsController.cjs
-index 7869c149db4678616dd467723a686b722629ec96..5cfd5dcbf3a2b6a2a63914f32b453bc742abe02e 100644
+index 7869c149db4678616dd467723a686b722629ec96..2745120fa5ab3014e64cc18529e6a9dceb5473d8 100644
 --- a/dist/AssetsController.cjs
 +++ b/dist/AssetsController.cjs
 @@ -13,7 +13,7 @@ var __classPrivateFieldSet = (this && this.__classPrivateFieldSet) || function (
@@ -36,6 +36,15 @@ index 7869c149db4678616dd467723a686b722629ec96..5cfd5dcbf3a2b6a2a63914f32b453bc7
          }), "f");
          __classPrivateFieldSet(this, _AssetsController_priceDataSource, new PriceDataSource_1.PriceDataSource({
              queryApiClient,
+@@ -1172,7 +1174,7 @@ _AssetsController_isEnabled = new WeakMap(), _AssetsController_isBasicFunctional
+             });
+         }
+     }
+-}, _AssetsController_executeMiddlewares = 
++}, _AssetsController_executeMiddlewares =
+ // ============================================================================
+ // MIDDLEWARE EXECUTION
+ // ============================================================================
 @@ -1280,6 +1282,16 @@ async function _AssetsController_executeMiddlewares(sources, request, initialRes
          return true;
      }
@@ -53,8 +62,40 @@ index 7869c149db4678616dd467723a686b722629ec96..5cfd5dcbf3a2b6a2a63914f32b453bc7
  }, _AssetsController_resolveNativeAssetIds = function _AssetsController_resolveNativeAssetIds(chains) {
      const nativeAssetMap = __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_getNativeAssetMap).call(this);
      const ids = [];
+@@ -1405,6 +1417,22 @@ async function _AssetsController_executeMiddlewares(sources, request, initialRes
+                     }
+                 }
+             }
++            // Reconcile & self-heal stale asset "types" (e.g. erc20 -> native)
++            // Important to dynamically update as we start receiving new chain native token changes
++            const assetsInfoAssetIdsSet = new Set(Object.keys(response.assetsInfo ?? {}));
++            for (const assetId of assetsInfoAssetIdsSet) {
++                const entry = metadata[assetId];
++                if (!entry) {
++                    continue;
++                }
++                const correctType = __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_getAssetType).call(this, assetId);
++                if (entry.type !== correctType) {
++                    metadata[assetId] = { ...entry, type: correctType };
++                    if (!changedMetadata.includes(assetId)) {
++                        changedMetadata.push(assetId);
++                    }
++                }
++            }
+             if (normalizedResponse.assetsBalance) {
+                 for (const [accountId, accountBalances] of Object.entries(normalizedResponse.assetsBalance)) {
+                     const previousBalances = previousState.assetsBalance[accountId] ?? {};
+@@ -1887,7 +1915,7 @@ async function _AssetsController_executeMiddlewares(sources, request, initialRes
+         }
+     }
+     return result;
+-}, _AssetsController_handleAccountGroupChanged = 
++}, _AssetsController_handleAccountGroupChanged =
+ // ============================================================================
+ // EVENT HANDLERS
+ // ============================================================================
 diff --git a/dist/AssetsController.mjs b/dist/AssetsController.mjs
-index 7552c96a765368243d30f099187c739b88c838c2..8e420a3e1ed51c3cbed5f58c2c854ba20e61e25a 100644
+index 7552c96a765368243d30f099187c739b88c838c2..e914a5d59331d2312136f525b7dff9cd967af8bb 100644
 --- a/dist/AssetsController.mjs
 +++ b/dist/AssetsController.mjs
 @@ -9,7 +9,7 @@ var __classPrivateFieldSet = (this && this.__classPrivateFieldSet) || function (
@@ -91,6 +132,15 @@ index 7552c96a765368243d30f099187c739b88c838c2..8e420a3e1ed51c3cbed5f58c2c854ba2
          }), "f");
          __classPrivateFieldSet(this, _AssetsController_priceDataSource, new PriceDataSource({
              queryApiClient,
+@@ -1165,7 +1167,7 @@ _AssetsController_isEnabled = new WeakMap(), _AssetsController_isBasicFunctional
+             });
+         }
+     }
+-}, _AssetsController_executeMiddlewares = 
++}, _AssetsController_executeMiddlewares =
+ // ============================================================================
+ // MIDDLEWARE EXECUTION
+ // ============================================================================
 @@ -1273,6 +1275,16 @@ async function _AssetsController_executeMiddlewares(sources, request, initialRes
          return true;
      }
@@ -108,6 +158,38 @@ index 7552c96a765368243d30f099187c739b88c838c2..8e420a3e1ed51c3cbed5f58c2c854ba2
  }, _AssetsController_resolveNativeAssetIds = function _AssetsController_resolveNativeAssetIds(chains) {
      const nativeAssetMap = __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_getNativeAssetMap).call(this);
      const ids = [];
+@@ -1398,6 +1410,22 @@ async function _AssetsController_executeMiddlewares(sources, request, initialRes
+                     }
+                 }
+             }
++            // Reconcile & self-heal stale asset "types" (e.g. erc20 -> native)
++            // Important to dynamically update as we start receiving new chain native token changes
++            const assetsInfoAssetIdsSet = new Set(Object.keys(response.assetsInfo ?? {}));
++            for (const assetId of assetsInfoAssetIdsSet) {
++                const entry = metadata[assetId];
++                if (!entry) {
++                    continue;
++                }
++                const correctType = __classPrivateFieldGet(this, _AssetsController_instances, "m", _AssetsController_getAssetType).call(this, assetId);
++                if (entry.type !== correctType) {
++                    metadata[assetId] = { ...entry, type: correctType };
++                    if (!changedMetadata.includes(assetId)) {
++                        changedMetadata.push(assetId);
++                    }
++                }
++            }
+             if (normalizedResponse.assetsBalance) {
+                 for (const [accountId, accountBalances] of Object.entries(normalizedResponse.assetsBalance)) {
+                     const previousBalances = previousState.assetsBalance[accountId] ?? {};
+@@ -1880,7 +1908,7 @@ async function _AssetsController_executeMiddlewares(sources, request, initialRes
+         }
+     }
+     return result;
+-}, _AssetsController_handleAccountGroupChanged = 
++}, _AssetsController_handleAccountGroupChanged =
+ // ============================================================================
+ // EVENT HANDLERS
+ // ============================================================================
 diff --git a/dist/data-sources/BackendWebsocketDataSource.cjs b/dist/data-sources/BackendWebsocketDataSource.cjs
 index 88f557ab6b2b6add5e3ca3620d230d01745bf168..9ab917c4cbe720e5e14fcc23ce7d1dfe9912ef28 100644
 --- a/dist/data-sources/BackendWebsocketDataSource.cjs

--- a/yarn.lock
+++ b/yarn.lock
@@ -5826,7 +5826,7 @@ __metadata:
 
 "@metamask/assets-controller@patch:@metamask/assets-controller@npm%3A8.3.2#~/.yarn/patches/@metamask-assets-controller-npm-8.3.2-f205cdbfee.patch":
   version: 8.3.2
-  resolution: "@metamask/assets-controller@patch:@metamask/assets-controller@npm%3A8.3.2#~/.yarn/patches/@metamask-assets-controller-npm-8.3.2-f205cdbfee.patch::version=8.3.2&hash=686654"
+  resolution: "@metamask/assets-controller@patch:@metamask/assets-controller@npm%3A8.3.2#~/.yarn/patches/@metamask-assets-controller-npm-8.3.2-f205cdbfee.patch::version=8.3.2&hash=a4462e"
   dependencies:
     "@ethereumjs/util": "npm:^9.1.0"
     "@ethersproject/abi": "npm:^5.7.0"
@@ -5857,7 +5857,7 @@ __metadata:
     bignumber.js: "npm:^9.1.2"
     lodash: "npm:^4.17.21"
     p-limit: "npm:^3.1.0"
-  checksum: 10/bb6cf5b813cdf8d4d997e4ed6c808a1ceb48cc28a7f51f93f9ca67fcca14363d9651c4a01324f1086025a151c36e69615dab582c6ca4acd742da7dc74d36c50a
+  checksum: 10/cc86c9d80c95cf6fbd9641f4c187ea282b18ab3440a931a51939d5a93c72d200d500872abe034a98a2c852f0f168e255da7550db178f400f90bd27338b110bea
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Patch for this core fix: https://github.com/MetaMask/core/pull/9099

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix(assets-controller): update patch to add reconciliation/self-healing metadata

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/43352

## **Manual testing steps**

1. Start application on 13.34.0. Add IMX chain and token.
2. Inspect state - `AssetsController.assetsInfo["eip155:13371/erc20:0x0000000000000000000000000000000000000000"]`
    - See that the token is marked as "erc20"
3. Start application with these changes
4. Inspect state - `AssetsController.assetsInfo["eip155:13371/erc20:0x0000000000000000000000000000000000000000"]`
    - See that the token is marked as "native"

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

```json
{
    "aggregators": [],
    "decimals": 18,
    "erc20Permit": false,
    "image": "https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/13371/erc20/0x0000000000000000000000000000000000000000.png",
    "name": "Immutable X",
    "occurrences": 100,
    "symbol": "IMX",
    "type": "erc20"
}
```

### **After**

```
{
    "aggregators": [],
    "decimals": 18,
    "erc20Permit": false,
    "image": "https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/13371/erc20/0x0000000000000000000000000000000000000000.png",
    "name": "Immutable X",
    "occurrences": 100,
    "symbol": "IMX",
    "type": "native"
}
```

https://www.loom.com/share/45f25216181146a69fc4730786c8fec9

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how persisted asset metadata types are updated across websocket/RPC flows; incorrect classification could affect portfolio display until the next reconcile, but the logic is narrowly corrective.
> 
> **Overview**
> Updates the **Yarn patch** for `@metamask/assets-controller@8.3.2` to backport MetaMask/core#9099: asset metadata **types** are reconciled when balance/info updates land, so mislabeled entries (e.g. IMX native at the zero address stored as `erc20`) are corrected to `native`, `spl`, or `erc20`.
> 
> The patch adds a **`getAssetType`** helper on `AssetsController` and passes it into **BackendWebsocket**, **RPC**, and **price** data sources (replacing the websocket’s `isNativeAsset` hook). During `_updateState`, it walks asset IDs from incoming `assetsInfo` / `assetsBalance` and **self-heals** `metadata[assetId].type` when it disagrees with `getAssetType`, marking those IDs as changed metadata.
> 
> `yarn.lock` is refreshed for the new patch hash/checksum only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13e0626102a0949855e73c636edb2a66dbe810fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->