### PR TITLE
refactor(analytics): migrate settings and privacy events

### DIFF
--- a/ui/components/app/delete-metametrics-data-button/delete-metametrics-data-button.test.tsx
+++ b/ui/components/app/delete-metametrics-data-button/delete-metametrics-data-button.test.tsx
@@ -24,6 +24,7 @@ jest.mock('react-redux', () => ({
 }));
 
 jest.mock('../../../store/actions', () => ({
+  ...jest.requireActual('../../../store/actions'),
   createMetaMetricsDataDeletionTask: jest.fn(),
 }));
 

--- a/ui/pages/settings/about-tab/about-info.tsx
+++ b/ui/pages/settings/about-tab/about-info.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useMemo } from 'react';
+import React, { useCallback } from 'react';
 import {
   Box,
   Text,
@@ -12,7 +12,8 @@ import {
 
 import { Tag } from '../../../components/component-library';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { useAnalytics } from '../../../hooks/useAnalytics';
+import { useSegmentContext } from '../../../hooks/useSegmentContext';
 import { SUPPORT_LINK } from '../../../helpers/constants/common';
 import { isBeta } from '../../../../shared/lib/build-types';
 import {
@@ -26,7 +27,8 @@ import { useBoolean } from '../../../hooks/useBoolean';
 
 export default function AboutInfo(): React.ReactElement {
   const t = useI18nContext();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
+  const segmentContext = useSegmentContext();
 
   const {
     value: isVisitSupportDataConsentModalOpen,
@@ -37,18 +39,15 @@ export default function AboutInfo(): React.ReactElement {
 
   const handleContactUsClick = useCallback(() => {
     trackEvent(
-      {
-        category: MetaMetricsEventCategory.Settings,
-        event: MetaMetricsEventName.SupportLinkClicked,
-        properties: {
+      createEventBuilder(MetaMetricsEventName.SupportLinkClicked)
+        .addCategory(MetaMetricsEventCategory.Settings)
+        .addProperties({
           url: SUPPORT_LINK,
-        },
-      },
-      {
-        contextPropsIntoEventProperties: [MetaMetricsContextProp.PageTitle],
-      },
+          [MetaMetricsContextProp.PageTitle]: segmentContext.page?.title,
+        })
+        .build(),
     );
-  }, [trackEvent]);
+  }, [createEventBuilder, segmentContext.page?.title, trackEvent]);
 
   function renderInfoLinks(): React.ReactElement {
     const privacyUrl = 'https://metamask.io/privacy.html';

--- a/ui/pages/settings/assets-tab/currency-sub-page.tsx
+++ b/ui/pages/settings/assets-tab/currency-sub-page.tsx
@@ -1,6 +1,4 @@
-import React, { useContext } from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
+import React from 'react';
 import {
   Box,
   BoxFlexDirection,
@@ -14,8 +12,10 @@ import {
   Text,
   TextVariant,
 } from '@metamask/design-system-react';
+import { useDispatch, useSelector } from 'react-redux';
+import { useNavigate } from 'react-router-dom';
 import availableCurrencies from '../../../helpers/constants/available-conversions.json';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { useAnalytics } from '../../../hooks/useAnalytics';
 import { setCurrentCurrency } from '../../../store/actions';
 import { PREFERENCES_AND_DISPLAY_ROUTE } from '../../../helpers/constants/routes';
 import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
@@ -36,19 +36,20 @@ const currencyOptions = sortedCurrencies.map(({ code, name }) => ({
 const CurrencySubPage = () => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const currentCurrency = useSelector(getCurrentCurrency).toLowerCase();
 
   const handleSelect = (value: string) => {
-    trackEvent({
-      category: MetaMetricsEventCategory.Settings,
-      event: MetaMetricsEventName.CurrentCurrency,
-      properties: {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        current_currency: value,
-        location: 'settings-page',
-      },
-    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.CurrentCurrency)
+        .addCategory(MetaMetricsEventCategory.Settings)
+        .addProperties({
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          current_currency: value,
+          location: 'settings-page',
+        })
+        .build(),
+    );
     dispatch(setCurrentCurrency(value));
     navigate(PREFERENCES_AND_DISPLAY_ROUTE);
   };

--- a/ui/pages/settings/developer-tools-tab/delete-activity-item.tsx
+++ b/ui/pages/settings/developer-tools-tab/delete-activity-item.tsx
@@ -1,7 +1,7 @@
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import { Button } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { useAnalytics } from '../../../hooks/useAnalytics';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
@@ -11,15 +11,15 @@ import DeleteActivityModal from './delete-activity-modal';
 
 export const DeleteActivityItem = () => {
   const t = useI18nContext();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const [showDeleteModal, setShowDeleteModal] = useState(false);
 
   const handleDeleteActivity = () => {
-    trackEvent({
-      category: MetaMetricsEventCategory.Settings,
-      event: MetaMetricsEventName.AccountReset,
-      properties: {},
-    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.AccountReset)
+        .addCategory(MetaMetricsEventCategory.Settings)
+        .build(),
+    );
     setShowDeleteModal(true);
   };
 

--- a/ui/pages/settings/preferences-and-display-tab/show-default-address-item.tsx
+++ b/ui/pages/settings/preferences-and-display-tab/show-default-address-item.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Box, BoxFlexDirection } from '@metamask/design-system-react';
 import Dropdown from '../../../components/ui/dropdown';
@@ -12,7 +12,7 @@ import {
   setShowDefaultAddress,
   setDefaultAddressScope,
 } from '../../../store/actions';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { useAnalytics } from '../../../hooks/useAnalytics';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
@@ -27,7 +27,7 @@ import { PREFERENCES_ITEMS } from '../search-config';
 export const ShowDefaultAddressItem = () => {
   const t = useI18nContext();
   const dispatch = useDispatch();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
 
   const isDefaultAddressEnabled = useSelector(getIsDefaultAddressEnabled);
   const showDefaultAddress = useSelector(getShowDefaultAddressPreference);
@@ -44,17 +44,18 @@ export const ShowDefaultAddressItem = () => {
     enabled: boolean,
     scope: DefaultAddressScope,
   ) => {
-    trackEvent({
-      event: MetaMetricsEventName.SettingsUpdated,
-      category: MetaMetricsEventCategory.Settings,
-      properties: {
-        /* eslint-disable @typescript-eslint/naming-convention */
-        show_default_address: enabled,
-        default_address_network: scope,
-        /* eslint-enable @typescript-eslint/naming-convention */
-        location: 'Settings Page',
-      },
-    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.SettingsUpdated)
+        .addCategory(MetaMetricsEventCategory.Settings)
+        .addProperties({
+          /* eslint-disable @typescript-eslint/naming-convention */
+          show_default_address: enabled,
+          default_address_network: scope,
+          /* eslint-enable @typescript-eslint/naming-convention */
+          location: 'Settings Page',
+        })
+        .build(),
+    );
   };
 
   const handleToggle = (value: boolean) => {

--- a/ui/pages/settings/privacy-tab/basic-functionality-item.tsx
+++ b/ui/pages/settings/privacy-tab/basic-functionality-item.tsx
@@ -1,11 +1,11 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { getUseExternalServices } from '../../../selectors';
 import { toggleExternalServices } from '../../../store/actions';
 import { openBasicFunctionalityModal } from '../../../ducks/app/app';
 import { SettingsToggleItem } from '../shared/settings-toggle-item';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { useAnalytics } from '../../../hooks/useAnalytics';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
@@ -16,7 +16,7 @@ import { PRIVACY_ITEMS } from '../search-config';
 export const BasicFunctionalityToggleItem = () => {
   const t = useI18nContext();
   const dispatch = useDispatch();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const useExternalServices = useSelector(getUseExternalServices);
 
   const handleToggle = (value: boolean) => {
@@ -24,20 +24,21 @@ export const BasicFunctionalityToggleItem = () => {
       dispatch(openBasicFunctionalityModal());
     } else {
       dispatch(toggleExternalServices(true));
-      trackEvent({
-        category: MetaMetricsEventCategory.Settings,
-        event: MetaMetricsEventName.SettingsUpdated,
-        properties: {
-          /* eslint-disable @typescript-eslint/naming-convention */
-          settings_group: 'security_privacy',
-          settings_type: 'basic_functionality',
-          old_value: false,
-          new_value: true,
-          was_notifications_on: false,
-          was_profile_syncing_on: false,
-          /* eslint-enable @typescript-eslint/naming-convention */
-        },
-      });
+      trackEvent(
+        createEventBuilder(MetaMetricsEventName.SettingsUpdated)
+          .addCategory(MetaMetricsEventCategory.Settings)
+          .addProperties({
+            /* eslint-disable @typescript-eslint/naming-convention */
+            settings_group: 'security_privacy',
+            settings_type: 'basic_functionality',
+            old_value: false,
+            new_value: true,
+            was_notifications_on: false,
+            was_profile_syncing_on: false,
+            /* eslint-enable @typescript-eslint/naming-convention */
+          })
+          .build(),
+      );
     }
   };
 

--- a/ui/pages/settings/privacy-tab/data-collection-item.tsx
+++ b/ui/pages/settings/privacy-tab/data-collection-item.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
@@ -17,7 +17,7 @@ import {
 } from '../../../store/actions';
 import { SettingsToggleItem } from '../shared/settings-toggle-item';
 import { PRIVACY_ITEMS } from '../search-config';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { useAnalytics } from '../../../hooks/useAnalytics';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
@@ -27,7 +27,7 @@ import {
 export const DataCollectionToggleItem = () => {
   const t = useI18nContext();
   const dispatch = useDispatch();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
 
   const dataCollectionForMarketing = useSelector(getDataCollectionForMarketing);
   const useExternalServices = useSelector(getUseExternalServices);
@@ -68,17 +68,18 @@ export const DataCollectionToggleItem = () => {
 
     dispatch(setDataCollectionForMarketing(newValue));
 
-    trackEvent({
-      category: MetaMetricsEventCategory.Settings,
-      event: MetaMetricsEventName.AnalyticsPreferenceSelected,
-      properties: {
-        /* eslint-disable @typescript-eslint/naming-convention */
-        [MetaMetricsUserTrait.IsMetricsOptedIn]: true,
-        [MetaMetricsUserTrait.HasMarketingConsent]: Boolean(newValue),
-        /* eslint-enable @typescript-eslint/naming-convention */
-        location: 'Settings',
-      },
-    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.AnalyticsPreferenceSelected)
+        .addCategory(MetaMetricsEventCategory.Settings)
+        .addProperties({
+          /* eslint-disable @typescript-eslint/naming-convention */
+          [MetaMetricsUserTrait.IsMetricsOptedIn]: true,
+          [MetaMetricsUserTrait.HasMarketingConsent]: Boolean(newValue),
+          /* eslint-enable @typescript-eslint/naming-convention */
+          location: 'Settings',
+        })
+        .build(),
+    );
   };
 
   const description = socialLoginEnabled

--- a/ui/pages/settings/privacy-tab/delete-metametrics-data-item.test.tsx
+++ b/ui/pages/settings/privacy-tab/delete-metametrics-data-item.test.tsx
@@ -17,7 +17,6 @@ jest.mock('../../../hooks/useAnalytics', () => {
   const { createEventBuilder } = jest.requireActual(
     '../../../../shared/lib/analytics/create-event-builder',
   );
-
   return {
     useAnalytics: () => ({
       trackEvent: jest.fn(),

--- a/ui/pages/settings/privacy-tab/delete-metametrics-data-item.test.tsx
+++ b/ui/pages/settings/privacy-tab/delete-metametrics-data-item.test.tsx
@@ -13,6 +13,19 @@ import {
 import { createMetaMetricsDataDeletionTask } from '../../../store/actions';
 import { DeleteMetametricsDataItem } from './delete-metametrics-data-item';
 
+jest.mock('../../../hooks/useAnalytics', () => {
+  const { createEventBuilder } = jest.requireActual(
+    '../../../../shared/lib/analytics/create-event-builder',
+  );
+
+  return {
+    useAnalytics: () => ({
+      trackEvent: jest.fn(),
+      createEventBuilder,
+    }),
+  };
+});
+
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
   useSelector: jest.fn(),

--- a/ui/pages/settings/privacy-tab/delete-metametrics-modal.tsx
+++ b/ui/pages/settings/privacy-tab/delete-metametrics-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import {
   Box,
   BoxFlexDirection,
@@ -25,7 +25,7 @@ import {
 } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { createMetaMetricsDataDeletionTask } from '../../../store/actions';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { useAnalytics } from '../../../hooks/useAnalytics';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
@@ -45,31 +45,23 @@ export default function DeleteMetametricsModal({
   onError,
 }: Readonly<DeleteMetametricsModalProps>) {
   const t = useI18nContext();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
 
   const deleteMetaMetricsData = async () => {
     try {
       await createMetaMetricsDataDeletionTask();
       trackEvent(
-        {
-          category: MetaMetricsEventCategory.Settings,
-          event: MetaMetricsEventName.MetricsDataDeletionRequest,
-        },
-        {
-          excludeMetaMetricsId: true,
-        },
+        createEventBuilder(MetaMetricsEventName.MetricsDataDeletionRequest)
+          .addCategory(MetaMetricsEventCategory.Settings)
+          .build({ excludeMetaMetricsId: true }),
       );
       onSuccess();
     } catch (error) {
       captureException(error);
       trackEvent(
-        {
-          category: MetaMetricsEventCategory.Settings,
-          event: MetaMetricsEventName.ErrorOccured,
-        },
-        {
-          excludeMetaMetricsId: true,
-        },
+        createEventBuilder(MetaMetricsEventName.ErrorOccured)
+          .addCategory(MetaMetricsEventCategory.Settings)
+          .build({ excludeMetaMetricsId: true }),
       );
       onError();
     } finally {

--- a/ui/pages/settings/privacy-tab/export-your-data-item.test.tsx
+++ b/ui/pages/settings/privacy-tab/export-your-data-item.test.tsx
@@ -6,10 +6,24 @@ import mockState from '../../../../test/data/mock-state.json';
 import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import { captureException } from '../../../../shared/lib/sentry';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
 import * as exportUtils from '../../../helpers/utils/export-utils';
 import { backupUserData } from '../../../store/actions';
 import { ExportYourDataItem } from './export-your-data-item';
+
+const mockTrackEvent = jest.fn().mockResolvedValue(undefined);
+
+jest.mock('../../../hooks/useAnalytics', () => {
+  const { createEventBuilder } = jest.requireActual(
+    '../../../../shared/lib/analytics/create-event-builder',
+  );
+
+  return {
+    useAnalytics: () => ({
+      trackEvent: mockTrackEvent,
+      createEventBuilder,
+    }),
+  };
+});
 
 jest.mock('../../../helpers/utils/export-utils', () => ({
   ...jest.requireActual('../../../helpers/utils/export-utils'),
@@ -34,25 +48,12 @@ const mockCaptureException = captureException as jest.MockedFunction<
   typeof captureException
 >;
 
-const metricsProvider = (children: React.ReactNode) => (
-  <MetaMetricsContext.Provider
-    value={{
-      trackEvent: jest.fn().mockResolvedValue(undefined),
-      bufferedTrace: jest.fn(),
-      bufferedEndTrace: jest.fn(),
-      onboardingParentContext: { current: null },
-    }}
-  >
-    {children}
-  </MetaMetricsContext.Provider>
-);
-
 describe('ExportYourDataItem', () => {
   const mockStore = configureMockStore([thunk])(mockState);
-  const trackEvent = jest.fn().mockResolvedValue(undefined);
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockTrackEvent.mockClear();
   });
 
   it('renders the button with correct text', () => {
@@ -67,7 +68,7 @@ describe('ExportYourDataItem', () => {
   });
 
   it('opens the export modal when the row is clicked', () => {
-    renderWithProvider(metricsProvider(<ExportYourDataItem />), mockStore);
+    renderWithProvider(<ExportYourDataItem />, mockStore);
 
     fireEvent.click(screen.getByTestId('privacy-tab-export-your-data-button'));
 
@@ -86,19 +87,7 @@ describe('ExportYourDataItem', () => {
     } as never);
     mockExportAsFile.mockResolvedValue(undefined);
 
-    renderWithProvider(
-      <MetaMetricsContext.Provider
-        value={{
-          trackEvent,
-          bufferedTrace: jest.fn(),
-          bufferedEndTrace: jest.fn(),
-          onboardingParentContext: { current: null },
-        }}
-      >
-        <ExportYourDataItem />
-      </MetaMetricsContext.Provider>,
-      mockStore,
-    );
+    renderWithProvider(<ExportYourDataItem />, mockStore);
 
     fireEvent.click(screen.getByTestId('privacy-tab-export-your-data-button'));
     fireEvent.click(
@@ -114,11 +103,14 @@ describe('ExportYourDataItem', () => {
       '{"accounts":[]}',
       exportUtils.ExportableContentType.JSON,
     );
-    expect(trackEvent).toHaveBeenCalledWith({
-      event: 'User Data Exported',
-      category: 'Backup',
-      properties: {},
-    });
+    expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'User Data Exported',
+        properties: expect.objectContaining({
+          category: 'Backup',
+        }),
+      }),
+    );
   });
 
   it('supports filename responses from the typed action', async () => {
@@ -128,19 +120,7 @@ describe('ExportYourDataItem', () => {
     });
     mockExportAsFile.mockResolvedValue(undefined);
 
-    renderWithProvider(
-      <MetaMetricsContext.Provider
-        value={{
-          trackEvent,
-          bufferedTrace: jest.fn(),
-          bufferedEndTrace: jest.fn(),
-          onboardingParentContext: { current: null },
-        }}
-      >
-        <ExportYourDataItem />
-      </MetaMetricsContext.Provider>,
-      mockStore,
-    );
+    renderWithProvider(<ExportYourDataItem />, mockStore);
 
     fireEvent.click(screen.getByTestId('privacy-tab-export-your-data-button'));
     fireEvent.click(
@@ -159,19 +139,7 @@ describe('ExportYourDataItem', () => {
   it('closes the modal and captures the error when backup fails', async () => {
     mockBackupUserData.mockRejectedValue(new Error('backup failed'));
 
-    renderWithProvider(
-      <MetaMetricsContext.Provider
-        value={{
-          trackEvent,
-          bufferedTrace: jest.fn(),
-          bufferedEndTrace: jest.fn(),
-          onboardingParentContext: { current: null },
-        }}
-      >
-        <ExportYourDataItem />
-      </MetaMetricsContext.Provider>,
-      mockStore,
-    );
+    renderWithProvider(<ExportYourDataItem />, mockStore);
 
     fireEvent.click(screen.getByTestId('privacy-tab-export-your-data-button'));
     fireEvent.click(
@@ -187,6 +155,6 @@ describe('ExportYourDataItem', () => {
     expect(
       screen.queryByTestId('export-your-data-modal-download-button'),
     ).not.toBeInTheDocument();
-    expect(trackEvent).not.toHaveBeenCalled();
+    expect(mockTrackEvent).not.toHaveBeenCalled();
   });
 });

--- a/ui/pages/settings/privacy-tab/export-your-data-modal.tsx
+++ b/ui/pages/settings/privacy-tab/export-your-data-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import {
   Box,
   BoxAlignItems,
@@ -28,7 +28,7 @@ import {
   ExportableContentType,
 } from '../../../helpers/utils/export-utils';
 import { captureException } from '../../../../shared/lib/sentry';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { useAnalytics } from '../../../hooks/useAnalytics';
 import { backupUserData } from '../../../store/actions';
 
 type BackupUserDataResponse = {
@@ -45,7 +45,7 @@ export default function ExportYourDataModal({
   onClose,
 }: Readonly<ExportYourDataModalProps>) {
   const t = useI18nContext();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
 
   const handleDownload = async () => {
     try {
@@ -58,11 +58,9 @@ export default function ExportYourDataModal({
         ExportableContentType.JSON,
       );
 
-      await trackEvent({
-        event: 'User Data Exported',
-        category: 'Backup',
-        properties: {},
-      });
+      trackEvent(
+        createEventBuilder('User Data Exported').addCategory('Backup').build(),
+      );
     } catch (error) {
       captureException(error);
     }

--- a/ui/pages/settings/privacy-tab/ipfs-gateway-item.tsx
+++ b/ui/pages/settings/privacy-tab/ipfs-gateway-item.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useState } from 'react';
+import React, { useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Box, BoxFlexDirection } from '@metamask/design-system-react';
 import { FormTextField } from '../../../components/component-library';
@@ -15,7 +15,7 @@ import {
 } from '../../../../shared/constants/network';
 import { addUrlProtocolPrefix } from '../../../../shared/lib/url-utils';
 import { THIRD_PARTY_API_ITEMS } from '../search-config';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { useAnalytics } from '../../../hooks/useAnalytics';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
@@ -24,7 +24,7 @@ import {
 export const IpfsGatewayItem = () => {
   const t = useI18nContext();
   const dispatch = useDispatch();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
 
   const ipfsGatewayFromState = useSelector(
     (state: MetaMaskReduxState) => state.metamask.ipfsGateway,
@@ -63,14 +63,15 @@ export const IpfsGatewayItem = () => {
   const handleToggle = (currentValue: boolean) => {
     const newValue = !currentValue;
 
-    trackEvent({
-      category: MetaMetricsEventCategory.Settings,
-      event: MetaMetricsEventName.SettingsUpdated,
-      properties: {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        use_ipfs_gateway: newValue,
-      },
-    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.SettingsUpdated)
+        .addCategory(MetaMetricsEventCategory.Settings)
+        .addProperties({
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          use_ipfs_gateway: newValue,
+        })
+        .build(),
+    );
 
     if (currentValue) {
       dispatch(setIsIpfsGatewayEnabled(false));

--- a/ui/pages/settings/privacy-tab/metametrics-item.test.tsx
+++ b/ui/pages/settings/privacy-tab/metametrics-item.test.tsx
@@ -6,7 +6,23 @@ import mockState from '../../../../test/data/mock-state.json';
 import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import { setBackgroundConnection } from '../../../store/background-connection';
+import { MetaMetricsEventName } from '../../../../shared/constants/metametrics';
 import { MetametricsToggleItem } from './metametrics-item';
+
+const mockTrackAnalyticsEvent = jest.fn();
+
+jest.mock('../../../hooks/useAnalytics', () => {
+  const { createEventBuilder } = jest.requireActual(
+    '../../../../shared/lib/analytics/create-event-builder',
+  );
+
+  return {
+    useAnalytics: () => ({
+      trackEvent: mockTrackAnalyticsEvent,
+      createEventBuilder,
+    }),
+  };
+});
 
 const mockEnableMetametrics = jest.fn().mockResolvedValue(undefined);
 const mockDisableMetametrics = jest.fn().mockResolvedValue(undefined);
@@ -136,23 +152,16 @@ describe('MetametricsToggleItem', () => {
   });
 
   it('fires TurnOffMetaMetrics event when toggled off', async () => {
-    const mockTrackEvent = jest.fn();
     const mockStore = createMockStore({ optedIn: true });
 
-    renderWithProvider(
-      <MetametricsToggleItem />,
-      mockStore,
-      '/',
-      undefined,
-      () => mockTrackEvent,
-    );
+    renderWithProvider(<MetametricsToggleItem />, mockStore);
 
     fireEvent.click(screen.getByTestId('participate-in-meta-metrics-input'));
 
     await waitFor(() => {
-      expect(mockTrackEvent).toHaveBeenCalledWith(
+      expect(mockTrackAnalyticsEvent).toHaveBeenCalledWith(
         expect.objectContaining({
-          event: 'MetaMetrics Turned Off',
+          name: MetaMetricsEventName.TurnOffMetaMetrics,
         }),
       );
     });

--- a/ui/pages/settings/privacy-tab/metametrics-item.tsx
+++ b/ui/pages/settings/privacy-tab/metametrics-item.tsx
@@ -1,8 +1,8 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { Text, TextColor, TextVariant } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { useAnalytics } from '../../../hooks/useAnalytics';
 import {
   useEnableMetametrics,
   useDisableMetametrics,
@@ -29,7 +29,7 @@ import { PRIVACY_ITEMS } from '../search-config';
 export const MetametricsToggleItem = () => {
   const t = useI18nContext();
   const dispatch = useDispatch();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const { enableMetametrics, error: enableMetametricsError } =
     useEnableMetametrics();
   const { disableMetametrics, error: disableMetametricsError } =
@@ -48,15 +48,16 @@ export const MetametricsToggleItem = () => {
 
     if (newValue) {
       await enableMetametrics();
-      trackEvent({
-        category: MetaMetricsEventCategory.Settings,
-        event: MetaMetricsEventName.TurnOnMetaMetrics,
-        properties: {
-          isProfileSyncingEnabled: isBackupAndSyncEnabled,
-          participateInMetaMetrics: isOptedIn,
-          location: 'Settings',
-        },
-      });
+      trackEvent(
+        createEventBuilder(MetaMetricsEventName.TurnOnMetaMetrics)
+          .addCategory(MetaMetricsEventCategory.Settings)
+          .addProperties({
+            isProfileSyncingEnabled: isBackupAndSyncEnabled,
+            participateInMetaMetrics: isOptedIn,
+            location: 'Settings',
+          })
+          .build(),
+      );
     } else {
       if (dataCollectionForMarketing) {
         if (socialLoginEnabled) {
@@ -65,26 +66,28 @@ export const MetametricsToggleItem = () => {
         dispatch(setDataCollectionForMarketing(false));
       }
 
-      trackEvent({
-        category: MetaMetricsEventCategory.Settings,
-        event: MetaMetricsEventName.TurnOffMetaMetrics,
-        properties: {
-          isProfileSyncingEnabled: isBackupAndSyncEnabled,
-          participateInMetaMetrics: isOptedIn,
-        },
-      });
+      trackEvent(
+        createEventBuilder(MetaMetricsEventName.TurnOffMetaMetrics)
+          .addCategory(MetaMetricsEventCategory.Settings)
+          .addProperties({
+            isProfileSyncingEnabled: isBackupAndSyncEnabled,
+            participateInMetaMetrics: isOptedIn,
+          })
+          .build(),
+      );
 
-      trackEvent({
-        category: MetaMetricsEventCategory.Settings,
-        event: MetaMetricsEventName.AnalyticsPreferenceSelected,
-        properties: {
-          /* eslint-disable @typescript-eslint/naming-convention */
-          [MetaMetricsUserTrait.IsMetricsOptedIn]: false,
-          [MetaMetricsUserTrait.HasMarketingConsent]: false,
-          /* eslint-enable @typescript-eslint/naming-convention */
-          location: 'Settings',
-        },
-      });
+      trackEvent(
+        createEventBuilder(MetaMetricsEventName.AnalyticsPreferenceSelected)
+          .addCategory(MetaMetricsEventCategory.Settings)
+          .addProperties({
+            /* eslint-disable @typescript-eslint/naming-convention */
+            [MetaMetricsUserTrait.IsMetricsOptedIn]: false,
+            [MetaMetricsUserTrait.HasMarketingConsent]: false,
+            /* eslint-enable @typescript-eslint/naming-convention */
+            location: 'Settings',
+          })
+          .build(),
+      );
 
       await disableMetametrics();
     }

--- a/ui/pages/settings/security-and-password-tab/auto-lock-sub-page.test.tsx
+++ b/ui/pages/settings/security-and-password-tab/auto-lock-sub-page.test.tsx
@@ -13,6 +13,21 @@ import { setBackgroundConnection } from '../../../store/background-connection';
 import { SECURITY_AND_PASSWORD_ROUTE } from '../../../helpers/constants/routes';
 import AutoLockSubPage from './auto-lock-sub-page';
 
+const mockTrackEvent = jest.fn();
+
+jest.mock('../../../hooks/useAnalytics', () => {
+  const { createEventBuilder } = jest.requireActual(
+    '../../../../shared/lib/analytics/create-event-builder',
+  );
+
+  return {
+    useAnalytics: () => ({
+      trackEvent: mockTrackEvent,
+      createEventBuilder,
+    }),
+  };
+});
+
 const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
@@ -78,26 +93,20 @@ describe('AutoLockSubPage', () => {
   });
 
   it('dispatches setAutoLockTimeLimit and navigates on click', () => {
-    const trackEvent = jest.fn().mockResolvedValue(undefined);
-    renderWithProvider(
-      <AutoLockSubPage />,
-      createMockStore(),
-      '/',
-      render,
-      () => trackEvent,
-    );
+    renderWithProvider(<AutoLockSubPage />, createMockStore());
 
     fireEvent.click(screen.getByText(messages.autoLockAfter1Minute.message));
 
-    expect(trackEvent).toHaveBeenCalledWith({
-      category: MetaMetricsEventCategory.Settings,
-      event: MetaMetricsEventName.SettingsUpdated,
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      name: MetaMetricsEventName.SettingsUpdated,
       properties: {
+        category: MetaMetricsEventCategory.Settings,
         // eslint-disable-next-line @typescript-eslint/naming-convention
         auto_lock_time_limit_minutes: 1,
         // eslint-disable-next-line @typescript-eslint/naming-convention
         previous_auto_lock_time_limit_minutes: 0,
       },
+      sensitiveProperties: {},
     });
     expect(mockSetAutoLockTimeLimit).toHaveBeenCalledWith(1);
     expect(mockNavigate).toHaveBeenCalledWith(SECURITY_AND_PASSWORD_ROUTE);

--- a/ui/pages/settings/security-and-password-tab/auto-lock-sub-page.tsx
+++ b/ui/pages/settings/security-and-password-tab/auto-lock-sub-page.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -19,7 +19,7 @@ import { SECURITY_AND_PASSWORD_ROUTE } from '../../../helpers/constants/routes';
 import { getPreferences } from '../../../../shared/lib/selectors/preferences';
 import { DEFAULT_AUTO_LOCK_TIME_LIMIT } from '../../../../shared/constants/preferences';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { useAnalytics } from '../../../hooks/useAnalytics';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
@@ -30,21 +30,22 @@ const AutoLockSubPage = () => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const t = useI18nContext();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const { autoLockTimeLimit = DEFAULT_AUTO_LOCK_TIME_LIMIT } =
     useSelector(getPreferences);
 
   const handleSelect = (value: number) => {
-    trackEvent({
-      category: MetaMetricsEventCategory.Settings,
-      event: MetaMetricsEventName.SettingsUpdated,
-      properties: {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        auto_lock_time_limit_minutes: value,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        previous_auto_lock_time_limit_minutes: autoLockTimeLimit,
-      },
-    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.SettingsUpdated)
+        .addCategory(MetaMetricsEventCategory.Settings)
+        .addProperties({
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          auto_lock_time_limit_minutes: value,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          previous_auto_lock_time_limit_minutes: autoLockTimeLimit,
+        })
+        .build(),
+    );
     dispatch(setAutoLockTimeLimit(value));
     navigate(SECURITY_AND_PASSWORD_ROUTE);
   };

--- a/ui/pages/settings/security-and-password-tab/passkey-item.tsx
+++ b/ui/pages/settings/security-and-password-tab/passkey-item.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import log from 'loglevel';
@@ -28,7 +22,6 @@ import {
 import { captureException } from '../../../../shared/lib/sentry';
 import PasskeyTroubleshootModal from '../../../components/app/passkey-troubleshoot-modal';
 import { toast, ToastContent } from '../../../components/ui/toast/toast';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
   SECURITY_AND_PASSWORD_ROUTE,
   SECURITY_REGISTER_PASSKEY_ROUTE,
@@ -45,6 +38,7 @@ import {
   removePasskeyWithPasskeyVerification,
 } from '../../../store/actions';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+import { useAnalytics } from '../../../hooks/useAnalytics';
 import { SettingsToggleItem } from '../shared/settings-toggle-item';
 import { SECURITY_ITEMS } from '../search-config';
 
@@ -61,7 +55,7 @@ const PasskeyItem = () => {
   );
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
 
   const isPasskeyFeatureAvailable = useSelector(getIsPasskeyFeatureAvailable);
   const isPasskeyRegistered = useSelector(getIsPasskeyRegistered);
@@ -109,15 +103,16 @@ const PasskeyItem = () => {
       isEnrolledPasskeyIncompatibleWithSidepanel
     ) {
       cancelPasskeyCeremony();
-      trackEvent({
-        category: MetaMetricsEventCategory.Settings,
-        event: MetaMetricsEventName.PasskeyTurnOff,
-        properties: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          verification_method: verificationMethod,
-          status: 'full_screen_opened',
-        },
-      });
+      trackEvent(
+        createEventBuilder(MetaMetricsEventName.PasskeyTurnOff)
+          .addCategory(MetaMetricsEventCategory.Settings)
+          .addProperties({
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            verification_method: verificationMethod,
+            status: 'full_screen_opened',
+          })
+          .build(),
+      );
       globalThis.platform?.openExtensionInBrowser?.(
         SECURITY_AND_PASSWORD_ROUTE,
       );
@@ -126,15 +121,16 @@ const PasskeyItem = () => {
 
     setIsPasskeyOperationPending(true);
     const startedAt = Date.now();
-    trackEvent({
-      category: MetaMetricsEventCategory.Settings,
-      event: MetaMetricsEventName.PasskeyTurnOff,
-      properties: {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        verification_method: verificationMethod,
-        status: 'started',
-      },
-    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.PasskeyTurnOff)
+        .addCategory(MetaMetricsEventCategory.Settings)
+        .addProperties({
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          verification_method: verificationMethod,
+          status: 'started',
+        })
+        .build(),
+    );
     try {
       const authOptions = await generatePasskeyAuthenticationOptions();
       const authenticationResponse =
@@ -142,17 +138,18 @@ const PasskeyItem = () => {
       await removePasskeyWithPasskeyVerification(authenticationResponse);
       await forceUpdateMetamaskState(dispatch);
 
-      trackEvent({
-        category: MetaMetricsEventCategory.Settings,
-        event: MetaMetricsEventName.PasskeyTurnOff,
-        properties: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          verification_method: verificationMethod,
-          status: 'completed',
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          duration_ms: Date.now() - startedAt,
-        },
-      });
+      trackEvent(
+        createEventBuilder(MetaMetricsEventName.PasskeyTurnOff)
+          .addCategory(MetaMetricsEventCategory.Settings)
+          .addProperties({
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            verification_method: verificationMethod,
+            status: 'completed',
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            duration_ms: Date.now() - startedAt,
+          })
+          .build(),
+      );
 
       toast.success(
         <ToastContent title={t('passkeyTurnedOff', [passkeyMethodLabel])} />,
@@ -161,18 +158,19 @@ const PasskeyItem = () => {
         },
       );
 
-      trackEvent({
-        category: MetaMetricsEventCategory.Settings,
-        event: MetaMetricsEventName.SettingsUpdated,
-        properties: {
-          /* eslint-disable @typescript-eslint/naming-convention */
-          settings_group: 'security_privacy',
-          settings_type: 'passkey',
-          old_value: true,
-          new_value: false,
-          /* eslint-enable @typescript-eslint/naming-convention */
-        },
-      });
+      trackEvent(
+        createEventBuilder(MetaMetricsEventName.SettingsUpdated)
+          .addCategory(MetaMetricsEventCategory.Settings)
+          .addProperties({
+            /* eslint-disable @typescript-eslint/naming-convention */
+            settings_group: 'security_privacy',
+            settings_type: 'passkey',
+            old_value: true,
+            new_value: false,
+            /* eslint-enable @typescript-eslint/naming-convention */
+          })
+          .build(),
+      );
 
       navigate(SECURITY_AND_PASSWORD_ROUTE, { replace: true });
     } catch (error: unknown) {
@@ -201,18 +199,19 @@ const PasskeyItem = () => {
         );
       }
 
-      trackEvent({
-        category: MetaMetricsEventCategory.Settings,
-        event: MetaMetricsEventName.PasskeyTurnOff,
-        properties: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          verification_method: verificationMethod,
-          status: errorStatus,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          duration_ms: durationMs,
-          reason: errorCode,
-        },
-      });
+      trackEvent(
+        createEventBuilder(MetaMetricsEventName.PasskeyTurnOff)
+          .addCategory(MetaMetricsEventCategory.Settings)
+          .addProperties({
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            verification_method: verificationMethod,
+            status: errorStatus,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            duration_ms: durationMs,
+            reason: errorCode,
+          })
+          .build(),
+      );
       navigate(SECURITY_TURN_OFF_PASSKEY_ROUTE, { replace: true });
     } finally {
       setIsPasskeyOperationPending(false);

--- a/ui/pages/settings/security-and-password-tab/passkey-register-sub-page.tsx
+++ b/ui/pages/settings/security-and-password-tab/passkey-register-sub-page.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import log from 'loglevel';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useLocation } from 'react-router-dom';
@@ -22,6 +22,7 @@ import {
 } from '../../../components/component-library';
 import { SECURITY_AND_PASSWORD_ROUTE } from '../../../helpers/constants/routes';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+import { useAnalytics } from '../../../hooks/useAnalytics';
 import { createSentryError } from '../../../../shared/lib/error';
 import {
   getPasskeyAuthMethodKey,
@@ -42,7 +43,6 @@ import {
 } from '../../../store/actions';
 import { toast, ToastContent } from '../../../components/ui/toast/toast';
 import { SECOND } from '../../../../shared/constants/time';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
@@ -84,7 +84,7 @@ export default function PasskeyRegisterSubPage() {
   const passkeyMethodSpecificLabel = t(
     getPasskeyAuthMethodKey({ specific: true }),
   );
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const isPasskeyRegistered = useSelector(getIsPasskeyRegistered);
 
   const fromSidepanel =
@@ -149,13 +149,14 @@ export default function PasskeyRegisterSubPage() {
 
     const enrollmentStartedAt = Date.now();
     let currentStep = 'register';
-    trackEvent({
-      category: MetaMetricsEventCategory.Settings,
-      event: MetaMetricsEventName.PasskeySetup,
-      properties: {
-        status: 'started',
-      },
-    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.PasskeySetup)
+        .addCategory(MetaMetricsEventCategory.Settings)
+        .addProperties({
+          status: 'started',
+        })
+        .build(),
+    );
 
     let registrationSucceeded = false;
 
@@ -189,17 +190,18 @@ export default function PasskeyRegisterSubPage() {
       const derivationMethod = getPasskeyDerivationMethod({
         metamask: newMetamaskState,
       });
-      trackEvent({
-        category: MetaMetricsEventCategory.Settings,
-        event: MetaMetricsEventName.PasskeySetup,
-        properties: {
-          status: 'completed',
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          derivation_method: derivationMethod,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          duration_ms: Date.now() - enrollmentStartedAt,
-        },
-      });
+      trackEvent(
+        createEventBuilder(MetaMetricsEventName.PasskeySetup)
+          .addCategory(MetaMetricsEventCategory.Settings)
+          .addProperties({
+            status: 'completed',
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            derivation_method: derivationMethod,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            duration_ms: Date.now() - enrollmentStartedAt,
+          })
+          .build(),
+      );
 
       await new Promise((resolve) => {
         setTimeout(resolve, PASSKEY_ENROLLMENT_SUCCESS_DISPLAY_MS);
@@ -210,33 +212,35 @@ export default function PasskeyRegisterSubPage() {
           duration: PASSKEY_SETTINGS_TOAST_DURATION_MS,
         },
       );
-      trackEvent({
-        category: MetaMetricsEventCategory.Settings,
-        event: MetaMetricsEventName.SettingsUpdated,
-        properties: {
-          /* eslint-disable @typescript-eslint/naming-convention */
-          settings_group: 'security_privacy',
-          settings_type: 'passkey',
-          old_value: false,
-          new_value: true,
-          /* eslint-enable @typescript-eslint/naming-convention */
-        },
-      });
+      trackEvent(
+        createEventBuilder(MetaMetricsEventName.SettingsUpdated)
+          .addCategory(MetaMetricsEventCategory.Settings)
+          .addProperties({
+            /* eslint-disable @typescript-eslint/naming-convention */
+            settings_group: 'security_privacy',
+            settings_type: 'passkey',
+            old_value: false,
+            new_value: true,
+            /* eslint-enable @typescript-eslint/naming-convention */
+          })
+          .build(),
+      );
       goToSettings();
     } catch (error) {
       const durationMs = Date.now() - enrollmentStartedAt;
       if (isPasskeyCeremonySilentError(error)) {
-        trackEvent({
-          category: MetaMetricsEventCategory.Settings,
-          event: MetaMetricsEventName.PasskeySetup,
-          properties: {
-            status: 'cancelled',
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            current_step: currentStep,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            duration_ms: durationMs,
-          },
-        });
+        trackEvent(
+          createEventBuilder(MetaMetricsEventName.PasskeySetup)
+            .addCategory(MetaMetricsEventCategory.Settings)
+            .addProperties({
+              status: 'cancelled',
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              current_step: currentStep,
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              duration_ms: durationMs,
+            })
+            .build(),
+        );
         log.debug(
           'Settings passkey enrollment ceremony cancelled or timed out',
           error,
@@ -253,18 +257,19 @@ export default function PasskeyRegisterSubPage() {
           extra: { currentStep, durationMs, errorCode },
         },
       );
-      trackEvent({
-        category: MetaMetricsEventCategory.Settings,
-        event: MetaMetricsEventName.PasskeySetup,
-        properties: {
-          status: 'failed',
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          error_step: currentStep,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          duration_ms: durationMs,
-          reason: errorCode,
-        },
-      });
+      trackEvent(
+        createEventBuilder(MetaMetricsEventName.PasskeySetup)
+          .addCategory(MetaMetricsEventCategory.Settings)
+          .addProperties({
+            status: 'failed',
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            error_step: currentStep,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            duration_ms: durationMs,
+            reason: errorCode,
+          })
+          .build(),
+      );
       setEnrollmentError(
         translatePasskeyError(error, t, passkeyMethodLabel) ??
           (registrationSucceeded

--- a/ui/pages/settings/security-and-password-tab/passkey-turn-off-sub-page.tsx
+++ b/ui/pages/settings/security-and-password-tab/passkey-turn-off-sub-page.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import {
@@ -17,6 +17,7 @@ import {
 } from '../../../components/component-library';
 import { SECURITY_AND_PASSWORD_ROUTE } from '../../../helpers/constants/routes';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+import { useAnalytics } from '../../../hooks/useAnalytics';
 import { createSentryError } from '../../../../shared/lib/error';
 import {
   getPasskeyAuthMethodKey,
@@ -31,7 +32,6 @@ import {
 } from '../../../store/actions';
 import { toast, ToastContent } from '../../../components/ui/toast/toast';
 import { SECOND } from '../../../../shared/constants/time';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
@@ -45,7 +45,7 @@ export default function PasskeyTurnOffSubPage() {
   const dispatch = useDispatch();
   const t = useI18nContext();
   const passkeyMethodLabel = t(getPasskeyAuthMethodKey());
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const isPasskeyRegistered = useSelector(getIsPasskeyRegistered);
 
   const [walletPassword, setWalletPassword] = useState('');
@@ -87,60 +87,64 @@ export default function PasskeyTurnOffSubPage() {
         // eslint-disable-next-line @typescript-eslint/naming-convention
         verification_method: 'password',
       };
-      trackEvent({
-        category: MetaMetricsEventCategory.Settings,
-        event: MetaMetricsEventName.PasskeyTurnOff,
-        properties: {
-          ...baseProperties,
-          status: 'started',
-        },
-      });
+      trackEvent(
+        createEventBuilder(MetaMetricsEventName.PasskeyTurnOff)
+          .addCategory(MetaMetricsEventCategory.Settings)
+          .addProperties({
+            ...baseProperties,
+            status: 'started',
+          })
+          .build(),
+      );
       try {
         await removePasskeyWithPasswordVerification(walletPassword);
         await forceUpdateMetamaskState(dispatch);
-        trackEvent({
-          category: MetaMetricsEventCategory.Settings,
-          event: MetaMetricsEventName.PasskeyTurnOff,
-          properties: {
-            ...baseProperties,
-            status: 'completed',
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            duration_ms: Date.now() - startedAt,
-          },
-        });
+        trackEvent(
+          createEventBuilder(MetaMetricsEventName.PasskeyTurnOff)
+            .addCategory(MetaMetricsEventCategory.Settings)
+            .addProperties({
+              ...baseProperties,
+              status: 'completed',
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              duration_ms: Date.now() - startedAt,
+            })
+            .build(),
+        );
         toast.success(
           <ToastContent title={t('passkeyTurnedOff', [passkeyMethodLabel])} />,
           {
             duration: PASSKEY_SETTINGS_TOAST_DURATION_MS,
           },
         );
-        trackEvent({
-          category: MetaMetricsEventCategory.Settings,
-          event: MetaMetricsEventName.SettingsUpdated,
-          properties: {
-            /* eslint-disable @typescript-eslint/naming-convention */
-            settings_group: 'security_privacy',
-            settings_type: 'passkey',
-            old_value: true,
-            new_value: false,
-            /* eslint-enable @typescript-eslint/naming-convention */
-          },
-        });
+        trackEvent(
+          createEventBuilder(MetaMetricsEventName.SettingsUpdated)
+            .addCategory(MetaMetricsEventCategory.Settings)
+            .addProperties({
+              /* eslint-disable @typescript-eslint/naming-convention */
+              settings_group: 'security_privacy',
+              settings_type: 'passkey',
+              old_value: true,
+              new_value: false,
+              /* eslint-enable @typescript-eslint/naming-convention */
+            })
+            .build(),
+        );
         goToSettings();
       } catch (error: unknown) {
         const durationMs = Date.now() - startedAt;
         const errorCode = getPasskeyErrorCode(error);
-        trackEvent({
-          category: MetaMetricsEventCategory.Settings,
-          event: MetaMetricsEventName.PasskeyTurnOff,
-          properties: {
-            ...baseProperties,
-            status: 'failed',
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            duration_ms: durationMs,
-            reason: errorCode,
-          },
-        });
+        trackEvent(
+          createEventBuilder(MetaMetricsEventName.PasskeyTurnOff)
+            .addCategory(MetaMetricsEventCategory.Settings)
+            .addProperties({
+              ...baseProperties,
+              status: 'failed',
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              duration_ms: durationMs,
+              reason: errorCode,
+            })
+            .build(),
+        );
         captureException(
           createSentryError('Passkey turn off in settings failed', error),
           { extra: { verificationMethod: 'password', durationMs, errorCode } },

--- a/ui/pages/settings/shared/autodetect-nfts-item.tsx
+++ b/ui/pages/settings/shared/autodetect-nfts-item.tsx
@@ -1,7 +1,7 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { useAnalytics } from '../../../hooks/useAnalytics';
 import { getOpenSeaEnabled, getUseNftDetection } from '../../../selectors';
 import { setOpenSeaEnabled, setUseNftDetection } from '../../../store/actions';
 import {
@@ -14,7 +14,7 @@ import { SettingsToggleItem } from './settings-toggle-item';
 export const AutodetectNftsToggleItem = () => {
   const t = useI18nContext();
   const dispatch = useDispatch();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const openSeaEnabled = useSelector(getOpenSeaEnabled);
   const useNftDetection = useSelector(getUseNftDetection);
 
@@ -24,15 +24,16 @@ export const AutodetectNftsToggleItem = () => {
       description={t('useNftDetectionDescription')}
       value={useNftDetection}
       onToggle={(value) => {
-        trackEvent({
-          category: MetaMetricsEventCategory.Settings,
-          event: MetaMetricsEventName.NftDetected,
-          properties: {
-            action: MetaMetricsEventName.NftDetected,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            legacy_event: true,
-          },
-        });
+        trackEvent(
+          createEventBuilder(MetaMetricsEventName.NftDetected)
+            .addCategory(MetaMetricsEventCategory.Settings)
+            .addProperties({
+              action: MetaMetricsEventName.NftDetected,
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              legacy_event: true,
+            })
+            .build(),
+        );
         if (!value && !openSeaEnabled) {
           dispatch(setOpenSeaEnabled(true));
         }

--- a/ui/pages/settings/shared/create-toggle-item.test.tsx
+++ b/ui/pages/settings/shared/create-toggle-item.test.tsx
@@ -10,8 +10,22 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
 import { createToggleItem, ToggleItemConfig } from './create-toggle-item';
+
+const mockTrackEvent = jest.fn();
+
+jest.mock('../../../hooks/useAnalytics', () => {
+  const { createEventBuilder } = jest.requireActual(
+    '../../../../shared/lib/analytics/create-event-builder',
+  );
+
+  return {
+    useAnalytics: () => ({
+      trackEvent: mockTrackEvent,
+      createEventBuilder,
+    }),
+  };
+});
 
 const mockAction = jest.fn((value: boolean) => ({
   type: 'MOCK_TOGGLE_ACTION',
@@ -147,8 +161,6 @@ describe('createToggleItem', () => {
   });
 
   describe('with trackEvent', () => {
-    const mockTrackEvent = jest.fn();
-
     const configWithTracking: ToggleItemConfig = {
       ...testConfig,
       dataTestId: 'test-toggle-with-tracking',
@@ -160,30 +172,20 @@ describe('createToggleItem', () => {
 
     const TestToggleWithTracking = createToggleItem(configWithTracking);
 
-    const renderWithMetaMetrics = (store: ReturnType<typeof createMockStore>) =>
-      renderWithProvider(
-        <MetaMetricsContext.Provider
-          value={{ trackEvent: mockTrackEvent } as never}
-        >
-          <TestToggleWithTracking />
-        </MetaMetricsContext.Provider>,
-        store,
-      );
-
-    beforeEach(() => {
-      mockTrackEvent.mockClear();
-    });
-
     it('tracks event when toggled', () => {
       const mockStore = createMockStore({ testToggleValue: false });
-      renderWithMetaMetrics(mockStore);
+      renderWithProvider(<TestToggleWithTracking />, mockStore);
 
       fireEvent.click(screen.getByTestId('test-toggle-with-tracking'));
 
       expect(mockTrackEvent).toHaveBeenCalledWith({
-        category: MetaMetricsEventCategory.Settings,
-        event: MetaMetricsEventName.SettingsUpdated,
-        properties: { settingName: 'testToggle', newValue: true },
+        name: MetaMetricsEventName.SettingsUpdated,
+        properties: {
+          category: MetaMetricsEventCategory.Settings,
+          settingName: 'testToggle',
+          newValue: true,
+        },
+        sensitiveProperties: {},
       });
     });
 
@@ -196,28 +198,23 @@ describe('createToggleItem', () => {
         configWithTrackingAndProperty,
       );
       const mockStore = createMockStore({ testToggleValue: false });
-      renderWithProvider(
-        <MetaMetricsContext.Provider
-          value={{ trackEvent: mockTrackEvent } as never}
-        >
-          <TestToggleWithTrackingAndProperty />
-        </MetaMetricsContext.Provider>,
-        mockStore,
-      );
+      renderWithProvider(<TestToggleWithTrackingAndProperty />, mockStore);
 
       fireEvent.click(screen.getByTestId('test-toggle-with-tracking'));
 
       expect(mockTrackEvent).toHaveBeenCalledWith({
-        category: MetaMetricsEventCategory.Settings,
-        event: MetaMetricsEventName.SettingsUpdated,
-        properties: { settingName: 'testToggle', newValue: true },
+        name: MetaMetricsEventName.SettingsUpdated,
+        properties: {
+          category: MetaMetricsEventCategory.Settings,
+          settingName: 'testToggle',
+          newValue: true,
+        },
+        sensitiveProperties: {},
       });
     });
   });
 
   describe('with trackEventProperty', () => {
-    const mockTrackEvent = jest.fn();
-
     const configWithPropertyTracking: ToggleItemConfig = {
       ...testConfig,
       dataTestId: 'test-toggle-with-property-tracking',
@@ -228,45 +225,37 @@ describe('createToggleItem', () => {
       configWithPropertyTracking,
     );
 
-    const renderWithMetaMetrics = (store: ReturnType<typeof createMockStore>) =>
-      renderWithProvider(
-        <MetaMetricsContext.Provider
-          value={{ trackEvent: mockTrackEvent } as never}
-        >
-          <TestToggleWithPropertyTracking />
-        </MetaMetricsContext.Provider>,
-        store,
-      );
-
-    beforeEach(() => {
-      mockTrackEvent.mockClear();
-    });
-
     it('tracks SettingsUpdated event with property name when toggled on', () => {
       const mockStore = createMockStore({ testToggleValue: false });
-      renderWithMetaMetrics(mockStore);
+      renderWithProvider(<TestToggleWithPropertyTracking />, mockStore);
 
       fireEvent.click(screen.getByTestId('test-toggle-with-property-tracking'));
 
       expect(mockTrackEvent).toHaveBeenCalledWith({
-        category: MetaMetricsEventCategory.Settings,
-        event: MetaMetricsEventName.SettingsUpdated,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        properties: { test_setting_enabled: true },
+        name: MetaMetricsEventName.SettingsUpdated,
+        properties: {
+          category: MetaMetricsEventCategory.Settings,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          test_setting_enabled: true,
+        },
+        sensitiveProperties: {},
       });
     });
 
     it('tracks SettingsUpdated event with property name when toggled off', () => {
       const mockStore = createMockStore({ testToggleValue: true });
-      renderWithMetaMetrics(mockStore);
+      renderWithProvider(<TestToggleWithPropertyTracking />, mockStore);
 
       fireEvent.click(screen.getByTestId('test-toggle-with-property-tracking'));
 
       expect(mockTrackEvent).toHaveBeenCalledWith({
-        category: MetaMetricsEventCategory.Settings,
-        event: MetaMetricsEventName.SettingsUpdated,
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        properties: { test_setting_enabled: false },
+        name: MetaMetricsEventName.SettingsUpdated,
+        properties: {
+          category: MetaMetricsEventCategory.Settings,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          test_setting_enabled: false,
+        },
+        sensitiveProperties: {},
       });
     });
   });

--- a/ui/pages/settings/shared/create-toggle-item.tsx
+++ b/ui/pages/settings/shared/create-toggle-item.tsx
@@ -1,12 +1,12 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import type { Json } from '@metamask/utils';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+import { useAnalytics } from '../../../hooks/useAnalytics';
 import type {
   MetaMaskReduxDispatch,
   MetaMaskReduxState,
 } from '../../../store/store';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
@@ -51,7 +51,7 @@ export const createToggleItem = (
   const ToggleItem = () => {
     const t = useI18nContext();
     const dispatch = useDispatch();
-    const { trackEvent } = useContext(MetaMetricsContext);
+    const { trackEvent, createEventBuilder } = useAnalytics();
     const value = useSelector(config.selector);
     const disabled = useSelector(config.disabledSelector ?? selectAlwaysFalse);
 
@@ -59,19 +59,21 @@ export const createToggleItem = (
       const newValue = !currentValue;
 
       if (config.trackEvent) {
-        trackEvent({
-          category: MetaMetricsEventCategory.Settings,
-          event: config.trackEvent.event,
-          properties: config.trackEvent.properties(newValue),
-        });
+        trackEvent(
+          createEventBuilder(config.trackEvent.event)
+            .addCategory(MetaMetricsEventCategory.Settings)
+            .addProperties(config.trackEvent.properties(newValue))
+            .build(),
+        );
       } else if (config.trackEventProperty) {
-        trackEvent({
-          category: MetaMetricsEventCategory.Settings,
-          event: MetaMetricsEventName.SettingsUpdated,
-          properties: {
-            [config.trackEventProperty]: newValue,
-          },
-        });
+        trackEvent(
+          createEventBuilder(MetaMetricsEventName.SettingsUpdated)
+            .addCategory(MetaMetricsEventCategory.Settings)
+            .addProperties({
+              [config.trackEventProperty]: newValue,
+            })
+            .build(),
+        );
       }
 
       const result = config.action(newValue);

--- a/ui/pages/settings/shared/display-nft-media-item.tsx
+++ b/ui/pages/settings/shared/display-nft-media-item.tsx
@@ -1,7 +1,7 @@
-import React, { useContext } from 'react';
+import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { useAnalytics } from '../../../hooks/useAnalytics';
 import { getOpenSeaEnabled, getUseNftDetection } from '../../../selectors';
 import { setOpenSeaEnabled, setUseNftDetection } from '../../../store/actions';
 import {
@@ -14,7 +14,7 @@ import { SettingsToggleItem } from './settings-toggle-item';
 export const DisplayNftMediaToggleItem = () => {
   const t = useI18nContext();
   const dispatch = useDispatch();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const openSeaEnabled = useSelector(getOpenSeaEnabled);
   const useNftDetection = useSelector(getUseNftDetection);
 
@@ -24,15 +24,16 @@ export const DisplayNftMediaToggleItem = () => {
       description={t('displayNftMediaDescriptionV2')}
       value={openSeaEnabled}
       onToggle={(value) => {
-        trackEvent({
-          category: MetaMetricsEventCategory.Settings,
-          event: MetaMetricsEventName.EnabledDisabledOpenSea,
-          properties: {
-            action: MetaMetricsEventName.EnabledDisabledOpenSea,
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            legacy_event: true,
-          },
-        });
+        trackEvent(
+          createEventBuilder(MetaMetricsEventName.EnabledDisabledOpenSea)
+            .addCategory(MetaMetricsEventCategory.Settings)
+            .addProperties({
+              action: MetaMetricsEventName.EnabledDisabledOpenSea,
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              legacy_event: true,
+            })
+            .build(),
+        );
         if (value && useNftDetection) {
           dispatch(setUseNftDetection(false));
         }

--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -97,7 +97,7 @@ export const currentCurrencySelector = (state) =>
 export const conversionRateSelector = (state) =>
   getCurrencyRateControllerCurrencyRates(state)[getProviderConfig(state).ticker]
     ?.conversionRate;
-export const txDataSelector = (state) => state.confirmTransaction.txData;
+export const txDataSelector = (state) => state.confirmTransaction?.txData;
 
 export const transactionFeeSelector = function (state, txData) {
   const currentCurrency = currentCurrencySelector(state);

--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -97,7 +97,7 @@ export const currentCurrencySelector = (state) =>
 export const conversionRateSelector = (state) =>
   getCurrencyRateControllerCurrencyRates(state)[getProviderConfig(state).ticker]
     ?.conversionRate;
-export const txDataSelector = (state) => state.confirmTransaction?.txData;
+export const txDataSelector = (state) => state.confirmTransaction.txData;
 
 export const transactionFeeSelector = function (state, txData) {
   const currentCurrency = currentCurrencySelector(state);


### PR DESCRIPTION
## **Description**

Sub-PR of umbrella tracker [#43885](https://github.com/MetaMask/metamask-extension/pull/43885).

Migrates MetaMetrics `trackEvent` call sites in this CODEOWNERS domain to `createEventBuilder` + `trackEvent` via `useAnalytics()` (UI) or `app/scripts/controllers/analytics` (background).

**Dependency note:** Can merge in parallel with other domain PRs after PR1.

**Files in this PR:** 29

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of analytics migration umbrella: #43885

## **Manual testing steps**

1. Check out this branch and run `yarn start`.
2. Exercise flows in the touched domain (see diff file list).
3. Confirm no console errors and representative events still fire.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide refactor across privacy, security, and passkey flows could subtly change analytics payloads or context (e.g. page title, excludeMetaMetricsId), though product behavior is unchanged.
> 
> **Overview**
> This PR continues the umbrella analytics migration by replacing **`MetaMetricsContext`** `trackEvent` usage across **settings** (about, assets, preferences, privacy, security, developer tools, shared toggles) with **`useAnalytics()`** and the **`createEventBuilder` → `build()`** event shape.
> 
> Call sites now build events with **`addCategory` / `addProperties`** instead of legacy `{ category, event, properties }` objects. Notable behavioral tweaks: **About** contact-us tracking pulls **page title** from **`useSegmentContext`** instead of `contextPropsIntoEventProperties`; **delete MetaMetrics data** success/error events pass **`excludeMetaMetricsId`** via **`build({ excludeMetaMetricsId: true })`** instead of a second `trackEvent` options argument.
> 
> Tests drop **`MetaMetricsContext.Provider`** wrappers and **mock `useAnalytics`** (often with the real **`createEventBuilder`**), asserting the new payload shape (`name`, `properties.category`, `sensitiveProperties`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f70ace8f8186822b228a648b15affac9c5474946. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->