### PR TITLE
fix: evm address selector for activity

### DIFF
--- a/ui/pages/activity/useTransactionsQuery.ts
+++ b/ui/pages/activity/useTransactionsQuery.ts
@@ -8,7 +8,7 @@ import { getErrorBodyMessage } from '../../../shared/lib/error';
 import { getIntlLocale } from '../../ducks/locale/locale';
 import { apiClient } from '../../helpers/api-client';
 import { getUseExternalServices } from '../../selectors';
-import { selectEvmAddress } from '../../selectors/accounts';
+import { selectEvmAddress } from '../../selectors/activity';
 import type { ActivityListFilter } from './helpers';
 import { useQueryFilters } from './query-filters/useQueryFilters';
 

--- a/ui/pages/details/transaction-details.tsx
+++ b/ui/pages/details/transaction-details.tsx
@@ -2,8 +2,8 @@ import React, { useMemo } from 'react';
 import { V1TransactionByHashResponse } from '@metamask/core-backend';
 import { useSelector } from 'react-redux';
 import { mapApiEvmTransactions } from '../../../shared/lib/activity/adapters/api-evm-transactions';
-import { selectEvmAddress } from '../../selectors/accounts';
 import {
+  selectEvmAddress,
   selectLocalActivityItemsByIdentifier,
   selectNonEvmActivityItemsById,
 } from '../../selectors/activity';

--- a/ui/selectors/activity.test.ts
+++ b/ui/selectors/activity.test.ts
@@ -1,36 +1,23 @@
-import { AccountGroupId } from '@metamask/account-api';
 import type { Transaction } from '@metamask/keyring-api';
 import type { MultichainTransactionsControllerState } from '@metamask/multichain-transactions-controller';
 import { MultichainNetworks } from '../../shared/constants/multichain/networks';
-import type { MetaMaskReduxState as _MetaMaskReduxState } from '../store/store';
+import type { MetaMaskReduxState } from '../store/store';
 import { generateTokenCacheKey } from '../helpers/utils/token-scan';
-import type { AccountTreeState } from './multichain-accounts/account-tree.types';
-import { selectNonEvmTransactionsForActivity } from './activity';
+import mockState from '../../test/data/mock-state.json';
+import { MOCK_ACCOUNT_SOLANA_MAINNET } from '../../test/data/mock-accounts';
+import type { MultichainAccountsState } from './multichain-accounts/account-tree.types';
+import {
+  selectNonEvmTransactionsForActivity,
+  selectEvmAddress,
+} from './activity';
 
-const groups = [
-  { id: 'group-1', accounts: [{ id: 'acc-1' }, { id: 'acc-2' }] },
-  { id: 'group-2', accounts: [{ id: 'acc-x' }] },
-];
-
-jest.mock('./multichain-accounts/account-tree', () => {
-  return {
-    getSelectedAccountGroup: jest.fn(() => 'group-1'),
-    getAccountGroupWithInternalAccounts: jest.fn(() => groups),
-  };
-});
+const typedMockState = mockState as unknown as MultichainAccountsState;
 
 type NonEvmTransactionsMap =
   MultichainTransactionsControllerState['nonEvmTransactions'];
 
-type MetaMaskReduxState = _MetaMaskReduxState & {
-  metamask: {
-    selectedAccountGroup: AccountGroupId;
-    accountTree: AccountTreeState;
-  };
-};
-
 function buildState(
-  nonEvmTransactions: unknown,
+  nonEvmTransactions: NonEvmTransactionsMap,
   tokenScanCache?: Record<
     string,
     {
@@ -41,9 +28,13 @@ function buildState(
     }
   >,
 ): MetaMaskReduxState {
+  const baseState = structuredClone(mockState);
+
   return {
+    ...baseState,
     metamask: {
-      nonEvmTransactions: nonEvmTransactions as NonEvmTransactionsMap,
+      ...baseState.metamask,
+      nonEvmTransactions,
       enabledNetworkMap: {
         solana: { [MultichainNetworks.SOLANA]: true },
       },
@@ -83,7 +74,7 @@ describe('selectNonEvmTransactionsForActivity', () => {
 
     const state = buildState(
       {
-        'acc-1': {
+        [mockState.metamask.internalAccounts.selectedAccount]: {
           [MultichainNetworks.SOLANA]: {
             transactions: [maliciousTx, benignTx],
             next: null,
@@ -99,8 +90,53 @@ describe('selectNonEvmTransactionsForActivity', () => {
           },
         },
       },
-    );
+    ) as unknown as MetaMaskReduxState & MultichainAccountsState;
 
     expect(selectNonEvmTransactionsForActivity(state)).toEqual([benignTx]);
+  });
+});
+
+describe('selectEvmAddress', () => {
+  const evmAddressInGroup = '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc';
+
+  it('returns the EVM address from the selected account group when an EVM account is globally selected', () => {
+    expect(selectEvmAddress(typedMockState)).toBe(evmAddressInGroup);
+  });
+
+  it('returns the EVM address from the selected account group when a non-EVM account is globally selected', () => {
+    const state = structuredClone(typedMockState);
+
+    state.metamask.internalAccounts.selectedAccount =
+      MOCK_ACCOUNT_SOLANA_MAINNET.id;
+    state.metamask.internalAccounts.accounts = {
+      ...state.metamask.internalAccounts.accounts,
+      [MOCK_ACCOUNT_SOLANA_MAINNET.id]: MOCK_ACCOUNT_SOLANA_MAINNET,
+    };
+    state.metamask.accountTree.wallets[
+      'entropy:01JKAF3DSGM3AB87EM9N0K41AJ'
+    ].groups['entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0'].accounts.push(
+      MOCK_ACCOUNT_SOLANA_MAINNET.id,
+    );
+
+    expect(selectEvmAddress(state)).toBe(evmAddressInGroup);
+  });
+
+  it('returns undefined when the selected account group has no EVM account', () => {
+    const state = structuredClone(typedMockState);
+
+    state.metamask.selectedAccountGroup =
+      'entropy:01JKAF3PJ247KAM6C03G5Q0NP8/0';
+    state.metamask.internalAccounts.selectedAccount =
+      MOCK_ACCOUNT_SOLANA_MAINNET.id;
+    state.metamask.internalAccounts.accounts = {
+      [MOCK_ACCOUNT_SOLANA_MAINNET.id]: MOCK_ACCOUNT_SOLANA_MAINNET,
+    } as typeof state.metamask.internalAccounts.accounts;
+    state.metamask.accountTree.wallets[
+      'entropy:01JKAF3PJ247KAM6C03G5Q0NP8'
+    ].groups['entropy:01JKAF3PJ247KAM6C03G5Q0NP8/0'].accounts = [
+      MOCK_ACCOUNT_SOLANA_MAINNET.id,
+    ];
+
+    expect(selectEvmAddress(state)).toBeUndefined();
   });
 });

--- a/ui/selectors/activity.test.ts
+++ b/ui/selectors/activity.test.ts
@@ -97,7 +97,9 @@ describe('selectNonEvmTransactionsForActivity', () => {
 });
 
 describe('selectEvmAddress', () => {
-  const evmAddressInGroup = '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc';
+  const { internalAccounts } = typedMockState.metamask;
+  const evmAddressInGroup =
+    internalAccounts.accounts[internalAccounts.selectedAccount].address;
 
   it('returns the EVM address from the selected account group when an EVM account is globally selected', () => {
     expect(selectEvmAddress(typedMockState)).toBe(evmAddressInGroup);

--- a/ui/selectors/activity.ts
+++ b/ui/selectors/activity.ts
@@ -7,7 +7,11 @@ import {
 import { isCrossChain, StatusTypes } from '@metamask/bridge-controller';
 import type { BridgeHistoryItem } from '@metamask/bridge-status-controller';
 import type { TransactionPayControllerState } from '@metamask/transaction-pay-controller';
-import type { Transaction as KeyringTransaction } from '@metamask/keyring-api';
+import {
+  EthScope,
+  isEvmAccountType,
+  type Transaction as KeyringTransaction,
+} from '@metamask/keyring-api';
 import { KnownCaipNamespace, toCaipChainId } from '@metamask/utils';
 import { ResultType } from '../../shared/lib/trust-signals';
 import { EXCLUDED_TRANSACTION_TYPES } from '../helpers/constants/transactions';
@@ -31,6 +35,8 @@ import { mapLocalTransaction } from '../../shared/lib/activity/adapters/local-tr
 import { isProtectedByEnforcedSimulations } from '../pages/confirmations/utils/confirm';
 import { Status } from '../../shared/lib/activity/types';
 import { getInternalAccountsObject } from './accounts';
+import { getInternalAccountBySelectedAccountGroupAndCaip } from './multichain-accounts/account-tree';
+import type { MultichainAccountsState } from './multichain-accounts/account-tree.types';
 import { enrichLocalMusdClaimActivity } from './activity/enrich-local-musd-claim';
 import { getAssetsMetadata } from './assets';
 import {
@@ -568,4 +574,12 @@ export const selectMarketRates = createSelector(
 
     return rates;
   },
+);
+
+// Selects the EVM address of the currently selected account group, irrespective of the currently selected network
+export const selectEvmAddress = createSelector(
+  (state: MultichainAccountsState) =>
+    getInternalAccountBySelectedAccountGroupAndCaip(state, EthScope.Eoa),
+  (account) =>
+    account && isEvmAccountType(account.type) ? account.address : undefined,
 );


### PR DESCRIPTION
## **Description**

After filtering tokens to a non-EVM network and returning to all popular networks, opening an EVM token asset page can show an empty activity

This happens because switching the network filter back to All popular networks does not reset the global account selection.

## **Changelog**

CHANGELOG entry: fix: empty activity on asset pages after switching network filters when a non-EVM chain was previously selected

## **Related issues**

Fixes: 

## **Manual testing steps**

1. Run the extension with Activity List v3 enabled.
2. On the home token list, filter to a Solana network.
3. Open a Solana asset, then navigate back.
4. Switch the network filter to "All popular networks".
5. Click an EVM token (e.g. mUSD on Mainnet).
6. Verify the asset page activity tab shows EVM transactions (not empty).

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped selector change for activity/transaction-details with unit tests; the accounts selector remains unchanged for other callers.
> 
> **Overview**
> Fixes empty EVM activity on asset pages after filtering to a non-EVM network and switching back to all popular networks, when the global account selection stays on a Solana account.
> 
> **`selectEvmAddress`** is added under activity selectors and resolves the EVM address from the **selected account group** via `getInternalAccountBySelectedAccountGroupAndCaip` and `EthScope.Eoa`, instead of tying it to the globally selected internal account. Activity transaction list and transaction details now import this selector from `activity` rather than `accounts`.
> 
> Tests for `selectEvmAddress` cover EVM-selected, non-EVM-selected (still returns group EVM address), and groups with no EVM account; non-EVM activity tests were updated to use shared `mock-state.json` instead of mocked account-tree helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aa94280badf37f4c12dd6fe07212ce6d41391598. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->