### PR TITLE
feat: replace TextButton with Button (tertiary) in AddRewardsAccount

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -8207,6 +8207,9 @@
   "rewardsLinkAccount": {
     "message": "Add account"
   },
+  "rewardsLinkAccountLoading": {
+    "message": "Adding account"
+  },
   "rewardsLinkAccountError": {
     "message": "Failed to add account"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -8207,10 +8207,7 @@
   "rewardsLinkAccount": {
     "message": "Add account"
   },
-  "rewardsLinkAccountLoading": {
-    "message": "Adding account"
-  },
-  "rewardsLinkAccountError": {
+"rewardsLinkAccountError": {
     "message": "Failed to add account"
   },
   "rewardsOnboardingCheckingRegion": {

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -8207,7 +8207,7 @@
   "rewardsLinkAccount": {
     "message": "Add account"
   },
-"rewardsLinkAccountError": {
+  "rewardsLinkAccountError": {
     "message": "Failed to add account"
   },
   "rewardsOnboardingCheckingRegion": {

--- a/ui/components/app/rewards/AddRewardsAccount.test.tsx
+++ b/ui/components/app/rewards/AddRewardsAccount.test.tsx
@@ -29,7 +29,7 @@ describe('AddRewardsAccount', () => {
     if (key === 'rewardsLinkAccount') {
       return 'Link Account';
     }
-if (key === 'rewardsLinkAccountError') {
+    if (key === 'rewardsLinkAccountError') {
       return 'Error linking account';
     }
     if (key === 'rewardsPointsIcon') {

--- a/ui/components/app/rewards/AddRewardsAccount.test.tsx
+++ b/ui/components/app/rewards/AddRewardsAccount.test.tsx
@@ -29,6 +29,9 @@ describe('AddRewardsAccount', () => {
     if (key === 'rewardsLinkAccount') {
       return 'Link Account';
     }
+    if (key === 'rewardsLinkAccountLoading') {
+      return 'Adding account';
+    }
     if (key === 'rewardsLinkAccountError') {
       return 'Error linking account';
     }

--- a/ui/components/app/rewards/AddRewardsAccount.test.tsx
+++ b/ui/components/app/rewards/AddRewardsAccount.test.tsx
@@ -29,10 +29,7 @@ describe('AddRewardsAccount', () => {
     if (key === 'rewardsLinkAccount') {
       return 'Link Account';
     }
-    if (key === 'rewardsLinkAccountLoading') {
-      return 'Adding account';
-    }
-    if (key === 'rewardsLinkAccountError') {
+if (key === 'rewardsLinkAccountError') {
       return 'Error linking account';
     }
     if (key === 'rewardsPointsIcon') {

--- a/ui/components/app/rewards/AddRewardsAccount.test.tsx
+++ b/ui/components/app/rewards/AddRewardsAccount.test.tsx
@@ -110,9 +110,6 @@ if (key === 'rewardsLinkAccountError') {
 
       const loadingIcon = container.querySelector('svg');
       expect(loadingIcon).toBeInTheDocument();
-      expect(
-        screen.queryByAltText('Rewards Points Icon'),
-      ).not.toBeInTheDocument();
     });
 
     it('should disable button when isLoading is true', () => {

--- a/ui/components/app/rewards/AddRewardsAccount.test.tsx
+++ b/ui/components/app/rewards/AddRewardsAccount.test.tsx
@@ -123,7 +123,7 @@ describe('AddRewardsAccount', () => {
 
       render(<AddRewardsAccount account={mockAccount} />);
 
-      const button = screen.getByText('Link Account').closest('button');
+      const button = screen.getByTestId('add-rewards-account-button');
       expect(button).toBeDisabled();
     });
 
@@ -221,7 +221,7 @@ describe('AddRewardsAccount', () => {
 
       const loadingIcon = container.querySelector('svg');
       expect(loadingIcon).toBeInTheDocument();
-      const button = screen.getByText('Link Account').closest('button');
+      const button = screen.getByTestId('add-rewards-account-button');
       expect(button).toBeDisabled();
     });
 

--- a/ui/components/app/rewards/AddRewardsAccount.tsx
+++ b/ui/components/app/rewards/AddRewardsAccount.tsx
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import {
   Button,
+  ButtonSize,
   ButtonVariant,
   IconSize,
   IconName,
@@ -34,10 +35,12 @@ const AddRewardsAccount = ({ account }: AddRewardsAccountProps) => {
   return (
     <Button
       variant={ButtonVariant.Tertiary}
+      size={ButtonSize.Sm}
       onClick={handleClick}
       data-testid="add-rewards-account-button"
       isLoading={isLoading}
       isDisabled={isLoading}
+      loadingText={t('rewardsLinkAccount')}
       startAccessory={
         isLoading ? undefined : (
           <img

--- a/ui/components/app/rewards/AddRewardsAccount.tsx
+++ b/ui/components/app/rewards/AddRewardsAccount.tsx
@@ -40,7 +40,7 @@ const AddRewardsAccount = ({ account }: AddRewardsAccountProps) => {
       data-testid="add-rewards-account-button"
       isLoading={isLoading}
       isDisabled={isLoading}
-      loadingText={t('rewardsLinkAccount')}
+      loadingText={t('rewardsLinkAccountLoading')}
       startAccessory={
         isLoading ? undefined : (
           <img

--- a/ui/components/app/rewards/AddRewardsAccount.tsx
+++ b/ui/components/app/rewards/AddRewardsAccount.tsx
@@ -1,10 +1,10 @@
 import React, { useCallback } from 'react';
 import { InternalAccount } from '@metamask/keyring-internal-api';
 import {
+  Button,
+  ButtonVariant,
   IconSize,
   IconName,
-  TextButton,
-  TextVariant,
   Icon,
   IconColor,
 } from '@metamask/design-system-react';
@@ -32,21 +32,21 @@ const AddRewardsAccount = ({ account }: AddRewardsAccountProps) => {
   }
 
   return (
-    <TextButton
+    <Button
+      variant={ButtonVariant.Tertiary}
       onClick={handleClick}
-      textProps={{ variant: TextVariant.BodySm }}
       data-testid="add-rewards-account-button"
+      isLoading={isLoading}
+      isDisabled={isLoading}
       startAccessory={
-        isLoading ? (
-          <Icon name={IconName.Loading} size={IconSize.Sm} />
-        ) : (
+        !isLoading ? (
           <img
             src={'./images/metamask-rewards-points-alternative.svg'}
             alt={t('rewardsPointsIcon')}
             width={16}
             height={16}
           />
-        )
+        ) : undefined
       }
       endAccessory={
         isError ? (
@@ -57,10 +57,9 @@ const AddRewardsAccount = ({ account }: AddRewardsAccountProps) => {
           />
         ) : undefined
       }
-      disabled={isLoading}
     >
       {isError ? t('rewardsLinkAccountError') : t('rewardsLinkAccount')}
-    </TextButton>
+    </Button>
   );
 };
 

--- a/ui/components/app/rewards/AddRewardsAccount.tsx
+++ b/ui/components/app/rewards/AddRewardsAccount.tsx
@@ -40,7 +40,7 @@ const AddRewardsAccount = ({ account }: AddRewardsAccountProps) => {
       data-testid="add-rewards-account-button"
       isLoading={isLoading}
       isDisabled={isLoading}
-      loadingText={t('rewardsLinkAccountLoading')}
+      loadingText={t('rewardsLinkAccount')}
       startAccessory={
         isLoading ? undefined : (
           <img

--- a/ui/components/app/rewards/AddRewardsAccount.tsx
+++ b/ui/components/app/rewards/AddRewardsAccount.tsx
@@ -42,14 +42,12 @@ const AddRewardsAccount = ({ account }: AddRewardsAccountProps) => {
       isDisabled={isLoading}
       loadingText={t('rewardsLinkAccount')}
       startAccessory={
-        isLoading ? undefined : (
-          <img
-            src={'./images/metamask-rewards-points-alternative.svg'}
-            alt={t('rewardsPointsIcon')}
-            width={16}
-            height={16}
-          />
-        )
+        <img
+          src={'./images/metamask-rewards-points-alternative.svg'}
+          alt={t('rewardsPointsIcon')}
+          width={16}
+          height={16}
+        />
       }
       endAccessory={
         isError ? (

--- a/ui/components/app/rewards/AddRewardsAccount.tsx
+++ b/ui/components/app/rewards/AddRewardsAccount.tsx
@@ -39,14 +39,14 @@ const AddRewardsAccount = ({ account }: AddRewardsAccountProps) => {
       isLoading={isLoading}
       isDisabled={isLoading}
       startAccessory={
-        !isLoading ? (
+        isLoading ? undefined : (
           <img
             src={'./images/metamask-rewards-points-alternative.svg'}
             alt={t('rewardsPointsIcon')}
             width={16}
             height={16}
           />
-        ) : undefined
+        )
       }
       endAccessory={
         isError ? (


### PR DESCRIPTION
## **Description**

Replaces the `TextButton` component in `AddRewardsAccount` with the MMDS `Button` component using `ButtonVariant.Tertiary`, as part of the ongoing migration to MetaMask Design System components.

Changes:
- Swapped `TextButton` import for `Button` + `ButtonVariant` from `@metamask/design-system-react`
- Replaced `disabled` prop with `isDisabled`
- Replaced manual `startAccessory` loading icon with the built-in `isLoading` prop (the `startAccessory` now only shows the rewards img when not loading)
- Removed unused `TextVariant` and `IconName.Loading` imports

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A
Related: https://github.com/MetaMask/metamask-extension/pull/43424

## **Manual testing steps**

1. Navigate to the Rewards section in MetaMask
2. Find an account that has not been linked to rewards
3. Verify the "Link Account" button renders as a tertiary button
4. Click the button and verify the loading state displays correctly
5. Verify the error state (refresh icon + error text) still appears on failure

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/2306d5a2-ba06-4364-97be-89a390290652

### **After**

https://github.com/user-attachments/assets/3c19d16f-c024-4eb7-ad1f-beb7f5c9595b

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only design-system swap in Rewards linking with no auth, transaction, or data-layer changes; behavior is covered by existing unit tests.
> 
> **Overview**
> Migrates the Rewards **Link Account** control in `AddRewardsAccount` from `TextButton` to the MetaMask Design System **`Button`** with **`ButtonVariant.Tertiary`** and **`ButtonSize.Sm`**, aligning with the broader MMDS component migration.
> 
> Loading is now driven by the Button’s built-in **`isLoading`**, **`isDisabled`**, and **`loadingText`** props instead of swapping the rewards image for a manual loading icon in **`startAccessory`**. The rewards points image stays in **`startAccessory`** at all times; error handling (refresh icon + error copy) is unchanged.
> 
> Tests were updated to target the button via **`data-testid`** when asserting disabled/loading behavior and to drop assertions that the rewards icon is hidden while loading.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51520c3e2f7d805b74976dfd08597d69065cd503. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->