### PR TITLE
chore: install preview packages for design system PR testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -307,7 +307,8 @@
     "@metamask/permission-controller@npm:^12.2.1": "^13.0.0",
     "@metamask/permission-controller@npm:^12.3.0": "^13.0.0",
     "@metamask/assets-controller@npm:^7.1.2": "patch:@metamask/assets-controller@npm%3A8.3.2#~/.yarn/patches/@metamask-assets-controller-npm-8.3.2-f205cdbfee.patch",
-    "@metamask/assets-controller@npm:^8.1.0": "patch:@metamask/assets-controller@npm%3A8.3.2#~/.yarn/patches/@metamask-assets-controller-npm-8.3.2-f205cdbfee.patch"
+    "@metamask/assets-controller@npm:^8.1.0": "patch:@metamask/assets-controller@npm%3A8.3.2#~/.yarn/patches/@metamask-assets-controller-npm-8.3.2-f205cdbfee.patch",
+    "@metamask/design-tokens": "npm:@metamask-previews/design-tokens@8.5.0-preview.55a2d71"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.29.2#~/.yarn/patches/@babel-runtime-npm-7.29.2-b49cad1c67.patch",
@@ -332,6 +333,7 @@
     "@ledgerhq/hw-app-eth": "^6.42.0",
     "@ledgerhq/hw-transport": "^6.31.0",
     "@ledgerhq/hw-transport-webhid": "^6.31.0",
+    "@metamask-previews/design-tokens": "8.5.0-preview.55a2d71",
     "@metamask/7715-permission-types": "^0.7.1",
     "@metamask/abi-utils": "^3.0.0",
     "@metamask/account-api": "^1.0.4",
@@ -363,7 +365,7 @@
     "@metamask/delegation-deployments": "^1.3.0",
     "@metamask/design-system-react": "^0.25.0",
     "@metamask/design-system-tailwind-preset": "^0.9.0",
-    "@metamask/design-tokens": "^8.5.0",
+    "@metamask/design-tokens": "npm:@metamask-previews/design-tokens@8.5.0-preview.55a2d71",
     "@metamask/eip-5792-middleware": "3.0.3",
     "@metamask/eip-7702-internal-rpc-middleware": "^0.1.0",
     "@metamask/ens-controller": "^19.1.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5349,6 +5349,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask-previews/design-tokens@npm:8.5.0-preview.55a2d71, @metamask/design-tokens@npm:@metamask-previews/design-tokens@8.5.0-preview.55a2d71":
+  version: 8.5.0-preview.55a2d71
+  resolution: "@metamask-previews/design-tokens@npm:8.5.0-preview.55a2d71"
+  checksum: 10/0c9614ba8fe5ca9d27e862ac7170ddc980a70cbda7b4cf0e5820ca36d0648108037b451978391f7ec4c89abe86bcc608a6e7b0e0e1502518435007b624574dc2
+  languageName: node
+  linkType: hard
+
 "@metamask/7715-permission-types@npm:^0.7.1":
   version: 0.7.1
   resolution: "@metamask/7715-permission-types@npm:0.7.1"
@@ -6195,20 +6202,6 @@ __metadata:
     "@metamask/design-tokens": ^8.0.0
     tailwindcss: ^3.0.0
   checksum: 10/1c1385cd3750ca496cb545d9fc413c28f32e515cc0c2751649973904125374b70c88814691f1f2167d80a4df85984fc951413390189baa839561d3e5b8788197
-  languageName: node
-  linkType: hard
-
-"@metamask/design-tokens@npm:^7.1.0":
-  version: 7.1.0
-  resolution: "@metamask/design-tokens@npm:7.1.0"
-  checksum: 10/a4f1379bdf5f6b99c9a228ce4f5bb07ace4ed5abc61384e7f04cf5bdf943b32dd13ec9676a88f6b6c7314cdba6e2967b9fd99707a64a645865f21f8d8a2566d9
-  languageName: node
-  linkType: hard
-
-"@metamask/design-tokens@npm:^8.5.0":
-  version: 8.5.0
-  resolution: "@metamask/design-tokens@npm:8.5.0"
-  checksum: 10/55374e1d9a0866f6062a1f0191b0a7d7bdb2efaa703eb870204bd123dcdb9958058ddd1bfa06cc39f9be06bdc662414a7ca59b0fe2c0099433988e156652535f
   languageName: node
   linkType: hard
 
@@ -33286,6 +33279,7 @@ __metadata:
     "@ledgerhq/hw-transport": "npm:^6.31.0"
     "@ledgerhq/hw-transport-webhid": "npm:^6.31.0"
     "@lydell/node-pty": "npm:^1.1.0"
+    "@metamask-previews/design-tokens": "npm:8.5.0-preview.55a2d71"
     "@metamask/7715-permission-types": "npm:^0.7.1"
     "@metamask/abi-utils": "npm:^3.0.0"
     "@metamask/account-api": "npm:^1.0.4"
@@ -33323,7 +33317,7 @@ __metadata:
     "@metamask/design-system-react": "npm:^0.25.0"
     "@metamask/design-system-shared": "npm:^0.21.0"
     "@metamask/design-system-tailwind-preset": "npm:^0.9.0"
-    "@metamask/design-tokens": "npm:^8.5.0"
+    "@metamask/design-tokens": "npm:@metamask-previews/design-tokens@8.5.0-preview.55a2d71"
     "@metamask/eip-5792-middleware": "npm:3.0.3"
     "@metamask/eip-7702-internal-rpc-middleware": "npm:^0.1.0"
     "@metamask/ens-controller": "npm:^19.1.4"


### PR DESCRIPTION
## **Description**

Installed the preview design token package needed to test MetaMask design system PR https://github.com/MetaMask/metamask-design-system/pull/1045. The branch swaps `@metamask/design-tokens` to `@metamask-previews/design-tokens@8.5.0-preview.55a2d71` so this extension can validate the upstream preview package.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: none

## **Manual testing steps**

1. Run `yarn install`.
2. Confirm `@metamask/design-tokens` resolves to the preview package from MetaMask design system PR 1045.
3. Start the extension build and verify the app boots normally.

## **Screenshots/Recordings**

Not applicable.

### **Before**


https://github.com/user-attachments/assets/0e2d3fa0-b13a-4918-8dc9-2c347b2053aa


### **After**

https://github.com/user-attachments/assets/5a5de143-2d15-4caf-b150-88c7881e96ac

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only dependency alias with no runtime or security logic changes; preview tokens may differ visually from production.
> 
> **Overview**
> This PR retargets **`@metamask/design-tokens`** from the stable **`^8.5.0`** release to the preview **`@metamask-previews/design-tokens@8.5.0-preview.55a2d71`**, so the extension can exercise upstream changes from metamask-design-system PR 1045 before they ship.
> 
> **`package.json`** adds **`@metamask-previews/design-tokens`** as a dependency, sets **`@metamask/design-tokens`** to the same preview via the **`npm:`** alias, and adds a **`resolutions`** entry so transitive consumers still resolve to that preview. **`yarn.lock`** is updated to lock the preview and drop the previous **`7.1.0`** / **`8.5.0`** stable lock entries.
> 
> There are no extension source changes—only dependency wiring for manual validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fdc35a04d0be62ca58fcee004d30b63b67b7122. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->