### PR TITLE
feat: updated icon for disable button in networks pae

### DIFF
--- a/ui/components/multichain/network-list-item-menu/network-list-item-menu.js
+++ b/ui/components/multichain/network-list-item-menu/network-list-item-menu.js
@@ -93,7 +93,9 @@ export const NetworkListItemMenu = ({
         {onDeleteClick ? (
           <MenuItem
             ref={deleteRef}
-            iconNameLegacy={IconName.Trash}
+            iconNameLegacy={
+              deleteMenuLabel === 'disable' ? IconName.Ban : IconName.Trash
+            }
             onClick={(e) => {
               e.stopPropagation();
               onDeleteClick();

--- a/ui/components/multichain/network-list-item/network-list-item.test.js
+++ b/ui/components/multichain/network-list-item/network-list-item.test.js
@@ -108,6 +108,26 @@ describe('NetworkListItem', () => {
       queryByTestId('network-list-item-options-delete'),
     ).not.toBeInTheDocument();
   });
+
+  it('uses the ban icon for the disable menu item', () => {
+    const { getByTestId } = render(
+      <NetworkListItem
+        {...DEFAULT_PROPS}
+        deleteMenuLabel="disable"
+        onDeleteClick={jest.fn()}
+      />,
+    );
+
+    const menuButton = getByTestId('network-list-item-options-button-0x1');
+    fireEvent.click(menuButton);
+
+    const icon = getByTestId('network-list-item-options-delete').querySelector(
+      '.mm-icon',
+    );
+    expect(icon).toHaveStyle("mask-image: url('./images/icons/ban.svg')");
+
+    fireEvent.click(menuButton);
+  });
 });
 
 describe('NetworkListItem - Gas fees sponsored', () => {


### PR DESCRIPTION
This PR is to update the icon for the Disable button

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to networks page
2. Add a custom network, click on three dot menu. Check the delete button appears with Trash icon
3. Click on three dot menu for OP or BNB. Check the disable button appears with Ban Icon

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="628" height="372" alt="Screenshot 2026-06-24 at 11 35 54 AM" src="https://github.com/user-attachments/assets/bf4ebaf3-2f14-47e6-a6c9-860552b968ec" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic icon mapping in the network list menu with no auth, data, or business-logic changes.
> 
> **Overview**
> The network list item overflow menu now shows a **ban** icon when the destructive action is labeled **disable** (e.g. built-in networks), and keeps the **trash** icon for **delete** (e.g. custom networks).
> 
> Selection is driven by the existing `deleteMenuLabel` prop (`'disable'` vs default `'delete'`). A unit test asserts the disable menu item renders with the ban SVG mask.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49cbf55c4a9cdf4e92b1b2ee660f86dfed59e41e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->