### PR TITLE
fix(rewards): refetch VIP tier once subscription hydrates on cold start

### DIFF
--- a/ui/hooks/rewards/useVipTier.test.ts
+++ b/ui/hooks/rewards/useVipTier.test.ts
@@ -1,4 +1,4 @@
-import { waitFor } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
 import { renderHookWithProvider } from '../../../test/lib/render-helpers-navigate';
 import { setBackgroundConnection } from '../../store/background-connection';
 import { useVipTier } from './useVipTier';
@@ -216,5 +216,41 @@ describe('useVipTier', () => {
 
     expect(result.current).toBeNull();
     expect(mockGetVipTierForAccount).not.toHaveBeenCalled();
+  });
+
+  it('refetches the VIP tier once the rewards subscription hydrates (cold-start race)', async () => {
+    // Cold start: subscription state is not hydrated yet, so the controller
+    // resolves no subscription and the background returns null (no /vip/fees).
+    mockGetVipTierForAccount.mockResolvedValueOnce(null);
+
+    const { result, store } = renderHookWithProvider(
+      () => useVipTier(),
+      stateWithAccount,
+    );
+
+    await waitFor(() => {
+      expect(mockGetVipTierForAccount).toHaveBeenCalledTimes(1);
+    });
+    expect(result.current).toBeNull();
+
+    // Silent auth completes and populates the active rewards subscription id.
+    // The query is keyed on it, so this triggers a refetch that now resolves.
+    mockGetVipTierForAccount.mockResolvedValueOnce(5);
+    act(() => {
+      store.dispatch({
+        type: 'UPDATE_METAMASK_STATE',
+        value: {
+          rewardsActiveAccount: {
+            account: 'eip155:1:0xabc123',
+            subscriptionId: 'sub-1',
+          },
+        },
+      });
+    });
+
+    await waitFor(() => {
+      expect(result.current).toBe(5);
+    });
+    expect(mockGetVipTierForAccount).toHaveBeenCalledTimes(2);
   });
 });

--- a/ui/hooks/rewards/useVipTier.ts
+++ b/ui/hooks/rewards/useVipTier.ts
@@ -10,6 +10,7 @@ import log from 'loglevel';
 import { submitRequestToBackground } from '../../store/background-connection';
 import { getSelectedInternalAccount } from '../../../shared/lib/selectors/accounts';
 import { selectVipProgramEnabled } from '../../ducks/rewards/selectors';
+import { useAppSelector } from '../../store/store';
 
 /**
  * Derives the selected account's CAIP-10 ID and fetches its VIP tier from the
@@ -24,9 +25,19 @@ import { selectVipProgramEnabled } from '../../ducks/rewards/selectors';
 export function useVipTier(): number | null {
   const isVipProgramEnabled = useSelector(selectVipProgramEnabled);
   const accountId = useVipTierAccountId();
+  // The active rewards subscription id is populated asynchronously by the
+  // controller's silent auth (after keyring unlock / account changes). Keying
+  // the query on it ensures the cached cold-start `null` (returned while the
+  // subscription state is still unhydrated, before any `/vip/fees` call) is
+  // invalidated and the tier is refetched once the subscription becomes
+  // available — otherwise the badge stays hidden until a full reset.
+  const rewardsSubscriptionId = useAppSelector(
+    (state) => state.metamask.rewardsActiveAccount?.subscriptionId ?? null,
+  );
 
   const { data } = useRewardsVipTierQuery(
     isVipProgramEnabled ? accountId : null,
+    rewardsSubscriptionId,
   );
 
   return data ?? null;
@@ -49,9 +60,12 @@ function useVipTierAccountId() {
   }, [selectedAccount?.address, selectedAccount?.scopes]);
 }
 
-function useRewardsVipTierQuery(accountId: string | null) {
+function useRewardsVipTierQuery(
+  accountId: string | null,
+  subscriptionId: string | null,
+) {
   return useQuery({
-    queryKey: ['rewardsVipTier', accountId],
+    queryKey: ['rewardsVipTier', accountId, subscriptionId],
     queryFn: async () => {
       const tier = await submitRequestToBackground<number | null>(
         'rewardsGetVipTierForAccount',


### PR DESCRIPTION
## **Description**

**What is the reason for the change?**

QA (Rewards VIP pilot, #mm-trade-vip-program thread, 2026-06-25) reported that on a **fresh install** of the extension (13.36 prod and 13.37 RC), the VIP tier **badge does not render** next to the discounted swap/perps/bridge fee for a VIP account — even though the **fee discount itself is correctly applied** (the bridge API requests the discounted fee tiers server-side, independent of the client). After a wallet **reset** (or reopening later), the badge shows up correctly. The same account is a real tier‑5 VIP.

The badge is driven by the client's own VIP tier lookup (`useVipTier` → background `rewardsGetVipTierForAccount` → `RewardsController.getVipTierForAccount` → `GET /vip/fees`). On a fresh install, **no `/vip/fees` call is made at all**.

**Root cause (cold-start race + cached `null`):**

- `RewardsController.getVipTierForAccount` short-circuits to `null` **before** any network call when the per-account rewards state isn't hydrated yet: it needs the account's `subscriptionId` (and the subscription record in state), which are populated **asynchronously** by silent auth (triggered on `KeyringController:unlock` / account-group change). Its own code comment notes this is intended so "the caller can retry once the subscription is loaded."
- The caller never retries. `useVipTier` uses a React Query keyed only on the account id (`['rewardsVipTier', accountId]`). The cold-start `null` is cached, and **nothing invalidates it** when the subscription state later hydrates — there is no `invalidateQueries(['rewardsVipTier'])` anywhere. So the badge stays hidden for the whole session.
- A **reset/reopen fixes it** because `rewardsAccounts` / `rewardsSubscriptions` / `rewardsSubscriptionTokens` / `rewardsActiveAccount` are all persisted (`persist: true`); they rehydrate from disk at boot, so the very first `getVipTierForAccount` already resolves the subscription and fires `/vip/fees`.

**What is the improvement/solution?**

Add the active rewards subscription id (`state.metamask.rewardsActiveAccount?.subscriptionId`, already mirrored to the UI and consumed by other hooks) to the React Query key:

`['rewardsVipTier', accountId, subscriptionId]`

When silent auth completes and the subscription id flips `null → real`, the query key changes and React Query refetches automatically. The controller now resolves the subscription, calls `/vip/fees`, and the badge appears — no reset required. The change is client-only and minimal (no controller changes).

**Not a 13.37 regression:** this gap has existed since the VIP badge shipped in #42782 (13.33.0), unchanged by #42861 (flag gate) and #43874 (non-EVM CAIP fix). It can ride normally, but can be cherry-picked into the 13.37 RC if QA wants the cold-start UX fixed there.

## **Changelog**

CHANGELOG entry: Fixed the VIP tier badge not appearing on swap/perps/bridge fees on a fresh install until the wallet was reset.

## **Related issues**

Refs: N/A

## **Manual testing steps**

1. On a **fresh install** (no persisted rewards state), onboard/import a wallet whose selected account is an active VIP (tier ≥ 1).
2. Open a swap/perps/bridge quote surface that shows the MetaMask fee.
3. **Before this change:** the discounted fee is shown, but the VIP badge is missing; it only appears after a wallet reset / reopen.
4. **After this change:** once silent auth completes (shortly after unlock), the VIP badge appears next to the discounted fee without any reset.

## **Screenshots/Recordings**

N/A — no new UI; this restores the existing badge's visibility on cold start. Behavior is covered by a new unit test (`useVipTier` refetches the tier once the subscription hydrates).

### **Before**

<!-- VIP badge absent on fresh install until reset -->

### **After**

<!-- VIP badge appears once silent auth populates the subscription -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small client-only change to a rewards display hook and its query cache key, with no controller or auth changes.
> 
> **Overview**
> Fixes the **VIP tier badge** staying hidden on a fresh install when fee discounts already apply, by refetching tier data after rewards silent auth completes.
> 
> `useVipTier` now reads `rewardsActiveAccount.subscriptionId` and includes it in the React Query key (`['rewardsVipTier', accountId, subscriptionId]`). On cold start the first lookup can cache `null` while subscription state is still empty; when the id later hydrates, the key change triggers an automatic refetch so `/vip/fees` runs and the badge can render without a wallet reset.
> 
> A unit test covers the `null` → subscription id → second fetch → tier value path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec56040b06d76a699a42a6299ab691a258a641af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->