### PR TITLE
chore(bridge): relocate submit hooks to ui/hooks/bridge

### DIFF
--- a/ui/hooks/bridge/__snapshots__/useSubmitBridgeTransaction.test.tsx.snap
+++ b/ui/hooks/bridge/__snapshots__/useSubmitBridgeTransaction.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ui/pages/bridge/hooks/useSubmitBridgeTransaction submitBridgeTransaction executes EVM bridge transaction 1`] = `
+exports[`ui/hooks/bridge/useSubmitBridgeTransaction submitBridgeTransaction executes EVM bridge transaction 1`] = `
 [
   [
     "0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc",
@@ -165,7 +165,7 @@ exports[`ui/pages/bridge/hooks/useSubmitBridgeTransaction submitBridgeTransactio
 ]
 `;
 
-exports[`ui/pages/bridge/hooks/useSubmitBridgeTransaction submitBridgeTransaction executes EVM bridge transaction with no approval 1`] = `
+exports[`ui/hooks/bridge/useSubmitBridgeTransaction submitBridgeTransaction executes EVM bridge transaction with no approval 1`] = `
 [
   [
     "0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc",

--- a/ui/hooks/bridge/useEnableMissingNetwork.test.ts
+++ b/ui/hooks/bridge/useEnableMissingNetwork.test.ts
@@ -1,6 +1,6 @@
-import { renderHookWithProvider } from '../../../../test/lib/render-helpers-navigate';
-import { createBridgeMockStore } from '../../../../test/data/bridge/mock-bridge-store';
-import * as ActionsModule from '../../../store/actions';
+import { renderHookWithProvider } from '../../../test/lib/render-helpers-navigate';
+import { createBridgeMockStore } from '../../../test/data/bridge/mock-bridge-store';
+import * as ActionsModule from '../../store/actions';
 import { useEnableMissingNetwork } from './useEnableMissingNetwork';
 
 describe('useEnableMissingNetwork', () => {

--- a/ui/hooks/bridge/useEnableMissingNetwork.ts
+++ b/ui/hooks/bridge/useEnableMissingNetwork.ts
@@ -6,9 +6,9 @@ import {
 } from '@metamask/bridge-controller';
 import { type CaipChainId, type Hex, parseCaipChainId } from '@metamask/utils';
 import { useSelector, useDispatch } from 'react-redux';
-import { getEnabledNetworksByNamespace } from '../../../selectors';
-import { FEATURED_NETWORK_CHAIN_IDS } from '../../../../shared/constants/network';
-import { setEnabledAllPopularNetworks } from '../../../store/actions';
+import { getEnabledNetworksByNamespace } from '../../selectors';
+import { FEATURED_NETWORK_CHAIN_IDS } from '../../../shared/constants/network';
+import { setEnabledAllPopularNetworks } from '../../store/actions';
 
 /**
  * Ensures that any missing network gets added to the NetworkEnabledMap (which handles network polling)

--- a/ui/hooks/bridge/useSubmitBridgeTransaction.test.tsx
+++ b/ui/hooks/bridge/useSubmitBridgeTransaction.test.tsx
@@ -99,9 +99,7 @@ const MOCK_NETWORK_CONFIGURATIONS_BY_CHAIN_ID = {
 };
 
 jest.mock('../../../shared/lib/selectors/networks', () => {
-  const original = jest.requireActual(
-    '../../../shared/lib/selectors/networks',
-  );
+  const original = jest.requireActual('../../../shared/lib/selectors/networks');
   return {
     ...original,
     getSelectedNetworkClientId: () => 'mainnet',

--- a/ui/hooks/bridge/useSubmitBridgeTransaction.test.tsx
+++ b/ui/hooks/bridge/useSubmitBridgeTransaction.test.tsx
@@ -3,26 +3,26 @@ import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { renderHook } from '@testing-library/react-hooks';
 import { act } from '@testing-library/react';
-import { createMemoryRouterWrapper } from '../../../../test/lib/render-helpers-navigate';
+import { createMemoryRouterWrapper } from '../../../test/lib/render-helpers-navigate';
 import {
   createBridgeMockStore,
   MOCK_LEDGER_ACCOUNT,
-} from '../../../../test/data/bridge/mock-bridge-store';
+} from '../../../test/data/bridge/mock-bridge-store';
 import {
   DummyQuotesNoApproval,
   DummyQuotesWithApproval,
-} from '../../../../test/data/bridge/dummy-quotes';
+} from '../../../test/data/bridge/dummy-quotes';
 import {
   AWAITING_SIGNATURES_ROUTE,
   CROSS_CHAIN_SWAP_ROUTE,
   DEFAULT_ROUTE,
-} from '../../../helpers/constants/routes';
-import * as keyringSelectors from '../../../../shared/lib/selectors/keyring';
-import * as sentry from '../../../../shared/lib/sentry';
-import * as bridgeStatusActions from '../../../ducks/bridge-status/actions';
-import * as bridgeActions from '../../../ducks/bridge/actions';
-import { setBackgroundConnection } from '../../../store/background-connection';
-import { HardwareWalletProvider } from '../../../contexts/hardware-wallets';
+} from '../../helpers/constants/routes';
+import * as keyringSelectors from '../../../shared/lib/selectors/keyring';
+import * as sentry from '../../../shared/lib/sentry';
+import * as bridgeStatusActions from '../../ducks/bridge-status/actions';
+import * as bridgeActions from '../../ducks/bridge/actions';
+import { setBackgroundConnection } from '../../store/background-connection';
+import { HardwareWalletProvider } from '../../contexts/hardware-wallets';
 import useSubmitBridgeTransaction from './useSubmitBridgeTransaction';
 
 const mockUseNavigate = jest.fn();
@@ -33,8 +33,8 @@ jest.mock('react-router-dom', () => {
   };
 });
 
-jest.mock('../../../ducks/bridge/utils', () => ({
-  ...jest.requireActual('../../../ducks/bridge/utils'),
+jest.mock('../../ducks/bridge/utils', () => ({
+  ...jest.requireActual('../../ducks/bridge/utils'),
   getTxGasEstimates: jest.fn(() => ({
     baseAndPriorityFeePerGas: '0',
     maxFeePerGas: '0x1036640',
@@ -43,10 +43,10 @@ jest.mock('../../../ducks/bridge/utils', () => ({
 }));
 
 const mockEnsureDeviceReady = jest.fn().mockResolvedValue(true);
-jest.mock('../../../contexts/hardware-wallets/HardwareWalletContext', () => {
+jest.mock('../../contexts/hardware-wallets/HardwareWalletContext', () => {
   return {
     ...jest.requireActual(
-      '../../../contexts/hardware-wallets/HardwareWalletContext',
+      '../../contexts/hardware-wallets/HardwareWalletContext',
     ),
     useHardwareWalletActions: () => ({
       ensureDeviceReady: () => mockEnsureDeviceReady(),
@@ -54,8 +54,8 @@ jest.mock('../../../contexts/hardware-wallets/HardwareWalletContext', () => {
   };
 });
 
-jest.mock('../../../store/actions', () => {
-  const original = jest.requireActual('../../../store/actions');
+jest.mock('../../store/actions', () => {
+  const original = jest.requireActual('../../store/actions');
   return {
     ...original,
     addTransaction: jest.fn(),
@@ -98,9 +98,9 @@ const MOCK_NETWORK_CONFIGURATIONS_BY_CHAIN_ID = {
   },
 };
 
-jest.mock('../../../../shared/lib/selectors/networks', () => {
+jest.mock('../../../shared/lib/selectors/networks', () => {
   const original = jest.requireActual(
-    '../../../../shared/lib/selectors/networks',
+    '../../../shared/lib/selectors/networks',
   );
   return {
     ...original,
@@ -132,8 +132,8 @@ jest.mock('../../../../shared/lib/selectors/networks', () => {
   };
 });
 
-jest.mock('../../../selectors', () => {
-  const original = jest.requireActual('../../../selectors');
+jest.mock('../../selectors', () => {
+  const original = jest.requireActual('../../selectors');
   return {
     ...original,
     getIsBridgeEnabled: () => true,
@@ -141,8 +141,8 @@ jest.mock('../../../selectors', () => {
     checkNetworkAndAccountSupports1559: () => true,
   };
 });
-jest.mock('../../../../shared/lib/selectors/keyring', () => ({
-  ...jest.requireActual('../../../../shared/lib/selectors/keyring'),
+jest.mock('../../../shared/lib/selectors/keyring', () => ({
+  ...jest.requireActual('../../../shared/lib/selectors/keyring'),
   getHardwareWalletType: jest.fn(() => undefined),
   isHardwareWallet: jest.fn(() => false),
 }));
@@ -192,7 +192,7 @@ const captureExceptionSpy = jest.spyOn(sentry, 'captureException');
 const mockResetState = jest.fn();
 const resetBridgeStoreSpy = jest.spyOn(bridgeActions, 'resetInputFields');
 
-describe('ui/pages/bridge/hooks/useSubmitBridgeTransaction', () => {
+describe('ui/hooks/bridge/useSubmitBridgeTransaction', () => {
   describe('submitBridgeTransaction', () => {
     beforeEach(() => {
       jest.clearAllMocks();

--- a/ui/hooks/bridge/useSubmitBridgeTransaction.ts
+++ b/ui/hooks/bridge/useSubmitBridgeTransaction.ts
@@ -7,14 +7,14 @@ import {
 } from '@metamask/bridge-controller';
 import type { QuoteMetadata, QuoteResponse } from '@metamask/bridge-controller';
 import { useNavigate } from 'react-router-dom';
-import { getExtensionSkipTransactionStatusPage } from '../../../../shared/lib/selectors/smart-transactions';
-import { isHardwareWallet } from '../../../../shared/lib/selectors/keyring';
-import { captureException } from '../../../../shared/lib/sentry';
+import { getExtensionSkipTransactionStatusPage } from '../../../shared/lib/selectors/smart-transactions';
+import { isHardwareWallet } from '../../../shared/lib/selectors/keyring';
+import { captureException } from '../../../shared/lib/sentry';
 import {
   submitBridgeIntent,
   submitBridgeTx,
-} from '../../../ducks/bridge-status/actions';
-import { setWasTxDeclined } from '../../../ducks/bridge/actions';
+} from '../../ducks/bridge-status/actions';
+import { setWasTxDeclined } from '../../ducks/bridge/actions';
 import {
   getBridgeQuotes,
   getFromAccount,
@@ -23,16 +23,16 @@ import {
   getToToken,
   getWarningLabels,
   type BridgeAppState,
-} from '../../../ducks/bridge/selectors';
-import { useHasSufficientGasForQuoteForMetrics } from '../../../hooks/bridge/useHasSufficientGasForQuoteForMetrics';
+} from '../../ducks/bridge/selectors';
 import {
   useHardwareWalletActions,
   useHardwareWalletConfig,
-} from '../../../contexts/hardware-wallets/HardwareWalletContext';
-import { useBridgeNavigation } from '../../../hooks/bridge/useBridgeNavigation';
-import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
-import { type MetaMaskReduxDispatch } from '../../../store/store';
-import { isHardwareWalletUserRejection } from '../utils/hardware-wallet-errors';
+} from '../../contexts/hardware-wallets/HardwareWalletContext';
+import { DEFAULT_ROUTE } from '../../helpers/constants/routes';
+import { type MetaMaskReduxDispatch } from '../../store/store';
+import { isHardwareWalletUserRejection } from '../../pages/bridge/utils/hardware-wallet-errors';
+import { useBridgeNavigation } from './useBridgeNavigation';
+import { useHasSufficientGasForQuoteForMetrics } from './useHasSufficientGasForQuoteForMetrics';
 import { useEnableMissingNetwork } from './useEnableMissingNetwork';
 
 const ALLOWANCE_RESET_ERROR = 'Eth USDT allowance reset failed';

--- a/ui/pages/bridge/prepare/bridge-cta-button.test.tsx
+++ b/ui/pages/bridge/prepare/bridge-cta-button.test.tsx
@@ -27,7 +27,7 @@ import {
 import { setBackgroundConnection } from '../../../store/background-connection';
 import { MetaMetricsHardwareWalletRecoveryLocation } from '../../../../shared/constants/metametrics';
 import { trackHardwareWalletRecoveryConnectCtaClicked } from '../../../helpers/utils/track-hardware-wallet-recovery-connect-cta-clicked';
-import * as useSubmitBridgeTransactionModule from '../hooks/useSubmitBridgeTransaction';
+import * as useSubmitBridgeTransactionModule from '../../../hooks/bridge/useSubmitBridgeTransaction';
 import { BridgeCTAButton } from './bridge-cta-button';
 
 const mockTrackHardwareWalletRecoveryConnectCtaClicked = jest.mocked(

--- a/ui/pages/bridge/prepare/bridge-cta-button.tsx
+++ b/ui/pages/bridge/prepare/bridge-cta-button.tsx
@@ -29,7 +29,7 @@ import {
 import { MetaMetricsContext } from '../../../contexts/metametrics';
 import { trackHardwareWalletRecoveryConnectCtaClicked } from '../../../helpers/utils/track-hardware-wallet-recovery-connect-cta-clicked';
 import { isFirefoxBrowser } from '../../../../shared/lib/browser-runtime.utils';
-import useSubmitBridgeTransaction from '../hooks/useSubmitBridgeTransaction';
+import useSubmitBridgeTransaction from '../../../hooks/bridge/useSubmitBridgeTransaction';
 
 export const BridgeCTAButton = ({
   onFetchNewQuotes,

--- a/ui/pages/bridge/prepare/components/bridge-alert-modal.test.tsx
+++ b/ui/pages/bridge/prepare/components/bridge-alert-modal.test.tsx
@@ -13,7 +13,7 @@ import { DummyQuotesNoApproval } from '../../../../../test/data/bridge/dummy-quo
 import { enLocale as messages } from '../../../../../test/lib/i18n-helpers';
 import configureStore from '../../../../store/store';
 import { HardwareWalletProvider } from '../../../../contexts/hardware-wallets/HardwareWalletContext';
-import * as useSubmitBridgeTransactionModule from '../../hooks/useSubmitBridgeTransaction';
+import * as useSubmitBridgeTransactionModule from '../../../../hooks/bridge/useSubmitBridgeTransaction';
 import * as bridgeSelectors from '../../../../ducks/bridge/selectors';
 import { BridgeAlert } from '../types';
 import { BridgeAlertModal } from './bridge-alert-modal';
@@ -21,7 +21,7 @@ import { BridgeAlertModal } from './bridge-alert-modal';
 const mockOnClose = jest.fn();
 const mockSubmitBridgeTransaction = jest.fn();
 
-jest.mock('../../hooks/useSubmitBridgeTransaction', () => ({
+jest.mock('../../../../hooks/bridge/useSubmitBridgeTransaction', () => ({
   // eslint-disable-next-line @typescript-eslint/naming-convention
   __esModule: true,
   default: jest.fn(() => ({

--- a/ui/pages/bridge/prepare/components/bridge-alert-modal.tsx
+++ b/ui/pages/bridge/prepare/components/bridge-alert-modal.tsx
@@ -30,7 +30,7 @@ import {
   getValidationErrors,
 } from '../../../../ducks/bridge/selectors';
 import { Column, Row } from '../../layout';
-import useSubmitBridgeTransaction from '../../hooks/useSubmitBridgeTransaction';
+import useSubmitBridgeTransaction from '../../../../hooks/bridge/useSubmitBridgeTransaction';
 import { useBridgeAlerts } from '../../hooks/useBridgeAlerts';
 import { type BridgeAlert } from '../types';
 


### PR DESCRIPTION
## **Description**

Moves `useSubmitBridgeTransaction` and `useEnableMissingNetwork` from `ui/pages/bridge/hooks/` to `ui/hooks/bridge/` so bridge submission logic can be imported from shared hook locations (e.g. hardware wallet signing flows) without coupling to the prepare page directory. This is in accordance to [ADR 21 ](https://github.com/MetaMask/decisions/blob/main/decisions/core/0021-modularize-routes.md)

This is a **pure relocation** — no behavior changes. Import paths in bridge prepare consumers are updated accordingly.

Part of splitting MUL-1717 into smaller reviewable PRs.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related to MUL-1717

## **Manual testing steps**

1. Build and load the extension (`yarn start`).
2. Open Bridge from the wallet with a standard (non-hardware) account.
3. Select source/destination tokens and a valid quote on the prepare page.
4. Submit the bridge transaction via the CTA button and via any alert modal confirmation path.
5. Verify submission still succeeds and navigation behaves as before (status/awaiting-signatures flow unchanged).

## **Screenshots/Recordings**

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)