### PR TITLE
chore: migrate `getNextNonce` to `LegacyBackgroundApiService`

### DIFF
--- a/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
@@ -34,6 +34,7 @@ export function getLegacyBackgroundApiServiceMessenger(
       'KeyringController:exportSeedPhrase',
       'AccountsController:getSelectedAccount',
       'ApprovalController:getState',
+      'TransactionController:getNonceLock',
       'TransactionController:getState',
       'ApprovalController:rejectRequest',
       'TransactionController:wipeTransactions',

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3448,7 +3448,10 @@ export default class MetamaskController extends EventEmitter {
       createSpeedUpTransaction: this.createSpeedUpTransaction.bind(this),
       estimateGas: this.estimateGas.bind(this),
       estimateGasFee: txController.estimateGasFee.bind(txController),
-      getNextNonce: this.getNextNonce.bind(this),
+      getNextNonce: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'LegacyBackgroundApiService:getNextNonce',
+      ),
       addTransaction: (transactionParams, transactionOptions) =>
         addTransaction(
           this.getAddTransactionRequest({
@@ -8097,22 +8100,6 @@ export default class MetamaskController extends EventEmitter {
 
     releaseLock();
     return pendingNonce;
-  }
-
-  /**
-   * Returns the next nonce according to the nonce-tracker
-   *
-   * @param {string} address - The hex string address for the transaction
-   * @param networkClientId - The networkClientId to get the nonce lock with
-   * @returns {Promise<number>}
-   */
-  async getNextNonce(address, networkClientId) {
-    const nonceLock = await this.txController.getNonceLock(
-      address,
-      networkClientId,
-    );
-    nonceLock.releaseLock();
-    return nonceLock.nextNonce;
   }
 
   /**

--- a/app/scripts/services/legacy-background-api-service-method-action-types.ts
+++ b/app/scripts/services/legacy-background-api-service-method-action-types.ts
@@ -161,6 +161,18 @@ export type LegacyBackgroundApiServiceGetAccountsBySnapIdAction = {
 };
 
 /**
+ * Returns the next nonce according to the nonce-tracker
+ *
+ * @param address - The hex string address for the transaction
+ * @param networkClientId - The networkClientId to get the nonce lock with
+ * @returns The next nonce.
+ */
+export type LegacyBackgroundApiServiceGetNextNonceAction = {
+  type: `LegacyBackgroundApiService:getNextNonce`;
+  handler: LegacyBackgroundApiService['getNextNonce'];
+};
+
+/**
  * Checks if the seedless password is outdated.
  *
  * @param args - The arguments for the checkIsSeedlessPasswordOutdated method.
@@ -239,6 +251,7 @@ export type LegacyBackgroundApiServiceMethodActions =
   | LegacyBackgroundApiServiceOnAccountRemovedAction
   | LegacyBackgroundApiServiceImportAccountWithStrategyAction
   | LegacyBackgroundApiServiceGetAccountsBySnapIdAction
+  | LegacyBackgroundApiServiceGetNextNonceAction
   | LegacyBackgroundApiServiceCheckIsSeedlessPasswordOutdatedAction
   | LegacyBackgroundApiServiceSyncPasswordAndUnlockWalletAction
   | LegacyBackgroundApiServiceSubmitPasswordOrEncryptionKeyAction

--- a/app/scripts/services/legacy-background-api-service.test.ts
+++ b/app/scripts/services/legacy-background-api-service.test.ts
@@ -389,6 +389,30 @@ describe('LegacyBackgroundApiService', () => {
     });
   });
 
+  describe('getNextNonce', () => {
+    it('returns the next nonce and releases the nonce lock', async () => {
+      await withService(async ({ rootMessenger }) => {
+        const releaseLock = jest.fn();
+        rootMessenger.registerActionHandler(
+          'TransactionController:getNonceLock',
+          jest.fn().mockResolvedValue({
+            nextNonce: 5,
+            releaseLock,
+          }),
+        );
+
+        const result = await rootMessenger.call(
+          'LegacyBackgroundApiService:getNextNonce',
+          '0x123',
+          'networkClientId',
+        );
+
+        expect(result).toStrictEqual(5);
+        expect(releaseLock).toHaveBeenCalled();
+      });
+    });
+  });
+
   describe('getSeedPhrase', () => {
     it('returns the seed phrase', async () => {
       const mnemonic =
@@ -1930,6 +1954,7 @@ function getMessenger(
       'KeyringController:exportSeedPhrase',
       'AccountsController:getSelectedAccount',
       'ApprovalController:getState',
+      'TransactionController:getNonceLock',
       'TransactionController:getState',
       'ApprovalController:rejectRequest',
       'TransactionController:wipeTransactions',

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -30,6 +30,7 @@ import {
   AccountsControllerUpdateAccountsAction,
 } from '@metamask/accounts-controller';
 import {
+  TransactionControllerGetNonceLockAction,
   TransactionControllerGetStateAction,
   TransactionControllerWipeTransactionsAction,
 } from '@metamask/transaction-controller';
@@ -125,6 +126,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'getAccountsBySnapId',
   'getCode',
   'getGlobalChainId',
+  'getNextNonce',
   'getOpenMetamaskTabsIds',
   'getRequestAccountTabIds',
   'getSeedPhrase',
@@ -205,6 +207,7 @@ type AllowedActions =
   | SeedlessOnboardingControllerUpdateBackupMetadataStateAction
   | SmartTransactionsControllerWipeSmartTransactionsAction
   | SubscriptionControllerStopAllPollingAction
+  | TransactionControllerGetNonceLockAction
   | TransactionControllerGetStateAction
   | TransactionControllerWipeTransactionsAction
   | SnapAccountServiceGetLegacySnapKeyringAction;
@@ -691,6 +694,26 @@ export class LegacyBackgroundApiService {
       getSnapKeyring.bind(null, this.#messenger),
       snapId,
     );
+  }
+
+  /**
+   * Returns the next nonce according to the nonce-tracker
+   *
+   * @param address - The hex string address for the transaction
+   * @param networkClientId - The networkClientId to get the nonce lock with
+   * @returns The next nonce.
+   */
+  async getNextNonce(
+    address: string,
+    networkClientId: string,
+  ): Promise<number> {
+    const nonceLock = await this.#messenger.call(
+      'TransactionController:getNonceLock',
+      address,
+      networkClientId,
+    );
+    nonceLock.releaseLock();
+    return nonceLock.nextNonce;
   }
 
   /**


### PR DESCRIPTION
## **Description**

This moves `getNextNonce` from `MetamaskController` to `LegacyBackgroundApiService`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Progresses: https://consensyssoftware.atlassian.net/browse/WPC-1078

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving relocation with tests; external `getNextNonce` callers still go through the same controller API path.
> 
> **Overview**
> Moves **`getNextNonce`** out of `MetaMaskController` into **`LegacyBackgroundApiService`**, continuing the gradual shift of background API surface off the controller.
> 
> The service implementation still calls **`TransactionController:getNonceLock`**, immediately **`releaseLock()`**, and returns **`nextNonce`**—same behavior as the removed controller method. **`MetaMaskController`’s** public API keeps a **`getNextNonce`** entry, but it now forwards through **`controllerMessenger`** to **`LegacyBackgroundApiService:getNextNonce`** instead of calling the transaction controller directly.
> 
> Messenger wiring adds **`TransactionController:getNonceLock`** to the legacy background API service delegate list, registers the new action type, and adds a unit test that asserts the nonce is returned and the lock is released.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 594203d05c5be7973127f370333d9c8532afbf66. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->