### PR TITLE
fix: respect operator precedence in MetaMetrics fragment timeout check

### DIFF
--- a/app/scripts/controllers/metametrics-controller.test.ts
+++ b/app/scripts/controllers/metametrics-controller.test.ts
@@ -455,6 +455,70 @@ describe('MetaMetricsController', function () {
     });
   });
 
+  describe('finalizeAbandonedFragments', function () {
+    const NOW = 1730798303333;
+    const TIMEOUT_SECONDS = 60;
+
+    it('finalizes a fragment whose timeout has elapsed', async function () {
+      const lastUpdated = NOW - (TIMEOUT_SECONDS + 1) * 1000;
+      await withController(
+        {
+          options: {
+            state: {
+              fragments: {
+                abandoned: {
+                  ...SAMPLE_PERSISTED_EVENT_NO_ID,
+                  id: 'abandoned',
+                  canDeleteIfAbandoned: true,
+                  timeout: TIMEOUT_SECONDS,
+                  lastUpdated,
+                },
+              },
+            },
+          },
+        },
+        ({ controller }) => {
+          jest.useFakeTimers().setSystemTime(NOW);
+
+          controller.finalizeAbandonedFragments();
+
+          expect(controller.state.fragments.abandoned).toBeUndefined();
+        },
+      );
+    });
+
+    it('leaves a fragment whose timeout has not elapsed', async function () {
+      // Pre-fix, the precedence bug `Date.now() - fragment.lastUpdated / 1000`
+      // would treat any fresh fragment as abandoned because the subtraction
+      // produced a value many orders of magnitude larger than the timeout.
+      const lastUpdated = NOW - (TIMEOUT_SECONDS - 1) * 1000;
+      await withController(
+        {
+          options: {
+            state: {
+              fragments: {
+                fresh: {
+                  ...SAMPLE_PERSISTED_EVENT_NO_ID,
+                  id: 'fresh',
+                  canDeleteIfAbandoned: true,
+                  timeout: TIMEOUT_SECONDS,
+                  lastUpdated,
+                },
+              },
+            },
+          },
+        },
+        ({ controller }) => {
+          jest.useFakeTimers().setSystemTime(NOW);
+
+          controller.finalizeAbandonedFragments();
+
+          expect(controller.state.fragments.fresh).toBeDefined();
+        },
+      );
+    });
+  });
+
   describe('getMetaMetricsId', function () {
     it('returns the analytics metametrics id and keeps it stable across calls', async function () {
       await withController(({ controller, controllerMessenger }) => {

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -518,7 +518,7 @@ export class MetaMetricsController extends BaseController<
       if (
         fragment.timeout &&
         fragment.lastUpdated &&
-        Date.now() - fragment.lastUpdated / 1000 > fragment.timeout
+        (Date.now() - fragment.lastUpdated) / 1000 > fragment.timeout
       ) {
         this.processAbandonedFragment(fragment);
       }


### PR DESCRIPTION
- fix: respect operator precedence in MetaMetrics fragment timeout check

Closes #42895

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-expression fix in analytics cleanup with new unit tests; no auth or transaction logic touched.
> 
> **Overview**
> Fixes a **operator precedence bug** in `finalizeAbandonedFragments` so elapsed idle time is compared to each fragment’s `timeout` in **seconds**, not a bogus value from subtracting milliseconds after dividing `lastUpdated` by 1000.
> 
> The condition changes from `Date.now() - fragment.lastUpdated / 1000` to `(Date.now() - fragment.lastUpdated) / 1000`. **Before the fix**, in-flight MetaMetrics event fragments (e.g. transaction funnels) could be treated as abandoned almost immediately and finalized or deleted on the periodic alarm/interval, skewing analytics. **After the fix**, only fragments that have actually exceeded their timeout are processed.
> 
> Adds unit tests that assert a timed-out fragment is removed and a fragment still inside the window is left in state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89c4c6fcbd42caf474fe8a56fbdefeaff6a6e5dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->