### PR TITLE
chore: bind `verifyPassword` directly to `KeyringController:verifyPassword`

### DIFF
--- a/app/scripts/metamask-controller.actions.test.js
+++ b/app/scripts/metamask-controller.actions.test.js
@@ -858,7 +858,7 @@ describe('MetaMaskController', function () {
             completedOnboarding: true,
           });
         const verifyPasswordSpy = jest
-          .spyOn(metamaskController, 'verifyPassword')
+          .spyOn(metamaskController.keyringController, 'verifyPassword')
           .mockResolvedValue(true);
         jest
           .spyOn(metamaskController.keyringController, 'exportEncryptionKey')
@@ -892,7 +892,7 @@ describe('MetaMaskController', function () {
             completedOnboarding: false,
           });
         const verifyPasswordSpy = jest.spyOn(
-          metamaskController,
+          metamaskController.keyringController,
           'verifyPassword',
         );
         jest
@@ -1021,7 +1021,7 @@ describe('MetaMaskController', function () {
           .spyOn(metamaskController.passkeyController, 'isPasskeyEnrolled')
           .mockReturnValue(false);
         const verifyPasswordSpy = jest.spyOn(
-          metamaskController,
+          metamaskController.keyringController,
           'verifyPassword',
         );
 
@@ -1040,7 +1040,7 @@ describe('MetaMaskController', function () {
           .spyOn(metamaskController.passkeyController, 'isPasskeyEnrolled')
           .mockReturnValue(true);
         const verifyPasswordSpy = jest
-          .spyOn(metamaskController, 'verifyPassword')
+          .spyOn(metamaskController.keyringController, 'verifyPassword')
           .mockResolvedValue(true);
         const removePasskeySpy = jest
           .spyOn(metamaskController.passkeyController, 'removePasskey')
@@ -1237,7 +1237,7 @@ describe('MetaMaskController', function () {
           .spyOn(metamaskController.keyringController, 'changePassword')
           .mockResolvedValue();
         const verifyPasswordSpy = jest.spyOn(
-          metamaskController,
+          metamaskController.keyringController,
           'verifyPassword',
         );
         const renewVaultKeyProtectionSpy = jest.spyOn(

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3000,7 +3000,10 @@ export default class MetamaskController extends EventEmitter {
 
       // vault management
       submitPassword: this.submitPassword.bind(this),
-      verifyPassword: this.verifyPassword.bind(this),
+      verifyPassword: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'KeyringController:verifyPassword',
+      ),
 
       // passkey management
       generatePasskeyRegistrationOptions:
@@ -4013,7 +4016,7 @@ export default class MetamaskController extends EventEmitter {
   }
 
   async exportAccount(address, password) {
-    await this.verifyPassword(password);
+    await this.keyringController.verifyPassword(password);
     return this.keyringController.exportAccount({ password }, address);
   }
 
@@ -4390,7 +4393,7 @@ export default class MetamaskController extends EventEmitter {
         throw new Error('Password required to register passkey');
       }
       // verify password
-      await this.verifyPassword(password);
+      await this.keyringController.verifyPassword(password);
     }
 
     const vaultKey = await this.keyringController.exportEncryptionKey();
@@ -4465,7 +4468,7 @@ export default class MetamaskController extends EventEmitter {
         },
       );
     }
-    await this.verifyPassword(password);
+    await this.keyringController.verifyPassword(password);
     this.passkeyController.removePasskey();
   }
 
@@ -5375,15 +5378,6 @@ export default class MetamaskController extends EventEmitter {
 
   async clearLoginArtifacts() {
     await this.extension.storage.session.remove(['loginToken', 'loginSalt']);
-  }
-
-  /**
-   * Submits a user's password to check its validity.
-   *
-   * @param {string} password - The user's password
-   */
-  async verifyPassword(password) {
-    await this.keyringController.verifyPassword(password);
   }
 
   //


### PR DESCRIPTION
## **Description**

`verifyPassword` was a pure pass-through to `keyringController.verifyPassword`. Rather than adding a `LegacyBackgroundApiService` wrapper, `getApi()` now binds directly to the `KeyringController:verifyPassword` messenger action and the method is removed from `MetamaskController`; internal callers use `this.keyringController.verifyPassword` directly.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Progresses: https://consensyssoftware.atlassian.net/browse/WPC-1074

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor with no change to vault verification logic; only call routing and test spies were updated.
> 
> **Overview**
> Removes the **`MetamaskController.verifyPassword`** pass-through and routes password checks through **`KeyringController`** instead.
> 
> **`getApi()`** still exposes **`verifyPassword`**, but it is now a bound **`controllerMessenger.call`** to **`KeyringController:verifyPassword`** rather than a controller method. Internal flows (**`exportAccount`**, passkey registration/removal, etc.) call **`this.keyringController.verifyPassword`** directly.
> 
> Action tests were updated so spies target **`keyringController.verifyPassword`** to match the new call sites.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 134b92fea922c5d61228990ee544b1643ec9afcb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->