### PR TITLE
refactor(analytics): migrate token management assets events

### DIFF
--- a/ui/pages/custom-token-import/custom-token-import.test.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.test.tsx
@@ -14,6 +14,7 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../shared/constants/metametrics';
+import { setBackgroundConnection } from '../../store/background-connection';
 import { AssetType } from '../../../shared/constants/transaction';
 import {
   CustomTokenImportPage,
@@ -30,6 +31,23 @@ const METRICS_PROPERTIES = {
   tokenSymbol: 'token_symbol',
   viewState: 'view_state',
 } as const;
+
+jest.mock('../../hooks/useSegmentContext', () => ({
+  useSegmentContext: jest.fn(() => ({})),
+}));
+
+const trackAnalyticsEventMock = jest.fn().mockResolvedValue(undefined);
+const backgroundConnectionMock = new Proxy(
+  {
+    trackAnalyticsEvent: trackAnalyticsEventMock,
+  },
+  {
+    get: (target, prop) =>
+      prop in target
+        ? target[prop as keyof typeof target]
+        : jest.fn().mockResolvedValue(undefined),
+  },
+);
 
 const mockNavigate = jest.fn();
 
@@ -157,6 +175,7 @@ describe('mergeCustomTokenMetadataForImport', () => {
 
 describe('CustomTokenImportPage', () => {
   beforeEach(() => {
+    setBackgroundConnection(backgroundConnectionMock as never);
     mockNavigate.mockClear();
     const actions = getMockedActions();
     actions.addImportedTokens.mockClear();
@@ -174,6 +193,9 @@ describe('CustomTokenImportPage', () => {
     ...mockState,
     metamask: {
       ...mockState.metamask,
+      analyticsId: 'test-analytics-id',
+      completedMetaMetricsOnboarding: true,
+      optedIn: true,
       selectedNetworkClientId: 'mainnet',
       selectedMultichainNetworkChainId: 'eip155:1',
       networkConfigurationsByChainId: {
@@ -195,10 +217,7 @@ describe('CustomTokenImportPage', () => {
     },
   });
 
-  const renderPage = (
-    trackEvent = jest.fn(),
-    metamaskOverrides: Record<string, unknown> = {},
-  ) => {
+  const renderPage = (metamaskOverrides: Record<string, unknown> = {}) => {
     const store = configureStore(buildState(metamaskOverrides));
     return {
       store,
@@ -206,8 +225,6 @@ describe('CustomTokenImportPage', () => {
         <CustomTokenImportPage />,
         store,
         CUSTOM_TOKEN_IMPORT_ROUTE,
-        undefined,
-        () => trackEvent,
       ),
     };
   };
@@ -215,8 +232,7 @@ describe('CustomTokenImportPage', () => {
   const submitCustomToken = async (
     metamaskOverrides: Record<string, unknown> = {},
   ) => {
-    const trackEvent = jest.fn();
-    const rendered = renderPage(trackEvent, metamaskOverrides);
+    const rendered = renderPage(metamaskOverrides);
 
     fireEvent.change(screen.getByTestId('custom-token-import-address-input'), {
       target: { value: '0x1111111111111111111111111111111111111111' },
@@ -231,7 +247,7 @@ describe('CustomTokenImportPage', () => {
 
     fireEvent.click(screen.getByTestId('custom-token-import-submit-button'));
 
-    return { trackEvent, ...rendered };
+    return { ...rendered };
   };
 
   it('renders the form scaffolding without crashing', () => {
@@ -251,17 +267,22 @@ describe('CustomTokenImportPage', () => {
   });
 
   it('tracks the custom token import default view state on page open', async () => {
-    const trackEvent = jest.fn();
-    renderPage(trackEvent);
+    renderPage();
 
     await waitFor(() =>
-      expect(trackEvent).toHaveBeenCalledWith({
-        category: MetaMetricsEventCategory.Wallet,
-        event: MetaMetricsEventName.ImportCustomTokenViewed,
-        properties: {
-          [METRICS_PROPERTIES.viewState]: 'default',
-        },
-      }),
+      expect(trackAnalyticsEventMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: MetaMetricsEventName.ImportCustomTokenViewed,
+          properties: {
+            category: MetaMetricsEventCategory.Wallet,
+            [METRICS_PROPERTIES.viewState]: 'default',
+          },
+          sensitiveProperties: {},
+        }),
+        expect.objectContaining({
+          environmentType: expect.any(String),
+        }),
+      ),
     );
   });
 
@@ -327,7 +348,7 @@ describe('CustomTokenImportPage', () => {
 
   it('returns to token management with success toast state after submitting a custom token', async () => {
     const actions = getMockedActions();
-    const { trackEvent } = await submitCustomToken();
+    await submitCustomToken();
 
     await waitFor(() =>
       expect(actions.addImportedTokens).toHaveBeenCalledWith(
@@ -353,20 +374,27 @@ describe('CustomTokenImportPage', () => {
       }),
     );
     await waitFor(() =>
-      expect(trackEvent).toHaveBeenCalledWith({
-        category: MetaMetricsEventCategory.Wallet,
-        event: MetaMetricsEventName.ImportCustomTokenInteracted,
-        sensitiveProperties: {
-          [METRICS_PROPERTIES.addedToken]: 1,
-          [METRICS_PROPERTIES.assetType]: AssetType.token,
-          [METRICS_PROPERTIES.chainId]: '0x1',
-          [METRICS_PROPERTIES.clickedSecurityLink]: false,
-          [METRICS_PROPERTIES.tokenContractAddress]:
-            '0x1111111111111111111111111111111111111111',
-          [METRICS_PROPERTIES.tokenStandard]: 'ERC20',
-          [METRICS_PROPERTIES.tokenSymbol]: 'APE',
-        },
-      }),
+      expect(trackAnalyticsEventMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: MetaMetricsEventName.ImportCustomTokenInteracted,
+          properties: {
+            category: MetaMetricsEventCategory.Wallet,
+          },
+          sensitiveProperties: {
+            [METRICS_PROPERTIES.addedToken]: 1,
+            [METRICS_PROPERTIES.assetType]: AssetType.token,
+            [METRICS_PROPERTIES.chainId]: '0x1',
+            [METRICS_PROPERTIES.clickedSecurityLink]: false,
+            [METRICS_PROPERTIES.tokenContractAddress]:
+              '0x1111111111111111111111111111111111111111',
+            [METRICS_PROPERTIES.tokenStandard]: 'ERC20',
+            [METRICS_PROPERTIES.tokenSymbol]: 'APE',
+          },
+        }),
+        expect.objectContaining({
+          environmentType: expect.any(String),
+        }),
+      ),
     );
   });
 
@@ -460,7 +488,7 @@ describe('CustomTokenImportPage', () => {
       const assetId = `eip155:1/erc20:${tokenAddress}`;
       const accountId = 'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3';
 
-      renderPage(jest.fn(), {
+      renderPage({
         remoteFeatureFlags: ASSETS_UNIFY_STATE_FLAG_ON,
         // Simulate state after the user hid the token from the manage tokens
         // list when assets-unify-state is on: the token remains in
@@ -518,7 +546,7 @@ describe('CustomTokenImportPage', () => {
     const assetId = `eip155:1/erc20:${tokenAddress}`;
     const accountId = 'cf8dace4-9439-4bd4-b3a8-88c821c8fcb3';
 
-    renderPage(jest.fn(), {
+    renderPage({
       remoteFeatureFlags: ASSETS_UNIFY_STATE_FLAG_ON,
       // Token is present in `customAssets` but NOT hidden: the unified
       // selector should still return it, so the "already added" guard

--- a/ui/pages/custom-token-import/custom-token-import.test.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.test.tsx
@@ -175,6 +175,7 @@ describe('mergeCustomTokenMetadataForImport', () => {
 
 describe('CustomTokenImportPage', () => {
   beforeEach(() => {
+    trackAnalyticsEventMock.mockClear();
     setBackgroundConnection(backgroundConnectionMock as never);
     mockNavigate.mockClear();
     const actions = getMockedActions();

--- a/ui/pages/custom-token-import/custom-token-import.test.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.test.tsx
@@ -279,9 +279,7 @@ describe('CustomTokenImportPage', () => {
           },
           sensitiveProperties: {},
         }),
-        expect.objectContaining({
-          environmentType: expect.any(String),
-        }),
+        expect.anything(),
       ),
     );
   });
@@ -391,9 +389,7 @@ describe('CustomTokenImportPage', () => {
             [METRICS_PROPERTIES.tokenSymbol]: 'APE',
           },
         }),
-        expect.objectContaining({
-          environmentType: expect.any(String),
-        }),
+        expect.anything(),
       ),
     );
   });

--- a/ui/pages/custom-token-import/custom-token-import.tsx
+++ b/ui/pages/custom-token-import/custom-token-import.tsx
@@ -1,6 +1,5 @@
 import React, {
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -56,7 +55,7 @@ import {
   MetaMetricsEventName,
 } from '../../../shared/constants/metametrics';
 import { AssetType } from '../../../shared/constants/transaction';
-import { MetaMetricsContext } from '../../contexts/metametrics';
+import { useAnalytics } from '../../hooks/useAnalytics';
 import { type CustomTokenImportNetworkOption } from './custom-token-import-network-selector';
 import { CustomTokenImportForm } from './custom-token-import-form';
 
@@ -122,7 +121,7 @@ export const CustomTokenImportPage = () => {
   const t = useI18nContext();
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
 
   const currentChainId = useSelector(getCurrentChainId) as Hex;
   const networkConfigurations = useSelector(getNetworkConfigurationsByChainId);
@@ -239,15 +238,16 @@ export const CustomTokenImportPage = () => {
 
   const trackViewed = useCallback(
     (viewState: string) => {
-      trackEvent({
-        category: MetaMetricsEventCategory.Wallet,
-        event: MetaMetricsEventName.ImportCustomTokenViewed,
-        properties: {
-          [METRICS_PROPERTIES.viewState]: viewState,
-        },
-      });
+      trackEvent(
+        createEventBuilder(MetaMetricsEventName.ImportCustomTokenViewed)
+          .addCategory(MetaMetricsEventCategory.Wallet)
+          .addProperties({
+            [METRICS_PROPERTIES.viewState]: viewState,
+          })
+          .build(),
+      );
     },
-    [trackEvent],
+    [createEventBuilder, trackEvent],
   );
 
   useEffect(() => {
@@ -464,22 +464,23 @@ export const CustomTokenImportPage = () => {
 
   const trackSubmitAttempt = useCallback(
     (addedToken: 0 | 1) => {
-      trackEvent({
-        category: MetaMetricsEventCategory.Wallet,
-        event: MetaMetricsEventName.ImportCustomTokenInteracted,
-        sensitiveProperties: {
-          [METRICS_PROPERTIES.addedToken]: addedToken,
-          [METRICS_PROPERTIES.tokenSymbol]: symbol,
-          [METRICS_PROPERTIES.tokenContractAddress]: address,
-          [METRICS_PROPERTIES.chainId]: selectedNetwork,
-          [METRICS_PROPERTIES.clickedSecurityLink]:
-            clickedSecurityLinkRef.current,
-          [METRICS_PROPERTIES.assetType]: AssetType.token,
-          [METRICS_PROPERTIES.tokenStandard]: ERC20,
-        },
-      });
+      trackEvent(
+        createEventBuilder(MetaMetricsEventName.ImportCustomTokenInteracted)
+          .addCategory(MetaMetricsEventCategory.Wallet)
+          .addSensitiveProperties({
+            [METRICS_PROPERTIES.addedToken]: addedToken,
+            [METRICS_PROPERTIES.tokenSymbol]: symbol,
+            [METRICS_PROPERTIES.tokenContractAddress]: address,
+            [METRICS_PROPERTIES.chainId]: selectedNetwork,
+            [METRICS_PROPERTIES.clickedSecurityLink]:
+              clickedSecurityLinkRef.current,
+            [METRICS_PROPERTIES.assetType]: AssetType.token,
+            [METRICS_PROPERTIES.tokenStandard]: ERC20,
+          })
+          .build(),
+      );
     },
-    [address, selectedNetwork, symbol, trackEvent],
+    [address, createEventBuilder, selectedNetwork, symbol, trackEvent],
   );
 
   const handleSubmit = useCallback(async () => {

--- a/ui/pages/token-management/token-management.test.tsx
+++ b/ui/pages/token-management/token-management.test.tsx
@@ -270,6 +270,7 @@ describe('TokenManagementPage', () => {
   beforeEach(() => {
     mockTokenManagementLocationState.current = null;
     mockUseNavigate.mockClear();
+    trackAnalyticsEventMock.mockClear();
     setBackgroundConnection(backgroundConnectionMock as never);
     resetTokenSearchState();
     const actions = getMockedActions();

--- a/ui/pages/token-management/token-management.test.tsx
+++ b/ui/pages/token-management/token-management.test.tsx
@@ -406,9 +406,7 @@ describe('TokenManagementPage', () => {
           },
           sensitiveProperties: {},
         }),
-        expect.objectContaining({
-          environmentType: expect.any(String),
-        }),
+        expect.anything(),
       ),
     );
   });
@@ -433,9 +431,7 @@ describe('TokenManagementPage', () => {
           },
           sensitiveProperties: {},
         }),
-        expect.objectContaining({
-          environmentType: expect.any(String),
-        }),
+        expect.anything(),
       ),
     );
   });
@@ -463,9 +459,7 @@ describe('TokenManagementPage', () => {
         },
         sensitiveProperties: {},
       }),
-      expect.objectContaining({
-        environmentType: expect.any(String),
-      }),
+      expect.anything(),
     );
   });
 
@@ -1026,9 +1020,7 @@ describe('TokenManagementPage', () => {
           [METRICS_PROPERTIES.tokenSymbol]: mainnetToken.symbol,
         }),
       }),
-      expect.objectContaining({
-        environmentType: expect.any(String),
-      }),
+      expect.anything(),
     );
 
     unmount();

--- a/ui/pages/token-management/token-management.test.tsx
+++ b/ui/pages/token-management/token-management.test.tsx
@@ -15,6 +15,7 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../shared/constants/metametrics';
+import { setBackgroundConnection } from '../../store/background-connection';
 import { AssetType } from '../../../shared/constants/transaction';
 import { TokenManagementPage } from './token-management';
 
@@ -27,6 +28,23 @@ const METRICS_PROPERTIES = {
   tokenSymbol: 'token_symbol',
   viewState: 'view_state',
 } as const;
+
+jest.mock('../../hooks/useSegmentContext', () => ({
+  useSegmentContext: jest.fn(() => ({})),
+}));
+
+const trackAnalyticsEventMock = jest.fn().mockResolvedValue(undefined);
+const backgroundConnectionMock = new Proxy(
+  {
+    trackAnalyticsEvent: trackAnalyticsEventMock,
+  },
+  {
+    get: (target, prop) =>
+      prop in target
+        ? target[prop as keyof typeof target]
+        : jest.fn().mockResolvedValue(undefined),
+  },
+);
 
 const mockTokenManagementLocationState = {
   current: null as unknown,
@@ -252,6 +270,7 @@ describe('TokenManagementPage', () => {
   beforeEach(() => {
     mockTokenManagementLocationState.current = null;
     mockUseNavigate.mockClear();
+    setBackgroundConnection(backgroundConnectionMock as never);
     resetTokenSearchState();
     const actions = getMockedActions();
     actions.addCustomAsset.mockClear();
@@ -294,6 +313,9 @@ describe('TokenManagementPage', () => {
     ...mockState,
     metamask: {
       ...mockState.metamask,
+      analyticsId: 'test-analytics-id',
+      completedMetaMetricsOnboarding: true,
+      optedIn: true,
       selectedMultichainNetworkChainId,
       useExternalServices: true,
       preferences: {
@@ -336,11 +358,7 @@ describe('TokenManagementPage', () => {
     },
   });
 
-  const renderPage = (
-    state = createState(),
-    routeState?: unknown,
-    trackEvent = jest.fn(),
-  ) => {
+  const renderPage = (state = createState(), routeState?: unknown) => {
     mockTokenManagementLocationState.current = routeState ?? null;
     const store = configureStore({
       ...state,
@@ -351,8 +369,6 @@ describe('TokenManagementPage', () => {
         <TokenManagementPage />,
         store,
         TOKEN_MANAGEMENT_ROUTE,
-        undefined,
-        () => trackEvent,
       ),
     };
   };
@@ -377,48 +393,55 @@ describe('TokenManagementPage', () => {
   });
 
   it('tracks the manage tokens screen opening with the default view state', async () => {
-    const trackEvent = jest.fn();
-    renderPage(createState(), undefined, trackEvent);
+    renderPage(createState());
 
     await waitFor(() =>
-      expect(trackEvent).toHaveBeenCalledWith({
-        category: MetaMetricsEventCategory.Home,
-        event: MetaMetricsEventName.TokenScreenOpened,
-        properties: {
-          screen: 'manage_tokens',
-          [METRICS_PROPERTIES.viewState]: 'default',
-        },
-      }),
+      expect(trackAnalyticsEventMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: MetaMetricsEventName.TokenScreenOpened,
+          properties: {
+            category: MetaMetricsEventCategory.Home,
+            screen: 'manage_tokens',
+            [METRICS_PROPERTIES.viewState]: 'default',
+          },
+          sensitiveProperties: {},
+        }),
+        expect.objectContaining({
+          environmentType: expect.any(String),
+        }),
+      ),
     );
   });
 
   it('tracks the manage tokens screen opening with the no-results view state', async () => {
-    const trackEvent = jest.fn();
     renderPage(
       createState({
         accountGroupAssets: {
           '0x1': [],
         },
       }),
-      undefined,
-      trackEvent,
     );
 
     await waitFor(() =>
-      expect(trackEvent).toHaveBeenCalledWith({
-        category: MetaMetricsEventCategory.Home,
-        event: MetaMetricsEventName.TokenScreenOpened,
-        properties: {
-          screen: 'manage_tokens',
-          [METRICS_PROPERTIES.viewState]: 'no_results',
-        },
-      }),
+      expect(trackAnalyticsEventMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: MetaMetricsEventName.TokenScreenOpened,
+          properties: {
+            category: MetaMetricsEventCategory.Home,
+            screen: 'manage_tokens',
+            [METRICS_PROPERTIES.viewState]: 'no_results',
+          },
+          sensitiveProperties: {},
+        }),
+        expect.objectContaining({
+          environmentType: expect.any(String),
+        }),
+      ),
     );
   });
 
   it('navigates to the custom token import page from the sticky add custom token button', () => {
-    const trackEvent = jest.fn();
-    const { store } = renderPage(createState(), undefined, trackEvent);
+    const { store } = renderPage(createState());
 
     const addCustomTokenButton = screen.getByTestId(
       'token-management-add-custom-token-button',
@@ -431,13 +454,19 @@ describe('TokenManagementPage', () => {
 
     expect(store.getState().appState.importTokensModalOpen).toBeFalsy();
     expect(CUSTOM_TOKEN_IMPORT_ROUTE).toBe('/custom-token-import');
-    expect(trackEvent).toHaveBeenCalledWith({
-      category: MetaMetricsEventCategory.Navigation,
-      event: MetaMetricsEventName.TokenImportButtonClicked,
-      properties: {
-        location: 'MANAGE_TOKENS_CUSTOM_CTA',
-      },
-    });
+    expect(trackAnalyticsEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: MetaMetricsEventName.TokenImportButtonClicked,
+        properties: {
+          category: MetaMetricsEventCategory.Navigation,
+          location: 'MANAGE_TOKENS_CUSTOM_CTA',
+        },
+        sensitiveProperties: {},
+      }),
+      expect.objectContaining({
+        environmentType: expect.any(String),
+      }),
+    );
   });
 
   it('shows and dismisses the custom token success toast from route state', async () => {
@@ -969,9 +998,8 @@ describe('TokenManagementPage', () => {
 
   it('toggling OFF an EVM token defers the hide and keeps the row visible until unmount', async () => {
     const actions = getMockedActions();
-    const trackEvent = jest.fn();
 
-    const { unmount } = renderPage(createState(), undefined, trackEvent);
+    const { unmount } = renderPage(createState());
 
     const toggle = screen.getByTestId(
       `token-management-cell-0x1:${mainnetToken.address}-toggle`,
@@ -982,19 +1010,26 @@ describe('TokenManagementPage', () => {
     expect(toggle.value).toBe('false');
     expect(actions.ignoreTokens).not.toHaveBeenCalled();
     expect(actions.hideAsset).not.toHaveBeenCalled();
-    expect(trackEvent).toHaveBeenCalledWith({
-      category: MetaMetricsEventCategory.Wallet,
-      event: MetaMetricsEventName.TokenHidden,
-      sensitiveProperties: expect.objectContaining({
-        [METRICS_PROPERTIES.assetType]: AssetType.token,
-        [METRICS_PROPERTIES.chainId]: '0x1',
-        location: 'MANAGE_TOKENS',
-        [METRICS_PROPERTIES.tokenContractAddress]: mainnetToken.address,
-        [METRICS_PROPERTIES.tokenDecimalPrecision]: mainnetToken.decimals,
-        [METRICS_PROPERTIES.tokenStandard]: 'ERC20',
-        [METRICS_PROPERTIES.tokenSymbol]: mainnetToken.symbol,
+    expect(trackAnalyticsEventMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: MetaMetricsEventName.TokenHidden,
+        properties: {
+          category: MetaMetricsEventCategory.Wallet,
+        },
+        sensitiveProperties: expect.objectContaining({
+          [METRICS_PROPERTIES.assetType]: AssetType.token,
+          [METRICS_PROPERTIES.chainId]: '0x1',
+          location: 'MANAGE_TOKENS',
+          [METRICS_PROPERTIES.tokenContractAddress]: mainnetToken.address,
+          [METRICS_PROPERTIES.tokenDecimalPrecision]: mainnetToken.decimals,
+          [METRICS_PROPERTIES.tokenStandard]: 'ERC20',
+          [METRICS_PROPERTIES.tokenSymbol]: mainnetToken.symbol,
+        }),
       }),
-    });
+      expect.objectContaining({
+        environmentType: expect.any(String),
+      }),
+    );
 
     unmount();
 

--- a/ui/pages/token-management/token-management.tsx
+++ b/ui/pages/token-management/token-management.tsx
@@ -1,6 +1,5 @@
 import React, {
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useRef,
@@ -99,7 +98,7 @@ import {
   TextFieldSearch,
   TextFieldSearchSize,
 } from '../../components/component-library';
-import { MetaMetricsContext } from '../../contexts/metametrics';
+import { useAnalytics } from '../../hooks/useAnalytics';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
@@ -345,7 +344,7 @@ export const TokenManagementPage = () => {
   const dispatch = useDispatch();
   const navigate = useNavigate();
   const location = useLocation();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
 
   const [searchQuery, setSearchQuery] = useState('');
   const [pageToast, setPageToast] = useState<{ symbol: string } | null>(null);
@@ -764,15 +763,16 @@ export const TokenManagementPage = () => {
 
   const handleAddCustomToken = useCallback(() => {
     commitStagedHides().catch(() => undefined);
-    trackEvent({
-      category: MetaMetricsEventCategory.Navigation,
-      event: MetaMetricsEventName.TokenImportButtonClicked,
-      properties: {
-        location: TOKEN_MANAGEMENT_CUSTOM_CTA_LOCATION,
-      },
-    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.TokenImportButtonClicked)
+        .addCategory(MetaMetricsEventCategory.Navigation)
+        .addProperties({
+          location: TOKEN_MANAGEMENT_CUSTOM_CTA_LOCATION,
+        })
+        .build(),
+    );
     navigate(CUSTOM_TOKEN_IMPORT_ROUTE);
-  }, [commitStagedHides, navigate, trackEvent]);
+  }, [commitStagedHides, createEventBuilder, navigate, trackEvent]);
 
   const handleSearchChange = useCallback(
     (event: React.ChangeEvent<HTMLInputElement>) => {
@@ -900,15 +900,16 @@ export const TokenManagementPage = () => {
 
       if (nextValue) {
         unstageHide(stagedKey);
-        trackEvent({
-          category: MetaMetricsEventCategory.Wallet,
-          event: MetaMetricsEventName.TokenAdded,
-          sensitiveProperties: {
-            ...tokenMetricsProperties,
-            [METRICS_PROPERTIES.sourceConnectionMethod]:
-              MetaMetricsTokenEventSource.ManageTokens,
-          },
-        });
+        trackEvent(
+          createEventBuilder(MetaMetricsEventName.TokenAdded)
+            .addCategory(MetaMetricsEventCategory.Wallet)
+            .addSensitiveProperties({
+              ...tokenMetricsProperties,
+              [METRICS_PROPERTIES.sourceConnectionMethod]:
+                MetaMetricsTokenEventSource.ManageTokens,
+            })
+            .build(),
+        );
         return;
       }
 
@@ -927,14 +928,15 @@ export const TokenManagementPage = () => {
           address: token.address,
           caipAssetId: caipAssetId ?? undefined,
         });
-        trackEvent({
-          category: MetaMetricsEventCategory.Wallet,
-          event: MetaMetricsEventName.TokenHidden,
-          sensitiveProperties: {
-            ...tokenMetricsProperties,
-            location: TOKEN_MANAGEMENT_LOCATION,
-          },
-        });
+        trackEvent(
+          createEventBuilder(MetaMetricsEventName.TokenHidden)
+            .addCategory(MetaMetricsEventCategory.Wallet)
+            .addSensitiveProperties({
+              ...tokenMetricsProperties,
+              location: TOKEN_MANAGEMENT_LOCATION,
+            })
+            .build(),
+        );
         return;
       }
 
@@ -943,16 +945,24 @@ export const TokenManagementPage = () => {
         assetId: token.assetId as CaipAssetType,
         accountId: token.accountId,
       });
-      trackEvent({
-        category: MetaMetricsEventCategory.Wallet,
-        event: MetaMetricsEventName.TokenHidden,
-        sensitiveProperties: {
-          ...tokenMetricsProperties,
-          location: TOKEN_MANAGEMENT_LOCATION,
-        },
-      });
+      trackEvent(
+        createEventBuilder(MetaMetricsEventName.TokenHidden)
+          .addCategory(MetaMetricsEventCategory.Wallet)
+          .addSensitiveProperties({
+            ...tokenMetricsProperties,
+            location: TOKEN_MANAGEMENT_LOCATION,
+          })
+          .build(),
+      );
     },
-    [getNetworkMeta, getStagedHideKey, stageHide, trackEvent, unstageHide],
+    [
+      createEventBuilder,
+      getNetworkMeta,
+      getStagedHideKey,
+      stageHide,
+      trackEvent,
+      unstageHide,
+    ],
   );
 
   const handleSearchResultToggle = useCallback(
@@ -1303,15 +1313,17 @@ export const TokenManagementPage = () => {
     }
 
     hasTrackedScreenOpenedRef.current = true;
-    trackEvent({
-      category: MetaMetricsEventCategory.Home,
-      event: MetaMetricsEventName.TokenScreenOpened,
-      properties: {
-        screen: TOKEN_MANAGEMENT_SCREEN,
-        [METRICS_PROPERTIES.viewState]: tokenManagementViewState,
-      },
-    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.TokenScreenOpened)
+        .addCategory(MetaMetricsEventCategory.Home)
+        .addProperties({
+          screen: TOKEN_MANAGEMENT_SCREEN,
+          [METRICS_PROPERTIES.viewState]: tokenManagementViewState,
+        })
+        .build(),
+    );
   }, [
+    createEventBuilder,
     isFetchingNextPage,
     isSearchFetching,
     isSearching,


### PR DESCRIPTION
## **Description**

Sub-PR of umbrella tracker [#43885](https://github.com/MetaMask/metamask-extension/pull/43885).

Migrates MetaMetrics `trackEvent` call sites in this CODEOWNERS domain to `createEventBuilder` + `trackEvent` via `useAnalytics()` (UI) or `app/scripts/controllers/analytics` (background).

**Dependency note:** Can merge in parallel with other domain PRs after PR1.

**Files in this PR:** 4

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of analytics migration umbrella: #43885

## **Manual testing steps**

1. Check out this branch and run `yarn start`.
2. Exercise flows in the touched domain (see diff file list).
3. Confirm no console errors and representative events still fire.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only analytics wiring on token UI pages; token import/hide behavior is unchanged and tests were updated to match the new tracking path.
> 
> **Overview**
> Moves **custom token import** and **manage tokens** MetaMetrics off `MetaMetricsContext` onto **`useAnalytics()`**, building events with **`createEventBuilder`** and calling **`trackEvent`** with the built payload.
> 
> Coverage includes screen open/view states, custom import CTA and submit flows, and token add/hide toggles; event names and sensitive fields stay the same, with **category** folded into the builder’s **`properties`**.
> 
> Unit tests drop injected `trackEvent` helpers and instead **mock the background `trackAnalyticsEvent`** path (plus Segment context and opt-in state) so assertions match the new analytics pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8da9df64ea2c6be0d96151ba5fba865d360c5cff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

