### PR TITLE
fix: ARC swap usdc input force hide max button

### DIFF
--- a/ui/components/app/assets/enablement/arc.ts
+++ b/ui/components/app/assets/enablement/arc.ts
@@ -1,5 +1,5 @@
 import { BridgeAsset } from '@metamask/bridge-controller';
-import { hexToNumber } from '@metamask/utils';
+import { hexToNumber, CaipAssetType } from '@metamask/utils';
 
 /**
  * Arc Chain Augmentation Module
@@ -64,4 +64,14 @@ export function filterOutArcNativeAsset<
   TAsset extends { chainId?: string; isNative?: boolean },
 >(assets: TAsset[]): TAsset[] {
   return assets.filter((asset) => !isNativeArcAsset(asset));
+}
+
+/**
+ * Checks if a CAIP assetId corresponds to the ERC20 version of USDC on Arc.
+ * Which is eip155:5042/erc20:0x3600000000000000000000000000000000000000
+ * @param assetId
+ * @returns true if input assetId corresponds to the ERC20 version of USDC on Arc.
+ */
+export function isArcTokenUSDC(assetId: CaipAssetType): boolean {
+  return assetId === ARC_ERC20_USDC_BRIDGE_ASSET.assetId;
 }

--- a/ui/pages/bridge/prepare/prepare-bridge-page.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.tsx
@@ -73,6 +73,7 @@ import { Toast, ToastContainer } from '../../../components/multichain';
 import type { BridgeToken } from '../../../ducks/bridge/types';
 import { useLatestBalance } from '../../../hooks/bridge/useLatestBalance';
 import { MarketClosedModal } from '../../../components/app/assets/market-closed-modal';
+import { isArcTokenUSDC } from '../../../components/app/assets/enablement/arc';
 import { useGasIncluded7702 } from '../hooks/useGasIncluded7702';
 import { useIsSendBundleSupported } from '../hooks/useIsSendBundleSupported';
 import {
@@ -156,7 +157,9 @@ const PrepareBridgePage = ({
   const effectiveGasIncluded7702 = !isUsingHardwareWallet && gasIncluded7702;
 
   const shouldShowMaxButton =
-    fromToken && isNativeAddress(fromToken.assetId)
+    fromToken &&
+    // Always show for non-native tokens. Arc ERC20 USDC considered as native.
+    (isNativeAddress(fromToken.assetId) || isArcTokenUSDC(fromToken.assetId))
       ? !isSolanaChainId(fromToken.chainId) &&
         (effectiveGasIncluded || effectiveGasIncluded7702)
       : true;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## Context:

On Arc, there are two USDC:
Native one, 18 decimals.
ERC20 one, 6 decimals.
After some back-and-forth, the deduplication approach is now the following:

For Asset list / Send features: We show the native USDC.
For Bridge/Swap: We show the ERC20 USDC.

Problem: For Swap/Bridge, when Arc USDC is the input token, the "max" button still appears, because it is not considered as native. However we know for sure that swapping max amount of USDC will deplete the USDC native balance, resulting in a revert.

20/80 solution: Start with hiding the "max" button for USDC (ERC20) on Arc.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: force-hide MAX button for Arc USDC swap/bridge

## **Related issues**

Fixes:

## **Manual testing steps**

- Use the Swap widget and select Arc USDC as "from" token.
- Check that the "max" button isn't there.

Non-regression:
- Play with the Swap widget and keep observing that "max" button appears for non-native tokens on other networks. It should also appear for native for gasless-supported networks, except when using a HW.


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, Arc-specific UI guard on the bridge prepare page with no auth, signing, or balance logic changes.
> 
> **Overview**
> Hides the **MAX** amount control on the bridge/swap prepare screen when Arc **ERC20 USDC** is the source token, so users cannot fill the ERC20 balance in a way that drains the separate native USDC balance and causes reverts.
> 
> Adds **`isArcTokenUSDC`** in the Arc enablement module (CAIP match against the bridge USDC asset) and folds that token into the same **`shouldShowMaxButton`** branch as true native assets—MAX only appears when gas-included / 7702 rules allow it, not by default for ERC20s.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67a3feeb3f26235f8d655fd527e7791919bf6c4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->