### PR TITLE
test: MMQA - 1913 - Moves identity-team E2E flow helpers

### DIFF
--- a/test/e2e/page-objects/flows/identity.flow.ts
+++ b/test/e2e/page-objects/flows/identity.flow.ts
@@ -1,13 +1,16 @@
+import HeaderNavbar from '../pages/header-navbar';
+import HomePage from '../pages/home/homepage';
+import PrivacySettings from '../pages/settings/privacy-settings';
+import SettingsPage from '../pages/settings/settings-page';
+import { Driver } from '../../webdriver/driver';
+import {
+  IDENTITY_TEAM_PASSWORD,
+  IDENTITY_TEAM_SEED_PHRASE,
+} from '../../tests/identity/constants';
 import {
   completeCreateNewWalletOnboardingFlow,
   completeImportSRPOnboardingFlow,
-} from '../../page-objects/flows/onboarding.flow';
-import HeaderNavbar from '../../page-objects/pages/header-navbar';
-import HomePage from '../../page-objects/pages/home/homepage';
-import PrivacySettings from '../../page-objects/pages/settings/privacy-settings';
-import SettingsPage from '../../page-objects/pages/settings/settings-page';
-import { Driver } from '../../webdriver/driver';
-import { IDENTITY_TEAM_PASSWORD, IDENTITY_TEAM_SEED_PHRASE } from './constants';
+} from './onboarding.flow';
 
 export const completeOnboardFlowIdentity = async (
   driver: Driver,

--- a/test/e2e/tests/identity/contact-syncing/sync-existing-user.spec.ts
+++ b/test/e2e/tests/identity/contact-syncing/sync-existing-user.spec.ts
@@ -11,7 +11,7 @@ import {
 } from '../constants';
 import { UserStorageMockttpController } from '../../../helpers/identity/user-storage/userStorageMockttpController';
 import { createEncryptedResponse } from '../../../helpers/identity/user-storage/generateEncryptedData';
-import { completeOnboardFlowIdentity } from '../flows';
+import { completeOnboardFlowIdentity } from '../../../page-objects/flows/identity.flow';
 import HeaderNavbar from '../../../page-objects/pages/header-navbar';
 import ContactsSettings from '../../../page-objects/pages/settings/contacts-settings';
 

--- a/test/e2e/tests/notifications/enable-notifications-with-accounts-sync.spec.ts
+++ b/test/e2e/tests/notifications/enable-notifications-with-accounts-sync.spec.ts
@@ -2,7 +2,7 @@ import { Mockttp } from 'mockttp';
 import { USER_STORAGE_FEATURE_NAMES } from '@metamask/profile-sync-controller/user-storage';
 import { withFixtures } from '../../helpers';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
-import { completeOnboardFlowIdentity } from '../identity/flows';
+import { completeOnboardFlowIdentity } from '../../page-objects/flows/identity.flow';
 import { UserStorageMockttpController } from '../../helpers/identity/user-storage/userStorageMockttpController';
 import { IDENTITY_TEAM_STORAGE_KEY } from '../identity/constants';
 import { createEncryptedResponse } from '../../helpers/identity/user-storage/generateEncryptedData';

--- a/test/e2e/tests/notifications/enable-notifications.spec.ts
+++ b/test/e2e/tests/notifications/enable-notifications.spec.ts
@@ -9,7 +9,7 @@ import {
 } from '../../page-objects/flows/notifications.flow';
 import NotificationsSettingsPage from '../../page-objects/pages/settings/notifications-settings-page';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
-import { completeOnboardFlowIdentity } from '../identity/flows';
+import { completeOnboardFlowIdentity } from '../../page-objects/flows/identity.flow';
 import AccountListPage from '../../page-objects/pages/account-list-page';
 import { MockttpNotificationTriggerServer } from '../../helpers/notifications/mock-notification-trigger-server';
 import { mockNotificationServices, notificationsMockAccounts } from './mocks';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Moves identity-team E2E flow helpers from `test/e2e/tests/identity/flows.ts` into the shared flows directory as `test/e2e/page-objects/flows/identity.flow.ts`.

**Problem:** Identity onboarding helpers lived alongside spec files under `tests/identity/`, while the rest of the E2E suite keeps multi-page orchestration in `page-objects/flows/*.flow.ts`. That inconsistency made shared flows harder to discover and reuse.

**Solution:**

- Relocate the three exports (`completeOnboardFlowIdentity`, `completeNewWalletFlowIdentity`, `getSRP`) to `identity.flow.ts` with updated import paths.
- Update the three consumer specs to import from the shared flows directory.
- Delete the old `tests/identity/flows.ts` file.

**Files changed:**

- `test/e2e/page-objects/flows/identity.flow.ts` (added)
- `test/e2e/tests/identity/flows.ts` (removed)
- `test/e2e/tests/notifications/enable-notifications.spec.ts`
- `test/e2e/tests/notifications/enable-notifications-with-accounts-sync.spec.ts`
- `test/e2e/tests/identity/contact-syncing/sync-existing-user.spec.ts`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: MMQA-1913

## **Manual testing steps**

1. Build the test extension:

```bash
yarn build:test
```

2. Run one affected notifications spec:

```bash
yarn test:e2e:single test/e2e/tests/notifications/enable-notifications.spec.ts --browser=chrome
```

3. Run the affected contact-syncing spec:

```bash
yarn test:e2e:single test/e2e/tests/identity/contact-syncing/sync-existing-user.spec.ts --browser=chrome
```

4. Confirm onboarding and post-onboarding assertions still pass in both specs.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
