### PR TITLE
fix(rewards): derive VIP badge CAIP-10 from account scope for non-EVM accounts cp-13.37.0

### DIFF
--- a/ui/hooks/rewards/useVipTier.test.ts
+++ b/ui/hooks/rewards/useVipTier.test.ts
@@ -3,11 +3,6 @@ import { renderHookWithProvider } from '../../../test/lib/render-helpers-navigat
 import { setBackgroundConnection } from '../../store/background-connection';
 import { useVipTier } from './useVipTier';
 
-jest.mock('../../helpers/utils/rewards-utils', () => ({
-  formatAccountToCaipAccountId: (address: string, chainId: string) =>
-    `eip155:${chainId}:${address}`,
-}));
-
 const mockGetVipTierForAccount = jest.fn();
 setBackgroundConnection({
   rewardsGetVipTierForAccount: async (...args: unknown[]) =>
@@ -24,7 +19,7 @@ const stateWithAccount = {
           address: '0xabc123',
           metadata: { name: 'Account', keyring: { type: 'HD Key Tree' } },
           type: 'eip155:eoa',
-          scopes: [],
+          scopes: ['eip155:1'],
           methods: [],
         },
       },
@@ -69,6 +64,50 @@ const stateWithVipDisabled = {
   },
 };
 
+const SOLANA_SCOPE = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+const SOLANA_ADDRESS = 'FdASaVKKMZr5QZqdBCi4SbDLeLJYKLGyMEy4gHukTykP';
+
+const stateWithSolanaAccount = {
+  metamask: {
+    ...stateWithAccount.metamask,
+    internalAccounts: {
+      selectedAccount: 'sol-1',
+      accounts: {
+        'sol-1': {
+          id: 'sol-1',
+          address: SOLANA_ADDRESS,
+          metadata: {
+            name: 'Solana Account',
+            keyring: { type: 'Snap Keyring' },
+          },
+          type: 'solana:data-account',
+          scopes: [SOLANA_SCOPE],
+          methods: [],
+        },
+      },
+    },
+  },
+};
+
+const stateWithScopelessAccount = {
+  metamask: {
+    ...stateWithAccount.metamask,
+    internalAccounts: {
+      selectedAccount: 'acc-2',
+      accounts: {
+        'acc-2': {
+          id: 'acc-2',
+          address: '0xdef456',
+          metadata: { name: 'Account', keyring: { type: 'HD Key Tree' } },
+          type: 'eip155:eoa',
+          scopes: [],
+          methods: [],
+        },
+      },
+    },
+  },
+};
+
 describe('useVipTier', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -85,7 +124,7 @@ describe('useVipTier', () => {
     expect(result.current).toBeNull();
   });
 
-  it('returns the VIP tier on success', async () => {
+  it('returns the VIP tier on success and derives the CAIP-10 id from the account scope', async () => {
     mockGetVipTierForAccount.mockResolvedValue(3);
 
     const { result } = renderHookWithProvider(
@@ -97,9 +136,34 @@ describe('useVipTier', () => {
       expect(result.current).toBe(3);
     });
 
-    expect(mockGetVipTierForAccount).toHaveBeenCalledWith(
-      'eip155:0x1:0xabc123',
+    expect(mockGetVipTierForAccount).toHaveBeenCalledWith('eip155:1:0xabc123');
+  });
+
+  it('builds a solana CAIP-10 id (not an eip155 one) for a non-EVM account', async () => {
+    mockGetVipTierForAccount.mockResolvedValue(5);
+
+    const { result } = renderHookWithProvider(
+      () => useVipTier(),
+      stateWithSolanaAccount,
     );
+
+    await waitFor(() => {
+      expect(result.current).toBe(5);
+    });
+
+    expect(mockGetVipTierForAccount).toHaveBeenCalledWith(
+      `${SOLANA_SCOPE}:${SOLANA_ADDRESS}`,
+    );
+  });
+
+  it('returns null and skips the lookup when the account has no scope', () => {
+    const { result } = renderHookWithProvider(
+      () => useVipTier(),
+      stateWithScopelessAccount,
+    );
+
+    expect(result.current).toBeNull();
+    expect(mockGetVipTierForAccount).not.toHaveBeenCalled();
   });
 
   it('returns null when no account is selected', () => {

--- a/ui/hooks/rewards/useVipTier.ts
+++ b/ui/hooks/rewards/useVipTier.ts
@@ -1,10 +1,14 @@
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useSelector } from 'react-redux';
+import {
+  parseCaipChainId,
+  toCaipAccountId,
+  type CaipAccountId,
+} from '@metamask/utils';
+import log from 'loglevel';
 import { submitRequestToBackground } from '../../store/background-connection';
 import { getSelectedInternalAccount } from '../../../shared/lib/selectors/accounts';
-import { getCurrentChainId } from '../../../shared/lib/selectors/networks';
-import { formatAccountToCaipAccountId } from '../../helpers/utils/rewards-utils';
 import { selectVipProgramEnabled } from '../../ducks/rewards/selectors';
 
 /**
@@ -30,14 +34,19 @@ export function useVipTier(): number | null {
 
 function useVipTierAccountId() {
   const selectedAccount = useSelector(getSelectedInternalAccount);
-  const chainId = useSelector(getCurrentChainId);
-  return useMemo(
-    () =>
-      selectedAccount?.address
-        ? formatAccountToCaipAccountId(selectedAccount.address, chainId)
-        : null,
-    [selectedAccount?.address, chainId],
-  );
+  return useMemo<CaipAccountId | null>(() => {
+    const [scope] = selectedAccount?.scopes ?? [];
+    if (!selectedAccount?.address || !scope) {
+      return null;
+    }
+    try {
+      const { namespace, reference } = parseCaipChainId(scope);
+      return toCaipAccountId(namespace, reference, selectedAccount.address);
+    } catch (error) {
+      log.error('[useVipTier] Error formatting account to CAIP-10:', error);
+      return null;
+    }
+  }, [selectedAccount?.address, selectedAccount?.scopes]);
 }
 
 function useRewardsVipTierQuery(accountId: string | null) {


### PR DESCRIPTION
## **Description**

The Extension VIP badge is hidden for non-EVM (e.g. Solana) selected accounts, even though the VIP fee discount still applies.

**Root cause:** `useVipTierAccountId` (in `ui/hooks/rewards/useVipTier.ts`) built the selected account's CAIP-10 id from the **globally-selected EVM chain** via the `getCurrentChainId` selector, then combined it with the selected account's address. `getCurrentChainId` reads the EVM `NetworkController`'s selected network and is independent of which account is selected — so for a Solana account it still returns the EVM chain (`0x1`). The resulting CAIP-10 was an EVM-namespaced id pairing an EVM chain with a Solana address:

```
eip155:1:FdASaVKKMZr5QZqdBCi4SbDLeLJYKLGyMEy4gHukTykP   (wrong)
```

instead of the correct Solana CAIP-10:

```
solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:FdASaVKKMZr5QZqdBCi4SbDLeLJYKLGyMEy4gHukTykP
```

`RewardsController.#getAccountState` then takes the `eip155` branch on the malformed id (and its raw-key fallback), neither of which matches the stored `solana:...` key, so `getVipTierForAccount` returns `null`, `useVipTier` returns `null`, and `RewardsVipBadge` renders nothing. The VIP **discount** is unaffected because it resolves the subscription through a separate path (`getPerpsDiscountForAccount`), which is why the user keeps the discount but loses the badge.

**Fix (minimal, one production file):** derive the CAIP-10 namespace/reference from the selected account's own scope (`scopes[0]`) instead of the global EVM chain. This mirrors exactly what:
- Mobile's `useVipTier` already does (`app/components/UI/Rewards/hooks/useVipTier.ts`), which is why Mobile shows the badge correctly for Solana accounts; and
- the Extension controller's own `convertInternalAccountToCaipAccountId` does when it **writes** the `rewardsAccounts` keys — so the read key now matches the stored key.

**Scope note (perps badge):** the perps VIP badge (perps fee display, close/reverse position modals, perps order entry page) and the bridge VIP fee message all render the same `RewardsVipBadge`, which uses this single `useVipTier()` hook. There is no separate perps badge hook, so this one change fixes the badge on every surface at once. The perps fee *discount* hook (`usePerpsMetamaskFeeDiscountBips`) is a separate, perps-only path (perps trading is EVM/Hyperliquid, so its account is EVM and its id resolves) and is intentionally left untouched.

## **Changelog**

CHANGELOG entry: Fixed the Rewards VIP badge not appearing for non-EVM (e.g. Solana) accounts.

## **Related issues**

Refs: N/A

## **Manual testing steps**

1. Be enrolled in the VIP program with a subscription that has a non-EVM (Solana) account linked and a VIP tier.
2. Select the Solana account.
3. Open a surface that shows the VIP badge (e.g. the perps fee display / swap or bridge fee row).
4. Before this change: the badge does not appear (though the VIP discount still applies). After this change: the VIP badge appears for the Solana account.
5. Select an EVM account and confirm the badge still appears as before (no regression).

## **Screenshots/Recordings**

<!-- Behavioral fix in a hook; verified via unit tests (scope-derived CAIP-10 id for EVM and Solana). -->

### **Before**

N/A — VIP badge hidden for non-EVM accounts (`eip155:1:<solanaAddress>` produced; controller lookup misses).

### **After**

N/A — VIP badge shown for non-EVM accounts (correct `solana:...:<address>` CAIP-10 produced; controller lookup hits).

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized hook change with expanded unit tests; no auth or payment logic touched.
> 
> **Overview**
> Fixes the Rewards VIP badge missing for non-EVM (e.g. Solana) accounts by changing how `useVipTier` builds the CAIP-10 id passed to `rewardsGetVipTierForAccount`.
> 
> **`useVipTierAccountId`** no longer uses the globally selected EVM chain (`getCurrentChainId`) and `formatAccountToCaipAccountId`. It now takes the first entry in the selected account’s `scopes`, parses it with `parseCaipChainId`, and builds the id via `toCaipAccountId` from `@metamask/utils`. Invalid or missing scope/address returns `null` and skips the background lookup; parse failures are logged.
> 
> Tests drop the rewards-utils mock, set EVM fixtures with `scopes: ['eip155:1']`, assert `eip155:1:<address>` for EVM, add Solana and scopeless-account cases, and verify the background is not called when there is no scope.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 475abe6ef85ae6b4020cf3eef80507b9829551a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->