### PR TITLE
feat: added transitions to global menu Page

### DIFF
--- a/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
@@ -40,7 +40,7 @@ import {
   ModalOverlay,
 } from '../../../../component-library';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
-import { transitionSlideForward } from '../../../../ui/transition';
+import { transitionForward } from '../../../../ui/transition';
 import { NETWORKS_ROUTE } from '../../../../../helpers/constants/routes';
 import {
   addNetwork,
@@ -402,10 +402,9 @@ const HomeNetworkFilterModalContent = ({
 
   const handleManageNetworks = useCallback(() => {
     // Don't close the modal first — letting the whole current view (modal
-    // included) slide out as one view-transition snapshot keeps the motion
-    // smooth. The modal's open state resets when the home route unmounts on
-    // navigation. Slide in from the right, mirroring the global menu.
-    transitionSlideForward(() => navigate(`${NETWORKS_ROUTE}?drawerOpen=true`));
+    // included) transition as one view-transition snapshot keeps the motion
+    // smooth. The modal's open state resets when the home route unmounts.
+    transitionForward(() => navigate(`${NETWORKS_ROUTE}?drawerOpen=true`));
   }, [navigate]);
 
   const sections = useMemo<NetworkSelectionSection[]>(() => {

--- a/ui/components/multichain/global-menu-drawer/global-menu-drawer.tsx
+++ b/ui/components/multichain/global-menu-drawer/global-menu-drawer.tsx
@@ -49,13 +49,16 @@ export const GlobalMenuDrawer = ({
   const environmentType = getEnvironmentType();
   const isFullscreen = environmentType === ENVIRONMENT_TYPE_FULLSCREEN;
   const isSidepanel = environmentType === ENVIRONMENT_TYPE_SIDEPANEL;
+  const usePortal = isFullscreen || isSidepanel;
   const [drawerStyle, setDrawerStyle] = useState<React.CSSProperties>({});
   const [backdropStyle, setBackdropStyle] = useState<React.CSSProperties>({});
   const [containerElement, setContainerElement] = useState<HTMLElement | null>(
     null,
   );
   const [contentTopOffset, setContentTopOffset] = useState(0);
-  const [drawerPhase, setDrawerPhase] = useState<DrawerPhase | null>(null);
+  const [drawerPhase, setDrawerPhase] = useState<DrawerPhase | null>(() =>
+    isOpen && !usePortal ? 'open' : null,
+  );
   const exitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const enterFrameRef = useRef<number | null>(null);
   const wasOpenRef = useRef(false);
@@ -65,12 +68,11 @@ export const GlobalMenuDrawer = ({
   const appContainerRef = useRef<HTMLElement | null>(null);
   const resizeTimeoutRef = useRef<NodeJS.Timeout | undefined>(undefined);
 
-  const usePortal = isFullscreen || isSidepanel;
   const hasPosition = Object.keys(drawerStyle).length > 0;
   const readyToShow = isOpen && (!usePortal || hasPosition);
 
   // Open drawer: use entering transition only when going from closed to open (hamburger click). When mounting or returning from a page with drawerOpen in URL, show immediately.
-  useEffect(() => {
+  useLayoutEffect(() => {
     if (readyToShow) {
       wasOpenRef.current = true;
       if (exitTimeoutRef.current !== null) {

--- a/ui/components/multichain/global-menu-drawer/useGlobalMenuSections.tsx
+++ b/ui/components/multichain/global-menu-drawer/useGlobalMenuSections.tsx
@@ -186,6 +186,7 @@ export function useGlobalMenuSections(
     });
     navigate(
       `${NOTIFICATIONS_ROUTE}?from=${encodeURIComponent(location.pathname)}`,
+      { state: { globalMenuTransition: 'slide-forward' } },
     );
   }, [
     hasThirdPartyNotifySnaps,

--- a/ui/components/multichain/global-menu-drawer/useGlobalMenuSections.tsx
+++ b/ui/components/multichain/global-menu-drawer/useGlobalMenuSections.tsx
@@ -316,31 +316,43 @@ export function useGlobalMenuSections(
       });
     }
 
-    if (
+    const shouldRenderSidePanelToggle =
       getBrowserName() !== PLATFORM_FIREFOX &&
-      browserSupportsSidePanel === true &&
+      browserSupportsSidePanel !== false &&
       isSidePanelEnabled &&
-      (isPopup || isSidepanel)
-    ) {
-      section2.items.push({
-        id: 'global-menu-toggle-view',
-        iconName: isSidepanel ? IconName.PopUp : IconName.SidePanel,
-        label: isSidepanel ? t('switchToPopup') : t('switchToSidePanel'),
-        onClick: async () => {
-          await dispatch(toggleDefaultView());
-          trackEvent({
-            event: MetaMetricsEventName.ViewportSwitched,
-            category: MetaMetricsEventCategory.Navigation,
-            properties: {
-              location: METRICS_LOCATION,
-              to: isSidepanel
-                ? ENVIRONMENT_TYPE_POPUP
-                : ENVIRONMENT_TYPE_SIDEPANEL,
-            },
-          });
-          onClose();
-        },
-      });
+      (isPopup || isSidepanel);
+
+    if (shouldRenderSidePanelToggle) {
+      if (browserSupportsSidePanel === null) {
+        section2.items.push({
+          id: 'global-menu-toggle-view-placeholder',
+          iconName: isSidepanel ? IconName.PopUp : IconName.SidePanel,
+          label: isSidepanel ? t('switchToPopup') : t('switchToSidePanel'),
+          onClick: () => undefined,
+          disabled: true,
+          className: 'invisible pointer-events-none',
+        });
+      } else {
+        section2.items.push({
+          id: 'global-menu-toggle-view',
+          iconName: isSidepanel ? IconName.PopUp : IconName.SidePanel,
+          label: isSidepanel ? t('switchToPopup') : t('switchToSidePanel'),
+          onClick: async () => {
+            await dispatch(toggleDefaultView());
+            trackEvent({
+              event: MetaMetricsEventName.ViewportSwitched,
+              category: MetaMetricsEventCategory.Navigation,
+              properties: {
+                location: METRICS_LOCATION,
+                to: isSidepanel
+                  ? ENVIRONMENT_TYPE_POPUP
+                  : ENVIRONMENT_TYPE_SIDEPANEL,
+              },
+            });
+            onClose();
+          },
+        });
+      }
     }
 
     const section2Manage: GlobalMenuSection = {

--- a/ui/components/multichain/global-menu-drawer/useGlobalMenuSections.tsx
+++ b/ui/components/multichain/global-menu-drawer/useGlobalMenuSections.tsx
@@ -186,7 +186,7 @@ export function useGlobalMenuSections(
     });
     navigate(
       `${NOTIFICATIONS_ROUTE}?from=${encodeURIComponent(location.pathname)}`,
-      { state: { globalMenuTransition: 'slide-forward' } },
+      { state: { globalMenuTransition: 'forward' } },
     );
   }, [
     hasThirdPartyNotifySnaps,

--- a/ui/components/multichain/global-menu/global-menu-list.tsx
+++ b/ui/components/multichain/global-menu/global-menu-list.tsx
@@ -18,7 +18,7 @@ import { GlobalMenuListProps, isRouteItem } from './global-menu-list.types';
 
 const getRouteState = (state?: object) => ({
   ...state,
-  globalMenuTransition: 'slide-forward',
+  globalMenuTransition: 'forward',
 });
 
 /**

--- a/ui/components/multichain/global-menu/global-menu-list.tsx
+++ b/ui/components/multichain/global-menu/global-menu-list.tsx
@@ -16,6 +16,11 @@ import {
 import { MenuItem } from '../../ui/menu';
 import { GlobalMenuListProps, isRouteItem } from './global-menu-list.types';
 
+const getRouteState = (state?: object) => ({
+  ...state,
+  globalMenuTransition: 'slide-forward',
+});
+
 /**
  * Renders menu item content with badge and chevron
  *
@@ -101,6 +106,7 @@ export const GlobalMenuList = ({
           {section.items.map((item) => {
             // Show chevron for route items or when explicitly requested (e.g. notifications)
             const showChevron = isRouteItem(item) || item.showChevron === true;
+
             return (
               <MenuItem
                 key={item.id}
@@ -111,7 +117,9 @@ export const GlobalMenuList = ({
                 fontWeight={FontWeight.Medium}
                 textColor={item.textColor}
                 to={isRouteItem(item) ? item.to : undefined}
-                state={isRouteItem(item) ? item.state : undefined}
+                state={
+                  isRouteItem(item) ? getRouteState(item.state) : undefined
+                }
                 onClick={item.onClick}
                 disabled={item.disabled}
                 showInfoDot={item.showInfoDot}

--- a/ui/components/multichain/global-menu/global-menu-list.tsx
+++ b/ui/components/multichain/global-menu/global-menu-list.tsx
@@ -124,7 +124,9 @@ export const GlobalMenuList = ({
                 disabled={item.disabled}
                 showInfoDot={item.showInfoDot}
                 subtitle={item.subtitle}
-                className="first:rounded-t-none last:rounded-b-none"
+                className={`first:rounded-t-none last:rounded-b-none ${
+                  item.className ?? ''
+                }`}
                 data-testid={item.id}
               >
                 {renderMenuItemContent(item.label, item.badge, showChevron)}

--- a/ui/components/multichain/global-menu/global-menu-list.types.ts
+++ b/ui/components/multichain/global-menu/global-menu-list.types.ts
@@ -47,6 +47,10 @@ type GlobalMenuItemBase = {
    */
   subtitle?: string;
   /**
+   * Optional class name applied to the rendered menu item
+   */
+  className?: string;
+  /**
    * Whether the item is disabled
    */
   disabled?: boolean;

--- a/ui/components/multichain/pages/gator-permissions/gator-permissions-page.tsx
+++ b/ui/components/multichain/pages/gator-permissions/gator-permissions-page.tsx
@@ -39,6 +39,7 @@ import {
   getAggregatedGatorPermissionsCountAcrossAllChains,
   getTotalUniqueSitesCount,
 } from '../../../../selectors/gator-permissions/gator-permissions';
+import { useGlobalMenuRouteTransition } from '../../../../pages/routes/global-menu-route-transition';
 import { PermissionListItem } from './components/permission-list-item';
 
 export const GatorPermissionsPage = () => {
@@ -46,12 +47,13 @@ export const GatorPermissionsPage = () => {
   const theme = useTheme();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const runCloseTransition = useGlobalMenuRouteTransition();
 
   const fromPath = searchParams.get('from') ?? undefined;
 
   const handleBack = () => {
     if (fromPath === DEFAULT_ROUTE) {
-      navigate(PREVIOUS_ROUTE);
+      runCloseTransition(() => navigate(PREVIOUS_ROUTE));
     } else {
       navigate(DEFAULT_ROUTE);
     }

--- a/ui/components/multichain/pages/permissions-page/permissions-page.js
+++ b/ui/components/multichain/pages/permissions-page/permissions-page.js
@@ -45,6 +45,7 @@ import {
 import { getMergedConnectionsListWithGatorPermissions } from '../../../../selectors/gator-permissions/gator-permissions';
 import { isGatorPermissionsRevocationFeatureEnabled } from '../../../../../shared/lib/environment';
 import { removePermissionsFor } from '../../../../store/actions';
+import { useGlobalMenuRouteTransition } from '../../../../pages/routes/global-menu-route-transition';
 import { DisconnectAllSitesModal } from '../../disconnect-all-modal';
 import { Toast, ToastContainer } from '../../toast';
 import { ConnectionListItem } from './connection-list-item';
@@ -54,6 +55,7 @@ const PermissionsPage = () => {
   const theme = useTheme();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const runCloseTransition = useGlobalMenuRouteTransition();
   const dispatch = useDispatch();
   const headerRef = useRef();
 
@@ -61,7 +63,7 @@ const PermissionsPage = () => {
 
   const handleBack = () => {
     if (fromPath === DEFAULT_ROUTE) {
-      navigate(PREVIOUS_ROUTE);
+      runCloseTransition(() => navigate(PREVIOUS_ROUTE));
     } else {
       navigate(
         isGatorPermissionsRevocationFeatureEnabled()

--- a/ui/css/utilities/page-transitions.scss
+++ b/ui/css/utilities/page-transitions.scss
@@ -4,6 +4,48 @@
   --page-transition-ease-out: cubic-bezier(0.4, 0, 0.2, 1);
   --page-transition-ease-in: cubic-bezier(0.4, 0, 1, 1);
   --page-scale-distance: 0.97;
+  --global-menu-page-transition-duration: 300ms;
+}
+
+.global-menu-route-transition-wrapper {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: 100%;
+}
+
+.global-menu-route-transition-wrapper--animating {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  z-index: 1051;
+  width: 100%;
+  max-width: clamp(var(--width-sm), 85vw, var(--width-max));
+  margin: 0 auto;
+  overflow: hidden;
+}
+
+.app--sidepanel .global-menu-route-transition-wrapper--animating {
+  max-width: var(--width-max-sidepanel);
+}
+
+.global-menu-route-transition-wrapper__content {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: 100%;
+  background: var(--color-background-default);
+}
+
+.global-menu-route-transition-wrapper__content--slide-forward {
+  animation: global-menu-page-slide-in var(--global-menu-page-transition-duration) ease-in-out both;
+}
+
+.global-menu-route-transition-wrapper__content--slide-back {
+  animation: global-menu-page-slide-out var(--global-menu-page-transition-duration) ease-in-out both;
 }
 
 /* Clip overflow and make size changes instant (don't animate height) */
@@ -79,6 +121,26 @@
   to { transform: translateX(100%); }
 }
 
+@keyframes global-menu-page-slide-in {
+  from {
+    transform: translateX(100%);
+  }
+
+  to {
+    transform: translateX(0);
+  }
+}
+
+@keyframes global-menu-page-slide-out {
+  from {
+    transform: translateX(0);
+  }
+
+  to {
+    transform: translateX(100%);
+  }
+}
+
 @keyframes fade-out {
   from { opacity: 1; }
   to { opacity: 0; }
@@ -117,6 +179,11 @@
 @media (prefers-reduced-motion: reduce) {
   ::view-transition-old(root),
   ::view-transition-new(root) {
+    animation-duration: 0.01ms !important;
+  }
+
+  .global-menu-route-transition-wrapper__content--slide-forward,
+  .global-menu-route-transition-wrapper__content--slide-back {
     animation-duration: 0.01ms !important;
   }
 }

--- a/ui/css/utilities/page-transitions.scss
+++ b/ui/css/utilities/page-transitions.scss
@@ -4,7 +4,6 @@
   --page-transition-ease-out: cubic-bezier(0.4, 0, 0.2, 1);
   --page-transition-ease-in: cubic-bezier(0.4, 0, 1, 1);
   --page-scale-distance: 0.97;
-  --global-menu-page-transition-duration: 300ms;
 }
 
 .global-menu-route-transition-wrapper {
@@ -40,12 +39,12 @@
   background: var(--color-background-default);
 }
 
-.global-menu-route-transition-wrapper__content--slide-forward {
-  animation: global-menu-page-slide-in var(--global-menu-page-transition-duration) ease-in-out both;
+.global-menu-route-transition-wrapper__content--forward {
+  animation: page-enter var(--page-transition-duration) var(--page-transition-ease-out) both;
 }
 
-.global-menu-route-transition-wrapper__content--slide-back {
-  animation: global-menu-page-slide-out var(--global-menu-page-transition-duration) ease-in-out both;
+.global-menu-route-transition-wrapper__content--back {
+  animation: page-exit var(--page-transition-duration) var(--page-transition-ease-in) both;
 }
 
 /* Clip overflow and make size changes instant (don't animate height) */
@@ -121,26 +120,6 @@
   to { transform: translateX(100%); }
 }
 
-@keyframes global-menu-page-slide-in {
-  from {
-    transform: translateX(100%);
-  }
-
-  to {
-    transform: translateX(0);
-  }
-}
-
-@keyframes global-menu-page-slide-out {
-  from {
-    transform: translateX(0);
-  }
-
-  to {
-    transform: translateX(100%);
-  }
-}
-
 @keyframes fade-out {
   from { opacity: 1; }
   to { opacity: 0; }
@@ -182,8 +161,8 @@
     animation-duration: 0.01ms !important;
   }
 
-  .global-menu-route-transition-wrapper__content--slide-forward,
-  .global-menu-route-transition-wrapper__content--slide-back {
+  .global-menu-route-transition-wrapper__content--forward,
+  .global-menu-route-transition-wrapper__content--back {
     animation-duration: 0.01ms !important;
   }
 }

--- a/ui/pages/contacts/contacts-list-page.tsx
+++ b/ui/pages/contacts/contacts-list-page.tsx
@@ -73,7 +73,7 @@ export function ContactsListPage() {
     () =>
       Boolean(
         completeAddressBook?.length &&
-          hasDuplicateContacts(completeAddressBook, internalAccounts ?? []),
+        hasDuplicateContacts(completeAddressBook, internalAccounts ?? []),
       ),
     [completeAddressBook, internalAccounts],
   );

--- a/ui/pages/contacts/contacts-list-page.tsx
+++ b/ui/pages/contacts/contacts-list-page.tsx
@@ -38,6 +38,7 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../shared/constants/metametrics';
+import { useGlobalMenuRouteTransition } from '../routes/global-menu-route-transition';
 import { buildDuplicateContactMap, hasDuplicateContacts } from './utils';
 import { ContactListItem } from './components/contact-list-item';
 import { ContactsEmptyState } from './components/contacts-empty-state';
@@ -47,6 +48,7 @@ const TOAST_AUTO_HIDE_MS = 2500;
 export function ContactsListPage() {
   const t = useI18nContext();
   const navigate = useNavigate();
+  const runCloseTransition = useGlobalMenuRouteTransition();
   const location = useLocation();
   const [searchParams] = useSearchParams();
   const fromPath = searchParams.get('from') ?? undefined;
@@ -71,7 +73,7 @@ export function ContactsListPage() {
     () =>
       Boolean(
         completeAddressBook?.length &&
-        hasDuplicateContacts(completeAddressBook, internalAccounts ?? []),
+          hasDuplicateContacts(completeAddressBook, internalAccounts ?? []),
       ),
     [completeAddressBook, internalAccounts],
   );
@@ -130,7 +132,7 @@ export function ContactsListPage() {
 
   const handleBack = () => {
     if (fromPath === DEFAULT_ROUTE) {
-      navigate(PREVIOUS_ROUTE);
+      runCloseTransition(() => navigate(PREVIOUS_ROUTE));
     } else {
       navigate(DEFAULT_ROUTE);
     }

--- a/ui/pages/networks/networks-page.tsx
+++ b/ui/pages/networks/networks-page.tsx
@@ -34,6 +34,7 @@ import {
 import { getEditedNetwork } from '../../selectors/selectors';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0021): route-isolation backlog
 import { SettingsHeader } from '../settings/shared/settings-header';
+import { useGlobalMenuRouteTransition } from '../routes/global-menu-route-transition';
 import { AddRpcUrlPageForm } from './add-rpc-url-page-form';
 import { NetworksPageList } from './networks-page-list';
 
@@ -93,6 +94,7 @@ export const NetworksPage = () => {
   const dispatch = useDispatch();
   const t = useI18nContext();
   const navigate = useNavigate();
+  const runCloseTransition = useGlobalMenuRouteTransition();
   const [searchParams, setSearchParams] = useSearchParams();
   const [isSearchOpen, setIsSearchOpen] = useState(false);
   const [searchValue, setSearchValue] = useState('');
@@ -189,8 +191,8 @@ export const NetworksPage = () => {
 
   const handleClose = useCallback(() => {
     dispatch(setEditedNetwork());
-    navigate(DEFAULT_ROUTE);
-  }, [dispatch, navigate]);
+    runCloseTransition(() => navigate(DEFAULT_ROUTE));
+  }, [dispatch, navigate, runCloseTransition]);
 
   const [pageToast, setPageToast] = useState<{
     chainId: string;
@@ -254,12 +256,13 @@ export const NetworksPage = () => {
 
   const handleRootBack = useCallback(() => {
     dispatch(setEditedNetwork());
-    navigate(
+    const route =
       searchParams.get('drawerOpen') === 'true'
         ? `${DEFAULT_ROUTE}?drawerOpen=true`
-        : DEFAULT_ROUTE,
-    );
-  }, [dispatch, navigate, searchParams]);
+        : DEFAULT_ROUTE;
+
+    runCloseTransition(() => navigate(route));
+  }, [dispatch, navigate, runCloseTransition, searchParams]);
 
   return (
     <Box className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-background-default">

--- a/ui/pages/notifications/notifications.tsx
+++ b/ui/pages/notifications/notifications.tsx
@@ -35,6 +35,7 @@ import {
   JustifyContent,
 } from '../../helpers/constants/design-system';
 import { deleteExpiredNotifications } from '../../store/actions';
+import { useGlobalMenuRouteTransition } from '../routes/global-menu-route-transition';
 import { NotificationsList, TAB_KEYS } from './notifications-list';
 import { NewFeatureTag } from './NewFeatureTag';
 
@@ -139,6 +140,7 @@ export const filterNotifications = (
 export default function Notifications() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const runCloseTransition = useGlobalMenuRouteTransition();
   const t = useI18nContext();
   const dispatch = useDispatch();
 
@@ -146,7 +148,7 @@ export default function Notifications() {
 
   const handleBack = () => {
     if (fromPath === DEFAULT_ROUTE) {
-      navigate(PREVIOUS_ROUTE);
+      runCloseTransition(() => navigate(PREVIOUS_ROUTE));
     } else {
       navigate(DEFAULT_ROUTE);
     }

--- a/ui/pages/routes/global-menu-route-transition.tsx
+++ b/ui/pages/routes/global-menu-route-transition.tsx
@@ -3,7 +3,7 @@ import React, {
   createContext,
   useCallback,
   useContext,
-  useEffect,
+  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -29,10 +29,12 @@ export const GlobalMenuRouteTransition = ({
   const location = useLocation();
   const shouldAnimate = location.state?.globalMenuTransition === 'forward';
   const [transitionDirection, setTransitionDirection] =
-    useState<TransitionDirection | null>(null);
+    useState<TransitionDirection | null>(() =>
+      shouldAnimate ? 'forward' : null,
+    );
   const onCloseCompleteRef = useRef<(() => void) | null>(null);
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     setTransitionDirection(shouldAnimate ? 'forward' : null);
   }, [location.key, shouldAnimate]);
 

--- a/ui/pages/routes/global-menu-route-transition.tsx
+++ b/ui/pages/routes/global-menu-route-transition.tsx
@@ -27,8 +27,7 @@ export const GlobalMenuRouteTransition = ({
   children: React.ReactNode;
 }) => {
   const location = useLocation();
-  const shouldAnimate =
-    location.state?.globalMenuTransition === 'slide-forward';
+  const shouldAnimate = location.state?.globalMenuTransition === 'forward';
   const [transitionDirection, setTransitionDirection] =
     useState<TransitionDirection | null>(null);
   const onCloseCompleteRef = useRef<(() => void) | null>(null);
@@ -71,9 +70,9 @@ export const GlobalMenuRouteTransition = ({
           className={classnames(
             'global-menu-route-transition-wrapper__content',
             {
-              'global-menu-route-transition-wrapper__content--slide-forward':
+              'global-menu-route-transition-wrapper__content--forward':
                 transitionDirection === 'forward',
-              'global-menu-route-transition-wrapper__content--slide-back':
+              'global-menu-route-transition-wrapper__content--back':
                 transitionDirection === 'back',
             },
           )}

--- a/ui/pages/routes/global-menu-route-transition.tsx
+++ b/ui/pages/routes/global-menu-route-transition.tsx
@@ -1,0 +1,87 @@
+import classnames from 'clsx';
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { useLocation } from 'react-router-dom';
+
+type TransitionDirection = 'forward' | 'back';
+
+type RunCloseTransition = (onComplete: () => void) => void;
+
+const GlobalMenuRouteTransitionContext = createContext<RunCloseTransition>(
+  (onComplete) => onComplete(),
+);
+
+export const useGlobalMenuRouteTransition = () =>
+  useContext(GlobalMenuRouteTransitionContext);
+
+export const GlobalMenuRouteTransition = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const location = useLocation();
+  const shouldAnimate =
+    location.state?.globalMenuTransition === 'slide-forward';
+  const [transitionDirection, setTransitionDirection] =
+    useState<TransitionDirection | null>(null);
+  const onCloseCompleteRef = useRef<(() => void) | null>(null);
+
+  useEffect(() => {
+    setTransitionDirection(shouldAnimate ? 'forward' : null);
+  }, [location.key, shouldAnimate]);
+
+  const runCloseTransition = useCallback<RunCloseTransition>((onComplete) => {
+    onCloseCompleteRef.current = onComplete;
+    setTransitionDirection('back');
+  }, []);
+
+  const contextValue = useMemo(() => runCloseTransition, [runCloseTransition]);
+
+  const handleAnimationEnd = (event: React.AnimationEvent<HTMLDivElement>) => {
+    if (event.currentTarget !== event.target) {
+      return;
+    }
+
+    if (transitionDirection !== 'back') {
+      setTransitionDirection(null);
+      return;
+    }
+
+    const onCloseComplete = onCloseCompleteRef.current;
+    onCloseCompleteRef.current = null;
+    onCloseComplete?.();
+  };
+
+  return (
+    <GlobalMenuRouteTransitionContext.Provider value={contextValue}>
+      <div
+        className={classnames('global-menu-route-transition-wrapper', {
+          'global-menu-route-transition-wrapper--animating':
+            transitionDirection !== null,
+        })}
+      >
+        <div
+          className={classnames(
+            'global-menu-route-transition-wrapper__content',
+            {
+              'global-menu-route-transition-wrapper__content--slide-forward':
+                transitionDirection === 'forward',
+              'global-menu-route-transition-wrapper__content--slide-back':
+                transitionDirection === 'back',
+            },
+          )}
+          onAnimationEnd={handleAnimationEnd}
+        >
+          {children}
+        </div>
+      </div>
+    </GlobalMenuRouteTransitionContext.Provider>
+  );
+};

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -201,27 +201,19 @@ const Asset = mmLazy(() => import('../asset/index.js'));
 const DeFiPage = mmLazy(() => import('../defi/index.ts'));
 const PermissionsPage = mmLazy(
   () =>
-    import(
-      '../../components/multichain/pages/permissions-page/permissions-page.js'
-    ),
+    import('../../components/multichain/pages/permissions-page/permissions-page.js'),
 );
 const GatorPermissionsPage = mmLazy(
   () =>
-    import(
-      '../../components/multichain/pages/gator-permissions/gator-permissions-page.tsx'
-    ),
+    import('../../components/multichain/pages/gator-permissions/gator-permissions-page.tsx'),
 );
 const GatorPermissionsTokenTransferPermissionsPage = mmLazy(
   () =>
-    import(
-      '../../components/multichain/pages/gator-permissions/token-transfer/token-transfer-page.tsx'
-    ),
+    import('../../components/multichain/pages/gator-permissions/token-transfer/token-transfer-page.tsx'),
 );
 const GatorPermissionsReviewPermissionsPage = mmLazy(
   () =>
-    import(
-      '../../components/multichain/pages/gator-permissions/review-permissions/review-gator-permissions-page.tsx'
-    ),
+    import('../../components/multichain/pages/gator-permissions/review-permissions/review-gator-permissions-page.tsx'),
 );
 const Home = mmLazy(() => import('../home/index.ts'));
 const DeepLink = mmLazy(() => import('../deep-link/deep-link.tsx'));

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -144,6 +144,7 @@ import { getConnectingLabel, setTheme } from './utils';
 import { ConfirmationRouter } from './confirmation-router';
 import { Modals } from './modals';
 import { NetworkHandler } from './network-handler';
+import { GlobalMenuRouteTransition } from './global-menu-route-transition';
 
 // Begin Lazy Routes
 const OnboardingFlow = mmLazy(() => import('../onboarding-flow/index.ts'));
@@ -200,19 +201,27 @@ const Asset = mmLazy(() => import('../asset/index.js'));
 const DeFiPage = mmLazy(() => import('../defi/index.ts'));
 const PermissionsPage = mmLazy(
   () =>
-    import('../../components/multichain/pages/permissions-page/permissions-page.js'),
+    import(
+      '../../components/multichain/pages/permissions-page/permissions-page.js'
+    ),
 );
 const GatorPermissionsPage = mmLazy(
   () =>
-    import('../../components/multichain/pages/gator-permissions/gator-permissions-page.tsx'),
+    import(
+      '../../components/multichain/pages/gator-permissions/gator-permissions-page.tsx'
+    ),
 );
 const GatorPermissionsTokenTransferPermissionsPage = mmLazy(
   () =>
-    import('../../components/multichain/pages/gator-permissions/token-transfer/token-transfer-page.tsx'),
+    import(
+      '../../components/multichain/pages/gator-permissions/token-transfer/token-transfer-page.tsx'
+    ),
 );
 const GatorPermissionsReviewPermissionsPage = mmLazy(
   () =>
-    import('../../components/multichain/pages/gator-permissions/review-permissions/review-gator-permissions-page.tsx'),
+    import(
+      '../../components/multichain/pages/gator-permissions/review-permissions/review-gator-permissions-page.tsx'
+    ),
 );
 const Home = mmLazy(() => import('../home/index.ts'));
 const DeepLink = mmLazy(() => import('../deep-link/deep-link.tsx'));
@@ -337,7 +346,11 @@ export const routeConfig = [
       },
       {
         path: NETWORKS_ROUTE,
-        element: <NetworksPage />,
+        element: (
+          <GlobalMenuRouteTransition>
+            <NetworksPage />
+          </GlobalMenuRouteTransition>
+        ),
       },
       {
         path: TOKEN_MANAGEMENT_ROUTE,
@@ -349,7 +362,11 @@ export const routeConfig = [
       },
       {
         path: `${SETTINGS_ROUTE}/*`,
-        element: <Settings />,
+        element: (
+          <GlobalMenuRouteTransition>
+            <Settings />
+          </GlobalMenuRouteTransition>
+        ),
       },
       {
         path: `${LEGACY_SETTINGS_V2_ROUTE}/*`,
@@ -401,11 +418,19 @@ export const routeConfig = [
       },
       {
         path: PERMISSIONS,
-        element: <PermissionsPage />,
+        element: (
+          <GlobalMenuRouteTransition>
+            <PermissionsPage />
+          </GlobalMenuRouteTransition>
+        ),
       },
       {
         path: GATOR_PERMISSIONS,
-        element: <GatorPermissionsPage />,
+        element: (
+          <GlobalMenuRouteTransition>
+            <GatorPermissionsPage />
+          </GlobalMenuRouteTransition>
+        ),
       },
       {
         path: `${TOKEN_TRANSFER_ROUTE}/:origin?`,
@@ -453,6 +478,11 @@ export const routeConfig = [
       },
       {
         path: CONTACTS_ROUTE,
+        element: (
+          <GlobalMenuRouteTransition>
+            <Outlet />
+          </GlobalMenuRouteTransition>
+        ),
         children: contactsRoutes,
       },
       {
@@ -476,11 +506,19 @@ export const routeConfig = [
           },
           {
             path: NOTIFICATIONS_ROUTE,
-            element: <Notifications />,
+            element: (
+              <GlobalMenuRouteTransition>
+                <Notifications />
+              </GlobalMenuRouteTransition>
+            ),
           },
           {
             path: SNAPS_ROUTE,
-            element: <SnapList />,
+            element: (
+              <GlobalMenuRouteTransition>
+                <SnapList />
+              </GlobalMenuRouteTransition>
+            ),
           },
           createRouteWithMessenger({
             path: SNAPS_VIEW_ROUTE,

--- a/ui/pages/settings/settings.tsx
+++ b/ui/pages/settings/settings.tsx
@@ -58,6 +58,7 @@ import ShieldEntryModal from '../../components/app/shield-entry-modal';
 // eslint-disable-next-line import-x/no-restricted-paths
 import { SHIELD_QUERY_PARAMS } from '../../../shared/lib/deep-links/routes/shield';
 import { toRelativeRoutePath } from '../routes/utils';
+import { useGlobalMenuRouteTransition } from '../routes/global-menu-route-transition';
 import TabBar from './tab-bar';
 import {
   SETTINGS_ROOT_SECTIONS,
@@ -95,6 +96,7 @@ const clearReactInternalReferences = (element: Element) => {
  */
 const SettingsLayout = ({ children }: { children: React.ReactNode }) => {
   const navigate = useNavigate();
+  const runCloseTransition = useGlobalMenuRouteTransition();
   const location = useLocation();
   const t = useSettingsI18n();
   const normalizedPathname = normalizeSettingsPath(location.pathname);
@@ -170,6 +172,15 @@ const SettingsLayout = ({ children }: { children: React.ReactNode }) => {
   );
 
   const currentPageLabelKey = meta?.labelKey;
+
+  const handleClose = useCallback(() => {
+    if (backRoute.startsWith(DEFAULT_ROUTE)) {
+      runCloseTransition(() => navigate(backRoute));
+      return;
+    }
+
+    navigate(backRoute);
+  }, [backRoute, navigate, runCloseTransition]);
 
   // Header: "Settings" on fullscreen; tab or sub-page name on popup/sidepanel
   const headerTitle =
@@ -426,7 +437,7 @@ const SettingsLayout = ({ children }: { children: React.ReactNode }) => {
         title={headerTitle}
         isPopupOrSidepanel={isPopupOrSidepanel}
         isOnSettingsRoot={isOnSettingsRoot}
-        onClose={() => navigate(backRoute)}
+        onClose={handleClose}
         isSearchOpen={isSearchOpen}
         onOpenSearch={() => setIsSearchOpen(true)}
         onCloseSearch={handleCloseSearch}

--- a/ui/pages/snaps/snaps-list/snap-list.js
+++ b/ui/pages/snaps/snaps-list/snap-list.js
@@ -39,17 +39,19 @@ import {
   Page,
 } from '../../../components/multichain/pages/page';
 import { getSnapRoute } from '../../../helpers/utils/util';
+import { useGlobalMenuRouteTransition } from '../../routes/global-menu-route-transition';
 
 const SnapList = () => {
   const t = useI18nContext();
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
+  const runCloseTransition = useGlobalMenuRouteTransition();
 
   const fromPath = searchParams.get('from') ?? undefined;
 
   const handleBack = () => {
     if (fromPath === DEFAULT_ROUTE) {
-      navigate(PREVIOUS_ROUTE);
+      runCloseTransition(() => navigate(PREVIOUS_ROUTE));
     } else {
       navigate(DEFAULT_ROUTE);
     }


### PR DESCRIPTION
This PR is to add transitions to the pages in global menu

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**




https://github.com/user-attachments/assets/023ae98f-9808-4509-b832-41be2debf849




## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Navigation-only UI animation and drawer timing changes; no auth, transaction, or data-layer logic.
> 
> **Overview**
> Adds **page enter/exit animations** when opening destinations from the global menu and when backing out to home, instead of instant route swaps.
> 
> A new `GlobalMenuRouteTransition` provider wraps settings, networks, contacts, notifications, snaps, and permissions routes. Menu navigations set router state `globalMenuTransition: 'forward'`; back/close actions call `useGlobalMenuRouteTransition()` so navigation runs after the **back** animation. Matching styles live in `page-transitions.scss` (including reduced-motion).
> 
> Related polish: the global menu drawer uses `useLayoutEffect` and a better initial open phase; route menu items can take a custom `className` (used for a hidden side-panel toggle placeholder while support is still `null`); home network “manage networks” uses `transitionForward` instead of `transitionSlideForward`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c14fa5ebb8d6e9bf7091aeeaafd19527e9ac11ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->