### PR TITLE
perf(6646): memory toast master individual components

### DIFF
--- a/ui/components/app/toast-master/toast-master.js
+++ b/ui/components/app/toast-master/toast-master.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types -- TODO: upgrade to TypeScript */
 
-import React, { useContext, useEffect, useState } from 'react';
+import React, { memo, useContext, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useLocation } from 'react-router-dom';
 import {
@@ -84,6 +84,19 @@ import {
   dismissSidePanelMigrationToast,
 } from './utils';
 
+// Memoized to prevent re-renders when ToastMaster re-renders due to location changes.
+const MemoizedSurveyToast = memo(SurveyToast);
+const MemoizedPrivacyPolicyToast = memo(PrivacyPolicyToast);
+const MemoizedPermittedNetworkToast = memo(PermittedNetworkToast);
+const MemoizedInfuraSwitchToast = memo(InfuraSwitchToast);
+const MemoizedMerklClaimToast = memo(MerklClaimToast);
+const MemoizedMusdConversionToast = memo(MusdConversionToast);
+const MemoizedPerpsWithdrawToast = memo(PerpsWithdrawToast);
+const MemoizedShieldPausedToast = memo(ShieldPausedToast);
+const MemoizedShieldEndingToast = memo(ShieldEndingToast);
+const MemoizedSidePanelMigrationToast = memo(SidePanelMigrationToast);
+const MemoizedStorageErrorToast = memo(StorageErrorToast);
+
 export function ToastMaster() {
   const location = useLocation();
 
@@ -97,23 +110,20 @@ export function ToastMaster() {
   const onPerpsScreen = currentPathname.startsWith(PERPS_ROUTE);
   const onSettingsScreen = currentPathname.startsWith(SETTINGS_ROUTE);
 
-  // Storage error toast should show on ALL screens
-  const storageErrorToast = <StorageErrorToast />;
-
   if (onHomeScreen) {
     return (
       <ToastContainer>
-        {storageErrorToast}
-        <SurveyToast />
-        <PrivacyPolicyToast />
-        <PermittedNetworkToast />
-        <InfuraSwitchToast />
-        <MerklClaimToast />
-        <MusdConversionToast />
-        <PerpsWithdrawToast />
-        <ShieldPausedToast />
-        <ShieldEndingToast />
-        <SidePanelMigrationToast />
+        <MemoizedStorageErrorToast />
+        <MemoizedSurveyToast />
+        <MemoizedPrivacyPolicyToast />
+        <MemoizedPermittedNetworkToast />
+        <MemoizedInfuraSwitchToast />
+        <MemoizedMerklClaimToast />
+        <MemoizedMusdConversionToast />
+        <MemoizedPerpsWithdrawToast />
+        <MemoizedShieldPausedToast />
+        <MemoizedShieldEndingToast />
+        <MemoizedSidePanelMigrationToast />
       </ToastContainer>
     );
   }
@@ -121,20 +131,28 @@ export function ToastMaster() {
   if (onPerpsScreen) {
     return (
       <ToastContainer>
-        {storageErrorToast}
-        <PerpsWithdrawToast />
+        <MemoizedStorageErrorToast />
+        <MemoizedPerpsWithdrawToast />
       </ToastContainer>
     );
   }
 
   if (onSettingsScreen) {
-    return <ToastContainer>{storageErrorToast}</ToastContainer>;
+    return (
+      <ToastContainer>
+        <MemoizedStorageErrorToast />
+      </ToastContainer>
+    );
   }
 
   // On other screens, only render ToastContainer if storage error toast should show
   // ToastContainer provides essential CSS styling (position: fixed, z-index, etc.)
   if (shouldShowStorageErrorToast) {
-    return <ToastContainer>{storageErrorToast}</ToastContainer>;
+    return (
+      <ToastContainer>
+        <MemoizedStorageErrorToast />
+      </ToastContainer>
+    );
   }
 
   return null;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
`ToastMaster` calls `useLocation()` to determine which screen is active, which causes it to re-render on every navigation. Because all toast sub-components were rendered inline, each one would also re-render and re-evaluate its selectors on every route change, even when nothing toast-related had changed.

Wrapped each toast component in `React.memo`. Since none of them receive props, memo always short-circuits their re-render when `ToastMaster` component re-renders due to a location change. Each toast now only re-renders when its own Redux selectors return a new value.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6646

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
