### PR TITLE
fix: cp-13.37.0 do not render local approval values in activity

### DIFF
--- a/shared/lib/activity/adapters/local-transaction.test.ts
+++ b/shared/lib/activity/adapters/local-transaction.test.ts
@@ -420,6 +420,50 @@ describe('mapLocalTransaction', () => {
     });
   });
 
+  it('omits the approved amount for a token approve (mirrors the API path)', () => {
+    const spender = '0x80181d3ba89220cdb80234fc7aa19d5cc56229cc';
+    const transaction = {
+      chainId: CHAIN_IDS.LINEA_MAINNET,
+      id: 'approve-amount-id',
+      hash: '0xapproveamount',
+      status: TransactionStatus.confirmed,
+      time: 1716367781000,
+      type: TransactionType.tokenMethodApprove,
+      txParams: {
+        from,
+        to: lineaMusd,
+        data: buildApproveTransactionData(spender, 1000),
+      },
+    };
+    const transactionGroup = {
+      hasCancelled: false,
+      hasRetried: false,
+      initialTransaction: transaction,
+      nonce: '0x8',
+      primaryTransaction: transaction,
+      transactions: [transaction],
+    } as unknown as TransactionGroup;
+
+    const item = mapLocalTransaction({
+      ...transactionGroup,
+      contractTokenMetadata: { symbol: 'mUSD', decimals: 18 },
+    });
+
+    expect(item).toMatchObject({
+      type: 'approveSpendingCap',
+      data: {
+        token: {
+          direction: 'out',
+          symbol: 'mUSD',
+          assetId: toAssetId(lineaMusd, 'eip155:59144'),
+        },
+      },
+    });
+    expect(
+      item.type === 'approveSpendingCap' ? item.data.token?.amount : 'unset',
+    ).toBeUndefined();
+  });
+
   it('maps an mUSD conversion to a Convert activity', () => {
     const transaction = {
       chainId: CHAIN_IDS.LINEA_MAINNET,

--- a/shared/lib/activity/adapters/local-transaction.ts
+++ b/shared/lib/activity/adapters/local-transaction.ts
@@ -121,15 +121,11 @@ export function mapLocalTransaction(
     };
   };
 
-  const mapApprovalToken = ({
-    amount,
-  }: {
-    amount?: string;
-  } = {}) => {
+  // EVM approvals mirror the API path, which never returns an approved amount
+  const mapApprovalToken = () => {
     const contractAddress =
       resolveApprovalTokenContractAddress(initialTransaction);
     return getContractToken({
-      amount,
       transaction: initialTransaction,
       direction: 'out',
       contractAddress,
@@ -421,18 +417,12 @@ export function mapLocalTransaction(
         hash,
         data: {
           from,
-          token: mapApprovalToken({ amount: approveAmount }),
+          token: mapApprovalToken(),
         },
       };
     }
 
-    case TransactionType.tokenMethodIncreaseAllowance: {
-      const increaseData = initialTransaction.txParams.data
-        ? parseApprovalTransactionData(
-            initialTransaction.txParams.data as `0x${string}`,
-          )
-        : undefined;
-      const increaseAmount = increaseData?.amountOrTokenId?.toFixed(0);
+    case TransactionType.tokenMethodIncreaseAllowance:
       return {
         type: 'increaseSpendingCap',
         chainId,
@@ -441,10 +431,9 @@ export function mapLocalTransaction(
         hash,
         data: {
           from,
-          token: mapApprovalToken({ amount: increaseAmount }),
+          token: mapApprovalToken(),
         },
       };
-    }
 
     case TransactionType.lendingDeposit:
       return {

--- a/test/e2e/page-objects/pages/home/activity-tab.ts
+++ b/test/e2e/page-objects/pages/home/activity-tab.ts
@@ -241,19 +241,16 @@ class ActivityTab extends HomePage {
   }
 
   /**
-   * Checks that the spending cap value is displayed in the transaction details view.
+   * Checks the title shown in the transaction details view.
    * Must be called after clicking on a transaction to open its details.
    *
-   * @param expectedValue - The expected spending cap text (e.g. '3 TST').
+   * @param expectedTitle - The expected details title (e.g. 'Revoked spending cap').
    */
-  async checkSpendingCapValueInDetails(expectedValue: string): Promise<void> {
-    console.log(
-      `Check spending cap value ${expectedValue} in transaction details`,
-    );
-    await this.driver.waitForSelector({
-      css: this.transactionBreakdownAmount,
-      text: expectedValue,
-    });
+  async checkTransactionDetailsTitle(expectedTitle: string): Promise<void> {
+    console.log(`Check transaction details title is "${expectedTitle}"`);
+    // Ensure the details view has opened before asserting on its content.
+    await this.driver.waitForSelector(this.backButton);
+    await this.driver.waitForSelector({ text: expectedTitle });
   }
 
   /**

--- a/test/e2e/tests/confirmations/transactions/increase-token-allowance-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/increase-token-allowance-redesign.spec.ts
@@ -48,7 +48,9 @@ describe('Confirmation Redesign ERC20 Increase Allowance', function () {
         const activityTab = new ActivityTab(driver);
         await activityTab.checkConfirmedTxNumberDisplayedInActivity(1);
         await activityTab.clickConfirmedTransaction();
-        await activityTab.checkTransactionDetailsTitle('Increased spending cap');
+        await activityTab.checkTransactionDetailsTitle(
+          'Increased spending cap',
+        );
       },
     );
   });

--- a/test/e2e/tests/confirmations/transactions/increase-token-allowance-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/increase-token-allowance-redesign.spec.ts
@@ -12,7 +12,7 @@ import { mocked4BytesIncreaseAllowance, TestSuiteArguments } from './shared';
 describe('Confirmation Redesign ERC20 Increase Allowance', function () {
   const smartContract = SMART_CONTRACTS.HST;
 
-  it('submits an increase allowance transaction with a small spending cap', async function () {
+  it('submits an increase allowance transaction', async function () {
     await withFixtures(
       {
         dappOptions: { numberOfTestDapps: 1 },
@@ -48,48 +48,7 @@ describe('Confirmation Redesign ERC20 Increase Allowance', function () {
         const activityTab = new ActivityTab(driver);
         await activityTab.checkConfirmedTxNumberDisplayedInActivity(1);
         await activityTab.clickConfirmedTransaction();
-        await activityTab.checkSpendingCapValueInDetails('3 TST');
-      },
-    );
-  });
-
-  it('submits an increase allowance transaction with a large spending cap', async function () {
-    await withFixtures(
-      {
-        dappOptions: { numberOfTestDapps: 1 },
-        fixtures: new FixtureBuilderV2()
-          .withPermissionControllerConnectedToTestDapp()
-          .build(),
-        smartContract,
-        testSpecificMock: mocked4BytesIncreaseAllowance,
-        title: this.test?.fullTitle(),
-      },
-      async ({ driver, contractRegistry, localNodes }: TestSuiteArguments) => {
-        const contractAddress =
-          await contractRegistry?.getContractAddress(smartContract);
-        await login(driver, { localNode: localNodes?.[0] });
-        const testDapp = new TestDapp(driver);
-        await testDapp.openTestDappPage({ contractAddress });
-        await testDapp.checkPageIsLoaded();
-
-        await testDapp.clickERC20IncreaseAllowanceButton();
-
-        await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
-        const txConfirmation = new ERC20ApproveTransactionConfirmation(driver);
-        await txConfirmation.editSpendingCap('3000');
-
-        await txConfirmation.clickScrollToBottomButton();
-        await txConfirmation.clickFooterConfirmButton();
-
-        await driver.switchToWindowWithTitle(
-          WINDOW_TITLES.ExtensionInFullScreenView,
-        );
-        const homePage = new HomePage(driver);
-        await homePage.goToActivityList();
-        const activityTab = new ActivityTab(driver);
-        await activityTab.checkConfirmedTxNumberDisplayedInActivity(1);
-        await activityTab.clickConfirmedTransaction();
-        await activityTab.checkSpendingCapValueInDetails('3,000 TST');
+        await activityTab.checkTransactionDetailsTitle('Increased spending cap');
       },
     );
   });

--- a/test/e2e/tests/confirmations/transactions/revoke-allowance-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/revoke-allowance-redesign.spec.ts
@@ -49,7 +49,7 @@ describe('Confirmation Redesign ERC20 Revoke Allowance', function () {
         const activityTab = new ActivityTab(driver);
         await activityTab.checkConfirmedTxNumberDisplayedInActivity(1);
         await activityTab.clickConfirmedTransaction();
-        await activityTab.checkSpendingCapValueInDetails('0 TST');
+        await activityTab.checkTransactionDetailsTitle('Revoked spending cap');
       },
     );
   });

--- a/ui/pages/details/components/shared.tsx
+++ b/ui/pages/details/components/shared.tsx
@@ -97,10 +97,10 @@ export function Row({
   );
 }
 
-export function Section({ children }: { children: ReactNode }) {
-  return <section className="py-2">{children}</section>;
+export function Section({ children }: Readonly<{ children: ReactNode }>) {
+  return <section className="py-2 empty:hidden">{children}</section>;
 }
 
-export function Footer({ children }: { children: ReactNode }) {
+export function Footer({ children }: Readonly<{ children: ReactNode }>) {
   return <div className="mt-auto flex flex-col gap-4 pt-4">{children}</div>;
 }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes an issue where unlimited local approvals where showing incorrectly. Now we don't show approval amounts locally at all, mirroring the experience coming from the evm api. This provides a more consistent user experience. Non-evm approvals are untouched. Updates e2e approval tests to assert on transaction details title rather than amount.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: do not show a value for local transaction approval amounts in activity

## **Related issues**

Fixes:

## **Manual testing steps**

1. Approve a token value on an evm chain
2. Confirm that the value does not show in the transaction activity list and details

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="498" height="502" alt="image" src="https://github.com/user-attachments/assets/f4717d3c-50bc-4247-b073-587e93c241eb" />

<img width="496" height="724" alt="image" src="https://github.com/user-attachments/assets/9d46e9e8-a61f-41e3-b62a-bd64edc330da" />


### **After**

<img width="495" height="430" alt="image" src="https://github.com/user-attachments/assets/c1899bfc-b8a7-4c02-8820-b5844dd924a0" />

<img width="498" height="733" alt="image" src="https://github.com/user-attachments/assets/7a4f1207-e2f1-467a-997e-a70d13932a43" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Activity display mapping and e2e assertions only; non-EVM approvals are unchanged.
> 
> **Overview**
> **Local EVM approval activity** no longer attaches an approved **amount** on approve, revoke, or increase-allowance transactions, aligning with the EVM API path and avoiding incorrect display for unlimited approvals. Approve vs revoke still uses on-chain data only to pick the activity **type**; **increase allowance** no longer parses calldata for an amount.
> 
> E2E coverage now asserts transaction **details titles** (e.g. “Increased spending cap”, “Revoked spending cap”) instead of spending-cap values in the breakdown. Transaction details **Section** uses `empty:hidden` so empty breakdown sections are not shown.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81748b41b4f55ec0f322890e1cec67ddf84f580f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->