### PR TITLE
feat(analytics): emit Asset Viewed for swaps and perps flows

### DIFF
--- a/app/scripts/controllers/perps/infrastructure.test.ts
+++ b/app/scripts/controllers/perps/infrastructure.test.ts
@@ -1,9 +1,10 @@
+/* eslint-disable @typescript-eslint/naming-convention -- MetaMetrics event properties use snake_case */
 import {
   PERPS_EVENT_PROPERTY,
   PERPS_EVENT_VALUE,
   PerpsAnalyticsEvent,
 } from '../../../../shared/constants/perps-events';
-import { MetaMetricsEventCategory } from '../../../../shared/constants/metametrics';
+import { MetaMetricsEventCategory, MetaMetricsEventName } from '../../../../shared/constants/metametrics';
 
 import {
   createPerpsInfrastructure,
@@ -99,14 +100,25 @@ describe('createPerpsInfrastructure', () => {
           PERPS_EVENT_VALUE.SCREEN_TYPE.MARKET_LIST,
       });
 
-      expect(mockTrackEvent).toHaveBeenCalledTimes(1);
-      expect(mockTrackEvent).toHaveBeenCalledWith({
+      expect(mockTrackEvent).toHaveBeenCalledTimes(2);
+      expect(mockTrackEvent).toHaveBeenNthCalledWith(1, {
         event: PerpsAnalyticsEvent.ScreenViewed,
         category: MetaMetricsEventCategory.Perps,
         properties: {
           [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
             PERPS_EVENT_VALUE.SCREEN_TYPE.MARKET_LIST,
           [PERPS_EVENT_PROPERTY.TIMESTAMP]: expect.any(Number),
+        },
+      });
+      expect(mockTrackEvent).toHaveBeenNthCalledWith(2, {
+        event: MetaMetricsEventName.AssetViewed,
+        category: MetaMetricsEventCategory.Perps,
+        properties: {
+          [PERPS_EVENT_PROPERTY.SCREEN_TYPE]:
+            PERPS_EVENT_VALUE.SCREEN_TYPE.MARKET_LIST,
+          [PERPS_EVENT_PROPERTY.TIMESTAMP]: expect.any(Number),
+          trade_type: 'Perps',
+          implementation_type: 'native',
         },
       });
     });

--- a/app/scripts/controllers/perps/infrastructure.ts
+++ b/app/scripts/controllers/perps/infrastructure.ts
@@ -33,8 +33,13 @@ import {
 import { PERPS_EVENT_PROPERTY } from '../../../../shared/constants/perps-events';
 import {
   MetaMetricsEventCategory,
+  MetaMetricsEventName,
   type MetaMetricsEventPayload,
 } from '../../../../shared/constants/metametrics';
+import {
+  mergeAssetViewedProperties,
+  shouldEmitAssetViewedForPerpsScreenViewed,
+} from '../../../../shared/lib/analytics/trade-transaction-funnel/assetViewedAnalytics';
 import { captureException } from '../../../../shared/lib/sentry';
 import { validatedVersionGatedFeatureFlag } from '../../../../shared/lib/feature-flags/version-gating';
 import { isBenignDisconnectError } from './perps-error-utils';
@@ -149,14 +154,27 @@ function createMetrics(deps: InfrastructureDeps): PerpsMetrics {
       event: PerpsAnalyticsEvent,
       properties: PerpsAnalyticsProperties,
     ) => {
+      const props = {
+        ...properties,
+        [PERPS_EVENT_PROPERTY.TIMESTAMP]: Date.now(),
+      };
+
       deps.trackEvent({
         event,
         category: MetaMetricsEventCategory.Perps,
-        properties: {
-          ...properties,
-          [PERPS_EVENT_PROPERTY.TIMESTAMP]: Date.now(),
-        },
+        properties: props,
       });
+
+      if (
+        event === MetaMetricsEventName.PerpsScreenViewed &&
+        shouldEmitAssetViewedForPerpsScreenViewed(props)
+      ) {
+        deps.trackEvent({
+          event: MetaMetricsEventName.AssetViewed,
+          category: MetaMetricsEventCategory.Perps,
+          properties: mergeAssetViewedProperties('Perps', props),
+        });
+      }
     },
   };
 }

--- a/app/scripts/messenger-client-init/bridge-controller-init.ts
+++ b/app/scripts/messenger-client-init/bridge-controller-init.ts
@@ -9,6 +9,8 @@ import { handleFetch, HttpError } from '@metamask/controller-utils';
 import { TransactionController } from '@metamask/transaction-controller';
 import type { Json } from '@metamask/utils';
 import { BRIDGE_API_BASE_URL } from '../../../shared/constants/bridge';
+import { MetaMetricsEventName } from '../../../shared/constants/metametrics';
+import { mergeAssetViewedProperties } from '../../../shared/lib/analytics/trade-transaction-funnel/assetViewedAnalytics';
 import {
   ASSETS_UNIFY_STATE_FLAG,
   ASSETS_UNIFY_STATE_VERSION_1,
@@ -144,6 +146,20 @@ export const BridgeControllerInit: MessengerClientInitFunction<
           actionId,
         },
       });
+
+      if (event === UnifiedSwapBridgeEventName.PageViewed) {
+        initMessenger.call('MetaMetricsController:trackEvent', {
+          category: UNIFIED_SWAP_BRIDGE_EVENT_CATEGORY,
+          event: MetaMetricsEventName.AssetViewed,
+          environmentType:
+            propertiesObj.environment_type ?? getEnvironmentType(),
+          properties: mergeAssetViewedProperties('Swaps', {
+            ...propertiesObj,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            ...(activeTabDomain ? { active_tab_domain: activeTabDomain } : {}),
+          }),
+        });
+      }
     },
 
     // @ts-expect-error: `trace` function type does not match the expected type.

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -1076,6 +1076,7 @@ export enum MetaMetricsEventName {
   DeFiDetailsOpened = 'DeFi Details Opened',
   ActivityScreenOpened = 'Activity Screen Opened',
   PerpsScreenViewed = 'Perp Screen Viewed',
+  AssetViewed = 'Asset Viewed',
   PerpsUiInteraction = 'Perp UI Interaction',
   PerpsTradeTransaction = 'Perp Trade Transaction',
   PerpsPositionCloseTransaction = 'Perp Position Close Transaction',

--- a/shared/lib/analytics/trade-transaction-funnel/assetViewedAnalytics.test.ts
+++ b/shared/lib/analytics/trade-transaction-funnel/assetViewedAnalytics.test.ts
@@ -1,0 +1,77 @@
+/* eslint-disable @typescript-eslint/naming-convention -- MetaMetrics event properties use snake_case */
+import {
+  ASSET_VIEWED_IMPLEMENTATION_TYPE_NATIVE,
+  ASSET_VIEWED_PROPERTY,
+  mergeAssetViewedProperties,
+  shouldEmitAssetViewedForPerpsScreenViewed,
+} from './assetViewedAnalytics';
+
+describe('mergeAssetViewedProperties', () => {
+  it('appends trade_type and implementation_type after base properties', () => {
+    expect(
+      mergeAssetViewedProperties('Swaps', { chain_id_source: '1' }),
+    ).toStrictEqual({
+      chain_id_source: '1',
+      [ASSET_VIEWED_PROPERTY.TRADE_TYPE]: 'Swaps',
+      [ASSET_VIEWED_PROPERTY.IMPLEMENTATION_TYPE]:
+        ASSET_VIEWED_IMPLEMENTATION_TYPE_NATIVE,
+    });
+  });
+
+  it('does not let base properties override unified keys', () => {
+    expect(
+      mergeAssetViewedProperties('Perps', {
+        trade_type: 'should-not-win',
+        implementation_type: 'should-not-win',
+      }),
+    ).toStrictEqual({
+      trade_type: 'Perps',
+      implementation_type: 'native',
+    });
+  });
+
+  it('maps Perps open_position to open_positions_count on Asset Viewed', () => {
+    expect(
+      mergeAssetViewedProperties('Perps', {
+        open_position: 3,
+        screen_type: 'home',
+      }),
+    ).toStrictEqual({
+      screen_type: 'home',
+      [ASSET_VIEWED_PROPERTY.OPEN_POSITIONS_COUNT]: 3,
+      [ASSET_VIEWED_PROPERTY.TRADE_TYPE]: 'Perps',
+      [ASSET_VIEWED_PROPERTY.IMPLEMENTATION_TYPE]:
+        ASSET_VIEWED_IMPLEMENTATION_TYPE_NATIVE,
+    });
+  });
+
+  it('maps openPositionsCount camelCase to open_positions_count on Asset Viewed', () => {
+    expect(mergeAssetViewedProperties('Perps', { openPositionsCount: 2 })).toStrictEqual(
+      {
+        [ASSET_VIEWED_PROPERTY.OPEN_POSITIONS_COUNT]: 2,
+        [ASSET_VIEWED_PROPERTY.TRADE_TYPE]: 'Perps',
+        [ASSET_VIEWED_PROPERTY.IMPLEMENTATION_TYPE]:
+          ASSET_VIEWED_IMPLEMENTATION_TYPE_NATIVE,
+      },
+    );
+  });
+});
+
+describe('shouldEmitAssetViewedForPerpsScreenViewed', () => {
+  it('returns false for cancel_all_orders screen_type', () => {
+    expect(
+      shouldEmitAssetViewedForPerpsScreenViewed({
+        screen_type: 'cancel_all_orders',
+        open_position: 3,
+      }),
+    ).toBe(false);
+  });
+
+  it('returns true for other perps screen types', () => {
+    expect(
+      shouldEmitAssetViewedForPerpsScreenViewed({
+        screen_type: 'wallet_home_perps_tab',
+      }),
+    ).toBe(true);
+  });
+});

--- a/shared/lib/analytics/trade-transaction-funnel/assetViewedAnalytics.ts
+++ b/shared/lib/analytics/trade-transaction-funnel/assetViewedAnalytics.ts
@@ -1,0 +1,83 @@
+import type { Json } from '@metamask/utils';
+
+/**
+ * Trade Transaction funnel — unified Segment "Asset Viewed" payload helpers.
+ * "Asset Viewed" is emitted alongside legacy `Perp Screen Viewed` and
+ * `Unified SwapBridge Page Viewed` events.
+ */
+export const ASSET_VIEWED_PROPERTY = {
+  TRADE_TYPE: 'trade_type',
+  IMPLEMENTATION_TYPE: 'implementation_type',
+  OPEN_POSITIONS_COUNT: 'open_positions_count',
+} as const;
+
+export type AssetViewedTradeType = 'Perps' | 'Swaps';
+
+export const ASSET_VIEWED_IMPLEMENTATION_TYPE_NATIVE = 'native' as const;
+
+/**
+ * Product-specific keys for open position count on legacy events.
+ * Mapped to {@link ASSET_VIEWED_PROPERTY.OPEN_POSITIONS_COUNT} on Asset Viewed only.
+ */
+const ASSET_VIEWED_OPEN_POSITIONS_SOURCE_KEYS = [
+  ASSET_VIEWED_PROPERTY.OPEN_POSITIONS_COUNT,
+  'open_position',
+  'openPositionsCount',
+] as const;
+
+const PERPS_SCREEN_TYPES_SKIP_ASSET_VIEWED = new Set(['cancel_all_orders']);
+
+function resolveOpenPositionsCount(
+  properties: Record<string, Json>,
+): number | undefined {
+  for (const key of ASSET_VIEWED_OPEN_POSITIONS_SOURCE_KEYS) {
+    const value = properties[key];
+    if (value === undefined || value === null) {
+      continue;
+    }
+    const count = typeof value === 'number' ? value : Number(value);
+    if (!Number.isNaN(count)) {
+      return count;
+    }
+  }
+  return undefined;
+}
+
+function normalizeAssetViewedBaseProperties(
+  baseProperties: Record<string, Json>,
+): Record<string, Json> {
+  const openPositionsCount = resolveOpenPositionsCount(baseProperties);
+  const normalized = { ...baseProperties };
+
+  for (const key of ASSET_VIEWED_OPEN_POSITIONS_SOURCE_KEYS) {
+    delete normalized[key];
+  }
+
+  if (openPositionsCount !== undefined) {
+    normalized[ASSET_VIEWED_PROPERTY.OPEN_POSITIONS_COUNT] = openPositionsCount;
+  }
+
+  return normalized;
+}
+
+export function mergeAssetViewedProperties(
+  tradeType: AssetViewedTradeType,
+  baseProperties: Record<string, Json> = {},
+): Record<string, Json> {
+  return {
+    ...normalizeAssetViewedBaseProperties(baseProperties),
+    [ASSET_VIEWED_PROPERTY.TRADE_TYPE]: tradeType,
+    [ASSET_VIEWED_PROPERTY.IMPLEMENTATION_TYPE]:
+      ASSET_VIEWED_IMPLEMENTATION_TYPE_NATIVE,
+  };
+}
+
+export function shouldEmitAssetViewedForPerpsScreenViewed(
+  perpsScreenViewedProperties: Record<string, Json>,
+): boolean {
+  const screenType = perpsScreenViewedProperties.screen_type;
+  return !(
+    typeof screenType === 'string' &&
+    PERPS_SCREEN_TYPES_SKIP_ASSET_VIEWED.has(screenType)
+  );
+}

--- a/ui/hooks/perps/usePerpsEventTracking.test.tsx
+++ b/ui/hooks/perps/usePerpsEventTracking.test.tsx
@@ -41,12 +41,42 @@ describe('usePerpsEventTracking', () => {
         screen_type: 'market_list',
       });
 
+      expect(mockTrackEvent).toHaveBeenCalledTimes(2);
+      expect(mockTrackEvent).toHaveBeenNthCalledWith(1, {
+        event: MetaMetricsEventName.PerpsScreenViewed,
+        category: MetaMetricsEventCategory.Perps,
+        properties: {
+          screen_type: 'market_list',
+          [PERPS_EVENT_PROPERTY.TIMESTAMP]: expect.any(Number),
+        },
+      });
+      expect(mockTrackEvent).toHaveBeenNthCalledWith(2, {
+        event: MetaMetricsEventName.AssetViewed,
+        category: MetaMetricsEventCategory.Perps,
+        properties: {
+          screen_type: 'market_list',
+          [PERPS_EVENT_PROPERTY.TIMESTAMP]: expect.any(Number),
+          trade_type: 'Perps',
+          implementation_type: 'native',
+        },
+      });
+    });
+
+    it('does not track Asset Viewed for cancel_all_orders screen_type', () => {
+      const { result } = renderHook(() => usePerpsEventTracking(), { wrapper });
+
+      result.current.track(MetaMetricsEventName.PerpsScreenViewed, {
+        screen_type: 'cancel_all_orders',
+        [PERPS_EVENT_PROPERTY.OPEN_POSITION]: 3,
+      });
+
       expect(mockTrackEvent).toHaveBeenCalledTimes(1);
       expect(mockTrackEvent).toHaveBeenCalledWith({
         event: MetaMetricsEventName.PerpsScreenViewed,
         category: MetaMetricsEventCategory.Perps,
         properties: {
-          screen_type: 'market_list',
+          screen_type: 'cancel_all_orders',
+          [PERPS_EVENT_PROPERTY.OPEN_POSITION]: 3,
           [PERPS_EVENT_PROPERTY.TIMESTAMP]: expect.any(Number),
         },
       });
@@ -72,13 +102,23 @@ describe('usePerpsEventTracking', () => {
 
       rerender({ conditions: true });
 
-      expect(mockTrackEvent).toHaveBeenCalledTimes(1);
-      expect(mockTrackEvent).toHaveBeenCalledWith({
+      expect(mockTrackEvent).toHaveBeenCalledTimes(2);
+      expect(mockTrackEvent).toHaveBeenNthCalledWith(1, {
         event: MetaMetricsEventName.PerpsScreenViewed,
         category: MetaMetricsEventCategory.Perps,
         properties: {
           screen_type: 'trading',
           [PERPS_EVENT_PROPERTY.TIMESTAMP]: expect.any(Number),
+        },
+      });
+      expect(mockTrackEvent).toHaveBeenNthCalledWith(2, {
+        event: MetaMetricsEventName.AssetViewed,
+        category: MetaMetricsEventCategory.Perps,
+        properties: {
+          screen_type: 'trading',
+          [PERPS_EVENT_PROPERTY.TIMESTAMP]: expect.any(Number),
+          trade_type: 'Perps',
+          implementation_type: 'native',
         },
       });
     });
@@ -96,12 +136,12 @@ describe('usePerpsEventTracking', () => {
         },
       );
 
-      expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+      expect(mockTrackEvent).toHaveBeenCalledTimes(2);
 
       rerender({ conditions: true });
       rerender({ conditions: true });
 
-      expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+      expect(mockTrackEvent).toHaveBeenCalledTimes(2);
     });
 
     it('fires again after conditions cycles false then true (modal re-open)', () => {
@@ -117,12 +157,12 @@ describe('usePerpsEventTracking', () => {
         },
       );
 
-      expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+      expect(mockTrackEvent).toHaveBeenCalledTimes(2);
 
       rerender({ conditions: false });
       rerender({ conditions: true });
 
-      expect(mockTrackEvent).toHaveBeenCalledTimes(2);
+      expect(mockTrackEvent).toHaveBeenCalledTimes(4);
     });
 
     it('fires again when resetKey changes while conditions stays true', () => {
@@ -139,13 +179,13 @@ describe('usePerpsEventTracking', () => {
         },
       );
 
-      expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+      expect(mockTrackEvent).toHaveBeenCalledTimes(2);
 
       act(() => {
         rerender({ conditions: true, resetKey: 'ETH' });
       });
 
-      expect(mockTrackEvent).toHaveBeenCalledTimes(2);
+      expect(mockTrackEvent).toHaveBeenCalledTimes(4);
     });
 
     it('does not fire again when resetKey changes while conditions is false', () => {

--- a/ui/hooks/perps/usePerpsEventTracking.ts
+++ b/ui/hooks/perps/usePerpsEventTracking.ts
@@ -1,6 +1,10 @@
 import { useCallback, useContext, useEffect, useMemo, useRef } from 'react';
 import { Json } from '@metamask/utils';
 import { PERPS_EVENT_PROPERTY } from '../../../shared/constants/perps-events';
+import {
+  mergeAssetViewedProperties,
+  shouldEmitAssetViewedForPerpsScreenViewed,
+} from '../../../shared/lib/analytics/trade-transaction-funnel/assetViewedAnalytics';
 import { MetaMetricsContext } from '../../contexts/metametrics';
 import {
   MetaMetricsEventCategory,
@@ -41,18 +45,41 @@ export function usePerpsEventTracking(
   const { trackEvent } = useContext(MetaMetricsContext);
   const hasFiredDeclarativeRef = useRef(false);
 
-  const track = useCallback<PerpsTrackEventFn>(
-    (eventName, properties) => {
+  const trackPerpsMetricsEvent = useCallback(
+    (
+      eventName: MetaMetricsEventName,
+      properties: Record<string, Json> = {},
+    ) => {
+      const props = {
+        ...properties,
+        [PERPS_EVENT_PROPERTY.TIMESTAMP]: Date.now(),
+      };
+
       trackEvent({
         event: eventName,
         category: MetaMetricsEventCategory.Perps,
-        properties: {
-          ...properties,
-          [PERPS_EVENT_PROPERTY.TIMESTAMP]: Date.now(),
-        },
+        properties: props,
       });
+
+      if (
+        eventName === MetaMetricsEventName.PerpsScreenViewed &&
+        shouldEmitAssetViewedForPerpsScreenViewed(props)
+      ) {
+        trackEvent({
+          event: MetaMetricsEventName.AssetViewed,
+          category: MetaMetricsEventCategory.Perps,
+          properties: mergeAssetViewedProperties('Perps', props),
+        });
+      }
     },
     [trackEvent],
+  );
+
+  const track = useCallback<PerpsTrackEventFn>(
+    (eventName, properties) => {
+      trackPerpsMetricsEvent(eventName, properties ?? {});
+    },
+    [trackPerpsMetricsEvent],
   );
 
   const imperativeApi = useMemo(() => ({ track }), [track]);
@@ -88,15 +115,8 @@ export function usePerpsEventTracking(
     }
 
     hasFiredDeclarativeRef.current = true;
-    trackEvent({
-      event: eventName,
-      category: MetaMetricsEventCategory.Perps,
-      properties: {
-        ...properties,
-        [PERPS_EVENT_PROPERTY.TIMESTAMP]: Date.now(),
-      },
-    });
-  }, [options, trackEvent]);
+    trackPerpsMetricsEvent(eventName, properties ?? {});
+  }, [options, trackPerpsMetricsEvent]);
 
   if (options) {
     return undefined;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Mobile already emits the unified trade funnel event `Asset Viewed` alongside legacy `Perp Screen Viewed` and `Unified SwapBridge Page Viewed`. Extension needs the same instrumentation for **Swaps** and **Perps** only (Predict and Explore are mobile-only).

This PR adds shared Asset Viewed payload helpers and emits the event in parallel when:
- `Perp Screen Viewed` is tracked (UI hook + perps infrastructure)
- `Unified SwapBridge Page Viewed` is tracked (bridge controller init)

Legacy Perps `open_position` is normalized to canonical `open_positions_count` on Asset Viewed, matching mobile behavior.

Related schema PR: https://github.com/Consensys/segment-schema/pull/635

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Build and load the extension (`yarn start` or a test build).
2. Open the Swap/Bridge flow and select a source token.
3. In MetaMetrics debug output (or Segment debugger), verify both `Unified SwapBridge Page Viewed` and `Asset Viewed` fire with `trade_type: Swaps`.
4. Open a Perps screen (e.g. wallet home perps tab or market list).
5. Verify both `Perp Screen Viewed` and `Asset Viewed` fire with `trade_type: Perps`.
6. When a Perps screen includes `open_position`, confirm Asset Viewed sends `open_positions_count` instead.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.