### PR TITLE
refactor(analytics): remove MetaMetricsController getMetaMetricsId action

### DIFF
--- a/app/scripts/controllers/metametrics-controller-method-action-types.ts
+++ b/app/scripts/controllers/metametrics-controller-method-action-types.ts
@@ -198,11 +198,6 @@ export type MetaMetricsControllerUpdateTraitsAction = {
   handler: MetaMetricsController['updateTraits'];
 };
 
-export type MetaMetricsControllerGetMetaMetricsIdAction = {
-  type: `MetaMetricsController:getMetaMetricsId`;
-  handler: MetaMetricsController['getMetaMetricsId'];
-};
-
 /**
  * Union of all MetaMetricsController action types.
  */
@@ -230,5 +225,4 @@ export type MetaMetricsControllerMethodActions =
   | MetaMetricsControllerAddTraceBeforeMetricsOptInAction
   | MetaMetricsControllerBufferedTraceAction
   | MetaMetricsControllerBufferedEndTraceAction
-  | MetaMetricsControllerUpdateTraitsAction
-  | MetaMetricsControllerGetMetaMetricsIdAction;
+  | MetaMetricsControllerUpdateTraitsAction;

--- a/app/scripts/controllers/metametrics-controller.test.ts
+++ b/app/scripts/controllers/metametrics-controller.test.ts
@@ -217,12 +217,14 @@ describe('MetaMetricsController', function () {
   describe('constructor', function () {
     it('should properly initialize', async function () {
       const spy = jest.spyOn(segmentMock, 'track');
-      await withController(({ controller }) => {
+      await withController(({ controller, controllerMessenger }) => {
         expect(controller.version).toStrictEqual(VERSION);
         expect(controller.chainId).toStrictEqual(DEFAULT_CHAIN_ID);
         expect(controller.state.completedMetaMetricsOnboarding).toBe(true);
         expect(controller.state.marketingCampaignCookieId).toStrictEqual(null);
-        expect(controller.getMetaMetricsId()).toStrictEqual(TEST_ANALYTICS_ID);
+        expect(
+          controllerMessenger.call('AnalyticsController:getState').analyticsId,
+        ).toStrictEqual(TEST_ANALYTICS_ID);
         expect(controller.locale).toStrictEqual(LOCALE.replace('_', '-'));
         expect(controller.state.fragments).toStrictEqual({
           testid: SAMPLE_PERSISTED_EVENT,
@@ -455,26 +457,6 @@ describe('MetaMetricsController', function () {
     });
   });
 
-  describe('getMetaMetricsId', function () {
-    it('returns the analytics metametrics id and keeps it stable across calls', async function () {
-      await withController(({ controller, controllerMessenger }) => {
-        const { analyticsId: initialAnalyticsId } = controllerMessenger.call(
-          'AnalyticsController:getState',
-        );
-        expect(initialAnalyticsId).toStrictEqual(TEST_ANALYTICS_ID);
-
-        const clientMetaMetricsId = controller.getMetaMetricsId();
-        expect(clientMetaMetricsId).toStrictEqual(TEST_ANALYTICS_ID);
-        expect(clientMetaMetricsId).toMatch(
-          /^[\da-f]{8}-[\da-f]{4}-4[\da-f]{3}-[89ab][\da-f]{3}-[\da-f]{12}$/iu,
-        );
-
-        const sameMetaMetricsId = controller.getMetaMetricsId();
-        expect(clientMetaMetricsId).toStrictEqual(sameMetaMetricsId);
-      });
-    });
-  });
-
   describe('identify', function () {
     it('should call segment.identify for valid traits if user is participating in metametrics', async function () {
       const spy = jest.spyOn(segmentMock, 'identify');
@@ -586,10 +568,12 @@ describe('MetaMetricsController', function () {
         },
       );
     });
-    it('should not nullify the metaMetricsId when set to false', async function () {
-      await withController(async ({ controller }) => {
+    it('should not nullify the analyticsId when set to false', async function () {
+      await withController(async ({ controller, controllerMessenger }) => {
         await controller.setParticipateInMetaMetrics(false);
-        expect(controller.getMetaMetricsId()).toStrictEqual(TEST_ANALYTICS_ID);
+        expect(
+          controllerMessenger.call('AnalyticsController:getState').analyticsId,
+        ).toStrictEqual(TEST_ANALYTICS_ID);
       });
     });
     it('should nullify the marketingCampaignCookieId when participateInMetaMetrics is toggled off', async function () {

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -343,7 +343,6 @@ const MESSENGER_EXPOSED_METHODS = [
   'finalizeAbandonedFragments',
   'finalizeEventFragment',
   'getEventFragmentById',
-  'getMetaMetricsId',
   'handleMetaMaskStateUpdate',
   'identify',
   'processAbandonedFragment',
@@ -786,7 +785,7 @@ export class MetaMetricsController extends BaseController<
   async setParticipateInMetaMetrics(
     participateInMetaMetrics: boolean | null,
   ): Promise<string | null> {
-    const analyticsId = this.getMetaMetricsId();
+    const { analyticsId } = this.#analyticsGetState();
 
     if (participateInMetaMetrics === true) {
       this.messenger.call('AnalyticsController:optIn');
@@ -1248,12 +1247,6 @@ export class MetaMetricsController extends BaseController<
     this.update((state) => {
       state.traits = { ...state.traits, ...newTraits };
     });
-  }
-
-  // Retrieve the client metametrics id from AnalyticsController state
-  getMetaMetricsId(): string {
-    const { analyticsId } = this.#analyticsGetState();
-    return analyticsId;
   }
 
   #isBasicFunctionalityEnabled(): boolean {


### PR DESCRIPTION
## **Description**

This is a cleanup PR to remove remaining occurrences of `getMetaMetricsId`.

Consumers should read `analyticsId` from `AnalyticsController` state directly instead of via a `MetaMetricsController` messenger wrapper.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/7331

## **Manual testing steps**

NA

## **Screenshots/Recordings**

NA

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal API cleanup with no behavior change beyond removing a thin delegate; tests updated to the canonical analytics state source.
> 
> **Overview**
> Removes **`getMetaMetricsId`** from `MetaMetricsController`—including the messenger action type, exposed method registration, and the public method that only forwarded **`analyticsId`** from `AnalyticsController`.
> 
> **`setParticipateInMetaMetrics`** now reads **`analyticsId`** via the existing **`#analyticsGetState()`** helper instead of the removed wrapper. Tests assert the ID through **`AnalyticsController:getState`** on the messenger rather than **`controller.getMetaMetricsId()`**, and the dedicated **`getMetaMetricsId`** spec block is dropped.
> 
> Callers should use **`AnalyticsController`** state (**`analyticsId`**) directly instead of a MetaMetrics messenger indirection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16f391afd25715a1fd5ad4476f4b520d79cd1327. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->