### PR TITLE
fix(background): send BACKGROUND_INITIALIZED only to UI ports

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -642,8 +642,11 @@ const handleOnConnect = async (port) => {
     // Notify UI that background initialization is complete, before sending state.
     // This is sent on the raw port (like ALIVE) so the UI can distinguish between
     // "background still initializing" vs "background initialized but state sync failed".
-    if (!tryPostMessage(port, BACKGROUND_INITIALIZED_METHOD)) {
-      return;
+    // Only MetaMask UI ports listen for this message (contentscripts do not).
+    if (isMetaMaskUIPort) {
+      if (!tryPostMessage(port, BACKGROUND_INITIALIZED_METHOD)) {
+        return;
+      }
     }
 
     // For testing: skip connectWindowPostMessage to simulate state sync hang.


### PR DESCRIPTION
## **Description**

Contentscript ports (e.g. from the MV2 phishing-warning preload iframe) do not listen for BACKGROUND_INITIALIZED, so posting it after init could log a disconnected-port error when those short-lived connections close.
## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/7345

## **Manual testing steps**

1. Build Extension with `yarn start:mv2` and launch it on FireFox
2. Confirm you don't see the following error: "MetaMask - Failed to message to port Error: Attempt to postMessage on disconnected port"
```
data: Object { method: "BACKGROUND_INITIALIZED", params: undefined }
```

## **Screenshots/Recordings**

NA

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 99df19d78a40d30fa73bef4c27d5a45d91972889. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->