### PR TITLE
fix: arc ignore erc20 usdc balance count cp-13.38.0

### DIFF
--- a/ui/components/app/assets/enablement/arc.test.ts
+++ b/ui/components/app/assets/enablement/arc.test.ts
@@ -1,4 +1,9 @@
-import { filterOutArcNativeAsset } from './arc';
+import { AssetsControllerState } from '@metamask/assets-controller';
+import {
+  ARC_ERC20_USDC_ASSET_ID,
+  augmentAssetControllersState,
+  filterOutArcNativeAsset,
+} from './arc';
 
 const ARC_NATIVE_CAIP_CHAIN_ID = 'eip155:5042';
 const ARC_NATIVE_HEX_CHAIN_ID = '0x13b2';
@@ -117,4 +122,58 @@ describe('filterOutArcNativeAsset', () => {
       expect(filterOutArcNativeAsset(assets)).toStrictEqual(expected);
     },
   );
+});
+
+describe('augmentAssetControllersState', () => {
+  const buildState = (
+    assetsBalance: Record<string, Record<string, { amount: string }>>,
+  ) => ({ assetsBalance }) as unknown as AssetsControllerState;
+
+  it('removes the ERC20 USDC asset from every account', () => {
+    const state = buildState({
+      'account-1': {
+        [ARC_NATIVE_ASSET_ID]: { amount: '5' },
+        [ARC_ERC20_USDC_ASSET_ID]: { amount: '5' },
+      },
+      'account-2': {
+        [ARC_ERC20_USDC_ASSET_ID]: { amount: '0' },
+      },
+    });
+
+    expect(augmentAssetControllersState(state).assetsBalance).toStrictEqual({
+      'account-1': { [ARC_NATIVE_ASSET_ID]: { amount: '5' } },
+      'account-2': {},
+    });
+  });
+
+  it('leaves accounts without the ERC20 USDC asset untouched', () => {
+    const assetsBalance = {
+      'account-1': { [ARC_NATIVE_ASSET_ID]: { amount: '5' } },
+    };
+
+    expect(
+      augmentAssetControllersState(buildState(assetsBalance)).assetsBalance,
+    ).toStrictEqual(assetsBalance);
+  });
+
+  it('does not mutate the original state', () => {
+    const state = buildState({
+      'account-1': { [ARC_ERC20_USDC_ASSET_ID]: { amount: '5' } },
+    });
+
+    augmentAssetControllersState(state);
+
+    expect(state.assetsBalance['account-1']).toHaveProperty(
+      ARC_ERC20_USDC_ASSET_ID,
+    );
+  });
+
+  it('preserves other top-level state keys', () => {
+    const state = {
+      assetsBalance: {},
+      assetsMetadata: { foo: 'bar' },
+    } as unknown as AssetsControllerState;
+
+    expect(augmentAssetControllersState(state)).toStrictEqual(state);
+  });
 });

--- a/ui/components/app/assets/enablement/arc.ts
+++ b/ui/components/app/assets/enablement/arc.ts
@@ -1,5 +1,6 @@
 import { BridgeAsset } from '@metamask/bridge-controller';
 import { hexToNumber, CaipAssetType } from '@metamask/utils';
+import { AssetsControllerState } from '@metamask/assets-controller';
 import {
   ARC_USDC_TOKEN_ADDRESS,
   CHAIN_IDS,
@@ -18,8 +19,10 @@ import {
  */
 export const ARC_HEX_CHAIN_ID = '0x13b2';
 export const ARC_NATIVE_CAIP_CHAIN_ID = 'eip155:5042';
-const ARC_NATIVE_ASSET_ID =
+export const ARC_NATIVE_ASSET_ID =
   'eip155:5042/erc20:0x0000000000000000000000000000000000000000';
+export const ARC_ERC20_USDC_ASSET_ID =
+  'eip155:5042/erc20:0x3600000000000000000000000000000000000000';
 const ARC_NATIVE_ADDRESS = '0x0000000000000000000000000000000000000000';
 
 export const ARC_ERC20_USDC_BRIDGE_ASSET: BridgeAsset = {
@@ -101,4 +104,26 @@ export function filterOutArcNativeAsset<
  */
 export function isArcTokenUSDC(assetId: CaipAssetType): boolean {
   return assetId === ARC_ERC20_USDC_BRIDGE_ASSET.assetId;
+}
+
+/**
+ * Augments the Asset Controller state for Arc-related concerns.
+ * Precisely for Arc: Removing ERC20 USDC balances to avoid double counting in balance total.
+ * @param assetsControllerState
+ * @returns altered (copy) version of assetsControllerState with no ERC20 USDC balance
+ */
+export function augmentAssetControllersState(
+  assetsControllerState: AssetsControllerState,
+): AssetsControllerState {
+  return {
+    ...assetsControllerState,
+    assetsBalance: Object.fromEntries(
+      Object.entries(assetsControllerState.assetsBalance).map(
+        ([accountId, assets]) => {
+          const { [ARC_ERC20_USDC_ASSET_ID]: _omit, ...rest } = assets;
+          return [accountId, rest];
+        },
+      ),
+    ),
+  };
 }

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -89,6 +89,7 @@ import {
 import { traceAsControllerCallback } from '../../shared/lib/trace';
 import { getSelectedInternalAccount } from '../../shared/lib/selectors/accounts';
 import { getPreferences } from '../../shared/lib/selectors/preferences';
+import { augmentAssetControllersState } from '../components/app/assets/enablement/arc';
 import {
   calculateBalanceForAllWallets as calculateBalanceForAllWalletsFromUnified,
   calculateBalanceChangeForAccountGroup as calculateBalanceChangeForAccountGroupFromUnified,
@@ -929,7 +930,7 @@ export const selectBalanceForAllWallets = createSelector(
   ) => {
     if (isAssetsUnifyStateEnabled) {
       return calculateBalanceForAllWalletsFromUnified(
-        assetsControllerState,
+        augmentAssetControllersState(assetsControllerState),
         accountTreeState,
         accountsById,
         enabledNetworkMap,
@@ -998,7 +999,7 @@ export const selectBalanceChangeBySelectedAccountGroup = (
       }
       if (isAssetsUnifyStateEnabled) {
         return calculateBalanceChangeForAccountGroupFromUnified(
-          assetsControllerState,
+          augmentAssetControllersState(assetsControllerState),
           accountTreeState,
           accountsById,
           enabledNetworkMap,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: excludes Arc USDC ERC20 contract from total balance and balance change calculations.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes aggregated balance and balance-change math for Arc under the assets-unify flag; scope is narrow but user-visible totals depend on correct filtering.
> 
> **Overview**
> Fixes **inflated wallet and balance-change totals on Arc** when assets-unify state is enabled, where both the native USDC balance and the mirrored ERC20 USDC entry could be summed.
> 
> Adds **`augmentAssetControllersState`** in the Arc enablement module: it returns a shallow copy of `AssetsController` state with **`ARC_ERC20_USDC_ASSET_ID` removed from every account’s `assetsBalance`**, leaving other keys untouched and not mutating the original state. Exports **`ARC_ERC20_USDC_ASSET_ID`** (and **`ARC_NATIVE_ASSET_ID`**) for tests and callers.
> 
> Wires that augmentation into **`selectBalanceForAllWallets`** and **`selectBalanceChangeBySelectedAccountGroup`** only on the unified code path (`calculateBalanceForAllWalletsFromUnified` / `calculateBalanceChangeForAccountGroupFromUnified`), aligning unified totals with the existing legacy behavior that already strips the Arc USDC ERC20 from token balances.
> 
> Unit tests cover per-account removal, no-op when ERC20 USDC is absent, immutability, and preservation of other top-level state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76dccf9373c772106b4dd25f13be3ec2d9dbb119. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->