### PR TITLE
chore: migrate `changePassword` to `LegacyBackgroundApiService`

### DIFF
--- a/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
@@ -48,6 +48,7 @@ export function getLegacyBackgroundApiServiceMessenger(
       'AccountsController:getAccountByAddress',
       'AccountsController:setSelectedAccount',
       'SeedlessOnboardingController:addNewSecretData',
+      'SeedlessOnboardingController:changePassword',
       'SeedlessOnboardingController:updateBackupMetadataState',
       'PermissionController:updatePermissionsByCaveat',
       'KeyringController:getKeyringsByType',

--- a/app/scripts/metamask-controller.actions.test.js
+++ b/app/scripts/metamask-controller.actions.test.js
@@ -1466,36 +1466,6 @@ describe('MetaMaskController', function () {
       });
     });
 
-    describe('#changePassword', function () {
-      it('does not remove passkey after keyring password change', async function () {
-        const releaseLock = jest.fn();
-        jest
-          .spyOn(metamaskController.seedlessOperationMutex, 'acquire')
-          .mockResolvedValue(releaseLock);
-        jest
-          .spyOn(
-            metamaskController.onboardingController,
-            'getIsSocialLoginFlow',
-          )
-          .mockReturnValue(false);
-        const changePasswordSpy = jest
-          .spyOn(metamaskController.keyringController, 'changePassword')
-          .mockResolvedValue();
-        jest
-          .spyOn(metamaskController.passkeyController, 'isPasskeyEnrolled')
-          .mockReturnValue(true);
-        const removePasskeySpy = jest
-          .spyOn(metamaskController.passkeyController, 'removePasskey')
-          .mockReturnValue();
-
-        await metamaskController.changePassword('new-password', 'old-password');
-
-        expect(changePasswordSpy).toHaveBeenCalledWith('new-password');
-        expect(removePasskeySpy).not.toHaveBeenCalled();
-        expect(releaseLock).toHaveBeenCalledTimes(1);
-      });
-    });
-
     describe('#resetWallet', function () {
       it('clears passkey controller state as part of reset flow', async function () {
         const clearPasskeyStateSpy = jest

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3416,7 +3416,10 @@ export default class MetamaskController extends EventEmitter {
       restoreSocialBackupAndGetSeedPhrase:
         this.restoreSocialBackupAndGetSeedPhrase.bind(this),
       syncSeedPhrases: this.syncSeedPhrases.bind(this),
-      changePassword: this.changePassword.bind(this),
+      changePassword: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'LegacyBackgroundApiService:changePassword',
+      ),
       getIsSeedlessOnboardingUserAuthenticated:
         this.seedlessOnboardingController.getIsUserAuthenticated.bind(
           this.seedlessOnboardingController,
@@ -4751,61 +4754,6 @@ export default class MetamaskController extends EventEmitter {
         data: seedPhraseAsUint8Array,
         type: SecretType.Mnemonic,
       });
-    }
-  }
-
-  /**
-   * Changes the password for the wallet.
-   *
-   * If the flow is social login flow, it will also change the password for the seedless onboarding controller.
-   *
-   * @param {string} newPassword - The new password.
-   * @param {string} oldPassword - The old password.
-   */
-  async changePassword(newPassword, oldPassword) {
-    const releaseLock = await this.seedlessOperationMutex.acquire();
-    const isSocialLoginFlow = this.onboardingController.getIsSocialLoginFlow();
-    try {
-      await this.keyringController.changePassword(newPassword);
-
-      if (isSocialLoginFlow) {
-        try {
-          await this.seedlessOnboardingController.changePassword(
-            newPassword,
-            oldPassword,
-          );
-          // store the new keyring encryption key in the seedless onboarding controller
-          const keyringEncKey =
-            await this.keyringController.exportEncryptionKey();
-          await this.seedlessOnboardingController.storeKeyringEncryptionKey(
-            keyringEncKey,
-          );
-        } catch (err) {
-          log.error('error while changing seedless-onboarding password', err);
-          log.error('reverting keyring password change');
-          // revert the keyring password change by changing the password back to the old password
-          await this.keyringController.changePassword(oldPassword);
-          // store the old keyring encryption key in the seedless onboarding controller
-          const revertedKeyringEncKey =
-            await this.keyringController.exportEncryptionKey();
-          await this.seedlessOnboardingController.storeKeyringEncryptionKey(
-            revertedKeyringEncKey,
-          );
-
-          this.controllerMessenger?.captureException?.(
-            createSentryError(
-              'error while changing password for social login flow',
-              err,
-            ),
-          );
-          throw err;
-        }
-      }
-    } catch (error) {
-      log.error('error while changing password', error);
-      throw error;
-    } finally {
-      releaseLock();
     }
   }
 

--- a/app/scripts/services/legacy-background-api-service-method-action-types.ts
+++ b/app/scripts/services/legacy-background-api-service-method-action-types.ts
@@ -173,6 +173,19 @@ export type LegacyBackgroundApiServiceGetNextNonceAction = {
 };
 
 /**
+ * Changes the password for the wallet.
+ *
+ * If the flow is social login flow, it will also change the password for the seedless onboarding controller.
+ *
+ * @param newPassword - The new password.
+ * @param oldPassword - The old password.
+ */
+export type LegacyBackgroundApiServiceChangePasswordAction = {
+  type: `LegacyBackgroundApiService:changePassword`;
+  handler: LegacyBackgroundApiService['changePassword'];
+};
+
+/**
  * Checks if the seedless password is outdated.
  *
  * @param args - The arguments for the checkIsSeedlessPasswordOutdated method.
@@ -264,6 +277,7 @@ export type LegacyBackgroundApiServiceMethodActions =
   | LegacyBackgroundApiServiceImportAccountWithStrategyAction
   | LegacyBackgroundApiServiceGetAccountsBySnapIdAction
   | LegacyBackgroundApiServiceGetNextNonceAction
+  | LegacyBackgroundApiServiceChangePasswordAction
   | LegacyBackgroundApiServiceCheckIsSeedlessPasswordOutdatedAction
   | LegacyBackgroundApiServiceSyncPasswordAndUnlockWalletAction
   | LegacyBackgroundApiServiceSubmitPasswordOrEncryptionKeyAction

--- a/app/scripts/services/legacy-background-api-service.test.ts
+++ b/app/scripts/services/legacy-background-api-service.test.ts
@@ -1401,6 +1401,230 @@ describe('LegacyBackgroundApiService', () => {
     });
   });
 
+  describe('changePassword', () => {
+    it('changes the keyring password and releases the lock for a non-social login flow', async () => {
+      await withService(async ({ rootMessenger, serviceMessenger }) => {
+        rootMessenger.registerActionHandler(
+          'OnboardingController:getIsSocialLoginFlow',
+          jest.fn().mockReturnValue(false),
+        );
+        const changePasswordHandler = jest.fn().mockResolvedValue(undefined);
+        rootMessenger.registerActionHandler(
+          'KeyringController:changePassword',
+          changePasswordHandler,
+        );
+
+        const callSpy = jest.spyOn(serviceMessenger, 'call');
+
+        await expect(
+          rootMessenger.call(
+            'LegacyBackgroundApiService:changePassword',
+            'new-password',
+            'old-password',
+          ),
+        ).resolves.toBeUndefined();
+
+        expect(changePasswordHandler).toHaveBeenCalledTimes(1);
+        expect(callSpy).toHaveBeenCalledWith(
+          'KeyringController:changePassword',
+          'new-password',
+        );
+        // No seedless onboarding controller calls for a non-social login flow.
+        expect(callSpy).not.toHaveBeenCalledWith(
+          'SeedlessOnboardingController:changePassword',
+          expect.anything(),
+          expect.anything(),
+        );
+      });
+    });
+
+    it('releases the seedless operation mutex after a successful change', async () => {
+      const releaseLock = jest.fn();
+      const seedlessOperationMutex = new Mutex();
+      jest
+        .spyOn(seedlessOperationMutex, 'acquire')
+        .mockResolvedValue(releaseLock);
+
+      await withService(
+        { options: { seedlessOperationMutex } },
+        async ({ rootMessenger }) => {
+          rootMessenger.registerActionHandler(
+            'OnboardingController:getIsSocialLoginFlow',
+            jest.fn().mockReturnValue(false),
+          );
+          rootMessenger.registerActionHandler(
+            'KeyringController:changePassword',
+            jest.fn().mockResolvedValue(undefined),
+          );
+
+          await rootMessenger.call(
+            'LegacyBackgroundApiService:changePassword',
+            'new-password',
+            'old-password',
+          );
+
+          expect(seedlessOperationMutex.acquire).toHaveBeenCalledTimes(1);
+          expect(releaseLock).toHaveBeenCalledTimes(1);
+        },
+      );
+    });
+
+    it('also changes the seedless onboarding password and stores the new keyring encryption key for a social login flow', async () => {
+      await withService(async ({ rootMessenger, serviceMessenger }) => {
+        rootMessenger.registerActionHandler(
+          'OnboardingController:getIsSocialLoginFlow',
+          jest.fn().mockReturnValue(true),
+        );
+        rootMessenger.registerActionHandler(
+          'KeyringController:changePassword',
+          jest.fn().mockResolvedValue(undefined),
+        );
+        rootMessenger.registerActionHandler(
+          'SeedlessOnboardingController:changePassword',
+          jest.fn().mockResolvedValue(undefined),
+        );
+        rootMessenger.registerActionHandler(
+          'KeyringController:exportEncryptionKey',
+          jest.fn().mockResolvedValue('new-encryption-key'),
+        );
+        rootMessenger.registerActionHandler(
+          'SeedlessOnboardingController:storeKeyringEncryptionKey',
+          jest.fn().mockResolvedValue(undefined),
+        );
+
+        const callSpy = jest.spyOn(serviceMessenger, 'call');
+
+        await expect(
+          rootMessenger.call(
+            'LegacyBackgroundApiService:changePassword',
+            'new-password',
+            'old-password',
+          ),
+        ).resolves.toBeUndefined();
+
+        expect(callSpy).toHaveBeenCalledWith(
+          'KeyringController:changePassword',
+          'new-password',
+        );
+        expect(callSpy).toHaveBeenCalledWith(
+          'SeedlessOnboardingController:changePassword',
+          'new-password',
+          'old-password',
+        );
+        expect(callSpy).toHaveBeenCalledWith(
+          'KeyringController:exportEncryptionKey',
+        );
+        expect(callSpy).toHaveBeenCalledWith(
+          'SeedlessOnboardingController:storeKeyringEncryptionKey',
+          'new-encryption-key',
+        );
+      });
+    });
+
+    it('reverts the keyring password change and captures the error when the seedless onboarding password change fails', async () => {
+      await withService(async ({ rootMessenger, serviceMessenger }) => {
+        const error = new Error('seedless change failed');
+
+        rootMessenger.registerActionHandler(
+          'OnboardingController:getIsSocialLoginFlow',
+          jest.fn().mockReturnValue(true),
+        );
+        const changePasswordHandler = jest.fn().mockResolvedValue(undefined);
+        rootMessenger.registerActionHandler(
+          'KeyringController:changePassword',
+          changePasswordHandler,
+        );
+        rootMessenger.registerActionHandler(
+          'SeedlessOnboardingController:changePassword',
+          jest.fn().mockRejectedValue(error),
+        );
+        const exportEncryptionKeyHandler = jest
+          .fn()
+          .mockResolvedValue('reverted-encryption-key');
+        rootMessenger.registerActionHandler(
+          'KeyringController:exportEncryptionKey',
+          exportEncryptionKeyHandler,
+        );
+        const storeKeyringEncryptionKeyHandler = jest
+          .fn()
+          .mockResolvedValue(undefined);
+        rootMessenger.registerActionHandler(
+          'SeedlessOnboardingController:storeKeyringEncryptionKey',
+          storeKeyringEncryptionKeyHandler,
+        );
+
+        const captureExceptionSpy = jest.spyOn(
+          serviceMessenger,
+          'captureException',
+        );
+        const callSpy = jest.spyOn(serviceMessenger, 'call');
+
+        await expect(
+          rootMessenger.call(
+            'LegacyBackgroundApiService:changePassword',
+            'new-password',
+            'old-password',
+          ),
+        ).rejects.toThrow(error);
+
+        // The keyring password is first changed to the new password, then
+        // reverted to the old password.
+        expect(changePasswordHandler).toHaveBeenNthCalledWith(
+          1,
+          'new-password',
+        );
+        expect(changePasswordHandler).toHaveBeenNthCalledWith(
+          2,
+          'old-password',
+        );
+        expect(callSpy).toHaveBeenCalledWith(
+          'SeedlessOnboardingController:storeKeyringEncryptionKey',
+          'reverted-encryption-key',
+        );
+        expect(captureExceptionSpy).toHaveBeenCalledWith(
+          createSentryError(
+            'error while changing password for social login flow',
+            error,
+          ),
+        );
+      });
+    });
+
+    it('releases the lock and rethrows when the keyring password change fails', async () => {
+      const releaseLock = jest.fn();
+      const seedlessOperationMutex = new Mutex();
+      jest
+        .spyOn(seedlessOperationMutex, 'acquire')
+        .mockResolvedValue(releaseLock);
+
+      await withService(
+        { options: { seedlessOperationMutex } },
+        async ({ rootMessenger }) => {
+          const error = new Error('keyring change failed');
+
+          rootMessenger.registerActionHandler(
+            'OnboardingController:getIsSocialLoginFlow',
+            jest.fn().mockReturnValue(false),
+          );
+          rootMessenger.registerActionHandler(
+            'KeyringController:changePassword',
+            jest.fn().mockRejectedValue(error),
+          );
+
+          await expect(
+            rootMessenger.call(
+              'LegacyBackgroundApiService:changePassword',
+              'new-password',
+              'old-password',
+            ),
+          ).rejects.toThrow(error);
+
+          expect(releaseLock).toHaveBeenCalledTimes(1);
+        },
+      );
+    });
+  });
+
   describe('setLocked', () => {
     beforeEach(() => {
       jest.useFakeTimers();
@@ -2061,6 +2285,7 @@ function getMessenger(
       'KeyringController:setLocked',
       'KeyringController:submitEncryptionKey',
       'KeyringController:submitPassword',
+      'SeedlessOnboardingController:changePassword',
       'SeedlessOnboardingController:loadKeyringEncryptionKey',
       'SeedlessOnboardingController:revokePendingRefreshTokens',
       'SeedlessOnboardingController:setLocked',

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -50,6 +50,7 @@ import {
   EncAccountDataType,
   SecretType,
   SeedlessOnboardingControllerAddNewSecretDataAction,
+  SeedlessOnboardingControllerChangePasswordAction,
   SeedlessOnboardingControllerCheckIsPasswordOutdatedAction,
   SeedlessOnboardingControllerGetStateAction,
   SeedlessOnboardingControllerRunMigrationsAction,
@@ -123,6 +124,7 @@ const serviceName = 'LegacyBackgroundApiService';
  * This is currently empty, but it can be extended in the future to replace `MetaMaskController.getApi()`.
  */
 const MESSENGER_EXPOSED_METHODS = [
+  'changePassword',
   'checkIsSeedlessPasswordOutdated',
   'exportAccount',
   'getAccountsBySnapId',
@@ -197,6 +199,7 @@ type AllowedActions =
   | PreferencesControllerSetPasswordForgottenAction
   | RemoteFeatureFlagControllerGetStateAction
   | SeedlessOnboardingControllerAddNewSecretDataAction
+  | SeedlessOnboardingControllerChangePasswordAction
   | SeedlessOnboardingControllerCheckIsPasswordOutdatedAction
   | SeedlessOnboardingControllerGetStateAction
   | SeedlessOnboardingControllerRunMigrationsAction
@@ -717,6 +720,77 @@ export class LegacyBackgroundApiService {
     );
     nonceLock.releaseLock();
     return nonceLock.nextNonce;
+  }
+
+  /**
+   * Changes the password for the wallet.
+   *
+   * If the flow is social login flow, it will also change the password for the seedless onboarding controller.
+   *
+   * @param newPassword - The new password.
+   * @param oldPassword - The old password.
+   */
+  async changePassword(
+    newPassword: string,
+    oldPassword: string,
+  ): Promise<void> {
+    const releaseLock = await this.#seedlessOperationMutex.acquire();
+    const isSocialLoginFlow = this.#messenger.call(
+      'OnboardingController:getIsSocialLoginFlow',
+    );
+    try {
+      await this.#messenger.call(
+        'KeyringController:changePassword',
+        newPassword,
+      );
+
+      if (isSocialLoginFlow) {
+        try {
+          await this.#messenger.call(
+            'SeedlessOnboardingController:changePassword',
+            newPassword,
+            oldPassword,
+          );
+          // store the new keyring encryption key in the seedless onboarding controller
+          const keyringEncKey = await this.#messenger.call(
+            'KeyringController:exportEncryptionKey',
+          );
+          await this.#messenger.call(
+            'SeedlessOnboardingController:storeKeyringEncryptionKey',
+            keyringEncKey,
+          );
+        } catch (err) {
+          log.error('error while changing seedless-onboarding password', err);
+          log.error('reverting keyring password change');
+          // revert the keyring password change by changing the password back to the old password
+          await this.#messenger.call(
+            'KeyringController:changePassword',
+            oldPassword,
+          );
+          // store the old keyring encryption key in the seedless onboarding controller
+          const revertedKeyringEncKey = await this.#messenger.call(
+            'KeyringController:exportEncryptionKey',
+          );
+          await this.#messenger.call(
+            'SeedlessOnboardingController:storeKeyringEncryptionKey',
+            revertedKeyringEncKey,
+          );
+
+          this.#messenger.captureException?.(
+            createSentryError(
+              'error while changing password for social login flow',
+              err,
+            ),
+          );
+          throw err;
+        }
+      }
+    } catch (error) {
+      log.error('error while changing password', error);
+      throw error;
+    } finally {
+      releaseLock();
+    }
   }
 
   /**

--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -137,7 +137,6 @@ describe('Actions', () => {
     background.requestAccountsAndChainPermissionsWithId = sinon.stub();
     background.grantPermissions = sinon.stub();
     background.grantPermissionsIncremental = sinon.stub();
-    background.changePassword = sinon.stub();
     background.changePasswordWithPasskeyVerification = sinon.stub();
     background.generatePasskeyRegistrationOptions = sinon.stub();
     background.generatePasskeyAuthenticationOptions = sinon.stub();
@@ -302,13 +301,18 @@ describe('Actions', () => {
       const oldPassword = 'old-password';
       const newPassword = 'new-password';
 
-      background.changePassword.resolves();
-      setBackgroundConnection(background);
+      const changePasswordStub = sinon.stub().resolves();
+
+      background.getApi.returns({
+        changePassword: changePasswordStub,
+      });
+
+      setBackgroundConnection(background.getApi());
 
       await store.dispatch(actions.changePassword(newPassword, oldPassword));
 
       expect(
-        background.changePassword.calledOnceWith(newPassword, oldPassword),
+        changePasswordStub.calledOnceWith(newPassword, oldPassword),
       ).toStrictEqual(true);
     });
   });


### PR DESCRIPTION
## **Description**

This moves `changePassword` from `MetamaskController` to `LegacyBackgroundApiService`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Progresses: https://consensyssoftware.atlassian.net/browse/WPC-1075

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Password and seedless keyring encryption key updates are security-critical; behavior is intended to be equivalent but routing and test coverage moved, so regressions in social-login rollback or mutex handling would be impactful.
> 
> **Overview**
> **Wallet password changes** are now handled by `LegacyBackgroundApiService` instead of a method on `MetaMaskController`, as part of moving background APIs onto the messenger.
> 
> `getApi().changePassword` forwards to `LegacyBackgroundApiService:changePassword` via `controllerMessenger.call`. The service implementation keeps the same behavior: seedless operation mutex, `KeyringController:changePassword`, and for social login flows also `SeedlessOnboardingController:changePassword` plus storing the exported keyring encryption key, with rollback and Sentry capture if seedless update fails.
> 
> Messenger wiring adds `SeedlessOnboardingController:changePassword` to the legacy background API delegate list and exposes the new action type. Tests for this flow move from `metamask-controller.actions.test.js` to `legacy-background-api-service.test.js`; UI store tests stub `getApi().changePassword` instead of `background.changePassword`. **`changePasswordWithPasskeyVerification` remains on `MetaMaskController`.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 554957085cbd4d776b8418ea1a5462350567c60c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->