### PR TITLE
fix(asset): show correct network activity and balance on token details pages

### DIFF
--- a/ui/components/multichain/activity-v2/activity-list.tsx
+++ b/ui/components/multichain/activity-v2/activity-list.tsx
@@ -14,7 +14,7 @@ import {
   selectNonEvmTransactionsForActivity,
   selectLocalTransactions,
 } from '../../../selectors/activity';
-import { selectEvmAddress } from '../../../selectors/accounts';
+import { getSelectedAccountGroupEvmAddress } from '../../../selectors/multichain-accounts/account-tree';
 import { selectEnabledNetworksAsCaipChainIds } from '../../../selectors/multichain/networks';
 import { useEarliestNonceByChain } from '../../../hooks/useEarliestNonceByChain';
 import { useFormatters } from '../../../hooks/useFormatters';
@@ -57,7 +57,9 @@ export const ActivityList = ({ filter }: Props) => {
   const [selectedNonEvmTransaction, setSelectedNonEvmTransaction] =
     useState<Transaction | null>(null);
 
-  const evmAddress = (useSelector(selectEvmAddress) || '').toLowerCase();
+  const evmAddress = (
+    useSelector(getSelectedAccountGroupEvmAddress) || ''
+  ).toLowerCase();
   const enabledNetworks = useSelector(selectEnabledNetworksAsCaipChainIds);
 
   // Clear modal state on account switch

--- a/ui/components/multichain/activity-v2/hooks.ts
+++ b/ui/components/multichain/activity-v2/hooks.ts
@@ -53,7 +53,9 @@ function classifyNft(
 
 export function useGetTitle(transaction: TransactionViewModel): string {
   const t = useI18nContext();
-  const evmAddress = useSelector(getSelectedAccountGroupEvmAddress)?.toLowerCase();
+  const evmAddress = useSelector(
+    getSelectedAccountGroupEvmAddress,
+  )?.toLowerCase();
   const isExtensionTransactionLabelsEnabled = useSelector(
     getIsTransactionLabelsEnabled,
   );

--- a/ui/components/multichain/activity-v2/hooks.ts
+++ b/ui/components/multichain/activity-v2/hooks.ts
@@ -6,7 +6,7 @@ import type {
   TransactionViewModel,
 } from '../../../../shared/lib/multichain/types';
 import { selectMarketRates } from '../../../selectors/activity';
-import { selectEvmAddress } from '../../../selectors/accounts';
+import { getSelectedAccountGroupEvmAddress } from '../../../selectors/multichain-accounts/account-tree';
 import { parseApprovalTransactionData } from '../../../../shared/lib/transaction.utils';
 import { SET_APPROVAL_FOR_ALL } from '../../../../shared/constants/transaction';
 import { getIsTransactionLabelsEnabled } from '../../../selectors/multichain/feature-flags';
@@ -53,7 +53,7 @@ function classifyNft(
 
 export function useGetTitle(transaction: TransactionViewModel): string {
   const t = useI18nContext();
-  const evmAddress = useSelector(selectEvmAddress)?.toLowerCase();
+  const evmAddress = useSelector(getSelectedAccountGroupEvmAddress)?.toLowerCase();
   const isExtensionTransactionLabelsEnabled = useSelector(
     getIsTransactionLabelsEnabled,
   );

--- a/ui/components/multichain/activity-v2/useTransactionsQuery.ts
+++ b/ui/components/multichain/activity-v2/useTransactionsQuery.ts
@@ -7,7 +7,7 @@ import { getErrorBodyMessage } from '../../../../shared/lib/error';
 import { selectTransactions } from '../../../../shared/lib/multichain/transformations';
 import { MINUTE } from '../../../../shared/constants/time';
 import { getUseExternalServices } from '../../../selectors';
-import { selectEvmAddress } from '../../../selectors/accounts';
+import { getSelectedAccountGroupEvmAddress } from '../../../selectors/multichain-accounts/account-tree';
 import { getIntlLocale } from '../../../ducks/locale/locale';
 import { apiClient } from '../../../helpers/api-client';
 import { selectEnabledNetworksAsCaipChainIds } from '../../../selectors/multichain/networks';
@@ -65,7 +65,9 @@ function getTransactionApiLanguage(locale: string) {
 }
 
 function useTransactionParams(caipChainId?: CaipChainId) {
-  const evmAddress = (useSelector(selectEvmAddress) || '').toLowerCase();
+  const evmAddress = (
+    useSelector(getSelectedAccountGroupEvmAddress) || ''
+  ).toLowerCase();
   const locale = useSelector(getIntlLocale);
   const enabledNetworks = useSelector(selectEnabledNetworksAsCaipChainIds);
 

--- a/ui/pages/activity/useTransactionsQuery.ts
+++ b/ui/pages/activity/useTransactionsQuery.ts
@@ -8,7 +8,7 @@ import { getErrorBodyMessage } from '../../../shared/lib/error';
 import { getIntlLocale } from '../../ducks/locale/locale';
 import { apiClient } from '../../helpers/api-client';
 import { getUseExternalServices } from '../../selectors';
-import { selectEvmAddress } from '../../selectors/accounts';
+import { getSelectedAccountGroupEvmAddress } from '../../selectors/multichain-accounts/account-tree';
 import type { ActivityListFilter } from './helpers';
 import { useQueryFilters } from './query-filters/useQueryFilters';
 
@@ -62,7 +62,9 @@ function withKnownApiResponse(queryFn: TransactionQueryOptions['queryFn']) {
 
 export function useTransactionsQuery(filters: ActivityListFilter) {
   const useExternalServices = useSelector(getUseExternalServices);
-  const evmAddress = (useSelector(selectEvmAddress) || '').toLowerCase();
+  const evmAddress = (
+    useSelector(getSelectedAccountGroupEvmAddress) || ''
+  ).toLowerCase();
   const locale = useSelector(getIntlLocale);
   const selectFn = useQueryFilters({ subjectAddress: evmAddress, ...filters });
   const networks =

--- a/ui/pages/asset/components/asset-page.test.tsx
+++ b/ui/pages/asset/components/asset-page.test.tsx
@@ -2,7 +2,13 @@ import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { fireEvent, waitFor } from '@testing-library/react';
-import { EthAccountType, EthScope } from '@metamask/keyring-api';
+import {
+  EthAccountType,
+  EthScope,
+  SolAccountType,
+  SolScope,
+  TrxScope,
+} from '@metamask/keyring-api';
 import nock from 'nock';
 import { toChecksumHexAddress } from '@metamask/controller-utils';
 import {
@@ -89,11 +95,18 @@ jest.mock('../../../hooks/musd', () => {
     }),
   };
 });
+const mockActivityListFilters: { v2?: unknown; v3?: unknown } = {};
 jest.mock('../../../components/multichain/activity-v2/activity-list', () => ({
-  ActivityList: () => <div data-testid="mock-activity-list" />,
+  ActivityList: ({ filter }: { filter?: unknown }) => {
+    mockActivityListFilters.v2 = filter;
+    return <div data-testid="mock-activity-list" />;
+  },
 }));
 jest.mock('../../activity/activity-list', () => ({
-  ActivityList: () => <div data-testid="mock-activity-list" />,
+  ActivityList: ({ filter }: { filter?: unknown }) => {
+    mockActivityListFilters.v3 = filter;
+    return <div data-testid="mock-activity-list" />;
+  },
 }));
 
 jest.mock('../../../hooks/useMultiPolling', () => ({
@@ -841,6 +854,106 @@ describe('AssetPage', () => {
       expect(
         getByText(messages.musdAssetBonusAccruing.message),
       ).toBeInTheDocument();
+    });
+  });
+
+  describe('non-EVM native asset activity scope', () => {
+    const SOLANA_NATIVE_ASSET_ID = `${SolScope.Mainnet}/slip44:501`;
+    const TRON_NATIVE_ASSET_ID = `${TrxScope.Mainnet}/slip44:195`;
+    const SOLANA_ACCOUNT_ID = 'solana-account-id';
+    const WALLET_ID = 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ';
+    const GROUP_ID = 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0';
+
+    const solanaNativeAsset = {
+      type: AssetType.native,
+      chainId: SolScope.Mainnet as unknown as `0x${string}`,
+      symbol: 'SOL',
+      image: '',
+      isOriginalNativeSymbol: true,
+      decimals: 9,
+    } as const;
+
+    // Selected account stays EVM while the user views the Solana token page,
+    // mirroring the bug repro where a different (e.g. Tron) network/account is
+    // globally selected.
+    const buildSolanaStore = () =>
+      configureMockStore([thunk])({
+        ...mockStore,
+        metamask: {
+          ...mockStore.metamask,
+          accountTree: {
+            wallets: {
+              [WALLET_ID]: {
+                ...mockStore.metamask.accountTree.wallets[WALLET_ID],
+                groups: {
+                  [GROUP_ID]: {
+                    ...mockStore.metamask.accountTree.wallets[WALLET_ID].groups[
+                      GROUP_ID
+                    ],
+                    accounts: [selectedAccountAddress, SOLANA_ACCOUNT_ID],
+                  },
+                },
+              },
+            },
+          },
+          internalAccounts: {
+            accounts: {
+              ...mockStore.metamask.internalAccounts.accounts,
+              [SOLANA_ACCOUNT_ID]: {
+                address: '7S3P4HxJpyyigGzodYwHtCxZyUQe9JiBMHyRWXArAaKv',
+                id: SOLANA_ACCOUNT_ID,
+                metadata: {
+                  name: 'Solana Account',
+                  keyring: { type: 'Snap Keyring' },
+                },
+                options: {},
+                methods: [],
+                type: SolAccountType.DataAccount,
+                scopes: [SolScope.Mainnet],
+              },
+            },
+            selectedAccount: selectedAccountAddress,
+          },
+        },
+      });
+
+    it('scopes activity to the viewed chain native asset, not the globally selected one', () => {
+      (
+        getAssetsBySelectedAccountGroup as unknown as jest.Mock
+      ).mockReturnValueOnce({
+        [SolScope.Mainnet]: [
+          {
+            assetId: SOLANA_NATIVE_ASSET_ID,
+            isNative: true,
+            rawBalance: '0x1',
+            balance: '1',
+            fiat: { balance: 1 },
+          },
+        ],
+        [TrxScope.Mainnet]: [
+          {
+            assetId: TRON_NATIVE_ASSET_ID,
+            isNative: true,
+            rawBalance: '0x1',
+            balance: '1',
+            fiat: { balance: 1 },
+          },
+        ],
+      });
+
+      renderWithProvider(
+        <AssetPage asset={solanaNativeAsset} optionsButton={null} />,
+        buildSolanaStore(),
+      );
+
+      // Redesign flag is off in the mock store, so the v2 activity list renders.
+      expect(mockActivityListFilters.v2).toMatchObject({
+        chainId: SolScope.Mainnet,
+        assetScope: {
+          kind: 'native',
+          caipAssetType: SOLANA_NATIVE_ASSET_ID,
+        },
+      });
     });
   });
 });

--- a/ui/pages/asset/components/asset-page.tsx
+++ b/ui/pages/asset/components/asset-page.tsx
@@ -70,7 +70,6 @@ import {
 import {
   getAsset,
   getAssetsBySelectedAccountGroup,
-  getMultichainNativeAssetType,
 } from '../../../selectors/assets';
 import { getIsActivityListRedesignEnabled } from '../../../selectors/activity/feature-flags';
 import {
@@ -118,8 +117,6 @@ const AssetPage = ({
   const currency = useSelector(getCurrentCurrency);
   const isBuyableChain = useSelector(getIsNativeTokenBuyable);
   const isEvm = isEvmChainId(asset.chainId);
-  // TODO BIP44 Refactor: This selector does not work with BIP44 enabled, pass the information in the asset object
-  const nativeAssetType = useSelector(getMultichainNativeAssetType);
   const accountGroupIdAssets = useSelector(getAssetsBySelectedAccountGroup);
   const caipChainId = isCaipChainId(asset.chainId)
     ? asset.chainId
@@ -178,7 +175,16 @@ const AssetPage = ({
       if (type === AssetType.token) {
         return isEvm ? toChecksumHexAddress(asset.address) : asset.address;
       }
-      return isEvm ? getNativeTokenAddress(chainId) : nativeAssetType;
+      if (isEvm) {
+        return getNativeTokenAddress(chainId);
+      }
+      // For non-EVM native assets, derive the native asset id from the asset
+      // being viewed (its chainId within the selected account group) rather
+      // than from the globally selected account/network. Using global
+      // selection caused the wrong chain's native asset to leak in (e.g.
+      // showing Tron activity/balance on the Solana or Bitcoin token page).
+      return accountGroupIdAssets[caipChainId]?.find((item) => item.isNative)
+        ?.assetId;
     })() ?? '';
 
   const shouldShowContractAddress = type === AssetType.token;

--- a/ui/selectors/multichain-accounts/account-tree.test.ts
+++ b/ui/selectors/multichain-accounts/account-tree.test.ts
@@ -7,6 +7,7 @@ import {
 import { AccountGroupObject } from '@metamask/account-tree-controller';
 
 import { KeyringTypes } from '@metamask/keyring-controller';
+import { EthAccountType, SolAccountType } from '@metamask/keyring-api';
 
 import mockState from '../../../test/data/mock-state.json';
 import { createMockInternalAccount } from '../../../test/jest/mocks';
@@ -19,6 +20,8 @@ import {
   getCaip25IdByAccountGroupAndScope,
   getInternalAccountByGroupAndCaip,
   getInternalAccountBySelectedAccountGroupAndCaip,
+  getSelectedAccountGroupEvmAddress,
+  getSelectedAccountGroupEvmInternalAccount,
   getInternalAccountsFromGroupById,
   getMultichainAccountGroupById,
   getMultichainAccountGroups,
@@ -829,6 +832,130 @@ describe('Multichain Accounts Selectors', () => {
       );
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe('getSelectedAccountGroupEvmAddress', () => {
+    const EVM_ACCOUNT_ID = 'evm-account-id';
+    const SOLANA_ACCOUNT_ID = 'solana-account-id';
+    const EVM_ADDRESS = '0xabc0000000000000000000000000000000000001';
+    const SOLANA_ADDRESS = '7S3P4HxJpyyigGzodYwHtCxZyUQe9JiBMHyRWXArAaKv';
+
+    const createStateWithMixedGroup = (selectedAccountId: string) => {
+      const evmAccount = createMockInternalAccount({
+        id: EVM_ACCOUNT_ID,
+        name: 'EVM Account',
+        address: EVM_ADDRESS,
+        type: EthAccountType.Eoa,
+      });
+      const solanaAccount = createMockInternalAccount({
+        id: SOLANA_ACCOUNT_ID,
+        name: 'Solana Account',
+        address: SOLANA_ADDRESS,
+        type: SolAccountType.DataAccount,
+      });
+
+      return createMockMultichainAccountsState(
+        {
+          wallets: {
+            'entropy:test': {
+              id: 'entropy:test' as const,
+              type: AccountWalletType.Entropy as const,
+              status: 'ready',
+              groups: {
+                'entropy:test/0': {
+                  id: 'entropy:test/0' as const,
+                  type: AccountGroupType.MultichainAccount as const,
+                  accounts: [EVM_ACCOUNT_ID, SOLANA_ACCOUNT_ID] as [
+                    string,
+                    ...string[],
+                  ],
+                  metadata: {
+                    name: 'Test',
+                    entropy: { groupIndex: 0 },
+                    pinned: false,
+                    hidden: false,
+                    lastSelected: 0,
+                  },
+                },
+              },
+              metadata: {
+                name: 'Test Wallet',
+                entropy: { id: 'test' },
+              },
+            },
+          },
+        },
+        {
+          accounts: {
+            [EVM_ACCOUNT_ID]: evmAccount,
+            [SOLANA_ACCOUNT_ID]: solanaAccount,
+          },
+          selectedAccount: selectedAccountId,
+        },
+        undefined,
+        'entropy:test/0' as AccountGroupId,
+      );
+    };
+
+    it('returns the group EVM address even when the selected account is non-EVM', () => {
+      // Selected account is the Solana account; selectEvmAddress would return
+      // undefined here, but the group still has an EVM account.
+      const state = createStateWithMixedGroup(SOLANA_ACCOUNT_ID);
+
+      expect(getSelectedAccountGroupEvmInternalAccount(state)?.address).toBe(
+        EVM_ADDRESS,
+      );
+      expect(getSelectedAccountGroupEvmAddress(state)).toBe(EVM_ADDRESS);
+    });
+
+    it('returns the group EVM address when the selected account is the EVM account', () => {
+      const state = createStateWithMixedGroup(EVM_ACCOUNT_ID);
+
+      expect(getSelectedAccountGroupEvmAddress(state)).toBe(EVM_ADDRESS);
+    });
+
+    it('falls back to the selected account when no account group is selected but the selected account is EVM', () => {
+      const evmAccount = createMockInternalAccount({
+        id: EVM_ACCOUNT_ID,
+        name: 'EVM Account',
+        address: EVM_ADDRESS,
+        type: EthAccountType.Eoa,
+      });
+
+      const state = createMockMultichainAccountsState(
+        { wallets: {} },
+        {
+          accounts: { [EVM_ACCOUNT_ID]: evmAccount },
+          selectedAccount: EVM_ACCOUNT_ID,
+        },
+        undefined,
+        null as unknown as AccountGroupId,
+      );
+
+      expect(getSelectedAccountGroupEvmInternalAccount(state)).toBeNull();
+      expect(getSelectedAccountGroupEvmAddress(state)).toBe(EVM_ADDRESS);
+    });
+
+    it('returns undefined when neither the group nor the selected account is EVM', () => {
+      const solanaAccount = createMockInternalAccount({
+        id: SOLANA_ACCOUNT_ID,
+        name: 'Solana Account',
+        address: SOLANA_ADDRESS,
+        type: SolAccountType.DataAccount,
+      });
+
+      const state = createMockMultichainAccountsState(
+        { wallets: {} },
+        {
+          accounts: { [SOLANA_ACCOUNT_ID]: solanaAccount },
+          selectedAccount: SOLANA_ACCOUNT_ID,
+        },
+        undefined,
+        null as unknown as AccountGroupId,
+      );
+
+      expect(getSelectedAccountGroupEvmAddress(state)).toBeUndefined();
     });
   });
 

--- a/ui/selectors/multichain-accounts/account-tree.ts
+++ b/ui/selectors/multichain-accounts/account-tree.ts
@@ -578,6 +578,62 @@ export const getInternalAccountBySelectedAccountGroupAndCaip =
   );
 
 /**
+ * Get the EVM internal account belonging to the currently selected account
+ * group, regardless of which member of the group is the active internal
+ * account. A BIP-44 account group always contains a single EVM account, so
+ * this resolves the wallet's EVM account even when a non-EVM account (e.g.
+ * Solana, Bitcoin, Tron) is currently selected.
+ *
+ * @param state - The multichain accounts state.
+ * @returns The EVM internal account, or null if not found.
+ */
+export const getSelectedAccountGroupEvmInternalAccount = createSelector(
+  getAccountTree,
+  getInternalAccountsObject,
+  getSelectedAccountGroup,
+  (accountTree, internalAccounts, selectedAccountGroup) => {
+    if (!selectedAccountGroup) {
+      return null;
+    }
+
+    const { wallets } = accountTree;
+    const group = getGroupByGroupId(wallets, selectedAccountGroup);
+
+    // 'eip155:0' is the wildcard EVM scope shared by all EVM accounts.
+    return getInternalAccountFromGroup(
+      group,
+      'eip155:0' as CaipChainId,
+      internalAccounts,
+    );
+  },
+);
+
+/**
+ * Get the EVM address of the currently selected account group. Prefer this
+ * over `selectEvmAddress` (which only resolves when the active internal
+ * account is itself EVM) when you need the wallet's EVM address irrespective
+ * of which network/account is currently selected. Falls back to the selected
+ * internal account when it is EVM, to preserve legacy behavior in states
+ * without a resolvable account group.
+ *
+ * @param state - The multichain accounts state.
+ * @returns The EVM address, or undefined if not found.
+ */
+export const getSelectedAccountGroupEvmAddress = createSelector(
+  getSelectedAccountGroupEvmInternalAccount,
+  getSelectedInternalAccount,
+  (groupEvmAccount, selectedAccount) => {
+    if (groupEvmAccount) {
+      return groupEvmAccount.address;
+    }
+
+    return selectedAccount && isEvmAccountType(selectedAccount.type)
+      ? selectedAccount.address
+      : undefined;
+  },
+);
+
+/**
  * Retrieve wallet from account tree state.
  *
  * @param state - Redux state.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

The "Your Activity" section on a token details page could show transactions for the wrong network. This was reported for non-EVM chains (a Solana or Bitcoin token page showing Tron events on a new wallet), and also manifests across EVM chains (no transactions shown when a non-EVM network/account is selected).

There are two distinct root causes, both stemming from the token details page trusting the *globally selected* account/network instead of the *asset being viewed*:

1. **Non-EVM native assets (Tron events + 0 balance).** For a non-EVM native asset, the page derived `address` from `getMultichainNativeAssetType`, which is keyed by the globally selected account + selected multichain network. When Tron was the active network, this resolved to the Tron native asset, which then (via `toAssetId`, whose CAIP-asset-type precedence ignores the passed chainId) corrupted the activity filter's `caipAssetId` to the Tron asset and broke the balance lookup (showing 0). Fix: derive the non-EVM native asset id from the viewed chain within the selected account group (`getAssetsBySelectedAccountGroup[caipChainId]`).

2. **EVM token activity is empty when a non-EVM account is selected.** The activity transaction queries derived the EVM address from `selectEvmAddress`, which returns `undefined` whenever the active internal account is non-EVM. This left `accountAddresses` empty and disabled the query, so no EVM transactions were fetched. Fix: add `getSelectedAccountGroupEvmAddress`, which resolves the EVM account of the selected account group regardless of which member is active (falling back to the legacy behavior when no group is resolvable), and use it in the activity query/title hooks.

## **Changelog**

CHANGELOG entry: Fixed the token details "Your Activity" section showing transactions from the wrong network (e.g. Tron activity and a 0 balance on Solana/Bitcoin token pages, and missing EVM transactions when a non-EVM account was selected).

## **Related issues**

Fixes: #43677

## **Manual testing steps**

Non-EVM native assets (Tron leaking into Solana/Bitcoin):

1. Use a wallet that holds balances on Tron, Solana and Bitcoin.
2. Receive funds on Tron first and open the Tron token details page so Tron becomes the active network.
3. Open the Solana token details page.
4. Verify the balance reflects the real SOL balance (not 0) and "Your activity" shows only Solana events (no "Received TRX").
5. Open the Bitcoin token details page and verify the balance is correct and "Your activity" shows only Bitcoin events.

EVM activity with a non-EVM account selected:

1. In a multichain wallet, select a non-EVM network/account (e.g. Solana).
2. Switch the network filter to "All popular networks".
3. Open an EVM token's details page (e.g. ETH on Ethereum Mainnet).
4. Verify "Your activity" lists the EVM token's transactions instead of being empty.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e2c12392-fa2a-4eb1-93dd-b50fc1d796a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e2c12392-fa2a-4eb1-93dd-b50fc1d796a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

