### PR TITLE
chore: [STELLAR] - Fix UX/UI

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -9912,7 +9912,7 @@
   },
   "stellarClassicDeactivateOnStellar": {
     "message": "Remove",
-    "description": "Button label to deactivate an active Stellar classic asset on the asset detail page. $1 is the token symbol."
+    "description": "Button label to deactivate an active Stellar classic asset on the asset detail page."
   },
   "stellarClassicTrustlineAddError": {
     "message": "Something went wrong while adding this trustline. Try again.",

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -9902,25 +9902,17 @@
   "statusNotConnected": {
     "message": "Not connected"
   },
-  "stellarClassicActivateOnStellarBody": {
-    "message": "Two steps: fund wallet with XLM, then add $1",
+  "stellarClassicActivateOnStellar": {
+    "message": "Activate $1 on Stellar to get started.",
     "description": "Explainer for the trustline activation card on the Stellar asset detail page. $1 is the token symbol."
   },
   "stellarClassicActivateOnStellarButton": {
     "message": "Activate",
     "description": "Primary button to submit a Stellar classic trustline add via the wallet snap"
   },
-  "stellarClassicActivateOnStellarTitle": {
-    "message": "Activate $1 on Stellar",
-    "description": "Title for the trustline activation card on the Stellar asset detail page. $1 is the token symbol."
-  },
   "stellarClassicDeactivateOnStellar": {
-    "message": "Deactivate $1 on Stellar",
+    "message": "Remove",
     "description": "Button label to deactivate an active Stellar classic asset on the asset detail page. $1 is the token symbol."
-  },
-  "stellarClassicDeactivateOnStellarDetail": {
-    "message": "Remove trustline to deactivate",
-    "description": "Tooltip for the deactivate Stellar classic asset button on the asset detail page"
   },
   "stellarClassicTrustlineAddError": {
     "message": "Something went wrong while adding this trustline. Try again.",

--- a/shared/constants/multichain/networks.ts
+++ b/shared/constants/multichain/networks.ts
@@ -211,6 +211,7 @@ export const MULTICHAIN_NETWORK_BLOCK_EXPLORER_FORMAT_URLS_MAP: Record<
     name: STELLAR_BLOCK_EXPLORER_NAME,
     url: STELLAR_BLOCK_EXPLORER_URL,
     address: `${STELLAR_BLOCK_EXPLORER_URL}/explorer/public/account/{address}`,
+    asset: `${STELLAR_BLOCK_EXPLORER_URL}/explorer/public/asset/{asset}`,
     transaction: `${STELLAR_BLOCK_EXPLORER_URL}/explorer/public/tx/{txId}`,
   },
 } as const;

--- a/shared/lib/asset-utils.test.ts
+++ b/shared/lib/asset-utils.test.ts
@@ -177,9 +177,9 @@ describe('asset-utils', () => {
       expect(toAssetId(contractId, chainId)).toBe(
         `${chainId}/sep41:${contractId}`,
       );
-      expect(
-        toAssetId(`sep41:${contractId}`, chainId),
-      ).toBe(`${chainId}/sep41:${contractId}`);
+      expect(toAssetId(`sep41:${contractId}`, chainId)).toBe(
+        `${chainId}/sep41:${contractId}`,
+      );
     });
   });
 

--- a/shared/lib/multichain/networks.ts
+++ b/shared/lib/multichain/networks.ts
@@ -35,6 +35,11 @@ export type MultichainBlockExplorerFormatUrls = {
    * Format URL of the block explorer for transactions.
    */
   transaction: MultichainBlockExplorerFormatUrl<'txId'>;
+
+  /**
+   * Format URL of the block explorer for assets (optional).
+   */
+  asset?: MultichainBlockExplorerFormatUrl<'asset'>;
 };
 
 /**
@@ -79,4 +84,21 @@ export function formatBlockExplorerTransactionUrl(
   txId: string,
 ): string {
   return urls.transaction.replace('{txId}', txId);
+}
+
+/**
+ * Format a URL for assets.
+ *
+ * @param urls - The group of format URLs for a given block explorer.
+ * @param asset - The asset reference to create the URL for.
+ * @returns The formatted URL for the given asset, or empty string if not supported.
+ */
+export function formatBlockExplorerAssetUrl(
+  urls: MultichainBlockExplorerFormatUrls,
+  asset: string,
+): string {
+  if (!urls.asset) {
+    return '';
+  }
+  return urls.asset.replace('{asset}', asset);
 }

--- a/ui/components/app/assets/hooks/useTokenDisplayInfo.tsx
+++ b/ui/components/app/assets/hooks/useTokenDisplayInfo.tsx
@@ -86,12 +86,13 @@ export const useTokenDisplayInfo = ({
   const isStakeable =
     token.isStakeable || (isEvmMainnet && isEvm && token.isNative);
 
-  const isStellarTrustlineInactive = isStellarClassicTrustlineInactiveForDisplay({
-    chainId: token.chainId,
-    assetId: token.assetId,
-    isNative: token.isNative,
-    extra: token.extra,
-  });
+  const isStellarTrustlineInactive =
+    isStellarClassicTrustlineInactiveForDisplay({
+      chainId: token.chainId,
+      assetId: token.assetId,
+      isNative: token.isNative,
+      extra: token.extra,
+    });
 
   if (isEvm) {
     const tokenData = (

--- a/ui/components/app/assets/stellar-trustline-inactive-badge/stellar-trustline-inactive-badge.tsx
+++ b/ui/components/app/assets/stellar-trustline-inactive-badge/stellar-trustline-inactive-badge.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { TextColor, TextVariant } from '@metamask/design-system-react';
-import { BackgroundColor, BorderRadius } from '../../../../helpers/constants/design-system';
+import {
+  BackgroundColor,
+  BorderRadius,
+} from '../../../../helpers/constants/design-system';
 import { Tag } from '../../../component-library';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 

--- a/ui/components/app/assets/token-cell/cells/token-cell-primary-display.tsx
+++ b/ui/components/app/assets/token-cell/cells/token-cell-primary-display.tsx
@@ -27,10 +27,6 @@ export const TokenCellPrimaryDisplay = React.memo(
       selectAnyEnabledNetworksAreAvailable,
     );
 
-    if (token.isStellarTrustlineInactive) {
-      return null;
-    }
-
     return (
       <Skeleton
         hideChildren={

--- a/ui/components/app/assets/token-cell/cells/token-cell-secondary-display.tsx
+++ b/ui/components/app/assets/token-cell/cells/token-cell-secondary-display.tsx
@@ -60,10 +60,6 @@ export const TokenCellSecondaryDisplay = React.memo(
       selectAnyEnabledNetworksAreAvailable,
     );
 
-    if (token.isStellarTrustlineInactive) {
-      return null;
-    }
-
     const secondaryDisplayText = useCurrencyRateCheck
       ? token.secondary || '—'
       : '';

--- a/ui/components/app/assets/token-cell/cells/token-cell-title.test.tsx
+++ b/ui/components/app/assets/token-cell/cells/token-cell-title.test.tsx
@@ -42,11 +42,14 @@ jest.mock('../../stock-badge/stock-badge', () => ({
   ),
 }));
 
-jest.mock('../../stellar-trustline-inactive-badge/stellar-trustline-inactive-badge', () => ({
-  StellarTrustlineInactiveBadge: () => (
-    <span data-testid="stellar-trustline-inactive-badge" />
-  ),
-}));
+jest.mock(
+  '../../stellar-trustline-inactive-badge/stellar-trustline-inactive-badge',
+  () => ({
+    StellarTrustlineInactiveBadge: () => (
+      <span data-testid="stellar-trustline-inactive-badge" />
+    ),
+  }),
+);
 
 const mockIsStockToken = jest.fn();
 const mockIsTokenTradingOpen = jest.fn();

--- a/ui/components/app/assets/token-cell/token-cell.tsx
+++ b/ui/components/app/assets/token-cell/token-cell.tsx
@@ -161,17 +161,7 @@ export default function TokenCell({
         />
       );
     }
-    if (displayToken.isStellarTrustlineInactive) {
-      return (
-        <Text
-          variant={TextVariant.BodySmMedium}
-          color={TextColor.TextAlternative}
-          data-testid="stellar-trustline-inactive-network-label"
-        >
-          {t('networkNameStellar')}
-        </Text>
-      );
-    }
+
     return <TokenCellPercentChange token={displayToken} />;
   };
 

--- a/ui/helpers/utils/multichain/blockExplorer.ts
+++ b/ui/helpers/utils/multichain/blockExplorer.ts
@@ -3,7 +3,10 @@ import { getAccountLink } from '@metamask/etherscan-link';
 import type { MultichainNetwork } from '../../../selectors/multichain/networks';
 import { normalizeSafeAddress } from '../../../../shared/lib/multichain/address';
 import { MultichainProviderConfig } from '../../../../shared/constants/multichain/networks';
-import { formatBlockExplorerAddressUrl } from '../../../../shared/lib/multichain/networks';
+import {
+  formatBlockExplorerAddressUrl,
+  formatBlockExplorerAssetUrl,
+} from '../../../../shared/lib/multichain/networks';
 
 export const getMultichainBlockExplorerUrl = (
   network: MultichainNetwork,
@@ -47,6 +50,15 @@ export const getAssetDetailsAccountUrl = (
   const { blockExplorerFormatUrls } =
     network.network as MultichainProviderConfig;
   if (blockExplorerFormatUrls) {
+    // For Stellar and other networks with asset support, use asset URL format
+    const assetUrl = formatBlockExplorerAssetUrl(
+      blockExplorerFormatUrls,
+      address,
+    );
+    if (assetUrl) {
+      return assetUrl;
+    }
+    // Fallback to address format for networks without asset support
     return formatBlockExplorerAddressUrl(blockExplorerFormatUrls, address);
   }
 

--- a/ui/pages/asset/components/asset-page.tsx
+++ b/ui/pages/asset/components/asset-page.tsx
@@ -37,9 +37,7 @@ import React, { ReactNode, useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
 import { getBaseReserveFromExtra } from '../../../helpers/stellar/base-reserve-from-extra';
-import {
-  isStellarClassicTrustlineInactiveForDisplay,
-} from '../../../helpers/stellar/trustline-from-extra';
+import { isStellarClassicTrustlineInactiveForDisplay } from '../../../helpers/stellar/trustline-from-extra';
 import { AssetType } from '../../../../shared/constants/transaction';
 import { isEvmChainId, toAssetId } from '../../../../shared/lib/asset-utils';
 import { endTrace, TraceName } from '../../../../shared/lib/trace';
@@ -339,12 +337,14 @@ const AssetPage = ({
 
   const stellarNativeBaseReserve =
     isStellarChainId && type === AssetType.native
-      ? getBaseReserveFromExtra(assetWithBalance?.extra)
+      ? getBaseReserveFromExtra(
+          assetWithBalance?.extra as { baseReserve?: string } | undefined,
+        ) ?? '0' // Default to '0' instead of undefined
       : undefined;
+
   const showStellarNativeBalanceSection =
     isStellarChainId &&
-    type === AssetType.native &&
-    stellarNativeBaseReserve !== undefined;
+    type === AssetType.native; // Always show for Stellar native
 
   const isUpdatedAssetNative = isNativeAsset(updatedAsset);
   const tokenAsset = isUpdatedAssetNative ? null : updatedAsset;
@@ -428,11 +428,7 @@ const AssetPage = ({
             />
           )}
           <MusdConvertSection />
-          <Box
-            marginTop={5}
-            marginBottom={5}
-            className="asset-page__divider"
-          />
+          <Box marginTop={5} marginBottom={5} className="asset-page__divider" />
         </>
       );
     }
@@ -442,9 +438,8 @@ const AssetPage = ({
         <StellarNativeBalanceSection
           totalBalance={String(balance)}
           symbol={symbol}
-          baseReserve={stellarNativeBaseReserve}
-          fiatValue={showFiat ? tokenFiatAmount : null}
-          showFiat={showFiat}
+          baseReserve={stellarNativeBaseReserve ?? '0'}
+          fiatValue={tokenFiatAmount}
         />
       );
     }
@@ -491,9 +486,6 @@ const AssetPage = ({
         </Box>
         {optionsButton}
       </Box>
-      <Box paddingLeft={4}>
-        {renderAssetTitleSection()}
-      </Box>
       <StellarClassicTrustlineActivateCard
         visible={showStellarClassicTrustlineActivate}
         account={selectedAccount}
@@ -501,6 +493,7 @@ const AssetPage = ({
         assetId={assetId as CaipAssetType}
         symbol={symbol}
       />
+      <Box paddingLeft={4}>{renderAssetTitleSection()}</Box>
       <AssetChart
         chainId={chainId}
         address={address}

--- a/ui/pages/asset/components/stellar-classic-trustline-activate-card.tsx
+++ b/ui/pages/asset/components/stellar-classic-trustline-activate-card.tsx
@@ -122,13 +122,10 @@ export const StellarClassicTrustlineActivateCard = ({
           <Box flexDirection={BoxFlexDirection.Column} gap={1}>
             <Text
               variant={TextVariant.BodyMd}
-              fontWeight={FontWeight.Medium}
+              fontWeight={FontWeight.Regular}
               color={TextColor.TextDefault}
             >
-              {t('stellarClassicActivateOnStellarTitle', [symbol])}
-            </Text>
-            <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-              {t('stellarClassicActivateOnStellarBody', [symbol])}
+              {t('stellarClassicActivateOnStellar', [symbol])}
             </Text>
           </Box>
           <Button

--- a/ui/pages/asset/components/stellar-native-balance-section.test.tsx
+++ b/ui/pages/asset/components/stellar-native-balance-section.test.tsx
@@ -33,7 +33,6 @@ describe('StellarNativeBalanceSection', () => {
         symbol="XLM"
         baseReserve="2.5"
         fiatValue={105}
-        showFiat
       />,
     );
 
@@ -43,9 +42,9 @@ describe('StellarNativeBalanceSection', () => {
     expect(
       screen.getByText(messages.stellarNativeBalanceTitle.message),
     ).toBeInTheDocument();
-    expect(screen.getByTestId('stellar-native-total-balance')).toHaveTextContent(
-      '250.00 XLM',
-    );
+    expect(
+      screen.getByTestId('stellar-native-total-balance'),
+    ).toHaveTextContent('250.00 XLM');
     expect(
       screen.getByTestId('stellar-native-spendable-balance'),
     ).toHaveTextContent('247.50 XLM');
@@ -64,7 +63,6 @@ describe('StellarNativeBalanceSection', () => {
         symbol="XLM"
         baseReserve="2.5"
         fiatValue={105}
-        showFiat={false}
       />,
     );
 
@@ -80,7 +78,6 @@ describe('StellarNativeBalanceSection', () => {
         symbol="XLM"
         baseReserve="2.5"
         fiatValue={null}
-        showFiat={false}
       />,
     );
 

--- a/ui/pages/asset/components/stellar-native-balance-section.tsx
+++ b/ui/pages/asset/components/stellar-native-balance-section.tsx
@@ -15,7 +15,6 @@ export type StellarNativeBalanceSectionProps = {
   symbol: string;
   baseReserve: string;
   fiatValue: number | null;
-  showFiat: boolean;
 };
 
 function formatDisplayAmount(value: number): string {
@@ -32,14 +31,12 @@ function formatDisplayAmount(value: number): string {
  * @param options0.symbol
  * @param options0.baseReserve
  * @param options0.fiatValue
- * @param options0.showFiat
  */
 export function StellarNativeBalanceSection({
   totalBalance,
   symbol,
   baseReserve,
   fiatValue,
-  showFiat,
 }: StellarNativeBalanceSectionProps) {
   const t = useI18nContext();
   const formatFiat = useFiatFormatter();
@@ -65,7 +62,7 @@ export function StellarNativeBalanceSection({
   }, [baseReserve, symbol, totalBalance]);
 
   const valueDisplay =
-    showFiat && fiatValue !== null && Number.isFinite(fiatValue)
+    fiatValue !== null && Number.isFinite(fiatValue)
       ? formatFiat(fiatValue)
       : '—';
 
@@ -103,7 +100,6 @@ export function StellarNativeBalanceSection({
             {totalDisplay}
           </Text>
         </Box>
-        {showFiat ? (
           <Box
             flexDirection={BoxFlexDirection.Column}
             gap={1}
@@ -123,7 +119,6 @@ export function StellarNativeBalanceSection({
               {valueDisplay}
             </Text>
           </Box>
-        ) : null}
       </Box>
       <Box flexDirection={BoxFlexDirection.Row} gap={3}>
         <Box

--- a/ui/pages/asset/components/token-buttons.tsx
+++ b/ui/pages/asset/components/token-buttons.tsx
@@ -191,92 +191,83 @@ const TokenButtons = ({
   ]);
 
   return (
-    <Box className="flex" gap={3} justifyContent={BoxJustifyContent.Evenly}>
-      <IconButton
-        className="token-overview__button"
-        Icon={
-          <Icon
-            name={IconName.Dollar}
-            color={IconColor.iconAlternative}
-            size={IconSize.Md}
-          />
-        }
-        label={t('buy')}
-        data-testid="token-overview-buy"
-        onClick={handleBuyAndSellOnClick}
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        disabled={token.isERC721 || !isBuyableChain}
-      />
-
-      {shouldShowSendButton ? (
-        <IconButton
-          className="token-overview__button"
-          onClick={handleSendOnClick}
-          Icon={
-            <Icon
-              name={IconName.Send}
-              color={IconColor.iconAlternative}
-              size={IconSize.Md}
-            />
-          }
-          label={t('send')}
-          data-testid="eth-overview-send"
-          disabled={
-            token.isERC721 ||
-            (disableSendForNonEvm && !isEvm && !isExternalServicesEnabled)
-          }
-        />
-      ) : null}
-
-      <IconButton
-        className="token-overview__button"
-        Icon={
-          <Icon
-            name={IconName.SwapVertical}
-            color={IconColor.iconAlternative}
-            size={IconSize.Md}
-          />
-        }
-        onClick={handleSwapOnClick}
-        data-testid="token-overview-swap"
-        label={t('swap')}
-        disabled={!isExternalServicesEnabled || isMarketClosed}
-      />
-
-      {stellarClassicTrustlineRemove ? (
+    <>
+      <Box className="flex" gap={3} justifyContent={BoxJustifyContent.Evenly}>
         <IconButton
           className="token-overview__button"
           Icon={
             <Icon
-              name={IconName.Trash}
+              name={IconName.Dollar}
               color={IconColor.iconAlternative}
               size={IconSize.Md}
             />
           }
-          onClick={handleRemoveStellarTrustline}
-          data-testid="token-overview-stellar-remove-trustline"
-          label={t('stellarClassicDeactivateOnStellar', [token.symbol]) as string}
-          tooltipRender={(contents) => (
-            <Tooltip
-              title={t('stellarClassicDeactivateOnStellarDetail') as string}
-              position="bottom"
-            >
-              {contents}
-            </Tooltip>
-          )}
-          disabled={
-            !stellarClassicTrustlineRemove.hasTrustline ||
-            isRemovingStellarTrustline
-          }
+          label={t('buy')}
+          data-testid="token-overview-buy"
+          onClick={handleBuyAndSellOnClick}
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          disabled={token.isERC721 || !isBuyableChain}
         />
-      ) : null}
+
+        {shouldShowSendButton ? (
+          <IconButton
+            className="token-overview__button"
+            onClick={handleSendOnClick}
+            Icon={
+              <Icon
+                name={IconName.Send}
+                color={IconColor.iconAlternative}
+                size={IconSize.Md}
+              />
+            }
+            label={t('send')}
+            data-testid="eth-overview-send"
+            disabled={
+              token.isERC721 ||
+              (disableSendForNonEvm && !isEvm && !isExternalServicesEnabled)
+            }
+          />
+        ) : null}
+
+        <IconButton
+          className="token-overview__button"
+          Icon={
+            <Icon
+              name={IconName.SwapVertical}
+              color={IconColor.iconAlternative}
+              size={IconSize.Md}
+            />
+          }
+          onClick={handleSwapOnClick}
+          data-testid="token-overview-swap"
+          label={t('swap')}
+          disabled={!isExternalServicesEnabled || isMarketClosed}
+        />
+
+        {stellarClassicTrustlineRemove?.hasTrustline ? (
+          <IconButton
+            className="token-overview__button"
+            Icon={
+              <Icon
+                name={IconName.Trash}
+                color={IconColor.iconAlternative}
+                size={IconSize.Md}
+              />
+            }
+            onClick={handleRemoveStellarTrustline}
+            data-testid="token-overview-stellar-remove-trustline"
+            label={t('stellarClassicDeactivateOnStellar') as string}
+            disabled={isRemovingStellarTrustline}
+          />
+        ) : null}
+      </Box>
       <StellarClassicTrustlineErrorToast
         message={trustlineRemoveErrorMessage}
         onClose={dismissTrustlineRemoveErrorToast}
         dataTestId="stellar-classic-trustline-remove-error-toast"
       />
-    </Box>
+    </>
   );
 };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly copy, layout, and display gating for Stellar assets; explorer URL behavior is scoped to asset-detail links with address fallback.
> 
> **Overview**
> **Stellar classic trustlines** — Inactive trustline tokens in the asset list again show **balance, fiat, and percent change** instead of hiding those fields or substituting a network label. The activate card is a **single line of copy** (merged i18n keys); deactivate is a **“Remove”** trash action without tooltip, only when a trustline exists. The activate card is placed **above** the asset title on the detail page.
> 
> **Native XLM on the asset page** — The total / spendable / reserved section **always renders** for Stellar native (reserve defaults to `0` when missing). Fiat value is shown whenever a numeric fiat amount exists; the `showFiat` prop was removed.
> 
> **Explorer** — Stellar block explorer config and `formatBlockExplorerAssetUrl` support **asset** URLs; `getAssetDetailsAccountUrl` prefers asset links on non-EVM networks that define them.
> 
> Minor formatting/test updates elsewhere; no functional change to trustline detection logic beyond display.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da6031c9efd0d4eef06678450fa316df9281c3a0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->