### PR TITLE
feat(confirmations): Enable mUSD conversion for hardware wallets

### DIFF
--- a/ui/pages/confirmations/hooks/alerts/transactions/usePayHardwareAccountAlert.test.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/usePayHardwareAccountAlert.test.ts
@@ -18,70 +18,66 @@ import { usePayHardwareAccountAlert } from './usePayHardwareAccountAlert';
 
 const HARDWARE_ACCOUNT_ID = 'hardware-account-id';
 
-function createHardwareAccountState(keyringType: string) {
+function buildAccountState(keyringType: string) {
+  return {
+    internalAccounts: {
+      accounts: {
+        [HARDWARE_ACCOUNT_ID]: {
+          address: CONTRACT_INTERACTION_SENDER_ADDRESS,
+          id: HARDWARE_ACCOUNT_ID,
+          metadata: {
+            importTime: 0,
+            name: 'Hardware Account',
+            keyring: { type: keyringType },
+            lastSelected: 0,
+          },
+          options: {},
+          methods: [
+            'personal_sign',
+            'eth_signTransaction',
+            'eth_signTypedData_v1',
+            'eth_signTypedData_v3',
+            'eth_signTypedData_v4',
+          ],
+          scopes: ['eip155:0'],
+          type: 'eip155:eoa',
+        },
+      },
+      selectedAccount: HARDWARE_ACCOUNT_ID,
+    },
+    accountIdByAddress: {
+      [CONTRACT_INTERACTION_SENDER_ADDRESS]: HARDWARE_ACCOUNT_ID,
+    },
+  };
+}
+
+function buildState(keyringType: string, flagEnabled: boolean) {
   return {
     metamask: {
-      internalAccounts: {
-        accounts: {
-          [HARDWARE_ACCOUNT_ID]: {
-            address: CONTRACT_INTERACTION_SENDER_ADDRESS,
-            id: HARDWARE_ACCOUNT_ID,
-            metadata: {
-              importTime: 0,
-              name: 'Hardware Account',
-              keyring: {
-                type: keyringType,
-              },
-              lastSelected: 0,
-            },
-            options: {},
-            methods: [
-              'personal_sign',
-              'eth_signTransaction',
-              'eth_signTypedData_v1',
-              'eth_signTypedData_v3',
-              'eth_signTypedData_v4',
-            ],
-            scopes: ['eip155:0'],
-            type: 'eip155:eoa',
-          },
-        },
-        selectedAccount: HARDWARE_ACCOUNT_ID,
-      },
-      accountIdByAddress: {
-        [CONTRACT_INTERACTION_SENDER_ADDRESS]: HARDWARE_ACCOUNT_ID,
+      ...buildAccountState(keyringType),
+      remoteFeatureFlags: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        confirmations_pay_hardware: { enabled: flagEnabled },
       },
     },
   };
 }
 
-function runHookWithMusdConversion(keyringType: string = 'HD Key Tree') {
+function runHook(
+  transactionType: TransactionType,
+  keyringType: string,
+  flagEnabled: boolean,
+) {
   const transaction = {
     ...genUnapprovedContractInteractionConfirmation({
       address: CONTRACT_INTERACTION_SENDER_ADDRESS as Hex,
     }),
-    type: TransactionType.musdConversion,
+    type: transactionType,
   };
 
   const state = getMockConfirmStateForTransaction(
     transaction,
-    createHardwareAccountState(keyringType),
-  );
-
-  return renderHookWithConfirmContextProvider(
-    () => usePayHardwareAccountAlert(),
-    state,
-  );
-}
-
-function runHookWithContractInteraction(keyringType: string) {
-  const transaction = genUnapprovedContractInteractionConfirmation({
-    address: CONTRACT_INTERACTION_SENDER_ADDRESS as Hex,
-  });
-
-  const state = getMockConfirmStateForTransaction(
-    transaction,
-    createHardwareAccountState(keyringType),
+    buildState(keyringType, flagEnabled),
   );
 
   return renderHookWithConfirmContextProvider(
@@ -91,11 +87,9 @@ function runHookWithContractInteraction(keyringType: string) {
 }
 
 function runHookWithoutTransaction() {
-  const state = getMockConfirmState();
-
   return renderHookWithConfirmContextProvider(
     () => usePayHardwareAccountAlert(),
-    state,
+    getMockConfirmState(),
   );
 }
 
@@ -109,47 +103,125 @@ const EXPECTED_ALERT = {
 };
 
 describe('usePayHardwareAccountAlert', () => {
-  it('returns alert for Ledger account on musdConversion', async () => {
-    const { result } = runHookWithMusdConversion(KeyringTypes.ledger);
+  // predictDeposit and predictWithdraw are in PAY_HARDWARE_ALERT_TRANSACTION_TYPES
+  // but are not yet in REDESIGN_USER_TRANSACTION_TYPES (confirmation.utils.ts),
+  // so currentConfirmation is undefined for those types and the hook cannot fire.
+  // Tests below cover the types that go through the redesigned confirmation flow.
+  describe('PAY_HARDWARE_ALERT_TRANSACTION_TYPES — always blocked regardless of flag', () => {
+    const alwaysBlockedTypes = [
+      TransactionType.perpsDeposit,
+      TransactionType.perpsWithdraw,
+    ];
 
-    await waitFor(() => {
-      expect(result.current).toStrictEqual([EXPECTED_ALERT]);
+    for (const txType of alwaysBlockedTypes) {
+      it(`returns alert for ${txType} when flag is enabled`, async () => {
+        const { result } = runHook(txType, KeyringTypes.ledger, true);
+        await waitFor(() => {
+          expect(result.current).toStrictEqual([EXPECTED_ALERT]);
+        });
+      });
+
+      it(`returns alert for ${txType} when flag is disabled`, async () => {
+        const { result } = runHook(txType, KeyringTypes.ledger, false);
+        await waitFor(() => {
+          expect(result.current).toStrictEqual([EXPECTED_ALERT]);
+        });
+      });
+
+      it(`returns no alert for ${txType} when non-hardware wallet`, async () => {
+        const { result } = runHook(txType, 'HD Key Tree', true);
+        await waitFor(() => {
+          expect(result.current).toStrictEqual([]);
+        });
+      });
+    }
+  });
+
+  describe('PAY_HARDWARE_FLAG_GATED_TYPES — blocked only when flag is disabled', () => {
+    it('returns alert for musdConversion when flag is disabled', async () => {
+      const { result } = runHook(
+        TransactionType.musdConversion,
+        KeyringTypes.ledger,
+        false,
+      );
+      await waitFor(() => {
+        expect(result.current).toStrictEqual([EXPECTED_ALERT]);
+      });
+    });
+
+    it('returns no alert for musdConversion when flag is enabled', async () => {
+      const { result } = runHook(
+        TransactionType.musdConversion,
+        KeyringTypes.ledger,
+        true,
+      );
+      await waitFor(() => {
+        expect(result.current).toStrictEqual([]);
+      });
+    });
+
+    it('returns no alert for musdConversion with non-hardware wallet regardless of flag', async () => {
+      const { result } = runHook(
+        TransactionType.musdConversion,
+        'HD Key Tree',
+        false,
+      );
+      await waitFor(() => {
+        expect(result.current).toStrictEqual([]);
+      });
     });
   });
 
-  it('returns alert for Trezor account on musdConversion', async () => {
-    const { result } = runHookWithMusdConversion(KeyringTypes.trezor);
+  describe('hardware wallet keyring types', () => {
+    it('returns alert for Ledger', async () => {
+      const { result } = runHook(
+        TransactionType.perpsDeposit,
+        KeyringTypes.ledger,
+        false,
+      );
+      await waitFor(() => {
+        expect(result.current).toStrictEqual([EXPECTED_ALERT]);
+      });
+    });
 
-    await waitFor(() => {
-      expect(result.current).toStrictEqual([EXPECTED_ALERT]);
+    it('returns alert for Trezor', async () => {
+      const { result } = runHook(
+        TransactionType.perpsDeposit,
+        KeyringTypes.trezor,
+        false,
+      );
+      await waitFor(() => {
+        expect(result.current).toStrictEqual([EXPECTED_ALERT]);
+      });
+    });
+
+    it('returns alert for Lattice', async () => {
+      const { result } = runHook(
+        TransactionType.perpsDeposit,
+        KeyringTypes.lattice,
+        false,
+      );
+      await waitFor(() => {
+        expect(result.current).toStrictEqual([EXPECTED_ALERT]);
+      });
     });
   });
 
-  it('returns alert for Lattice account on musdConversion', async () => {
-    const { result } = runHookWithMusdConversion(KeyringTypes.lattice);
-
-    await waitFor(() => {
-      expect(result.current).toStrictEqual([EXPECTED_ALERT]);
-    });
-  });
-
-  it('returns no alert for non-hardware wallet account on musdConversion', () => {
-    const { result } = runHookWithMusdConversion('HD Key Tree');
-
-    expect(result.current).toStrictEqual([]);
-  });
-
-  it('returns no alert for hardware wallet on contractInteraction', async () => {
-    const { result } = runHookWithContractInteraction(KeyringTypes.ledger);
-
-    await waitFor(() => {
-      expect(result.current).toStrictEqual([]);
+  describe('non-applicable transaction types', () => {
+    it('returns no alert for contractInteraction with hardware wallet', async () => {
+      const { result } = runHook(
+        TransactionType.contractInteraction,
+        KeyringTypes.ledger,
+        false,
+      );
+      await waitFor(() => {
+        expect(result.current).toStrictEqual([]);
+      });
     });
   });
 
   it('returns no alert if there is no current confirmation', () => {
     const { result } = runHookWithoutTransaction();
-
     expect(result.current).toStrictEqual([]);
   });
 });

--- a/ui/pages/confirmations/hooks/alerts/transactions/usePayHardwareAccountAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/usePayHardwareAccountAlert.ts
@@ -72,5 +72,11 @@ export function usePayHardwareAccountAlert(): Alert[] {
         isBlocking: true,
       },
     ];
-  }, [isHardwareWallet, isAlwaysBlockedType, isFlagGatedType, isPayHardwareEnabled, t]);
+  }, [
+    isHardwareWallet,
+    isAlwaysBlockedType,
+    isFlagGatedType,
+    isPayHardwareEnabled,
+    t,
+  ]);
 }

--- a/ui/pages/confirmations/hooks/alerts/transactions/usePayHardwareAccountAlert.ts
+++ b/ui/pages/confirmations/hooks/alerts/transactions/usePayHardwareAccountAlert.ts
@@ -13,20 +13,25 @@ import { AlertsName } from '../constants';
 import { useConfirmContext } from '../../../context/confirm';
 import { getInternalAccountByAddress } from '../../../../../selectors/accounts';
 import { isHardwareAccount } from '../../../../../components/app/rewards/utils/isHardwareAccount';
+import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
+import { selectIsPayHardwareEnabled } from '../../../selectors/feature-flags';
 
 const PAY_HARDWARE_ALERT_TRANSACTION_TYPES: TransactionType[] = [
-  TransactionType.musdConversion,
   TransactionType.perpsDeposit,
   TransactionType.perpsWithdraw,
   TransactionType.predictDeposit,
   TransactionType.predictWithdraw,
 ];
 
+const PAY_HARDWARE_FLAG_GATED_TYPES: TransactionType[] = [
+  TransactionType.musdConversion,
+];
+
 export function usePayHardwareAccountAlert(): Alert[] {
   const t = useI18nContext();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
 
-  const transactionType = currentConfirmation?.type;
+  const isPayHardwareEnabled = useSelector(selectIsPayHardwareEnabled);
   const fromAddress = currentConfirmation?.txParams?.from as Hex | undefined;
 
   const account = useSelector((state) =>
@@ -35,12 +40,25 @@ export function usePayHardwareAccountAlert(): Alert[] {
 
   const isHardwareWallet = account ? isHardwareAccount(account) : false;
 
-  const isApplicableType =
-    transactionType !== undefined &&
-    PAY_HARDWARE_ALERT_TRANSACTION_TYPES.includes(transactionType);
+  const isAlwaysBlockedType = hasTransactionType(
+    currentConfirmation,
+    PAY_HARDWARE_ALERT_TRANSACTION_TYPES,
+  );
+
+  const isFlagGatedType = hasTransactionType(
+    currentConfirmation,
+    PAY_HARDWARE_FLAG_GATED_TYPES,
+  );
 
   return useMemo(() => {
-    if (!isApplicableType || !isHardwareWallet) {
+    if (!isHardwareWallet) {
+      return [];
+    }
+
+    const shouldAlert =
+      isAlwaysBlockedType || (isFlagGatedType && !isPayHardwareEnabled);
+
+    if (!shouldAlert) {
       return [];
     }
 
@@ -54,5 +72,5 @@ export function usePayHardwareAccountAlert(): Alert[] {
         isBlocking: true,
       },
     ];
-  }, [isApplicableType, isHardwareWallet, t]);
+  }, [isHardwareWallet, isAlwaysBlockedType, isFlagGatedType, isPayHardwareEnabled, t]);
 }

--- a/ui/pages/confirmations/selectors/feature-flags.test.ts
+++ b/ui/pages/confirmations/selectors/feature-flags.test.ts
@@ -5,6 +5,7 @@ import {
   selectIsEnforcedSimulationsEnabled,
   selectIsMetaMaskPayDappsEnabled,
   selectIsPayAmountPrefillEnabled,
+  selectIsPayHardwareEnabled,
   selectPayQuoteConfig,
   selectPreferredPayToken,
 } from './feature-flags';
@@ -57,6 +58,10 @@ type PayExtendedFlag = {
   };
 };
 
+type HardwareWalletFlag = {
+  enabled?: boolean;
+};
+
 type MockState = {
   metamask: {
     remoteFeatureFlags: {
@@ -65,6 +70,7 @@ type MockState = {
       confirmations_pay_post_quote?: PayPostQuoteFlag;
       confirmations_pay_tokens?: PayTokensFlag;
       confirmations_pay_extended?: PayExtendedFlag;
+      confirmations_pay_hardware?: HardwareWalletFlag;
     };
   };
 };
@@ -356,6 +362,45 @@ describe('Confirmations Pay Feature Flags', () => {
       expect(selectIsPayAmountPrefillEnabled(state, 'musdConversion')).toBe(
         false,
       );
+    });
+  });
+
+  describe('selectIsPayHardwareEnabled', () => {
+    const getMockPayHardwareState = (
+      confirmations_pay_hardware?: HardwareWalletFlag,
+    ): MockState => ({
+      metamask: {
+        remoteFeatureFlags: {
+          ...(confirmations_pay_hardware !== undefined && {
+            confirmations_pay_hardware,
+          }),
+        },
+      },
+    });
+
+    it('returns true when enabled is true', () => {
+      const state = getMockPayHardwareState({ enabled: true });
+      expect(selectIsPayHardwareEnabled(state)).toBe(true);
+    });
+
+    it('returns false when enabled is false', () => {
+      const state = getMockPayHardwareState({ enabled: false });
+      expect(selectIsPayHardwareEnabled(state)).toBe(false);
+    });
+
+    it('defaults to false when confirmations_pay_hardware is not set', () => {
+      const state = getMockPayHardwareState();
+      expect(selectIsPayHardwareEnabled(state)).toBe(false);
+    });
+
+    it('defaults to false when confirmations_pay_hardware is an empty object', () => {
+      const state = getMockPayHardwareState({});
+      expect(selectIsPayHardwareEnabled(state)).toBe(false);
+    });
+
+    it('defaults to false when remoteFeatureFlags is empty', () => {
+      const state: MockState = { metamask: { remoteFeatureFlags: {} } };
+      expect(selectIsPayHardwareEnabled(state)).toBe(false);
     });
   });
 });

--- a/ui/pages/confirmations/selectors/feature-flags.ts
+++ b/ui/pages/confirmations/selectors/feature-flags.ts
@@ -58,6 +58,10 @@ type RawPayExtendedFlag = {
   };
 };
 
+type HardwareWalletConfig = {
+  enabled?: boolean;
+};
+
 const selectConfirmationsPayDappsFlag = createSelector(
   getRemoteFeatureFlags,
   (flags) =>
@@ -108,6 +112,18 @@ const selectPayExtendedFlag = createSelector(
         confirmations_pay_extended?: RawPayExtendedFlag;
       }
     ).confirmations_pay_extended,
+  /* eslint-enable @typescript-eslint/naming-convention */
+);
+
+const selectPayHardwareFlag = createSelector(
+  getRemoteFeatureFlags,
+  /* eslint-disable @typescript-eslint/naming-convention */
+  (flags) =>
+    (
+      flags as unknown as {
+        confirmations_pay_hardware?: HardwareWalletConfig;
+      }
+    ).confirmations_pay_hardware,
   /* eslint-enable @typescript-eslint/naming-convention */
 );
 
@@ -193,6 +209,11 @@ export const selectEnforcedSimulationsSlippage = createSelector(
   getRemoteFeatureFlags,
   (remoteFeatureFlags): number =>
     getEnforcedSimulationsSlippage({ remoteFeatureFlags }),
+);
+
+export const selectIsPayHardwareEnabled = createSelector(
+  selectPayHardwareFlag,
+  (flag): boolean => flag?.enabled ?? false,
 );
 
 function getPreferredTokensForTransaction(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Refactors the Pay hardware wallet alert logic:

- **Two transaction type lists**: `PAY_HARDWARE_ALERT_TRANSACTION_TYPES` (perps/predict) always block hardware wallets. `PAY_HARDWARE_FLAG_GATED_TYPES` (musdConversion) only blocks when `confirmations_pay_hardware.enabled = false`, allowing musdConversion to be unblocked via remote flag.
- **Selector pattern**: `selectMetaMaskPayHardwareFlags` split into private `selectPayHardwareFlag` + public `selectIsPayHardwareEnabled` (plain boolean), consistent with other selectors in the file.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Use a Ledger/Trezor/Lattice hardware wallet account.
2. Initiate a perps deposit or withdraw — confirm the "Hardware wallets aren't supported" blocking alert appears regardless of `confirmations_pay_hardware` flag value.
3. Set `confirmations_pay_hardware.enabled = false` (via `.manifest-overrides.json`), initiate a musdConversion — confirm the blocking alert appears.
4. Set `confirmations_pay_hardware.enabled = true`, initiate a musdConversion — confirm no alert appears.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/858d8d55-08cf-42f7-a701-c488e0972ffd



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which Pay confirmations block hardware signers and introduces a remote flag path for musdConversion, affecting user ability to confirm Pay flows.
> 
> **Overview**
> **Pay hardware blocking** is split by transaction type: perps/predict flows still always show the blocking alert for Ledger/Trezor/Lattice, while **musdConversion** only blocks hardware when `confirmations_pay_hardware.enabled` is false (or missing).
> 
> `usePayHardwareAccountAlert` reads **`selectIsPayHardwareEnabled`** from remote flags and uses **`hasTransactionType`** against two lists (`PAY_HARDWARE_ALERT_TRANSACTION_TYPES` vs `PAY_HARDWARE_FLAG_GATED_TYPES`). Confirmations feature-flag selectors add private **`selectPayHardwareFlag`** and public **`selectIsPayHardwareEnabled`**, with unit tests. Hook tests are reorganized to cover flag on/off, always-blocked types, and non-applicable txs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c84af481878af2f8ee657f53d583b4a4108a2c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->