### PR TITLE
feat(analytics): track Onboarding Completed alongside Wallet Setup Completed

### DIFF
--- a/shared/lib/analytics/onboardingCompletedAnalytics.test.ts
+++ b/shared/lib/analytics/onboardingCompletedAnalytics.test.ts
@@ -1,0 +1,35 @@
+import {
+  getOnboardingCompletedAnalyticsProps,
+  ONBOARDING_IMPLEMENTATION_TYPE_EXTENSION,
+  ONBOARDING_TYPE_SEED_PHRASE,
+  ONBOARDING_TYPE_SOCIAL_LOGIN,
+} from './onboardingCompletedAnalytics';
+
+const walletSetupCompletedProps = {
+  wallet_setup_type: 'new' as const,
+  new_wallet: true,
+  account_type: 'metamask',
+  utm_source: 'newsletter',
+};
+
+describe('getOnboardingCompletedAnalyticsProps', () => {
+  it('returns wallet setup completed props with extension implementation and seed_phrase onboarding type', () => {
+    expect(
+      getOnboardingCompletedAnalyticsProps(walletSetupCompletedProps, false),
+    ).toEqual({
+      ...walletSetupCompletedProps,
+      implementation_type: ONBOARDING_IMPLEMENTATION_TYPE_EXTENSION,
+      onboarding_type: ONBOARDING_TYPE_SEED_PHRASE,
+    });
+  });
+
+  it('returns wallet setup completed props with extension implementation and social_login onboarding type', () => {
+    expect(
+      getOnboardingCompletedAnalyticsProps(walletSetupCompletedProps, true),
+    ).toEqual({
+      ...walletSetupCompletedProps,
+      implementation_type: ONBOARDING_IMPLEMENTATION_TYPE_EXTENSION,
+      onboarding_type: ONBOARDING_TYPE_SOCIAL_LOGIN,
+    });
+  });
+});

--- a/shared/lib/analytics/onboardingCompletedAnalytics.test.ts
+++ b/shared/lib/analytics/onboardingCompletedAnalytics.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention, camelcase -- Segment-shaped assertions match analytics schema */
 import {
   getOnboardingCompletedAnalyticsProps,
+  normalizeOnboardingCompletedAccountType,
   ONBOARDING_IMPLEMENTATION_TYPE_EXTENSION,
   ONBOARDING_TYPE_SEED_PHRASE,
   ONBOARDING_TYPE_SOCIAL_LOGIN,
@@ -12,6 +13,24 @@ const walletSetupCompletedProps = {
   account_type: 'metamask',
   utm_source: 'newsletter',
 };
+
+describe('normalizeOnboardingCompletedAccountType', () => {
+  it('maps social login account types to schema account_type enums', () => {
+    expect(normalizeOnboardingCompletedAccountType('metamask_google')).toBe(
+      'metamask',
+    );
+    expect(normalizeOnboardingCompletedAccountType('imported_apple')).toBe(
+      'imported',
+    );
+  });
+
+  it('preserves supported hardware account types', () => {
+    expect(normalizeOnboardingCompletedAccountType('Ledger')).toBe('Ledger');
+    expect(normalizeOnboardingCompletedAccountType('QR Hardware')).toBe(
+      'QR Hardware',
+    );
+  });
+});
 
 describe('getOnboardingCompletedAnalyticsProps', () => {
   it('returns wallet setup completed props with extension implementation and seed_phrase onboarding type', () => {
@@ -26,9 +45,16 @@ describe('getOnboardingCompletedAnalyticsProps', () => {
 
   it('returns wallet setup completed props with extension implementation and social_login onboarding type', () => {
     expect(
-      getOnboardingCompletedAnalyticsProps(walletSetupCompletedProps, true),
+      getOnboardingCompletedAnalyticsProps(
+        {
+          ...walletSetupCompletedProps,
+          account_type: 'metamask_google',
+        },
+        true,
+      ),
     ).toStrictEqual({
       ...walletSetupCompletedProps,
+      account_type: 'metamask',
       implementation_type: ONBOARDING_IMPLEMENTATION_TYPE_EXTENSION,
       onboarding_type: ONBOARDING_TYPE_SOCIAL_LOGIN,
     });

--- a/shared/lib/analytics/onboardingCompletedAnalytics.test.ts
+++ b/shared/lib/analytics/onboardingCompletedAnalytics.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention, camelcase -- Segment-shaped assertions match analytics schema */
 import {
   getOnboardingCompletedAnalyticsProps,
   ONBOARDING_IMPLEMENTATION_TYPE_EXTENSION,
@@ -16,7 +17,7 @@ describe('getOnboardingCompletedAnalyticsProps', () => {
   it('returns wallet setup completed props with extension implementation and seed_phrase onboarding type', () => {
     expect(
       getOnboardingCompletedAnalyticsProps(walletSetupCompletedProps, false),
-    ).toEqual({
+    ).toStrictEqual({
       ...walletSetupCompletedProps,
       implementation_type: ONBOARDING_IMPLEMENTATION_TYPE_EXTENSION,
       onboarding_type: ONBOARDING_TYPE_SEED_PHRASE,
@@ -26,7 +27,7 @@ describe('getOnboardingCompletedAnalyticsProps', () => {
   it('returns wallet setup completed props with extension implementation and social_login onboarding type', () => {
     expect(
       getOnboardingCompletedAnalyticsProps(walletSetupCompletedProps, true),
-    ).toEqual({
+    ).toStrictEqual({
       ...walletSetupCompletedProps,
       implementation_type: ONBOARDING_IMPLEMENTATION_TYPE_EXTENSION,
       onboarding_type: ONBOARDING_TYPE_SOCIAL_LOGIN,

--- a/shared/lib/analytics/onboardingCompletedAnalytics.ts
+++ b/shared/lib/analytics/onboardingCompletedAnalytics.ts
@@ -8,6 +8,15 @@ export type OnboardingType =
   | typeof ONBOARDING_TYPE_SEED_PHRASE
   | typeof ONBOARDING_TYPE_SOCIAL_LOGIN;
 
+export type OnboardingCompletedAccountType =
+  | 'metamask'
+  | 'imported'
+  | 'snap'
+  | 'Ledger'
+  | 'Trezor'
+  | 'QR Hardware'
+  | 'Lattice';
+
 export type WalletSetupCompletedAnalyticsProps = {
   wallet_setup_type: 'new' | 'import';
   new_wallet: boolean;
@@ -20,18 +29,48 @@ export type WalletSetupCompletedAnalyticsProps = {
   attribution_id?: string;
 };
 
-export type OnboardingCompletedAnalyticsProps =
-  WalletSetupCompletedAnalyticsProps & {
-    implementation_type: typeof ONBOARDING_IMPLEMENTATION_TYPE_EXTENSION;
-    onboarding_type: OnboardingType;
-  };
+export type OnboardingCompletedAnalyticsProps = Omit<
+  WalletSetupCompletedAnalyticsProps,
+  'account_type'
+> & {
+  account_type: OnboardingCompletedAccountType;
+  implementation_type: typeof ONBOARDING_IMPLEMENTATION_TYPE_EXTENSION;
+  onboarding_type: OnboardingType;
+};
+
+export function normalizeOnboardingCompletedAccountType(
+  accountType: string,
+): OnboardingCompletedAccountType {
+  if (accountType === 'imported' || accountType.startsWith('imported_')) {
+    return 'imported';
+  }
+
+  if (accountType === 'snap') {
+    return 'snap';
+  }
+
+  if (
+    accountType === 'Ledger' ||
+    accountType === 'Trezor' ||
+    accountType === 'QR Hardware' ||
+    accountType === 'Lattice'
+  ) {
+    return accountType;
+  }
+
+  return 'metamask';
+}
 
 export function getOnboardingCompletedAnalyticsProps(
   walletSetupCompletedProps: WalletSetupCompletedAnalyticsProps,
   isSocialLogin: boolean,
 ): OnboardingCompletedAnalyticsProps {
+  const { account_type: accountType, ...walletSetupCompletedPropsWithoutAccountType } =
+    walletSetupCompletedProps;
+
   return {
-    ...walletSetupCompletedProps,
+    ...walletSetupCompletedPropsWithoutAccountType,
+    account_type: normalizeOnboardingCompletedAccountType(accountType),
     implementation_type: ONBOARDING_IMPLEMENTATION_TYPE_EXTENSION,
     onboarding_type: isSocialLogin
       ? ONBOARDING_TYPE_SOCIAL_LOGIN

--- a/shared/lib/analytics/onboardingCompletedAnalytics.ts
+++ b/shared/lib/analytics/onboardingCompletedAnalytics.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/naming-convention, camelcase -- Segment event properties use snake_case */
 export const ONBOARDING_IMPLEMENTATION_TYPE_EXTENSION = 'extension' as const;
 
 export const ONBOARDING_TYPE_SEED_PHRASE = 'seed_phrase' as const;
@@ -7,7 +8,7 @@ export type OnboardingType =
   | typeof ONBOARDING_TYPE_SEED_PHRASE
   | typeof ONBOARDING_TYPE_SOCIAL_LOGIN;
 
-export interface WalletSetupCompletedAnalyticsProps {
+export type WalletSetupCompletedAnalyticsProps = {
   wallet_setup_type: 'new' | 'import';
   new_wallet: boolean;
   account_type: string;
@@ -17,7 +18,7 @@ export interface WalletSetupCompletedAnalyticsProps {
   utm_term?: string;
   utm_content?: string;
   attribution_id?: string;
-}
+};
 
 export type OnboardingCompletedAnalyticsProps =
   WalletSetupCompletedAnalyticsProps & {

--- a/shared/lib/analytics/onboardingCompletedAnalytics.ts
+++ b/shared/lib/analytics/onboardingCompletedAnalytics.ts
@@ -1,0 +1,39 @@
+export const ONBOARDING_IMPLEMENTATION_TYPE_EXTENSION = 'extension' as const;
+
+export const ONBOARDING_TYPE_SEED_PHRASE = 'seed_phrase' as const;
+export const ONBOARDING_TYPE_SOCIAL_LOGIN = 'social_login' as const;
+
+export type OnboardingType =
+  | typeof ONBOARDING_TYPE_SEED_PHRASE
+  | typeof ONBOARDING_TYPE_SOCIAL_LOGIN;
+
+export interface WalletSetupCompletedAnalyticsProps {
+  wallet_setup_type: 'new' | 'import';
+  new_wallet: boolean;
+  account_type: string;
+  utm_source?: string;
+  utm_medium?: string;
+  utm_campaign?: string;
+  utm_term?: string;
+  utm_content?: string;
+  attribution_id?: string;
+}
+
+export type OnboardingCompletedAnalyticsProps =
+  WalletSetupCompletedAnalyticsProps & {
+    implementation_type: typeof ONBOARDING_IMPLEMENTATION_TYPE_EXTENSION;
+    onboarding_type: OnboardingType;
+  };
+
+export function getOnboardingCompletedAnalyticsProps(
+  walletSetupCompletedProps: WalletSetupCompletedAnalyticsProps,
+  isSocialLogin: boolean,
+): OnboardingCompletedAnalyticsProps {
+  return {
+    ...walletSetupCompletedProps,
+    implementation_type: ONBOARDING_IMPLEMENTATION_TYPE_EXTENSION,
+    onboarding_type: isSocialLogin
+      ? ONBOARDING_TYPE_SOCIAL_LOGIN
+      : ONBOARDING_TYPE_SEED_PHRASE,
+  };
+}

--- a/test/integration/onboarding/import-wallet.test.tsx
+++ b/test/integration/onboarding/import-wallet.test.tsx
@@ -5,10 +5,6 @@ import mockMetaMaskState from '../data/onboarding-completion-route.json';
 import { integrationTestRender } from '../../lib/render-helpers';
 import * as backgroundConnection from '../../../ui/store/background-connection';
 import {
-  MetaMetricsEventCategory,
-  MetaMetricsEventName,
-} from '../../../shared/constants/metametrics';
-import {
   clickElementById,
   createMockImplementation,
   waitForElementByText,
@@ -90,46 +86,15 @@ describe('Import Wallet Events', () => {
     await waitForElementByText('Your wallet is ready!');
     await clickElementById('onboarding-complete-done');
 
-    // Verify both completeOnboarding and ExtensionPinned event are called
     let completeOnboardingCall;
-    let extensionPinnedEvent;
 
     await waitFor(() => {
-      // Check for completeOnboarding call
       completeOnboardingCall =
         mockedBackgroundConnection.submitRequestToBackground.mock.calls?.find(
           (call) => call[0] === 'completeOnboarding',
         );
 
-      // Check for ExtensionPinned tracking event
-      extensionPinnedEvent =
-        mockedBackgroundConnection.submitRequestToBackground.mock.calls?.find(
-          (call) => call[0] === 'trackMetaMetricsEvent',
-        );
-
       expect(completeOnboardingCall?.[0]).toBe('completeOnboarding');
-      expect(extensionPinnedEvent?.[0]).toBe('trackMetaMetricsEvent');
     });
-
-    // Verify ExtensionPinned event has correct properties for import flow
-    expect(extensionPinnedEvent?.[1]).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          category: MetaMetricsEventCategory.Onboarding,
-          event: MetaMetricsEventName.OnboardingCompleted,
-          properties: {
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            wallet_setup_type: 'import',
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            new_wallet: false,
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            is_basic_functionality_enabled: true,
-          },
-        }),
-      ]),
-    );
   });
 });

--- a/test/integration/onboarding/wallet-created.test.tsx
+++ b/test/integration/onboarding/wallet-created.test.tsx
@@ -5,10 +5,6 @@ import mockMetaMaskState from '../data/onboarding-completion-route.json';
 import { integrationTestRender } from '../../lib/render-helpers';
 import * as backgroundConnection from '../../../ui/store/background-connection';
 import {
-  MetaMetricsEventCategory,
-  MetaMetricsEventName,
-} from '../../../shared/constants/metametrics';
-import {
   clickElementById,
   createMockImplementation,
   waitForElementByText,
@@ -99,9 +95,7 @@ describe('Wallet Created Events', () => {
     await waitForElementByText('Your wallet is ready!');
     await clickElementById('onboarding-complete-done');
 
-    // Verify both completeOnboarding and ExtensionPinned event are called
     let completeOnboardingCall;
-    let extensionPinnedEvent;
 
     await waitFor(() => {
       completeOnboardingCall =
@@ -109,33 +103,7 @@ describe('Wallet Created Events', () => {
           (call) => call[0] === 'completeOnboarding',
         );
 
-      extensionPinnedEvent =
-        mockedBackgroundConnection.submitRequestToBackground.mock.calls?.find(
-          (call) => call[0] === 'trackMetaMetricsEvent',
-        );
-
       expect(completeOnboardingCall?.[0]).toBe('completeOnboarding');
-      expect(extensionPinnedEvent?.[0]).toBe('trackMetaMetricsEvent');
     });
-
-    expect(extensionPinnedEvent?.[1]).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          category: MetaMetricsEventCategory.Onboarding,
-          event: MetaMetricsEventName.OnboardingCompleted,
-          properties: {
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            wallet_setup_type: 'create',
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            new_wallet: true,
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            is_basic_functionality_enabled: true,
-          },
-        }),
-      ]),
-    );
   });
 });

--- a/ui/pages/onboarding-flow/create-password/create-password.test.tsx
+++ b/ui/pages/onboarding-flow/create-password/create-password.test.tsx
@@ -603,6 +603,8 @@ describe('Onboarding Create Password', () => {
           // eslint-disable-next-line @typescript-eslint/naming-convention
           new_wallet: true,
           // eslint-disable-next-line @typescript-eslint/naming-convention
+          account_type: 'metamask',
+          // eslint-disable-next-line @typescript-eslint/naming-convention
           implementation_type: 'extension',
           // eslint-disable-next-line @typescript-eslint/naming-convention
           onboarding_type: 'seed_phrase',
@@ -789,6 +791,8 @@ describe('Onboarding Create Password', () => {
           wallet_setup_type: 'import',
           // eslint-disable-next-line @typescript-eslint/naming-convention
           new_wallet: false,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          account_type: 'imported',
           // eslint-disable-next-line @typescript-eslint/naming-convention
           implementation_type: 'extension',
           // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/ui/pages/onboarding-flow/create-password/create-password.test.tsx
+++ b/ui/pages/onboarding-flow/create-password/create-password.test.tsx
@@ -43,6 +43,12 @@ const getWalletSetupCompletedEvent = (mockTrackEvent: jest.Mock) => {
   )?.[0];
 };
 
+const getOnboardingCompletedEvent = (mockTrackEvent: jest.Mock) => {
+  return mockTrackEvent.mock.calls.find(
+    (args) => args[0]?.event === MetaMetricsEventName.OnboardingCompleted,
+  )?.[0];
+};
+
 const backgroundConnectionMock = new Proxy(
   {},
   {
@@ -587,6 +593,23 @@ describe('Onboarding Create Password', () => {
         },
       });
       expect(walletSetupCompletedEvent.properties).not.toHaveProperty('foo');
+
+      const onboardingCompletedEvent =
+        getOnboardingCompletedEvent(mockTrackEvent);
+      expect(onboardingCompletedEvent).toMatchObject({
+        properties: {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          wallet_setup_type: 'new',
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          new_wallet: true,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          implementation_type: 'extension',
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          onboarding_type: 'seed_phrase',
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          utm_source: 'newsletter',
+        },
+      });
     });
   });
 
@@ -755,6 +778,23 @@ describe('Onboarding Create Password', () => {
           utm_content: 'hero-banner',
           // eslint-disable-next-line @typescript-eslint/naming-convention
           utm_term: 'wallet',
+        },
+      });
+
+      const onboardingCompletedEvent =
+        getOnboardingCompletedEvent(mockTrackEvent);
+      expect(onboardingCompletedEvent).toMatchObject({
+        properties: {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          wallet_setup_type: 'import',
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          new_wallet: false,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          implementation_type: 'extension',
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          onboarding_type: 'seed_phrase',
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          utm_source: 'partner',
         },
       });
       expect(walletSetupCompletedEvent.properties).not.toHaveProperty('foo');

--- a/ui/pages/onboarding-flow/create-password/create-password.tsx
+++ b/ui/pages/onboarding-flow/create-password/create-password.tsx
@@ -41,6 +41,7 @@ import {
 } from '../../../store/actions';
 import { TraceName, TraceOperation } from '../../../../shared/lib/trace';
 import { getIsWalletResetInProgress } from '../../../ducks/metamask/metamask';
+import { getOnboardingCompletedAnalyticsProps } from '../../../../shared/lib/analytics/onboardingCompletedAnalytics';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0021): route-isolation backlog
 import { CreatePasswordForm } from '../../create-password-form';
 
@@ -191,18 +192,28 @@ export default function CreatePassword({
       },
     });
 
+    const walletSetupCompletedProps = {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      wallet_setup_type: 'import' as const,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      new_wallet: false,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      account_type: accountTypeForMetrics,
+      ...utmProperties,
+    };
+
     trackEvent({
       category: MetaMetricsEventCategory.Onboarding,
       event: MetaMetricsEventName.WalletSetupCompleted,
-      properties: {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        wallet_setup_type: 'import',
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        new_wallet: false,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        account_type: accountTypeForMetrics,
-        ...utmProperties,
-      },
+      properties: walletSetupCompletedProps,
+    });
+    trackEvent({
+      category: MetaMetricsEventCategory.Onboarding,
+      event: MetaMetricsEventName.OnboardingCompleted,
+      properties: getOnboardingCompletedAnalyticsProps(
+        walletSetupCompletedProps,
+        isSocialLoginFlow,
+      ),
     });
 
     if (isPasskeyFeatureAvailable) {
@@ -246,18 +257,28 @@ export default function CreatePassword({
       },
     });
 
+    const walletSetupCompletedProps = {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      wallet_setup_type: 'new' as const,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      new_wallet: true,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      account_type: accountTypeForMetrics,
+      ...utmProperties,
+    };
+
     trackEvent({
       category: MetaMetricsEventCategory.Onboarding,
       event: MetaMetricsEventName.WalletSetupCompleted,
-      properties: {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        wallet_setup_type: 'new',
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        new_wallet: true,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        account_type: accountTypeForMetrics,
-        ...utmProperties,
-      },
+      properties: walletSetupCompletedProps,
+    });
+    trackEvent({
+      category: MetaMetricsEventCategory.Onboarding,
+      event: MetaMetricsEventName.OnboardingCompleted,
+      properties: getOnboardingCompletedAnalyticsProps(
+        walletSetupCompletedProps,
+        isSocialLoginFlow,
+      ),
     });
     if (isSocialLoginFlow) {
       // track analytics preference selected event for social login users

--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.tsx
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.tsx
@@ -36,7 +36,6 @@ import {
 import {
   getBackupAndSyncOnboardingToggleState,
   getExternalServicesOnboardingToggleState,
-  getFirstTimeFlowType,
   getOptedIn,
   getDeferredDeepLink,
   getAccountTypeForOnboardingMetrics,
@@ -46,7 +45,6 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
-import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
 import {
   getCompletedOnboarding,
   getIsInitialized,
@@ -91,7 +89,6 @@ export default function CreationSuccessful() {
     getBackupAndSyncOnboardingToggleState,
   );
   const { trackEvent } = useContext(MetaMetricsContext);
-  const firstTimeFlowType = useSelector(getFirstTimeFlowType);
   const isSidePanelEnabled = useSidePanelEnabled();
   const isOnboardingCompleted = useSelector(getCompletedOnboarding);
   const isOptedIn = useSelector(getOptedIn);
@@ -270,26 +267,6 @@ export default function CreationSuccessful() {
       deferredDeepLinkResult?.type !== DeferredDeepLinkRouteType.Navigate &&
       deferredDeepLinkResult?.type !== DeferredDeepLinkRouteType.Interstitial;
 
-    // Track onboarding completion event
-    if (!isOnboardingCompleted) {
-      const isNewWallet =
-        firstTimeFlowType === FirstTimeFlowType.create ||
-        firstTimeFlowType === FirstTimeFlowType.socialCreate;
-
-      trackEvent({
-        category: MetaMetricsEventCategory.Onboarding,
-        event: MetaMetricsEventName.OnboardingCompleted,
-        properties: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          wallet_setup_type: firstTimeFlowType,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          new_wallet: isNewWallet,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          is_basic_functionality_enabled: externalServicesOnboardingToggleState,
-        },
-      });
-    }
-
     await dispatch(
       toggleExternalServices(externalServicesOnboardingToggleState),
     );
@@ -372,7 +349,6 @@ export default function CreationSuccessful() {
     isSidePanelEnabled,
     navigate,
     isFromSettingsSecurity,
-    firstTimeFlowType,
     trackEvent,
     isOptedIn,
     handleOnDoneNavigation,


### PR DESCRIPTION
## **Description**

Adds `Onboarding Completed` analytics at wallet create/import, fired alongside the existing `Wallet Setup Completed` event.

**Reason for change:** Product analytics needs a cross-platform onboarding completion milestone with `implementation_type` and `onboarding_type`, while preserving the wallet setup context already captured on `Wallet Setup Completed`.

**What changed:**
- Fire `Onboarding Completed` from `create-password.tsx` on successful wallet create and import
- Mirror `Wallet Setup Completed` properties (`wallet_setup_type`, `new_wallet`, `account_type`, UTM attribution) and add `implementation_type: extension` plus `onboarding_type` (`seed_phrase` | `social_login`)
- Remove the previous `Onboarding Completed` trigger from the onboarding completion/pin step in `creation-successful.tsx`
- Add shared analytics helper and unit tests

**Related PRs (merge schema first):**
- Schema: https://github.com/Consensys/segment-schema/pull/624
- Mobile instrumentation: https://github.com/MetaMask/metamask-mobile/pull/31752

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Merge https://github.com/Consensys/segment-schema/pull/624 first (or test against that branch locally).
2. Create a new wallet via seed phrase onboarding and confirm Segment/MetaMetrics receives both `Wallet Setup Completed` and `Onboarding Completed` with matching wallet setup properties plus `implementation_type: extension` and `onboarding_type: seed_phrase`.
3. Import a wallet via seed phrase and confirm the same pair of events with `wallet_setup_type: import`, `new_wallet: false`, and `onboarding_type: seed_phrase`.
4. Create a wallet via social login and confirm `onboarding_type: social_login`.
5. Complete onboarding through the final pin/completion step and confirm `Onboarding Completed` does **not** fire there anymore.
6. Run unit tests: `yarn jest shared/lib/analytics/onboardingCompletedAnalytics.test.ts`

## **Screenshots/Recordings**

N/A — analytics instrumentation only.

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.