### PR TITLE
test(e2e): Tron account derivation E2E tests [WPN-685]

### DIFF
--- a/test/e2e/page-objects/flows/network.flow.ts
+++ b/test/e2e/page-objects/flows/network.flow.ts
@@ -17,3 +17,13 @@ export const switchToNetworkFromNetworkSelect = async (
   await networkManager.selectTab(networkCategory);
   await networkManager.selectNetworkByNameWithWait(networkName);
 };
+
+export async function clearOrphanedNetworkManagerBackdrop(
+  driver: Driver,
+): Promise<void> {
+  await driver.executeScript(`
+    document.querySelectorAll('.modal__backdrop').forEach((element) => {
+      element.remove();
+    });
+  `);
+}

--- a/test/e2e/page-objects/flows/tron-account-derivation.flow.ts
+++ b/test/e2e/page-objects/flows/tron-account-derivation.flow.ts
@@ -1,0 +1,76 @@
+import { Driver } from '../../webdriver/driver';
+import { getCleanAppState } from '../../helpers';
+import {
+  BASE_ACCOUNT_SYNC_INTERVAL,
+  BASE_ACCOUNT_SYNC_TIMEOUT,
+} from '../../tests/identity/account-syncing/helpers';
+import HomePage from '../pages/home/homepage';
+import AccountListPage from '../pages/account-list-page';
+
+/**
+ * Waits until the AccountTreeController's `isAccountTreeSyncingInProgress`
+ * flag is false.  This is more reliable than
+ * `checkHasAccountSyncingSyncedAtLeastOnce` for cases where a second sync is
+ * triggered (e.g. when a new non-EVM network is enabled) because that flag is
+ * never reset to false once it becomes true.
+ *
+ * @param driver - The WebDriver instance.
+ */
+export async function waitUntilAccountTreeSyncIdle(
+  driver: Driver,
+): Promise<void> {
+  await driver.waitUntil(
+    async () => {
+      const uiState = await getCleanAppState(driver);
+      return uiState?.metamask?.isAccountTreeSyncingInProgress === false;
+    },
+    {
+      interval: BASE_ACCOUNT_SYNC_INTERVAL,
+      timeout: BASE_ACCOUNT_SYNC_TIMEOUT,
+    },
+  );
+}
+
+/**
+ * Adds Ethereum HD accounts 2..total via the multichain "Add account" flow.
+ * BIP44 Stage 2 (gated by the `bip44Stage2` feature flag and the snap's
+ * `tron:728126428` discoverability) automatically derives a matching Tron
+ * account at the same index for every HD account that exists, so this
+ * function is the only step required before asserting Tron addresses 1..total.
+ *
+ * Why the name: this helper does NOT call any Tron-specific UI. It piggybacks
+ * on the EVM "Add account" flow because that's the only one that grows the
+ * HD index, and Tron derivation follows.
+ *
+ * Waits for the account-tree sync to become idle before each "Add account"
+ * action so the button is not stuck in "Syncing..." state.
+ *
+ * @param driver - The WebDriver instance.
+ * @param total - The total number of accounts desired (must be >= 2 to add any).
+ */
+export async function addNHdAccountsForTronDerivation(
+  driver: Driver,
+  total: number,
+): Promise<void> {
+  if (total < 2) {
+    return;
+  }
+  const homepage = new HomePage(driver);
+  const accountList = new AccountListPage(driver);
+  // Open the multichain accounts page once. Subsequent additions stay on the
+  // same page — `addMultichainAccount` does not navigate away — so re-opening
+  // the account menu inside the loop would fail because the
+  // `account-menu-icon` trigger isn't present on the multichain accounts page.
+  await waitUntilAccountTreeSyncIdle(driver);
+  await homepage.headerNavbar.openAccountMenu();
+  await accountList.checkPageIsLoaded();
+  for (let i = 2; i <= total; i += 1) {
+    // Wait for any in-progress account-tree sync to finish before interacting.
+    // Selecting the Tron network triggers BIP44 Stage 2 which syncs accounts
+    // and shows "Syncing…" on the multichain accounts page button.
+    await waitUntilAccountTreeSyncIdle(driver);
+    await accountList.addMultichainAccount();
+    await accountList.checkMultichainAccountNameDisplayed(`Account ${i}`);
+  }
+  await accountList.closeMultichainAccountsPage();
+}

--- a/test/e2e/page-objects/flows/tron-network.flow.ts
+++ b/test/e2e/page-objects/flows/tron-network.flow.ts
@@ -1,0 +1,14 @@
+import { Driver } from '../../webdriver/driver';
+import NetworkManager from '../pages/network-manager';
+import { clearOrphanedNetworkManagerBackdrop } from './network.flow';
+
+export async function selectTronNetwork(driver: Driver): Promise<void> {
+  const networkManager = new NetworkManager(driver);
+  await networkManager.openNetworkManager();
+  await networkManager.selectTab('Popular');
+  await networkManager.selectNetworkByNameWithWait('Tron');
+
+  // Network Manager close transitions can leave an orphan backdrop that blocks
+  // Selenium clicks even after the modal itself has gone away.
+  await clearOrphanedNetworkManagerBackdrop(driver);
+}

--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -9,9 +9,6 @@ import SettingsPage from './settings/settings-page';
 class AccountListPage {
   private readonly driver: Driver;
 
-  private readonly accountListAddressItem =
-    '[data-testid="account-list-address"]';
-
   private readonly accountListBalance =
     '[data-testid="first-currency-display"]';
 
@@ -36,28 +33,14 @@ class AccountListPage {
     tag: 'button',
   };
 
-  private readonly accountNameInput = '#account-name';
-
-  private readonly accountOptionsMenuButton =
-    '[data-testid="account-list-item-menu-button"]';
-
   private readonly multichainAccountOptionsMenuButton =
     '[data-testid="multichain-account-cell-end-accessory"]';
 
-  private readonly addAccountConfirmButton =
-    '[data-testid="submit-add-account-with-name"]';
-
-  private readonly addEthereumAccountButton =
-    '[data-testid="multichain-account-menu-popover-add-account"]';
-
-  private readonly addEoaAccountButton =
-    '[data-testid="multichain-account-menu-popover-add-watch-only-account"]';
-
   private readonly addHardwareWalletButton =
-    '[data-testid="add-wallet-modal-hardware-wallet"]';
+    '[data-testid="choose-wallet-type-hardware-wallet"]';
 
-  private readonly addImportedAccountButton =
-    '[data-testid="multichain-account-menu-popover-add-imported-account"]';
+  private readonly chooseWalletTypeWatchEthereumAccountButton =
+    '[data-testid="choose-wallet-type-watch-ethereum-account"]';
 
   private readonly addingAccountMessage = {
     text: 'Adding account...',
@@ -65,7 +48,7 @@ class AccountListPage {
   };
 
   private readonly addSnapAccountButton =
-    '[data-testid="add-wallet-modal-snap-account"]';
+    '[data-testid="choose-wallet-type-snap-account"]';
 
   private readonly walletDetailsButton = {
     text: 'Details',
@@ -75,6 +58,8 @@ class AccountListPage {
   private readonly closeAccountModalButton =
     'header button[aria-label="Close"]';
 
+  private readonly chooseWalletTypeBackButton = '[data-testid="back-button"]';
+
   private readonly closeMultichainAccountsPageButton =
     '.multichain-page-header button[aria-label="Back"]';
 
@@ -82,10 +67,10 @@ class AccountListPage {
     '[data-testid="account-list-add-wallet-button"]';
 
   private readonly importWalletFromMultichainWalletModalButton =
-    '[data-testid="add-wallet-modal-import-wallet"]';
+    '[data-testid="choose-wallet-type-import-wallet"]';
 
   private readonly importAccountFromMultichainWalletModalButton =
-    '[data-testid="add-wallet-modal-import-account"]';
+    '[data-testid="choose-wallet-type-import-account"]';
 
   private readonly multichainAccountMenuItem =
     '.multichain-account-cell-menu-item';
@@ -94,10 +79,7 @@ class AccountListPage {
     '[data-testid="account-name-input"] input';
 
   private readonly multichainAccountNameInputConfirmButton =
-    '.mm-button-base[aria-label="Confirm"]';
-
-  private readonly createAccountButton =
-    '[data-testid="multichain-account-menu-popover-action-button"]';
+    '[data-testid="account-name-confirm-button"]';
 
   private readonly addMultichainAccountButton =
     '[data-testid="add-multichain-account-button"]';
@@ -227,16 +209,13 @@ class AccountListPage {
     this.driver = driver;
   }
 
-  async checkPageIsLoaded(timeout: number = 10000): Promise<void> {
+  async checkPageIsLoaded(
+    timeout: number = 10000,
+    { waitForSync = true }: { waitForSync?: boolean } = {},
+  ): Promise<void> {
     try {
       await this.driver.waitForMultipleSelectors(
-        [
-          {
-            css: this.addMultichainAccountButton,
-            text: 'Add account',
-          },
-          this.addMultichainWalletButton,
-        ],
+        [this.addMultichainAccountButton, this.addMultichainWalletButton],
         { timeout },
       );
     } catch (e) {
@@ -244,7 +223,9 @@ class AccountListPage {
       throw e;
     }
 
-    await this.waitUntilSyncingIsCompleted();
+    if (waitForSync) {
+      await this.waitUntilSyncingIsCompleted();
+    }
     console.log('Account list is loaded');
   }
 
@@ -259,8 +240,10 @@ class AccountListPage {
     expectedErrorMessage: string = '',
   ): Promise<void> {
     console.log(`Watch EOA account with address ${address}`);
-    await this.driver.clickElement(this.createAccountButton);
-    await this.driver.clickElement(this.addEoaAccountButton);
+    await this.driver.clickElement(this.addMultichainWalletButton);
+    await this.driver.clickElement(
+      this.chooseWalletTypeWatchEthereumAccountButton,
+    );
     await this.driver.waitForSelector(this.watchAccountModalTitle);
     await this.driver.fill(this.watchAccountAddressInput, address);
     if (expectedErrorMessage) {
@@ -284,37 +267,16 @@ class AccountListPage {
    *
    * @param privateKey - Private key of the account
    * @param expectedErrorMessage - Expected error message if the import should fail
-   * @param options - Additional options
-   * @param options.isMultichainAccountsState2Enabled - Whether the multichain accounts state 2 feature is enabled
    */
   async addNewImportedAccount(
     privateKey: string,
     expectedErrorMessage?: string,
-    options?: { isMultichainAccountsState2Enabled?: boolean },
   ): Promise<void> {
     console.log(`Adding new imported account`);
-    if (options?.isMultichainAccountsState2Enabled) {
-      await this.driver.clickElement(this.addMultichainWalletButton);
-      await this.driver.clickElement(
-        this.importAccountFromMultichainWalletModalButton,
-      );
-      await this.driver.fill(this.importAccountPrivateKeyInput, privateKey);
-      if (expectedErrorMessage) {
-        await this.driver.clickElement(this.importAccountConfirmButton);
-        await this.driver.waitForSelector({
-          css: '.mm-help-text',
-          text: expectedErrorMessage,
-        });
-      } else {
-        await this.driver.clickElementAndWaitToDisappear(
-          this.importAccountConfirmButton,
-        );
-      }
-      return;
-    }
-
-    await this.driver.clickElement(this.createAccountButton);
-    await this.driver.clickElement(this.addImportedAccountButton);
+    await this.driver.clickElement(this.addMultichainWalletButton);
+    await this.driver.clickElement(
+      this.importAccountFromMultichainWalletModalButton,
+    );
     await this.driver.fill(this.importAccountPrivateKeyInput, privateKey);
     if (expectedErrorMessage) {
       await this.driver.clickElement(this.importAccountConfirmButton);
@@ -326,6 +288,7 @@ class AccountListPage {
       await this.driver.clickElementAndWaitToDisappear(
         this.importAccountConfirmButton,
       );
+      await this.closeChooseWalletTypePage();
     }
   }
 
@@ -351,10 +314,8 @@ class AccountListPage {
    */
   async waitUntilSyncingIsCompleted(): Promise<void> {
     console.log(`Check that account syncing not displayed in account list`);
-    await this.driver.assertElementNotPresent({
-      css: this.addMultichainAccountButton,
-      text: 'Syncing',
-    });
+    await this.checkAddWalletButtonIsDisplayed();
+    await this.driver.assertElementNotPresent(this.syncingMessage);
   }
 
   /**
@@ -395,6 +356,11 @@ class AccountListPage {
     await this.driver.clickElementAndWaitToDisappear(
       this.closeAccountModalButton,
     );
+  }
+
+  async closeChooseWalletTypePage(): Promise<void> {
+    console.log(`Navigate back from choose wallet type page`);
+    await this.driver.clickElement(this.chooseWalletTypeBackButton);
   }
 
   async closeMultichainAccountsPage(): Promise<void> {
@@ -439,6 +405,7 @@ class AccountListPage {
     await this.driver.clickElementAndWaitToDisappear(
       this.importAccountConfirmButton,
     );
+    await this.closeChooseWalletTypePage();
   }
 
   /**
@@ -728,18 +695,6 @@ class AccountListPage {
     });
   }
 
-  async checkMultichainAccountNameNotDisplayed(
-    expectedLabel: string,
-  ): Promise<void> {
-    console.log(
-      `Check that multichain account label ${expectedLabel} is not displayed on account list page`,
-    );
-    await this.driver.assertElementNotPresent({
-      css: this.multichainAccountListItem,
-      text: expectedLabel,
-    });
-  }
-
   async checkWalletDisplayedInAccountListMenu(
     expectedLabel: string = 'Wallet',
   ): Promise<void> {
@@ -755,6 +710,11 @@ class AccountListPage {
   async checkWalletDetailsButtonIsDisplayed(): Promise<void> {
     console.log('Check wallet details button is displayed');
     await this.driver.waitForSelector(this.walletDetailsButton);
+  }
+
+  async checkAddWalletButtonIsDisplayed(): Promise<void> {
+    console.log('Check add wallet button is displayed');
+    await this.driver.waitForSelector(this.addMultichainWalletButton);
   }
 
   async clickWalletDetailsButton(): Promise<void> {
@@ -812,24 +772,27 @@ class AccountListPage {
   }
 
   /**
-   * Checks that the add watch account button is displayed in the create account modal.
+   * Checks that the watch ethereum account option is displayed in the choose wallet type page.
    *
-   * @param expectedAvailability - Whether the add watch account button is expected to be displayed.
+   * @param expectedAvailability - Whether the watch ethereum account option is expected to be displayed.
    */
   async checkAddWatchAccountAvailable(
     expectedAvailability: boolean,
   ): Promise<void> {
     console.log(
-      `Check add watch account button is ${
+      `Check watch ethereum account option is ${
         expectedAvailability ? 'displayed ' : 'not displayed'
       }`,
     );
-    await this.driver.clickElement(this.createAccountButton);
-    await this.driver.waitForSelector(this.addEthereumAccountButton);
+    await this.driver.clickElement(this.addMultichainWalletButton);
     if (expectedAvailability) {
-      await this.driver.waitForSelector(this.addEoaAccountButton);
+      await this.driver.waitForSelector(
+        this.chooseWalletTypeWatchEthereumAccountButton,
+      );
     } else {
-      await this.driver.assertElementNotPresent(this.addEoaAccountButton);
+      await this.driver.assertElementNotPresent(
+        this.chooseWalletTypeWatchEthereumAccountButton,
+      );
     }
   }
 
@@ -925,7 +888,7 @@ class AccountListPage {
         } is equal to ${expectedNumberOfAccounts}? ${isValid}`,
       );
       return isValid;
-    }, 20000);
+    });
   }
 
   /**

--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -1,6 +1,7 @@
 import { Driver } from '../../webdriver/driver';
 import { largeDelayMs } from '../../helpers';
 import { quoteXPathText } from '../../../helpers/quoteXPathText';
+import messages from '../../../../app/_locales/en/messages.json';
 import { ACCOUNT_TYPE } from '../../constants';
 import PrivacySettings from './settings/privacy-settings';
 import HeaderNavbar from './header-navbar';
@@ -8,6 +9,9 @@ import SettingsPage from './settings/settings-page';
 
 class AccountListPage {
   private readonly driver: Driver;
+
+  private readonly accountListAddressItem =
+    '[data-testid="account-list-address"]';
 
   private readonly accountListBalance =
     '[data-testid="first-currency-display"]';
@@ -33,14 +37,38 @@ class AccountListPage {
     tag: 'button',
   };
 
+  private readonly accountNameInput = '#account-name';
+
+  private readonly accountOptionsMenuButton =
+    '[data-testid="account-list-item-menu-button"]';
+
   private readonly multichainAccountOptionsMenuButton =
     '[data-testid="multichain-account-cell-end-accessory"]';
 
-  private readonly addHardwareWalletButton =
-    '[data-testid="choose-wallet-type-hardware-wallet"]';
+  private readonly addAccountConfirmButton =
+    '[data-testid="submit-add-account-with-name"]';
 
-  private readonly chooseWalletTypeWatchEthereumAccountButton =
-    '[data-testid="choose-wallet-type-watch-ethereum-account"]';
+  private readonly addBtcAccountButton = {
+    text: messages.addBitcoinAccountLabel.message,
+    tag: 'button',
+  };
+
+  private readonly addSolanaAccountButton = {
+    text: messages.addNewSolanaAccountLabel.message,
+    tag: 'button',
+  };
+
+  private readonly addEthereumAccountButton =
+    '[data-testid="multichain-account-menu-popover-add-account"]';
+
+  private readonly addEoaAccountButton =
+    '[data-testid="multichain-account-menu-popover-add-watch-only-account"]';
+
+  private readonly addHardwareWalletButton =
+    '[data-testid="add-wallet-modal-hardware-wallet"]';
+
+  private readonly addImportedAccountButton =
+    '[data-testid="multichain-account-menu-popover-add-imported-account"]';
 
   private readonly addingAccountMessage = {
     text: 'Adding account...',
@@ -48,7 +76,7 @@ class AccountListPage {
   };
 
   private readonly addSnapAccountButton =
-    '[data-testid="choose-wallet-type-snap-account"]';
+    '[data-testid="add-wallet-modal-snap-account"]';
 
   private readonly walletDetailsButton = {
     text: 'Details',
@@ -58,8 +86,6 @@ class AccountListPage {
   private readonly closeAccountModalButton =
     'header button[aria-label="Close"]';
 
-  private readonly chooseWalletTypeBackButton = '[data-testid="back-button"]';
-
   private readonly closeMultichainAccountsPageButton =
     '.multichain-page-header button[aria-label="Back"]';
 
@@ -67,10 +93,10 @@ class AccountListPage {
     '[data-testid="account-list-add-wallet-button"]';
 
   private readonly importWalletFromMultichainWalletModalButton =
-    '[data-testid="choose-wallet-type-import-wallet"]';
+    '[data-testid="add-wallet-modal-import-wallet"]';
 
   private readonly importAccountFromMultichainWalletModalButton =
-    '[data-testid="choose-wallet-type-import-account"]';
+    '[data-testid="add-wallet-modal-import-account"]';
 
   private readonly multichainAccountMenuItem =
     '.multichain-account-cell-menu-item';
@@ -79,7 +105,10 @@ class AccountListPage {
     '[data-testid="account-name-input"] input';
 
   private readonly multichainAccountNameInputConfirmButton =
-    '[data-testid="account-name-confirm-button"]';
+    '.mm-button-base[aria-label="Confirm"]';
+
+  private readonly createAccountButton =
+    '[data-testid="multichain-account-menu-popover-action-button"]';
 
   private readonly addMultichainAccountButton =
     '[data-testid="add-multichain-account-button"]';
@@ -90,14 +119,10 @@ class AccountListPage {
   private readonly hiddenAccountOptionsMenuButton =
     '.multichain-account-menu-popover__list--menu-item-hidden-account [data-testid="account-list-item-menu-button"]';
 
-  private readonly hiddenAccountsList =
-    '[data-testid="multichain-account-tree-hidden-header"]';
+  private readonly hiddenAccountsList = '[data-testid="hidden-accounts-list"]';
 
-  private readonly hideAccountButton =
-    '[data-testid="multichain-account-menu-item-hideAccount"]';
-
-  private readonly unhideAccountButton =
-    '[data-testid="multichain-account-menu-item-showAccount"]';
+  private readonly hideUnhideAccountButton =
+    '[data-testid="account-list-menu-hide"]';
 
   private readonly importAccountConfirmButton =
     '[data-testid="import-account-confirm-button"]';
@@ -142,14 +167,10 @@ class AccountListPage {
     text: 'Rename',
   };
 
-  private readonly pinAccountButton =
-    '[data-testid="multichain-account-menu-item-pinToTop"]';
+  private readonly pinUnpinAccountButton =
+    '[data-testid="account-list-menu-pin"]';
 
-  private readonly unpinAccountButton =
-    '[data-testid="multichain-account-menu-item-unpin"]';
-
-  private readonly pinnedHeader =
-    '[data-testid="multichain-account-tree-pinned-header"]';
+  private readonly pinnedIcon = '[data-testid="account-pinned-icon"]';
 
   private readonly removeAccountButton =
     '[data-testid="account-list-menu-remove"]';
@@ -182,6 +203,16 @@ class AccountListPage {
     tag: 'h4',
   };
 
+  private readonly importSrpButton = {
+    text: 'Secret Recovery Phrase',
+    tag: 'button',
+  };
+
+  private readonly importSrpModalTitle = {
+    text: 'Import Secret Recovery Phrase',
+    tag: 'p',
+  };
+
   private readonly importSrpInput =
     '[data-testid="srp-input-import__srp-note"]';
 
@@ -195,8 +226,18 @@ class AccountListPage {
     tag: 'button',
   };
 
+  private readonly srpListTitle = {
+    text: 'Select Secret Recovery Phrase',
+    tag: 'label',
+  };
+
   private readonly viewAccountOnExplorerButton = {
     text: 'View on explorer',
+    tag: 'p',
+  };
+
+  private readonly addAccountButton = {
+    text: 'Add account',
     tag: 'p',
   };
 
@@ -209,13 +250,16 @@ class AccountListPage {
     this.driver = driver;
   }
 
-  async checkPageIsLoaded(
-    timeout: number = 10000,
-    { waitForSync = true }: { waitForSync?: boolean } = {},
-  ): Promise<void> {
+  async checkPageIsLoaded(timeout: number = 10000): Promise<void> {
     try {
       await this.driver.waitForMultipleSelectors(
-        [this.addMultichainAccountButton, this.addMultichainWalletButton],
+        [
+          {
+            css: this.addMultichainAccountButton,
+            text: 'Add account',
+          },
+          this.addMultichainWalletButton,
+        ],
         { timeout },
       );
     } catch (e) {
@@ -223,9 +267,7 @@ class AccountListPage {
       throw e;
     }
 
-    if (waitForSync) {
-      await this.waitUntilSyncingIsCompleted();
-    }
+    await this.waitUntilSyncingIsCompleted();
     console.log('Account list is loaded');
   }
 
@@ -240,14 +282,14 @@ class AccountListPage {
     expectedErrorMessage: string = '',
   ): Promise<void> {
     console.log(`Watch EOA account with address ${address}`);
-    await this.driver.clickElement(this.addMultichainWalletButton);
-    await this.driver.clickElement(
-      this.chooseWalletTypeWatchEthereumAccountButton,
-    );
+    await this.driver.clickElement(this.createAccountButton);
+    await this.driver.clickElement(this.addEoaAccountButton);
     await this.driver.waitForSelector(this.watchAccountModalTitle);
     await this.driver.fill(this.watchAccountAddressInput, address);
+    await this.driver.clickElementAndWaitToDisappear(
+      this.watchAccountConfirmButton,
+    );
     if (expectedErrorMessage) {
-      await this.driver.clickElement(this.watchAccountConfirmButton);
       console.log(
         `Check if error message is displayed: ${expectedErrorMessage}`,
       );
@@ -257,7 +299,7 @@ class AccountListPage {
       });
     } else {
       await this.driver.clickElementAndWaitToDisappear(
-        this.watchAccountConfirmButton,
+        this.addAccountConfirmButton,
       );
     }
   }
@@ -267,16 +309,37 @@ class AccountListPage {
    *
    * @param privateKey - Private key of the account
    * @param expectedErrorMessage - Expected error message if the import should fail
+   * @param options - Additional options
+   * @param options.isMultichainAccountsState2Enabled - Whether the multichain accounts state 2 feature is enabled
    */
   async addNewImportedAccount(
     privateKey: string,
     expectedErrorMessage?: string,
+    options?: { isMultichainAccountsState2Enabled?: boolean },
   ): Promise<void> {
     console.log(`Adding new imported account`);
-    await this.driver.clickElement(this.addMultichainWalletButton);
-    await this.driver.clickElement(
-      this.importAccountFromMultichainWalletModalButton,
-    );
+    if (options?.isMultichainAccountsState2Enabled) {
+      await this.driver.clickElement(this.addMultichainWalletButton);
+      await this.driver.clickElement(
+        this.importAccountFromMultichainWalletModalButton,
+      );
+      await this.driver.fill(this.importAccountPrivateKeyInput, privateKey);
+      if (expectedErrorMessage) {
+        await this.driver.clickElement(this.importAccountConfirmButton);
+        await this.driver.waitForSelector({
+          css: '.mm-help-text',
+          text: expectedErrorMessage,
+        });
+      } else {
+        await this.driver.clickElementAndWaitToDisappear(
+          this.importAccountConfirmButton,
+        );
+      }
+      return;
+    }
+
+    await this.driver.clickElement(this.createAccountButton);
+    await this.driver.clickElement(this.addImportedAccountButton);
     await this.driver.fill(this.importAccountPrivateKeyInput, privateKey);
     if (expectedErrorMessage) {
       await this.driver.clickElement(this.importAccountConfirmButton);
@@ -288,7 +351,45 @@ class AccountListPage {
       await this.driver.clickElementAndWaitToDisappear(
         this.importAccountConfirmButton,
       );
-      await this.closeChooseWalletTypePage();
+    }
+  }
+
+  /**
+   * Adds a new Solana account with optional custom name.
+   *
+   * @param options - Options for creating the Solana account
+   * @param [options.solanaAccountCreationEnabled] - Whether Solana account creation is enabled. If false, verifies the create button is disabled.
+   * @param [options.accountName] - Optional custom name for the new account
+   * @returns Promise that resolves when account creation is complete
+   */
+  async addNewSolanaAccount({
+    solanaAccountCreationEnabled = true,
+    accountName = '',
+  }: {
+    solanaAccountCreationEnabled?: boolean;
+    accountName?: string;
+  } = {}): Promise<void> {
+    console.log(
+      `Adding new Solana account${
+        accountName ? ` with custom name: ${accountName}` : ' with default name'
+      }`,
+    );
+    if (solanaAccountCreationEnabled) {
+      await this.driver.clickElement(this.addSolanaAccountButton);
+      // needed to mitigate a race condition with the state update
+      // there is no condition we can wait for in the UI
+      if (accountName) {
+        await this.driver.fill(this.accountNameInput, accountName);
+      }
+      await this.driver.clickElementAndWaitToDisappear(
+        this.addAccountConfirmButton,
+      );
+    } else {
+      const createButton = await this.driver.findElement(
+        this.addSolanaAccountButton,
+      );
+      assert.equal(await createButton.isEnabled(), false);
+      await this.driver.clickElement(this.closeAccountModalButton);
     }
   }
 
@@ -314,8 +415,10 @@ class AccountListPage {
    */
   async waitUntilSyncingIsCompleted(): Promise<void> {
     console.log(`Check that account syncing not displayed in account list`);
-    await this.checkAddWalletButtonIsDisplayed();
-    await this.driver.assertElementNotPresent(this.syncingMessage);
+    await this.driver.assertElementNotPresent({
+      css: this.addMultichainAccountButton,
+      text: 'Syncing',
+    });
   }
 
   /**
@@ -351,16 +454,86 @@ class AccountListPage {
     });
   }
 
+  /**
+   * Adds a new account of the specified type with an optional custom name.
+   *
+   * @param options - Options for adding a new account
+   * @param options.accountType - The type of account to add (Ethereum, Bitcoin, or Solana)
+   * @param [options.accountName] - Optional custom name for the new account
+   * @param [options.srpIndex] - Optional SRP index for the new account
+   * @param options.fromModal
+   * @throws {Error} If the specified account type is not supported
+   * @example
+   * // Add a new Ethereum account with default name
+   * await accountListPage.addAccount({ accountType: ACCOUNT_TYPE.Ethereum });
+   *
+   * // Add a new Bitcoin account with custom name
+   * await accountListPage.addAccount({ accountType: ACCOUNT_TYPE.Bitcoin, accountName: 'My BTC Wallet' });
+   */
+  async addAccount({
+    accountType,
+    accountName,
+    srpIndex,
+    fromModal = false,
+  }: {
+    accountType: ACCOUNT_TYPE;
+    accountName?: string;
+    srpIndex?: number;
+    fromModal?: boolean;
+  }) {
+    console.log(`Adding new account of type: ${ACCOUNT_TYPE[accountType]}`);
+    if (!fromModal) {
+      let addAccountButton;
+      switch (accountType) {
+        case ACCOUNT_TYPE.Ethereum:
+          addAccountButton = this.addEthereumAccountButton;
+          break;
+        case ACCOUNT_TYPE.Bitcoin:
+          addAccountButton = this.addBtcAccountButton;
+          break;
+        case ACCOUNT_TYPE.Solana:
+          addAccountButton = this.addSolanaAccountButton;
+          break;
+        default:
+          throw new Error('Account type not supported');
+      }
+
+      await this.driver.clickElement(this.createAccountButton);
+      addAccountButton && (await this.driver.clickElement(addAccountButton));
+    }
+    // Run if there are multiple srps
+    if (accountType === ACCOUNT_TYPE.Ethereum && srpIndex) {
+      const srpName = `Secret Recovery Phrase ${srpIndex.toString()}`;
+      // First, we first click here to go to the SRP List.
+      await this.driver.clickElement({
+        text: 'Secret Recovery Phrase 2',
+      });
+      // Then, we select the SRP that we want to add the account to.
+      await this.driver.clickElement({
+        text: srpName,
+      });
+    }
+
+    if (accountName) {
+      console.log(
+        `Customize the new account with account name: ${accountName}`,
+      );
+      await this.driver.fill(this.accountNameInput, accountName);
+    }
+    // needed to mitigate a race condition with the state update
+    // there is no condition we can wait for in the UI
+    await this.driver.delay(largeDelayMs);
+    await this.driver.clickElementAndWaitToDisappear(
+      this.addAccountConfirmButton,
+      5000,
+    );
+  }
+
   async closeAccountModal(): Promise<void> {
     console.log(`Close account modal in account list`);
     await this.driver.clickElementAndWaitToDisappear(
       this.closeAccountModalButton,
     );
-  }
-
-  async closeChooseWalletTypePage(): Promise<void> {
-    console.log(`Navigate back from choose wallet type page`);
-    await this.driver.clickElement(this.chooseWalletTypeBackButton);
   }
 
   async closeMultichainAccountsPage(): Promise<void> {
@@ -372,8 +545,7 @@ class AccountListPage {
 
   async hideAccount(): Promise<void> {
     console.log(`Hide account in account list`);
-    await this.openAccountOptionsMenu();
-    await this.driver.clickElement(this.hideAccountButton);
+    await this.driver.clickElement(this.hideUnhideAccountButton);
   }
 
   /**
@@ -405,7 +577,13 @@ class AccountListPage {
     await this.driver.clickElementAndWaitToDisappear(
       this.importAccountConfirmButton,
     );
-    await this.closeChooseWalletTypePage();
+  }
+
+  async isBtcAccountCreationButtonEnabled(): Promise<boolean> {
+    const createButton = await this.driver.findElement(
+      this.addBtcAccountButton,
+    );
+    return await createButton.isEnabled();
   }
 
   /**
@@ -528,10 +706,37 @@ class AccountListPage {
     );
   }
 
+  async checkAddBitcoinAccountAvailable(
+    expectedAvailability: boolean,
+  ): Promise<void> {
+    console.log(
+      `Check add bitcoin account button is ${
+        expectedAvailability ? 'displayed ' : 'not displayed'
+      }`,
+    );
+    await this.openAddAccountModal();
+    if (expectedAvailability) {
+      await this.driver.waitForSelector(this.addBtcAccountButton);
+    } else {
+      await this.driver.assertElementNotPresent(this.addBtcAccountButton);
+    }
+  }
+
   async openAccountOptionsMenu(): Promise<void> {
     console.log(`Open account option menu`);
     await this.driver.waitForSelector(this.accountListItem);
-    await this.driver.clickElement(this.multichainAccountOptionsMenuButton);
+    await this.driver.clickElement(this.accountOptionsMenuButton);
+  }
+
+  async openAddAccountModal(): Promise<void> {
+    console.log(`Open add account modal in account list`);
+    await this.driver.clickElement(this.createAccountButton);
+    await this.driver.waitForSelector(this.addEthereumAccountButton);
+  }
+
+  async openImportSrpModal(): Promise<void> {
+    await this.openAddAccountModal();
+    await this.driver.clickElement(this.importSrpButton);
   }
 
   async openConnectHardwareWalletModal(): Promise<void> {
@@ -555,8 +760,7 @@ class AccountListPage {
 
   async pinAccount(): Promise<void> {
     console.log(`Pin account in account list`);
-    await this.openAccountOptionsMenu();
-    await this.driver.clickElement(this.pinAccountButton);
+    await this.driver.clickElement(this.pinUnpinAccountButton);
   }
 
   /**
@@ -594,14 +798,12 @@ class AccountListPage {
 
   async unhideAccount(): Promise<void> {
     console.log(`Unhide account in account list`);
-    await this.openAccountOptionsMenu();
-    await this.driver.clickElement(this.unhideAccountButton);
+    await this.driver.clickElement(this.hideUnhideAccountButton);
   }
 
   async unpinAccount(): Promise<void> {
     console.log(`Unpin account in account list`);
-    await this.openAccountOptionsMenu();
-    await this.driver.clickElement(this.unpinAccountButton);
+    await this.driver.clickElement(this.pinUnpinAccountButton);
   }
 
   /**
@@ -695,6 +897,18 @@ class AccountListPage {
     });
   }
 
+  async checkMultichainAccountNameNotDisplayed(
+    expectedLabel: string,
+  ): Promise<void> {
+    console.log(
+      `Check that multichain account label ${expectedLabel} is not displayed on account list page`,
+    );
+    await this.driver.assertElementNotPresent({
+      css: this.multichainAccountListItem,
+      text: expectedLabel,
+    });
+  }
+
   async checkWalletDisplayedInAccountListMenu(
     expectedLabel: string = 'Wallet',
   ): Promise<void> {
@@ -712,7 +926,7 @@ class AccountListPage {
     await this.driver.waitForSelector(this.walletDetailsButton);
   }
 
-  async checkAddWalletButtonIsDisplayed(): Promise<void> {
+  async checkAddWalletButttonIsDisplayed(): Promise<void> {
     console.log('Check add wallet button is displayed');
     await this.driver.waitForSelector(this.addMultichainWalletButton);
   }
@@ -753,12 +967,12 @@ class AccountListPage {
 
   async checkAccountIsPinned(): Promise<void> {
     console.log(`Check that account is pinned`);
-    await this.driver.waitForSelector(this.pinnedHeader);
+    await this.driver.waitForSelector(this.pinnedIcon);
   }
 
   async checkAccountIsUnpinned(): Promise<void> {
     console.log(`Check that account is unpinned`);
-    await this.driver.assertElementNotPresent(this.pinnedHeader);
+    await this.driver.assertElementNotPresent(this.pinnedIcon);
   }
 
   async checkAddAccountSnapButtonIsDisplayed(): Promise<void> {
@@ -772,27 +986,23 @@ class AccountListPage {
   }
 
   /**
-   * Checks that the watch ethereum account option is displayed in the choose wallet type page.
+   * Checks that the add watch account button is displayed in the create account modal.
    *
-   * @param expectedAvailability - Whether the watch ethereum account option is expected to be displayed.
+   * @param expectedAvailability - Whether the add watch account button is expected to be displayed.
    */
   async checkAddWatchAccountAvailable(
     expectedAvailability: boolean,
   ): Promise<void> {
     console.log(
-      `Check watch ethereum account option is ${
+      `Check add watch account button is ${
         expectedAvailability ? 'displayed ' : 'not displayed'
       }`,
     );
-    await this.driver.clickElement(this.addMultichainWalletButton);
+    await this.openAddAccountModal();
     if (expectedAvailability) {
-      await this.driver.waitForSelector(
-        this.chooseWalletTypeWatchEthereumAccountButton,
-      );
+      await this.driver.waitForSelector(this.addEoaAccountButton);
     } else {
-      await this.driver.assertElementNotPresent(
-        this.chooseWalletTypeWatchEthereumAccountButton,
-      );
+      await this.driver.assertElementNotPresent(this.addEoaAccountButton);
     }
   }
 
@@ -888,7 +1098,7 @@ class AccountListPage {
         } is equal to ${expectedNumberOfAccounts}? ${isValid}`,
       );
       return isValid;
-    });
+    }, 20000);
   }
 
   /**

--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -1,7 +1,6 @@
 import { Driver } from '../../webdriver/driver';
 import { largeDelayMs } from '../../helpers';
 import { quoteXPathText } from '../../../helpers/quoteXPathText';
-import messages from '../../../../app/_locales/en/messages.json';
 import { ACCOUNT_TYPE } from '../../constants';
 import PrivacySettings from './settings/privacy-settings';
 import HeaderNavbar from './header-navbar';
@@ -47,16 +46,6 @@ class AccountListPage {
 
   private readonly addAccountConfirmButton =
     '[data-testid="submit-add-account-with-name"]';
-
-  private readonly addBtcAccountButton = {
-    text: messages.addBitcoinAccountLabel.message,
-    tag: 'button',
-  };
-
-  private readonly addSolanaAccountButton = {
-    text: messages.addNewSolanaAccountLabel.message,
-    tag: 'button',
-  };
 
   private readonly addEthereumAccountButton =
     '[data-testid="multichain-account-menu-popover-add-account"]';
@@ -203,16 +192,6 @@ class AccountListPage {
     tag: 'h4',
   };
 
-  private readonly importSrpButton = {
-    text: 'Secret Recovery Phrase',
-    tag: 'button',
-  };
-
-  private readonly importSrpModalTitle = {
-    text: 'Import Secret Recovery Phrase',
-    tag: 'p',
-  };
-
   private readonly importSrpInput =
     '[data-testid="srp-input-import__srp-note"]';
 
@@ -226,18 +205,8 @@ class AccountListPage {
     tag: 'button',
   };
 
-  private readonly srpListTitle = {
-    text: 'Select Secret Recovery Phrase',
-    tag: 'label',
-  };
-
   private readonly viewAccountOnExplorerButton = {
     text: 'View on explorer',
-    tag: 'p',
-  };
-
-  private readonly addAccountButton = {
-    text: 'Add account',
     tag: 'p',
   };
 
@@ -355,45 +324,6 @@ class AccountListPage {
   }
 
   /**
-   * Adds a new Solana account with optional custom name.
-   *
-   * @param options - Options for creating the Solana account
-   * @param [options.solanaAccountCreationEnabled] - Whether Solana account creation is enabled. If false, verifies the create button is disabled.
-   * @param [options.accountName] - Optional custom name for the new account
-   * @returns Promise that resolves when account creation is complete
-   */
-  async addNewSolanaAccount({
-    solanaAccountCreationEnabled = true,
-    accountName = '',
-  }: {
-    solanaAccountCreationEnabled?: boolean;
-    accountName?: string;
-  } = {}): Promise<void> {
-    console.log(
-      `Adding new Solana account${
-        accountName ? ` with custom name: ${accountName}` : ' with default name'
-      }`,
-    );
-    if (solanaAccountCreationEnabled) {
-      await this.driver.clickElement(this.addSolanaAccountButton);
-      // needed to mitigate a race condition with the state update
-      // there is no condition we can wait for in the UI
-      if (accountName) {
-        await this.driver.fill(this.accountNameInput, accountName);
-      }
-      await this.driver.clickElementAndWaitToDisappear(
-        this.addAccountConfirmButton,
-      );
-    } else {
-      const createButton = await this.driver.findElement(
-        this.addSolanaAccountButton,
-      );
-      assert.equal(await createButton.isEnabled(), false);
-      await this.driver.clickElement(this.closeAccountModalButton);
-    }
-  }
-
-  /**
    * Adds a new multichain wallet.
    */
   async addMultichainWallet(): Promise<void> {
@@ -454,81 +384,6 @@ class AccountListPage {
     });
   }
 
-  /**
-   * Adds a new account of the specified type with an optional custom name.
-   *
-   * @param options - Options for adding a new account
-   * @param options.accountType - The type of account to add (Ethereum, Bitcoin, or Solana)
-   * @param [options.accountName] - Optional custom name for the new account
-   * @param [options.srpIndex] - Optional SRP index for the new account
-   * @param options.fromModal
-   * @throws {Error} If the specified account type is not supported
-   * @example
-   * // Add a new Ethereum account with default name
-   * await accountListPage.addAccount({ accountType: ACCOUNT_TYPE.Ethereum });
-   *
-   * // Add a new Bitcoin account with custom name
-   * await accountListPage.addAccount({ accountType: ACCOUNT_TYPE.Bitcoin, accountName: 'My BTC Wallet' });
-   */
-  async addAccount({
-    accountType,
-    accountName,
-    srpIndex,
-    fromModal = false,
-  }: {
-    accountType: ACCOUNT_TYPE;
-    accountName?: string;
-    srpIndex?: number;
-    fromModal?: boolean;
-  }) {
-    console.log(`Adding new account of type: ${ACCOUNT_TYPE[accountType]}`);
-    if (!fromModal) {
-      let addAccountButton;
-      switch (accountType) {
-        case ACCOUNT_TYPE.Ethereum:
-          addAccountButton = this.addEthereumAccountButton;
-          break;
-        case ACCOUNT_TYPE.Bitcoin:
-          addAccountButton = this.addBtcAccountButton;
-          break;
-        case ACCOUNT_TYPE.Solana:
-          addAccountButton = this.addSolanaAccountButton;
-          break;
-        default:
-          throw new Error('Account type not supported');
-      }
-
-      await this.driver.clickElement(this.createAccountButton);
-      addAccountButton && (await this.driver.clickElement(addAccountButton));
-    }
-    // Run if there are multiple srps
-    if (accountType === ACCOUNT_TYPE.Ethereum && srpIndex) {
-      const srpName = `Secret Recovery Phrase ${srpIndex.toString()}`;
-      // First, we first click here to go to the SRP List.
-      await this.driver.clickElement({
-        text: 'Secret Recovery Phrase 2',
-      });
-      // Then, we select the SRP that we want to add the account to.
-      await this.driver.clickElement({
-        text: srpName,
-      });
-    }
-
-    if (accountName) {
-      console.log(
-        `Customize the new account with account name: ${accountName}`,
-      );
-      await this.driver.fill(this.accountNameInput, accountName);
-    }
-    // needed to mitigate a race condition with the state update
-    // there is no condition we can wait for in the UI
-    await this.driver.delay(largeDelayMs);
-    await this.driver.clickElementAndWaitToDisappear(
-      this.addAccountConfirmButton,
-      5000,
-    );
-  }
-
   async closeAccountModal(): Promise<void> {
     console.log(`Close account modal in account list`);
     await this.driver.clickElementAndWaitToDisappear(
@@ -577,13 +432,6 @@ class AccountListPage {
     await this.driver.clickElementAndWaitToDisappear(
       this.importAccountConfirmButton,
     );
-  }
-
-  async isBtcAccountCreationButtonEnabled(): Promise<boolean> {
-    const createButton = await this.driver.findElement(
-      this.addBtcAccountButton,
-    );
-    return await createButton.isEnabled();
   }
 
   /**
@@ -706,37 +554,10 @@ class AccountListPage {
     );
   }
 
-  async checkAddBitcoinAccountAvailable(
-    expectedAvailability: boolean,
-  ): Promise<void> {
-    console.log(
-      `Check add bitcoin account button is ${
-        expectedAvailability ? 'displayed ' : 'not displayed'
-      }`,
-    );
-    await this.openAddAccountModal();
-    if (expectedAvailability) {
-      await this.driver.waitForSelector(this.addBtcAccountButton);
-    } else {
-      await this.driver.assertElementNotPresent(this.addBtcAccountButton);
-    }
-  }
-
   async openAccountOptionsMenu(): Promise<void> {
     console.log(`Open account option menu`);
     await this.driver.waitForSelector(this.accountListItem);
     await this.driver.clickElement(this.accountOptionsMenuButton);
-  }
-
-  async openAddAccountModal(): Promise<void> {
-    console.log(`Open add account modal in account list`);
-    await this.driver.clickElement(this.createAccountButton);
-    await this.driver.waitForSelector(this.addEthereumAccountButton);
-  }
-
-  async openImportSrpModal(): Promise<void> {
-    await this.openAddAccountModal();
-    await this.driver.clickElement(this.importSrpButton);
   }
 
   async openConnectHardwareWalletModal(): Promise<void> {
@@ -926,11 +747,6 @@ class AccountListPage {
     await this.driver.waitForSelector(this.walletDetailsButton);
   }
 
-  async checkAddWalletButttonIsDisplayed(): Promise<void> {
-    console.log('Check add wallet button is displayed');
-    await this.driver.waitForSelector(this.addMultichainWalletButton);
-  }
-
   async clickWalletDetailsButton(): Promise<void> {
     console.log('Click wallet details button');
     await this.driver.clickElement(this.walletDetailsButton);
@@ -998,7 +814,8 @@ class AccountListPage {
         expectedAvailability ? 'displayed ' : 'not displayed'
       }`,
     );
-    await this.openAddAccountModal();
+    await this.driver.clickElement(this.createAccountButton);
+    await this.driver.waitForSelector(this.addEthereumAccountButton);
     if (expectedAvailability) {
       await this.driver.waitForSelector(this.addEoaAccountButton);
     } else {

--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -108,10 +108,14 @@ class AccountListPage {
   private readonly hiddenAccountOptionsMenuButton =
     '.multichain-account-menu-popover__list--menu-item-hidden-account [data-testid="account-list-item-menu-button"]';
 
-  private readonly hiddenAccountsList = '[data-testid="hidden-accounts-list"]';
+  private readonly hiddenAccountsList =
+    '[data-testid="multichain-account-tree-hidden-header"]';
 
-  private readonly hideUnhideAccountButton =
-    '[data-testid="account-list-menu-hide"]';
+  private readonly hideAccountButton =
+    '[data-testid="multichain-account-menu-item-hideAccount"]';
+
+  private readonly unhideAccountButton =
+    '[data-testid="multichain-account-menu-item-showAccount"]';
 
   private readonly importAccountConfirmButton =
     '[data-testid="import-account-confirm-button"]';
@@ -156,10 +160,14 @@ class AccountListPage {
     text: 'Rename',
   };
 
-  private readonly pinUnpinAccountButton =
-    '[data-testid="account-list-menu-pin"]';
+  private readonly pinAccountButton =
+    '[data-testid="multichain-account-menu-item-pinToTop"]';
 
-  private readonly pinnedIcon = '[data-testid="account-pinned-icon"]';
+  private readonly unpinAccountButton =
+    '[data-testid="multichain-account-menu-item-unpin"]';
+
+  private readonly pinnedHeader =
+    '[data-testid="multichain-account-tree-pinned-header"]';
 
   private readonly removeAccountButton =
     '[data-testid="account-list-menu-remove"]';
@@ -255,10 +263,8 @@ class AccountListPage {
     await this.driver.clickElement(this.addEoaAccountButton);
     await this.driver.waitForSelector(this.watchAccountModalTitle);
     await this.driver.fill(this.watchAccountAddressInput, address);
-    await this.driver.clickElementAndWaitToDisappear(
-      this.watchAccountConfirmButton,
-    );
     if (expectedErrorMessage) {
+      await this.driver.clickElement(this.watchAccountConfirmButton);
       console.log(
         `Check if error message is displayed: ${expectedErrorMessage}`,
       );
@@ -268,7 +274,7 @@ class AccountListPage {
       });
     } else {
       await this.driver.clickElementAndWaitToDisappear(
-        this.addAccountConfirmButton,
+        this.watchAccountConfirmButton,
       );
     }
   }
@@ -400,7 +406,8 @@ class AccountListPage {
 
   async hideAccount(): Promise<void> {
     console.log(`Hide account in account list`);
-    await this.driver.clickElement(this.hideUnhideAccountButton);
+    await this.openAccountOptionsMenu();
+    await this.driver.clickElement(this.hideAccountButton);
   }
 
   /**
@@ -557,7 +564,7 @@ class AccountListPage {
   async openAccountOptionsMenu(): Promise<void> {
     console.log(`Open account option menu`);
     await this.driver.waitForSelector(this.accountListItem);
-    await this.driver.clickElement(this.accountOptionsMenuButton);
+    await this.driver.clickElement(this.multichainAccountOptionsMenuButton);
   }
 
   async openConnectHardwareWalletModal(): Promise<void> {
@@ -581,7 +588,8 @@ class AccountListPage {
 
   async pinAccount(): Promise<void> {
     console.log(`Pin account in account list`);
-    await this.driver.clickElement(this.pinUnpinAccountButton);
+    await this.openAccountOptionsMenu();
+    await this.driver.clickElement(this.pinAccountButton);
   }
 
   /**
@@ -619,12 +627,14 @@ class AccountListPage {
 
   async unhideAccount(): Promise<void> {
     console.log(`Unhide account in account list`);
-    await this.driver.clickElement(this.hideUnhideAccountButton);
+    await this.openAccountOptionsMenu();
+    await this.driver.clickElement(this.unhideAccountButton);
   }
 
   async unpinAccount(): Promise<void> {
     console.log(`Unpin account in account list`);
-    await this.driver.clickElement(this.pinUnpinAccountButton);
+    await this.openAccountOptionsMenu();
+    await this.driver.clickElement(this.unpinAccountButton);
   }
 
   /**
@@ -783,12 +793,12 @@ class AccountListPage {
 
   async checkAccountIsPinned(): Promise<void> {
     console.log(`Check that account is pinned`);
-    await this.driver.waitForSelector(this.pinnedIcon);
+    await this.driver.waitForSelector(this.pinnedHeader);
   }
 
   async checkAccountIsUnpinned(): Promise<void> {
     console.log(`Check that account is unpinned`);
-    await this.driver.assertElementNotPresent(this.pinnedIcon);
+    await this.driver.assertElementNotPresent(this.pinnedHeader);
   }
 
   async checkAddAccountSnapButtonIsDisplayed(): Promise<void> {

--- a/test/e2e/page-objects/pages/home/non-evm-homepage.ts
+++ b/test/e2e/page-objects/pages/home/non-evm-homepage.ts
@@ -1,18 +1,9 @@
-import { Driver } from '../../../webdriver/driver';
 import HomePage from './homepage';
 import TokensTab from './tokens-tab';
 
 class NonEvmHomepage extends HomePage {
-  private readonly receiveButtonTestId = '[data-testid="coin-overview-receive"]';
-
-  constructor(driver: Driver) {
-    super(driver);
-  }
-
-  async clickOnReceiveButton(): Promise<void> {
-    console.log('Click Receive on non-EVM homepage');
-    await this.driver.clickElement(this.receiveButtonTestId);
-  }
+  private readonly receiveButtonTestId =
+    '[data-testid="coin-overview-receive"]';
 
   async checkExpectedTokenBalanceIsDisplayed(
     expectedTokenBalance: string,
@@ -23,6 +14,11 @@ class NonEvmHomepage extends HomePage {
       expectedTokenBalance,
       symbol,
     );
+  }
+
+  async clickOnReceiveButton(): Promise<void> {
+    console.log('Click Receive on non-EVM homepage');
+    await this.driver.clickElement(this.receiveButtonTestId);
   }
 }
 

--- a/test/e2e/page-objects/pages/multichain/address-list-modal.ts
+++ b/test/e2e/page-objects/pages/multichain/address-list-modal.ts
@@ -1,4 +1,6 @@
+import assert from 'assert';
 import { Driver } from '../../../webdriver/driver';
+import { quoteXPathText } from '../../../../helpers/quoteXPathText';
 
 class AddressListModal {
   private driver: Driver;
@@ -15,11 +17,21 @@ class AddressListModal {
   private readonly backButton =
     '[data-testid="multichain-account-address-list-page-back-button"]';
 
-  private readonly networkName =
-    '[data-testid="multichain-address-row-network-name"]';
-
   private readonly shortenedAddress =
     '[data-testid="multichain-address-row-address"]';
+
+  private readonly addressRowsList =
+    '[data-testid="multichain-address-rows-list"]';
+
+  private readonly addressRow = '[data-testid="multichain-address-row"]';
+
+  private readonly qrModalAddress = '[data-testid="account-address"]';
+
+  private readonly qrModalCopyButton =
+    '[data-testid="address-qr-code-modal-copy-button"]';
+
+  private readonly viewOnExplorerButton =
+    '[data-testid="view-address-on-etherscan"]';
 
   private readonly addressCopiedMessage = {
     css: '[data-testid="multichain-address-row-address"]',
@@ -28,6 +40,18 @@ class AddressListModal {
 
   constructor(driver: Driver) {
     this.driver = driver;
+  }
+
+  private addressListRowByNetworkName(networkName: string) {
+    return {
+      xpath: `//*[@data-testid='multichain-address-row'][.//*[@data-testid='multichain-address-row-network-name' and contains(normalize-space(.), ${quoteXPathText(networkName)})]]`,
+    };
+  }
+
+  private quickCopyRowByNetworkName(networkName: string) {
+    return {
+      xpath: `//*[@data-testid='multichain-address-row'][contains(normalize-space(.), ${quoteXPathText(networkName)}) and not(.//*[@data-testid='multichain-address-row-network-name'])]`,
+    };
   }
 
   async checkPageIsLoaded(): Promise<void> {
@@ -41,6 +65,22 @@ class AddressListModal {
       throw e;
     }
     console.log('Address list modal is loaded');
+  }
+
+  async checkQuickCopyPopoverIsLoaded(): Promise<void> {
+    try {
+      await this.driver.waitForMultipleSelectors([
+        this.addressRowsList,
+        this.addressRow,
+      ]);
+    } catch (e) {
+      console.log(
+        'Timeout while waiting for quick-copy address popover to be loaded',
+        e,
+      );
+      throw e;
+    }
+    console.log('Quick-copy address popover is loaded');
   }
 
   async checkNetworkNameisDisplayed(networkName: string): Promise<void> {
@@ -57,6 +97,125 @@ class AddressListModal {
       text: networkAddress,
       css: this.shortenedAddress,
     });
+  }
+
+  async checkNetworkAddressIsDisplayedForNetwork({
+    networkName,
+    networkAddress,
+  }: {
+    networkName: string;
+    networkAddress: string;
+  }): Promise<void> {
+    console.log(
+      `Check "${networkAddress}" is displayed for network "${networkName}"`,
+    );
+    const row = await this.driver.findElement(
+      this.addressListRowByNetworkName(networkName),
+    );
+    await this.driver.findNestedElement(row, {
+      css: this.shortenedAddress,
+      text: networkAddress,
+    });
+  }
+
+  async checkQuickCopyAddressIsDisplayedForNetwork({
+    networkName,
+    networkAddress,
+  }: {
+    networkName: string;
+    networkAddress: string;
+  }): Promise<void> {
+    console.log(
+      `Check quick-copy popover shows "${networkAddress}" for "${networkName}"`,
+    );
+    const row = await this.driver.findElement(
+      this.quickCopyRowByNetworkName(networkName),
+    );
+    const rowText = await row.getText();
+    if (!rowText.includes(networkAddress)) {
+      throw new Error(
+        `Expected quick-copy row for "${networkName}" to include "${networkAddress}" but got "${rowText}"`,
+      );
+    }
+  }
+
+  async clickCopyButtonForNetwork(networkName: string): Promise<void> {
+    console.log(`Click copy button for network "${networkName}"`);
+    const row = await this.driver.findElement(
+      this.addressListRowByNetworkName(networkName),
+    );
+    const copyButton = await this.driver.findNestedElement(row, this.copyButton);
+    await copyButton.click();
+  }
+
+  async clickCopyButtonForNetworkAndAssertClipboard({
+    networkName,
+    expectedAddress,
+  }: {
+    networkName: string;
+    expectedAddress: string;
+  }): Promise<void> {
+    await this.clickCopyButtonForNetwork(networkName);
+    assert.strictEqual(
+      await this.driver.getClipboardContent(),
+      expectedAddress,
+    );
+  }
+
+  async clickQuickCopyButtonForNetwork({
+    networkName,
+    expectedAddress,
+  }: {
+    networkName: string;
+    expectedAddress: string;
+  }): Promise<void> {
+    console.log(`Click quick-copy row for network "${networkName}"`);
+    const row = await this.driver.findElement(
+      this.quickCopyRowByNetworkName(networkName),
+    );
+    await row.click();
+    assert.strictEqual(
+      await this.driver.getClipboardContent(),
+      expectedAddress,
+    );
+  }
+
+  async clickQRbuttonForNetwork(networkName: string): Promise<void> {
+    console.log(`Click QR button for network "${networkName}"`);
+    const row = await this.driver.findElement(
+      this.addressListRowByNetworkName(networkName),
+    );
+    const qrButton = await this.driver.findNestedElement(row, this.qrButton);
+    await qrButton.click();
+  }
+
+  async checkQrPopupShowsAddress(expectedAddress: string): Promise<void> {
+    console.log(`Check QR popup shows address "${expectedAddress}"`);
+    await this.driver.waitForSelector(this.qrModalAddress);
+    const addressElement = await this.driver.findElement(this.qrModalAddress);
+    const displayedAddress = (await addressElement.getText()).replace(/\s+/gu, '');
+    if (displayedAddress !== expectedAddress) {
+      throw new Error(
+        `Expected QR popup address "${expectedAddress}" but got "${displayedAddress}"`,
+      );
+    }
+  }
+
+  async checkViewOnTronscanButton(): Promise<void> {
+    console.log('Verify View on Tronscan button is present');
+    await this.driver.waitForSelector({
+      css: this.viewOnExplorerButton,
+      text: 'View on Tronscan',
+    });
+  }
+
+  async clickQrCopyAddressLink(expectedAddress: string): Promise<void> {
+    console.log('Click copy address button in QR popup');
+    await this.driver.clickElement(this.qrModalCopyButton);
+    assert.strictEqual(
+      await this.driver.getClipboardContent(),
+      expectedAddress,
+    );
   }
 
   async clickCopyButton(addressIndex: number = 0): Promise<void> {

--- a/test/e2e/page-objects/pages/multichain/address-list-modal.ts
+++ b/test/e2e/page-objects/pages/multichain/address-list-modal.ts
@@ -144,7 +144,10 @@ class AddressListModal {
     const row = await this.driver.findElement(
       this.addressListRowByNetworkName(networkName),
     );
-    const copyButton = await this.driver.findNestedElement(row, this.copyButton);
+    const copyButton = await this.driver.findNestedElement(
+      row,
+      this.copyButton,
+    );
     await copyButton.click();
   }
 
@@ -193,7 +196,10 @@ class AddressListModal {
     console.log(`Check QR popup shows address "${expectedAddress}"`);
     await this.driver.waitForSelector(this.qrModalAddress);
     const addressElement = await this.driver.findElement(this.qrModalAddress);
-    const displayedAddress = (await addressElement.getText()).replace(/\s+/gu, '');
+    const displayedAddress = (await addressElement.getText()).replace(
+      /\s+/gu,
+      '',
+    );
     if (displayedAddress !== expectedAddress) {
       throw new Error(
         `Expected QR popup address "${expectedAddress}" but got "${displayedAddress}"`,

--- a/test/e2e/tests/tron/account-derivation.spec.ts
+++ b/test/e2e/tests/tron/account-derivation.spec.ts
@@ -252,13 +252,7 @@ describe('Tron account derivation', function (this: Suite) {
     );
   });
 
-  // TODO: Re-enable when the address-list QR button can open the Tron QR
-  // modal. It currently opens the Ethereum QR modal even when clicking the
-  // Tron row.
-  // Tracking: WPN-non-EVM-QR-modal — requires upstream work on the
-  // address QR component to support non-EVM addresses.
-  // eslint-disable-next-line mocha/no-skipped-tests
-  it.skip('Shows Account 1 QR popup with address, copy link, and View on Tronscan', async function () {
+  it('Shows Account 1 QR popup with address, copy link, and View on Tronscan', async function () {
     await withTronFixtures(
       {
         accounts: [EMPTY_TRON_ACCOUNT],

--- a/test/e2e/tests/tron/account-derivation.spec.ts
+++ b/test/e2e/tests/tron/account-derivation.spec.ts
@@ -3,7 +3,7 @@ import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { Driver } from '../../webdriver/driver';
 import { login } from '../../page-objects/flows/login.flow';
 import { completeImportSRPOnboardingFlow } from '../../page-objects/flows/onboarding.flow';
-import { waitUntilAccountTreeSyncIdle } from '../../page-objects/flows/tron-account-derivation.flow';
+import { waitUntilAccountTreeSyncIdle, addNHdAccountsForTronDerivation } from '../../page-objects/flows/tron-account-derivation.flow';
 import { EXPECTED_TRON_ADDRESSES_BY_INDEX } from '../../constants';
 import { shortenAddress } from '../../../../ui/helpers/utils/util';
 import HomePage from '../../page-objects/pages/home/homepage';
@@ -96,32 +96,19 @@ async function assertTronAddressesForAccounts(
   await accountList.closeMultichainAccountsPage();
 }
 
-async function addMultichainAccountsThrough(
-  driver: Driver,
-  total: number,
-): Promise<void> {
-  if (total < 2) {
-    return;
-  }
-
-  const homepage = new HomePage(driver);
-  const accountList = new AccountListPage(driver);
-
-  await waitUntilAccountTreeSyncIdle(driver);
-  await homepage.headerNavbar.openAccountMenu();
-  await accountList.checkPageIsLoaded();
-
-  for (let accountNumber = 2; accountNumber <= total; accountNumber += 1) {
-    await waitUntilAccountTreeSyncIdle(driver);
-    await accountList.addMultichainAccount();
-    await accountList.checkMultichainAccountNameDisplayed(
-      `Account ${accountNumber}`,
-    );
-  }
-
-  await accountList.closeMultichainAccountsPage();
-}
-
+/**
+ * Tron HD address derivation E2E cluster (WPN-685).
+ *
+ * Two concepts:
+ * - Tron address derivation (automatic): BIP44 Stage 2 derives Tron for each HD index once Tron is enabled (mocked via BIP44_STAGE_TWO).
+ * - HD account groups (manual in most tests): a fresh wallet only has Account 1; Accounts 2-8 are added via "Add account" or asset discovery.
+ *
+ * Coverage map:
+ * - incremental add 1-8: add + assert per step — derivation correct at each new HD index
+ * - 8 existing groups: add 8, then enable Tron — retroactive alignment when network enabled later
+ * - asset discovery 1-5: mocked txs, no manual add — automatic discovery; Account 6 absent
+ * - quick-copy / QR / Receive: add 8 upfront — Tron address on each surface for all indices
+ */
 describe('Tron account derivation', function (this: Suite) {
   this.timeout(240_000);
 
@@ -183,7 +170,7 @@ describe('Tron account derivation', function (this: Suite) {
       async ({ driver }: { driver: Driver }) => {
         await login(driver, { validateBalance: false });
 
-        await addMultichainAccountsThrough(driver, 8);
+        await addNHdAccountsForTronDerivation(driver, 8);
 
         await selectTronNetwork(driver);
         await waitUntilAccountTreeSyncIdle(driver);
@@ -222,7 +209,7 @@ describe('Tron account derivation', function (this: Suite) {
       async ({ driver }: { driver: Driver }) => {
         await login(driver, { validateBalance: false });
         await selectTronNetwork(driver);
-        await addMultichainAccountsThrough(driver, 8);
+        await addNHdAccountsForTronDerivation(driver, 8);
 
         const homepage = new HomePage(driver);
         const accountList = new AccountListPage(driver);
@@ -297,7 +284,7 @@ describe('Tron account derivation', function (this: Suite) {
       async ({ driver }: { driver: Driver }) => {
         await login(driver, { validateBalance: false });
         await selectTronNetwork(driver);
-        await addMultichainAccountsThrough(driver, 8);
+        await addNHdAccountsForTronDerivation(driver, 8);
 
         const homepage = new NonEvmHomepage(driver);
         const accountList = new AccountListPage(driver);

--- a/test/e2e/tests/tron/account-derivation.spec.ts
+++ b/test/e2e/tests/tron/account-derivation.spec.ts
@@ -287,7 +287,7 @@ describe('Tron account derivation', function (this: Suite) {
     );
   });
 
-  it('Shows Account 1 Tron address on the Receive page and copies it', async function () {
+  it('Shows each account Tron address on the Receive page and copies it', async function () {
     await withTronFixtures(
       {
         accounts: [EMPTY_TRON_ACCOUNT],
@@ -297,24 +297,35 @@ describe('Tron account derivation', function (this: Suite) {
       async ({ driver }: { driver: Driver }) => {
         await login(driver, { validateBalance: false });
         await selectTronNetwork(driver);
+        await addMultichainAccountsThrough(driver, 8);
 
         const homepage = new NonEvmHomepage(driver);
+        const accountList = new AccountListPage(driver);
         const addressList = new AddressListModal(driver);
-        const expected = EXPECTED_TRON_ADDRESSES_BY_INDEX[0];
 
-        await homepage.checkPageIsLoaded();
-        await homepage.clickOnReceiveButton();
-        await addressList.checkPageIsLoaded();
-        await addressList.checkNetworkAddressIsDisplayedForNetwork({
-          networkName: 'Tron',
-          networkAddress: shortenAddress(expected),
-        });
-        await addressList.clickCopyButtonForNetworkAndAssertClipboard({
-          networkName: 'Tron',
-          expectedAddress: expected,
-        });
-        await addressList.verifyCopyButtonFeedback();
-        await addressList.goBack();
+        for (let index = 0; index < 8; index += 1) {
+          const accountLabel = `Account ${index + 1}`;
+          const expected = EXPECTED_TRON_ADDRESSES_BY_INDEX[index];
+
+          await homepage.headerNavbar.openAccountMenu();
+          await accountList.checkPageIsLoaded();
+          await accountList.selectAccount(accountLabel);
+          await waitUntilAccountTreeSyncIdle(driver);
+
+          await homepage.checkPageIsLoaded();
+          await homepage.clickOnReceiveButton();
+          await addressList.checkPageIsLoaded();
+          await addressList.checkNetworkAddressIsDisplayedForNetwork({
+            networkName: 'Tron',
+            networkAddress: shortenAddress(expected),
+          });
+          await addressList.clickCopyButtonForNetworkAndAssertClipboard({
+            networkName: 'Tron',
+            expectedAddress: expected,
+          });
+          await addressList.verifyCopyButtonFeedback();
+          await addressList.goBack();
+        }
       },
     );
   });

--- a/test/e2e/tests/tron/account-derivation.spec.ts
+++ b/test/e2e/tests/tron/account-derivation.spec.ts
@@ -1,0 +1,327 @@
+import { Suite } from 'mocha';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
+import { Driver } from '../../webdriver/driver';
+import { login } from '../../page-objects/flows/login.flow';
+import { completeImportSRPOnboardingFlow } from '../../page-objects/flows/onboarding.flow';
+import { waitUntilAccountTreeSyncIdle } from '../../page-objects/flows/tron-account-derivation.flow';
+import { EXPECTED_TRON_ADDRESSES_BY_INDEX } from '../../constants';
+import { shortenAddress } from '../../../../ui/helpers/utils/util';
+import HomePage from '../../page-objects/pages/home/homepage';
+import AccountListPage from '../../page-objects/pages/account-list-page';
+import AddressListModal from '../../page-objects/pages/multichain/address-list-modal';
+import NonEvmHomepage from '../../page-objects/pages/home/non-evm-homepage';
+import { selectTronNetwork } from '../../page-objects/flows/tron-network.flow';
+import { base58AddressToHex, SUN_PER_TRX } from '../../seeder/tron/assets';
+import { TRON_ACCOUNT_ADDRESS, TRX_TO_USD_RATE } from './mocks/common-tron';
+import { EMPTY_TRON_ACCOUNT } from './fixtures/environments';
+import { withTronFixtures } from './fixtures/with-tron-fixtures';
+import { TRX } from './fixtures/tokens';
+
+/* eslint-disable @typescript-eslint/naming-convention */
+function createDiscoveryTronTransaction(address: string) {
+  const timestamp = Date.now() - 60_000;
+  return {
+    ret: [{ contractRet: 'SUCCESS', fee: 0 }],
+    txID: `1${base58AddressToHex(address).slice(2)}`.padEnd(64, '0'),
+    blockNumber: 77_000_000,
+    block_timestamp: timestamp,
+    raw_data: {
+      contract: [
+        {
+          parameter: {
+            value: {
+              amount: SUN_PER_TRX,
+              owner_address: base58AddressToHex(TRON_ACCOUNT_ADDRESS),
+              to_address: base58AddressToHex(address),
+            },
+            type_url: 'type.googleapis.com/protocol.TransferContract',
+          },
+          type: 'TransferContract',
+        },
+      ],
+      expiration: timestamp + 60_000,
+      ref_block_bytes: '0000',
+      ref_block_hash: '0000000000000000',
+      timestamp,
+    },
+  };
+}
+/* eslint-enable @typescript-eslint/naming-convention */
+
+function buildDiscoveryAccountsThrough(total: number) {
+  return EXPECTED_TRON_ADDRESSES_BY_INDEX.slice(0, total).map((address) => ({
+    address,
+    assets: [{ ...TRX, balance: SUN_PER_TRX, priceUsd: TRX_TO_USD_RATE }],
+    transactions: {
+      raw: [createDiscoveryTronTransaction(address)],
+      trc20: [],
+    },
+  }));
+}
+
+async function assertTronAddressesForAccounts(
+  driver: Driver,
+  total: number,
+  options: { absentAccountLabel?: string } = {},
+): Promise<void> {
+  const homepage = new HomePage(driver);
+  const accountList = new AccountListPage(driver);
+  const addressList = new AddressListModal(driver);
+
+  await homepage.headerNavbar.openAccountMenu();
+  await accountList.checkPageIsLoaded();
+
+  for (let index = 0; index < total; index += 1) {
+    const accountLabel = `Account ${index + 1}`;
+    const expected = EXPECTED_TRON_ADDRESSES_BY_INDEX[index];
+
+    await accountList.openMultichainAccountMenu({ accountLabel });
+    await accountList.clickMultichainAccountMenuItem('Addresses');
+    await addressList.checkPageIsLoaded();
+    await addressList.checkNetworkNameisDisplayed('Tron');
+    await addressList.checkNetworkAddressIsDisplayed(shortenAddress(expected));
+    await addressList.clickCopyButtonForNetworkAndAssertClipboard({
+      networkName: 'Tron',
+      expectedAddress: expected,
+    });
+    await addressList.goBack();
+  }
+
+  if (options.absentAccountLabel) {
+    await accountList.checkMultichainAccountNameNotDisplayed(
+      options.absentAccountLabel,
+    );
+  }
+
+  await accountList.closeMultichainAccountsPage();
+}
+
+async function addMultichainAccountsThrough(
+  driver: Driver,
+  total: number,
+): Promise<void> {
+  if (total < 2) {
+    return;
+  }
+
+  const homepage = new HomePage(driver);
+  const accountList = new AccountListPage(driver);
+
+  await waitUntilAccountTreeSyncIdle(driver);
+  await homepage.headerNavbar.openAccountMenu();
+  await accountList.checkPageIsLoaded();
+
+  for (let accountNumber = 2; accountNumber <= total; accountNumber += 1) {
+    await waitUntilAccountTreeSyncIdle(driver);
+    await accountList.addMultichainAccount();
+    await accountList.checkMultichainAccountNameDisplayed(
+      `Account ${accountNumber}`,
+    );
+  }
+
+  await accountList.closeMultichainAccountsPage();
+}
+
+describe('Tron account derivation', function (this: Suite) {
+  this.timeout(240_000);
+
+  it('derives Tron addresses while adding multichain accounts from Account 1 to Account 8', async function () {
+    await withTronFixtures(
+      {
+        accounts: [EMPTY_TRON_ACCOUNT],
+        fixtures: new FixtureBuilderV2().build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await login(driver, { validateBalance: false });
+        await selectTronNetwork(driver);
+
+        const homepage = new HomePage(driver);
+        const accountList = new AccountListPage(driver);
+        const addressList = new AddressListModal(driver);
+
+        await waitUntilAccountTreeSyncIdle(driver);
+        await homepage.headerNavbar.openAccountMenu();
+        await accountList.checkPageIsLoaded();
+
+        for (let index = 0; index < 8; index += 1) {
+          const accountLabel = `Account ${index + 1}`;
+          const expected = EXPECTED_TRON_ADDRESSES_BY_INDEX[index];
+
+          if (index > 0) {
+            await waitUntilAccountTreeSyncIdle(driver);
+            await accountList.addMultichainAccount();
+            await accountList.checkMultichainAccountNameDisplayed(accountLabel);
+          }
+
+          await accountList.openMultichainAccountMenu({ accountLabel });
+          await accountList.clickMultichainAccountMenuItem('Addresses');
+          await addressList.checkPageIsLoaded();
+          await addressList.checkNetworkNameisDisplayed('Tron');
+          await addressList.checkNetworkAddressIsDisplayed(
+            shortenAddress(expected),
+          );
+          await addressList.clickCopyButtonForNetworkAndAssertClipboard({
+            networkName: 'Tron',
+            expectedAddress: expected,
+          });
+          await addressList.goBack();
+        }
+
+        await accountList.closeMultichainAccountsPage();
+      },
+    );
+  });
+
+  it('aligns Tron addresses for 8 existing multichain account groups', async function () {
+    await withTronFixtures(
+      {
+        accounts: [EMPTY_TRON_ACCOUNT],
+        fixtures: new FixtureBuilderV2().build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await login(driver, { validateBalance: false });
+
+        await addMultichainAccountsThrough(driver, 8);
+
+        await selectTronNetwork(driver);
+        await waitUntilAccountTreeSyncIdle(driver);
+
+        await assertTronAddressesForAccounts(driver, 8);
+      },
+    );
+  });
+
+  it('discovers Tron accounts through Account 5 when each account has assets', async function () {
+    await withTronFixtures(
+      {
+        accounts: buildDiscoveryAccountsThrough(5),
+        fixtures: new FixtureBuilderV2({ onboarding: true }).build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await completeImportSRPOnboardingFlow({ driver });
+
+        await waitUntilAccountTreeSyncIdle(driver);
+
+        await assertTronAddressesForAccounts(driver, 5, {
+          absentAccountLabel: 'Account 6',
+        });
+      },
+    );
+  });
+
+  it('Shows each account Tron address on the quick-copy popup and copies it', async function () {
+    await withTronFixtures(
+      {
+        accounts: [EMPTY_TRON_ACCOUNT],
+        fixtures: new FixtureBuilderV2().build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await login(driver, { validateBalance: false });
+        await selectTronNetwork(driver);
+        await addMultichainAccountsThrough(driver, 8);
+
+        const homepage = new HomePage(driver);
+        const accountList = new AccountListPage(driver);
+        const addressList = new AddressListModal(driver);
+
+        for (let index = 0; index < 8; index += 1) {
+          const accountLabel = `Account ${index + 1}`;
+          const expected = EXPECTED_TRON_ADDRESSES_BY_INDEX[index];
+
+          await homepage.headerNavbar.openAccountMenu();
+          await accountList.checkPageIsLoaded();
+          await accountList.selectAccount(accountLabel);
+          await waitUntilAccountTreeSyncIdle(driver);
+
+          await homepage.headerNavbar.clickNetworkAddresses();
+          await addressList.checkQuickCopyPopoverIsLoaded();
+          await addressList.checkQuickCopyAddressIsDisplayedForNetwork({
+            networkName: 'Tron',
+            networkAddress: shortenAddress(expected),
+          });
+          await addressList.clickQuickCopyButtonForNetwork({
+            networkName: 'Tron',
+            expectedAddress: expected,
+          });
+        }
+      },
+    );
+  });
+
+  // TODO: Re-enable when the address-list QR button can open the Tron QR
+  // modal. It currently opens the Ethereum QR modal even when clicking the
+  // Tron row.
+  // Tracking: WPN-non-EVM-QR-modal — requires upstream work on the
+  // address QR component to support non-EVM addresses.
+  // eslint-disable-next-line mocha/no-skipped-tests
+  it.skip('Shows Account 1 QR popup with address, copy link, and View on Tronscan', async function () {
+    await withTronFixtures(
+      {
+        accounts: [EMPTY_TRON_ACCOUNT],
+        fixtures: new FixtureBuilderV2().build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await login(driver, { validateBalance: false });
+        await selectTronNetwork(driver);
+
+        const homepage = new HomePage(driver);
+        const accountList = new AccountListPage(driver);
+        const addressList = new AddressListModal(driver);
+        await homepage.headerNavbar.openAccountMenu();
+        await accountList.checkPageIsLoaded();
+
+        await accountList.openMultichainAccountMenu({
+          accountLabel: 'Account 1',
+        });
+        await accountList.clickMultichainAccountMenuItem('Addresses');
+        await addressList.checkPageIsLoaded();
+        await addressList.clickQRbuttonForNetwork('Tron');
+
+        await addressList.checkQrPopupShowsAddress(
+          EXPECTED_TRON_ADDRESSES_BY_INDEX[0],
+        );
+        await addressList.checkViewOnTronscanButton();
+        await addressList.clickQrCopyAddressLink(
+          EXPECTED_TRON_ADDRESSES_BY_INDEX[0],
+        );
+      },
+    );
+  });
+
+  it('Shows Account 1 Tron address on the Receive page and copies it', async function () {
+    await withTronFixtures(
+      {
+        accounts: [EMPTY_TRON_ACCOUNT],
+        fixtures: new FixtureBuilderV2().build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await login(driver, { validateBalance: false });
+        await selectTronNetwork(driver);
+
+        const homepage = new NonEvmHomepage(driver);
+        const addressList = new AddressListModal(driver);
+        const expected = EXPECTED_TRON_ADDRESSES_BY_INDEX[0];
+
+        await homepage.checkPageIsLoaded();
+        await homepage.clickOnReceiveButton();
+        await addressList.checkPageIsLoaded();
+        await addressList.checkNetworkAddressIsDisplayedForNetwork({
+          networkName: 'Tron',
+          networkAddress: shortenAddress(expected),
+        });
+        await addressList.clickCopyButtonForNetworkAndAssertClipboard({
+          networkName: 'Tron',
+          expectedAddress: expected,
+        });
+        await addressList.verifyCopyButtonFeedback();
+        await addressList.goBack();
+      },
+    );
+  });
+});


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds E2E tests verifying Tron HD account address derivation for Accounts 1–8 across the address hover popover, account address list, and Receive (Receiving Addresses) surfaces.

### What's included

- `test/e2e/tests/tron/account-derivation.spec.ts` — asserts Accounts 1–8 derived from the E2E SRP using BIP44 path `m/44'/195'/0'/0/i` match `EXPECTED_TRON_ADDRESSES_BY_INDEX` on hover popover, address list, and Receive page
- `test/e2e/page-objects/flows/tron-account-derivation.flow.ts` — flow helpers for account-tree sync and multichain account creation
- `test/e2e/page-objects/flows/tron-network.flow.ts` + `network.flow.ts` — Tron network selection with backdrop cleanup
- `test/e2e/page-objects/pages/multichain/address-list-modal.ts` — network-scoped address list / quick-copy / QR helpers
- `test/e2e/page-objects/pages/home/non-evm-homepage.ts` — Receive button helper for non-EVM home
- `test/e2e/page-objects/pages/account-list-page.ts` — multichain accounts page object updates required for add-account and address-list flows (see scope note in review)

### Base branch

Targets `WPN-536c-tron-fixtures` (Tron fixtures split tip).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

- [WPN-685](https://consensyssoftware.atlassian.net/browse/WPN-685) — Account addresses derived correctly (Accounts 1–8)
- [WPN-407](https://consensyssoftware.atlassian.net/browse/WPN-407) — Add E2E tests to Accounts + Receive cluster

## **Manual testing steps**

1. Build the test extension: `yarn build:test`
2. Run the Tron account derivation cluster:
   ```
   yarn test:e2e:tron -- --grep "account-derivation"
   ```
3. Confirm each test passes for Accounts 1–8 on hover popover, address list, and Receive page.

## **Screenshots/Recordings**

### **Before**

n/a

### **After**

n/a

[WPN-685]: https://consensyssoftware.atlassian.net/browse/WPN-685?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes to E2E specs and page objects; no production wallet or derivation logic is modified.
> 
> **Overview**
> Adds a **Tron account derivation** E2E cluster (`account-derivation.spec.ts`) that checks HD accounts 1–8 match `EXPECTED_TRON_ADDRESSES_BY_INDEX` on the multichain address list, header quick-copy popover, QR modal (Tronscan + copy), and non-EVM **Receive** flow. Scenarios cover incremental “Add account,” enabling Tron after eight HD groups already exist, and onboarding with mocked balances/transactions through Account 5 (Account 6 absent).
> 
> New flow helpers wait on `isAccountTreeSyncingInProgress`, grow HD indices via the multichain add-account UI (`addNHdAccountsForTronDerivation`), select Tron in the network manager, and strip leftover `.modal__backdrop` nodes that block clicks. **`AddressListModal`** gains network-scoped XPath helpers for display, copy, quick-copy, and QR; **`NonEvmHomepage`** keeps a Receive click helper with a small refactor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b238aaa6d5cc30c1bc8b244e32b7eae53bfcfa38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->