### PR TITLE
ci: Enable `skip-benchmark-gate` label on release branches cp-13.35.0

### DIFF
--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -250,23 +250,38 @@ jobs:
           merge-multiple: true
 
       # skip-benchmark-gate label: convenience escape hatch for Phase 2–3.
+      # Honored on pull_request runs and on release/* push runs (RC validation)
+      # by resolving the open PR(s) containing the commit; never on main pushes.
+      # Labels are read at run time, so re-running this job picks up a label
+      # added after the failure.
       # Remove when graduating to Phase 4 (required check) — at that point,
       # use admin bypass or update thresholds instead.
       - name: Check for skip label
         id: skip-check
         continue-on-error: true
-        if: >-
-          ${{
-            steps.download-benchmarks.outcome == 'success' &&
-            github.event_name == 'pull_request'
-          }}
+        if: ${{ steps.download-benchmarks.outcome == 'success' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
+          EVENT_REF: ${{ github.ref }}
+          REPO: ${{ github.repository }}
+          COMMIT_SHA: ${{ github.sha }}
         run: |
-          LABELS=$(gh api repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/labels --jq '.[].name')
-          if echo "$LABELS" | grep -qx 'skip-benchmark-gate'; then
-            echo "skip=true" >> "$GITHUB_OUTPUT"
+          if [ "$EVENT_NAME" = 'pull_request' ]; then
+            PR_NUMBERS="$EVENT_PR_NUMBER"
+          elif [[ "$EVENT_REF" == refs/heads/release/* ]]; then
+            PR_NUMBERS=$(gh api "repos/$REPO/commits/$COMMIT_SHA/pulls" --jq '.[] | select(.state == "open") | .number')
+          else
+            PR_NUMBERS=''
           fi
+          for pr in $PR_NUMBERS; do
+            LABELS=$(gh api "repos/$REPO/issues/$pr/labels" --jq '.[].name')
+            if echo "$LABELS" | grep -qx 'skip-benchmark-gate'; then
+              echo "skip-benchmark-gate label found on PR #$pr — skipping quality gate"
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+            fi
+          done
         shell: bash
 
       - name: Run quality gate


### PR DESCRIPTION
## **Description**

The `skip-benchmark-gate` label — the documented escape hatch for the `run-benchmarks / quality-gate` job (Phase 2–3 rollout) — is currently only honored on `pull_request`-event runs. But RC validation produces **push**-event runs on `release/*` branches, where the step is unconditionally skipped and the label is never read.

This PR makes the skip-check event-aware:

- `pull_request` runs: unchanged — read labels of the PR itself.
- `release/*` push runs: resolve the open PR(s) containing the pushed commit via `commits/{sha}/pulls` and read their labels (RC branches always have an open release PR).
- `main` pushes and anything else: label resolution is explicitly skipped, so gate coverage on `main` is unchanged.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related: #43518, #43256

## **Manual testing steps**

1. Both new code paths were dry-run against the live v13.35.0 RC data:
   - `gh api repos/MetaMask/metamask-extension/commits/e3121b4cb0f5e0ff040b0e53183bf34e0e5d38e6/pulls --jq '.[] | select(.state == "open") | .number'` → returns `43256`
   - `gh api repos/MetaMask/metamask-extension/issues/43256/labels --jq '.[].name'` → includes `skip-benchmark-gate`
2. After this lands on a `release/*` branch, the next push run's `quality-gate` job should log `skip-benchmark-gate label found on PR #<n> — skipping quality gate` and pass.
3. `pull_request` runs on this PR exercise the unchanged PR-event path.

## **Screenshots/Recordings**

### **Before**

Gate job on RC push run, attempt 5 — `Check for skip label: skipped`, gate fails despite label: https://github.com/MetaMask/metamask-extension/actions/runs/27433212146/job/81103386745

### **After**

N/A (CI behavior — see manual testing steps)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.