### PR TITLE
fix: align ButtonIcon icon sizes with MMDS

### DIFF
--- a/ui/components/app/assets/nfts/nft-details/__snapshots__/nft-details.test.js.snap
+++ b/ui/components/app/assets/nfts/nft-details/__snapshots__/nft-details.test.js.snap
@@ -22,7 +22,7 @@ exports[`NFT Details should match minimal props and state snapshot 1`] = `
             data-testid="nft__back"
           >
             <span
-              class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+              class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
               style="mask-image: url('./images/icons/arrow-left.svg');"
             />
           </button>
@@ -35,7 +35,7 @@ exports[`NFT Details should match minimal props and state snapshot 1`] = `
               data-testid="nft-options__button"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                 style="mask-image: url('./images/icons/more-vertical.svg');"
               />
             </button>
@@ -127,7 +127,7 @@ exports[`NFT Details should match minimal props and state snapshot 1`] = `
                 data-testid="nft-address-copy"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/copy.svg');"
                 />
               </button>

--- a/ui/components/app/assets/nfts/nft-details/__snapshots__/nft-full-image.test.js.snap
+++ b/ui/components/app/assets/nfts/nft-details/__snapshots__/nft-full-image.test.js.snap
@@ -32,7 +32,7 @@ exports[`NFT full image should match snapshot 1`] = `
               data-testid="nft-details__close"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                 style="mask-image: url('./images/icons/close.svg');"
               />
             </button>

--- a/ui/components/app/confirm/info/row/__snapshots__/copy-icon.test.tsx.snap
+++ b/ui/components/app/confirm/info/row/__snapshots__/copy-icon.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`CopyIcon should match snapshot 1`] = `
     style="cursor: pointer; position: absolute; right: 0px; top: 2px;"
   >
     <span
-      class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+      class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
       style="mask-image: url('./images/icons/copy.svg');"
     />
   </button>
@@ -23,7 +23,7 @@ exports[`CopyIcon should match snapshot with isStopPropagationEnabled 1`] = `
     style="cursor: pointer; position: absolute; right: 0px; top: 2px;"
   >
     <span
-      class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+      class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
       style="mask-image: url('./images/icons/copy.svg');"
     />
   </button>

--- a/ui/components/app/confirm/info/row/__snapshots__/expandable-row.test.tsx.snap
+++ b/ui/components/app/confirm/info/row/__snapshots__/expandable-row.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`ConfirmInfoExpandableRow should match snapshot 1`] = `
         class="mm-box mm-button-icon mm-button-icon--size-sm expandIcon mm-box--margin-left-1 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-lg"
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/arrow-down.svg');"
         />
       </button>

--- a/ui/components/app/confirm/info/row/__snapshots__/row.test.tsx.snap
+++ b/ui/components/app/confirm/info/row/__snapshots__/row.test.tsx.snap
@@ -72,7 +72,7 @@ exports[`ConfirmInfoRow should match snapshot when copy is enabled 1`] = `
       style="cursor: pointer; position: absolute; right: 4px; top: 2px;"
     >
       <span
-        class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
         style="mask-image: url('./images/icons/copy.svg');"
       />
     </button>

--- a/ui/components/app/import-token/network-filter-import-token/__snapshots__/index.test.tsx.snap
+++ b/ui/components/app/import-token/network-filter-import-token/__snapshots__/index.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`NetworkFilterImportToken should match snapshot 1`] = `
         data-testid="mockButtonDataTestId"
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/arrow-down.svg');"
         />
       </button>
@@ -81,7 +81,7 @@ exports[`NetworkFilterImportToken should renders "popular networks" text when is
         data-testid="mockButtonDataTestId"
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/arrow-down.svg');"
         />
       </button>

--- a/ui/components/app/import-token/network-filter-import-token/network-filter-dropdown/__snapshots__/index.test.tsx.snap
+++ b/ui/components/app/import-token/network-filter-import-token/network-filter-dropdown/__snapshots__/index.test.tsx.snap
@@ -37,7 +37,7 @@ exports[`NetworkFilterDropdown should render correctly 1`] = `
       data-testid="mockButtonDataTestId"
     >
       <span
-        class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
         style="mask-image: url('./images/icons/arrow-up.svg');"
       />
     </button>

--- a/ui/components/app/import-token/network-selector-custom-import/__snapshots__/index.test.tsx.snap
+++ b/ui/components/app/import-token/network-selector-custom-import/__snapshots__/index.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`NetworkSelectorCustomImport should match snapshot 1`] = `
           class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--margin-left-auto mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
         >
           <span
-            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+            class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
             style="mask-image: url('./images/icons/arrow-right.svg');"
           />
         </button>

--- a/ui/components/app/modals/customize-nonce/__snapshots__/customize-nonce.test.js.snap
+++ b/ui/components/app/modals/customize-nonce/__snapshots__/customize-nonce.test.js.snap
@@ -24,7 +24,7 @@ exports[`Customize Nonce should match snapshot 1`] = `
             class="mm-box mm-button-icon mm-button-icon--size-sm customize-nonce-modal__close mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
           >
             <span
-              class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+              class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
               style="mask-image: url('./images/icons/close.svg');"
             />
           </button>

--- a/ui/components/app/name/name-details/__snapshots__/name-details.test.tsx.snap
+++ b/ui/components/app/name/name-details/__snapshots__/name-details.test.tsx.snap
@@ -54,7 +54,7 @@ exports[`NameDetails renders proposed names 1`] = `
                 class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/close.svg');"
                 />
               </button>
@@ -151,7 +151,7 @@ exports[`NameDetails renders proposed names 1`] = `
                   class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
                 >
                   <span
-                    class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                    class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                     style="mask-image: url('./images/icons/copy.svg');"
                   />
                 </button>
@@ -184,7 +184,7 @@ exports[`NameDetails renders proposed names 1`] = `
                         class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
                       >
                         <span
-                          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                           style="mask-image: url('./images/icons/close.svg');"
                         />
                       </button>
@@ -311,7 +311,7 @@ exports[`NameDetails renders when no address value is passed 1`] = `
                 class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/close.svg');"
                 />
               </button>
@@ -406,7 +406,7 @@ exports[`NameDetails renders when no address value is passed 1`] = `
                   class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
                 >
                   <span
-                    class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                    class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                     style="mask-image: url('./images/icons/copy.svg');"
                   />
                 </button>
@@ -439,7 +439,7 @@ exports[`NameDetails renders when no address value is passed 1`] = `
                         class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
                       >
                         <span
-                          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                           style="mask-image: url('./images/icons/close.svg');"
                         />
                       </button>
@@ -531,7 +531,7 @@ exports[`NameDetails renders with no saved name 1`] = `
                 class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/close.svg');"
                 />
               </button>
@@ -628,7 +628,7 @@ exports[`NameDetails renders with no saved name 1`] = `
                   class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
                 >
                   <span
-                    class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                    class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                     style="mask-image: url('./images/icons/copy.svg');"
                   />
                 </button>
@@ -661,7 +661,7 @@ exports[`NameDetails renders with no saved name 1`] = `
                         class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
                       >
                         <span
-                          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                           style="mask-image: url('./images/icons/close.svg');"
                         />
                       </button>
@@ -753,7 +753,7 @@ exports[`NameDetails renders with recognized name 1`] = `
                 class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/close.svg');"
                 />
               </button>
@@ -850,7 +850,7 @@ exports[`NameDetails renders with recognized name 1`] = `
                   class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
                 >
                   <span
-                    class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                    class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                     style="mask-image: url('./images/icons/copy.svg');"
                   />
                 </button>
@@ -883,7 +883,7 @@ exports[`NameDetails renders with recognized name 1`] = `
                         class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
                       >
                         <span
-                          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                           style="mask-image: url('./images/icons/close.svg');"
                         />
                       </button>
@@ -975,7 +975,7 @@ exports[`NameDetails renders with saved name 1`] = `
                 class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/close.svg');"
                 />
               </button>
@@ -1072,7 +1072,7 @@ exports[`NameDetails renders with saved name 1`] = `
                   class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
                 >
                   <span
-                    class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                    class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                     style="mask-image: url('./images/icons/copy.svg');"
                   />
                 </button>
@@ -1105,7 +1105,7 @@ exports[`NameDetails renders with saved name 1`] = `
                         class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
                       >
                         <span
-                          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                           style="mask-image: url('./images/icons/close.svg');"
                         />
                       </button>

--- a/ui/components/app/update-modal/__snapshots__/update-modal.test.tsx.snap
+++ b/ui/components/app/update-modal/__snapshots__/update-modal.test.tsx.snap
@@ -45,7 +45,7 @@ exports[`UpdateModal renders correctly with required props 1`] = `
                 data-testid="update-modal-close-button"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/close.svg');"
                 />
               </button>

--- a/ui/components/component-library/button-icon/__snapshots__/button-icon.test.tsx.snap
+++ b/ui/components/component-library/button-icon/__snapshots__/button-icon.test.tsx.snap
@@ -8,7 +8,7 @@ exports[`ButtonIcon should render button element correctly 1`] = `
     data-testid="button-icon"
   >
     <span
-      class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
+      class="mm-box mm-icon mm-icon--size-xl mm-box--display-inline-block mm-box--color-inherit"
       style="mask-image: url('./images/icons/add-square.svg');"
     />
   </button>

--- a/ui/components/component-library/button-icon/button-icon.scss
+++ b/ui/components/component-library/button-icon/button-icon.scss
@@ -34,11 +34,11 @@
   }
 
   &--size-md {
-    --button-icon-size: 28px;
+    --button-icon-size: 32px;
   }
 
   &--size-lg {
-    --button-icon-size: 32px;
+    --button-icon-size: 40px;
   }
 }
 

--- a/ui/components/component-library/button-icon/button-icon.tsx
+++ b/ui/components/component-library/button-icon/button-icon.tsx
@@ -19,9 +19,9 @@ import {
 } from './button-icon.types';
 
 const buttonIconSizeToIconSize: Record<ButtonIconSize, IconSize> = {
-  [ButtonIconSize.Sm]: IconSize.Sm,
-  [ButtonIconSize.Md]: IconSize.Md,
-  [ButtonIconSize.Lg]: IconSize.Lg,
+  [ButtonIconSize.Sm]: IconSize.Md,
+  [ButtonIconSize.Md]: IconSize.Lg,
+  [ButtonIconSize.Lg]: IconSize.Xl,
 };
 
 /**

--- a/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
+++ b/ui/components/multichain/app-header/__snapshots__/app-header.test.js.snap
@@ -250,7 +250,7 @@ exports[`App Header unlocked state matches snapshot: unlocked 1`] = `
               data-testid="account-options-menu-button"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
+                class="mm-box mm-icon mm-icon--size-xl mm-box--display-inline-block mm-box--color-inherit"
                 style="mask-image: url('./images/icons/menu.svg');"
               />
             </button>

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/__snapshots__/asset-picker-modal-network.test.tsx.snap
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/__snapshots__/asset-picker-modal-network.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`AssetPickerModalNetwork renders modal with no network list by default 1
                 class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/close.svg');"
                 />
               </button>
@@ -121,7 +121,7 @@ exports[`AssetPickerModalNetwork should not show selected network when network p
                 class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/close.svg');"
                 />
               </button>
@@ -275,7 +275,7 @@ exports[`AssetPickerModalNetwork should use passed in network as default when ne
                 class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/arrow-left.svg');"
                 />
               </button>
@@ -298,7 +298,7 @@ exports[`AssetPickerModalNetwork should use passed in network as default when ne
                 class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/close.svg');"
                 />
               </button>

--- a/ui/components/multichain/network-list-item/__snapshots__/network-list-item.test.js.snap
+++ b/ui/components/multichain/network-list-item/__snapshots__/network-list-item.test.js.snap
@@ -48,7 +48,7 @@ exports[`NetworkListItem renders properly 1`] = `
       data-testid="network-list-item-options-button-0x1"
     >
       <span
-        class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
         style="mask-image: url('./images/icons/more-vertical.svg');"
       />
     </button>

--- a/ui/components/multichain/network-list-menu/__snapshots__/network-list-menu.test.tsx.snap
+++ b/ui/components/multichain/network-list-menu/__snapshots__/network-list-menu.test.tsx.snap
@@ -50,7 +50,7 @@ exports[`NetworkListMenu renders properly 1`] = `
                 class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/close.svg');"
                 />
               </button>
@@ -155,7 +155,7 @@ exports[`NetworkListMenu renders properly 1`] = `
                       data-testid="network-list-item-options-button-eip155:1"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                         style="mask-image: url('./images/icons/more-vertical.svg');"
                       />
                     </button>
@@ -218,7 +218,7 @@ exports[`NetworkListMenu renders properly 1`] = `
                       data-testid="network-list-item-options-button-eip155:59144"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                         style="mask-image: url('./images/icons/more-vertical.svg');"
                       />
                     </button>
@@ -281,7 +281,7 @@ exports[`NetworkListMenu renders properly 1`] = `
                       data-testid="network-list-item-options-button-eip155:56"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                         style="mask-image: url('./images/icons/more-vertical.svg');"
                       />
                     </button>
@@ -344,7 +344,7 @@ exports[`NetworkListMenu renders properly 1`] = `
                       data-testid="network-list-item-options-button-eip155:143"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                         style="mask-image: url('./images/icons/more-vertical.svg');"
                       />
                     </button>
@@ -412,7 +412,7 @@ exports[`NetworkListMenu renders properly 1`] = `
                       data-testid="network-list-item-options-button-eip155:5"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                         style="mask-image: url('./images/icons/more-vertical.svg');"
                       />
                     </button>
@@ -1106,7 +1106,7 @@ exports[`NetworkListMenu should match snapshot when adding a network 1`] = `
                 class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/arrow-left.svg');"
                 />
               </button>
@@ -1129,7 +1129,7 @@ exports[`NetworkListMenu should match snapshot when adding a network 1`] = `
                 class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/close.svg');"
                 />
               </button>
@@ -1192,7 +1192,7 @@ exports[`NetworkListMenu should match snapshot when adding a network 1`] = `
                     data-testid="test-add-rpc-drop-down"
                   >
                     <span
-                      class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                      class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                       style="mask-image: url('./images/icons/arrow-down.svg');"
                     />
                   </button>
@@ -1274,7 +1274,7 @@ exports[`NetworkListMenu should match snapshot when adding a network 1`] = `
                     data-testid="test-explorer-drop-down"
                   >
                     <span
-                      class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                      class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                       style="mask-image: url('./images/icons/arrow-down.svg');"
                     />
                   </button>
@@ -1382,7 +1382,7 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                 class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/close.svg');"
                 />
               </button>
@@ -1487,7 +1487,7 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                       data-testid="network-list-item-options-button-eip155:1"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                         style="mask-image: url('./images/icons/more-vertical.svg');"
                       />
                     </button>
@@ -1550,7 +1550,7 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                       data-testid="network-list-item-options-button-eip155:59144"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                         style="mask-image: url('./images/icons/more-vertical.svg');"
                       />
                     </button>
@@ -1613,7 +1613,7 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                       data-testid="network-list-item-options-button-eip155:56"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                         style="mask-image: url('./images/icons/more-vertical.svg');"
                       />
                     </button>
@@ -1676,7 +1676,7 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                       data-testid="network-list-item-options-button-eip155:143"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                         style="mask-image: url('./images/icons/more-vertical.svg');"
                       />
                     </button>
@@ -1744,7 +1744,7 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                       data-testid="network-list-item-options-button-eip155:5"
                     >
                       <span
-                        class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                         style="mask-image: url('./images/icons/more-vertical.svg');"
                       />
                     </button>

--- a/ui/components/multichain/pages/gator-permissions/__snapshots__/gator-permissions-page.test.tsx.snap
+++ b/ui/components/multichain/pages/gator-permissions/__snapshots__/gator-permissions-page.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`Gator Permissions Page render renders correctly 1`] = `
             class="mm-box mm-button-icon mm-button-icon--size-sm connections-header__start-accessory mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
           >
             <span
-              class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+              class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
               style="mask-image: url('./images/icons/arrow-left.svg');"
             />
           </button>

--- a/ui/components/multichain/pages/gator-permissions/components/__snapshots__/review-gator-permission-item.test.tsx.snap
+++ b/ui/components/multichain/pages/gator-permissions/components/__snapshots__/review-gator-permission-item.test.tsx.snap
@@ -150,7 +150,7 @@ exports[`Permission List Item render ERC20 token permissions renders erc20 token
             style="cursor: pointer; position: static;"
           >
             <span
-              class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+              class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
               style="mask-image: url('./images/icons/copy.svg');"
             />
           </button>
@@ -351,7 +351,7 @@ exports[`Permission List Item render ERC20 token permissions renders erc20 token
             style="cursor: pointer; position: static;"
           >
             <span
-              class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+              class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
               style="mask-image: url('./images/icons/copy.svg');"
             />
           </button>
@@ -547,7 +547,7 @@ exports[`Permission List Item render ERC20 token permissions renders erc20 token
             style="cursor: pointer; position: static;"
           >
             <span
-              class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+              class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
               style="mask-image: url('./images/icons/copy.svg');"
             />
           </button>
@@ -722,7 +722,7 @@ exports[`Permission List Item render ERC20 token permissions renders token appro
             style="cursor: pointer; position: static;"
           >
             <span
-              class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+              class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
               style="mask-image: url('./images/icons/copy.svg');"
             />
           </button>
@@ -918,7 +918,7 @@ exports[`Permission List Item render NATIVE token permissions renders native tok
             style="cursor: pointer; position: static;"
           >
             <span
-              class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+              class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
               style="mask-image: url('./images/icons/copy.svg');"
             />
           </button>
@@ -1114,7 +1114,7 @@ exports[`Permission List Item render NATIVE token permissions renders native tok
             style="cursor: pointer; position: static;"
           >
             <span
-              class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+              class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
               style="mask-image: url('./images/icons/copy.svg');"
             />
           </button>

--- a/ui/components/multichain/pages/permissions-page/__snapshots__/permissions-page.test.js.snap
+++ b/ui/components/multichain/pages/permissions-page/__snapshots__/permissions-page.test.js.snap
@@ -23,7 +23,7 @@ exports[`All Connections render renders correctly 1`] = `
             data-testid="permissions-page-back"
           >
             <span
-              class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+              class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
               style="mask-image: url('./images/icons/arrow-left.svg');"
             />
           </button>

--- a/ui/components/multichain/token-list-item/__snapshots__/token-list-item.test.tsx.snap
+++ b/ui/components/multichain/token-list-item/__snapshots__/token-list-item.test.tsx.snap
@@ -149,7 +149,7 @@ exports[`TokenListItem should display warning scam modal 1`] = `
             data-testid="scam-warning"
           >
             <span
-              class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+              class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
               style="mask-image: url('./images/icons/danger.svg');"
             />
           </button>
@@ -231,7 +231,7 @@ exports[`TokenListItem should display warning scam modal fallback when safechain
             data-testid="scam-warning"
           >
             <span
-              class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+              class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
               style="mask-image: url('./images/icons/danger.svg');"
             />
           </button>

--- a/ui/components/ui/form-combo-field/__snapshots__/form-combo-field.test.tsx.snap
+++ b/ui/components/ui/form-combo-field/__snapshots__/form-combo-field.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`FormComboField renders with no options 1`] = `
               class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                 style="mask-image: url('./images/icons/close.svg');"
               />
             </button>
@@ -85,7 +85,7 @@ exports[`FormComboField renders with options 1`] = `
               class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                 style="mask-image: url('./images/icons/close.svg');"
               />
             </button>
@@ -161,7 +161,7 @@ exports[`FormComboField should not render "no options" if hideDropdownIfNoOption
               class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-muted mm-box--background-color-transparent mm-box--rounded-lg"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                 style="mask-image: url('./images/icons/close.svg');"
               />
             </button>

--- a/ui/pages/bridge/__snapshots__/index.test.tsx.snap
+++ b/ui/pages/bridge/__snapshots__/index.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`Bridge renders the component with initial props 1`] = `
             class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
           >
             <span
-              class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+              class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
               style="mask-image: url('./images/icons/arrow-left.svg');"
             />
           </button>
@@ -45,7 +45,7 @@ exports[`Bridge renders the component with initial props 1`] = `
             data-testid="bridge__header-settings-button"
           >
             <span
-              class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+              class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
               style="mask-image: url('./images/icons/setting.svg');"
             />
           </button>
@@ -159,7 +159,7 @@ exports[`Bridge renders the component with initial props 1`] = `
                 style="align-self: center; border-radius: 100%; width: 100%; height: 100%;"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-xl mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/swap-vertical.svg');"
                 />
               </button>

--- a/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
+++ b/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`BridgeInputGroup should render destination networks 1`] = `
               class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                 style="mask-image: url('./images/icons/close.svg');"
               />
             </button>
@@ -535,7 +535,7 @@ exports[`BridgeInputGroup should render source networks 1`] = `
               class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                 style="mask-image: url('./images/icons/close.svg');"
               />
             </button>
@@ -925,7 +925,7 @@ exports[`BridgeInputGroup should search for tokens 1`] = `
               class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                 style="mask-image: url('./images/icons/close.svg');"
               />
             </button>
@@ -1310,7 +1310,7 @@ exports[`BridgeInputGroup should search for tokens 5`] = `
               class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                 style="mask-image: url('./images/icons/close.svg');"
               />
             </button>

--- a/ui/pages/bridge/prepare/__snapshots__/bridge-transaction-settings-modal.test.tsx.snap
+++ b/ui/pages/bridge/prepare/__snapshots__/bridge-transaction-settings-modal.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`BridgeTransactionSettingsModal should render the component, with initia
               data-testid="bridge__tx-settings-modal-close-button"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                 style="mask-image: url('./images/icons/close.svg');"
               />
             </button>
@@ -194,7 +194,7 @@ exports[`BridgeTransactionSettingsModal should render the component, with initia
               data-testid="bridge__tx-settings-modal-close-button"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                 style="mask-image: url('./images/icons/close.svg');"
               />
             </button>

--- a/ui/pages/bridge/prepare/__snapshots__/prepare-bridge-page.test.tsx.snap
+++ b/ui/pages/bridge/prepare/__snapshots__/prepare-bridge-page.test.tsx.snap
@@ -106,7 +106,7 @@ exports[`PrepareBridgePage should render the component, with initial state 1`] =
           style="align-self: center; border-radius: 100%; width: 100%; height: 100%;"
         >
           <span
-            class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
+            class="mm-box mm-icon mm-icon--size-xl mm-box--display-inline-block mm-box--color-inherit"
             style="mask-image: url('./images/icons/swap-vertical.svg');"
           />
         </button>
@@ -339,7 +339,7 @@ exports[`PrepareBridgePage should render the component, with inputs set 1`] = `
           style="align-self: center; border-radius: 100%; width: 100%; height: 100%;"
         >
           <span
-            class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
+            class="mm-box mm-icon mm-icon--size-xl mm-box--display-inline-block mm-box--color-inherit"
             style="mask-image: url('./images/icons/swap-vertical.svg');"
           />
         </button>

--- a/ui/pages/bridge/prepare/components/__snapshots__/bridge-alert-modal.test.tsx.snap
+++ b/ui/pages/bridge/prepare/components/__snapshots__/bridge-alert-modal.test.tsx.snap
@@ -110,7 +110,7 @@ exports[`BridgeAlertModal quote-card should render alert banner when there is a 
                 class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/close.svg');"
                 />
               </button>
@@ -257,7 +257,7 @@ exports[`BridgeAlertModal quote-card should render when there is a price impact 
                 class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/close.svg');"
                 />
               </button>
@@ -376,7 +376,7 @@ exports[`BridgeAlertModal quote-card should render when there is a price impact 
                 class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/close.svg');"
                 />
               </button>
@@ -495,7 +495,7 @@ exports[`BridgeAlertModal quote-card should render when there is a price impact 
                 class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/close.svg');"
                 />
               </button>
@@ -614,7 +614,7 @@ exports[`BridgeAlertModal submit-cta should disable the submit button when submi
                 class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/close.svg');"
                 />
               </button>
@@ -848,7 +848,7 @@ exports[`BridgeAlertModal submit-cta should render when there is a price impact 
                 class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/close.svg');"
                 />
               </button>

--- a/ui/pages/bridge/prepare/components/__snapshots__/destination-account-picker-modal.test.tsx.snap
+++ b/ui/pages/bridge/prepare/components/__snapshots__/destination-account-picker-modal.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`DestinationAccountPickerModal should render the modal when an account i
               class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                 style="mask-image: url('./images/icons/close.svg');"
               />
             </button>
@@ -450,7 +450,7 @@ exports[`DestinationAccountPickerModal should render the modal when no account i
               class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                 style="mask-image: url('./images/icons/close.svg');"
               />
             </button>

--- a/ui/pages/bridge/quotes/__snapshots__/bridge-quotes-modal.test.tsx.snap
+++ b/ui/pages/bridge/quotes/__snapshots__/bridge-quotes-modal.test.tsx.snap
@@ -41,7 +41,7 @@ exports[`BridgeQuotesModal should render gasIncluded quotes 1`] = `
                 class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/arrow-left.svg');"
                 />
               </button>
@@ -219,7 +219,7 @@ exports[`BridgeQuotesModal should render the modal 1`] = `
                 class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/arrow-left.svg');"
                 />
               </button>
@@ -397,7 +397,7 @@ exports[`BridgeQuotesModal should render the modal when exchange rates are not a
                 class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/arrow-left.svg');"
                 />
               </button>

--- a/ui/pages/bridge/quotes/__snapshots__/multichain-bridge-quote-card.test.tsx.snap
+++ b/ui/pages/bridge/quotes/__snapshots__/multichain-bridge-quote-card.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`MultichainBridgeQuoteCard should render a quote with MM fee 1`] = `
           class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
         >
           <span
-            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+            class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
             style="mask-image: url('./images/icons/arrow-right.svg');"
           />
         </button>
@@ -127,7 +127,7 @@ exports[`MultichainBridgeQuoteCard should render a quote with MM fee 1`] = `
           data-testid="slippage-edit-button"
         >
           <span
-            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+            class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
             style="mask-image: url('./images/icons/edit.svg');"
           />
         </button>
@@ -238,7 +238,7 @@ exports[`MultichainBridgeQuoteCard should render gas sponsored text when gasSpon
           class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
         >
           <span
-            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+            class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
             style="mask-image: url('./images/icons/arrow-right.svg');"
           />
         </button>
@@ -321,7 +321,7 @@ exports[`MultichainBridgeQuoteCard should render gas sponsored text when gasSpon
           data-testid="slippage-edit-button"
         >
           <span
-            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+            class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
             style="mask-image: url('./images/icons/edit.svg');"
           />
         </button>
@@ -488,7 +488,7 @@ exports[`MultichainBridgeQuoteCard should render the recommended quote (no MM fe
           class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
         >
           <span
-            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+            class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
             style="mask-image: url('./images/icons/arrow-right.svg');"
           />
         </button>
@@ -563,7 +563,7 @@ exports[`MultichainBridgeQuoteCard should render the recommended quote (no MM fe
           data-testid="slippage-edit-button"
         >
           <span
-            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+            class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
             style="mask-image: url('./images/icons/edit.svg');"
           />
         </button>
@@ -674,7 +674,7 @@ exports[`MultichainBridgeQuoteCard should render the recommended quote while loa
           class="mm-box mm-button-icon mm-button-icon--size-sm mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-alternative mm-box--background-color-transparent mm-box--rounded-lg"
         >
           <span
-            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+            class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
             style="mask-image: url('./images/icons/arrow-right.svg');"
           />
         </button>
@@ -749,7 +749,7 @@ exports[`MultichainBridgeQuoteCard should render the recommended quote while loa
           data-testid="slippage-edit-button"
         >
           <span
-            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+            class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
             style="mask-image: url('./images/icons/edit.svg');"
           />
         </button>

--- a/ui/pages/confirmations/components/confirm/header/__snapshots__/advanced-details-button.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/header/__snapshots__/advanced-details-button.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`<AdvancedDetailsButton /> should match snapshot 1`] = `
           data-testid="header-advanced-details-button"
         >
           <span
-            class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+            class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
             style="mask-image: url('./images/icons/customize.svg');"
           />
         </button>

--- a/ui/pages/confirmations/components/confirm/header/__snapshots__/dapp-initiated-header.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/header/__snapshots__/dapp-initiated-header.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<DAppInitiatedHeader /> should match snapshot 1`] = `
 <div>
@@ -28,7 +28,7 @@ exports[`<DAppInitiatedHeader /> should match snapshot 1`] = `
               data-testid="header-advanced-details-button"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                 style="mask-image: url('./images/icons/customize.svg');"
               />
             </button>

--- a/ui/pages/confirmations/components/confirm/header/__snapshots__/header-info.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/header/__snapshots__/header-info.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`Header should match snapshot 1`] = `
           data-testid="header-info__account-details-button"
         >
           <span
-            class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+            class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
             style="mask-image: url('./images/icons/info.svg');"
           />
         </button>

--- a/ui/pages/confirmations/components/confirm/header/__snapshots__/header.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/header/__snapshots__/header.test.tsx.snap
@@ -95,7 +95,7 @@ exports[`Header should match snapshot with signature confirmation 1`] = `
               data-testid="header-info__account-details-button"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                 style="mask-image: url('./images/icons/info.svg');"
               />
             </button>
@@ -135,7 +135,7 @@ exports[`Header should match snapshot with token transfer confirmation initiated
               data-testid="header-advanced-details-button"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                 style="mask-image: url('./images/icons/customize.svg');"
               />
             </button>
@@ -159,7 +159,7 @@ exports[`Header should match snapshot with token transfer confirmation initiated
       data-testid="wallet-initiated-header-back-button"
     >
       <span
-        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+        class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
         style="mask-image: url('./images/icons/arrow-left.svg');"
       />
     </button>
@@ -181,7 +181,7 @@ exports[`Header should match snapshot with token transfer confirmation initiated
             data-testid="header-advanced-details-button"
           >
             <span
-              class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+              class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
               style="mask-image: url('./images/icons/customize.svg');"
             />
           </button>
@@ -287,7 +287,7 @@ exports[`Header should match snapshot with transaction confirmation 1`] = `
               data-testid="header-info__account-details-button"
             >
               <span
-                class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                 style="mask-image: url('./images/icons/info.svg');"
               />
             </button>
@@ -311,7 +311,7 @@ exports[`Header should match snapshot with transaction confirmation 1`] = `
                 data-testid="header-advanced-details-button"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/customize.svg');"
                 />
               </button>

--- a/ui/pages/confirmations/components/confirm/header/__snapshots__/wallet-initiated-header.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/header/__snapshots__/wallet-initiated-header.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<WalletInitiatedHeader /> should match snapshot 1`] = `
 <div>
@@ -12,7 +12,7 @@ exports[`<WalletInitiatedHeader /> should match snapshot 1`] = `
       data-testid="wallet-initiated-header-back-button"
     >
       <span
-        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+        class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
         style="mask-image: url('./images/icons/arrow-left.svg');"
       />
     </button>
@@ -34,7 +34,7 @@ exports[`<WalletInitiatedHeader /> should match snapshot 1`] = `
             data-testid="header-advanced-details-button"
           >
             <span
-              class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+              class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
               style="mask-image: url('./images/icons/customize.svg');"
             />
           </button>

--- a/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/__snapshots__/info.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Info renders info section for approve request 1`] = `
 <div>
@@ -923,7 +923,7 @@ exports[`Info renders info section for personal sign request 1`] = `
         style="cursor: pointer; position: absolute; right: 32px; top: 2px;"
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/copy.svg');"
         />
       </button>
@@ -934,7 +934,7 @@ exports[`Info renders info section for personal sign request 1`] = `
         style="cursor: pointer; position: absolute; right: 8px;"
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/collapse.svg');"
         />
       </button>
@@ -1594,7 +1594,7 @@ exports[`Info renders info section for typed sign request 1`] = `
         style="cursor: pointer; position: absolute; right: 4px; top: 2px;"
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/copy.svg');"
         />
       </button>

--- a/ui/pages/confirmations/components/confirm/info/approve/__snapshots__/approve.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/approve/__snapshots__/approve.test.tsx.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+// Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`<ApproveInfo /> renders component for approve request 1`] = `
 <div>
@@ -83,7 +83,7 @@ exports[`<ApproveInfo /> renders component for approve request 1`] = `
             data-testid="edit-spending-cap-icon"
           >
             <span
-              class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+              class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
               style="mask-image: url('./images/icons/edit.svg');"
             />
           </button>
@@ -582,7 +582,7 @@ exports[`<ApproveInfo /> renders component for approve request 1`] = `
           style="margin-right: -4px;"
         >
           <span
-            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+            class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
             style="mask-image: url('./images/icons/edit.svg');"
           />
         </button>
@@ -609,7 +609,7 @@ exports[`<ApproveInfo /> renders component for approve request 1`] = `
         style="cursor: pointer; position: absolute; right: 4px; top: 2px;"
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/copy.svg');"
         />
       </button>

--- a/ui/pages/confirmations/components/confirm/info/approve/approve-static-simulation/__snapshots__/approve-static-simulation.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/approve/approve-static-simulation/__snapshots__/approve-static-simulation.test.tsx.snap
@@ -194,7 +194,7 @@ exports[`<ApproveStaticSimulation /> renders component when token is not an NFT 
             data-testid="edit-spending-cap-icon"
           >
             <span
-              class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+              class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
               style="mask-image: url('./images/icons/edit.svg');"
             />
           </button>

--- a/ui/pages/confirmations/components/confirm/info/personal-sign/__snapshots__/personal-sign.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/personal-sign/__snapshots__/personal-sign.test.tsx.snap
@@ -97,7 +97,7 @@ exports[`PersonalSignInfo handle reverse string properly 1`] = `
         style="cursor: pointer; position: absolute; right: 32px; top: 2px;"
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/copy.svg');"
         />
       </button>
@@ -108,7 +108,7 @@ exports[`PersonalSignInfo handle reverse string properly 1`] = `
         style="cursor: pointer; position: absolute; right: 8px;"
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/collapse.svg');"
         />
       </button>
@@ -241,7 +241,7 @@ exports[`PersonalSignInfo renders correctly for personal sign request 1`] = `
         style="cursor: pointer; position: absolute; right: 32px; top: 2px;"
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/copy.svg');"
         />
       </button>
@@ -252,7 +252,7 @@ exports[`PersonalSignInfo renders correctly for personal sign request 1`] = `
         style="cursor: pointer; position: absolute; right: 8px;"
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/collapse.svg');"
         />
       </button>

--- a/ui/pages/confirmations/components/confirm/info/personal-sign/siwe-sign/__snapshots__/siwe-sign.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/personal-sign/siwe-sign/__snapshots__/siwe-sign.test.tsx.snap
@@ -12,7 +12,7 @@ exports[`SIWESignInfo renders correctly for SIWE signature request 1`] = `
       style="cursor: pointer; position: absolute; right: 32px; top: 2px;"
     >
       <span
-        class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
         style="mask-image: url('./images/icons/copy.svg');"
       />
     </button>
@@ -23,7 +23,7 @@ exports[`SIWESignInfo renders correctly for SIWE signature request 1`] = `
       style="cursor: pointer; position: absolute; right: 8px;"
     >
       <span
-        class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
         style="mask-image: url('./images/icons/collapse.svg');"
       />
     </button>
@@ -319,7 +319,7 @@ exports[`SIWESignInfo renders correctly for SIWE signature request with resource
       style="cursor: pointer; position: absolute; right: 32px; top: 2px;"
     >
       <span
-        class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
         style="mask-image: url('./images/icons/copy.svg');"
       />
     </button>
@@ -330,7 +330,7 @@ exports[`SIWESignInfo renders correctly for SIWE signature request with resource
       style="cursor: pointer; position: absolute; right: 8px;"
     >
       <span
-        class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+        class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
         style="mask-image: url('./images/icons/collapse.svg');"
       />
     </button>

--- a/ui/pages/confirmations/components/confirm/info/shared/advanced-details/__snapshots__/advanced-details.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/shared/advanced-details/__snapshots__/advanced-details.test.tsx.snap
@@ -53,7 +53,7 @@ exports[`<AdvancedDetails /> renders component when the prop override is passed 
           style="margin-right: -4px;"
         >
           <span
-            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+            class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
             style="mask-image: url('./images/icons/edit.svg');"
           />
         </button>
@@ -188,7 +188,7 @@ exports[`<AdvancedDetails /> renders component when the state property is true 1
           style="margin-right: -4px;"
         >
           <span
-            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+            class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
             style="mask-image: url('./images/icons/edit.svg');"
           />
         </button>

--- a/ui/pages/confirmations/components/confirm/info/shared/transaction-data/__snapshots__/transaction-data.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/shared/transaction-data/__snapshots__/transaction-data.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`TransactionData renders a truncated token id for an NFT with a long tok
         style="cursor: pointer; position: absolute; right: 4px; top: 2px;"
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/copy.svg');"
         />
       </button>
@@ -368,7 +368,7 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
         style="cursor: pointer; position: absolute; right: 4px; top: 2px;"
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/copy.svg');"
         />
       </button>
@@ -418,7 +418,7 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
           class="mm-box mm-button-icon mm-button-icon--size-sm expandIcon expanded mm-box--margin-left-1 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-lg"
         >
           <span
-            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+            class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
             style="mask-image: url('./images/icons/arrow-down.svg');"
           />
         </button>
@@ -588,7 +588,7 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
           class="mm-box mm-button-icon mm-button-icon--size-sm expandIcon expanded mm-box--margin-left-1 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-lg"
         >
           <span
-            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+            class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
             style="mask-image: url('./images/icons/arrow-down.svg');"
           />
         </button>
@@ -976,7 +976,7 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
           class="mm-box mm-button-icon mm-button-icon--size-sm expandIcon expanded mm-box--margin-left-1 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-lg"
         >
           <span
-            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+            class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
             style="mask-image: url('./images/icons/arrow-down.svg');"
           />
         </button>
@@ -1204,7 +1204,7 @@ exports[`TransactionData renders decoded data with names and descriptions 1`] = 
           class="mm-box mm-button-icon mm-button-icon--size-sm expandIcon expanded mm-box--margin-left-1 mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-primary-default mm-box--background-color-transparent mm-box--rounded-lg"
         >
           <span
-            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+            class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
             style="mask-image: url('./images/icons/arrow-down.svg');"
           />
         </button>
@@ -1418,7 +1418,7 @@ exports[`TransactionData renders decoded data with no names 1`] = `
         style="cursor: pointer; position: absolute; right: 4px; top: 2px;"
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/copy.svg');"
         />
       </button>
@@ -1649,7 +1649,7 @@ exports[`TransactionData renders decoded data with tuples and arrays 1`] = `
         style="cursor: pointer; position: absolute; right: 4px; top: 2px;"
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/copy.svg');"
         />
       </button>
@@ -2758,7 +2758,7 @@ exports[`TransactionData renders raw hexadecimal if no decoded data 1`] = `
         style="cursor: pointer; position: absolute; right: 4px; top: 2px;"
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/copy.svg');"
         />
       </button>

--- a/ui/pages/confirmations/components/confirm/info/typed-sign-v1/__snapshots__/typed-sign-v1.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign-v1/__snapshots__/typed-sign-v1.test.tsx.snap
@@ -99,7 +99,7 @@ exports[`TypedSignInfo correctly renders typed sign data request 1`] = `
         style="cursor: pointer; position: absolute; right: 32px; top: 2px;"
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/copy.svg');"
         />
       </button>
@@ -110,7 +110,7 @@ exports[`TypedSignInfo correctly renders typed sign data request 1`] = `
         style="cursor: pointer; position: absolute; right: 8px;"
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/collapse.svg');"
         />
       </button>

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/__snapshots__/typed-sign.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/__snapshots__/typed-sign.test.tsx.snap
@@ -333,7 +333,7 @@ exports[`TypedSignInfo correctly renders permit sign type 1`] = `
         style="cursor: pointer; position: absolute; right: 32px; top: 2px;"
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/copy.svg');"
         />
       </button>
@@ -344,7 +344,7 @@ exports[`TypedSignInfo correctly renders permit sign type 1`] = `
         style="cursor: pointer; position: absolute; right: 8px;"
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/expand.svg');"
         />
       </button>
@@ -701,7 +701,7 @@ exports[`TypedSignInfo correctly renders permit sign type with no deadline 1`] =
         style="cursor: pointer; position: absolute; right: 32px; top: 2px;"
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/copy.svg');"
         />
       </button>
@@ -712,7 +712,7 @@ exports[`TypedSignInfo correctly renders permit sign type with no deadline 1`] =
         style="cursor: pointer; position: absolute; right: 8px;"
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/expand.svg');"
         />
       </button>
@@ -895,7 +895,7 @@ exports[`TypedSignInfo renders origin for typed sign data request 1`] = `
         style="cursor: pointer; position: absolute; right: 4px; top: 2px;"
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/copy.svg');"
         />
       </button>
@@ -1589,7 +1589,7 @@ exports[`TypedSignInfo should render message for typed sign v3 request 1`] = `
         style="cursor: pointer; position: absolute; right: 4px; top: 2px;"
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/copy.svg');"
         />
       </button>
@@ -2040,7 +2040,7 @@ exports[`TypedSignInfo should render message for typed sign v4 request 1`] = `
         style="cursor: pointer; position: absolute; right: 4px; top: 2px;"
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/copy.svg');"
         />
       </button>

--- a/ui/pages/confirmations/components/confirm/nav/__snapshots__/nav.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/nav/__snapshots__/nav.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`ConfirmNav should match snapshot 1`] = `
         disabled=""
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/arrow-left.svg');"
         />
       </button>
@@ -34,7 +34,7 @@ exports[`ConfirmNav should match snapshot 1`] = `
         data-testid="confirm-nav__next-confirmation"
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/arrow-right.svg');"
         />
       </button>

--- a/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
+++ b/ui/pages/confirmations/confirm/__snapshots__/confirm.test.tsx.snap
@@ -102,7 +102,7 @@ exports[`Confirm matches snapshot for signature - personal sign type 1`] = `
                   data-testid="header-info__account-details-button"
                 >
                   <span
-                    class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                    class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                     style="mask-image: url('./images/icons/info.svg');"
                   />
                 </button>
@@ -226,7 +226,7 @@ exports[`Confirm matches snapshot for signature - personal sign type 1`] = `
                 style="cursor: pointer; position: absolute; right: 32px; top: 2px;"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/copy.svg');"
                 />
               </button>
@@ -237,7 +237,7 @@ exports[`Confirm matches snapshot for signature - personal sign type 1`] = `
                 style="cursor: pointer; position: absolute; right: 8px;"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/collapse.svg');"
                 />
               </button>
@@ -713,7 +713,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
                 style="cursor: pointer; position: absolute; right: 32px; top: 2px;"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/copy.svg');"
                 />
               </button>
@@ -724,7 +724,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitB
                 style="cursor: pointer; position: absolute; right: 8px;"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/expand.svg');"
                 />
               </button>
@@ -1137,7 +1137,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitS
                 style="cursor: pointer; position: absolute; right: 32px; top: 2px;"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/copy.svg');"
                 />
               </button>
@@ -1148,7 +1148,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 - PermitS
                 style="cursor: pointer; position: absolute; right: 8px;"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/expand.svg');"
                 />
               </button>
@@ -1298,7 +1298,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 1`] = `
                   data-testid="header-info__account-details-button"
                 >
                   <span
-                    class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                    class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                     style="mask-image: url('./images/icons/info.svg');"
                   />
                 </button>
@@ -1480,7 +1480,7 @@ exports[`Confirm should match snapshot for signature - typed sign - V4 1`] = `
                 style="cursor: pointer; position: absolute; right: 4px; top: 2px;"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/copy.svg');"
                 />
               </button>
@@ -2399,7 +2399,7 @@ exports[`Confirm should match snapshot for signature - typed sign - permit 1`] =
                 style="cursor: pointer; position: absolute; right: 32px; top: 2px;"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/copy.svg');"
                 />
               </button>
@@ -2410,7 +2410,7 @@ exports[`Confirm should match snapshot for signature - typed sign - permit 1`] =
                 style="cursor: pointer; position: absolute; right: 8px;"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/expand.svg');"
                 />
               </button>
@@ -2640,7 +2640,7 @@ exports[`Confirm should match snapshot signature - typed sign - order 1`] = `
                 style="cursor: pointer; position: absolute; right: 32px; top: 2px;"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/copy.svg');"
                 />
               </button>
@@ -2651,7 +2651,7 @@ exports[`Confirm should match snapshot signature - typed sign - order 1`] = `
                 style="cursor: pointer; position: absolute; right: 8px;"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/collapse.svg');"
                 />
               </button>
@@ -3277,7 +3277,7 @@ exports[`Confirm should render SmartTransactionsBannerAlert for transaction type
                   data-testid="header-info__account-details-button"
                 >
                   <span
-                    class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+                    class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
                     style="mask-image: url('./images/icons/info.svg');"
                   />
                 </button>
@@ -3462,7 +3462,7 @@ exports[`Confirm should render SmartTransactionsBannerAlert for transaction type
                 style="cursor: pointer; position: absolute; right: 4px; top: 2px;"
               >
                 <span
-                  class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                  class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                   style="mask-image: url('./images/icons/copy.svg');"
                 />
               </button>

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/create-snap-account.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/create-snap-account.test.js.snap
@@ -21,7 +21,7 @@ exports[`create-snap-account confirmation should match snapshot 1`] = `
             class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
           >
             <span
-              class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+              class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
               style="mask-image: url('./images/icons/close.svg');"
             />
           </button>

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/remove-snap-account.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/remove-snap-account.test.js.snap
@@ -21,7 +21,7 @@ exports[`remove-snap-account confirmation should match snapshot 1`] = `
             class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
           >
             <span
-              class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
+              class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
               style="mask-image: url('./images/icons/close.svg');"
             />
           </button>

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/snap-account-redirect.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/snap-account-redirect.test.js.snap
@@ -121,7 +121,7 @@ exports[`snap-account-redirect confirmation should match snapshot 1`] = `
                         data-testid="snap-account-redirect-url-icon"
                       >
                         <span
-                          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                           style="mask-image: url('./images/icons/export.svg');"
                         />
                       </button>

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/switch-ethereum-chain.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/switch-ethereum-chain.test.js.snap
@@ -229,7 +229,7 @@ exports[`switch-ethereum-chain confirmation should show alert if there are pendi
           class="mm-box mm-button-icon mm-button-icon--size-sm callout__close-button mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
         >
           <span
-            class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+            class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
             style="mask-image: url('./images/icons/close.svg');"
           />
         </button>

--- a/ui/pages/defi/components/__snapshots__/defi-details-page.test.tsx.snap
+++ b/ui/pages/defi/components/__snapshots__/defi-details-page.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`DeFiDetailsPage renders defi asset page 1`] = `
         data-testid="defi-details-page-back-button"
       >
         <span
-          class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+          class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
           style="mask-image: url('./images/icons/arrow-left.svg');"
         />
       </button>

--- a/ui/pages/snap-account-redirect/__snapshots__/create-snap-redirect.test.tsx.snap
+++ b/ui/pages/snap-account-redirect/__snapshots__/create-snap-redirect.test.tsx.snap
@@ -117,7 +117,7 @@ exports[`<SnapAccountRedirect /> renders the url and message when provided and i
                     data-testid="snap-account-redirect-url-icon"
                   >
                     <span
-                      class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
+                      class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"
                       style="mask-image: url('./images/icons/export.svg');"
                     />
                   </button>


### PR DESCRIPTION
## **Description**

Aligns the legacy `ButtonIcon` component's container dimensions and icon size mapping with the MetaMask Design System React spec.

**Legacy — Extension & Mobile `component-library` (before this PR):**

| ButtonIconSize | Button container | Icon size |
|----------------|------------------|-----------|
| Sm             | 24×24px          | 16×16px   |
| Md             | 28×28px          | 20×20px   |
| Lg             | 32×32px          | 24×24px   |

**Design system (React & React Native — target values):**

| ButtonIconSize | Button container | Icon size |
|----------------|------------------|-----------|
| Sm             | 24×24px          | 20×20px   |
| Md             | 32×32px          | 24×24px   |
| Lg             | 40×40px          | 32×32px   |

**Changes:**
- `button-icon.scss`: container sizes updated (`md` 28→32px, `lg` 32→40px)
- `button-icon.tsx`: icon size mapping updated (`Sm→Md`, `Md→Lg`, `Lg→Xl`)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Open Storybook and navigate to `ComponentLibrary / ButtonIcon`
2. Verify `Sm`, `Md`, and `Lg` sizes render at the correct container and icon dimensions per the table above

## **Screenshots/Recordings**

### **Before**

Storybook 

https://github.com/user-attachments/assets/eb98cee1-5ee9-48c2-a9c2-a56b281cbd61

App 

https://github.com/user-attachments/assets/5d488d47-cea0-42b8-953c-0391b38cdc1e

### **After**

Storybook

https://github.com/user-attachments/assets/cd55db4e-6b2b-44b6-ab3d-5e601121f04e

App

https://github.com/user-attachments/assets/dade0418-d8d5-4d72-a710-e5cbecaf2631

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.