### PR TITLE
fix: Changing the Destination Token should not change the Source token cp-13.37.0

### DIFF
--- a/ui/pages/bridge/prepare/bridge-asset-picker-page.tsx
+++ b/ui/pages/bridge/prepare/bridge-asset-picker-page.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { formatChainIdToCaip } from '@metamask/bridge-controller';
@@ -83,6 +83,13 @@ const BridgeAssetPickerPage = () => {
   );
 
   const contentRef = useRef<BridgeAssetPickerContentHandle>(null);
+
+  useEffect(() => {
+    return () => {
+      dispatch(setIsDestAssetPickerOpen(false));
+      dispatch(setIsSrcAssetPickerOpen(false));
+    };
+  }, [dispatch]);
 
   const handleClose = () => {
     dispatch(setIsDestAssetPickerOpen(false));

--- a/ui/pages/bridge/prepare/bridge-input-group.test.tsx
+++ b/ui/pages/bridge/prepare/bridge-input-group.test.tsx
@@ -431,6 +431,36 @@ describe('BridgeInputGroup', () => {
     expect(mockNavigate).toHaveBeenCalledWith(SWAP_PATH, { replace: true });
   });
 
+  it('clears picker flags when browser navigation unmounts the page', async () => {
+    setupFetchMock();
+    const setDestinationPickerOpenSpy = jest.spyOn(
+      actions,
+      'setIsDestAssetPickerOpen',
+    );
+    const setSourcePickerOpenSpy = jest.spyOn(
+      actions,
+      'setIsSrcAssetPickerOpen',
+    );
+
+    const { unmount } = renderAssetPickerPage(undefined, {
+      isSrcAssetPickerOpen: true,
+      isDestAssetPickerOpen: false,
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('bridge-asset-picker-search-input'),
+      ).toBeVisible();
+    });
+
+    unmount();
+
+    expect(setDestinationPickerOpenSpy).toHaveBeenCalledWith(false);
+    expect(setSourcePickerOpenSpy).toHaveBeenCalledWith(false);
+    setDestinationPickerOpenSpy.mockRestore();
+    setSourcePickerOpenSpy.mockRestore();
+  });
+
   it('uses the source picker when both picker flags are stale-open', async () => {
     setupFetchMock(
       undefined,


### PR DESCRIPTION
With the page update, `BridgeInputGroup` only sets Redux flags and navigates. This PR fixes it by clearing both picker flags on `BridgeAssetPickerPage` unmount, which covers browser `Back`. Added a regression test for that unmount path.
## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: update swaps page

## **Related issues**

Fixes:  #43717 

## **Manual testing steps**

1. Start a Swap
2. Enter any amount
3. Click Source token
4. Click Back from the Browser action (not the back arrow in the app)
5. Now click Destination token
6. See Source token is selected
7. Select any other token
8. See Source token is not the one changed, and destination token changes

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/394f49c9-b542-438d-bdc2-012179e10810



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI state cleanup on unmount in the bridge asset picker page, covered by a new unit test with no auth or transaction logic changes.
> 
> **Overview**
> Fixes a swap/bridge UX bug where **browser Back** left `isSrcAssetPickerOpen` stuck `true`, so opening the destination picker still behaved like the source picker and token changes hit the wrong side.
> 
> **`BridgeAssetPickerPage`** now runs an unmount cleanup that dispatches `setIsDestAssetPickerOpen(false)` and `setIsSrcAssetPickerOpen(false)`, matching what the in-app back path already does in `handleClose`. A regression test asserts both actions fire when the page unmounts without using the header back button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 826ea14fb54e1b843509d55248808ee97a02af7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->