### PR TITLE
fix(perps): render perps toast via portal to escape CSS transform containing block

### DIFF
--- a/ui/components/app/perps/perps-toast/perps-toast-provider.test.tsx
+++ b/ui/components/app/perps/perps-toast/perps-toast-provider.test.tsx
@@ -648,4 +648,23 @@ describe('PerpsToastProvider', () => {
       screen.queryByText(messages.perpsToastMarginAdjustmentFailed.message),
     ).not.toBeInTheDocument();
   });
+
+  it('renders the toast via portal to document.body, not inside the provider subtree', () => {
+    const { container } = renderWithProvider(
+      <PerpsToastProvider>
+        <ToastHarness />
+      </PerpsToastProvider>,
+      getStore(),
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show Info' }));
+
+    expect(screen.getByText('Submitting order...')).toBeInTheDocument();
+    expect(
+      container.querySelector('[data-testid="perps-toast"]'),
+    ).not.toBeInTheDocument();
+    expect(
+      document.body.querySelector('[data-testid="perps-toast"]'),
+    ).toBeInTheDocument();
+  });
 });

--- a/ui/components/app/perps/perps-toast/perps-toast-provider.tsx
+++ b/ui/components/app/perps/perps-toast/perps-toast-provider.tsx
@@ -7,6 +7,7 @@ import React, {
   useState,
   type ReactNode,
 } from 'react';
+import ReactDOM from 'react-dom';
 import { Box } from '@metamask/design-system-react';
 import { Toast } from '../../../multichain/toast';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
@@ -170,22 +171,25 @@ export const PerpsToastProvider = ({ children }: PerpsToastProviderProps) => {
   return (
     <PerpsToastContext.Provider value={contextValue}>
       {children}
-      {activeToast ? (
-        <Box className="toasts-container bottom-20 w-[calc(100%-32px)] max-w-[408px]">
-          <Toast
-            key={activeToast.id}
-            startAdornment={getPerpsToastIcon(activeToast.presentation)}
-            text={activeToast.message}
-            description={activeToast.description}
-            className="perps-toast"
-            contentProps={{ className: 'items-center' }}
-            autoHideTime={activeToast.autoHideTime}
-            onClose={hidePerpsToast}
-            onAutoHideToast={hidePerpsToast}
-            dataTestId={activeToast.dataTestId ?? 'perps-toast'}
-          />
-        </Box>
-      ) : null}
+      {activeToast
+        ? ReactDOM.createPortal(
+            <Box className="toasts-container bottom-20 w-[calc(100%-32px)] max-w-[408px]">
+              <Toast
+                key={activeToast.id}
+                startAdornment={getPerpsToastIcon(activeToast.presentation)}
+                text={activeToast.message}
+                description={activeToast.description}
+                className="perps-toast"
+                contentProps={{ className: 'items-center' }}
+                autoHideTime={activeToast.autoHideTime}
+                onClose={hidePerpsToast}
+                onAutoHideToast={hidePerpsToast}
+                dataTestId={activeToast.dataTestId ?? 'perps-toast'}
+              />
+            </Box>,
+            document.body,
+          )
+        : null}
     </PerpsToastContext.Provider>
   );
 };


### PR DESCRIPTION
## **Description**

The `Tabs` component (`ui/components/ui/tabs/tabs.tsx`) applies the Tailwind class `transform-gpu`, which translates to `transform: translateZ(0)`. Per CSS spec, any ancestor with a `transform` creates a new containing block for `position: fixed` descendants. This caused perps toasts rendered inside `PerpsToastProvider` (which sits inside the Tabs tree on the home screen perps tab) to be positioned relative to the Tabs container instead of the viewport — making them effectively invisible.

This only affected toasts triggered from the **perps tab** (home screen). All other perps toasts (close single position, cancel order, edit margin, etc.) are triggered from dedicated perps pages inside `PerpsLayout`, which is NOT a descendant of the `Tabs` component and therefore unaffected.

**Fix:** Render the perps toast via `ReactDOM.createPortal()` to `document.body`, escaping the CSS transform containing block. This follows the same portal pattern the `Modal` component already uses.

## **Changelog**

CHANGELOG entry: Fixed perps close-all-positions toasts not appearing on the home screen perps tab

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-2852

## **Manual testing steps**

1. Run the extension locally.
2. Navigate to the home screen and switch to the Perps tab.
3. Ensure you have open positions.
4. Click the "Close all" button in the positions header.
5. Confirm the close in the modal that appears.
6. Verify that an in-progress toast ("Closing all positions") appears at the bottom of the viewport.
7. After the operation completes, verify that a success toast ("All positions closed") or error toast appears.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

https://github.com/user-attachments/assets/41f4ef39-8dc6-4386-baef-7a972f8a2ffa



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
