### PR TITLE
build: add Jest support for MTS tooling scripts

### DIFF
--- a/development/lint-changed.mts
+++ b/development/lint-changed.mts
@@ -13,7 +13,7 @@ type LintChangedOptions = {
   fix: boolean;
 };
 
-const JS_TS_TSX_SNAP_FILE_REGEX = /\.(js|ts|tsx|snap)$/u;
+const JS_TS_TSX_MTS_SNAP_FILE_REGEX = /\.(js|ts|tsx|mts|snap)$/u;
 
 function runGit(args: string[]): string {
   const result = spawnSync('git', args, {
@@ -101,11 +101,11 @@ function main(): void {
   const options = parseArgs(process.argv.slice(2));
 
   const changedFiles = getChangedFileNames().filter((file) =>
-    JS_TS_TSX_SNAP_FILE_REGEX.test(file),
+    JS_TS_TSX_MTS_SNAP_FILE_REGEX.test(file),
   );
 
   if (changedFiles.length === 0) {
-    process.stdout.write('No changed JS/TS/TSX/SNAP files to lint.\n');
+    process.stdout.write('No changed JS/TS/TSX/MTS/SNAP files to lint.\n');
     return;
   }
 

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,8 +7,6 @@ module.exports = {
     '<rootDir>/shared/**/*.(js|ts|tsx)',
     '<rootDir>/ui/**/*.(js|ts|tsx)',
     '<rootDir>/development/build/transforms/**/*.js',
-    '<rootDir>/development/skills-postinstall.ts',
-    '<rootDir>/development/skills-sync.ts',
     '<rootDir>/development/metamaskbot-build-announce/**/*.(js|ts)',
     '<rootDir>/test/unit-global/**/*.test.(js|ts|tsx)',
   ],
@@ -24,6 +22,20 @@ module.exports = {
     '^@metamask/perps-controller$':
       '<rootDir>/test/mocks/metamask-perps-controller.js',
   },
+  // This mirrors Jest's default module extensions with `mts` added. Importing
+  // `jest-config` defaults would avoid this list, but lint rejects that package
+  // because it is not a declared dependency of this project.
+  moduleFileExtensions: [
+    'js',
+    'mjs',
+    'cjs',
+    'jsx',
+    'ts',
+    'tsx',
+    'mts',
+    'json',
+    'node',
+  ],
   // The path to the Prettier executable used to format snapshots
   // Jest doesn't support Prettier 3 yet, so we use Prettier 2
   prettierPath: require.resolve('prettier-2'),
@@ -64,9 +76,10 @@ module.exports = {
   testMatch: [
     '<rootDir>/app/scripts/**/*.test.(js|ts|tsx)',
     '<rootDir>/app/offscreen/**/*.test.(js|ts|tsx)',
+    '<rootDir>/.github/scripts/**/*.test.(js|ts|mts)',
     '<rootDir>/shared/**/*.test.(js|ts|tsx)',
     '<rootDir>/ui/**/*.test.(js|ts|tsx)',
-    '<rootDir>/development/**/*.test.(js|ts|tsx)',
+    '<rootDir>/development/**/*.test.(js|ts|tsx|mts)',
     '<rootDir>/test/unit-global/**/*.test.(js|ts|tsx)',
     '<rootDir>/test/e2e/helpers.test.js',
     '<rootDir>/test/e2e/helpers/**/*.test.(js|ts|tsx)',
@@ -83,6 +96,15 @@ module.exports = {
   testEnvironment: 'jest-fixed-jsdom',
   testEnvironmentOptions: {
     customExportConditions: ['node', 'node-addons'],
+  },
+  transform: {
+    '^.+\\.(js|jsx|ts|tsx)$': 'babel-jest',
+    '^.+\\.mts$': [
+      'babel-jest',
+      {
+        plugins: [require.resolve('./test/jest/transform-import-meta-url.js')],
+      },
+    ],
   },
   workerIdleMemoryLimit: '500MB',
   // Ensure console output is buffered (not streamed) so reporters can access testResult.console

--- a/test/jest/transform-import-meta-url.js
+++ b/test/jest/transform-import-meta-url.js
@@ -1,0 +1,34 @@
+// Jest runs these tests through Babel/CommonJS, but a few Node `.mts` scripts
+// use `import.meta.url` for their direct-execution guard. Rewrite that one ESM
+// expression to its CommonJS equivalent so tests can import those scripts.
+module.exports = function transformImportMetaUrl({ types: t }) {
+  return {
+    name: 'transform-import-meta-url-for-jest',
+    visitor: {
+      MemberExpression(memberPath) {
+        const { node } = memberPath;
+        if (
+          t.isMetaProperty(node.object) &&
+          node.object.meta.name === 'import' &&
+          node.object.property.name === 'meta' &&
+          t.isIdentifier(node.property, { name: 'url' })
+        ) {
+          memberPath.replaceWith(
+            t.memberExpression(
+              t.callExpression(
+                t.memberExpression(
+                  t.callExpression(t.identifier('require'), [
+                    t.stringLiteral('node:url'),
+                  ]),
+                  t.identifier('pathToFileURL'),
+                ),
+                [t.identifier('__filename')],
+              ),
+              t.identifier('href'),
+            ),
+          );
+        }
+      },
+    },
+  };
+};


### PR DESCRIPTION
## **Description**

There is currently uneven support for `.mts` files, and they fall through the cracks in a few places: changed-file linting ignores them, Jest does not discover `.test.mts` files, and tests that import Node-style `.mts` scripts using `fileURLToPath(import.meta.url)` cannot run under Jest's Babel/CommonJS transform.

This adds the small pieces needed to make `.mts` tooling scripts work consistently in those paths.

- Include `.mts` files in `development/lint-changed.mts`
- Allow Jest to discover `.test.mts` files under `development/` and `.github/scripts/`
- Add a Jest Babel transform for `import.meta.url`, so Node-style `.mts` scripts can be imported in tests
- Remove stale Jest coverage entries for deleted local skills scripts

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to lint-on-changed and Jest/test infrastructure; no runtime extension or production app behavior is modified.
> 
> **Overview**
> **`.mts` tooling scripts** are now treated like other JS/TS sources in the dev workflow: `lint-changed` includes `.mts` in its file filter and messaging, and Jest can resolve, discover, and transform them.
> 
> Jest gains **`mts` in `moduleFileExtensions`**, **`testMatch` patterns** for `development/**/*.test.mts` and `.github/scripts/**/*.test.mts`, and an explicit **`transform`** that runs `babel-jest` on `.mts` with a small plugin that rewrites **`import.meta.url`** to a CommonJS `pathToFileURL(__filename).href` equivalent so Node-style direct-execution guards in imported `.mts` modules work under Jest.
> 
> Stale **`collectCoverageFrom` entries** for removed `development/skills-*.ts` scripts are dropped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 241653807451a1d0ae1e872831ba64493d315bae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->