### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ Once you have your test build ready, choose the browser for your e2e tests:
   - Note: If you are running Firefox as a snap package on Linux, ensure you enable the appropriate environment variable: `FIREFOX_SNAP=true yarn test:e2e:firefox`
 - For Chrome, run `yarn test:e2e:chrome`.
 
-These scripts support additional options for debugging. Use `--help`to see all available options.
+These scripts support additional options for debugging. Use `--help` to see all available options.
 
 #### Running a single e2e test
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fixes a minor typo in the README where a missing space caused `--help` and `to` to run together.

This improves readability in the E2E testing instructions without changing any code or behavior.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Open `README.md`.
2. Navigate to the "Running a single e2e test" section.
3. Confirm the sentence reads: `Use --help to see all available options.`

## **Screenshots/Recordings**

N/A. Documentation-only change.

### **Before**

`Use --help`to see all available options.

### **After**

`Use --help` to see all available options.

## **Pre-merge author checklist**

* [x] I've followed [[MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs)](https://github.com/MetaMask/contributor-docs) and [[MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md)](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
* [x] I've completed the PR template to the best of my ability
* [x] I’ve included tests if applicable
* [x] I’ve documented my code using [[JSDoc](https://jsdoc.app/)](https://jsdoc.app/) format if applicable
* [ ] I’ve applied the right labels on the PR (see [[labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

* [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
* [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single README wording fix with no runtime, security, or data impact.
> 
> **Overview**
> Fixes a typo in the **Running Tests** E2E section of `README.md`: the sentence about debug options now reads `Use \`--help\` to see all available options` instead of `\`--help\`to` with no space.
> 
> Documentation-only; no application or test behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f34f2be90e94cffd0c9ff7b0aa1d44fc87cea567. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->