### PR TITLE
fix: dismiss add-token page when approval resolves

### DIFF
--- a/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.js
+++ b/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.js
@@ -173,15 +173,14 @@ const ConfirmAddSuggestedToken = () => {
     navigate(mostRecentOverviewPage);
   }, [dispatch, navigate, mostRecentOverviewPage, suggestedTokens]);
 
-  const goBackIfNoSuggestedTokensOnFirstRender = () => {
+  useEffect(() => {
+    // Also fires when the approval is resolved in another window (popup or
+    // sidepanel) while the full-page view is open, leaving this tab with no
+    // suggested tokens to display.
     if (!suggestedTokens.length) {
       navigate(mostRecentOverviewPage);
     }
-  };
-
-  useEffect(() => {
-    goBackIfNoSuggestedTokensOnFirstRender();
-  }, []);
+  }, [suggestedTokens.length, navigate, mostRecentOverviewPage]);
 
   return (
     <div className={classNames}>

--- a/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.js
+++ b/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.js
@@ -173,10 +173,8 @@ const ConfirmAddSuggestedToken = () => {
     navigate(mostRecentOverviewPage);
   }, [dispatch, navigate, mostRecentOverviewPage, suggestedTokens]);
 
+  // Go back if there are no suggested tokens to render
   useEffect(() => {
-    // Also fires when the approval is resolved in another window (popup or
-    // sidepanel) while the full-page view is open, leaving this tab with no
-    // suggested tokens to display.
     if (!suggestedTokens.length) {
       navigate(mostRecentOverviewPage);
     }

--- a/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.test.js
+++ b/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.test.js
@@ -133,7 +133,7 @@ const renderComponent = (tokens = []) => {
       mostRecentOverviewPage: '/',
     },
   });
-  return renderWithProvider(<ConfirmAddSuggestedToken />, store);
+  return { ...renderWithProvider(<ConfirmAddSuggestedToken />, store), store };
 };
 
 describe('ConfirmAddSuggestedToken Component', () => {
@@ -252,5 +252,22 @@ describe('ConfirmAddSuggestedToken Component', () => {
         screen.getByText(messages.reusedTokenNameWarning.message),
       ).toBeInTheDocument();
     });
+  });
+
+  it('navigates to the overview page when suggested tokens are cleared after mount', () => {
+    const { store } = renderComponent();
+
+    mockNavigate.mockClear();
+
+    act(() => {
+      store.dispatch({
+        type: 'UPDATE_METAMASK_STATE',
+        value: {
+          pendingApprovals: {},
+        },
+      });
+    });
+
+    expect(mockNavigate).toHaveBeenCalledWith('/');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

When a dapp triggers `wallet_watchAsset`, MetaMask can show the Confirm Add Token page in multiple UI surfaces at once (full-page tab, popup, side panel). If the user approves the request in one surface while another surface is still on `/confirm-add-suggested-token`, that stale tab kept showing an empty add-token page instead of returning to the homepage.

The empty-list guard only ran on first mount (`useEffect` with `[]` deps). After the approval was resolved elsewhere, shared Redux state cleared `pendingApprovals`, but the full-page view never re-ran the guard.

This change re-runs the guard whenever `suggestedTokens.length` changes, matching the existing behavior in `confirm-add-suggested-nft.js`.

## **Changelog**

CHANGELOG entry: Fixed the Confirm Add Token full-page view staying open with an empty list after approving the request in another MetaMask window.

## **Related issues**

Fixes: #43620

## **Manual testing steps**

1. Open MetaMask in a full-page tab on the homepage.
2. In another browser tab, open the test dapp and connect an account on Sepolia.
3. Deploy an ERC20 token and click **Add token to the wallet**.
4. Confirm the MetaMask popup/side-panel dialog.
5. Switch back to the MetaMask full-page tab.
6. Verify you land on the homepage (or most recent overview page), not an empty Add token page.

## **Screenshots/Recordings**

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7c4dfbdf-ba9f-4724-b5d0-af217fb22b3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7c4dfbdf-ba9f-4724-b5d0-af217fb22b3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

