### PR TITLE
refactor(analytics): migrate multichain chrome events

### DIFF
--- a/ui/components/app/toast-master/toast-master.js
+++ b/ui/components/app/toast-master/toast-master.js
@@ -1,6 +1,6 @@
 /* eslint-disable react/prop-types -- TODO: upgrade to TypeScript */
 
-import React, { memo, useContext, useEffect, useState } from 'react';
+import React, { memo, useEffect, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useLocation } from 'react-router-dom';
 import {
@@ -8,6 +8,7 @@ import {
   AvatarNetworkSize,
 } from '@metamask/design-system-react';
 import { PRODUCT_TYPES } from '@metamask/subscription-controller';
+import { useAnalytics } from '../../../hooks/useAnalytics';
 import { SECOND } from '../../../../shared/constants/time';
 import { ENVIRONMENT_TYPE_SIDEPANEL } from '../../../../shared/constants/app';
 import { getEnvironmentType } from '../../../../shared/lib/environment-type';
@@ -55,7 +56,6 @@ import {
   isCryptoPaymentMethod,
 } from '../../../pages/shield/transaction-shield/types';
 import { useSubscriptionMetrics } from '../../../hooks/shield/metrics/useSubscriptionMetrics';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
@@ -409,7 +409,7 @@ function ShieldEndingToast() {
 function StorageErrorToast() {
   const t = useI18nContext();
   const navigate = useNavigate();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const [isDismissed, setIsDismissed] = useState(false);
   const [hasTrackedView, setHasTrackedView] = useState(false);
 
@@ -430,28 +430,33 @@ function StorageErrorToast() {
   // Track "Viewed" event when toast becomes visible
   useEffect(() => {
     if (shouldShow && !hasTrackedView) {
-      trackEvent({
-        event: MetaMetricsEventName.StorageErrorToastViewed,
-        category: MetaMetricsEventCategory.Error,
-      });
+      trackEvent(
+        createEventBuilder(MetaMetricsEventName.StorageErrorToastViewed)
+          .addCategory(MetaMetricsEventCategory.Error)
+          .build(),
+      );
       setHasTrackedView(true);
     }
   }, [shouldShow, hasTrackedView, trackEvent]);
 
   const handleRevealSrpClick = () => {
-    trackEvent({
-      event: MetaMetricsEventName.StorageErrorToastBackupSrpButtonPressed,
-      category: MetaMetricsEventCategory.Error,
-    });
+    trackEvent(
+      createEventBuilder(
+        MetaMetricsEventName.StorageErrorToastBackupSrpButtonPressed,
+      )
+        .addCategory(MetaMetricsEventCategory.Error)
+        .build(),
+    );
     setIsDismissed(true);
     navigate(REVEAL_SEED_ROUTE, { state: { skipQuiz: true } });
   };
 
   const handleClose = () => {
-    trackEvent({
-      event: MetaMetricsEventName.StorageErrorToastDismissed,
-      category: MetaMetricsEventCategory.Error,
-    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.StorageErrorToastDismissed)
+        .addCategory(MetaMetricsEventCategory.Error)
+        .build(),
+    );
     setIsDismissed(true);
   };
 

--- a/ui/components/app/toast-master/toast-master.js
+++ b/ui/components/app/toast-master/toast-master.js
@@ -437,7 +437,7 @@ function StorageErrorToast() {
       );
       setHasTrackedView(true);
     }
-  }, [shouldShow, hasTrackedView, trackEvent]);
+  }, [shouldShow, hasTrackedView, trackEvent, createEventBuilder]);
 
   const handleRevealSrpClick = () => {
     trackEvent(


### PR DESCRIPTION
## **Description**

Sub-PR of umbrella tracker [#43885](https://github.com/MetaMask/metamask-extension/pull/43885).

Migrates MetaMetrics `trackEvent` call sites in this CODEOWNERS domain to `createEventBuilder` + `trackEvent` via `useAnalytics()` (UI) or `app/scripts/controllers/analytics` (background).

**Dependency note:** Can merge in parallel with other domain PRs after PR1.

**Files in this PR:** 59

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of analytics migration umbrella: #43885

## **Manual testing steps**

1. Check out this branch and run `yarn start`.
2. Exercise flows in the touched domain (see diff file list).
3. Confirm no console errors and representative events still fire.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics instrumentation only; event names and categories are unchanged, with no user-facing or storage behavior changes.
> 
> **Overview**
> **Storage error toast** analytics in `toast-master.js` now go through `useAnalytics()` instead of `MetaMetricsContext`.
> 
> View, backup-SRP, and dismiss events are built with `createEventBuilder(...).addCategory(...).build()` before `trackEvent`, matching the broader MetaMetrics migration. The `useContext` import was dropped in favor of the analytics hook, and the view-tracking `useEffect` dependency list includes `createEventBuilder`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d31456a54c7254fd6a511ddd9a44e095f7d115d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->