### PR TITLE
test: add Sentry coverage-equivalence harness (envelope parse/normalize/diff)

### DIFF
--- a/test/e2e/helpers/sentry-coverage.test.ts
+++ b/test/e2e/helpers/sentry-coverage.test.ts
@@ -1,0 +1,163 @@
+import {
+  parseSentryEnvelope,
+  parseSentryEnvelopes,
+  stripVolatile,
+  itemSignature,
+  summarizeCoverage,
+  diffCoverage,
+} from './sentry-coverage';
+
+// A realistic error envelope: header line, item-header line, payload line.
+const ERROR_ENVELOPE = [
+  '{"event_id":"aaaa","sent_at":"2024-01-01T00:00:00.000Z","sdk":{"name":"sentry.javascript.browser","version":"10.38.0"}}',
+  '{"type":"event"}',
+  '{"event_id":"aaaa","level":"error","exception":{"values":[{"type":"TypeError","value":"boom"}]},"tags":{"otelTraceId":"t1","release":"13.0.0"},"timestamp":1700000000}',
+].join('\n');
+
+const TRANSACTION_ENVELOPE = [
+  '{"event_id":"bbbb","sent_at":"2024-01-01T00:00:01.000Z","trace":{"trace_id":"t2","public_key":"k"}}',
+  '{"type":"transaction"}',
+  '{"type":"transaction","transaction":"UI Startup","start_timestamp":1,"timestamp":2,"contexts":{"trace":{"trace_id":"t2","span_id":"s1","op":"pageload"}},"tags":{"release":"13.0.0"}}',
+].join('\n');
+
+describe('sentry-coverage harness', () => {
+  describe('parseSentryEnvelope', () => {
+    it('parses an error envelope into a typed item', () => {
+      const items = parseSentryEnvelope(ERROR_ENVELOPE);
+      expect(items).toHaveLength(1);
+      expect(items[0].type).toBe('event');
+      expect(items[0].payload.level).toBe('error');
+    });
+
+    it('parses a transaction envelope', () => {
+      const items = parseSentryEnvelope(TRANSACTION_ENVELOPE);
+      expect(items).toHaveLength(1);
+      expect(items[0].type).toBe('transaction');
+      expect(items[0].payload.transaction).toBe('UI Startup');
+    });
+
+    it('skips malformed lines instead of throwing', () => {
+      expect(
+        parseSentryEnvelope('not json\n{"type":"event"}\nalso not json'),
+      ).toStrictEqual([]);
+      expect(parseSentryEnvelope('')).toStrictEqual([]);
+    });
+
+    it('flattens multiple envelope bodies', () => {
+      const items = parseSentryEnvelopes([
+        ERROR_ENVELOPE,
+        TRANSACTION_ENVELOPE,
+      ]);
+      expect(items.map((item) => item.type)).toStrictEqual([
+        'event',
+        'transaction',
+      ]);
+    });
+  });
+
+  describe('stripVolatile', () => {
+    it('recursively removes run-specific ids and timestamps', () => {
+      /* eslint-disable @typescript-eslint/naming-convention -- real Sentry payload field names are snake_case */
+      const cleaned = stripVolatile({
+        event_id: 'x',
+        level: 'error',
+        contexts: { trace: { trace_id: 't', span_id: 's', op: 'pageload' } },
+        spans: [{ span_id: 's2', description: 'db' }],
+      });
+      /* eslint-enable @typescript-eslint/naming-convention */
+      expect(cleaned).toStrictEqual({
+        level: 'error',
+        contexts: { trace: { op: 'pageload' } },
+        spans: [{ description: 'db' }],
+      });
+    });
+  });
+
+  describe('itemSignature', () => {
+    it('keys errors on exception type+value, transactions on name', () => {
+      const [errItem] = parseSentryEnvelope(ERROR_ENVELOPE);
+      const [txItem] = parseSentryEnvelope(TRANSACTION_ENVELOPE);
+      expect(itemSignature(errItem)).toBe('event:TypeError:boom');
+      expect(itemSignature(txItem)).toBe('transaction:UI Startup');
+    });
+  });
+
+  describe('diffCoverage', () => {
+    const baselineItems = parseSentryEnvelopes([
+      ERROR_ENVELOPE,
+      TRANSACTION_ENVELOPE,
+    ]);
+
+    it('reports equivalence for the same capture modulo volatile fields', () => {
+      // Same payloads, different ids/timestamps — must still be equivalent.
+      const drifted = parseSentryEnvelopes([
+        ERROR_ENVELOPE.replace('aaaa', 'zzzz').replace(
+          '1700000000',
+          '1800000000',
+        ),
+        TRANSACTION_ENVELOPE.replace('bbbb', 'yyyy').replace('"t2"', '"t9"'),
+      ]);
+      const diff = diffCoverage(
+        summarizeCoverage(baselineItems),
+        summarizeCoverage(drifted),
+      );
+      expect(diff.equivalent).toBe(true);
+    });
+
+    it('detects a removed envelope item (lost coverage)', () => {
+      const diff = diffCoverage(
+        summarizeCoverage(baselineItems),
+        summarizeCoverage(parseSentryEnvelope(ERROR_ENVELOPE)),
+      );
+      expect(diff.equivalent).toBe(false);
+      expect(diff.removedSignatures).toContain('transaction:UI Startup');
+      expect(diff.countDeltas).toContainEqual({
+        type: 'transaction',
+        baseline: 1,
+        current: 0,
+      });
+    });
+
+    it('detects a dropped correlation tag (e.g. otelTraceId regression)', () => {
+      const withoutTag = ERROR_ENVELOPE.replace(
+        '"tags":{"otelTraceId":"t1","release":"13.0.0"}',
+        '"tags":{"release":"13.0.0"}',
+      );
+      const diff = diffCoverage(
+        summarizeCoverage(parseSentryEnvelope(ERROR_ENVELOPE)),
+        summarizeCoverage(parseSentryEnvelope(withoutTag)),
+      );
+      expect(diff.equivalent).toBe(false);
+      expect(diff.tagChanges).toContainEqual({
+        signature: 'event:TypeError:boom',
+        added: [],
+        removed: ['otelTraceId'],
+      });
+    });
+
+    it('detects a new envelope type / volume increase', () => {
+      const sessionEnvelope = [
+        '{"sent_at":"2024-01-01T00:00:02.000Z"}',
+        '{"type":"session"}',
+        '{"sid":"s","status":"ok","started":"2024-01-01T00:00:00.000Z"}',
+      ].join('\n');
+      const diff = diffCoverage(
+        summarizeCoverage(baselineItems),
+        summarizeCoverage(
+          parseSentryEnvelopes([
+            ERROR_ENVELOPE,
+            TRANSACTION_ENVELOPE,
+            sessionEnvelope,
+          ]),
+        ),
+      );
+      expect(diff.equivalent).toBe(false);
+      expect(diff.addedSignatures).toContain('session');
+      expect(diff.countDeltas).toContainEqual({
+        type: 'session',
+        baseline: 0,
+        current: 1,
+      });
+    });
+  });
+});

--- a/test/e2e/helpers/sentry-coverage.ts
+++ b/test/e2e/helpers/sentry-coverage.ts
@@ -1,0 +1,301 @@
+/**
+ * Sentry coverage harness — parse / normalize / diff the envelopes the
+ * extension sends to Sentry, so a migration (e.g. SDK v8 → v10) can be checked
+ * for *behavioral* equivalence rather than trusted on a green suite.
+ *
+ * Usage (see `test/e2e/tests/metrics/sentry-coverage.spec.ts`): capture every
+ * raw POST body to the mocked Sentry DSN during a fixed flow, then
+ * `parseSentryEnvelopes` → `summarizeCoverage` → `diffCoverage(baseline,
+ * current)` to surface structural deltas (added/removed items, per-type counts,
+ * changed tag coverage) with volatile ids/timestamps normalized away.
+ *
+ * Tracked by #43819. Pure functions, no Sentry/runtime imports — unit-tested in
+ * `sentry-coverage.test.ts`.
+ */
+
+/** A single item unpacked from a Sentry envelope (event, transaction, …). */
+export type EnvelopeItem = {
+  /** The item header's `type` (`event`, `transaction`, `session`, `client_report`, …). */
+  type: string;
+  /** The item payload (the line after the item header). */
+  payload: Record<string, unknown>;
+};
+
+/** Keys whose values vary run-to-run and must be dropped before comparing. */
+export const VOLATILE_KEYS: ReadonlySet<string> = new Set([
+  'event_id',
+  'timestamp',
+  'start_timestamp',
+  'sent_at',
+  'trace_id',
+  'span_id',
+  'parent_span_id',
+  'replay_id',
+  'sid', // session id
+  'started',
+  'duration',
+  'sdkProcessingMetadata',
+  'received',
+  'profile_id',
+  'segment_id',
+]);
+
+/**
+ * Parse one raw Sentry envelope body. Envelopes are newline-delimited JSON: an
+ * envelope header line, then repeating [item-header, payload] line pairs
+ * (https://develop.sentry.dev/sdk/envelopes/).
+ *
+ * @param rawBody - The raw POST body sent to the Sentry `/envelope` endpoint.
+ * @returns The envelope's items. Malformed lines are skipped, not thrown on,
+ * so one bad envelope can't sink a whole capture run.
+ */
+export function parseSentryEnvelope(rawBody: string): EnvelopeItem[] {
+  const lines = rawBody.split('\n').filter((line) => line.trim() !== '');
+  if (lines.length === 0) {
+    return [];
+  }
+
+  const items: EnvelopeItem[] = [];
+  // Line 0 is the envelope header; items start at line 1 as header/payload pairs.
+  for (let i = 1; i < lines.length; i += 2) {
+    const header = safeJsonParse(lines[i]);
+    const payload = safeJsonParse(lines[i + 1]);
+    // Require both a typed item header and a parseable payload — an item we
+    // can't read can't be normalized or diffed, so skip it rather than emit noise.
+    if (!header || typeof header.type !== 'string' || !payload) {
+      continue;
+    }
+    items.push({
+      type: header.type,
+      payload,
+    });
+  }
+  return items;
+}
+
+/**
+ * Parse many raw envelope bodies into one flat item list.
+ *
+ * @param rawBodies - All raw POST bodies captured during a flow.
+ * @returns Every envelope item across all bodies.
+ */
+export function parseSentryEnvelopes(rawBodies: string[]): EnvelopeItem[] {
+  return rawBodies.flatMap(parseSentryEnvelope);
+}
+
+/**
+ * Recursively drop volatile keys from a value so two runs compare equal modulo
+ * run-specific ids/timestamps.
+ *
+ * @param value - Any JSON value.
+ * @param volatileKeys - Keys to strip (defaults to {@link VOLATILE_KEYS}).
+ * @returns A deep copy with volatile keys removed.
+ */
+export function stripVolatile(
+  value: unknown,
+  volatileKeys: ReadonlySet<string> = VOLATILE_KEYS,
+): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => stripVolatile(entry, volatileKeys));
+  }
+  if (value && typeof value === 'object') {
+    const out: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+      if (volatileKeys.has(key)) {
+        continue;
+      }
+      out[key] = stripVolatile(val, volatileKeys);
+    }
+    return out;
+  }
+  return value;
+}
+
+/**
+ * A stable identity for an envelope item, used to pair items across runs even
+ * though their order and ids differ. Errors key on exception type+value (their
+ * Sentry grouping inputs); transactions on their name; everything else on type.
+ *
+ * @param item - The envelope item.
+ * @returns A stable signature string.
+ */
+export function itemSignature(item: EnvelopeItem): string {
+  const { type, payload } = item;
+  if (type === 'transaction') {
+    return `transaction:${String(payload.transaction ?? '<unnamed>')}`;
+  }
+  if (type === 'event') {
+    const exception = (
+      payload.exception as { values?: { type?: string; value?: string }[] }
+    )?.values?.[0];
+    if (exception) {
+      return `event:${exception.type ?? ''}:${exception.value ?? ''}`;
+    }
+    return `event:message:${String(payload.message ?? '')}`;
+  }
+  return `${type}`;
+}
+
+/**
+ * Tag keys present on an item's payload (errors/transactions carry `tags`).
+ * @param payload
+ */
+function tagKeysOf(payload: Record<string, unknown>): string[] {
+  const { tags } = payload;
+  return tags && typeof tags === 'object'
+    ? Object.keys(tags as Record<string, unknown>).sort()
+    : [];
+}
+
+/** A normalized, diff-friendly view of one envelope item. */
+export type NormalizedItem = {
+  signature: string;
+  type: string;
+  /** Sorted tag keys (coverage of correlation tags like `otelTraceId`). */
+  tagKeys: string[];
+  /** The volatile-stripped payload (structural comparison). */
+  payload: unknown;
+};
+
+/** A stable snapshot of an entire capture, ready to baseline or diff. */
+export type CoverageSummary = {
+  /** Count of envelope items by `type` (the volume / quota axis). */
+  countsByType: Record<string, number>;
+  /** Normalized items keyed by signature (multiple per signature allowed). */
+  items: NormalizedItem[];
+};
+
+/**
+ * Reduce captured items to a stable snapshot: per-type counts plus each item
+ * normalized (volatile-stripped, tag keys extracted), sorted by signature.
+ *
+ * @param items - Parsed envelope items.
+ * @returns A deterministic {@link CoverageSummary}.
+ */
+export function summarizeCoverage(items: EnvelopeItem[]): CoverageSummary {
+  const countsByType: Record<string, number> = {};
+  const normalized: NormalizedItem[] = [];
+
+  for (const item of items) {
+    countsByType[item.type] = (countsByType[item.type] ?? 0) + 1;
+    normalized.push({
+      signature: itemSignature(item),
+      type: item.type,
+      tagKeys: tagKeysOf(item.payload),
+      payload: stripVolatile(item.payload),
+    });
+  }
+
+  normalized.sort((a, b) => a.signature.localeCompare(b.signature));
+  return { countsByType, items: normalized };
+}
+
+/** The result of comparing a baseline capture to a current one. */
+export type CoverageDiff = {
+  /** True when the two captures are equivalent (no structural delta). */
+  equivalent: boolean;
+  /** Item signatures present in current but not baseline. */
+  addedSignatures: string[];
+  /** Item signatures present in baseline but not current. */
+  removedSignatures: string[];
+  /** Per-signature tag-key deltas (added/removed correlation tags). */
+  tagChanges: { signature: string; added: string[]; removed: string[] }[];
+  /** Per-type envelope-count deltas (the volume / quota axis). */
+  countDeltas: { type: string; baseline: number; current: number }[];
+};
+
+/**
+ * Diff two coverage summaries. Surfaces what a reviewer of an SDK migration
+ * actually cares about: missing/extra envelope items, changed tag coverage, and
+ * volume changes — with volatile ids/timestamps already normalized away.
+ *
+ * @param baseline - The reference capture (e.g. v8).
+ * @param current - The capture to verify (e.g. v10).
+ * @returns A {@link CoverageDiff}; `equivalent` is true when all deltas are empty.
+ */
+export function diffCoverage(
+  baseline: CoverageSummary,
+  current: CoverageSummary,
+): CoverageDiff {
+  const baseBySig = groupBySignature(baseline.items);
+  const currBySig = groupBySignature(current.items);
+
+  const allSignatures = new Set([...baseBySig.keys(), ...currBySig.keys()]);
+  const addedSignatures: string[] = [];
+  const removedSignatures: string[] = [];
+  const tagChanges: CoverageDiff['tagChanges'] = [];
+
+  for (const signature of [...allSignatures].sort()) {
+    const inBase = baseBySig.has(signature);
+    const inCurr = currBySig.has(signature);
+    if (inCurr && !inBase) {
+      addedSignatures.push(signature);
+      continue;
+    }
+    if (inBase && !inCurr) {
+      removedSignatures.push(signature);
+      continue;
+    }
+    const baseTags = new Set(baseBySig.get(signature)?.[0]?.tagKeys ?? []);
+    const currTags = new Set(currBySig.get(signature)?.[0]?.tagKeys ?? []);
+    const added = [...currTags].filter((tag) => !baseTags.has(tag)).sort();
+    const removed = [...baseTags].filter((tag) => !currTags.has(tag)).sort();
+    if (added.length > 0 || removed.length > 0) {
+      tagChanges.push({ signature, added, removed });
+    }
+  }
+
+  const countDeltas: CoverageDiff['countDeltas'] = [];
+  const allTypes = new Set([
+    ...Object.keys(baseline.countsByType),
+    ...Object.keys(current.countsByType),
+  ]);
+  for (const type of [...allTypes].sort()) {
+    const base = baseline.countsByType[type] ?? 0;
+    const curr = current.countsByType[type] ?? 0;
+    if (base !== curr) {
+      countDeltas.push({ type, baseline: base, current: curr });
+    }
+  }
+
+  return {
+    equivalent:
+      addedSignatures.length === 0 &&
+      removedSignatures.length === 0 &&
+      tagChanges.length === 0 &&
+      countDeltas.length === 0,
+    addedSignatures,
+    removedSignatures,
+    tagChanges,
+    countDeltas,
+  };
+}
+
+function groupBySignature(
+  items: NormalizedItem[],
+): Map<string, NormalizedItem[]> {
+  const map = new Map<string, NormalizedItem[]>();
+  for (const item of items) {
+    const bucket = map.get(item.signature);
+    if (bucket) {
+      bucket.push(item);
+    } else {
+      map.set(item.signature, [item]);
+    }
+  }
+  return map;
+}
+
+function safeJsonParse(
+  line: string | undefined,
+): Record<string, unknown> | null {
+  if (!line) {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(line);
+    return parsed && typeof parsed === 'object' ? parsed : null;
+  } catch {
+    return null;
+  }
+}

--- a/test/e2e/helpers/sentry-coverage.ts
+++ b/test/e2e/helpers/sentry-coverage.ts
@@ -236,8 +236,15 @@ export function diffCoverage(
       removedSignatures.push(signature);
       continue;
     }
-    const baseTags = new Set(baseBySig.get(signature)?.[0]?.tagKeys ?? []);
-    const currTags = new Set(currBySig.get(signature)?.[0]?.tagKeys ?? []);
+    // Union tag coverage across every item sharing this signature — duplicates
+    // (e.g. two pageload transactions) can each carry different tags, so a tag
+    // counts as covered if any item in the group has it, not just the first.
+    const baseTags = new Set(
+      (baseBySig.get(signature) ?? []).flatMap((item) => item.tagKeys),
+    );
+    const currTags = new Set(
+      (currBySig.get(signature) ?? []).flatMap((item) => item.tagKeys),
+    );
     const added = [...currTags].filter((tag) => !baseTags.has(tag)).sort();
     const removed = [...baseTags].filter((tag) => !currTags.has(tag)).sort();
     if (added.length > 0 || removed.length > 0) {

--- a/test/e2e/tests/metrics/sentry-coverage.spec.ts
+++ b/test/e2e/tests/metrics/sentry-coverage.spec.ts
@@ -45,9 +45,9 @@ const BASELINE_PATH = resolve(
 const UPDATE_BASELINE = process.env.UPDATE_SENTRY_COVERAGE_BASELINE === 'true';
 
 // The fixed flow emits three envelope categories; wait until all have arrived
-// (or the cap elapses) before snapshotting, so we never capture a half-flushed
-// batch: `session` is eager, the pageload `transaction`s follow UI Startup, and
-// the developer-options error `event` is the last to flush.
+// before snapshotting (failing if the cap elapses first), so we never capture a
+// half-flushed batch: `session` is eager, the pageload `transaction`s follow UI
+// Startup, and the developer-options error `event` is the last to flush.
 const REQUIRED_TYPES = ['session', 'event', 'transaction'];
 const MAX_WAIT_FOR_ENVELOPES_MS = 30_000;
 // Let stragglers (e.g. a second pageload transaction) accumulate after the
@@ -112,9 +112,10 @@ describe('Sentry coverage equivalence (#43819)', function () {
             'window.stateHooks.throwTestError("Sentry coverage equivalence error")',
           );
 
-          // Wait until all three envelope categories have been POSTed (or the cap
-          // elapses), then settle for stragglers — so we snapshot the full set,
-          // not just the eager session envelope.
+          // Wait until all three envelope categories have been POSTed, then
+          // settle for stragglers — so we snapshot the full set, not just the
+          // eager session envelope. A timeout here means the capture is
+          // incomplete, so fail loudly rather than snapshot/diff partial data.
           await driver
             .wait(async () => {
               const seen = await mockedEndpoint.getSeenRequests();
@@ -126,7 +127,12 @@ describe('Sentry coverage equivalence (#43819)', function () {
               );
               return REQUIRED_TYPES.every((type) => types.has(type));
             }, MAX_WAIT_FOR_ENVELOPES_MS)
-            .catch(() => undefined);
+            .catch(() => {
+              throw new Error(
+                `Timed out after ${MAX_WAIT_FOR_ENVELOPES_MS}ms waiting for all envelope categories ` +
+                  `(${REQUIRED_TYPES.join(', ')}); refusing to snapshot an incomplete capture.`,
+              );
+            });
           await driver.delay(SETTLE_MS);
 
           const requests = await mockedEndpoint.getSeenRequests();

--- a/test/e2e/tests/metrics/sentry-coverage.spec.ts
+++ b/test/e2e/tests/metrics/sentry-coverage.spec.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'path';
-import { promises as fs } from 'fs';
+import { existsSync, promises as fs } from 'fs';
 import { strict as assert } from 'assert';
-import { MockttpServer } from 'mockttp';
+import { CompletedRequest, MockttpServer } from 'mockttp';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { withFixtures, sentryRegEx } from '../../helpers';
 import { PAGES } from '../../webdriver/driver';
@@ -41,80 +41,89 @@ const WAIT_FOR_FIRST_SENTRY_MS = 15_000;
 // Let the envelope batch accumulate after the first arrives before snapshotting.
 const SETTLE_MS = 3_000;
 
+// A manual cross-build harness, not a standard always-on e2e check: generate
+// the baseline on v8 (`UPDATE_SENTRY_COVERAGE_BASELINE=true`), then compare on
+// v10. The baseline is intentionally not committed, so skip by default in normal
+// CI runs rather than fail on a missing baseline.
+const runOrSkip = UPDATE_BASELINE || existsSync(BASELINE_PATH) ? it : it.skip;
+
 describe('Sentry coverage equivalence (#43819)', function () {
-  it('captures the envelope set for a fixed flow and matches the v8 baseline', async function () {
-    await withFixtures(
-      {
-        fixtures: {
-          ...new FixtureBuilderV2()
-            .withMetaMetricsController({
-              analyticsId: MOCK_ANALYTICS_ID,
-              completedMetaMetricsOnboarding: true,
-              optedIn: true,
-            })
-            .build(),
-          // Corrupt state to provoke a deterministic init/migration error event,
-          // so every run emits a comparable error envelope alongside the
-          // pageload transactions.
-          meta: undefined,
+  runOrSkip(
+    'captures the envelope set for a fixed flow and matches the v8 baseline',
+    async function () {
+      await withFixtures(
+        {
+          fixtures: {
+            ...new FixtureBuilderV2()
+              .withMetaMetricsController({
+                analyticsId: MOCK_ANALYTICS_ID,
+                completedMetaMetricsOnboarding: true,
+                optedIn: true,
+              })
+              .build(),
+            // Corrupt state to provoke a deterministic init/migration error event,
+            // so every run emits a comparable error envelope alongside the
+            // pageload transactions.
+            meta: undefined,
+          },
+          title: this.test?.fullTitle(),
+          // Capture EVERY Sentry POST (no `withBodyIncluding` filter), returning a
+          // 200 so the SDK doesn't retry. One endpoint accumulates all envelopes.
+          testSpecificMock: async (mockServer: MockttpServer) =>
+            mockServer
+              .forPost(sentryRegEx)
+              .thenCallback(() => ({ statusCode: 200, json: {} })),
+          manifestFlags: { sentry: { forceEnable: true } },
         },
-        title: this.test?.fullTitle(),
-        // Capture EVERY Sentry POST (no `withBodyIncluding` filter), returning a
-        // 200 so the SDK doesn't retry. One endpoint accumulates all envelopes.
-        testSpecificMock: async (mockServer: MockttpServer) =>
-          mockServer
-            .forPost(sentryRegEx)
-            .thenCallback(() => ({ statusCode: 200, json: {} })),
-        manifestFlags: { sentry: { forceEnable: true } },
-      },
-      async ({ driver, mockedEndpoint }) => {
-        // Pageload (transactions) + the migration error (event).
-        await driver.navigate(PAGES.HOME, { waitForControllers: false });
-        await driver
-          .wait(
-            async () => !(await mockedEndpoint.isPending()),
-            WAIT_FOR_FIRST_SENTRY_MS,
-          )
-          .catch(() => undefined);
-        await driver.delay(SETTLE_MS);
+        async ({ driver, mockedEndpoint }) => {
+          // Pageload (transactions) + the migration error (event).
+          await driver.navigate(PAGES.HOME, { waitForControllers: false });
+          await driver
+            .wait(
+              async () => !(await mockedEndpoint.isPending()),
+              WAIT_FOR_FIRST_SENTRY_MS,
+            )
+            .catch(() => undefined);
+          await driver.delay(SETTLE_MS);
 
-        const requests = await mockedEndpoint.getSeenRequests();
-        const rawBodies = await Promise.all(
-          requests.map((request) => request.body.getText()),
-        );
-        const current = summarizeCoverage(parseSentryEnvelopes(rawBodies));
-
-        if (UPDATE_BASELINE) {
-          await fs.writeFile(
-            BASELINE_PATH,
-            `${JSON.stringify(current, null, 2)}\n`,
+          const requests = await mockedEndpoint.getSeenRequests();
+          const rawBodies = await Promise.all(
+            requests.map((request: CompletedRequest) => request.body.getText()),
           );
-          console.log(
-            `Wrote Sentry coverage baseline (${current.items.length} items) to ${BASELINE_PATH}`,
-          );
-          return;
-        }
+          const current = summarizeCoverage(parseSentryEnvelopes(rawBodies));
 
-        const baselineRaw = await fs
-          .readFile(BASELINE_PATH, 'utf8')
-          .catch(() => {
-            throw new Error(
-              `No Sentry coverage baseline at ${BASELINE_PATH}. Generate it on a v8 build first: ` +
-                `UPDATE_SENTRY_COVERAGE_BASELINE=true run this spec.`,
+          if (UPDATE_BASELINE) {
+            await fs.writeFile(
+              BASELINE_PATH,
+              `${JSON.stringify(current, null, 2)}\n`,
             );
-          });
-        const baseline = JSON.parse(baselineRaw) as CoverageSummary;
-        const diff = diffCoverage(baseline, current);
+            console.log(
+              `Wrote Sentry coverage baseline (${current.items.length} items) to ${BASELINE_PATH}`,
+            );
+            return;
+          }
 
-        assert.ok(
-          diff.equivalent,
-          `Sentry coverage diverged from the v8 baseline — triage each delta as benign (timing) vs regression:\n${JSON.stringify(
-            diff,
-            null,
-            2,
-          )}`,
-        );
-      },
-    );
-  });
+          const baselineRaw = await fs
+            .readFile(BASELINE_PATH, 'utf8')
+            .catch(() => {
+              throw new Error(
+                `No Sentry coverage baseline at ${BASELINE_PATH}. Generate it on a v8 build first: ` +
+                  `UPDATE_SENTRY_COVERAGE_BASELINE=true run this spec.`,
+              );
+            });
+          const baseline = JSON.parse(baselineRaw) as CoverageSummary;
+          const diff = diffCoverage(baseline, current);
+
+          assert.ok(
+            diff.equivalent,
+            `Sentry coverage diverged from the v8 baseline — triage each delta as benign (timing) vs regression:\n${JSON.stringify(
+              diff,
+              null,
+              2,
+            )}`,
+          );
+        },
+      );
+    },
+  );
 });

--- a/test/e2e/tests/metrics/sentry-coverage.spec.ts
+++ b/test/e2e/tests/metrics/sentry-coverage.spec.ts
@@ -1,0 +1,120 @@
+import { resolve } from 'path';
+import { promises as fs } from 'fs';
+import { strict as assert } from 'assert';
+import { MockttpServer } from 'mockttp';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
+import { withFixtures, sentryRegEx } from '../../helpers';
+import { PAGES } from '../../webdriver/driver';
+import { MOCK_ANALYTICS_ID } from '../../constants';
+import {
+  parseSentryEnvelopes,
+  summarizeCoverage,
+  diffCoverage,
+  type CoverageSummary,
+} from '../../helpers/sentry-coverage';
+
+/**
+ * Sentry coverage-equivalence harness (#43819).
+ *
+ * Captures the FULL set of envelopes the extension sends to Sentry during a
+ * fixed flow, normalizes away volatile ids/timestamps, and compares against a
+ * committed baseline. The point is to verify an SDK migration (v8 → v10,
+ * PR #42867) produces equivalent telemetry — the same errors, transactions,
+ * tags, and volume — rather than trusting a green suite.
+ *
+ * Workflow (run the same flow on each side). First, on `main` (v8), run with
+ * `UPDATE_SENTRY_COVERAGE_BASELINE=true` to write
+ * `state-snapshots/sentry-coverage-baseline.json`. Then, on the v10 branch, run
+ * without the env var: it diffs against the baseline and fails on any structural
+ * delta (added/removed item, dropped tag, volume change), each then triaged
+ * benign (timing) vs regression.
+ *
+ * The baseline is intentionally NOT committed here — it must be generated from a
+ * v8 build so it captures the reference behavior, not whatever SDK is checked out.
+ */
+const BASELINE_PATH = resolve(
+  __dirname,
+  './state-snapshots/sentry-coverage-baseline.json',
+);
+const UPDATE_BASELINE = process.env.UPDATE_SENTRY_COVERAGE_BASELINE === 'true';
+const WAIT_FOR_FIRST_SENTRY_MS = 15_000;
+// Let the envelope batch accumulate after the first arrives before snapshotting.
+const SETTLE_MS = 3_000;
+
+describe('Sentry coverage equivalence (#43819)', function () {
+  it('captures the envelope set for a fixed flow and matches the v8 baseline', async function () {
+    await withFixtures(
+      {
+        fixtures: {
+          ...new FixtureBuilderV2()
+            .withMetaMetricsController({
+              analyticsId: MOCK_ANALYTICS_ID,
+              completedMetaMetricsOnboarding: true,
+              optedIn: true,
+            })
+            .build(),
+          // Corrupt state to provoke a deterministic init/migration error event,
+          // so every run emits a comparable error envelope alongside the
+          // pageload transactions.
+          meta: undefined,
+        },
+        title: this.test?.fullTitle(),
+        // Capture EVERY Sentry POST (no `withBodyIncluding` filter), returning a
+        // 200 so the SDK doesn't retry. One endpoint accumulates all envelopes.
+        testSpecificMock: async (mockServer: MockttpServer) =>
+          mockServer
+            .forPost(sentryRegEx)
+            .thenCallback(() => ({ statusCode: 200, json: {} })),
+        manifestFlags: { sentry: { forceEnable: true } },
+      },
+      async ({ driver, mockedEndpoint }) => {
+        // Pageload (transactions) + the migration error (event).
+        await driver.navigate(PAGES.HOME, { waitForControllers: false });
+        await driver
+          .wait(
+            async () => !(await mockedEndpoint.isPending()),
+            WAIT_FOR_FIRST_SENTRY_MS,
+          )
+          .catch(() => undefined);
+        await driver.delay(SETTLE_MS);
+
+        const requests = await mockedEndpoint.getSeenRequests();
+        const rawBodies = await Promise.all(
+          requests.map((request) => request.body.getText()),
+        );
+        const current = summarizeCoverage(parseSentryEnvelopes(rawBodies));
+
+        if (UPDATE_BASELINE) {
+          await fs.writeFile(
+            BASELINE_PATH,
+            `${JSON.stringify(current, null, 2)}\n`,
+          );
+          console.log(
+            `Wrote Sentry coverage baseline (${current.items.length} items) to ${BASELINE_PATH}`,
+          );
+          return;
+        }
+
+        const baselineRaw = await fs
+          .readFile(BASELINE_PATH, 'utf8')
+          .catch(() => {
+            throw new Error(
+              `No Sentry coverage baseline at ${BASELINE_PATH}. Generate it on a v8 build first: ` +
+                `UPDATE_SENTRY_COVERAGE_BASELINE=true run this spec.`,
+            );
+          });
+        const baseline = JSON.parse(baselineRaw) as CoverageSummary;
+        const diff = diffCoverage(baseline, current);
+
+        assert.ok(
+          diff.equivalent,
+          `Sentry coverage diverged from the v8 baseline — triage each delta as benign (timing) vs regression:\n${JSON.stringify(
+            diff,
+            null,
+            2,
+          )}`,
+        );
+      },
+    );
+  });
+});

--- a/test/e2e/tests/metrics/sentry-coverage.spec.ts
+++ b/test/e2e/tests/metrics/sentry-coverage.spec.ts
@@ -4,8 +4,8 @@ import { strict as assert } from 'assert';
 import { CompletedRequest, MockttpServer } from 'mockttp';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { withFixtures, sentryRegEx } from '../../helpers';
-import { PAGES } from '../../webdriver/driver';
 import { MOCK_ANALYTICS_ID } from '../../constants';
+import { login } from '../../page-objects/flows/login.flow';
 import {
   parseSentryEnvelopes,
   summarizeCoverage,
@@ -22,6 +22,12 @@ import {
  * PR #42867) produces equivalent telemetry — the same errors, transactions,
  * tags, and volume — rather than trusting a green suite.
  *
+ * The fixed flow is the #43819 scenario: unlock (eager `session` envelope +
+ * `UI Startup` / `/home.html` pageload transactions) → trigger a known
+ * developer-options error (`event`). We wait until all three envelope
+ * categories have been POSTed before snapshotting, so we capture the full set
+ * rather than just the eager session envelope.
+ *
  * Workflow (run the same flow on each side). First, on `main` (v8), run with
  * `UPDATE_SENTRY_COVERAGE_BASELINE=true` to write
  * `state-snapshots/sentry-coverage-baseline.json`. Then, on the v10 branch, run
@@ -37,9 +43,16 @@ const BASELINE_PATH = resolve(
   './state-snapshots/sentry-coverage-baseline.json',
 );
 const UPDATE_BASELINE = process.env.UPDATE_SENTRY_COVERAGE_BASELINE === 'true';
-const WAIT_FOR_FIRST_SENTRY_MS = 15_000;
-// Let the envelope batch accumulate after the first arrives before snapshotting.
-const SETTLE_MS = 3_000;
+
+// The fixed flow emits three envelope categories; wait until all have arrived
+// (or the cap elapses) before snapshotting, so we never capture a half-flushed
+// batch: `session` is eager, the pageload `transaction`s follow UI Startup, and
+// the developer-options error `event` is the last to flush.
+const REQUIRED_TYPES = ['session', 'event', 'transaction'];
+const MAX_WAIT_FOR_ENVELOPES_MS = 30_000;
+// Let stragglers (e.g. a second pageload transaction) accumulate after the
+// required set has arrived before snapshotting.
+const SETTLE_MS = 5_000;
 
 // A manual cross-build harness, not a standard always-on e2e check: generate
 // the baseline on v8 (`UPDATE_SENTRY_COVERAGE_BASELINE=true`), then compare on
@@ -53,36 +66,58 @@ describe('Sentry coverage equivalence (#43819)', function () {
     async function () {
       await withFixtures(
         {
-          fixtures: {
-            ...new FixtureBuilderV2()
-              .withMetaMetricsController({
-                analyticsId: MOCK_ANALYTICS_ID,
-                completedMetaMetricsOnboarding: true,
-                optedIn: true,
-              })
-              .build(),
-            // Corrupt state to provoke a deterministic init/migration error event,
-            // so every run emits a comparable error envelope alongside the
-            // pageload transactions.
-            meta: undefined,
-          },
+          fixtures: new FixtureBuilderV2()
+            .withMetaMetricsController({
+              analyticsId: MOCK_ANALYTICS_ID,
+              completedMetaMetricsOnboarding: true,
+              optedIn: true,
+            })
+            .build(),
           title: this.test?.fullTitle(),
           // Capture EVERY Sentry POST (no `withBodyIncluding` filter), returning a
-          // 200 so the SDK doesn't retry. One endpoint accumulates all envelopes.
+          // 200 so the SDK doesn't retry. One endpoint accumulates all envelopes
+          // (error DSN and performance DSN both match `sentryRegEx`).
           testSpecificMock: async (mockServer: MockttpServer) =>
             mockServer
               .forPost(sentryRegEx)
               .thenCallback(() => ({ statusCode: 200, json: {} })),
-          manifestFlags: { sentry: { forceEnable: true } },
+          // optedIn already enables Sentry; force 100% trace sampling so the
+          // pageload transactions are emitted deterministically.
+          manifestFlags: {
+            sentry: { forceEnable: false, tracesSampleRate: 1 },
+          },
+          // The developer-options test error logs to the console by design.
+          ignoredConsoleErrors: ['TestError'],
         },
         async ({ driver, mockedEndpoint }) => {
-          // Pageload (transactions) + the migration error (event).
-          await driver.navigate(PAGES.HOME, { waitForControllers: false });
+          // Unlock → session envelope + UI Startup / /home.html pageload
+          // transactions. Skip the non-EVM/snap-discovery wait (#43817) and
+          // balance validation — irrelevant to telemetry and a flake source.
+          await login(driver, {
+            validateBalance: false,
+            waitForNonEvmAccounts: false,
+          });
+
+          // Trigger a deterministic error captured by Sentry via the
+          // developer-options hook, so every run emits a comparable error event.
+          await driver.executeScript(
+            'window.stateHooks.throwTestError("Sentry coverage equivalence error")',
+          );
+
+          // Wait until all three envelope categories have been POSTed (or the cap
+          // elapses), then settle for stragglers — so we snapshot the full set,
+          // not just the eager session envelope.
           await driver
-            .wait(
-              async () => !(await mockedEndpoint.isPending()),
-              WAIT_FOR_FIRST_SENTRY_MS,
-            )
+            .wait(async () => {
+              const seen = await mockedEndpoint.getSeenRequests();
+              const bodies = await Promise.all(
+                seen.map((request: CompletedRequest) => request.body.getText()),
+              );
+              const types = new Set(
+                parseSentryEnvelopes(bodies).map((item) => item.type),
+              );
+              return REQUIRED_TYPES.every((type) => types.has(type));
+            }, MAX_WAIT_FOR_ENVELOPES_MS)
             .catch(() => undefined);
           await driver.delay(SETTLE_MS);
 

--- a/test/e2e/tests/metrics/sentry-coverage.spec.ts
+++ b/test/e2e/tests/metrics/sentry-coverage.spec.ts
@@ -54,6 +54,13 @@ const MAX_WAIT_FOR_ENVELOPES_MS = 30_000;
 // required set has arrived before snapshotting.
 const SETTLE_MS = 5_000;
 
+// Outrank mock-e2e.js's global Sentry DSN handlers — they are registered after
+// `testSpecificMock` and so otherwise win the match, leaving this endpoint with
+// only a fraction of the envelopes. With a higher priority our one endpoint
+// intercepts EVERY Sentry envelope (both DSNs), independent of the per-branch
+// mock-e2e setup, so the capture is the full per-flow set.
+const SENTRY_CAPTURE_PRIORITY = 100;
+
 // A manual cross-build harness, not a standard always-on e2e check: generate
 // the baseline on v8 (`UPDATE_SENTRY_COVERAGE_BASELINE=true`), then compare on
 // v10. The baseline is intentionally not committed, so skip by default in normal
@@ -75,11 +82,12 @@ describe('Sentry coverage equivalence (#43819)', function () {
             .build(),
           title: this.test?.fullTitle(),
           // Capture EVERY Sentry POST (no `withBodyIncluding` filter), returning a
-          // 200 so the SDK doesn't retry. One endpoint accumulates all envelopes
-          // (error DSN and performance DSN both match `sentryRegEx`).
+          // 200 so the SDK doesn't retry. One high-priority endpoint accumulates
+          // all envelopes — error DSN and performance DSN both match `sentryRegEx`.
           testSpecificMock: async (mockServer: MockttpServer) =>
             mockServer
               .forPost(sentryRegEx)
+              .asPriority(SENTRY_CAPTURE_PRIORITY)
               .thenCallback(() => ({ statusCode: 200, json: {} })),
           // optedIn already enables Sentry; force 100% trace sampling so the
           // pageload transactions are emitted deterministically.


### PR DESCRIPTION
## **Description**

Layer-2 verification tooling for the Sentry v8→v10 migration (#42867), implementing the harness spec'd in #43819.

Captures the **full set of envelopes** the extension sends to a mocked Sentry DSN during a fixed flow, normalizes away volatile ids/timestamps, and diffs a v10 run against a v8 baseline — surfacing any added/removed envelope item, dropped correlation tag (e.g. `otelTraceId`), or volume change that a green suite would miss. The point is to verify *behavioral* equivalence of telemetry, not just that tests pass.

**What's here:**

- `test/e2e/helpers/sentry-coverage.ts` — pure parse/normalize/diff utility: a Sentry newline-delimited envelope parser, volatile-key stripping, stable per-item signatures, and a structural diff with per-type counts. No runtime/Sentry imports.
- `test/e2e/helpers/sentry-coverage.test.ts` — 10 unit tests over realistic error/transaction/session envelope fixtures: parsing, normalization, and diff-detection of removed items, dropped tags, and volume increases.
- `test/e2e/tests/metrics/sentry-coverage.spec.ts` — the e2e capture spec. A manual cross-build harness (not an always-on check): it **skips by default** and runs only with `UPDATE_SENTRY_COVERAGE_BASELINE=true` (write the baseline on v8) or when a baseline is present (compare on v10).

**How to use (the v8-vs-v10 protocol):** on `main` (v8), run the spec with `UPDATE_SENTRY_COVERAGE_BASELINE=true` to write `state-snapshots/sentry-coverage-baseline.json`; then on the v10 branch (#42867), run it without the env var to diff against the baseline and fail on any structural delta, each triaged benign (timing) vs regression. The baseline JSON is intentionally not committed — it must be generated from a v8 build.

## **Related issues**

Closes #43819

Related:
- #42867 — the Sentry v8→v10 upgrade this verifies.
- #43410 — quota/volume context (the per-type envelope-count diff is the volume axis).

## **Manual testing steps**

1. `yarn jest test/e2e/helpers/sentry-coverage.test.ts` → 10 passing (the pure parse/normalize/diff utility).
2. The capture spec requires a built extension; run per the protocol above on v8 then v10. In normal CI it skips (no committed baseline), so it doesn't gate unrelated runs.

## **Screenshots/Recordings**

N/A — E2E verification tooling only; no user-facing change.

### **Before**

No way to verify the v8→v10 migration preserves equivalent telemetry beyond the existing per-field snapshot assertions.

### **After**

A reusable harness diffs the full v8 vs v10 envelope set (items, tags, volume), with the pure core unit-tested.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New e2e test utilities only; no production or runtime Sentry behavior changes.
> 
> **Overview**
> Adds **test-only** tooling to compare full Sentry telemetry between SDK builds (e.g. v8 vs v10) instead of relying on a green e2e suite alone.
> 
> A new pure helper (`sentry-coverage.ts`) **parses** newline-delimited Sentry envelope POST bodies, **strips** volatile ids/timestamps, builds stable per-item **signatures**, and **diffs** baseline vs current captures for added/removed items, tag-key changes (e.g. `otelTraceId`), and per-type volume. Unit tests cover parsing, normalization, and diff scenarios on realistic fixtures.
> 
> An optional e2e spec **mocks all Sentry envelope traffic** at high mock priority, runs a fixed flow (login → developer-options test error), waits for `session` / `event` / `transaction`, then either writes a local baseline (`UPDATE_SENTRY_COVERAGE_BASELINE=true`) or asserts equivalence against that file. The spec **skips by default** when no baseline exists so normal CI is unaffected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f1ae801858e6f54be988d91840ab2fc0af266ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->