### PR TITLE
chore(ci): add Runway sender verification and dry-run mode to CWS upload workflow

### DIFF
--- a/.github/workflows/upload-extension-to-cws.yml
+++ b/.github/workflows/upload-extension-to-cws.yml
@@ -4,7 +4,7 @@ name: Upload extension to Chrome Web Store
 # Beta: cws-beta environment + *_BETA repo variables (INFRA-3645).
 # Production: cws-production environment + prod variables (INFRA-3644).
 # CWS API v2 upload (v1.1 sunsets 2026-10-15): chromewebstore.googleapis.com/upload/v2/...
-# Runway sender verification: deferred to INFRA-3649 (RAPID runtime identity enforcement).
+# INFRA-3649 — Runway sender verification (defense-in-depth; primary gate is WIF CEL on actor_id).
 
 on:
   workflow_dispatch:
@@ -21,6 +21,11 @@ on:
         options:
           - beta
           - production
+      dry-run:
+        description: 'Verify sender identity and WIF auth without uploading (skips download and CWS upload)'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -121,7 +126,44 @@ jobs:
             echo "| Service account | \`${WIF_SERVICE_ACCOUNT}\` |"
           } >> "${GITHUB_STEP_SUMMARY}"
 
+      # Defense-in-depth: fail fast if a non-Runway actor dispatches a production run.
+      # The authoritative gate is WIF CEL (INFRA-3644) which rejects non-Runway OIDC
+      # tokens at GCP token exchange; this step provides an earlier, human-readable error.
+      - name: Verify Runway sender (production only)
+        if: inputs.target == 'production'
+        env:
+          SENDER_ID: ${{ github.event.sender.id }}
+          SENDER_LOGIN: ${{ github.event.sender.login }}
+          RUNWAY_ACTOR_ID: '73448015'
+          RUNWAY_ACTOR_LOGIN: 'runway-github[bot]'
+        run: |
+          set -euo pipefail
+          echo "Sender: ${SENDER_LOGIN} (id=${SENDER_ID})"
+          echo "Expected: ${RUNWAY_ACTOR_LOGIN} (id=${RUNWAY_ACTOR_ID})"
+          if [[ "${SENDER_ID}" != "${RUNWAY_ACTOR_ID}" ]]; then
+            echo "::error::Production uploads must be dispatched by Runway (expected sender_id=${RUNWAY_ACTOR_ID} / ${RUNWAY_ACTOR_LOGIN}, got ${SENDER_ID} / ${SENDER_LOGIN}). WIF CEL would also reject this request at GCP token exchange."
+            exit 1
+          fi
+          echo "Sender verified: ${SENDER_LOGIN} (id=${SENDER_ID})"
+
+      - name: Dry-run complete
+        if: inputs.dry-run
+        run: |
+          {
+            echo "## Dry-run complete"
+            echo ""
+            echo "| Field | Value |"
+            echo "|-------|-------|"
+            echo "| Target | \`${{ inputs.target }}\` |"
+            echo "| Version | \`${{ inputs.version }}\` |"
+            echo "| Sender | \`${{ github.event.sender.login }}\` (id=\`${{ github.event.sender.id }}\`) |"
+            echo "| Dry-run | \`true\` |"
+            echo "| Result | Validation and sender verification passed. No download or upload performed. |"
+          } >> "${GITHUB_STEP_SUMMARY}"
+          echo "Dry-run mode: skipping download, GCP auth, and CWS upload."
+
       - name: Download release asset
+        if: ${{ !inputs.dry-run }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -134,7 +176,7 @@ jobs:
 
       # Beta/dev listing rejects manifest.key tied to production extension ID (POC lesson).
       - name: Strip manifest key from zip (beta only)
-        if: inputs.target == 'beta'
+        if: inputs.target == 'beta' && !inputs.dry-run
         run: |
           set -euo pipefail
           mkdir -p /tmp/extension
@@ -146,6 +188,7 @@ jobs:
           echo "Stripped manifest key and set version in manifest.json"
 
       - name: Authenticate to Google Cloud
+        if: ${{ !inputs.dry-run }}
         id: auth
         uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3.0.0
         with:
@@ -155,6 +198,7 @@ jobs:
           access_token_scopes: https://www.googleapis.com/auth/chromewebstore
 
       - name: Upload to Chrome Web Store
+        if: ${{ !inputs.dry-run }}
         id: cws-upload
         env:
           ACCESS_TOKEN: ${{ steps.auth.outputs.access_token }}
@@ -231,7 +275,7 @@ jobs:
           echo "Package uploaded (draft/pending review). Not published to users."
 
       - name: Summary
-        if: always()
+        if: ${{ always() && !inputs.dry-run }}
         run: |
           {
             echo ""


### PR DESCRIPTION
## **Description**

**INFRA-3649** — Adds Runway sender verification (defense-in-depth) and a `dry-run` mode to the `upload-extension-to-cws` workflow.

**Why:** The RAPID for automated store submission requires runtime identity enforcement on production CWS uploads. The primary security gate is the GCP WIF CEL expression (INFRA-3644) which rejects non-Runway OIDC tokens at token exchange. This PR adds a defense-in-depth workflow step that fails fast with a human-readable error when a non-Runway actor dispatches a production upload, before reaching GCP auth.

**What changed:**

1. **Sender verification step** (production only): checks `github.event.sender.id` against Runway's confirmed `actor_id` (`73448015`). Beta is intentionally left open for manual RE testing (per INFRA-3645).
2. **`dry-run` input**: when `true`, the workflow validates inputs and sender identity, writes a summary, then exits — skipping download, GCP auth, and CWS upload. This enables safe verification of Runway's OIDC identity without triggering a real store submission.
3. **Updated header comment**: replaced the INFRA-3649 deferral note with implementation reference.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

- [INFRA-3649](https://consensyssoftware.atlassian.net/browse/INFRA-3649) (this ticket — Runway integration + identity proof)
- [INFRA-3644](https://consensyssoftware.atlassian.net/browse/INFRA-3644) (production WIF CEL)
- [INFRA-3645](https://consensyssoftware.atlassian.net/browse/INFRA-3645) (beta CWS path)
- [INFRA-3646](https://consensyssoftware.atlassian.net/browse/INFRA-3646) (workflow foundation)
- [RAPID: Automated Store Submission](https://consensyssoftware.atlassian.net/wiki/spaces/PRDC/pages/401553981471)

## **Manual testing steps**

1. After merge, trigger the workflow from the GitHub Actions UI with `target=production`, `dry-run=true`, any valid version (e.g. `13.31.0`).
2. Verify the run **fails** at the "Verify Runway sender" step (since a human dispatched it, not Runway).
3. Verify the error message includes the expected vs actual sender IDs.
4. Trigger with `target=beta`, `dry-run=true` — verify it succeeds (no sender check on beta).
5. When Runway is wired: trigger from Runway with `target=production`, `dry-run=true` — verify sender verification passes and the run completes at the "Dry-run complete" step without downloading or uploading.

## **Test evidence**

Workflow runs triggered from the PR branch via `gh workflow run`:

| Test | Target | Dry-run | Result | Run |
|------|--------|---------|--------|-----|
| Beta dry-run | `beta` | `true` | **Pass** — Validated inputs, logged sender (`alucardzom` / id=`560018`), wrote dry-run summary, skipped download/auth/upload. | [#28020068782](https://github.com/MetaMask/metamask-extension/actions/runs/28020068782) |
| Production dry-run | `production` | `true` | **Fail (expected)** — `cws-production` environment protection rules rejected the branch (`ale/INFRA-3649-...`); only `main` and `release/*` are allowed. Environment-level gate kicked in before the workflow steps ran. | [#28020075314](https://github.com/MetaMask/metamask-extension/actions/runs/28020075314) |

**Note:** The full negative test (sender verification rejecting a human on `main`) and the positive test (Runway dispatch accepted) require the PR to be merged to `main` first, since the `cws-production` environment only allows `main` and `release/*` branches.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[INFRA-3649]: https://consensyssoftware.atlassian.net/browse/INFRA-3649?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes guardrails on the production CWS upload path; misconfigured Runway actor id could block legitimate releases, though WIF remains the primary gate and normal non-dry-run behavior is unchanged for authorized Runway dispatches.
> 
> **Overview**
> Extends the **Chrome Web Store upload** GitHub Actions workflow with **Runway identity checks** and a **dry-run** path for safe validation.
> 
> For **`target=production`**, a new step fails the run unless `github.event.sender.id` matches Runway’s fixed actor id (`73448015` / `runway-github[bot]`). Beta uploads are unchanged (no sender gate). This is defense-in-depth alongside existing GCP WIF CEL enforcement.
> 
> A new **`dry-run`** dispatch input runs input/config validation and production sender verification when applicable, writes a step summary, and **skips** release download, manifest stripping, GCP auth, and CWS upload. The post-upload **Summary** step is also skipped on dry-run.
> 
> Workflow header comments now reference INFRA-3649 instead of deferring sender verification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e9118fd22698cec5ddd6c50c9e10191401ea9c4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->