### PR TITLE
chore: add Storybook stories for design system v44 upgrade components

### DIFF
--- a/ui/components/app/assets/market-closed-modal.stories.tsx
+++ b/ui/components/app/assets/market-closed-modal.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { MarketClosedModal } from './market-closed-modal';
+
+const meta: Meta<typeof MarketClosedModal> = {
+  title: 'Components/App/Assets/MarketClosedModal',
+  component: MarketClosedModal,
+  args: {
+    isOpen: true,
+    onClose: () => undefined,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MarketClosedModal>;
+
+export const DefaultStory: Story = {};
+DefaultStory.storyName = 'Default';

--- a/ui/components/app/confirm/info/row/address-display.stories.tsx
+++ b/ui/components/app/confirm/info/row/address-display.stories.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { TrustSignalDisplayState } from '../../../../../hooks/useTrustSignals';
+import { ConfirmInfoRowAddressDisplay } from './address-display';
+import { TEST_ADDRESS } from './constants';
+
+const meta: Meta<typeof ConfirmInfoRowAddressDisplay> = {
+  title: 'Components/App/Confirm/ConfirmInfoRowAddressDisplay',
+  component: ConfirmInfoRowAddressDisplay,
+  argTypes: {
+    displayState: {
+      control: 'select',
+      options: Object.values(TrustSignalDisplayState),
+    },
+  },
+  args: {
+    address: TEST_ADDRESS,
+    chainId: '0x1',
+    name: 'Uniswap V3',
+    isAccount: false,
+    displayState: TrustSignalDisplayState.Verified,
+    showAvatar: true,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ConfirmInfoRowAddressDisplay>;
+
+export const DefaultStory: Story = {};
+DefaultStory.storyName = 'Default';

--- a/ui/components/app/passkey-troubleshoot-modal/passkey-troubleshoot-modal.stories.tsx
+++ b/ui/components/app/passkey-troubleshoot-modal/passkey-troubleshoot-modal.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import PasskeyTroubleshootModal from './passkey-troubleshoot-modal';
+
+const meta: Meta<typeof PasskeyTroubleshootModal> = {
+  title: 'Components/App/PasskeyTroubleshootModal',
+  component: PasskeyTroubleshootModal,
+  args: {
+    mode: 'unlock',
+    location: 'unlock_page',
+    onClose: () => undefined,
+    onOpenFullScreen: () => undefined,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof PasskeyTroubleshootModal>;
+
+export const DefaultStory: Story = {};
+DefaultStory.storyName = 'Default';

--- a/ui/components/app/rewards/AddRewardsAccount.stories.tsx
+++ b/ui/components/app/rewards/AddRewardsAccount.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import type { InternalAccount } from '@metamask/keyring-internal-api';
+import AddRewardsAccount from './AddRewardsAccount';
+
+const mockAccount: InternalAccount = {
+  address: '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc',
+  id: 'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3',
+  metadata: {
+    importTime: 0,
+    name: 'Test Account',
+    keyring: { type: 'HD Key Tree' },
+  },
+  options: { entropySource: '01JKAF3DSGM3AB87EM9N0K41AJ' },
+  methods: [
+    'personal_sign',
+    'eth_signTransaction',
+    'eth_signTypedData_v1',
+    'eth_signTypedData_v3',
+    'eth_signTypedData_v4',
+  ],
+  scopes: ['eip155:0'],
+  type: 'eip155:eoa',
+};
+
+const meta: Meta<typeof AddRewardsAccount> = {
+  title: 'Components/App/Rewards/AddRewardsAccount',
+  component: AddRewardsAccount,
+  args: {
+    account: mockAccount,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof AddRewardsAccount>;
+
+export const DefaultStory: Story = {};
+DefaultStory.storyName = 'Default';

--- a/ui/components/app/rewards/onboarding/OnboardingMainStep.stories.tsx
+++ b/ui/components/app/rewards/onboarding/OnboardingMainStep.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import OnboardingMainStep from './OnboardingMainStep';
+
+const meta: Meta<typeof OnboardingMainStep> = {
+  title: 'Components/App/Rewards/OnboardingMainStep',
+  component: OnboardingMainStep,
+  args: {
+    rewardPoints: 100,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof OnboardingMainStep>;
+
+export const DefaultStory: Story = {};
+DefaultStory.storyName = 'Default';

--- a/ui/components/multichain-accounts/smart-contract-account-toggle-section/smart-contract-account-toggle-section.stories.tsx
+++ b/ui/components/multichain-accounts/smart-contract-account-toggle-section/smart-contract-account-toggle-section.stories.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { SmartContractAccountToggleSection } from './smart-contract-account-toggle-section';
+
+const meta: Meta<typeof SmartContractAccountToggleSection> = {
+  title: 'Components/MultichainAccounts/SmartContractAccountToggleSection',
+  component: SmartContractAccountToggleSection,
+  argTypes: {
+    address: {
+      control: 'text',
+      description: 'The account address to display smart contract toggles for.',
+    },
+    returnToPage: {
+      control: 'text',
+      description: 'Optional page path to return to after a transaction.',
+    },
+  },
+  args: {
+    address: '0x64a845a5b02460acf8a3d84503b0d68d028b4bb4',
+    returnToPage: undefined,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SmartContractAccountToggleSection>;
+
+export const DefaultStory: Story = {};
+
+DefaultStory.storyName = 'Default';

--- a/ui/components/multichain/multi-srp/srp-list/srp-card.stories.tsx
+++ b/ui/components/multichain/multi-srp/srp-list/srp-card.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import type { AccountWalletId } from '@metamask/account-api';
+import { SrpCard } from './srp-card';
+const WALLET_ID = 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ' as AccountWalletId;
+
+const meta: Meta<typeof SrpCard> = {
+  title: 'Components/Multichain/MultiSrp/SrpCard',
+  component: SrpCard,
+  args: {
+    index: 0,
+    walletId: WALLET_ID,
+    shouldTriggerBackup: false,
+    onActionComplete: () => undefined,
+    isSettingsPage: false,
+    hideShowAccounts: false,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SrpCard>;
+
+export const DefaultStory: Story = {};
+DefaultStory.storyName = 'Default';

--- a/ui/pages/asset/components/musd-bonus-section.stories.tsx
+++ b/ui/pages/asset/components/musd-bonus-section.stories.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { createSwapsMockStore } from '../../../../test/jest/mock-store';
+import { MUSD_TOKEN_ADDRESS } from '../../../components/app/musd/constants';
+import { MusdBonusSection } from './musd-bonus-section';
+
+const CHAIN_ID = '0x1' as const;
+
+const baseState = createSwapsMockStore();
+
+const store = configureMockStore()({
+  ...baseState,
+  metamask: {
+    ...baseState.metamask,
+    remoteFeatureFlags: {
+      ...baseState.metamask.remoteFeatureFlags,
+      earnMusdConversionFlowEnabled: true,
+      earnMerklCampaignClaiming: true,
+    },
+    networkConfigurationsByChainId: {
+      '0x1': {
+        chainId: '0x1' as const,
+        name: 'Ethereum Mainnet',
+        nativeCurrency: 'ETH',
+        blockExplorerUrl: 'https://etherscan.io',
+        defaultRpcEndpointIndex: 0,
+        rpcEndpoints: [{ url: 'https://mainnet.infura.io/v3/', type: 'custom' }],
+      },
+    },
+    marketData: {
+      ...baseState.metamask.marketData,
+      '0x1': {
+        [MUSD_TOKEN_ADDRESS]: { price: 0.000256 },
+      },
+    },
+  },
+});
+
+const meta: Meta<typeof MusdBonusSection> = {
+  title: 'Pages/Asset/MusdBonusSection',
+  component: MusdBonusSection,
+  decorators: [
+    (Story) => (
+      <Provider store={store}>
+        <QueryClientProvider
+          client={
+            new QueryClient({
+              defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+            })
+          }
+        >
+          <div
+            style={{ width: 360, backgroundColor: 'var(--color-background-default)' }}
+          >
+            <Story />
+          </div>
+        </QueryClientProvider>
+      </Provider>
+    ),
+  ],
+  args: {
+    chainId: CHAIN_ID,
+    tokenAddress: MUSD_TOKEN_ADDRESS,
+    positionFiatValue: 1000,
+    showFiat: true,
+    hasPositiveBalance: true,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MusdBonusSection>;
+
+export const DefaultStory: Story = {};
+DefaultStory.storyName = 'Default';

--- a/ui/pages/asset/components/musd-bonus-section.stories.tsx
+++ b/ui/pages/asset/components/musd-bonus-section.stories.tsx
@@ -27,7 +27,9 @@ const store = configureMockStore()({
         nativeCurrency: 'ETH',
         blockExplorerUrl: 'https://etherscan.io',
         defaultRpcEndpointIndex: 0,
-        rpcEndpoints: [{ url: 'https://mainnet.infura.io/v3/', type: 'custom' }],
+        rpcEndpoints: [
+          { url: 'https://mainnet.infura.io/v3/', type: 'custom' },
+        ],
       },
     },
     marketData: {
@@ -48,12 +50,17 @@ const meta: Meta<typeof MusdBonusSection> = {
         <QueryClientProvider
           client={
             new QueryClient({
-              defaultOptions: { queries: { retry: false, staleTime: Infinity } },
+              defaultOptions: {
+                queries: { retry: false, staleTime: Infinity },
+              },
             })
           }
         >
           <div
-            style={{ width: 360, backgroundColor: 'var(--color-background-default)' }}
+            style={{
+              width: 360,
+              backgroundColor: 'var(--color-background-default)',
+            }}
           >
             <Story />
           </div>


### PR DESCRIPTION
## **Description**

Adds Storybook stories for components migrated as part of the design system v44 upgrade ([#43424](https://github.com/MetaMask/metamask-extension/pull/43424)).

### Why stories matter for design system upgrades

Design system upgrades touch many components at once, making it easy for subtle visual regressions to slip through — shifted spacing, broken icon alignment, wrong colour tokens, or unexpected layout changes. Storybook stories give us a dedicated, isolated render of each component that:

1. **Enables before/after visual regression screenshots** — by capturing stories against `main` and again on the upgrade branch, reviewers can diff the two side-by-side and catch regressions without having to navigate the full app.
2. **Serves as living documentation** — stories make the component's props and variants discoverable, so future upgrade PRs have a clear baseline to compare against.
3. **Decouples story coverage from migration code** — keeping stories in a separate PR means #43424 stays small and reviewable on its own, while this PR provides the visual evidence that the upgrade introduced no unintended changes.

Stories added:
- `MarketClosedModal`
- `AddressDisplay` (confirm info row)
- `PasskeyTroubleshootModal`
- `AddRewardsAccount`
- `OnboardingMainStep` (rewards)
- `SmartContractAccountToggleSection`
- `SrpCard` (multi-SRP)
- `MusdBonusSection`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related: https://github.com/MetaMask/metamask-extension/pull/43424

## **Manual testing steps**

1. Run Storybook locally (`yarn storybook`)
2. Navigate to each story listed above and confirm it renders without errors

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

No stories existed for these components.

### **After**

Story screenshots in inline comments.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.