### PR TITLE
fix: adjust UI startup trace boundary

### DIFF
--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -243,15 +243,22 @@ async function initializeUiWithTab(
   initialState,
 ) {
   try {
+    let uiStartupEndTimestamp;
     const store = await launchMetamaskUi({
       activeTab,
       container,
       backgroundConnection,
       traceContext,
       initialState,
+      onBeforeFirstRender: (timestamp) => {
+        uiStartupEndTimestamp = timestamp;
+      },
     });
 
-    endTrace({ name: TraceName.UIStartup });
+    endTrace({
+      name: TraceName.UIStartup,
+      timestamp: uiStartupEndTimestamp,
+    });
 
     if (process.env.IN_TEST) {
       window.document?.documentElement?.classList.add('controller-loaded');

--- a/ui/index.js
+++ b/ui/index.js
@@ -22,7 +22,11 @@ import { COPY_OPTIONS } from '../shared/constants/copy';
 import { START_UI_SYNC } from '../shared/constants/ui-initialization';
 import { switchDirection } from '../shared/lib/switch-direction';
 import { setupLocale } from '../shared/lib/error-utils';
-import { trace, TraceName } from '../shared/lib/trace';
+import {
+  getPerformanceTimestamp,
+  trace,
+  TraceName,
+} from '../shared/lib/trace';
 import { getCurrentChainId } from '../shared/lib/selectors/networks';
 import { MESSENGER_SUBSCRIPTION_NOTIFICATION } from '../shared/constants/messages';
 import { getSelectedInternalAccount } from '../shared/lib/selectors/accounts';
@@ -245,6 +249,11 @@ async function startApp(metamaskState, opts) {
   // UI messenger is created here in preparation for completely replacing
   // `submitRequestToBackground` with it.
   const uiMessenger = createUIMessenger();
+
+  // UI Startup measures setup before React begins resolving the routed UI.
+  // Capture the boundary before render can trigger lazy route chunk loading.
+  opts.onBeforeFirstRender?.(getPerformanceTimestamp());
+
   trace({ name: TraceName.FirstRender, parentContext: traceContext }, () =>
     render(<Root store={store} uiMessenger={uiMessenger} />, opts.container),
   );


### PR DESCRIPTION
## **Description**

Adjusts the `UI Startup` trace so it measures the same pre-React-render startup boundary it effectively measured before lazy route chunk loading was introduced.

The UI still waits to end the trace until `launchMetamaskUi()` succeeds, but it now records the end timestamp immediately before the first React render begins. That keeps lazy route resolution and first render work in the existing `First Render` trace instead of inflating `UI Startup`.

Root cause: once route components are actually split into async chunks, the previous `UI Startup` end point included work triggered by React resolving the routed UI. That made the metric regress even when initial bundle and page-load work improved.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Build and load the extension.
2. Open the home, unlock, and notification UIs.
3. Verify each UI renders normally.
4. Capture benchmark trace output and verify `UI Startup` ends before first React render work while `First Render` still captures render timing.

<!-- ## **Screenshots/Recordings**

Not applicable; this is a tracing-only change.

### **Before**

N/A

### **After**

N/A
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## Validation

- `yarn lint:changed:fix` passed.
- `git diff --check` passed.
- Local webpack launch was attempted with `./node_modules/.bin/tsx ./development/webpack/launch.ts`, but this checkout's `node_modules` is stale and missing `@metamask/bitcoin-wallet-standard`, which is already declared in `package.json` and `yarn.lock`.
