### PR TITLE
refactor: activity types + fee icon

### DIFF
--- a/shared/lib/asset-utils.ts
+++ b/shared/lib/asset-utils.ts
@@ -115,7 +115,7 @@ export const getAssetImageUrl = (
  * @param assetId - The CAIP-formatted asset id
  * @returns The image url for the asset
  */
-export const getCaipAssetImageUrl = (assetId: CaipAssetType) => {
+export const getCaipAssetImageUrl = (assetId?: CaipAssetType) => {
   if (!assetId) {
     return undefined;
   }

--- a/shared/lib/asset-utils.ts
+++ b/shared/lib/asset-utils.ts
@@ -109,6 +109,21 @@ export const getAssetImageUrl = (
   }
 };
 
+/**
+ * Returns the image url for a CAIP-formatted asset
+ *
+ * @param assetId - The CAIP-formatted asset id
+ * @returns The image url for the asset
+ */
+export const getCaipAssetImageUrl = (assetId: CaipAssetType) => {
+  if (!assetId) {
+    return undefined;
+  }
+
+  const chainId = assetId.split('/')[0] as CaipChainId;
+  return getAssetImageUrl(assetId, chainId);
+};
+
 export type AssetMetadata = {
   assetId: CaipAssetType;
   symbol: string;

--- a/ui/components/app/activity-list-item-avatar/activity-list-item-avatar.tsx
+++ b/ui/components/app/activity-list-item-avatar/activity-list-item-avatar.tsx
@@ -6,7 +6,8 @@ import {
   AvatarToken,
   AvatarTokenSize,
 } from '@metamask/design-system-react';
-import { getAssetImageUrl } from '../../../../shared/lib/asset-utils';
+import type { CaipAssetType } from '@metamask/utils';
+import { getCaipAssetImageUrl } from '../../../../shared/lib/asset-utils';
 
 export type ActivityListItemAvatarTokens = readonly (string | undefined)[];
 
@@ -15,40 +16,15 @@ const fallbackText = '?';
 const sanitizeTokens = (tokens: ActivityListItemAvatarTokens): string[] =>
   tokens.filter((token): token is string => Boolean(token));
 
-const getTokenAvatarData = (assetId: string) => {
-  try {
-    const [chainId] = assetId.split('/');
-
-    if (!chainId) {
-      throw new Error('Invalid asset id');
-    }
-
-    return {
-      name: fallbackText,
-      src: getAssetImageUrl(
-        assetId as `${string}:${string}/${string}:${string}`,
-        chainId as `${string}:${string}`,
-      ),
-    };
-  } catch {
-    return {
-      name: fallbackText,
-      src: undefined,
-    };
-  }
-};
-
 const ActivityTokenAvatar = ({
   assetId,
   className,
 }: Readonly<{ assetId: string; className?: string }>) => {
-  const { name, src } = getTokenAvatarData(assetId);
-
   return (
     <AvatarToken
       size={AvatarTokenSize.Md}
-      name={name}
-      src={src}
+      name={fallbackText}
+      src={getCaipAssetImageUrl(assetId as CaipAssetType)}
       className={classnames(className)}
       imageProps={{ className: 'bg-alternative' }}
       data-testid="activity-list-item-avatar-token"

--- a/ui/components/app/activity-list-item-avatar/index.ts
+++ b/ui/components/app/activity-list-item-avatar/index.ts
@@ -1,3 +1,2 @@
 export { ActivityListItemAvatar as ActivityAvatar } from './activity-list-item-avatar';
-export { ActivityListItemAvatar } from './activity-list-item-avatar';
 export type { ActivityListItemAvatarTokens } from './activity-list-item-avatar';

--- a/ui/components/app/chain-badge/chain-badge.test.tsx
+++ b/ui/components/app/chain-badge/chain-badge.test.tsx
@@ -46,11 +46,41 @@ describe('ChainBadge', () => {
     mockGetImage.mockReturnValue(undefined);
 
     const { getByText } = render(
-      <ChainBadge chainId="0xunknown">
+      <ChainBadge chainId="0x12345">
         <div>Unknown Chain Content</div>
       </ChainBadge>,
     );
 
     expect(getByText('Unknown Chain Content')).toBeInTheDocument();
+  });
+
+  it('resolves the image with the CAIP id for an EVM CAIP-2 chainId', () => {
+    mockGetImage.mockReturnValue('https://example.com/ethereum.png');
+
+    const { getByRole } = render(
+      <ChainBadge chainId="eip155:1">
+        <div>Content</div>
+      </ChainBadge>,
+    );
+
+    expect(mockGetImage).toHaveBeenCalledWith(CHAIN_IDS.MAINNET);
+    expect(getByRole('img')).toHaveAttribute(
+      'src',
+      'https://example.com/ethereum.png',
+    );
+  });
+
+  it('resolves the image with the CAIP id for a non-EVM (Solana) chainId', () => {
+    const solanaChainId = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+    mockGetImage.mockReturnValue('https://example.com/solana.png');
+
+    const { getByText } = render(
+      <ChainBadge chainId={solanaChainId}>
+        <div>Solana Content</div>
+      </ChainBadge>,
+    );
+
+    expect(mockGetImage).toHaveBeenCalledWith(solanaChainId);
+    expect(getByText('Solana Content')).toBeInTheDocument();
   });
 });

--- a/ui/components/app/chain-badge/chain-badge.tsx
+++ b/ui/components/app/chain-badge/chain-badge.tsx
@@ -1,27 +1,31 @@
-import React from 'react';
+import React, { type ReactNode } from 'react';
+import type { Hex } from 'viem';
 import {
   AvatarNetwork,
   AvatarNetworkSize,
   BadgeWrapper,
 } from '@metamask/design-system-react';
+import type { CaipChainId } from '@metamask/utils';
 import {
   CHAIN_IDS,
   NETWORK_TO_NAME_MAP,
 } from '../../../../shared/constants/network';
+import { MULTICHAIN_NETWORK_TO_NICKNAME } from '../../../../shared/constants/multichain/networks';
 import { getImageForChainId } from '../../../selectors/multichain';
+import { getMaybeHexChainId } from '../../../ducks/bridge/utils';
 
-type ChainBadgeProps = {
-  chainId: string;
+type Props = {
+  chainId: CaipChainId | Hex | undefined;
   size?: AvatarNetworkSize;
-  children: React.ReactNode;
+  children: ReactNode;
 };
 
 // Ported from transaction-list-item
-const getTestNetworkBackground = (chainId: string) => {
-  if (chainId === CHAIN_IDS.SEPOLIA) {
+const getTestNetworkBackground = (hexChainId?: string) => {
+  if (hexChainId === CHAIN_IDS.SEPOLIA) {
     return { backgroundColor: 'var(--color-network-sepolia-default)' };
   }
-  if (chainId === CHAIN_IDS.GOERLI) {
+  if (hexChainId === CHAIN_IDS.GOERLI) {
     return { backgroundColor: 'var(--color-network-goerli-default)' };
   }
   return {};
@@ -31,17 +35,27 @@ export const ChainBadge = ({
   chainId,
   size = AvatarNetworkSize.Xs,
   children,
-}: ChainBadgeProps) => {
+}: Props) => {
+  if (!chainId) {
+    return <>{children}</>;
+  }
+
+  const hexChainId = getMaybeHexChainId(chainId);
+
   const networkName =
-    NETWORK_TO_NAME_MAP[chainId as keyof typeof NETWORK_TO_NAME_MAP] || '?';
-  const networkImageSrc = getImageForChainId(chainId) ?? undefined;
+    (hexChainId
+      ? NETWORK_TO_NAME_MAP[hexChainId as keyof typeof NETWORK_TO_NAME_MAP]
+      : MULTICHAIN_NETWORK_TO_NICKNAME[chainId as CaipChainId]) ?? '?';
+
+  const networkImageSrc =
+    getImageForChainId(hexChainId ?? chainId) ?? undefined;
 
   return (
     <BadgeWrapper
       badge={
         <AvatarNetwork
           className="border-2 border-background-default rounded-md"
-          style={getTestNetworkBackground(chainId)}
+          style={getTestNetworkBackground(hexChainId)}
           size={size}
           name={networkName}
           src={networkImageSrc}

--- a/ui/components/app/transaction-list-item/transaction-list-item.component.test.js
+++ b/ui/components/app/transaction-list-item/transaction-list-item.component.test.js
@@ -356,7 +356,7 @@ describe('TransactionListItem', () => {
     );
 
     expect(queryByTestId('activity-list-item')).toHaveTextContent(
-      '?Swap USDC to UNISigningCancel',
+      'Swap USDC to UNISigningCancel',
     );
     expect(getByText(messages.signing.message)).toBeInTheDocument();
   });
@@ -368,7 +368,7 @@ describe('TransactionListItem', () => {
     );
 
     expect(queryByTestId('activity-list-item')).toHaveTextContent(
-      '?Swap USDC to UNIConfirmed-2 USDC',
+      'Swap USDC to UNIConfirmed-2 USDC',
     );
   });
 
@@ -387,7 +387,7 @@ describe('TransactionListItem', () => {
     );
 
     expect(queryByTestId('activity-list-item')).toHaveTextContent(
-      '?Swap USDC to UNIFailed-2 USDC',
+      'Swap USDC to UNIFailed-2 USDC',
     );
     expect(getByText(messages.failed.message)).toBeInTheDocument();
   });

--- a/ui/components/app/transaction-list-item/transaction-list-item.component.unified-swap-bridge.test.tsx
+++ b/ui/components/app/transaction-list-item/transaction-list-item.component.unified-swap-bridge.test.tsx
@@ -59,7 +59,7 @@ describe('TransactionListItem for Unified Swap and Bridge', () => {
     );
 
     expect(queryByTestId('activity-list-item')).toHaveTextContent(
-      '?Swap to Confirmed-0 ETH',
+      'Swap to Confirmed-0 ETH',
     );
   });
 
@@ -91,7 +91,7 @@ describe('TransactionListItem for Unified Swap and Bridge', () => {
     );
 
     expect(queryByTestId('activity-list-item')).toHaveTextContent(
-      '?Swap USDC to USDCFailed-2 USDC-USD 0.00',
+      'Swap USDC to USDCFailed-2 USDC-USD 0.00',
     );
     expect(getByText(messages.failed.message)).toBeInTheDocument();
   });
@@ -182,7 +182,7 @@ describe('TransactionListItem for Unified Swap and Bridge', () => {
     );
 
     expect(queryByTestId('activity-list-item')).toHaveTextContent(
-      '?Bridged to OPTransaction 2 of 2-2 USDC-USD 0.00',
+      'Bridged to OPTransaction 2 of 2-2 USDC-USD 0.00',
     );
   });
 
@@ -222,7 +222,7 @@ describe('TransactionListItem for Unified Swap and Bridge', () => {
     );
 
     expect(queryByTestId('activity-list-item')).toHaveTextContent(
-      '?Bridged to OPTransaction 2 of 2-2 USDC-USD 0.00',
+      'Bridged to OPTransaction 2 of 2-2 USDC-USD 0.00',
     );
   });
 
@@ -249,7 +249,7 @@ describe('TransactionListItem for Unified Swap and Bridge', () => {
     );
 
     expect(queryByTestId('activity-list-item')).toHaveTextContent(
-      '?Bridged to OPConfirmed-2 USDC-USD 0.00',
+      'Bridged to OPConfirmed-2 USDC-USD 0.00',
     );
 
     fireEvent.click(getByTestId('activity-list-item'));
@@ -287,7 +287,7 @@ describe('TransactionListItem for Unified Swap and Bridge', () => {
     );
 
     expect(queryByTestId('activity-list-item')).toHaveTextContent(
-      '?Bridged to OPFailed-2 USDC-USD 0.00',
+      'Bridged to OPFailed-2 USDC-USD 0.00',
     );
     expect(getByText(messages.failed.message)).toBeInTheDocument();
 

--- a/ui/components/app/transaction/token-label.tsx
+++ b/ui/components/app/transaction/token-label.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { AvatarToken, AvatarTokenSize } from '@metamask/design-system-react';
+import type { CaipAssetType, CaipChainId } from '@metamask/utils';
+import { getCaipAssetImageUrl } from '../../../../shared/lib/asset-utils';
+import { ChainBadge } from '../chain-badge/chain-badge';
+
+type Props = {
+  assetId: CaipAssetType;
+  symbol?: string;
+};
+
+export function TokenLabel({ assetId, symbol }: Props) {
+  const src = getCaipAssetImageUrl(assetId);
+  const chainId = assetId.split('/')[0] as CaipChainId;
+
+  return (
+    <span className="inline-flex items-center gap-2">
+      {src ? (
+        <ChainBadge chainId={chainId}>
+          <AvatarToken
+            className="rounded"
+            size={AvatarTokenSize.Xs}
+            name={symbol}
+            src={src}
+          />
+        </ChainBadge>
+      ) : null}
+      {symbol ? <span>{symbol}</span> : null}
+    </span>
+  );
+}

--- a/ui/components/app/transaction/token-label.tsx
+++ b/ui/components/app/transaction/token-label.tsx
@@ -5,13 +5,13 @@ import { getCaipAssetImageUrl } from '../../../../shared/lib/asset-utils';
 import { ChainBadge } from '../chain-badge/chain-badge';
 
 type Props = {
-  assetId: CaipAssetType;
+  assetId?: CaipAssetType;
   symbol?: string;
 };
 
 export function TokenLabel({ assetId, symbol }: Props) {
   const src = getCaipAssetImageUrl(assetId);
-  const chainId = assetId.split('/')[0] as CaipChainId;
+  const chainId = assetId?.split('/')[0] as CaipChainId;
 
   return (
     <span className="inline-flex items-center gap-2">

--- a/ui/pages/details/components/amounts-section.tsx
+++ b/ui/pages/details/components/amounts-section.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { CaipAssetType } from '@metamask/utils';
 import type {
   ActivityFee,
   ActivityListItem,
@@ -8,6 +9,7 @@ import type {
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useFormatters } from '../../../hooks/useFormatters';
 import { TokenFiatValue } from '../../../components/app/transaction/token-fiat-value';
+import { TokenLabel } from '../../../components/app/transaction/token-label';
 // eslint-disable-next-line import-x/no-restricted-paths
 import { PERPS_CURRENCY } from '../../confirmations/constants/perps';
 import { Row } from './shared';
@@ -54,7 +56,15 @@ export function FeesRows({ item }: { item: ActivityListItem }) {
             key={`${type}-${assetId ?? symbol ?? index}`}
             label={label}
             testId={type === 'base' ? 'transaction-base-fee' : undefined}
-            value={<TokenFiatValue token={feeToToken(fee)} />}
+            value={
+              <div className="flex items-center justify-end gap-2">
+                <TokenFiatValue token={feeToToken(fee)} />
+                <TokenLabel
+                  assetId={assetId as CaipAssetType}
+                  symbol={symbol}
+                />
+              </div>
+            }
           />
         );
       })}

--- a/ui/pages/details/components/token-row.tsx
+++ b/ui/pages/details/components/token-row.tsx
@@ -1,9 +1,6 @@
 import React, { useMemo } from 'react';
-import {
-  formatChainIdToHex,
-  isNonEvmChainId,
-} from '@metamask/bridge-controller';
 import { Text } from '@metamask/design-system-react';
+import type { CaipChainId } from '@metamask/utils';
 import {
   applyDisplaySign,
   getDisplaySignPrefix,
@@ -37,15 +34,11 @@ export function TokenRow({
           getDisplaySignPrefix(token.direction, { showPlus: true }),
         );
 
-  const hexChainId = useMemo(() => {
+  const chainId = useMemo(() => {
     if (!showNetworkBadge || !token.assetId) {
       return undefined;
     }
-    const caipChainId = token.assetId.split('/')[0];
-    if (!caipChainId || isNonEvmChainId(caipChainId)) {
-      return caipChainId;
-    }
-    return formatChainIdToHex(caipChainId);
+    return token.assetId.split('/')[0] as CaipChainId;
   }, [showNetworkBadge, token.assetId]);
 
   if (!formattedAmount) {
@@ -56,11 +49,7 @@ export function TokenRow({
 
   return (
     <div className="flex items-center gap-2">
-      {hexChainId ? (
-        <ChainBadge chainId={hexChainId}>{avatar}</ChainBadge>
-      ) : (
-        avatar
-      )}
+      <ChainBadge chainId={chainId}>{avatar}</ChainBadge>
       <Text
         variant="heading-lg"
         color={

--- a/ui/pages/details/transaction-details.tsx
+++ b/ui/pages/details/transaction-details.tsx
@@ -7,6 +7,7 @@ import {
   selectLocalActivityItemsByIdentifier,
   selectNonEvmActivityItemsById,
 } from '../../selectors/activity';
+import ErrorBoundary from '../../components/app/error-boundary/error-boundary';
 import { Header } from './components/header';
 import { TemplateLoader } from './templates/template-loader';
 import { useCachedEvmTransaction } from './useCachedEvmTransaction';
@@ -101,7 +102,9 @@ export function TransactionDetails({ chainId, txIdentifier, onBack }: Props) {
       </div>
 
       <div className="flex flex-col flex-1 overflow-y-auto px-4 pb-4">
-        <TemplateLoader item={transaction} />
+        <ErrorBoundary>
+          <TemplateLoader item={transaction} />
+        </ErrorBoundary>
       </div>
     </div>
   );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

- Refactor activity component types
- Add token icon to fee

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly presentational refactors and shared helpers; ErrorBoundary only limits render failures on transaction details.
> 
> **Overview**
> Centralizes **CAIP asset image** resolution via new `getCaipAssetImageUrl` and reuses it in activity avatars and a new **`TokenLabel`** (token icon + optional chain badge + symbol).
> 
> **Activity / details UI:** Network and base/priority **fee rows** show token icons; `ChainBadge` now accepts **hex or CAIP-2** chain IDs (including Solana), resolves EVM images via hex when needed, and renders children only when `chainId` is missing. Token rows pass the CAIP chain segment directly instead of bridge-specific hex conversion. Transaction details wrap the template in an **`ErrorBoundary`**.
> 
> **Cleanup:** Drops duplicate activity avatar export and local avatar URL parsing; list-item tests no longer expect a leading `?` in summary text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9951ef1328ea780444f694b31448fda9153928c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->