### PR TITLE
fix: reset offscreen trezor SDK before reconnecting on Chrome cp-13.36.0

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -10587,7 +10587,7 @@
     "description": "Hardware device name"
   },
   "trezorDesktopAppRequiredError": {
-    "message": "Trezor Suite Desktop is required to use Trezor with Firefox. Please install and open Trezor Suite (suite.trezor.io) and try again.",
+    "message": "Trezor Suite Desktop is required to use Trezor. Please install and open Trezor Suite (suite.trezor.io) and try again.",
     "description": "An error message shown to the user during the hardware connect flow."
   },
   "tronBandwidth": {

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -10587,7 +10587,7 @@
     "description": "Hardware device name"
   },
   "trezorDesktopAppRequiredError": {
-    "message": "Trezor Suite Desktop is required to use Trezor with Firefox. Please install and open Trezor Suite (suite.trezor.io) and try again.",
+    "message": "Trezor Suite Desktop is required to use Trezor. Please install and open Trezor Suite (suite.trezor.io) and try again.",
     "description": "An error message shown to the user during the hardware connect flow."
   },
   "tronBandwidth": {

--- a/app/offscreen/hardware-wallets/trezor.test.ts
+++ b/app/offscreen/hardware-wallets/trezor.test.ts
@@ -1,0 +1,291 @@
+import {
+  OffscreenCommunicationEvents,
+  OffscreenCommunicationTarget,
+  TrezorAction,
+} from '../../../shared/constants/offscreen-communication';
+import init from './trezor';
+
+const mockOn = jest.fn();
+const mockInit = jest.fn();
+const mockDispose = jest.fn();
+const mockGetPublicKey = jest.fn();
+const mockEthereumSignTransaction = jest.fn();
+const mockEthereumSignMessage = jest.fn();
+const mockEthereumSignTypedData = jest.fn();
+const mockGetFeatures = jest.fn();
+
+jest.mock('@trezor/connect-web', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  __esModule: true,
+  default: {
+    on: (...args: unknown[]) => mockOn(...args),
+    init: (...args: unknown[]) => mockInit(...args),
+    dispose: (...args: unknown[]) => mockDispose(...args),
+    getPublicKey: (...args: unknown[]) => mockGetPublicKey(...args),
+    ethereumSignTransaction: (...args: unknown[]) =>
+      mockEthereumSignTransaction(...args),
+    ethereumSignMessage: (...args: unknown[]) =>
+      mockEthereumSignMessage(...args),
+    ethereumSignTypedData: (...args: unknown[]) =>
+      mockEthereumSignTypedData(...args),
+    getFeatures: (...args: unknown[]) => mockGetFeatures(...args),
+  },
+  DEVICE: { CONNECT: 'device-connect' },
+  DEVICE_EVENT: 'DEVICE_EVENT',
+}));
+
+type MessageListener = (
+  msg: {
+    target: string;
+    action?: TrezorAction;
+    params?: Record<string, unknown>;
+  },
+  sender: unknown,
+  sendResponse: (response?: unknown) => void,
+) => boolean;
+
+describe('Trezor Offscreen', () => {
+  let capturedMessageListener: MessageListener;
+  let mockSendMessage: jest.Mock;
+  let mockAddListener: jest.Mock;
+
+  // The init handler chains several promises (dispose -> init -> respond);
+  // a macrotask turn drains all pending microtasks so the chain settles.
+  const flush = () =>
+    new Promise((resolve) => {
+      setTimeout(resolve, 0);
+    });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockInit.mockResolvedValue(undefined);
+    mockDispose.mockResolvedValue(undefined);
+
+    mockSendMessage = jest.fn();
+    mockAddListener = jest.fn((callback: MessageListener) => {
+      capturedMessageListener = callback;
+    });
+
+    Object.defineProperty(globalThis, 'chrome', {
+      value: {
+        runtime: {
+          sendMessage: mockSendMessage,
+          onMessage: {
+            addListener: mockAddListener,
+          },
+        },
+      },
+      writable: true,
+      configurable: true,
+    });
+
+    init();
+  });
+
+  const sendInit = (params?: Record<string, unknown>) => {
+    const sendResponse = jest.fn();
+    capturedMessageListener(
+      {
+        target: OffscreenCommunicationTarget.trezorOffscreen,
+        action: TrezorAction.init,
+        params,
+      },
+      undefined,
+      sendResponse,
+    );
+    return sendResponse;
+  };
+
+  it('registers a single message listener', () => {
+    expect(mockAddListener).toHaveBeenCalledTimes(1);
+    expect(mockAddListener).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('ignores messages that do not target the Trezor offscreen', () => {
+    const sendResponse = jest.fn();
+
+    const result = capturedMessageListener(
+      { target: 'some-other-target', action: TrezorAction.getPublicKey },
+      undefined,
+      sendResponse,
+    );
+
+    expect(result).toBeUndefined();
+    expect(mockGetPublicKey).not.toHaveBeenCalled();
+    expect(sendResponse).not.toHaveBeenCalled();
+  });
+
+  describe('init', () => {
+    it('disposes any stale connection before re-initializing', async () => {
+      const params = { manifest: { appName: 'MetaMask', email: 'x@y.z' } };
+
+      const sendResponse = sendInit(params);
+      await flush();
+
+      expect(mockDispose).toHaveBeenCalledTimes(1);
+      expect(mockInit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          ...params,
+          env: 'webextension',
+        }),
+      );
+      // dispose must happen before init so a stale connection is torn down first.
+      expect(mockDispose.mock.invocationCallOrder[0]).toBeLessThan(
+        mockInit.mock.invocationCallOrder[0],
+      );
+      expect(sendResponse).toHaveBeenCalledWith();
+    });
+
+    it('does not hardcode the core mode so both Suite Desktop and iframe work', async () => {
+      sendInit();
+      await flush();
+
+      const initSettings = mockInit.mock.calls[0][0];
+      expect(initSettings.coreMode).toBeUndefined();
+    });
+
+    it('forwards a caller-provided core mode unchanged', async () => {
+      sendInit({ coreMode: 'suite-desktop' });
+      await flush();
+
+      const initSettings = mockInit.mock.calls[0][0];
+      expect(initSettings.coreMode).toBe('suite-desktop');
+    });
+
+    it('re-opens the iframe on a second connection without hanging', async () => {
+      await flush();
+      sendInit();
+      await flush();
+
+      // Simulate the SDK throwing Init_AlreadyInitialized if the previous
+      // iframe were not disposed first.
+      mockInit.mockImplementationOnce(() => {
+        throw Object.assign(new Error('Init_AlreadyInitialized'), {
+          code: 'Init_AlreadyInitialized',
+        });
+      });
+
+      const secondSendResponse = sendInit();
+      await flush();
+
+      // The second connection still resolves the bridge (no hang) and the
+      // stale connection was disposed on each init.
+      expect(mockDispose).toHaveBeenCalledTimes(2);
+      expect(secondSendResponse).toHaveBeenCalledWith();
+    });
+
+    it('resolves the bridge even when init rejects', async () => {
+      mockInit.mockRejectedValueOnce(new Error('boom'));
+
+      const sendResponse = sendInit();
+      await flush();
+
+      expect(sendResponse).toHaveBeenCalledWith();
+    });
+
+    it('registers the device-connect listener', async () => {
+      sendInit();
+      await flush();
+
+      expect(mockOn).toHaveBeenCalledWith('DEVICE_EVENT', expect.any(Function));
+    });
+
+    it('forwards a connected Trezor device to the extension', async () => {
+      sendInit();
+      await flush();
+
+      const deviceEventCallback = mockOn.mock.calls[0][1];
+      deviceEventCallback({
+        type: 'device-connect',
+        payload: {
+          features: {
+            model: 'T',
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            minor_version: 2,
+          },
+        },
+      });
+
+      expect(mockSendMessage).toHaveBeenCalledWith({
+        target: OffscreenCommunicationTarget.extension,
+        event: OffscreenCommunicationEvents.trezorDeviceConnect,
+        payload: { model: 'T', minorVersion: 2 },
+      });
+    });
+
+    it('ignores non-connect device events', async () => {
+      sendInit();
+      await flush();
+
+      const deviceEventCallback = mockOn.mock.calls[0][1];
+      deviceEventCallback({ type: 'device-changed', payload: {} });
+
+      expect(mockSendMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('getPublicKey', () => {
+    it('passes through the SDK response', async () => {
+      const sdkResult = {
+        success: true,
+        payload: { publicKey: 'abc', chainCode: 'def' },
+      };
+      mockGetPublicKey.mockResolvedValue(sdkResult);
+      const sendResponse = jest.fn();
+      const params = { path: "m/44'/60'/0'/0", coin: 'ETH' };
+
+      capturedMessageListener(
+        {
+          target: OffscreenCommunicationTarget.trezorOffscreen,
+          action: TrezorAction.getPublicKey,
+          params,
+        },
+        undefined,
+        sendResponse,
+      );
+      await flush();
+
+      expect(mockGetPublicKey).toHaveBeenCalledWith(params);
+      expect(sendResponse).toHaveBeenCalledWith(sdkResult);
+    });
+  });
+
+  describe('dispose', () => {
+    it('disposes the Trezor connection', () => {
+      const sendResponse = jest.fn();
+
+      capturedMessageListener(
+        {
+          target: OffscreenCommunicationTarget.trezorOffscreen,
+          action: TrezorAction.dispose,
+        },
+        undefined,
+        sendResponse,
+      );
+
+      expect(mockDispose).toHaveBeenCalledTimes(1);
+      expect(sendResponse).toHaveBeenCalledWith();
+    });
+  });
+
+  describe('unsupported action', () => {
+    it('responds with an error payload', () => {
+      const sendResponse = jest.fn();
+
+      capturedMessageListener(
+        {
+          target: OffscreenCommunicationTarget.trezorOffscreen,
+          action: 'not-a-real-action' as TrezorAction,
+        },
+        undefined,
+        sendResponse,
+      );
+
+      expect(sendResponse).toHaveBeenCalledWith({
+        success: false,
+        payload: { error: 'Trezor action not supported' },
+      });
+    });
+  });
+});

--- a/app/offscreen/hardware-wallets/trezor.ts
+++ b/app/offscreen/hardware-wallets/trezor.ts
@@ -32,29 +32,48 @@ export default function init() {
 
       switch (msg.action) {
         case TrezorAction.init:
-          TrezorConnectSDK.on(DEVICE_EVENT, (event) => {
-            if (event.type !== DEVICE.CONNECT) {
-              return;
-            }
+          // `@trezor/connect-web`'s SDK is a singleton that lives for the
+          // lifetime of the offscreen document, independent of the background
+          // keyring it serves. When the keyring is recreated (e.g. the user
+          // cancels the connect flow and starts it again) `init` runs a second
+          // time while the previous core (iframe or Suite Desktop) is still
+          // mounted, and `CoreInIframe.init` throws `Init_AlreadyInitialized`.
+          // That would leave `sendResponse` uncalled and hang MetaMask on
+          // "Looking for your Trezor" state. Disposing first tears down any stale
+          // connection so each request re-opens a fresh one. The core mode is
+          // intentionally left to the SDK's default ('auto') / caller-provided
+          // setting so users can connect through Trezor Suite Desktop or the
+          // remote iframe.
+          Promise.resolve()
+            .then(() => TrezorConnectSDK.dispose())
+            .catch(() => undefined)
+            .then(() => {
+              TrezorConnectSDK.on(DEVICE_EVENT, (event) => {
+                if (event.type !== DEVICE.CONNECT) {
+                  return;
+                }
 
-            if (event.payload.features?.model) {
-              chrome.runtime.sendMessage({
-                target: OffscreenCommunicationTarget.extension,
-                event: OffscreenCommunicationEvents.trezorDeviceConnect,
-                payload: {
-                  model: event.payload.features.model,
-                  minorVersion: event.payload.features.minor_version,
-                },
+                if (event.payload.features?.model) {
+                  chrome.runtime.sendMessage({
+                    target: OffscreenCommunicationTarget.extension,
+                    event: OffscreenCommunicationEvents.trezorDeviceConnect,
+                    payload: {
+                      model: event.payload.features.model,
+                      minorVersion: event.payload.features.minor_version,
+                    },
+                  });
+                }
               });
-            }
-          });
 
-          TrezorConnectSDK.init({
-            ...msg.params,
-            env: 'webextension',
-          }).then(() => {
-            sendResponse();
-          });
+              return TrezorConnectSDK.init({
+                ...msg.params,
+                env: 'webextension',
+              });
+            })
+            .then(() => sendResponse())
+            // Resolve the bridge even if init fails so it does not hang; the
+            // subsequent call surfaces the real error to the UI.
+            .catch(() => sendResponse());
 
           break;
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->


Fixes a Chrome-only Trezor connection regression where MetaMask gets stuck on "Looking for your Trezor" when connecting a Trezor device.

In Chrome MV3, Trezor communication runs through the offscreen document via `@trezor/connect-web`. That SDK instance is a singleton for the lifetime of the offscreen document, independent of the background keyring lifecycle. When a user starts the connect flow, backs out, and tries again, `init` can run while the previous core (iframe or Suite Desktop) is still mounted. `CoreInIframe.init` then throws `Init_AlreadyInitialized`, `sendResponse` is never called, and the connect flow hangs indefinitely.

The proposed solution to fix this uses the offscreen Trezor handler, dispose any existing SDK connection before re-initializing. This tears down stale state so each connect attempt starts fresh and can reopen the remote iframe or reconnect to Suite Desktop. The bridge `init` response is also resolved on failure so the UI does not hang while waiting for a message reply.

Note: This PR also updates the `trezorDesktopAppRequiredError` copy to be browser-agnostic and adds unit tests for the offscreen handler.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug that could cause Trezor connection to hang on Chrome when retrying the connect flow

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/43505
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1931

## **Manual testing steps**

1. Build and load the extension in Chrome
2. Ensure Trezor Suite Desktop is **not** running.
3. Open MetaMask and go to **Add account or hardware wallet** → **Connect hardware wallet** → **Trezor**.
4. The Trezor webapp will open, close the window at any moment
5. Try again and this time finish the import in the Trezor webapp
6. Wait for the account list to load, select an account, and click **Next**.
7. Verify MetaMask does not hang on "Looking for your Trezor" and the flow can proceed or show a meaningful error.
8. Cancel or back out of the connect flow without adding accounts.
9. Start the Trezor connect flow again and repeat step 5.
10. Verify the second attempt also completes without hanging.
11. Optional: open Trezor Suite Desktop and repeat steps 3–10 to confirm Suite Desktop connection still works.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Check linked issue: https://github.com/MetaMask/metamask-extension/issues/43505

### **After**

https://github.com/user-attachments/assets/a62aabf0-454e-4bc7-beb7-9df1fea652fb

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
