### PR TITLE
fix: encapsulate Pay with row alignment via alignWithDefaultRows prop

### DIFF
--- a/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.test.tsx
@@ -317,6 +317,26 @@ describe('PayWithRow', () => {
       expect(screen.queryByTestId('pay-with-arrow')).not.toBeInTheDocument();
     });
   });
+
+  describe('alignWithDefaultRows', () => {
+    it('indents the row to align with default-sized rows when set', () => {
+      const store = mockStore(getMockState());
+      renderWithProvider(<PayWithRow alignWithDefaultRows />, store);
+
+      expect(screen.getByTestId('pay-with-row')).toHaveStyle({
+        paddingLeft: '8px',
+      });
+    });
+
+    it('does not indent the row by default', () => {
+      const store = mockStore(getMockState());
+      renderWithProvider(<PayWithRow />, store);
+
+      expect(screen.getByTestId('pay-with-row')).not.toHaveStyle({
+        paddingLeft: '8px',
+      });
+    });
+  });
 });
 
 describe('PayWithRowSkeleton', () => {

--- a/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
+++ b/ui/pages/confirmations/components/rows/pay-with-row/pay-with-row.tsx
@@ -35,6 +35,14 @@ import { TokenIcon } from '../../token-icon';
 
 export { ConfirmInfoRowSize };
 
+/**
+ * Left padding (in px) that `Default`-sized `ConfirmInfoRow`s add (`paddingLeft={2}`).
+ * A `Small` row has `paddingLeft: 0`, so when this row is rendered alongside
+ * default-sized rows inside a `ConfirmInfoSection` its label needs this padding
+ * to line up with its siblings.
+ */
+const DEFAULT_ROW_PADDING_LEFT = 8;
+
 type PayWithRowContentProps = {
   displayToken: {
     chainId: string;
@@ -50,6 +58,12 @@ type PayWithRowContentProps = {
 
 export type PayWithRowProps = {
   variant?: ConfirmInfoRowSize;
+  /**
+   * Indents the row so its label aligns with `Default`-sized sibling rows when
+   * it is rendered inside a `ConfirmInfoSection` alongside them. Only required
+   * for the `Small` variant, which otherwise has no left padding.
+   */
+  alignWithDefaultRows?: boolean;
 };
 
 export const PayWithRowSkeleton = () => {
@@ -77,6 +91,7 @@ export const PayWithRowSkeleton = () => {
 
 export function PayWithRow({
   variant = ConfirmInfoRowSize.Small,
+  alignWithDefaultRows = false,
 }: PayWithRowProps = {}) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { payToken } = useTransactionPayToken();
@@ -132,6 +147,7 @@ export function PayWithRow({
         isPerpsWithdraw={isPerpsWithdraw}
         ownerId={currentConfirmation?.id ?? ''}
         rowVariant={variant}
+        alignWithDefaultRows={alignWithDefaultRows}
       />
     </>
   );
@@ -145,9 +161,11 @@ function PayWithRowInline({
   ownerId,
   isPerpsWithdraw,
   rowVariant,
+  alignWithDefaultRows,
 }: PayWithRowContentProps & {
   ownerId: string;
   rowVariant: ConfirmInfoRowSize;
+  alignWithDefaultRows: boolean;
 }) {
   const t = useI18nContext();
 
@@ -158,6 +176,11 @@ function PayWithRowInline({
       data-testid="pay-with-row"
       label={isPerpsWithdraw ? t('withdrawTo') : t('payWith')}
       rowVariant={rowVariant}
+      style={
+        alignWithDefaultRows
+          ? { paddingLeft: DEFAULT_ROW_PADDING_LEFT }
+          : undefined
+      }
     >
       <Box
         data-testid="pay-with-pill"

--- a/ui/pages/confirmations/components/rows/transaction-pay-section/transaction-pay-section.tsx
+++ b/ui/pages/confirmations/components/rows/transaction-pay-section/transaction-pay-section.tsx
@@ -34,7 +34,7 @@ export const TransactionPaySection = () => {
   return (
     <ConfirmInfoSection data-testid="transaction-pay-section">
       <RequiredTokensRow />
-      <PayWithRow />
+      <PayWithRow alignWithDefaultRows />
       {hasPaymentToken && (
         <>
           <BridgeFeeRow />


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Follow-up to the review feedback on [#43792](https://github.com/MetaMask/metamask-extension/pull/43792):

> Ideally the rows are self-contained so they encapsulate their own styles based on the underlying row component etc. Could we embed this inside the `PayWithRow` itself for the relevant variant?

The `Pay with` row in `TransactionPaySection` is a `Small` `ConfirmInfoRow` (`paddingLeft: 0`) sitting next to `Default`-sized rows (`paddingLeft: 2` → 8px), so its label is misaligned. PR #43792 fixed this by passing a raw `style={{ paddingLeft: 8 }}` from the parent section, which leaks the row's internal layout concern (and a magic number) into the parent.

This change moves that styling decision **into `PayWithRow`**. The component now exposes an intent-revealing `alignWithDefaultRows` prop; when set, the row applies the left padding (a named `DEFAULT_ROW_PADDING_LEFT` constant) itself. The parent only declares intent (`<PayWithRow alignWithDefaultRows />`).

Crucially, the padding is **not** keyed off the `Small` variant. All three current call sites use the `Small` variant (`TransactionPaySection`, `MusdOverrideContent`, and `CustomAmountInfo`), but only the pay section sits inside a `ConfirmInfoSection` next to default-sized rows. Gating on the variant would have inadvertently indented the standalone rows in the other two screens. The opt-in prop defaults to `false`, so those usages are untouched.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Start a Send transaction where you can pay with a different token (so the transaction pay section renders).
2. On the confirmation, verify the `Pay with` label's left edge lines up with the other rows in the section (required tokens, fees, total).
3. Open the mUSD conversion flow and the custom amount flow.
4. Verify the `Pay with` row in those screens is not indented (its alignment is unchanged from before).

## **Screenshots/Recordings**

<!--
### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-794503ad-bf8f-46cc-a534-9a49d9d90a9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-794503ad-bf8f-46cc-a534-9a49d9d90a9a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

