### PR TITLE
fix(ramps): fetch buyable networks on all routes

### DIFF
--- a/ui/hooks/ramps/useFetchBuyableChains.test.ts
+++ b/ui/hooks/ramps/useFetchBuyableChains.test.ts
@@ -1,0 +1,51 @@
+import { renderHookWithProvider } from '../../../test/lib/render-helpers-navigate';
+import { fetchBuyableChains } from '../../ducks/ramps';
+import { useFetchBuyableChains } from './useFetchBuyableChains';
+
+jest.mock('../../ducks/ramps', () => ({
+  ...jest.requireActual('../../ducks/ramps'),
+  fetchBuyableChains: jest.fn(() => ({
+    type: 'ramps/fetchBuyableChains/mock',
+  })),
+}));
+
+const mockFetchBuyableChains = jest.mocked(fetchBuyableChains);
+
+describe('useFetchBuyableChains', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('dispatches fetchBuyableChains when the wallet is unlocked and onboarding is complete', () => {
+    renderHookWithProvider(() => useFetchBuyableChains(), {
+      metamask: {
+        isUnlocked: true,
+        completedOnboarding: true,
+      },
+    });
+
+    expect(mockFetchBuyableChains).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not dispatch fetchBuyableChains when the wallet is locked', () => {
+    renderHookWithProvider(() => useFetchBuyableChains(), {
+      metamask: {
+        isUnlocked: false,
+        completedOnboarding: true,
+      },
+    });
+
+    expect(mockFetchBuyableChains).not.toHaveBeenCalled();
+  });
+
+  it('does not dispatch fetchBuyableChains when onboarding is incomplete', () => {
+    renderHookWithProvider(() => useFetchBuyableChains(), {
+      metamask: {
+        isUnlocked: true,
+        completedOnboarding: false,
+      },
+    });
+
+    expect(mockFetchBuyableChains).not.toHaveBeenCalled();
+  });
+});

--- a/ui/hooks/ramps/useFetchBuyableChains.ts
+++ b/ui/hooks/ramps/useFetchBuyableChains.ts
@@ -1,0 +1,24 @@
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { getIsUnlocked } from '../../ducks/metamask/base-selectors';
+import { getCompletedOnboarding } from '../../ducks/metamask/metamask';
+import { fetchBuyableChains } from '../../ducks/ramps';
+
+/**
+ * Fetches buyable networks from the ramp API when the wallet is ready.
+ * The thunk caches results in Redux, so this only triggers one network request
+ * per session regardless of how many components mount the hook.
+ */
+export function useFetchBuyableChains(): void {
+  const dispatch = useDispatch();
+  const isUnlocked = useSelector(getIsUnlocked);
+  const completedOnboarding = useSelector(getCompletedOnboarding);
+
+  useEffect(() => {
+    if (!isUnlocked || !completedOnboarding) {
+      return;
+    }
+
+    dispatch(fetchBuyableChains());
+  }, [dispatch, isUnlocked, completedOnboarding]);
+}

--- a/ui/pages/home/home.component.stories.tsx
+++ b/ui/pages/home/home.component.stories.tsx
@@ -95,7 +95,6 @@ const meta: Meta<typeof Home> = {
     clearEditedNetwork: () => {},
     setActiveNetwork: () => {},
     setBasicFunctionalityModalOpen: () => {},
-    fetchBuyableChains: () => {},
     clearRedirectAfterDefaultPage: () => {},
     lookupSelectedNetworks: () => {},
   },

--- a/ui/pages/home/home.component.test.tsx
+++ b/ui/pages/home/home.component.test.tsx
@@ -77,7 +77,6 @@ function buildDefaultProps(overrides: Record<string, unknown> = {}) {
     attemptCloseNotificationPopup: jest.fn(),
     setNewTokensImported: jest.fn(),
     setNewTokensImportedError: jest.fn(),
-    fetchBuyableChains: jest.fn(),
     lookupSelectedNetworks: jest.fn(),
     showPna25Modal: false,
     envType: ENVIRONMENT_TYPE_POPUP,

--- a/ui/pages/home/home.component.tsx
+++ b/ui/pages/home/home.component.tsx
@@ -156,7 +156,6 @@ export type HomeProps = {
   setActiveNetwork?: (networkConfigurationId: string) => void;
   useExternalServices?: boolean;
   setBasicFunctionalityModalOpen?: () => void;
-  fetchBuyableChains: () => void;
   redirectAfterDefaultPage?: RedirectAfterDefaultPage;
   setRedirectAfterDefaultPage?: (redirect: { path: string }) => void;
   clearRedirectAfterDefaultPage?: () => void;
@@ -347,8 +346,6 @@ class HomeBase extends PureComponent<HomeProps, HomeState> {
   }
 
   componentDidMount() {
-    this.props.fetchBuyableChains();
-
     this.checkPendingRedirectRoute();
     this.checkLastVisitedPerpsRoute();
     this.checkRedirectAfterDefaultPage();

--- a/ui/pages/home/home.container.tsx
+++ b/ui/pages/home/home.container.tsx
@@ -58,7 +58,6 @@ import {
   getIsSeedlessPasswordOutdated,
   getWeb3ShimUsageAlertEnabledness,
 } from '../../ducks/metamask/metamask';
-import { fetchBuyableChains } from '../../ducks/ramps';
 import {
   selectRewardsEnabled,
   selectRewardsModalOpen,
@@ -314,7 +313,6 @@ function useHomeActions() {
         dispatch(setActiveNetwork(networkConfigurationId)),
       setBasicFunctionalityModalOpen: () =>
         dispatch(openBasicFunctionalityModal()),
-      fetchBuyableChains: () => dispatch(fetchBuyableChains()),
       setRedirectAfterDefaultPage: (redirect: object) =>
         dispatch(setRedirectAfterDefaultPage(redirect)),
       clearRedirectAfterDefaultPage: () =>

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -123,6 +123,7 @@ import { MultichainAccountAddressListPage } from '../multichain-accounts/multich
 import { MultichainAccountPrivateKeyListPage } from '../multichain-accounts/multichain-account-private-key-list-page';
 import MultichainAccountIntroModalContainer from '../../components/app/modals/multichain-accounts/intro-modal';
 import { useMultichainAccountsIntroModal } from '../../hooks/useMultichainAccountsIntroModal';
+import { useFetchBuyableChains } from '../../hooks/ramps/useFetchBuyableChains';
 import { AccountList } from '../multichain-accounts/account-list';
 import { AddWalletPage } from '../multichain-accounts/add-wallet-page';
 import { ChooseNewWalletTypePage } from '../multichain-accounts/choose-new-wallet-type';
@@ -608,6 +609,8 @@ export default function Routes() {
   // Multichain intro modal logic (extracted to custom hook)
   const { showMultichainIntroModal, setShowMultichainIntroModal } =
     useMultichainAccountsIntroModal(isUnlocked, location);
+
+  useFetchBuyableChains();
 
   const isUsingRedesignedConfirmationType = useIsRedesignedConfirmationType();
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

**Context:** The extension fetches buyable ramp networks from `https://on-ramp-content.api.cx.metamask.io/regions/networks` and stores them in Redux. When that fetch has not run, a hardcoded fallback list is used.

**Problem:** `fetchBuyableChains` was only dispatched from the Home page `componentDidMount`. Refreshing directly on an asset page (or other non-home routes) skipped the API fetch, leaving buy disabled for assets like BTC, SOL, and mUSD that depend on the live network list.

**Solution:** Introduce a shared `useFetchBuyableChains` hook and call it from the app-level `Routes` component so the ramp API is requested once per session regardless of landing page. Remove the Home-only fetch to avoid duplication.

## **Changelog**

CHANGELOG entry: Fixed buy being disabled for some assets when refreshing directly on an asset page.

## **Related issues**

Fixes: TRAM-310776

## **Manual testing steps**

1. Build and load the extension (`yarn start` or `yarn build:test`).
2. Unlock the wallet and ensure Basic Functionality (external services) is enabled.
3. Navigate to an asset page (e.g. BTC, SOL, or mUSD) from the home asset list.
4. Hard-refresh the extension while on that asset page.
5. Verify the Buy button is enabled (not greyed out) for buyable assets.
6. Repeat from the home page and confirm Buy still works there.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-45b32a40-66f7-4331-a18a-cb6cb166bc61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-45b32a40-66f7-4331-a18a-cb6cb166bc61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

