### PR TITLE
feat(e2e): Tron default test-account fixtures [WPN-536]

### DIFF
--- a/test/e2e/constants.ts
+++ b/test/e2e/constants.ts
@@ -259,6 +259,37 @@ export const DEFAULT_TRON_ADDRESS_2 = 'TEcjynxEx7bPfDByW1uwPgsLCBhqynvpQx';
 /* Default TRON address shortened display (Account 1) */
 export const DEFAULT_TRON_ADDRESS_SHORT = 'TJ3Q...vGS3';
 
+/**
+ * Tron addresses derived from `E2E_SRP` for HD accounts 1-8 (BIP44 path
+ * `m/44'/195'/0'/0/i`). Used by `account-derivation.spec.ts` to verify
+ * derivation across the first 8 accounts. Re-derive with the script in
+ * `docs/superpowers/plans/2026-04-30-tron-account-derivation.md` Task 1
+ * if the SRP or derivation path ever changes.
+ *
+ * Note: index 0 matches `DEFAULT_TRON_ADDRESS`. `DEFAULT_TRON_ADDRESS_2` is
+ * an unrelated recipient address used in send-flow tests — it is not a
+ * snap-derived account and does not appear in this array.
+ */
+export const EXPECTED_TRON_ADDRESSES_BY_INDEX = [
+  DEFAULT_TRON_ADDRESS,
+  'TQMPuQSHEiUevynTJSCDeh3QSBwJeFKC6W',
+  'TRQwNiQKov6hQ3pEKVGj2t8ge8YM9vu8ZY',
+  'TR5uG9oGNSr5hKcCLdN5zF498BTij5Yz1x',
+  'THbDj5zszwXFqBuzexjXF71uEU58BVcp3A',
+  'TBfAcJpbucUvLashnYvQ3uQyeLuD2vAs5J',
+  'TFcoStNDSQZLadR2MasxMo7E3c19hwvw63',
+  'TRnntwBfRqh4aXZVaZuLT9Htk1r9JBU4WY',
+] as const satisfies readonly [
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+  string,
+];
+
 /* Account types */
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -160,6 +160,9 @@ async function withFixtures(options, testSuite) {
     title,
     ignoredConsoleErrors = [],
     disableServerMochaToBackground = false,
+    afterLocalNodesStart = async function () {
+      // do nothing.
+    },
     testSpecificMock = function () {
       // do nothing.
     },
@@ -244,6 +247,8 @@ async function withFixtures(options, testSuite) {
           );
       }
     }
+
+    await afterLocalNodesStart({ localNodes });
 
     let contractRegistry;
     let seeder;

--- a/test/e2e/helpers/tron-fixtures.test.ts
+++ b/test/e2e/helpers/tron-fixtures.test.ts
@@ -1,0 +1,47 @@
+import { TRON_ACCOUNT_ADDRESS } from '../tests/tron/mocks/common-tron';
+import {
+  GAS_FREE,
+  HTX,
+  SEED,
+  TRX,
+  USDD,
+  USDT,
+} from '../tests/tron/fixtures/tokens';
+import { buildTronNodeOptions } from '../tests/tron/fixtures/with-tron-fixtures';
+
+describe('withTronFixtures', () => {
+  it('builds Tron local node options from explicit account assets', () => {
+    expect(
+      buildTronNodeOptions([
+        {
+          address: TRON_ACCOUNT_ADDRESS,
+          assets: [
+            { ...TRX, balance: 6_072_392, priceUsd: 0.29469 },
+            { ...GAS_FREE, balance: '33333333', priceUsd: 0.000_000_001 },
+            { ...HTX, balance: '3156454956836360132407885' },
+            { ...SEED, balance: '89851311' },
+            { ...USDD, balance: '289757448699320931' },
+            { ...USDT, balance: '2804595', priceUsd: 0.999176 },
+          ],
+        },
+      ]),
+    ).toStrictEqual({
+      initialBalances: {
+        [TRON_ACCOUNT_ADDRESS]: 6_072_392,
+      },
+      trc10Balances: {
+        [TRON_ACCOUNT_ADDRESS]: {
+          GAS_FREE: '33333333',
+        },
+      },
+      trc20Balances: {
+        [TRON_ACCOUNT_ADDRESS]: {
+          HTX: '3156454956836360132407885',
+          SEED: '89851311',
+          USDD: '289757448699320931',
+          USDT: '2804595',
+        },
+      },
+    });
+  });
+});

--- a/test/e2e/page-objects/pages/home/non-evm-homepage.ts
+++ b/test/e2e/page-objects/pages/home/non-evm-homepage.ts
@@ -1,0 +1,29 @@
+import { Driver } from '../../../webdriver/driver';
+import HomePage from './homepage';
+import TokensTab from './tokens-tab';
+
+class NonEvmHomepage extends HomePage {
+  private readonly receiveButtonTestId = '[data-testid="coin-overview-receive"]';
+
+  constructor(driver: Driver) {
+    super(driver);
+  }
+
+  async clickOnReceiveButton(): Promise<void> {
+    console.log('Click Receive on non-EVM homepage');
+    await this.driver.clickElement(this.receiveButtonTestId);
+  }
+
+  async checkExpectedTokenBalanceIsDisplayed(
+    expectedTokenBalance: string,
+    symbol: string,
+  ): Promise<void> {
+    const tokensTab = new TokensTab(this.driver);
+    await tokensTab.checkExpectedTokenBalanceIsDisplayed(
+      expectedTokenBalance,
+      symbol,
+    );
+  }
+}
+
+export default NonEvmHomepage;

--- a/test/e2e/tests/tron/fixtures/environments.ts
+++ b/test/e2e/tests/tron/fixtures/environments.ts
@@ -1,0 +1,47 @@
+import { TRON_ACCOUNT_ADDRESS, TRX_TO_USD_RATE } from '../mocks/common-tron';
+import { TronFixtureAccount } from './with-tron-fixtures';
+import { GAS_FREE, HTX, SEED, TRX, USDD, USDT } from './tokens';
+
+export const TRON_PORTFOLIO_TRX_BALANCE_IN_SUN = 6_072_392;
+
+export const EMPTY_TRON_ACCOUNT: TronFixtureAccount = {
+  address: TRON_ACCOUNT_ADDRESS,
+  assets: [{ ...TRX, balance: 0, priceUsd: TRX_TO_USD_RATE }],
+};
+
+export const TRON_PORTFOLIO_ACCOUNT: TronFixtureAccount = {
+  address: TRON_ACCOUNT_ADDRESS,
+  assets: [
+    {
+      ...TRX,
+      balance: TRON_PORTFOLIO_TRX_BALANCE_IN_SUN,
+      priceUsd: TRX_TO_USD_RATE,
+    },
+    { ...GAS_FREE, balance: '33333333', priceUsd: 0.000_000_001 },
+    { ...HTX, balance: '3156454956836360132407885', priceUsd: 0.00000168 },
+    { ...SEED, balance: '89851311', priceUsd: 0.000_000_001 },
+    { ...USDD, balance: '289757448699320931', priceUsd: 0.999959 },
+    { ...USDT, balance: '2804595', priceUsd: 0.999176 },
+  ],
+};
+
+export const TRON_STAKED_PORTFOLIO_ACCOUNT: TronFixtureAccount = {
+  ...TRON_PORTFOLIO_ACCOUNT,
+  assets: TRON_PORTFOLIO_ACCOUNT.assets?.map((asset) =>
+    asset.type === 'native'
+      ? {
+          ...asset,
+          balance: TRON_PORTFOLIO_TRX_BALANCE_IN_SUN + 20_000_000,
+        }
+      : asset,
+  ),
+  stakedTrxBalance: '20000000',
+};
+
+export const TRON_LOW_TRX_WITH_USDT_ACCOUNT: TronFixtureAccount = {
+  address: TRON_ACCOUNT_ADDRESS,
+  assets: [
+    { ...TRX, balance: 1, priceUsd: TRX_TO_USD_RATE },
+    { ...USDT, balance: '2000000', priceUsd: 0.999176 },
+  ],
+};

--- a/test/e2e/tests/tron/fixtures/tokens.ts
+++ b/test/e2e/tests/tron/fixtures/tokens.ts
@@ -1,0 +1,46 @@
+export const TRX = {
+  decimals: 6,
+  name: 'Tron',
+  symbol: 'TRX',
+  type: 'native',
+} as const;
+
+export const GAS_FREE = {
+  decimals: 6,
+  name: 'GasFreeTransferSolution',
+  symbol: 'GAS_FREE',
+  tokenId: '1005074',
+  type: 'trc10',
+} as const;
+
+export const HTX = {
+  address: 'TUPM7K8REVzD2UdV4R5fe5M8XbnR2DdoJ6',
+  decimals: 18,
+  name: 'HTX DAO',
+  symbol: 'HTX',
+  type: 'trc20',
+} as const;
+
+export const SEED = {
+  address: 'TBwoSTyywvLrgjSgaatxrBhxt3DGpVuENh',
+  decimals: 6,
+  name: 'SEED',
+  symbol: 'SEED',
+  type: 'trc20',
+} as const;
+
+export const USDD = {
+  address: 'TXDk8mbtRbXeYuMNS83CfKPaYYT8XWv9Hz',
+  decimals: 18,
+  name: 'USDD',
+  symbol: 'USDD',
+  type: 'trc20',
+} as const;
+
+export const USDT = {
+  address: 'TR7NHqjeKQxGTCi8q8ZY4pL8otSzgjLj6t',
+  decimals: 6,
+  name: 'Tether',
+  symbol: 'USDT',
+  type: 'trc20',
+} as const;

--- a/test/e2e/tests/tron/fixtures/with-tron-fixtures.ts
+++ b/test/e2e/tests/tron/fixtures/with-tron-fixtures.ts
@@ -1,0 +1,431 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { MockedEndpoint, Mockttp } from 'mockttp';
+import { withFixtures } from '../../../helpers';
+import {
+  TRON_CHAIN_ID,
+  TronLocalNodeOptions,
+  TronTrc10Symbol,
+  TronTrc20Symbol,
+  createEmptyTronGridTransactionsResponse,
+  createTronGridAccountResponse,
+} from '../../../seeder/tron/assets';
+import { TronNode } from '../../../seeder/tron/node';
+import { TronSeeder } from '../../../seeder/tron/tron-seeder';
+import {
+  TRON_ACCOUNT_ADDRESS,
+  TRON_RECIPIENT_ADDRESS,
+  mockExchangeRates,
+  mockFiatExchangeRates,
+  mockTronFeatureFlags,
+} from '../mocks/common-tron';
+import { proxyTronBlockchainCalls } from '../mocks/local-tron-node-mocks';
+
+const TRON_PROVIDER_ANY_ACCOUNT_RE =
+  /^(https:\/\/tron-mainnet\.infura\.io\/v3\/[^/]+|https:\/\/api\.trongrid\.io|https:\/\/api\.shasta\.trongrid\.io|https:\/\/nile\.trongrid\.io)\/v1\/accounts\/([A-Za-z0-9]{20,})(\/transactions(\/trc20)?)?(\?.*)?$/u;
+
+type WithFixturesOptions = Parameters<typeof withFixtures>[0];
+type WithFixturesTestSuite = Parameters<typeof withFixtures>[1];
+
+export type TronFixtureAsset =
+  | TronNativeFixtureAsset
+  | TronTrc10FixtureAsset
+  | TronTrc20FixtureAsset;
+
+export type TronNativeFixtureAsset = {
+  balance: number;
+  decimals: number;
+  name: string;
+  priceUsd?: number | null;
+  symbol: 'TRX';
+  type: 'native';
+};
+
+export type TronTrc10FixtureAsset = {
+  balance: string;
+  decimals: number;
+  name: string;
+  priceUsd?: number | null;
+  symbol: string;
+  tokenId: string;
+  type: 'trc10';
+};
+
+export type TronTrc20FixtureAsset = {
+  address: string;
+  balance: string;
+  decimals: number;
+  name: string;
+  priceUsd?: number | null;
+  symbol: string;
+  type: 'trc20';
+};
+
+export type TronFixtureAccount = {
+  address: string;
+  assets?: TronFixtureAsset[];
+  stakedTrxBalance?: string;
+  transactions?: {
+    raw?: unknown[];
+    trc20?: unknown[];
+  };
+};
+
+export type WithTronFixturesOptions = Omit<
+  WithFixturesOptions,
+  'localNodeOptions' | 'testSpecificMock'
+> & {
+  accounts: TronFixtureAccount[];
+  afterLocalNodesStart?: (context: {
+    localNodes: unknown[];
+  }) => Promise<void> | void;
+  fixtures?: unknown;
+  includeAnvil?: boolean;
+  testSpecificMock?: (
+    mockServer: Mockttp,
+    context: { localNodes: unknown[] },
+  ) => Promise<MockedEndpoint[]>;
+  title?: string;
+  tronState?: string;
+};
+
+export function buildTronNodeOptions(
+  accounts: TronFixtureAccount[],
+  options: Pick<TronLocalNodeOptions, 'loadState'> = {},
+): TronLocalNodeOptions {
+  const initialBalances: Record<string, number> = {};
+  const trc10Balances: Record<
+    string,
+    Partial<Record<TronTrc10Symbol, string>>
+  > = {};
+  const trc20Balances: Record<
+    string,
+    Partial<Record<TronTrc20Symbol, string>>
+  > = {};
+  const stakedTrxBalances: Record<string, string> = {};
+
+  for (const account of accounts) {
+    for (const asset of account.assets ?? []) {
+      if (asset.type === 'native') {
+        initialBalances[account.address] = asset.balance;
+      } else if (asset.type === 'trc10') {
+        trc10Balances[account.address] = {
+          ...trc10Balances[account.address],
+          [asset.symbol]: asset.balance,
+        };
+      } else {
+        trc20Balances[account.address] = {
+          ...trc20Balances[account.address],
+          [asset.symbol]: asset.balance,
+        };
+      }
+    }
+
+    if (account.stakedTrxBalance) {
+      stakedTrxBalances[account.address] = account.stakedTrxBalance;
+    }
+  }
+
+  return {
+    ...(Object.keys(initialBalances).length ? { initialBalances } : {}),
+    ...(options.loadState ? { loadState: options.loadState } : {}),
+    ...(Object.keys(trc10Balances).length ? { trc10Balances } : {}),
+    ...(Object.keys(trc20Balances).length ? { trc20Balances } : {}),
+    ...(Object.keys(stakedTrxBalances).length ? { stakedTrxBalances } : {}),
+  };
+}
+
+export async function withTronFixtures(
+  options: WithTronFixturesOptions,
+  testSuite: WithFixturesTestSuite,
+): Promise<void> {
+  const {
+    afterLocalNodesStart,
+    accounts,
+    includeAnvil = true,
+    testSpecificMock,
+    tronState,
+    ...withFixtureOptions
+  } = options;
+  const nodeOptions = buildTronNodeOptions(accounts, { loadState: tronState });
+  const { trc20Balances, ...startupNodeOptions } = nodeOptions;
+  let tronSeeder: TronSeeder | undefined;
+
+  await withFixtures(
+    {
+      ...withFixtureOptions,
+      localNodeOptions: [
+        ...(includeAnvil ? ['anvil'] : []),
+        {
+          type: 'tron',
+          options: startupNodeOptions,
+        },
+      ],
+      afterLocalNodesStart: async (context: { localNodes: unknown[] }) => {
+        tronSeeder = await seedTronSmartContracts(
+          context.localNodes,
+          trc20Balances,
+        );
+        await afterLocalNodesStart?.(context);
+      },
+      testSpecificMock: async (
+        mockServer: Mockttp,
+        context: { localNodes: unknown[] },
+      ) => {
+        const customEndpoints =
+          (await testSpecificMock?.(mockServer, context)) ?? [];
+        const tronEndpoints = await mockTronFixtureApis(mockServer, {
+          accounts,
+          localNodes: context.localNodes,
+        });
+        return [...customEndpoints, ...tronEndpoints];
+      },
+    },
+    async (context) => {
+      await testSuite({
+        ...context,
+        contractRegistry:
+          context.contractRegistry ?? tronSeeder?.getContractRegistry(),
+      });
+    },
+  );
+}
+
+async function seedTronSmartContracts(
+  localNodes: unknown[],
+  trc20Balances: TronLocalNodeOptions['trc20Balances'],
+): Promise<TronSeeder | undefined> {
+  if (!trc20Balances || Object.keys(trc20Balances).length === 0) {
+    return undefined;
+  }
+
+  const tronNode = localNodes.find(
+    (node): node is TronNode => node instanceof TronNode,
+  );
+  if (!tronNode) {
+    throw new Error('Tron local node was not started');
+  }
+
+  const seeder = new TronSeeder(tronNode);
+  await seeder.seedSmartContractBalances(trc20Balances);
+  return seeder;
+}
+
+async function mockTronFixtureApis(
+  mockServer: Mockttp,
+  {
+    accounts,
+    localNodes,
+  }: { accounts: TronFixtureAccount[]; localNodes: unknown[] },
+): Promise<MockedEndpoint[]> {
+  const tronNode = localNodes.find(
+    (node): node is TronNode => node instanceof TronNode,
+  );
+  if (!tronNode) {
+    throw new Error('Tron local node was not started');
+  }
+
+  const accountByAddress = new Map(
+    accounts.map((account) => [account.address, account]),
+  );
+  const fixtureHistoryEndpoints = await mockFixtureTransactionHistory(
+    mockServer,
+    accounts,
+  );
+
+  const allAddresses = [
+    ...accounts.map((a) => a.address),
+    TRON_RECIPIENT_ADDRESS,
+  ].filter((v, i, arr) => arr.indexOf(v) === i);
+
+  return [
+    await mockTronFeatureFlags(mockServer),
+    await mockExchangeRates(mockServer),
+    await mockFiatExchangeRates(mockServer),
+    await mockTronFixtureSpotPrices(mockServer, accounts, tronNode),
+    await mockTronFixtureAssets(mockServer, accounts, tronNode),
+    ...fixtureHistoryEndpoints,
+    ...(await proxyTronBlockchainCalls(mockServer, tronNode, allAddresses)),
+    await mockWildcardTronAccountApis(mockServer, tronNode, accountByAddress),
+  ];
+}
+
+async function mockFixtureTransactionHistory(
+  mockServer: Mockttp,
+  accounts: TronFixtureAccount[],
+): Promise<MockedEndpoint[]> {
+  const endpoints: MockedEndpoint[] = [];
+
+  for (const account of accounts) {
+    if (!account.transactions) {
+      continue;
+    }
+
+    endpoints.push(
+      await mockServer
+        .forGet(tronProviderUrl(`/v1/accounts/${account.address}/transactions`))
+        .always()
+        .thenCallback(() =>
+          createTransactionsResponse(account.transactions?.raw),
+        ),
+      await mockServer
+        .forGet(
+          tronProviderUrl(`/v1/accounts/${account.address}/transactions/trc20`),
+        )
+        .always()
+        .thenCallback(() =>
+          createTransactionsResponse(account.transactions?.trc20),
+        ),
+    );
+  }
+
+  return endpoints;
+}
+
+async function mockWildcardTronAccountApis(
+  mockServer: Mockttp,
+  tronNode: TronNode,
+  accountByAddress: Map<string, TronFixtureAccount>,
+): Promise<MockedEndpoint> {
+  return mockServer
+    .forGet(TRON_PROVIDER_ANY_ACCOUNT_RE)
+    .always()
+    .thenCallback(async (req) => {
+      const match = req.url.match(TRON_PROVIDER_ANY_ACCOUNT_RE);
+      const address = match?.[2] ?? '';
+      const suffix = match?.[3] ?? '';
+      const account = accountByAddress.get(address);
+
+      if (suffix.startsWith('/transactions')) {
+        const transactions = suffix.includes('/trc20')
+          ? account?.transactions?.trc20
+          : account?.transactions?.raw;
+        return createTransactionsResponse(transactions);
+      }
+
+      if (account) {
+        return {
+          statusCode: 200,
+          json: await tronNode.getTronGridAccountResponse(address),
+        };
+      }
+
+      return {
+        statusCode: 200,
+        json: createTronGridAccountResponse({ address }),
+      };
+    });
+}
+
+async function mockTronFixtureAssets(
+  mockServer: Mockttp,
+  accounts: TronFixtureAccount[],
+  tronNode: TronNode,
+): Promise<MockedEndpoint> {
+  return mockServer
+    .forGet('https://tokens.api.cx.metamask.io/v3/assets')
+    .always()
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: getUniqueAssets(accounts)
+        .filter((asset) => asset.type !== 'native')
+        .map((asset) => ({
+          assetId: getAssetId(asset, tronNode),
+          decimals: asset.decimals,
+          name: asset.name,
+          symbol: asset.symbol,
+        })),
+    }));
+}
+
+async function mockTronFixtureSpotPrices(
+  mockServer: Mockttp,
+  accounts: TronFixtureAccount[],
+  tronNode: TronNode,
+): Promise<MockedEndpoint> {
+  const pricesByAssetId = Object.fromEntries([
+    ['tron:3448148188/slip44:195', null],
+    ['tron:2494104990/slip44:195', null],
+    ...getUniqueAssets(accounts).map((asset) => [
+      getAssetId(asset, tronNode),
+      createSpotPriceResponse(asset),
+    ]),
+  ]);
+
+  return mockServer
+    .forGet('https://price.api.cx.metamask.io/v3/spot-prices')
+    .always()
+    .thenCallback((request) => {
+      const assetIds = new URL(request.url).searchParams
+        .get('assetIds')
+        ?.split(',');
+
+      return {
+        statusCode: 200,
+        json: Object.fromEntries(
+          (assetIds ?? Object.keys(pricesByAssetId)).map((assetId) => [
+            assetId,
+            pricesByAssetId[assetId] ?? null,
+          ]),
+        ),
+      };
+    });
+}
+
+function createSpotPriceResponse(asset: TronFixtureAsset) {
+  if (asset.priceUsd === undefined || asset.priceUsd === null) {
+    return null;
+  }
+
+  return {
+    id: asset.symbol.toLowerCase(),
+    price: asset.priceUsd,
+    marketCap: 1_000_000,
+    pricePercentChange1d: 0,
+  };
+}
+
+function createTransactionsResponse(transactions: unknown[] | undefined) {
+  const data = transactions ?? [];
+  return {
+    statusCode: 200,
+    json: {
+      ...createEmptyTronGridTransactionsResponse(),
+      data,
+      meta: {
+        at: Date.now(),
+        page_size: data.length,
+      },
+    },
+  };
+}
+
+function getAssetId(asset: TronFixtureAsset, tronNode: TronNode): string {
+  if (asset.type === 'native') {
+    return `${TRON_CHAIN_ID}/slip44:195`;
+  }
+
+  if (asset.type === 'trc10') {
+    const token = tronNode.trc10Tokens[asset.symbol as TronTrc10Symbol];
+    return `${TRON_CHAIN_ID}/trc10:${token?.tokenId ?? asset.tokenId}`;
+  }
+
+  const token = tronNode.trc20Tokens[asset.symbol as TronTrc20Symbol];
+  return `${TRON_CHAIN_ID}/trc20:${token?.address ?? asset.address}`;
+}
+
+function getUniqueAssets(accounts: TronFixtureAccount[]): TronFixtureAsset[] {
+  const assetsByKey = new Map<string, TronFixtureAsset>();
+  for (const account of accounts) {
+    for (const asset of account.assets ?? []) {
+      assetsByKey.set(`${asset.type}:${asset.symbol}`, asset);
+    }
+  }
+  return [...assetsByKey.values()];
+}
+
+function tronProviderUrl(path: string): RegExp {
+  return new RegExp(
+    `^(https://tron-mainnet\\.infura\\.io/v3/[^/]+|https://api\\.trongrid\\.io|https://api\\.shasta\\.trongrid\\.io|https://nile\\.trongrid\\.io)${path}(\\?[^#]*)?$`,
+    'u',
+  );
+}

--- a/test/e2e/tests/tron/fixtures/with-tron-fixtures.ts
+++ b/test/e2e/tests/tron/fixtures/with-tron-fixtures.ts
@@ -2,7 +2,6 @@
 import { MockedEndpoint, Mockttp } from 'mockttp';
 import { withFixtures } from '../../../helpers';
 import {
-  TRON_CHAIN_ID,
   TronLocalNodeOptions,
   TronTrc10Symbol,
   TronTrc20Symbol,
@@ -13,6 +12,7 @@ import { TronNode } from '../../../seeder/tron/node';
 import { TronSeeder } from '../../../seeder/tron/tron-seeder';
 import {
   TRON_ACCOUNT_ADDRESS,
+  TRON_CHAIN_ID,
   TRON_RECIPIENT_ADDRESS,
   mockExchangeRates,
   mockFiatExchangeRates,
@@ -85,12 +85,10 @@ export type WithTronFixturesOptions = Omit<
     context: { localNodes: unknown[] },
   ) => Promise<MockedEndpoint[]>;
   title?: string;
-  tronState?: string;
 };
 
 export function buildTronNodeOptions(
   accounts: TronFixtureAccount[],
-  options: Pick<TronLocalNodeOptions, 'loadState'> = {},
 ): TronLocalNodeOptions {
   const initialBalances: Record<string, number> = {};
   const trc10Balances: Record<
@@ -127,7 +125,6 @@ export function buildTronNodeOptions(
 
   return {
     ...(Object.keys(initialBalances).length ? { initialBalances } : {}),
-    ...(options.loadState ? { loadState: options.loadState } : {}),
     ...(Object.keys(trc10Balances).length ? { trc10Balances } : {}),
     ...(Object.keys(trc20Balances).length ? { trc20Balances } : {}),
     ...(Object.keys(stakedTrxBalances).length ? { stakedTrxBalances } : {}),
@@ -143,10 +140,9 @@ export async function withTronFixtures(
     accounts,
     includeAnvil = true,
     testSpecificMock,
-    tronState,
     ...withFixtureOptions
   } = options;
-  const nodeOptions = buildTronNodeOptions(accounts, { loadState: tronState });
+  const nodeOptions = buildTronNodeOptions(accounts);
   const { trc20Balances, ...startupNodeOptions } = nodeOptions;
   let tronSeeder: TronSeeder | undefined;
 


### PR DESCRIPTION
## Summary

Adds `withTronFixtures` — a fixture helper that composes local `TronNode` seeding, smart-contract deployment, and API mocks from explicit per-account asset declarations.

**Stack:** builds on #43723 (full WPN-536 stack complete after merge)

This PR also introduces `afterLocalNodesStart` in `withFixtures` so TRC20 contracts can be deployed after the local Tron node is up. JSON `loadState` / `tronState` file loading was dropped from the stack design.

## Explainer — default test accounts (Accounts 1–8)

Addresses are derived from `E2E_SRP` at BIP44 path `m/44'/195'/0'/0/i` (see `EXPECTED_TRON_ADDRESSES_BY_INDEX` in `test/e2e/constants.ts`). **Only Account 1** has a canonical default portfolio; Accounts 2–8 have **no default on-chain seeding** unless a test passes them in `withTronFixtures({ accounts: [...] })`.

### Default holdings table

| Account | Address | TRX (liquid) | TRC10 | TRC20 | Notes |
|---------|---------|--------------|-------|-------|-------|
| **1** | `TJ3QZbBREK1Xybe1jf4nR9Attb8i54vGS3` | **6.072392 TRX** (6,072,392 SUN) | **GAS_FREE** 33.333333 | **HTX** 3,156,454,956,836,360,132,407,885 · **SEED** 89.851311 · **USDD** 0.289757 · **USDT** 2.804595 | `TRON_PORTFOLIO_ACCOUNT` / `mockTronApis()` default |
| **2** | `TQMPuQSHEiUevynTJSCDeh3QSBwJeFKC6W` | 0 | — | — | Address constant only; seed per-test |
| **3** | `TRQwNiQKov6hQ3pEKVGj2t8ge8YM9vu8ZY` | 0 | — | — | Address constant only; seed per-test |
| **4** | `TR5uG9oGNSr5hKcCLdN5zF498BTij5Yz1x` | 0 | — | — | Address constant only; seed per-test |
| **5** | `THbDj5zszwXFqBuzexjXF71uEU58BVcp3A` | 0 | — | — | Address constant only; seed per-test |
| **6** | `TBfAcJpbucUvLashnYvQ3uQyeLuD2vAs5J` | 0 | — | — | Address constant only; seed per-test |
| **7** | `TFcoStNDSQZLadR2MasxMo7E3c19hwvw63` | 0 | — | — | Address constant only; seed per-test |
| **8** | `TRnntwBfRqh4aXZVaZuLT9Htk1r9JBU4WY` | 0 | — | — | Address constant only; seed per-test |

> `DEFAULT_TRON_ADDRESS_2` (`TEcjynxEx7bPfDByW1uwPgsLCBhqynvpQx`) is an **unrelated send-recipient** address, not an HD account.

### Named environment presets (`fixtures/environments.ts`)

All presets target **Account 1** unless a test overrides `accounts`:

| Preset | TRX | TRC10 / TRC20 | Extra |
|--------|-----|---------------|-------|
| `EMPTY_TRON_ACCOUNT` | 0 | — | Zero-balance mock path |
| `TRON_PORTFOLIO_ACCOUNT` | 6.072392 TRX | GAS_FREE + HTX/SEED/USDD/USDT (as above) | Default balance/check tests |
| `TRON_STAKED_PORTFOLIO_ACCOUNT` | 26.072392 TRX liquid | Same tokens | +20 TRX staked (`stakedTrxBalance`) |
| `TRON_LOW_TRX_WITH_USDT_ACCOUNT` | 0.000001 TRX (1 SUN) | USDT 2.0 | Insufficient-fee scenarios |

### How `withTronFixtures` works

1. `buildTronNodeOptions(accounts)` → inline `TronNode` startup balances.
2. `afterLocalNodesStart` (in `withFixtures`) deploys TRC20 contracts when needed (`TronSeeder`).
3. `mockTronFixtureApis` registers mocks whose account/tx responses mirror the `accounts` array, optionally proxied through the live node.

## Test plan

- [x] `yarn test:unit test/e2e/helpers/tron-fixtures.test.ts`
- [ ] Tron E2E specs using `withTronFixtures` / `environments.ts` presets

CHANGELOG entry: null

Made with [Cursor](https://cursor.com)