### PR TITLE
feat(notifications): include app version in push registration metadata

### DIFF
--- a/app/scripts/messenger-client-init/notifications/notification-services-push-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/notifications/notification-services-push-controller-init.test.ts
@@ -1,3 +1,5 @@
+// Mocha's global `it` type lacks `.each`, so use Jest's typed `it`.
+import { it } from '@jest/globals';
 import {
   Controller as NotificationServicesPushController,
   defaultState,
@@ -11,6 +13,7 @@ import {
   type NotificationServicesPushControllerMessenger,
 } from '../messengers/notifications';
 import { getRootMessenger } from '../../lib/messenger';
+import ExtensionPlatform from '../../platforms/extension';
 import {
   getNormalisedLocale,
   NotificationServicesPushControllerInit,
@@ -51,8 +54,15 @@ describe('NotificationServicesPushControllerInit', () => {
     };
   };
 
+  const getControllerConfig = (
+    mock: jest.MockedObjectDeep<typeof NotificationServicesPushController>,
+  ) => mock.mock.calls[0][0].config;
+
   beforeEach(() => {
     jest.resetAllMocks();
+    jest
+      .spyOn(ExtensionPlatform.prototype, 'getVersion')
+      .mockReturnValue('7.80.0');
   });
 
   it('returns controller instance', () => {
@@ -93,8 +103,59 @@ describe('NotificationServicesPushControllerInit', () => {
           subscribeToPushNotifications: expect.any(Function),
         },
         getLocale: expect.any(Function),
+        appVersion: '7.80.0',
       },
     });
+  });
+
+  it.each(['7.80', '7.80.0', '12.18.3.0'])(
+    'includes backend-safe app version %s in the push registration config',
+    (version) => {
+      const { requestMock, NotificationServicesPushControllerClassMock } =
+        arrange();
+      jest
+        .spyOn(ExtensionPlatform.prototype, 'getVersion')
+        .mockReturnValue(version);
+
+      NotificationServicesPushControllerInit(requestMock);
+
+      expect(
+        getControllerConfig(NotificationServicesPushControllerClassMock),
+      ).toEqual(expect.objectContaining({ appVersion: version }));
+    },
+  );
+
+  it.each(['7', '7.80.0.1.2', '7.80.0-flask.1', '7.80.0+build.1', 'v7.80.0'])(
+    'omits app version when %s is not backend-safe',
+    (version) => {
+      const { requestMock, NotificationServicesPushControllerClassMock } =
+        arrange();
+      jest
+        .spyOn(ExtensionPlatform.prototype, 'getVersion')
+        .mockReturnValue(version);
+
+      NotificationServicesPushControllerInit(requestMock);
+
+      expect(
+        getControllerConfig(NotificationServicesPushControllerClassMock),
+      ).toEqual(expect.not.objectContaining({ appVersion: expect.any(String) }));
+    },
+  );
+
+  it('omits app version when the version lookup fails', () => {
+    const { requestMock, NotificationServicesPushControllerClassMock } =
+      arrange();
+    jest
+      .spyOn(ExtensionPlatform.prototype, 'getVersion')
+      .mockImplementation(() => {
+        throw new Error('Version lookup failed');
+      });
+
+    NotificationServicesPushControllerInit(requestMock);
+
+    expect(
+      getControllerConfig(NotificationServicesPushControllerClassMock),
+    ).toEqual(expect.not.objectContaining({ appVersion: expect.any(String) }));
   });
 });
 

--- a/app/scripts/messenger-client-init/notifications/notification-services-push-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/notifications/notification-services-push-controller-init.test.ts
@@ -138,7 +138,9 @@ describe('NotificationServicesPushControllerInit', () => {
 
       expect(
         getControllerConfig(NotificationServicesPushControllerClassMock),
-      ).toEqual(expect.not.objectContaining({ appVersion: expect.any(String) }));
+      ).toEqual(
+        expect.not.objectContaining({ appVersion: expect.any(String) }),
+      );
     },
   );
 

--- a/app/scripts/messenger-client-init/notifications/notification-services-push-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/notifications/notification-services-push-controller-init.test.ts
@@ -13,8 +13,8 @@ import {
   type NotificationServicesPushControllerMessenger,
 } from '../messengers/notifications';
 import { getRootMessenger } from '../../lib/messenger';
-import ExtensionPlatform from '../../platforms/extension';
 import {
+  getAppVersionForRegistration,
   getNormalisedLocale,
   NotificationServicesPushControllerInit,
 } from './notification-services-push-controller-init';
@@ -41,12 +41,15 @@ function buildInitRequestMock(): jest.Mocked<
 }
 
 describe('NotificationServicesPushControllerInit', () => {
-  const arrange = () => {
+  const arrange = (platformVersion = '7.80.0') => {
     const NotificationServicesPushControllerClassMock = jest.mocked(
       NotificationServicesPushController,
     );
 
     const requestMock = buildInitRequestMock();
+    jest
+      .spyOn(requestMock.platform, 'getVersion')
+      .mockReturnValue(platformVersion);
 
     return {
       NotificationServicesPushControllerClassMock,
@@ -54,15 +57,8 @@ describe('NotificationServicesPushControllerInit', () => {
     };
   };
 
-  const getControllerConfig = (
-    mock: jest.MockedObjectDeep<typeof NotificationServicesPushController>,
-  ) => mock.mock.calls[0][0].config;
-
   beforeEach(() => {
     jest.resetAllMocks();
-    jest
-      .spyOn(ExtensionPlatform.prototype, 'getVersion')
-      .mockReturnValue('7.80.0');
   });
 
   it('returns controller instance', () => {
@@ -82,7 +78,7 @@ describe('NotificationServicesPushControllerInit', () => {
       messenger: requestMock.controllerMessenger,
       state: {
         ...defaultState,
-        ...requestMock.persistedState.NotificationServicesController,
+        ...requestMock.persistedState.NotificationServicesPushController,
       },
       env: {
         apiKey: '',
@@ -108,56 +104,43 @@ describe('NotificationServicesPushControllerInit', () => {
     });
   });
 
+  it('omits app version when platform version is not backend-safe', () => {
+    const { requestMock, NotificationServicesPushControllerClassMock } =
+      arrange('7.80.0-flask.1');
+
+    NotificationServicesPushControllerInit(requestMock);
+
+    expect(NotificationServicesPushControllerClassMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.not.objectContaining({
+          appVersion: expect.any(String),
+        }),
+      }),
+    );
+  });
+});
+
+describe('getAppVersionForRegistration', () => {
   it.each(['7.80', '7.80.0', '12.18.3.0'])(
-    'includes backend-safe app version %s in the push registration config',
+    'returns backend-safe app version %s',
     (version) => {
-      const { requestMock, NotificationServicesPushControllerClassMock } =
-        arrange();
-      jest
-        .spyOn(ExtensionPlatform.prototype, 'getVersion')
-        .mockReturnValue(version);
-
-      NotificationServicesPushControllerInit(requestMock);
-
-      expect(
-        getControllerConfig(NotificationServicesPushControllerClassMock),
-      ).toEqual(expect.objectContaining({ appVersion: version }));
+      expect(getAppVersionForRegistration(() => version)).toBe(version);
     },
   );
 
   it.each(['7', '7.80.0.1.2', '7.80.0-flask.1', '7.80.0+build.1', 'v7.80.0'])(
-    'omits app version when %s is not backend-safe',
+    'returns undefined when %s is not backend-safe',
     (version) => {
-      const { requestMock, NotificationServicesPushControllerClassMock } =
-        arrange();
-      jest
-        .spyOn(ExtensionPlatform.prototype, 'getVersion')
-        .mockReturnValue(version);
-
-      NotificationServicesPushControllerInit(requestMock);
-
-      expect(
-        getControllerConfig(NotificationServicesPushControllerClassMock),
-      ).toEqual(
-        expect.not.objectContaining({ appVersion: expect.any(String) }),
-      );
+      expect(getAppVersionForRegistration(() => version)).toBeUndefined();
     },
   );
 
-  it('omits app version when the version lookup fails', () => {
-    const { requestMock, NotificationServicesPushControllerClassMock } =
-      arrange();
-    jest
-      .spyOn(ExtensionPlatform.prototype, 'getVersion')
-      .mockImplementation(() => {
-        throw new Error('Version lookup failed');
-      });
-
-    NotificationServicesPushControllerInit(requestMock);
-
+  it('returns undefined when the version lookup fails', () => {
     expect(
-      getControllerConfig(NotificationServicesPushControllerClassMock),
-    ).toEqual(expect.not.objectContaining({ appVersion: expect.any(String) }));
+      getAppVersionForRegistration(() => {
+        throw new Error('Version lookup failed');
+      }),
+    ).toBeUndefined();
   });
 });
 

--- a/app/scripts/messenger-client-init/notifications/notification-services-push-controller-init.ts
+++ b/app/scripts/messenger-client-init/notifications/notification-services-push-controller-init.ts
@@ -47,13 +47,16 @@ export const getNormalisedLocale = (locale: string): string =>
  * it is in a backend-safe numeric format. Returns undefined otherwise (or if
  * the version lookup fails) so the field is omitted from the registration.
  *
+ * @param getVersion - Returns the extension version to validate.
  * @returns The backend-safe app version, or undefined.
  */
-export const getAppVersionForRegistration = (): string | undefined => {
+export const getAppVersionForRegistration = (
+  getVersion: () => string = () => new ExtensionPlatform().getVersion(),
+): string | undefined => {
   let appVersion: string;
 
   try {
-    appVersion = new ExtensionPlatform().getVersion();
+    appVersion = getVersion();
   } catch {
     return undefined;
   }
@@ -70,8 +73,9 @@ export const NotificationServicesPushControllerInit: MessengerClientInitFunction
   initMessenger,
   persistedState,
   getMessengerClient,
+  platform,
 }) => {
-  const appVersion = getAppVersionForRegistration();
+  const appVersion = getAppVersionForRegistration(() => platform.getVersion());
 
   const messengerClient = new NotificationServicesPushController({
     messenger: controllerMessenger,

--- a/app/scripts/messenger-client-init/notifications/notification-services-push-controller-init.ts
+++ b/app/scripts/messenger-client-init/notifications/notification-services-push-controller-init.ts
@@ -24,6 +24,14 @@ import {
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
 import { createEventBuilder, trackEvent } from '../../controllers/analytics';
+import ExtensionPlatform from '../../platforms/extension';
+
+/**
+ * Matches backend-safe extension versions: 2 to 4 dot-separated numeric
+ * segments (e.g. `7.80`, `7.80.0`, `12.18.3.0`). Rejects bare majors,
+ * prerelease (`-flask.1`), build metadata (`+build.1`), and `v` prefixes.
+ */
+const APP_VERSION_REGEX = /^\d+\.\d+(?:\.\d+){0,2}$/u;
 
 /**
  * normalises the extension locale path to use hyphens ('-') instead of underscores ('_')
@@ -33,6 +41,25 @@ import { createEventBuilder, trackEvent } from '../../controllers/analytics';
  */
 export const getNormalisedLocale = (locale: string): string =>
   locale.replace('_', '-');
+
+/**
+ * Returns the extension version for push registration metadata, but only when
+ * it is in a backend-safe numeric format. Returns undefined otherwise (or if
+ * the version lookup fails) so the field is omitted from the registration.
+ *
+ * @returns The backend-safe app version, or undefined.
+ */
+export const getAppVersionForRegistration = (): string | undefined => {
+  let appVersion: string;
+
+  try {
+    appVersion = new ExtensionPlatform().getVersion();
+  } catch {
+    return undefined;
+  }
+
+  return APP_VERSION_REGEX.test(appVersion) ? appVersion : undefined;
+};
 
 export const NotificationServicesPushControllerInit: MessengerClientInitFunction<
   NotificationServicesPushController,
@@ -44,6 +71,8 @@ export const NotificationServicesPushControllerInit: MessengerClientInitFunction
   persistedState,
   getMessengerClient,
 }) => {
+  const appVersion = getAppVersionForRegistration();
+
   const messengerClient = new NotificationServicesPushController({
     messenger: controllerMessenger,
     state: {
@@ -78,6 +107,7 @@ export const NotificationServicesPushControllerInit: MessengerClientInitFunction
         getNormalisedLocale(
           getMessengerClient('PreferencesController').state.currentLocale,
         ),
+      ...(appVersion ? { appVersion } : {}),
     },
   });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Push notification registration did not include the extension app version, which the notification services backend needs for targeting and diagnostics.

This PR adds `appVersion` to the `NotificationServicesPushController` registration config when the extension version is in a backend-safe numeric format (2–4 dot-separated segments, e.g. `7.80`, `7.80.0`, `12.18.3.0`). Versions that are not backend-safe (bare major, prerelease, build metadata, `v` prefix) or unavailable are omitted so registration still succeeds without the field.

Changes:
- Add `getAppVersionForRegistration()` in `notification-services-push-controller-init.ts`
- Pass `appVersion` into the push controller config when valid
- Add unit tests for valid, invalid, and failed version lookup cases

## **Changelog**

CHANGELOG entry: null

## **Related issues**
https://consensyssoftware.atlassian.net/browse/GE-211

Fixes:

## **Manual testing steps**

1. Build and load the extension (`yarn start` or `yarn build:test`).
2. Unlock the wallet and enable push notifications (Settings → Notifications, or the onboarding flow if applicable).
3. Confirm push notifications still register and work as before (no regression in opt-in or delivery).
4. Inspect the push registration request in DevTools (Network tab) and verify `appVersion` is present with the current extension version (e.g. `7.80.0`) when the version matches the backend-safe format.

## **Screenshots/Recordings**

Not applicable — no user-facing UI changes.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive change to push init metadata with defensive omission of invalid versions; no auth or registration flow changes beyond an optional field.
> 
> **Overview**
> Push registration can now send **`appVersion`** to the notification services backend when the extension version passes a strict numeric format check (2–4 dot-separated segments).
> 
> **`getAppVersionForRegistration`** reads the version from `platform.getVersion()`, validates it with `APP_VERSION_REGEX`, and returns `undefined` on lookup errors or non–backend-safe strings (prerelease, build metadata, bare major, `v` prefix, etc.). **`NotificationServicesPushControllerInit`** spreads `appVersion` into the push controller `config` only when that helper returns a value, so registration still works without the field on Flask or odd builds.
> 
> Tests cover init wiring (including omitting `appVersion` for `7.80.0-flask.1`), the validator matrix, and a fix to use **`NotificationServicesPushController`** persisted state in expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6976bf233d3b481ecfc844ce834df8d669f49371. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->