### PR TITLE
fix(perps): display asset symbol instead of full name in market cards cp-13.36.0

### DIFF
--- a/ui/components/app/perps/perps-explore-markets/perps-explore-markets.tsx
+++ b/ui/components/app/perps/perps-explore-markets/perps-explore-markets.tsx
@@ -64,7 +64,6 @@ export const PerpsExploreMarkets = ({ markets }: PerpsExploreMarketsProps) => {
             <PerpsMarketCard
               key={market.symbol}
               symbol={market.symbol}
-              name={market.name}
               price={market.price}
               change24hPercent={market.change24hPercent}
               volume={market.volume}

--- a/ui/components/app/perps/perps-market-card/perps-market-card.tsx
+++ b/ui/components/app/perps/perps-market-card/perps-market-card.tsx
@@ -23,7 +23,6 @@ const CARD_STYLES =
 
 export type PerpsMarketCardProps = {
   symbol: string;
-  name?: string;
   price: string;
   change24hPercent: string;
   volume?: string;
@@ -33,7 +32,6 @@ export type PerpsMarketCardProps = {
 
 export const PerpsMarketCard = ({
   symbol,
-  name,
   price,
   change24hPercent,
   volume,
@@ -41,7 +39,6 @@ export const PerpsMarketCard = ({
   'data-testid': testId,
 }: PerpsMarketCardProps) => {
   const displaySymbol = getDisplayName(symbol);
-  const displayName = name ? getDisplayName(name) : displaySymbol;
   const displayChange24hPercent = formatSignedChangePercent(change24hPercent);
   const changeColor = getChangeColor(displayChange24hPercent);
 
@@ -67,7 +64,7 @@ export const PerpsMarketCard = ({
           fontWeight={FontWeight.Medium}
           className="text-s-body-md @compact:text-s-body-sm"
         >
-          {displayName}
+          {displaySymbol}
         </Text>
         {volume ? (
           <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>

--- a/ui/components/app/perps/perps-watchlist/perps-watchlist.test.tsx
+++ b/ui/components/app/perps/perps-watchlist/perps-watchlist.test.tsx
@@ -3,7 +3,6 @@ import { fireEvent, screen } from '@testing-library/react';
 import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import configureStore from '../../../../store/store';
 import mockState from '../../../../../test/data/mock-state.json';
-import { tEn } from '../../../../../test/lib/i18n-helpers';
 import { mockCryptoMarkets } from '../mocks';
 import { PERPS_MARKET_DETAIL_ROUTE } from '../../../../helpers/constants/routes';
 import { PerpsWatchlist } from './perps-watchlist';
@@ -54,14 +53,14 @@ describe('PerpsWatchlist', () => {
     expect(screen.getByTestId('perps-watchlist-ETH')).toBeInTheDocument();
   });
 
-  it('displays market name, volume, and price for each watchlist item', () => {
+  it('displays market symbol, volume, and price for each watchlist item', () => {
     renderWithProvider(
       <PerpsWatchlist markets={mockCryptoMarkets.slice(0, 2)} />,
       mockStore,
     );
 
-    expect(screen.getByText(tEn('networkNameBitcoin'))).toBeInTheDocument();
-    expect(screen.getByText(tEn('networkNameEthereum'))).toBeInTheDocument();
+    expect(screen.getByText('BTC')).toBeInTheDocument();
+    expect(screen.getByText('ETH')).toBeInTheDocument();
     expect(screen.getByText('$1.2B')).toBeInTheDocument();
     expect(screen.getByText('$850M')).toBeInTheDocument();
     expect(screen.getByText('$45,250.00')).toBeInTheDocument();

--- a/ui/components/app/perps/perps-watchlist/perps-watchlist.tsx
+++ b/ui/components/app/perps/perps-watchlist/perps-watchlist.tsx
@@ -58,7 +58,6 @@ export const PerpsWatchlist = ({ markets }: PerpsWatchlistProps) => {
           <PerpsMarketCard
             key={market.symbol}
             symbol={market.symbol}
-            name={market.name}
             price={market.price}
             change24hPercent={market.change24hPercent}
             volume={market.volume}


### PR DESCRIPTION
## **Description**

The `PerpsMarketCard` component accepted an optional `name` prop containing the full asset name (e.g. "Bitcoin", "Ethereum", "Tesla") and displayed it instead of the ticker symbol when available. This was inconsistent with every other perps UI surface (market detail page, market list, position cards, order cards, transaction cards, modals), which all display the symbol/ticker (e.g. "BTC", "ETH", "TSLA").

This PR removes the `name` prop from `PerpsMarketCard` so it always displays the symbol, making the Explore Markets and Watchlist sections consistent with the rest of the perps UI.

## **Changelog**

CHANGELOG entry: In perps, use ticker in explore markets and watchlist

## **Related issues**

<!--
Fixes:
-->

## **Manual testing steps**

1. Run the extension locally.
2. Navigate to the Perps tab.
3. Observe the **Watchlist** section — each market card should display the ticker symbol (e.g. "BTC", "ETH") instead of the full name (e.g. "Bitcoin", "Ethereum").
4. Observe the **Explore Markets** section — same behavior: symbols only, no full asset names.

## **Screenshots/Recordings**

### **Before**
<img width="369" height="958" alt="Screenshot 2026-06-16 at 11 02 00" src="https://github.com/user-attachments/assets/d59c7660-17b0-4706-be7c-86eb009f9f92" />

### **After**
<img width="369" height="958" alt="Screenshot 2026-06-16 at 11 01 26" src="https://github.com/user-attachments/assets/4d147e16-f772-4a75-90fa-e96ca59e933c" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
