### PR TITLE
ci: update sonarcloud org id

### DIFF
--- a/app/scripts/platforms/extension.test.js
+++ b/app/scripts/platforms/extension.test.js
@@ -31,7 +31,7 @@ jest.mock('@metamask/etherscan-link', () => {
 describe('extension platform', () => {
   const metamaskVersion = process.env.METAMASK_VERSION;
   beforeEach(() => {
-    // TODO: Delete this an enable 'resetMocks' in `jest.config.js` instead
+    // TODO: Delete this an enable 'resetMocks' in `jest.config.js` insteaddd
     jest.resetAllMocks();
   });
 

--- a/app/scripts/platforms/extension.test.js
+++ b/app/scripts/platforms/extension.test.js
@@ -31,7 +31,7 @@ jest.mock('@metamask/etherscan-link', () => {
 describe('extension platform', () => {
   const metamaskVersion = process.env.METAMASK_VERSION;
   beforeEach(() => {
-    // TODO: Delete this an enable 'resetMocks' in `jest.config.js` insteaddd
+    // TODO: Delete this an enable 'resetMocks' in `jest.config.js` instead
     jest.resetAllMocks();
   });
 

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -2,7 +2,7 @@
 # The SonarCloud scan workflow always uses the latest version from the default branch.
 # This means any changes made to this file in a feature branch will not be considered until they are merged.
 
-sonar.projectKey=metamask-extension
+sonar.projectKey=MetaMask_metamask-extension
 sonar.organization=metamask
 
 # Source

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@
 # This means any changes made to this file in a feature branch will not be considered until they are merged.
 
 sonar.projectKey=metamask-extension
-sonar.organization=consensys
+sonar.organization=metamask
 
 # Source
 sonar.sources=app,development,shared,types,ui


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Since 3 weeks we are not receiving PRs decoration anymore with Sonar analysis findings. It seems that now is required the project to be bound to the same github org that is attached to the sonarcloud instance, but MetaMask project was configured under `consensy` org instead of `metamask` org.

[https://docs.sonarsource.com/sonarqube-cloud/administering-sonarcloud/about-sonarqube-cloud-solution/resources-structure/binding](https://docs.sonarsource.com/sonarqube-cloud/administering-sonarcloud/about-sonarqube-cloud-solution/resources-structure/binding-with-dop?_gl=1*18fevs1*_gcl_au*MTQxNDYyODA2Ni4xNzgxNTk2NDMx*_ga*MjA0MzEzNDQ5OS4xNzgxNTk2MzY1*_ga_9JZ0GZ5TC6*czE3ODE2ODcxNjIkbzQkZzEkdDE3ODE2ODg5MDQkajYwJGwwJGgw)

This PR changes the sonar config so the analysis is pushed to the `metamask` org configured in our sonarcloud instance. PR decoration is now working as we can see in this PR:

<img width="953" height="395" alt="Screenshot 2026-06-17 at 11 14 40" src="https://github.com/user-attachments/assets/330d6dd2-70d9-4556-a9e0-34b003aeab91" />


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
