### PR TITLE
fix: removed transition from sub pages in settings

### DIFF
--- a/ui/pages/settings/settings.test.tsx
+++ b/ui/pages/settings/settings.test.tsx
@@ -21,10 +21,17 @@ import Settings from './settings';
 
 const mockNavigate = jest.fn();
 const mockGetEnvironmentType = jest.fn(() => ENVIRONMENT_TYPE_POPUP);
+const mockRunCloseTransition = jest.fn((onComplete: () => void) =>
+  onComplete(),
+);
 
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../routes/global-menu-route-transition', () => ({
+  useGlobalMenuRouteTransition: () => mockRunCloseTransition,
 }));
 
 jest.mock('../../../shared/lib/environment-type', () => ({
@@ -174,6 +181,7 @@ describe('Settings', () => {
           `${DEFAULT_ROUTE}?drawerOpen=true`,
         );
       });
+      expect(mockRunCloseTransition).toHaveBeenCalledTimes(1);
     });
 
     it('navigates to home with the drawer open when back is clicked at settings root regardless of settings URL query', async () => {
@@ -191,9 +199,10 @@ describe('Settings', () => {
           `${DEFAULT_ROUTE}?drawerOpen=true`,
         );
       });
+      expect(mockRunCloseTransition).toHaveBeenCalledTimes(1);
     });
 
-    it('navigates to parent tab when back is clicked on a sub-page', async () => {
+    it('navigates to parent tab without global-menu transition when back is clicked on a sub-page', async () => {
       mockPathname = CURRENCY_ROUTE;
       renderSettings(mockStore);
 
@@ -208,6 +217,7 @@ describe('Settings', () => {
           PREFERENCES_AND_DISPLAY_ROUTE,
         );
       });
+      expect(mockRunCloseTransition).not.toHaveBeenCalled();
     });
   });
 });

--- a/ui/pages/settings/settings.tsx
+++ b/ui/pages/settings/settings.tsx
@@ -174,13 +174,13 @@ const SettingsLayout = ({ children }: { children: React.ReactNode }) => {
   const currentPageLabelKey = meta?.labelKey;
 
   const handleClose = useCallback(() => {
-    if (backRoute.startsWith(DEFAULT_ROUTE)) {
+    if (isOnSettingsRoot) {
       runCloseTransition(() => navigate(backRoute));
       return;
     }
 
     navigate(backRoute);
-  }, [backRoute, navigate, runCloseTransition]);
+  }, [backRoute, isOnSettingsRoot, navigate, runCloseTransition]);
 
   // Header: "Settings" on fullscreen; tab or sub-page name on popup/sidepanel
   const headerTitle =


### PR DESCRIPTION
This PR is to remove the transition from sub pages in settings

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized navigation/UX change in settings with no auth or data impact; behavior is covered by updated unit tests.
> 
> **Overview**
> **Settings back navigation** now runs the global menu close animation only when leaving the **settings root** (returning home with the drawer open), not when moving up within settings.
> 
> `handleClose` switches from checking whether `backRoute` starts with `DEFAULT_ROUTE` to **`isOnSettingsRoot`**, so sub-page backs (e.g. currency → parent tab) call `navigate` directly without `runCloseTransition`. Tests mock `useGlobalMenuRouteTransition` and assert the transition runs on root back and is skipped on sub-page back.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2236432502023e141119eb35f4d6450be6208fb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->