### PR TITLE
fix: perps withdraw details

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -11051,16 +11051,16 @@
     "message": "You received",
     "description": "Label indicating the amount and asset the user received."
   },
-  "youWithdrew": {
-    "message": "You withdrew",
-    "description": "Label indicating the amount and asset the user withdrew."
-  },
   "youSell": {
     "message": "You sell"
   },
   "youSent": {
     "message": "You sent",
     "description": "Label indicating the amount and asset the user sent."
+  },
+  "youWithdrew": {
+    "message": "You withdrew",
+    "description": "Label indicating the amount and asset the user withdrew."
   },
   "youllReceive": {
     "message": "You'll receive",

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -11051,6 +11051,10 @@
     "message": "You received",
     "description": "Label indicating the amount and asset the user received."
   },
+  "youWithdrew": {
+    "message": "You withdrew",
+    "description": "Label indicating the amount and asset the user withdrew."
+  },
   "youSell": {
     "message": "You sell"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -11051,16 +11051,16 @@
     "message": "You received",
     "description": "Label indicating the amount and asset the user received."
   },
-  "youWithdrew": {
-    "message": "You withdrew",
-    "description": "Label indicating the amount and asset the user withdrew."
-  },
   "youSell": {
     "message": "You sell"
   },
   "youSent": {
     "message": "You sent",
     "description": "Label indicating the amount and asset the user sent."
+  },
+  "youWithdrew": {
+    "message": "You withdrew",
+    "description": "Label indicating the amount and asset the user withdrew."
   },
   "youllReceive": {
     "message": "You'll receive",

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -11051,6 +11051,10 @@
     "message": "You received",
     "description": "Label indicating the amount and asset the user received."
   },
+  "youWithdrew": {
+    "message": "You withdrew",
+    "description": "Label indicating the amount and asset the user withdrew."
+  },
   "youSell": {
     "message": "You sell"
   },

--- a/ui/pages/details/components/sections.tsx
+++ b/ui/pages/details/components/sections.tsx
@@ -14,8 +14,10 @@ import { TokenRow } from './token-row';
 
 export function TokensSection({
   tokens,
+  showBadge,
 }: {
   tokens: { label?: string; token?: TokenAmount }[];
+  showBadge?: boolean;
 }) {
   const visibleTokens = tokens.flatMap(({ label, token }) =>
     token ? [{ label, token }] : [],
@@ -30,7 +32,7 @@ export function TokensSection({
       {visibleTokens.map(({ label, token }) => (
         <div key={token?.assetId}>
           {label && <p className="text-alternative mb-1">{label}</p>}
-          <TokenRow token={token} />
+          <TokenRow token={token} showNetworkBadge={showBadge} />
         </div>
       ))}
     </div>

--- a/ui/pages/details/templates/helpers.ts
+++ b/ui/pages/details/templates/helpers.ts
@@ -1,0 +1,76 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { getNativeTokenAddress } from '@metamask/assets-controllers';
+import type { MetamaskPayMetadata } from '@metamask/transaction-controller';
+import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
+import type { Hex } from '@metamask/utils';
+import { getTokenMetadataFromKnownToken } from '../../../../shared/lib/activity/adapters/helpers';
+import { toAssetId } from '../../../../shared/lib/asset-utils';
+import {
+  getNativeTokenInfo,
+  getUSDConversionRateByChainId,
+} from '../../../selectors';
+import { isEqualCaseInsensitive as equalsIgnoreCase } from '../../../../shared/lib/string-utils';
+
+// This should be common helper
+function getNativeToken(chainId: Hex) {
+  return {
+    address: getNativeTokenAddress(chainId),
+    ...getNativeTokenInfo({}, chainId),
+  };
+}
+
+// Builds the "You received" token amount from `metamaskPay`
+// Converts targetFiat → token
+export function useDestinationToken(
+  metamaskPay: MetamaskPayMetadata | undefined,
+) {
+  const { chainId, targetFiat, tokenAddress } = metamaskPay ?? {};
+  const fiatUsd = Number.parseFloat(targetFiat || '');
+
+  const nativeTokenUsdRate = useSelector((state) =>
+    chainId ? getUSDConversionRateByChainId(chainId)(state) : undefined,
+  );
+
+  return useMemo(() => {
+    if (!targetFiat || !tokenAddress || !chainId) {
+      return undefined;
+    }
+
+    if (!Number.isFinite(fiatUsd) || fiatUsd <= 0) {
+      return undefined;
+    }
+
+    const knownToken = getTokenMetadataFromKnownToken(
+      tokenAddress,
+      'in',
+      toEvmCaipChainId(chainId),
+    );
+
+    const nativeToken = getNativeToken(chainId);
+    const isNative = equalsIgnoreCase(tokenAddress, nativeToken.address);
+
+    let amount: string | undefined;
+
+    if (isNative) {
+      if (!nativeTokenUsdRate) {
+        return undefined;
+      }
+
+      const tokenAmount = fiatUsd / nativeTokenUsdRate;
+
+      amount =
+        tokenAmount >= 1 ? tokenAmount.toFixed(2) : tokenAmount.toPrecision(4);
+    } else {
+      amount = targetFiat;
+    }
+
+    return {
+      amount,
+      direction: 'in' as const,
+      decimals: knownToken?.decimals ?? 18,
+      assetId: toAssetId(tokenAddress as Hex, chainId),
+      symbol: isNative ? nativeToken.symbol : knownToken?.symbol,
+    };
+  }, [chainId, targetFiat, tokenAddress, nativeTokenUsdRate]);
+}

--- a/ui/pages/details/templates/perps-details.tsx
+++ b/ui/pages/details/templates/perps-details.tsx
@@ -1,23 +1,117 @@
-import React from 'react';
-import type { ActivityListItem } from '../../../../shared/lib/activity/types';
-import { PerpsFiatRows } from '../components/amounts-section';
-import { Footer, Section } from '../components/shared';
+import React, { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
+import type {
+  ActivityListItem,
+  TokenAmount,
+} from '../../../../shared/lib/activity/types';
+import { toAssetId } from '../../../../shared/lib/asset-utils';
+import { AccountName } from '../../../components/app/transaction/account-name';
+import { NetworkName } from '../../../components/app/transaction/network-name';
+import { TransactionStatus } from '../../../components/app/transaction/transaction-status';
+import { selectLocalTransactionsByHash } from '../../../selectors/activity';
+import {
+  ARBITRUM_USDC,
+  PERPS_CURRENCY,
+  // eslint-disable-next-line import-x/no-restricted-paths
+} from '../../confirmations/constants/perps';
 import { BlockExplorerButton } from '../components/block-explorer-button';
-import { MetadataSection, TokensSection } from '../components/sections';
+import { Footer, Row, Section } from '../components/shared';
+import { TokensSection } from '../components/sections';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { useFormatters } from '../../../hooks/useFormatters';
+
+const ARBITRUM_USDC_ASSET_ID = toAssetId(
+  ARBITRUM_USDC.address,
+  toEvmCaipChainId(ARBITRUM_USDC.chainId),
+);
+
+function useTransactionMeta(hash: string | undefined) {
+  const localTransactions = useSelector(selectLocalTransactionsByHash);
+  return localTransactions.get(hash || '')?.initialTransaction;
+}
 
 export function PerpsDetails({
   item,
 }: {
   item: Extract<ActivityListItem, { type: 'perpsAddFunds' | 'perpsWithdraw' }>;
 }) {
+  const t = useI18nContext();
+  const { formatDateTime, formatCurrencyWithMinThreshold } = useFormatters();
+  const transactionMeta = useTransactionMeta(item.hash);
+  const { metamaskPay } = transactionMeta || {};
+  const { targetFiat, totalFiat, networkFeeFiat, bridgeFeeFiat } =
+    metamaskPay || {};
+
+  const withdrewToken = useMemo((): TokenAmount | undefined => {
+    if (!totalFiat) {
+      return undefined;
+    }
+
+    return {
+      assetId: ARBITRUM_USDC_ASSET_ID,
+      amount: totalFiat,
+      decimals: ARBITRUM_USDC.decimals,
+      symbol: ARBITRUM_USDC.symbol,
+      direction: 'out',
+    };
+  }, [totalFiat]);
+
+  const receivedToken = useMemo((): TokenAmount | undefined => {
+    const amount = targetFiat;
+
+    if (!amount) {
+      return undefined;
+    }
+
+    return {
+      amount,
+      direction: 'in',
+    };
+  }, [targetFiat]);
+
+  const transactionFeeAmount =
+    Number(networkFeeFiat ?? 0) + Number(bridgeFeeFiat ?? 0);
+
+  const formattedTransactionFee = Number.isFinite(transactionFeeAmount)
+    ? formatCurrencyWithMinThreshold(transactionFeeAmount, PERPS_CURRENCY)
+    : null;
+
   return (
     <div className="flex grow flex-col">
       <div className="divide-y divide-border-muted">
-        <TokensSection tokens={[{ token: item.data.token }]} />
-        <MetadataSection item={item} />
+        <TokensSection
+          tokens={[
+            { label: t('youWithdrew'), token: withdrewToken },
+            { label: t('youReceived'), token: receivedToken },
+          ]}
+        />
+
         <Section>
-          <PerpsFiatRows item={item} />
+          <Row
+            label={t('status')}
+            value={<TransactionStatus status={item.status} />}
+          />
+          <Row label={t('date')} value={formatDateTime(item.timestamp)} />
+          <Row
+            label={t('account')}
+            value={<AccountName address={item.data.from} />}
+          />
+          <Row
+            label={t('network')}
+            value={<NetworkName chainId={item.chainId} />}
+          />
         </Section>
+
+        {formattedTransactionFee ? (
+          <Section>
+            <Row
+              label={t('transactionFee')}
+              testId="transaction-base-fee"
+              value={formattedTransactionFee}
+            />
+          </Section>
+        ) : null}
       </div>
 
       <Footer>

--- a/ui/pages/details/templates/perps-details.tsx
+++ b/ui/pages/details/templates/perps-details.tsx
@@ -5,6 +5,7 @@ import type {
   ActivityListItem,
   TokenAmount,
 } from '../../../../shared/lib/activity/types';
+import { getTokenMetadataFromKnownToken } from '../../../../shared/lib/activity/adapters/helpers';
 import { toAssetId } from '../../../../shared/lib/asset-utils';
 import { AccountName } from '../../../components/app/transaction/account-name';
 import { NetworkName } from '../../../components/app/transaction/network-name';
@@ -58,17 +59,22 @@ export function PerpsDetails({
   }, [totalFiat]);
 
   const receivedToken = useMemo((): TokenAmount | undefined => {
-    const amount = targetFiat;
-
-    if (!amount) {
+    if (!targetFiat || !metamaskPay?.chainId) {
       return undefined;
     }
 
+    const tokenMetadata = getTokenMetadataFromKnownToken(
+      metamaskPay?.tokenAddress,
+      'in',
+      toEvmCaipChainId(metamaskPay.chainId),
+    );
+
     return {
-      amount,
+      amount: targetFiat,
       direction: 'in',
+      ...tokenMetadata,
     };
-  }, [targetFiat]);
+  }, [targetFiat, metamaskPay?.chainId, metamaskPay?.tokenAddress]);
 
   const transactionFeeAmount =
     Number(networkFeeFiat ?? 0) + Number(bridgeFeeFiat ?? 0);
@@ -76,6 +82,13 @@ export function PerpsDetails({
   const formattedTransactionFee = Number.isFinite(transactionFeeAmount)
     ? formatCurrencyWithMinThreshold(transactionFeeAmount, PERPS_CURRENCY)
     : null;
+
+  const chainId =
+    metamaskPay?.isPostQuote && metamaskPay.chainId
+      ? toEvmCaipChainId(metamaskPay.chainId)
+      : item.chainId;
+
+  const blockExplorerHash = item.hash === '0x0' ? undefined : item.hash;
 
   return (
     <div className="flex grow flex-col">
@@ -85,6 +98,7 @@ export function PerpsDetails({
             { label: t('youWithdrew'), token: withdrewToken },
             { label: t('youReceived'), token: receivedToken },
           ]}
+          showBadge
         />
 
         <Section>
@@ -97,10 +111,7 @@ export function PerpsDetails({
             label={t('account')}
             value={<AccountName address={item.data.from} />}
           />
-          <Row
-            label={t('network')}
-            value={<NetworkName chainId={item.chainId} />}
-          />
+          <Row label={t('network')} value={<NetworkName chainId={chainId} />} />
         </Section>
 
         {formattedTransactionFee ? (
@@ -115,7 +126,7 @@ export function PerpsDetails({
       </div>
 
       <Footer>
-        <BlockExplorerButton chainId={item.chainId} txHash={item.hash} />
+        <BlockExplorerButton chainId={chainId} txHash={blockExplorerHash} />
       </Footer>
     </div>
   );

--- a/ui/pages/details/templates/perps-details.tsx
+++ b/ui/pages/details/templates/perps-details.tsx
@@ -48,14 +48,19 @@ export function PerpsDetails({
       return undefined;
     }
 
+    const amount =
+      Number(totalFiat) -
+      Number(bridgeFeeFiat ?? 0) -
+      Number(networkFeeFiat ?? 0);
+
     return {
       assetId: ARBITRUM_USDC_ASSET_ID,
-      amount: totalFiat,
+      amount: String(amount),
       decimals: ARBITRUM_USDC.decimals,
       symbol: ARBITRUM_USDC.symbol,
       direction: 'out',
     };
-  }, [totalFiat]);
+  }, [totalFiat, bridgeFeeFiat, networkFeeFiat]);
   const receivedToken = useDestinationToken(metamaskPay);
 
   const formattedTransactionFee = formatCurrencyWithMinThreshold(

--- a/ui/pages/details/templates/perps-details.tsx
+++ b/ui/pages/details/templates/perps-details.tsx
@@ -5,7 +5,6 @@ import type {
   ActivityListItem,
   TokenAmount,
 } from '../../../../shared/lib/activity/types';
-import { getTokenMetadataFromKnownToken } from '../../../../shared/lib/activity/adapters/helpers';
 import { toAssetId } from '../../../../shared/lib/asset-utils';
 import { AccountName } from '../../../components/app/transaction/account-name';
 import { NetworkName } from '../../../components/app/transaction/network-name';
@@ -21,6 +20,7 @@ import { Footer, Row, Section } from '../components/shared';
 import { TokensSection } from '../components/sections';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useFormatters } from '../../../hooks/useFormatters';
+import { useDestinationToken } from './helpers';
 
 const ARBITRUM_USDC_ASSET_ID = toAssetId(
   ARBITRUM_USDC.address,
@@ -41,8 +41,7 @@ export function PerpsDetails({
   const { formatDateTime, formatCurrencyWithMinThreshold } = useFormatters();
   const transactionMeta = useTransactionMeta(item.hash);
   const { metamaskPay } = transactionMeta || {};
-  const { targetFiat, totalFiat, networkFeeFiat, bridgeFeeFiat } =
-    metamaskPay || {};
+  const { totalFiat, networkFeeFiat, bridgeFeeFiat } = metamaskPay || {};
 
   const withdrewToken = useMemo((): TokenAmount | undefined => {
     if (!totalFiat) {
@@ -57,31 +56,12 @@ export function PerpsDetails({
       direction: 'out',
     };
   }, [totalFiat]);
+  const receivedToken = useDestinationToken(metamaskPay);
 
-  const receivedToken = useMemo((): TokenAmount | undefined => {
-    if (!targetFiat || !metamaskPay?.chainId) {
-      return undefined;
-    }
-
-    const tokenMetadata = getTokenMetadataFromKnownToken(
-      metamaskPay?.tokenAddress,
-      'in',
-      toEvmCaipChainId(metamaskPay.chainId),
-    );
-
-    return {
-      amount: targetFiat,
-      direction: 'in',
-      ...tokenMetadata,
-    };
-  }, [targetFiat, metamaskPay?.chainId, metamaskPay?.tokenAddress]);
-
-  const transactionFeeAmount =
-    Number(networkFeeFiat ?? 0) + Number(bridgeFeeFiat ?? 0);
-
-  const formattedTransactionFee = Number.isFinite(transactionFeeAmount)
-    ? formatCurrencyWithMinThreshold(transactionFeeAmount, PERPS_CURRENCY)
-    : null;
+  const formattedTransactionFee = formatCurrencyWithMinThreshold(
+    Number(networkFeeFiat ?? 0) + Number(bridgeFeeFiat ?? 0),
+    PERPS_CURRENCY,
+  );
 
   const chainId =
     metamaskPay?.isPostQuote && metamaskPay.chainId


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Improve rendering of Perps withdraw details screen
- adds withdrawn and received tokens

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

Feature behind a flag

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to Perps and make a withdraw
2. Observe activity item details

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="395" height="673" alt="image" src="https://github.com/user-attachments/assets/485b67df-3c74-4cf6-bbf9-638ff0296c8f" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only activity UI behind a flag; amounts come from stored transaction metadata with no auth or signing changes.
> 
> **Overview**
> **Perps withdraw** activity details now mirror bridge-style **You withdrew** / **You received** token rows instead of a single activity token and generic fiat rows.
> 
> Withdrawn amount is derived from `metamaskPay` (`totalFiat` minus bridge and network fees) as Arbitrum USDC; received amount uses new `useDestinationToken`, which maps `targetFiat` and `tokenAddress` to a token amount (native via USD rate, otherwise fiat as amount). Status, date, account, network, and combined transaction fee rows are inlined; network and block explorer use post-quote `chainId` when present and skip explorer for placeholder `0x0` hashes.
> 
> `TokensSection` gains optional `showBadge` to show per-token network badges on withdraw rows. Adds `youWithdrew` locale strings (`en`, `en_GB`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0a79975328a4c5eb1dd467f498be3d3ba0a200b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->