### PR TITLE
chore: migrate `exportAccount` to `LegacyBackgroundApiService`

### DIFF
--- a/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
@@ -60,6 +60,7 @@ export function getLegacyBackgroundApiServiceMessenger(
       'SeedlessOnboardingController:runMigrations',
       'MetaMetricsController:trackEvent',
       'KeyringController:verifyPassword',
+      'KeyringController:exportAccount',
       'KeyringController:changePassword',
       'KeyringController:exportEncryptionKey',
       'KeyringController:setLocked',

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3440,7 +3440,10 @@ export default class MetamaskController extends EventEmitter {
       createNewVaultAndKeychain: this.createNewVaultAndKeychain.bind(this),
       createNewVaultAndRestore: this.createNewVaultAndRestore.bind(this),
       importMnemonicToVault: this.importMnemonicToVault.bind(this),
-      exportAccount: this.exportAccount.bind(this),
+      exportAccount: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'LegacyBackgroundApiService:exportAccount',
+      ),
       exportAccountsWithPasskey: this.exportAccountsWithPasskey.bind(this),
       exportSeedPhraseWithPasskey: this.exportSeedPhraseWithPasskey.bind(this),
 
@@ -4018,11 +4021,6 @@ export default class MetamaskController extends EventEmitter {
       this.onboardingController.resetOnboarding();
       this.appStateController.setIsWalletResetInProgress(true);
     }
-  }
-
-  async exportAccount(address, password) {
-    await this.keyringController.verifyPassword(password);
-    return this.keyringController.exportAccount({ password }, address);
   }
 
   async getTokenStandardAndDetails(address, userAddress, tokenId) {

--- a/app/scripts/services/legacy-background-api-service-method-action-types.ts
+++ b/app/scripts/services/legacy-background-api-service-method-action-types.ts
@@ -233,6 +233,18 @@ export type LegacyBackgroundApiServiceSyncKeyringEncryptionKeyAction = {
 };
 
 /**
+ * Verifies the password and exports the private key for the given account.
+ *
+ * @param address - The address of the account to export.
+ * @param password - The password of the vault.
+ * @returns The private key of the account.
+ */
+export type LegacyBackgroundApiServiceExportAccountAction = {
+  type: `LegacyBackgroundApiService:exportAccount`;
+  handler: LegacyBackgroundApiService['exportAccount'];
+};
+
+/**
  * Union of all LegacyBackgroundApiService action types.
  */
 export type LegacyBackgroundApiServiceMethodActions =
@@ -256,4 +268,5 @@ export type LegacyBackgroundApiServiceMethodActions =
   | LegacyBackgroundApiServiceSyncPasswordAndUnlockWalletAction
   | LegacyBackgroundApiServiceSubmitPasswordOrEncryptionKeyAction
   | LegacyBackgroundApiServiceSetLockedAction
-  | LegacyBackgroundApiServiceSyncKeyringEncryptionKeyAction;
+  | LegacyBackgroundApiServiceSyncKeyringEncryptionKeyAction
+  | LegacyBackgroundApiServiceExportAccountAction;

--- a/app/scripts/services/legacy-background-api-service.test.ts
+++ b/app/scripts/services/legacy-background-api-service.test.ts
@@ -1048,6 +1048,83 @@ describe('LegacyBackgroundApiService', () => {
     });
   });
 
+  describe('exportAccount', () => {
+    it('verifies the password and returns the private key', async () => {
+      const address = '0xAddress';
+      const password = 'a-test-password';
+      const privateKey = 'a-test-private-key';
+
+      await withService(async ({ rootMessenger, serviceMessenger }) => {
+        const verifyPasswordHandler = jest.fn().mockResolvedValue(undefined);
+        const exportAccountHandler = jest.fn().mockResolvedValue(privateKey);
+
+        rootMessenger.registerActionHandler(
+          'KeyringController:verifyPassword',
+          verifyPasswordHandler,
+        );
+        rootMessenger.registerActionHandler(
+          'KeyringController:exportAccount',
+          exportAccountHandler,
+        );
+
+        const callSpy = jest.spyOn(serviceMessenger, 'call');
+
+        const result = await rootMessenger.call(
+          'LegacyBackgroundApiService:exportAccount',
+          address,
+          password,
+        );
+
+        expect(result).toStrictEqual(privateKey);
+        expect(callSpy).toHaveBeenCalledWith(
+          'KeyringController:verifyPassword',
+          password,
+        );
+        expect(callSpy).toHaveBeenCalledWith(
+          'KeyringController:exportAccount',
+          { password },
+          address,
+        );
+      });
+    });
+
+    it('rejects and does not export the account when the password is invalid', async () => {
+      const address = '0xAddress';
+      const password = 'wrong-password';
+      const error = new Error('Incorrect password.');
+
+      await withService(async ({ rootMessenger, serviceMessenger }) => {
+        const verifyPasswordHandler = jest.fn().mockRejectedValue(error);
+        const exportAccountHandler = jest.fn();
+
+        rootMessenger.registerActionHandler(
+          'KeyringController:verifyPassword',
+          verifyPasswordHandler,
+        );
+        rootMessenger.registerActionHandler(
+          'KeyringController:exportAccount',
+          exportAccountHandler,
+        );
+
+        const callSpy = jest.spyOn(serviceMessenger, 'call');
+
+        await expect(
+          rootMessenger.call(
+            'LegacyBackgroundApiService:exportAccount',
+            address,
+            password,
+          ),
+        ).rejects.toThrow(error);
+
+        expect(callSpy).toHaveBeenCalledWith(
+          'KeyringController:verifyPassword',
+          password,
+        );
+        expect(exportAccountHandler).not.toHaveBeenCalled();
+      });
+    });
+  });
+
   describe('checkIsSeedlessPasswordOutdated', () => {
     it("returns false if it's a social login flow", async () => {
       await withService(async ({ rootMessenger }) => {
@@ -1978,6 +2055,7 @@ function getMessenger(
       'SeedlessOnboardingController:runMigrations',
       'MetaMetricsController:trackEvent',
       'KeyringController:verifyPassword',
+      'KeyringController:exportAccount',
       'KeyringController:changePassword',
       'KeyringController:exportEncryptionKey',
       'KeyringController:setLocked',

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -11,6 +11,7 @@ import {
   AccountImportStrategy,
   KeyringControllerAddNewKeyringAction,
   KeyringControllerChangePasswordAction,
+  KeyringControllerExportAccountAction,
   KeyringControllerExportEncryptionKeyAction,
   KeyringControllerExportSeedPhraseAction,
   KeyringControllerGetKeyringsByTypeAction,
@@ -123,6 +124,7 @@ const serviceName = 'LegacyBackgroundApiService';
  */
 const MESSENGER_EXPOSED_METHODS = [
   'checkIsSeedlessPasswordOutdated',
+  'exportAccount',
   'getAccountsBySnapId',
   'getCode',
   'getGlobalChainId',
@@ -168,6 +170,7 @@ type AllowedActions =
   | CurrencyRateControllerSetCurrentCurrencyAction
   | KeyringControllerAddNewKeyringAction
   | KeyringControllerChangePasswordAction
+  | KeyringControllerExportAccountAction
   | KeyringControllerExportEncryptionKeyAction
   | KeyringControllerExportSeedPhraseAction
   | KeyringControllerGetKeyringsByTypeAction
@@ -1047,6 +1050,22 @@ export class LegacyBackgroundApiService {
     await this.#messenger.call(
       'SeedlessOnboardingController:storeKeyringEncryptionKey',
       keyringEncryptionKey,
+    );
+  }
+
+  /**
+   * Verifies the password and exports the private key for the given account.
+   *
+   * @param address - The address of the account to export.
+   * @param password - The password of the vault.
+   * @returns The private key of the account.
+   */
+  async exportAccount(address: string, password: string): Promise<string> {
+    await this.#messenger.call('KeyringController:verifyPassword', password);
+    return this.#messenger.call(
+      'KeyringController:exportAccount',
+      { password },
+      address,
     );
   }
 }


### PR DESCRIPTION
## **Description**

This moves `exportAccount` from `MetamaskController` to `LegacyBackgroundApiService`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Progresses: https://consensyssoftware.atlassian.net/browse/WPC-1076

## **Manual testing steps**

1. Go to the account menu and select "Account details" for an account.
2. Click "Show private key" and enter your password.
3. Confirm the correct private key is revealed, and that an incorrect password is rejected.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches private-key export and password verification paths; behavior is intended to be unchanged but routing through a new service layer warrants careful manual testing.
> 
> **Overview**
> **`exportAccount`** is no longer implemented on **`MetaMaskController`**; the public API now forwards through **`LegacyBackgroundApiService:exportAccount`** via the controller messenger.
> 
> The service adds **`exportAccount(address, password)`**, which still **`verifyPassword`**s first and only then calls **`KeyringController:exportAccount`**. Messenger wiring exposes the new action type, registers **`KeyringController:exportAccount`** on the legacy background API messenger, and adds unit tests for success and invalid-password (export not called on failure).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2b3ecc90523cd30811edb0cc870de15b4a17ed8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->