### PR TITLE
chore: Add deprecation message to `getApi`

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2665,7 +2665,7 @@ export default class MetamaskController extends EventEmitter {
    * @returns {object} Object containing API functions.
    *
    * @deprecated This method is deprecated and will be removed in a future release.
-   * All legacy methods from getApi() are being migrated to the LegacyBackgroundApiService and accessed via the controllerMessenger.
+   * All legacy methods from getApi() are being migrated to the LegacyBackgroundApiService and can be accessed via the messenger.
    * New methods should be defined in controllers and exposed via the controllerMessenger, rather than being added to this API object.
    */
   getApi() {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2663,6 +2663,10 @@ export default class MetamaskController extends EventEmitter {
    * The API object can be transmitted over a stream via JSON-RPC.
    *
    * @returns {object} Object containing API functions.
+   *
+   * @deprecated This method is deprecated and will be removed in a future release.
+   * All legacy methods from getApi() are being migrated to the LegacyBackgroundApiService and accessed via the controllerMessenger.
+   * New methods should be defined in controllers and exposed via the controllerMessenger, rather than being added to this API object.
    */
   getApi() {
     const {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2666,7 +2666,7 @@ export default class MetamaskController extends EventEmitter {
    *
    * @deprecated This method is deprecated and will be removed in a future release.
    * All legacy methods from getApi() are being migrated to the LegacyBackgroundApiService and can be accessed via the messenger.
-   * New methods should be defined in controllers and exposed via the controllerMessenger, rather than being added to this API object.
+   * New methods should be defined in controllers and exposed via the messenger, rather than being added to this API object.
    */
   getApi() {
     const {


### PR DESCRIPTION
## **Description**

This adds a deprecation to the `getApi()` method in `MetamaskController`.

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only change with no functional impact.
> 
> **Overview**
> Documents that **`MetamaskController#getApi()`** is deprecated and slated for removal.
> 
> The new JSDoc points contributors to **`LegacyBackgroundApiService`** and the **messenger** for legacy background APIs, and says new surface area should live on controllers exposed via the messenger instead of this monolithic API object. **No runtime behavior changes**—documentation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 858cfbd20e5dbe8b4b1884ac6eb6f95a043da8dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->