### PR TITLE
refactor(analytics): migrate RPC method tracking middleware

### DIFF
--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.js
@@ -28,6 +28,7 @@ import {
   // eslint-disable-next-line import-x/no-restricted-paths
 } from '../../../ui/helpers/utils/metrics';
 import { isSnapPreinstalled } from '../../../shared/lib/snaps/snaps';
+import { createEventBuilder, trackEvent } from '../controllers/analytics';
 import { getSnapAndHardwareInfoForMetrics } from './snap-keyring/metrics';
 import { getIframeProperties } from './getIframeProperties';
 
@@ -468,14 +469,16 @@ export default function createRPCMethodTrackingMiddleware({
           eventCategory,
         );
       } else {
-        metaMetricsController.trackEvent({
-          event,
-          category: eventCategory,
-          referrer: {
-            url: origin,
-          },
-          properties: eventProperties,
-        });
+        trackEvent(
+          createEventBuilder(event)
+            .addCategory(eventCategory)
+            .addProperties(eventProperties)
+            .build({
+              referrer: {
+                url: origin,
+              },
+            }),
+        );
       }
 
       if (rateLimitType === RATE_LIMIT_TYPES.TIMEOUT) {
@@ -581,14 +584,16 @@ export default function createRPCMethodTrackingMiddleware({
           fragmentPayload,
         );
       } else {
-        metaMetricsController.trackEvent({
-          event,
-          category: eventCategory,
-          referrer: {
-            url: origin,
-          },
-          properties,
-        });
+        trackEvent(
+          createEventBuilder(event)
+            .addCategory(eventCategory)
+            .addProperties(properties)
+            .build({
+              referrer: {
+                url: origin,
+              },
+            }),
+        );
       }
       return callback();
     });

--- a/app/scripts/lib/createRPCMethodTrackingMiddleware.test.js
+++ b/app/scripts/lib/createRPCMethodTrackingMiddleware.test.js
@@ -24,6 +24,10 @@ import {
   orderSignatureMsg,
 } from '../../../test/data/confirmations/typed_sign';
 import { getDefaultPreferencesControllerState } from '../controllers/preferences-controller';
+import {
+  configureAnalytics,
+  getAnalyticsMessenger,
+} from '../controllers/analytics';
 import createRPCMethodTrackingMiddleware from './createRPCMethodTrackingMiddleware';
 import * as snapKeyringMetrics from './snap-keyring/metrics';
 
@@ -35,15 +39,6 @@ jest.mock('./snap-keyring/metrics', () => {
 const MockSnapKeyringMetrics = jest.mocked(snapKeyringMetrics);
 
 const MOCK_ID = '123';
-
-const expectedMetametricsEventUndefinedProps = {
-  currency: undefined,
-  environmentType: undefined,
-  page: undefined,
-  revenue: undefined,
-  sensitiveProperties: undefined,
-  value: undefined,
-};
 
 const appStateController = {
   state: {
@@ -66,16 +61,13 @@ messenger.registerActionHandler('PreferencesController:getState', () => ({
   currentLocale: 'en_US',
 }));
 
-messenger.registerActionHandler(
-  'NetworkController:getState',
-  jest.fn().mockReturnValue({
-    selectedNetworkClientId: 'selectedNetworkClientId',
-  }),
-);
+messenger.registerActionHandler('NetworkController:getState', () => ({
+  selectedNetworkClientId: 'selectedNetworkClientId',
+}));
 
 messenger.registerActionHandler(
   'NetworkController:getNetworkClientById',
-  jest.fn().mockReturnValue({
+  () => ({
     configuration: {
       chainId: '0x1338',
     },
@@ -99,7 +91,11 @@ messenger.registerActionHandler('AnalyticsController:optOut', () => {
   analyticsControllerState.optedIn = false;
 });
 
-messenger.registerActionHandler('AnalyticsController:trackEvent', jest.fn());
+const trackEventSpy = jest.fn();
+messenger.registerActionHandler(
+  'AnalyticsController:trackEvent',
+  trackEventSpy,
+);
 messenger.registerActionHandler('AnalyticsController:identify', jest.fn());
 messenger.registerActionHandler('AnalyticsController:trackView', jest.fn());
 
@@ -148,6 +144,32 @@ const metaMetricsController = new MetaMetricsController({
     },
   },
 });
+
+messenger.registerActionHandler('MultichainNetworkController:getState', () => ({
+  isEvmSelected: true,
+  selectedMultichainNetworkChainId: 'eip155:1',
+}));
+
+messenger.registerActionHandler('RemoteFeatureFlagController:getState', () => ({
+  remoteFeatureFlags: {},
+}));
+
+configureAnalytics({
+  messenger: getAnalyticsMessenger(messenger),
+  version: '0.0.1',
+  environment: 'test',
+});
+
+function getTrackedEventCall(callIndex) {
+  const [trackingEvent, context] = trackEventSpy.mock.calls[callIndex];
+  return {
+    event: trackingEvent.name,
+    category: trackingEvent.properties?.category,
+    properties: trackingEvent.properties,
+    sensitiveProperties: trackingEvent.sensitiveProperties,
+    referrer: context?.referrer,
+  };
+}
 
 const createHandler = (opts) =>
   createRPCMethodTrackingMiddleware({
@@ -203,12 +225,8 @@ jest.mock('@metamask/controller-utils', () => {
 });
 
 describe('createRPCMethodTrackingMiddleware', () => {
-  let trackEventSpy;
-
   beforeEach(() => {
-    trackEventSpy = jest
-      .spyOn(MetaMetricsController.prototype, 'trackEvent')
-      .mockImplementation(() => undefined);
+    trackEventSpy.mockClear();
   });
   afterEach(() => {
     jest.resetAllMocks();
@@ -283,7 +301,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
       await handler(req, res, next);
 
       expect(trackEventSpy).toHaveBeenCalledTimes(1);
-      expect(trackEventSpy.mock.calls[0][0]).toMatchObject({
+      expect(getTrackedEventCall(0)).toMatchObject({
         category: MetaMetricsEventCategory.InpageProvider,
         event: MetaMetricsEventName.SignatureRequested,
         properties: {
@@ -348,7 +366,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
       await handler(req, res, next);
 
       expect(trackEventSpy).toHaveBeenCalledTimes(1);
-      expect(trackEventSpy.mock.calls[0][0]).toMatchObject({
+      expect(getTrackedEventCall(0)).toMatchObject({
         category: MetaMetricsEventCategory.InpageProvider,
         event: MetaMetricsEventName.SignatureRequested,
         properties: {
@@ -385,12 +403,10 @@ describe('createRPCMethodTrackingMiddleware', () => {
       const handler = createHandler();
       await handler(req, res, next);
       expect(trackEventSpy).toHaveBeenCalledTimes(1);
-      expect(trackEventSpy.mock.calls[0][0]).toStrictEqual({
-        ...expectedMetametricsEventUndefinedProps,
+      expect(getTrackedEventCall(0)).toMatchObject({
         category: MetaMetricsEventCategory.InpageProvider,
         event: MetaMetricsEventName.SignatureRequested,
         properties: {
-          hd_entropy_index: undefined,
           signature_type: MESSAGE_TYPE.ETH_SIGN_TYPED_DATA_V4,
           security_alert_response: BlockaidResultType.Malicious,
           security_alert_reason: BlockaidReason.maliciousDomain,
@@ -423,7 +439,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
       await handler(req, res, next);
       await executeMiddlewareStack();
       expect(trackEventSpy).toHaveBeenCalledTimes(2);
-      expect(trackEventSpy.mock.calls[1][0]).toMatchObject({
+      expect(getTrackedEventCall(1)).toMatchObject({
         category: MetaMetricsEventCategory.InpageProvider,
         event: MetaMetricsEventName.SignatureApproved,
         properties: {
@@ -459,7 +475,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
       await handler(req, res, next);
       await executeMiddlewareStack();
       expect(trackEventSpy).toHaveBeenCalledTimes(2);
-      expect(trackEventSpy.mock.calls[1][0]).toMatchObject({
+      expect(getTrackedEventCall(1)).toMatchObject({
         category: MetaMetricsEventCategory.InpageProvider,
         event: MetaMetricsEventName.SignatureRejected,
         properties: {
@@ -494,7 +510,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
       await handler(req, res, next);
       await executeMiddlewareStack();
       expect(trackEventSpy).toHaveBeenCalledTimes(2);
-      expect(trackEventSpy.mock.calls[1][0]).toMatchObject({
+      expect(getTrackedEventCall(1)).toMatchObject({
         category: MetaMetricsEventCategory.InpageProvider,
         event: MetaMetricsEventName.SignatureRejected,
         properties: {
@@ -519,7 +535,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
       await handler(req, res, next);
       await executeMiddlewareStack();
       expect(trackEventSpy).toHaveBeenCalledTimes(2);
-      expect(trackEventSpy.mock.calls[1][0]).toMatchObject({
+      expect(getTrackedEventCall(1)).toMatchObject({
         category: MetaMetricsEventCategory.InpageProvider,
         event: MetaMetricsEventName.PermissionsApproved,
         properties: {
@@ -622,8 +638,8 @@ describe('createRPCMethodTrackingMiddleware', () => {
 
           const expectedNumberOfCalls = 2 * eventsTrackedPerRequest;
           expect(trackEventSpy).toHaveBeenCalledTimes(expectedNumberOfCalls);
-          trackEventSpy.mock.calls.forEach((call) => {
-            expect(call[0].properties.method).toBe(method);
+          trackEventSpy.mock.calls.forEach((_, index) => {
+            expect(getTrackedEventCall(index).properties.method).toBe(method);
           });
         },
       );
@@ -670,8 +686,8 @@ describe('createRPCMethodTrackingMiddleware', () => {
 
           const expectedNumberOfCalls = 2 * eventsTrackedPerRequest;
           expect(trackEventSpy).toHaveBeenCalledTimes(expectedNumberOfCalls);
-          trackEventSpy.mock.calls.forEach((call) => {
-            expect(call[0].properties.method).toBe(method);
+          trackEventSpy.mock.calls.forEach((_, index) => {
+            expect(getTrackedEventCall(index).properties.method).toBe(method);
           });
         },
       );
@@ -707,8 +723,8 @@ describe('createRPCMethodTrackingMiddleware', () => {
         }
 
         expect(trackEventSpy).toHaveBeenCalledTimes(3);
-        trackEventSpy.mock.calls.forEach((call) => {
-          expect(call[0].properties.method).toBe(
+        trackEventSpy.mock.calls.forEach((_, index) => {
+          expect(getTrackedEventCall(index).properties.method).toBe(
             'some_method_rate_limited_by_sample',
           );
         });
@@ -732,7 +748,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
 
       expect(trackEventSpy).toHaveBeenCalledTimes(2);
 
-      expect(trackEventSpy.mock.calls[1][0]).toMatchObject({
+      expect(getTrackedEventCall(1)).toMatchObject({
         category: MetaMetricsEventCategory.InpageProvider,
         event: MetaMetricsEventName.SignatureApproved,
         properties: {
@@ -763,7 +779,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
 
       expect(trackEventSpy).toHaveBeenCalledTimes(2);
 
-      expect(trackEventSpy.mock.calls[1][0]).toMatchObject({
+      expect(getTrackedEventCall(1)).toMatchObject({
         category: MetaMetricsEventCategory.InpageProvider,
         event: MetaMetricsEventName.SignatureApproved,
         properties: {
@@ -795,7 +811,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
 
       expect(trackEventSpy).toHaveBeenCalledTimes(2);
 
-      expect(trackEventSpy.mock.calls[1][0]).toMatchObject({
+      expect(getTrackedEventCall(1)).toMatchObject({
         category: MetaMetricsEventCategory.InpageProvider,
         event: MetaMetricsEventName.SignatureApproved,
         properties: {
@@ -824,7 +840,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
 
       expect(trackEventSpy).toHaveBeenCalledTimes(2);
 
-      expect(trackEventSpy.mock.calls[1][0]).toMatchObject({
+      expect(getTrackedEventCall(1)).toMatchObject({
         category: MetaMetricsEventCategory.InpageProvider,
         event: MetaMetricsEventName.SignatureApproved,
         properties: {
@@ -853,7 +869,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
 
       expect(trackEventSpy).toHaveBeenCalledTimes(2);
 
-      expect(trackEventSpy.mock.calls[1][0]).toMatchObject({
+      expect(getTrackedEventCall(1)).toMatchObject({
         category: MetaMetricsEventCategory.InpageProvider,
         event: MetaMetricsEventName.SignatureApproved,
         properties: {
@@ -879,7 +895,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
       await handler(req, res, next);
       await executeMiddlewareStack();
       expect(trackEventSpy).toHaveBeenCalledTimes(2);
-      expect(trackEventSpy.mock.calls[1][0]).toMatchObject({
+      expect(getTrackedEventCall(1)).toMatchObject({
         category: MetaMetricsEventCategory.InpageProvider,
         event: MetaMetricsEventName.SignatureApproved,
         properties: {
@@ -911,7 +927,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
       await executeMiddlewareStack();
 
       expect(trackEventSpy).toHaveBeenCalledTimes(2);
-      expect(trackEventSpy.mock.calls[1][0]).toMatchObject({
+      expect(getTrackedEventCall(1)).toMatchObject({
         category: MetaMetricsEventCategory.InpageProvider,
         event: MetaMetricsEventName.SignatureApproved,
         properties: {
@@ -940,7 +956,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
         await handler(req, res, next);
 
         expect(trackEventSpy).toHaveBeenCalledTimes(1);
-        expect(trackEventSpy.mock.calls[0][0]).toMatchObject({
+        expect(getTrackedEventCall(0)).toMatchObject({
           category: MetaMetricsEventCategory.InpageProvider,
           event: MetaMetricsEventName.SignatureRequested,
           properties: {
@@ -1053,7 +1069,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
         await handler(req, res, next);
 
         expect(trackEventSpy).toHaveBeenCalledTimes(1);
-        expect(trackEventSpy.mock.calls[0][0].properties.params).toStrictEqual(
+        expect(getTrackedEventCall(0).properties.params).toStrictEqual(
           expected,
         );
       },
@@ -1133,10 +1149,8 @@ describe('createRPCMethodTrackingMiddleware', () => {
         await handler(req, res, next);
 
         expect(trackEventSpy).toHaveBeenCalledTimes(1);
-        expect(trackEventSpy.mock.calls[0][0].event).toBe(event);
-        expect(trackEventSpy.mock.calls[0][0].properties).toStrictEqual(
-          properties,
-        );
+        expect(getTrackedEventCall(0).event).toBe(event);
+        expect(getTrackedEventCall(0).properties).toMatchObject(properties);
       },
     );
     describe('iframe detection properties', () => {
@@ -1155,7 +1169,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
         await handler(req, res, next);
 
         expect(trackEventSpy).toHaveBeenCalledTimes(1);
-        expect(trackEventSpy.mock.calls[0][0].properties).toMatchObject({
+        expect(getTrackedEventCall(0).properties).toMatchObject({
           is_iframe: false,
           is_cross_origin_iframe: false,
           iframe_origin: null,
@@ -1178,7 +1192,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
         await handler(req, res, next);
 
         expect(trackEventSpy).toHaveBeenCalledTimes(1);
-        expect(trackEventSpy.mock.calls[0][0].properties).toMatchObject({
+        expect(getTrackedEventCall(0).properties).toMatchObject({
           is_iframe: true,
           is_cross_origin_iframe: true,
           iframe_origin: 'https://iframe.malicious.com',
@@ -1201,7 +1215,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
         await handler(req, res, next);
 
         expect(trackEventSpy).toHaveBeenCalledTimes(1);
-        expect(trackEventSpy.mock.calls[0][0].properties).toMatchObject({
+        expect(getTrackedEventCall(0).properties).toMatchObject({
           is_iframe: true,
           is_cross_origin_iframe: false,
           iframe_origin: null,
@@ -1222,7 +1236,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
         await handler(req, res, next);
 
         expect(trackEventSpy).toHaveBeenCalledTimes(1);
-        expect(trackEventSpy.mock.calls[0][0].properties).toMatchObject({
+        expect(getTrackedEventCall(0).properties).toMatchObject({
           is_iframe: false,
           is_cross_origin_iframe: false,
           iframe_origin: null,
@@ -1254,7 +1268,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
         await executeMiddlewareStack();
 
         expect(trackEventSpy).toHaveBeenCalledTimes(2);
-        expect(trackEventSpy.mock.calls[0][0]).toMatchObject({
+        expect(getTrackedEventCall(0)).toMatchObject({
           event: MetaMetricsEventName.PermissionsRequested,
           properties: {
             is_iframe: true,
@@ -1262,7 +1276,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
             top_level_origin: 'https://top-level.dapp.com',
           },
         });
-        expect(trackEventSpy.mock.calls[1][0]).toMatchObject({
+        expect(getTrackedEventCall(1)).toMatchObject({
           event: MetaMetricsEventName.PermissionsApproved,
           properties: {
             is_iframe: true,
@@ -1294,7 +1308,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
         await executeMiddlewareStack();
 
         expect(trackEventSpy).toHaveBeenCalledTimes(2);
-        expect(trackEventSpy.mock.calls[1][0]).toMatchObject({
+        expect(getTrackedEventCall(1)).toMatchObject({
           event: MetaMetricsEventName.PermissionsRejected,
           properties: {
             is_iframe: true,
@@ -1319,7 +1333,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
         await handler(req, res, next);
 
         expect(trackEventSpy).toHaveBeenCalledTimes(1);
-        expect(trackEventSpy.mock.calls[0][0]).toMatchObject({
+        expect(getTrackedEventCall(0)).toMatchObject({
           event: MetaMetricsEventName.SignatureRequested,
           properties: {
             is_iframe: true,
@@ -1364,7 +1378,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
         await handler(req, res, next);
         expect(trackEventSpy).toHaveBeenCalledTimes(1);
 
-        expect(trackEventSpy.mock.calls[0][0]).toMatchObject({
+        expect(getTrackedEventCall(0)).toMatchObject({
           category: MetaMetricsEventCategory.MultichainApi,
           event: MetaMetricsEventName.PermissionsRequested,
           properties: {
@@ -1381,7 +1395,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
         await executeMiddlewareStack();
         expect(trackEventSpy).toHaveBeenCalledTimes(2);
 
-        expect(trackEventSpy.mock.calls[1][0]).toMatchObject({
+        expect(getTrackedEventCall(1)).toMatchObject({
           category: MetaMetricsEventCategory.MultichainApi,
           event: MetaMetricsEventName.PermissionsApproved,
           properties: {
@@ -1414,7 +1428,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
         await executeMiddlewareStack();
 
         expect(trackEventSpy).toHaveBeenCalledTimes(2);
-        expect(trackEventSpy.mock.calls[0][0]).toMatchObject({
+        expect(getTrackedEventCall(0)).toMatchObject({
           category: MetaMetricsEventCategory.MultichainApi,
           event: MetaMetricsEventName.SignatureRequested,
           properties: {
@@ -1426,7 +1440,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
           referrer: { url: 'multichain.dapp' },
         });
 
-        expect(trackEventSpy.mock.calls[1][0]).toMatchObject({
+        expect(getTrackedEventCall(1)).toMatchObject({
           category: MetaMetricsEventCategory.MultichainApi,
           event: MetaMetricsEventName.SignatureApproved,
           properties: {
@@ -1464,7 +1478,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
         await executeMiddlewareStack();
 
         expect(trackEventSpy).toHaveBeenCalledTimes(2);
-        expect(trackEventSpy.mock.calls[0][0]).toMatchObject({
+        expect(getTrackedEventCall(0)).toMatchObject({
           category: MetaMetricsEventCategory.MultichainApi,
           event: MetaMetricsEventName.SignatureRequested,
           properties: {
@@ -1476,7 +1490,7 @@ describe('createRPCMethodTrackingMiddleware', () => {
           referrer: { url: 'multichain.dapp' },
         });
 
-        expect(trackEventSpy.mock.calls[1][0]).toMatchObject({
+        expect(getTrackedEventCall(1)).toMatchObject({
           category: MetaMetricsEventCategory.MultichainApi,
           event: MetaMetricsEventName.SignatureRejected,
           properties: {


### PR DESCRIPTION
## **Description**

Sub-PR of umbrella tracker [#43885](https://github.com/MetaMask/metamask-extension/pull/43885).

Migrates MetaMetrics `trackEvent` call sites in this CODEOWNERS domain to `createEventBuilder` + `trackEvent` via `useAnalytics()` (UI) or `app/scripts/controllers/analytics` (background).

**Dependency note:** Independent — RPC middleware only, can merge anytime.

**Files in this PR:** 8

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of analytics migration umbrella: #43885

## **Manual testing steps**

1. Check out this branch and run `yarn start`.
2. Exercise flows in the touched domain (see diff file list).
3. Confirm no console errors and representative events still fire.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics plumbing swap with broad test updates; behavior should be equivalent aside from event payload structure. No RPC or security logic changes.
> 
> **Overview**
> **RPC method tracking middleware** now emits non–signature-fragment analytics through `createEventBuilder` + `trackEvent` from `app/scripts/controllers/analytics` instead of `metaMetricsController.trackEvent`, for both the initial “requested” path and post-callback approve/reject flows. **Signature flows** still use `MetaMetricsController` event fragments unchanged.
> 
> **Tests** wire `configureAnalytics`, spy `AnalyticsController:trackEvent`, and assert via a `getTrackedEventCall` helper that maps the new event shape; several expectations were relaxed from `toStrictEqual` to `toMatchObject` where the builder payload differs from the old flat object.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3d557283440f3dbb1079f16bd0d5728c1d4db8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->