### PR TITLE
feat: remove CTA button under notification

### DIFF
--- a/ui/components/multichain/notification-list-item/notification-list-item.tsx
+++ b/ui/components/multichain/notification-list-item/notification-list-item.tsx
@@ -175,7 +175,6 @@ export const NotificationListItem = ({
           )}
         </Box>
       </Box>
-
     </Box>
   );
 };

--- a/ui/components/multichain/notification-list-item/notification-list-item.tsx
+++ b/ui/components/multichain/notification-list-item/notification-list-item.tsx
@@ -1,9 +1,6 @@
 import React from 'react';
 
 import {
-  Button,
-  ButtonSize,
-  ButtonVariant,
   Icon,
   IconName,
   IconColor,
@@ -49,25 +46,6 @@ export type NotificationListItemProps =
   | NotificationToken
   | NotificationPlatform;
 
-const CTAButton = (props: {
-  content: string;
-  link: string;
-  onClick: () => void;
-}) => (
-  <Button
-    variant={ButtonVariant.Secondary}
-    size={ButtonSize.Md}
-    onClick={() => {
-      props.onClick();
-      global.platform.openTab({ url: props.link });
-    }}
-    isFullWidth
-    endIconName={IconName.Arrow2UpRight}
-  >
-    {props.content}
-  </Button>
-);
-
 /**
  * `NotificationListItem` is a component that displays a single notification item.
  *
@@ -94,6 +72,9 @@ export const NotificationListItem = ({
 }: NotificationListItemProps) => {
   const handleClick = () => {
     onClick();
+    if ('cta' in restProps && restProps.cta) {
+      global.platform.openTab({ url: restProps.cta.link });
+    }
   };
 
   return (
@@ -195,14 +176,6 @@ export const NotificationListItem = ({
         </Box>
       </Box>
 
-      {/* CTA Button */}
-      {'cta' in restProps && restProps.cta && (
-        <CTAButton
-          content={restProps.cta.content}
-          link={restProps.cta.link}
-          onClick={handleClick}
-        />
-      )}
     </Box>
   );
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Removed additional button rendering. CTA is clicked on notification level (when you tap on it).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: remove CTA button under notification

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/GE-294

## **Manual testing steps**

1. Go to notification page
2. Make sure there is no CTA button under notification
3. Make sure that when you click on notification you get redirected to corresponding deeplink;

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="450" height="291" alt="image" src="https://github.com/user-attachments/assets/fa39bca9-aae6-4bde-bde6-54952d582b89" />

When clicked

<img width="456" height="654" alt="image" src="https://github.com/user-attachments/assets/d2cd472a-9417-448e-90b6-e75adb77b711" />

### **After**

<img width="448" height="170" alt="image" src="https://github.com/user-attachments/assets/8eb7e7c7-cfe1-4987-ab39-af56c1c36f08" />

When clicked

<img width="453" height="650" alt="image" src="https://github.com/user-attachments/assets/f0d2c605-8748-4d73-9d5e-a918e185d2f6" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change in notification list presentation and click handling; no auth, security, or data-path changes.
> 
> **Overview**
> Platform notifications no longer show a separate **CTA button** under each item. Tapping the **notification row** still runs the existing `onClick` handler and, when a `cta` is present, opens `restProps.cta.link` via `global.platform.openTab`.
> 
> The inline `CTAButton` helper and **design-system** `Button` imports are removed from `notification-list-item.tsx`; deeplink behavior is consolidated into `handleClick` on the main clickable area.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee89657ad58cbde40496b8db448dac850a2da0c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->