### PR TITLE
test: fix broken withTokenControllerERC20 due to unify assets

### DIFF
--- a/test/e2e/fixtures/fixture-builder-v2.ts
+++ b/test/e2e/fixtures/fixture-builder-v2.ts
@@ -1,6 +1,6 @@
 import { merge, cloneDeep } from 'lodash';
 import { toHex } from '@metamask/controller-utils';
-import type { Hex, Json } from '@metamask/utils';
+import type { CaipAssetType, Hex, Json } from '@metamask/utils';
 import type { AccountsControllerState } from '@metamask/accounts-controller';
 import type { AccountTreeControllerState } from '@metamask/account-tree-controller';
 import type { AddressBookControllerState } from '@metamask/address-book-controller';
@@ -57,6 +57,7 @@ import {
   DAPP_TWO_URL,
   DAPP_URL,
   DAPP_URL_LOCALHOST,
+  DEFAULT_FIXTURE_ACCOUNT_ID,
   DEFAULT_FIXTURE_ACCOUNT_LOWERCASE,
   HARDWARE_WALLET_ACCOUNT_ID,
   IMPORTED_ACCOUNT_FIXTURE_VAULT,
@@ -1319,24 +1320,32 @@ class FixtureBuilderV2 {
   }
 
   withTokensControllerERC20({ chainId = 1337 } = {}): this {
-    return this.withTokensController({
-      allTokens: {
-        [toHex(chainId)]: {
-          '0x5cfe73b6021e818b776b421b1c4db2474086a7e1': [
-            {
-              address: `__FIXTURE_SUBSTITUTION__CONTRACT${SMART_CONTRACTS.HST}`,
-              symbol: 'TST',
-              image: `https://static.cx.metamask.io/api/v1/tokenIcons/${chainId}/0x581c3c1a2a4ebde2a0df29b5cf4c116e42945947.png`,
-              isERC721: false,
-              decimals: 4,
-              aggregators: ['Metamask', 'Aave'],
-              name: 'test',
+    const tokenAddress: Hex = '0x581c3c1a2a4ebde2a0df29b5cf4c116e42945947';
+    const assetId: CaipAssetType = `eip155:${chainId}/erc20:${tokenAddress}`;
+    return (
+      this
+        // When `assetsUnifyState` is enabled the asset list is derived from the
+        // AssetsController (`customAssets` + `assetsInfo` + `assetsBalance`),
+        // not from TokensController/TokenBalancesController.
+        .withAssetsController({
+          customAssets: { [DEFAULT_FIXTURE_ACCOUNT_ID]: [assetId] },
+          assetsBalance: {
+            [DEFAULT_FIXTURE_ACCOUNT_ID]: {
+              [assetId]: { amount: '10' },
             },
-          ],
-        },
-      },
-      allIgnoredTokens: {},
-    });
+          },
+          assetsInfo: {
+            [assetId]: {
+              aggregators: ['Metamask', 'Aave'],
+              decimals: 4,
+              image: `https://static.cx.metamask.io/api/v1/tokenIcons/${chainId}/0x581c3c1a2a4ebde2a0df29b5cf4c116e42945947.png`,
+              name: 'TST',
+              symbol: 'TST',
+              type: 'erc20',
+            },
+          },
+        })
+    );
   }
 
   withTrezorAccount(): this {

--- a/test/e2e/tests/bridge/bridge-positive-cases.spec.ts
+++ b/test/e2e/tests/bridge/bridge-positive-cases.spec.ts
@@ -22,7 +22,6 @@ describe('Bridge tests', function (this: Suite) {
       getBridgeFixtures({
         title: this.test?.fullTitle(),
         featureFlags: BRIDGE_FEATURE_FLAGS_WITH_SSE_ENABLED,
-        withErc20: false,
       }),
       async ({ driver }) => {
         // the balance has been fixed now , we show native balance when currency controller is set
@@ -97,7 +96,6 @@ describe('Bridge tests', function (this: Suite) {
       getBridgeFixtures({
         title: this.test?.fullTitle(),
         featureFlags: BRIDGE_FEATURE_FLAGS_WITH_SSE_ENABLED,
-        withErc20: false,
       }),
       async ({ driver, mockedEndpoint }) => {
         await login(driver, { expectedBalance: '$225,730.11' });
@@ -139,7 +137,6 @@ describe('Bridge tests', function (this: Suite) {
       getBridgeFixtures({
         title: this.test?.fullTitle(),
         featureFlags: BRIDGE_FEATURE_FLAGS_WITH_SSE_ENABLED,
-        withErc20: false,
       }),
       async ({ driver, mockedEndpoint }) => {
         await login(driver, { expectedBalance: '$225,730.11' });
@@ -183,7 +180,6 @@ describe('Bridge tests', function (this: Suite) {
       getBridgeFixtures({
         title: this.test?.fullTitle(),
         featureFlags: BRIDGE_FEATURE_FLAGS_WITH_SSE_ENABLED,
-        withErc20: false,
       }),
       async ({ driver }) => {
         await login(driver, { expectedBalance: '$225,730.11' });
@@ -215,7 +211,6 @@ describe('Bridge tests', function (this: Suite) {
       getBridgeFixtures({
         title: this.test?.fullTitle(),
         featureFlags: BRIDGE_FEATURE_FLAGS_WITH_SSE_ENABLED,
-        withErc20: false,
       }),
       async ({ driver }) => {
         await login(driver, { expectedBalance: '$225,730.11' });
@@ -250,7 +245,6 @@ describe('Bridge tests', function (this: Suite) {
       getBridgeFixtures({
         title: this.test?.fullTitle(),
         featureFlags: BRIDGE_FEATURE_FLAGS_WITH_SSE_ENABLED,
-        withErc20: false,
       }),
       async ({ driver }) => {
         await login(driver, { expectedBalance: '$225,730.11' });
@@ -288,7 +282,6 @@ describe('Bridge tests', function (this: Suite) {
       getBridgeFixtures({
         title: this.test?.fullTitle(),
         featureFlags: BRIDGE_FEATURE_FLAGS_WITH_SSE_ENABLED,
-        withErc20: false,
       }),
       async ({ driver }) => {
         await login(driver, { expectedBalance: '$225,730.11' });

--- a/test/e2e/tests/bridge/bridge-test-utils.ts
+++ b/test/e2e/tests/bridge/bridge-test-utils.ts
@@ -1348,10 +1348,6 @@ export const getBridgeFixtures = ({
       assetsPrice: getMockAssetsPrice(ETH_CONVERSION_RATE_USD),
     });
 
-  if (withErc20) {
-    fixtureBuilder.withTokensControllerERC20({ chainId: 1 });
-  }
-
   return {
     forceBip44Version: false,
     fixtures: fixtureBuilder.build(),
@@ -1449,7 +1445,6 @@ export const getQuoteNegativeCasesFixtures = (
   const fixtureBuilder = new FixtureBuilderV2()
     .withNetworkRpcUrlOnLocalhost('0x1')
     .withCurrencyController(MOCK_CURRENCY_RATES)
-    .withTokensControllerERC20({ chainId: 1 })
     .withEnabledNetworks({
       eip155: {
         '0x1': true,
@@ -1509,7 +1504,6 @@ export const getBridgeNegativeCasesFixtures = (
   const fixtureBuilder = new FixtureBuilderV2()
     .withNetworkRpcUrlOnLocalhost('0x1')
     .withCurrencyController(MOCK_CURRENCY_RATES)
-    .withTokensControllerERC20({ chainId: 1 })
     .withEnabledNetworks({
       eip155: {
         '0x1': true,
@@ -1569,7 +1563,6 @@ export const getInsufficientFundsFixtures = (
   const fixtureBuilder = new FixtureBuilderV2()
     .withNetworkRpcUrlOnLocalhost('0x1')
     .withCurrencyController(MOCK_CURRENCY_RATES)
-    .withTokensControllerERC20({ chainId: 1 })
     .withEnabledNetworks({
       eip155: {
         '0x1': true,
@@ -1844,7 +1837,6 @@ export const getGasIncludedSwapFixtures = (title?: string) => {
   const fixtureBuilder = new FixtureBuilderV2()
     .withNetworkRpcUrlOnLocalhost('0x1')
     .withCurrencyController(MOCK_CURRENCY_RATES)
-    .withTokensControllerERC20({ chainId: 1 })
     .withEnabledNetworks({
       eip155: {
         '0x1': true,
@@ -1943,7 +1935,6 @@ export const getGasless7702SwapFixtures = (title?: string) => {
   const fixtureBuilder = new FixtureBuilderV2()
     .withNetworkRpcUrlOnLocalhost('0x1')
     .withCurrencyController(MOCK_CURRENCY_RATES)
-    .withTokensControllerERC20({ chainId: 1 })
     .withEnabledNetworks({
       eip155: {
         '0x1': true,

--- a/test/e2e/tests/bridge/bridge-test-utils.ts
+++ b/test/e2e/tests/bridge/bridge-test-utils.ts
@@ -1272,12 +1272,10 @@ async function mockSmartTransactionsForBridge(
 export const getBridgeFixtures = ({
   title,
   featureFlags = {},
-  withErc20 = true,
   tokenWarnings = [],
 }: {
   title?: string;
   featureFlags?: Partial<FeatureFlagResponse>;
-  withErc20?: boolean;
   tokenWarnings?: TokenFeature[];
 } = {}) => {
   const fixtureBuilder = new FixtureBuilderV2()

--- a/test/e2e/tests/bridge/swap-positive-cases.spec.ts
+++ b/test/e2e/tests/bridge/swap-positive-cases.spec.ts
@@ -55,7 +55,6 @@ describe('Swap tests', function (this: Suite) {
           ...BRIDGE_FEATURE_FLAGS_WITH_SSE_ENABLED,
           refreshRate: 30000,
         },
-        withErc20: false,
       }),
       async ({ driver, mockedEndpoint: mockedEndpoints }) => {
         await login(driver, { expectedBalance: '$225,730.11' });
@@ -138,7 +137,6 @@ describe('Swap tests', function (this: Suite) {
       getBridgeFixtures({
         title: this.test?.fullTitle(),
         featureFlags: BRIDGE_FEATURE_FLAGS_WITH_SSE_ENABLED,
-        withErc20: false,
       }),
       async ({ driver, mockedEndpoint: mockedEndpoints }) => {
         await login(driver, { expectedBalance: '$225,730.11' });

--- a/test/e2e/tests/metrics/bridge.spec.ts
+++ b/test/e2e/tests/metrics/bridge.spec.ts
@@ -32,7 +32,6 @@ describe('Bridge tests', function (this: Suite) {
       getBridgeFixtures({
         title: this.test?.fullTitle(),
         featureFlags: DEFAULT_BRIDGE_FEATURE_FLAGS,
-        withErc20: false,
       }),
       async ({ driver, mockedEndpoint: mockedEndpoints }) => {
         await login(driver, {

--- a/test/e2e/tests/send/send-hex-address.spec.ts
+++ b/test/e2e/tests/send/send-hex-address.spec.ts
@@ -63,19 +63,18 @@ describe('Send - Hex Address Normalization', function () {
       await withFixtures(
         {
           dappOptions: { numberOfTestDapps: 1 },
-          fixtures: new FixtureBuilderV2()
-            .withTokensControllerERC20()
-            .build(),
-          smartContract: SMART_CONTRACTS.HST,
+          fixtures: new FixtureBuilderV2().withTokensControllerERC20().build(),
+          smartContract,
           title: this.test?.fullTitle(),
         },
         async ({ driver, localNodes }) => {
           await login(driver, { localNode: localNodes[0] });
+
           // Send TST
           const homePage = new HomePage(driver);
           await homePage.goToTokensTab();
           const tokensTab = new TokensTab(driver);
-          await tokensTab.clickOnAsset('TST')
+          await tokensTab.clickOnAsset('TST');
           await tokensTab.clickMultichainTokenListButton();
           await homePage.clickOnSendButton();
           // Paste address without hex prefix
@@ -94,9 +93,7 @@ describe('Send - Hex Address Normalization', function () {
       await withFixtures(
         {
           dappOptions: { numberOfTestDapps: 1 },
-          fixtures: new FixtureBuilderV2()
-            .withTokensControllerERC20()
-            .build(),
+          fixtures: new FixtureBuilderV2().withTokensControllerERC20().build(),
           smartContract,
           title: this.test?.fullTitle(),
         },

--- a/test/e2e/tests/send/send-hex-address.spec.ts
+++ b/test/e2e/tests/send/send-hex-address.spec.ts
@@ -65,18 +65,17 @@ describe('Send - Hex Address Normalization', function () {
           dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilderV2()
             .withTokensControllerERC20()
-            .withEnabledNetworks({ eip155: { '0x539': true } })
             .build(),
-          smartContract,
+          smartContract: SMART_CONTRACTS.HST,
           title: this.test?.fullTitle(),
         },
         async ({ driver, localNodes }) => {
           await login(driver, { localNode: localNodes[0] });
-
           // Send TST
           const homePage = new HomePage(driver);
           await homePage.goToTokensTab();
           const tokensTab = new TokensTab(driver);
+          await tokensTab.clickOnAsset('TST')
           await tokensTab.clickMultichainTokenListButton();
           await homePage.clickOnSendButton();
           // Paste address without hex prefix
@@ -96,7 +95,6 @@ describe('Send - Hex Address Normalization', function () {
         {
           dappOptions: { numberOfTestDapps: 1 },
           fixtures: new FixtureBuilderV2()
-            .withEnabledNetworks({ eip155: { '0x539': true } })
             .withTokensControllerERC20()
             .build(),
           smartContract,
@@ -109,6 +107,7 @@ describe('Send - Hex Address Normalization', function () {
           const homePage = new HomePage(driver);
           await homePage.goToTokensTab();
           const tokensTab = new TokensTab(driver);
+          await tokensTab.clickOnAsset('TST');
           await tokensTab.clickMultichainTokenListButton();
           await homePage.clickOnSendButton();
 
@@ -120,7 +119,7 @@ describe('Send - Hex Address Normalization', function () {
 
           // Confirm transaction
           const transactionConfirmation = new TransactionConfirmation(driver);
-          await transactionConfirmation.checkSendAmount('0 ETH');
+          await transactionConfirmation.checkSendAmount('0 TST');
           const confirmation = new Confirmation(driver);
           await confirmation.clickFooterConfirmButton();
           await homePage.goToActivityList();
@@ -131,7 +130,7 @@ describe('Send - Hex Address Normalization', function () {
 
           // Verify address in activity log
           await transactionDetailsPage.checkAddressInActivityLog(
-            hexPrefixedAddress.toLowerCase(),
+            hexPrefixedAddress,
           );
         },
       );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

In the send-hex-address.spec.ts there are 2 tests which claim to send an ERC20 token TST:
- ERC20 normalizes pasted address without 0x prefix
- ERC20 normalizes typed address without 0x prefix and sends TST

However, the reality is that they were sending ETH. This has now been fixed. 

The fixture builder method used to import the ERC20 token in state `withTokensControllerERC20` was broken, due to the assets unify state change, causing that the token the list is now derived from the AssetsController, not from the TokensController.

While investigating this, also found other specs that were using the method, but without any reason, so that has been removed from those that didn't use the ERC20.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

See ETH
<img width="1366" height="682" alt="image" src="https://github.com/user-attachments/assets/7db8e81d-7587-4c8a-8b42-aadf555a9421" />


### **After**

See TST

<img width="1193" height="912" alt="image" src="https://github.com/user-attachments/assets/e4134f08-b8ea-4aff-92c2-ecb2c5d2b8c0" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test and fixture-only changes with no production code paths affected.
> 
> **Overview**
> Updates **`withTokensControllerERC20`** so TST is seeded through **`AssetsController`** (CAIP `erc20` asset id, `customAssets`, `assetsBalance`, `assetsInfo`) instead of **`TokensController`**, matching behavior when **`assetsUnifyState`** drives the token list.
> 
> Removes redundant **`withTokensControllerERC20`** usage from several bridge e2e fixture helpers where it was no longer needed or duplicated.
> 
> Stabilizes **Send – hex address normalization (ERC20)** by selecting **TST** in the tokens UI, dropping extra enabled-network fixture setup, and fixing assertions (**0 TST** on confirm, recipient casing in activity).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b0d8d11d064dd20a1dec8d59e983ec1bf42517f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->