### PR TITLE
chore: add `sha256` hash to `packageManager` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -856,7 +856,7 @@
       "ethereumjs-util>ethereum-cryptography>secp256k1#4.0.4": false
     }
   },
-  "packageManager": "yarn@4.14.1",
+  "packageManager": "yarn@4.14.1+sha256.5c7a0c5ea1c5b690df603c8e16b3742f87169b814d56bb5e63881145e8a84033",
   "foundryup": {
     "binaries": [
       "anvil"


### PR DESCRIPTION
## **Description**

Corepack supports an optional `+sha256.<hash>` suffix on the `packageManager` field that pins the Yarn binary to a known checksum, ensuring that anyone running `corepack` against this repo gets the exact same Yarn binary that was vetted.

This mirrors the equivalent change made in `MetaMask/core` (MetaMask/core#9122).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run `corepack enable` and `yarn --version` — Yarn `4.14.1` should be installed and usable as before.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.