### PR TITLE
fix: updated title for the network filter in homepage with the networks modal

### DIFF
--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
@@ -3,6 +3,8 @@ import { fireEvent, waitFor } from '@testing-library/react';
 import thunk from 'redux-thunk';
 import configureMockStore from 'redux-mock-store';
 import type { NetworkConfiguration } from '@metamask/network-controller';
+// eslint-disable-next-line import-x/no-restricted-paths
+import messages from '../../../../../../app/_locales/en/messages.json';
 import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
 import mockState from '../../../../../../test/data/mock-state.json';
 import * as actions from '../../../../../store/actions';
@@ -225,7 +227,7 @@ describe('NFTs options', () => {
 
     const manageTokensButton = await findByTestId('manageTokens__button');
 
-    expect(manageTokensButton).toHaveTextContent('Manage tokens');
+    expect(manageTokensButton).toHaveTextContent(messages.manageTokens.message);
     expect(queryByTestId('importTokens__button')).not.toBeInTheDocument();
 
     fireEvent.click(manageTokensButton);
@@ -253,7 +255,7 @@ describe('NFTs options', () => {
     fireEvent.click(actionButton);
 
     expect(await findByTestId('importTokens__button')).toHaveTextContent(
-      'Import tokens',
+      messages.importTokensCamelCase.message,
     );
     expect(queryByTestId('manageTokens__button')).not.toBeInTheDocument();
   });
@@ -271,6 +273,69 @@ describe('NFTs options', () => {
     expect(mockUseNavigate).toHaveBeenCalledWith(
       `${NETWORKS_ROUTE}?drawerOpen=true`,
     );
+  });
+
+  it('labels selected default networks as All networks when there are no custom or test networks visible', async () => {
+    const state = createMockState();
+    state.metamask.preferences.showTestNetworks = false;
+    state.metamask.enabledNetworkMap = {
+      eip155: {
+        '0x1': true,
+        '0x89': true,
+      },
+    };
+    const store = configureMockStore([thunk])(state);
+
+    const { findByTestId } = renderWithProvider(<AssetListControlBar />, store);
+
+    const networkFilterButton = await findByTestId('sort-by-networks');
+    expect(networkFilterButton).toHaveTextContent(messages.allNetworks.message);
+
+    fireEvent.click(networkFilterButton);
+    expect(
+      await findByTestId('home-network-filter-all-default'),
+    ).toHaveTextContent(messages.allNetworks.message);
+  });
+
+  it('labels selected default networks as All default networks when custom networks exist', async () => {
+    const state = createMockState();
+    state.metamask.preferences.showTestNetworks = false;
+    state.metamask.enabledNetworkMap = {
+      eip155: {
+        '0x1': true,
+        '0x89': true,
+      },
+    };
+    state.metamask.networkConfigurationsByChainId = {
+      ...state.metamask.networkConfigurationsByChainId,
+      '0x123': {
+        chainId: '0x123',
+        name: 'Custom Network',
+        nativeCurrency: 'TST',
+        defaultRpcEndpointIndex: 0,
+        rpcEndpoints: [
+          {
+            networkClientId: 'customNetworkClientId',
+            type: 'custom',
+            url: 'https://custom-network.example',
+          },
+        ],
+        blockExplorerUrls: [],
+      } as unknown as NetworkConfiguration,
+    };
+    const store = configureMockStore([thunk])(state);
+
+    const { findByTestId } = renderWithProvider(<AssetListControlBar />, store);
+
+    const networkFilterButton = await findByTestId('sort-by-networks');
+    expect(networkFilterButton).toHaveTextContent(
+      messages.allDefaultNetworks.message,
+    );
+
+    fireEvent.click(networkFilterButton);
+    expect(
+      await findByTestId('home-network-filter-all-default'),
+    ).toHaveTextContent(messages.allDefaultNetworks.message);
   });
 
   it('calls onNetworkSelect with CAIP IDs when one network is enabled', async () => {
@@ -297,10 +362,7 @@ describe('NFTs options', () => {
     const state = createMockState();
     const store = configureMockStore([thunk])(state);
 
-    const { findByTestId, findByText } = renderWithProvider(
-      <AssetListControlBar />,
-      store,
-    );
+    const { findByTestId } = renderWithProvider(<AssetListControlBar />, store);
 
     fireEvent.click(await findByTestId('sort-by-networks'));
 

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
@@ -14,7 +14,9 @@ import {
   getAllChainsToPoll,
   getIsLineaMainnet,
   getIsMainnet,
+  getShowTestNetworks,
   getTokenNetworkFilter,
+  getUseExternalServices,
   getUseNftDetection,
 } from '../../../../../selectors';
 import { getSelectedInternalAccount } from '../../../../../../shared/lib/selectors/accounts';
@@ -94,6 +96,7 @@ import {
   getIsNetworkManagementEnabled,
   getIsTokenManagementFilterEnabled,
 } from '../../../../../selectors/multichain/feature-flags';
+import { useNetworkManagerState } from '../../../../multichain/network-manager/hooks/useNetworkManagerState';
 import { HomeNetworkFilterModal } from './home-network-filter-modal';
 
 type AssetListControlBarProps = {
@@ -119,6 +122,8 @@ const AssetListControlBar = ({
   const currentMultichainNetwork = useSelector(getMultichainNetwork);
   const allNetworks = useSelector(getNetworkConfigurationsByChainId);
   const allCaipNetworks = useSelector(getAllNetworkConfigurationsByCaipChainId);
+  const showTestnets = useSelector(getShowTestNetworks);
+  const useExternalServices = useSelector(getUseExternalServices);
   const isMainnet = useSelector(getIsMainnet);
   const isLineaMainnet = useSelector(getIsLineaMainnet);
   const allChainIds = useSelector(getAllChainsToPoll);
@@ -147,6 +152,21 @@ const AssetListControlBar = ({
   const [isImportTokensPopoverOpen, setIsImportTokensPopoverOpen] =
     useState(false);
   const [isImportNftPopoverOpen, setIsImportNftPopoverOpen] = useState(false);
+  const { nonTestNetworks: customNetworkMap, testNetworks: testNetworkMap } =
+    useNetworkManagerState();
+
+  const hasOnlyDefaultNetworks = useMemo(() => {
+    const hasVisibleCustomNetworks = Object.values(customNetworkMap).some(
+      (network) => useExternalServices || network.isEvm,
+    );
+    const hasVisibleTestNetworks =
+      showTestnets &&
+      Object.values(testNetworkMap).some(
+        (network) => useExternalServices || network.isEvm,
+      );
+
+    return !hasVisibleCustomNetworks && !hasVisibleTestNetworks;
+  }, [customNetworkMap, showTestnets, testNetworkMap, useExternalServices]);
 
   const allNetworkClientIds = useMemo(() => {
     return Object.keys(tokenNetworkFilter).flatMap((chainId) => {
@@ -347,9 +367,12 @@ const AssetListControlBar = ({
       return allCaipNetworks[caipChainId]?.name ?? t('currentNetwork');
     }
 
-    // > 1 network selected, show "all networks"
+    // > 1 network selected, show whether that means every visible network or
+    // only the default-network set.
     if (totalEnabledNetworkCount > 1) {
-      return t('allPopularNetworks');
+      return hasOnlyDefaultNetworks
+        ? t('allNetworks')
+        : t('allDefaultNetworks');
     }
 
     if (totalEnabledNetworkCount === 0) {
@@ -359,6 +382,7 @@ const AssetListControlBar = ({
     return t('popularNetworks');
   }, [
     allEnabledNetworksForAllNamespaces,
+    hasOnlyDefaultNetworks,
     totalEnabledNetworkCount,
     t,
     allCaipNetworks,

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
@@ -357,11 +357,9 @@ const HomeNetworkFilterModalContent = ({
   }, [orderedNetworksList, testNetworkMap, useExternalServices]);
 
   // When there are no custom networks and no visible test networks, the default
-  // (popular) list is the *only* list: the redundant "Default networks" header
-  // is hidden and the top "select all" row reads "All default networks". Once a
-  // custom network exists or test networks are shown, multiple sections appear,
-  // so the top row becomes "All networks" and the default section shows its
-  // "Default networks" header.
+  // list is the only list, so selecting default networks is equivalent to
+  // selecting all networks. Once custom or test networks are visible, the top row
+  // specifically selects "All default networks".
   const hasOnlyDefaultNetworks =
     customNetworks.length === 0 && !(showTestnets && testNetworks.length > 0);
 
@@ -498,8 +496,8 @@ const HomeNetworkFilterModalContent = ({
       topItem={{
         key: 'all-default-networks',
         name: hasOnlyDefaultNetworks
-          ? t('allDefaultNetworks')
-          : t('allNetworks'),
+          ? t('allNetworks')
+          : t('allDefaultNetworks'),
         iconSrc: IconName.Global,
         selected: isAllDefaultSelected,
         onClick: handleSelectAllDefaultNetworks,


### PR DESCRIPTION
This PR is to update the homepage network filter title and match it with the networks modal


## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: title update

## **Related issues**

Fixes: #43728 

## **Manual testing steps**

1. If users have just default networks, we always just call it all networks in both the picker and the modal
2. If users have test networks or custom networks, we call it all default networks for both the picker and the modal

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/37be12b3-4507-482a-8219-65547e9c474a



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and label-selection logic only in the assets network filter UI; no changes to which networks are enabled or how selection is persisted.
> 
> **Overview**
> Aligns the homepage network filter button text with the network filter modal so both use the same **All networks** vs **All default networks** wording.
> 
> When multiple default networks are selected and the user has **no** visible custom or test networks, the picker and modal top row now show **All networks** (replacing the previous **allPopularNetworks** / mismatched modal label). When custom or test networks are visible, both surfaces show **All default networks**. The control bar derives `hasOnlyDefaultNetworks` via `useNetworkManagerState` and the same visibility rules as the modal.
> 
> Tests assert both the filter button and modal row use locale strings from `messages.json`, and several expectations were updated from hard-coded English to those keys.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9dc6f04240bb7433c323ae53f510b58d0a008e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->