### PR TITLE
feat: Add new account selector page for hardware wallets

### DIFF
--- a/test/data/hardware-wallet-accounts.ts
+++ b/test/data/hardware-wallet-accounts.ts
@@ -1,0 +1,56 @@
+import { ETH_TOKEN_IMAGE_URL } from '../../shared/constants/network';
+import type { HardwareWalletAccount } from '../../ui/components/multichain-accounts/hardware-account-card';
+
+const ETHEREUM_ADDRESS = {
+  id: 'eth-0',
+  networkName: 'Ethereum',
+  address: '0x091234567890123456789012345678901234b272',
+  balance: '$120.00',
+  iconUrl: ETH_TOKEN_IMAGE_URL,
+  iconType: 'network' as const,
+};
+
+export const createMockHardwareAccounts = (
+  count: number,
+  options?: {
+    includeMultichainAddresses?: boolean;
+  },
+): HardwareWalletAccount[] => {
+  const includeMultichainAddresses = options?.includeMultichainAddresses ?? false;
+
+  return Array.from({ length: count }, (_, index) => {
+    const accountNumber = index + 1;
+    const addresses = includeMultichainAddresses
+      ? [
+          ETHEREUM_ADDRESS,
+          {
+            id: `sol-${index}`,
+            networkName: 'Solana',
+            address: '6dk7RD1234567890abcdefghijklmnopqrstuvDEtXQ',
+            balance: '$120.00',
+            iconUrl: './images/solana-logo.svg',
+            iconType: 'network' as const,
+          },
+          {
+            id: `btc-${index}`,
+            networkName: 'Bitcoin',
+            address: 'bc1qea1234567890abcdefghijklmnopqrstuvwer2fx',
+            balance: '$120.00',
+            iconUrl: './images/bitcoin-logo.svg',
+            iconType: 'token' as const,
+            addressType: 'Taproot',
+          },
+        ]
+      : [ETHEREUM_ADDRESS];
+
+    return {
+      id: `account-${index}`,
+      name: `Account ${accountNumber}`,
+      totalBalance: includeMultichainAddresses ? '$360.00' : '$120.00',
+      addresses,
+      isAlreadyConnected: index === 2,
+    };
+  });
+};
+
+export const MOCK_HARDWARE_ACCOUNTS = createMockHardwareAccounts(5);

--- a/test/data/hardware-wallet-accounts.ts
+++ b/test/data/hardware-wallet-accounts.ts
@@ -11,6 +11,29 @@ export const MOCK_ETHEREUM_HARDWARE_ADDRESS: HardwareWalletAccountAddress = {
   iconType: 'network',
 };
 
+const createMultichainAddresses = (
+  index: number,
+): HardwareWalletAccountAddress[] => [
+  MOCK_ETHEREUM_HARDWARE_ADDRESS,
+  {
+    id: `sol-${index}`,
+    networkName: 'Solana',
+    address: '6dk7RD1234567890abcdefghijklmnopqrstuvDEtXQ',
+    balance: '$120.00',
+    iconUrl: './images/solana-logo.svg',
+    iconType: 'network',
+  },
+  {
+    id: `btc-${index}`,
+    networkName: 'Bitcoin',
+    address: 'bc1qea1234567890abcdefghijklmnopqrstuvwer2fx',
+    balance: '$120.00',
+    iconUrl: './images/bitcoin-logo.svg',
+    iconType: 'token',
+    addressType: 'Taproot',
+  },
+];
+
 export const createHardwareWalletAccount = (
   overrides: Partial<HardwareWalletAccount> = {},
 ): HardwareWalletAccount => ({
@@ -21,38 +44,20 @@ export const createHardwareWalletAccount = (
   ...overrides,
 });
 
+type CreateMockHardwareAccountsOptions = {
+  includeMultichainAddresses?: boolean;
+};
+
 export const createMockHardwareAccounts = (
   count: number,
-  options?: {
-    includeMultichainAddresses?: boolean;
-  },
+  options: CreateMockHardwareAccountsOptions = {},
 ): HardwareWalletAccount[] => {
-  const includeMultichainAddresses =
-    options?.includeMultichainAddresses ?? false;
+  const { includeMultichainAddresses = false } = options;
 
   return Array.from({ length: count }, (_, index) => {
     const accountNumber = index + 1;
     const addresses = includeMultichainAddresses
-      ? [
-          MOCK_ETHEREUM_HARDWARE_ADDRESS,
-          {
-            id: `sol-${index}`,
-            networkName: 'Solana',
-            address: '6dk7RD1234567890abcdefghijklmnopqrstuvDEtXQ',
-            balance: '$120.00',
-            iconUrl: './images/solana-logo.svg',
-            iconType: 'network' as const,
-          },
-          {
-            id: `btc-${index}`,
-            networkName: 'Bitcoin',
-            address: 'bc1qea1234567890abcdefghijklmnopqrstuvwer2fx',
-            balance: '$120.00',
-            iconUrl: './images/bitcoin-logo.svg',
-            iconType: 'token' as const,
-            addressType: 'Taproot',
-          },
-        ]
+      ? createMultichainAddresses(index)
       : [MOCK_ETHEREUM_HARDWARE_ADDRESS];
 
     return {

--- a/test/data/hardware-wallet-accounts.ts
+++ b/test/data/hardware-wallet-accounts.ts
@@ -1,27 +1,31 @@
 import { ETH_TOKEN_IMAGE_URL } from '../../shared/constants/network';
-import type { HardwareWalletAccountAddress } from '../../ui/components/multichain-accounts/hardware-account-address-row';
+import {
+  HardwareWalletAddressIconTypes,
+  type HardwareWalletAccountAddress,
+} from '../../ui/components/multichain-accounts/hardware-account-address-row';
 import type { HardwareWalletAccount } from '../../ui/components/multichain-accounts/hardware-account-card';
 
+/** Default Ethereum address fixture for hardware wallet tests and stories. */
 export const MOCK_ETHEREUM_HARDWARE_ADDRESS: HardwareWalletAccountAddress = {
   id: 'eth-0',
   networkName: 'Ethereum',
   address: '0x091234567890123456789012345678901234b272',
   balance: '$120.00',
   iconUrl: ETH_TOKEN_IMAGE_URL,
-  iconType: 'network',
+  iconType: HardwareWalletAddressIconTypes.Network,
 };
 
 const createMultichainAddresses = (
   index: number,
 ): HardwareWalletAccountAddress[] => [
-  MOCK_ETHEREUM_HARDWARE_ADDRESS,
+  { ...MOCK_ETHEREUM_HARDWARE_ADDRESS, id: `eth-${index}` },
   {
     id: `sol-${index}`,
     networkName: 'Solana',
     address: '6dk7RD1234567890abcdefghijklmnopqrstuvDEtXQ',
     balance: '$120.00',
     iconUrl: './images/solana-logo.svg',
-    iconType: 'network',
+    iconType: HardwareWalletAddressIconTypes.Network,
   },
   {
     id: `btc-${index}`,
@@ -29,11 +33,15 @@ const createMultichainAddresses = (
     address: 'bc1qea1234567890abcdefghijklmnopqrstuvwer2fx',
     balance: '$120.00',
     iconUrl: './images/bitcoin-logo.svg',
-    iconType: 'token',
+    iconType: HardwareWalletAddressIconTypes.Token,
     addressType: 'Taproot',
   },
 ];
 
+/**
+ * Creates a single hardware wallet account fixture with optional overrides.
+ * @param overrides
+ */
 export const createHardwareWalletAccount = (
   overrides: Partial<HardwareWalletAccount> = {},
 ): HardwareWalletAccount => ({
@@ -48,6 +56,11 @@ type CreateMockHardwareAccountsOptions = {
   includeMultichainAddresses?: boolean;
 };
 
+/**
+ * Creates a list of hardware wallet account fixtures for tests and stories.
+ * @param count
+ * @param options
+ */
 export const createMockHardwareAccounts = (
   count: number,
   options: CreateMockHardwareAccountsOptions = {},
@@ -70,4 +83,5 @@ export const createMockHardwareAccounts = (
   });
 };
 
+/** Default list of five hardware wallet accounts for page-level tests. */
 export const MOCK_HARDWARE_ACCOUNTS = createMockHardwareAccounts(5);

--- a/test/data/hardware-wallet-accounts.ts
+++ b/test/data/hardware-wallet-accounts.ts
@@ -1,14 +1,25 @@
 import { ETH_TOKEN_IMAGE_URL } from '../../shared/constants/network';
+import type { HardwareWalletAccountAddress } from '../../ui/components/multichain-accounts/hardware-account-address-row';
 import type { HardwareWalletAccount } from '../../ui/components/multichain-accounts/hardware-account-card';
 
-const ETHEREUM_ADDRESS = {
+export const MOCK_ETHEREUM_HARDWARE_ADDRESS: HardwareWalletAccountAddress = {
   id: 'eth-0',
   networkName: 'Ethereum',
   address: '0x091234567890123456789012345678901234b272',
   balance: '$120.00',
   iconUrl: ETH_TOKEN_IMAGE_URL,
-  iconType: 'network' as const,
+  iconType: 'network',
 };
+
+export const createHardwareWalletAccount = (
+  overrides: Partial<HardwareWalletAccount> = {},
+): HardwareWalletAccount => ({
+  id: 'account-0',
+  name: 'Account 1',
+  totalBalance: '$120.00',
+  addresses: [MOCK_ETHEREUM_HARDWARE_ADDRESS],
+  ...overrides,
+});
 
 export const createMockHardwareAccounts = (
   count: number,
@@ -23,7 +34,7 @@ export const createMockHardwareAccounts = (
     const accountNumber = index + 1;
     const addresses = includeMultichainAddresses
       ? [
-          ETHEREUM_ADDRESS,
+          MOCK_ETHEREUM_HARDWARE_ADDRESS,
           {
             id: `sol-${index}`,
             networkName: 'Solana',
@@ -42,7 +53,7 @@ export const createMockHardwareAccounts = (
             addressType: 'Taproot',
           },
         ]
-      : [ETHEREUM_ADDRESS];
+      : [MOCK_ETHEREUM_HARDWARE_ADDRESS];
 
     return {
       id: `account-${index}`,

--- a/test/data/hardware-wallet-accounts.ts
+++ b/test/data/hardware-wallet-accounts.ts
@@ -34,7 +34,7 @@ const createMultichainAddresses = (
 
 /**
  * Creates a single hardware wallet account fixture with optional overrides.
- * @param overrides
+ * @param overrides - Optional account field overrides.
  */
 export const createHardwareWalletAccount = (
   overrides: Partial<HardwareWalletAccount> = {},
@@ -52,8 +52,8 @@ type CreateMockHardwareAccountsOptions = {
 
 /**
  * Creates a list of hardware wallet account fixtures for tests and stories.
- * @param count
- * @param options
+ * @param count - Number of accounts to create.
+ * @param options - Optional fixture configuration.
  */
 export const createMockHardwareAccounts = (
   count: number,

--- a/test/data/hardware-wallet-accounts.ts
+++ b/test/data/hardware-wallet-accounts.ts
@@ -1,8 +1,5 @@
 import { ETH_TOKEN_IMAGE_URL } from '../../shared/constants/network';
-import {
-  HardwareWalletAddressIconTypes,
-  type HardwareWalletAccountAddress,
-} from '../../ui/components/multichain-accounts/hardware-account-address-row';
+import type { HardwareWalletAccountAddress } from '../../ui/components/multichain-accounts/hardware-account-address-row';
 import type { HardwareWalletAccount } from '../../ui/components/multichain-accounts/hardware-account-card';
 
 /** Default Ethereum address fixture for hardware wallet tests and stories. */
@@ -12,7 +9,6 @@ export const MOCK_ETHEREUM_HARDWARE_ADDRESS: HardwareWalletAccountAddress = {
   address: '0x091234567890123456789012345678901234b272',
   balance: '$120.00',
   iconUrl: ETH_TOKEN_IMAGE_URL,
-  iconType: HardwareWalletAddressIconTypes.Network,
 };
 
 const createMultichainAddresses = (
@@ -25,7 +21,6 @@ const createMultichainAddresses = (
     address: '6dk7RD1234567890abcdefghijklmnopqrstuvDEtXQ',
     balance: '$120.00',
     iconUrl: './images/solana-logo.svg',
-    iconType: HardwareWalletAddressIconTypes.Network,
   },
   {
     id: `btc-${index}`,
@@ -33,7 +28,6 @@ const createMultichainAddresses = (
     address: 'bc1qea1234567890abcdefghijklmnopqrstuvwer2fx',
     balance: '$120.00',
     iconUrl: './images/bitcoin-logo.svg',
-    iconType: HardwareWalletAddressIconTypes.Token,
     addressType: 'Taproot',
   },
 ];

--- a/test/data/hardware-wallet-accounts.ts
+++ b/test/data/hardware-wallet-accounts.ts
@@ -16,7 +16,8 @@ export const createMockHardwareAccounts = (
     includeMultichainAddresses?: boolean;
   },
 ): HardwareWalletAccount[] => {
-  const includeMultichainAddresses = options?.includeMultichainAddresses ?? false;
+  const includeMultichainAddresses =
+    options?.includeMultichainAddresses ?? false;
 
   return Array.from({ length: count }, (_, index) => {
     const accountNumber = index + 1;

--- a/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.stories.tsx
+++ b/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.stories.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 import { MOCK_ETHEREUM_HARDWARE_ADDRESS } from '../../../../test/data/hardware-wallet-accounts';
-import { HardwareWalletAddressIconTypes } from './hardware-account-address-row.types';
 import { HardwareAccountAddressRow } from './hardware-account-address-row';
 
 export default {
@@ -29,7 +28,6 @@ export const WithAddressType: StoryFn<typeof HardwareAccountAddressRow> = (
       networkName: 'Bitcoin',
       address: 'bc1qea1234567890abcdefghijklmnopqrstuvwer2fx',
       iconUrl: './images/bitcoin-logo.svg',
-      iconType: HardwareWalletAddressIconTypes.Token,
       addressType: 'Taproot',
     }}
   />

--- a/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.stories.tsx
+++ b/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.stories.tsx
@@ -1,23 +1,13 @@
 import React from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
-import { ETH_TOKEN_IMAGE_URL } from '../../../../shared/constants/network';
+import { MOCK_ETHEREUM_HARDWARE_ADDRESS } from '../../../../test/data/hardware-wallet-accounts';
 import { HardwareAccountAddressRow } from './hardware-account-address-row';
-import type { HardwareWalletAccountAddress } from './hardware-account-address-row.types';
-
-const baseAddress: HardwareWalletAccountAddress = {
-  id: 'eth-0',
-  networkName: 'Ethereum',
-  address: '0x091234567890123456789012345678901234b272',
-  balance: '$120.00',
-  iconUrl: ETH_TOKEN_IMAGE_URL,
-  iconType: 'network',
-};
 
 export default {
   title: 'Components/MultichainAccounts/HardwareAccountAddressRow',
   component: HardwareAccountAddressRow,
   args: {
-    address: baseAddress,
+    address: MOCK_ETHEREUM_HARDWARE_ADDRESS,
   },
 } as Meta<typeof HardwareAccountAddressRow>;
 
@@ -33,7 +23,8 @@ export const WithAddressType: StoryFn<typeof HardwareAccountAddressRow> = (
   <HardwareAccountAddressRow
     {...args}
     address={{
-      ...baseAddress,
+      ...MOCK_ETHEREUM_HARDWARE_ADDRESS,
+      id: 'btc-0',
       networkName: 'Bitcoin',
       address: 'bc1qea1234567890abcdefghijklmnopqrstuvwer2fx',
       iconUrl: './images/bitcoin-logo.svg',

--- a/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.stories.tsx
+++ b/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.stories.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import type { Meta, StoryFn } from '@storybook/react';
+import { ETH_TOKEN_IMAGE_URL } from '../../../../shared/constants/network';
+import { HardwareAccountAddressRow } from './hardware-account-address-row';
+import type { HardwareWalletAccountAddress } from './hardware-account-address-row.types';
+
+const baseAddress: HardwareWalletAccountAddress = {
+  id: 'eth-0',
+  networkName: 'Ethereum',
+  address: '0x091234567890123456789012345678901234b272',
+  balance: '$120.00',
+  iconUrl: ETH_TOKEN_IMAGE_URL,
+  iconType: 'network',
+};
+
+export default {
+  title: 'Components/MultichainAccounts/HardwareAccountAddressRow',
+  component: HardwareAccountAddressRow,
+  args: {
+    address: baseAddress,
+  },
+} as Meta<typeof HardwareAccountAddressRow>;
+
+export const DefaultStory: StoryFn<typeof HardwareAccountAddressRow> = (
+  args,
+) => <HardwareAccountAddressRow {...args} />;
+
+DefaultStory.storyName = 'Default';
+
+export const WithAddressType: StoryFn<typeof HardwareAccountAddressRow> = (
+  args,
+) => (
+  <HardwareAccountAddressRow
+    {...args}
+    address={{
+      ...baseAddress,
+      networkName: 'Bitcoin',
+      address: 'bc1qea1234567890abcdefghijklmnopqrstuvwer2fx',
+      iconUrl: './images/bitcoin-logo.svg',
+      iconType: 'token',
+      addressType: 'Taproot',
+    }}
+  />
+);

--- a/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.stories.tsx
+++ b/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.stories.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
 import { MOCK_ETHEREUM_HARDWARE_ADDRESS } from '../../../../test/data/hardware-wallet-accounts';
+import { HardwareWalletAddressIconTypes } from './hardware-account-address-row.types';
 import { HardwareAccountAddressRow } from './hardware-account-address-row';
 
 export default {
@@ -28,7 +29,7 @@ export const WithAddressType: StoryFn<typeof HardwareAccountAddressRow> = (
       networkName: 'Bitcoin',
       address: 'bc1qea1234567890abcdefghijklmnopqrstuvwer2fx',
       iconUrl: './images/bitcoin-logo.svg',
-      iconType: 'token',
+      iconType: HardwareWalletAddressIconTypes.Token,
       addressType: 'Taproot',
     }}
   />

--- a/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.test.tsx
+++ b/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.test.tsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { ETH_TOKEN_IMAGE_URL } from '../../../../shared/constants/network';
+import type { HardwareWalletAccountAddress } from './hardware-account-address-row.types';
+import { HardwareAccountAddressRow } from './hardware-account-address-row';
+
+const renderWithProviders = (ui: React.ReactElement) =>
+  render(<div>{ui}</div>);
+
+describe('HardwareAccountAddressRow', () => {
+  const baseAddress: HardwareWalletAccountAddress = {
+    id: 'eth-0',
+    networkName: 'Ethereum',
+    address: '0x091234567890123456789012345678901234b272',
+    balance: '$120.00',
+    iconUrl: ETH_TOKEN_IMAGE_URL,
+    iconType: 'network',
+  };
+
+  it('renders network address details', () => {
+    renderWithProviders(<HardwareAccountAddressRow address={baseAddress} />);
+
+    expect(screen.getByText('Ethereum')).toBeInTheDocument();
+    expect(screen.getByText('$120.00')).toBeInTheDocument();
+    expect(screen.getByText('0x091...b272')).toBeInTheDocument();
+  });
+
+  it('renders token avatar and address type badge when provided', () => {
+    renderWithProviders(
+      <HardwareAccountAddressRow
+        address={{
+          ...baseAddress,
+          networkName: 'Bitcoin',
+          iconType: 'token',
+          addressType: 'Taproot',
+        }}
+      />,
+    );
+
+    expect(screen.getByText('Bitcoin')).toBeInTheDocument();
+    expect(screen.getByText('Taproot')).toBeInTheDocument();
+  });
+
+  it('defaults to network avatar when icon type is omitted', () => {
+    renderWithProviders(
+      <HardwareAccountAddressRow
+        address={{
+          ...baseAddress,
+          iconType: undefined,
+        }}
+      />,
+    );
+
+    expect(screen.getByTestId('hardware-account-address-row')).toBeInTheDocument();
+  });
+});

--- a/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.test.tsx
+++ b/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.test.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { tEn } from '../../../../test/lib/i18n-helpers';
 import { MOCK_ETHEREUM_HARDWARE_ADDRESS } from '../../../../test/data/hardware-wallet-accounts';
-import type { HardwareWalletAccountAddress } from './hardware-account-address-row.types';
+import {
+  HardwareWalletAddressIconTypes,
+  type HardwareWalletAccountAddress,
+} from './hardware-account-address-row.types';
 import { HardwareAccountAddressRow } from './hardware-account-address-row';
 
 const renderRow = (address: HardwareWalletAccountAddress) =>
@@ -22,7 +25,7 @@ describe('HardwareAccountAddressRow', () => {
       renderRow({
         ...MOCK_ETHEREUM_HARDWARE_ADDRESS,
         networkName: 'Bitcoin',
-        iconType: 'token',
+        iconType: HardwareWalletAddressIconTypes.Token,
         addressType: 'Taproot',
       });
 
@@ -39,7 +42,10 @@ describe('HardwareAccountAddressRow', () => {
 
   describe('avatar', () => {
     it('renders a network avatar when iconType is network', () => {
-      renderRow({ ...MOCK_ETHEREUM_HARDWARE_ADDRESS, iconType: 'network' });
+      renderRow({
+        ...MOCK_ETHEREUM_HARDWARE_ADDRESS,
+        iconType: HardwareWalletAddressIconTypes.Network,
+      });
 
       expect(
         screen.getByRole('img', { name: tEn('networkNameEthereum') }),
@@ -50,7 +56,7 @@ describe('HardwareAccountAddressRow', () => {
       renderRow({
         ...MOCK_ETHEREUM_HARDWARE_ADDRESS,
         networkName: 'Bitcoin',
-        iconType: 'token',
+        iconType: HardwareWalletAddressIconTypes.Token,
         iconUrl: './images/bitcoin-logo.svg',
       });
 

--- a/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.test.tsx
+++ b/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.test.tsx
@@ -1,58 +1,70 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
-import { ETH_TOKEN_IMAGE_URL } from '../../../../shared/constants/network';
 import { tEn } from '../../../../test/lib/i18n-helpers';
+import { MOCK_ETHEREUM_HARDWARE_ADDRESS } from '../../../../test/data/hardware-wallet-accounts';
 import type { HardwareWalletAccountAddress } from './hardware-account-address-row.types';
 import { HardwareAccountAddressRow } from './hardware-account-address-row';
 
-const renderWithProviders = (ui: React.ReactElement) => render(<div>{ui}</div>);
+const renderRow = (address: HardwareWalletAccountAddress) =>
+  render(<HardwareAccountAddressRow address={address} />);
 
 describe('HardwareAccountAddressRow', () => {
-  const baseAddress: HardwareWalletAccountAddress = {
-    id: 'eth-0',
-    networkName: 'Ethereum',
-    address: '0x091234567890123456789012345678901234b272',
-    balance: '$120.00',
-    iconUrl: ETH_TOKEN_IMAGE_URL,
-    iconType: 'network',
-  };
+  describe('rendering', () => {
+    it('renders network name, truncated address, and balance', () => {
+      renderRow(MOCK_ETHEREUM_HARDWARE_ADDRESS);
 
-  it('renders network address details', () => {
-    renderWithProviders(<HardwareAccountAddressRow address={baseAddress} />);
+      expect(screen.getByText(tEn('networkNameEthereum'))).toBeInTheDocument();
+      expect(screen.getByText('0x091...b272')).toBeInTheDocument();
+      expect(screen.getByText('$120.00')).toBeInTheDocument();
+    });
 
-    expect(screen.getByText(tEn('networkNameEthereum'))).toBeInTheDocument();
-    expect(screen.getByText('$120.00')).toBeInTheDocument();
-    expect(screen.getByText('0x091...b272')).toBeInTheDocument();
+    it('renders address type badge when addressType is provided', () => {
+      renderRow({
+        ...MOCK_ETHEREUM_HARDWARE_ADDRESS,
+        networkName: 'Bitcoin',
+        iconType: 'token',
+        addressType: 'Taproot',
+      });
+
+      expect(screen.getByText(tEn('networkNameBitcoin'))).toBeInTheDocument();
+      expect(screen.getByText('Taproot')).toBeInTheDocument();
+    });
+
+    it('omits address type badge when addressType is not provided', () => {
+      renderRow(MOCK_ETHEREUM_HARDWARE_ADDRESS);
+
+      expect(screen.queryByText('Taproot')).not.toBeInTheDocument();
+    });
   });
 
-  it('renders token avatar and address type badge when provided', () => {
-    renderWithProviders(
-      <HardwareAccountAddressRow
-        address={{
-          ...baseAddress,
-          networkName: 'Bitcoin',
-          iconType: 'token',
-          addressType: 'Taproot',
-        }}
-      />,
-    );
+  describe('avatar', () => {
+    it('renders a network avatar when iconType is network', () => {
+      renderRow({ ...MOCK_ETHEREUM_HARDWARE_ADDRESS, iconType: 'network' });
 
-    expect(screen.getByText(tEn('networkNameBitcoin'))).toBeInTheDocument();
-    expect(screen.getByText('Taproot')).toBeInTheDocument();
-  });
+      expect(
+        screen.getByRole('img', { name: tEn('networkNameEthereum') }),
+      ).toBeInTheDocument();
+    });
 
-  it('defaults to network avatar when icon type is omitted', () => {
-    renderWithProviders(
-      <HardwareAccountAddressRow
-        address={{
-          ...baseAddress,
-          iconType: undefined,
-        }}
-      />,
-    );
+    it('renders a token avatar when iconType is token', () => {
+      renderRow({
+        ...MOCK_ETHEREUM_HARDWARE_ADDRESS,
+        networkName: 'Bitcoin',
+        iconType: 'token',
+        iconUrl: './images/bitcoin-logo.svg',
+      });
 
-    expect(
-      screen.getByTestId('hardware-account-address-row'),
-    ).toBeInTheDocument();
+      expect(
+        screen.getByRole('img', { name: tEn('networkNameBitcoin') }),
+      ).toBeInTheDocument();
+    });
+
+    it('defaults to a network avatar when iconType is omitted', () => {
+      renderRow({ ...MOCK_ETHEREUM_HARDWARE_ADDRESS, iconType: undefined });
+
+      expect(
+        screen.getByRole('img', { name: tEn('networkNameEthereum') }),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.test.tsx
+++ b/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.test.tsx
@@ -2,10 +2,7 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { tEn } from '../../../../test/lib/i18n-helpers';
 import { MOCK_ETHEREUM_HARDWARE_ADDRESS } from '../../../../test/data/hardware-wallet-accounts';
-import {
-  HardwareWalletAddressIconTypes,
-  type HardwareWalletAccountAddress,
-} from './hardware-account-address-row.types';
+import type { HardwareWalletAccountAddress } from './hardware-account-address-row.types';
 import { HardwareAccountAddressRow } from './hardware-account-address-row';
 
 const renderRow = (address: HardwareWalletAccountAddress) =>
@@ -13,9 +10,12 @@ const renderRow = (address: HardwareWalletAccountAddress) =>
 
 describe('HardwareAccountAddressRow', () => {
   describe('rendering', () => {
-    it('renders network name, truncated address, and balance', () => {
+    it('renders network name, chain icon, truncated address, and balance', () => {
       renderRow(MOCK_ETHEREUM_HARDWARE_ADDRESS);
 
+      expect(
+        screen.getByRole('img', { name: tEn('networkNameEthereum') }),
+      ).toBeInTheDocument();
       expect(screen.getByText(tEn('networkNameEthereum'))).toBeInTheDocument();
       expect(screen.getByText('0x091...b272')).toBeInTheDocument();
       expect(screen.getByText('$120.00')).toBeInTheDocument();
@@ -25,7 +25,7 @@ describe('HardwareAccountAddressRow', () => {
       renderRow({
         ...MOCK_ETHEREUM_HARDWARE_ADDRESS,
         networkName: 'Bitcoin',
-        iconType: HardwareWalletAddressIconTypes.Token,
+        iconUrl: './images/bitcoin-logo.svg',
         addressType: 'Taproot',
       });
 
@@ -37,40 +37,6 @@ describe('HardwareAccountAddressRow', () => {
       renderRow(MOCK_ETHEREUM_HARDWARE_ADDRESS);
 
       expect(screen.queryByText('Taproot')).not.toBeInTheDocument();
-    });
-  });
-
-  describe('avatar', () => {
-    it('renders a network avatar when iconType is network', () => {
-      renderRow({
-        ...MOCK_ETHEREUM_HARDWARE_ADDRESS,
-        iconType: HardwareWalletAddressIconTypes.Network,
-      });
-
-      expect(
-        screen.getByRole('img', { name: tEn('networkNameEthereum') }),
-      ).toBeInTheDocument();
-    });
-
-    it('renders a token avatar when iconType is token', () => {
-      renderRow({
-        ...MOCK_ETHEREUM_HARDWARE_ADDRESS,
-        networkName: 'Bitcoin',
-        iconType: HardwareWalletAddressIconTypes.Token,
-        iconUrl: './images/bitcoin-logo.svg',
-      });
-
-      expect(
-        screen.getByRole('img', { name: tEn('networkNameBitcoin') }),
-      ).toBeInTheDocument();
-    });
-
-    it('defaults to a network avatar when iconType is omitted', () => {
-      renderRow({ ...MOCK_ETHEREUM_HARDWARE_ADDRESS, iconType: undefined });
-
-      expect(
-        screen.getByRole('img', { name: tEn('networkNameEthereum') }),
-      ).toBeInTheDocument();
     });
   });
 });

--- a/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.test.tsx
+++ b/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { ETH_TOKEN_IMAGE_URL } from '../../../../shared/constants/network';
+import { tEn } from '../../../../test/lib/i18n-helpers';
 import type { HardwareWalletAccountAddress } from './hardware-account-address-row.types';
 import { HardwareAccountAddressRow } from './hardware-account-address-row';
 
@@ -19,7 +20,7 @@ describe('HardwareAccountAddressRow', () => {
   it('renders network address details', () => {
     renderWithProviders(<HardwareAccountAddressRow address={baseAddress} />);
 
-    expect(screen.getByText('Ethereum')).toBeInTheDocument();
+    expect(screen.getByText(tEn('networkNameEthereum'))).toBeInTheDocument();
     expect(screen.getByText('$120.00')).toBeInTheDocument();
     expect(screen.getByText('0x091...b272')).toBeInTheDocument();
   });
@@ -36,7 +37,7 @@ describe('HardwareAccountAddressRow', () => {
       />,
     );
 
-    expect(screen.getByText('Bitcoin')).toBeInTheDocument();
+    expect(screen.getByText(tEn('networkNameBitcoin'))).toBeInTheDocument();
     expect(screen.getByText('Taproot')).toBeInTheDocument();
   });
 

--- a/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.test.tsx
+++ b/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.test.tsx
@@ -4,8 +4,7 @@ import { ETH_TOKEN_IMAGE_URL } from '../../../../shared/constants/network';
 import type { HardwareWalletAccountAddress } from './hardware-account-address-row.types';
 import { HardwareAccountAddressRow } from './hardware-account-address-row';
 
-const renderWithProviders = (ui: React.ReactElement) =>
-  render(<div>{ui}</div>);
+const renderWithProviders = (ui: React.ReactElement) => render(<div>{ui}</div>);
 
 describe('HardwareAccountAddressRow', () => {
   const baseAddress: HardwareWalletAccountAddress = {
@@ -51,6 +50,8 @@ describe('HardwareAccountAddressRow', () => {
       />,
     );
 
-    expect(screen.getByTestId('hardware-account-address-row')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('hardware-account-address-row'),
+    ).toBeInTheDocument();
   });
 });

--- a/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.tsx
+++ b/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.tsx
@@ -17,8 +17,7 @@ import { shortenString } from '../../../helpers/utils/util';
 import type { HardwareAccountAddressRowProps } from './hardware-account-address-row.types';
 
 /**
- * Displays a single blockchain address row within a hardware wallet account card,
- * including network icon, name, truncated address, optional address type badge, and balance.
+ * Address row for a hardware wallet account card.
  * @param options0
  * @param options0.address
  */

--- a/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.tsx
+++ b/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.tsx
@@ -14,7 +14,10 @@ import {
   TextVariant,
 } from '@metamask/design-system-react';
 import { shortenString } from '../../../helpers/utils/util';
-import type { HardwareAccountAddressRowProps } from './hardware-account-address-row.types';
+import {
+  HardwareWalletAddressIconTypes,
+  type HardwareAccountAddressRowProps,
+} from './hardware-account-address-row.types';
 
 /**
  * Address row for a hardware wallet account card.
@@ -32,7 +35,7 @@ export const HardwareAccountAddressRow = ({
   });
 
   const avatar =
-    address.iconType === 'token' ? (
+    address.iconType === HardwareWalletAddressIconTypes.Token ? (
       <AvatarToken
         name={address.networkName}
         src={address.iconUrl}

--- a/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.tsx
+++ b/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.tsx
@@ -2,8 +2,6 @@ import React from 'react';
 import {
   AvatarNetwork,
   AvatarNetworkSize,
-  AvatarToken,
-  AvatarTokenSize,
   Box,
   BoxAlignItems,
   BoxBackgroundColor,
@@ -14,10 +12,7 @@ import {
   TextVariant,
 } from '@metamask/design-system-react';
 import { shortenString } from '../../../helpers/utils/util';
-import {
-  HardwareWalletAddressIconTypes,
-  type HardwareAccountAddressRowProps,
-} from './hardware-account-address-row.types';
+import type { HardwareAccountAddressRowProps } from './hardware-account-address-row.types';
 
 /**
  * Address row for a hardware wallet account card.
@@ -34,21 +29,6 @@ export const HardwareAccountAddressRow = ({
     skipCharacterInEnd: false,
   });
 
-  const avatar =
-    address.iconType === HardwareWalletAddressIconTypes.Token ? (
-      <AvatarToken
-        name={address.networkName}
-        src={address.iconUrl}
-        size={AvatarTokenSize.Lg}
-      />
-    ) : (
-      <AvatarNetwork
-        name={address.networkName}
-        src={address.iconUrl}
-        size={AvatarNetworkSize.Lg}
-      />
-    );
-
   return (
     <Box
       flexDirection={BoxFlexDirection.Row}
@@ -57,7 +37,11 @@ export const HardwareAccountAddressRow = ({
       className="min-h-[46px] w-full"
       data-testid="hardware-account-address-row"
     >
-      {avatar}
+      <AvatarNetwork
+        name={address.networkName}
+        src={address.iconUrl}
+        size={AvatarNetworkSize.Lg}
+      />
       <Box flexDirection={BoxFlexDirection.Column} className="min-w-0 flex-1">
         <Box
           flexDirection={BoxFlexDirection.Row}

--- a/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.tsx
+++ b/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.tsx
@@ -1,0 +1,100 @@
+import React from 'react';
+import {
+  AvatarNetwork,
+  AvatarNetworkSize,
+  AvatarToken,
+  AvatarTokenSize,
+  Box,
+  BoxAlignItems,
+  BoxBackgroundColor,
+  BoxFlexDirection,
+  FontWeight,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react';
+import { shortenString } from '../../../helpers/utils/util';
+import type { HardwareAccountAddressRowProps } from './hardware-account-address-row.types';
+
+/**
+ * Displays a single blockchain address row within a hardware wallet account card,
+ * including network icon, name, truncated address, optional address type badge, and balance.
+ * @param options0
+ * @param options0.address
+ */
+export const HardwareAccountAddressRow = ({
+  address,
+}: HardwareAccountAddressRowProps) => {
+  const truncatedAddress = shortenString(address.address, {
+    truncatedStartChars: 5,
+    truncatedEndChars: 4,
+    truncatedCharLimit: 4,
+    skipCharacterInEnd: false,
+  });
+
+  const avatar =
+    address.iconType === 'token' ? (
+      <AvatarToken
+        name={address.networkName}
+        src={address.iconUrl}
+        size={AvatarTokenSize.Lg}
+      />
+    ) : (
+      <AvatarNetwork
+        name={address.networkName}
+        src={address.iconUrl}
+        size={AvatarNetworkSize.Lg}
+      />
+    );
+
+  return (
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      gap={4}
+      className="min-h-[46px] w-full"
+      data-testid="hardware-account-address-row"
+    >
+      {avatar}
+      <Box flexDirection={BoxFlexDirection.Column} className="min-w-0 flex-1">
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          className="min-w-0 gap-1.5"
+        >
+          <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+            {address.networkName}
+          </Text>
+          {address.addressType ? (
+            <Box
+              backgroundColor={BoxBackgroundColor.BackgroundMuted}
+              className="rounded px-1.5"
+            >
+              <Text
+                variant={TextVariant.BodyXs}
+                fontWeight={FontWeight.Medium}
+                color={TextColor.TextAlternative}
+              >
+                {address.addressType}
+              </Text>
+            </Box>
+          ) : null}
+        </Box>
+        <Text
+          variant={TextVariant.BodySm}
+          fontWeight={FontWeight.Medium}
+          color={TextColor.TextAlternative}
+        >
+          {truncatedAddress}
+        </Text>
+      </Box>
+      <Text
+        variant={TextVariant.BodyMd}
+        fontWeight={FontWeight.Medium}
+        className="shrink-0 text-right"
+      >
+        {address.balance}
+      </Text>
+    </Box>
+  );
+};

--- a/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.types.ts
+++ b/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.types.ts
@@ -1,0 +1,18 @@
+/** Avatar style used for a hardware wallet address row. */
+export type HardwareWalletAddressIconType = 'network' | 'token';
+
+/** Blockchain address displayed within a hardware wallet account card. */
+export type HardwareWalletAccountAddress = {
+  id: string;
+  networkName: string;
+  address: string;
+  balance: string;
+  iconUrl: string;
+  iconType?: HardwareWalletAddressIconType;
+  addressType?: string;
+};
+
+/** Props for {@link HardwareAccountAddressRow}. */
+export type HardwareAccountAddressRowProps = {
+  address: HardwareWalletAccountAddress;
+};

--- a/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.types.ts
+++ b/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.types.ts
@@ -1,21 +1,10 @@
-/** Icon type values for a hardware wallet address row avatar. */
-export const HardwareWalletAddressIconTypes = {
-  Network: 'network',
-  Token: 'token',
-} as const;
-
-/** Icon type for a hardware wallet address row avatar. */
-export type HardwareWalletAddressIconType =
-  (typeof HardwareWalletAddressIconTypes)[keyof typeof HardwareWalletAddressIconTypes];
-
-/** Address data for a row in a hardware wallet account card. */
+/** Address data for a network row in a hardware wallet account card. */
 export type HardwareWalletAccountAddress = {
   id: string;
   networkName: string;
   address: string;
   balance: string;
   iconUrl: string;
-  iconType?: HardwareWalletAddressIconType;
   addressType?: string;
 };
 

--- a/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.types.ts
+++ b/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.types.ts
@@ -1,7 +1,7 @@
-/** Avatar style used for a hardware wallet address row. */
+/** Icon type for a hardware wallet address row avatar. */
 export type HardwareWalletAddressIconType = 'network' | 'token';
 
-/** Blockchain address displayed within a hardware wallet account card. */
+/** Address data for a row in a hardware wallet account card. */
 export type HardwareWalletAccountAddress = {
   id: string;
   networkName: string;
@@ -12,7 +12,7 @@ export type HardwareWalletAccountAddress = {
   addressType?: string;
 };
 
-/** Props for {@link HardwareAccountAddressRow}. */
+/** Props for HardwareAccountAddressRow. */
 export type HardwareAccountAddressRowProps = {
   address: HardwareWalletAccountAddress;
 };

--- a/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.types.ts
+++ b/ui/components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.types.ts
@@ -1,5 +1,12 @@
+/** Icon type values for a hardware wallet address row avatar. */
+export const HardwareWalletAddressIconTypes = {
+  Network: 'network',
+  Token: 'token',
+} as const;
+
 /** Icon type for a hardware wallet address row avatar. */
-export type HardwareWalletAddressIconType = 'network' | 'token';
+export type HardwareWalletAddressIconType =
+  (typeof HardwareWalletAddressIconTypes)[keyof typeof HardwareWalletAddressIconTypes];
 
 /** Address data for a row in a hardware wallet account card. */
 export type HardwareWalletAccountAddress = {

--- a/ui/components/multichain-accounts/hardware-account-address-row/index.ts
+++ b/ui/components/multichain-accounts/hardware-account-address-row/index.ts
@@ -1,7 +1,5 @@
 export { HardwareAccountAddressRow } from './hardware-account-address-row';
-export {
-  HardwareWalletAddressIconTypes,
-  type HardwareAccountAddressRowProps,
-  type HardwareWalletAccountAddress,
-  type HardwareWalletAddressIconType,
+export type {
+  HardwareAccountAddressRowProps,
+  HardwareWalletAccountAddress,
 } from './hardware-account-address-row.types';

--- a/ui/components/multichain-accounts/hardware-account-address-row/index.ts
+++ b/ui/components/multichain-accounts/hardware-account-address-row/index.ts
@@ -1,0 +1,6 @@
+export { HardwareAccountAddressRow } from './hardware-account-address-row';
+export type {
+  HardwareAccountAddressRowProps,
+  HardwareWalletAccountAddress,
+  HardwareWalletAddressIconType,
+} from './hardware-account-address-row.types';

--- a/ui/components/multichain-accounts/hardware-account-address-row/index.ts
+++ b/ui/components/multichain-accounts/hardware-account-address-row/index.ts
@@ -1,6 +1,7 @@
 export { HardwareAccountAddressRow } from './hardware-account-address-row';
-export type {
-  HardwareAccountAddressRowProps,
-  HardwareWalletAccountAddress,
-  HardwareWalletAddressIconType,
+export {
+  HardwareWalletAddressIconTypes,
+  type HardwareAccountAddressRowProps,
+  type HardwareWalletAccountAddress,
+  type HardwareWalletAddressIconType,
 } from './hardware-account-address-row.types';

--- a/ui/components/multichain-accounts/hardware-account-card/hardware-account-card.stories.tsx
+++ b/ui/components/multichain-accounts/hardware-account-card/hardware-account-card.stories.tsx
@@ -1,44 +1,15 @@
 import React, { useState } from 'react';
 import type { Meta, StoryFn } from '@storybook/react';
-import { ETH_TOKEN_IMAGE_URL } from '../../../../shared/constants/network';
+import {
+  createHardwareWalletAccount,
+  createMockHardwareAccounts,
+} from '../../../../test/data/hardware-wallet-accounts';
 import { HardwareAccountCard } from './hardware-account-card';
-import type {
-  HardwareAccountCardProps,
-  HardwareWalletAccount,
-} from './hardware-account-card.types';
+import type { HardwareAccountCardProps } from './hardware-account-card.types';
 
-const account: HardwareWalletAccount = {
-  id: 'account-0',
-  name: 'Account 1',
-  totalBalance: '$360.00',
-  addresses: [
-    {
-      id: 'eth-0',
-      networkName: 'Ethereum',
-      address: '0x091234567890123456789012345678901234b272',
-      balance: '$120.00',
-      iconUrl: ETH_TOKEN_IMAGE_URL,
-      iconType: 'network',
-    },
-    {
-      id: 'sol-0',
-      networkName: 'Solana',
-      address: '6dk7RD1234567890abcdefghijklmnopqrstuvDEtXQ',
-      balance: '$120.00',
-      iconUrl: './images/solana-logo.svg',
-      iconType: 'network',
-    },
-    {
-      id: 'btc-0',
-      networkName: 'Bitcoin',
-      address: 'bc1qea1234567890abcdefghijklmnopqrstuvwer2fx',
-      balance: '$120.00',
-      iconUrl: './images/bitcoin-logo.svg',
-      iconType: 'token',
-      addressType: 'Taproot',
-    },
-  ],
-};
+const account = createMockHardwareAccounts(1, {
+  includeMultichainAddresses: true,
+})[0];
 
 type HardwareAccountCardStoryProps = Omit<
   HardwareAccountCardProps,
@@ -84,14 +55,7 @@ export const Unchecked: StoryFn<HardwareAccountCardStoryProps> = (args) => (
 );
 
 export const EthereumOnly: StoryFn<HardwareAccountCardStoryProps> = (args) => (
-  <HardwareAccountCardStory
-    {...args}
-    account={{
-      ...account,
-      totalBalance: '$120.00',
-      addresses: [account.addresses[0]],
-    }}
-  />
+  <HardwareAccountCardStory {...args} account={createHardwareWalletAccount()} />
 );
 
 export const AlreadyConnected: StoryFn<HardwareAccountCardStoryProps> = (

--- a/ui/components/multichain-accounts/hardware-account-card/hardware-account-card.stories.tsx
+++ b/ui/components/multichain-accounts/hardware-account-card/hardware-account-card.stories.tsx
@@ -1,0 +1,106 @@
+import React, { useState } from 'react';
+import type { Meta, StoryFn } from '@storybook/react';
+import { ETH_TOKEN_IMAGE_URL } from '../../../../shared/constants/network';
+import { HardwareAccountCard } from './hardware-account-card';
+import type {
+  HardwareAccountCardProps,
+  HardwareWalletAccount,
+} from './hardware-account-card.types';
+
+const account: HardwareWalletAccount = {
+  id: 'account-0',
+  name: 'Account 1',
+  totalBalance: '$360.00',
+  addresses: [
+    {
+      id: 'eth-0',
+      networkName: 'Ethereum',
+      address: '0x091234567890123456789012345678901234b272',
+      balance: '$120.00',
+      iconUrl: ETH_TOKEN_IMAGE_URL,
+      iconType: 'network',
+    },
+    {
+      id: 'sol-0',
+      networkName: 'Solana',
+      address: '6dk7RD1234567890abcdefghijklmnopqrstuvDEtXQ',
+      balance: '$120.00',
+      iconUrl: './images/solana-logo.svg',
+      iconType: 'network',
+    },
+    {
+      id: 'btc-0',
+      networkName: 'Bitcoin',
+      address: 'bc1qea1234567890abcdefghijklmnopqrstuvwer2fx',
+      balance: '$120.00',
+      iconUrl: './images/bitcoin-logo.svg',
+      iconType: 'token',
+      addressType: 'Taproot',
+    },
+  ],
+};
+
+type HardwareAccountCardStoryProps = Omit<
+  HardwareAccountCardProps,
+  'isSelected' | 'onToggleSelection'
+> & {
+  initialSelected?: boolean;
+};
+
+const HardwareAccountCardStory = ({
+  initialSelected = false,
+  account: accountProp,
+}: HardwareAccountCardStoryProps) => {
+  const [isSelected, setIsSelected] = useState(initialSelected);
+
+  return (
+    <HardwareAccountCard
+      account={accountProp}
+      isSelected={isSelected}
+      onToggleSelection={() => {
+        setIsSelected((previousValue) => !previousValue);
+      }}
+    />
+  );
+};
+
+export default {
+  title: 'Components/MultichainAccounts/HardwareAccountCard',
+  component: HardwareAccountCard,
+  args: {
+    account,
+    initialSelected: true,
+  },
+} as Meta<HardwareAccountCardStoryProps>;
+
+export const DefaultStory: StoryFn<HardwareAccountCardStoryProps> = (args) => (
+  <HardwareAccountCardStory {...args} />
+);
+
+DefaultStory.storyName = 'Default';
+
+export const Unchecked: StoryFn<HardwareAccountCardStoryProps> = (args) => (
+  <HardwareAccountCardStory {...args} initialSelected={false} />
+);
+
+export const EthereumOnly: StoryFn<HardwareAccountCardStoryProps> = (args) => (
+  <HardwareAccountCardStory
+    {...args}
+    account={{
+      ...account,
+      totalBalance: '$120.00',
+      addresses: [account.addresses[0]],
+    }}
+  />
+);
+
+export const AlreadyConnected: StoryFn<HardwareAccountCardStoryProps> = (
+  args,
+) => (
+  <HardwareAccountCard
+    {...args}
+    account={{ ...account, isAlreadyConnected: true }}
+    isSelected={false}
+    onToggleSelection={() => undefined}
+  />
+);

--- a/ui/components/multichain-accounts/hardware-account-card/hardware-account-card.test.tsx
+++ b/ui/components/multichain-accounts/hardware-account-card/hardware-account-card.test.tsx
@@ -1,144 +1,145 @@
 import React from 'react';
 import { fireEvent, screen } from '@testing-library/react';
-import { ETH_TOKEN_IMAGE_URL } from '../../../../shared/constants/network';
+import { createHardwareWalletAccount } from '../../../../test/data/hardware-wallet-accounts';
 import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
-import type { HardwareWalletAccount } from './hardware-account-card.types';
+import type { HardwareAccountCardProps } from './hardware-account-card.types';
 import { HardwareAccountCard } from './hardware-account-card';
 
-describe('HardwareAccountCard', () => {
-  const account: HardwareWalletAccount = {
-    id: 'account-0',
-    name: 'Account 1',
-    totalBalance: '$120.00',
-    addresses: [
-      {
-        id: 'eth-0',
-        networkName: 'Ethereum',
-        address: '0x091234567890123456789012345678901234b272',
-        balance: '$120.00',
-        iconUrl: ETH_TOKEN_IMAGE_URL,
-        iconType: 'network',
-      },
-    ],
+const defaultAccount = createHardwareWalletAccount();
+
+const renderCard = (props: Partial<HardwareAccountCardProps> = {}) => {
+  const onToggleSelection = props.onToggleSelection ?? jest.fn();
+
+  return {
+    onToggleSelection,
+    ...renderWithProvider(
+      <HardwareAccountCard
+        account={defaultAccount}
+        isSelected={false}
+        onToggleSelection={onToggleSelection}
+        {...props}
+      />,
+    ),
   };
+};
 
-  it('renders account details and toggles selection from the checkbox', () => {
-    const onToggleSelection = jest.fn();
+describe('HardwareAccountCard', () => {
+  describe('rendering', () => {
+    it('renders account name, total balance, and address rows', () => {
+      renderCard();
 
-    renderWithProvider(
-      <HardwareAccountCard
-        account={account}
-        isSelected={false}
-        onToggleSelection={onToggleSelection}
-      />,
-    );
+      expect(screen.getByText('Account 1')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('hardware-account-card-total-balance'),
+      ).toHaveTextContent('$120.00');
+      expect(
+        screen.getAllByTestId('hardware-account-address-row'),
+      ).toHaveLength(1);
+    });
 
-    expect(screen.getByText('Account 1')).toBeInTheDocument();
-    expect(
-      screen.getByTestId('hardware-account-card-total-balance'),
-    ).toHaveTextContent('$120.00');
+    it('marks the card as selected when isSelected is true', () => {
+      renderCard({ isSelected: true });
 
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Account 1' }));
+      expect(screen.getByTestId('hardware-account-card')).toHaveAttribute(
+        'data-selected',
+        'true',
+      );
+    });
 
-    expect(onToggleSelection).toHaveBeenCalledWith('account-0');
+    it('marks the card as unselected when isSelected is false', () => {
+      renderCard({ isSelected: false });
+
+      expect(screen.getByTestId('hardware-account-card')).toHaveAttribute(
+        'data-selected',
+        'false',
+      );
+    });
+
+    it('does not set a tooltip title when the account is selectable', () => {
+      renderCard();
+
+      expect(screen.getByTestId('hardware-account-card')).not.toHaveAttribute(
+        'title',
+      );
+    });
   });
 
-  it('toggles selection when the account header is clicked', () => {
-    const onToggleSelection = jest.fn();
+  describe('selection', () => {
+    it('calls onToggleSelection when the checkbox is clicked', () => {
+      const { onToggleSelection } = renderCard();
 
-    renderWithProvider(
-      <HardwareAccountCard
-        account={account}
-        isSelected={false}
-        onToggleSelection={onToggleSelection}
-      />,
-    );
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Account 1' }));
 
-    fireEvent.click(screen.getByTestId('hardware-account-card-header'));
+      expect(onToggleSelection).toHaveBeenCalledTimes(1);
+      expect(onToggleSelection).toHaveBeenCalledWith('account-0');
+    });
 
-    expect(onToggleSelection).toHaveBeenCalledWith('account-0');
+    it('calls onToggleSelection when the header is clicked', () => {
+      const { onToggleSelection } = renderCard();
+
+      fireEvent.click(screen.getByTestId('hardware-account-card-header'));
+
+      expect(onToggleSelection).toHaveBeenCalledTimes(1);
+      expect(onToggleSelection).toHaveBeenCalledWith('account-0');
+    });
+
+    it('calls onToggleSelection when Enter is pressed on the header', () => {
+      const { onToggleSelection } = renderCard();
+
+      fireEvent.keyDown(screen.getByTestId('hardware-account-card-header'), {
+        key: 'Enter',
+      });
+
+      expect(onToggleSelection).toHaveBeenCalledTimes(1);
+      expect(onToggleSelection).toHaveBeenCalledWith('account-0');
+    });
+
+    it('calls onToggleSelection when Space is pressed on the header', () => {
+      const { onToggleSelection } = renderCard();
+
+      fireEvent.keyDown(screen.getByTestId('hardware-account-card-header'), {
+        key: ' ',
+      });
+
+      expect(onToggleSelection).toHaveBeenCalledTimes(1);
+      expect(onToggleSelection).toHaveBeenCalledWith('account-0');
+    });
   });
 
-  it('toggles selection when the account name is clicked', () => {
-    const onToggleSelection = jest.fn();
+  describe('already connected accounts', () => {
+    const connectedAccount = createHardwareWalletAccount({
+      isAlreadyConnected: true,
+    });
 
-    renderWithProvider(
-      <HardwareAccountCard
-        account={account}
-        isSelected={false}
-        onToggleSelection={onToggleSelection}
-      />,
-    );
+    it('disables selection and shows an already connected tooltip', () => {
+      const onToggleSelection = jest.fn();
 
-    fireEvent.click(screen.getByText('Account 1'));
+      renderCard({
+        account: connectedAccount,
+        onToggleSelection,
+      });
 
-    expect(onToggleSelection).toHaveBeenCalledWith('account-0');
-  });
+      expect(
+        screen.getByRole('checkbox', { name: 'Account 1' }),
+      ).toBeDisabled();
+      expect(
+        screen.getByTitle(messages.selectAnAccountAlreadyConnected.message),
+      ).toBeInTheDocument();
 
-  it('applies selected styling when selected', () => {
-    renderWithProvider(
-      <HardwareAccountCard
-        account={account}
-        isSelected
-        onToggleSelection={jest.fn()}
-      />,
-    );
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Account 1' }));
+      fireEvent.click(screen.getByTestId('hardware-account-card-header'));
 
-    expect(screen.getByTestId('hardware-account-card')).toHaveAttribute(
-      'data-selected',
-      'true',
-    );
-  });
+      expect(onToggleSelection).not.toHaveBeenCalled();
+    });
 
-  it('disables selection for already connected accounts', () => {
-    const onToggleSelection = jest.fn();
+    it('renders the checkbox as checked even when isSelected is false', () => {
+      renderCard({
+        account: connectedAccount,
+        isSelected: false,
+      });
 
-    renderWithProvider(
-      <HardwareAccountCard
-        account={{ ...account, isAlreadyConnected: true }}
-        isSelected={false}
-        onToggleSelection={onToggleSelection}
-      />,
-    );
-
-    expect(screen.getByRole('checkbox', { name: 'Account 1' })).toBeDisabled();
-    expect(
-      screen.getByTitle(messages.selectAnAccountAlreadyConnected.message),
-    ).toBeInTheDocument();
-
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Account 1' }));
-    fireEvent.click(screen.getByTestId('hardware-account-card-header'));
-
-    expect(onToggleSelection).not.toHaveBeenCalled();
-  });
-
-  it('does not apply selected styling when unselected', () => {
-    renderWithProvider(
-      <HardwareAccountCard
-        account={account}
-        isSelected={false}
-        onToggleSelection={jest.fn()}
-      />,
-    );
-
-    expect(screen.getByTestId('hardware-account-card')).toHaveAttribute(
-      'data-selected',
-      'false',
-    );
-  });
-
-  it('does not set a title when the account is selectable', () => {
-    renderWithProvider(
-      <HardwareAccountCard
-        account={account}
-        isSelected={false}
-        onToggleSelection={jest.fn()}
-      />,
-    );
-
-    expect(screen.getByTestId('hardware-account-card')).not.toHaveAttribute(
-      'title',
-    );
+      expect(screen.getByRole('checkbox', { name: 'Account 1' })).toBeChecked();
+    });
   });
 });

--- a/ui/components/multichain-accounts/hardware-account-card/hardware-account-card.test.tsx
+++ b/ui/components/multichain-accounts/hardware-account-card/hardware-account-card.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+import { ETH_TOKEN_IMAGE_URL } from '../../../../shared/constants/network';
+import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import type { HardwareWalletAccount } from './hardware-account-card.types';
+import { HardwareAccountCard } from './hardware-account-card';
+
+describe('HardwareAccountCard', () => {
+  const account: HardwareWalletAccount = {
+    id: 'account-0',
+    name: 'Account 1',
+    totalBalance: '$120.00',
+    addresses: [
+      {
+        id: 'eth-0',
+        networkName: 'Ethereum',
+        address: '0x091234567890123456789012345678901234b272',
+        balance: '$120.00',
+        iconUrl: ETH_TOKEN_IMAGE_URL,
+        iconType: 'network',
+      },
+    ],
+  };
+
+  it('renders account details and toggles selection from the checkbox', () => {
+    const onToggleSelection = jest.fn();
+
+    renderWithProvider(
+      <HardwareAccountCard
+        account={account}
+        isSelected={false}
+        onToggleSelection={onToggleSelection}
+      />,
+    );
+
+    expect(screen.getByText('Account 1')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('hardware-account-card-total-balance'),
+    ).toHaveTextContent('$120.00');
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Account 1' }));
+
+    expect(onToggleSelection).toHaveBeenCalledWith('account-0');
+  });
+
+  it('toggles selection when the account header is clicked', () => {
+    const onToggleSelection = jest.fn();
+
+    renderWithProvider(
+      <HardwareAccountCard
+        account={account}
+        isSelected={false}
+        onToggleSelection={onToggleSelection}
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('hardware-account-card-header'));
+
+    expect(onToggleSelection).toHaveBeenCalledWith('account-0');
+  });
+
+  it('toggles selection when the account name is clicked', () => {
+    const onToggleSelection = jest.fn();
+
+    renderWithProvider(
+      <HardwareAccountCard
+        account={account}
+        isSelected={false}
+        onToggleSelection={onToggleSelection}
+      />,
+    );
+
+    fireEvent.click(screen.getByText('Account 1'));
+
+    expect(onToggleSelection).toHaveBeenCalledWith('account-0');
+  });
+
+  it('applies selected styling when selected', () => {
+    renderWithProvider(
+      <HardwareAccountCard
+        account={account}
+        isSelected
+        onToggleSelection={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('hardware-account-card')).toHaveAttribute(
+      'data-selected',
+      'true',
+    );
+  });
+
+  it('disables selection for already connected accounts', () => {
+    const onToggleSelection = jest.fn();
+
+    renderWithProvider(
+      <HardwareAccountCard
+        account={{ ...account, isAlreadyConnected: true }}
+        isSelected={false}
+        onToggleSelection={onToggleSelection}
+      />,
+    );
+
+    expect(
+      screen.getByRole('checkbox', { name: 'Account 1' }),
+    ).toBeDisabled();
+    expect(
+      screen.getByTitle(messages.selectAnAccountAlreadyConnected.message),
+    ).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Account 1' }));
+    fireEvent.click(screen.getByTestId('hardware-account-card-header'));
+
+    expect(onToggleSelection).not.toHaveBeenCalled();
+  });
+
+  it('does not apply selected styling when unselected', () => {
+    renderWithProvider(
+      <HardwareAccountCard
+        account={account}
+        isSelected={false}
+        onToggleSelection={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('hardware-account-card')).toHaveAttribute(
+      'data-selected',
+      'false',
+    );
+  });
+
+  it('does not set a title when the account is selectable', () => {
+    renderWithProvider(
+      <HardwareAccountCard
+        account={account}
+        isSelected={false}
+        onToggleSelection={jest.fn()}
+      />,
+    );
+
+    expect(screen.getByTestId('hardware-account-card')).not.toHaveAttribute(
+      'title',
+    );
+  });
+});

--- a/ui/components/multichain-accounts/hardware-account-card/hardware-account-card.test.tsx
+++ b/ui/components/multichain-accounts/hardware-account-card/hardware-account-card.test.tsx
@@ -102,9 +102,7 @@ describe('HardwareAccountCard', () => {
       />,
     );
 
-    expect(
-      screen.getByRole('checkbox', { name: 'Account 1' }),
-    ).toBeDisabled();
+    expect(screen.getByRole('checkbox', { name: 'Account 1' })).toBeDisabled();
     expect(
       screen.getByTitle(messages.selectAnAccountAlreadyConnected.message),
     ).toBeInTheDocument();

--- a/ui/components/multichain-accounts/hardware-account-card/hardware-account-card.test.tsx
+++ b/ui/components/multichain-accounts/hardware-account-card/hardware-account-card.test.tsx
@@ -133,6 +133,21 @@ describe('HardwareAccountCard', () => {
       expect(onToggleSelection).not.toHaveBeenCalled();
     });
 
+    it('does not toggle selection when Enter is pressed on a disabled header', () => {
+      const onToggleSelection = jest.fn();
+
+      renderCard({
+        account: connectedAccount,
+        onToggleSelection,
+      });
+
+      fireEvent.keyDown(screen.getByTestId('hardware-account-card-header'), {
+        key: 'Enter',
+      });
+
+      expect(onToggleSelection).not.toHaveBeenCalled();
+    });
+
     it('renders the checkbox as checked even when isSelected is false', () => {
       renderCard({
         account: connectedAccount,

--- a/ui/components/multichain-accounts/hardware-account-card/hardware-account-card.tsx
+++ b/ui/components/multichain-accounts/hardware-account-card/hardware-account-card.tsx
@@ -1,0 +1,110 @@
+import React, { useCallback } from 'react';
+import {
+  Box,
+  BoxAlignItems,
+  BoxBackgroundColor,
+  BoxBorderColor,
+  BoxFlexDirection,
+  Checkbox,
+  FontWeight,
+  Text,
+  TextColor,
+  TextVariant,
+} from '@metamask/design-system-react';
+import { HardwareAccountAddressRow } from '../hardware-account-address-row';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import type { HardwareAccountCardProps } from './hardware-account-card.types';
+
+/**
+ * Selectable multichain account card used during hardware wallet onboarding.
+ * Renders account name, total balance, checkbox, and nested address rows.
+ * @param options0
+ * @param options0.account
+ * @param options0.isSelected
+ * @param options0.onToggleSelection
+ */
+export const HardwareAccountCard = ({
+  account,
+  isSelected,
+  onToggleSelection,
+}: HardwareAccountCardProps) => {
+  const t = useI18nContext();
+  const isDisabled = Boolean(account.isAlreadyConnected);
+
+  const handleToggleSelection = useCallback(() => {
+    if (isDisabled) {
+      return;
+    }
+    onToggleSelection(account.id);
+  }, [account.id, isDisabled, onToggleSelection]);
+
+  return (
+    <Box
+      flexDirection={BoxFlexDirection.Column}
+      gap={3}
+      paddingTop={3}
+      paddingBottom={3}
+      paddingLeft={4}
+      paddingRight={4}
+      backgroundColor={BoxBackgroundColor.BackgroundMuted}
+      borderColor={BoxBorderColor.BorderMuted}
+      borderWidth={isSelected ? 1 : 0}
+      className="w-full rounded-xl"
+      data-testid="hardware-account-card"
+      data-selected={isSelected}
+      title={
+        isDisabled ? (t('selectAnAccountAlreadyConnected') as string) : undefined
+      }
+    >
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        className="w-full"
+      >
+        <Box
+          flexDirection={BoxFlexDirection.Column}
+          className={`min-w-0 flex-1 ${isDisabled ? '' : 'cursor-pointer'}`}
+          data-testid="hardware-account-card-header"
+          onClick={isDisabled ? undefined : handleToggleSelection}
+          onKeyDown={
+            isDisabled
+              ? undefined
+              : (event) => {
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    handleToggleSelection();
+                  }
+                }
+          }
+          role={isDisabled ? undefined : 'button'}
+          tabIndex={isDisabled ? undefined : 0}
+        >
+          <Text variant={TextVariant.BodyMd} fontWeight={FontWeight.Medium}>
+            {account.name}
+          </Text>
+          <Text
+            variant={TextVariant.BodySm}
+            fontWeight={FontWeight.Medium}
+            color={TextColor.TextAlternative}
+            data-testid="hardware-account-card-total-balance"
+          >
+            {account.totalBalance}
+          </Text>
+        </Box>
+        <Checkbox
+          id={`hardware-account-${account.id}`}
+          isSelected={isSelected || isDisabled}
+          isDisabled={isDisabled}
+          onChange={handleToggleSelection}
+          aria-label={account.name}
+        />
+      </Box>
+      <Box className="h-px w-full bg-border-muted" />
+      <Box flexDirection={BoxFlexDirection.Column} gap={2} className="w-full">
+        {account.addresses.map((address) => (
+          <HardwareAccountAddressRow key={address.id} address={address} />
+        ))}
+      </Box>
+    </Box>
+  );
+};

--- a/ui/components/multichain-accounts/hardware-account-card/hardware-account-card.tsx
+++ b/ui/components/multichain-accounts/hardware-account-card/hardware-account-card.tsx
@@ -16,8 +16,7 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import type { HardwareAccountCardProps } from './hardware-account-card.types';
 
 /**
- * Selectable multichain account card used during hardware wallet onboarding.
- * Renders account name, total balance, checkbox, and nested address rows.
+ * Account card for hardware wallet onboarding with selection and address rows.
  * @param options0
  * @param options0.account
  * @param options0.isSelected

--- a/ui/components/multichain-accounts/hardware-account-card/hardware-account-card.tsx
+++ b/ui/components/multichain-accounts/hardware-account-card/hardware-account-card.tsx
@@ -53,7 +53,9 @@ export const HardwareAccountCard = ({
       data-testid="hardware-account-card"
       data-selected={isSelected}
       title={
-        isDisabled ? (t('selectAnAccountAlreadyConnected') as string) : undefined
+        isDisabled
+          ? (t('selectAnAccountAlreadyConnected') as string)
+          : undefined
       }
     >
       <Box

--- a/ui/components/multichain-accounts/hardware-account-card/hardware-account-card.types.ts
+++ b/ui/components/multichain-accounts/hardware-account-card/hardware-account-card.types.ts
@@ -1,6 +1,6 @@
 import type { HardwareWalletAccountAddress } from '../hardware-account-address-row';
 
-/** Multichain account option shown during hardware wallet onboarding. */
+/** Hardware wallet account available for import during onboarding. */
 export type HardwareWalletAccount = {
   id: string;
   name: string;
@@ -9,7 +9,7 @@ export type HardwareWalletAccount = {
   isAlreadyConnected?: boolean;
 };
 
-/** Props for {@link HardwareAccountCard}. */
+/** Props for HardwareAccountCard. */
 export type HardwareAccountCardProps = {
   account: HardwareWalletAccount;
   isSelected: boolean;

--- a/ui/components/multichain-accounts/hardware-account-card/hardware-account-card.types.ts
+++ b/ui/components/multichain-accounts/hardware-account-card/hardware-account-card.types.ts
@@ -1,0 +1,17 @@
+import type { HardwareWalletAccountAddress } from '../hardware-account-address-row';
+
+/** Multichain account option shown during hardware wallet onboarding. */
+export type HardwareWalletAccount = {
+  id: string;
+  name: string;
+  totalBalance: string;
+  addresses: HardwareWalletAccountAddress[];
+  isAlreadyConnected?: boolean;
+};
+
+/** Props for {@link HardwareAccountCard}. */
+export type HardwareAccountCardProps = {
+  account: HardwareWalletAccount;
+  isSelected: boolean;
+  onToggleSelection: (accountId: string) => void;
+};

--- a/ui/components/multichain-accounts/hardware-account-card/index.ts
+++ b/ui/components/multichain-accounts/hardware-account-card/index.ts
@@ -1,0 +1,5 @@
+export { HardwareAccountCard } from './hardware-account-card';
+export type {
+  HardwareAccountCardProps,
+  HardwareWalletAccount,
+} from './hardware-account-card.types';

--- a/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/index.ts
+++ b/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/index.ts
@@ -9,5 +9,4 @@ export type {
 export type {
   HardwareAccountAddressRowProps,
   HardwareWalletAccountAddress,
-  HardwareWalletAddressIconType,
 } from '../../../../components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.types';

--- a/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/index.ts
+++ b/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/index.ts
@@ -1,9 +1,13 @@
 export { SelectHardwareAccountsPage } from './select-hardware-accounts-page';
-export type {
-  HardwareWalletAccount,
-  HardwareWalletAccountAddress,
-  HardwareWalletAddressIconType,
-  SelectHardwareAccountsPageProps,
-} from './select-hardware-accounts-page.types';
+export type { SelectHardwareAccountsPageProps } from './select-hardware-accounts-page.types';
 export { HardwareAccountCard } from '../../../../components/multichain-accounts/hardware-account-card';
 export { HardwareAccountAddressRow } from '../../../../components/multichain-accounts/hardware-account-address-row';
+export type {
+  HardwareAccountCardProps,
+  HardwareWalletAccount,
+} from '../../../../components/multichain-accounts/hardware-account-card/hardware-account-card.types';
+export type {
+  HardwareAccountAddressRowProps,
+  HardwareWalletAccountAddress,
+  HardwareWalletAddressIconType,
+} from '../../../../components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.types';

--- a/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/index.ts
+++ b/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/index.ts
@@ -1,0 +1,9 @@
+export { SelectHardwareAccountsPage } from './select-hardware-accounts-page';
+export type {
+  HardwareWalletAccount,
+  HardwareWalletAccountAddress,
+  HardwareWalletAddressIconType,
+  SelectHardwareAccountsPageProps,
+} from './select-hardware-accounts-page.types';
+export { HardwareAccountCard } from '../../../../components/multichain-accounts/hardware-account-card';
+export { HardwareAccountAddressRow } from '../../../../components/multichain-accounts/hardware-account-address-row';

--- a/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/select-hardware-accounts-page.stories.tsx
+++ b/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/select-hardware-accounts-page.stories.tsx
@@ -133,16 +133,22 @@ export const MultichainAccounts: StoryFn<typeof SelectHardwareAccountsPage> = (
 
 export const WithAlreadyConnectedAccount: StoryFn<
   typeof SelectHardwareAccountsPage
-> = (args) => (
-  <SelectHardwareAccountsPageStory
-    {...args}
-    accounts={createMockHardwareAccounts(2, {
-      includeMultichainAddresses: true,
-    })}
-    selectedAccountIds={['account-0']}
-    hasMoreAccounts={true}
-  />
-);
+> = (args) => {
+  const accounts = createMockHardwareAccounts(2, {
+    includeMultichainAddresses: true,
+  }).map((account, index) =>
+    index === 1 ? { ...account, isAlreadyConnected: true } : account,
+  );
+
+  return (
+    <SelectHardwareAccountsPageStory
+      {...args}
+      accounts={accounts}
+      selectedAccountIds={['account-0']}
+      hasMoreAccounts={true}
+    />
+  );
+};
 
 export const LoadingMoreAccounts: StoryFn<typeof SelectHardwareAccountsPage> = (
   args,

--- a/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/select-hardware-accounts-page.stories.tsx
+++ b/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/select-hardware-accounts-page.stories.tsx
@@ -118,9 +118,9 @@ export const EthereumOnlyAccounts: StoryFn<
   />
 );
 
-export const MultichainAccounts: StoryFn<
-  typeof SelectHardwareAccountsPage
-> = (args) => (
+export const MultichainAccounts: StoryFn<typeof SelectHardwareAccountsPage> = (
+  args,
+) => (
   <SelectHardwareAccountsPageStory
     {...args}
     accounts={createMockHardwareAccounts(3, {
@@ -144,9 +144,9 @@ export const WithAlreadyConnectedAccount: StoryFn<
   />
 );
 
-export const LoadingMoreAccounts: StoryFn<
-  typeof SelectHardwareAccountsPage
-> = (args) => (
+export const LoadingMoreAccounts: StoryFn<typeof SelectHardwareAccountsPage> = (
+  args,
+) => (
   <SelectHardwareAccountsPageStory
     {...args}
     accounts={FIGMA_DEFAULT_ACCOUNTS}
@@ -165,9 +165,9 @@ export const WithoutSettingsButton: StoryFn<
   />
 );
 
-export const FullscreenLayout: StoryFn<
-  typeof SelectHardwareAccountsPage
-> = (args) => (
+export const FullscreenLayout: StoryFn<typeof SelectHardwareAccountsPage> = (
+  args,
+) => (
   <div style={{ width: '100%', minHeight: '100vh' }}>
     <SelectHardwareAccountsPageStory {...args} />
   </div>

--- a/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/select-hardware-accounts-page.stories.tsx
+++ b/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/select-hardware-accounts-page.stories.tsx
@@ -1,0 +1,176 @@
+import React, { useMemo, useState } from 'react';
+import type { Meta, StoryFn } from '@storybook/react';
+import { createMockHardwareAccounts } from '../../../../../test/data/hardware-wallet-accounts';
+import { SelectHardwareAccountsPage } from './select-hardware-accounts-page';
+import type { SelectHardwareAccountsPageProps } from './select-hardware-accounts-page.types';
+
+const FIGMA_DEFAULT_ACCOUNTS = createMockHardwareAccounts(2, {
+  includeMultichainAddresses: true,
+});
+
+const SelectHardwareAccountsPageStory = (
+  args: SelectHardwareAccountsPageProps,
+) => {
+  const [selectedAccountIds, setSelectedAccountIds] = useState(
+    args.selectedAccountIds,
+  );
+
+  return (
+    <SelectHardwareAccountsPage
+      {...args}
+      selectedAccountIds={selectedAccountIds}
+      onAccountSelectionChange={setSelectedAccountIds}
+    />
+  );
+};
+
+const SelectHardwareAccountsPageWithPaginationStory = (
+  args: Omit<SelectHardwareAccountsPageProps, 'accounts' | 'hasMoreAccounts'>,
+) => {
+  const allAccounts = useMemo(
+    () =>
+      createMockHardwareAccounts(10, {
+        includeMultichainAddresses: true,
+      }),
+    [],
+  );
+  const [visibleAccountCount, setVisibleAccountCount] = useState(2);
+  const [selectedAccountIds, setSelectedAccountIds] = useState(
+    args.selectedAccountIds,
+  );
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+
+  const accounts = allAccounts.slice(0, visibleAccountCount);
+  const hasMoreAccounts = visibleAccountCount < allAccounts.length;
+
+  const handleShowMore = () => {
+    setIsLoadingMore(true);
+    window.setTimeout(() => {
+      setVisibleAccountCount((currentCount) =>
+        Math.min(currentCount + 5, allAccounts.length),
+      );
+      setIsLoadingMore(false);
+    }, 600);
+  };
+
+  return (
+    <SelectHardwareAccountsPage
+      {...args}
+      accounts={accounts}
+      selectedAccountIds={selectedAccountIds}
+      onAccountSelectionChange={setSelectedAccountIds}
+      hasMoreAccounts={hasMoreAccounts}
+      isLoadingMore={isLoadingMore}
+      onShowMore={handleShowMore}
+    />
+  );
+};
+
+export default {
+  title: 'Pages/CreateAccount/ConnectHardware/SelectHardwareAccountsPage',
+  component: SelectHardwareAccountsPage,
+  decorators: [
+    (Story: StoryFn) => (
+      <div style={{ width: '460px', minHeight: '800px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  argTypes: {
+    onBack: { action: 'onBack' },
+    onShowMore: { action: 'onShowMore' },
+    onContinue: { action: 'onContinue' },
+    onForgetDevice: { action: 'onForgetDevice' },
+    onSettingsClick: { action: 'onSettingsClick' },
+    onAccountSelectionChange: { action: 'onAccountSelectionChange' },
+  },
+  args: {
+    accounts: FIGMA_DEFAULT_ACCOUNTS,
+    selectedAccountIds: ['account-0'],
+    hasMoreAccounts: true,
+    isLoadingMore: false,
+    showSettingsButton: true,
+  },
+} as Meta<typeof SelectHardwareAccountsPage>;
+
+export const DefaultStory: StoryFn<typeof SelectHardwareAccountsPage> = (
+  args,
+) => <SelectHardwareAccountsPageStory {...args} />;
+
+DefaultStory.storyName = 'Default';
+
+export const WithShowMore: StoryFn<typeof SelectHardwareAccountsPage> = (
+  args,
+) => <SelectHardwareAccountsPageWithPaginationStory {...args} />;
+
+WithShowMore.storyName = 'With Show More Pagination';
+
+export const EthereumOnlyAccounts: StoryFn<
+  typeof SelectHardwareAccountsPage
+> = (args) => (
+  <SelectHardwareAccountsPageStory
+    {...args}
+    accounts={createMockHardwareAccounts(2, {
+      includeMultichainAddresses: false,
+    })}
+    selectedAccountIds={[]}
+    hasMoreAccounts={true}
+  />
+);
+
+export const MultichainAccounts: StoryFn<
+  typeof SelectHardwareAccountsPage
+> = (args) => (
+  <SelectHardwareAccountsPageStory
+    {...args}
+    accounts={createMockHardwareAccounts(3, {
+      includeMultichainAddresses: true,
+    })}
+    selectedAccountIds={['account-0', 'account-1']}
+    hasMoreAccounts={true}
+  />
+);
+
+export const WithAlreadyConnectedAccount: StoryFn<
+  typeof SelectHardwareAccountsPage
+> = (args) => (
+  <SelectHardwareAccountsPageStory
+    {...args}
+    accounts={createMockHardwareAccounts(2, {
+      includeMultichainAddresses: true,
+    })}
+    selectedAccountIds={['account-0']}
+    hasMoreAccounts={true}
+  />
+);
+
+export const LoadingMoreAccounts: StoryFn<
+  typeof SelectHardwareAccountsPage
+> = (args) => (
+  <SelectHardwareAccountsPageStory
+    {...args}
+    accounts={FIGMA_DEFAULT_ACCOUNTS}
+    hasMoreAccounts={true}
+    isLoadingMore={true}
+  />
+);
+
+export const WithoutSettingsButton: StoryFn<
+  typeof SelectHardwareAccountsPage
+> = (args) => (
+  <SelectHardwareAccountsPageStory
+    {...args}
+    showSettingsButton={false}
+    onSettingsClick={undefined}
+  />
+);
+
+export const FullscreenLayout: StoryFn<
+  typeof SelectHardwareAccountsPage
+> = (args) => (
+  <div style={{ width: '100%', minHeight: '100vh' }}>
+    <SelectHardwareAccountsPageStory {...args} />
+  </div>
+);
+
+FullscreenLayout.decorators = [];

--- a/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/select-hardware-accounts-page.test.tsx
+++ b/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/select-hardware-accounts-page.test.tsx
@@ -123,7 +123,9 @@ describe('SelectHardwareAccountsPage', () => {
   });
 
   it('calls onContinue with selected account ids', () => {
-    const { props } = render({ selectedAccountIds: ['account-0', 'account-1'] });
+    const { props } = render({
+      selectedAccountIds: ['account-0', 'account-1'],
+    });
 
     fireEvent.click(
       screen.getByTestId('select-hardware-accounts-page-continue-button'),

--- a/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/select-hardware-accounts-page.test.tsx
+++ b/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/select-hardware-accounts-page.test.tsx
@@ -23,15 +23,15 @@ const defaultProps: SelectHardwareAccountsPageProps = {
   showSettingsButton: true,
 };
 
-const render = (props: Partial<SelectHardwareAccountsPageProps> = {}) => {
-  const mergedProps = {
+const renderPage = (props: Partial<SelectHardwareAccountsPageProps> = {}) => {
+  const mergedProps: SelectHardwareAccountsPageProps = {
     ...defaultProps,
     ...props,
   };
 
   return {
-    ...renderWithProvider(<SelectHardwareAccountsPage {...mergedProps} />),
     props: mergedProps,
+    ...renderWithProvider(<SelectHardwareAccountsPage {...mergedProps} />),
   };
 };
 
@@ -40,154 +40,201 @@ describe('SelectHardwareAccountsPage', () => {
     jest.clearAllMocks();
   });
 
-  it('renders the page title and account cards', () => {
-    render();
+  describe('rendering', () => {
+    it('renders the page title, account cards, footer actions, and show more button', () => {
+      renderPage();
 
-    expect(screen.getByText(tEn('selectAnAccount'))).toBeInTheDocument();
-    expect(screen.getAllByTestId('hardware-account-card')).toHaveLength(5);
-  });
-
-  it('calls onBack when the back button is clicked', () => {
-    const { props } = render();
-
-    fireEvent.click(
-      screen.getByTestId('select-hardware-accounts-page-back-button'),
-    );
-
-    expect(props.onBack).toHaveBeenCalledTimes(1);
-  });
-
-  it('calls onSettingsClick when the settings button is clicked', () => {
-    const { props } = render();
-
-    fireEvent.click(
-      screen.getByTestId('select-hardware-accounts-page-settings-button'),
-    );
-
-    expect(props.onSettingsClick).toHaveBeenCalledTimes(1);
-  });
-
-  it('hides the settings button when showSettingsButton is false', () => {
-    render({ showSettingsButton: false, onSettingsClick: undefined });
-
-    expect(
-      screen.queryByTestId('select-hardware-accounts-page-settings-button'),
-    ).not.toBeInTheDocument();
-  });
-
-  it('updates account selection through onAccountSelectionChange', () => {
-    const onAccountSelectionChange = jest.fn();
-    render({ selectedAccountIds: ['account-0'], onAccountSelectionChange });
-
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Account 2' }));
-
-    expect(onAccountSelectionChange).toHaveBeenCalledWith([
-      'account-0',
-      'account-1',
-    ]);
-  });
-
-  it('removes account from selection when toggled off', () => {
-    const onAccountSelectionChange = jest.fn();
-    render({ selectedAccountIds: ['account-0'], onAccountSelectionChange });
-
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Account 1' }));
-
-    expect(onAccountSelectionChange).toHaveBeenCalledWith([]);
-  });
-
-  it('calls onShowMore when the show more button is clicked', () => {
-    const { props } = render({ hasMoreAccounts: true });
-
-    fireEvent.click(
-      screen.getByTestId('select-hardware-accounts-page-show-more-button'),
-    );
-
-    expect(props.onShowMore).toHaveBeenCalledTimes(1);
-  });
-
-  it('does not render the show more button when hasMoreAccounts is false', () => {
-    render({ hasMoreAccounts: false });
-
-    expect(
-      screen.queryByTestId('select-hardware-accounts-page-show-more-button'),
-    ).not.toBeInTheDocument();
-  });
-
-  it('disables continue when no accounts are selected', () => {
-    render({ selectedAccountIds: [] });
-
-    expect(
-      screen.getByTestId('select-hardware-accounts-page-continue-button'),
-    ).toBeDisabled();
-  });
-
-  it('calls onContinue with selected account ids', () => {
-    const { props } = render({
-      selectedAccountIds: ['account-0', 'account-1'],
+      expect(screen.getByText(tEn('selectAnAccount'))).toBeInTheDocument();
+      expect(screen.getAllByTestId('hardware-account-card')).toHaveLength(5);
+      expect(screen.getByText(tEn('forgetDevice'))).toBeInTheDocument();
+      expect(screen.getByText(tEn('continue'))).toBeInTheDocument();
+      expect(
+        screen.getByTestId('select-hardware-accounts-page-show-more-button'),
+      ).toBeInTheDocument();
     });
 
-    fireEvent.click(
-      screen.getByTestId('select-hardware-accounts-page-continue-button'),
-    );
+    it('renders no account cards when accounts is empty', () => {
+      renderPage({ accounts: [] });
 
-    expect(props.onContinue).toHaveBeenCalledWith(['account-0', 'account-1']);
+      expect(
+        screen.queryByTestId('hardware-account-card'),
+      ).not.toBeInTheDocument();
+    });
   });
 
-  it('calls onForgetDevice when the forget device button is clicked', () => {
-    const { props } = render();
+  describe('navigation', () => {
+    it('calls onBack when the back button is clicked', () => {
+      const { props } = renderPage();
 
-    fireEvent.click(
-      screen.getByTestId('select-hardware-accounts-page-forget-device-button'),
-    );
+      fireEvent.click(
+        screen.getByTestId('select-hardware-accounts-page-back-button'),
+      );
 
-    expect(props.onForgetDevice).toHaveBeenCalledTimes(1);
+      expect(props.onBack).toHaveBeenCalledTimes(1);
+    });
   });
 
-  it('renders footer action labels from translations', () => {
-    render();
+  describe('settings', () => {
+    it('calls onSettingsClick when the settings button is clicked', () => {
+      const { props } = renderPage();
 
-    expect(screen.getByText(tEn('forgetDevice'))).toBeInTheDocument();
-    expect(screen.getByText(tEn('continue'))).toBeInTheDocument();
-  });
+      fireEvent.click(
+        screen.getByTestId('select-hardware-accounts-page-settings-button'),
+      );
 
-  it('renders multichain address rows including address type badges', () => {
-    render({
-      accounts: createMockHardwareAccounts(1, {
-        includeMultichainAddresses: true,
-      }),
+      expect(props.onSettingsClick).toHaveBeenCalledTimes(1);
     });
 
-    expect(screen.getByText(tEn('networkNameEthereum'))).toBeInTheDocument();
-    expect(screen.getByText(tEn('networkNameSolana'))).toBeInTheDocument();
-    expect(screen.getByText(tEn('networkNameBitcoin'))).toBeInTheDocument();
-    expect(screen.getByText('Taproot')).toBeInTheDocument();
+    it('hides the settings button when showSettingsButton is false', () => {
+      renderPage({ showSettingsButton: false, onSettingsClick: undefined });
+
+      expect(
+        screen.queryByTestId('select-hardware-accounts-page-settings-button'),
+      ).not.toBeInTheDocument();
+    });
   });
 
-  it('shows loading state on the show more button', () => {
-    render({ hasMoreAccounts: true, isLoadingMore: true });
+  describe('account selection', () => {
+    it('adds an account to the selection when toggled on', () => {
+      const onAccountSelectionChange = jest.fn();
+      renderPage({
+        selectedAccountIds: ['account-0'],
+        onAccountSelectionChange,
+      });
 
-    expect(
-      screen.getByTestId('select-hardware-accounts-page-show-more-button'),
-    ).toBeInTheDocument();
-  });
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Account 2' }));
 
-  it('uses default optional props when they are omitted', () => {
-    render({
-      hasMoreAccounts: undefined,
-      isLoadingMore: undefined,
-      showSettingsButton: undefined,
-      onSettingsClick: jest.fn(),
+      expect(onAccountSelectionChange).toHaveBeenCalledTimes(1);
+      expect(onAccountSelectionChange).toHaveBeenCalledWith([
+        'account-0',
+        'account-1',
+      ]);
     });
 
-    expect(
-      screen.queryByTestId('select-hardware-accounts-page-show-more-button'),
-    ).not.toBeInTheDocument();
-    expect(
-      screen.getByTestId('select-hardware-accounts-page-settings-button'),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByTestId('select-hardware-accounts-page-forget-device-button'),
-    ).toBeInTheDocument();
+    it('removes an account from the selection when toggled off', () => {
+      const onAccountSelectionChange = jest.fn();
+      renderPage({
+        selectedAccountIds: ['account-0'],
+        onAccountSelectionChange,
+      });
+
+      fireEvent.click(screen.getByRole('checkbox', { name: 'Account 1' }));
+
+      expect(onAccountSelectionChange).toHaveBeenCalledTimes(1);
+      expect(onAccountSelectionChange).toHaveBeenCalledWith([]);
+    });
+
+    it('updates selection when an account card header is clicked', () => {
+      const onAccountSelectionChange = jest.fn();
+      renderPage({ selectedAccountIds: [], onAccountSelectionChange });
+
+      fireEvent.click(screen.getAllByTestId('hardware-account-card-header')[0]);
+
+      expect(onAccountSelectionChange).toHaveBeenCalledTimes(1);
+      expect(onAccountSelectionChange).toHaveBeenCalledWith(['account-0']);
+    });
+
+    it('disables the already connected account checkbox', () => {
+      renderPage();
+
+      expect(
+        screen.getByRole('checkbox', { name: 'Account 3' }),
+      ).toBeDisabled();
+    });
+  });
+
+  describe('show more', () => {
+    it('calls onShowMore when the show more button is clicked', () => {
+      const { props } = renderPage({ hasMoreAccounts: true });
+
+      fireEvent.click(
+        screen.getByTestId('select-hardware-accounts-page-show-more-button'),
+      );
+
+      expect(props.onShowMore).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not render the show more button when hasMoreAccounts is false', () => {
+      renderPage({ hasMoreAccounts: false });
+
+      expect(
+        screen.queryByTestId('select-hardware-accounts-page-show-more-button'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('disables the show more button while loading more accounts', () => {
+      renderPage({ hasMoreAccounts: true, isLoadingMore: true });
+
+      expect(
+        screen.getByTestId('select-hardware-accounts-page-show-more-button'),
+      ).toBeDisabled();
+    });
+  });
+
+  describe('footer actions', () => {
+    it('disables continue when no accounts are selected', () => {
+      renderPage({ selectedAccountIds: [] });
+
+      expect(
+        screen.getByTestId('select-hardware-accounts-page-continue-button'),
+      ).toBeDisabled();
+    });
+
+    it('enables continue when at least one account is selected', () => {
+      renderPage({ selectedAccountIds: ['account-0'] });
+
+      expect(
+        screen.getByTestId('select-hardware-accounts-page-continue-button'),
+      ).toBeEnabled();
+    });
+
+    it('calls onContinue with selected account ids', () => {
+      const { props } = renderPage({
+        selectedAccountIds: ['account-0', 'account-1'],
+      });
+
+      fireEvent.click(
+        screen.getByTestId('select-hardware-accounts-page-continue-button'),
+      );
+
+      expect(props.onContinue).toHaveBeenCalledTimes(1);
+      expect(props.onContinue).toHaveBeenCalledWith(['account-0', 'account-1']);
+    });
+
+    it('calls onForgetDevice when the forget device button is clicked', () => {
+      const { props } = renderPage();
+
+      fireEvent.click(
+        screen.getByTestId(
+          'select-hardware-accounts-page-forget-device-button',
+        ),
+      );
+
+      expect(props.onForgetDevice).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('default props', () => {
+    it('uses default optional props when they are omitted', () => {
+      renderPage({
+        accounts: createMockHardwareAccounts(1),
+        hasMoreAccounts: undefined,
+        isLoadingMore: undefined,
+        showSettingsButton: undefined,
+        onSettingsClick: jest.fn(),
+      });
+
+      expect(
+        screen.queryByTestId('select-hardware-accounts-page-show-more-button'),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId('select-hardware-accounts-page-settings-button'),
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId(
+          'select-hardware-accounts-page-forget-device-button',
+        ),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/select-hardware-accounts-page.test.tsx
+++ b/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/select-hardware-accounts-page.test.tsx
@@ -158,9 +158,9 @@ describe('SelectHardwareAccountsPage', () => {
       }),
     });
 
-    expect(screen.getByText('Ethereum')).toBeInTheDocument();
-    expect(screen.getByText('Solana')).toBeInTheDocument();
-    expect(screen.getByText('Bitcoin')).toBeInTheDocument();
+    expect(screen.getByText(tEn('networkNameEthereum'))).toBeInTheDocument();
+    expect(screen.getByText(tEn('networkNameSolana'))).toBeInTheDocument();
+    expect(screen.getByText(tEn('networkNameBitcoin'))).toBeInTheDocument();
     expect(screen.getByText('Taproot')).toBeInTheDocument();
   });
 

--- a/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/select-hardware-accounts-page.test.tsx
+++ b/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/select-hardware-accounts-page.test.tsx
@@ -92,6 +92,14 @@ describe('SelectHardwareAccountsPage', () => {
         screen.queryByTestId('select-hardware-accounts-page-settings-button'),
       ).not.toBeInTheDocument();
     });
+
+    it('hides the settings button when onSettingsClick is not provided', () => {
+      renderPage({ onSettingsClick: undefined, showSettingsButton: undefined });
+
+      expect(
+        screen.queryByTestId('select-hardware-accounts-page-settings-button'),
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe('account selection', () => {

--- a/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/select-hardware-accounts-page.test.tsx
+++ b/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/select-hardware-accounts-page.test.tsx
@@ -1,0 +1,191 @@
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
+import { tEn } from '../../../../../test/lib/i18n-helpers';
+import {
+  createMockHardwareAccounts,
+  MOCK_HARDWARE_ACCOUNTS,
+} from '../../../../../test/data/hardware-wallet-accounts';
+import { SelectHardwareAccountsPage } from './select-hardware-accounts-page';
+import type { SelectHardwareAccountsPageProps } from './select-hardware-accounts-page.types';
+
+const defaultProps: SelectHardwareAccountsPageProps = {
+  accounts: MOCK_HARDWARE_ACCOUNTS,
+  selectedAccountIds: ['account-0'],
+  onAccountSelectionChange: jest.fn(),
+  onBack: jest.fn(),
+  onShowMore: jest.fn(),
+  onContinue: jest.fn(),
+  onForgetDevice: jest.fn(),
+  hasMoreAccounts: true,
+  isLoadingMore: false,
+  onSettingsClick: jest.fn(),
+  showSettingsButton: true,
+};
+
+const render = (props: Partial<SelectHardwareAccountsPageProps> = {}) => {
+  const mergedProps = {
+    ...defaultProps,
+    ...props,
+  };
+
+  return {
+    ...renderWithProvider(<SelectHardwareAccountsPage {...mergedProps} />),
+    props: mergedProps,
+  };
+};
+
+describe('SelectHardwareAccountsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the page title and account cards', () => {
+    render();
+
+    expect(screen.getByText(tEn('selectAnAccount'))).toBeInTheDocument();
+    expect(screen.getAllByTestId('hardware-account-card')).toHaveLength(5);
+  });
+
+  it('calls onBack when the back button is clicked', () => {
+    const { props } = render();
+
+    fireEvent.click(
+      screen.getByTestId('select-hardware-accounts-page-back-button'),
+    );
+
+    expect(props.onBack).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls onSettingsClick when the settings button is clicked', () => {
+    const { props } = render();
+
+    fireEvent.click(
+      screen.getByTestId('select-hardware-accounts-page-settings-button'),
+    );
+
+    expect(props.onSettingsClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides the settings button when showSettingsButton is false', () => {
+    render({ showSettingsButton: false, onSettingsClick: undefined });
+
+    expect(
+      screen.queryByTestId('select-hardware-accounts-page-settings-button'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('updates account selection through onAccountSelectionChange', () => {
+    const onAccountSelectionChange = jest.fn();
+    render({ selectedAccountIds: ['account-0'], onAccountSelectionChange });
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Account 2' }));
+
+    expect(onAccountSelectionChange).toHaveBeenCalledWith([
+      'account-0',
+      'account-1',
+    ]);
+  });
+
+  it('removes account from selection when toggled off', () => {
+    const onAccountSelectionChange = jest.fn();
+    render({ selectedAccountIds: ['account-0'], onAccountSelectionChange });
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Account 1' }));
+
+    expect(onAccountSelectionChange).toHaveBeenCalledWith([]);
+  });
+
+  it('calls onShowMore when the show more button is clicked', () => {
+    const { props } = render({ hasMoreAccounts: true });
+
+    fireEvent.click(
+      screen.getByTestId('select-hardware-accounts-page-show-more-button'),
+    );
+
+    expect(props.onShowMore).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not render the show more button when hasMoreAccounts is false', () => {
+    render({ hasMoreAccounts: false });
+
+    expect(
+      screen.queryByTestId('select-hardware-accounts-page-show-more-button'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('disables continue when no accounts are selected', () => {
+    render({ selectedAccountIds: [] });
+
+    expect(
+      screen.getByTestId('select-hardware-accounts-page-continue-button'),
+    ).toBeDisabled();
+  });
+
+  it('calls onContinue with selected account ids', () => {
+    const { props } = render({ selectedAccountIds: ['account-0', 'account-1'] });
+
+    fireEvent.click(
+      screen.getByTestId('select-hardware-accounts-page-continue-button'),
+    );
+
+    expect(props.onContinue).toHaveBeenCalledWith(['account-0', 'account-1']);
+  });
+
+  it('calls onForgetDevice when the forget device button is clicked', () => {
+    const { props } = render();
+
+    fireEvent.click(
+      screen.getByTestId('select-hardware-accounts-page-forget-device-button'),
+    );
+
+    expect(props.onForgetDevice).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders footer action labels from translations', () => {
+    render();
+
+    expect(screen.getByText(tEn('forgetDevice'))).toBeInTheDocument();
+    expect(screen.getByText(tEn('continue'))).toBeInTheDocument();
+  });
+
+  it('renders multichain address rows including address type badges', () => {
+    render({
+      accounts: createMockHardwareAccounts(1, {
+        includeMultichainAddresses: true,
+      }),
+    });
+
+    expect(screen.getByText('Ethereum')).toBeInTheDocument();
+    expect(screen.getByText('Solana')).toBeInTheDocument();
+    expect(screen.getByText('Bitcoin')).toBeInTheDocument();
+    expect(screen.getByText('Taproot')).toBeInTheDocument();
+  });
+
+  it('shows loading state on the show more button', () => {
+    render({ hasMoreAccounts: true, isLoadingMore: true });
+
+    expect(
+      screen.getByTestId('select-hardware-accounts-page-show-more-button'),
+    ).toBeInTheDocument();
+  });
+
+  it('uses default optional props when they are omitted', () => {
+    render({
+      hasMoreAccounts: undefined,
+      isLoadingMore: undefined,
+      showSettingsButton: undefined,
+      onSettingsClick: jest.fn(),
+    });
+
+    expect(
+      screen.queryByTestId('select-hardware-accounts-page-show-more-button'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId('select-hardware-accounts-page-settings-button'),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('select-hardware-accounts-page-forget-device-button'),
+    ).toBeInTheDocument();
+  });
+});

--- a/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/select-hardware-accounts-page.tsx
+++ b/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/select-hardware-accounts-page.tsx
@@ -1,0 +1,140 @@
+import React, { useCallback } from 'react';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  Button,
+  ButtonIcon,
+  ButtonIconSize,
+  ButtonSize,
+  ButtonVariant,
+  IconName,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react';
+import {
+  Content,
+  Footer,
+  Page,
+} from '../../../../components/multichain/pages/page';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { HardwareAccountCard } from '../../../../components/multichain-accounts/hardware-account-card';
+import type { SelectHardwareAccountsPageProps } from './select-hardware-accounts-page.types';
+
+export const SelectHardwareAccountsPage = ({
+  accounts,
+  selectedAccountIds,
+  onAccountSelectionChange,
+  onBack,
+  onShowMore,
+  onContinue,
+  onForgetDevice,
+  hasMoreAccounts = false,
+  isLoadingMore = false,
+  onSettingsClick,
+  showSettingsButton = Boolean(onSettingsClick),
+}: SelectHardwareAccountsPageProps) => {
+  const t = useI18nContext();
+
+  const handleToggleSelection = useCallback(
+    (accountId: string) => {
+      const isSelected = selectedAccountIds.includes(accountId);
+      const nextSelectedAccountIds = isSelected
+        ? selectedAccountIds.filter((id) => id !== accountId)
+        : [...selectedAccountIds, accountId];
+
+      onAccountSelectionChange(nextSelectedAccountIds);
+    },
+    [onAccountSelectionChange, selectedAccountIds],
+  );
+
+  const handleContinue = useCallback(() => {
+    onContinue(selectedAccountIds);
+  }, [onContinue, selectedAccountIds]);
+
+  const isContinueDisabled = selectedAccountIds.length === 0;
+
+  return (
+    <Page className="mx-auto w-full max-w-[460px] sm:max-w-[520px]">
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Between}
+        className="min-h-14 px-1 py-2"
+      >
+        <ButtonIcon
+          size={ButtonIconSize.Md}
+          iconName={IconName.ArrowLeft}
+          ariaLabel={t('back') as string}
+          onClick={onBack}
+          data-testid="select-hardware-accounts-page-back-button"
+        />
+        {showSettingsButton && onSettingsClick ? (
+          <ButtonIcon
+            size={ButtonIconSize.Md}
+            iconName={IconName.Setting}
+            ariaLabel={t('settings') as string}
+            onClick={onSettingsClick}
+            data-testid="select-hardware-accounts-page-settings-button"
+          />
+        ) : (
+          <Box className="w-10 shrink-0" />
+        )}
+      </Box>
+      <Content className="flex flex-col gap-6">
+        <Text
+          variant={TextVariant.HeadingLg}
+          className="md:text-s-heading-lg md:leading-s-heading-lg md:tracking-s-heading-lg"
+        >
+          {t('selectAnAccount')}
+        </Text>
+        <Box flexDirection={BoxFlexDirection.Column} gap={3} className="w-full">
+          {accounts.map((account) => (
+            <HardwareAccountCard
+              key={account.id}
+              account={account}
+              isSelected={selectedAccountIds.includes(account.id)}
+              onToggleSelection={handleToggleSelection}
+            />
+          ))}
+          {hasMoreAccounts ? (
+            <Button
+              variant={ButtonVariant.Secondary}
+              size={ButtonSize.Lg}
+              isFullWidth
+              isLoading={isLoadingMore}
+              onClick={onShowMore}
+              data-testid="select-hardware-accounts-page-show-more-button"
+            >
+              {t('showMore')}
+            </Button>
+          ) : null}
+        </Box>
+      </Content>
+      <Footer>
+        <Box flexDirection={BoxFlexDirection.Row} gap={4} className="w-full">
+          <Button
+            variant={ButtonVariant.Secondary}
+            size={ButtonSize.Lg}
+            isFullWidth
+            onClick={onForgetDevice}
+            data-testid="select-hardware-accounts-page-forget-device-button"
+          >
+            {t('forgetDevice')}
+          </Button>
+          <Button
+            variant={ButtonVariant.Primary}
+            size={ButtonSize.Lg}
+            isFullWidth
+            isDisabled={isContinueDisabled}
+            onClick={handleContinue}
+            data-testid="select-hardware-accounts-page-continue-button"
+          >
+            {t('continue')}
+          </Button>
+        </Box>
+      </Footer>
+    </Page>
+  );
+};

--- a/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/select-hardware-accounts-page.tsx
+++ b/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/select-hardware-accounts-page.tsx
@@ -22,6 +22,21 @@ import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { HardwareAccountCard } from '../../../../components/multichain-accounts/hardware-account-card';
 import type { SelectHardwareAccountsPageProps } from './select-hardware-accounts-page.types';
 
+/**
+ * Lets the user select hardware wallet accounts to import.
+ * @param options0
+ * @param options0.accounts
+ * @param options0.selectedAccountIds
+ * @param options0.onAccountSelectionChange
+ * @param options0.onBack
+ * @param options0.onShowMore
+ * @param options0.onContinue
+ * @param options0.onForgetDevice
+ * @param options0.hasMoreAccounts
+ * @param options0.isLoadingMore
+ * @param options0.onSettingsClick
+ * @param options0.showSettingsButton
+ */
 export const SelectHardwareAccountsPage = ({
   accounts,
   selectedAccountIds,

--- a/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/select-hardware-accounts-page.types.ts
+++ b/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/select-hardware-accounts-page.types.ts
@@ -1,0 +1,22 @@
+import type { HardwareWalletAccount } from '../../../../components/multichain-accounts/hardware-account-card';
+
+export type { HardwareWalletAccount } from '../../../../components/multichain-accounts/hardware-account-card/hardware-account-card.types';
+export type {
+  HardwareWalletAccountAddress,
+  HardwareWalletAddressIconType,
+} from '../../../../components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.types';
+
+/** Props for {@link SelectHardwareAccountsPage}. */
+export type SelectHardwareAccountsPageProps = {
+  accounts: HardwareWalletAccount[];
+  selectedAccountIds: string[];
+  onAccountSelectionChange: (selectedAccountIds: string[]) => void;
+  onBack: () => void;
+  onShowMore: () => void;
+  onContinue: (selectedAccountIds: string[]) => void;
+  onForgetDevice: () => void;
+  hasMoreAccounts?: boolean;
+  isLoadingMore?: boolean;
+  onSettingsClick?: () => void;
+  showSettingsButton?: boolean;
+};

--- a/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/select-hardware-accounts-page.types.ts
+++ b/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/select-hardware-accounts-page.types.ts
@@ -1,11 +1,5 @@
 import type { HardwareWalletAccount } from '../../../../components/multichain-accounts/hardware-account-card';
 
-export type { HardwareWalletAccount } from '../../../../components/multichain-accounts/hardware-account-card/hardware-account-card.types';
-export type {
-  HardwareWalletAccountAddress,
-  HardwareWalletAddressIconType,
-} from '../../../../components/multichain-accounts/hardware-account-address-row/hardware-account-address-row.types';
-
 /** Props for {@link SelectHardwareAccountsPage}. */
 export type SelectHardwareAccountsPageProps = {
   accounts: HardwareWalletAccount[];

--- a/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/select-hardware-accounts-page.types.ts
+++ b/ui/pages/create-account/connect-hardware/select-hardware-accounts-page/select-hardware-accounts-page.types.ts
@@ -1,6 +1,6 @@
 import type { HardwareWalletAccount } from '../../../../components/multichain-accounts/hardware-account-card';
 
-/** Props for {@link SelectHardwareAccountsPage}. */
+/** Props for SelectHardwareAccountsPage. */
 export type SelectHardwareAccountsPageProps = {
   accounts: HardwareWalletAccount[];
   selectedAccountIds: string[];


### PR DESCRIPTION
## **Description**
This PR adds new stack of UI components that will be used for new hardware wallet onboarding in the near future. The purpose of these components is to enable users to select and unlock their hardware wallet accounts.

**Changes on this PR do not affect any production code or functionality in general. Integration is not done.**

## **Changelog**
<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->
CHANGELOG entry: null

## **Related issues**
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1831

## **Manual testing steps**
1. Start storybook and check the new components (`Components/MultichainAccounts/HardwareAccountAddressRow`, `Components/MultichainAccounts/HardwareAccountCard`, `Pages/CreateAccount/ConnectHardware/SelectHardwareAccountsPage`).
2. Make sure that new components are matching Figma specification.

## **Screenshots/Recordings**
### **Before**
These components did not exist before. Nothing to show here.

### **After**
#### Storybook screenshots
<img width="750" height="104" alt="Screenshot 2026-06-15 at 12 41 44" src="https://github.com/user-attachments/assets/bcc30791-2751-42b9-a5d3-56eeac5c2928" />
<img width="750" height="104" alt="Screenshot 2026-06-15 at 12 41 53" src="https://github.com/user-attachments/assets/b4873e91-465c-4b6c-939b-ca85bedb4192" />
<img width="750" height="310" alt="Screenshot 2026-06-15 at 12 42 24" src="https://github.com/user-attachments/assets/5cd338ce-966e-4b0b-81fb-8ef62fc25b3b" />
<img width="750" height="310" alt="Screenshot 2026-06-15 at 12 42 32" src="https://github.com/user-attachments/assets/0b55876b-32ce-467e-8cd4-0761b0db6e9e" />
<img width="750" height="310" alt="Screenshot 2026-06-15 at 12 42 51" src="https://github.com/user-attachments/assets/ecc57707-32b0-429e-b364-8ef0b666cea7" />
<img width="750" height="310" alt="Screenshot 2026-06-15 at 12 42 58" src="https://github.com/user-attachments/assets/4c02e76a-de41-4a4d-9f16-4b3ac7ad9d4c" />
<img width="505" height="819" alt="Screenshot 2026-06-15 at 12 43 32" src="https://github.com/user-attachments/assets/4b70bc44-4fd7-4612-974f-a3ab8552f82a" />
<img width="505" height="599" alt="Screenshot 2026-06-15 at 12 43 47" src="https://github.com/user-attachments/assets/597ab208-9823-462d-b7ff-7d140fc95993" />


## **Pre-merge author checklist**
- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**
- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.