### PR TITLE
chore: remove code ownership from snapshot files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -270,3 +270,8 @@ app/scripts/lib/metaRPCClientFactory.ts              @MetaMask/extension-platfor
 ui/hooks/gator-permissions                           @MetaMask/delegation
 app/scripts/messenger-client-init/gator-permissions  @MetaMask/delegation
 shared/lib/gator-permissions                         @MetaMask/delegation
+
+# Snapshots – no code owners assigned
+# This allows anyone with write access to approve changes to any *.snap files.
+# ⚠️ Note: Leaving this rule unassigned disables Code Owner review enforcement for snapshot files.
+**/*.snap


### PR DESCRIPTION
## **Description**

Removes code ownership from `*.snap` files so that snapshot changes no longer trigger automatic review requests from teams across the codebase.

Snapshot files are a significant blocker for sweeping design system changes. When any `*.snap` file changes, GitHub requests a review from every team whose path patterns match those files — even teams with no stake in the visual change itself. This turns a routine alignment (e.g. fixing icon sizes across components) into a multi-team review coordination problem that can stall PRs for days.

This mirrors the strategy adopted by metamask-mobile ([CODEOWNERS](https://github.com/MetaMask/metamask-mobile/blob/main/.github/CODEOWNERS)), where the mobile team took the same approach before eventually removing all snapshots entirely. Anyone with write access can still review and approve snapshot changes; this simply prevents automatic review requests from being triggered.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Open a PR that modifies any `*.snap` file
2. Verify that no teams are automatically added as required reviewers for the snapshot changes

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.