### PR TITLE
feat: navigate back from the Manage Network page should redirect to home

### DIFF
--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
@@ -270,9 +270,7 @@ describe('NFTs options', () => {
     fireEvent.click(await findByTestId('sort-by-networks'));
     fireEvent.click(await findByTestId('home-network-filter-manage-networks'));
 
-    expect(mockUseNavigate).toHaveBeenCalledWith(
-      `${NETWORKS_ROUTE}?drawerOpen=true`,
-    );
+    expect(mockUseNavigate).toHaveBeenCalledWith(NETWORKS_ROUTE);
   });
 
   it('labels selected default networks as All networks when there are no custom or test networks visible', async () => {
@@ -368,9 +366,7 @@ describe('NFTs options', () => {
 
     fireEvent.click(await findByTestId('home-network-filter-manage-networks'));
 
-    expect(mockUseNavigate).toHaveBeenCalledWith(
-      `${NETWORKS_ROUTE}?drawerOpen=true`,
-    );
+    expect(mockUseNavigate).toHaveBeenCalledWith(NETWORKS_ROUTE);
   });
 
   it('opens the legacy Network Manager modal when network management feature flag is disabled', async () => {

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
@@ -402,7 +402,7 @@ const HomeNetworkFilterModalContent = ({
     // Don't close the modal first — letting the whole current view (modal
     // included) transition as one view-transition snapshot keeps the motion
     // smooth. The modal's open state resets when the home route unmounts.
-    transitionForward(() => navigate(`${NETWORKS_ROUTE}?drawerOpen=true`));
+    transitionForward(() => navigate(NETWORKS_ROUTE));
   }, [navigate]);
 
   const sections = useMemo<NetworkSelectionSection[]>(() => {

--- a/ui/pages/token-management/token-management.test.tsx
+++ b/ui/pages/token-management/token-management.test.tsx
@@ -493,11 +493,7 @@ describe('TokenManagementPage', () => {
       await screen.findByTestId('home-network-filter-manage-networks'),
     );
 
-    await waitFor(() =>
-      expect(mockUseNavigate).toHaveBeenCalledWith(
-        `${NETWORKS_ROUTE}?drawerOpen=true`,
-      ),
-    );
+    expect(mockUseNavigate).toHaveBeenCalledWith(NETWORKS_ROUTE);
   });
 
   it('shows tokens from all enabled networks when the home page filter is all networks', () => {


### PR DESCRIPTION
If the user is redirected to networks page from networks modal, and they click on back button in page. It should redirect the user back to home page

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: #43678 

## **Manual testing steps**

1. From the MM wallet landing page, select the All Popular Networks dropdown
2. Click on Manage Network button
3. Observe that it takes the user to a new page from the dropdown popup
4. try navigating back using the back icon
5. It should redirect back to home page

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/3b6d2ef9-b943-4bf5-9dc2-dbe33ee7dd43


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small navigation URL change with test updates only; no auth or data handling impact.
> 
> **Overview**
> **Manage Networks** from the home network filter modal (and related flows) now navigates to `NETWORKS_ROUTE` only, instead of appending `?drawerOpen=true`.
> 
> That query param was tied to keeping the global menu drawer open in the URL; dropping it fixes **back** from the networks page so users return to the home view instead of getting stuck in drawer/history behavior.
> 
> Tests in `asset-list-control-bar`, `home-network-filter-modal`, and `token-management` were updated to expect plain `NETWORKS_ROUTE`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c1ca15b16bdd11667a31a4fd3eb775c5a733baa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->