### PR TITLE
chore: Set `core-platform` as codeowners of `LegacyBackgroundApiService`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -99,11 +99,14 @@ test/e2e/tests/perps/ @MetaMask/perps
 docs/perps/ @MetaMask/perps
 **/perps/** @MetaMask/perps
 
-# Snaps
-**/snaps/**                          @MetaMask/core-platform
-shared/constants/permissions.ts      @MetaMask/core-platform
-ui/helpers/utils/permission.js       @MetaMask/core-platform
-app/scripts/constants/snaps.ts       @MetaMask/core-platform
+# Core Platform
+**/snaps/**                                                @MetaMask/core-platform
+shared/constants/permissions.ts                            @MetaMask/core-platform
+ui/helpers/utils/permission.js                             @MetaMask/core-platform
+app/scripts/constants/snaps.ts                             @MetaMask/core-platform
+app/scripts/services/legacy-background-api-service.ts      @MetaMask/core-platform
+app/scripts/services/legacy-background-api-service.test.ts @MetaMask/core-platform
+
 
 # Co-owned by Confirmations and Snaps
 ui/components/app/metamask-template-renderer @MetaMask/confirmations @MetaMask/core-platform


### PR DESCRIPTION
## **Description**

This makes `@MetaMask/core-platform` codeowners of `LegacyBackgroundApiService`.
## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
