### PR TITLE
fix(sentry): defer breadcrumb scrubbing to send time cp-13.36.0

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -95,6 +95,8 @@ function getClientOptions() {
     // which would otherwise make the next error look like a different stack (background timers
     // usually run after beforeSend finished; rapid UI captures often dedupe first).
     beforeSend: (report) => rewriteReport(safeCloneReport(report)),
+    beforeSendTransaction: (report) =>
+      rewriteTransactionReport(safeCloneReport(report)),
     debug: METAMASK_DEBUG,
     dist: isManifestV3 ? 'mv3' : 'mv2',
     dsn: sentryTarget,
@@ -291,8 +293,7 @@ export function beforeBreadcrumb() {
     ) {
       return null;
     }
-    const newBreadcrumb = removeUrlsFromBreadCrumb(breadcrumb);
-    return newBreadcrumb;
+    return breadcrumb;
   };
 }
 
@@ -339,7 +340,8 @@ export function shouldCreateSpanForRequest(url) {
 /**
  * Receives a Sentry breadcrumb object and potentially removes urls
  * from its `data` property, it particular those possibly found at
- * data.from, data.to and data.url
+ * data.from, data.to and data.url. Performs a deep address scrub for use when
+ * an event is about to be sent (not on every breadcrumb capture).
  *
  * @param {object} breadcrumb - A Sentry breadcrumb object: https://develop.sentry.dev/sdk/event-payloads/breadcrumbs/
  * @returns {object} A modified Sentry breadcrumb object.
@@ -366,6 +368,33 @@ export function removeUrlsFromBreadCrumb(breadcrumb) {
 }
 
 /**
+ * Deep-scrubs all breadcrumbs attached to an outbound error report.
+ *
+ * @param {object} report - A Sentry event object.
+ */
+export function sanitizeBreadcrumbsInReport(report) {
+  if (!Array.isArray(report.breadcrumbs)) {
+    return;
+  }
+  report.breadcrumbs = report.breadcrumbs.map((crumb) =>
+    removeUrlsFromBreadCrumb(cloneDeep(crumb)),
+  );
+}
+
+/**
+ * Scrubs breadcrumb payloads on performance transaction events before send.
+ * {@link rewriteReport} handles errors via `beforeSend`; transactions use
+ * `beforeSendTransaction` instead.
+ *
+ * @param {object} report - A Sentry transaction event object.
+ * @returns {object} The modified report (same reference).
+ */
+export function rewriteTransactionReport(report) {
+  sanitizeBreadcrumbsInReport(report);
+  return report;
+}
+
+/**
  * Receives a Sentry event object and modifies it before the error is sent to Sentry.
  * Sanitizes messages/URLs and attaches app state.
  *
@@ -383,6 +412,8 @@ export function rewriteReport(report) {
     // but putting the code here as well gives public visibility to how we are handling
     // privacy with respect to sentry.
     sanitizeAddressesFromErrorMessages(report);
+    // Deep-scrub breadcrumb payloads only when an error is being sent.
+    sanitizeBreadcrumbsInReport(report);
     // Remove addresses from other error parameters (extra, contexts).
     // Done before attaching appState below so the (already masked) appState is
     // not re-walked.

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -339,7 +339,7 @@ export function shouldCreateSpanForRequest(url) {
 
 /**
  * Receives a Sentry breadcrumb object and potentially removes urls
- * from its `data` property, it particular those possibly found at
+ * from its `data` property, in particular those possibly found at
  * data.from, data.to and data.url. Performs a deep address scrub for use when
  * an event is about to be sent (not on every breadcrumb capture).
  *
@@ -368,7 +368,9 @@ export function removeUrlsFromBreadCrumb(breadcrumb) {
 }
 
 /**
- * Deep-scrubs all breadcrumbs attached to an outbound error report.
+ * Deep-scrubs all breadcrumbs attached to an outbound Sentry event (errors and
+ * transactions). The report must already be cloned (see `safeCloneReport` in
+ * `beforeSend` / `beforeSendTransaction`) so breadcrumb mutation is safe.
  *
  * @param {object} report - A Sentry event object.
  */
@@ -376,9 +378,9 @@ export function sanitizeBreadcrumbsInReport(report) {
   if (!Array.isArray(report.breadcrumbs)) {
     return;
   }
-  report.breadcrumbs = report.breadcrumbs.map((crumb) =>
-    removeUrlsFromBreadCrumb(cloneDeep(crumb)),
-  );
+  for (let i = 0; i < report.breadcrumbs.length; i++) {
+    removeUrlsFromBreadCrumb(report.breadcrumbs[i]);
+  }
 }
 
 /**

--- a/app/scripts/lib/setupSentry.test.js
+++ b/app/scripts/lib/setupSentry.test.js
@@ -1,3 +1,4 @@
+import { cloneDeep } from 'lodash';
 import {
   removeUrlsFromBreadCrumb,
   rewriteReport,
@@ -296,6 +297,32 @@ describe('Setup Sentry', () => {
       rewriteReport(testReport);
       expect(testReport.breadcrumbs[0].data.arguments[0].message).toStrictEqual(
         'Failed for 0x**',
+      );
+    });
+
+    it('scrubs breadcrumbs without mutating live source objects', () => {
+      const liveError = new Error(
+        'Failed for 0x790A8A9E9bc1C9dB991D8721a92e461Db4CfB235',
+      );
+      const liveArgs = [liveError];
+      const testReport = cloneDeep({
+        message: 'An error occurred',
+        breadcrumbs: [
+          {
+            message: 'console.error',
+            data: { arguments: liveArgs, logger: 'console' },
+          },
+        ],
+        request: {},
+      });
+
+      rewriteReport(testReport);
+
+      expect(testReport.breadcrumbs[0].data.arguments[0].message).toStrictEqual(
+        'Failed for 0x**',
+      );
+      expect(liveError.message).toStrictEqual(
+        'Failed for 0x790A8A9E9bc1C9dB991D8721a92e461Db4CfB235',
       );
     });
   });

--- a/app/scripts/lib/setupSentry.test.js
+++ b/app/scripts/lib/setupSentry.test.js
@@ -1,6 +1,7 @@
 import {
   removeUrlsFromBreadCrumb,
   rewriteReport,
+  rewriteTransactionReport,
   shouldCreateSpanForRequest,
 } from './setupSentry';
 
@@ -273,6 +274,48 @@ describe('Setup Sentry', () => {
       };
       rewriteReport(testReport);
       expect(testReport.contexts.account.address).toStrictEqual('**');
+    });
+
+    it('removes addresses from breadcrumbs when sending an error report', () => {
+      const testReport = {
+        message: 'An error occurred',
+        breadcrumbs: [
+          {
+            message: 'console.error',
+            data: {
+              arguments: [
+                new Error(
+                  'Failed for 0x790A8A9E9bc1C9dB991D8721a92e461Db4CfB235',
+                ),
+              ],
+            },
+          },
+        ],
+        request: {},
+      };
+      rewriteReport(testReport);
+      expect(testReport.breadcrumbs[0].data.arguments[0].message).toStrictEqual(
+        'Failed for 0x**',
+      );
+    });
+  });
+
+  describe('rewriteTransactionReport', () => {
+    it('removes addresses from breadcrumbs when sending a transaction', () => {
+      const testReport = {
+        type: 'transaction',
+        transaction: 'ui.popup',
+        breadcrumbs: [
+          {
+            message: 'fetch',
+            data: {
+              url: 'https://api.example.com/0x790A8A9E9bc1C9dB991D8721a92e461Db4CfB235',
+            },
+          },
+        ],
+      };
+      rewriteTransactionReport(testReport);
+      expect(testReport.breadcrumbs[0].data.url).toStrictEqual('');
     });
   });
 

--- a/ui/pages/onboarding-flow/creation-successful/wallet-ready-animation.tsx
+++ b/ui/pages/onboarding-flow/creation-successful/wallet-ready-animation.tsx
@@ -56,7 +56,7 @@ export default function WalletReadyAnimation() {
   // Trigger the animation start when rive is loaded
   useEffect(() => {
     if (rive && isWasmReady && !bufferLoading && buffer) {
-      console.log('rive is loaded', rive);
+      console.log('rive is loaded');
       const inputs = rive.stateMachineInputs('OnboardingLoader');
       if (inputs) {
         const darkToggle = inputs.find((input) => input.name === 'Dark mode');


### PR DESCRIPTION
## **Description**

We've noticed an important performance regression (especially on Firefox) after #43337 was merged (see [Slack thread](https://consensys.slack.com/archives/C0B9YSTLGKC/p1781541507385799)). That PR expanded address sanitization beyond EVM account addresses (Bitcoin, Solana, Tron, etc.). The fact that it resulted in a performance regression showed that the breadcrumb scrubbing function was being executed not only before sending error events to Sentry, but also on every fetch/console event when analytics was on.

In reality, we're not interested in scrubbing breadcrumbs at capture time, only at send time.

This PR fixes it by:
- Stopping breadcrumb scrubbing at capture time (`beforeBreadcrumb` only filters, it no longer deep-scrubs)
- Deep-scrubbing breadcrumbs only when events are sent: errors via `rewriteReport` (`beforeSend`), and transactions via `rewriteTransactionReport` (`beforeSendTransaction`)

Also, this PR avoids logging the full Rive runtime object on the wallet-ready screen, which Sentry's console integration would otherwise capture into breadcrumbs, thus slowing down the app.

## **Changelog**

CHANGELOG entry: Fixes a performance issue that was slowing down the app

## **Related issues**

Fixes: None

## **Manual testing steps**

1. Create a Firefox build with `yarn start:mv2 --sentry`
2. Go through the onboarding and confirm performance regression is gone
3. Confirm manual testing steps defined in this [PR](https://github.com/MetaMask/metamask-extension/pull/43337) still work as expected

## **Screenshots/Recordings**

None

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
