### PR TITLE
test(hardware-wallets): cover signing page support code

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -45,6 +45,39 @@ module.exports = {
     config.resolve.alias['../../../store/actions$'] = require.resolve(
       '../ui/__mocks__/actions.js',
     );
+
+    const hwSwapHooksMock = path.resolve(
+      __dirname,
+      '..',
+      'ui',
+      '__mocks__',
+      'hardware-wallet-swap',
+      'hooks',
+    );
+    config.resolve.alias[
+      '../../../hooks/hardware-wallets/useHwSwapQuoteData$'
+    ] = hwSwapHooksMock;
+    config.resolve.alias[
+      '../../../hooks/hardware-wallets/useHwSwapSubmission$'
+    ] = hwSwapHooksMock;
+    config.resolve.alias[
+      '../../../hooks/hardware-wallets/useHwSwapConnectionMonitoring$'
+    ] = hwSwapHooksMock;
+    config.resolve.alias[
+      '../../../hooks/hardware-wallets/useHwSwapConfirmationMonitoring$'
+    ] = hwSwapHooksMock;
+    config.resolve.alias['../../../hooks/hardware-wallets/useHwSwapQrState$'] =
+      hwSwapHooksMock;
+    config.resolve.alias[
+      '../../../hooks/hardware-wallets/useHwSwapNavigation$'
+    ] = hwSwapHooksMock;
+    config.resolve.alias['../../../hooks/hardware-wallets/useHwSignTracker$'] =
+      hwSwapHooksMock;
+    config.resolve.alias['../../../hooks/bridge/useSubmitBridgeTransaction$'] =
+      hwSwapHooksMock;
+    config.resolve.alias['../../../hooks/bridge/useBridgeNavigation$'] =
+      hwSwapHooksMock;
+
     config.resolve.fallback = {
       child_process: false,
       constants: false,

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -504,6 +504,9 @@
     "ui/hooks/accounts/useAccountsOperationsLoadingStates.test.ts": {
       "MetaMask: Background connection not initialized": 2
     },
+    "ui/hooks/bridge/useEnableMissingNetwork.test.ts": {
+      "MetaMask: Background connection not initialized": 1
+    },
     "ui/hooks/bridge/useInitialBridgeTokens.test.ts": {
       "React: Act warnings (component updates not wrapped)": 1,
       "Reselect: Input stability warnings": 1
@@ -511,6 +514,9 @@
     "ui/hooks/bridge/usePopularTokens.test.ts": {
       "React: Act warnings (component updates not wrapped)": 2,
       "Reselect: Input stability warnings": 1
+    },
+    "ui/hooks/bridge/useSubmitBridgeTransaction.test.tsx": {
+      "Reselect: Identity function warnings": 1
     },
     "ui/hooks/bridge/useTokenSearchResults.test.ts": {
       "React: Act warnings (component updates not wrapped)": 2,
@@ -621,12 +627,6 @@
     },
     "ui/pages/asset/components/asset-page.test.tsx": {
       "React: DOM nesting violations": 2,
-      "Reselect: Identity function warnings": 1
-    },
-    "ui/pages/bridge/hooks/useEnableMissingNetwork.test.ts": {
-      "MetaMask: Background connection not initialized": 1
-    },
-    "ui/pages/bridge/hooks/useSubmitBridgeTransaction.test.tsx": {
       "Reselect: Identity function warnings": 1
     },
     "ui/pages/bridge/index.test.tsx": {

--- a/ui/__mocks__/hardware-wallet-swap/hooks.ts
+++ b/ui/__mocks__/hardware-wallet-swap/hooks.ts
@@ -1,0 +1,228 @@
+import { useEffect, useRef } from 'react';
+import type {
+  HardwareWalletSignaturesAction,
+  HardwareWalletSignaturesState,
+} from '../../pages/hardware-wallets/swap/hardware-wallet-signatures-state-machine';
+import {
+  HardwareWalletSignatureEvent,
+  HardwareWalletSignatureStatus,
+} from '../../pages/hardware-wallets/swap/hardware-wallet-signatures-state-machine';
+import { hwSwapStoryState } from './story-state';
+
+const FROM_ADDRESS = '0x1234567890123456789012345678901234567890';
+const TO_ADDRESS = '0x0987654321098765432109876543210987654321';
+const SPENDER_ADDRESS = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+const FROM_TOKEN = { symbol: 'ETH' };
+const TO_TOKEN = { symbol: 'USDC' };
+
+type Dispatch = (action: HardwareWalletSignaturesAction) => void;
+
+function buildLockedQuote(needsTwoConfirmations: boolean) {
+  return {
+    sentAmount: { amount: '1.5' },
+    trade: { from: FROM_ADDRESS, to: TO_ADDRESS },
+    approval: needsTwoConfirmations ? { to: SPENDER_ADDRESS } : undefined,
+    quote: {
+      srcTokenAmount: '1500000000000000000',
+      destTokenAmount: '3000000000',
+      requestId: 'story-request-id',
+    },
+  };
+}
+
+function isSigning(status: HardwareWalletSignatureStatus): boolean {
+  return (
+    status === HardwareWalletSignatureStatus.AwaitingFirstSignature ||
+    status === HardwareWalletSignatureStatus.AwaitingFinalSignature
+  );
+}
+
+function driveToStatus(
+  target: HardwareWalletSignatureStatus,
+  current: HardwareWalletSignatureStatus,
+  needsTwoConfirmations: boolean,
+  dispatch: Dispatch,
+): void {
+  if (target === current) {
+    return;
+  }
+
+  const reset = (): void =>
+    dispatch({
+      type: HardwareWalletSignatureEvent.Reset,
+      needsTwoConfirmations,
+    });
+
+  if (target === HardwareWalletSignatureStatus.AwaitingFirstSignature) {
+    reset();
+    return;
+  }
+
+  if (target === HardwareWalletSignatureStatus.AwaitingFinalSignature) {
+    if (
+      current === HardwareWalletSignatureStatus.AwaitingFirstSignature &&
+      needsTwoConfirmations
+    ) {
+      dispatch({ type: HardwareWalletSignatureEvent.FirstSignatureSubmitted });
+    } else {
+      reset();
+    }
+    return;
+  }
+
+  if (target === HardwareWalletSignatureStatus.Submitted) {
+    if (
+      needsTwoConfirmations &&
+      current === HardwareWalletSignatureStatus.AwaitingFirstSignature
+    ) {
+      dispatch({ type: HardwareWalletSignatureEvent.FirstSignatureSubmitted });
+    } else if (isSigning(current)) {
+      dispatch({ type: HardwareWalletSignatureEvent.TransactionSubmitted });
+    } else {
+      reset();
+    }
+    return;
+  }
+
+  if (target === HardwareWalletSignatureStatus.Rejected) {
+    if (isSigning(current)) {
+      dispatch({ type: HardwareWalletSignatureEvent.TransactionRejected });
+    } else {
+      reset();
+    }
+    return;
+  }
+
+  if (target === HardwareWalletSignatureStatus.Failed) {
+    if (isSigning(current)) {
+      dispatch({ type: HardwareWalletSignatureEvent.TransactionFailed });
+    } else {
+      reset();
+    }
+    return;
+  }
+
+  if (target === HardwareWalletSignatureStatus.Disconnected) {
+    if (isSigning(current)) {
+      dispatch({ type: HardwareWalletSignatureEvent.DeviceDisconnected });
+    } else {
+      reset();
+    }
+  }
+}
+
+export function useHwSwapQuoteData() {
+  const { needsTwoConfirmations, hardwareWalletType } =
+    hwSwapStoryState.current;
+  const ref = useRef<{
+    needsTwoConf: boolean;
+    quote: ReturnType<typeof buildLockedQuote>;
+  }>({
+    needsTwoConf: needsTwoConfirmations,
+    quote: buildLockedQuote(needsTwoConfirmations),
+  });
+
+  if (ref.current.needsTwoConf !== needsTwoConfirmations) {
+    ref.current = {
+      needsTwoConf: needsTwoConfirmations,
+      quote: buildLockedQuote(needsTwoConfirmations),
+    };
+  }
+
+  const lockedQuote = ref.current.quote;
+  return {
+    activeQuote: lockedQuote,
+    lockedQuote,
+    fromToken: FROM_TOKEN,
+    toToken: TO_TOKEN,
+    hardwareWalletType,
+  };
+}
+
+export function useHwSwapSubmission({
+  signatureState,
+  dispatchSignatureEvent,
+  needsTwoConfirmations,
+}: {
+  signatureState: HardwareWalletSignaturesState;
+  dispatchSignatureEvent: Dispatch;
+  needsTwoConfirmations: boolean;
+}) {
+  const hasStartedSubmission = useRef(true);
+  const target = hwSwapStoryState.current.status;
+
+  useEffect(() => {
+    driveToStatus(
+      target,
+      signatureState.status,
+      needsTwoConfirmations,
+      dispatchSignatureEvent,
+    );
+  }, [
+    target,
+    signatureState.status,
+    needsTwoConfirmations,
+    dispatchSignatureEvent,
+  ]);
+
+  return {
+    submitActiveQuote: async () => undefined,
+    retrySubmission: async () => undefined,
+    hasStartedSubmission,
+  };
+}
+
+function useSubmitBridgeTransaction() {
+  return {
+    submitBridgeTransaction: async () => undefined,
+  };
+}
+
+export default useSubmitBridgeTransaction;
+
+export function useHwSwapConnectionMonitoring() {
+  return {
+    isDeviceDisconnectedRef: { current: false },
+    resetConnectionError: () => undefined,
+  };
+}
+
+export function useHwSwapConfirmationMonitoring() {
+  return { confirmationTxData: null };
+}
+
+export function useHwSwapQrState({
+  signatureState,
+}: {
+  signatureState: HardwareWalletSignaturesState;
+}) {
+  const { showInlineQrSigning, isReadingQrSignature } =
+    hwSwapStoryState.current;
+  const awaiting = isSigning(signatureState.status);
+  return {
+    isReadingQrSignature,
+    setIsReadingQrSignature: () => undefined,
+    qrSignRequest: null,
+    showInlineQrSigning,
+    activeQrStep:
+      showInlineQrSigning && awaiting ? signatureState.status : null,
+    handleQrScanSuccess: () => undefined,
+    handleQrSignatureCancel: () => undefined,
+  };
+}
+
+export function useHwSwapNavigation() {
+  // Intentionally a no-op so the Submitted story stays mounted.
+}
+
+export function useHwSignTracker() {
+  return {
+    cancelCurrentBatch: async () => undefined,
+  };
+}
+
+export function useBridgeNavigation() {
+  return {
+    navigateToBridgePage: () => undefined,
+  };
+}

--- a/ui/__mocks__/hardware-wallet-swap/story-state.ts
+++ b/ui/__mocks__/hardware-wallet-swap/story-state.ts
@@ -1,0 +1,19 @@
+import { HardwareWalletSignatureStatus } from '../../pages/hardware-wallets/swap/hardware-wallet-signatures-state-machine';
+
+export type HwSwapStoryArgs = {
+  status: HardwareWalletSignatureStatus;
+  needsTwoConfirmations: boolean;
+  hardwareWalletType: 'trezor' | 'ledger' | 'keystore';
+  showInlineQrSigning: boolean;
+  isReadingQrSignature: boolean;
+};
+
+export const hwSwapStoryState: { current: HwSwapStoryArgs } = {
+  current: {
+    status: HardwareWalletSignatureStatus.AwaitingFirstSignature,
+    needsTwoConfirmations: true,
+    hardwareWalletType: 'ledger',
+    showInlineQrSigning: false,
+    isReadingQrSignature: false,
+  },
+};

--- a/ui/pages/hardware-wallets/swap/hardware-wallet-signatures-state-machine/test-helpers.ts
+++ b/ui/pages/hardware-wallets/swap/hardware-wallet-signatures-state-machine/test-helpers.ts
@@ -1,25 +1,26 @@
 import { HardwareWalletSignatureStatus } from '.';
-import type { HardwareWalletSignaturesState } from '.';
+import type { HardwareWalletSignaturesState, SigningStatus } from '.';
 
 export const createSignatureState = (
   status: HardwareWalletSignatureStatus,
+  savedStep?: SigningStatus,
 ): HardwareWalletSignaturesState => {
   switch (status) {
     case HardwareWalletSignatureStatus.Rejected:
       return {
         status,
-        rejectedSignature: HardwareWalletSignatureStatus.AwaitingFirstSignature,
+        rejectedSignature: savedStep ?? HardwareWalletSignatureStatus.AwaitingFirstSignature,
       };
     case HardwareWalletSignatureStatus.Failed:
       return {
         status,
-        failedSignature: HardwareWalletSignatureStatus.AwaitingFirstSignature,
+        failedSignature: savedStep ?? HardwareWalletSignatureStatus.AwaitingFirstSignature,
       };
     case HardwareWalletSignatureStatus.Disconnected:
       return {
         status,
         disconnectedSignature:
-          HardwareWalletSignatureStatus.AwaitingFirstSignature,
+          savedStep ?? HardwareWalletSignatureStatus.AwaitingFirstSignature,
       };
     default:
       return { status };

--- a/ui/pages/hardware-wallets/swap/hardware-wallet-signatures.stories.tsx
+++ b/ui/pages/hardware-wallets/swap/hardware-wallet-signatures.stories.tsx
@@ -1,0 +1,260 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+import { Provider } from 'react-redux';
+import configureStore from '../../../store/store';
+import HardwareWalletSignatures from './hardware-wallet-signatures';
+import { HardwareWalletSignatureStatus } from './hardware-wallet-signatures-state-machine';
+import { ConnectionState } from '../../../contexts/hardware-wallets';
+import {
+  HardwareWalletActionsContext,
+  HardwareWalletStateContext,
+} from '../../../contexts/hardware-wallets/HardwareWalletContext';
+import { HardwareConnectionPermissionState } from '../../../contexts/hardware-wallets/types';
+import { MetaMetricsContext } from '../../../contexts/metametrics';
+import mockState from '../../../../test/data/mock-state.json';
+import { mockNetworkState } from '../../../../test/stub/networks';
+import {
+  hwSwapStoryState,
+  type HwSwapStoryArgs,
+} from '../../../__mocks__/hardware-wallet-swap/story-state';
+
+/**
+ * Stories for the real `HardwareWalletSignatures` component.
+ *
+ * The component reads its state from hooks that touch Redux, the hardware
+ * wallet contexts, and the background. Those I/O hooks are intercepted via the
+ * scoped webpack aliases defined in `.storybook/main.js` (pointing at
+ * `ui/__mocks__/hardware-wallet-swap/hooks.ts`), which neutralize side effects
+ * and drive the component's REAL internal state machine to the status selected
+ * in the controls. Everything rendered here — the state machine, the step
+ * derivation, the JSX — is the genuine component output.
+ */
+
+const CHAIN_ID_MOCK = '0x1';
+
+type Args = HwSwapStoryArgs;
+
+const createMockStore = () =>
+  configureStore({
+    metamask: {
+      ...mockState.metamask,
+      preferences: {
+        ...mockState.metamask.preferences,
+        useNativeCurrencyAsPrimaryCurrency: false,
+      },
+      ...mockNetworkState({ chainId: CHAIN_ID_MOCK }),
+    },
+  });
+
+const metricsValue = {
+  trackEvent: () => Promise.resolve(),
+  bufferedTrace: () => Promise.resolve(undefined),
+  bufferedEndTrace: () => undefined,
+  onboardingParentContext: { current: null },
+};
+
+const hardwareWalletActionsValue = {
+  connect: async () => undefined,
+  disconnect: async () => undefined,
+  clearError: () => undefined,
+  setConnectionReady: () => undefined,
+  checkHardwareWalletPermission: async () =>
+    HardwareConnectionPermissionState.Granted,
+  requestHardwareWalletPermission: async () => false,
+  ensureDeviceReady: async () => true,
+  setSigningInProgress: (_value: boolean) => undefined,
+};
+
+interface StoryContext {
+  args: Args;
+}
+
+const withProviders = (Story: React.ComponentType, context: StoryContext) => {
+  hwSwapStoryState.current = { ...context.args };
+  const store = createMockStore();
+
+  return (
+    <Provider store={store}>
+      <MetaMetricsContext.Provider value={metricsValue}>
+        <HardwareWalletStateContext.Provider
+          value={{ connectionState: ConnectionState.ready() }}
+        >
+          <HardwareWalletActionsContext.Provider
+            value={hardwareWalletActionsValue}
+          >
+            <Story />
+          </HardwareWalletActionsContext.Provider>
+        </HardwareWalletStateContext.Provider>
+      </MetaMetricsContext.Provider>
+    </Provider>
+  );
+};
+
+const meta: Meta<Args> = {
+  title: 'Pages/HardwareWallets/Swap/HardwareWalletSignatures',
+  component: HardwareWalletSignatures,
+  decorators: [withProviders],
+  args: {
+    status: HardwareWalletSignatureStatus.AwaitingFirstSignature,
+    needsTwoConfirmations: true,
+    hardwareWalletType: 'trezor',
+    showInlineQrSigning: false,
+    isReadingQrSignature: false,
+  },
+  argTypes: {
+    status: {
+      control: 'select',
+      options: [
+        HardwareWalletSignatureStatus.AwaitingFirstSignature,
+        HardwareWalletSignatureStatus.AwaitingFinalSignature,
+        HardwareWalletSignatureStatus.Submitted,
+        HardwareWalletSignatureStatus.Rejected,
+        HardwareWalletSignatureStatus.Failed,
+        HardwareWalletSignatureStatus.Disconnected,
+      ],
+      description: 'Signature state-machine status to visualize',
+    },
+    needsTwoConfirmations: {
+      control: 'boolean',
+      description:
+        'Whether an approval step is required (drives the two-step layout)',
+    },
+    hardwareWalletType: {
+      control: 'select',
+      options: ['trezor', 'ledger', 'keystore'],
+      description: 'Hardware wallet device type shown by the animation',
+    },
+    showInlineQrSigning: {
+      control: 'boolean',
+      description: 'Whether the inline QR signing UI is shown',
+    },
+    isReadingQrSignature: {
+      control: 'boolean',
+      description: 'Whether the QR scanner is active',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<Args>;
+
+export const Interactive: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Use the controls to explore every hardware wallet signing state. ' +
+          'The status control drives the real state machine via dispatched ' +
+          'reducer events, so the rendered UI is genuine.',
+      },
+    },
+  },
+};
+
+export const ApprovalRequiredFirstSignature: Story = {
+  args: {
+    status: HardwareWalletSignatureStatus.AwaitingFirstSignature,
+    needsTwoConfirmations: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Initial state when approval is required: two-step layout with ' +
+          'step 1 (approve) active.',
+      },
+    },
+  },
+};
+
+export const ApprovalRequiredFinalSignature: Story = {
+  args: {
+    status: HardwareWalletSignatureStatus.AwaitingFinalSignature,
+    needsTwoConfirmations: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'After the approval is signed: step 1 complete, step 2 (swap) active.',
+      },
+    },
+  },
+};
+
+export const SingleConfirmationAwaiting: Story = {
+  args: {
+    status: HardwareWalletSignatureStatus.AwaitingFinalSignature,
+    needsTwoConfirmations: false,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'No approval needed: single-step layout with only the swap signature.',
+      },
+    },
+  },
+};
+
+export const SuccessSubmitted: Story = {
+  args: {
+    status: HardwareWalletSignatureStatus.Submitted,
+    needsTwoConfirmations: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Terminal success state: all steps complete and the footer is hidden.',
+      },
+    },
+  },
+};
+
+export const Rejected: Story = {
+  args: {
+    status: HardwareWalletSignatureStatus.Rejected,
+    needsTwoConfirmations: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'User rejected a signature on the device: failed step highlighted ' +
+          'and the retry button is shown.',
+      },
+    },
+  },
+};
+
+export const Failed: Story = {
+  args: {
+    status: HardwareWalletSignatureStatus.Failed,
+    needsTwoConfirmations: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Signing failed due to an error: failed step highlighted and the ' +
+          'retry button is shown.',
+      },
+    },
+  },
+};
+
+export const Disconnected: Story = {
+  args: {
+    status: HardwareWalletSignatureStatus.Disconnected,
+    needsTwoConfirmations: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'Device disconnected mid-flow: reconnect-and-retry button is shown.',
+      },
+    },
+  },
+};

--- a/ui/pages/hardware-wallets/swap/hardware-wallet-signatures.utils.test.ts
+++ b/ui/pages/hardware-wallets/swap/hardware-wallet-signatures.utils.test.ts
@@ -8,6 +8,9 @@ import {
   getFinalStepLabel,
   getFirstStepDescription,
   getFinalStepDescription,
+  getQrHardwareSigningPageTitle,
+  getStepLabels,
+  getStepDescriptions,
   isQrHardwareSignRequest,
   getTransactionField,
 } from './hardware-wallet-signatures.utils';
@@ -380,6 +383,184 @@ describe('hardware-wallet-signatures utils', () => {
           t,
         }),
       ).toBeUndefined();
+    });
+  });
+
+  describe('getStepLabels', () => {
+    it('returns the send label on the first step and gas label on the final step for a two-step sendBundle', () => {
+      const { firstStepLabel, finalStepLabel } = getStepLabels({
+        isSendBundleFlow: true,
+        needsTwoConfirmations: true,
+        status: HardwareWalletSignatureStatus.AwaitingFirstSignature,
+        firstStepStatus: SignatureStepStatus.Active,
+        finalStepStatus: SignatureStepStatus.Pending,
+        sendAmount: '1.5',
+        sendSymbol: 'ETH',
+        gasSymbol: 'ETH',
+        t,
+      });
+
+      expect(firstStepLabel).toBe('bridgeHwSendingAmount[1.5,ETH]');
+      expect(finalStepLabel).toBe('sendBundleHwGasPayment[ETH]');
+    });
+
+    it('returns the send label on the final step for a single-step sendBundle', () => {
+      const { firstStepLabel, finalStepLabel } = getStepLabels({
+        isSendBundleFlow: true,
+        needsTwoConfirmations: false,
+        status: HardwareWalletSignatureStatus.AwaitingFinalSignature,
+        firstStepStatus: SignatureStepStatus.Pending,
+        finalStepStatus: SignatureStepStatus.Active,
+        sendAmount: '1.5',
+        sendSymbol: 'ETH',
+        t,
+      });
+
+      // Only the final step is rendered for a single-step sendBundle; it is
+      // the SEND tx so it uses the send label.
+      expect(finalStepLabel).toBe('bridgeHwSendingAmount[1.5,ETH]');
+      // firstStepLabel is not rendered but stays valid.
+      expect(firstStepLabel).toBe('bridgeHwSendingAmount[1.5,ETH]');
+    });
+
+    it('returns the send label with undefined amount/symbol when not provided for sendBundle', () => {
+      const { finalStepLabel } = getStepLabels({
+        isSendBundleFlow: true,
+        needsTwoConfirmations: false,
+        status: HardwareWalletSignatureStatus.AwaitingFinalSignature,
+        firstStepStatus: SignatureStepStatus.Pending,
+        finalStepStatus: SignatureStepStatus.Active,
+        t,
+      });
+
+      expect(finalStepLabel).toBe('bridgeHwSendingAmount[,]');
+    });
+
+    it('returns approve/send labels for the bridge flow', () => {
+      const { firstStepLabel, finalStepLabel } = getStepLabels({
+        isSendBundleFlow: false,
+        needsTwoConfirmations: true,
+        status: HardwareWalletSignatureStatus.AwaitingFirstSignature,
+        firstStepStatus: SignatureStepStatus.Active,
+        finalStepStatus: SignatureStepStatus.Pending,
+        fromAmount: '1.5',
+        fromTokenSymbol: 'ETH',
+        t,
+      });
+
+      expect(firstStepLabel).toBe('bridgeHwApproveAmount[1.5,ETH]');
+      expect(finalStepLabel).toBe('bridgeHwSendAmount[1.5,ETH]');
+    });
+  });
+
+  describe('getStepDescriptions', () => {
+    it('returns the destination on the first step for a two-step sendBundle', () => {
+      const { firstStepDescription, finalStepDescription } =
+        getStepDescriptions({
+          isSendBundleFlow: true,
+          needsTwoConfirmations: true,
+          firstStepStatus: SignatureStepStatus.Active,
+          toAddress: '0x1234567890abcdef1234567890abcdef12345678',
+          t,
+        });
+
+      expect(firstStepDescription).toBe('bridgeHwToAddress[0x12345...45678]');
+      expect(finalStepDescription).toBeUndefined();
+    });
+
+    it('returns the destination on the final step for a single-step sendBundle', () => {
+      const { firstStepDescription, finalStepDescription } =
+        getStepDescriptions({
+          isSendBundleFlow: true,
+          needsTwoConfirmations: false,
+          firstStepStatus: SignatureStepStatus.Pending,
+          toAddress: '0x1234567890abcdef1234567890abcdef12345678',
+          t,
+        });
+
+      // Only the final step is rendered; the SEND destination shows there.
+      expect(finalStepDescription).toBe('bridgeHwToAddress[0x12345...45678]');
+      expect(firstStepDescription).toBeUndefined();
+    });
+
+    it('returns destination on both steps for the bridge flow', () => {
+      const { firstStepDescription, finalStepDescription } =
+        getStepDescriptions({
+          isSendBundleFlow: false,
+          needsTwoConfirmations: true,
+          firstStepStatus: SignatureStepStatus.Active,
+          spenderAddress: '0x1234567890abcdef1234567890abcdef12345678',
+          toAddress: '0x1234567890abcdef1234567890abcdef12345678',
+          t,
+        });
+
+      expect(firstStepDescription).toBe('bridgeHwSpender[0x12345...45678]');
+      expect(finalStepDescription).toBe('bridgeHwToAddress[0x12345...45678]');
+    });
+  });
+
+  describe('getQrHardwareSigningPageTitle', () => {
+    it('returns the approval scan title when awaiting the first signature (scan phase)', () => {
+      expect(
+        getQrHardwareSigningPageTitle({
+          activeQrStep: HardwareWalletSignatureStatus.AwaitingFirstSignature,
+          needsTwoConfirmations: true,
+          t,
+        }),
+      ).toBe('bridgeQrHardwareSignStepTitle[2,4]');
+    });
+
+    it('returns the last step title when awaiting the final signature (scan phase)', () => {
+      expect(
+        getQrHardwareSigningPageTitle({
+          activeQrStep: HardwareWalletSignatureStatus.AwaitingFinalSignature,
+          needsTwoConfirmations: true,
+          t,
+        }),
+      ).toBe('bridgeQrHardwareSignLastStepTitle');
+    });
+
+    it('returns the last step title for a single-confirmation scan', () => {
+      expect(
+        getQrHardwareSigningPageTitle({
+          activeQrStep: HardwareWalletSignatureStatus.AwaitingFinalSignature,
+          needsTwoConfirmations: false,
+          t,
+        }),
+      ).toBe('bridgeQrHardwareSignLastStepTitle');
+    });
+
+    it('returns the approval display title for the first signature (display phase)', () => {
+      expect(
+        getQrHardwareSigningPageTitle({
+          activeQrStep: HardwareWalletSignatureStatus.AwaitingFirstSignature,
+          isDisplayPhase: true,
+          needsTwoConfirmations: true,
+          t,
+        }),
+      ).toBe('bridgeQrHardwareSignDisplayStepTitle[1,4]');
+    });
+
+    it('returns the trade display title for the final signature (display phase)', () => {
+      expect(
+        getQrHardwareSigningPageTitle({
+          activeQrStep: HardwareWalletSignatureStatus.AwaitingFinalSignature,
+          isDisplayPhase: true,
+          needsTwoConfirmations: true,
+          t,
+        }),
+      ).toBe('bridgeQrHardwareSignDisplayStepTitle[3,4]');
+    });
+
+    it('returns the single-confirmation display title (display phase)', () => {
+      expect(
+        getQrHardwareSigningPageTitle({
+          activeQrStep: HardwareWalletSignatureStatus.AwaitingFinalSignature,
+          isDisplayPhase: true,
+          needsTwoConfirmations: false,
+          t,
+        }),
+      ).toBe('bridgeQrHardwareSignDisplayStepTitle[1,2]');
     });
   });
 

--- a/ui/pages/hardware-wallets/swap/qr-hardware-signing-page/qr-hardware-signing-page.stories.tsx
+++ b/ui/pages/hardware-wallets/swap/qr-hardware-signing-page/qr-hardware-signing-page.stories.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { Meta, StoryObj } from '@storybook/react';
+import QrHardwareSigningPage from '.';
+import { QrHardwareSigningPhase } from './qr-hardware-signing-page.types';
+
+const meta: Meta<typeof QrHardwareSigningPage> = {
+  title: 'Pages/HardwareWallets/Swap/QrHardwareSigningPage',
+  component: QrHardwareSigningPage,
+  args: {
+    payload: {
+      type: 'eth-sign-request',
+      cbor: 'a201010203',
+    },
+    requestId: 'sign-request-id',
+    onBack: () => undefined,
+    onCancel: () => undefined,
+    onContinueToScan: () => undefined,
+    onScanSuccess: async () => undefined,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof QrHardwareSigningPage>;
+
+export const ApprovalStep: Story = {
+  args: {
+    title: 'Step 2 of 4: Scan the QR code shown on your wallet',
+    phase: QrHardwareSigningPhase.DisplayQrCode,
+  },
+};
+
+export const SwapStepScanSignature: Story = {
+  args: {
+    title: 'Last step: Scan the QR code shown on your wallet',
+    phase: QrHardwareSigningPhase.ScanSignature,
+  },
+};

--- a/ui/pages/hardware-wallets/swap/qr-hardware-signing-page/qr-hardware-signing-page.test.tsx
+++ b/ui/pages/hardware-wallets/swap/qr-hardware-signing-page/qr-hardware-signing-page.test.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import {
+  createMemoryRouterWrapper,
+  en,
+  I18nProvider,
+} from '../../../../../test/lib/render-helpers-navigate';
+import { QrHardwareSigningPhase } from './qr-hardware-signing-page.types';
+import QrHardwareSigningPage from '.';
+
+function renderQrHardwareSigningPage(
+  props: React.ComponentProps<typeof QrHardwareSigningPage>,
+) {
+  const RouterWrapper = createMemoryRouterWrapper();
+
+  return render(
+    <RouterWrapper>
+      <I18nProvider currentLocale="en" current={en} en={en}>
+        <QrHardwareSigningPage {...props} />
+      </I18nProvider>
+    </RouterWrapper>,
+  );
+}
+
+jest.mock(
+  '../../../../components/app/qr-hardware-popover/qr-hardware-sign-request/qr-reader',
+  () => ({
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    __esModule: true,
+    default: jest.fn(() => <div data-testid="qr-reader-mock" />),
+  }),
+);
+
+jest.mock('../qr-signature-code', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  __esModule: true,
+  default: jest.fn(() => <div data-testid="qr-signature-code-mock" />),
+}));
+
+const defaultProps = {
+  title: 'Step 2 of 4: Scan the QR code shown on your wallet',
+  phase: QrHardwareSigningPhase.DisplayQrCode,
+  payload: {
+    type: 'eth-sign-request',
+    cbor: 'a201010203',
+  },
+  requestId: 'sign-request-id',
+  onBack: jest.fn(),
+  onCancel: jest.fn(),
+  onContinueToScan: jest.fn(),
+  onScanSuccess: jest.fn(),
+};
+
+describe('QrHardwareSigningPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the title and animated QR code in display mode', () => {
+    renderQrHardwareSigningPage(defaultProps);
+
+    expect(
+      screen.getByTestId('qr-hardware-signing-page__title'),
+    ).toHaveTextContent(defaultProps.title);
+    expect(screen.getByTestId('qr-signature-code-mock')).toBeInTheDocument();
+    expect(screen.queryByTestId('qr-reader-mock')).not.toBeInTheDocument();
+    expect(
+      screen.getByTestId('qr-hardware-signing-page__continue-button'),
+    ).toHaveTextContent('Scan next QR code');
+  });
+
+  it('shows the "Scan final QR code" label for the final signature', () => {
+    renderQrHardwareSigningPage({ ...defaultProps, isFinalSignature: true });
+
+    expect(
+      screen.getByTestId('qr-hardware-signing-page__continue-button'),
+    ).toHaveTextContent('Scan final QR code');
+  });
+
+  it('renders the scanner in scan mode', () => {
+    renderQrHardwareSigningPage({
+      ...defaultProps,
+      phase: QrHardwareSigningPhase.ScanSignature,
+      title: 'Last step: Scan the QR code shown on your wallet',
+    });
+
+    expect(screen.getByTestId('qr-reader-mock')).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('qr-signature-code-mock'),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('qr-hardware-signing-page__continue-button'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('calls the expected handlers from footer and header actions', () => {
+    renderQrHardwareSigningPage(defaultProps);
+
+    fireEvent.click(
+      screen.getByTestId('qr-hardware-signing-page__back-button'),
+    );
+    fireEvent.click(
+      screen.getByTestId('qr-hardware-signing-page__continue-button'),
+    );
+    fireEvent.click(
+      screen.getByTestId('qr-hardware-signing-page__cancel-button'),
+    );
+
+    expect(defaultProps.onBack).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onContinueToScan).toHaveBeenCalledTimes(1);
+    expect(defaultProps.onCancel).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/pages/hardware-wallets/swap/signature-status-icon/signature-status-icon.test.tsx
+++ b/ui/pages/hardware-wallets/swap/signature-status-icon/signature-status-icon.test.tsx
@@ -3,10 +3,6 @@ import { render } from '@testing-library/react';
 import { SignatureStepStatus } from '../types';
 import SignatureStatusIcon from '.';
 
-jest.mock('../../../../components/ui/pulse-loader', () => () => (
-  <div data-testid="pulse-loader" />
-));
-
 describe('SignatureStatusIcon', () => {
   it('renders check icon when status is Complete', () => {
     const { container } = render(
@@ -52,15 +48,15 @@ describe('SignatureStatusIcon', () => {
     expect(container.querySelector('svg')).not.toBeNull();
   });
 
-  it('renders pulse loader when status is Active', () => {
-    const { getByTestId } = render(
+  it('renders loading spinner when status is Active', () => {
+    const { container } = render(
       <SignatureStatusIcon
         status={SignatureStepStatus.Active}
         stepNumber={1}
       />,
     );
 
-    expect(getByTestId('pulse-loader')).toBeDefined();
+    expect(container.querySelector('svg')).not.toBeNull();
   });
 
   it('renders step number when status is Pending', () => {
@@ -83,5 +79,17 @@ describe('SignatureStatusIcon', () => {
     );
 
     expect(getByText('1')).toBeDefined();
+  });
+
+  it('does not render step number when status is Active', () => {
+    const { queryByText, container } = render(
+      <SignatureStatusIcon
+        status={SignatureStepStatus.Active}
+        stepNumber={2}
+      />,
+    );
+
+    expect(container.querySelector('svg')).not.toBeNull();
+    expect(queryByText('2')).toBeNull();
   });
 });


### PR DESCRIPTION
## **Description**

Adds mocks, stories, and focused tests for signing page utilities and support components.

Dependencies: Depends on https://github.com/MetaMask/metamask-extension/pull/43943.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Pull this branch.
2. Review Storybook entries for the hardware wallet signing page and confirm they load.
3. Verify the touched flow still behaves as described above.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)