### PR TITLE
feat(release): publish AMO reviewer artifacts to private S3 (INFRA-3683)

### DIFF
--- a/.github/actions/publish-amo-reviewer-artifacts/action.yml
+++ b/.github/actions/publish-amo-reviewer-artifacts/action.yml
@@ -1,0 +1,75 @@
+name: Publish AMO reviewer artifacts
+description: >-
+  Package Firefox reviewer source + approval notes (firefox-bundle-script) and
+  upload to private S3 via OIDC. Requires caller job env RELEASE_TAG,
+  FIREFOX_BUNDLE_SCRIPT_TOKEN, and id-token write for AWS OIDC.
+
+inputs:
+  firefox_bundle_script_ref:
+    description: Git ref for MetaMask/firefox-bundle-script (empty = main in script)
+    required: false
+    default: ''
+  amo_last_listed_version:
+    description: Previous AMO-listed version for submission notes (optional)
+    required: false
+    default: ''
+  amo_reviewer_publisher_role_arn_uat:
+    description: OIDC role ARN for UAT reviewer-source bucket PutObject
+    required: false
+    default: ''
+  amo_reviewer_publisher_role_arn_prd:
+    description: OIDC role ARN for PRD reviewer-source bucket PutObject
+    required: false
+    default: ''
+  amo_reviewer_bucket_uat:
+    description: UAT S3 bucket id for reviewer-source prefix
+    required: false
+    default: ''
+  amo_reviewer_bucket_prd:
+    description: PRD S3 bucket id for reviewer-source prefix
+    required: false
+    default: ''
+  aws_region:
+    description: AWS region for S3 uploads
+    required: false
+    default: us-east-2
+
+runs:
+  using: composite
+  steps:
+    - name: Package Firefox reviewer artifacts
+      shell: bash
+      env:
+        FIREFOX_BUNDLE_SCRIPT_REF: ${{ inputs.firefox_bundle_script_ref }}
+        AMO_LAST_LISTED_VERSION: ${{ inputs.amo_last_listed_version }}
+      run: bash "${GITHUB_WORKSPACE}/.github/scripts/publish-firefox-reviewer-artifacts.sh" package
+
+    - name: Configure AWS credentials (UAT reviewer publisher)
+      if: inputs.amo_reviewer_publisher_role_arn_uat != ''
+      uses: aws-actions/configure-aws-credentials@acca2b1b2070338fb9fd1ca27ecee81d687e58e5 # v6.1.2
+      with:
+        role-to-assume: ${{ inputs.amo_reviewer_publisher_role_arn_uat }}
+        aws-region: ${{ inputs.aws_region }}
+
+    - name: Upload Firefox reviewer artifacts (UAT)
+      if: inputs.amo_reviewer_publisher_role_arn_uat != ''
+      shell: bash
+      env:
+        AMO_REVIEWER_BUCKET: ${{ inputs.amo_reviewer_bucket_uat }}
+        AWS_DEFAULT_REGION: ${{ inputs.aws_region }}
+      run: bash "${GITHUB_WORKSPACE}/.github/scripts/publish-firefox-reviewer-artifacts.sh" upload
+
+    - name: Configure AWS credentials (PRD reviewer publisher)
+      if: inputs.amo_reviewer_publisher_role_arn_prd != ''
+      uses: aws-actions/configure-aws-credentials@acca2b1b2070338fb9fd1ca27ecee81d687e58e5 # v6.1.2
+      with:
+        role-to-assume: ${{ inputs.amo_reviewer_publisher_role_arn_prd }}
+        aws-region: ${{ inputs.aws_region }}
+
+    - name: Upload Firefox reviewer artifacts (PRD)
+      if: inputs.amo_reviewer_publisher_role_arn_prd != ''
+      shell: bash
+      env:
+        AMO_REVIEWER_BUCKET: ${{ inputs.amo_reviewer_bucket_prd }}
+        AWS_DEFAULT_REGION: ${{ inputs.aws_region }}
+      run: bash "${GITHUB_WORKSPACE}/.github/scripts/publish-firefox-reviewer-artifacts.sh" upload

--- a/.github/actions/publish-amo-reviewer-artifacts/action.yml
+++ b/.github/actions/publish-amo-reviewer-artifacts/action.yml
@@ -1,8 +1,13 @@
 name: Publish AMO reviewer artifacts
 description: >-
   Package Firefox reviewer source + approval notes (firefox-bundle-script) and
-  upload to private S3 via OIDC. Requires caller job env RELEASE_TAG,
-  FIREFOX_BUNDLE_SCRIPT_TOKEN, and id-token write for AWS OIDC.
+  upload to PRD private S3 via OIDC for production and flask AMO submission.
+  Requires caller job env RELEASE_TAG, FIREFOX_BUNDLE_SCRIPT_TOKEN, and
+  id-token write for AWS OIDC.
+
+# PRD platform contract (va-mmc-extension-submission-infra amo_reviewer_source.tf):
+#   bucket: prd-va-mmc-extension-submission-amo-reviewer-source
+#   role:   arn:aws:iam::363762752069:role/amo-reviewer-publisher
 
 inputs:
   firefox_bundle_script_ref:
@@ -13,26 +18,6 @@ inputs:
     description: Previous AMO-listed version for submission notes (optional)
     required: false
     default: ''
-  amo_reviewer_publisher_role_arn_uat:
-    description: OIDC role ARN for UAT reviewer-source bucket PutObject
-    required: false
-    default: ''
-  amo_reviewer_publisher_role_arn_prd:
-    description: OIDC role ARN for PRD reviewer-source bucket PutObject
-    required: false
-    default: ''
-  amo_reviewer_bucket_uat:
-    description: UAT S3 bucket id for reviewer-source prefix
-    required: false
-    default: ''
-  amo_reviewer_bucket_prd:
-    description: PRD S3 bucket id for reviewer-source prefix
-    required: false
-    default: ''
-  aws_region:
-    description: AWS region for S3 uploads
-    required: false
-    default: us-east-2
 
 runs:
   using: composite
@@ -44,32 +29,15 @@ runs:
         AMO_LAST_LISTED_VERSION: ${{ inputs.amo_last_listed_version }}
       run: bash "${GITHUB_WORKSPACE}/.github/scripts/publish-firefox-reviewer-artifacts.sh" package
 
-    - name: Configure AWS credentials (UAT reviewer publisher)
-      if: inputs.amo_reviewer_publisher_role_arn_uat != ''
-      uses: aws-actions/configure-aws-credentials@acca2b1b2070338fb9fd1ca27ecee81d687e58e5 # v6.1.2
-      with:
-        role-to-assume: ${{ inputs.amo_reviewer_publisher_role_arn_uat }}
-        aws-region: ${{ inputs.aws_region }}
-
-    - name: Upload Firefox reviewer artifacts (UAT)
-      if: inputs.amo_reviewer_publisher_role_arn_uat != ''
-      shell: bash
-      env:
-        AMO_REVIEWER_BUCKET: ${{ inputs.amo_reviewer_bucket_uat }}
-        AWS_DEFAULT_REGION: ${{ inputs.aws_region }}
-      run: bash "${GITHUB_WORKSPACE}/.github/scripts/publish-firefox-reviewer-artifacts.sh" upload
-
     - name: Configure AWS credentials (PRD reviewer publisher)
-      if: inputs.amo_reviewer_publisher_role_arn_prd != ''
       uses: aws-actions/configure-aws-credentials@acca2b1b2070338fb9fd1ca27ecee81d687e58e5 # v6.1.2
       with:
-        role-to-assume: ${{ inputs.amo_reviewer_publisher_role_arn_prd }}
-        aws-region: ${{ inputs.aws_region }}
+        role-to-assume: arn:aws:iam::363762752069:role/amo-reviewer-publisher
+        aws-region: us-east-2
 
     - name: Upload Firefox reviewer artifacts (PRD)
-      if: inputs.amo_reviewer_publisher_role_arn_prd != ''
       shell: bash
       env:
-        AMO_REVIEWER_BUCKET: ${{ inputs.amo_reviewer_bucket_prd }}
-        AWS_DEFAULT_REGION: ${{ inputs.aws_region }}
+        AMO_REVIEWER_BUCKET: prd-va-mmc-extension-submission-amo-reviewer-source
+        AWS_DEFAULT_REGION: us-east-2
       run: bash "${GITHUB_WORKSPACE}/.github/scripts/publish-firefox-reviewer-artifacts.sh" upload

--- a/.github/actions/publish-amo-reviewer-artifacts/action.yml
+++ b/.github/actions/publish-amo-reviewer-artifacts/action.yml
@@ -16,10 +16,6 @@ inputs:
       empty uses script default SHA until merged to main)
     required: false
     default: ''
-  amo_last_listed_version:
-    description: Previous AMO-listed version for submission notes (optional)
-    required: false
-    default: ''
 
 runs:
   using: composite
@@ -28,7 +24,6 @@ runs:
       shell: bash
       env:
         FIREFOX_BUNDLE_SCRIPT_REF: ${{ inputs.firefox_bundle_script_ref }}
-        AMO_LAST_LISTED_VERSION: ${{ inputs.amo_last_listed_version }}
       run: bash "${GITHUB_WORKSPACE}/.github/scripts/publish-firefox-reviewer-artifacts.sh" package
 
     - name: Configure AWS credentials (PRD reviewer publisher)

--- a/.github/actions/publish-amo-reviewer-artifacts/action.yml
+++ b/.github/actions/publish-amo-reviewer-artifacts/action.yml
@@ -11,7 +11,9 @@ description: >-
 
 inputs:
   firefox_bundle_script_ref:
-    description: Git ref for MetaMask/firefox-bundle-script (empty = main in script)
+    description: >-
+      Git ref for MetaMask/firefox-bundle-script (Flask packaging needs PR #9+;
+      empty uses script default SHA until merged to main)
     required: false
     default: ''
   amo_last_listed_version:

--- a/.github/scripts/publish-firefox-reviewer-artifacts.sh
+++ b/.github/scripts/publish-firefox-reviewer-artifacts.sh
@@ -5,8 +5,8 @@
 #   publish-firefox-reviewer-artifacts.sh package
 #   publish-firefox-reviewer-artifacts.sh upload
 #
-# package — clone firefox-bundle-script, compare builds, create submission packages
-#           for production and Flask (requires PR #9+ script contract).
+# package — clone firefox-bundle-script and run prepare_release.sh for production
+#           and Flask to create submission packages (requires PR #9+ script contract).
 # upload  — s3 cp artifacts (requires AMO_REVIEWER_BUCKET + active AWS creds from OIDC).
 #
 # Environment:
@@ -54,10 +54,9 @@ ensure_mtree() {
 }
 
 resolve_last_listed_version() {
-  if [[ -n "${AMO_LAST_LISTED_VERSION:-}" ]]; then
-    echo "${AMO_LAST_LISTED_VERSION}"
-    return
-  fi
+  # Best-effort for reviewer notes at release time (previous semver tag).
+  # Authoritative last-listed version at submit time comes from the Lambda
+  # (fetchLastListedVersion against the live AMO listing).
   local previous
   previous="$(git -C "${GITHUB_WORKSPACE:-.}" tag -l 'v*' --sort=-v:refname 2>/dev/null \
     | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
@@ -89,40 +88,35 @@ clone_firefox_bundle_script() {
 package_release_variant() {
   local variant="$1"
   local clone_dir="$2"
-  local work_root="$3"
-  local last_listed="$4"
+  local last_listed="$3"
 
-  local work_dir production_build_file submission_dir_prefix bundle_args
-  local submission_dir source_zip notes_file source_dest notes_dest
-
-  work_dir="${work_root}/work-${variant}"
+  local submission_dir_prefix source_dest notes_dest
+  local -a prepare_args=()
 
   if [[ "${variant}" == "flask" ]]; then
     local flask_version="${raw_version}-flask.0"
-    production_build_file="metamask-firefox-${flask_version}.zip"
     submission_dir_prefix="flask_submission"
-    bundle_args="--flask"
+    prepare_args=(--flask)
     source_dest="${PACKAGE_DIR}/metamask-firefox-${flask_version}-source.zip"
     notes_dest="${PACKAGE_DIR}/metamask-firefox-${flask_version}-amo-approval-notes.txt"
   else
-    production_build_file="metamask-firefox-${raw_version}.zip"
     submission_dir_prefix="submission"
-    bundle_args=""
     source_dest="${PACKAGE_DIR}/metamask-firefox-${raw_version}-source.zip"
     notes_dest="${PACKAGE_DIR}/metamask-firefox-${raw_version}-amo-approval-notes.txt"
   fi
 
-  mkdir -p "${work_dir}" "${PACKAGE_DIR}"
+  mkdir -p "${PACKAGE_DIR}"
 
-  export PRODUCTION_BUILD_FILE="${production_build_file}"
-  export FIREFOX_BUNDLE_SCRIPT_ARGS="${bundle_args}"
-  export SUBMISSION_DIR_PREFIX="${submission_dir_prefix}"
+  # prepare_release.sh is the canonical orchestrator: it fetches bundle.sh from
+  # origin/release, runs compare_builds.sh + create_submission_package.sh, and
+  # writes packages under output/. It also sets PRODUCTION_BUILD_FILE /
+  # FIREFOX_BUNDLE_SCRIPT_ARGS / SUBMISSION_DIR_PREFIX internally (per --flask),
+  # and exits non-zero when the reproduced build differs from the published one,
+  # which under set -e correctly fails the reviewer publish.
+  echo "Packaging ${variant} reviewer artifacts via prepare_release.sh..."
+  ( cd "${clone_dir}" && bash ./prepare_release.sh "${prepare_args[@]}" "${raw_version}" "${last_listed}" )
 
-  echo "Packaging ${variant} reviewer artifacts (build: ${production_build_file})..."
-  bash "${clone_dir}/scripts/compare_builds.sh" "${raw_version}" "${work_dir}"
-
-  bash "${clone_dir}/scripts/create_submission_package.sh" "${raw_version}" "${last_listed}" "${work_dir}"
-
+  local submission_dir source_zip notes_file
   submission_dir="${clone_dir}/output/${submission_dir_prefix}_v${raw_version}"
   source_zip="${submission_dir}/metamask-extension-${raw_version}.zip"
   notes_file="${submission_dir}/reviewer_instructions_v${raw_version}.txt"
@@ -159,17 +153,16 @@ run_package() {
   echo "Cloning firefox-bundle-script at ref ${script_ref}..."
   clone_firefox_bundle_script "${script_ref}" "${clone_dir}"
 
-  # compare_builds.sh resolves bundle.sh as dirname(work_dir)/bundle.sh (see firefox-bundle-script).
-  echo "Fetching populated bundle.sh from release branch..."
-  git -C "${clone_dir}" fetch origin release --depth 1
-  git -C "${clone_dir}" show "origin/release:bundle.sh" > "${work_root}/bundle.sh"
-  chmod +x "${work_root}/bundle.sh"
+  # prepare_release.sh reads bundle.sh via `git show origin/release:bundle.sh`,
+  # so the origin/release remote-tracking ref must exist in the shallow clone.
+  echo "Fetching release branch so prepare_release.sh can read bundle.sh..."
+  git -C "${clone_dir}" fetch origin "+refs/heads/release:refs/remotes/origin/release" --depth 1
 
   last_listed="$(resolve_last_listed_version)"
   echo "Using last listed version: ${last_listed}"
 
-  package_release_variant main "${clone_dir}" "${work_root}" "${last_listed}"
-  package_release_variant flask "${clone_dir}" "${work_root}" "${last_listed}"
+  package_release_variant main "${clone_dir}" "${last_listed}"
+  package_release_variant flask "${clone_dir}" "${last_listed}"
 }
 
 run_upload() {

--- a/.github/scripts/publish-firefox-reviewer-artifacts.sh
+++ b/.github/scripts/publish-firefox-reviewer-artifacts.sh
@@ -159,6 +159,7 @@ run_package() {
   echo "Cloning firefox-bundle-script at ref ${script_ref}..."
   clone_firefox_bundle_script "${script_ref}" "${clone_dir}"
 
+  # compare_builds.sh resolves bundle.sh as dirname(work_dir)/bundle.sh (see firefox-bundle-script).
   echo "Fetching populated bundle.sh from release branch..."
   git -C "${clone_dir}" fetch origin release --depth 1
   git -C "${clone_dir}" show "origin/release:bundle.sh" > "${work_root}/bundle.sh"

--- a/.github/scripts/publish-firefox-reviewer-artifacts.sh
+++ b/.github/scripts/publish-firefox-reviewer-artifacts.sh
@@ -5,18 +5,22 @@
 #   publish-firefox-reviewer-artifacts.sh package
 #   publish-firefox-reviewer-artifacts.sh upload
 #
-# package — clone firefox-bundle-script, compare builds, create submission package.
+# package — clone firefox-bundle-script, compare builds, create submission packages
+#           for production and Flask (requires PR #9+ script contract).
 # upload  — s3 cp artifacts (requires AMO_REVIEWER_BUCKET + active AWS creds from OIDC).
 #
 # Environment:
 #   RELEASE_TAG                  — e.g. v13.37.0 (required)
-#   FIREFOX_BUNDLE_SCRIPT_TOKEN    — clone private repo + read release branch bundle.sh
-#   FIREFOX_BUNDLE_SCRIPT_REF      — git ref (default: main)
-#   AMO_REVIEWER_PACKAGE_ROOT      — output root (default: $RUNNER_TEMP/amo-reviewer-artifacts)
+#   FIREFOX_BUNDLE_SCRIPT_TOKEN  — clone private repo + read release branch bundle.sh
+#   FIREFOX_BUNDLE_SCRIPT_REF    — git ref (default: PR #9 SHA until merged to main)
+#   AMO_REVIEWER_PACKAGE_ROOT    — output root (default: $RUNNER_TEMP/amo-reviewer-artifacts)
 #   AMO_REVIEWER_BUCKET            — required for upload
 #   AWS_DEFAULT_REGION             — default us-east-2
 
 set -euo pipefail
+
+# MetaMask/firefox-bundle-script PR #9 — Flask + webpack reproducibility. Bump after merge to main.
+DEFAULT_FIREFOX_BUNDLE_SCRIPT_REF="fea5132b24a17a4765d87d4735bd6684ce8c78c4"
 
 MODE="${1:-}"
 if [[ "${MODE}" != "package" && "${MODE}" != "upload" ]]; then
@@ -67,6 +71,60 @@ resolve_last_listed_version() {
   fi
 }
 
+package_release_variant() {
+  local variant="$1"
+  local clone_dir="$2"
+  local work_root="$3"
+  local last_listed="$4"
+
+  local work_dir production_build_file submission_dir_prefix bundle_args
+  local submission_dir source_zip notes_file source_dest notes_dest
+
+  work_dir="${work_root}/work-${variant}"
+
+  if [[ "${variant}" == "flask" ]]; then
+    local flask_version="${raw_version}-flask.0"
+    production_build_file="metamask-firefox-${flask_version}.zip"
+    submission_dir_prefix="flask_submission"
+    bundle_args="--flask"
+    source_dest="${PACKAGE_DIR}/metamask-firefox-${flask_version}-source.zip"
+    notes_dest="${PACKAGE_DIR}/metamask-firefox-${flask_version}-amo-approval-notes.txt"
+  else
+    production_build_file="metamask-firefox-${raw_version}.zip"
+    submission_dir_prefix="submission"
+    bundle_args=""
+    source_dest="${PACKAGE_DIR}/metamask-firefox-${raw_version}-source.zip"
+    notes_dest="${PACKAGE_DIR}/metamask-firefox-${raw_version}-amo-approval-notes.txt"
+  fi
+
+  mkdir -p "${work_dir}" "${PACKAGE_DIR}"
+
+  export PRODUCTION_BUILD_FILE="${production_build_file}"
+  export FIREFOX_BUNDLE_SCRIPT_ARGS="${bundle_args}"
+  export SUBMISSION_DIR_PREFIX="${submission_dir_prefix}"
+
+  echo "Packaging ${variant} reviewer artifacts (build: ${production_build_file})..."
+  bash "${clone_dir}/scripts/compare_builds.sh" "${raw_version}" "${work_dir}"
+
+  bash "${clone_dir}/scripts/create_submission_package.sh" "${raw_version}" "${last_listed}" "${work_dir}"
+
+  submission_dir="${clone_dir}/output/${submission_dir_prefix}_v${raw_version}"
+  source_zip="${submission_dir}/metamask-extension-${raw_version}.zip"
+  notes_file="${submission_dir}/reviewer_instructions_v${raw_version}.txt"
+
+  if [[ ! -f "${source_zip}" || ! -f "${notes_file}" ]]; then
+    echo "::error::Expected ${variant} package files missing under ${submission_dir}"
+    exit 1
+  fi
+
+  cp "${source_zip}" "${source_dest}"
+  cp "${notes_file}" "${notes_dest}"
+
+  echo "Packaged ${variant} reviewer artifacts:"
+  echo "  ${source_dest}"
+  echo "  ${notes_dest}"
+}
+
 run_package() {
   if [[ -z "${FIREFOX_BUNDLE_SCRIPT_TOKEN:-}" ]]; then
     echo "::error::FIREFOX_BUNDLE_SCRIPT_TOKEN is required for packaging"
@@ -75,13 +133,12 @@ run_package() {
 
   ensure_mtree
 
-  local work_root script_ref clone_dir bundle_dir work_dir last_listed
+  local work_root script_ref clone_dir last_listed
   work_root="$(mktemp -d)"
-  script_ref="${FIREFOX_BUNDLE_SCRIPT_REF:-main}"
+  script_ref="${FIREFOX_BUNDLE_SCRIPT_REF:-${DEFAULT_FIREFOX_BUNDLE_SCRIPT_REF}}"
   clone_dir="${work_root}/firefox-bundle-script"
-  work_dir="${work_root}/work"
 
-  mkdir -p "${work_dir}" "${PACKAGE_DIR}"
+  mkdir -p "${PACKAGE_DIR}"
 
   echo "Cloning firefox-bundle-script at ref ${script_ref}..."
   git clone --depth 1 --branch "${script_ref}" \
@@ -96,30 +153,11 @@ run_package() {
   git -C "${clone_dir}" show "origin/release:bundle.sh" > "${work_root}/bundle.sh"
   chmod +x "${work_root}/bundle.sh"
 
-  echo "Comparing production vs locally rebuilt Firefox build..."
-  bash "${clone_dir}/scripts/compare_builds.sh" "${raw_version}" "${work_dir}"
-
   last_listed="$(resolve_last_listed_version)"
   echo "Using last listed version: ${last_listed}"
 
-  bash "${clone_dir}/scripts/create_submission_package.sh" "${raw_version}" "${last_listed}" "${work_dir}"
-
-  local submission_dir source_zip notes_file
-  submission_dir="${clone_dir}/output/submission_v${raw_version}"
-  source_zip="${submission_dir}/metamask-extension-${raw_version}.zip"
-  notes_file="${submission_dir}/reviewer_instructions_v${raw_version}.txt"
-
-  if [[ ! -f "${source_zip}" || ! -f "${notes_file}" ]]; then
-    echo "::error::Expected package files missing under ${submission_dir}"
-    exit 1
-  fi
-
-  cp "${source_zip}" "${PACKAGE_DIR}/metamask-firefox-${raw_version}-source.zip"
-  cp "${notes_file}" "${PACKAGE_DIR}/metamask-firefox-${raw_version}-amo-approval-notes.txt"
-
-  echo "Packaged reviewer artifacts:"
-  echo "  ${PACKAGE_DIR}/metamask-firefox-${raw_version}-source.zip"
-  echo "  ${PACKAGE_DIR}/metamask-firefox-${raw_version}-amo-approval-notes.txt"
+  package_release_variant main "${clone_dir}" "${work_root}" "${last_listed}"
+  package_release_variant flask "${clone_dir}" "${work_root}" "${last_listed}"
 
   rm -rf "${work_root}"
 }
@@ -130,23 +168,26 @@ run_upload() {
     exit 1
   fi
 
-  local source_key notes_key source_path notes_path
-  source_path="${PACKAGE_DIR}/metamask-firefox-${raw_version}-source.zip"
-  notes_path="${PACKAGE_DIR}/metamask-firefox-${raw_version}-amo-approval-notes.txt"
+  local required=(
+    "${PACKAGE_DIR}/metamask-firefox-${raw_version}-source.zip"
+    "${PACKAGE_DIR}/metamask-firefox-${raw_version}-amo-approval-notes.txt"
+    "${PACKAGE_DIR}/metamask-firefox-${raw_version}-flask.0-source.zip"
+    "${PACKAGE_DIR}/metamask-firefox-${raw_version}-flask.0-amo-approval-notes.txt"
+  )
 
-  if [[ ! -f "${source_path}" || ! -f "${notes_path}" ]]; then
-    echo "::error::Package files not found in ${PACKAGE_DIR}. Run package step first."
-    exit 1
-  fi
+  local artifact
+  for artifact in "${required[@]}"; do
+    if [[ ! -f "${artifact}" ]]; then
+      echo "::error::Package file not found: ${artifact}. Run package step first."
+      exit 1
+    fi
+  done
 
-  source_key="${S3_PREFIX}/metamask-firefox-${raw_version}-source.zip"
-  notes_key="${S3_PREFIX}/metamask-firefox-${raw_version}-amo-approval-notes.txt"
-
-  echo "Uploading to s3://${AMO_REVIEWER_BUCKET}/${source_key}"
-  aws s3 cp "${source_path}" "s3://${AMO_REVIEWER_BUCKET}/${source_key}" --region "${AWS_DEFAULT_REGION}"
-
-  echo "Uploading to s3://${AMO_REVIEWER_BUCKET}/${notes_key}"
-  aws s3 cp "${notes_path}" "s3://${AMO_REVIEWER_BUCKET}/${notes_key}" --region "${AWS_DEFAULT_REGION}"
+  for artifact in "${required[@]}"; do
+    local key="${S3_PREFIX}/$(basename "${artifact}")"
+    echo "Uploading to s3://${AMO_REVIEWER_BUCKET}/${key}"
+    aws s3 cp "${artifact}" "s3://${AMO_REVIEWER_BUCKET}/${key}" --region "${AWS_DEFAULT_REGION}"
+  done
 
   echo "Reviewer artifacts uploaded to s3://${AMO_REVIEWER_BUCKET}/${S3_PREFIX}/"
 }

--- a/.github/scripts/publish-firefox-reviewer-artifacts.sh
+++ b/.github/scripts/publish-firefox-reviewer-artifacts.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# Package and/or upload AMO reviewer source + approval notes to private S3 (INFRA-3683).
+#
+# Usage:
+#   publish-firefox-reviewer-artifacts.sh package
+#   publish-firefox-reviewer-artifacts.sh upload
+#
+# package — clone firefox-bundle-script, compare builds, create submission package.
+# upload  — s3 cp artifacts (requires AMO_REVIEWER_BUCKET + active AWS creds from OIDC).
+#
+# Environment:
+#   RELEASE_TAG                  — e.g. v13.37.0 (required)
+#   FIREFOX_BUNDLE_SCRIPT_TOKEN    — clone private repo + read release branch bundle.sh
+#   FIREFOX_BUNDLE_SCRIPT_REF      — git ref (default: main)
+#   AMO_REVIEWER_PACKAGE_ROOT      — output root (default: $RUNNER_TEMP/amo-reviewer-artifacts)
+#   AMO_REVIEWER_BUCKET            — required for upload
+#   AWS_DEFAULT_REGION             — default us-east-2
+
+set -euo pipefail
+
+MODE="${1:-}"
+if [[ "${MODE}" != "package" && "${MODE}" != "upload" ]]; then
+  echo "::error::Usage: $0 package|upload"
+  exit 1
+fi
+
+if [[ -z "${RELEASE_TAG:-}" ]]; then
+  echo "::error::RELEASE_TAG is required"
+  exit 1
+fi
+
+raw_version="${RELEASE_TAG#v}"
+if [[ -z "${raw_version}" || "${raw_version}" == "${RELEASE_TAG}" ]]; then
+  echo "::error::RELEASE_TAG must look like vX.Y.Z (got '${RELEASE_TAG}')"
+  exit 1
+fi
+
+AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-2}"
+PACKAGE_ROOT="${AMO_REVIEWER_PACKAGE_ROOT:-${RUNNER_TEMP:-/tmp}/amo-reviewer-artifacts}"
+PACKAGE_DIR="${PACKAGE_ROOT}/${raw_version}"
+S3_PREFIX="reviewer-source/${raw_version}"
+
+ensure_mtree() {
+  if command -v mtree >/dev/null 2>&1; then
+    return
+  fi
+  echo "Installing mtree for build comparison..."
+  sudo apt-get update -qq
+  sudo apt-get install -y mtree
+}
+
+resolve_last_listed_version() {
+  if [[ -n "${AMO_LAST_LISTED_VERSION:-}" ]]; then
+    echo "${AMO_LAST_LISTED_VERSION}"
+    return
+  fi
+  local previous
+  previous="$(git -C "${GITHUB_WORKSPACE:-.}" tag -l 'v*' --sort=-v:refname 2>/dev/null \
+    | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+    | grep -v "^v${raw_version}$" \
+    | head -1 \
+    | sed 's/^v//' || true)"
+  if [[ -z "${previous}" ]]; then
+    echo "${raw_version}"
+  else
+    echo "${previous}"
+  fi
+}
+
+run_package() {
+  if [[ -z "${FIREFOX_BUNDLE_SCRIPT_TOKEN:-}" ]]; then
+    echo "::error::FIREFOX_BUNDLE_SCRIPT_TOKEN is required for packaging"
+    exit 1
+  fi
+
+  ensure_mtree
+
+  local work_root script_ref clone_dir bundle_dir work_dir last_listed
+  work_root="$(mktemp -d)"
+  script_ref="${FIREFOX_BUNDLE_SCRIPT_REF:-main}"
+  clone_dir="${work_root}/firefox-bundle-script"
+  work_dir="${work_root}/work"
+
+  mkdir -p "${work_dir}" "${PACKAGE_DIR}"
+
+  echo "Cloning firefox-bundle-script at ref ${script_ref}..."
+  git clone --depth 1 --branch "${script_ref}" \
+    "https://${FIREFOX_BUNDLE_SCRIPT_TOKEN}@github.com/MetaMask/firefox-bundle-script.git" \
+    "${clone_dir}" 2>/dev/null || {
+    git clone "https://${FIREFOX_BUNDLE_SCRIPT_TOKEN}@github.com/MetaMask/firefox-bundle-script.git" "${clone_dir}"
+    git -C "${clone_dir}" checkout "${script_ref}"
+  }
+
+  echo "Fetching populated bundle.sh from release branch..."
+  git -C "${clone_dir}" fetch origin release --depth 1
+  git -C "${clone_dir}" show "origin/release:bundle.sh" > "${work_root}/bundle.sh"
+  chmod +x "${work_root}/bundle.sh"
+
+  echo "Comparing production vs locally rebuilt Firefox build..."
+  bash "${clone_dir}/scripts/compare_builds.sh" "${raw_version}" "${work_dir}"
+
+  last_listed="$(resolve_last_listed_version)"
+  echo "Using last listed version: ${last_listed}"
+
+  bash "${clone_dir}/scripts/create_submission_package.sh" "${raw_version}" "${last_listed}" "${work_dir}"
+
+  local submission_dir source_zip notes_file
+  submission_dir="${clone_dir}/output/submission_v${raw_version}"
+  source_zip="${submission_dir}/metamask-extension-${raw_version}.zip"
+  notes_file="${submission_dir}/reviewer_instructions_v${raw_version}.txt"
+
+  if [[ ! -f "${source_zip}" || ! -f "${notes_file}" ]]; then
+    echo "::error::Expected package files missing under ${submission_dir}"
+    exit 1
+  fi
+
+  cp "${source_zip}" "${PACKAGE_DIR}/metamask-firefox-${raw_version}-source.zip"
+  cp "${notes_file}" "${PACKAGE_DIR}/metamask-firefox-${raw_version}-amo-approval-notes.txt"
+
+  echo "Packaged reviewer artifacts:"
+  echo "  ${PACKAGE_DIR}/metamask-firefox-${raw_version}-source.zip"
+  echo "  ${PACKAGE_DIR}/metamask-firefox-${raw_version}-amo-approval-notes.txt"
+
+  rm -rf "${work_root}"
+}
+
+run_upload() {
+  if [[ -z "${AMO_REVIEWER_BUCKET:-}" ]]; then
+    echo "::error::AMO_REVIEWER_BUCKET is required for upload"
+    exit 1
+  fi
+
+  local source_key notes_key source_path notes_path
+  source_path="${PACKAGE_DIR}/metamask-firefox-${raw_version}-source.zip"
+  notes_path="${PACKAGE_DIR}/metamask-firefox-${raw_version}-amo-approval-notes.txt"
+
+  if [[ ! -f "${source_path}" || ! -f "${notes_path}" ]]; then
+    echo "::error::Package files not found in ${PACKAGE_DIR}. Run package step first."
+    exit 1
+  fi
+
+  source_key="${S3_PREFIX}/metamask-firefox-${raw_version}-source.zip"
+  notes_key="${S3_PREFIX}/metamask-firefox-${raw_version}-amo-approval-notes.txt"
+
+  echo "Uploading to s3://${AMO_REVIEWER_BUCKET}/${source_key}"
+  aws s3 cp "${source_path}" "s3://${AMO_REVIEWER_BUCKET}/${source_key}" --region "${AWS_DEFAULT_REGION}"
+
+  echo "Uploading to s3://${AMO_REVIEWER_BUCKET}/${notes_key}"
+  aws s3 cp "${notes_path}" "s3://${AMO_REVIEWER_BUCKET}/${notes_key}" --region "${AWS_DEFAULT_REGION}"
+
+  echo "Reviewer artifacts uploaded to s3://${AMO_REVIEWER_BUCKET}/${S3_PREFIX}/"
+}
+
+case "${MODE}" in
+  package) run_package ;;
+  upload) run_upload ;;
+esac

--- a/.github/scripts/publish-firefox-reviewer-artifacts.sh
+++ b/.github/scripts/publish-firefox-reviewer-artifacts.sh
@@ -194,7 +194,8 @@ run_upload() {
   done
 
   for artifact in "${required[@]}"; do
-    local key="${S3_PREFIX}/$(basename "${artifact}")"
+    local key
+    key="${S3_PREFIX}/$(basename "${artifact}")"
     echo "Uploading to s3://${AMO_REVIEWER_BUCKET}/${key}"
     aws s3 cp "${artifact}" "s3://${AMO_REVIEWER_BUCKET}/${key}" --region "${AWS_DEFAULT_REGION}"
   done

--- a/.github/scripts/publish-firefox-reviewer-artifacts.sh
+++ b/.github/scripts/publish-firefox-reviewer-artifacts.sh
@@ -6,21 +6,20 @@
 #   publish-firefox-reviewer-artifacts.sh upload
 #
 # package — clone firefox-bundle-script and run prepare_release.sh for production
-#           and Flask to create submission packages (requires PR #9+ script contract).
+#           and Flask to create submission packages.
 # upload  — s3 cp artifacts (requires AMO_REVIEWER_BUCKET + active AWS creds from OIDC).
 #
 # Environment:
 #   RELEASE_TAG                  — e.g. v13.37.0 (required)
 #   FIREFOX_BUNDLE_SCRIPT_TOKEN  — clone private repo + read release branch bundle.sh
-#   FIREFOX_BUNDLE_SCRIPT_REF    — git ref (default: PR #9 SHA until merged to main)
+#   FIREFOX_BUNDLE_SCRIPT_REF    — git ref (default: main)
 #   AMO_REVIEWER_PACKAGE_ROOT    — output root (default: $RUNNER_TEMP/amo-reviewer-artifacts)
 #   AMO_REVIEWER_BUCKET            — required for upload
 #   AWS_DEFAULT_REGION             — default us-east-2
 
 set -euo pipefail
 
-# MetaMask/firefox-bundle-script PR #9 — Flask + webpack reproducibility. Bump after merge to main.
-DEFAULT_FIREFOX_BUNDLE_SCRIPT_REF="fea5132b24a17a4765d87d4735bd6684ce8c78c4"
+DEFAULT_FIREFOX_BUNDLE_SCRIPT_REF="main"
 
 MODE="${1:-}"
 if [[ "${MODE}" != "package" && "${MODE}" != "upload" ]]; then

--- a/.github/scripts/publish-firefox-reviewer-artifacts.sh
+++ b/.github/scripts/publish-firefox-reviewer-artifacts.sh
@@ -71,6 +71,21 @@ resolve_last_listed_version() {
   fi
 }
 
+clone_firefox_bundle_script() {
+  local script_ref="$1"
+  local clone_dir="$2"
+  local repo_url="https://${FIREFOX_BUNDLE_SCRIPT_TOKEN}@github.com/MetaMask/firefox-bundle-script.git"
+
+  if [[ "${script_ref}" =~ ^[0-9a-fA-F]{7,40}$ ]]; then
+    git init "${clone_dir}"
+    git -C "${clone_dir}" remote add origin "${repo_url}"
+    git -C "${clone_dir}" fetch --depth 1 origin "${script_ref}"
+    git -C "${clone_dir}" checkout FETCH_HEAD
+  else
+    git clone --depth 1 --branch "${script_ref}" "${repo_url}" "${clone_dir}"
+  fi
+}
+
 package_release_variant() {
   local variant="$1"
   local clone_dir="$2"
@@ -135,18 +150,14 @@ run_package() {
 
   local work_root script_ref clone_dir last_listed
   work_root="$(mktemp -d)"
+  trap 'rm -rf "${work_root}"' EXIT
   script_ref="${FIREFOX_BUNDLE_SCRIPT_REF:-${DEFAULT_FIREFOX_BUNDLE_SCRIPT_REF}}"
   clone_dir="${work_root}/firefox-bundle-script"
 
   mkdir -p "${PACKAGE_DIR}"
 
   echo "Cloning firefox-bundle-script at ref ${script_ref}..."
-  git clone --depth 1 --branch "${script_ref}" \
-    "https://${FIREFOX_BUNDLE_SCRIPT_TOKEN}@github.com/MetaMask/firefox-bundle-script.git" \
-    "${clone_dir}" 2>/dev/null || {
-    git clone "https://${FIREFOX_BUNDLE_SCRIPT_TOKEN}@github.com/MetaMask/firefox-bundle-script.git" "${clone_dir}"
-    git -C "${clone_dir}" checkout "${script_ref}"
-  }
+  clone_firefox_bundle_script "${script_ref}" "${clone_dir}"
 
   echo "Fetching populated bundle.sh from release branch..."
   git -C "${clone_dir}" fetch origin release --depth 1
@@ -158,8 +169,6 @@ run_package() {
 
   package_release_variant main "${clone_dir}" "${work_root}" "${last_listed}"
   package_release_variant flask "${clone_dir}" "${work_root}" "${last_listed}"
-
-  rm -rf "${work_root}"
 }
 
 run_upload() {

--- a/.github/workflows/publish-release-from-release-head.yml
+++ b/.github/workflows/publish-release-from-release-head.yml
@@ -326,7 +326,6 @@ jobs:
         uses: ./.github/actions/publish-amo-reviewer-artifacts
         with:
           firefox_bundle_script_ref: ${{ vars.FIREFOX_BUNDLE_SCRIPT_REF }}
-          amo_last_listed_version: ${{ vars.AMO_LAST_LISTED_VERSION }}
 
       - name: Summary
         env:

--- a/.github/workflows/publish-release-from-release-head.yml
+++ b/.github/workflows/publish-release-from-release-head.yml
@@ -320,40 +320,18 @@ jobs:
       - name: Push Firefox bundle script
         run: .github/scripts/push-firefox-bundle-script.sh
 
-      - name: Package Firefox reviewer artifacts
+      - name: Publish AMO reviewer artifacts to S3
         if: >-
           vars.AMO_REVIEWER_PUBLISHER_ROLE_ARN_UAT != '' ||
           vars.AMO_REVIEWER_PUBLISHER_ROLE_ARN_PRD != ''
-        env:
-          FIREFOX_BUNDLE_SCRIPT_REF: ${{ vars.FIREFOX_BUNDLE_SCRIPT_REF }}
-          AMO_LAST_LISTED_VERSION: ${{ vars.AMO_LAST_LISTED_VERSION }}
-        run: bash .github/scripts/publish-firefox-reviewer-artifacts.sh package
-
-      - name: Configure AWS credentials (UAT reviewer publisher)
-        if: vars.AMO_REVIEWER_PUBLISHER_ROLE_ARN_UAT != ''
-        uses: aws-actions/configure-aws-credentials@acca2b1b2070338fb9fd1ca27ecee81d687e58e5 # v6.1.2
+        uses: ./.github/actions/publish-amo-reviewer-artifacts
         with:
-          role-to-assume: ${{ vars.AMO_REVIEWER_PUBLISHER_ROLE_ARN_UAT }}
-          aws-region: us-east-2
-
-      - name: Upload Firefox reviewer artifacts (UAT)
-        if: vars.AMO_REVIEWER_PUBLISHER_ROLE_ARN_UAT != ''
-        env:
-          AMO_REVIEWER_BUCKET: ${{ vars.AMO_REVIEWER_BUCKET_UAT }}
-        run: bash .github/scripts/publish-firefox-reviewer-artifacts.sh upload
-
-      - name: Configure AWS credentials (PRD reviewer publisher)
-        if: vars.AMO_REVIEWER_PUBLISHER_ROLE_ARN_PRD != ''
-        uses: aws-actions/configure-aws-credentials@acca2b1b2070338fb9fd1ca27ecee81d687e58e5 # v6.1.2
-        with:
-          role-to-assume: ${{ vars.AMO_REVIEWER_PUBLISHER_ROLE_ARN_PRD }}
-          aws-region: us-east-2
-
-      - name: Upload Firefox reviewer artifacts (PRD)
-        if: vars.AMO_REVIEWER_PUBLISHER_ROLE_ARN_PRD != ''
-        env:
-          AMO_REVIEWER_BUCKET: ${{ vars.AMO_REVIEWER_BUCKET_PRD }}
-        run: bash .github/scripts/publish-firefox-reviewer-artifacts.sh upload
+          firefox_bundle_script_ref: ${{ vars.FIREFOX_BUNDLE_SCRIPT_REF }}
+          amo_last_listed_version: ${{ vars.AMO_LAST_LISTED_VERSION }}
+          amo_reviewer_publisher_role_arn_uat: ${{ vars.AMO_REVIEWER_PUBLISHER_ROLE_ARN_UAT }}
+          amo_reviewer_publisher_role_arn_prd: ${{ vars.AMO_REVIEWER_PUBLISHER_ROLE_ARN_PRD }}
+          amo_reviewer_bucket_uat: ${{ vars.AMO_REVIEWER_BUCKET_UAT }}
+          amo_reviewer_bucket_prd: ${{ vars.AMO_REVIEWER_BUCKET_PRD }}
 
       - name: Summary
         env:
@@ -374,7 +352,7 @@ jobs:
             echo "| Sentry (Flask MV2 webpack) | ✅ Published |"
             echo "| GitHub Release | ✅ Created |"
             echo "| Firefox Bundle | ✅ Pushed |"
-            echo "| AMO reviewer S3 | see upload steps (skipped until infra vars wired) |"
+            echo "| AMO reviewer S3 | publish-amo-reviewer-artifacts action (skipped until vars wired) |"
             echo ""
             echo "**Release:** [${RELEASE_TAG}](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG})"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/publish-release-from-release-head.yml
+++ b/.github/workflows/publish-release-from-release-head.yml
@@ -321,17 +321,10 @@ jobs:
         run: .github/scripts/push-firefox-bundle-script.sh
 
       - name: Publish AMO reviewer artifacts to S3
-        if: >-
-          vars.AMO_REVIEWER_PUBLISHER_ROLE_ARN_UAT != '' ||
-          vars.AMO_REVIEWER_PUBLISHER_ROLE_ARN_PRD != ''
         uses: ./.github/actions/publish-amo-reviewer-artifacts
         with:
           firefox_bundle_script_ref: ${{ vars.FIREFOX_BUNDLE_SCRIPT_REF }}
           amo_last_listed_version: ${{ vars.AMO_LAST_LISTED_VERSION }}
-          amo_reviewer_publisher_role_arn_uat: ${{ vars.AMO_REVIEWER_PUBLISHER_ROLE_ARN_UAT }}
-          amo_reviewer_publisher_role_arn_prd: ${{ vars.AMO_REVIEWER_PUBLISHER_ROLE_ARN_PRD }}
-          amo_reviewer_bucket_uat: ${{ vars.AMO_REVIEWER_BUCKET_UAT }}
-          amo_reviewer_bucket_prd: ${{ vars.AMO_REVIEWER_BUCKET_PRD }}
 
       - name: Summary
         env:
@@ -352,7 +345,7 @@ jobs:
             echo "| Sentry (Flask MV2 webpack) | ✅ Published |"
             echo "| GitHub Release | ✅ Created |"
             echo "| Firefox Bundle | ✅ Pushed |"
-            echo "| AMO reviewer S3 | publish-amo-reviewer-artifacts action (skipped until vars wired) |"
+            echo "| AMO reviewer S3 (PRD) | ✅ Published |"
             echo ""
             echo "**Release:** [${RELEASE_TAG}](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG})"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/publish-release-from-release-head.yml
+++ b/.github/workflows/publish-release-from-release-head.yml
@@ -185,7 +185,7 @@ jobs:
       - build-flask-mv2-webpack
     runs-on: ubuntu-latest
     environment: release-branch
-    timeout-minutes: 30
+    timeout-minutes: 45
     env:
       RELEASE_TAG: ${{ needs.validate-branch.outputs.tag }}
       RELEASE_SHA: ${{ needs.validate-branch.outputs.release-sha }}
@@ -320,6 +320,41 @@ jobs:
       - name: Push Firefox bundle script
         run: .github/scripts/push-firefox-bundle-script.sh
 
+      - name: Package Firefox reviewer artifacts
+        if: >-
+          vars.AMO_REVIEWER_PUBLISHER_ROLE_ARN_UAT != '' ||
+          vars.AMO_REVIEWER_PUBLISHER_ROLE_ARN_PRD != ''
+        env:
+          FIREFOX_BUNDLE_SCRIPT_REF: ${{ vars.FIREFOX_BUNDLE_SCRIPT_REF }}
+          AMO_LAST_LISTED_VERSION: ${{ vars.AMO_LAST_LISTED_VERSION }}
+        run: bash .github/scripts/publish-firefox-reviewer-artifacts.sh package
+
+      - name: Configure AWS credentials (UAT reviewer publisher)
+        if: vars.AMO_REVIEWER_PUBLISHER_ROLE_ARN_UAT != ''
+        uses: aws-actions/configure-aws-credentials@acca2b1b2070338fb9fd1ca27ecee81d687e58e5 # v6.1.2
+        with:
+          role-to-assume: ${{ vars.AMO_REVIEWER_PUBLISHER_ROLE_ARN_UAT }}
+          aws-region: us-east-2
+
+      - name: Upload Firefox reviewer artifacts (UAT)
+        if: vars.AMO_REVIEWER_PUBLISHER_ROLE_ARN_UAT != ''
+        env:
+          AMO_REVIEWER_BUCKET: ${{ vars.AMO_REVIEWER_BUCKET_UAT }}
+        run: bash .github/scripts/publish-firefox-reviewer-artifacts.sh upload
+
+      - name: Configure AWS credentials (PRD reviewer publisher)
+        if: vars.AMO_REVIEWER_PUBLISHER_ROLE_ARN_PRD != ''
+        uses: aws-actions/configure-aws-credentials@acca2b1b2070338fb9fd1ca27ecee81d687e58e5 # v6.1.2
+        with:
+          role-to-assume: ${{ vars.AMO_REVIEWER_PUBLISHER_ROLE_ARN_PRD }}
+          aws-region: us-east-2
+
+      - name: Upload Firefox reviewer artifacts (PRD)
+        if: vars.AMO_REVIEWER_PUBLISHER_ROLE_ARN_PRD != ''
+        env:
+          AMO_REVIEWER_BUCKET: ${{ vars.AMO_REVIEWER_BUCKET_PRD }}
+        run: bash .github/scripts/publish-firefox-reviewer-artifacts.sh upload
+
       - name: Summary
         env:
           VERSION: ${{ needs.validate-branch.outputs.version }}
@@ -339,6 +374,7 @@ jobs:
             echo "| Sentry (Flask MV2 webpack) | ✅ Published |"
             echo "| GitHub Release | ✅ Created |"
             echo "| Firefox Bundle | ✅ Pushed |"
+            echo "| AMO reviewer S3 | see upload steps (skipped until infra vars wired) |"
             echo ""
             echo "**Release:** [${RELEASE_TAG}](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG})"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/publish-release-from-release-head.yml
+++ b/.github/workflows/publish-release-from-release-head.yml
@@ -328,6 +328,7 @@ jobs:
           amo_last_listed_version: ${{ vars.AMO_LAST_LISTED_VERSION }}
 
       - name: Summary
+        if: always()
         env:
           VERSION: ${{ needs.validate-branch.outputs.version }}
         run: |

--- a/.github/workflows/publish-release-from-release-head.yml
+++ b/.github/workflows/publish-release-from-release-head.yml
@@ -347,9 +347,9 @@ jobs:
             echo "| Sentry (Flask MV2 webpack) | ✅ Published |"
             echo "| GitHub Release | ✅ Created |"
             echo "| Firefox Bundle | ✅ Pushed |"
-            if [[ "${{ steps.amo-reviewer-s3.outcome }}" == "success" ]]; then
+            if [[ "${{ steps.amo-reviewer-s3.conclusion }}" == "success" ]]; then
               echo "| AMO reviewer S3 (PRD) | ✅ Published |"
-            elif [[ "${{ steps.amo-reviewer-s3.outcome }}" == "skipped" ]]; then
+            elif [[ "${{ steps.amo-reviewer-s3.conclusion }}" == "skipped" ]]; then
               echo "| AMO reviewer S3 (PRD) | ⏭ Skipped |"
             else
               echo "| AMO reviewer S3 (PRD) | ❌ Failed |"
@@ -357,6 +357,6 @@ jobs:
             echo ""
             echo "**Release:** [${RELEASE_TAG}](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG})"
           } >> "${GITHUB_STEP_SUMMARY}"
-          if [[ "${{ steps.amo-reviewer-s3.outcome }}" == "failure" ]]; then
+          if [[ "${{ steps.amo-reviewer-s3.conclusion }}" == "failure" ]]; then
             exit 1
           fi

--- a/.github/workflows/publish-release-from-release-head.yml
+++ b/.github/workflows/publish-release-from-release-head.yml
@@ -321,6 +321,7 @@ jobs:
         run: .github/scripts/push-firefox-bundle-script.sh
 
       - name: Publish AMO reviewer artifacts to S3
+        id: amo-reviewer-s3
         uses: ./.github/actions/publish-amo-reviewer-artifacts
         with:
           firefox_bundle_script_ref: ${{ vars.FIREFOX_BUNDLE_SCRIPT_REF }}
@@ -345,7 +346,11 @@ jobs:
             echo "| Sentry (Flask MV2 webpack) | ✅ Published |"
             echo "| GitHub Release | ✅ Created |"
             echo "| Firefox Bundle | ✅ Pushed |"
-            echo "| AMO reviewer S3 (PRD) | ✅ Published |"
+            if [[ "${{ steps.amo-reviewer-s3.outcome }}" == "success" ]]; then
+              echo "| AMO reviewer S3 (PRD) | ✅ Published |"
+            else
+              echo "| AMO reviewer S3 (PRD) | ❌ Failed |"
+            fi
             echo ""
             echo "**Release:** [${RELEASE_TAG}](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG})"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/publish-release-from-release-head.yml
+++ b/.github/workflows/publish-release-from-release-head.yml
@@ -322,13 +322,13 @@ jobs:
 
       - name: Publish AMO reviewer artifacts to S3
         id: amo-reviewer-s3
+        continue-on-error: true
         uses: ./.github/actions/publish-amo-reviewer-artifacts
         with:
           firefox_bundle_script_ref: ${{ vars.FIREFOX_BUNDLE_SCRIPT_REF }}
           amo_last_listed_version: ${{ vars.AMO_LAST_LISTED_VERSION }}
 
       - name: Summary
-        if: always()
         env:
           VERSION: ${{ needs.validate-branch.outputs.version }}
         run: |
@@ -349,9 +349,14 @@ jobs:
             echo "| Firefox Bundle | ✅ Pushed |"
             if [[ "${{ steps.amo-reviewer-s3.outcome }}" == "success" ]]; then
               echo "| AMO reviewer S3 (PRD) | ✅ Published |"
+            elif [[ "${{ steps.amo-reviewer-s3.outcome }}" == "skipped" ]]; then
+              echo "| AMO reviewer S3 (PRD) | ⏭ Skipped |"
             else
               echo "| AMO reviewer S3 (PRD) | ❌ Failed |"
             fi
             echo ""
             echo "**Release:** [${RELEASE_TAG}](https://github.com/${GITHUB_REPOSITORY}/releases/tag/${RELEASE_TAG})"
           } >> "${GITHUB_STEP_SUMMARY}"
+          if [[ "${{ steps.amo-reviewer-s3.outcome }}" == "failure" ]]; then
+            exit 1
+          fi


### PR DESCRIPTION
## **Description**

Release cuts now package and upload Firefox AMO reviewer source zips and approval notes (production + Flask) to private PRD S3 after the existing Firefox bundle push.

- New `publish-firefox-reviewer-artifacts.sh` clones `firefox-bundle-script`, runs compare + submission packaging, uploads four objects under `reviewer-source/{version}/`
- New composite action `publish-amo-reviewer-artifacts` uses OIDC (`amo-reviewer-publisher`) with **hardcoded PRD bucket/role** per `va-mmc-extension-submission-infra` CONVENTIONS (no extra GitHub repository variables)
- `publish-release-from-release-head` wires the step in, bumps publish timeout to 45 minutes, and reports AMO S3 success/failure in the job summary

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [INFRA-3683](https://consensyssoftware.atlassian.net/browse/INFRA-3683)

Infra: consensys-vertical-apps/va-mmc-extension-submission-infra#7 (merged)

Lambda consumer: consensys-vertical-apps/va-mmc-extension-submission#14

## **Manual testing steps**

1. Merge after infra PRD bucket/role exist (done via infra#7)
2. On next release cut, verify four objects under `s3://prd-va-mmc-extension-submission-amo-reviewer-source/reviewer-source/{version}/`
3. Confirm Lambda phase 2 reads them (va-mmc-extension-submission#14)

## **Screenshots/Recordings**

N/A (CI/release pipeline only)

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] Followed MetaMask Extension coding standards for workflow/script changes
- [x] Included tests where applicable (script exercised via release workflow; unit tests in submission repo)
- [x] Documented non-obvious behavior (bundle.sh path, PRD-only hardcoded OIDC contract)

## **Pre-merge reviewer checklist**

- [ ] Review OIDC scope (PRD `amo-reviewer-publisher` only) and S3 key layout matches infra + Lambda
- [ ] Confirm release job timeout increase is acceptable
- [ ] Verify no secrets in workflow or script

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds production release automation that writes to PRD S3 via OIDC and gates release success on packaging/build-repro checks; misconfiguration or upload failure blocks the cut.
> 
> **Overview**
> Release cuts now **package and upload Firefox AMO reviewer source zips and approval notes** (production and Flask) to private PRD S3, immediately after the existing Firefox bundle push.
> 
> A new **`publish-firefox-reviewer-artifacts.sh`** script clones `firefox-bundle-script`, runs `prepare_release.sh` for both variants (failing the job if reproduced builds diverge from published), and uploads four objects under `reviewer-source/{version}/`. A composite action **`publish-amo-reviewer-artifacts`** performs package + OIDC auth (`amo-reviewer-publisher`) + upload to the hardcoded PRD bucket.
> 
> **`publish-release-from-release-head`** wires in the new step (optional `FIREFOX_BUNDLE_SCRIPT_REF`), increases the publish job timeout from 30 to **45 minutes**, surfaces AMO S3 status in the job summary, and **fails the release job** if that step fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 67b144a3838f7726f91cfcae777793ca1294ad66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[INFRA-3683]: https://consensyssoftware.atlassian.net/browse/INFRA-3683?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ