### PR TITLE
feat(support): include canonical profile id in support request URLs

### DIFF
--- a/shared/lib/build-support-link.test.ts
+++ b/shared/lib/build-support-link.test.ts
@@ -1,0 +1,54 @@
+import { buildSupportLinkWithUserData } from './build-support-link';
+import { SUPPORT_LINK } from './ui-utils';
+
+describe('buildSupportLinkWithUserData', () => {
+  const baseSupportLink = SUPPORT_LINK as string;
+  const version = 'MOCK_VERSION';
+
+  it('appends all user-identifying query parameters when provided', () => {
+    const result = buildSupportLinkWithUserData(baseSupportLink, {
+      version,
+      profileId: 'profile-id',
+      canonicalProfileId: 'canonical-profile-id',
+      analyticsId: 'analytics-id',
+      shieldCustomerId: 'shield-id',
+    });
+
+    const url = new URL(result);
+    expect(url.searchParams.get('metamask_version')).toBe(version);
+    expect(url.searchParams.get('metamask_profile_id')).toBe('profile-id');
+    expect(url.searchParams.get('metamask_canonical_profile_id')).toBe(
+      'canonical-profile-id',
+    );
+    expect(url.searchParams.get('metamask_metametrics_id')).toBe(
+      'analytics-id',
+    );
+    expect(url.searchParams.get('shield_id')).toBe('shield-id');
+  });
+
+  it('omits optional query parameters when values are undefined', () => {
+    const result = buildSupportLinkWithUserData(baseSupportLink, {
+      version,
+    });
+
+    const url = new URL(result);
+    expect(url.searchParams.get('metamask_version')).toBe(version);
+    expect(url.searchParams.has('metamask_profile_id')).toBe(false);
+    expect(url.searchParams.has('metamask_canonical_profile_id')).toBe(false);
+    expect(url.searchParams.has('metamask_metametrics_id')).toBe(false);
+    expect(url.searchParams.has('shield_id')).toBe(false);
+  });
+
+  it('includes canonical profile id independently of profile id', () => {
+    const result = buildSupportLinkWithUserData(baseSupportLink, {
+      version,
+      canonicalProfileId: 'canonical-profile-id',
+    });
+
+    const url = new URL(result);
+    expect(url.searchParams.get('metamask_canonical_profile_id')).toBe(
+      'canonical-profile-id',
+    );
+    expect(url.searchParams.has('metamask_profile_id')).toBe(false);
+  });
+});

--- a/shared/lib/build-support-link.ts
+++ b/shared/lib/build-support-link.ts
@@ -7,10 +7,11 @@ export type SupportLinkUserData = {
 };
 
 /**
- * Builds a MetaMask support URL with optional user-identifying query parameters.
+ * Builds a MetaMask support URL with user-identifying query parameters.
  *
  * @param supportLink - Base support URL from environment configuration.
- * @param userData - Optional user data to append as query parameters.
+ * @param userData - User data to append as query parameters. `version` is required;
+ * other fields are included only when provided.
  * @param userData.version
  * @param userData.profileId
  * @param userData.canonicalProfileId

--- a/shared/lib/build-support-link.ts
+++ b/shared/lib/build-support-link.ts
@@ -1,0 +1,49 @@
+export type SupportLinkUserData = {
+  version: string;
+  profileId?: string;
+  canonicalProfileId?: string;
+  analyticsId?: string;
+  shieldCustomerId?: string;
+};
+
+/**
+ * Builds a MetaMask support URL with optional user-identifying query parameters.
+ *
+ * @param supportLink - Base support URL from environment configuration.
+ * @param userData - Optional user data to append as query parameters.
+ * @param userData.version
+ * @param userData.profileId
+ * @param userData.canonicalProfileId
+ * @param userData.analyticsId
+ * @param userData.shieldCustomerId
+ * @returns Support URL with appended query parameters.
+ */
+export function buildSupportLinkWithUserData(
+  supportLink: string,
+  {
+    version,
+    profileId,
+    canonicalProfileId,
+    analyticsId,
+    shieldCustomerId,
+  }: SupportLinkUserData,
+): string {
+  const url = new URL(supportLink);
+  url.searchParams.append('metamask_version', version);
+  if (profileId) {
+    url.searchParams.append('metamask_profile_id', profileId);
+  }
+  if (canonicalProfileId) {
+    url.searchParams.append(
+      'metamask_canonical_profile_id',
+      canonicalProfileId,
+    );
+  }
+  if (analyticsId) {
+    url.searchParams.append('metamask_metametrics_id', analyticsId);
+  }
+  if (shieldCustomerId) {
+    url.searchParams.append('shield_id', shieldCustomerId);
+  }
+  return url.toString();
+}

--- a/ui/components/app/modals/visit-support-data-consent-modal/visit-support-data-consent-modal.tsx
+++ b/ui/components/app/modals/visit-support-data-consent-modal/visit-support-data-consent-modal.tsx
@@ -28,6 +28,7 @@ import {
   MetaMetricsEventName,
 } from '../../../../../shared/constants/metametrics';
 import { MetaMetricsContext } from '../../../../contexts/metametrics';
+import { buildSupportLinkWithUserData } from '../../../../../shared/lib/build-support-link';
 import { SUPPORT_LINK } from '../../../../../shared/lib/ui-utils';
 import { useUserSubscriptions } from '../../../../hooks/subscription/useSubscription';
 
@@ -45,6 +46,7 @@ const VisitSupportDataConsentModal = ({
   const { trackEvent } = useContext(MetaMetricsContext);
   const sessionData = useSelector(selectSessionData);
   const profileId = sessionData?.profile?.profileId;
+  const canonicalProfileId = sessionData?.profile?.canonicalProfileId;
   const analyticsId = useSelector(getAnalyticsId);
   const { customerId: shieldCustomerId } = useUserSubscriptions();
 
@@ -52,23 +54,15 @@ const VisitSupportDataConsentModal = ({
     (params: {
       version: string;
       profileId?: string;
+      canonicalProfileId?: string;
       analyticsId?: string;
       shieldCustomerId?: string;
     }) => {
       onClose();
-      const url = new URL(SUPPORT_LINK as string);
-      url.searchParams.append('metamask_version', params.version);
-      if (params.profileId) {
-        url.searchParams.append('metamask_profile_id', params.profileId);
-      }
-      if (params.analyticsId) {
-        url.searchParams.append('metamask_metametrics_id', params.analyticsId);
-      }
-      if (params.shieldCustomerId) {
-        url.searchParams.append('shield_id', params.shieldCustomerId);
-      }
-
-      const supportLinkWithUserId = url.toString();
+      const supportLinkWithUserId = buildSupportLinkWithUserData(
+        SUPPORT_LINK as string,
+        params,
+      );
 
       trackEvent(
         {
@@ -142,6 +136,7 @@ const VisitSupportDataConsentModal = ({
                 handleClickContactSupportButton({
                   version,
                   profileId,
+                  canonicalProfileId,
                   analyticsId,
                   shieldCustomerId,
                 })

--- a/ui/components/app/modals/visit-support-data-consent-modal/visit-support-data-consent-modal.tsx
+++ b/ui/components/app/modals/visit-support-data-consent-modal/visit-support-data-consent-modal.tsx
@@ -28,7 +28,10 @@ import {
   MetaMetricsEventName,
 } from '../../../../../shared/constants/metametrics';
 import { MetaMetricsContext } from '../../../../contexts/metametrics';
-import { buildSupportLinkWithUserData } from '../../../../../shared/lib/build-support-link';
+import {
+  buildSupportLinkWithUserData,
+  type SupportLinkUserData,
+} from '../../../../../shared/lib/build-support-link';
 import { SUPPORT_LINK } from '../../../../../shared/lib/ui-utils';
 import { useUserSubscriptions } from '../../../../hooks/subscription/useSubscription';
 
@@ -51,13 +54,7 @@ const VisitSupportDataConsentModal = ({
   const { customerId: shieldCustomerId } = useUserSubscriptions();
 
   const handleClickContactSupportButton = useCallback(
-    (params: {
-      version: string;
-      profileId?: string;
-      canonicalProfileId?: string;
-      analyticsId?: string;
-      shieldCustomerId?: string;
-    }) => {
+    (params: SupportLinkUserData) => {
       onClose();
       const supportLinkWithUserId = buildSupportLinkWithUserData(
         SUPPORT_LINK as string,

--- a/ui/components/app/modals/visit-support-data-consent-modal/visit-support-data.test.tsx
+++ b/ui/components/app/modals/visit-support-data-consent-modal/visit-support-data.test.tsx
@@ -10,6 +10,7 @@ import {
   MetaMetricsEventName,
 } from '../../../../../shared/constants/metametrics';
 import { SUPPORT_LINK } from '../../../../../shared/lib/ui-utils';
+import { buildSupportLinkWithUserData } from '../../../../../shared/lib/build-support-link';
 import mockState from '../../../../../test/data/mock-state.json';
 import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import { MetaMetricsContext } from '../../../../contexts/metametrics';
@@ -43,6 +44,7 @@ describe('VisitSupportDataConsentModal', () => {
   };
   const mockOnClose = jest.fn();
   const mockProfileId = 'test-profile-id';
+  const mockCanonicalProfileId = 'test-canonical-profile-id';
   const mockAnalyticsId = 'test-metrics-id';
   const mockShieldCustomerId = 'test-shield-customer-id';
   const useSelectorMock = useSelector as jest.Mock;
@@ -51,7 +53,12 @@ describe('VisitSupportDataConsentModal', () => {
   beforeEach(() => {
     useSelectorMock.mockImplementation((selector) => {
       if (selector === selectSessionData) {
-        return { profile: { profileId: mockProfileId } };
+        return {
+          profile: {
+            profileId: mockProfileId,
+            canonicalProfileId: mockCanonicalProfileId,
+          },
+        };
       }
       if (selector === getAnalyticsId) {
         return mockAnalyticsId;
@@ -102,12 +109,13 @@ describe('VisitSupportDataConsentModal', () => {
       );
     });
 
-    const url = new URL(SUPPORT_LINK as string);
-    url.searchParams.append('metamask_version', 'MOCK_VERSION');
-    url.searchParams.append('metamask_profile_id', mockProfileId);
-    url.searchParams.append('metamask_metametrics_id', mockAnalyticsId);
-    url.searchParams.append('shield_id', mockShieldCustomerId);
-    const expectedUrl = url.toString();
+    const expectedUrl = buildSupportLinkWithUserData(SUPPORT_LINK as string, {
+      version: 'MOCK_VERSION',
+      profileId: mockProfileId,
+      canonicalProfileId: mockCanonicalProfileId,
+      analyticsId: mockAnalyticsId,
+      shieldCustomerId: mockShieldCustomerId,
+    });
 
     expect(mockTrackEvent).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -168,11 +176,12 @@ describe('VisitSupportDataConsentModal', () => {
       );
     });
 
-    const url = new URL(SUPPORT_LINK as string);
-    url.searchParams.append('metamask_version', 'MOCK_VERSION');
-    url.searchParams.append('metamask_profile_id', mockProfileId);
-    url.searchParams.append('metamask_metametrics_id', mockAnalyticsId);
-    const expectedUrl = url.toString();
+    const expectedUrl = buildSupportLinkWithUserData(SUPPORT_LINK as string, {
+      version: 'MOCK_VERSION',
+      profileId: mockProfileId,
+      canonicalProfileId: mockCanonicalProfileId,
+      analyticsId: mockAnalyticsId,
+    });
 
     expect(mockTrackEvent).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -216,9 +225,9 @@ describe('VisitSupportDataConsentModal', () => {
       );
     });
 
-    const url = new URL(SUPPORT_LINK as string);
-    url.searchParams.append('metamask_version', 'MOCK_VERSION');
-    const expectedUrl = url.toString();
+    const expectedUrl = buildSupportLinkWithUserData(SUPPORT_LINK as string, {
+      version: 'MOCK_VERSION',
+    });
 
     expect(mockTrackEvent).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -267,6 +276,7 @@ describe('VisitSupportDataConsentModal', () => {
 
     // Verify personal params are not in URL
     expect(calledUrl).not.toContain('metamask_profile_id');
+    expect(calledUrl).not.toContain('metamask_canonical_profile_id');
     expect(calledUrl).not.toContain('metamask_metametrics_id');
     expect(calledUrl).not.toContain('shield_id');
     expect(calledUrl).not.toContain('metamask_version');
@@ -328,11 +338,11 @@ describe('VisitSupportDataConsentModal', () => {
       );
     });
 
-    const url = new URL(SUPPORT_LINK as string);
-    url.searchParams.append('metamask_version', 'MOCK_VERSION');
-    url.searchParams.append('metamask_metametrics_id', mockAnalyticsId);
-    url.searchParams.append('shield_id', mockShieldCustomerId);
-    const expectedUrl = url.toString();
+    const expectedUrl = buildSupportLinkWithUserData(SUPPORT_LINK as string, {
+      version: 'MOCK_VERSION',
+      analyticsId: mockAnalyticsId,
+      shieldCustomerId: mockShieldCustomerId,
+    });
 
     expect(openWindow).toHaveBeenCalledWith(expectedUrl);
   });
@@ -356,11 +366,11 @@ describe('VisitSupportDataConsentModal', () => {
       );
     });
 
-    const url = new URL(SUPPORT_LINK as string);
-    url.searchParams.append('metamask_version', 'MOCK_VERSION');
-    url.searchParams.append('metamask_metametrics_id', mockAnalyticsId);
-    url.searchParams.append('shield_id', mockShieldCustomerId);
-    const expectedUrl = url.toString();
+    const expectedUrl = buildSupportLinkWithUserData(SUPPORT_LINK as string, {
+      version: 'MOCK_VERSION',
+      analyticsId: mockAnalyticsId,
+      shieldCustomerId: mockShieldCustomerId,
+    });
 
     expect(openWindow).toHaveBeenCalledWith(expectedUrl);
   });
@@ -392,10 +402,10 @@ describe('VisitSupportDataConsentModal', () => {
       );
     });
 
-    const url = new URL(SUPPORT_LINK as string);
-    url.searchParams.append('metamask_version', 'MOCK_VERSION');
-    url.searchParams.append('metamask_metametrics_id', mockAnalyticsId);
-    const expectedUrl = url.toString();
+    const expectedUrl = buildSupportLinkWithUserData(SUPPORT_LINK as string, {
+      version: 'MOCK_VERSION',
+      analyticsId: mockAnalyticsId,
+    });
 
     expect(openWindow).toHaveBeenCalledWith(expectedUrl);
     expect(mockOnClose).toHaveBeenCalled();

--- a/ui/hooks/subscription/useSubscription.ts
+++ b/ui/hooks/subscription/useSubscription.ts
@@ -753,13 +753,7 @@ export const useHandleSubscriptionSupportAction = () => {
     );
 
     openWindow(supportLinkWithUserId);
-  }, [
-    version,
-    profileId,
-    canonicalProfileId,
-    analyticsId,
-    shieldCustomerId,
-  ]);
+  }, [version, profileId, canonicalProfileId, analyticsId, shieldCustomerId]);
 
   return {
     handleClickContactSupport,

--- a/ui/hooks/subscription/useSubscription.ts
+++ b/ui/hooks/subscription/useSubscription.ts
@@ -83,6 +83,7 @@ import {
 import { DefaultSubscriptionPaymentOptions } from '../../../shared/types';
 import { useI18nContext } from '../useI18nContext';
 import { openWindow } from '../../helpers/utils/window';
+import { buildSupportLinkWithUserData } from '../../../shared/lib/build-support-link';
 import { SUPPORT_LINK } from '../../../shared/lib/ui-utils';
 import { MetaMetricsEventName } from '../../../shared/constants/metametrics';
 import { useAccountTotalFiatBalance } from '../useAccountTotalFiatBalance';
@@ -735,26 +736,30 @@ export const useHandleSubscriptionSupportAction = () => {
   const version = process.env.METAMASK_VERSION as string;
   const sessionData = useSelector(selectSessionData);
   const profileId = sessionData?.profile?.profileId;
+  const canonicalProfileId = sessionData?.profile?.canonicalProfileId;
   const analyticsId = useSelector(getAnalyticsId);
   const { customerId: shieldCustomerId } = useUserSubscriptions();
 
   const handleClickContactSupport = useCallback(() => {
-    const url = new URL(SUPPORT_LINK as string);
-    url.searchParams.append('metamask_version', version);
-    if (profileId) {
-      url.searchParams.append('metamask_profile_id', profileId);
-    }
-    if (analyticsId) {
-      url.searchParams.append('metamask_metametrics_id', analyticsId);
-    }
-    if (shieldCustomerId) {
-      url.searchParams.append('shield_id', shieldCustomerId);
-    }
-
-    const supportLinkWithUserId = url.toString();
+    const supportLinkWithUserId = buildSupportLinkWithUserData(
+      SUPPORT_LINK as string,
+      {
+        version,
+        profileId,
+        canonicalProfileId,
+        analyticsId,
+        shieldCustomerId,
+      },
+    );
 
     openWindow(supportLinkWithUserId);
-  }, [version, profileId, analyticsId, shieldCustomerId]);
+  }, [
+    version,
+    profileId,
+    canonicalProfileId,
+    analyticsId,
+    shieldCustomerId,
+  ]);
 
   return {
     handleClickContactSupport,


### PR DESCRIPTION
## **Description**

Add `metamask_canonical_profile_id` to support links when users consent to share data, using a shared buildSupportLinkWithUserData helper.

## **Changelog**


CHANGELOG entry: Adds `metamask_canonical_profile_id` to support links when users consent to share data

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/43777

## **Manual testing steps**

1. Go to menu > Support > Confirm (Share device details with support): this opens a new tab with the support website => confirm metamask_canonical_profile_id param is defined in the url
2. Go to menu > Settings > About MetaMask > Visit our support center > Confirm (Share device details with support): this opens a new tab with the support website => confirm metamask_canonical_profile_id param is defined in the url
3. Build Extension with `ENABLE_SETTINGS_PAGE_DEV_OPTIONS=true` in `.metamaskrc`. Go to menu > Settings > Debug > Generate a Page Crash > Contact support > Confirm (Share device details with support): this opens a new tab with the support website => confirm metamask_canonical_profile_id param is defined in the url

## **Screenshots/Recordings**

NA

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, consent-gated change to support link query params with dedicated tests; no auth or payment logic touched.
> 
> **Overview**
> Adds **`metamask_canonical_profile_id`** to support URLs when the user accepts sharing device details, so support can correlate requests with the canonical identity profile.
> 
> Support link query building is centralized in **`buildSupportLinkWithUserData`** (`shared/lib/build-support-link.ts`), replacing duplicated `URL`/`searchParams` logic. The helper always sets `metamask_version` and optionally appends profile, canonical profile, MetaMetrics, and Shield IDs when values exist.
> 
> **`VisitSupportDataConsentModal`** and **`useHandleSubscriptionSupportAction`** now read `canonicalProfileId` from session data and pass it through the helper on accept/contact-support flows. Modal and helper unit tests assert the new param and that reject still omits identifying query params.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e5d50aa07afc3aff09581d0cfa47829a504af25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->