### PR TITLE
fix: double banner events

### DIFF
--- a/ui/components/multichain/account-overview/carousel.tsx
+++ b/ui/components/multichain/account-overview/carousel.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useRef, useCallback, useMemo } from 'react';
+import React, { useContext, useRef, useState, useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { removeSlide } from '../../../store/actions';
 import { CarouselWithEmptyState } from '../carousel';

--- a/ui/components/multichain/account-overview/carousel.tsx
+++ b/ui/components/multichain/account-overview/carousel.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState, useCallback, useMemo } from 'react';
+import React, { useContext, useRef, useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { removeSlide } from '../../../store/actions';
 import { CarouselWithEmptyState } from '../carousel';
@@ -21,9 +21,7 @@ export const Carousel = () => {
     remoteFeatureFlags && remoteFeatureFlags.carouselBanners,
   );
   const { trackEvent } = useContext(MetaMetricsContext);
-  const [displayedSlideIds, setDisplayedSlideIds] = useState<Set<string>>(
-    new Set(),
-  );
+  const displayedSlideIds = useRef<Set<string>>(new Set());
 
   const [showDownloadMobileAppModal, setShowDownloadMobileAppModal] =
     useState(false);
@@ -76,7 +74,8 @@ export const Carousel = () => {
 
   const handleActiveSlideChange = useCallback(
     (slide: CarouselSlide) => {
-      if (!displayedSlideIds.has(slide.id)) {
+      if (!displayedSlideIds.current.has(slide.id)) {
+        displayedSlideIds.current.add(slide.id);
         trackEvent({
           event: MetaMetricsEventName.BannerDisplay,
           category: MetaMetricsEventCategory.Banner,
@@ -86,10 +85,9 @@ export const Carousel = () => {
             banner_name: slide.id,
           },
         });
-        setDisplayedSlideIds((prev) => new Set(prev).add(slide.id));
       }
     },
-    [displayedSlideIds, trackEvent],
+    [trackEvent],
   );
 
   if (!isCarouselEnabled) {

--- a/ui/components/multichain/account-overview/carousel.tsx
+++ b/ui/components/multichain/account-overview/carousel.tsx
@@ -1,4 +1,10 @@
-import React, { useContext, useRef, useState, useCallback, useMemo } from 'react';
+import React, {
+  useContext,
+  useRef,
+  useState,
+  useCallback,
+  useMemo,
+} from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { removeSlide } from '../../../store/actions';
 import { CarouselWithEmptyState } from '../carousel';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

In this PR I try to reduce reactivity and reduce amount of re-renders/callback re-creation/effects re-run.

When we mark banner as shown we were updating state, which then triggers re-render, changes the identity of callback, triggers effect again.

In this PR I'm removing this re-render, which:
- makes an update synchronously
- improves performance
- don't trigger effect twice

So the problem with double function invocation should gone.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: prevent sending double banner events

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/GE-288

## **Manual testing steps**

1. Open extension
2. Check `banner` events to MixPanel
3. Make sure we send only one event

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="2388" height="1292" alt="image" src="https://github.com/user-attachments/assets/f8b80757-cde8-4d6a-96a5-a52add16940c" />

### **After**

<img width="1494" height="706" alt="image" src="https://github.com/user-attachments/assets/f5e532f1-11e3-4e32-9a5f-e9922f386ebd" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small analytics-only change in the account-overview carousel; behavior is unchanged except deduplicating banner display events.
> 
> **Overview**
> Fixes **duplicate `BannerDisplay` Mixpanel events** when a carousel banner becomes active.
> 
> **`displayedSlideIds`** moves from `useState` to **`useRef`**. Recording a slide as shown no longer calls `setState`, so the account-overview carousel does not re-render and **`handleActiveSlideChange` keeps a stable identity** (deps are only `[trackEvent]`). The child carousel’s `useEffect` that depends on `onActiveSlideChange` therefore runs once per active slide instead of firing again after the “already displayed” update.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 228cdc7371dd1f823ab60565dd27c787ce186547. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->