### PR TITLE
test: fix flaky Send - Edit Transaction by waiting for gas fee row

### DIFF
--- a/test/e2e/page-objects/pages/confirmations/transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/transaction-confirmation.ts
@@ -276,6 +276,15 @@ class TransactionConfirmation extends Confirmation {
     });
   }
 
+  /**
+   * Waits until the network fee is displayed, confirming the gas fee row (which
+   * contains the edit gas fee icon) has rendered on the confirmation page.
+   */
+  async checkGasFeeIsDisplayed(): Promise<void> {
+    console.log('Checking the network fee is displayed');
+    await this.driver.waitForSelector(this.gasFeeText);
+  }
+
   async checkGasFeeLabel(label: string): Promise<void> {
     console.log(`Checking gas fee label is ${label}`);
     await this.driver.waitForSelector({ text: label });

--- a/test/e2e/page-objects/pages/confirmations/transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/transaction-confirmation.ts
@@ -277,12 +277,16 @@ class TransactionConfirmation extends Confirmation {
   }
 
   /**
-   * Waits until the network fee is displayed, confirming the gas fee row (which
-   * contains the edit gas fee icon) has rendered on the confirmation page.
+   * Waits until the network fee value is displayed, confirming the gas fee row
+   * (which contains the edit gas fee icon) has rendered on the confirmation
+   * page. The fee renders as fiat (`native-currency`) or token
+   * (`first-gas-field`) depending on preferences, so we accept either.
    */
   async checkGasFeeIsDisplayed(): Promise<void> {
     console.log('Checking the network fee is displayed');
-    await this.driver.waitForSelector(this.gasFeeText);
+    await this.driver.waitForSelector(
+      `${this.gasFeeFiatText as string}, ${this.gasFeeText as string}`,
+    );
   }
 
   async checkGasFeeLabel(label: string): Promise<void> {

--- a/test/e2e/page-objects/pages/confirmations/transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/transaction-confirmation.ts
@@ -276,19 +276,6 @@ class TransactionConfirmation extends Confirmation {
     });
   }
 
-  /**
-   * Waits until the network fee value is displayed, confirming the gas fee row
-   * (which contains the edit gas fee icon) has rendered on the confirmation
-   * page. The fee renders as fiat (`native-currency`) or token
-   * (`first-gas-field`) depending on preferences, so we accept either.
-   */
-  async checkGasFeeIsDisplayed(): Promise<void> {
-    console.log('Checking the network fee is displayed');
-    await this.driver.waitForSelector(
-      `${this.gasFeeFiatText as string}, ${this.gasFeeText as string}`,
-    );
-  }
-
   async checkGasFeeLabel(label: string): Promise<void> {
     console.log(`Checking gas fee label is ${label}`);
     await this.driver.waitForSelector({ text: label });

--- a/test/e2e/tests/send/send-edit.spec.ts
+++ b/test/e2e/tests/send/send-edit.spec.ts
@@ -76,6 +76,9 @@ describe('Send - Edit Transaction', function () {
 
         await sendPage.pressContinueButton();
 
+        // Wait for the gas fee row (containing the edit gas fee icon) to render
+        await transactionConfirmation.checkGasFeeIsDisplayed();
+
         // Open gas fee modal and set custom legacy gas values
         await transactionConfirmation.openGasFeeModal();
         await gasFeeModal.setCustomLegacyGasFee({
@@ -136,6 +139,9 @@ describe('Send - Edit Transaction', function () {
         await sendPage.editAmountByKeys([driver.Key.BACK_SPACE, '2', '.', '2']);
 
         await sendPage.pressContinueButton();
+
+        // Wait for the gas fee row (containing the edit gas fee icon) to render
+        await transactionConfirmation.checkGasFeeIsDisplayed();
 
         // Open gas fee modal and set custom EIP-1559 gas values
         await transactionConfirmation.openGasFeeModal();

--- a/test/e2e/tests/send/send-edit.spec.ts
+++ b/test/e2e/tests/send/send-edit.spec.ts
@@ -76,8 +76,8 @@ describe('Send - Edit Transaction', function () {
 
         await sendPage.pressContinueButton();
 
-        // Wait for the gas fee row (containing the edit gas fee icon) to render
-        await transactionConfirmation.checkGasFeeIsDisplayed();
+        // Wait for the gas fee to load before opening the gas fee modal
+        await transactionConfirmation.checkGasFeeFiat('$0.07');
 
         // Open gas fee modal and set custom legacy gas values
         await transactionConfirmation.openGasFeeModal();
@@ -140,8 +140,8 @@ describe('Send - Edit Transaction', function () {
 
         await sendPage.pressContinueButton();
 
-        // Wait for the gas fee row (containing the edit gas fee icon) to render
-        await transactionConfirmation.checkGasFeeIsDisplayed();
+        // Wait for the gas fee to load before opening the gas fee modal
+        await transactionConfirmation.checkGasFeeFiat('$0.75');
 
         // Open gas fee modal and set custom EIP-1559 gas values
         await transactionConfirmation.openGasFeeModal();


### PR DESCRIPTION


## **Description**

Test is failing in [CI](https://github.com/MetaMask/metamask-extension/actions/runs/28149043173/job/83363805941) with error: `TimeoutError: Waiting for element to be located By(css selector, [data-testid="edit-gas-fee-icon"]) Wait timed out after 10134ms     at /home/runner/w...`

After editing the amount and clicking Continue, the test tried to click `edit-gas-fee-icon `(`openGasFeeModal`), which only exists on the confirmation screen. When that screen hadn't finished rendering, it failed with a misleading 10s "element not located" timeout.

Added `checkGasFeeIsDisplayed()` a wait for the network fee row (which contains the edit gas fee icon) to render.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<img width="1366" height="682" alt="test-failure-screenshot-1" src="https://github.com/user-attachments/assets/033f846b-ed0b-4113-9aa2-54c55db257fd" />


### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only synchronization in `send-edit.spec.ts`; no application or production behavior changes.
> 
> **Overview**
> Fixes flaky **Send - Edit Transaction** E2E failures where `openGasFeeModal` timed out waiting for `edit-gas-fee-icon` after returning from the send flow with an updated amount.
> 
> In both legacy and EIP-1559 cases, the tests now call `checkGasFeeFiat` with the expected fee (`$0.07` / `$0.75`) **after** `pressContinueButton` and **before** opening the gas fee modal, so the confirmation screen and network-fee row finish rendering before the edit icon is clicked.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d46a7e8eea956e60d943dc85f15c6f1a93b4f05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->