### PR TITLE
fix: Correct `SnapUIFooterButton` text color

### DIFF
--- a/ui/components/app/snaps/snap-ui-footer-button/index.scss
+++ b/ui/components/app/snaps/snap-ui-footer-button/index.scss
@@ -13,7 +13,7 @@
       }
 
       &:not(.snap-ui-renderer__footer-button--danger) {
-        color: var(--color-text-alternative);
+        color: var(--color-icon-inverse);
         background-color: var(--color-icon-default);
       }
     }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The `SnapUIFooterButton` text color drifted at some point recently, this PR fixes that.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="372" height="737" alt="Screenshot 2026-06-15 at 10 55 07" src="https://github.com/user-attachments/assets/d3eb210d-12bf-4c4a-8fa0-8c67d8ee0974" />

### **After**
<img width="371" height="745" alt="Screenshot 2026-06-15 at 10 52 44" src="https://github.com/user-attachments/assets/f8d6d7f0-e5c0-47e1-a406-e0bc35932bfe" />
