### PR TITLE
test: fix flaky State Persistence split state should update from data state to split state

### DIFF
--- a/test/e2e/tests/state-persistence/state-persistence.spec.ts
+++ b/test/e2e/tests/state-persistence/state-persistence.spec.ts
@@ -270,17 +270,62 @@ const assertDataStateStorage = (storage: DataStorage) => {
 };
 
 /**
+ * Polls extension storage until the provided assertion passes, then returns it.
+ *
+ * State persistence to `storage.local` is asynchronous and debounced, so reading
+ * storage immediately after a UI action can observe a partially written snapshot
+ * (for example an empty `KeyringController`). Polling avoids relying on fixed
+ * delays, while a final assertion ensures the descriptive error still surfaces
+ * if the expected shape is never reached.
+ *
+ * @param driver - WebDriver instance.
+ * @param assertStorage - Assertion to run against each storage snapshot.
+ * @param logLabel - Label used when logging the resulting storage keys.
+ * @param timeout - Max time (ms) to wait for the assertion to pass.
+ * @returns Parsed storage snapshot once the assertion passes.
+ */
+const waitForStorage = async <Storage extends StoredState>(
+  driver: Driver,
+  assertStorage: (storage: Storage) => void,
+  logLabel: string,
+  timeout = 30000,
+): Promise<Storage> => {
+  let storage = (await readStorage(driver)) as Storage;
+  try {
+    await driver.waitUntil(
+      async () => {
+        storage = (await readStorage(driver)) as Storage;
+        try {
+          assertStorage(storage);
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      { interval: 1000, timeout },
+    );
+  } catch {
+    // Re-read and assert once more so the descriptive AssertionError surfaces
+    // instead of the generic "Condition not met" timeout error.
+    storage = (await readStorage(driver)) as Storage;
+    assertStorage(storage);
+  }
+  console.log(`${logLabel}:`, Object.keys(storage));
+  return storage;
+};
+
+/**
  * Ensures the split state storage is present and valid.
  *
  * @param driver - WebDriver instance.
  * @returns Parsed split state storage snapshot.
  */
-const expectSplitStateStorage = async (driver: Driver) => {
-  const storage = await readStorage(driver);
-  console.log('split storage:', Object.keys(storage));
-  assertSplitStateStorage(storage as SplitStateStorage);
-  return storage;
-};
+const expectSplitStateStorage = async (driver: Driver) =>
+  waitForStorage<SplitStateStorage>(
+    driver,
+    assertSplitStateStorage,
+    'split storage',
+  );
 
 /**
  * Ensures the data state storage is present and valid.
@@ -288,12 +333,8 @@ const expectSplitStateStorage = async (driver: Driver) => {
  * @param driver - WebDriver instance.
  * @returns Parsed data state storage snapshot.
  */
-const expectDataStateStorage = async (driver: Driver) => {
-  const storage = await readStorage(driver);
-  console.log('data storage:', Object.keys(storage));
-  assertDataStateStorage(storage as DataStorage);
-  return storage;
-};
+const expectDataStateStorage = async (driver: Driver) =>
+  waitForStorage<DataStorage>(driver, assertDataStateStorage, 'data storage');
 
 /**
  * Waits for the extension to reload and the home screen to appear.
@@ -410,7 +451,11 @@ const assertAccountVisible = async (
 };
 
 describe('State Persistence', function () {
-  this.timeout(120000);
+  // Generous timeout: this flow onboards, adds an account, and reloads/unlocks
+  // the extension twice while waiting for the split-state migration. On slower
+  // CI (notably Firefox) the condition-based storage waits need headroom so the
+  // suite-level timeout does not kill a run that is still making progress.
+  this.timeout(180000);
 
   describe('split state', function () {
     it('should default to the split state storage', async function () {
@@ -452,7 +497,8 @@ describe('State Persistence', function () {
             accountName,
           );
 
-          await driver.delay(5000); // wait for any background migrations to finish
+          // No fixed delay needed: expectDataStateStorage polls storage until
+          // the data-state shape (incl. a populated KeyringController) is written.
           console.log('expectDataStateStorage');
           await expectDataStateStorage(driver);
 
@@ -469,7 +515,8 @@ describe('State Persistence', function () {
             accountListPage,
             accountName,
           );
-          await driver.delay(5000); // wait for any background migrations to finish
+          // No fixed delay needed: expectSplitStateStorage polls storage until
+          // the split-state migration has fully written the split-state shape.
           console.log('expectSplitStateStorage');
           await expectSplitStateStorage(driver);
 


### PR DESCRIPTION


## **Description**

Test failing in [CI](https://github.com/MetaMask/metamask-extension/actions/runs/28017996122/job/82929352318) with error `AssertionError [ERR_ASSERTION]: KeyringController should contain persisted data; length=0`

- Replaced the single read + assert with a `waitForStorage` helper that polls `storage.local` until the expected shape (incl. a populated `KeyringController`) is written, then asserts. A final assertion still runs on timeout so the original descriptive error surfaces.
- Removed the now-redundant fixed delays that preceded the storage checks (polling subsumes them).
- Raised the suite timeout to give the condition-based flow headroom on slower CI.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<img width="1366" height="682" alt="test-failure-screenshot-1" src="https://github.com/user-attachments/assets/e6a2fad3-e664-4698-97f4-81600b3bd4c3" />


### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to e2e test helpers and timeouts; no production or persistence logic is modified.
> 
> **Overview**
> Fixes flaky **State Persistence** e2e failures where `KeyringController` was read as empty because `storage.local` writes are **async/debounced**.
> 
> Introduces **`waitForStorage`**, which polls until `assertDataStateStorage` / `assertSplitStateStorage` succeed (30s default, 1s interval), with a **final assert on timeout** so the original `AssertionError` still appears instead of a generic wait timeout. **`expectDataStateStorage`** and **`expectSplitStateStorage`** now delegate to this helper.
> 
> Removes **fixed 5s delays** immediately before those storage checks in the data→split migration test; bumps the **suite timeout** from 120s to **180s** for slower CI (e.g. Firefox) while migrations and polling run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 390f13d0359fb97fc573da7594c54d5083ca0712. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->