### PR TITLE
refactor(analytics): migrate onboarding welcome events

### DIFF
--- a/ui/pages/onboarding-flow/account-exist/account-exist.tsx
+++ b/ui/pages/onboarding-flow/account-exist/account-exist.tsx
@@ -20,6 +20,7 @@ export default function AccountExist() {
     descriptionInterpolation,
     resetOnboardingAndReturn,
     trackEvent,
+    createEventBuilder,
     bufferedTrace,
     onboardingParentContext,
   } = useAccountStatusContext({
@@ -38,15 +39,16 @@ export default function AccountExist() {
   };
 
   const onDone = async () => {
-    trackEvent({
-      category: MetaMetricsEventCategory.Onboarding,
-      event: MetaMetricsEventName.WalletImportStarted,
-      properties: {
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        account_type: accountTypeForMetrics,
-      },
-    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.WalletImportStarted)
+        .addCategory(MetaMetricsEventCategory.Onboarding)
+        .addProperties({
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          account_type: accountTypeForMetrics,
+        })
+        .build(),
+    );
     bufferedTrace?.({
       name: TraceName.OnboardingExistingSocialLogin,
       op: TraceOperation.OnboardingUserJourney,

--- a/ui/pages/onboarding-flow/account-not-found/account-not-found.tsx
+++ b/ui/pages/onboarding-flow/account-not-found/account-not-found.tsx
@@ -20,6 +20,7 @@ export default function AccountNotFound() {
     descriptionInterpolation,
     resetOnboardingAndReturn,
     trackEvent,
+    createEventBuilder,
     bufferedTrace,
     onboardingParentContext,
   } = useAccountStatusContext({
@@ -35,15 +36,16 @@ export default function AccountNotFound() {
   };
 
   const onCreateNewAccount = () => {
-    trackEvent({
-      category: MetaMetricsEventCategory.Onboarding,
-      event: MetaMetricsEventName.WalletSetupStarted,
-      properties: {
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        account_type: accountTypeForMetrics,
-      },
-    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.WalletSetupStarted)
+        .addCategory(MetaMetricsEventCategory.Onboarding)
+        .addProperties({
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          account_type: accountTypeForMetrics,
+        })
+        .build(),
+    );
     bufferedTrace?.({
       name: TraceName.OnboardingNewSocialCreateWallet,
       op: TraceOperation.OnboardingUserJourney,

--- a/ui/pages/onboarding-flow/hooks/useAccountStatusContext.ts
+++ b/ui/pages/onboarding-flow/hooks/useAccountStatusContext.ts
@@ -16,6 +16,7 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
+import { useAnalytics } from '../../../hooks/useAnalytics';
 import { TraceName, TraceOperation } from '../../../../shared/lib/trace';
 import { ONBOARDING_WELCOME_ROUTE } from '../../../helpers/constants/routes';
 import { useOnboardingReset } from './useOnboardingReset';
@@ -63,12 +64,9 @@ export function useAccountStatusContext({
   const socialLoginType = useSelector(getSocialLoginType);
   const accountTypeForMetrics = useSelector(getAccountTypeForOnboardingMetrics);
 
-  const {
-    trackEvent,
-    bufferedTrace,
-    bufferedEndTrace,
-    onboardingParentContext,
-  } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
+  const { bufferedTrace, bufferedEndTrace, onboardingParentContext } =
+    useContext(MetaMetricsContext);
 
   const descriptionKey = useMemo(() => {
     if (socialLoginType === AuthConnection.Telegram) {
@@ -86,10 +84,11 @@ export function useAccountStatusContext({
 
   useEffect(() => {
     if (firstTimeFlowType === validFlowType) {
-      trackEvent({
-        category: MetaMetricsEventCategory.Onboarding,
-        event: pageViewedEventName,
-      });
+      trackEvent(
+        createEventBuilder(pageViewedEventName)
+          .addCategory(MetaMetricsEventCategory.Onboarding)
+          .build(),
+      );
       bufferedTrace?.({
         name: pageTraceName,
         op: TraceOperation.OnboardingUserJourney,
@@ -112,6 +111,7 @@ export function useAccountStatusContext({
     onboardingParentContext,
     bufferedTrace,
     bufferedEndTrace,
+    createEventBuilder,
     trackEvent,
   ]);
 
@@ -121,6 +121,7 @@ export function useAccountStatusContext({
     descriptionInterpolation,
     resetOnboardingAndReturn,
     trackEvent,
+    createEventBuilder,
     bufferedTrace,
     onboardingParentContext,
   };

--- a/ui/pages/onboarding-flow/onboarding-flow.test.tsx
+++ b/ui/pages/onboarding-flow/onboarding-flow.test.tsx
@@ -36,6 +36,19 @@ import { getIsSeedlessOnboardingFeatureEnabled } from '../../../shared/lib/envir
 import { useSidePanelEnabled } from '../../hooks/useSidePanelEnabled';
 import OnboardingFlow from './onboarding-flow';
 
+jest.mock('../../hooks/useAnalytics', () => {
+  const { createEventBuilder } = jest.requireActual(
+    '../../../shared/lib/analytics/create-event-builder',
+  );
+
+  return {
+    useAnalytics: () => ({
+      trackEvent: jest.fn(),
+      createEventBuilder,
+    }),
+  };
+});
+
 // Mock mmLazy to return a synchronous component instead of React.lazy.
 // React 17's lazy resolution fires a state update after test cleanup unmounts
 // the tree, producing a spurious "state update on unmounted component" warning.

--- a/ui/pages/onboarding-flow/welcome/login-error-modal.test.tsx
+++ b/ui/pages/onboarding-flow/welcome/login-error-modal.test.tsx
@@ -193,10 +193,7 @@ describe('LoginErrorModal', () => {
           properties: expect.objectContaining({
             category: MetaMetricsEventCategory.Onboarding,
             url: SUPPORT_LINK,
-            location: 'Welcome page',
-          }),
-          options: expect.objectContaining({
-            page: { title: 'Welcome' },
+            location: 'Welcome',
           }),
         }),
       );

--- a/ui/pages/onboarding-flow/welcome/login-error-modal.test.tsx
+++ b/ui/pages/onboarding-flow/welcome/login-error-modal.test.tsx
@@ -7,9 +7,7 @@ import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate
 import { enLocale as messages, tEn } from '../../../../test/lib/i18n-helpers';
 import { SUPPORT_LINK } from '../../../helpers/constants/common';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
 import {
-  MetaMetricsContextProp,
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
@@ -17,6 +15,27 @@ import { isPopupOrSidePanelEnvironment } from '../../../../shared/lib/environmen
 import { getSocialLoginType } from '../../../selectors';
 import LoginErrorModal from './login-error-modal';
 import { LOGIN_ERROR } from './types';
+
+const mockTrackEvent = jest.fn();
+
+jest.mock('../../../hooks/useAnalytics', () => {
+  const { createEventBuilder } = jest.requireActual(
+    '../../../../shared/lib/analytics/create-event-builder',
+  );
+
+  return {
+    useAnalytics: () => ({
+      trackEvent: mockTrackEvent,
+      createEventBuilder,
+    }),
+  };
+});
+
+jest.mock('../../../hooks/useSegmentContext', () => ({
+  useSegmentContext: () => ({
+    page: { title: 'Welcome' },
+  }),
+}));
 
 const mockNavigate = jest.fn();
 
@@ -52,23 +71,13 @@ const buildStore = () => configureMockStore([thunk])({ metamask: {} });
 
 function renderModal(
   props: Partial<React.ComponentProps<typeof LoginErrorModal>> = {},
-  trackEvent = jest.fn(),
 ) {
-  const mockMetaMetricsContext = {
-    trackEvent,
-    bufferedTrace: jest.fn(),
-    bufferedEndTrace: jest.fn(),
-    onboardingParentContext: { current: null },
-  };
-
   return renderWithProvider(
-    <MetaMetricsContext.Provider value={mockMetaMetricsContext}>
-      <LoginErrorModal
-        onClose={jest.fn()}
-        loginError={LOGIN_ERROR.GENERIC}
-        {...props}
-      />
-    </MetaMetricsContext.Provider>,
+    <LoginErrorModal
+      onClose={jest.fn()}
+      loginError={LOGIN_ERROR.GENERIC}
+      {...props}
+    />,
     buildStore(),
   );
 }
@@ -170,9 +179,7 @@ describe('LoginErrorModal', () => {
 
   describe('support link', () => {
     it('tracks the support link click for the generic error', () => {
-      const mockTrackEvent = jest.fn();
-
-      renderModal({ loginError: LOGIN_ERROR.GENERIC }, mockTrackEvent);
+      renderModal({ loginError: LOGIN_ERROR.GENERIC });
 
       fireEvent.click(
         screen.getByRole('link', {
@@ -181,17 +188,17 @@ describe('LoginErrorModal', () => {
       );
 
       expect(mockTrackEvent).toHaveBeenCalledWith(
-        {
-          category: MetaMetricsEventCategory.Onboarding,
-          event: MetaMetricsEventName.SupportLinkClicked,
-          properties: {
+        expect.objectContaining({
+          name: MetaMetricsEventName.SupportLinkClicked,
+          properties: expect.objectContaining({
+            category: MetaMetricsEventCategory.Onboarding,
             url: SUPPORT_LINK,
             location: 'Welcome page',
-          },
-        },
-        {
-          contextPropsIntoEventProperties: [MetaMetricsContextProp.PageTitle],
-        },
+          }),
+          options: expect.objectContaining({
+            page: { title: 'Welcome' },
+          }),
+        }),
       );
     });
   });
@@ -270,28 +277,26 @@ describe('LoginErrorModal', () => {
 
     it('tracks the Telegram update CTA, opens the Telegram site, and closes the modal', () => {
       const onClose = jest.fn();
-      const mockTrackEvent = jest.fn();
 
-      renderModal(
-        {
-          onClose,
-          loginError: LOGIN_ERROR.TELEGRAM_OUTDATED,
-        },
-        mockTrackEvent,
-      );
+      renderModal({
+        onClose,
+        loginError: LOGIN_ERROR.TELEGRAM_OUTDATED,
+      });
 
       fireEvent.click(
         screen.getByTestId('login-error-modal-update-telegram-button'),
       );
 
-      expect(mockTrackEvent).toHaveBeenCalledWith({
-        category: MetaMetricsEventCategory.Onboarding,
-        event: MetaMetricsEventName.SupportLinkClicked,
-        properties: {
-          url: TELEGRAM_DESKTOP_UPDATE_URL,
-          location: 'Telegram outdated modal',
-        },
-      });
+      expect(mockTrackEvent).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: MetaMetricsEventName.SupportLinkClicked,
+          properties: expect.objectContaining({
+            category: MetaMetricsEventCategory.Onboarding,
+            url: TELEGRAM_DESKTOP_UPDATE_URL,
+            location: 'Telegram outdated modal',
+          }),
+        }),
+      );
       expect(globalThis.platform.openTab).toHaveBeenCalledWith({
         url: TELEGRAM_DESKTOP_UPDATE_URL,
       });

--- a/ui/pages/onboarding-flow/welcome/login-error-modal.tsx
+++ b/ui/pages/onboarding-flow/welcome/login-error-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   Box,
@@ -25,13 +25,13 @@ import {
 import { AlignItems } from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
-  MetaMetricsContextProp,
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
 import { SUPPORT_LINK } from '../../../helpers/constants/common';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
 import { getSocialLoginType } from '../../../selectors';
+import { useAnalytics } from '../../../hooks/useAnalytics';
+import { useSegmentContext } from '../../../hooks/useSegmentContext';
 import { isPopupOrSidePanelEnvironment } from '../../../../shared/lib/environment-type';
 import { resetWallet } from '../../../store/actions';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
@@ -62,7 +62,8 @@ export default function LoginErrorModal({
   loginError,
 }: LoginErrorModalProps) {
   const t = useI18nContext();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
+  const segmentContext = useSegmentContext();
   const socialLoginType = useSelector(getSocialLoginType);
   const dispatch = useDispatch();
   const navigate = useNavigate();
@@ -102,19 +103,13 @@ export default function LoginErrorModal({
         size={TextButtonSize.BodyMd}
         onClick={() => {
           trackEvent(
-            {
-              category: MetaMetricsEventCategory.Onboarding,
-              event: MetaMetricsEventName.SupportLinkClicked,
-              properties: {
+            createEventBuilder(MetaMetricsEventName.SupportLinkClicked)
+              .addCategory(MetaMetricsEventCategory.Onboarding)
+              .addProperties({
                 url: SUPPORT_LINK,
                 location: 'Welcome page',
-              },
-            },
-            {
-              contextPropsIntoEventProperties: [
-                MetaMetricsContextProp.PageTitle,
-              ],
-            },
+              })
+              .build({ page: segmentContext.page }),
           );
         }}
         asChild
@@ -154,14 +149,15 @@ export default function LoginErrorModal({
   };
 
   const handleUpdateTelegramClick = () => {
-    trackEvent({
-      category: MetaMetricsEventCategory.Onboarding,
-      event: MetaMetricsEventName.SupportLinkClicked,
-      properties: {
-        url: TELEGRAM_DESKTOP_UPDATE_URL,
-        location: 'Telegram outdated modal',
-      },
-    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.SupportLinkClicked)
+        .addCategory(MetaMetricsEventCategory.Onboarding)
+        .addProperties({
+          url: TELEGRAM_DESKTOP_UPDATE_URL,
+          location: 'Telegram outdated modal',
+        })
+        .build(),
+    );
     globalThis.platform.openTab({ url: TELEGRAM_DESKTOP_UPDATE_URL });
     onClose();
   };

--- a/ui/pages/onboarding-flow/welcome/login-error-modal.tsx
+++ b/ui/pages/onboarding-flow/welcome/login-error-modal.tsx
@@ -107,9 +107,9 @@ export default function LoginErrorModal({
               .addCategory(MetaMetricsEventCategory.Onboarding)
               .addProperties({
                 url: SUPPORT_LINK,
-                location: 'Welcome page',
+                location: segmentContext.page?.title,
               })
-              .build({ page: segmentContext.page }),
+              .build(),
           );
         }}
         asChild

--- a/ui/pages/onboarding-flow/welcome/login-error-modal.tsx
+++ b/ui/pages/onboarding-flow/welcome/login-error-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   Box,
@@ -107,7 +107,7 @@ export default function LoginErrorModal({
               .addCategory(MetaMetricsEventCategory.Onboarding)
               .addProperties({
                 url: SUPPORT_LINK,
-                location: segmentContext.page?.title,
+                location: segmentContext.page?.title ?? 'Welcome page',
               })
               .build(),
           );

--- a/ui/pages/onboarding-flow/welcome/welcome.test.tsx
+++ b/ui/pages/onboarding-flow/welcome/welcome.test.tsx
@@ -19,6 +19,21 @@ import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import { OAuthErrorMessages } from '../../../../shared/lib/error';
 import Welcome from './welcome';
 
+const mockTrackEvent = jest.fn();
+
+jest.mock('../../../hooks/useAnalytics', () => {
+  const { createEventBuilder } = jest.requireActual(
+    '../../../../shared/lib/analytics/create-event-builder',
+  );
+
+  return {
+    useAnalytics: () => ({
+      trackEvent: mockTrackEvent,
+      createEventBuilder,
+    }),
+  };
+});
+
 const mockUseNavigate = jest.fn();
 
 jest.mock('react-router-dom', () => {
@@ -89,9 +104,8 @@ describe('Welcome Page', () => {
     },
   };
   const mockStore = configureMockStore([thunk])(mockState);
-  const mockTrackEvent = jest.fn();
   const mockMetaMetricsContext = {
-    trackEvent: mockTrackEvent,
+    trackEvent: jest.fn(),
     bufferedTrace: jest.fn(),
     bufferedEndTrace: jest.fn(),
     onboardingParentContext: { current: null },
@@ -217,24 +231,30 @@ describe('Welcome Page', () => {
       expect(mockTrackEvent).toHaveBeenCalledTimes(2);
 
       // should track wallet import started
-      expect(mockTrackEvent).toHaveBeenNthCalledWith(1, {
-        category: MetaMetricsEventCategory.Onboarding,
-        event: MetaMetricsEventName.WalletSetupStarted,
-        properties: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          account_type: `${MetaMetricsEventAccountType.Default}_google`,
-        },
-      });
+      expect(mockTrackEvent).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          name: MetaMetricsEventName.WalletSetupStarted,
+          properties: expect.objectContaining({
+            category: MetaMetricsEventCategory.Onboarding,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            account_type: `${MetaMetricsEventAccountType.Default}_google`,
+          }),
+        }),
+      );
 
       // should track wallet import completed
-      expect(mockTrackEvent).toHaveBeenNthCalledWith(2, {
-        category: MetaMetricsEventCategory.Onboarding,
-        event: MetaMetricsEventName.SocialLoginCompleted,
-        properties: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          account_type: `${MetaMetricsEventAccountType.Default}_google`,
-        },
-      });
+      expect(mockTrackEvent).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          name: MetaMetricsEventName.SocialLoginCompleted,
+          properties: expect.objectContaining({
+            category: MetaMetricsEventCategory.Onboarding,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            account_type: `${MetaMetricsEventAccountType.Default}_google`,
+          }),
+        }),
+      );
 
       // should set setParticipateInMetaMetrics to true and send the queued events to Segment
       expect(enabledMetricsSpy).toHaveBeenCalledWith(true);
@@ -285,24 +305,30 @@ describe('Welcome Page', () => {
       expect(mockTrackEvent).toHaveBeenCalledTimes(2);
 
       // should track wallet import started
-      expect(mockTrackEvent).toHaveBeenNthCalledWith(1, {
-        category: MetaMetricsEventCategory.Onboarding,
-        event: MetaMetricsEventName.WalletImportStarted,
-        properties: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          account_type: `${MetaMetricsEventAccountType.Imported}_google`,
-        },
-      });
+      expect(mockTrackEvent).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          name: MetaMetricsEventName.WalletImportStarted,
+          properties: expect.objectContaining({
+            category: MetaMetricsEventCategory.Onboarding,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            account_type: `${MetaMetricsEventAccountType.Imported}_google`,
+          }),
+        }),
+      );
 
       // should track wallet import completed
-      expect(mockTrackEvent).toHaveBeenNthCalledWith(2, {
-        category: MetaMetricsEventCategory.Onboarding,
-        event: MetaMetricsEventName.SocialLoginCompleted,
-        properties: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          account_type: `${MetaMetricsEventAccountType.Imported}_google`,
-        },
-      });
+      expect(mockTrackEvent).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          name: MetaMetricsEventName.SocialLoginCompleted,
+          properties: expect.objectContaining({
+            category: MetaMetricsEventCategory.Onboarding,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            account_type: `${MetaMetricsEventAccountType.Imported}_google`,
+          }),
+        }),
+      );
 
       // should set Metametrics optin status for social login import
       expect(enabledMetricsSpy).toHaveBeenCalledWith(true);
@@ -357,24 +383,30 @@ describe('Welcome Page', () => {
       expect(mockTrackEvent).toHaveBeenCalledTimes(2);
 
       // should track wallet import started
-      expect(mockTrackEvent).toHaveBeenNthCalledWith(1, {
-        category: MetaMetricsEventCategory.Onboarding,
-        event: MetaMetricsEventName.WalletImportStarted,
-        properties: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          account_type: `${MetaMetricsEventAccountType.Imported}_google`,
-        },
-      });
+      expect(mockTrackEvent).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          name: MetaMetricsEventName.WalletImportStarted,
+          properties: expect.objectContaining({
+            category: MetaMetricsEventCategory.Onboarding,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            account_type: `${MetaMetricsEventAccountType.Imported}_google`,
+          }),
+        }),
+      );
 
       // should track wallet import completed
-      expect(mockTrackEvent).toHaveBeenNthCalledWith(2, {
-        category: MetaMetricsEventCategory.Onboarding,
-        event: MetaMetricsEventName.SocialLoginCompleted,
-        properties: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          account_type: `${MetaMetricsEventAccountType.Imported}_google`,
-        },
-      });
+      expect(mockTrackEvent).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          name: MetaMetricsEventName.SocialLoginCompleted,
+          properties: expect.objectContaining({
+            category: MetaMetricsEventCategory.Onboarding,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            account_type: `${MetaMetricsEventAccountType.Imported}_google`,
+          }),
+        }),
+      );
 
       expect(getBrowserNameSpy).toHaveBeenCalled();
 
@@ -425,14 +457,17 @@ describe('Welcome Page', () => {
       expect(mockTrackEvent).toHaveBeenCalledTimes(1);
 
       // should track wallet import started
-      expect(mockTrackEvent).toHaveBeenNthCalledWith(1, {
-        category: MetaMetricsEventCategory.Onboarding,
-        event: MetaMetricsEventName.WalletSetupStarted,
-        properties: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          account_type: MetaMetricsEventAccountType.Default,
-        },
-      });
+      expect(mockTrackEvent).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          name: MetaMetricsEventName.WalletSetupStarted,
+          properties: expect.objectContaining({
+            category: MetaMetricsEventCategory.Onboarding,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            account_type: MetaMetricsEventAccountType.Default,
+          }),
+        }),
+      );
 
       // should not set Metametrics optin status for SPR user
       expect(enabledMetricsSpy).not.toHaveBeenCalledWith(true);
@@ -503,20 +538,23 @@ describe('Welcome Page', () => {
 
     const expectOutdatedAppEventTracked = () => {
       expect(mockTrackEvent).toHaveBeenCalledTimes(2);
-      expect(mockTrackEvent).toHaveBeenNthCalledWith(2, {
-        category: MetaMetricsEventCategory.Onboarding,
-        event: MetaMetricsEventName.SocialLoginFailed,
-        properties: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          account_type: `${MetaMetricsEventAccountType.Default}_telegram`,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          is_rehydration: 'unknown',
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          failure_type: 'outdated_app',
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          error_category: 'telegram_app',
-        },
-      });
+      expect(mockTrackEvent).toHaveBeenNthCalledWith(
+        2,
+        expect.objectContaining({
+          name: MetaMetricsEventName.SocialLoginFailed,
+          properties: expect.objectContaining({
+            category: MetaMetricsEventCategory.Onboarding,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            account_type: `${MetaMetricsEventAccountType.Default}_telegram`,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            is_rehydration: 'unknown',
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            failure_type: 'outdated_app',
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            error_category: 'telegram_app',
+          }),
+        }),
+      );
     };
 
     it('routes to TELEGRAM_OUTDATED when verify rejects with 403', async () => {

--- a/ui/pages/onboarding-flow/welcome/welcome.tsx
+++ b/ui/pages/onboarding-flow/welcome/welcome.tsx
@@ -37,6 +37,9 @@ import {
 import { getCurrentKeyring } from '../../../../shared/lib/selectors/keyring';
 import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
 import { MetaMetricsContext } from '../../../contexts/metametrics';
+import type { UIMetricsEventPayload } from '../../../contexts/metametrics';
+import { useAnalytics } from '../../../hooks/useAnalytics';
+import type { MetaMetricsEventOptions } from '../../../../shared/constants/metametrics';
 import { ENVIRONMENT } from '../../../../shared/constants/build';
 import {
   setFirstTimeFlowType,
@@ -198,25 +201,43 @@ export default function OnboardingWelcome() {
     isPasskeyFeatureAvailable,
   ]);
 
-  const {
-    trackEvent,
-    bufferedTrace,
-    bufferedEndTrace,
-    onboardingParentContext,
-  } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
+  const { bufferedTrace, bufferedEndTrace, onboardingParentContext } =
+    useContext(MetaMetricsContext);
+
+  const trackLegacyEventForAction = useCallback(
+    async (
+      payload: UIMetricsEventPayload,
+      options?: MetaMetricsEventOptions,
+    ): Promise<void> => {
+      trackEvent(
+        createEventBuilder(payload.event)
+          .addProperties({
+            ...payload.properties,
+            ...(payload.category === undefined
+              ? {}
+              : { category: payload.category }),
+          })
+          .addSensitiveProperties(payload.sensitiveProperties)
+          .build(options),
+      );
+    },
+    [createEventBuilder, trackEvent],
+  );
 
   const onCreateClick = useCallback(async () => {
     setIsLoggingIn(true);
     setNewAccountCreationInProgress(true);
     await dispatch(setFirstTimeFlowType(FirstTimeFlowType.create));
-    trackEvent({
-      category: MetaMetricsEventCategory.Onboarding,
-      event: MetaMetricsEventName.WalletSetupStarted,
-      properties: {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        account_type: accountTypeForMetrics,
-      },
-    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.WalletSetupStarted)
+        .addCategory(MetaMetricsEventCategory.Onboarding)
+        .addProperties({
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          account_type: accountTypeForMetrics,
+        })
+        .build(),
+    );
     bufferedTrace?.({
       name: TraceName.OnboardingNewSrpCreateWallet,
       op: TraceOperation.OnboardingUserJourney,
@@ -227,6 +248,7 @@ export default function OnboardingWelcome() {
   }, [
     dispatch,
     navigate,
+    createEventBuilder,
     trackEvent,
     onboardingParentContext,
     bufferedTrace,
@@ -236,14 +258,15 @@ export default function OnboardingWelcome() {
   const onImportClick = useCallback(async () => {
     setIsLoggingIn(true);
     await dispatch(setFirstTimeFlowType(FirstTimeFlowType.import));
-    trackEvent({
-      category: MetaMetricsEventCategory.Onboarding,
-      event: MetaMetricsEventName.WalletImportStarted,
-      properties: {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        account_type: accountTypeForMetrics,
-      },
-    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.WalletImportStarted)
+        .addCategory(MetaMetricsEventCategory.Onboarding)
+        .addProperties({
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          account_type: accountTypeForMetrics,
+        })
+        .build(),
+    );
     bufferedTrace?.({
       name: TraceName.OnboardingExistingSrpImport,
       op: TraceOperation.OnboardingUserJourney,
@@ -254,6 +277,7 @@ export default function OnboardingWelcome() {
   }, [
     dispatch,
     navigate,
+    createEventBuilder,
     trackEvent,
     onboardingParentContext,
     bufferedTrace,
@@ -274,7 +298,7 @@ export default function OnboardingWelcome() {
             socialConnectionType as AuthConnection,
             bufferedTrace,
             bufferedEndTrace,
-            trackEvent,
+            trackLegacyEventForAction,
           ),
         );
         bufferedEndTrace?.({ name: TraceName.OnboardingSocialLoginAttempt });
@@ -288,7 +312,7 @@ export default function OnboardingWelcome() {
       onboardingParentContext,
       bufferedTrace,
       bufferedEndTrace,
-      trackEvent,
+      trackLegacyEventForAction,
     ],
   );
 
@@ -326,20 +350,21 @@ export default function OnboardingWelcome() {
           errorMessage === OAuthErrorMessages.NO_REDIRECT_URL_FOUND_ERROR;
 
         if (isLikelyOutdatedApp) {
-          trackEvent({
-            category: MetaMetricsEventCategory.Onboarding,
-            event: MetaMetricsEventName.SocialLoginFailed,
-            properties: {
-              // eslint-disable-next-line @typescript-eslint/naming-convention
-              account_type: `${MetaMetricsEventAccountType.Default}_${loginType}`,
-              // eslint-disable-next-line @typescript-eslint/naming-convention
-              is_rehydration: 'unknown',
-              // eslint-disable-next-line @typescript-eslint/naming-convention
-              failure_type: 'outdated_app',
-              // eslint-disable-next-line @typescript-eslint/naming-convention
-              error_category: 'telegram_app',
-            },
-          });
+          trackEvent(
+            createEventBuilder(MetaMetricsEventName.SocialLoginFailed)
+              .addCategory(MetaMetricsEventCategory.Onboarding)
+              .addProperties({
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                account_type: `${MetaMetricsEventAccountType.Default}_${loginType}`,
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                is_rehydration: 'unknown',
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                failure_type: 'outdated_app',
+                // eslint-disable-next-line @typescript-eslint/naming-convention
+                error_category: 'telegram_app',
+              })
+              .build(),
+          );
           setLoginError(LOGIN_ERROR.TELEGRAM_OUTDATED);
           return;
         }
@@ -352,7 +377,7 @@ export default function OnboardingWelcome() {
 
       setLoginError(LOGIN_ERROR.GENERIC);
     },
-    [bufferedEndTrace, trackEvent],
+    [bufferedEndTrace, createEventBuilder, trackEvent],
   );
 
   const onSocialLoginCreateClick = useCallback(
@@ -362,27 +387,29 @@ export default function OnboardingWelcome() {
       // here, we cannot use the selector yet because the social login flow is not complete and the state is not updated yet
       const accountTypeForSocialLoginMetrics = `${MetaMetricsEventAccountType.Default}_${socialConnectionType}`;
 
-      await trackEvent({
-        category: MetaMetricsEventCategory.Onboarding,
-        event: MetaMetricsEventName.WalletSetupStarted,
-        properties: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          account_type: accountTypeForSocialLoginMetrics,
-        },
-      });
+      trackEvent(
+        createEventBuilder(MetaMetricsEventName.WalletSetupStarted)
+          .addCategory(MetaMetricsEventCategory.Onboarding)
+          .addProperties({
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            account_type: accountTypeForSocialLoginMetrics,
+          })
+          .build(),
+      );
 
       try {
         const isNewUser = await handleSocialLogin(socialConnectionType);
 
         // Track wallet setup completed for social login users
-        await trackEvent({
-          category: MetaMetricsEventCategory.Onboarding,
-          event: MetaMetricsEventName.SocialLoginCompleted,
-          properties: {
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            account_type: accountTypeForSocialLoginMetrics,
-          },
-        });
+        trackEvent(
+          createEventBuilder(MetaMetricsEventName.SocialLoginCompleted)
+            .addCategory(MetaMetricsEventCategory.Onboarding)
+            .addProperties({
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              account_type: accountTypeForSocialLoginMetrics,
+            })
+            .build(),
+        );
         if (isNewUser) {
           bufferedTrace?.({
             name: TraceName.OnboardingNewSocialCreateWallet,
@@ -404,6 +431,7 @@ export default function OnboardingWelcome() {
     [
       dispatch,
       handleSocialLogin,
+      createEventBuilder,
       trackEvent,
       navigate,
       onboardingParentContext,
@@ -419,27 +447,29 @@ export default function OnboardingWelcome() {
       // here, we cannot use the selector yet because the social login flow is not complete and the state is not updated yet
       const accountTypeForSocialLoginMetrics = `${MetaMetricsEventAccountType.Imported}_${socialConnectionType}`;
 
-      await trackEvent({
-        category: MetaMetricsEventCategory.Onboarding,
-        event: MetaMetricsEventName.WalletImportStarted,
-        properties: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          account_type: accountTypeForSocialLoginMetrics,
-        },
-      });
+      trackEvent(
+        createEventBuilder(MetaMetricsEventName.WalletImportStarted)
+          .addCategory(MetaMetricsEventCategory.Onboarding)
+          .addProperties({
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            account_type: accountTypeForSocialLoginMetrics,
+          })
+          .build(),
+      );
 
       try {
         const isNewUser = await handleSocialLogin(socialConnectionType);
 
         // Track wallet login completed for existing social login users
-        await trackEvent({
-          category: MetaMetricsEventCategory.Onboarding,
-          event: MetaMetricsEventName.SocialLoginCompleted,
-          properties: {
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            account_type: accountTypeForSocialLoginMetrics,
-          },
-        });
+        trackEvent(
+          createEventBuilder(MetaMetricsEventName.SocialLoginCompleted)
+            .addCategory(MetaMetricsEventCategory.Onboarding)
+            .addProperties({
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              account_type: accountTypeForSocialLoginMetrics,
+            })
+            .build(),
+        );
 
         if (isNewUser) {
           await dispatch(setFirstTimeFlowType(FirstTimeFlowType.socialCreate));
@@ -461,6 +491,7 @@ export default function OnboardingWelcome() {
     },
     [
       handleSocialLogin,
+      createEventBuilder,
       trackEvent,
       navigate,
       onboardingParentContext,

--- a/ui/selectors/confirm-transaction.js
+++ b/ui/selectors/confirm-transaction.js
@@ -97,7 +97,7 @@ export const currentCurrencySelector = (state) =>
 export const conversionRateSelector = (state) =>
   getCurrencyRateControllerCurrencyRates(state)[getProviderConfig(state).ticker]
     ?.conversionRate;
-export const txDataSelector = (state) => state.confirmTransaction.txData;
+export const txDataSelector = (state) => state.confirmTransaction?.txData;
 
 export const transactionFeeSelector = function (state, txData) {
   const currentCurrency = currentCurrencySelector(state);


### PR DESCRIPTION
## **Description**

Sub-PR of umbrella tracker [#43885](https://github.com/MetaMask/metamask-extension/pull/43885).

Migrates MetaMetrics `trackEvent` call sites in this CODEOWNERS domain to `createEventBuilder` + `trackEvent` via `useAnalytics()` (UI) or `app/scripts/controllers/analytics` (background).

**Dependency note:** Can merge in parallel with other domain PRs after PR1.

**Files in this PR:** 15

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of analytics migration umbrella: #43885

## **Manual testing steps**

1. Check out this branch and run `yarn start`.
2. Exercise flows in the touched domain (see diff file list).
3. Confirm no console errors and representative events still fire.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Analytics event shape and property placement change across onboarding and OAuth callbacks, which could alter Segment payloads if builders differ from legacy context merging; user-facing onboarding behavior is unchanged.
> 
> **Overview**
> Onboarding **welcome and account-status flows** now emit MetaMetrics through **`useAnalytics()`** and **`createEventBuilder().addCategory().addProperties().build()`** instead of legacy `MetaMetricsContext.trackEvent({ category, event, properties })`.
> 
> **`useAccountStatusContext`** sources `trackEvent` / `createEventBuilder` from analytics while keeping buffered traces on `MetaMetricsContext`. **Welcome** adds **`trackLegacyEventForAction`** so **`startOAuthLogin`** still receives a legacy-shaped callback that is converted to builder events. **Login error modal** drops context-based tracking; support-link events use **`useSegmentContext`** for `location` (e.g. page title **Welcome**) instead of `MetaMetricsContextProp.PageTitle`.
> 
> Tests mock **`useAnalytics`** (and segment context where needed) and assert the new payload shape (`name` + `properties` including `category`). **`txDataSelector`** uses optional chaining on `confirmTransaction` as a small unrelated hardening.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c671f60337a5d272fb94be131917af9a8a5594d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->