### PR TITLE
fix: prevent tokens without symbol from breaking the app cp-13.35.0 cp-13.36.0

### DIFF
--- a/shared/lib/selectors/assets-migration.test.ts
+++ b/shared/lib/selectors/assets-migration.test.ts
@@ -2250,6 +2250,8 @@ describe('getMultichainAssetsRatesControllerConversionRates', () => {
 describe('getRatesControllerRates', () => {
   const solanaNativeAssetId =
     'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/slip44:501';
+  const solanaSplMissingSymbolAssetId =
+    'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:2NzMQx8TiDFbw5p3oMNVBh59UkKAPLHoa62YV6vXNmmG';
 
   describe('when assets unify state feature is disabled', () => {
     it('returns rates from state unchanged', () => {
@@ -2336,6 +2338,44 @@ describe('getRatesControllerRates', () => {
           conversionDate: lastUpdated,
           conversionRate: 91.69,
           usdConversionRate: 91.69,
+        },
+      });
+    });
+
+    it('skips assetsInfo entries with missing symbol without throwing', () => {
+      const lastUpdated = 1700000000000;
+      const state = {
+        metamask: {
+          ...enabledFlags,
+          rates: {},
+          assetsInfo: {
+            [solanaSplMissingSymbolAssetId]: {
+              decimals: 9,
+              type: 'spl',
+            },
+            [bitcoinNativeAssetId]: {
+              type: 'native',
+              symbol: 'BTC',
+              decimals: 8,
+            },
+          },
+          assetsPrice: {
+            [bitcoinNativeAssetId]: makeMockPrice({
+              id: 'btc',
+              price: 71052.43,
+              usdPrice: 71052.43,
+              lastUpdated,
+            }),
+          },
+        },
+      };
+
+      expect(() => getRatesControllerRates(state)).not.toThrow();
+      expect(getRatesControllerRates(state)).toStrictEqual({
+        btc: {
+          conversionDate: lastUpdated,
+          conversionRate: 71052.43,
+          usdConversionRate: 71052.43,
         },
       });
     });

--- a/shared/lib/selectors/assets-migration.ts
+++ b/shared/lib/selectors/assets-migration.ts
@@ -909,7 +909,7 @@ export const getRatesControllerRates = createDeepEqualSelector(
     const result: RatesControllerState['rates'] = {};
 
     for (const [assetId, metadata] of Object.entries(assetsInfo)) {
-      const symbol = metadata.symbol.toLowerCase();
+      const symbol = metadata.symbol?.toLowerCase();
 
       // Skip if we already have an entry for this symbol
       if (result[symbol]) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Fixes crash accessing Swap page when an asset with no symbol is present.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug causing Swap page to crash

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/43508

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/3c11daf9-7882-43d1-9906-b61c5441555e

### **After**

<!-- [screenshots/recordings] -->

https://github.com/user-attachments/assets/e725a3b8-1fdc-4342-8da0-6e7519d8f098


## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small defensive change in a migration selector with a focused unit test; no auth or payment paths touched.
> 
> **Overview**
> Fixes a crash when **assets unify state** is enabled and `getRatesControllerRates` walks `assetsInfo` entries that omit `symbol` (e.g. some Solana SPL metadata).
> 
> The selector now uses optional chaining on `metadata.symbol` before lowercasing, so missing symbols no longer throw during rate derivation. Other assets with valid metadata still map into the legacy `rates` shape as before.
> 
> Adds a unit test that mixes a symbol-less SPL `assetsInfo` entry with a priced BTC native asset and asserts the selector does not throw and only returns the BTC rate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c12e2f9b0d2c9e5d6b2e10a7bdb8059837b2d9d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->