### PR TITLE
fix: social login onboarding keyring v2 error cp-13.36.0

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1028,7 +1028,9 @@ export default class MetamaskController extends EventEmitter {
 
           if (firstTimeFlowType === FirstTimeFlowType.socialImport) {
             // importing multiple SRPs on social login rehydration
-            for (const { metadata: { id: entropySource } } of this.getHDKeyringObjects()) {
+            for (const {
+              metadata: { id: entropySource },
+            } of this.getHDKeyringObjects()) {
               await this.discoverAndCreateAccounts(entropySource);
             }
           } else {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1028,7 +1028,9 @@ export default class MetamaskController extends EventEmitter {
 
           if (firstTimeFlowType === FirstTimeFlowType.socialImport) {
             // importing multiple SRPs on social login rehydration
-            await this._importAccountsWithBalances();
+            for (const { metadata: { id: entropySource } } of this.getHDKeyringObjects()) {
+              await this.discoverAndCreateAccounts(entropySource);
+            }
           } else {
             await this.discoverAndCreateAccounts(id);
           }
@@ -5319,29 +5321,6 @@ export default class MetamaskController extends EventEmitter {
   }
 
   /**
-   * Imports accounts with balances to the keyring.
-   */
-  async _importAccountsWithBalances() {
-    const { keyrings } = this.keyringController.state;
-
-    // walk through all the keyrings and import the solana accounts for the HD keyrings
-    for (const { metadata } of keyrings) {
-      // check if the keyring is an HD keyring
-      const isHdKeyring = await this.keyringController.withKeyringV2(
-        { id: metadata.id },
-        async ({ keyring }) => {
-          return keyring.type === KeyringType.Hd;
-        },
-      );
-      if (isHdKeyring) {
-        await getSnapKeyring(this.controllerMessenger);
-        await this.accountTreeController.syncWithUserStorageAtLeastOnce();
-        await this.discoverAndCreateAccounts(metadata.id);
-      }
-    }
-  }
-
-  /**
    * Encodes a BIP-39 mnemonic as the indices of words in the English BIP-39 wordlist.
    *
    * @param {Buffer} mnemonic - The BIP-39 mnemonic.
@@ -6669,15 +6648,24 @@ export default class MetamaskController extends EventEmitter {
   }
 
   /**
+   * Returns the list of HD keyring objects in the keyring controller's state.
+   *
+   * @returns {Array} The list of HD keyring objects.
+   */
+  getHDKeyringObjects() {
+    return this.keyringController.state.keyrings.filter(
+      (keyring) => keyring.type === KeyringTypes.hdKeyTree,
+    );
+  }
+
+  /**
    * Returns the index of the HD keyring containing the selected account.
    *
    * @returns {number | undefined} The index of the HD keyring containing the selected account.
    */
   getHDEntropyIndex() {
     const selectedAccount = this.accountsController.getSelectedAccount();
-    const hdKeyrings = this.keyringController.state.keyrings.filter(
-      (keyring) => keyring.type === KeyringTypes.hdKeyTree,
-    );
+    const hdKeyrings = this.getHDKeyringObjects();
     const index = hdKeyrings.findIndex((keyring) =>
       keyring.accounts.includes(selectedAccount.address),
     );

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -6279,9 +6279,6 @@ describe('MetaMaskController', () => {
       });
 
       jest
-        .spyOn(metamaskController, '_importAccountsWithBalances')
-        .mockResolvedValue({});
-      jest
         .spyOn(metamaskController, 'discoverAndCreateAccounts')
         .mockResolvedValue({});
       jest
@@ -6297,7 +6294,7 @@ describe('MetaMaskController', () => {
       await metamaskController.createNewVaultAndRestore(password, TEST_SEED);
     });
 
-    it('calls _importAccountsWithBalances when firstTimeFlowType is socialImport', async () => {
+    it('calls discoverAndCreateAccounts for each HD keyring when firstTimeFlowType is socialImport', async () => {
       jest
         .spyOn(
           metamaskController.accountTreeController,
@@ -6319,12 +6316,22 @@ describe('MetaMaskController', () => {
       // Allow async subscription handler to run
       await new Promise((resolve) => setImmediate(resolve));
 
+      const { keyrings } = metamaskController.keyringController.state;
+      const hdIds = keyrings
+        .filter((keyring) => keyring.type === 'HD Key Tree')
+        .map((keyring) => keyring.metadata.id);
+
       expect(
-        metamaskController._importAccountsWithBalances,
+        metamaskController.accountTreeController.syncWithUserStorageAtLeastOnce,
       ).toHaveBeenCalledTimes(1);
       expect(
         metamaskController.discoverAndCreateAccounts,
-      ).not.toHaveBeenCalled();
+      ).toHaveBeenCalledTimes(hdIds.length);
+      hdIds.forEach((id) => {
+        expect(
+          metamaskController.discoverAndCreateAccounts,
+        ).toHaveBeenCalledWith(id);
+      });
     });
 
     it('calls discoverAndCreateAccounts when firstTimeFlowType is not socialImport', async () => {
@@ -6354,75 +6361,6 @@ describe('MetaMaskController', () => {
       expect(
         metamaskController.discoverAndCreateAccounts,
       ).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe('_importAccountsWithBalances', () => {
-    let metamaskController;
-
-    beforeEach(async () => {
-      metamaskController = new MetaMaskController({
-        showUserConfirmation: noop,
-        encryptor: mockEncryptor,
-        initState: cloneDeep(firstTimeState),
-        initLangCode: 'en_US',
-        platform: {
-          showTransactionNotification: () => undefined,
-          getVersion: () => 'foo',
-          switchToAnotherURL: jest.fn(),
-        },
-        browser: browserPolyfillMock,
-        getRequestAccountTabIds: () => ({}),
-        getOpenMetamaskTabsIds: () => ({}),
-        notificationManager: {
-          markAsAutomaticallyClosed: jest.fn(),
-        },
-        infuraProjectId: 'foo',
-        isFirstMetaMaskControllerSetup: true,
-        cronjobControllerStorageManager:
-          createMockCronjobControllerStorageManager(),
-        controllerMessenger: new Messenger({
-          namespace: MOCK_ANY_NAMESPACE,
-        }),
-      });
-
-      // Avoid KC.addNewKeyring side-effects and AccountTracker sync touching NetworkController
-      jest.spyOn(getSnapKeyringUtil, 'getSnapKeyring').mockResolvedValue({
-        setSelectedAccounts: jest.fn(),
-      });
-
-      await metamaskController.createNewVaultAndRestore('foo', TEST_SEED);
-    });
-
-    it('calls getSnapKeyring, syncWithUserStorageAtLeastOnce, and discoverAndCreateAccounts for each HD keyring', async () => {
-      jest
-        .spyOn(
-          metamaskController.accountTreeController,
-          'syncWithUserStorageAtLeastOnce',
-        )
-        .mockResolvedValue(undefined);
-      jest
-        .spyOn(metamaskController, 'discoverAndCreateAccounts')
-        .mockResolvedValue({});
-
-      await metamaskController._importAccountsWithBalances();
-
-      const { keyrings } = metamaskController.keyringController.state;
-      const hdIds = keyrings
-        .filter((keyring) => keyring.type === 'HD Key Tree')
-        .map((keyring) => keyring.metadata.id);
-
-      expect(
-        metamaskController.accountTreeController.syncWithUserStorageAtLeastOnce,
-      ).toHaveBeenCalledTimes(hdIds.length);
-      expect(
-        metamaskController.discoverAndCreateAccounts,
-      ).toHaveBeenCalledTimes(hdIds.length);
-      hdIds.forEach((id) => {
-        expect(
-          metamaskController.discoverAndCreateAccounts,
-        ).toHaveBeenCalledWith(id);
-      });
     });
   });
 

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -512,7 +512,9 @@ export class LegacyBackgroundApiService {
                 'Imported account keyring does not export accounts',
               );
             }
-            const privateKeyObj = await keyring.exportAccount(importedAccount.id);
+            const privateKeyObj = await keyring.exportAccount(
+              importedAccount.id,
+            );
             return { id: metadata.id, privateKey: privateKeyObj.privateKey };
           },
         )) as { id: string; privateKey: string };

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -507,13 +507,12 @@ export class LegacyBackgroundApiService {
           'KeyringController:withKeyringV2',
           { address: importedAccountAddress },
           async ({ keyring, metadata }) => {
-            const { exportAccount } = keyring;
-            if (!exportAccount) {
+            if (!keyring.exportAccount) {
               throw new Error(
                 'Imported account keyring does not export accounts',
               );
             }
-            const privateKeyObj = await exportAccount(importedAccount.id);
+            const privateKeyObj = await keyring.exportAccount(importedAccount.id);
             return { id: metadata.id, privateKey: privateKeyObj.privateKey };
           },
         )) as { id: string; privateKey: string };


### PR DESCRIPTION
## **Description**

We cannot use `:withKeyringV2` yet with the legacy Snap keyring, so this ended up login an error.

The logic actually don't need to use `:withKeyringV2` at all since we only need the `keyring.type` and `keyring.id` to start the discovery.

There was also another bug with `exportAccount` that was not binding its instance correctly, so I just remove the destructure part for this to keep it bound correctly.

## **Changelog**

CHANGELOG entry: Fix SRP re-hydration with social login

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/43589

## **Manual testing steps**

1. Onboard with social login
2. You should be able to re-hydrate multiple SRPs without any console errors

## **Screenshots/Recordings**

### **Before**

<img width="928" height="110" alt="Screenshot 2026-06-16 at 10 33 53" src="https://github.com/user-attachments/assets/cb5fb006-d1e4-4962-b4a7-57b91a72afa0" />

<img width="612" height="579" alt="Screenshot 2026-06-16 at 10 59 06" src="https://github.com/user-attachments/assets/d2c6df82-2691-4fe2-9694-b2d5050fd87c" />


### **After**

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
