### PR TITLE
refactor(analytics): migrate shield and subscription events

### DIFF
--- a/app/scripts/messenger-client-init/messengers/subscription/subscription-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/subscription/subscription-service-messenger.ts
@@ -51,7 +51,6 @@ export function getSubscriptionServiceMessenger(
       'SmartTransactionsController:getState',
       'NetworkController:getState',
       'RemoteFeatureFlagController:getState',
-      'MetaMetricsController:trackEvent',
       'KeyringController:getState',
       // Rewards Integration
       'RewardsController:getSeasonStatus',

--- a/app/scripts/messenger-client-init/seedless-onboarding/oauth-service-init.test.ts
+++ b/app/scripts/messenger-client-init/seedless-onboarding/oauth-service-init.test.ts
@@ -21,19 +21,24 @@ function buildInitRequestMock(): jest.Mocked<
 describe('OAuthServiceInit', () => {
   it('returns the service instance', () => {
     const requestMock = buildInitRequestMock();
+    const metaMetricsController = {
+      bufferedTrace: jest.fn(),
+      bufferedEndTrace: jest.fn(),
+      addEventBeforeMetricsOptIn: jest.fn(),
+      state: { completedMetaMetricsOnboarding: true },
+    };
+    const analyticsController = {
+      state: { optedIn: false },
+    };
 
+    // OAuthServiceInit reads MetaMetrics onboarding state and Analytics opt-in state.
     // @ts-expect-error: Partial mock for testing.
     requestMock.getMessengerClient.mockImplementation((controllerName) => {
       if (controllerName === 'AnalyticsController') {
-        return { state: { optedIn: false } };
+        return analyticsController;
       }
 
-      return {
-        bufferedTrace: jest.fn(),
-        bufferedEndTrace: jest.fn(),
-        addEventBeforeMetricsOptIn: jest.fn(),
-        state: { completedMetaMetricsOnboarding: true },
-      };
+      return metaMetricsController;
     });
 
     expect(OAuthServiceInit(requestMock).messengerClient).toBeInstanceOf(

--- a/app/scripts/messenger-client-init/seedless-onboarding/oauth-service-init.test.ts
+++ b/app/scripts/messenger-client-init/seedless-onboarding/oauth-service-init.test.ts
@@ -23,13 +23,16 @@ describe('OAuthServiceInit', () => {
     const requestMock = buildInitRequestMock();
 
     // @ts-expect-error: Partial mock for testing.
-    requestMock.getMessengerClient.mockImplementation(() => {
+    requestMock.getMessengerClient.mockImplementation((controllerName) => {
+      if (controllerName === 'AnalyticsController') {
+        return { state: { optedIn: false } };
+      }
+
       return {
         bufferedTrace: jest.fn(),
         bufferedEndTrace: jest.fn(),
-        trackEvent: jest.fn(),
         addEventBeforeMetricsOptIn: jest.fn(),
-        state: { completedMetaMetricsOnboarding: true, optedIn: false },
+        state: { completedMetaMetricsOnboarding: true },
       };
     });
 

--- a/app/scripts/messenger-client-init/seedless-onboarding/oauth-service-init.ts
+++ b/app/scripts/messenger-client-init/seedless-onboarding/oauth-service-init.ts
@@ -32,8 +32,6 @@ export const OAuthServiceInit: MessengerClientInitFunction<
       metaMetricsController,
     ),
 
-    trackEvent: metaMetricsController.trackEvent.bind(metaMetricsController),
-
     addEventBeforeMetricsOptIn:
       metaMetricsController.addEventBeforeMetricsOptIn.bind(
         metaMetricsController,

--- a/app/scripts/services/oauth/oauth-service.test.ts
+++ b/app/scripts/services/oauth/oauth-service.test.ts
@@ -19,6 +19,12 @@ import { OAuthService } from './oauth-service';
 import { createLoginHandler } from './create-login-handler';
 import { loadOAuthConfig } from './config';
 
+jest.mock('../../controllers/analytics', () => ({
+  createEventBuilder: jest.requireActual('../../controllers/analytics')
+    .createEventBuilder,
+  trackEvent: jest.fn(),
+}));
+
 type Actions = MessengerActions<OAuthServiceMessenger>;
 
 type Events = MessengerEvents<OAuthServiceMessenger>;
@@ -113,7 +119,6 @@ const mockWebAuthenticator: WebAuthenticator = {
 
 const mockBufferedTrace = jest.fn();
 const mockBufferedEndTrace = jest.fn();
-const mockTrackEvent = jest.fn();
 const mockAddEventBeforeMetricsOptIn = jest.fn();
 const mockGetCompletedMetaMetricsOnboarding = jest.fn().mockReturnValue(true);
 const mockGetOptedIn = jest.fn().mockReturnValue(true);
@@ -163,7 +168,6 @@ describe('OAuthService - startOAuthLogin', () => {
       platform: mockPlatform,
       bufferedTrace: mockBufferedTrace,
       bufferedEndTrace: mockBufferedEndTrace,
-      trackEvent: mockTrackEvent,
       addEventBeforeMetricsOptIn: mockAddEventBeforeMetricsOptIn,
       getCompletedMetaMetricsOnboarding: mockGetCompletedMetaMetricsOnboarding,
       getOptedIn: mockGetOptedIn,
@@ -194,7 +198,6 @@ describe('OAuthService - startOAuthLogin', () => {
       platform: mockPlatform,
       bufferedTrace: mockBufferedTrace,
       bufferedEndTrace: mockBufferedEndTrace,
-      trackEvent: mockTrackEvent,
       addEventBeforeMetricsOptIn: mockAddEventBeforeMetricsOptIn,
       getCompletedMetaMetricsOnboarding: mockGetCompletedMetaMetricsOnboarding,
       getOptedIn: mockGetOptedIn,
@@ -279,7 +282,6 @@ describe('OAuthService - startOAuthLogin', () => {
       platform: mockPlatform,
       bufferedTrace: mockBufferedTrace,
       bufferedEndTrace: mockBufferedEndTrace,
-      trackEvent: mockTrackEvent,
       addEventBeforeMetricsOptIn: mockAddEventBeforeMetricsOptIn,
       getCompletedMetaMetricsOnboarding: mockGetCompletedMetaMetricsOnboarding,
       getOptedIn: mockGetOptedIn,
@@ -375,7 +377,6 @@ describe('OAuthService - startOAuthLogin', () => {
       platform: mockPlatform,
       bufferedTrace: mockBufferedTrace,
       bufferedEndTrace: mockBufferedEndTrace,
-      trackEvent: mockTrackEvent,
       addEventBeforeMetricsOptIn: mockAddEventBeforeMetricsOptIn,
       getCompletedMetaMetricsOnboarding: mockGetCompletedMetaMetricsOnboarding,
       getOptedIn: mockGetOptedIn,
@@ -412,7 +413,6 @@ describe('OAuthService - startOAuthLogin', () => {
       platform: mockPlatform,
       bufferedTrace: mockBufferedTrace,
       bufferedEndTrace: mockBufferedEndTrace,
-      trackEvent: mockTrackEvent,
       addEventBeforeMetricsOptIn: mockAddEventBeforeMetricsOptIn,
       getCompletedMetaMetricsOnboarding: mockGetCompletedMetaMetricsOnboarding,
       getOptedIn: mockGetOptedIn,
@@ -439,7 +439,6 @@ describe('OAuthService - startOAuthLogin', () => {
       platform: mockPlatform,
       bufferedTrace: mockBufferedTrace,
       bufferedEndTrace: mockBufferedEndTrace,
-      trackEvent: mockTrackEvent,
       addEventBeforeMetricsOptIn: mockAddEventBeforeMetricsOptIn,
       getCompletedMetaMetricsOnboarding: mockGetCompletedMetaMetricsOnboarding,
       getOptedIn: mockGetOptedIn,
@@ -484,7 +483,6 @@ describe('OAuthService - startOAuthLogin', () => {
       },
       bufferedTrace: mockBufferedTrace,
       bufferedEndTrace: mockBufferedEndTrace,
-      trackEvent: mockTrackEvent,
       addEventBeforeMetricsOptIn: mockAddEventBeforeMetricsOptIn,
       getCompletedMetaMetricsOnboarding: mockGetCompletedMetaMetricsOnboarding,
       getOptedIn: mockGetOptedIn,
@@ -526,7 +524,6 @@ describe('OAuthService - startOAuthLogin', () => {
       },
       bufferedTrace: mockBufferedTrace,
       bufferedEndTrace: mockBufferedEndTrace,
-      trackEvent: mockTrackEvent,
       addEventBeforeMetricsOptIn: mockAddEventBeforeMetricsOptIn,
       getCompletedMetaMetricsOnboarding: mockGetCompletedMetaMetricsOnboarding,
       getOptedIn: mockGetOptedIn,
@@ -566,7 +563,6 @@ describe('OAuthService - startOAuthLogin', () => {
       },
       bufferedTrace: mockBufferedTrace,
       bufferedEndTrace: mockBufferedEndTrace,
-      trackEvent: mockTrackEvent,
       addEventBeforeMetricsOptIn: mockAddEventBeforeMetricsOptIn,
       getCompletedMetaMetricsOnboarding: mockGetCompletedMetaMetricsOnboarding,
       getOptedIn: mockGetOptedIn,
@@ -598,7 +594,6 @@ describe('OAuthService - startOAuthLogin', () => {
         platform: mockPlatform,
         bufferedTrace: mockBufferedTrace,
         bufferedEndTrace: mockBufferedEndTrace,
-        trackEvent: mockTrackEvent,
         addEventBeforeMetricsOptIn: mockAddEventBeforeMetricsOptIn,
         getCompletedMetaMetricsOnboarding:
           mockGetCompletedMetaMetricsOnboarding,
@@ -657,7 +652,6 @@ describe('OAuthService - getNewRefreshToken', () => {
       platform: mockPlatform,
       bufferedTrace: mockBufferedTrace,
       bufferedEndTrace: mockBufferedEndTrace,
-      trackEvent: mockTrackEvent,
       addEventBeforeMetricsOptIn: mockAddEventBeforeMetricsOptIn,
       getCompletedMetaMetricsOnboarding: mockGetCompletedMetaMetricsOnboarding,
       getOptedIn: mockGetOptedIn,
@@ -720,7 +714,6 @@ describe('OAuthService - getNewRefreshToken', () => {
       platform: mockPlatform,
       bufferedTrace: mockBufferedTrace,
       bufferedEndTrace: mockBufferedEndTrace,
-      trackEvent: mockTrackEvent,
       addEventBeforeMetricsOptIn: mockAddEventBeforeMetricsOptIn,
       getCompletedMetaMetricsOnboarding: mockGetCompletedMetaMetricsOnboarding,
       getOptedIn: mockGetOptedIn,
@@ -761,7 +754,6 @@ describe('OAuthService - getNewRefreshToken', () => {
         platform: mockPlatform,
         bufferedTrace: mockBufferedTrace,
         bufferedEndTrace: mockBufferedEndTrace,
-        trackEvent: mockTrackEvent,
         addEventBeforeMetricsOptIn: mockAddEventBeforeMetricsOptIn,
         getCompletedMetaMetricsOnboarding:
           mockGetCompletedMetaMetricsOnboarding,
@@ -808,7 +800,6 @@ describe('OAuthService - renewRefreshToken', () => {
       platform: mockPlatform,
       bufferedTrace: mockBufferedTrace,
       bufferedEndTrace: mockBufferedEndTrace,
-      trackEvent: mockTrackEvent,
       addEventBeforeMetricsOptIn: mockAddEventBeforeMetricsOptIn,
       getCompletedMetaMetricsOnboarding: mockGetCompletedMetaMetricsOnboarding,
       getOptedIn: mockGetOptedIn,
@@ -863,7 +854,6 @@ describe('OAuthService - renewRefreshToken', () => {
       platform: mockPlatform,
       bufferedTrace: mockBufferedTrace,
       bufferedEndTrace: mockBufferedEndTrace,
-      trackEvent: mockTrackEvent,
       addEventBeforeMetricsOptIn: mockAddEventBeforeMetricsOptIn,
       getCompletedMetaMetricsOnboarding: mockGetCompletedMetaMetricsOnboarding,
       getOptedIn: mockGetOptedIn,
@@ -900,7 +890,6 @@ describe('OAuthService - revokeRefreshToken', () => {
       platform: mockPlatform,
       bufferedTrace: mockBufferedTrace,
       bufferedEndTrace: mockBufferedEndTrace,
-      trackEvent: mockTrackEvent,
       addEventBeforeMetricsOptIn: mockAddEventBeforeMetricsOptIn,
       getCompletedMetaMetricsOnboarding: mockGetCompletedMetaMetricsOnboarding,
       getOptedIn: mockGetOptedIn,
@@ -950,7 +939,6 @@ describe('OAuthService - revokeRefreshToken', () => {
       platform: mockPlatform,
       bufferedTrace: mockBufferedTrace,
       bufferedEndTrace: mockBufferedEndTrace,
-      trackEvent: mockTrackEvent,
       addEventBeforeMetricsOptIn: mockAddEventBeforeMetricsOptIn,
       getCompletedMetaMetricsOnboarding: mockGetCompletedMetaMetricsOnboarding,
       getOptedIn: mockGetOptedIn,
@@ -991,7 +979,6 @@ describe('OAuthService - revokeRefreshToken', () => {
         platform: mockPlatform,
         bufferedTrace: mockBufferedTrace,
         bufferedEndTrace: mockBufferedEndTrace,
-        trackEvent: mockTrackEvent,
         addEventBeforeMetricsOptIn: mockAddEventBeforeMetricsOptIn,
         getCompletedMetaMetricsOnboarding:
           mockGetCompletedMetaMetricsOnboarding,

--- a/app/scripts/services/oauth/oauth-service.ts
+++ b/app/scripts/services/oauth/oauth-service.ts
@@ -11,13 +11,14 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventAccountType,
   MetaMetricsEventPayload,
-  MetaMetricsEventOptions,
 } from '../../../../shared/constants/metametrics';
 import {
   AuthConnection,
   FirstTimeFlowType,
 } from '../../../../shared/constants/onboarding';
 import ExtensionPlatform from '../../platforms/extension';
+import { createEventBuilder, trackEvent } from '../../controllers/analytics';
+import type { AnalyticsEvent } from '../../controllers/analytics';
 import { BaseLoginHandler } from './base-login-handler';
 import { createLoginHandler } from './create-login-handler';
 import {
@@ -62,8 +63,6 @@ export class OAuthService {
 
   #bufferedEndTrace: OAuthServiceOptions['bufferedEndTrace'];
 
-  #trackEvent: OAuthServiceOptions['trackEvent'];
-
   #addEventBeforeMetricsOptIn: OAuthServiceOptions['addEventBeforeMetricsOptIn'];
 
   #getCompletedMetaMetricsOnboarding: OAuthServiceOptions['getCompletedMetaMetricsOnboarding'];
@@ -76,7 +75,6 @@ export class OAuthService {
     platform,
     bufferedTrace,
     bufferedEndTrace,
-    trackEvent,
     addEventBeforeMetricsOptIn,
     getCompletedMetaMetricsOnboarding,
     getOptedIn,
@@ -88,7 +86,6 @@ export class OAuthService {
     this.#platform = platform;
     this.#bufferedTrace = bufferedTrace;
     this.#bufferedEndTrace = bufferedEndTrace;
-    this.#trackEvent = trackEvent;
     this.#addEventBeforeMetricsOptIn = addEventBeforeMetricsOptIn;
     this.#getCompletedMetaMetricsOnboarding = getCompletedMetaMetricsOnboarding;
     this.#getOptedIn = getOptedIn;
@@ -102,25 +99,28 @@ export class OAuthService {
   /**
    * Track a MetaMetrics event with buffering (handles consent checking)
    *
-   * @param payload - The event payload
-   * @param options - Optional event options
+   * @param built - The built analytics event.
    */
-  #trackEventWithBuffering(
-    payload: MetaMetricsEventPayload,
-    options?: MetaMetricsEventOptions,
-  ): void {
+  #trackEventWithBuffering(built: AnalyticsEvent): void {
     const isMetricsEnabled =
       this.#getCompletedMetaMetricsOnboarding() && this.#getOptedIn();
 
     if (isMetricsEnabled) {
-      this.#trackEvent(payload, options);
-    } else {
-      const bufferedPayload = {
-        ...payload,
-        actionId: `${Date.now() + Math.random()}`,
-      };
-      this.#addEventBeforeMetricsOptIn(bufferedPayload);
+      trackEvent(built);
+      return;
     }
+
+    const { category, ...properties } = built.properties;
+    const bufferedPayload: MetaMetricsEventPayload = {
+      event: built.name,
+      category: category as MetaMetricsEventCategory,
+      properties: {
+        ...properties,
+        actionId: `${Date.now() + Math.random()}`,
+      },
+      sensitiveProperties: built.sensitiveProperties,
+    };
+    this.#addEventBeforeMetricsOptIn(bufferedPayload);
   }
 
   /**
@@ -383,21 +383,22 @@ export class OAuthService {
     errorCategory: 'provider_login' | 'get_auth_tokens';
     failureType: 'error' | 'user_cancelled';
   }): void {
-    this.#trackEventWithBuffering({
-      event: MetaMetricsEventName.SocialLoginFailed,
-      category: MetaMetricsEventCategory.Onboarding,
-      properties: {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        account_type: `${MetaMetricsEventAccountType.Default}_${authConnection}`,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        is_rehydration:
-          isRehydration === null ? 'unknown' : String(isRehydration),
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        failure_type: failureType,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        error_category: errorCategory,
-      },
-    });
+    this.#trackEventWithBuffering(
+      createEventBuilder(MetaMetricsEventName.SocialLoginFailed)
+        .addCategory(MetaMetricsEventCategory.Onboarding)
+        .addProperties({
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          account_type: `${MetaMetricsEventAccountType.Default}_${authConnection}`,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          is_rehydration:
+            isRehydration === null ? 'unknown' : String(isRehydration),
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          failure_type: failureType,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          error_category: errorCategory,
+        })
+        .build(),
+    );
   }
 
   /**

--- a/app/scripts/services/oauth/types.ts
+++ b/app/scripts/services/oauth/types.ts
@@ -6,10 +6,7 @@ import {
 import type { Env as ProfileSyncEnv } from '@metamask/profile-sync-controller/sdk';
 import { Messenger } from '@metamask/messenger';
 import { GeolocationControllerGetGeolocationAction } from '@metamask/geolocation-controller';
-import type {
-  MetaMetricsEventPayload,
-  MetaMetricsEventOptions,
-} from '../../../../shared/constants/metametrics';
+import type { MetaMetricsEventPayload } from '../../../../shared/constants/metametrics';
 import type {
   TraceRequest,
   EndTraceRequest,
@@ -160,14 +157,6 @@ export type OAuthServiceOptions = {
     fn?: (context?: unknown) => unknown,
   ) => void;
   bufferedEndTrace: (request: EndTraceRequest) => void;
-
-  /**
-   * Track a MetaMetrics event
-   */
-  trackEvent: (
-    payload: MetaMetricsEventPayload,
-    options?: MetaMetricsEventOptions,
-  ) => void;
 
   /**
    * Add an event before metrics opt-in (for buffering before user consent)

--- a/app/scripts/services/subscription/subscription-service.test.ts
+++ b/app/scripts/services/subscription/subscription-service.test.ts
@@ -26,6 +26,12 @@ import { SHIELD_ERROR } from '../../../../shared/lib/shield';
 import { SubscriptionService } from './subscription-service';
 import { SubscriptionServiceMessenger } from './types';
 
+jest.mock('../../controllers/analytics', () => ({
+  createEventBuilder: jest.requireActual('../../controllers/analytics')
+    .createEventBuilder,
+  trackEvent: jest.fn(),
+}));
+
 type Actions = MessengerActions<SubscriptionServiceMessenger>;
 
 type Events = MessengerEvents<SubscriptionServiceMessenger>;
@@ -87,7 +93,6 @@ const mockGetSubscriptions = jest.fn();
 const mockGetNetworkControllerState = jest.fn();
 const mockGetRemoteFeatureFlagState = jest.fn();
 const mockGetAppStateControllerState = jest.fn();
-const mockGetMetaMetricsControllerState = jest.fn();
 const mockGetSubscriptionControllerState = jest.fn();
 const mockGetKeyringControllerState = jest.fn();
 const mockGetRewardSeasonMetadata = jest.fn();
@@ -140,10 +145,6 @@ rootMessenger.registerActionHandler(
 rootMessenger.registerActionHandler(
   'AppStateController:getState',
   mockGetAppStateControllerState,
-);
-rootMessenger.registerActionHandler(
-  'MetaMetricsController:trackEvent',
-  mockGetMetaMetricsControllerState,
 );
 rootMessenger.registerActionHandler(
   'SubscriptionController:getState',
@@ -204,7 +205,6 @@ rootMessenger.delegate({
     'AppStateController:getState',
     'AppStateController:setPendingRedirectRoute',
     'AppStateController:setShieldSubscriptionError',
-    'MetaMetricsController:trackEvent',
     'SubscriptionController:getState',
     'KeyringController:getState',
     'RewardsController:getHasAccountOptedIn',

--- a/app/scripts/services/subscription/subscription-service.ts
+++ b/app/scripts/services/subscription/subscription-service.ts
@@ -708,19 +708,23 @@ export class SubscriptionService {
         );
 
         // Track the Shield eligibility cohort assigned event
-        this.#trackShieldEvent(
-          MetaMetricsEventName.ShieldEligibilityCohortAssigned,
-          {
-            ...this.#getAccountTypeAndCategoryForMetrics(),
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            multi_chain_balance_category: getUserBalanceCategory(
-              shieldSubscriptionMetricsProps?.userBalanceInUSD ?? 0,
-            ),
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            assigned_cohort: COHORT_NAMES.POST_TX,
-          },
+        trackEvent(
+          createEventBuilder(
+            MetaMetricsEventName.ShieldEligibilityCohortAssigned,
+          )
+            .addCategory(MetaMetricsEventCategory.Shield)
+            .addProperties({
+              ...this.#getAccountTypeAndCategoryForMetrics(),
+              // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              multi_chain_balance_category: getUserBalanceCategory(
+                shieldSubscriptionMetricsProps?.userBalanceInUSD ?? 0,
+              ),
+              // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              assigned_cohort: COHORT_NAMES.POST_TX,
+            })
+            .build(),
         );
       }
     } catch (error) {
@@ -770,12 +774,17 @@ export class SubscriptionService {
       transactionMeta,
     );
 
-    this.#trackShieldEvent(MetaMetricsEventName.ShieldSubscriptionRequest, {
-      ...accountTypeAndCategory,
-      ...trackingProps,
-      ...extrasProps,
-      status: requestStatus,
-    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.ShieldSubscriptionRequest)
+        .addCategory(MetaMetricsEventCategory.Shield)
+        .addProperties({
+          ...accountTypeAndCategory,
+          ...trackingProps,
+          ...extrasProps,
+          status: requestStatus,
+        })
+        .build(),
+    );
   }
 
   /**
@@ -810,12 +819,17 @@ export class SubscriptionService {
       transactionMeta,
     );
 
-    this.#trackShieldEvent(MetaMetricsEventName.ShieldPaymentMethodChange, {
-      ...accountTypeAndCategory,
-      ...trackingProps,
-      ...extrasProps,
-      status: changeStatus,
-    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.ShieldPaymentMethodChange)
+        .addCategory(MetaMetricsEventCategory.Shield)
+        .addProperties({
+          ...accountTypeAndCategory,
+          ...trackingProps,
+          ...extrasProps,
+          status: changeStatus,
+        })
+        .build(),
+    );
   }
 
   #trackShieldOptInRewardsEvent(
@@ -834,30 +848,23 @@ export class SubscriptionService {
       return;
     }
 
-    this.#trackShieldEvent(MetaMetricsEventName.ShieldOptInRewards, {
-      ...accountTypeAndCategory,
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      multi_chain_balance_category: getUserBalanceCategory(
-        shieldSubscriptionMetricsProps?.userBalanceInUSD ?? 0,
-      ),
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      rewards_point: claimedRewardPoints,
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-      // eslint-disable-next-line @typescript-eslint/naming-convention
-      rewards_opt_in_type: rewardsOptInType,
-    });
-  }
-
-  #trackShieldEvent(
-    eventName: MetaMetricsEventName,
-    properties: Record<string, Json>,
-  ): void {
     trackEvent(
-      createEventBuilder(eventName)
+      createEventBuilder(MetaMetricsEventName.ShieldOptInRewards)
         .addCategory(MetaMetricsEventCategory.Shield)
-        .addProperties(properties)
+        .addProperties({
+          ...accountTypeAndCategory,
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          multi_chain_balance_category: getUserBalanceCategory(
+            shieldSubscriptionMetricsProps?.userBalanceInUSD ?? 0,
+          ),
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          rewards_point: claimedRewardPoints,
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          rewards_opt_in_type: rewardsOptInType,
+        })
         .build(),
     );
   }

--- a/app/scripts/services/subscription/subscription-service.ts
+++ b/app/scripts/services/subscription/subscription-service.ts
@@ -43,6 +43,7 @@ import {
   getShieldSubscription,
   SHIELD_ERROR,
 } from '../../../../shared/lib/shield';
+import { createEventBuilder, trackEvent } from '../../controllers/analytics';
 import {
   SubscriptionServiceOptions,
   SERVICE_NAME,
@@ -707,10 +708,9 @@ export class SubscriptionService {
         );
 
         // Track the Shield eligibility cohort assigned event
-        this.#messenger.call('MetaMetricsController:trackEvent', {
-          event: MetaMetricsEventName.ShieldEligibilityCohortAssigned,
-          category: MetaMetricsEventCategory.Shield,
-          properties: {
+        this.#trackShieldEvent(
+          MetaMetricsEventName.ShieldEligibilityCohortAssigned,
+          {
             ...this.#getAccountTypeAndCategoryForMetrics(),
             // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
             // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -721,7 +721,7 @@ export class SubscriptionService {
             // eslint-disable-next-line @typescript-eslint/naming-convention
             assigned_cohort: COHORT_NAMES.POST_TX,
           },
-        });
+        );
       }
     } catch (error) {
       log.error('Failed to assign post tx cohort', error);
@@ -770,15 +770,11 @@ export class SubscriptionService {
       transactionMeta,
     );
 
-    this.#messenger.call('MetaMetricsController:trackEvent', {
-      event: MetaMetricsEventName.ShieldSubscriptionRequest,
-      category: MetaMetricsEventCategory.Shield,
-      properties: {
-        ...accountTypeAndCategory,
-        ...trackingProps,
-        ...extrasProps,
-        status: requestStatus,
-      },
+    this.#trackShieldEvent(MetaMetricsEventName.ShieldSubscriptionRequest, {
+      ...accountTypeAndCategory,
+      ...trackingProps,
+      ...extrasProps,
+      status: requestStatus,
     });
   }
 
@@ -814,15 +810,11 @@ export class SubscriptionService {
       transactionMeta,
     );
 
-    this.#messenger.call('MetaMetricsController:trackEvent', {
-      event: MetaMetricsEventName.ShieldPaymentMethodChange,
-      category: MetaMetricsEventCategory.Shield,
-      properties: {
-        ...accountTypeAndCategory,
-        ...trackingProps,
-        ...extrasProps,
-        status: changeStatus,
-      },
+    this.#trackShieldEvent(MetaMetricsEventName.ShieldPaymentMethodChange, {
+      ...accountTypeAndCategory,
+      ...trackingProps,
+      ...extrasProps,
+      status: changeStatus,
     });
   }
 
@@ -842,24 +834,32 @@ export class SubscriptionService {
       return;
     }
 
-    this.#messenger.call('MetaMetricsController:trackEvent', {
-      event: MetaMetricsEventName.ShieldOptInRewards,
-      category: MetaMetricsEventCategory.Shield,
-      properties: {
-        ...accountTypeAndCategory,
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        multi_chain_balance_category: getUserBalanceCategory(
-          shieldSubscriptionMetricsProps?.userBalanceInUSD ?? 0,
-        ),
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        rewards_point: claimedRewardPoints,
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        rewards_opt_in_type: rewardsOptInType,
-      },
+    this.#trackShieldEvent(MetaMetricsEventName.ShieldOptInRewards, {
+      ...accountTypeAndCategory,
+      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      multi_chain_balance_category: getUserBalanceCategory(
+        shieldSubscriptionMetricsProps?.userBalanceInUSD ?? 0,
+      ),
+      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      rewards_point: claimedRewardPoints,
+      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      rewards_opt_in_type: rewardsOptInType,
     });
+  }
+
+  #trackShieldEvent(
+    eventName: MetaMetricsEventName,
+    properties: Record<string, Json>,
+  ): void {
+    trackEvent(
+      createEventBuilder(eventName)
+        .addCategory(MetaMetricsEventCategory.Shield)
+        .addProperties(properties)
+        .build(),
+    );
   }
 
   async #getCurrentShieldSubscription(): Promise<Subscription | undefined> {

--- a/ui/components/app/modals/add-funds-modal/add-funds-modal.test.tsx
+++ b/ui/components/app/modals/add-funds-modal/add-funds-modal.test.tsx
@@ -6,6 +6,20 @@ import { CHAIN_IDS } from '../../../../../shared/constants/network';
 import { mockNetworkState } from '../../../../../test/stub/networks';
 import AddFundsModal from './add-funds-modal';
 
+const mockTrackEvent = jest.fn();
+
+jest.mock('../../../../hooks/useAnalytics', () => {
+  const { createEventBuilder } = jest.requireActual(
+    '../../../../../shared/lib/analytics/create-event-builder',
+  );
+  return {
+    useAnalytics: () => ({
+      trackEvent: mockTrackEvent,
+      createEventBuilder,
+    }),
+  };
+});
+
 describe('Add funds modal Component', () => {
   const defaultState = {
     metamask: {

--- a/ui/components/app/modals/add-funds-modal/add-funds-modal.tsx
+++ b/ui/components/app/modals/add-funds-modal/add-funds-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import {
   Box,
   Icon,
@@ -28,7 +28,7 @@ import {
   MetaMetricsEventName,
   MetaMetricsSwapsEventSource,
 } from '../../../../../shared/constants/metametrics';
-import { MetaMetricsContext } from '../../../../contexts/metametrics';
+import { useAnalytics } from '../../../../hooks/useAnalytics';
 import { hexToDecimal } from '../../../../../shared/lib/conversion.utils';
 import { AggregatorNetwork } from '../../../../ducks/ramps/types';
 import { trace, TraceName } from '../../../../../shared/lib/trace';
@@ -46,7 +46,7 @@ const AddFundsModal = ({
 }) => {
   const t = useI18nContext();
   const { openBuyCryptoInPdapp } = useRamps();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
 
   const buyableChains = useSelector(getBuyableChains);
 
@@ -66,39 +66,48 @@ const AddFundsModal = ({
 
   const handleBuyAndSellOnClick = useCallback(() => {
     openBuyCryptoInPdapp();
-    trackEvent({
-      event: MetaMetricsEventName.NavBuyButtonClicked,
-      category: MetaMetricsEventCategory.Navigation,
-      properties: {
-        location: 'Transaction Shield',
-        text: 'Buy',
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        chain_id: chainId,
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        token_symbol: token.symbol,
-      },
-    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.NavBuyButtonClicked)
+        .addCategory(MetaMetricsEventCategory.Navigation)
+        .addProperties({
+          location: 'Transaction Shield',
+          text: 'Buy',
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          chain_id: chainId,
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          token_symbol: token.symbol,
+        })
+        .build(),
+    );
     onClose();
-  }, [chainId, onClose, openBuyCryptoInPdapp, token.symbol, trackEvent]);
+  }, [
+    chainId,
+    onClose,
+    openBuyCryptoInPdapp,
+    token.symbol,
+    createEventBuilder,
+    trackEvent,
+  ]);
 
   const handleReceiveOnClick = useCallback(() => {
     trace({ name: TraceName.ReceiveModal });
-    trackEvent({
-      event: MetaMetricsEventName.NavReceiveButtonClicked,
-      category: MetaMetricsEventCategory.Navigation,
-      properties: {
-        text: 'Receive',
-        location: 'Transaction Shield',
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        chain_id: chainId,
-      },
-    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.NavReceiveButtonClicked)
+        .addCategory(MetaMetricsEventCategory.Navigation)
+        .addProperties({
+          text: 'Receive',
+          location: 'Transaction Shield',
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          chain_id: chainId,
+        })
+        .build(),
+    );
 
     setShowReceiveModal(true);
-  }, [chainId, trackEvent]);
+  }, [chainId, createEventBuilder, trackEvent]);
 
   const handleSwapOnClick = useCallback(async () => {
     openBridgeExperience(MetaMetricsSwapsEventSource.TransactionShield, {

--- a/ui/components/app/modals/visit-support-data-consent-modal/visit-support-data-consent-modal.tsx
+++ b/ui/components/app/modals/visit-support-data-consent-modal/visit-support-data-consent-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext } from 'react';
+import React, { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { Box } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
@@ -27,7 +27,8 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../../shared/constants/metametrics';
-import { MetaMetricsContext } from '../../../../contexts/metametrics';
+import { useAnalytics } from '../../../../hooks/useAnalytics';
+import { useSegmentContext } from '../../../../hooks/useSegmentContext';
 import {
   buildSupportLinkWithUserData,
   type SupportLinkUserData,
@@ -46,7 +47,8 @@ const VisitSupportDataConsentModal = ({
 }: VisitSupportDataConsentModalProps) => {
   const version = process.env.METAMASK_VERSION as string;
   const t = useI18nContext();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
+  const segmentContext = useSegmentContext();
   const sessionData = useSelector(selectSessionData);
   const profileId = sessionData?.profile?.profileId;
   const canonicalProfileId = sessionData?.profile?.canonicalProfileId;
@@ -62,39 +64,33 @@ const VisitSupportDataConsentModal = ({
       );
 
       trackEvent(
-        {
-          category: MetaMetricsEventCategory.Settings,
-          event: MetaMetricsEventName.SupportLinkClicked,
-          properties: {
+        createEventBuilder(MetaMetricsEventName.SupportLinkClicked)
+          .addCategory(MetaMetricsEventCategory.Settings)
+          .addProperties({
             url: supportLinkWithUserId,
-          },
-        },
-        {
-          contextPropsIntoEventProperties: [MetaMetricsContextProp.PageTitle],
-        },
+            [MetaMetricsContextProp.PageTitle]: segmentContext.page?.title,
+          })
+          .build(),
       );
       openWindow(supportLinkWithUserId);
     },
-    [onClose, trackEvent],
+    [onClose, trackEvent, createEventBuilder, segmentContext.page?.title],
   );
 
   const handleClickNoShare = useCallback(() => {
     onClose();
 
     trackEvent(
-      {
-        category: MetaMetricsEventCategory.Settings,
-        event: MetaMetricsEventName.SupportLinkClicked,
-        properties: {
+      createEventBuilder(MetaMetricsEventName.SupportLinkClicked)
+        .addCategory(MetaMetricsEventCategory.Settings)
+        .addProperties({
           url: SUPPORT_LINK,
-        },
-      },
-      {
-        contextPropsIntoEventProperties: [MetaMetricsContextProp.PageTitle],
-      },
+          [MetaMetricsContextProp.PageTitle]: segmentContext.page?.title,
+        })
+        .build(),
     );
     openWindow(SUPPORT_LINK as string);
-  }, [onClose, trackEvent]);
+  }, [onClose, trackEvent, createEventBuilder, segmentContext.page?.title]);
 
   return (
     <Modal

--- a/ui/components/app/modals/visit-support-data-consent-modal/visit-support-data.test.tsx
+++ b/ui/components/app/modals/visit-support-data-consent-modal/visit-support-data.test.tsx
@@ -13,12 +13,32 @@ import { SUPPORT_LINK } from '../../../../../shared/lib/ui-utils';
 import { buildSupportLinkWithUserData } from '../../../../../shared/lib/build-support-link';
 import mockState from '../../../../../test/data/mock-state.json';
 import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
-import { MetaMetricsContext } from '../../../../contexts/metametrics';
 import { openWindow } from '../../../../helpers/utils/window';
 import { useUserSubscriptions } from '../../../../hooks/subscription/useSubscription';
 import { selectSessionData } from '../../../../selectors/identity/authentication';
 import { getAnalyticsId } from '../../../../selectors/selectors';
 import VisitSupportDataConsentModal from './visit-support-data-consent-modal';
+
+const mockTrackEvent = jest.fn();
+
+jest.mock('../../../../hooks/useAnalytics', () => {
+  const { createEventBuilder } = jest.requireActual(
+    '../../../../../shared/lib/analytics/create-event-builder',
+  );
+
+  return {
+    useAnalytics: () => ({
+      trackEvent: mockTrackEvent,
+      createEventBuilder,
+    }),
+  };
+});
+
+jest.mock('../../../../hooks/useSegmentContext', () => ({
+  useSegmentContext: jest.fn(() => ({
+    page: { title: 'Settings' },
+  })),
+}));
 
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
@@ -35,13 +55,6 @@ jest.mock('../../../../hooks/subscription/useSubscription', () => ({
 
 describe('VisitSupportDataConsentModal', () => {
   const store = configureMockState([thunk])(mockState);
-  const mockTrackEvent = jest.fn();
-  const mockMetaMetricsContext = {
-    trackEvent: mockTrackEvent,
-    bufferedTrace: jest.fn(),
-    bufferedEndTrace: jest.fn(),
-    onboardingParentContext: { current: null },
-  };
   const mockOnClose = jest.fn();
   const mockProfileId = 'test-profile-id';
   const mockCanonicalProfileId = 'test-canonical-profile-id';
@@ -87,9 +100,7 @@ describe('VisitSupportDataConsentModal', () => {
     };
 
     return renderWithProvider(
-      <MetaMetricsContext.Provider value={mockMetaMetricsContext}>
-        <VisitSupportDataConsentModal {...defaultProps} />
-      </MetaMetricsContext.Provider>,
+      <VisitSupportDataConsentModal {...defaultProps} />,
       store,
     );
   };
@@ -119,15 +130,13 @@ describe('VisitSupportDataConsentModal', () => {
 
     expect(mockTrackEvent).toHaveBeenCalledWith(
       expect.objectContaining({
-        category: MetaMetricsEventCategory.Settings,
-        event: MetaMetricsEventName.SupportLinkClicked,
-        properties: {
+        name: MetaMetricsEventName.SupportLinkClicked,
+        properties: expect.objectContaining({
+          category: MetaMetricsEventCategory.Settings,
           url: expectedUrl,
-        },
+          [MetaMetricsContextProp.PageTitle]: 'Settings',
+        }),
       }),
-      {
-        contextPropsIntoEventProperties: [MetaMetricsContextProp.PageTitle],
-      },
     );
     expect(openWindow).toHaveBeenCalledWith(expectedUrl);
   });
@@ -147,15 +156,13 @@ describe('VisitSupportDataConsentModal', () => {
     expect(mockOnClose).toHaveBeenCalled();
     expect(mockTrackEvent).toHaveBeenCalledWith(
       expect.objectContaining({
-        category: MetaMetricsEventCategory.Settings,
-        event: MetaMetricsEventName.SupportLinkClicked,
-        properties: {
+        name: MetaMetricsEventName.SupportLinkClicked,
+        properties: expect.objectContaining({
+          category: MetaMetricsEventCategory.Settings,
           url: expectedUrl,
-        },
+          [MetaMetricsContextProp.PageTitle]: 'Settings',
+        }),
       }),
-      {
-        contextPropsIntoEventProperties: [MetaMetricsContextProp.PageTitle],
-      },
     );
     expect(openWindow).toHaveBeenCalledWith(expectedUrl);
   });
@@ -185,15 +192,13 @@ describe('VisitSupportDataConsentModal', () => {
 
     expect(mockTrackEvent).toHaveBeenCalledWith(
       expect.objectContaining({
-        category: MetaMetricsEventCategory.Settings,
-        event: MetaMetricsEventName.SupportLinkClicked,
-        properties: {
+        name: MetaMetricsEventName.SupportLinkClicked,
+        properties: expect.objectContaining({
+          category: MetaMetricsEventCategory.Settings,
           url: expectedUrl,
-        },
+          [MetaMetricsContextProp.PageTitle]: 'Settings',
+        }),
       }),
-      {
-        contextPropsIntoEventProperties: [MetaMetricsContextProp.PageTitle],
-      },
     );
     expect(openWindow).toHaveBeenCalledWith(expectedUrl);
   });
@@ -231,15 +236,13 @@ describe('VisitSupportDataConsentModal', () => {
 
     expect(mockTrackEvent).toHaveBeenCalledWith(
       expect.objectContaining({
-        category: MetaMetricsEventCategory.Settings,
-        event: MetaMetricsEventName.SupportLinkClicked,
-        properties: {
+        name: MetaMetricsEventName.SupportLinkClicked,
+        properties: expect.objectContaining({
+          category: MetaMetricsEventCategory.Settings,
           url: expectedUrl,
-        },
+          [MetaMetricsContextProp.PageTitle]: 'Settings',
+        }),
       }),
-      {
-        contextPropsIntoEventProperties: [MetaMetricsContextProp.PageTitle],
-      },
     );
     expect(openWindow).toHaveBeenCalledWith(expectedUrl);
   });
@@ -295,11 +298,11 @@ describe('VisitSupportDataConsentModal', () => {
 
     expect(mockTrackEvent).toHaveBeenCalledWith(
       expect.objectContaining({
-        category: MetaMetricsEventCategory.Settings,
-        event: MetaMetricsEventName.SupportLinkClicked,
-      }),
-      expect.objectContaining({
-        contextPropsIntoEventProperties: [MetaMetricsContextProp.PageTitle],
+        name: MetaMetricsEventName.SupportLinkClicked,
+        properties: expect.objectContaining({
+          category: MetaMetricsEventCategory.Settings,
+          [MetaMetricsContextProp.PageTitle]: 'Settings',
+        }),
       }),
     );
     expect(openWindow).toHaveBeenCalled();

--- a/ui/hooks/shield/metrics/useSubscriptionMetrics.ts
+++ b/ui/hooks/shield/metrics/useSubscriptionMetrics.ts
@@ -1,6 +1,7 @@
-import { useCallback, useContext } from 'react';
+import { useCallback } from 'react';
+import { omitBy } from 'lodash';
 import { useDispatch, useSelector } from 'react-redux';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
+import type { Json } from '@metamask/utils';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
@@ -23,6 +24,7 @@ import {
   CaptureShieldPaymentMethodChangeEventParams,
   ExistingSubscriptionEventParams,
 } from '../../../../shared/types';
+import { useAnalytics } from '../../useAnalytics';
 import {
   CaptureShieldClaimSubmissionEventParams,
   CaptureShieldCtaClickedEventParams,
@@ -44,7 +46,7 @@ import {
 
 export const useSubscriptionMetrics = () => {
   const dispatch = useDispatch<MetaMaskReduxDispatch>();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const evmInternalAccount = useSelector((state) =>
     // Account address will be the same for all EVM accounts
     getInternalAccountBySelectedAccountGroupAndCaip(state, 'eip155:1'),
@@ -57,6 +59,38 @@ export const useSubscriptionMetrics = () => {
     true, // use USD conversion rate instead of the current currency
   );
   const pendingShieldCohortTxType = useSelector(getPendingShieldCohortTxType);
+
+  const trackShieldEvent = useCallback(
+    (
+      eventName: MetaMetricsEventName,
+      extraProperties: Record<string, Json | undefined>,
+    ) => {
+      const commonTrackingProps = getShieldCommonTrackingProps(
+        selectedAccount,
+        hdKeyingsMetadata,
+        Number(totalFiatBalance),
+      );
+
+      trackEvent(
+        createEventBuilder(eventName)
+          .addCategory(MetaMetricsEventCategory.Shield)
+          .addProperties(
+            omitBy(
+              { ...commonTrackingProps, ...extraProperties },
+              (value) => value === undefined,
+            ) as Record<string, Json>,
+          )
+          .build(),
+      );
+    },
+    [
+      trackEvent,
+      createEventBuilder,
+      selectedAccount,
+      hdKeyingsMetadata,
+      totalFiatBalance,
+    ],
+  );
 
   /**
    * Set the Shield subscription metrics properties to the background.
@@ -91,25 +125,13 @@ export const useSubscriptionMetrics = () => {
         | CaptureShieldEligibilityCohortTimeoutEventParams,
       event: MetaMetricsEventName,
     ) => {
-      const commonTrackingProps = getShieldCommonTrackingProps(
-        selectedAccount,
-        hdKeyingsMetadata,
-        Number(totalFiatBalance),
-      );
       const formattedParams = formatCaptureShieldEligibilityCohortEventsProps(
         params,
         Number(totalFiatBalance),
       );
-      trackEvent({
-        event,
-        category: MetaMetricsEventCategory.Shield,
-        properties: {
-          ...commonTrackingProps,
-          ...formattedParams,
-        },
-      });
+      trackShieldEvent(event, formattedParams);
     },
-    [trackEvent, selectedAccount, hdKeyingsMetadata, totalFiatBalance],
+    [trackShieldEvent, totalFiatBalance],
   );
 
   /**
@@ -117,43 +139,26 @@ export const useSubscriptionMetrics = () => {
    */
   const captureShieldEntryModalEvent = useCallback(
     (params: CaptureShieldEntryModalEventParams) => {
-      const commonTrackingProps = getShieldCommonTrackingProps(
-        selectedAccount,
-        hdKeyingsMetadata,
-        Number(totalFiatBalance),
-      );
-
       const postTransactionType =
         params.source === ShieldMetricsSourceEnum.PostTransaction
           ? pendingShieldCohortTxType
           : undefined;
 
-      trackEvent({
-        event: MetaMetricsEventName.ShieldEntryModal,
-        category: MetaMetricsEventCategory.Shield,
-        properties: {
-          ...commonTrackingProps,
-          ...getShieldMarketingTrackingProps(params.marketingUtmParams),
-          source: params.source,
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          modal_type: params.type,
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          modal_cta_action_clicked: params.modalCtaActionClicked,
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          post_transaction_type: postTransactionType,
-        },
+      trackShieldEvent(MetaMetricsEventName.ShieldEntryModal, {
+        ...getShieldMarketingTrackingProps(params.marketingUtmParams),
+        source: params.source,
+        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        modal_type: params.type,
+        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        modal_cta_action_clicked: params.modalCtaActionClicked,
+        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        post_transaction_type: postTransactionType,
       });
     },
-    [
-      trackEvent,
-      selectedAccount,
-      hdKeyingsMetadata,
-      totalFiatBalance,
-      pendingShieldCohortTxType,
-    ],
+    [trackShieldEvent, pendingShieldCohortTxType],
   );
 
   /**
@@ -161,24 +166,15 @@ export const useSubscriptionMetrics = () => {
    */
   const captureShieldSubscriptionRequestEvent = useCallback(
     (params: CaptureShieldSubscriptionRequestParams) => {
-      const commonTrackingProps = getShieldCommonTrackingProps(
-        selectedAccount,
-        hdKeyingsMetadata,
-        Number(totalFiatBalance),
-      );
       const formattedParams =
         formatDefaultShieldSubscriptionRequestEventProps(params);
 
-      trackEvent({
-        event: MetaMetricsEventName.ShieldSubscriptionRequest,
-        category: MetaMetricsEventCategory.Shield,
-        properties: {
-          ...commonTrackingProps,
-          ...formattedParams,
-        },
-      });
+      trackShieldEvent(
+        MetaMetricsEventName.ShieldSubscriptionRequest,
+        formattedParams,
+      );
     },
-    [trackEvent, selectedAccount, hdKeyingsMetadata, totalFiatBalance],
+    [trackShieldEvent],
   );
 
   /**
@@ -186,24 +182,14 @@ export const useSubscriptionMetrics = () => {
    */
   const captureShieldSubscriptionRestartRequestEvent = useCallback(
     (params: CaptureShieldSubscriptionRestartRequestEventParams) => {
-      const commonTrackingProps = getShieldCommonTrackingProps(
-        selectedAccount,
-        hdKeyingsMetadata,
-        Number(totalFiatBalance),
-      );
       const formattedParams = formatExistingSubscriptionEventProps(params);
-      trackEvent({
-        event: MetaMetricsEventName.ShieldMembershipRestartRequest,
-        category: MetaMetricsEventCategory.Shield,
-        properties: {
-          ...commonTrackingProps,
-          ...formattedParams,
-          status: params.requestStatus,
-          error: params.errorMessage,
-        },
+      trackShieldEvent(MetaMetricsEventName.ShieldMembershipRestartRequest, {
+        ...formattedParams,
+        status: params.requestStatus,
+        error: params.errorMessage,
       });
     },
-    [trackEvent, selectedAccount, hdKeyingsMetadata, totalFiatBalance],
+    [trackShieldEvent],
   );
 
   /**
@@ -211,29 +197,19 @@ export const useSubscriptionMetrics = () => {
    */
   const captureShieldMembershipCancelledEvent = useCallback(
     (params: CaptureShieldMembershipCancelledEventParams) => {
-      const commonTrackingProps = getShieldCommonTrackingProps(
-        selectedAccount,
-        hdKeyingsMetadata,
-        Number(totalFiatBalance),
-      );
       const formattedParams = formatExistingSubscriptionEventProps(params);
-      trackEvent({
-        event: MetaMetricsEventName.ShieldMembershipCancelled,
-        category: MetaMetricsEventCategory.Shield,
-        properties: {
-          ...commonTrackingProps,
-          ...formattedParams,
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          status: params.cancellationStatus,
-          error: params.errorMessage,
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          latest_subscription_duration: params.latestSubscriptionDuration,
-        },
+      trackShieldEvent(MetaMetricsEventName.ShieldMembershipCancelled, {
+        ...formattedParams,
+        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        status: params.cancellationStatus,
+        error: params.errorMessage,
+        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        latest_subscription_duration: params.latestSubscriptionDuration,
       });
     },
-    [trackEvent, selectedAccount, hdKeyingsMetadata, totalFiatBalance],
+    [trackShieldEvent],
   );
 
   /**
@@ -241,27 +217,17 @@ export const useSubscriptionMetrics = () => {
    */
   const captureShieldPaymentMethodChangeEvent = useCallback(
     (params: CaptureShieldPaymentMethodChangeEventParams) => {
-      const commonTrackingProps = getShieldCommonTrackingProps(
-        selectedAccount,
-        hdKeyingsMetadata,
-        Number(totalFiatBalance),
-      );
       const formattedParams =
         formatCaptureShieldPaymentMethodChangeEventProps(params);
-      trackEvent({
-        event: MetaMetricsEventName.ShieldPaymentMethodChange,
-        category: MetaMetricsEventCategory.Shield,
-        properties: {
-          ...commonTrackingProps,
-          ...formattedParams,
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          status: params.changeStatus,
-          error: params.errorMessage,
-        },
+      trackShieldEvent(MetaMetricsEventName.ShieldPaymentMethodChange, {
+        ...formattedParams,
+        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        status: params.changeStatus,
+        error: params.errorMessage,
       });
     },
-    [selectedAccount, hdKeyingsMetadata, totalFiatBalance, trackEvent],
+    [trackShieldEvent],
   );
 
   /**
@@ -272,70 +238,36 @@ export const useSubscriptionMetrics = () => {
    */
   const captureCommonExistingShieldSubscriptionEvents = useCallback(
     (params: ExistingSubscriptionEventParams, event: MetaMetricsEventName) => {
-      const commonTrackingProps = getShieldCommonTrackingProps(
-        selectedAccount,
-        hdKeyingsMetadata,
-        Number(totalFiatBalance),
-      );
       const formattedParams = formatExistingSubscriptionEventProps(params);
-      trackEvent({
-        event,
-        category: MetaMetricsEventCategory.Shield,
-        properties: {
-          ...commonTrackingProps,
-          ...formattedParams,
-        },
-      });
+      trackShieldEvent(event, formattedParams);
     },
-    [trackEvent, selectedAccount, hdKeyingsMetadata, totalFiatBalance],
+    [trackShieldEvent],
   );
 
   const captureShieldCtaClickedEvent = useCallback(
     (params: CaptureShieldCtaClickedEventParams) => {
-      const commonTrackingProps = getShieldCommonTrackingProps(
-        selectedAccount,
-        hdKeyingsMetadata,
-        Number(totalFiatBalance),
-      );
       const formattedParams = formatCaptureShieldCtaClickedEventProps(params);
-      trackEvent({
-        event: MetaMetricsEventName.ShieldCtaClicked,
-        category: MetaMetricsEventCategory.Shield,
-        properties: {
-          ...commonTrackingProps,
-          ...formattedParams,
-        },
-      });
+      trackShieldEvent(MetaMetricsEventName.ShieldCtaClicked, formattedParams);
     },
-    [trackEvent, selectedAccount, hdKeyingsMetadata, totalFiatBalance],
+    [trackShieldEvent],
   );
 
   const captureShieldClaimSubmissionEvent = useCallback(
     (params: CaptureShieldClaimSubmissionEventParams) => {
-      const commonTrackingProps = getShieldCommonTrackingProps(
-        selectedAccount,
-        hdKeyingsMetadata,
-        Number(totalFiatBalance),
-      );
-      trackEvent({
-        event: MetaMetricsEventName.ShieldClaimSubmission,
-        category: MetaMetricsEventCategory.Shield,
-        properties: {
-          ...commonTrackingProps,
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          subscription_status: params.subscriptionStatus,
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          attachments_count: params.attachmentsCount,
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          submission_status: params.submissionStatus,
-          error: params.errorMessage,
-        },
+      trackShieldEvent(MetaMetricsEventName.ShieldClaimSubmission, {
+        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        subscription_status: params.subscriptionStatus,
+        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        attachments_count: params.attachmentsCount,
+        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        submission_status: params.submissionStatus,
+        error: params.errorMessage,
       });
     },
-    [trackEvent, selectedAccount, hdKeyingsMetadata, totalFiatBalance],
+    [trackShieldEvent],
   );
 
   /**
@@ -343,26 +275,16 @@ export const useSubscriptionMetrics = () => {
    */
   const captureShieldErrorStateClickedEvent = useCallback(
     (params: CaptureShieldErrorStateClickedEventParams) => {
-      const commonTrackingProps = getShieldCommonTrackingProps(
-        selectedAccount,
-        hdKeyingsMetadata,
-        Number(totalFiatBalance),
-      );
       const formattedParams = formatExistingSubscriptionEventProps(params);
-      trackEvent({
-        event: MetaMetricsEventName.ShieldMembershipErrorStateClicked,
-        category: MetaMetricsEventCategory.Shield,
-        properties: {
-          ...commonTrackingProps,
-          ...formattedParams,
-          type: params.errorCause,
-          action: params.actionClicked,
-          location: params.location,
-          view: params.view,
-        },
+      trackShieldEvent(MetaMetricsEventName.ShieldMembershipErrorStateClicked, {
+        ...formattedParams,
+        type: params.errorCause,
+        action: params.actionClicked,
+        location: params.location,
+        view: params.view,
       });
     },
-    [trackEvent, selectedAccount, hdKeyingsMetadata, totalFiatBalance],
+    [trackShieldEvent],
   );
 
   /**
@@ -370,24 +292,17 @@ export const useSubscriptionMetrics = () => {
    */
   const captureShieldUnexpectedErrorEvent = useCallback(
     (params: CaptureShieldUnexpectedErrorEventParams) => {
-      const commonTrackingProps = getShieldCommonTrackingProps(
-        selectedAccount,
-        hdKeyingsMetadata,
-        Number(totalFiatBalance),
-      );
-      trackEvent({
-        event: MetaMetricsEventName.ShieldSubscriptionUnexpectedErrorEvent,
-        category: MetaMetricsEventCategory.Shield,
-        properties: {
-          ...commonTrackingProps,
+      trackShieldEvent(
+        MetaMetricsEventName.ShieldSubscriptionUnexpectedErrorEvent,
+        {
           // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
           // eslint-disable-next-line @typescript-eslint/naming-convention
           error_message: params.errorMessage,
           location: params.location,
         },
-      });
+      );
     },
-    [trackEvent, selectedAccount, hdKeyingsMetadata, totalFiatBalance],
+    [trackShieldEvent],
   );
 
   return {

--- a/ui/hooks/shield/metrics/useSubscriptionMetrics.ts
+++ b/ui/hooks/shield/metrics/useSubscriptionMetrics.ts
@@ -1,5 +1,4 @@
 import { useCallback } from 'react';
-import { omitBy } from 'lodash';
 import { useDispatch, useSelector } from 'react-redux';
 import type { Json } from '@metamask/utils';
 import {
@@ -74,12 +73,10 @@ export const useSubscriptionMetrics = () => {
       trackEvent(
         createEventBuilder(eventName)
           .addCategory(MetaMetricsEventCategory.Shield)
-          .addProperties(
-            omitBy(
-              { ...commonTrackingProps, ...extraProperties },
-              (value) => value === undefined,
-            ) as Record<string, Json>,
-          )
+          .addProperties({
+            ...commonTrackingProps,
+            ...extraProperties,
+          })
           .build(),
       );
     },

--- a/ui/pages/shield/transaction-shield/manage-shield-plan/manage-shield-plan.test.tsx
+++ b/ui/pages/shield/transaction-shield/manage-shield-plan/manage-shield-plan.test.tsx
@@ -25,6 +25,19 @@ jest.mock('react-router-dom', () => {
   };
 });
 
+jest.mock('../../../../hooks/useAnalytics', () => {
+  const { createEventBuilder } = jest.requireActual(
+    '../../../../../shared/lib/analytics/create-event-builder',
+  );
+
+  return {
+    useAnalytics: () => ({
+      trackEvent: jest.fn(),
+      createEventBuilder,
+    }),
+  };
+});
+
 describe('Manage Shield Plan Page', () => {
   const STATE_MOCK = {
     ...mockState,

--- a/ui/pages/shield/transaction-shield/transaction-shield.test.tsx
+++ b/ui/pages/shield/transaction-shield/transaction-shield.test.tsx
@@ -15,12 +15,26 @@ import { initialState as rewardsInitialState } from '../../../ducks/rewards';
 import TransactionShield from './transaction-shield';
 
 const mockUseNavigate = jest.fn();
-const mockUseLocation = jest.fn();
+const mockUseLocation = jest.fn(() => ({ pathname: '/' }));
+
+jest.mock('../../../hooks/useAnalytics', () => {
+  const { createEventBuilder } = jest.requireActual(
+    '../../../../shared/lib/analytics/create-event-builder',
+  );
+
+  return {
+    useAnalytics: () => ({
+      trackEvent: jest.fn(),
+      createEventBuilder,
+    }),
+  };
+});
+
 jest.mock('react-router-dom', () => {
   return {
     ...jest.requireActual('react-router-dom'),
     useNavigate: () => mockUseNavigate,
-    useLocation: () => mockUseLocation,
+    useLocation: () => mockUseLocation(),
   };
 });
 

--- a/ui/pages/shield/transaction-shield/transaction-shield.test.tsx
+++ b/ui/pages/shield/transaction-shield/transaction-shield.test.tsx
@@ -15,7 +15,7 @@ import { initialState as rewardsInitialState } from '../../../ducks/rewards';
 import TransactionShield from './transaction-shield';
 
 const mockUseNavigate = jest.fn();
-const mockUseLocation = jest.fn(() => ({ pathname: '/' }));
+const mockUseLocation = jest.fn(() => ({ pathname: '/', search: '' }));
 
 jest.mock('../../../hooks/useAnalytics', () => {
   const { createEventBuilder } = jest.requireActual(


### PR DESCRIPTION
## **Description**

Sub-PR of umbrella tracker [#43885](https://github.com/MetaMask/metamask-extension/pull/43885).

Migrates MetaMetrics `trackEvent` call sites in this CODEOWNERS domain to `createEventBuilder` + `trackEvent` via `useAnalytics()` (UI) or `app/scripts/controllers/analytics` (background).

**Dependency note:** Can merge in parallel with other domain PRs after PR1.

**Files in this PR:** 21

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of analytics migration umbrella: #43885

## **Manual testing steps**

1. Check out this branch and run `yarn start`.
2. Exercise flows in the touched domain (see diff file list).
3. Confirm no console errors and representative events still fire.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches analytics emission across OAuth onboarding failures and Shield subscription flows; behavior should be equivalent but any regression could skew product metrics or drop pre-consent buffered events.
> 
> **Overview**
> Migrates **Shield, subscription, OAuth, and related UI** from legacy `MetaMetricsController:trackEvent` / `MetaMetricsContext` to **`createEventBuilder` + `trackEvent`** (`app/scripts/controllers/analytics` in background, `useAnalytics()` in UI).
> 
> **Background:** `SubscriptionService` drops the `MetaMetricsController:trackEvent` messenger delegate and emits Shield metrics (cohort assignment, subscription requests, payment method changes, rewards opt-in) via the analytics module. `OAuthService` no longer accepts an injected `trackEvent`; social login failure events use the builder API while **pre–opt-in buffering** still maps built events back to `addEventBeforeMetricsOptIn` when onboarding/opt-in are incomplete.
> 
> **UI:** Modals (`AddFundsModal`, support data consent) and `useSubscriptionMetrics` switch to `useAnalytics`, with a shared `trackShieldEvent` helper to reduce duplication. Support link clicks now put **page title** on the event properties (via `useSegmentContext`) instead of the old `contextPropsIntoEventProperties` option.
> 
> Tests are updated to mock `useAnalytics` / `controllers/analytics` and to split OAuth init mocks between `MetaMetricsController` and `AnalyticsController` for opt-in state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e77a542d3e86cf5796e81aff1500d15dffcfd9d4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->