### PR TITLE
ci: add automated security dependency update workflow

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -220,3 +220,54 @@ creating new workflow files.
 - It requires a different runner type or container
 - It has complex matrix strategies or conditional job graphs
 - It needs to report as a separate required status check
+
+---
+
+## Automated Security Dependency Update
+
+**Workflow file:** [`.github/workflows/automated-security-dep-update.yml`](.github/workflows/automated-security-dep-update.yml)
+**Script:** [`.github/scripts/security-dep-update.mts`](.github/scripts/security-dep-update.mts)
+
+### How it runs
+
+The workflow fires automatically on a **biweekly schedule** (1st and 15th of every month, 08:00 UTC) and can also be triggered manually.
+
+On each run it:
+
+1. Runs `yarn npm audit --recursive --environment production --severity moderate` to find CVEs
+2. Skips any advisory IDs listed in `npmAuditIgnoreAdvisories` in `.yarnrc.yml`
+3. Skips packages that have a local `.yarn/patches/` patch applied (would break the patch)
+4. For each remaining vulnerable package: runs `yarn up "pkg@^<currentMajor>"` to update to the latest patch/minor in the same major (no major bumps)
+5. Runs the post-dep-change chain: `yarn install --immutable` → `yarn dedupe` → `yarn allow-scripts auto` → `yarn lavamoat:auto` → `yarn attributions:generate` → `yarn lint:changed:fix`
+6. Validates: `yarn lint:tsc` → `yarn test:unit` → `yarn dist`
+
+**If all validations pass:** creates a branch named `refactor/deps-security-update-YYYY-MM-DD` and opens a **DRAFT PR** against `main`.
+
+**If any validation fails:** opens a **GitHub Issue** with the full list of attempted updates and which step failed. No branch is pushed.
+
+### How to trigger manually
+
+1. Go to **Actions → Automated Security Dependency Update → Run workflow**
+2. Leave `dry_run` unchecked for a real update run, or check it to scan and report without making any changes
+3. Review the step summary in the workflow run for the vulnerability report
+
+### How to read the PR / issue report
+
+**DRAFT PR body contains:**
+
+| Section | What it means |
+|---------|---------------|
+| ✅ Updated Packages | Packages updated with old→new version and the advisory IDs fixed |
+| ⚠️ Packages with patches | Cannot be auto-updated — update the `.yarn/patches/` file manually |
+| ⚠️ Requires major bump | Only a major-version upgrade fixes the CVE — evaluate the breaking changes manually |
+| ⚠️ Failed updates | `yarn up` exited non-zero — check the workflow log for details |
+
+**GitHub Issue (failure case):**
+The issue includes a "Validation Step Results" table with ✅/❌ for each step, the list of packages that were attempted before the failure, and a direct link to the workflow run log.
+
+### Operational notes
+
+- **Token:** Uses `MetaMask/github-tools/.github/actions/get-token@v1` via `TOKEN_EXCHANGE_URL`. Without this variable, the workflow will fail at the auth step.
+- **E2E tests are intentionally skipped** inside the workflow — they run normally as part of CI on the resulting DRAFT PR.
+- **LavaMoat step** (`yarn lavamoat:auto`) can take 20–30 minutes and is the most likely step to fail. If it fails, check the workflow log for policy diff errors.
+- To permanently ignore a new advisory, add its numeric ID to `npmAuditIgnoreAdvisories` in `.yarnrc.yml` with a comment explaining why.

--- a/.github/scripts/security-dep-update.mts
+++ b/.github/scripts/security-dep-update.mts
@@ -1,0 +1,662 @@
+#!/usr/bin/env tsx
+/**
+ * security-dep-update.mts
+ *
+ * Detects vulnerable npm packages via `yarn npm audit` and attempts to update
+ * each one to the latest patch/minor version within its current major, skipping:
+ *   - Advisory IDs listed in `npmAuditIgnoreAdvisories` in .yarnrc.yml
+ *   - Packages that have a local `.yarn/patches/` patch (patch: protocol in resolutions)
+ *   - Packages where the only fix requires a major version bump
+ *
+ * Writes:
+ *   .tmp/pr-body.md        — body for the DRAFT PR (full table of changes)
+ *   .tmp/failure-report.md — issue body template (validation outcomes appended by workflow)
+ *
+ * Sets GITHUB_OUTPUT:
+ *   packages_updated  — number of packages successfully updated (0 = nothing to do)
+ *   update_summary    — human-readable one-liner
+ */
+
+import { spawnSync } from 'child_process';
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'fs';
+import semver from 'semver';
+import * as core from '@actions/core';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface PackageJson {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+  resolutions?: Record<string, string>;
+}
+
+type UpdateStatus =
+  | 'updated'
+  | 'skipped-patched'
+  | 'skipped-major'
+  | 'skipped-ignored'
+  | 'failed';
+
+interface PackageResult {
+  name: string;
+  oldVersion: string | null;
+  newVersion: string | null;
+  status: UpdateStatus;
+  advisoryIds: number[];
+  advisoryTitles: string[];
+  advisoryUrls: string[];
+  reason?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Shell helper
+// ---------------------------------------------------------------------------
+
+function run(
+  cmd: string,
+  opts: { silent?: boolean } = {},
+): { ok: boolean; output: string } {
+  if (!opts.silent) {
+    console.log(`  $ ${cmd}`);
+  }
+  const res = spawnSync(cmd, { encoding: 'utf8', shell: true });
+  const output = `${res.stdout ?? ''}${res.stderr ?? ''}`.trim();
+  return { ok: res.status === 0, output };
+}
+
+// ---------------------------------------------------------------------------
+// 1. Patched packages — resolutions that use the `patch:` protocol
+//    These have a hand-crafted patch file in .yarn/patches/ and must be
+//    manually updated to avoid corrupting the patch.
+// ---------------------------------------------------------------------------
+
+function getPatchedPackages(pkg: PackageJson): Set<string> {
+  const patched = new Set<string>();
+  for (const [key, value] of Object.entries(pkg.resolutions ?? {})) {
+    if (typeof value === 'string' && value.startsWith('patch:')) {
+      // Key forms: "@scope/name@npm:^x.y.z" | "name@^x" | "name"
+      const stripped = key
+        .replace(/@npm:.*/u, '')
+        .replace(/@[\^~><=].*/u, '');
+      patched.add(stripped);
+    }
+  }
+  return patched;
+}
+
+// ---------------------------------------------------------------------------
+// 2. Ignored advisory IDs — npmAuditIgnoreAdvisories in .yarnrc.yml
+// ---------------------------------------------------------------------------
+
+function getIgnoredAdvisoryIds(): Set<number> {
+  const ids = new Set<number>();
+  try {
+    const yarnrc = readFileSync('.yarnrc.yml', 'utf8');
+    let inSection = false;
+    for (const line of yarnrc.split('\n')) {
+      if (line.trimEnd() === 'npmAuditIgnoreAdvisories:') {
+        inSection = true;
+        continue;
+      }
+      if (inSection) {
+        const numMatch = line.match(/^\s+-\s+(\d+)/u);
+        if (numMatch) {
+          ids.add(Number(numMatch[1]));
+          continue;
+        }
+        // Section ends at a non-indented, non-comment, non-blank line
+        if (
+          line.length > 0 &&
+          !line.startsWith(' ') &&
+          !line.startsWith('\t') &&
+          !line.startsWith('#') &&
+          !line.startsWith('-')
+        ) {
+          inSection = false;
+        }
+      }
+    }
+  } catch {
+    // .yarnrc.yml not readable — proceed without ignore list
+  }
+  return ids;
+}
+
+// ---------------------------------------------------------------------------
+// 3. Run `yarn npm audit` and parse Berry's tree output
+//    Berry emits newline-delimited JSON (NDJSON) or a single JSON object.
+//    Each advisory appears as a leaf node in the package tree.
+// ---------------------------------------------------------------------------
+
+interface AuditLeaf {
+  ID?: number;
+  Issue?: string;
+  URL?: string;
+  Severity?: string;
+  'Vulnerable Versions'?: string;
+  'Tree Versions'?: string[];
+}
+
+function isAuditLeaf(v: unknown): v is AuditLeaf {
+  if (!v || typeof v !== 'object') return false;
+  const obj = v as Record<string, unknown>;
+  return typeof obj.Issue === 'string' && typeof obj.Severity === 'string';
+}
+
+function collectLeaves(
+  node: unknown,
+  moduleName: string | null,
+  out: Array<{ moduleName: string; leaf: AuditLeaf }>,
+): void {
+  if (isAuditLeaf(node)) {
+    out.push({ moduleName: moduleName ?? 'unknown', leaf: node });
+    return;
+  }
+  if (Array.isArray(node)) {
+    for (const item of node) {
+      collectLeaves(item, moduleName, out);
+    }
+    return;
+  }
+  if (!node || typeof node !== 'object') return;
+
+  const rec = node as Record<string, unknown>;
+  // Berry's tree node: { value: "pkg-name@version", children: [...] }
+  if (typeof rec.value === 'string' && 'children' in rec) {
+    collectLeaves(rec.children, rec.value, out);
+    return;
+  }
+  for (const val of Object.values(rec)) {
+    collectLeaves(val, moduleName, out);
+  }
+}
+
+function parseJsonOrNdjson(text: string): unknown[] {
+  const trimmed = text.trim();
+  if (!trimmed) return [];
+  try {
+    return [JSON.parse(trimmed) as unknown];
+  } catch {
+    // Fall through to NDJSON
+  }
+  return trimmed
+    .split('\n')
+    .filter(Boolean)
+    .flatMap((line) => {
+      try {
+        return [JSON.parse(line) as unknown];
+      } catch {
+        return [];
+      }
+    });
+}
+
+interface AuditEntry {
+  moduleName: string;
+  id: number | null;
+  title: string;
+  url: string;
+  severity: string;
+}
+
+function runAudit(): AuditEntry[] {
+  console.log('Running yarn npm audit …');
+  // Yarn exits non-zero when vulnerabilities are found — that is expected.
+  const res = spawnSync(
+    'yarn npm audit --recursive --environment production --severity moderate --json',
+    { encoding: 'utf8', shell: true },
+  );
+  const text = `${res.stdout ?? ''}\n${res.stderr ?? ''}`;
+  const records = parseJsonOrNdjson(text);
+
+  const leaves: Array<{ moduleName: string; leaf: AuditLeaf }> = [];
+  for (const record of records) {
+    collectLeaves(record, null, leaves);
+  }
+
+  return leaves.map(({ moduleName, leaf }) => ({
+    // moduleName comes from the parent tree node's `value` field, e.g. "pkg@1.0.0"
+    // Strip the version suffix to get the bare package name.
+    moduleName: moduleName.replace(/@\d.*$/u, '').replace(/@npm:.*/u, ''),
+    id: typeof leaf.ID === 'number' ? leaf.ID : null,
+    title: leaf.Issue ?? '(unknown)',
+    url: leaf.URL ?? '',
+    severity: leaf.Severity ?? 'unknown',
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// 4. Installed version helper — reads from node_modules
+// ---------------------------------------------------------------------------
+
+function getInstalledVersion(name: string): string | null {
+  const p = `node_modules/${name}/package.json`;
+  if (!existsSync(p)) return null;
+  try {
+    return (
+      (JSON.parse(readFileSync(p, 'utf8')) as { version?: string }).version ??
+      null
+    );
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 5. GitHub Actions step summary helper
+// ---------------------------------------------------------------------------
+
+function writeStepSummary(text: string): void {
+  const path = process.env.GITHUB_STEP_SUMMARY;
+  if (!path) return;
+  try {
+    appendFileSync(path, text, 'utf8');
+  } catch {
+    // Non-fatal
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 6. Report generators
+// ---------------------------------------------------------------------------
+
+function workflowRunUrl(): string {
+  const { GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID } = process.env;
+  if (GITHUB_SERVER_URL && GITHUB_REPOSITORY && GITHUB_RUN_ID) {
+    return `${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}`;
+  }
+  return '(workflow run URL unavailable)';
+}
+
+function advisoryLink(url: string, title: string): string {
+  return url ? `[${title}](${url})` : title;
+}
+
+function buildPrBody(results: PackageResult[], date: string): string {
+  const runUrl = workflowRunUrl();
+  const updated = results.filter((r) => r.status === 'updated');
+  const skippedPatched = results.filter((r) => r.status === 'skipped-patched');
+  const skippedMajor = results.filter((r) => r.status === 'skipped-major');
+  const failed = results.filter((r) => r.status === 'failed');
+
+  let body = `## Automated Security Dependency Update — ${date}
+
+This PR was opened automatically by the [automated-security-dep-update](${runUrl}) workflow.
+
+It updates npm packages with known CVEs to the **latest patch/minor version within their current major**, keeping lockfile and resolution changes minimal. Major version bumps, patched packages, and pinned-exact packages are skipped and listed below.
+
+> **Review, then remove the Draft status to trigger full CI** (lint, unit tests, build, E2E). The workflow itself skips E2E — they run normally on this PR.
+
+---
+
+## ✅ Updated Packages
+
+`;
+
+  if (updated.length === 0) {
+    body += '_No packages were updated._\n\n';
+  } else {
+    body +=
+      '| Package | Old Version | New Version | Advisory ID(s) | Issue |\n';
+    body +=
+      '|---------|------------|------------|----------------|-------|\n';
+    for (const r of updated) {
+      const idsStr = r.advisoryIds.join(', ') || '—';
+      const issueSummary = r.advisoryUrls.length > 0
+        ? r.advisoryUrls
+            .map((u, i) => advisoryLink(u, r.advisoryTitles[i] ?? 'Advisory'))
+            .join(', ')
+        : r.advisoryTitles.join(', ') || '—';
+      body += `| \`${r.name}\` | \`${r.oldVersion ?? '?'}\` | \`${r.newVersion ?? '?'}\` | ${idsStr} | ${issueSummary} |\n`;
+    }
+    body += '\n';
+  }
+
+  // --- Manual attention section ---
+  const hasManual =
+    skippedPatched.length > 0 || skippedMajor.length > 0 || failed.length > 0;
+
+  if (hasManual) {
+    body += `---\n\n## ⚠️ Packages Requiring Manual Attention\n\nThe following vulnerabilities were **not automatically fixed**.\n\n`;
+
+    if (skippedPatched.length > 0) {
+      body += `### Packages with local \`.yarn/patches/\` patches\n\nThese packages have hand-crafted patch files in \`.yarn/patches/\`. Upgrading them requires updating or removing the patch first.\n\n`;
+      body +=
+        '| Package | Installed Version | Advisory ID(s) | Issue |\n';
+      body +=
+        '|---------|------------------|----------------|-------|\n';
+      for (const r of skippedPatched) {
+        const idsStr = r.advisoryIds.join(', ') || '—';
+        const issueSummary = r.advisoryUrls.length > 0
+          ? r.advisoryUrls
+              .map((u, i) =>
+                advisoryLink(u, r.advisoryTitles[i] ?? 'Advisory'),
+              )
+              .join(', ')
+          : r.advisoryTitles.join(', ') || '—';
+        body += `| \`${r.name}\` | \`${r.oldVersion ?? '?'}\` | ${idsStr} | ${issueSummary} |\n`;
+      }
+      body += '\n';
+    }
+
+    if (skippedMajor.length > 0) {
+      body += `### Packages requiring a major version bump\n\nThe security fix for these packages is only available in a newer major version, which may introduce breaking changes.\n\n`;
+      body +=
+        '| Package | Installed Version | Advisory ID(s) | Reason |\n';
+      body +=
+        '|---------|------------------|----------------|--------|\n';
+      for (const r of skippedMajor) {
+        const idsStr = r.advisoryIds.join(', ') || '—';
+        body += `| \`${r.name}\` | \`${r.oldVersion ?? '?'}\` | ${idsStr} | ${r.reason ?? '—'} |\n`;
+      }
+      body += '\n';
+    }
+
+    if (failed.length > 0) {
+      body += `### Failed updates\n\n| Package | Reason |\n|---------|--------|\n`;
+      for (const r of failed) {
+        body += `| \`${r.name}\` | ${r.reason ?? 'Unknown error'} |\n`;
+      }
+      body += '\n';
+    }
+  }
+
+  body += `---\n\n## Pre-merge checklist\n\n- [ ] CI passes (lint, unit tests, build, E2E)\n- [ ] Reviewed the "Packages Requiring Manual Attention" section above\n- [ ] \`yarn.lock\` changes look as expected (no unrelated major version jumps)\n\n`;
+  body += `---\n\n_Auto-generated by the [automated-security-dep-update](${runUrl}) workflow · ${date}_\n`;
+
+  return body;
+}
+
+function buildFailureReport(results: PackageResult[], date: string): string {
+  const runUrl = workflowRunUrl();
+  const updated = results.filter((r) => r.status === 'updated');
+
+  let body = `## Automated Security Dependency Update — Failed (${date})
+
+The [automated-security-dep-update](${runUrl}) workflow ran on ${date} but **could not open a PR** because one or more validation steps failed. No branch was pushed.
+
+**Workflow run (full logs):** ${runUrl}
+
+---
+
+## Packages Attempted
+
+`;
+
+  if (updated.length === 0) {
+    body += '_No packages were updated before the failure._\n\n';
+  } else {
+    body += '| Package | Old Version | New Version | Advisory ID(s) |\n';
+    body += '|---------|------------|------------|----------------|\n';
+    for (const r of updated) {
+      body += `| \`${r.name}\` | \`${r.oldVersion ?? '?'}\` | \`${r.newVersion ?? '?'}\` | ${r.advisoryIds.join(', ') || '—'} |\n`;
+    }
+    body += '\n';
+  }
+
+  // Workflow will append step outcomes after this marker
+  body += `---\n\n`;
+
+  body += `## How to Investigate\n\n1. Open the [workflow run](${runUrl}) and click the failing step to see the full log\n2. Cross-reference the failing step with the "Packages Attempted" table above — the most recently updated package is the likely culprit\n3. To retry without a specific package, edit the script's skip list or revert that package's \`yarn up\` change\n4. Trigger a fresh run via \`workflow_dispatch\` once the issue is resolved\n\n`;
+  body += `---\n\n_Auto-generated by the [automated-security-dep-update](${runUrl}) workflow · ${date}_\n`;
+
+  return body;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  mkdirSync('.tmp', { recursive: true });
+
+  const date = new Date().toISOString().split('T')[0] ?? 'unknown';
+  const dryRun = process.env.DRY_RUN === 'true';
+
+  if (dryRun) {
+    console.log('🔍 DRY RUN — vulnerabilities will be detected and reported but NO packages will be updated.\n');
+  }
+
+  const pkgJson = JSON.parse(
+    readFileSync('package.json', 'utf8'),
+  ) as PackageJson;
+
+  const patchedPackages = getPatchedPackages(pkgJson);
+  const ignoredIds = getIgnoredAdvisoryIds();
+
+  console.log(
+    `Patched packages (skipped): ${[...patchedPackages].join(', ') || 'none'}`,
+  );
+  console.log(
+    `Ignored advisory IDs:       ${[...ignoredIds].join(', ') || 'none'}`,
+  );
+
+  // Run audit
+  const allEntries = runAudit();
+
+  if (allEntries.length === 0) {
+    console.log('\n✅ No vulnerabilities found. Nothing to do.');
+    core.setOutput('packages_updated', '0');
+    core.setOutput('update_summary', 'No vulnerable packages found.');
+    writeStepSummary('## ✅ No vulnerabilities found\n\nThe `yarn npm audit` found no moderate+ severity production advisories.\n');
+    return;
+  }
+
+  // Group advisories by package name
+  const byModule = new Map<string, AuditEntry[]>();
+  for (const entry of allEntries) {
+    const existing = byModule.get(entry.moduleName) ?? [];
+    existing.push(entry);
+    byModule.set(entry.moduleName, existing);
+  }
+
+  // Remove packages whose only remaining advisories are in the ignore list
+  for (const [name, entries] of byModule.entries()) {
+    const active = entries.filter(
+      (e) => e.id === null || !ignoredIds.has(e.id),
+    );
+    if (active.length === 0) {
+      byModule.delete(name);
+    } else {
+      byModule.set(name, active);
+    }
+  }
+
+  console.log(
+    `\nActive vulnerable packages (after filtering ignored): ${byModule.size}`,
+  );
+
+  if (byModule.size === 0) {
+    console.log('All found advisories are in the ignore list. Nothing to do.');
+    core.setOutput('packages_updated', '0');
+    core.setOutput(
+      'update_summary',
+      'All vulnerabilities are in the .yarnrc.yml ignore list.',
+    );
+    writeStepSummary(
+      '## ✅ No actionable vulnerabilities\n\nAll advisories found by `yarn npm audit` are in the `npmAuditIgnoreAdvisories` ignore list in `.yarnrc.yml`.\n',
+    );
+    return;
+  }
+
+  const results: PackageResult[] = [];
+
+  for (const [name, entries] of byModule.entries()) {
+    const advisoryIds = [
+      ...new Set(
+        entries
+          .map((e) => e.id)
+          .filter((id): id is number => id !== null),
+      ),
+    ];
+    const advisoryTitles = [...new Set(entries.map((e) => e.title))];
+    const advisoryUrls = [
+      ...new Set(entries.map((e) => e.url).filter(Boolean)),
+    ];
+
+    console.log(`\nProcessing: ${name}`);
+
+    // Skip packages with a local patch
+    if (patchedPackages.has(name)) {
+      console.log(`  ⚠️  Skipping — has a .yarn/patches/ patch applied`);
+      results.push({
+        name,
+        oldVersion: getInstalledVersion(name),
+        newVersion: null,
+        status: 'skipped-patched',
+        advisoryIds,
+        advisoryTitles,
+        advisoryUrls,
+        reason:
+          'Has a `.yarn/patches/` patch applied — requires manual update to avoid breaking the patch',
+      });
+      continue;
+    }
+
+    const oldVersion = getInstalledVersion(name);
+    console.log(
+      `  Installed version: ${oldVersion ?? '(not found in node_modules)'}`,
+    );
+
+    if (!oldVersion) {
+      console.log(`  ⚠️  Cannot determine installed version — skipping`);
+      results.push({
+        name,
+        oldVersion: null,
+        newVersion: null,
+        status: 'failed',
+        advisoryIds,
+        advisoryTitles,
+        advisoryUrls,
+        reason:
+          'Could not determine installed version from node_modules — package may be transitive-only or not installed',
+      });
+      continue;
+    }
+
+    const currentMajor = semver.major(oldVersion);
+
+    if (dryRun) {
+      console.log(
+        `  DRY RUN — would run: yarn up "${name}@^${currentMajor}"`,
+      );
+      // In dry run we record the current state for the report without updating
+      results.push({
+        name,
+        oldVersion,
+        newVersion: '(dry run — not updated)',
+        status: 'updated',
+        advisoryIds,
+        advisoryTitles,
+        advisoryUrls,
+        reason: 'DRY RUN — no changes applied',
+      });
+      continue;
+    }
+
+    // Attempt patch/minor update, constrained to the current major
+    // `yarn up "pkg@^M"` resolves to the latest M.x.x satisfying any existing
+    // package.json range. The `^M` constraint prevents unintentional major bumps.
+    const upgradeCmd = `yarn up "${name}@^${currentMajor}"`;
+    console.log(`  Running: ${upgradeCmd}`);
+    const { ok, output } = run(upgradeCmd, { silent: true });
+
+    if (!ok) {
+      console.log(`  ❌ yarn up failed`);
+      results.push({
+        name,
+        oldVersion,
+        newVersion: null,
+        status: 'failed',
+        advisoryIds,
+        advisoryTitles,
+        advisoryUrls,
+        reason: `\`yarn up\` exited non-zero: ${output.slice(0, 300)}`,
+      });
+      continue;
+    }
+
+    const newVersion = getInstalledVersion(name);
+
+    if (!newVersion || newVersion === oldVersion) {
+      // Version unchanged — already at the latest patch/minor in this major.
+      // The CVE fix may only be available in a new major version.
+      console.log(
+        `  ℹ️  Version unchanged (${oldVersion}) — fix may require a major bump`,
+      );
+      results.push({
+        name,
+        oldVersion,
+        newVersion: null,
+        status: 'skipped-major',
+        advisoryIds,
+        advisoryTitles,
+        advisoryUrls,
+        reason: `Already at latest v${currentMajor}.x.x — the CVE fix may only be available in v${currentMajor + 1}+`,
+      });
+      continue;
+    }
+
+    console.log(`  ✅ ${oldVersion} → ${newVersion}`);
+    results.push({
+      name,
+      oldVersion,
+      newVersion,
+      status: 'updated',
+      advisoryIds,
+      advisoryTitles,
+      advisoryUrls,
+    });
+  }
+
+  // Count real updates (excluding dry-run placeholders)
+  const updatedCount = dryRun
+    ? 0
+    : results.filter((r) => r.status === 'updated').length;
+
+  // Write reports
+  const prBody = buildPrBody(results, date);
+  const failureReport = buildFailureReport(results, date);
+
+  writeFileSync('.tmp/pr-body.md', prBody, 'utf8');
+  writeFileSync('.tmp/failure-report.md', failureReport, 'utf8');
+
+  // Write step summary (visible in GitHub Actions UI)
+  writeStepSummary(prBody);
+
+  // Print summary
+  console.log('\n=== Update Summary ===');
+  console.log(
+    `  Updated:                   ${results.filter((r) => r.status === 'updated').length}`,
+  );
+  console.log(
+    `  Skipped (patched):         ${results.filter((r) => r.status === 'skipped-patched').length}`,
+  );
+  console.log(
+    `  Skipped (major bump only): ${results.filter((r) => r.status === 'skipped-major').length}`,
+  );
+  console.log(
+    `  Failed:                    ${results.filter((r) => r.status === 'failed').length}`,
+  );
+
+  core.setOutput('packages_updated', String(updatedCount));
+  core.setOutput(
+    'update_summary',
+    `Updated ${updatedCount} package(s) to fix CVEs; ` +
+      `${results.filter((r) => r.status === 'skipped-patched').length} patched package(s) skipped (manual attention needed); ` +
+      `${results.filter((r) => r.status === 'skipped-major').length} require major bumps`,
+  );
+}
+
+main().catch((error: unknown) => {
+  console.error('Fatal error in security-dep-update script:', error);
+  process.exit(1);
+});

--- a/.github/workflows/automated-security-dep-update.yml
+++ b/.github/workflows/automated-security-dep-update.yml
@@ -1,0 +1,334 @@
+# Automated Security Dependency Update
+# ======================================
+# Scans for vulnerable npm packages, updates them to the latest patch/minor
+# version within their current major, verifies the build, and:
+#
+#   ALL PASS  → creates a DRAFT PR against main with a full change report
+#   ANY FAIL  → opens a GitHub Issue with diagnostics for manual follow-up
+#
+# Triggers:
+#   - Scheduled: 1st and 15th of every month at 08:00 UTC
+#   - Manual:    workflow_dispatch (supports dry_run mode)
+#
+# What is skipped:
+#   - Packages with a local .yarn/patches/ patch (would break the patch)
+#   - Packages where the CVE fix requires a major version bump
+#   - Advisory IDs listed in npmAuditIgnoreAdvisories in .yarnrc.yml
+#   - E2E tests (run by CI on the resulting PR instead)
+#
+# Token note:
+#   Uses a GitHub App token so that CI workflows trigger automatically on the
+#   resulting PR.  GITHUB_TOKEN-created PRs do NOT trigger other Actions.
+#   Requires TOKEN_EXCHANGE_URL to be set at the repo/org level
+#   (same pattern as update-lavamoat-policies.yml).
+#
+# See ".github/AGENTS.md" → "Automated Security Dependency Update" for
+# operational guidance.
+
+name: Automated Security Dependency Update
+
+on:
+  schedule:
+    # Biweekly: 1st and 15th of every month at 08:00 UTC.
+    - cron: '0 8 1,15 * *'
+
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: >-
+          Dry run — scan and report vulnerabilities without updating packages,
+          pushing a branch, or opening a PR / issue.
+        type: boolean
+        required: false
+        default: false
+
+# Minimum default permissions; each job explicitly elevates what it needs.
+permissions:
+  contents: read
+
+jobs:
+  security-dep-update:
+    name: Detect and remediate vulnerable dependencies
+    runs-on: ubuntu-latest
+    # Allow up to 90 min: yarn lavamoat:auto alone can take ~20-30 min,
+    # and yarn test:unit across all shards can take another 20+ min.
+    timeout-minutes: 90
+
+    permissions:
+      contents: write      # create a branch and push commits
+      pull-requests: write # open a DRAFT PR
+      issues: write        # open a failure issue
+      id-token: write      # exchange OIDC token for a GitHub App token
+
+    steps:
+      # -----------------------------------------------------------------------
+      # Auth
+      # Obtain a GitHub App token so that CI workflows trigger automatically on
+      # the resulting PR.  GITHUB_TOKEN cannot do this — it is excluded from
+      # triggering other Actions by GitHub's security model.
+      # -----------------------------------------------------------------------
+      - name: Get GitHub App token
+        id: token
+        uses: MetaMask/github-tools/.github/actions/get-token@v1
+        with:
+          token-exchange-url: ${{ vars.TOKEN_EXCHANGE_URL }}
+          permissions: |
+            contents: write
+            pull_requests: write
+            issues: write
+
+      # -----------------------------------------------------------------------
+      # Checkout + setup
+      # MetaMask/action-checkout-and-setup handles Node (from .nvmrc),
+      # Yarn 4 via Corepack, and dependency caching.
+      # skip-allow-scripts: true avoids running install scripts during setup
+      # (they are re-evaluated after dep changes by `yarn allow-scripts auto`).
+      # -----------------------------------------------------------------------
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v3
+        with:
+          is-high-risk-environment: false
+          skip-allow-scripts: true
+
+      # -----------------------------------------------------------------------
+      # Configure git so the automated commit is attributed to the Actions bot
+      # and pushes are authenticated via the App token.
+      # -----------------------------------------------------------------------
+      - name: Configure git author and remote
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin \
+            "https://x-access-token:${{ steps.token.outputs.token }}@github.com/${{ github.repository }}.git"
+
+      # -----------------------------------------------------------------------
+      # Detect + update
+      # Runs .github/scripts/security-dep-update.mts which:
+      #   1. Parses npmAuditIgnoreAdvisories from .yarnrc.yml
+      #   2. Detects packages with patch: resolutions (skips them safely)
+      #   3. Runs `yarn npm audit` to find moderate+ production CVEs
+      #   4. For each actionable package: `yarn up "pkg@^currentMajor"`
+      #   5. Writes .tmp/pr-body.md and .tmp/failure-report.md
+      #   6. Sets GITHUB_OUTPUT: packages_updated, update_summary
+      #
+      # packages_updated = 0 → nothing to do → all later steps are skipped.
+      # -----------------------------------------------------------------------
+      - name: Detect and apply security updates
+        id: detect-update
+        run: yarn tsx .github/scripts/security-dep-update.mts
+        env:
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
+
+      # -----------------------------------------------------------------------
+      # Update-phase steps
+      # These modify files (yarn.lock, policy files, attribution.txt, etc.).
+      # Any failure here causes the job to fail; the "Open failure issue" step
+      # at the end catches this via failure() in its condition.
+      # -----------------------------------------------------------------------
+
+      - name: Verify lockfile consistency
+        id: verify-install
+        if: steps.detect-update.outputs.packages_updated != '0'
+        # --immutable fails if yarn install would change the lockfile,
+        # catching any inconsistency introduced by yarn up.
+        run: yarn install --immutable
+
+      - name: Deduplicate lockfile
+        id: dedupe
+        if: steps.detect-update.outputs.packages_updated != '0'
+        run: yarn dedupe
+
+      - name: Update install-script allowlist
+        id: allow-scripts
+        if: steps.detect-update.outputs.packages_updated != '0'
+        # LavaMoat's allow-scripts plugin tracks which packages are permitted
+        # to run install scripts. Must be re-run after any dep change.
+        run: yarn allow-scripts auto
+
+      - name: Regenerate LavaMoat policies
+        id: lavamoat
+        if: steps.detect-update.outputs.packages_updated != '0'
+        # Updates lavamoat/browserify/*/policy.json and
+        # lavamoat/build-system/policy.json.  Can take up to 30 minutes.
+        timeout-minutes: 30
+        run: yarn lavamoat:auto
+
+      - name: Regenerate attribution file
+        id: attributions
+        if: steps.detect-update.outputs.packages_updated != '0'
+        run: yarn attributions:generate
+
+      - name: Auto-fix lint on changed files
+        id: lint-fix
+        if: steps.detect-update.outputs.packages_updated != '0'
+        # oxfmt + ESLint + Stylelint auto-fix on only the changed files so the
+        # committed code is clean without running the full (multi-minute) lint.
+        run: yarn lint:changed:fix
+
+      # -----------------------------------------------------------------------
+      # Validation-phase steps
+      # These are read-only checks that determine whether to open a PR or issue.
+      # continue-on-error: true ensures all three run so we can report every
+      # failure at once rather than stopping at the first one.
+      # -----------------------------------------------------------------------
+
+      - name: TypeScript type-check
+        id: lint-tsc
+        if: steps.detect-update.outputs.packages_updated != '0'
+        continue-on-error: true
+        run: yarn lint:tsc
+
+      - name: Unit tests
+        id: unit-tests
+        if: steps.detect-update.outputs.packages_updated != '0'
+        continue-on-error: true
+        run: yarn test:unit
+
+      - name: Production build
+        id: build
+        if: steps.detect-update.outputs.packages_updated != '0'
+        continue-on-error: true
+        # yarn dist uses Browserify + LavaMoat (matches production).
+        # If this passes, the extension is confirmed buildable with the new deps.
+        run: yarn dist
+
+      # -----------------------------------------------------------------------
+      # Outcome reporting
+      # Appends validation step outcomes to .tmp/failure-report.md so the issue
+      # body is complete whether the failure occurred in the update phase or the
+      # validation phase.  Runs with if: always() so it executes in both paths.
+      # -----------------------------------------------------------------------
+      - name: Write validation outcomes to failure report
+        id: write-outcomes
+        if: >-
+          ${{
+            always() &&
+            steps.detect-update.outcome == 'success' &&
+            steps.detect-update.outputs.packages_updated != '0'
+          }}
+        env:
+          VERIFY_OUTCOME: ${{ steps.verify-install.outcome }}
+          DEDUPE_OUTCOME: ${{ steps.dedupe.outcome }}
+          ALLOW_SCRIPTS_OUTCOME: ${{ steps.allow-scripts.outcome }}
+          LAVAMOAT_OUTCOME: ${{ steps.lavamoat.outcome }}
+          ATTRIBUTIONS_OUTCOME: ${{ steps.attributions.outcome }}
+          LINT_FIX_OUTCOME: ${{ steps.lint-fix.outcome }}
+          LINT_TSC_OUTCOME: ${{ steps.lint-tsc.outcome }}
+          UNIT_TESTS_OUTCOME: ${{ steps.unit-tests.outcome }}
+          BUILD_OUTCOME: ${{ steps.build.outcome }}
+        run: |
+          write_outcome() {
+            local label="$1" outcome="$2"
+            case "$outcome" in
+              success) icon="✅" ;;
+              failure) icon="❌" ;;
+              skipped) icon="⏭️" ;;
+              *)        icon="❓" ;;
+            esac
+            echo "- ${icon} **${label}**: \`${outcome}\`"
+          }
+
+          {
+            echo ""
+            echo "## Validation Step Results"
+            echo ""
+            write_outcome "Verify lockfile (yarn install --immutable)" "$VERIFY_OUTCOME"
+            write_outcome "Deduplicate lockfile (yarn dedupe)"         "$DEDUPE_OUTCOME"
+            write_outcome "Update allow-scripts"                        "$ALLOW_SCRIPTS_OUTCOME"
+            write_outcome "Regenerate LavaMoat policies"                "$LAVAMOAT_OUTCOME"
+            write_outcome "Regenerate attribution file"                 "$ATTRIBUTIONS_OUTCOME"
+            write_outcome "Auto-fix lint (yarn lint:changed:fix)"       "$LINT_FIX_OUTCOME"
+            write_outcome "TypeScript type-check (yarn lint:tsc)"       "$LINT_TSC_OUTCOME"
+            write_outcome "Unit tests (yarn test:unit)"                 "$UNIT_TESTS_OUTCOME"
+            write_outcome "Production build (yarn dist)"                "$BUILD_OUTCOME"
+          } >> .tmp/failure-report.md
+
+      # -----------------------------------------------------------------------
+      # SUCCESS PATH
+      # All three validation steps passed → commit all changes, push a new
+      # branch, and open a DRAFT PR against main.
+      # -----------------------------------------------------------------------
+      - name: Create branch and open DRAFT PR
+        if: >-
+          ${{
+            steps.detect-update.outputs.packages_updated != '0' &&
+            steps.lint-tsc.outcome == 'success' &&
+            steps.unit-tests.outcome == 'success' &&
+            steps.build.outcome == 'success' &&
+            inputs.dry_run != 'true'
+          }}
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+          BRANCH="refactor/deps-security-update-${DATE}"
+
+          git checkout -b "$BRANCH"
+          git add -A
+          git commit -m "fix(deps): automated security dependency updates ${DATE}
+
+          Updated vulnerable npm packages to the latest patch/minor version
+          within their current major. See PR description for the full list
+          of changed packages and fixed CVEs.
+
+          Generated by the automated-security-dep-update workflow."
+
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --repo "$GITHUB_REPOSITORY" \
+            --draft \
+            --title "fix(deps): automated security dependency updates ${DATE}" \
+            --body-file .tmp/pr-body.md \
+            --base main
+
+          echo "✅ Draft PR created for branch ${BRANCH}"
+
+      # -----------------------------------------------------------------------
+      # FAILURE PATH
+      # Any update-phase step failed (failure()) OR any validation step failed
+      # (outcome == 'failure') → open a GitHub Issue with the failure report.
+      # No branch is pushed; the issue points to the workflow run for details.
+      # -----------------------------------------------------------------------
+      - name: Open failure issue
+        if: >-
+          ${{
+            always() &&
+            steps.detect-update.outcome == 'success' &&
+            steps.detect-update.outputs.packages_updated != '0' &&
+            inputs.dry_run != 'true' &&
+            (
+              failure() ||
+              steps.lint-tsc.outcome    == 'failure' ||
+              steps.unit-tests.outcome  == 'failure' ||
+              steps.build.outcome       == 'failure'
+            )
+          }}
+        env:
+          GH_TOKEN: ${{ steps.token.outputs.token }}
+        run: |
+          DATE=$(date -u +%Y-%m-%d)
+
+          # Ensure the failure report file exists even if the workflow
+          # failed before the update script could write it.
+          if [ ! -f .tmp/failure-report.md ]; then
+            mkdir -p .tmp
+            RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            cat > .tmp/failure-report.md <<EOF
+          ## Automated Security Dependency Update — Failed (${DATE})
+
+          The workflow failed before generating a detailed report.
+
+          **Workflow run (full logs):** ${RUN_URL}
+          EOF
+          fi
+
+          gh issue create \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "Automated security dep update failed — ${DATE}" \
+            --body-file .tmp/failure-report.md
+
+          echo "❌ Failure issue created. No PR was opened."


### PR DESCRIPTION
Adds a biweekly GitHub Actions workflow that scans for vulnerable npm packages via `yarn npm audit`, updates each to the latest patch/minor version within its current major, runs the full post-dep-change chain (LavaMoat, allow-scripts, attributions, lint, unit tests, build), and either opens a DRAFT PR on success or a GitHub Issue on failure.

Key design decisions:
- Uses GitHub App token (TOKEN_EXCHANGE_URL) so CI triggers on the PR
- Respects npmAuditIgnoreAdvisories from .yarnrc.yml
- Skips packages with .yarn/patches/ entries to avoid breaking patches
- Constrains updates to ^currentMajor to prevent accidental major bumps
- Detects "needs major bump" vs "already fixed" vs "actually updated"
- Runs on cron (1st/15th at 08:00 UTC) and supports workflow_dispatch with a dry_run option for scanning without making changes

Companion script: .github/scripts/security-dep-update.mts
Docs: .github/AGENTS.md → "Automated Security Dependency Update"

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Automation can push lockfile, LavaMoat policy, and attribution changes and uses elevated write permissions; failures are gated on tsc/unit/dist but LavaMoat and long-running steps add operational risk.
> 
> **Overview**
> Adds **biweekly automated CVE remediation** via a new scheduled GitHub Actions workflow and a companion TypeScript script.
> 
> The workflow runs on the 1st and 15th at 08:00 UTC (plus `workflow_dispatch` with optional **dry run**). It uses a **GitHub App token** (`TOKEN_EXCHANGE_URL`) so CI runs on the draft PR it creates. The script runs `yarn npm audit`, honors `npmAuditIgnoreAdvisories` and **skips** packages with `.yarn/patches/` or fixes that need a **major** bump, then runs `yarn up` constrained to `^currentMajor`. If any packages change, the workflow runs the usual post-dep chain (immutable install, dedupe, allow-scripts, LavaMoat, attributions, lint fix) and validates with `lint:tsc`, unit tests, and `yarn dist`.
> 
> **Success** opens a draft PR on `refactor/deps-security-update-YYYY-MM-DD` with a detailed report; **failure** opens a GitHub issue with step outcomes (no branch). E2E is deferred to CI on the PR. **`.github/AGENTS.md`** documents operations and how to read PR/issue output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cc13394b75c54773dbf31ed5b3125bb89deb87b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->