### PR TITLE
fix: ARC bridge/swap USDC hide max button + arc bridge code cleanup

### DIFF
--- a/.yarn/patches/@metamask-bridge-controller-npm-73.2.0-be55b13227.patch
+++ b/.yarn/patches/@metamask-bridge-controller-npm-73.2.0-be55b13227.patch
@@ -113,8 +113,8 @@ index 57f207adbd3a0323a50c5288a2971ad785c29501..4c485411f0c44507ed1aa1877cbcc000
 +const ARC_SWAPS_TOKEN_OBJECT = {
 +    symbol: 'USDC',
 +    name: 'USDC',
-+    address: '0x0000000000000000000000000000000000000000',
-+    decimals: 18,
++    address: '0x3600000000000000000000000000000000000000',
++    decimals: 6,
 +    iconUrl: 'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/5042/erc20/0x0000000000000000000000000000000000000000.png',
 +};
  exports.SWAPS_CHAINID_DEFAULT_TOKEN_MAP = {
@@ -132,7 +132,7 @@ index 57f207adbd3a0323a50c5288a2971ad785c29501..4c485411f0c44507ed1aa1877cbcc000
      TRX: 'slip44:195',
      MON: 'slip44:268435779',
      HYPE: 'slip44:2457',
-+    USDC: 'erc20:0x0000000000000000000000000000000000000000',
++    USDC: 'erc20:0x3600000000000000000000000000000000000000',
  };
  //# sourceMappingURL=tokens.cjs.map
 \ No newline at end of file
@@ -155,8 +155,8 @@ index 8764f757f3e41a6614dac2095038e26eba641d9a..3038e2d005c0c040ef11993da1551c44
 +const ARC_SWAPS_TOKEN_OBJECT = {
 +    symbol: 'USDC',
 +    name: 'USDC',
-+    address: '0x0000000000000000000000000000000000000000',
-+    decimals: 18,
++    address: '0x3600000000000000000000000000000000000000',
++    decimals: 6,
 +    iconUrl: 'https://static.cx.metamask.io/api/v2/tokenIcons/assets/eip155/5042/erc20/0x0000000000000000000000000000000000000000.png',
 +};
  export const SWAPS_CHAINID_DEFAULT_TOKEN_MAP = {
@@ -174,7 +174,7 @@ index 8764f757f3e41a6614dac2095038e26eba641d9a..3038e2d005c0c040ef11993da1551c44
      TRX: 'slip44:195',
      MON: 'slip44:268435779',
      HYPE: 'slip44:2457',
-+    USDC: 'erc20:0x0000000000000000000000000000000000000000',
++    USDC: 'erc20:0x3600000000000000000000000000000000000000',
  };
  //# sourceMappingURL=tokens.mjs.map
 \ No newline at end of file
@@ -202,3 +202,144 @@ index 6b8ff6303061d23601ab02e41c96192bf09791f5..ea799db2d867d34c0d9b31b1060c7a34
  })(ChainId || (ChainId = {}));
  export var RequestStatus;
  (function (RequestStatus) {
+diff --git a/dist/utils/caip-formatters.cjs b/dist/utils/caip-formatters.cjs
+--- a/dist/utils/caip-formatters.cjs
++++ b/dist/utils/caip-formatters.cjs
+@@ -97,17 +97,17 @@
+ const formatAddressToCaipReference = (address) => {
+-    if ((0, utils_1.isStrictHexString)(address)) {
+-        return (0, address_1.getAddress)(address);
+-    }
++    const addressWithoutPrefix = address.split(':').at(-1);
++    if ((0, utils_1.isStrictHexString)(addressWithoutPrefix)) {
++        return (0, address_1.getAddress)(addressWithoutPrefix);
++    }
+     // If the address looks like a native token, return the zero address because it's
+     // what bridge-api uses to represent a native asset
+     if ((0, bridge_1.isNativeAddress)(address)) {
+         return constants_1.AddressZero;
+     }
+-    const addressWithoutPrefix = address.split(':').at(-1);
+     // If the address is not a valid hex string or CAIP address, throw an error
+     // This should never happen, but it's a sanity check
+     if (!addressWithoutPrefix) {
+         throw new Error('Invalid address');
+     }
+     return addressWithoutPrefix;
+ };
+diff --git a/dist/utils/caip-formatters.mjs b/dist/utils/caip-formatters.mjs
+--- a/dist/utils/caip-formatters.mjs
++++ b/dist/utils/caip-formatters.mjs
+@@ -91,17 +91,17 @@
+ export const formatAddressToCaipReference = (address) => {
+-    if (isStrictHexString(address)) {
+-        return getAddress(address);
+-    }
++    const addressWithoutPrefix = address.split(':').at(-1);
++    if (isStrictHexString(addressWithoutPrefix)) {
++        return getAddress(addressWithoutPrefix);
++    }
+     // If the address looks like a native token, return the zero address because it's
+     // what bridge-api uses to represent a native asset
+     if (isNativeAddress(address)) {
+         return AddressZero;
+     }
+-    const addressWithoutPrefix = address.split(':').at(-1);
+     // If the address is not a valid hex string or CAIP address, throw an error
+     // This should never happen, but it's a sanity check
+     if (!addressWithoutPrefix) {
+         throw new Error('Invalid address');
+     }
+     return addressWithoutPrefix;
+ };
+diff --git a/dist/utils/bridge.mjs b/dist/utils/bridge.mjs
+--- a/dist/utils/bridge.mjs
++++ b/dist/utils/bridge.mjs
+@@ -125,7 +125,13 @@
+-export const isNativeAddress = (address) => address === AddressZero || // bridge and swap apis set the native asset address to zero
+-    address === '' || // assets controllers set the native asset address to an empty string
+-    !address ||
+-    (!isStrictHexString(address) &&
+-        Object.values(SYMBOL_TO_SLIP44_MAP).some(
+-        // check if it matches any supported SLIP44 references
+-        (reference) => address.includes(reference) || reference.endsWith(address)));
++export const isNativeAddress = (address) => {
++    if (address === AddressZero || // bridge and swap apis set the native asset address to zero
++        address === '' || // assets controllers set the native asset address to an empty string
++        !address) {
++        return true;
++    }
++    // address may be a bare reference or a full CAIP-19 assetId (e.g.
++    // "eip155:5042/erc20:0x...."); only the segment after the last "/" matters
++    const suffix = address.includes('/') ? address.split('/').at(-1) : address;
++    return Object.values(SYMBOL_TO_SLIP44_MAP).some((reference) => reference === suffix ||
++        reference === `slip44:${suffix}` ||
++        reference === `erc20:${suffix}`);
++};
+diff --git a/dist/utils/bridge.cjs b/dist/utils/bridge.cjs
+--- a/dist/utils/bridge.cjs
++++ b/dist/utils/bridge.cjs
+@@ -136,8 +136,14 @@
+-const isNativeAddress = (address) => address === constants_1.AddressZero || // bridge and swap apis set the native asset address to zero
+-    address === '' || // assets controllers set the native asset address to an empty string
+-    !address ||
+-    (!(0, utils_1.isStrictHexString)(address) &&
+-        Object.values(tokens_1.SYMBOL_TO_SLIP44_MAP).some(
+-        // check if it matches any supported SLIP44 references
+-        (reference) => address.includes(reference) || reference.endsWith(address)));
+-exports.isNativeAddress = isNativeAddress;
++const isNativeAddress = (address) => {
++    if (address === constants_1.AddressZero || // bridge and swap apis set the native asset address to zero
++        address === '' || // assets controllers set the native asset address to an empty string
++        !address) {
++        return true;
++    }
++    // address may be a bare reference or a full CAIP-19 assetId (e.g.
++    // "eip155:5042/erc20:0x...."); only the segment after the last "/" matters
++    const suffix = address.includes('/') ? address.split('/').at(-1) : address;
++    return Object.values(tokens_1.SYMBOL_TO_SLIP44_MAP).some((reference) => reference === suffix ||
++        reference === `slip44:${suffix}` ||
++        reference === `erc20:${suffix}`);
++};
++exports.isNativeAddress = isNativeAddress;
+diff --git a/dist/utils/balance.cjs b/dist/utils/balance.cjs
+--- a/dist/utils/balance.cjs
++++ b/dist/utils/balance.cjs
+@@ -1,6 +1,7 @@
+ "use strict";
+ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.hasSufficientBalance = exports.calcLatestSrcBalance = exports.fetchTokenBalance = void 0;
++const constants_1 = require("@ethersproject/constants");
+ const address_1 = require("@ethersproject/address");
+ const contracts_1 = require("@ethersproject/contracts");
+ const providers_1 = require("@ethersproject/providers");
+@@ -18,6 +19,6 @@ exports.fetchTokenBalance = fetchTokenBalance;
+ const calcLatestSrcBalance = async (provider, selectedAddress, tokenAddress, chainId) => {
+     if (tokenAddress && chainId) {
+-        if ((0, bridge_1.isNativeAddress)(tokenAddress)) {
++        if (tokenAddress === constants_1.AddressZero) {
+             const ethersProvider = new providers_1.Web3Provider(provider);
+             return await ethersProvider.getBalance((0, address_1.getAddress)(selectedAddress));
+         }
+diff --git a/dist/utils/balance.mjs b/dist/utils/balance.mjs
+--- a/dist/utils/balance.mjs
++++ b/dist/utils/balance.mjs
+@@ -1,8 +1,8 @@
+ import { getAddress } from "@ethersproject/address";
++import { AddressZero } from "@ethersproject/constants";
+ import { Contract } from "@ethersproject/contracts";
+ import { Web3Provider } from "@ethersproject/providers";
+ import { abiERC20 } from "@metamask/metamask-eth-abis";
+-import { isNativeAddress } from "./bridge.mjs";
+ export const fetchTokenBalance = async (address, userAddress, provider) => {
+     const ethersProvider = new Web3Provider(provider);
+     const tokenContract = new Contract(address, abiERC20, ethersProvider);
+@@ -13,7 +13,7 @@ export const fetchTokenBalance = async (address, userAddress, provider) => {
+ };
+ export const calcLatestSrcBalance = async (provider, selectedAddress, tokenAddress, chainId) => {
+     if (tokenAddress && chainId) {
+-        if (isNativeAddress(tokenAddress)) {
++        if (tokenAddress === AddressZero) {
+             const ethersProvider = new Web3Provider(provider);
+             return await ethersProvider.getBalance(getAddress(selectedAddress));
+         }

--- a/shared/constants/bridge.ts
+++ b/shared/constants/bridge.ts
@@ -142,18 +142,6 @@ type BridgeChainTokenMap = Partial<
   >
 >;
 
-// We usually use the native asset as "from" token. In some chains we want to override that.
-export const BRIDGE_CHAINID_TO_DEFAULT_FROM_TOKEN: BridgeChainTokenMap = {
-  [toEvmCaipChainId(CHAIN_IDS.ARC)]: {
-    // USDC on Arc
-    address: '0x3600000000000000000000000000000000000000',
-    symbol: 'USDC',
-    decimals: 6,
-    name: 'USDC',
-    assetId: `${toEvmCaipChainId(CHAIN_IDS.ARC)}/erc20:${toChecksumHexAddress('0x3600000000000000000000000000000000000000')}`,
-  },
-};
-
 // This is actually for defining a default "toToken" when opening Bridge view
 export const BRIDGE_CHAINID_COMMON_TOKEN_PAIR: BridgeChainTokenMap = {
   [toEvmCaipChainId(CHAIN_IDS.MAINNET)]: {
@@ -287,8 +275,3 @@ export const BRIDGE_CHAINID_COMMON_TOKEN_PAIR: BridgeChainTokenMap = {
     assetId: `${MultichainNetworks.TRON}/trc20:TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t`,
   },
 } as const;
-
-export const BRIDGE_ASSET_PICKER_HIDDEN_ASSETS = new Set([
-  // Arc blockchain: Two USDC - one native, one ERC20. Hidding native for convenience.
-  'eip155:5042/erc20:0x0000000000000000000000000000000000000000',
-]);

--- a/shared/lib/activity/adapters/helpers.ts
+++ b/shared/lib/activity/adapters/helpers.ts
@@ -6,10 +6,7 @@ import {
 } from '@metamask/transaction-controller';
 import { getNativeAssetForChainId } from '@metamask/bridge-controller';
 import type { Hex } from 'viem';
-import {
-  BRIDGE_CHAINID_COMMON_TOKEN_PAIR,
-  BRIDGE_CHAINID_TO_DEFAULT_FROM_TOKEN,
-} from '../../../constants/bridge';
+import { BRIDGE_CHAINID_COMMON_TOKEN_PAIR } from '../../../constants/bridge';
 import { CHAIN_IDS } from '../../../constants/network';
 import {
   IN_PROGRESS_TRANSACTION_STATUSES,
@@ -225,10 +222,9 @@ export function getKnownTokenMetadata(
     (chainId === CHAIN_IDS.MAINNET || assetId?.startsWith('eip155:1/')
       ? STATIC_MAINNET_TOKEN_LIST[contractAddress.toLowerCase()]
       : undefined) ??
-    [
-      ...Object.values(BRIDGE_CHAINID_TO_DEFAULT_FROM_TOKEN),
-      ...Object.values(BRIDGE_CHAINID_COMMON_TOKEN_PAIR),
-    ].find((token) => token?.assetId === assetId);
+    Object.values(BRIDGE_CHAINID_COMMON_TOKEN_PAIR).find(
+      (token) => token?.assetId === assetId,
+    );
 
   return tokenMetadata
     ? { ...tokenMetadata, ...(assetId ? { assetId } : {}) }

--- a/ui/components/app/assets/enablement/arc.ts
+++ b/ui/components/app/assets/enablement/arc.ts
@@ -1,6 +1,3 @@
-import { BridgeAsset } from '@metamask/bridge-controller';
-import { hexToNumber } from '@metamask/utils';
-
 /**
  * Arc Chain Augmentation Module
  * Contains specific logic that is reused to across the app to augment Arc specific functionality.
@@ -17,15 +14,6 @@ const ARC_NATIVE_CAIP_CHAIN_ID = 'eip155:5042';
 const ARC_NATIVE_ASSET_ID =
   'eip155:5042/erc20:0x0000000000000000000000000000000000000000';
 const ARC_NATIVE_ADDRESS = '0x0000000000000000000000000000000000000000';
-
-export const ARC_ERC20_USDC_BRIDGE_ASSET: BridgeAsset = {
-  symbol: 'USDC',
-  name: 'USDC',
-  address: '0x3600000000000000000000000000000000000000',
-  assetId: 'eip155:5042/erc20:0x3600000000000000000000000000000000000000',
-  chainId: hexToNumber(ARC_HEX_CHAIN_ID),
-  decimals: 6,
-};
 
 function isNativeArcAsset(asset: {
   address?: string;

--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -8,10 +8,7 @@ import {
   isCaipAssetType,
   parseCaipAssetType,
 } from '@metamask/utils';
-import {
-  BridgeAsset,
-  getNativeAssetForChainId,
-} from '@metamask/bridge-controller';
+import { getNativeAssetForChainId } from '@metamask/bridge-controller';
 
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import {
@@ -80,25 +77,7 @@ import { navigateToSendRoute } from '../../../pages/confirmations/utils/send';
 import { useOnClickOutside } from '../perps/hooks/useClickOutside';
 import { useBatchSell } from '../../../hooks/batch-sell/useBatchSell';
 import { getIsBatchSellEnabled } from '../../../selectors/batch-sell/feature-flags';
-import {
-  ARC_ERC20_USDC_BRIDGE_ASSET,
-  ARC_HEX_CHAIN_ID,
-} from '../assets/enablement/arc';
 import { useHandleSendNonEvm } from './hooks/useHandleSendNonEvm';
-
-/**
- * Allows to manually set the default Swap token when clicking on the Swap CTA from
- * native token page. If unset, `getNativeAssetForChainId` of bridge-controller is used.
- */
-const NATIVE_SWAP_TOKEN_OVERRIDE_PER_CHAIN: { [key: string]: BridgeAsset } = {
-  // On Arc, we want to Bridge/Swap the ERC20 flavor of USDC, not the native one.
-  [ARC_HEX_CHAIN_ID]: ARC_ERC20_USDC_BRIDGE_ASSET,
-};
-
-function getSwapNativeTokenWithOverridesForChain(chainId: string): BridgeAsset {
-  const override = NATIVE_SWAP_TOKEN_OVERRIDE_PER_CHAIN[chainId];
-  return override ?? getNativeAssetForChainId(chainId);
-}
 
 type MoreButtonsGroupProps<TagElem extends React.ElementType = 'div'> = {
   classPrefix?: string;
@@ -454,7 +433,7 @@ const CoinButtons = ({
       openBridgeExperience(
         MetaMetricsSwapsEventSource.MainView,
         chainIdToUse && ALL_ALLOWED_BRIDGE_CHAIN_IDS.includes(chainIdToUse)
-          ? getSwapNativeTokenWithOverridesForChain(chainIdToUse)
+          ? getNativeAssetForChainId(chainIdToUse)
           : undefined,
       ),
     );

--- a/ui/ducks/bridge/asset-selectors.ts
+++ b/ui/ducks/bridge/asset-selectors.ts
@@ -12,14 +12,12 @@ import {
   type CaipAssetType,
   type CaipChainId,
   getChecksumAddress,
+  Hex,
   isCaipAssetType,
   isStrictHexString,
   parseCaipAssetType,
 } from '@metamask/utils';
-import {
-  ALLOWED_MULTICHAIN_BRIDGE_CHAIN_IDS,
-  BRIDGE_ASSET_PICKER_HIDDEN_ASSETS,
-} from '../../../shared/constants/bridge';
+import { ALLOWED_MULTICHAIN_BRIDGE_CHAIN_IDS } from '../../../shared/constants/bridge';
 import { isTronSpecialAsset, toAssetId } from '../../../shared/lib/asset-utils';
 import {
   getAccountTrackerControllerAccountsByChainId,
@@ -174,8 +172,14 @@ const getNativeAssetsWithBalance = createSelector(
     getEvmAccountAddress,
     getAllowedHexChainIds,
     getAccountTrackerControllerAccountsByChainId,
+    getTokenBalancesControllerTokenBalances,
   ],
-  (accountAddress, hexChainIds, balanceByChainIdByAccountAddress) => {
+  (
+    accountAddress,
+    hexChainIds,
+    balanceByChainIdByAccountAddress,
+    tokenBalancesByAccountAddress,
+  ) => {
     const assetsWithBalance: BridgeToken[] = [];
     if (!accountAddress || !isStrictHexString(accountAddress)) {
       return assetsWithBalance;
@@ -183,29 +187,41 @@ const getNativeAssetsWithBalance = createSelector(
     const normalizedAddress = getChecksumAddress(accountAddress);
     const lowercasedAddress = accountAddress.toLowerCase();
 
-    Object.entries(balanceByChainIdByAccountAddress).forEach(
-      ([chainId, accounts]) => {
-        if (!isStrictHexString(chainId) || !hexChainIds.includes(chainId)) {
-          return;
-        }
+    const tokenBalances =
+      tokenBalancesByAccountAddress[normalizedAddress] ??
+      // @ts-expect-error - lowercasedAddress is a Hex string
+      tokenBalancesByAccountAddress[lowercasedAddress];
 
-        const token = getNativeAssetForChainId(chainId);
-        const account =
-          accounts[normalizedAddress] ?? accounts[lowercasedAddress];
+    hexChainIds.forEach((chainId) => {
+      const token = getNativeAssetForChainId(chainId);
+      const { decimals, symbol, name, assetId } = token;
 
-        if (account?.balance && token) {
-          const { decimals, symbol, name, assetId } = token;
-          assetsWithBalance.push({
-            balance: convertHexBalanceToDecimal(account.balance, decimals),
-            chainId: formatChainIdToCaip(chainId),
-            symbol,
-            name,
-            decimals,
-            assetId,
-          });
-        }
-      },
-    );
+      /**
+       * When the native asset is a ERC20 - as opposed to actual native,
+       * use the ERC20 balances input as source of truth instead of native.
+       * Having this logic here means `exchangeRatesByAssetId` gets populated.
+       * Otherwise no USD price in the Bridge Asset Picker.
+       */
+      const balanceHex =
+        token.address === zeroAddress()
+          ? (balanceByChainIdByAccountAddress[chainId]?.[normalizedAddress]
+              ?.balance ??
+            balanceByChainIdByAccountAddress[chainId]?.[lowercasedAddress]
+              ?.balance)
+          : (tokenBalances?.[chainId]?.[token.address as Hex] ??
+            tokenBalances?.[chainId]?.[token.address.toLowerCase() as Hex]);
+
+      if (balanceHex) {
+        assetsWithBalance.push({
+          balance: convertHexBalanceToDecimal(balanceHex, decimals),
+          chainId: formatChainIdToCaip(chainId),
+          symbol,
+          name,
+          decimals,
+          assetId,
+        });
+      }
+    });
     return assetsWithBalance;
   },
 );
@@ -391,9 +407,7 @@ const getBridgeAssetsForAccountGroupId = createSelector(
           .toNumber(),
       }));
 
-    return nonEvmAssetsWithFiatBalances
-      .concat(evmAssetsWithFiatBalances)
-      .filter((item) => !BRIDGE_ASSET_PICKER_HIDDEN_ASSETS.has(item.assetId));
+    return nonEvmAssetsWithFiatBalances.concat(evmAssetsWithFiatBalances);
   },
 );
 

--- a/ui/ducks/bridge/bridge.ts
+++ b/ui/ducks/bridge/bridge.ts
@@ -10,11 +10,19 @@ import {
   type QuoteMetadata,
 } from '@metamask/bridge-controller';
 import { zeroAddress } from 'ethereumjs-util';
-import type { CaipAssetType, CaipChainId } from '@metamask/utils';
+import {
+  isStrictHexString,
+  type CaipAssetType,
+  type CaipChainId,
+} from '@metamask/utils';
 import { fetchTxAlerts } from '../../../shared/lib/bridge-utils/security-alerts-api.util';
 import { trace, TraceName } from '../../../shared/lib/trace';
 import { SlippageValue } from '../../pages/bridge/utils/slippage-service';
-import { getTokenExchangeRate, toBridgeToken } from './utils';
+import {
+  getNativeAssetForChainIdSafe,
+  getTokenExchangeRate,
+  toBridgeToken,
+} from './utils';
 import type { BridgeState, TokenPayload } from './types';
 
 export const initialState: BridgeState = {
@@ -72,7 +80,9 @@ const getBalanceAmount = async ({
         await calcLatestSrcBalance(
           global.ethereumProvider,
           selectedAddress,
-          isNative ? zeroAddress() : tokenAddress,
+          isNative && !isStrictHexString(tokenAddress)
+            ? zeroAddress()
+            : tokenAddress,
           formatChainIdToHex(chainId),
         )
       )?.toString(),
@@ -87,7 +97,8 @@ export const setEVMSrcNativeBalance = createAsyncThunk(
   }: Omit<Parameters<typeof getBalanceAmount>[0], 'tokenAddress'>) =>
     await getBalanceAmount({
       selectedAddress,
-      tokenAddress: zeroAddress(),
+      tokenAddress:
+        getNativeAssetForChainIdSafe(chainId)?.address ?? zeroAddress(),
       chainId,
     }),
 );

--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -114,7 +114,6 @@ import {
   isTronChainId,
   getMaybeHexChainId,
   isSupportedBridgeChain,
-  getDefaultFromToken,
 } from './utils';
 import type {
   BridgeNetwork,
@@ -379,12 +378,8 @@ export const getFromToken = createSelector(
     const fromChain = fromChains.find(
       ({ chainId }) => !isCrossChain(chainId, providerConfig?.chainId),
     );
-    // If the user has not selected a token, return the native token for the selected network as default
-    // If selected network is not supported by swap/bridge, return ETH (edge case)
-    if (!fromChain?.chainId) {
-      return toBridgeToken(getNativeAssetForChainId(FALLBACK_CHAIN_ID));
-    }
-    return getDefaultFromToken(fromChain.chainId);
+    const fromChainId = fromChain?.chainId ?? FALLBACK_CHAIN_ID;
+    return toBridgeToken(getNativeAssetForChainId(fromChainId));
   },
 );
 

--- a/ui/ducks/bridge/utils.ts
+++ b/ui/ducks/bridge/utils.ts
@@ -19,7 +19,6 @@ import { Numeric } from '../../../shared/lib/Numeric';
 import {
   ALL_ALLOWED_BRIDGE_CHAIN_IDS,
   BRIDGE_CHAINID_COMMON_TOKEN_PAIR,
-  BRIDGE_CHAINID_TO_DEFAULT_FROM_TOKEN,
 } from '../../../shared/constants/bridge';
 import { getAssetImageUrl } from '../../../shared/lib/asset-utils';
 import { BridgeAssetSecurityDataType } from '../../pages/bridge/utils/tokens';
@@ -214,18 +213,6 @@ export const toBridgeToken = (
   };
 };
 
-export const getDefaultFromToken = (fromChainId: CaipChainId) => {
-  const defaultFromTokenForChain =
-    BRIDGE_CHAINID_TO_DEFAULT_FROM_TOKEN[fromChainId];
-  // If commonPair is defined and is not the same as the fromToken, return it
-  if (defaultFromTokenForChain) {
-    return toBridgeToken(defaultFromTokenForChain);
-  }
-
-  // Last resort: native token
-  return toBridgeToken(getNativeAssetForChainId(fromChainId));
-};
-
 export const getDefaultToToken = (
   toChainId: CaipChainId,
   fromAssetId: CaipAssetType,
@@ -238,14 +225,7 @@ export const getDefaultToToken = (
   ) {
     return toBridgeToken(commonPair);
   }
-
-  /**
-   * Our current "from" asset is our default "to" token.
-   * Hence we can make our "to" token be the default "from" token.
-   * It will still fallback to native (original behavior).
-   * We know fromChainId === toChainId because of the assetId clash.
-   */
-  return getDefaultFromToken(toChainId);
+  return toBridgeToken(getNativeAssetForChainId(toChainId));
 };
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -6038,7 +6038,7 @@ __metadata:
 
 "@metamask/bridge-controller@patch:@metamask/bridge-controller@npm%3A73.2.0#~/.yarn/patches/@metamask-bridge-controller-npm-73.2.0-be55b13227.patch":
   version: 73.2.0
-  resolution: "@metamask/bridge-controller@patch:@metamask/bridge-controller@npm%3A73.2.0#~/.yarn/patches/@metamask-bridge-controller-npm-73.2.0-be55b13227.patch::version=73.2.0&hash=3a6413"
+  resolution: "@metamask/bridge-controller@patch:@metamask/bridge-controller@npm%3A73.2.0#~/.yarn/patches/@metamask-bridge-controller-npm-73.2.0-be55b13227.patch::version=73.2.0&hash=4ce85d"
   dependencies:
     "@ethersproject/address": "npm:^5.7.0"
     "@ethersproject/bignumber": "npm:^5.7.0"
@@ -6065,7 +6065,7 @@ __metadata:
     bignumber.js: "npm:^9.1.2"
     reselect: "npm:^5.1.1"
     uuid: "npm:^8.3.2"
-  checksum: 10/07341428f26082320ffc751927359dda0ef516a235af23c33471af8ba34e1ecbbca896fad4b010601a92d9ad498371b12cc5323fa72a41b5eac5b4fbc4c166fa
+  checksum: 10/b2bed84af2f2efe05c24876863d3fdab335b1f6442dffba3418717dc0a619f4b8f44274ceb33310766f351f9065d3879df4d2319052f541a98b694db00772c3e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Patch equivalent of https://github.com/MetaMask/core/pull/9196 for testing and non-reg.

**Goals:**

Solve remaining issues with Swap/Bridge on ARC: Most importantly the "max swap" behavior (since the current approach doesn't consider USDC as native, which leaves "max" button visible).
Remove as many "quick fixes" as possible from the codebase.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: hide max button for ARC USDC Swap

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared bridge-controller native/balance/CAIP parsing used across swap and bridge flows; incorrect native classification could affect max amounts, gas reserve checks, and balances on Arc and other ERC20-as-native chains.
> 
> **Overview**
> Moves Arc swap/bridge behavior into **`@metamask/bridge-controller`** (yarn patch) so Arc’s default asset is **USDC at `0x3600…` (6 decimals)** with chain id **5042**, and tightens **native detection** for CAIP-19 asset ids and **ERC20 balance** fetching when the “native” asset is really an ERC20.
> 
> The extension drops Arc-specific workarounds: **`BRIDGE_CHAINID_TO_DEFAULT_FROM_TOKEN`**, **`BRIDGE_ASSET_PICKER_HIDDEN_ASSETS`**, wallet **swap token overrides**, and **`ARC_ERC20_USDC_BRIDGE_ASSET`**. Defaults now use **`getNativeAssetForChainId`** everywhere; bridge **asset picker** reads ERC20 balances for pseudo-native tokens (fixes USD pricing); **balance** thunks pass the real native token address instead of always `0x0`.
> 
> Together this should treat Arc USDC as the chain native in bridge/swap (including **max** button / reserve logic that keys off `isNativeAddress`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 20d4ffe75de6677cad2cae6657d1e272a0fdd0c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->