### PR TITLE
feat(analytics): add event builder, delivery helpers, and UI hook

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -83,6 +83,7 @@ import NotificationManager, {
 import MetamaskController, {
   METAMASK_CONTROLLER_EVENTS,
 } from './metamask-controller';
+import { AnalyticsEventBuilder, trackEvent } from './controllers/analytics';
 import getObjStructure from './lib/getObjStructure';
 import setupEnsIpfsResolver from './lib/ens-ipfs/setup';
 import {
@@ -1391,14 +1392,14 @@ function emitAppOpenedMetricEvent(environmentType) {
     allowlist,
   );
 
-  controller.metaMetricsController.trackEvent({
-    event: MetaMetricsEventName.AppOpened,
-    category: MetaMetricsEventCategory.App,
-    environmentType,
-    properties: {
-      ...(activeTabDomain ? { active_tab_domain: activeTabDomain } : {}),
-    },
-  });
+  trackEvent(
+    AnalyticsEventBuilder.createEventBuilder(MetaMetricsEventName.AppOpened)
+      .addProperties({
+        category: MetaMetricsEventCategory.App,
+        ...(activeTabDomain ? { active_tab_domain: activeTabDomain } : {}),
+      })
+      .build({ environmentType }),
+  );
 }
 
 /**

--- a/app/scripts/controllers/analytics/analytics-delivery.test.ts
+++ b/app/scripts/controllers/analytics/analytics-delivery.test.ts
@@ -39,12 +39,24 @@ jest.mock('../../lib/segment', () => ({
 
 const mockSegment = segment as jest.Mocked<typeof segment>;
 
+function createMockAnalyticsTrackingEvent(
+  partial: Pick<AnalyticsTrackingEvent, 'name'> &
+    Partial<Omit<AnalyticsTrackingEvent, 'name'>>,
+): AnalyticsTrackingEvent {
+  return {
+    properties: {},
+    sensitiveProperties: {},
+    saveDataRecording: false,
+    hasProperties: true,
+    ...partial,
+  };
+}
+
 const builtEvent: BuiltAnalyticsEvent = {
-  event: {
+  event: createMockAnalyticsTrackingEvent({
     name: 'Test Event',
     properties: { foo: 'bar' },
-    sensitiveProperties: {},
-  } as AnalyticsTrackingEvent,
+  }),
   context: {
     app: { name: 'MetaMask Extension', version: '1.0.0' },
   },
@@ -76,17 +88,21 @@ function createConfiguredMessenger({
     namespace: MOCK_ANY_NAMESPACE,
   });
 
-  rootMessenger.registerActionHandler('PreferencesController:getState', () =>
-    ({
-      useExternalServices,
-    }) as never,
+  rootMessenger.registerActionHandler(
+    'PreferencesController:getState',
+    () =>
+      ({
+        useExternalServices,
+      }) as never,
   );
 
-  rootMessenger.registerActionHandler('AnalyticsController:getState', () =>
-    ({
-      analyticsId,
-      optedIn,
-    }) as never,
+  rootMessenger.registerActionHandler(
+    'AnalyticsController:getState',
+    () =>
+      ({
+        analyticsId,
+        optedIn,
+      }) as never,
   );
 
   configureAnalyticsDelivery({
@@ -172,11 +188,10 @@ describe('analytics delivery', () => {
       });
 
       const metricsOptOutEvent: BuiltAnalyticsEvent = {
-        event: {
+        event: createMockAnalyticsTrackingEvent({
           name: MetaMetricsEventName.MetricsOptOut,
           properties: { category: 'Settings' },
-          sensitiveProperties: {},
-        } as AnalyticsTrackingEvent,
+        }),
         context: {
           app: { name: 'MetaMask Extension', version: '1.0.0' },
         },
@@ -205,11 +220,9 @@ describe('analytics delivery', () => {
       });
 
       trackEvent({
-        event: {
+        event: createMockAnalyticsTrackingEvent({
           name: MetaMetricsEventName.MetricsOptOut,
-          properties: {},
-          sensitiveProperties: {},
-        } as AnalyticsTrackingEvent,
+        }),
         context: {
           app: { name: 'MetaMask Extension', version: '1.0.0' },
         },
@@ -238,7 +251,10 @@ describe('analytics delivery', () => {
     });
 
     it('delivers user traits to AnalyticsController', () => {
-      const userTraits = { installDateExt: '2024-01-01' };
+      const userTraits = {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        install_date_ext: '2024-01-01',
+      };
 
       identify(userTraits);
 
@@ -247,13 +263,17 @@ describe('analytics delivery', () => {
 
     it('filters invalid traits before delivery', () => {
       identify({
-        installDateExt: '2024-01-01',
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        install_date_ext: '2024-01-01',
         // eslint-disable-next-line @typescript-eslint/naming-convention
         test_null: null,
       } as never);
 
       expect(identifyHandler).toHaveBeenCalledWith(
-        { installDateExt: '2024-01-01' },
+        {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          install_date_ext: '2024-01-01',
+        },
         undefined,
       );
       expect(warnSpy).toHaveBeenCalledWith(
@@ -277,7 +297,10 @@ describe('analytics delivery', () => {
         identifyHandler as never,
       );
 
-      identify({ installDateExt: '2024-01-01' });
+      identify({
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        install_date_ext: '2024-01-01',
+      });
 
       expect(identifyHandler).not.toHaveBeenCalled();
     });

--- a/app/scripts/controllers/analytics/analytics-delivery.test.ts
+++ b/app/scripts/controllers/analytics/analytics-delivery.test.ts
@@ -1,0 +1,334 @@
+import {
+  ActionConstraint,
+  Messenger,
+  MOCK_ANY_NAMESPACE,
+  MockAnyNamespace,
+} from '@metamask/messenger';
+import type {
+  AnalyticsControllerGetStateAction,
+  AnalyticsControllerIdentifyAction,
+  AnalyticsControllerTrackEventAction,
+  AnalyticsControllerTrackViewAction,
+  AnalyticsTrackingEvent,
+} from '@metamask/analytics-controller';
+import type {
+  NetworkControllerGetNetworkClientByIdAction,
+  NetworkControllerGetStateAction,
+} from '@metamask/network-controller';
+import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
+import type { PreferencesControllerGetStateAction } from '../preferences-controller';
+import type { MetaMetricsControllerGetStateAction } from '../metametrics-controller';
+import { MetaMetricsEventName } from '../../../../shared/constants/metametrics';
+import { segment } from '../../lib/segment';
+import { getAnalyticsEventBuilderMessenger } from './analytics-event-builder-messenger';
+import {
+  configureAnalyticsDelivery,
+  canSubmitAnalytics,
+  identify,
+  trackEvent,
+  trackView,
+} from './analytics-delivery';
+import type { BuiltAnalyticsEvent } from './analytics-event-builder';
+
+jest.mock('../../lib/segment', () => ({
+  segment: {
+    track: jest.fn(),
+    flush: jest.fn(),
+  },
+}));
+
+const mockSegment = segment as jest.Mocked<typeof segment>;
+
+const builtEvent: BuiltAnalyticsEvent = {
+  event: {
+    name: 'Test Event',
+    properties: { foo: 'bar' },
+    sensitiveProperties: {},
+  } as AnalyticsTrackingEvent,
+  context: {
+    app: { name: 'MetaMask Extension', version: '1.0.0' },
+  },
+};
+
+function createConfiguredMessenger({
+  useExternalServices = true,
+  optedIn = true,
+  analyticsId = 'analytics-id',
+}: {
+  useExternalServices?: boolean;
+  optedIn?: boolean;
+  analyticsId?: string;
+} = {}) {
+  const rootMessenger = new Messenger<
+    MockAnyNamespace,
+    | PreferencesControllerGetStateAction
+    | NetworkControllerGetStateAction
+    | NetworkControllerGetNetworkClientByIdAction
+    | RemoteFeatureFlagControllerGetStateAction
+    | MetaMetricsControllerGetStateAction
+    | AnalyticsControllerGetStateAction
+    | AnalyticsControllerTrackEventAction
+    | AnalyticsControllerIdentifyAction
+    | AnalyticsControllerTrackViewAction
+    | ActionConstraint,
+    never
+  >({
+    namespace: MOCK_ANY_NAMESPACE,
+  });
+
+  rootMessenger.registerActionHandler('PreferencesController:getState', () =>
+    ({
+      useExternalServices,
+    }) as never,
+  );
+
+  rootMessenger.registerActionHandler('AnalyticsController:getState', () =>
+    ({
+      analyticsId,
+      optedIn,
+    }) as never,
+  );
+
+  configureAnalyticsDelivery({
+    messenger: getAnalyticsEventBuilderMessenger(rootMessenger),
+  });
+
+  return rootMessenger;
+}
+
+describe('analytics delivery', () => {
+  describe('canSubmitAnalytics', () => {
+    it('throws when analytics delivery is not configured', () => {
+      expect(() => canSubmitAnalytics()).toThrow(
+        'Analytics delivery has not been configured',
+      );
+    });
+
+    it('returns false when the user has not opted in', () => {
+      createConfiguredMessenger({ optedIn: false });
+
+      expect(canSubmitAnalytics()).toBe(false);
+    });
+
+    it('returns true for Metrics Opt Out when the user has not opted in', () => {
+      createConfiguredMessenger({ optedIn: false });
+
+      expect(canSubmitAnalytics(MetaMetricsEventName.MetricsOptOut)).toBe(true);
+    });
+  });
+
+  describe('trackEvent', () => {
+    let trackEventHandler: jest.Mock;
+
+    beforeEach(() => {
+      trackEventHandler = jest.fn();
+      const rootMessenger = createConfiguredMessenger();
+      rootMessenger.registerActionHandler(
+        'AnalyticsController:trackEvent',
+        trackEventHandler as never,
+      );
+    });
+
+    it('delivers a built event to AnalyticsController', () => {
+      trackEvent(builtEvent);
+
+      expect(trackEventHandler).toHaveBeenCalledWith(
+        builtEvent.event,
+        builtEvent.context,
+      );
+    });
+
+    it('does not deliver the event when basic functionality is disabled', () => {
+      const rootMessenger = createConfiguredMessenger({
+        useExternalServices: false,
+      });
+      rootMessenger.registerActionHandler(
+        'AnalyticsController:trackEvent',
+        trackEventHandler as never,
+      );
+
+      trackEvent(builtEvent);
+
+      expect(trackEventHandler).not.toHaveBeenCalled();
+    });
+
+    it('does not deliver the event when the user has not opted in', () => {
+      const rootMessenger = createConfiguredMessenger({ optedIn: false });
+      rootMessenger.registerActionHandler(
+        'AnalyticsController:trackEvent',
+        trackEventHandler as never,
+      );
+
+      trackEvent(builtEvent);
+
+      expect(trackEventHandler).not.toHaveBeenCalled();
+    });
+
+    it('tracks Metrics Opt Out through Segment when the user is opted out', () => {
+      jest.clearAllMocks();
+      createConfiguredMessenger({
+        optedIn: false,
+        analyticsId: 'metrics-opt-out-id',
+      });
+
+      const metricsOptOutEvent: BuiltAnalyticsEvent = {
+        event: {
+          name: MetaMetricsEventName.MetricsOptOut,
+          properties: { category: 'Settings' },
+          sensitiveProperties: {},
+        } as AnalyticsTrackingEvent,
+        context: {
+          app: { name: 'MetaMask Extension', version: '1.0.0' },
+        },
+      };
+
+      trackEvent(metricsOptOutEvent);
+
+      expect(trackEventHandler).not.toHaveBeenCalled();
+      expect(mockSegment.track).toHaveBeenCalledWith({
+        userId: 'metrics-opt-out-id',
+        event: MetaMetricsEventName.MetricsOptOut,
+        properties: { category: 'Settings' },
+        context: metricsOptOutEvent.context,
+      });
+      expect(mockSegment.flush).toHaveBeenCalled();
+    });
+
+    it('does not track Metrics Opt Out on Firefox', () => {
+      jest.clearAllMocks();
+      jest
+        .spyOn(window.navigator, 'userAgent', 'get')
+        .mockReturnValue('Mozilla/5.0 Firefox/126.0');
+      createConfiguredMessenger({
+        optedIn: false,
+        analyticsId: 'metrics-opt-out-id',
+      });
+
+      trackEvent({
+        event: {
+          name: MetaMetricsEventName.MetricsOptOut,
+          properties: {},
+          sensitiveProperties: {},
+        } as AnalyticsTrackingEvent,
+        context: {
+          app: { name: 'MetaMask Extension', version: '1.0.0' },
+        },
+      });
+
+      expect(mockSegment.track).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('identify', () => {
+    let identifyHandler: jest.Mock;
+    let warnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+      identifyHandler = jest.fn();
+      const rootMessenger = createConfiguredMessenger();
+      rootMessenger.registerActionHandler(
+        'AnalyticsController:identify',
+        identifyHandler as never,
+      );
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('delivers user traits to AnalyticsController', () => {
+      const userTraits = { installDateExt: '2024-01-01' };
+
+      identify(userTraits);
+
+      expect(identifyHandler).toHaveBeenCalledWith(userTraits, undefined);
+    });
+
+    it('filters invalid traits before delivery', () => {
+      identify({
+        installDateExt: '2024-01-01',
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        test_null: null,
+      } as never);
+
+      expect(identifyHandler).toHaveBeenCalledWith(
+        { installDateExt: '2024-01-01' },
+        undefined,
+      );
+      expect(warnSpy).toHaveBeenCalledWith(
+        'analytics delivery identify: "test_null" value is not a valid trait type',
+      );
+    });
+
+    it('does not deliver when no valid traits remain', () => {
+      identify({
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        test_null: null,
+      } as never);
+
+      expect(identifyHandler).not.toHaveBeenCalled();
+    });
+
+    it('does not deliver when the user has not opted in', () => {
+      const rootMessenger = createConfiguredMessenger({ optedIn: false });
+      rootMessenger.registerActionHandler(
+        'AnalyticsController:identify',
+        identifyHandler as never,
+      );
+
+      identify({ installDateExt: '2024-01-01' });
+
+      expect(identifyHandler).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('trackView', () => {
+    let trackViewHandler: jest.Mock;
+
+    beforeEach(() => {
+      trackViewHandler = jest.fn();
+      const rootMessenger = createConfiguredMessenger();
+      rootMessenger.registerActionHandler(
+        'AnalyticsController:trackView',
+        trackViewHandler as never,
+      );
+    });
+
+    it('delivers a page view to AnalyticsController', () => {
+      const built = {
+        name: 'Home',
+        properties: { locale: 'en-US' },
+        context: {
+          app: { name: 'MetaMask Extension', version: '1.0.0' },
+        },
+      };
+
+      trackView(built);
+
+      expect(trackViewHandler).toHaveBeenCalledWith(
+        built.name,
+        built.properties,
+        built.context,
+      );
+    });
+
+    it('does not deliver when basic functionality is disabled', () => {
+      const rootMessenger = createConfiguredMessenger({
+        useExternalServices: false,
+      });
+      rootMessenger.registerActionHandler(
+        'AnalyticsController:trackView',
+        trackViewHandler as never,
+      );
+
+      trackView({
+        name: 'Home',
+        properties: {},
+        context: { app: { name: 'MetaMask Extension', version: '1.0.0' } },
+      });
+
+      expect(trackViewHandler).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/app/scripts/controllers/analytics/analytics-delivery.ts
+++ b/app/scripts/controllers/analytics/analytics-delivery.ts
@@ -9,7 +9,10 @@ import { MetaMetricsEventName } from '../../../../shared/constants/metametrics';
 import type { MetaMetricsUserTraits } from '../../../../shared/constants/metametrics';
 import { trackSegmentEventWhileOptedOut } from '../../lib/segment/custom-segment-tracking';
 import { getPlatform } from '../../lib/util';
-import type { BuiltAnalyticsEvent, BuiltPageViewPayload } from './analytics-event-builder';
+import type {
+  BuiltAnalyticsEvent,
+  BuiltPageViewPayload,
+} from './analytics-event-builder';
 import type { AnalyticsEventBuilderMessenger } from './analytics-event-builder-messenger';
 
 export type ConfigureAnalyticsDeliveryOptions = {
@@ -23,7 +26,9 @@ export function canSubmitAnalytics(eventName?: string): boolean {
     throw new Error('Analytics delivery has not been configured');
   }
 
-  const { useExternalServices } = messenger.call('PreferencesController:getState');
+  const { useExternalServices } = messenger.call(
+    'PreferencesController:getState',
+  );
   if (!useExternalServices) {
     return false;
   }
@@ -32,7 +37,9 @@ export function canSubmitAnalytics(eventName?: string): boolean {
     return true;
   }
 
-  const { analyticsId, optedIn } = messenger.call('AnalyticsController:getState');
+  const { analyticsId, optedIn } = messenger.call(
+    'AnalyticsController:getState',
+  );
   return optedIn && analyticsId.length > 0;
 }
 

--- a/app/scripts/controllers/analytics/analytics-delivery.ts
+++ b/app/scripts/controllers/analytics/analytics-delivery.ts
@@ -1,0 +1,215 @@
+import type {
+  AnalyticsContext,
+  AnalyticsUserTraits,
+} from '@metamask/analytics-controller';
+import type { Json } from '@metamask/utils';
+import { captureException } from '../../../../shared/lib/sentry';
+import { PLATFORM_FIREFOX } from '../../../../shared/constants/app';
+import { MetaMetricsEventName } from '../../../../shared/constants/metametrics';
+import type { MetaMetricsUserTraits } from '../../../../shared/constants/metametrics';
+import { trackSegmentEventWhileOptedOut } from '../../lib/segment/custom-segment-tracking';
+import { getPlatform } from '../../lib/util';
+import type { BuiltAnalyticsEvent, BuiltPageViewPayload } from './analytics-event-builder';
+import type { AnalyticsEventBuilderMessenger } from './analytics-event-builder-messenger';
+
+export type ConfigureAnalyticsDeliveryOptions = {
+  messenger: AnalyticsEventBuilderMessenger;
+};
+
+let messenger: AnalyticsEventBuilderMessenger | undefined;
+
+export function canSubmitAnalytics(eventName?: string): boolean {
+  if (!messenger) {
+    throw new Error('Analytics delivery has not been configured');
+  }
+
+  const { useExternalServices } = messenger.call('PreferencesController:getState');
+  if (!useExternalServices) {
+    return false;
+  }
+
+  if (eventName === MetaMetricsEventName.MetricsOptOut) {
+    return true;
+  }
+
+  const { analyticsId, optedIn } = messenger.call('AnalyticsController:getState');
+  return optedIn && analyticsId.length > 0;
+}
+
+/**
+ * Configure shared analytics delivery helpers for the extension background.
+ *
+ * Call once during background initialization alongside
+ * {@link configureAnalyticsEventBuilder}.
+ *
+ * @param options - Configuration options.
+ * @param options.messenger - Messenger with access to analytics delivery actions.
+ */
+export function configureAnalyticsDelivery({
+  messenger: configuredMessenger,
+}: ConfigureAnalyticsDeliveryOptions): void {
+  messenger = configuredMessenger;
+}
+
+function isValidTraitDate(value: unknown): value is Date {
+  return Object.prototype.toString.call(value) === '[object Date]';
+}
+
+function isValidTraitArray(value: unknown): boolean {
+  return (
+    Array.isArray(value) &&
+    (value.every((element) => typeof element === 'string') ||
+      value.every((element) => typeof element === 'boolean') ||
+      value.every((element) => typeof element === 'number'))
+  );
+}
+
+function isValidTrait(value: unknown): boolean {
+  const type = typeof value;
+
+  return (
+    type === 'string' ||
+    type === 'boolean' ||
+    type === 'number' ||
+    isValidTraitArray(value) ||
+    isValidTraitDate(value)
+  );
+}
+
+/**
+ * Validate and normalize user traits before delivery to
+ * {@link AnalyticsController}.
+ *
+ * @param userTraits - Raw traits from MetaMetrics callers.
+ * @returns Normalized traits for AnalyticsController, or undefined when invalid.
+ */
+export function validateIdentifyPayload(
+  userTraits: Partial<MetaMetricsUserTraits>,
+): AnalyticsUserTraits | undefined {
+  if (!userTraits) {
+    return undefined;
+  }
+
+  if (typeof userTraits !== 'object') {
+    console.warn(
+      `analytics delivery identify: userTraits parameter must be an object. Received type: ${typeof userTraits}`,
+    );
+    return undefined;
+  }
+
+  const validTraits: Record<string, string> = {};
+
+  for (const [key, value] of Object.entries(userTraits)) {
+    if (isValidTraitDate(value)) {
+      validTraits[key] = value.toISOString();
+    } else if (isValidTrait(value)) {
+      (validTraits as Record<string, typeof value>)[key] = value;
+    } else {
+      console.warn(
+        `analytics delivery identify: "${key}" value is not a valid trait type`,
+      );
+    }
+  }
+
+  if (Object.keys(validTraits).length === 0) {
+    return undefined;
+  }
+
+  return validTraits as AnalyticsUserTraits;
+}
+
+function trackMetricsOptOutEvent(built: BuiltAnalyticsEvent): void {
+  const { analyticsId } = messenger?.call('AnalyticsController:getState') ?? {
+    analyticsId: '',
+  };
+
+  if (analyticsId.length === 0 || getPlatform() === PLATFORM_FIREFOX) {
+    return;
+  }
+
+  trackSegmentEventWhileOptedOut({
+    analyticsId,
+    event: MetaMetricsEventName.MetricsOptOut,
+    properties: built.event.properties as Record<string, Json> | undefined,
+    context: built.context,
+  });
+}
+
+/**
+ * Deliver a built analytics event to {@link AnalyticsController}.
+ *
+ * @param built - Event and context from {@link AnalyticsEventBuilder.createEventBuilder}.
+ */
+export function trackEvent(built: BuiltAnalyticsEvent): void {
+  try {
+    if (built.event.name === MetaMetricsEventName.MetricsOptOut) {
+      if (!canSubmitAnalytics(built.event.name)) {
+        return;
+      }
+
+      trackMetricsOptOutEvent(built);
+      return;
+    }
+
+    if (!canSubmitAnalytics()) {
+      return;
+    }
+
+    messenger?.call(
+      'AnalyticsController:trackEvent',
+      built.event,
+      built.context,
+    );
+  } catch (error) {
+    captureException(error);
+  }
+}
+
+/**
+ * Identify the user through {@link AnalyticsController}.
+ *
+ * @param userTraits - User traits to associate with the analytics identity.
+ * @param context - Optional analytics context.
+ */
+export function identify(
+  userTraits: Partial<MetaMetricsUserTraits>,
+  context?: AnalyticsContext,
+): void {
+  try {
+    const identifyPayload = validateIdentifyPayload(userTraits);
+
+    if (!identifyPayload) {
+      return;
+    }
+
+    if (!canSubmitAnalytics()) {
+      return;
+    }
+
+    messenger?.call('AnalyticsController:identify', identifyPayload, context);
+  } catch (error) {
+    captureException(error);
+  }
+}
+
+/**
+ * Deliver a built page view to {@link AnalyticsController}.
+ *
+ * @param built - Page view payload from {@link buildPageViewPayload}.
+ */
+export function trackView(built: BuiltPageViewPayload): void {
+  try {
+    if (!canSubmitAnalytics()) {
+      return;
+    }
+
+    messenger?.call(
+      'AnalyticsController:trackView',
+      built.name,
+      built.properties,
+      built.context,
+    );
+  } catch (error) {
+    captureException(error);
+  }
+}

--- a/app/scripts/controllers/analytics/analytics-event-builder-init.test.ts
+++ b/app/scripts/controllers/analytics/analytics-event-builder-init.test.ts
@@ -38,23 +38,29 @@ describe('configureAnalyticsEventBuilder', () => {
       namespace: MOCK_ANY_NAMESPACE,
     });
 
-    messenger.registerActionHandler('PreferencesController:getState', () =>
-      ({
-        currentLocale: 'en_US',
-      }) as never,
+    messenger.registerActionHandler(
+      'PreferencesController:getState',
+      () =>
+        ({
+          currentLocale: 'en_US',
+        }) as never,
     );
 
-    messenger.registerActionHandler('MultichainNetworkController:getState', () =>
-      ({
-        isEvmSelected: true,
-        selectedMultichainNetworkChainId: 'eip155:1',
-      }) as never,
+    messenger.registerActionHandler(
+      'MultichainNetworkController:getState',
+      () =>
+        ({
+          isEvmSelected: true,
+          selectedMultichainNetworkChainId: 'eip155:1',
+        }) as never,
     );
 
-    messenger.registerActionHandler('NetworkController:getState', () =>
-      ({
-        selectedNetworkClientId: 'mainnet',
-      }) as never,
+    messenger.registerActionHandler(
+      'NetworkController:getState',
+      () =>
+        ({
+          selectedNetworkClientId: 'mainnet',
+        }) as never,
     );
 
     messenger.registerActionHandler(
@@ -73,11 +79,13 @@ describe('configureAnalyticsEventBuilder', () => {
         }) as never,
     );
 
-    messenger.registerActionHandler('MetaMetricsController:getState', () =>
-      ({
-        marketingCampaignCookieId: MARKETING_CAMPAIGN_COOKIE_ID,
-        dataCollectionForMarketing: true,
-      }) as never,
+    messenger.registerActionHandler(
+      'MetaMetricsController:getState',
+      () =>
+        ({
+          marketingCampaignCookieId: MARKETING_CAMPAIGN_COOKIE_ID,
+          dataCollectionForMarketing: true,
+        }) as never,
     );
 
     configureAnalyticsEventBuilder({

--- a/app/scripts/controllers/analytics/analytics-event-builder-init.test.ts
+++ b/app/scripts/controllers/analytics/analytics-event-builder-init.test.ts
@@ -1,0 +1,104 @@
+import {
+  ActionConstraint,
+  Messenger,
+  MOCK_ANY_NAMESPACE,
+  MockAnyNamespace,
+} from '@metamask/messenger';
+import type { MultichainNetworkControllerGetStateAction } from '@metamask/multichain-network-controller';
+import type {
+  NetworkControllerGetNetworkClientByIdAction,
+  NetworkControllerGetStateAction,
+} from '@metamask/network-controller';
+import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
+import type { Hex } from '@metamask/utils';
+import type { PreferencesControllerGetStateAction } from '../preferences-controller';
+import type { MetaMetricsControllerGetStateAction } from '../metametrics-controller';
+import { configureAnalyticsEventBuilder } from './analytics-event-builder-init';
+import { AnalyticsEventBuilder } from './analytics-event-builder';
+import { getAnalyticsEventBuilderMessenger } from './analytics-event-builder-messenger';
+
+const CHAIN_ID = '0x1' as Hex;
+const LOCALE = 'en-US';
+const APP_VERSION = '1.2.3-test';
+const MARKETING_CAMPAIGN_COOKIE_ID = 'cookie-id';
+
+describe('configureAnalyticsEventBuilder', () => {
+  it('configures the builder from controller messenger state', () => {
+    const messenger = new Messenger<
+      MockAnyNamespace,
+      | PreferencesControllerGetStateAction
+      | MultichainNetworkControllerGetStateAction
+      | NetworkControllerGetStateAction
+      | NetworkControllerGetNetworkClientByIdAction
+      | RemoteFeatureFlagControllerGetStateAction
+      | MetaMetricsControllerGetStateAction
+      | ActionConstraint,
+      never
+    >({
+      namespace: MOCK_ANY_NAMESPACE,
+    });
+
+    messenger.registerActionHandler('PreferencesController:getState', () =>
+      ({
+        currentLocale: 'en_US',
+      }) as never,
+    );
+
+    messenger.registerActionHandler('MultichainNetworkController:getState', () =>
+      ({
+        isEvmSelected: true,
+        selectedMultichainNetworkChainId: 'eip155:1',
+      }) as never,
+    );
+
+    messenger.registerActionHandler('NetworkController:getState', () =>
+      ({
+        selectedNetworkClientId: 'mainnet',
+      }) as never,
+    );
+
+    messenger.registerActionHandler(
+      'NetworkController:getNetworkClientById',
+      () =>
+        ({
+          configuration: { chainId: CHAIN_ID },
+        }) as never,
+    );
+
+    messenger.registerActionHandler(
+      'RemoteFeatureFlagController:getState',
+      () =>
+        ({
+          remoteFeatureFlags: {},
+        }) as never,
+    );
+
+    messenger.registerActionHandler('MetaMetricsController:getState', () =>
+      ({
+        marketingCampaignCookieId: MARKETING_CAMPAIGN_COOKIE_ID,
+        dataCollectionForMarketing: true,
+      }) as never,
+    );
+
+    configureAnalyticsEventBuilder({
+      messenger: getAnalyticsEventBuilderMessenger(messenger),
+      version: '1.2.3',
+      environment: 'test',
+    });
+
+    const { event, context } =
+      AnalyticsEventBuilder.createEventBuilder('Wallet Opened').build();
+
+    expect(event.properties).toMatchObject({
+      locale: LOCALE,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      chain_id: CHAIN_ID,
+    });
+    expect(context).toMatchObject({
+      app: {
+        version: APP_VERSION,
+      },
+      marketingCampaignCookieId: MARKETING_CAMPAIGN_COOKIE_ID,
+    });
+  });
+});

--- a/app/scripts/controllers/analytics/analytics-event-builder-init.ts
+++ b/app/scripts/controllers/analytics/analytics-event-builder-init.ts
@@ -65,10 +65,8 @@ export function configureAnalyticsEventBuilder({
         chainId: getCurrentChainId(messenger),
         locale,
         appVersion,
-        marketingCampaignCookieId:
-          metaMetricsState.marketingCampaignCookieId,
-        dataCollectionForMarketing:
-          metaMetricsState.dataCollectionForMarketing,
+        marketingCampaignCookieId: metaMetricsState.marketingCampaignCookieId,
+        dataCollectionForMarketing: metaMetricsState.dataCollectionForMarketing,
         isEvmSelected,
         selectedMultichainNetworkChainId,
       };

--- a/app/scripts/controllers/analytics/analytics-event-builder-init.ts
+++ b/app/scripts/controllers/analytics/analytics-event-builder-init.ts
@@ -1,0 +1,82 @@
+import type { Hex } from '@metamask/utils';
+import type { NetworkClientId } from '@metamask/network-controller';
+import { getRemoteFeatureFlagsWithManifestOverrides } from '../../../../shared/lib/ab-testing/ab-test-analytics';
+import { AnalyticsEventBuilder } from './analytics-event-builder';
+import type { AnalyticsEventBuilderMessenger } from './analytics-event-builder-messenger';
+
+export type ConfigureAnalyticsEventBuilderOptions = {
+  messenger: AnalyticsEventBuilderMessenger;
+  version: string;
+  environment: string;
+};
+
+function formatAppVersion(version: string, environment: string): string {
+  return environment === 'production' ? version : `${version}-${environment}`;
+}
+
+function getCurrentChainId(
+  messenger: AnalyticsEventBuilderMessenger,
+  networkClientId?: NetworkClientId,
+): Hex {
+  const selectedNetworkClientId =
+    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    networkClientId ||
+    messenger.call('NetworkController:getState').selectedNetworkClientId;
+
+  const {
+    configuration: { chainId },
+  } = messenger.call(
+    'NetworkController:getNetworkClientById',
+    selectedNetworkClientId,
+  );
+
+  return chainId;
+}
+
+/**
+ * Configure the shared {@link AnalyticsEventBuilder} singleton for the extension.
+ *
+ * Call once during background initialization so all direct
+ * `AnalyticsController` callers receive the same event normalization.
+ *
+ * @param options - Configuration options.
+ * @param options.messenger - Messenger with access to required controller state.
+ * @param options.version - Extension version from build metadata.
+ * @param options.environment - Extension environment from build metadata.
+ */
+export function configureAnalyticsEventBuilder({
+  messenger,
+  version,
+  environment,
+}: ConfigureAnalyticsEventBuilderOptions): void {
+  const appVersion = formatAppVersion(version, environment);
+
+  AnalyticsEventBuilder.configure({
+    getExtensionContext: () => {
+      const preferencesState = messenger.call('PreferencesController:getState');
+      const locale = preferencesState.currentLocale.replace('_', '-');
+      const metaMetricsState = messenger.call('MetaMetricsController:getState');
+
+      const { isEvmSelected, selectedMultichainNetworkChainId } =
+        messenger.call('MultichainNetworkController:getState');
+
+      return {
+        chainId: getCurrentChainId(messenger),
+        locale,
+        appVersion,
+        marketingCampaignCookieId:
+          metaMetricsState.marketingCampaignCookieId,
+        dataCollectionForMarketing:
+          metaMetricsState.dataCollectionForMarketing,
+        isEvmSelected,
+        selectedMultichainNetworkChainId,
+      };
+    },
+    getRemoteFeatureFlags: () =>
+      getRemoteFeatureFlagsWithManifestOverrides(
+        messenger.call('RemoteFeatureFlagController:getState')
+          ?.remoteFeatureFlags as Record<string, unknown> | undefined,
+      ),
+  });
+}

--- a/app/scripts/controllers/analytics/analytics-event-builder-messenger.ts
+++ b/app/scripts/controllers/analytics/analytics-event-builder-messenger.ts
@@ -1,0 +1,73 @@
+import { Messenger } from '@metamask/messenger';
+import type {
+  AnalyticsControllerGetStateAction,
+  AnalyticsControllerIdentifyAction,
+  AnalyticsControllerTrackEventAction,
+  AnalyticsControllerTrackViewAction,
+} from '@metamask/analytics-controller';
+import type { MultichainNetworkControllerGetStateAction } from '@metamask/multichain-network-controller';
+import type {
+  NetworkControllerGetNetworkClientByIdAction,
+  NetworkControllerGetStateAction,
+} from '@metamask/network-controller';
+import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
+import type { PreferencesControllerGetStateAction } from '../preferences-controller';
+import type { MetaMetricsControllerGetStateAction } from '../metametrics-controller';
+import type { RootMessenger } from '../../lib/messenger';
+
+type AllowedActions =
+  | PreferencesControllerGetStateAction
+  | MultichainNetworkControllerGetStateAction
+  | NetworkControllerGetStateAction
+  | NetworkControllerGetNetworkClientByIdAction
+  | RemoteFeatureFlagControllerGetStateAction
+  | MetaMetricsControllerGetStateAction
+  | AnalyticsControllerGetStateAction
+  | AnalyticsControllerTrackEventAction
+  | AnalyticsControllerIdentifyAction
+  | AnalyticsControllerTrackViewAction;
+
+/**
+ * Messenger type for {@link AnalyticsEventBuilder} configuration.
+ *
+ * Restricted to controller state reads required to normalize analytics events.
+ */
+export type AnalyticsEventBuilderMessenger = Messenger<
+  'AnalyticsEventBuilder',
+  AllowedActions,
+  never
+>;
+
+/**
+ * Create a messenger restricted to actions the analytics event builder needs.
+ *
+ * @param messenger - The root messenger used to create the restricted messenger.
+ */
+export function getAnalyticsEventBuilderMessenger(
+  messenger: RootMessenger,
+): AnalyticsEventBuilderMessenger {
+  const analyticsEventBuilderMessenger: AnalyticsEventBuilderMessenger =
+    new Messenger({
+      namespace: 'AnalyticsEventBuilder',
+      parent: messenger,
+    });
+
+  messenger.delegate({
+    messenger: analyticsEventBuilderMessenger,
+    actions: [
+      'PreferencesController:getState',
+      'MultichainNetworkController:getState',
+      'NetworkController:getState',
+      'NetworkController:getNetworkClientById',
+      'RemoteFeatureFlagController:getState',
+      'MetaMetricsController:getState',
+      'AnalyticsController:getState',
+      'AnalyticsController:trackEvent',
+      'AnalyticsController:identify',
+      'AnalyticsController:trackView',
+    ],
+    events: [],
+  });
+
+  return analyticsEventBuilderMessenger;
+}

--- a/app/scripts/controllers/analytics/analytics-event-builder-messenger.ts
+++ b/app/scripts/controllers/analytics/analytics-event-builder-messenger.ts
@@ -28,9 +28,11 @@ type AllowedActions =
   | AnalyticsControllerTrackViewAction;
 
 /**
- * Messenger type for {@link AnalyticsEventBuilder} configuration.
+ * Messenger type shared by {@link AnalyticsEventBuilder} configuration and
+ * {@link configureAnalyticsDelivery}.
  *
- * Restricted to controller state reads required to normalize analytics events.
+ * Restricted to controller state reads required to normalize analytics events
+ * and to {@link AnalyticsController} delivery actions (track, identify, view).
  */
 export type AnalyticsEventBuilderMessenger = Messenger<
   'AnalyticsEventBuilder',
@@ -39,7 +41,8 @@ export type AnalyticsEventBuilderMessenger = Messenger<
 >;
 
 /**
- * Create a messenger restricted to actions the analytics event builder needs.
+ * Create a messenger restricted to actions used by the analytics event builder
+ * and delivery helpers.
  *
  * @param messenger - The root messenger used to create the restricted messenger.
  */

--- a/app/scripts/controllers/analytics/analytics-event-builder.test.ts
+++ b/app/scripts/controllers/analytics/analytics-event-builder.test.ts
@@ -227,8 +227,9 @@ describe('AnalyticsEventBuilder', () => {
   });
 
   it('auto-anonymizes send and confirm events by default', () => {
-    const { event } =
-      AnalyticsEventBuilder.createEventBuilder('send button clicked').build();
+    const { event } = AnalyticsEventBuilder.createEventBuilder(
+      'send button clicked',
+    ).build();
 
     expect(event.properties[ANONYMOUS_EVENT_PROPERTY]).toBe(true);
   });
@@ -358,4 +359,3 @@ describe('buildPageViewPayload', () => {
     });
   });
 });
-

--- a/app/scripts/controllers/analytics/analytics-event-builder.test.ts
+++ b/app/scripts/controllers/analytics/analytics-event-builder.test.ts
@@ -1,0 +1,361 @@
+import type { Hex } from '@metamask/utils';
+import {
+  ENVIRONMENT_TYPE_BACKGROUND,
+  ENVIRONMENT_TYPE_NOTIFICATION,
+} from '../../../../shared/constants/app';
+import { METAMETRICS_BACKGROUND_PAGE_OBJECT } from '../../../../shared/constants/metametrics';
+import {
+  AB_TEST_ANALYTICS_MAPPINGS,
+  clearABTestAnalyticsMappings,
+} from '../../../../shared/lib/ab-testing/ab-test-analytics';
+import { createActiveABTestAssignment } from '../../../../shared/lib/ab-testing/active-ab-test-assignment';
+import { ANONYMOUS_EVENT_PROPERTY } from './platform-adapter';
+import {
+  AnalyticsEventBuilder,
+  buildPageViewPayload,
+} from './analytics-event-builder';
+
+const CHAIN_ID = '0x1' as Hex;
+const LOCALE = 'en-US';
+const APP_VERSION = '1.2.3-test';
+const MARKETING_CAMPAIGN_COOKIE_ID = 'cookie-id';
+const TEST_FLAG_KEY = 'testAnalyticsBuilderFlag';
+
+describe('AnalyticsEventBuilder', () => {
+  let remoteFeatureFlags: Record<string, unknown>;
+
+  beforeEach(() => {
+    remoteFeatureFlags = {};
+    AnalyticsEventBuilder.configure({
+      getExtensionContext: () => ({
+        chainId: CHAIN_ID,
+        locale: LOCALE,
+        appVersion: APP_VERSION,
+        marketingCampaignCookieId: MARKETING_CAMPAIGN_COOKIE_ID,
+        dataCollectionForMarketing: true,
+        isEvmSelected: true,
+        selectedMultichainNetworkChainId: null,
+      }),
+      getRemoteFeatureFlags: () => remoteFeatureFlags,
+    });
+  });
+
+  afterEach(() => {
+    clearABTestAnalyticsMappings();
+  });
+
+  it('creates an event from a string event name', () => {
+    const { event, context } =
+      AnalyticsEventBuilder.createEventBuilder('Wallet Opened').build();
+
+    expect(event).toMatchObject({
+      name: 'Wallet Opened',
+      properties: {
+        locale: LOCALE,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        chain_id: CHAIN_ID,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        environment_type: ENVIRONMENT_TYPE_BACKGROUND,
+      },
+      sensitiveProperties: {},
+      saveDataRecording: false,
+    });
+    expect(event.hasProperties).toBe(true);
+    expect(context).toMatchObject({
+      app: {
+        name: 'MetaMask Extension',
+        version: APP_VERSION,
+      },
+      page: METAMETRICS_BACKGROUND_PAGE_OBJECT,
+      marketingCampaignCookieId: MARKETING_CAMPAIGN_COOKIE_ID,
+    });
+  });
+
+  it('adds, merges, overwrites, and removes properties', () => {
+    const { event } = AnalyticsEventBuilder.createEventBuilder('Test Event')
+      .addProperties({ foo: 'bar', removeMe: 'value' })
+      .addProperties({ foo: 'baz', answer: 42 })
+      .removeProperties(['removeMe'])
+      .build();
+
+    expect(event.properties).toMatchObject({
+      foo: 'baz',
+      answer: 42,
+    });
+    expect(event.properties).not.toHaveProperty('removeMe');
+  });
+
+  it('adds, merges, overwrites, and removes sensitive properties', () => {
+    const { event } = AnalyticsEventBuilder.createEventBuilder('Test Event')
+      .addSensitiveProperties({ secret: 'one', removeMe: 'value' })
+      .addSensitiveProperties({ secret: 'two', another: true })
+      .removeSensitiveProperties(['removeMe'])
+      .build();
+
+    expect(event.sensitiveProperties).toStrictEqual({
+      secret: 'two',
+      another: true,
+    });
+    expect(event.hasProperties).toBe(true);
+  });
+
+  it('omits undefined property values', () => {
+    const { event } = AnalyticsEventBuilder.createEventBuilder('Test Event')
+      .addProperties({ foo: undefined, bar: 'baz' })
+      .build();
+
+    expect(event.properties).toMatchObject({ bar: 'baz' });
+    expect(event.properties).not.toHaveProperty('foo');
+  });
+
+  it('overrides caller locale with extension locale', () => {
+    const { event } = AnalyticsEventBuilder.createEventBuilder('Test Event')
+      .addProperties({
+        revenue: 1,
+        value: 2,
+        currency: 'USD',
+        locale: 'caller-locale',
+      })
+      .build();
+
+    expect(event.properties).toMatchObject({
+      revenue: 1,
+      value: 2,
+      currency: 'USD',
+      locale: LOCALE,
+    });
+  });
+
+  it('preserves explicit chain_id', () => {
+    const { event } = AnalyticsEventBuilder.createEventBuilder('Test Event')
+      .addProperties({
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        chain_id: '0x5',
+      })
+      .build();
+
+    expect(event.properties.chain_id).toBe('0x5');
+  });
+
+  it('sets chain_id to null when chain_id_caip is present', () => {
+    const { event } = AnalyticsEventBuilder.createEventBuilder('Test Event')
+      .addProperties({
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        chain_id_caip: 'solana:mainnet',
+      })
+      .build();
+
+    expect(event.properties.chain_id).toBeNull();
+    expect(event.properties.chain_id_caip).toBe('solana:mainnet');
+  });
+
+  it('defaults to EVM chain_id on a non-EVM network when chain fields are omitted', () => {
+    AnalyticsEventBuilder.configure({
+      getExtensionContext: () => ({
+        chainId: CHAIN_ID,
+        locale: LOCALE,
+        appVersion: APP_VERSION,
+        marketingCampaignCookieId: MARKETING_CAMPAIGN_COOKIE_ID,
+        dataCollectionForMarketing: true,
+        isEvmSelected: false,
+        selectedMultichainNetworkChainId:
+          'bip122:000000000019d6689c085ae165831e93',
+      }),
+      getRemoteFeatureFlags: () => remoteFeatureFlags,
+    });
+
+    const { event } =
+      AnalyticsEventBuilder.createEventBuilder('Test Event').build();
+
+    expect(event.properties.chain_id).toBe(CHAIN_ID);
+    expect(event.properties).not.toHaveProperty('chain_id_caip');
+  });
+
+  it('falls back to extension chain_id when chain_id is not a string', () => {
+    const { event } = AnalyticsEventBuilder.createEventBuilder('Test Event')
+      .addProperties({
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        chain_id: 1,
+      })
+      .build();
+
+    expect(event.properties.chain_id).toBe(CHAIN_ID);
+  });
+
+  it('uses per-event context options when building context', () => {
+    const page = { path: '/confirm', title: 'Confirm' };
+    const referrer = { url: 'https://dapp.example' };
+
+    const { event, context } = AnalyticsEventBuilder.createEventBuilder(
+      'Test Event',
+    ).build({
+      page,
+      referrer,
+      environmentType: ENVIRONMENT_TYPE_NOTIFICATION,
+    });
+
+    expect(event.properties.environment_type).toBe(
+      ENVIRONMENT_TYPE_NOTIFICATION,
+    );
+    expect(context).toMatchObject({ page, referrer });
+  });
+
+  it('injects active AB test assignments for mapped events', () => {
+    AB_TEST_ANALYTICS_MAPPINGS.push({
+      flagKey: TEST_FLAG_KEY,
+      validVariants: ['control', 'treatment'],
+      eventNames: ['Mapped Event'],
+    });
+    remoteFeatureFlags = {
+      [TEST_FLAG_KEY]: 'treatment',
+    };
+
+    const { event } =
+      AnalyticsEventBuilder.createEventBuilder('Mapped Event').build();
+
+    expect(event.properties.active_ab_tests).toStrictEqual([
+      createActiveABTestAssignment(TEST_FLAG_KEY, 'treatment'),
+    ]);
+  });
+
+  it('marks events fully anonymous when excludeMetaMetricsId is true', () => {
+    const { event } = AnalyticsEventBuilder.createEventBuilder('Test Event')
+      .addProperties({ foo: 'bar' })
+      .build({ excludeMetaMetricsId: true });
+
+    expect(event.properties[ANONYMOUS_EVENT_PROPERTY]).toBe(true);
+  });
+
+  it('auto-anonymizes send and confirm events by default', () => {
+    const { event } =
+      AnalyticsEventBuilder.createEventBuilder('send button clicked').build();
+
+    expect(event.properties[ANONYMOUS_EVENT_PROPERTY]).toBe(true);
+  });
+
+  it('does not auto-anonymize send and confirm events when explicitly disabled', () => {
+    const { event } = AnalyticsEventBuilder.createEventBuilder(
+      'confirm button clicked',
+    ).build({ excludeMetaMetricsId: false });
+
+    expect(event.properties[ANONYMOUS_EVENT_PROPERTY]).toBeUndefined();
+  });
+
+  it('throws when event name is not provided', () => {
+    expect(() => AnalyticsEventBuilder.createEventBuilder('')).toThrow(
+      /Must specify event\./u,
+    );
+  });
+
+  it('throws when full anonymization is combined with sensitive properties', () => {
+    expect(() =>
+      AnalyticsEventBuilder.createEventBuilder('Test Event')
+        .addSensitiveProperties({ secret: 'value' })
+        .build({ excludeMetaMetricsId: true }),
+    ).toThrow(
+      'sensitiveProperties was specified in an event payload that also set the excludeMetaMetricsId flag',
+    );
+  });
+});
+
+describe('buildPageViewPayload', () => {
+  beforeEach(() => {
+    AnalyticsEventBuilder.configure({
+      getExtensionContext: () => ({
+        chainId: CHAIN_ID,
+        locale: LOCALE,
+        appVersion: APP_VERSION,
+        marketingCampaignCookieId: MARKETING_CAMPAIGN_COOKIE_ID,
+        dataCollectionForMarketing: true,
+        isEvmSelected: true,
+        selectedMultichainNetworkChainId: null,
+      }),
+      getRemoteFeatureFlags: () => ({}),
+    });
+  });
+
+  it('builds a page view with common properties and context', () => {
+    const pagePayload = buildPageViewPayload({
+      name: 'home',
+      environmentType: ENVIRONMENT_TYPE_BACKGROUND,
+      page: METAMETRICS_BACKGROUND_PAGE_OBJECT,
+    });
+
+    expect(pagePayload).toMatchObject({
+      name: 'home',
+      properties: {
+        locale: LOCALE,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        chain_id: CHAIN_ID,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        environment_type: ENVIRONMENT_TYPE_BACKGROUND,
+      },
+      context: {
+        app: {
+          name: 'MetaMask Extension',
+          version: APP_VERSION,
+        },
+        page: METAMETRICS_BACKGROUND_PAGE_OBJECT,
+        marketingCampaignCookieId: MARKETING_CAMPAIGN_COOKIE_ID,
+      },
+    });
+    expect(pagePayload.properties).not.toHaveProperty('chain_id_caip');
+  });
+
+  it('omits chain_id_caip on EVM networks even when a CAIP chain id is available', () => {
+    AnalyticsEventBuilder.configure({
+      getExtensionContext: () => ({
+        chainId: CHAIN_ID,
+        locale: LOCALE,
+        appVersion: APP_VERSION,
+        marketingCampaignCookieId: MARKETING_CAMPAIGN_COOKIE_ID,
+        dataCollectionForMarketing: true,
+        isEvmSelected: true,
+        selectedMultichainNetworkChainId: 'eip155:1',
+      }),
+      getRemoteFeatureFlags: () => ({}),
+    });
+
+    const pagePayload = buildPageViewPayload({
+      name: 'home',
+      environmentType: ENVIRONMENT_TYPE_BACKGROUND,
+      page: METAMETRICS_BACKGROUND_PAGE_OBJECT,
+    });
+
+    expect(pagePayload.properties.chain_id).toBe(CHAIN_ID);
+    expect(pagePayload.properties).not.toHaveProperty('chain_id_caip');
+  });
+
+  it('sends chain_id_caip and null chain_id when a non-EVM network is selected', () => {
+    AnalyticsEventBuilder.configure({
+      getExtensionContext: () => ({
+        chainId: CHAIN_ID,
+        locale: LOCALE,
+        appVersion: APP_VERSION,
+        marketingCampaignCookieId: MARKETING_CAMPAIGN_COOKIE_ID,
+        dataCollectionForMarketing: true,
+        isEvmSelected: false,
+        selectedMultichainNetworkChainId:
+          'bip122:000000000019d6689c085ae165831e93',
+      }),
+      getRemoteFeatureFlags: () => ({}),
+    });
+
+    const pagePayload = buildPageViewPayload({
+      name: 'New Confirmation Page',
+      environmentType: ENVIRONMENT_TYPE_BACKGROUND,
+      page: METAMETRICS_BACKGROUND_PAGE_OBJECT,
+    });
+
+    expect(pagePayload.properties).toMatchObject({
+      locale: LOCALE,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      chain_id: null,
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      chain_id_caip: 'bip122:000000000019d6689c085ae165831e93',
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      environment_type: ENVIRONMENT_TYPE_BACKGROUND,
+    });
+  });
+});
+

--- a/app/scripts/controllers/analytics/analytics-event-builder.ts
+++ b/app/scripts/controllers/analytics/analytics-event-builder.ts
@@ -106,6 +106,15 @@ function removePropertiesFromMap(
   });
 }
 
+function filterUndefinedProperties(
+  properties: AnalyticsUnfilteredProperties,
+): AnalyticsEventProperties {
+  return omitBy(
+    properties ?? {},
+    (propertyValue) => propertyValue === undefined,
+  ) as AnalyticsEventProperties;
+}
+
 function enrichPropertiesWithABTests(
   eventName: string,
   properties: AnalyticsEventProperties,
@@ -126,10 +135,10 @@ function enrichPropertiesWithABTests(
   }
 
   try {
-    return enrichWithABTests(
-      normalizedEvent,
-      config.getRemoteFeatureFlags(),
-    ).properties ?? {};
+    return (
+      enrichWithABTests(normalizedEvent, config.getRemoteFeatureFlags())
+        .properties ?? {}
+    );
   } catch {
     return normalizedEvent.properties ?? {};
   }
@@ -223,8 +232,7 @@ function normalizeProperties(
       locale,
       // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
       // eslint-disable-next-line @typescript-eslint/naming-convention
-      environment_type:
-        options?.environmentType ?? ENVIRONMENT_TYPE_BACKGROUND,
+      environment_type: options?.environmentType ?? ENVIRONMENT_TYPE_BACKGROUND,
     },
     (propertyValue) => propertyValue === undefined,
   ) as AnalyticsEventProperties;
@@ -287,8 +295,7 @@ export function buildAnalyticsContext(
       name: 'MetaMask Extension',
       version: appVersion,
     },
-    userAgent:
-      typeof window === 'undefined' ? '' : window.navigator.userAgent,
+    userAgent: typeof window === 'undefined' ? '' : window.navigator.userAgent,
     page: options?.page ?? METAMETRICS_BACKGROUND_PAGE_OBJECT,
     ...(options?.referrer ? { referrer: options.referrer } : {}),
     marketingCampaignCookieId,
@@ -369,10 +376,7 @@ function createBuilderFromEvent(
     addProperties: (properties: AnalyticsUnfilteredProperties) => {
       event.properties = {
         ...event.properties,
-        ...omitBy(
-          properties ?? {},
-          (propertyValue) => propertyValue === undefined,
-        ),
+        ...filterUndefinedProperties(properties),
       };
       return createBuilderFromEvent(event);
     },
@@ -380,10 +384,7 @@ function createBuilderFromEvent(
     addSensitiveProperties: (properties: AnalyticsUnfilteredProperties) => {
       event.sensitiveProperties = {
         ...event.sensitiveProperties,
-        ...omitBy(
-          properties ?? {},
-          (propertyValue) => propertyValue === undefined,
-        ),
+        ...filterUndefinedProperties(properties),
       };
       return createBuilderFromEvent(event);
     },
@@ -398,14 +399,11 @@ function createBuilderFromEvent(
       return createBuilderFromEvent(event);
     },
 
-    build: (options?: AnalyticsEventBuildOptions) =>
-      buildEvent(event, options),
+    build: (options?: AnalyticsEventBuildOptions) => buildEvent(event, options),
   };
 }
 
-function createEventBuilder(
-  eventName: string,
-): AnalyticsEventBuilderInterface {
+function createEventBuilder(eventName: string): AnalyticsEventBuilderInterface {
   if (!eventName) {
     throw new Error(`Must specify event. Event was: ${eventName}`);
   }
@@ -425,4 +423,3 @@ export const AnalyticsEventBuilder = {
   configure,
   createEventBuilder,
 };
-

--- a/app/scripts/controllers/analytics/analytics-event-builder.ts
+++ b/app/scripts/controllers/analytics/analytics-event-builder.ts
@@ -1,0 +1,428 @@
+import type {
+  AnalyticsContext,
+  AnalyticsEventProperties,
+  AnalyticsTrackingEvent,
+} from '@metamask/analytics-controller';
+import type { Hex, Json } from '@metamask/utils';
+import { omit, omitBy } from 'lodash';
+import {
+  ENVIRONMENT_TYPE_BACKGROUND,
+  type EnvironmentType,
+} from '../../../../shared/constants/app';
+import {
+  METAMETRICS_BACKGROUND_PAGE_OBJECT,
+  type MetaMetricsEventPayload,
+  type MetaMetricsPageObject,
+  type MetaMetricsPagePayload,
+  type MetaMetricsReferrerObject,
+} from '../../../../shared/constants/metametrics';
+import { UTM_PARAMETERS } from '../../../../shared/types/metametrics';
+import {
+  enrichWithABTests,
+  hasABTestAnalyticsMappingForEvent,
+} from '../../../../shared/lib/ab-testing/ab-test-analytics';
+import { ANONYMOUS_EVENT_PROPERTY } from './platform-adapter';
+
+type AnalyticsUnfilteredProperties =
+  | Record<string, Json | undefined>
+  | null
+  | undefined;
+
+type AnalyticsEventBuilderContext = {
+  chainId: Hex;
+  locale: string;
+  appVersion: string;
+  marketingCampaignCookieId: string | null;
+  dataCollectionForMarketing: boolean | null;
+  isEvmSelected: boolean;
+  selectedMultichainNetworkChainId: string | null;
+};
+
+const MARKETING_UTM_PARAMETERS = [...UTM_PARAMETERS];
+
+type AnalyticsEventBuilderConfig = {
+  getExtensionContext: () => AnalyticsEventBuilderContext;
+  getRemoteFeatureFlags: () => Record<string, unknown>;
+};
+
+export type AnalyticsEventBuildOptions = {
+  excludeMetaMetricsId?: boolean;
+  referrer?: MetaMetricsReferrerObject;
+  page?: MetaMetricsPageObject;
+  environmentType?: EnvironmentType | string;
+};
+
+export type BuiltPageViewPayload = {
+  name: string;
+  properties: AnalyticsEventProperties;
+  context: AnalyticsContext;
+};
+
+export type AnalyticsContextBuildOptions = {
+  page?: MetaMetricsPageObject;
+  referrer?: MetaMetricsReferrerObject;
+};
+
+export type BuiltAnalyticsEvent = {
+  event: AnalyticsTrackingEvent;
+  context: AnalyticsContext;
+};
+
+type AnalyticsEventBuilderInterface = {
+  addProperties: (
+    properties: AnalyticsUnfilteredProperties,
+  ) => AnalyticsEventBuilderInterface;
+  addSensitiveProperties: (
+    properties: AnalyticsUnfilteredProperties,
+  ) => AnalyticsEventBuilderInterface;
+  removeProperties: (propNames: string[]) => AnalyticsEventBuilderInterface;
+  removeSensitiveProperties: (
+    propNames: string[],
+  ) => AnalyticsEventBuilderInterface;
+  build: (options?: AnalyticsEventBuildOptions) => BuiltAnalyticsEvent;
+};
+
+type EventState = {
+  name: string;
+  properties: AnalyticsEventProperties;
+  sensitiveProperties: AnalyticsEventProperties;
+};
+
+const defaultConfig: AnalyticsEventBuilderConfig = {
+  getExtensionContext: () => {
+    throw new Error('AnalyticsEventBuilder has not been configured');
+  },
+  getRemoteFeatureFlags: () => ({}),
+};
+
+let config: AnalyticsEventBuilderConfig = defaultConfig;
+
+function removePropertiesFromMap(
+  map: AnalyticsEventProperties,
+  keys: string[],
+): void {
+  keys.forEach((key) => {
+    delete map[key];
+  });
+}
+
+function enrichPropertiesWithABTests(
+  eventName: string,
+  properties: AnalyticsEventProperties,
+): AnalyticsEventProperties {
+  const event = { event: eventName, properties } as MetaMetricsEventPayload;
+  let normalizedEvent = event;
+
+  if (properties.active_ab_tests !== undefined) {
+    try {
+      normalizedEvent = enrichWithABTests(event, null, []);
+    } catch {
+      normalizedEvent = event;
+    }
+  }
+
+  if (!hasABTestAnalyticsMappingForEvent(eventName)) {
+    return normalizedEvent.properties ?? {};
+  }
+
+  try {
+    return enrichWithABTests(
+      normalizedEvent,
+      config.getRemoteFeatureFlags(),
+    ).properties ?? {};
+  } catch {
+    return normalizedEvent.properties ?? {};
+  }
+}
+
+/**
+ * Derive chain fields from multichain network selection for page views.
+ * Matches legacy `MetaMetricsController#buildTrackPagePayload`.
+ */
+function buildPageChainIdProperties(): Partial<AnalyticsEventProperties> {
+  const { chainId, isEvmSelected, selectedMultichainNetworkChainId } =
+    config.getExtensionContext();
+
+  if (isEvmSelected) {
+    return {
+      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      chain_id: chainId,
+    };
+  }
+
+  return {
+    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    chain_id: null,
+    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    chain_id_caip: selectedMultichainNetworkChainId ?? undefined,
+  };
+}
+
+/**
+ * Derive chain fields for track events from caller properties.
+ * Matches legacy `MetaMetricsController#buildTrackEventPayload`.
+ *
+ * @param properties - Event properties that may include caller chain fields.
+ */
+function buildEventChainIdProperties(
+  properties: AnalyticsEventProperties,
+): Partial<AnalyticsEventProperties> {
+  const { chainId } = config.getExtensionContext();
+
+  if (typeof properties.chain_id_caip === 'string') {
+    return {
+      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      chain_id: null,
+      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      chain_id_caip: properties.chain_id_caip,
+    };
+  }
+
+  if (typeof properties.chain_id === 'string') {
+    return {
+      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      chain_id: properties.chain_id as Hex,
+    };
+  }
+
+  return {
+    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    chain_id: chainId,
+  };
+}
+
+function normalizeProperties(
+  eventName: string,
+  properties: AnalyticsEventProperties,
+  options?: AnalyticsEventBuildOptions,
+): AnalyticsEventProperties {
+  const { locale } = config.getExtensionContext();
+  const enrichedProperties = enrichPropertiesWithABTests(eventName, properties);
+  const {
+    locale: _callerLocale,
+    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    chain_id: _chainId,
+    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    chain_id_caip: _chainIdCaip,
+    ...remainingProperties
+  } = enrichedProperties;
+
+  return omitBy(
+    {
+      ...remainingProperties,
+      ...buildEventChainIdProperties(enrichedProperties),
+      locale,
+      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      environment_type:
+        options?.environmentType ?? ENVIRONMENT_TYPE_BACKGROUND,
+    },
+    (propertyValue) => propertyValue === undefined,
+  ) as AnalyticsEventProperties;
+}
+
+function removeUtmPropertiesWithoutMarketingConsent<
+  TProperties extends AnalyticsEventProperties,
+>(properties: TProperties): TProperties {
+  const { dataCollectionForMarketing } = config.getExtensionContext();
+
+  if (dataCollectionForMarketing) {
+    return properties;
+  }
+
+  return omit(properties, MARKETING_UTM_PARAMETERS) as TProperties;
+}
+
+function applyAnonymousOptions(
+  event: EventState,
+  properties: AnalyticsEventProperties,
+  options?: AnalyticsEventBuildOptions,
+): AnalyticsEventProperties {
+  const hasSensitiveProperties =
+    Object.keys(event.sensitiveProperties).length > 0;
+
+  if (hasSensitiveProperties && options?.excludeMetaMetricsId === true) {
+    throw new Error(
+      'sensitiveProperties was specified in an event payload that also set the excludeMetaMetricsId flag',
+    );
+  }
+
+  let excludeMetaMetricsId = options?.excludeMetaMetricsId ?? false;
+  // This is carried over from the old implementation, and will likely need
+  // to be updated to work with the new tracking plan. I think we should use
+  // a config setting for this instead of trying to match the event name
+  const isSendFlow = Boolean(event.name.match(/^send|^confirm/iu));
+  // do not filter if excludeMetaMetricsId is explicitly set to false
+  if (options?.excludeMetaMetricsId !== false && isSendFlow) {
+    excludeMetaMetricsId = true;
+  }
+
+  if (!excludeMetaMetricsId) {
+    return properties;
+  }
+
+  return {
+    ...properties,
+    [ANONYMOUS_EVENT_PROPERTY]: true,
+  };
+}
+
+export function buildAnalyticsContext(
+  options?: AnalyticsContextBuildOptions,
+): AnalyticsContext {
+  const { appVersion, marketingCampaignCookieId } =
+    config.getExtensionContext();
+
+  return {
+    app: {
+      name: 'MetaMask Extension',
+      version: appVersion,
+    },
+    userAgent:
+      typeof window === 'undefined' ? '' : window.navigator.userAgent,
+    page: options?.page ?? METAMETRICS_BACKGROUND_PAGE_OBJECT,
+    ...(options?.referrer ? { referrer: options.referrer } : {}),
+    marketingCampaignCookieId,
+  };
+}
+
+/**
+ * Build a page view payload for {@link AnalyticsController.trackView}.
+ *
+ * @param payload - Page view details from the UI or background.
+ * @returns Normalized page name, properties, and context.
+ */
+export function buildPageViewPayload(
+  payload: MetaMetricsPagePayload,
+): BuiltPageViewPayload {
+  const { locale } = config.getExtensionContext();
+  const { name, params, environmentType, page, referrer } = payload;
+
+  return {
+    name: name ?? '',
+    properties: omitBy(
+      {
+        params,
+        locale,
+        ...buildPageChainIdProperties(),
+        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        environment_type: environmentType,
+      },
+      (propertyValue) => propertyValue === undefined,
+    ) as AnalyticsEventProperties,
+    context: buildAnalyticsContext({ page, referrer }),
+  };
+}
+
+function buildEvent(
+  event: EventState,
+  options?: AnalyticsEventBuildOptions,
+): BuiltAnalyticsEvent {
+  const normalizedProperties = removeUtmPropertiesWithoutMarketingConsent(
+    normalizeProperties(event.name, event.properties, options),
+  );
+  const properties = applyAnonymousOptions(
+    event,
+    normalizedProperties,
+    options,
+  );
+  const sensitiveProperties = removeUtmPropertiesWithoutMarketingConsent(
+    event.sensitiveProperties,
+  );
+
+  const trackingEvent: AnalyticsTrackingEvent = {
+    name: event.name,
+    properties,
+    sensitiveProperties,
+    saveDataRecording: false, // Legacy property introduced by Mobile that is ignored by the analytics controller and will be removed from the type in the future.
+    get hasProperties(): boolean {
+      return (
+        Object.keys(this.properties).length > 0 ||
+        Object.keys(this.sensitiveProperties).length > 0
+      );
+    },
+  };
+
+  return {
+    event: trackingEvent,
+    context: buildAnalyticsContext({
+      page: options?.page,
+      referrer: options?.referrer,
+    }),
+  };
+}
+
+function createBuilderFromEvent(
+  event: EventState,
+): AnalyticsEventBuilderInterface {
+  return {
+    addProperties: (properties: AnalyticsUnfilteredProperties) => {
+      event.properties = {
+        ...event.properties,
+        ...omitBy(
+          properties ?? {},
+          (propertyValue) => propertyValue === undefined,
+        ),
+      };
+      return createBuilderFromEvent(event);
+    },
+
+    addSensitiveProperties: (properties: AnalyticsUnfilteredProperties) => {
+      event.sensitiveProperties = {
+        ...event.sensitiveProperties,
+        ...omitBy(
+          properties ?? {},
+          (propertyValue) => propertyValue === undefined,
+        ),
+      };
+      return createBuilderFromEvent(event);
+    },
+
+    removeProperties: (propNames: string[]) => {
+      removePropertiesFromMap(event.properties, propNames);
+      return createBuilderFromEvent(event);
+    },
+
+    removeSensitiveProperties: (propNames: string[]) => {
+      removePropertiesFromMap(event.sensitiveProperties, propNames);
+      return createBuilderFromEvent(event);
+    },
+
+    build: (options?: AnalyticsEventBuildOptions) =>
+      buildEvent(event, options),
+  };
+}
+
+function createEventBuilder(
+  eventName: string,
+): AnalyticsEventBuilderInterface {
+  if (!eventName) {
+    throw new Error(`Must specify event. Event was: ${eventName}`);
+  }
+
+  return createBuilderFromEvent({
+    name: eventName,
+    properties: {},
+    sensitiveProperties: {},
+  });
+}
+
+function configure(builderConfig: AnalyticsEventBuilderConfig): void {
+  config = builderConfig;
+}
+
+export const AnalyticsEventBuilder = {
+  configure,
+  createEventBuilder,
+};
+

--- a/app/scripts/controllers/analytics/index.ts
+++ b/app/scripts/controllers/analytics/index.ts
@@ -18,5 +18,6 @@ export {
   validateIdentifyPayload,
 } from './analytics-delivery';
 
-export const createEventBuilder =
-  AnalyticsEventBuilder.createEventBuilder.bind(AnalyticsEventBuilder);
+export const createEventBuilder = AnalyticsEventBuilder.createEventBuilder.bind(
+  AnalyticsEventBuilder,
+);

--- a/app/scripts/controllers/analytics/index.ts
+++ b/app/scripts/controllers/analytics/index.ts
@@ -1,0 +1,22 @@
+import { AnalyticsEventBuilder } from './analytics-event-builder';
+
+export {
+  AnalyticsEventBuilder,
+  buildPageViewPayload,
+  type AnalyticsEventBuildOptions,
+  type BuiltAnalyticsEvent,
+  type BuiltPageViewPayload,
+} from './analytics-event-builder';
+export { configureAnalyticsEventBuilder } from './analytics-event-builder-init';
+export type { AnalyticsEventBuilderMessenger } from './analytics-event-builder-messenger';
+export {
+  canSubmitAnalytics,
+  configureAnalyticsDelivery,
+  identify,
+  trackEvent,
+  trackView,
+  validateIdentifyPayload,
+} from './analytics-delivery';
+
+export const createEventBuilder =
+  AnalyticsEventBuilder.createEventBuilder.bind(AnalyticsEventBuilder);

--- a/app/scripts/controllers/metametrics-controller.test.ts
+++ b/app/scripts/controllers/metametrics-controller.test.ts
@@ -6,6 +6,7 @@ import type {
 import type {
   AnalyticsContext,
   AnalyticsControllerState,
+  AnalyticsTrackingEvent,
   AnalyticsUserTraits,
 } from '@metamask/analytics-controller';
 import { AddressBookEntry } from '@metamask/address-book-controller';
@@ -54,6 +55,7 @@ import { LedgerTransportTypes } from '../../../shared/constants/hardware-wallets
 import {
   AB_TEST_ANALYTICS_MAPPINGS,
   clearABTestAnalyticsMappings,
+  getRemoteFeatureFlagsWithManifestOverrides,
 } from '../../../shared/lib/ab-testing/ab-test-analytics';
 import { createActiveABTestAssignment } from '../../../shared/lib/ab-testing/active-ab-test-assignment';
 import * as ManifestFlags from '../../../shared/lib/manifestFlags';
@@ -66,6 +68,11 @@ import {
 } from '../../../test/data/mock-accounts';
 import type { Preferences } from '../../../shared/types/preferences';
 import { ANONYMOUS_EVENT_PROPERTY } from './analytics/platform-adapter';
+import { configureAnalyticsEventBuilder } from './analytics/analytics-event-builder-init';
+import { configureAnalyticsDelivery } from './analytics/analytics-delivery';
+import * as analyticsDelivery from './analytics/analytics-delivery';
+import { AnalyticsEventBuilder } from './analytics/analytics-event-builder';
+import { getAnalyticsEventBuilderMessenger } from './analytics/analytics-event-builder-messenger';
 import {
   MetaMetricsController,
   AllowedActions,
@@ -497,11 +504,11 @@ describe('MetaMetricsController', function () {
         expect(warnSpy).toHaveBeenCalledTimes(2);
         expect(warnSpy).toHaveBeenNthCalledWith(
           1,
-          'MetaMetricsController: "test_null" value is not a valid trait type',
+          'analytics delivery identify: "test_null" value is not a valid trait type',
         );
         expect(warnSpy).toHaveBeenNthCalledWith(
           2,
-          'MetaMetricsController: "test_array_multi_types" value is not a valid trait type',
+          'analytics delivery identify: "test_array_multi_types" value is not a valid trait type',
         );
       });
     });
@@ -553,11 +560,11 @@ describe('MetaMetricsController', function () {
         expect(warnSpy).toHaveBeenCalledTimes(2);
         expect(warnSpy).toHaveBeenNthCalledWith(
           1,
-          'MetaMetricsController: "test_null" value is not a valid trait type',
+          'analytics delivery identify: "test_null" value is not a valid trait type',
         );
         expect(warnSpy).toHaveBeenNthCalledWith(
           2,
-          'MetaMetricsController: "test_array_multi_types" value is not a valid trait type',
+          'analytics delivery identify: "test_array_multi_types" value is not a valid trait type',
         );
       });
     });
@@ -792,6 +799,47 @@ describe('MetaMetricsController', function () {
       );
     });
 
+    it('produces the same AnalyticsController payload as a direct AnalyticsEventBuilder call', async function () {
+      await withController(({ controller }) => {
+        let mmcBuiltPayload:
+          | {
+              event: AnalyticsTrackingEvent;
+              context?: AnalyticsContext;
+            }
+          | undefined;
+
+        jest
+          .spyOn(analyticsDelivery, 'trackEvent')
+          .mockImplementation((built) => {
+            mmcBuiltPayload = built;
+          });
+
+        const referrer = { url: 'https://dapp.example' };
+
+        controller.trackEvent({
+          event: 'Some Event',
+          category: 'Some Category',
+          revenue: 1,
+          value: 2,
+          currency: 'USD',
+          properties: { foo: 'bar' },
+          referrer,
+        });
+
+        const direct = AnalyticsEventBuilder.createEventBuilder('Some Event')
+          .addProperties({
+            category: 'Some Category',
+            revenue: 1,
+            value: 2,
+            currency: 'USD',
+            foo: 'bar',
+          })
+          .build({ referrer });
+
+        expect(mmcBuiltPayload).toStrictEqual(direct);
+      });
+    });
+
     it('should track a legacy event', async function () {
       await withController(({ controller }) => {
         const spy = jest.spyOn(segmentMock, 'track');
@@ -803,9 +851,11 @@ describe('MetaMetricsController', function () {
               // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
               // eslint-disable-next-line @typescript-eslint/naming-convention
               chain_id: '1',
+              // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              legacy_event: true,
             },
           },
-          { matomoEvent: true },
         );
         expect(spy).toHaveBeenCalledTimes(1);
         expect(spy).toHaveBeenCalledWith(
@@ -971,14 +1021,24 @@ describe('MetaMetricsController', function () {
       );
     });
 
-    it('should throw if event not provided', async function () {
-      await withController(({ controller }) => {
-        expect(() => {
+    it('captures an exception when event is not provided', async function () {
+      const captureExceptionMock = jest.fn();
+      await withController(
+        {
+          options: {
+            captureException: captureExceptionMock,
+          },
+        },
+        async ({ controller }) => {
           // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-expect-error because we are testing the error case
           controller.trackEvent({ category: 'test' });
-        }).toThrow(/Must specify event\./u);
-      });
+          await flushPromises();
+          expect(captureExceptionMock).toHaveBeenCalledWith(
+            new Error('Must specify event. Event was: undefined'),
+          );
+        },
+      );
     });
 
     it('should throw if provided sensitiveProperties, when excludeMetaMetricsId is true', async function () {
@@ -3254,16 +3314,51 @@ async function withController<ReturnValue>(
       ],
     });
 
-    return fn({
-      controller: new MetaMetricsController({
-        messenger: metaMetricsControllerMessenger,
-        version: '0.0.1',
-        environment: 'test',
-        extension: MOCK_EXTENSION,
-        ...options,
-        state: mmcState,
+    AnalyticsEventBuilder.configure({
+      getExtensionContext: () => ({
+        chainId: (
+          Object.values(
+            mockNetworkClientConfigurationsByNetworkClientId,
+          )[0] as { chainId: typeof DEFAULT_CHAIN_ID }
+        ).chainId,
+        locale: currentLocale.replace('_', '-'),
+        appVersion: '0.0.1-test',
+        marketingCampaignCookieId: mmcState.marketingCampaignCookieId,
+        dataCollectionForMarketing: mmcState.dataCollectionForMarketing,
+        isEvmSelected: mockMultichainNetworkState.isEvmSelected,
+        selectedMultichainNetworkChainId:
+          mockMultichainNetworkState.selectedMultichainNetworkChainId,
       }),
+      getRemoteFeatureFlags: () =>
+        getRemoteFeatureFlagsWithManifestOverrides(
+          messenger.call('RemoteFeatureFlagController:getState')
+            ?.remoteFeatureFlags as Record<string, unknown> | undefined,
+        ),
+    });
+
+    configureAnalyticsEventBuilder({
+      messenger: getAnalyticsEventBuilderMessenger(messenger),
+      version: '0.0.1',
+      environment: 'test',
+    });
+
+    configureAnalyticsDelivery({
+      messenger: getAnalyticsEventBuilderMessenger(messenger),
+    });
+
+    const controller = new MetaMetricsController({
+      messenger: metaMetricsControllerMessenger,
+      version: '0.0.1',
+      environment: 'test',
+      extension: MOCK_EXTENSION,
+      ...options,
+      state: mmcState,
+    });
+
+    return fn({
+      controller,
       controllerMessenger: metaMetricsControllerMessenger,
+      messenger,
       triggerPreferencesControllerStateChange: (state) =>
         messenger.publish('PreferencesController:stateChange', state, []),
       triggerNetworkDidChange: (state) =>

--- a/app/scripts/controllers/metametrics-controller.test.ts
+++ b/app/scripts/controllers/metametrics-controller.test.ts
@@ -843,20 +843,18 @@ describe('MetaMetricsController', function () {
     it('should track a legacy event', async function () {
       await withController(({ controller }) => {
         const spy = jest.spyOn(segmentMock, 'track');
-        controller.trackEvent(
-          {
-            event: 'Fake Event',
-            category: 'Unit Test',
-            properties: {
-              // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-              // eslint-disable-next-line @typescript-eslint/naming-convention
-              chain_id: '1',
-              // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-              // eslint-disable-next-line @typescript-eslint/naming-convention
-              legacy_event: true,
-            },
+        controller.trackEvent({
+          event: 'Fake Event',
+          category: 'Unit Test',
+          properties: {
+            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            chain_id: '1',
+            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            legacy_event: true,
           },
-        );
+        });
         expect(spy).toHaveBeenCalledTimes(1);
         expect(spy).toHaveBeenCalledWith(
           {
@@ -3358,7 +3356,6 @@ async function withController<ReturnValue>(
     return fn({
       controller,
       controllerMessenger: metaMetricsControllerMessenger,
-      messenger,
       triggerPreferencesControllerStateChange: (state) =>
         messenger.publish('PreferencesController:stateChange', state, []),
       triggerNetworkDidChange: (state) =>

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -2,7 +2,6 @@ import {
   isEqual,
   memoize,
   merge,
-  omit,
   omitBy,
   pickBy,
   size,
@@ -14,10 +13,6 @@ import { getErrorMessage } from '@metamask/utils';
 import type {
   AnalyticsControllerActions,
   AnalyticsControllerState,
-  AnalyticsContext,
-  AnalyticsEventProperties,
-  AnalyticsTrackingEvent,
-  AnalyticsUserTraits,
 } from '@metamask/analytics-controller';
 import type {
   NetworkClientId,
@@ -43,11 +38,6 @@ import type { Messenger } from '@metamask/messenger';
 import type { Json, Hex } from '@metamask/utils';
 import type { InternalAccount } from '@metamask/keyring-internal-api';
 import {
-  ENVIRONMENT_TYPE_BACKGROUND,
-  PLATFORM_FIREFOX,
-} from '../../../shared/constants/app';
-import {
-  METAMETRICS_BACKGROUND_PAGE_OBJECT,
   MetaMetricsEventAccountType,
   MetaMetricsEventCategory,
   MetaMetricsEventName,
@@ -56,15 +46,12 @@ import {
 import type {
   MetaMetricsEventFragment,
   MetaMetricsUserTraits,
-  SegmentEventPayload,
-  MetaMetricsContext,
   MetaMetricsEventPayload,
   MetaMetricsEventOptions,
   MetaMetricsPagePayload,
   MetaMetricsPageObject,
   MetaMetricsReferrerObject,
 } from '../../../shared/constants/metametrics';
-import { UTM_PARAMETERS } from '../../../shared/types/metametrics';
 import { SECOND } from '../../../shared/constants/time';
 import { isManifestV3 } from '../../../shared/lib/mv3.utils';
 import { METAMETRICS_FINALIZE_EVENT_FRAGMENT_ALARM } from '../../../shared/constants/alarms';
@@ -88,26 +75,25 @@ import { ENVIRONMENT } from '../../../shared/constants/build';
 import { KeyringType } from '../../../shared/constants/keyring';
 import type { captureException } from '../../../shared/lib/sentry';
 import type { FlattenedBackgroundStateProxy } from '../../../shared/types';
-import {
-  hasABTestAnalyticsMappingForEvent,
-  enrichWithABTests,
-  getRemoteFeatureFlagsWithManifestOverrides,
-} from '../../../shared/lib/ab-testing/ab-test-analytics';
 import { getTokensControllerAllTokens } from '../../../shared/lib/selectors/assets-migration';
 import { isMain } from '../../../shared/lib/build-types';
-import { trackSegmentEventWhileOptedOut } from '../lib/segment/custom-segment-tracking';
 import type {
   PreferencesControllerGetStateAction,
   PreferencesControllerStateChangeEvent,
 } from './preferences-controller';
 import { MetaMetricsControllerMethodActions } from './metametrics-controller-method-action-types';
-import { ANONYMOUS_EVENT_PROPERTY } from './analytics/platform-adapter';
+import {
+  AnalyticsEventBuilder,
+  buildPageViewPayload,
+  identify,
+  trackEvent,
+  trackView,
+} from './analytics';
 
 // Unique name for the controller
 const controllerName = 'MetaMetricsController';
 
 const EXTENSION_UNINSTALL_URL = 'https://metamask.io/uninstalled';
-const MARKETING_UTM_PARAMETERS = [...UTM_PARAMETERS];
 
 const defaultCaptureException = (err: unknown) => {
   // throw error on clean stack so its captured by platform integrations (eg sentry)
@@ -229,20 +215,6 @@ const controllerMetadata: StateMetadata<MetaMetricsControllerState> = {
  * @property dataCollectionForMarketing - Flag to determine if data collection for marketing is enabled.
  * @property marketingCampaignCookieId - The marketing campaign cookie id.
  */
-type SegmentTrackPayload = Omit<
-  SegmentEventPayload,
-  'properties' | 'timestamp'
-> & {
-  properties: AnalyticsEventProperties;
-  sensitiveProperties?: Record<string, Json>;
-};
-
-type SegmentPagePayload = {
-  name: string;
-  properties: AnalyticsEventProperties;
-  context: AnalyticsContext;
-};
-
 export type MetaMetricsControllerState = {
   completedMetaMetricsOnboarding: boolean;
   fragments: Record<string, MetaMetricsEventFragment>;
@@ -426,7 +398,6 @@ export class MetaMetricsController extends BaseController<
       environment === 'production' ? version : `${version}-${environment}`;
     this.#extension = extension;
     this.#environment = environment;
-
     this.messenger.registerMethodActionHandlers(
       this,
       MESSENGER_EXPOSED_METHODS,
@@ -858,52 +829,21 @@ export class MetaMetricsController extends BaseController<
     payload: MetaMetricsEventPayload,
     options?: MetaMetricsEventOptions,
   ): void {
-    // validation is not caught and handled
-    this.#validateTrackEventPayload(payload);
-
     try {
-      if (!this.#canSubmitAnalytics(payload.event)) {
-        return;
-      }
-
-      const eventPayload = this.#buildTrackEventPayload(payload);
-
-      if (payload.event === MetaMetricsEventName.MetricsOptOut) {
-        this.#trackMetricsOptOutEvent(eventPayload);
-        return;
-      }
-
-      this.#applyAnonymousEventOptions(eventPayload, options);
-      this.#applyLegacyEventOptions(eventPayload, options);
-
-      const properties = this.#removeUtmPropertiesWithoutMarketingConsent(
-        eventPayload.properties,
-      );
-      const sensitiveProperties =
-        this.#removeUtmPropertiesWithoutMarketingConsent(
-          eventPayload.sensitiveProperties ?? {},
-        );
-
-      this.messenger.call(
-        'AnalyticsController:trackEvent',
-        {
-          name: eventPayload.event,
-          properties,
-          sensitiveProperties,
-          saveDataRecording: false, // Legacy property that is ignored by the analytics controller and will be removed from the type in the future.
-          hasProperties:
-            Object.keys(properties).length > 0 ||
-            Object.keys(sensitiveProperties).length > 0,
-        } satisfies AnalyticsTrackingEvent,
-        eventPayload.context as AnalyticsContext | undefined,
+      trackEvent(
+        AnalyticsEventBuilder.createEventBuilder(payload.event)
+          .addProperties(this.#flattenMetaMetricsProperties(payload))
+          .addSensitiveProperties(payload.sensitiveProperties ?? {})
+          .build({
+            excludeMetaMetricsId: options?.excludeMetaMetricsId,
+            referrer: payload.referrer,
+            page: payload.page,
+            environmentType: payload.environmentType,
+          }),
       );
     } catch (err) {
       this.#captureException(err);
     }
-  }
-
-  #isAnonymousTrackEvent(eventPayload: SegmentTrackPayload): boolean {
-    return eventPayload.properties[ANONYMOUS_EVENT_PROPERTY] === true;
   }
 
   /**
@@ -913,25 +853,7 @@ export class MetaMetricsController extends BaseController<
    * @param userTraits
    */
   identify(userTraits: Partial<MetaMetricsUserTraits>): void {
-    const identifyPayload = this.#validateIdentifyPayload(userTraits);
-
-    if (!identifyPayload) {
-      return;
-    }
-
-    try {
-      if (!this.#canSubmitAnalytics()) {
-        return;
-      }
-
-      this.messenger.call(
-        'AnalyticsController:identify',
-        identifyPayload,
-        undefined,
-      );
-    } catch (err) {
-      this.#captureException(err);
-    }
+    identify(userTraits);
   }
 
   /**
@@ -943,40 +865,22 @@ export class MetaMetricsController extends BaseController<
     this.#validateTrackPagePayload(payload);
 
     try {
-      if (!this.#canSubmitAnalytics()) {
-        return;
-      }
-
-      const pagePayload = this.#buildTrackPagePayload(payload);
-
-      this.messenger.call(
-        'AnalyticsController:trackView',
-        pagePayload.name,
-        pagePayload.properties,
-        pagePayload.context,
-      );
+      trackView(buildPageViewPayload(payload));
     } catch (err) {
       this.#captureException(err);
     }
   }
 
-  #validateTrackEventPayload(payload: MetaMetricsEventPayload): void {
-    // event and category are required fields for all payloads
-    if (!payload.event) {
-      throw new Error(
-        `Must specify event. Event was: ${
-          payload.event
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31893
-          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-        }. Payload keys were: ${Object.keys(payload)}. ${
-          typeof payload.properties === 'object'
-            ? // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31893
-              // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-              `Payload property keys were: ${Object.keys(payload.properties)}`
-            : ''
-        }`,
-      );
-    }
+  #flattenMetaMetricsProperties(
+    payload: MetaMetricsEventPayload,
+  ): Record<string, Json | undefined> {
+    return {
+      ...payload.properties,
+      revenue: payload.revenue,
+      value: payload.value,
+      currency: payload.currency,
+      category: payload.category,
+    };
   }
 
   #validateTrackPagePayload(payload: MetaMetricsPagePayload): void {
@@ -985,145 +889,6 @@ export class MetaMetricsController extends BaseController<
         `MetaMetricsController#trackPage: payload parameter must be an object. Received type: ${typeof payload}`,
       );
     }
-  }
-
-  #validateIdentifyPayload(
-    userTraits: Partial<MetaMetricsUserTraits>,
-  ): AnalyticsUserTraits | undefined {
-    if (!userTraits) {
-      return undefined;
-    }
-    if (typeof userTraits !== 'object') {
-      console.warn(
-        `MetaMetricsController#identify: userTraits parameter must be an object. Received type: ${typeof userTraits}`,
-      );
-      return undefined;
-    }
-
-    const validTraits: Record<string, string> = {};
-
-    for (const [key, value] of Object.entries(userTraits)) {
-      if (this.#isValidTraitDate(value)) {
-        validTraits[key] = value.toISOString();
-      } else if (this.#isValidTrait(value)) {
-        (validTraits as Record<string, typeof value>)[key] = value;
-      } else {
-        console.warn(
-          `MetaMetricsController: "${key}" value is not a valid trait type`,
-        );
-      }
-    }
-
-    if (Object.keys(validTraits).length === 0) {
-      return undefined;
-    }
-
-    return validTraits as AnalyticsUserTraits;
-  }
-
-  /**
-   * Builds the event payload, processing all fields into a format that can be
-   * routed through AnalyticsController.
-   *
-   * @private
-   * @param rawPayload - raw payload provided to trackEvent
-   * @returns formatted analytics track event payload
-   */
-  #buildTrackEventPayload(
-    rawPayload: MetaMetricsEventPayload,
-  ): SegmentTrackPayload {
-    const enrichedPayload = this.#enrichWithABTestAnalytics(rawPayload);
-
-    const {
-      event,
-      properties,
-      revenue,
-      value,
-      currency,
-      category,
-      page,
-      referrer,
-      environmentType = ENVIRONMENT_TYPE_BACKGROUND,
-      sensitiveProperties,
-    } = enrichedPayload;
-
-    let chainId;
-    if (
-      properties &&
-      'chain_id_caip' in properties &&
-      typeof properties.chain_id_caip === 'string'
-    ) {
-      chainId = null;
-    } else if (
-      properties &&
-      'chain_id' in properties &&
-      typeof properties.chain_id === 'string'
-    ) {
-      chainId = properties.chain_id;
-    } else {
-      chainId = this.chainId;
-    }
-
-    return {
-      event,
-      properties: omitBy(
-        {
-          // These values are omitted from properties because they have special meaning
-          // in the Segment track spec: https://segment.com/docs/connections/spec/track/#properties.
-          // To avoid accidentally using these inappropriately,
-          // add them as top level properties on the event payload. We also exclude locale
-          // to prevent consumers from overwriting this context level property. We track it
-          // as a property because not all destinations map locale from context.
-          ...omit(properties, ['revenue', 'locale', 'currency', 'value']),
-          revenue,
-          value,
-          currency,
-          category,
-          locale: this.locale,
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          chain_id: chainId,
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          environment_type: environmentType,
-        },
-        (propertyValue) => propertyValue === undefined,
-      ) as AnalyticsEventProperties,
-      context: this.#buildContext(referrer, page),
-      sensitiveProperties,
-    };
-  }
-
-  #buildTrackPagePayload(payload: MetaMetricsPagePayload): SegmentPagePayload {
-    const { name, params, environmentType, page, referrer } = payload;
-
-    const { isEvmSelected, selectedMultichainNetworkChainId } =
-      this.messenger.call('MultichainNetworkController:getState');
-
-    return {
-      name: name ?? '',
-      properties: omitBy(
-        {
-          params,
-          locale: this.locale,
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          chain_id: isEvmSelected ? this.chainId : null,
-          ...(isEvmSelected
-            ? {}
-            : {
-                // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-                // eslint-disable-next-line @typescript-eslint/naming-convention
-                chain_id_caip: selectedMultichainNetworkChainId,
-              }),
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          environment_type: environmentType,
-        },
-        (propertyValue) => propertyValue === undefined,
-      ) as AnalyticsEventProperties,
-      context: this.#buildContext(referrer, page) as AnalyticsContext,
-    };
   }
 
   handleMetaMaskStateUpdate(newState: MetaMaskState): void {
@@ -1256,137 +1021,7 @@ export class MetaMetricsController extends BaseController<
     return analyticsId;
   }
 
-  #isBasicFunctionalityEnabled(): boolean {
-    const { useExternalServices } = this.messenger.call(
-      'PreferencesController:getState',
-    );
-    return useExternalServices;
-  }
-
-  #canSubmitAnalytics(eventName?: string): boolean {
-    if (!this.#isBasicFunctionalityEnabled()) {
-      return false;
-    }
-
-    if (eventName === MetaMetricsEventName.MetricsOptOut) {
-      return true;
-    }
-
-    const { analyticsId, optedIn } = this.#analyticsGetState();
-    return optedIn && analyticsId.length > 0;
-  }
-
-  #enrichWithABTestAnalytics(
-    payload: MetaMetricsEventPayload,
-  ): MetaMetricsEventPayload {
-    let normalizedPayload = payload;
-
-    if (payload.properties?.active_ab_tests !== undefined) {
-      try {
-        normalizedPayload = enrichWithABTests(payload, null, []);
-      } catch {
-        normalizedPayload = payload;
-      }
-    }
-
-    if (!hasABTestAnalyticsMappingForEvent(payload.event)) {
-      return normalizedPayload;
-    }
-
-    try {
-      return enrichWithABTests(
-        normalizedPayload,
-        this.#getRemoteFeatureFlags(),
-      );
-    } catch {
-      return normalizedPayload;
-    }
-  }
-
-  #applyAnonymousEventOptions(
-    eventPayload: SegmentTrackPayload,
-    options?: MetaMetricsEventOptions,
-  ): void {
-    if (
-      eventPayload.sensitiveProperties &&
-      options?.excludeMetaMetricsId === true
-    ) {
-      throw new Error(
-        'sensitiveProperties was specified in an event payload that also set the excludeMetaMetricsId flag',
-      );
-    }
-
-    let excludeMetaMetricsId = options?.excludeMetaMetricsId ?? false;
-    // This is carried over from the old implementation, and will likely need
-    // to be updated to work with the new tracking plan. I think we should use
-    // a config setting for this instead of trying to match the event name
-    const isSendFlow = Boolean(eventPayload.event.match(/^send|^confirm/iu));
-    // do not filter if excludeMetaMetricsId is explicitly set to false
-    if (options?.excludeMetaMetricsId !== false && isSendFlow) {
-      excludeMetaMetricsId = true;
-    }
-
-    // The platform adapter reads the "anonymous" marker from track `properties`
-    // and swaps the user id for the shared anonymous id when marked is true.
-    if (excludeMetaMetricsId) {
-      (eventPayload.properties as Record<string, Json>)[
-        ANONYMOUS_EVENT_PROPERTY
-      ] = true;
-    }
-  }
-
-  #applyLegacyEventOptions(
-    eventPayload: SegmentTrackPayload,
-    options?: MetaMetricsEventOptions,
-  ): void {
-    if (options?.matomoEvent === true) {
-      eventPayload.properties.legacy_event = true;
-    }
-  }
-
-  #removeUtmPropertiesWithoutMarketingConsent<
-    TProperties extends Record<string, Json>,
-  >(properties: TProperties): TProperties {
-    if (this.state.dataCollectionForMarketing) {
-      return properties;
-    }
-
-    return omit(properties, MARKETING_UTM_PARAMETERS) as TProperties;
-  }
-
   /** PRIVATE METHODS */
-
-  /**
-   * Build the context object to attach to page and track events.
-   *
-   * @private
-   * @param referrer - dapp origin that initialized
-   * the notification window.
-   * @param page - page object describing the current
-   * view of the extension. Defaults to the background-process object.
-   */
-  #buildContext(
-    referrer: MetaMetricsContext['referrer'],
-    page: MetaMetricsContext['page'] = METAMETRICS_BACKGROUND_PAGE_OBJECT,
-  ): MetaMetricsContext {
-    return {
-      app: {
-        name: 'MetaMask Extension',
-        version: this.version,
-      },
-      userAgent: window.navigator.userAgent,
-      page,
-      referrer,
-      marketingCampaignCookieId: this.state.marketingCampaignCookieId,
-    };
-  }
-
-  #getRemoteFeatureFlags(): Record<string, unknown> {
-    return getRemoteFeatureFlagsWithManifestOverrides(
-      this.messenger.call('RemoteFeatureFlagController:getState')
-        ?.remoteFeatureFlags as Record<string, unknown> | undefined,
-    );
-  }
 
   /**
    * This method generates the MetaMetrics user traits object, omitting any
@@ -1681,68 +1316,6 @@ export class MetaMetricsController extends BaseController<
         (numberOfLatticeAccounts > 0 ? 1 : 0) +
         (numberOfQrHardwareAccounts > 0 ? 1 : 0),
     };
-  }
-
-  /**
-   * Validates the trait value so AnalyticsController receives values supported
-   * by the configured analytics destinations.
-   *
-   * @param value
-   */
-  #isValidTrait(value: unknown): boolean {
-    const type = typeof value;
-
-    return (
-      type === 'string' ||
-      type === 'boolean' ||
-      type === 'number' ||
-      this.#isValidTraitArray(value) ||
-      this.#isValidTraitDate(value)
-    );
-  }
-
-  /**
-   * Validates trait arrays.
-   *
-   * @param value
-   */
-  #isValidTraitArray(value: unknown): boolean {
-    return (
-      Array.isArray(value) &&
-      (value.every((element) => {
-        return typeof element === 'string';
-      }) ||
-        value.every((element) => {
-          return typeof element === 'boolean';
-        }) ||
-        value.every((element) => {
-          return typeof element === 'number';
-        }))
-    );
-  }
-
-  /**
-   * Returns true if the value is an accepted date type
-   *
-   * @param value
-   */
-  #isValidTraitDate(value: unknown): value is Date {
-    return Object.prototype.toString.call(value) === '[object Date]';
-  }
-
-  #trackMetricsOptOutEvent(payload: SegmentTrackPayload): void {
-    const { analyticsId } = this.#analyticsGetState();
-
-    if (analyticsId.length === 0 || getPlatform() === PLATFORM_FIREFOX) {
-      return;
-    }
-
-    trackSegmentEventWhileOptedOut({
-      analyticsId,
-      event: MetaMetricsEventName.MetricsOptOut,
-      properties: payload.properties as Record<string, Json> | undefined,
-      context: payload.context as AnalyticsContext | undefined,
-    });
   }
 
   /**

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -1,12 +1,4 @@
-import {
-  isEqual,
-  memoize,
-  merge,
-  omitBy,
-  pickBy,
-  size,
-  sum,
-} from 'lodash';
+import { isEqual, memoize, merge, omitBy, pickBy, size, sum } from 'lodash';
 import { v4 as uuidv4 } from 'uuid';
 import { NameType } from '@metamask/name-controller';
 import { getErrorMessage } from '@metamask/utils';

--- a/app/scripts/messenger-client-init/analytics-controller-init.ts
+++ b/app/scripts/messenger-client-init/analytics-controller-init.ts
@@ -4,7 +4,10 @@ import {
   type AnalyticsControllerState,
 } from '@metamask/analytics-controller';
 import { generateMetaMetricsId } from '../../../shared/lib/generate-metametrics-id';
+import { configureAnalyticsEventBuilder } from '../controllers/analytics/analytics-event-builder-init';
+import { configureAnalyticsDelivery } from '../controllers/analytics/analytics-delivery';
 import { createPlatformAdapter } from '../controllers/analytics/platform-adapter';
+import type { AnalyticsEventBuilderMessenger } from '../controllers/analytics/analytics-event-builder-messenger';
 import { MessengerClientInitFunction } from './types';
 
 /**
@@ -14,12 +17,14 @@ import { MessengerClientInitFunction } from './types';
  * @param request.controllerMessenger - The messenger to use for the controller.
  * @param request.persistedState - The persisted state to use for the
  * controller.
+ * @param request.initMessenger
  * @returns The initialized controller.
  */
 export const AnalyticsControllerInit: MessengerClientInitFunction<
   AnalyticsController,
-  AnalyticsControllerMessenger
-> = ({ controllerMessenger, persistedState }) => {
+  AnalyticsControllerMessenger,
+  AnalyticsEventBuilderMessenger
+> = ({ controllerMessenger, initMessenger, persistedState }) => {
   const persisted = {
     ...persistedState.AnalyticsController,
   };
@@ -28,6 +33,16 @@ export const AnalyticsControllerInit: MessengerClientInitFunction<
     (typeof persisted.analyticsId === 'string' ? persisted.analyticsId : '') ||
     generateMetaMetricsId();
   persisted.optedIn = persisted.optedIn === true;
+
+  configureAnalyticsEventBuilder({
+    messenger: initMessenger,
+    version: process.env.METAMASK_VERSION as string,
+    environment: process.env.METAMASK_ENVIRONMENT as string,
+  });
+
+  configureAnalyticsDelivery({
+    messenger: initMessenger,
+  });
 
   const controller = new AnalyticsController({
     messenger: controllerMessenger,

--- a/app/scripts/messenger-client-init/messengers/index.ts
+++ b/app/scripts/messenger-client-init/messengers/index.ts
@@ -1,4 +1,5 @@
 import { noop } from 'lodash';
+import { getAnalyticsEventBuilderMessenger } from '../../controllers/analytics/analytics-event-builder-messenger';
 import { getAnalyticsControllerMessenger } from './analytics-controller-messenger';
 import {
   getPPOMControllerMessenger,
@@ -374,7 +375,7 @@ export const MESSENGER_FACTORIES = {
   },
   AnalyticsController: {
     getMessenger: getAnalyticsControllerMessenger,
-    getInitMessenger: noop,
+    getInitMessenger: getAnalyticsEventBuilderMessenger,
   },
   AssetsController: {
     getMessenger: getAssetsControllerMessenger,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -236,6 +236,10 @@ import {
   DEFI_REFERRAL_PARTNERS,
   DefiReferralPartner,
 } from '../../shared/constants/defi-referrals';
+import {
+  createEventBuilder,
+  trackEvent as trackAnalyticsEvent,
+} from './controllers/analytics';
 import { keyringSnapPermissionsBuilder } from './lib/snap-keyring/keyring-snaps-permissions';
 
 import { AddressBookPetnamesBridge } from './lib/AddressBookPetnamesBridge';
@@ -3629,6 +3633,18 @@ export default class MetamaskController extends EventEmitter {
       trackMetaMetricsEvent: metaMetricsController.trackEvent.bind(
         metaMetricsController,
       ),
+      trackAnalyticsEvent: (built, options) => {
+        try {
+          trackAnalyticsEvent(
+            createEventBuilder(built.name)
+              .addProperties(built.properties)
+              .addSensitiveProperties(built.sensitiveProperties)
+              .build(options),
+          );
+        } catch (error) {
+          captureException(error);
+        }
+      },
       trackMetaMetricsPage: metaMetricsController.trackPage.bind(
         metaMetricsController,
       ),
@@ -9316,10 +9332,13 @@ export default class MetamaskController extends EventEmitter {
           numberOfTokens: tokens.length,
           // TODO: remove this once we have migrated to the new account balances state
           numberOfAccounts: Object.keys(metamaskState.accounts).length,
+          // 'legacy_event' is holdover from Matomo that needs further migration: the property
+          // routes this event to a special Segment source that marks the data as not
+          // conforming to our schema.
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          legacy_event: true,
         },
-      },
-      {
-        matomoEvent: true,
       },
     );
   }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -9322,25 +9322,23 @@ export default class MetamaskController extends EventEmitter {
       return;
     }
 
-    this.metaMetricsController.trackEvent(
-      {
-        event: 'Tx Status Update: On-Chain Failure',
-        category: MetaMetricsEventCategory.Background,
-        properties: {
-          action: 'Transactions',
-          errorMessage: transactionMeta.simulationFails?.reason,
-          numberOfTokens: tokens.length,
-          // TODO: remove this once we have migrated to the new account balances state
-          numberOfAccounts: Object.keys(metamaskState.accounts).length,
-          // 'legacy_event' is holdover from Matomo that needs further migration: the property
-          // routes this event to a special Segment source that marks the data as not
-          // conforming to our schema.
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          legacy_event: true,
-        },
+    this.metaMetricsController.trackEvent({
+      event: 'Tx Status Update: On-Chain Failure',
+      category: MetaMetricsEventCategory.Background,
+      properties: {
+        action: 'Transactions',
+        errorMessage: transactionMeta.simulationFails?.reason,
+        numberOfTokens: tokens.length,
+        // TODO: remove this once we have migrated to the new account balances state
+        numberOfAccounts: Object.keys(metamaskState.accounts).length,
+        // 'legacy_event' is holdover from Matomo that needs further migration: the property
+        // routes this event to a special Segment source that marks the data as not
+        // conforming to our schema.
+        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        legacy_event: true,
       },
-    );
+    });
   }
 
   _getMetaMaskState() {

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -160,15 +160,21 @@ export type MetaMetricsEventOptions = {
    */
   excludeMetaMetricsId?: boolean;
   /**
-   * Is this event a holdover from Matomo that needs further migration? When
-   * true, sends the data to a special Segment source that marks the event data
-   * as not conforming to our schema.
-   */
-  matomoEvent?: boolean;
-  /**
    * Values that can used in the "properties" tracking object as keys,
    */
   contextPropsIntoEventProperties?: string | string[];
+};
+
+export type UIAnalyticsEventBuildOptions = Pick<
+  MetaMetricsEventOptions,
+  'excludeMetaMetricsId'
+>;
+
+export type UIAnalyticsEvent = {
+  name: string;
+  properties: Record<string, JsonWithUndefined>;
+  sensitiveProperties: Record<string, JsonWithUndefined>;
+  options?: UIAnalyticsEventBuildOptions;
 };
 
 export type MetaMetricsEventFragment = {

--- a/test/jest/console-reporter-rules-unit.js
+++ b/test/jest/console-reporter-rules-unit.js
@@ -76,7 +76,8 @@ module.exports = [
 
   // MetaMetrics warnings
   {
-    match: /MetaMetricsController:.*value is not a valid trait type/u,
+    match:
+      /(MetaMetricsController:|analytics delivery identify:).*value is not a valid trait type/u,
     group: 'MetaMask: MetaMetrics invalid trait types',
   },
 

--- a/ui/hooks/useAnalytics.ts
+++ b/ui/hooks/useAnalytics.ts
@@ -1,0 +1,161 @@
+import { useCallback, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { omitBy } from 'lodash';
+import type { Json } from '@metamask/utils';
+import {
+  MetaMetricsEventName,
+  type MetaMetricsPageObject,
+  type MetaMetricsReferrerObject,
+  type UIAnalyticsEvent,
+  type UIAnalyticsEventBuildOptions,
+} from '../../shared/constants/metametrics';
+import { getEnvironmentType } from '../../shared/lib/environment-type';
+import {
+  getAnalyticsId,
+  getCompletedMetaMetricsOnboarding,
+  getOptedIn,
+} from '../selectors';
+import { trackAnalyticsEvent } from '../store/actions';
+import { useSegmentContext } from './useSegmentContext';
+
+type AnalyticsUnfilteredProperties =
+  | Record<string, Json | undefined>
+  | null
+  | undefined;
+
+type UIAnalyticsEventBuilder = {
+  addProperties: (
+    properties: AnalyticsUnfilteredProperties,
+  ) => UIAnalyticsEventBuilder;
+  addSensitiveProperties: (
+    properties: AnalyticsUnfilteredProperties,
+  ) => UIAnalyticsEventBuilder;
+  removeProperties: (propNames: string[]) => UIAnalyticsEventBuilder;
+  removeSensitiveProperties: (propNames: string[]) => UIAnalyticsEventBuilder;
+  build: (options?: UIAnalyticsEventBuildOptions) => UIAnalyticsEvent;
+};
+
+type UIAnalyticsEventState = {
+  name: string;
+  properties: Record<string, Json | undefined>;
+  sensitiveProperties: Record<string, Json | undefined>;
+};
+
+type UIAnalyticsTrackEventOptions = UIAnalyticsEventBuildOptions & {
+  environmentType: string;
+  page?: MetaMetricsPageObject;
+  referrer?: MetaMetricsReferrerObject;
+};
+
+type UseAnalyticsResult = {
+  createEventBuilder: (eventName: string) => UIAnalyticsEventBuilder;
+  trackEvent: (built: UIAnalyticsEvent) => void;
+};
+
+function filterUndefinedValues(
+  properties: Record<string, Json | undefined>,
+): Record<string, Json> {
+  return omitBy(
+    properties,
+    (propertyValue) => propertyValue === undefined,
+  ) as Record<string, Json>;
+}
+
+function removePropertiesFromMap(
+  map: Record<string, Json | undefined>,
+  keys: string[],
+): void {
+  keys.forEach((key) => {
+    delete map[key];
+  });
+}
+
+function createBuilderFromEvent(
+  event: UIAnalyticsEventState,
+): UIAnalyticsEventBuilder {
+  return {
+    addProperties: (properties: AnalyticsUnfilteredProperties) => {
+      event.properties = {
+        ...event.properties,
+        ...filterUndefinedValues(properties ?? {}),
+      };
+      return createBuilderFromEvent(event);
+    },
+
+    addSensitiveProperties: (properties: AnalyticsUnfilteredProperties) => {
+      event.sensitiveProperties = {
+        ...event.sensitiveProperties,
+        ...filterUndefinedValues(properties ?? {}),
+      };
+      return createBuilderFromEvent(event);
+    },
+
+    removeProperties: (propNames: string[]) => {
+      removePropertiesFromMap(event.properties, propNames);
+      return createBuilderFromEvent(event);
+    },
+
+    removeSensitiveProperties: (propNames: string[]) => {
+      removePropertiesFromMap(event.sensitiveProperties, propNames);
+      return createBuilderFromEvent(event);
+    },
+
+    build: (options?: UIAnalyticsEventBuildOptions) => ({
+      name: event.name,
+      properties: filterUndefinedValues(event.properties),
+      sensitiveProperties: filterUndefinedValues(event.sensitiveProperties),
+      ...(options ? { options } : {}),
+    }),
+  };
+}
+
+function createEventBuilder(eventName: string): UIAnalyticsEventBuilder {
+  if (!eventName) {
+    throw new Error(`Must specify event. Event was: ${eventName}`);
+  }
+
+  return createBuilderFromEvent({
+    name: eventName,
+    properties: {},
+    sensitiveProperties: {},
+  });
+}
+
+export function useAnalytics(): UseAnalyticsResult {
+  const context = useSegmentContext();
+  const completedMetaMetricsOnboarding = useSelector(
+    getCompletedMetaMetricsOnboarding,
+  );
+  const isOptedIn = useSelector(getOptedIn);
+  const analyticsId = useSelector(getAnalyticsId);
+  const isMetricsEnabled = completedMetaMetricsOnboarding && isOptedIn;
+  const canTrackImmediately = isMetricsEnabled && Boolean(analyticsId);
+
+  const trackEvent = useCallback(
+    (built: UIAnalyticsEvent) => {
+      if (
+        !canTrackImmediately &&
+        built.name !== MetaMetricsEventName.MetricsOptOut
+      ) {
+        return;
+      }
+
+      const options: UIAnalyticsTrackEventOptions = {
+        ...built.options,
+        environmentType: getEnvironmentType(),
+        ...context,
+      };
+
+      trackAnalyticsEvent(built, options);
+    },
+    [canTrackImmediately, context],
+  );
+
+  return useMemo(
+    () => ({
+      createEventBuilder,
+      trackEvent,
+    }),
+    [trackEvent],
+  );
+}

--- a/ui/pages/settings/preferences-and-display-tab/theme-sub-page.test.tsx
+++ b/ui/pages/settings/preferences-and-display-tab/theme-sub-page.test.tsx
@@ -8,6 +8,10 @@ import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate
 import { setBackgroundConnection } from '../../../store/background-connection';
 import { PREFERENCES_AND_DISPLAY_ROUTE } from '../../../helpers/constants/routes';
 import { ThemeType } from '../../../../shared/constants/preferences';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../shared/constants/metametrics';
 import ThemeSubPage from './theme-sub-page';
 
 const mockNavigate = jest.fn();
@@ -25,9 +29,17 @@ jest.mock('../../../store/actions', () => ({
   },
 }));
 
+const trackAnalyticsEventMock = jest.fn().mockResolvedValue(undefined);
 const backgroundConnectionMock = new Proxy(
-  {},
-  { get: () => jest.fn().mockResolvedValue(undefined) },
+  {
+    trackAnalyticsEvent: trackAnalyticsEventMock,
+  },
+  {
+    get: (target, prop) =>
+      prop in target
+        ? target[prop as keyof typeof target]
+        : jest.fn().mockResolvedValue(undefined),
+  },
 );
 
 describe('ThemeSubPage', () => {
@@ -51,6 +63,9 @@ describe('ThemeSubPage', () => {
       ...mockState,
       metamask: {
         ...mockState.metamask,
+        analyticsId: 'test-analytics-id',
+        completedMetaMetricsOnboarding: true,
+        optedIn: true,
         theme: ThemeType.dark,
       },
     });
@@ -59,6 +74,20 @@ describe('ThemeSubPage', () => {
     fireEvent.click(screen.getByText(messages.lightTheme.message));
 
     expect(mockSetTheme).toHaveBeenCalledWith(ThemeType.light);
+    expect(trackAnalyticsEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: MetaMetricsEventName.ThemeChanged,
+        properties: {
+          category: MetaMetricsEventCategory.Settings,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          theme_selected: ThemeType.light,
+        },
+        sensitiveProperties: {},
+      }),
+      expect.objectContaining({
+        environmentType: expect.any(String),
+      }),
+    );
     expect(mockNavigate).toHaveBeenCalledWith(PREFERENCES_AND_DISPLAY_ROUTE);
   });
 });

--- a/ui/pages/settings/preferences-and-display-tab/theme-sub-page.tsx
+++ b/ui/pages/settings/preferences-and-display-tab/theme-sub-page.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -14,7 +14,6 @@ import {
   Text,
   TextVariant,
 } from '@metamask/design-system-react';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
 import { setTheme } from '../../../store/actions';
 import { PREFERENCES_AND_DISPLAY_ROUTE } from '../../../helpers/constants/routes';
 import { getTheme } from '../../../selectors';
@@ -24,24 +23,26 @@ import {
 } from '../../../../shared/constants/metametrics';
 import { ThemeType } from '../../../../shared/constants/preferences';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+import { useAnalytics } from '../../../hooks/useAnalytics';
 import { THEME_OPTIONS } from './theme-utils';
 
 const ThemeSubPage = () => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const t = useI18nContext();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const currentTheme = useSelector(getTheme) as ThemeType;
 
   const handleSelect = (value: ThemeType) => {
-    trackEvent({
-      category: MetaMetricsEventCategory.Settings,
-      event: MetaMetricsEventName.ThemeChanged,
-      properties: {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        theme_selected: value,
-      },
-    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.ThemeChanged)
+        .addProperties({
+          category: MetaMetricsEventCategory.Settings,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          theme_selected: value,
+        })
+        .build(),
+    );
     dispatch(setTheme(value));
     navigate(PREFERENCES_AND_DISPLAY_ROUTE);
   };

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -160,6 +160,8 @@ import {
   MetaMetricsEventAccountType,
   MetaMetricsUserTraits,
   MetaMetricsUserTrait,
+  UIAnalyticsEvent,
+  UIAnalyticsEventBuildOptions,
 } from '../../shared/constants/metametrics';
 import { parseSmartTransactionsError } from '../pages/swaps/swaps.util';
 import { isEqualCaseInsensitive } from '../../shared/lib/string-utils';
@@ -6311,6 +6313,17 @@ export function trackMetaMetricsEvent(
   options?: MetaMetricsEventOptions,
 ) {
   return submitRequestToBackground('trackMetaMetricsEvent', [payload, options]);
+}
+
+export function trackAnalyticsEvent(
+  payload: UIAnalyticsEvent,
+  options: UIAnalyticsEventBuildOptions & {
+    environmentType: string;
+    page?: MetaMetricsPageObject;
+    referrer?: MetaMetricsReferrerObject;
+  },
+) {
+  return submitRequestToBackground('trackAnalyticsEvent', [payload, options]);
 }
 
 export function createEventFragment(


### PR DESCRIPTION
## **Description**

Introduce AnalyticsEventBuilder and analytics-delivery for background analytics submission via AnalyticsController. Slim MetaMetricsController to delegate tracking, page views, and identify to the new module. Add useAnalytics with a fire-and-forget trackAnalyticsEvent RPC and migrate theme settings to the new path.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/7337

## **Manual testing steps**

1. Same as for https://github.com/MetaMask/metamask-extension/pull/42885

## **Screenshots/Recordings**

NA

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
