### PR TITLE
chore: bump network-controller to v34 to force failover build

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
   "resolutions": {
     "@grpc/grpc-js": "^1.9.16",
     "@metamask/messenger@npm:^0.3.0": "^1.2.0",
-    "@metamask/network-controller": "33.0.0",
+    "@metamask/network-controller": "34.0.0",
     "follow-redirects": "^1.16.0",
     "@unrs/resolver-binding-wasm32-wasi": "npm:npm-empty-package@1.0.0",
     "jest-clean-console-reporter/chalk": "^4.1.2",
@@ -408,7 +408,7 @@
     "@metamask/multichain-network-controller": "^3.1.0",
     "@metamask/multichain-transactions-controller": "^7.1.0",
     "@metamask/name-controller": "^9.1.0",
-    "@metamask/network-controller": "^33.0.0",
+    "@metamask/network-controller": "^34.0.0",
     "@metamask/network-enablement-controller": "^5.3.0",
     "@metamask/notification-services-controller": "^24.2.0",
     "@metamask/object-multiplex": "^2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7231,9 +7231,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/network-controller@npm:33.0.0":
-  version: 33.0.0
-  resolution: "@metamask/network-controller@npm:33.0.0"
+"@metamask/network-controller@npm:34.0.0":
+  version: 34.0.0
+  resolution: "@metamask/network-controller@npm:34.0.0"
   dependencies:
     "@metamask/base-controller": "npm:^9.1.0"
     "@metamask/connectivity-controller": "npm:^0.2.0"
@@ -7255,7 +7255,7 @@ __metadata:
     reselect: "npm:^5.1.1"
     uri-js: "npm:^4.4.1"
     uuid: "npm:^8.3.2"
-  checksum: 10/656cc33da4afc17b76623ed286ceac72035810eae467f4389f97aaf37376adc4e6d1e31facf4d26aca469f8ee5ab6217b982f10ae8777616019ff6d9ed7c1a67
+  checksum: 10/6afb874ca5702e1be616bf6ea92b35332d1969878794ce118138ca8f3733a1521a266d00bb658cf7a37e126545ac942ef5bc09bbd64159612b5424d848dbdc67
   languageName: node
   linkType: hard
 
@@ -33163,7 +33163,7 @@ __metadata:
     "@metamask/multichain-network-controller": "npm:^3.1.0"
     "@metamask/multichain-transactions-controller": "npm:^7.1.0"
     "@metamask/name-controller": "npm:^9.1.0"
-    "@metamask/network-controller": "npm:^33.0.0"
+    "@metamask/network-controller": "npm:^34.0.0"
     "@metamask/network-enablement-controller": "npm:^5.3.0"
     "@metamask/notification-services-controller": "npm:^24.2.0"
     "@metamask/object-multiplex": "npm:^2.0.0"


### PR DESCRIPTION
## **Description**

Bumps `@metamask/network-controller` to the build `34.0.0`.

RPC failover is now controlled by a single remote feature flag, `corePlatformRpcFailoverMode`, a string with three values: `disabled` (failover off), `enabled` (divert to the failover URLs when the primary endpoint is unavailable), and `forced` (Infura endpoints that have failover URLs route all traffic, including block tracker polling, to those failover URLs, bypassing Infura entirely). `forced` is the emergency kill switch for when the automatic failover logic itself misbehaves.

No client code changes are needed: network-controller reads the flag through `RemoteFeatureFlagController`, and the failover URLs come from the `QUICKNODE_*` env vars already wired into the controller. This is a breaking bump to the network-controller major (33.0.0); the controller no longer reads `walletFrameworkRpcFailoverEnabled`.

Core PR: https://github.com/MetaMask/core/pull/9175

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/WPC-1112

## **Manual testing steps**

With `corePlatformRpcFailoverMode` set to `forced` in LaunchDarkly (main-dev for local `yarn start` builds, the main distribution in the dev environment):

1. Add this to your `.metamaskrc` so Mainnet has a failover target:
   ```
   QUICKNODE_MAINNET_URL=https://ethereum-rpc.publicnode.com
   ```
2. `yarn start`, then load the unpacked build from `dist/chrome` in `chrome://extensions`.
3. Complete onboarding and turn on Settings > Security & Privacy > Use external services (the remote flag controller only fetches when this is on).
4. Select the Ethereum Mainnet network.
5. Open the extension's service worker DevTools (`chrome://extensions` > MetaMask > "service worker") and watch the Network tab. RPC requests, including `eth_blockNumber` polling, go to `ethereum-rpc.publicnode.com` and none go to `*.infura.io`.

Notes:
- The remote flag has a 15 minute fetch cache. If it does not pick up, remove and re-add the unpacked extension to force a fresh fetch.
- To confirm the flag is delivered, in that service worker console: `(await stateHooks.metamaskGetState()).data.RemoteFeatureFlagController.remoteFeatureFlags.corePlatformRpcFailoverMode` should be `'forced'`.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> This is a major bump on core RPC/network infrastructure; behavior changes are entirely inside the controller and depend on remote flags and env-configured failover URLs, but the extension diff itself is low-touch.
> 
> **Overview**
> Bumps **`@metamask/network-controller`** from **33.0.0** to **34.0.0** in `package.json` (direct dependency and Yarn resolution) and refreshes **`yarn.lock`**. There are **no extension source changes** in this PR.
> 
> v34 is a breaking major that changes how RPC failover is controlled: the controller now reads the remote flag **`corePlatformRpcFailoverMode`** (`disabled` / `enabled` / `forced`) via **`RemoteFeatureFlagController`** instead of **`walletFrameworkRpcFailoverEnabled`**. Failover targets still come from existing **`QUICKNODE_*`** env wiring into the controller.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90a5152e57f612e07f3ac2553d53c55164d34c6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->