### PR TITLE
fix: [STELLAR]  - send recipient picker

### DIFF
--- a/ui/pages/confirmations/hooks/send/useAccountRecipients.test.ts
+++ b/ui/pages/confirmations/hooks/send/useAccountRecipients.test.ts
@@ -35,6 +35,9 @@ const mockIsSolanaAccountForSend = jest.mocked(
 const mockIsBitcoinAccountForSend = jest.mocked(
   accountUtils.isBitcoinAccountForSend,
 );
+const mockIsStellarAccountForSend = jest.mocked(
+  accountUtils.isStellarAccountForSend,
+);
 
 describe('useAccountRecipients', () => {
   const mockWalletsWithAccounts = {
@@ -118,6 +121,40 @@ describe('useAccountRecipients', () => {
     } as unknown as ReturnType<typeof useSendType>);
     mockIsEVMAccountForSend.mockReturnValue(false);
     mockIsSolanaAccountForSend.mockReturnValue(true);
+
+    const { result } = renderHookWithProvider(
+      () => useAccountRecipients(),
+      mockState,
+    );
+
+    expect(result.current).toEqual([
+      {
+        accountGroupName: 'Account Group 1',
+        address: '0x1234567890abcdef1234567890abcdef12345678',
+        walletName: 'MetaMask Wallet',
+      },
+      {
+        accountGroupName: 'Account Group 1',
+        address: '0xabcdef1234567890abcdef1234567890abcdef12',
+        walletName: 'MetaMask Wallet',
+      },
+      {
+        accountGroupName: 'Account Group 2',
+        address: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty',
+        walletName: 'Hardware Wallet',
+      },
+    ]);
+  });
+
+  it('returns Stellar account recipients when isStellarSendType is true', () => {
+    mockUseSendType.mockReturnValue({
+      isEvmSendType: false,
+      isSolanaSendType: false,
+      isStellarSendType: true,
+    } as unknown as ReturnType<typeof useSendType>);
+    mockIsEVMAccountForSend.mockReturnValue(false);
+    mockIsSolanaAccountForSend.mockReturnValue(false);
+    mockIsStellarAccountForSend.mockReturnValue(true);
 
     const { result } = renderHookWithProvider(
       () => useAccountRecipients(),

--- a/ui/pages/confirmations/hooks/send/useAccountRecipients.ts
+++ b/ui/pages/confirmations/hooks/send/useAccountRecipients.ts
@@ -6,6 +6,7 @@ import {
   isBitcoinAccountForSend,
   isEVMAccountForSend,
   isSolanaAccountForSend,
+  isStellarAccountForSend,
   isTronAccountForSend,
 } from '../../utils/account';
 import { useSendContext } from '../../context/send';
@@ -14,8 +15,13 @@ import { useSendType } from './useSendType';
 import { useAccountAddressSeedIconMap } from './useAccountAddressSeedIconMap';
 
 export const useAccountRecipients = (): Recipient[] => {
-  const { isEvmSendType, isSolanaSendType, isBitcoinSendType, isTronSendType } =
-    useSendType();
+  const {
+    isEvmSendType,
+    isSolanaSendType,
+    isBitcoinSendType,
+    isTronSendType,
+    isStellarSendType,
+  } = useSendType();
   const { from } = useSendContext();
   const { accountAddressSeedIconMap } = useAccountAddressSeedIconMap();
 
@@ -39,7 +45,8 @@ export const useAccountRecipients = (): Recipient[] => {
             (isEvmSendType && isEVMAccountForSend(account)) ||
             (isSolanaSendType && isSolanaAccountForSend(account)) ||
             (isBitcoinSendType && isBitcoinAccountForSend(account)) ||
-            (isTronSendType && isTronAccountForSend(account));
+            (isTronSendType && isTronAccountForSend(account)) ||
+            (isStellarSendType && isStellarAccountForSend(account));
 
           if (shouldInclude) {
             recipients.push({
@@ -63,6 +70,7 @@ export const useAccountRecipients = (): Recipient[] => {
     isSolanaSendType,
     isBitcoinSendType,
     isTronSendType,
+    isStellarSendType,
     accountAddressSeedIconMap,
     walletsWithAccounts,
   ]);

--- a/ui/pages/confirmations/hooks/send/useSendType.test.ts
+++ b/ui/pages/confirmations/hooks/send/useSendType.test.ts
@@ -39,6 +39,7 @@ describe('useSendType', () => {
       isNonEvmNativeSendType: false,
       isNonEvmSendType: false,
       isSolanaSendType: false,
+      isStellarSendType: false,
       isTronSendType: false,
     });
   });
@@ -56,6 +57,7 @@ describe('useSendType', () => {
       isNonEvmNativeSendType: false,
       isNonEvmSendType: false,
       isSolanaSendType: false,
+      isStellarSendType: false,
       isTronSendType: false,
     });
   });
@@ -73,6 +75,7 @@ describe('useSendType', () => {
       isNonEvmNativeSendType: false,
       isNonEvmSendType: false,
       isSolanaSendType: false,
+      isStellarSendType: false,
       isTronSendType: false,
     });
   });
@@ -90,6 +93,7 @@ describe('useSendType', () => {
       isNonEvmNativeSendType: true,
       isNonEvmSendType: true,
       isSolanaSendType: true,
+      isStellarSendType: false,
       isTronSendType: false,
     });
   });
@@ -107,6 +111,7 @@ describe('useSendType', () => {
       isNonEvmNativeSendType: false,
       isNonEvmSendType: true,
       isSolanaSendType: true,
+      isStellarSendType: false,
       isTronSendType: false,
     });
   });
@@ -124,6 +129,7 @@ describe('useSendType', () => {
       isNonEvmNativeSendType: true,
       isNonEvmSendType: true,
       isSolanaSendType: false,
+      isStellarSendType: false,
       isTronSendType: false,
     });
   });

--- a/ui/pages/confirmations/utils/account.test.ts
+++ b/ui/pages/confirmations/utils/account.test.ts
@@ -3,6 +3,7 @@ import {
   isBitcoinAccountForSend,
   isEVMAccountForSend,
   isSolanaAccountForSend,
+  isStellarAccountForSend,
 } from './account';
 
 describe('Account Send Utils', () => {
@@ -234,6 +235,59 @@ describe('Account Send Utils', () => {
         scopes: ['eip155:1', 'solana:mainnet'],
       } as unknown as InternalAccount;
       expect(isBitcoinAccountForSend(account)).toBe(false);
+    });
+  });
+
+  describe('isStellarAccountForSend', () => {
+    it('returns false when account is null', () => {
+      expect(
+        isStellarAccountForSend(null as unknown as InternalAccount),
+      ).toBe(false);
+    });
+
+    it('returns false when account is undefined', () => {
+      expect(
+        isStellarAccountForSend(undefined as unknown as InternalAccount),
+      ).toBe(false);
+    });
+
+    it('returns true when account type starts with stellar:', () => {
+      const account = {
+        id: 'test-id',
+        type: 'stellar:account',
+        address: 'GADDRESS',
+        metadata: {},
+        methods: [],
+        options: {},
+        scopes: ['stellar:pubnet'],
+      } as unknown as InternalAccount;
+      expect(isStellarAccountForSend(account)).toBe(true);
+    });
+
+    it('returns true when account has a stellar scope', () => {
+      const account = {
+        id: 'test-id',
+        type: 'other:type',
+        address: 'GADDRESS',
+        metadata: {},
+        methods: [],
+        options: {},
+        scopes: ['stellar:pubnet'],
+      } as unknown as InternalAccount;
+      expect(isStellarAccountForSend(account)).toBe(true);
+    });
+
+    it('returns false for a non-stellar account', () => {
+      const account = {
+        id: 'test-id',
+        type: 'eip155:eoa',
+        address: '0x123',
+        metadata: {},
+        methods: [],
+        options: {},
+        scopes: ['eip155:1'],
+      } as unknown as InternalAccount;
+      expect(isStellarAccountForSend(account)).toBe(false);
     });
   });
 });

--- a/ui/pages/confirmations/utils/account.ts
+++ b/ui/pages/confirmations/utils/account.ts
@@ -88,3 +88,25 @@ export const isTronAccountForSend = (account: InternalAccount): boolean => {
 
   return false;
 };
+
+/**
+ * Checks if an account is Stellar-compatible for send operations.
+ *
+ * @param account - The internal account object to check
+ * @returns true if the account can be used for Stellar transactions
+ */
+export const isStellarAccountForSend = (account: InternalAccount): boolean => {
+  if (!account) {
+    return false;
+  }
+
+  if (account.type.startsWith('stellar:')) {
+    return true;
+  }
+
+  if (account.scopes?.some((scope) => scope.startsWith('stellar:'))) {
+    return true;
+  }
+
+  return false;
+};


### PR DESCRIPTION
## **Description**

On the redesigned send flow, the recipient address-book picker never appeared for Stellar (XLM) accounts — even when the wallet held other Stellar accounts that could be sent to. The "To" field was just a bare text input, so users had to paste a 56-character `G…` address by hand.

Root cause: `useAccountRecipients` builds the recipient list from a per-namespace whitelist with branches for EVM / Solana / Bitcoin / Tron, but **no Stellar branch**, and there was no `isStellarAccountForSend` helper. As a result the Stellar recipient list was always empty, and the picker — which is gated on `recipients.length > 0` (`recipient-input.tsx`) — was never rendered.

This change adds `isStellarAccountForSend` and wires `isStellarSendType` into `useAccountRecipients`, so a user's other Stellar accounts populate the recipient list and the picker renders

Notes:
- The picker still correctly stays hidden when there is only a single Stellar account and no contacts — identical to every other chain with an empty recipient list.

## **Changelog**

CHANGELOG entry: Fixed the send flow so the recipient picker now appears for Stellar (XLM) accounts, allowing a user's other Stellar accounts to be selected as the recipient.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Build the Flask extension and load `dist/chrome` as an unpacked extension; unlock a wallet with the Stellar snap enabled.
2. Ensure the wallet has **at least two accounts** (each account group has its own Stellar address).
3. Open **Send** and select **XLM** from the first account.
4. In the **To** field, confirm the address-book picker icon is shown; tap it and confirm the other Stellar account(s) are listed and selectable, and that selecting one fills the recipient address.
5. Regression: with only a **single** Stellar account and no contacts, confirm the picker remains hidden (unchanged behavior, consistent with other chains).

## **Screenshots/Recordings**

### **Before**

<img width="994" height="1414" alt="image" src="https://github.com/user-attachments/assets/f12a3235-84b9-4aa1-8749-a9b0326e6a36" />


### **After**
<img width="411" height="528" alt="Screenshot 2026-06-23 at 18 15 32" src="https://github.com/user-attachments/assets/f2547a11-da6f-441a-8981-f6810de4f692" />
<img width="409" height="900" alt="Screenshot 2026-06-23 at 18 15 26" src="https://github.com/user-attachments/assets/59d931c6-137a-4ab8-a4d7-0a4ea8ca919a" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://githocs) and [MetaMask Extension CodingStandards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my abili
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.ap
- [ ] I’ve applied the right labels on the PR (see [labeling
guidelines](https://github.com/MetaMask/metamask-extension/bABELING_GUIDELINES.md)). Not required for externalcontributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criter closes and includes the necessary testing evidence such asrecordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Send UI recipient-list filtering only; mirrors existing chain helpers with no auth or transaction-signing changes.
> 
> **Overview**
> Fixes the redesigned **Send** flow so Stellar (XLM) sends can pick recipients from the user’s other wallet accounts, not only by pasting an address.
> 
> Adds **`isStellarAccountForSend`** (same pattern as EVM/Solana/Bitcoin/Tron: `stellar:` account type or scope) and includes Stellar in **`useAccountRecipients`** when **`isStellarSendType`** is true. That populates the recipient list so the address-book picker (shown when `recipients.length > 0`) appears for XLM like other chains.
> 
> Unit tests cover the new helper, the Stellar branch in **`useAccountRecipients`**, and **`useSendType`** expectations now include **`isStellarSendType`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d5c439cf272c36f8f94b36e846a54395f734cbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->