### PR TITLE
fix: updated ux changes in the network filter

### DIFF
--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
@@ -408,6 +408,8 @@ const AssetListControlBar = ({
           className="asset-list-control-bar__button asset-list-control-bar__network_control"
           onClick={handleNetworkFilterClick}
           size={ButtonBaseSize.Sm}
+          startIconName={IconName.Filter}
+          startIconProps={{ marginInlineEnd: 1, size: IconSize.Md }}
           endIconName={IconName.ArrowDown}
           backgroundColor={
             isNetworkFilterModalOpen
@@ -452,7 +454,7 @@ const AssetListControlBar = ({
                 className="asset-list-control-bar__button"
                 onClick={toggleTokenSortPopover}
                 size={ButtonBaseSize.Sm}
-                startIconName={IconName.Filter}
+                startIconName={IconName.Sort}
                 startIconProps={{ marginInlineEnd: 0, size: IconSize.Md }}
                 backgroundColor={
                   isTokenSortPopoverOpen

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
@@ -189,12 +189,12 @@ export const NetworkSelectionModal = ({
           size={ModalContentSize.Sm}
           modalDialogProps={{
             padding: 0,
-            className: 'overflow-hidden',
+            className: 'flex h-full flex-col overflow-hidden',
           }}
         >
           <ModalHeader onClose={onClose}>{title}</ModalHeader>
           <Box
-            className="max-h-[calc(100vh-168px)] overflow-y-auto"
+            className="min-h-0 flex-1 overflow-y-auto"
             flexDirection={BoxFlexDirection.Column}
           >
             {topItem ? (
@@ -208,7 +208,7 @@ export const NetworkSelectionModal = ({
               >
                 <Box className="flex min-w-0 items-center gap-3">
                   {isIconName(topItem.iconSrc) ? (
-                    <Icon name={topItem.iconSrc} size={IconSize.Sm} />
+                    <Icon name={topItem.iconSrc} size={IconSize.Lg} />
                   ) : (
                     <AvatarNetwork
                       name={topItem.name}

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
@@ -6,6 +6,9 @@ import { type AddNetworkFields } from '@metamask/network-controller';
 import { type MultichainNetworkConfiguration } from '@metamask/multichain-network-controller';
 import { type CaipChainId } from '@metamask/utils';
 import {
+  AvatarIcon,
+  AvatarIconSeverity,
+  AvatarIconSize,
   AvatarNetwork,
   AvatarNetworkSize,
   Box,
@@ -14,6 +17,8 @@ import {
   ButtonSize,
   ButtonVariant,
   FontWeight,
+  IconColor as DsIconColor,
+  IconName as DsIconName,
   Text,
   TextColor,
   TextVariant,
@@ -166,6 +171,34 @@ const HomeNetworkFilterRow = ({
   );
 };
 
+const getDsIconName = (iconName: IconName): DsIconName =>
+  Object.keys(IconName).find(
+    (key) => IconName[key as keyof typeof IconName] === iconName,
+  ) as DsIconName;
+
+const NetworkSelectionItemIcon = ({
+  name,
+  iconSrc,
+}: {
+  name: string;
+  iconSrc?: string;
+}) => {
+  if (isIconName(iconSrc)) {
+    return (
+      <AvatarIcon
+        iconName={getDsIconName(iconSrc)}
+        size={AvatarIconSize.Md}
+        severity={AvatarIconSeverity.Neutral}
+        iconProps={{ color: DsIconColor.IconDefault }}
+      />
+    );
+  }
+
+  return (
+    <AvatarNetwork name={name} src={iconSrc} size={AvatarNetworkSize.Md} />
+  );
+};
+
 export const NetworkSelectionModal = ({
   isOpen,
   onClose,
@@ -207,15 +240,10 @@ export const NetworkSelectionModal = ({
                 onClick={topItem.onClick}
               >
                 <Box className="flex min-w-0 items-center gap-3">
-                  {isIconName(topItem.iconSrc) ? (
-                    <Icon name={topItem.iconSrc} size={IconSize.Lg} />
-                  ) : (
-                    <AvatarNetwork
-                      name={topItem.name}
-                      src={topItem.iconSrc}
-                      size={AvatarNetworkSize.Md}
-                    />
-                  )}
+                  <NetworkSelectionItemIcon
+                    name={topItem.name}
+                    iconSrc={topItem.iconSrc}
+                  />
                   <Text
                     variant={TextVariant.BodyMd}
                     color={TextColor.TextDefault}

--- a/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
+++ b/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`BridgeInputGroup should render destination networks 1`] = `
     >
       <section
         aria-modal="true"
-        class="mm-box mm-modal-content__dialog mm-modal-content__dialog--size-sm overflow-hidden mm-box--padding-0 mm-box--padding-top-4 mm-box--padding-bottom-4 mm-box--display-flex mm-box--flex-direction-column mm-box--width-full mm-box--background-color-background-default mm-box--rounded-lg"
+        class="mm-box mm-modal-content__dialog mm-modal-content__dialog--size-sm flex h-full flex-col overflow-hidden mm-box--padding-0 mm-box--padding-top-4 mm-box--padding-bottom-4 mm-box--display-flex mm-box--flex-direction-column mm-box--width-full mm-box--background-color-background-default mm-box--rounded-lg"
         role="dialog"
       >
         <header
@@ -53,7 +53,7 @@ exports[`BridgeInputGroup should render destination networks 1`] = `
           </div>
         </header>
         <div
-          class="flex flex-col max-h-[calc(100vh-168px)] overflow-y-auto"
+          class="flex flex-col min-h-0 flex-1 overflow-y-auto"
         >
           <button
             class="flex min-h-16 w-full cursor-pointer items-center justify-between border-0 p-4 text-left hover:bg-hover bg-muted"
@@ -63,10 +63,20 @@ exports[`BridgeInputGroup should render destination networks 1`] = `
             <div
               class="flex min-w-0 items-center gap-3"
             >
-              <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
-                style="mask-image: url('./images/icons/global.svg');"
-              />
+              <div
+                class="inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full h-8 w-8 bg-muted"
+              >
+                <svg
+                  class="inline-block w-5 h-5 text-icon-default"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 22q-2.05 0-3.875-.787c-1.825-.788-2.28-1.242-3.187-2.15s-1.625-1.971-2.15-3.188S2 13.367 2 12q0-2.075.788-3.887c.788-1.812 1.241-2.267 2.15-3.175s1.97-1.625 3.187-2.15S10.633 2 12 2q2.075 0 3.888.788c1.812.788 2.266 1.241 3.174 2.15s1.625 1.966 2.15 3.175S22 10.617 22 12q0 2.05-.787 3.875c-.788 1.825-1.242 2.28-2.15 3.188s-1.967 1.625-3.175 2.15S13.383 22 12 22m0-2.05q.65-.9 1.125-1.875c.475-.975.575-1.342.775-2.075h-3.8q.3 1.1.775 2.075c.475.975.692 1.275 1.125 1.875m-2.6-.4q-.45-.825-.787-1.712A11.6 11.6 0 0 1 8.05 16H5.1q.725 1.25 1.813 2.175C8 19.1 8.467 19.25 9.4 19.55m5.2 0q1.4-.45 2.488-1.375c1.088-.925 1.329-1.342 1.812-2.175h-2.95q-.225.95-.562 1.838c-.337.887-.488 1.162-.788 1.712M4.25 14h3.4q-.075-.5-.112-.987C7.5 12.525 7.5 12.35 7.5 12a13 13 0 0 1 .15-2h-3.4q-.125.5-.187.988C4 11.476 4 11.65 4 12a8 8 0 0 0 .25 2m5.4 0h4.7q.075-.5.113-.987c.038-.488.037-.663.037-1.013a13 13 0 0 0-.15-2h-4.7q-.075.5-.112.988C9.5 11.476 9.5 11.65 9.5 12a13 13 0 0 0 .15 2m6.7 0h3.4q.125-.5.188-.987C20 12.525 20 12.35 20 12a8 8 0 0 0-.25-2h-3.4q.075.5.113.988c.038.488.037.662.037 1.012a13 13 0 0 1-.15 2m-.4-6h2.95q-.725-1.25-1.812-2.175C16 4.9 15.533 4.75 14.6 4.45q.45.824.788 1.713c.338.888.412 1.204.562 1.837M10.1 8h3.8q-.3-1.1-.775-2.075C12.65 4.95 12.433 4.65 12 4.05q-.65.9-1.125 1.875C10.4 6.9 10.3 7.267 10.1 8m-5 0h2.95q.225-.95.563-1.837C8.95 5.275 9.1 5 9.4 4.45Q8 4.9 6.913 5.825C5.826 6.75 5.583 7.167 5.1 8"
+                  />
+                </svg>
+              </div>
               <p
                 class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default truncate"
               >
@@ -496,7 +506,7 @@ exports[`BridgeInputGroup should render source networks 1`] = `
     >
       <section
         aria-modal="true"
-        class="mm-box mm-modal-content__dialog mm-modal-content__dialog--size-sm overflow-hidden mm-box--padding-0 mm-box--padding-top-4 mm-box--padding-bottom-4 mm-box--display-flex mm-box--flex-direction-column mm-box--width-full mm-box--background-color-background-default mm-box--rounded-lg"
+        class="mm-box mm-modal-content__dialog mm-modal-content__dialog--size-sm flex h-full flex-col overflow-hidden mm-box--padding-0 mm-box--padding-top-4 mm-box--padding-bottom-4 mm-box--display-flex mm-box--flex-direction-column mm-box--width-full mm-box--background-color-background-default mm-box--rounded-lg"
         role="dialog"
       >
         <header
@@ -527,7 +537,7 @@ exports[`BridgeInputGroup should render source networks 1`] = `
           </div>
         </header>
         <div
-          class="flex flex-col max-h-[calc(100vh-168px)] overflow-y-auto"
+          class="flex flex-col min-h-0 flex-1 overflow-y-auto"
         >
           <button
             class="flex min-h-16 w-full cursor-pointer items-center justify-between border-0 p-4 text-left hover:bg-hover bg-muted"
@@ -537,10 +547,20 @@ exports[`BridgeInputGroup should render source networks 1`] = `
             <div
               class="flex min-w-0 items-center gap-3"
             >
-              <span
-                class="mm-box mm-icon mm-icon--size-sm mm-box--display-inline-block mm-box--color-inherit"
-                style="mask-image: url('./images/icons/global.svg');"
-              />
+              <div
+                class="inline-flex shrink-0 items-center justify-center overflow-hidden rounded-full h-8 w-8 bg-muted"
+              >
+                <svg
+                  class="inline-block w-5 h-5 text-icon-default"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M12 22q-2.05 0-3.875-.787c-1.825-.788-2.28-1.242-3.187-2.15s-1.625-1.971-2.15-3.188S2 13.367 2 12q0-2.075.788-3.887c.788-1.812 1.241-2.267 2.15-3.175s1.97-1.625 3.187-2.15S10.633 2 12 2q2.075 0 3.888.788c1.812.788 2.266 1.241 3.174 2.15s1.625 1.966 2.15 3.175S22 10.617 22 12q0 2.05-.787 3.875c-.788 1.825-1.242 2.28-2.15 3.188s-1.967 1.625-3.175 2.15S13.383 22 12 22m0-2.05q.65-.9 1.125-1.875c.475-.975.575-1.342.775-2.075h-3.8q.3 1.1.775 2.075c.475.975.692 1.275 1.125 1.875m-2.6-.4q-.45-.825-.787-1.712A11.6 11.6 0 0 1 8.05 16H5.1q.725 1.25 1.813 2.175C8 19.1 8.467 19.25 9.4 19.55m5.2 0q1.4-.45 2.488-1.375c1.088-.925 1.329-1.342 1.812-2.175h-2.95q-.225.95-.562 1.838c-.337.887-.488 1.162-.788 1.712M4.25 14h3.4q-.075-.5-.112-.987C7.5 12.525 7.5 12.35 7.5 12a13 13 0 0 1 .15-2h-3.4q-.125.5-.187.988C4 11.476 4 11.65 4 12a8 8 0 0 0 .25 2m5.4 0h4.7q.075-.5.113-.987c.038-.488.037-.663.037-1.013a13 13 0 0 0-.15-2h-4.7q-.075.5-.112.988C9.5 11.476 9.5 11.65 9.5 12a13 13 0 0 0 .15 2m6.7 0h3.4q.125-.5.188-.987C20 12.525 20 12.35 20 12a8 8 0 0 0-.25-2h-3.4q.075.5.113.988c.038.488.037.662.037 1.012a13 13 0 0 1-.15 2m-.4-6h2.95q-.725-1.25-1.812-2.175C16 4.9 15.533 4.75 14.6 4.45q.45.824.788 1.713c.338.888.412 1.204.562 1.837M10.1 8h3.8q-.3-1.1-.775-2.075C12.65 4.95 12.433 4.65 12 4.05q-.65.9-1.125 1.875C10.4 6.9 10.3 7.267 10.1 8m-5 0h2.95q.225-.95.563-1.837C8.95 5.275 9.1 5 9.4 4.45Q8 4.9 6.913 5.825C5.826 6.75 5.583 7.167 5.1 8"
+                  />
+                </svg>
+              </div>
               <p
                 class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default truncate"
               >


### PR DESCRIPTION
This PR is to fix:
1. Add filter icon in home page filter
2. Update sort icon in home page
3. Update the size and align the globe icon in the filter
4. Adjust the height of network filter in Send/Swaps

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Everything should be aligned with [Figma](https://www.figma.com/design/OwtE8UzBJB9w6c3AGncMJX/Network-page-update?node-id=385-1561&t=8VlmkGpqIVFvsBoN-0) 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**






https://github.com/user-attachments/assets/01b066f3-8654-493b-81e8-082d2598f911


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to icons and modal layout; no auth, data, or business-logic paths touched.
> 
> **Overview**
> Aligns **home asset list** network filter and sort controls with design: the network filter button now shows a **filter** start icon (with spacing), and the sort control uses **Sort** instead of **Filter**.
> 
> **`NetworkSelectionModal`** (home network filter and bridge network picker) gets layout tweaks so the dialog and scroll area use **flex column / `flex-1` scrolling** instead of a fixed `max-h` viewport calc—intended to fix height on Send/Swaps flows. The **“All networks”** row (and other icon-name entries) now render via **`AvatarIcon`** from the design system instead of a small mask `Icon`, so the globe is sized and aligned consistently; network image URLs still use **`AvatarNetwork`**.
> 
> Bridge prepare test snapshots were updated to match the new modal classes and globe markup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51d4332c65964587c9fae131391a78684b9b2f7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->