### PR TITLE
fix: skip failed-tx badge when user rejects a hardware-wallet tx

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -16,6 +16,7 @@ import { lightTheme } from '@metamask/design-tokens';
 import { finished } from 'readable-stream';
 import log from 'loglevel';
 import browser from 'webextension-polyfill';
+import { errorCodes } from '@metamask/rpc-errors';
 import { isObject, hasProperty } from '@metamask/utils';
 import { deriveStateFromMetadata } from '@metamask/base-controller';
 import { ExtensionPortStream } from 'extension-port-stream';
@@ -2007,8 +2008,15 @@ export function setupController(
   }
 
   function onTransactionStatusUpdated({ transactionMeta }) {
-    const { status, txParams, chainId } = transactionMeta ?? {};
+    const { status, txParams, chainId, error } = transactionMeta ?? {};
     if (status !== 'failed' && status !== 'dropped') {
+      return;
+    }
+
+    // A hardware-wallet rejection surfaces as a `failed` transaction whose
+    // error carries the standard user-rejected JSON-RPC code. The user
+    // deliberately cancelled, so don't surface a red failure badge.
+    if (error?.code === errorCodes.provider.userRejectedRequest) {
       return;
     }
 


### PR DESCRIPTION
- fix: skip failed-tx badge when user rejects a hardware-wallet tx

Hardware-wallet rejections fire \`TransactionController:transactionStatusUpdated\` with status \`failed\` and an error whose code is the standard JSON-RPC user-rejected (4001). The badge handler was treating every \`failed\`/\`dropped\` transition as a real failure. Guard on the rejection code so the icon stays clean when the user cancels on the device.

Closes #43614

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single early-return in badge logic with a standard RPC error code; no auth, persistence, or transaction submission changes.
> 
> **Overview**
> Fixes a false **red toolbar badge** when a user cancels a transaction on a hardware wallet. Those cancellations still emit `TransactionController:transactionStatusUpdated` with status `failed`, which `onTransactionStatusUpdated` treated like any other failure.
> 
> The handler now reads `error` from `transactionMeta` and **bails out** when `error.code` matches `errorCodes.provider.userRejectedRequest` (JSON-RPC 4001), so deliberate device rejections no longer increment `failedTxCount` or switch the landing tab to Activity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 744eb6f1b466a7902809305496b53cbb78b6e0f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->