### PR TITLE
ci: skip postinstall, and don't cache .metamask folder

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -83,14 +83,6 @@ jobs:
           cache-node-modules: true
           skip-allow-scripts: true
 
-      # Need to cache `.metamask` folder for the anvil binary
-      - name: Cache .metamask folder
-        if: ${{ steps.checkout-and-setup.outputs.node-modules-cache-hit != 'true' }}
-        uses: actions/cache/save@v5
-        with:
-          path: .metamask
-          key: .metamask-${{ hashFiles('yarn.lock') }}
-
   lint-workflows:
     name: Lint workflows
     if: ${{ needs.get-requirements.outputs.skip-everything != 'true' }}

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -56,16 +56,7 @@ jobs:
           is-high-risk-environment: false
           skip-allow-scripts: true
 
-      - name: Restore .metamask folder
-        id: restore-metamask
-        uses: actions/cache/restore@v5
-        with:
-          path: .metamask
-          key: .metamask-${{ hashFiles('yarn.lock') }}
-          fail-on-cache-miss: false
-
-      - name: Install anvil if cache missed
-        if: ${{ steps.restore-metamask.outputs.cache-hit != 'true' }}
+      - name: Install anvil
         run: yarn mm-foundryup
         shell: bash
 

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -83,16 +83,7 @@ jobs:
           is-high-risk-environment: false
           skip-allow-scripts: true
 
-      - name: Restore .metamask folder
-        id: restore-metamask
-        uses: actions/cache/restore@v5
-        with:
-          path: .metamask
-          key: .metamask-${{ hashFiles('yarn.lock') }}
-          fail-on-cache-miss: false
-
-      - name: Install anvil if cache missed
-        if: ${{ steps.restore-metamask.outputs.cache-hit != 'true'}}
+      - name: Install anvil
         run: yarn mm-foundryup
 
       - name: Download build artifact

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -151,16 +151,7 @@ jobs:
           is-high-risk-environment: false
           skip-allow-scripts: true
 
-      - name: Restore .metamask folder
-        id: restore-metamask
-        uses: actions/cache/restore@v5
-        with:
-          path: .metamask
-          key: .metamask-${{ hashFiles('yarn.lock') }}
-          fail-on-cache-miss: false
-
-      - name: Install anvil if cache missed
-        if: ${{ steps.restore-metamask.outputs.cache-hit != 'true' }}
+      - name: Install anvil
         run: yarn mm-foundryup
 
       - name: Restore dist artifact

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "webpack:lavamoat:policy:mv2": "concurrently 'yarn webpack:lavamoat:build:mv2 --generatePolicy' 'yarn webpack:lavamoat:build:mv2 --generatePolicy --type flask' 'yarn webpack:lavamoat:build:mv2 --generatePolicy --type beta' 'yarn webpack:lavamoat:build:mv2 --generatePolicy --type experimental' --kill-others-on-fail",
     "webpack:lavamoat:policy:mv3": "concurrently 'yarn webpack:lavamoat:build --generatePolicy' 'yarn webpack:lavamoat:build --generatePolicy --type flask' 'yarn webpack:lavamoat:build --generatePolicy --type beta' 'yarn webpack:lavamoat:build --generatePolicy --type experimental' --kill-others-on-fail",
     "foundryup": "yarn mm-foundryup",
-    "postinstall": "yarn webpack:clearcache && yarn foundryup && yarn skills:postinstall",
+    "postinstall": "node -e \"process.exit(process.env.CI ? 0 : 1)\" || (yarn webpack:clearcache && yarn foundryup && yarn skills:postinstall)",
     "skills": "metamask-skills sync",
     "skills:postinstall": "metamask-skills postinstall",
     "env:e2e": "SEGMENT_HOST='https://api.segment.io' SEGMENT_WRITE_KEY='FAKE' yarn",


### PR DESCRIPTION
## **Description**

CI currently runs the root `postinstall` work during dependency installs, even though most CI jobs do not need that local-development setup. This changes the root `postinstall` script to skip that work on CI, while preserving the existing behavior for local installs.

Because Anvil is only needed by E2E and benchmark jobs, this also removes the separate `.metamask` cache used to carry the Anvil binary from `prep-deps` into downstream jobs. Those jobs now run `yarn mm-foundryup` directly instead of restoring `.metamask` and conditionally installing Anvil.

### What Changed

- Skip root `postinstall` work on CI:
  - `webpack:clearcache`
  - `foundryup`
  - `skills:postinstall`
- Keep local `postinstall` behavior unchanged.
- Stop saving `.metamask` from `prep-deps`.
- Stop restoring `.metamask` in E2E, benchmark, and E2E fixture workflows.
- Always install Anvil explicitly in the workflows that need it.

### Why

The `.metamask` cache was useful when installing Anvil was relatively expensive. In current CI runs, `yarn mm-foundryup` is cheap, usually around 1-2 seconds, while the cache adds extra workflow complexity and consumes cache quota.

Skipping root `postinstall` also keeps generic CI dependency prep focused on dependency installation. Jobs that need Anvil now install it at the point of use.

### Validation

Benchmarked against `main` after the `action-checkout-and-setup` cache-path improvement had already merged, so both branches used the same action version:

- `MetaMask/action-checkout-and-setup@v3`
- SHA: `eb935d119d0a9b2564324d8821a1603b4a6208e8`

Paired cold-`node_modules`, warm-Yarn-cache runs:

- this branch: `1m44s` for `Prepare dependencies`
- main-like branch: `1m54s` for `Prepare dependencies`
- improvement: about `10s`

The `node_modules` cache save time was effectively the same in both runs, confirming this comparison is measuring the extension-side changes rather than the action cache-path change.

Observed details:

- this branch `yarn --immutable`: about `70s`
- main-like branch `yarn --immutable`: about `81s`
- `.metamask` cache save on main-like branch: less than `1s`
- sampled explicit Anvil installs via `yarn mm-foundryup`: about `1-2s`

So the measured setup improvement is modest, but the branch also removes unnecessary CI postinstall work from generic dependency prep and makes Anvil setup explicit only in the workflows that need it.

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow and install-script changes only; local postinstall is unchanged and Anvil is still installed in the same jobs that run chain tests.
> 
> **Overview**
> **CI dependency prep is lighter**, and **Anvil setup is explicit** only where E2E/benchmarks need it.
> 
> Root **`postinstall`** now no-ops when `CI` is set, so generic installs no longer run `webpack:clearcache`, `foundryup`, or `skills:postinstall`; local installs still run the full chain.
> 
> **`prep-deps`** no longer saves a `.metamask` GitHub Actions cache. **`run-benchmarks`**, **`run-e2e`**, and **`update-e2e-fixtures`** drop restore/conditional install steps and always run **`yarn mm-foundryup`** before tests that need Anvil.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b76e517f5b3807c8ab792a0fe90cbae82c6cabcf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->