### PR TITLE
feat(perps): display max leverage pill in market list cards

### DIFF
--- a/ui/components/app/perps/perps-explore-markets/perps-explore-markets.tsx
+++ b/ui/components/app/perps/perps-explore-markets/perps-explore-markets.tsx
@@ -67,6 +67,7 @@ export const PerpsExploreMarkets = ({ markets }: PerpsExploreMarketsProps) => {
               price={market.price}
               change24hPercent={market.change24hPercent}
               volume={market.volume}
+              maxLeverage={market.maxLeverage}
               onClick={handleMarketClick}
               data-testid={`explore-markets-${market.symbol.replaceAll(':', '-')}`}
             />

--- a/ui/components/app/perps/perps-market-card/perps-market-card.tsx
+++ b/ui/components/app/perps/perps-market-card/perps-market-card.tsx
@@ -26,6 +26,7 @@ export type PerpsMarketCardProps = {
   price: string;
   change24hPercent: string;
   volume?: string;
+  maxLeverage?: string;
   onClick: (symbol: string) => void;
   'data-testid'?: string;
 };
@@ -35,6 +36,7 @@ export const PerpsMarketCard = ({
   price,
   change24hPercent,
   volume,
+  maxLeverage,
   onClick,
   'data-testid': testId,
 }: PerpsMarketCardProps) => {
@@ -60,12 +62,28 @@ export const PerpsMarketCard = ({
         alignItems={BoxAlignItems.Start}
         gap={1}
       >
-        <Text
-          fontWeight={FontWeight.Medium}
-          className="text-s-body-md @compact:text-s-body-sm"
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          gap={2}
         >
-          {displaySymbol}
-        </Text>
+          <Text
+            fontWeight={FontWeight.Medium}
+            className="text-s-body-md @compact:text-s-body-sm"
+          >
+            {displaySymbol}
+          </Text>
+          {maxLeverage && (
+            <span className="shrink-0 rounded-md bg-background-muted px-1.5">
+              <Text
+                variant={TextVariant.BodyXs}
+                color={TextColor.TextAlternative}
+              >
+                {maxLeverage}
+              </Text>
+            </span>
+          )}
+        </Box>
         {volume ? (
           <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
             {volume}

--- a/ui/components/app/perps/perps-watchlist/perps-watchlist.tsx
+++ b/ui/components/app/perps/perps-watchlist/perps-watchlist.tsx
@@ -61,6 +61,7 @@ export const PerpsWatchlist = ({ markets }: PerpsWatchlistProps) => {
             price={market.price}
             change24hPercent={market.change24hPercent}
             volume={market.volume}
+            maxLeverage={market.maxLeverage}
             onClick={handleMarketClick}
             data-testid={`perps-watchlist-${market.symbol}`}
           />


### PR DESCRIPTION
## **Description**

The perps home tab market lists (Watchlist and Explore Markets sections) did not display the max leverage pill that is already shown in the full market list page and on mobile. This PR adds the max leverage pill (e.g. "50x") to `PerpsMarketCard`, matching the existing `MarketRow` and mobile `PerpsLeverage` visual patterns.

The data (`PerpsMarketData.maxLeverage`) was already available in both parent components via stream hooks — this is a pure UI change with no new data fetching.

## **Changelog**

CHANGELOG entry: Added max leverage pill display in perps market list cards

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3305

## **Manual testing steps**

1. Run the extension with `yarn start`
2. Navigate to the Perps tab on the home page
3. Verify the Watchlist section shows a leverage pill (e.g. "50x") next to each market symbol
4. Verify the Explore Markets section shows a leverage pill next to each market symbol
5. Click "Explore markets" to open the full market list and confirm the pills are consistent in style

## **Screenshots/Recordings**

### **Before**

### **After**
<img width="360" height="775" alt="Screenshot 2026-06-22 at 19 06 00" src="https://github.com/user-attachments/assets/f4920cc9-32ef-4ded-b9bc-ee04419b86da" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only change using data already on market objects; no auth, trading, or API logic touched.
> 
> **Overview**
> Perps home **Watchlist** and **Explore Markets** rows now show each market’s **max leverage** (e.g. `50x`) on `PerpsMarketCard`, aligned with the full market list and mobile.
> 
> `PerpsMarketCard` accepts an optional `maxLeverage` string and renders a muted pill beside the symbol when it’s set. **PerpsExploreMarkets** and **PerpsWatchlist** pass through `market.maxLeverage` from existing stream data—no new fetching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de357832afc6c3a21fd9c07888cc514bad055821. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->