### PR TITLE
fix(confirmations): prevent send account startsWith crash

### DIFF
--- a/ui/pages/confirmations/utils/account.test.ts
+++ b/ui/pages/confirmations/utils/account.test.ts
@@ -3,6 +3,7 @@ import {
   isBitcoinAccountForSend,
   isEVMAccountForSend,
   isSolanaAccountForSend,
+  isTronAccountForSend,
 } from './account';
 
 describe('Account Send Utils', () => {
@@ -235,5 +236,103 @@ describe('Account Send Utils', () => {
       } as unknown as InternalAccount;
       expect(isBitcoinAccountForSend(account)).toBe(false);
     });
+  });
+
+  describe('isTronAccountForSend', () => {
+    it('returns false when account is null', () => {
+      expect(isTronAccountForSend(null as unknown as InternalAccount)).toBe(
+        false,
+      );
+    });
+
+    it('returns false when account is undefined', () => {
+      expect(
+        isTronAccountForSend(undefined as unknown as InternalAccount),
+      ).toBe(false);
+    });
+
+    it('returns true when account type starts with tron:', () => {
+      const account = {
+        id: 'test-id',
+        type: 'tron:mainnet',
+        address: 'tron-address',
+        metadata: {},
+        methods: [],
+        options: {},
+      } as unknown as InternalAccount;
+      expect(isTronAccountForSend(account)).toBe(true);
+    });
+
+    it('returns true when account has tron scope', () => {
+      const account = {
+        id: 'test-id',
+        type: 'other:type',
+        address: 'tron-address',
+        metadata: {},
+        methods: [],
+        options: {},
+        scopes: ['tron:mainnet', 'other:scope'],
+      } as unknown as InternalAccount;
+      expect(isTronAccountForSend(account)).toBe(true);
+    });
+
+    it('returns false when account type does not start with tron and has no tron scopes', () => {
+      const account = {
+        id: 'test-id',
+        type: 'eip155:ethereum',
+        address: '0x123',
+        metadata: {},
+        methods: [],
+        options: {},
+        scopes: ['eip155:1'],
+      } as unknown as InternalAccount;
+      expect(isTronAccountForSend(account)).toBe(false);
+    });
+  });
+
+  describe('malformed account compatibility checks', () => {
+    const testCases: [
+      string,
+      (account: InternalAccount) => boolean,
+      string,
+      string,
+    ][] = [
+      ['EVM', isEVMAccountForSend, 'eip155:1', 'solana:mainnet'],
+      ['Solana', isSolanaAccountForSend, 'solana:mainnet', 'bip122:bitcoin'],
+      ['Bitcoin', isBitcoinAccountForSend, 'bip122:bitcoin', 'eip155:1'],
+      ['Tron', isTronAccountForSend, 'tron:mainnet', 'eip155:1'],
+    ];
+
+    it.each(testCases)(
+      'returns true for %s when account type is undefined but matching scope exists',
+      (_name, fn, matchingScope) => {
+        const account = {
+          id: 'test-id',
+          address: 'test-address',
+          metadata: {},
+          methods: [],
+          options: {},
+          scopes: [matchingScope],
+        } as unknown as InternalAccount;
+
+        expect(fn(account)).toBe(true);
+      },
+    );
+
+    it.each(testCases)(
+      'returns false for %s when account type is undefined and scopes do not match',
+      (_name, fn, _matchingScope, nonMatchingScope) => {
+        const account = {
+          id: 'test-id',
+          address: 'test-address',
+          metadata: {},
+          methods: [],
+          options: {},
+          scopes: [undefined, nonMatchingScope],
+        } as unknown as InternalAccount;
+
+        expect(fn(account)).toBe(false);
+      },
+    );
   });
 });

--- a/ui/pages/confirmations/utils/account.ts
+++ b/ui/pages/confirmations/utils/account.ts
@@ -1,5 +1,35 @@
 import { InternalAccount } from '@metamask/keyring-internal-api';
 
+const startsWithNamespace = (value: unknown, namespacePrefix: string): boolean =>
+  typeof value === 'string' && value.startsWith(namespacePrefix);
+
+const hasNamespaceInScopes = (
+  scopes: unknown,
+  namespacePrefix: string,
+): boolean => {
+  if (!Array.isArray(scopes)) {
+    return false;
+  }
+
+  return scopes.some((scope) => startsWithNamespace(scope, namespacePrefix));
+};
+
+const isAccountCompatibleForSend = (
+  account: InternalAccount,
+  namespace: string,
+): boolean => {
+  if (!account) {
+    return false;
+  }
+
+  const namespacePrefix = `${namespace}:`;
+
+  return (
+    startsWithNamespace(account.type, namespacePrefix) ||
+    hasNamespaceInScopes(account.scopes, namespacePrefix)
+  );
+};
+
 /**
  * Checks if an account is EVM-compatible for send operations.
  * This includes regular EVM accounts, hardware wallets, and private key accounts.
@@ -8,19 +38,7 @@ import { InternalAccount } from '@metamask/keyring-internal-api';
  * @returns true if the account can be used for EVM transactions
  */
 export const isEVMAccountForSend = (account: InternalAccount): boolean => {
-  if (!account) {
-    return false;
-  }
-
-  if (account.type.startsWith('eip155:')) {
-    return true;
-  }
-
-  if (account.scopes?.some((scope) => scope.startsWith('eip155:'))) {
-    return true;
-  }
-
-  return false;
+  return isAccountCompatibleForSend(account, 'eip155');
 };
 
 /**
@@ -30,19 +48,7 @@ export const isEVMAccountForSend = (account: InternalAccount): boolean => {
  * @returns true if the account can be used for Solana transactions
  */
 export const isSolanaAccountForSend = (account: InternalAccount): boolean => {
-  if (!account) {
-    return false;
-  }
-
-  if (account.type.startsWith('solana:')) {
-    return true;
-  }
-
-  if (account.scopes?.some((scope) => scope.startsWith('solana:'))) {
-    return true;
-  }
-
-  return false;
+  return isAccountCompatibleForSend(account, 'solana');
 };
 
 /**
@@ -52,39 +58,15 @@ export const isSolanaAccountForSend = (account: InternalAccount): boolean => {
  * @returns true if the account can be used for Bitcoin transactions
  */
 export const isBitcoinAccountForSend = (account: InternalAccount): boolean => {
-  if (!account) {
-    return false;
-  }
-
-  if (account.type.startsWith('bip122:')) {
-    return true;
-  }
-
-  if (account.scopes?.some((scope) => scope.startsWith('bip122:'))) {
-    return true;
-  }
-
-  return false;
+  return isAccountCompatibleForSend(account, 'bip122');
 };
 
 /**
  * Checks if an account is Tron-compatible for send operations.
  *
  * @param account - The internal account object to check
- * @returns true if the account can be used for Solana transactions
+ * @returns true if the account can be used for Tron transactions
  */
 export const isTronAccountForSend = (account: InternalAccount): boolean => {
-  if (!account) {
-    return false;
-  }
-
-  if (account.type.startsWith('tron:')) {
-    return true;
-  }
-
-  if (account.scopes?.some((scope) => scope.startsWith('tron:'))) {
-    return true;
-  }
-
-  return false;
+  return isAccountCompatibleForSend(account, 'tron');
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Context:
- ASSETS-3029 reports a crash in Extension Wallet 13.22.0 while entering send flows (`Send -> select token` or `token -> Send`).
- The error is `TypeError: Cannot read properties of undefined (reading 'startsWith')` and points to `ui/pages/confirmations/utils/account.ts`.

Problem:
- `isEVMAccountForSend`/`isSolanaAccountForSend`/`isBitcoinAccountForSend`/`isTronAccountForSend` assumed `account.type` and `account.scopes` always contained strings.
- When malformed account objects are present (e.g., missing `type`, or non-string scope entries), these checks could call `.startsWith` on `undefined` and crash the UI.

Solution:
- Added a shared, defensive compatibility helper that verifies values are strings before calling `.startsWith`.
- Updated all send-account compatibility helpers (EVM/Solana/Bitcoin/Tron) to use this guarded logic.
- Added regression tests for malformed account shapes (missing `type`, `undefined` scope entries) and added dedicated Tron coverage.

## **Changelog**

CHANGELOG entry: Fixed a crash that could occur in send flow when malformed account entries were missing account type metadata.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3029

## **Manual testing steps**

1. Open the extension and unlock a wallet with multiple token/account options.
2. Go through both reported flows:
   - Click **Send** and then select a token.
   - Select a token first and then click **Send**.
3. Confirm the send UI does not crash and recipients render normally.
4. Confirm this remains true even when account data includes non-EVM accounts in the wallet list.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83f3d48c-2aae-42a1-8f18-7079a3da3c91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83f3d48c-2aae-42a1-8f18-7079a3da3c91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

