### PR TITLE
feat(activity): display TRC20 approve transactions as approved spendi…

### DIFF
--- a/package.json
+++ b/package.json
@@ -306,7 +306,8 @@
     "@metamask/permission-controller@npm:^12.3.0": "^13.0.0",
     "@metamask/transaction-pay-controller@npm:^22.6.0": "patch:@metamask/transaction-pay-controller@npm%3A22.6.0#~/.yarn/patches/@metamask-transaction-pay-controller-npm-22.6.0-ecc6df0372.patch",
     "@metamask/assets-controller@npm:^7.1.2": "patch:@metamask/assets-controller@npm%3A8.3.2#~/.yarn/patches/@metamask-assets-controller-npm-8.3.2-f205cdbfee.patch",
-    "@metamask/assets-controller@npm:^8.1.0": "patch:@metamask/assets-controller@npm%3A8.3.2#~/.yarn/patches/@metamask-assets-controller-npm-8.3.2-f205cdbfee.patch"
+    "@metamask/assets-controller@npm:^8.1.0": "patch:@metamask/assets-controller@npm%3A8.3.2#~/.yarn/patches/@metamask-assets-controller-npm-8.3.2-f205cdbfee.patch",
+    "@metamask/tron-wallet-snap": "npm:@metamask-previews/tron-wallet-snap@1.26.0-preview-4cedfa4"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.29.2#~/.yarn/patches/@babel-runtime-npm-7.29.2-b49cad1c67.patch",

--- a/package.json
+++ b/package.json
@@ -306,8 +306,7 @@
     "@metamask/permission-controller@npm:^12.3.0": "^13.0.0",
     "@metamask/transaction-pay-controller@npm:^22.6.0": "patch:@metamask/transaction-pay-controller@npm%3A22.6.0#~/.yarn/patches/@metamask-transaction-pay-controller-npm-22.6.0-ecc6df0372.patch",
     "@metamask/assets-controller@npm:^7.1.2": "patch:@metamask/assets-controller@npm%3A8.3.2#~/.yarn/patches/@metamask-assets-controller-npm-8.3.2-f205cdbfee.patch",
-    "@metamask/assets-controller@npm:^8.1.0": "patch:@metamask/assets-controller@npm%3A8.3.2#~/.yarn/patches/@metamask-assets-controller-npm-8.3.2-f205cdbfee.patch",
-    "@metamask/tron-wallet-snap": "npm:@metamask-previews/tron-wallet-snap@1.26.0-preview-4cedfa4"
+    "@metamask/assets-controller@npm:^8.1.0": "patch:@metamask/assets-controller@npm%3A8.3.2#~/.yarn/patches/@metamask-assets-controller-npm-8.3.2-f205cdbfee.patch"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.29.2#~/.yarn/patches/@babel-runtime-npm-7.29.2-b49cad1c67.patch",
@@ -445,7 +444,7 @@
     "@metamask/subscription-controller": "^6.1.2",
     "@metamask/transaction-controller": "^68.0.0",
     "@metamask/transaction-pay-controller": "^22.6.0",
-    "@metamask/tron-wallet-snap": "^1.26.0",
+    "@metamask/tron-wallet-snap": "^1.27.0",
     "@metamask/user-operation-controller": "^41.2.0",
     "@metamask/utils": "^11.11.0",
     "@metamask/wallet": "^3.0.0",

--- a/shared/lib/activity/adapters/keyring-transaction.test.ts
+++ b/shared/lib/activity/adapters/keyring-transaction.test.ts
@@ -167,8 +167,8 @@ describe('mapKeyringTransaction', () => {
       chainId: MultichainNetworks.SOLANA,
       status: 'success',
       timestamp: 1716367781000,
+      hash: 'approve-id',
       data: {
-        hash: 'approve-id',
         from: 'owner-address',
         token: {
           amount: '999999999999999',
@@ -210,8 +210,8 @@ describe('mapKeyringTransaction', () => {
 
     expect(item).toMatchObject({
       type: 'approveSpendingCap',
+      hash: 'unlimited-approve-id',
       data: {
-        hash: 'unlimited-approve-id',
         token: {
           assetId: `${MultichainNetworks.SOLANA}/token:usdc`,
           symbol: 'USDC',

--- a/shared/lib/activity/adapters/keyring-transaction.test.ts
+++ b/shared/lib/activity/adapters/keyring-transaction.test.ts
@@ -136,6 +136,128 @@ describe('mapKeyringTransaction', () => {
     });
   });
 
+  it('maps token approve with amount ≤15 digits to approveSpendingCap preserving the amount', () => {
+    const item = mapKeyringTransaction({
+      transaction: {
+        id: 'approve-id',
+        chain: MultichainNetworks.SOLANA,
+        account: '00000000-0000-4000-8000-000000000000',
+        status: TransactionStatus.Confirmed,
+        timestamp: 1716367781,
+        type: TransactionType.TokenApprove,
+        from: [
+          {
+            address: 'owner-address',
+            asset: {
+              fungible: true,
+              type: `${MultichainNetworks.SOLANA}/token:usdc`,
+              unit: 'USDC',
+              amount: '999999999999999', // 15 digits — kept
+            },
+          },
+        ],
+        to: [{ address: 'spender-address', asset: null }],
+        fees: [],
+        events: [],
+      },
+    });
+
+    expect(item).toMatchObject({
+      type: 'approveSpendingCap',
+      chainId: MultichainNetworks.SOLANA,
+      status: 'success',
+      timestamp: 1716367781000,
+      data: {
+        hash: 'approve-id',
+        from: 'owner-address',
+        token: {
+          amount: '999999999999999',
+          assetId: `${MultichainNetworks.SOLANA}/token:usdc`,
+          direction: 'out',
+          symbol: 'USDC',
+        },
+      },
+    });
+  });
+
+  it('strips token amount for approve with >15 digit integer part (uint256.max)', () => {
+    const uint256Max =
+      '115792089237316195423570985008687907853269984665640564039457584007913129639935';
+    const item = mapKeyringTransaction({
+      transaction: {
+        id: 'unlimited-approve-id',
+        chain: MultichainNetworks.SOLANA,
+        account: '00000000-0000-4000-8000-000000000000',
+        status: TransactionStatus.Confirmed,
+        timestamp: 1716367781,
+        type: TransactionType.TokenApprove,
+        from: [
+          {
+            address: 'owner-address',
+            asset: {
+              fungible: true,
+              type: `${MultichainNetworks.SOLANA}/token:usdc`,
+              unit: 'USDC',
+              amount: uint256Max,
+            },
+          },
+        ],
+        to: [{ address: 'spender-address', asset: null }],
+        fees: [],
+        events: [],
+      },
+    });
+
+    expect(item).toMatchObject({
+      type: 'approveSpendingCap',
+      data: {
+        hash: 'unlimited-approve-id',
+        token: {
+          assetId: `${MultichainNetworks.SOLANA}/token:usdc`,
+          symbol: 'USDC',
+          direction: 'out',
+          amount: undefined,
+        },
+      },
+    });
+  });
+
+  it('strips token amount when integer part has exactly 16 digits (boundary)', () => {
+    const item = mapKeyringTransaction({
+      transaction: {
+        id: 'boundary-approve-id',
+        chain: MultichainNetworks.SOLANA,
+        account: '00000000-0000-4000-8000-000000000000',
+        status: TransactionStatus.Confirmed,
+        timestamp: 1716367781,
+        type: TransactionType.TokenApprove,
+        from: [
+          {
+            address: 'owner-address',
+            asset: {
+              fungible: true,
+              type: `${MultichainNetworks.SOLANA}/token:usdc`,
+              unit: 'USDC',
+              amount: '1000000000000000', // 16 digits — stripped
+            },
+          },
+        ],
+        to: [{ address: 'spender-address', asset: null }],
+        fees: [],
+        events: [],
+      },
+    });
+
+    expect(item).toMatchObject({
+      type: 'approveSpendingCap',
+      data: {
+        token: {
+          amount: undefined,
+        },
+      },
+    });
+  });
+
   it('maps bitcoin send from account address and to output address', () => {
     const item = mapKeyringTransaction({
       subjectAddress: 'bc1qcj8v4ft5uvt59jjrxd856a48xegclwne78h0ye',

--- a/shared/lib/activity/adapters/keyring-transaction.ts
+++ b/shared/lib/activity/adapters/keyring-transaction.ts
@@ -90,6 +90,10 @@ function getFees(transaction: Transaction) {
   });
 }
 
+// Amounts with more integer digits than this are treated as "unlimited" and hidden.
+// Mirrors TOKEN_VALUE_UNLIMITED_THRESHOLD = 10^15 used on EVM confirmation screens.
+const APPROVE_AMOUNT_MAX_INTEGER_DIGITS = 15;
+
 function mapBridgeStatus(bridgeStatus: BridgeStatusTypes): Status {
   switch (bridgeStatus) {
     case BridgeStatusTypes.FAILED:
@@ -221,6 +225,31 @@ export function mapKeyringTransaction({
         destinationToken: getToken(transaction.to, 'in'),
         sourceToken: getToken(transaction.from, 'out'),
         fees,
+      },
+    };
+  }
+
+  if (transaction.type === KeyringTransactionType.TokenApprove) {
+    const rawToken = getToken(transaction.from, 'out');
+    // Hide the approved amount when its integer part exceeds 15 digits (~1 quadrillion),
+    // matching the EVM API confirmed path which never exposes the approved amount.
+    // This also prevents uint256.max (78 digits) from collapsing the title column.
+    const isUnlimited =
+      rawToken?.amount !== undefined &&
+      rawToken.amount.split('.')[0].length > APPROVE_AMOUNT_MAX_INTEGER_DIGITS;
+
+    return {
+      type: 'approveSpendingCap',
+      chainId,
+      status,
+      timestamp,
+      data: {
+        hash: transaction.id,
+        from,
+        token: rawToken
+          ? { ...rawToken, amount: isUnlimited ? undefined : rawToken.amount }
+          : rawToken,
+        fees: getFees(transaction),
       },
     };
   }

--- a/shared/lib/activity/adapters/keyring-transaction.ts
+++ b/shared/lib/activity/adapters/keyring-transaction.ts
@@ -243,8 +243,8 @@ export function mapKeyringTransaction({
       chainId,
       status,
       timestamp,
+      hash: transaction.id,
       data: {
-        hash: transaction.id,
         from,
         token: rawToken
           ? { ...rawToken, amount: isUnlimited ? undefined : rawToken.amount }

--- a/shared/lib/activity/adapters/keyring-transaction.ts
+++ b/shared/lib/activity/adapters/keyring-transaction.ts
@@ -249,7 +249,7 @@ export function mapKeyringTransaction({
         token: rawToken
           ? { ...rawToken, amount: isUnlimited ? undefined : rawToken.amount }
           : rawToken,
-        fees: getFees(transaction),
+        fees,
       },
     };
   }

--- a/ui/hooks/useMultichainTransactionDisplay.test.ts
+++ b/ui/hooks/useMultichainTransactionDisplay.test.ts
@@ -223,8 +223,12 @@ describe('useMultichainTransactionDisplay', () => {
   it('returns approve spending cap title with token symbol for TokenApprove', () => {
     const tx = baseTransaction({
       type: TransactionType.TokenApprove,
-      from: [{ asset: makeAsset(USDC_ASSET_ID, '1000', 'USDC'), address: 'Addr' }],
-      to: [{ asset: makeAsset(USDC_ASSET_ID, '0', 'USDC'), address: 'Spender' }],
+      from: [
+        { asset: makeAsset(USDC_ASSET_ID, '1000', 'USDC'), address: 'Addr' },
+      ],
+      to: [
+        { asset: makeAsset(USDC_ASSET_ID, '0', 'USDC'), address: 'Spender' },
+      ],
     });
     const { result } = renderHookWithProvider(
       () => useMultichainTransactionDisplay(tx as never),
@@ -237,7 +241,9 @@ describe('useMultichainTransactionDisplay', () => {
     const tx = baseTransaction({
       type: TransactionType.TokenApprove,
       from: [],
-      to: [{ asset: makeAsset(USDC_ASSET_ID, '0', 'USDC'), address: 'Spender' }],
+      to: [
+        { asset: makeAsset(USDC_ASSET_ID, '0', 'USDC'), address: 'Spender' },
+      ],
     });
     const { result } = renderHookWithProvider(
       () => useMultichainTransactionDisplay(tx as never),

--- a/ui/hooks/useMultichainTransactionDisplay.test.ts
+++ b/ui/hooks/useMultichainTransactionDisplay.test.ts
@@ -220,6 +220,32 @@ describe('useMultichainTransactionDisplay', () => {
     expect(result.current.priorityFee).toBeDefined();
   });
 
+  it('returns approve spending cap title with token symbol for TokenApprove', () => {
+    const tx = baseTransaction({
+      type: TransactionType.TokenApprove,
+      from: [{ asset: makeAsset(USDC_ASSET_ID, '1000', 'USDC'), address: 'Addr' }],
+      to: [{ asset: makeAsset(USDC_ASSET_ID, '0', 'USDC'), address: 'Spender' }],
+    });
+    const { result } = renderHookWithProvider(
+      () => useMultichainTransactionDisplay(tx as never),
+      mockState,
+    );
+    expect(result.current.title).toContain('USDC');
+  });
+
+  it('returns a defined title for TokenApprove when from has no unit', () => {
+    const tx = baseTransaction({
+      type: TransactionType.TokenApprove,
+      from: [],
+      to: [{ asset: makeAsset(USDC_ASSET_ID, '0', 'USDC'), address: 'Spender' }],
+    });
+    const { result } = renderHookWithProvider(
+      () => useMultichainTransactionDisplay(tx as never),
+      mockState,
+    );
+    expect(result.current.title).toBeDefined();
+  });
+
   it('returns Swap title combining from and to units', () => {
     const tx = baseTransaction({
       type: TransactionType.Swap,

--- a/ui/hooks/useMultichainTransactionDisplay.ts
+++ b/ui/hooks/useMultichainTransactionDisplay.ts
@@ -83,6 +83,9 @@ export function useMultichainTransactionDisplay(transaction: Transaction) {
     ).toLowerCase()} ${to?.unit}`,
     [TransactionType.StakeDeposit]: t('stakingDeposit'),
     [TransactionType.StakeWithdraw]: t('stakingWithdrawal'),
+    [TransactionType.TokenApprove]: from?.unit
+      ? t('approveSpendingCap', [from.unit])
+      : t('approve'),
     [TransactionType.Unknown]: t('interaction'),
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8753,10 +8753,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/tron-wallet-snap@npm:^1.26.0":
-  version: 1.26.0
-  resolution: "@metamask/tron-wallet-snap@npm:1.26.0"
-  checksum: 10/ba7dc5d4bdae9f0a5c346744ea5eda311a1301a390c8ba3eedee4c99bf29d7d4937c65607198dcedda760223f07363638026e2649912123c4f89460de10906b4
+"@metamask/tron-wallet-snap@npm:^1.27.0":
+  version: 1.27.0
+  resolution: "@metamask/tron-wallet-snap@npm:1.27.0"
+  checksum: 10/7555f647d89502aebe5f629242113203b123ab981b9a59105cc9ae9c404cfe3ee2ac10c7d246bb58c86f15b87a874ced0629bb91429f9cc01696ac22132a5da9
   languageName: node
   linkType: hard
 
@@ -33425,7 +33425,7 @@ __metadata:
     "@metamask/test-snaps": "npm:^3.4.2"
     "@metamask/transaction-controller": "npm:^68.0.0"
     "@metamask/transaction-pay-controller": "npm:^22.6.0"
-    "@metamask/tron-wallet-snap": "npm:^1.26.0"
+    "@metamask/tron-wallet-snap": "npm:^1.27.0"
     "@metamask/user-operation-controller": "npm:^41.2.0"
     "@metamask/utils": "npm:^11.11.0"
     "@metamask/wallet": "npm:^3.0.0"


### PR DESCRIPTION
## **Description**

This pull request improves how token approval transactions are handled and displayed, particularly focusing on hiding extremely large approval amounts (such as "unlimited" approvals) and ensuring the UI displays appropriate titles for these transactions. The main changes include logic to strip the amount for approvals with integer parts exceeding 15 digits, new tests to cover these scenarios, and updates to the display logic and tests in the UI layer.

**Token Approval Amount Handling:**

* Added logic in `mapKeyringTransaction` to hide the token approval amount if its integer part exceeds 15 digits, treating it as "unlimited" and matching EVM confirmation behavior. This prevents display issues with extremely large values like `uint256.max`.

* Introduced the constant `APPROVE_AMOUNT_MAX_INTEGER_DIGITS` to define the digit threshold for hiding approval amounts.

**Testing:**

* Added tests in `keyring-transaction.test.ts` to verify that approval amounts ≤15 digits are preserved, while amounts with 16 or more digits (including `uint256.max`) are stripped from the output.

**UI Display Improvements:**

* Updated `useMultichainTransactionDisplay` to show the token symbol in the title for `TokenApprove` transactions when available, and fallback to a generic title otherwise.

* Added tests in `useMultichainTransactionDisplay.test.ts` to ensure the correct title is returned for token approvals, both when the token symbol is present and when it is missing.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fixed display approved transactions for Non-EVM networks

## **Related issues**

Fixes: Big number digit approved Non-EVM transactions break the display

## **Manual testing steps**

1. Go to a TRON explorer dApp like Tronscan.
2. Makes an approved transaction on a TRC20 tokens with more than 15 digits
3. The approved transaction does not display the amount

1. Makes an approved transaction on a TRC20 tokens with less than 15 digits
2. The approved transaction display the approved amount

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="494" height="532" alt="BEFORE approve ext SUN" src="https://github.com/user-attachments/assets/0a513781-79a2-422c-bf87-bb869e13973d" />



### **After**

<img width="484" height="514" alt="AFTER approve ext SUN" src="https://github.com/user-attachments/assets/b5212f65-6f4f-401e-a391-feb9003847e3" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
