### PR TITLE
feat(ramps): wire RampsController and aggregator client layer

### DIFF
--- a/app/scripts/messenger-client-init/messengers/transaction-pay-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/transaction-pay-controller-messenger.ts
@@ -54,6 +54,8 @@ export function getTransactionPayControllerMessenger(
       'TransactionController:updateTransaction',
       'KeyringController:getState',
       'KeyringController:signTypedMessage',
+      'RampsController:getOrder',
+      'RampsController:getQuotes',
     ],
     events: [
       'AssetsController:stateChange',

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -451,6 +451,7 @@ import { DataDeletionServiceInit } from './messenger-client-init/data-deletion-s
 import { LegacyBackgroundApiServiceInit } from './messenger-client-init/legacy-background-api-service-init';
 import { runSeedlessOnboardingMigrations } from './lib/seedless-onboarding/run-migrations';
 import { initializeWallet } from './wallet-init/initialization';
+import { getRampsControllerApi } from './wallet-init/ramps-controller-api';
 
 export const METAMASK_CONTROLLER_EVENTS = {
   // Fired after state changes that impact the extension badge (unapproved msg count)
@@ -745,6 +746,21 @@ export default class MetamaskController extends EventEmitter {
     this.controllerMemState = controllerMemState;
     this.controllerPersistedState = controllerPersistedState;
     this.messengerClientsByName = messengerClientsByName;
+
+    this.rampsController = this.wallet.getInstance('RampsController');
+    if (this.rampsController) {
+      this.rampsController
+        .init()
+        .then(() => {
+          this.rampsController.startOrderPolling();
+        })
+        .catch(() => {
+          // Initialization failed - error state is available via selectors.
+        });
+    }
+    this.rampsControllerApi = this.rampsController
+      ? getRampsControllerApi(this.rampsController)
+      : {};
 
     // Backwards compatibility for existing references
     this.approvalController = this.wallet.getInstance('ApprovalController');
@@ -1426,6 +1442,7 @@ export default class MetamaskController extends EventEmitter {
       NotificationServicesPushController:
         this.notificationServicesPushController,
       RemoteFeatureFlagController: this.remoteFeatureFlagController,
+      RampsController: this.rampsController,
       DeFiPositionsController: this.deFiPositionsController,
       ProfileMetricsController: this.profileMetricsController,
       ...resetOnRestartStore,
@@ -3393,6 +3410,9 @@ export default class MetamaskController extends EventEmitter {
       getGeolocation: this.geolocationController.getGeolocation.bind(
         this.geolocationController,
       ),
+
+      // RampsController
+      ...this.rampsControllerApi,
 
       // SeedlessOnboardingController
       preloadToprfNodeDetails:

--- a/app/scripts/wallet-init/__snapshots__/ramps-controller-api.test.ts.snap
+++ b/app/scripts/wallet-init/__snapshots__/ramps-controller-api.test.ts.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`getRampsControllerApi exposes ramps background methods 1`] = `
+[
+  "addRampsOrder",
+  "addRampsPrecreatedOrder",
+  "getRampsBuyWidgetData",
+  "getRampsOrderFromCallback",
+  "getRampsPaymentMethods",
+  "getRampsProviders",
+  "getRampsQuotes",
+  "getRampsTokens",
+  "refreshRampsOrder",
+  "removeRampsOrder",
+  "setRampsSelectedPaymentMethod",
+  "setRampsSelectedProvider",
+  "setRampsSelectedToken",
+  "setRampsUserRegion",
+]
+`;

--- a/app/scripts/wallet-init/initialization.ts
+++ b/app/scripts/wallet-init/initialization.ts
@@ -8,6 +8,8 @@ import { RootMessenger } from '../lib/messenger';
 import { BrowserStorageAdapter } from '../../../shared/lib/stores/browser-storage-adapter';
 import { SMART_TRANSACTION_CONFIRMATION_TYPES } from '../../../shared/constants/app';
 import { getKeyringBuilders, getKeyringV2Builders } from './keyrings';
+import { rampsController, rampsService } from './ramps';
+import { getRampsEnvironment } from './instance-options/ramps-environment';
 
 // TODO: Remove this workaround once @metamask/wallet types are updated to include approvalController.
 // The runtime (index.cjs) supports approvalController in instanceOptions, but the TypeScript
@@ -17,6 +19,12 @@ type WalletInstanceOptions = WalletOptions['instanceOptions'] & {
     showApprovalRequest?: ShowApprovalRequest;
     typesExcludedFromRateLimiting?: string[];
   };
+  rampsService?: {
+    environment?: ReturnType<typeof getRampsEnvironment>;
+    context: string;
+    fetch: typeof fetch;
+  };
+  rampsController?: Record<string, never>;
 };
 
 export function initializeWallet({
@@ -33,6 +41,7 @@ export function initializeWallet({
   return new Wallet({
     messenger,
     state,
+    initializationConfigurations: [rampsService, rampsController],
     instanceOptions: {
       approvalController: {
         showApprovalRequest,
@@ -60,6 +69,12 @@ export function initializeWallet({
       storageService: {
         storage: new BrowserStorageAdapter(),
       },
+      rampsService: {
+        environment: getRampsEnvironment(),
+        context: 'extension',
+        fetch: global.fetch.bind(global),
+      },
+      rampsController: {},
     } as WalletInstanceOptions,
   });
 }

--- a/app/scripts/wallet-init/instance-options/ramps-environment.ts
+++ b/app/scripts/wallet-init/instance-options/ramps-environment.ts
@@ -1,0 +1,20 @@
+import { RampsEnvironment } from '@metamask/ramps-controller';
+
+/**
+ * Determines the ramps API environment for the extension build.
+ *
+ * @returns The ramps environment for API requests.
+ */
+export function getRampsEnvironment(): RampsEnvironment {
+  const metamaskEnvironment = process.env.METAMASK_ENVIRONMENT;
+  switch (metamaskEnvironment) {
+    case 'production':
+    case 'beta':
+    case 'rc':
+      return RampsEnvironment.Production;
+    case 'dev':
+    case 'test':
+    default:
+      return RampsEnvironment.Staging;
+  }
+}

--- a/app/scripts/wallet-init/ramps-controller-api.test.ts
+++ b/app/scripts/wallet-init/ramps-controller-api.test.ts
@@ -1,0 +1,28 @@
+import { getRampsControllerApi } from './ramps-controller-api';
+
+describe('getRampsControllerApi', () => {
+  it('exposes ramps background methods', () => {
+    const rampsController = {
+      setUserRegion: jest.fn(),
+      setSelectedToken: jest.fn(),
+      setSelectedProvider: jest.fn(),
+      setSelectedPaymentMethod: jest.fn(),
+      getTokens: jest.fn(),
+      getProviders: jest.fn(),
+      getPaymentMethods: jest.fn(),
+      getQuotes: jest.fn(),
+      getBuyWidgetData: jest.fn(),
+      addPrecreatedOrder: jest.fn(),
+      addOrder: jest.fn(),
+      removeOrder: jest.fn(),
+      getOrder: jest.fn(),
+      getOrderFromCallback: jest.fn(),
+    };
+
+    const api = getRampsControllerApi(rampsController as never);
+
+    expect(Object.keys(api).sort()).toMatchSnapshot();
+    expect(typeof api.setRampsUserRegion).toBe('function');
+    expect(typeof api.getRampsQuotes).toBe('function');
+  });
+});

--- a/app/scripts/wallet-init/ramps-controller-api.ts
+++ b/app/scripts/wallet-init/ramps-controller-api.ts
@@ -1,0 +1,35 @@
+import type { RampsController } from '@metamask/ramps-controller';
+
+/**
+ * Background API methods for the RampsController.
+ *
+ * @param rampsController - The ramps controller instance.
+ * @returns API methods exposed to the UI via submitRequestToBackground.
+ */
+export function getRampsControllerApi(rampsController: RampsController) {
+  return {
+    setRampsUserRegion: rampsController.setUserRegion.bind(rampsController),
+    setRampsSelectedToken:
+      rampsController.setSelectedToken.bind(rampsController),
+    setRampsSelectedProvider:
+      rampsController.setSelectedProvider.bind(rampsController),
+    setRampsSelectedPaymentMethod:
+      rampsController.setSelectedPaymentMethod.bind(rampsController),
+    getRampsTokens: rampsController.getTokens.bind(rampsController),
+    getRampsProviders: rampsController.getProviders.bind(rampsController),
+    getRampsPaymentMethods:
+      rampsController.getPaymentMethods.bind(rampsController),
+    getRampsQuotes: rampsController.getQuotes.bind(rampsController),
+    getRampsBuyWidgetData:
+      rampsController.getBuyWidgetData.bind(rampsController),
+    addRampsPrecreatedOrder:
+      rampsController.addPrecreatedOrder.bind(rampsController),
+    addRampsOrder: rampsController.addOrder.bind(rampsController),
+    removeRampsOrder: rampsController.removeOrder.bind(rampsController),
+    refreshRampsOrder: rampsController.getOrder.bind(rampsController),
+    getRampsOrderFromCallback:
+      rampsController.getOrderFromCallback.bind(rampsController),
+  };
+}
+
+export type RampsControllerApi = ReturnType<typeof getRampsControllerApi>;

--- a/app/scripts/wallet-init/ramps/__snapshots__/index.test.ts.snap
+++ b/app/scripts/wallet-init/ramps/__snapshots__/index.test.ts.snap
@@ -1,0 +1,8 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`wallet-init ramps configurations matches snapshot for config names 1`] = `
+{
+  "rampsController": "RampsController",
+  "rampsService": "RampsService",
+}
+`;

--- a/app/scripts/wallet-init/ramps/index.test.ts
+++ b/app/scripts/wallet-init/ramps/index.test.ts
@@ -1,0 +1,11 @@
+import { rampsController } from './ramps-controller';
+import { rampsService } from './ramps-service';
+
+describe('wallet-init ramps configurations', () => {
+  it('matches snapshot for config names', () => {
+    expect({
+      rampsService: rampsService.name,
+      rampsController: rampsController.name,
+    }).toMatchSnapshot();
+  });
+});

--- a/app/scripts/wallet-init/ramps/index.ts
+++ b/app/scripts/wallet-init/ramps/index.ts
@@ -1,0 +1,6 @@
+export { rampsService } from './ramps-service';
+export { rampsController } from './ramps-controller';
+export type {
+  RampsControllerInstanceOptions,
+  RampsServiceInstanceOptions,
+} from './types';

--- a/app/scripts/wallet-init/ramps/ramps-controller.ts
+++ b/app/scripts/wallet-init/ramps/ramps-controller.ts
@@ -1,0 +1,44 @@
+import { Messenger } from '@metamask/messenger';
+import {
+  RampsController,
+  RampsControllerMessenger,
+  RAMPS_CONTROLLER_REQUIRED_SERVICE_ACTIONS,
+} from '@metamask/ramps-controller';
+import type { Json } from '@metamask/utils';
+
+import type { RampsControllerInstanceOptions } from './types';
+
+export type RampsControllerInitializationConfiguration = {
+  name: 'RampsController';
+  init: (args: {
+    messenger: RampsControllerMessenger;
+    state?: Record<string, Json>;
+    options: RampsControllerInstanceOptions;
+  }) => RampsController;
+  getMessenger: (parent: Messenger) => RampsControllerMessenger;
+};
+
+export const rampsController: RampsControllerInitializationConfiguration = {
+  name: 'RampsController',
+  init: ({ state, messenger, options }) =>
+    new RampsController({
+      messenger,
+      state: state ?? {},
+      requestCacheTTL: options.requestCacheTTL,
+      requestCacheMaxSize: options.requestCacheMaxSize,
+    }),
+  getMessenger: (parent) => {
+    const messenger: RampsControllerMessenger = new Messenger({
+      namespace: 'RampsController',
+      parent,
+    });
+
+    parent.delegate({
+      messenger,
+      actions: [...RAMPS_CONTROLLER_REQUIRED_SERVICE_ACTIONS],
+      events: [],
+    });
+
+    return messenger;
+  },
+};

--- a/app/scripts/wallet-init/ramps/ramps-service.ts
+++ b/app/scripts/wallet-init/ramps/ramps-service.ts
@@ -1,0 +1,43 @@
+import { Messenger } from '@metamask/messenger';
+import {
+  RampsService,
+  RampsServiceMessenger,
+} from '@metamask/ramps-controller';
+
+import type { RampsServiceInstanceOptions } from './types';
+
+export type RampsServiceInitializationConfiguration = {
+  name: 'RampsService';
+  init: (args: {
+    messenger: RampsServiceMessenger;
+    options: RampsServiceInstanceOptions;
+  }) => RampsService;
+  getMessenger: (parent: Messenger) => RampsServiceMessenger;
+};
+
+export const rampsService: RampsServiceInitializationConfiguration = {
+  name: 'RampsService',
+  init: ({ messenger, options }) =>
+    new RampsService({
+      messenger,
+      environment: options.environment,
+      context: options.context,
+      fetch: options.fetch,
+      policyOptions: options.policyOptions,
+      baseUrlOverride: options.baseUrlOverride,
+    }),
+  getMessenger: (parent) => {
+    const messenger: RampsServiceMessenger = new Messenger({
+      namespace: 'RampsService',
+      parent,
+    });
+
+    parent.delegate({
+      messenger,
+      actions: ['AuthenticationController:getBearerToken'],
+      events: [],
+    });
+
+    return messenger;
+  },
+};

--- a/app/scripts/wallet-init/ramps/types.ts
+++ b/app/scripts/wallet-init/ramps/types.ts
@@ -1,0 +1,15 @@
+import type { CreateServicePolicyOptions } from '@metamask/controller-utils';
+import type { RampsEnvironment } from '@metamask/ramps-controller';
+
+export type RampsServiceInstanceOptions = {
+  environment?: RampsEnvironment;
+  context: string;
+  fetch: typeof fetch;
+  policyOptions?: CreateServicePolicyOptions;
+  baseUrlOverride?: string;
+};
+
+export type RampsControllerInstanceOptions = {
+  requestCacheTTL?: number;
+  requestCacheMaxSize?: number;
+};

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -2294,6 +2294,20 @@
         "@metamask/providers>readable-stream": true
       }
     },
+    "@metamask/ramps-controller": {
+      "globals": {
+        "AbortController": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "clearInterval": true,
+        "setInterval": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true
+      }
+    },
     "@metamask/transaction-pay-controller>@metamask/ramps-controller": {
       "globals": {
         "AbortController": true,

--- a/lavamoat/browserify/experimental/policy.json
+++ b/lavamoat/browserify/experimental/policy.json
@@ -2294,6 +2294,20 @@
         "@metamask/providers>readable-stream": true
       }
     },
+    "@metamask/ramps-controller": {
+      "globals": {
+        "AbortController": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "clearInterval": true,
+        "setInterval": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true
+      }
+    },
     "@metamask/transaction-pay-controller>@metamask/ramps-controller": {
       "globals": {
         "AbortController": true,

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -2294,6 +2294,20 @@
         "@metamask/providers>readable-stream": true
       }
     },
+    "@metamask/ramps-controller": {
+      "globals": {
+        "AbortController": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "clearInterval": true,
+        "setInterval": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true
+      }
+    },
     "@metamask/transaction-pay-controller>@metamask/ramps-controller": {
       "globals": {
         "AbortController": true,

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -2294,6 +2294,20 @@
         "@metamask/providers>readable-stream": true
       }
     },
+    "@metamask/ramps-controller": {
+      "globals": {
+        "AbortController": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "clearInterval": true,
+        "setInterval": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true
+      }
+    },
     "@metamask/transaction-pay-controller>@metamask/ramps-controller": {
       "globals": {
         "AbortController": true,

--- a/lavamoat/webpack/mv2/beta/policy.json
+++ b/lavamoat/webpack/mv2/beta/policy.json
@@ -2102,6 +2102,20 @@
         "@metamask/providers>readable-stream": true
       }
     },
+    "@metamask/ramps-controller": {
+      "globals": {
+        "AbortController": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "clearInterval": true,
+        "setInterval": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true
+      }
+    },
     "@metamask/transaction-pay-controller>@metamask/ramps-controller": {
       "globals": {
         "URL": true

--- a/lavamoat/webpack/mv2/experimental/policy.json
+++ b/lavamoat/webpack/mv2/experimental/policy.json
@@ -2102,6 +2102,20 @@
         "@metamask/providers>readable-stream": true
       }
     },
+    "@metamask/ramps-controller": {
+      "globals": {
+        "AbortController": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "clearInterval": true,
+        "setInterval": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true
+      }
+    },
     "@metamask/transaction-pay-controller>@metamask/ramps-controller": {
       "globals": {
         "URL": true

--- a/lavamoat/webpack/mv2/flask/policy.json
+++ b/lavamoat/webpack/mv2/flask/policy.json
@@ -2102,6 +2102,20 @@
         "@metamask/providers>readable-stream": true
       }
     },
+    "@metamask/ramps-controller": {
+      "globals": {
+        "AbortController": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "clearInterval": true,
+        "setInterval": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true
+      }
+    },
     "@metamask/transaction-pay-controller>@metamask/ramps-controller": {
       "globals": {
         "URL": true

--- a/lavamoat/webpack/mv2/main/policy.json
+++ b/lavamoat/webpack/mv2/main/policy.json
@@ -2102,6 +2102,20 @@
         "@metamask/providers>readable-stream": true
       }
     },
+    "@metamask/ramps-controller": {
+      "globals": {
+        "AbortController": true,
+        "URL": true,
+        "URLSearchParams": true,
+        "clearInterval": true,
+        "setInterval": true,
+        "setTimeout": true
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true
+      }
+    },
     "@metamask/transaction-pay-controller>@metamask/ramps-controller": {
       "globals": {
         "URL": true

--- a/package.json
+++ b/package.json
@@ -425,6 +425,7 @@
     "@metamask/profile-sync-controller": "^28.2.0",
     "@metamask/providers": "^22.1.1",
     "@metamask/rate-limit-controller": "^7.0.0",
+    "@metamask/ramps-controller": "^14.3.0",
     "@metamask/react-data-query": "^0.2.0",
     "@metamask/remote-feature-flag-controller": "^4.2.2",
     "@metamask/rpc-errors": "^7.0.0",

--- a/ui/hooks/ramps/RampsBootstrap.tsx
+++ b/ui/hooks/ramps/RampsBootstrap.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { selectUserRegion } from '../../selectors/rampsController';
+import { getRampsTokens } from '../../store/controller-actions/ramps-controller';
+import useRampsProviders from './useRampsProviders';
+import useRampsPaymentMethods from './useRampsPaymentMethods';
+
+function RampsBootstrap(): null {
+  useRampsProviders({ enableSideEffects: true });
+  useRampsPaymentMethods();
+
+  const userRegion = useSelector(selectUserRegion);
+  useEffect(() => {
+    if (userRegion?.regionCode) {
+      getRampsTokens(userRegion.regionCode, 'buy');
+    }
+  }, [userRegion?.regionCode]);
+
+  return null;
+}
+
+export default RampsBootstrap;

--- a/ui/hooks/ramps/__snapshots__/useRampsController.test.tsx.snap
+++ b/ui/hooks/ramps/__snapshots__/useRampsController.test.tsx.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useRampsController matches snapshot 1`] = `
+{
+  "addOrder": [Function],
+  "addPrecreatedOrder": [Function],
+  "countries": [],
+  "countriesError": null,
+  "countriesLoading": false,
+  "getBuyWidgetData": [Function],
+  "getOrderById": [Function],
+  "getOrderFromCallback": [Function],
+  "getQuotes": [Function],
+  "orders": [],
+  "paymentMethods": [],
+  "paymentMethodsError": null,
+  "paymentMethodsFetching": false,
+  "paymentMethodsLoading": false,
+  "paymentMethodsStatus": "idle",
+  "providers": [],
+  "providersError": null,
+  "providersLoading": true,
+  "refreshOrder": [Function],
+  "removeOrder": [Function],
+  "selectedPaymentMethod": null,
+  "selectedProvider": null,
+  "selectedToken": null,
+  "setSelectedPaymentMethod": [Function],
+  "setSelectedProvider": [Function],
+  "setSelectedToken": [Function],
+  "setUserRegion": [Function],
+  "tokens": {
+    "allTokens": [],
+    "topTokens": [],
+  },
+  "tokensError": null,
+  "tokensLoading": false,
+  "userRegion": {
+    "country": {
+      "currency": "USD",
+      "isoCode": "US",
+      "name": "United States",
+    },
+    "regionCode": "us-ca",
+  },
+}
+`;

--- a/ui/hooks/ramps/__snapshots__/useRampsCountries.test.tsx.snap
+++ b/ui/hooks/ramps/__snapshots__/useRampsCountries.test.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useRampsCountries matches snapshot 1`] = `
+{
+  "countries": [],
+  "error": null,
+  "isLoading": false,
+}
+`;

--- a/ui/hooks/ramps/__snapshots__/useRampsOrders.test.tsx.snap
+++ b/ui/hooks/ramps/__snapshots__/useRampsOrders.test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useRampsOrders matches snapshot 1`] = `
+{
+  "addOrder": [Function],
+  "addPrecreatedOrder": [Function],
+  "getOrderById": [Function],
+  "getOrderFromCallback": [Function],
+  "orders": [],
+  "refreshOrder": [Function],
+  "removeOrder": [Function],
+}
+`;

--- a/ui/hooks/ramps/__snapshots__/useRampsPaymentMethods.test.tsx.snap
+++ b/ui/hooks/ramps/__snapshots__/useRampsPaymentMethods.test.tsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useRampsPaymentMethods matches snapshot 1`] = `
+{
+  "error": null,
+  "isFetching": false,
+  "isLoading": false,
+  "isSuccess": false,
+  "paymentMethods": [],
+  "selectedPaymentMethod": null,
+  "setSelectedPaymentMethod": [Function],
+  "status": "idle",
+}
+`;

--- a/ui/hooks/ramps/__snapshots__/useRampsProviders.test.tsx.snap
+++ b/ui/hooks/ramps/__snapshots__/useRampsProviders.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useRampsProviders matches snapshot 1`] = `
+{
+  "error": null,
+  "isLoading": true,
+  "providers": [],
+  "selectedProvider": null,
+  "setSelectedProvider": [Function],
+}
+`;

--- a/ui/hooks/ramps/__snapshots__/useRampsQuotes.test.tsx.snap
+++ b/ui/hooks/ramps/__snapshots__/useRampsQuotes.test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useRampsQuotes matches snapshot when query is disabled 1`] = `
+{
+  "data": null,
+  "error": null,
+  "getBuyWidgetData": [Function],
+  "getQuotes": [Function],
+  "isSuccess": false,
+  "loading": true,
+  "status": "idle",
+}
+`;

--- a/ui/hooks/ramps/__snapshots__/useRampsTokens.test.tsx.snap
+++ b/ui/hooks/ramps/__snapshots__/useRampsTokens.test.tsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useRampsTokens matches snapshot 1`] = `
+{
+  "error": null,
+  "isLoading": false,
+  "selectedToken": null,
+  "setSelectedToken": [Function],
+  "tokens": {
+    "allTokens": [],
+    "topTokens": [],
+  },
+}
+`;

--- a/ui/hooks/ramps/__snapshots__/useRampsUserRegion.test.tsx.snap
+++ b/ui/hooks/ramps/__snapshots__/useRampsUserRegion.test.tsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useRampsUserRegion matches snapshot 1`] = `
+{
+  "setUserRegion": [Function],
+  "userRegion": {
+    "country": {
+      "currency": "USD",
+      "isoCode": "US",
+      "name": "United States",
+    },
+    "regionCode": "us-ca",
+  },
+}
+`;

--- a/ui/hooks/ramps/queries/index.ts
+++ b/ui/hooks/ramps/queries/index.ts
@@ -1,0 +1,18 @@
+import { rampsPaymentMethodsKeys, rampsPaymentMethodsOptions } from './paymentMethods';
+import { rampsProvidersKeys, rampsProvidersOptions } from './providers';
+import { rampsQuotesKeys, rampsQuotesOptions } from './quotes';
+
+export const rampsQueries = {
+  paymentMethods: {
+    keys: rampsPaymentMethodsKeys,
+    options: rampsPaymentMethodsOptions,
+  },
+  providers: {
+    keys: rampsProvidersKeys,
+    options: rampsProvidersOptions,
+  },
+  quotes: {
+    keys: rampsQuotesKeys,
+    options: rampsQuotesOptions,
+  },
+};

--- a/ui/hooks/ramps/queries/paymentMethods.ts
+++ b/ui/hooks/ramps/queries/paymentMethods.ts
@@ -1,0 +1,41 @@
+import { queryOptions } from '@tanstack/react-query';
+import type {
+  PaymentMethod,
+  PaymentMethodsResponse,
+} from '@metamask/ramps-controller';
+import { getRampsPaymentMethods } from '../../../store/controller-actions/ramps-controller';
+
+interface PaymentMethodsQueryParams {
+  regionCode: string;
+  fiat: string;
+  assetId: string;
+  providerId: string;
+}
+
+export const rampsPaymentMethodsKeys = {
+  all: () => ['ramps', 'paymentMethods'] as const,
+  detail: ({
+    regionCode,
+    providerId,
+  }: Pick<PaymentMethodsQueryParams, 'regionCode' | 'providerId'>) =>
+    [
+      ...rampsPaymentMethodsKeys.all(),
+      regionCode.trim().toLowerCase(),
+      providerId,
+    ] as const,
+};
+
+export const rampsPaymentMethodsOptions = (params: PaymentMethodsQueryParams) =>
+  queryOptions({
+    queryKey: rampsPaymentMethodsKeys.detail(params),
+    queryFn: async (): Promise<PaymentMethod[]> => {
+      const response = (await getRampsPaymentMethods(params.regionCode, {
+        fiat: params.fiat,
+        assetId: params.assetId,
+        provider: params.providerId,
+      })) as PaymentMethodsResponse;
+
+      return response.payments;
+    },
+    staleTime: 5 * 60 * 1000,
+  });

--- a/ui/hooks/ramps/queries/providers.ts
+++ b/ui/hooks/ramps/queries/providers.ts
@@ -1,0 +1,23 @@
+import { queryOptions } from '@tanstack/react-query';
+import type { Provider } from '@metamask/ramps-controller';
+import { getRampsProviders } from '../../../store/controller-actions/ramps-controller';
+
+interface ProvidersQueryParams {
+  regionCode: string;
+}
+
+export const rampsProvidersKeys = {
+  all: () => ['ramps', 'providers'] as const,
+  detail: ({ regionCode }: ProvidersQueryParams) =>
+    [...rampsProvidersKeys.all(), regionCode.trim().toLowerCase()] as const,
+};
+
+export const rampsProvidersOptions = (params: ProvidersQueryParams) =>
+  queryOptions({
+    queryKey: rampsProvidersKeys.detail(params),
+    queryFn: async (): Promise<Provider[]> => {
+      const response = await getRampsProviders(params.regionCode);
+      return response.providers;
+    },
+    staleTime: 15 * 60 * 1000,
+  });

--- a/ui/hooks/ramps/queries/quotes.ts
+++ b/ui/hooks/ramps/queries/quotes.ts
@@ -1,0 +1,40 @@
+import { queryOptions } from '@tanstack/react-query';
+import type { QuotesResponse } from '@metamask/ramps-controller';
+import {
+  getRampsQuotes,
+  type GetRampsQuotesParams,
+} from '../../../store/controller-actions/ramps-controller';
+
+export const RAMPS_QUOTES_STALE_TIME_MS = 15_000;
+
+type RampsQuotesQueryParams = Pick<
+  GetRampsQuotesParams,
+  | 'assetId'
+  | 'amount'
+  | 'walletAddress'
+  | 'redirectUrl'
+  | 'forceRefresh'
+  | 'ttl'
+  | 'paymentMethods'
+  | 'providers'
+>;
+
+export const rampsQuotesKeys = {
+  all: () => ['ramps', 'quotes'] as const,
+  detail: (params: RampsQuotesQueryParams) =>
+    [
+      ...rampsQuotesKeys.all(),
+      params.assetId ?? '',
+      params.amount,
+      params.walletAddress,
+      (params.paymentMethods ?? []).join(','),
+      (params.providers ?? []).join(','),
+    ] as const,
+};
+
+export const rampsQuotesOptions = (params: RampsQuotesQueryParams) =>
+  queryOptions({
+    queryKey: rampsQuotesKeys.detail(params),
+    queryFn: async (): Promise<QuotesResponse> => getRampsQuotes(params),
+    staleTime: RAMPS_QUOTES_STALE_TIME_MS,
+  });

--- a/ui/hooks/ramps/test-utils.tsx
+++ b/ui/hooks/ramps/test-utils.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import configureStore from 'redux-mock-store';
+
+export const rampsMockMetamaskState = {
+  RampsController: {
+    userRegion: {
+      regionCode: 'us-ca',
+      country: { currency: 'USD', isoCode: 'US', name: 'United States' },
+    },
+    countries: {
+      data: [],
+      selected: null,
+      isLoading: false,
+      error: null,
+    },
+    providers: {
+      data: [],
+      selected: null,
+      isLoading: false,
+      error: null,
+    },
+    tokens: {
+      data: { topTokens: [], allTokens: [] },
+      selected: null,
+      isLoading: false,
+      error: null,
+    },
+    paymentMethods: {
+      data: [],
+      selected: null,
+      isLoading: false,
+      error: null,
+    },
+    orders: [],
+  },
+  internalAccounts: {
+    selectedAccount: 'account-1',
+    accounts: {
+      'account-1': {
+        id: 'account-1',
+        address: '0xabc123',
+        metadata: { name: 'Account 1' },
+      },
+    },
+  },
+};
+
+const mockStoreFactory = configureStore([]);
+
+export function createRampsMockStore(
+  overrides: Record<string, unknown> = {},
+) {
+  return mockStoreFactory({
+    metamask: {
+      ...rampsMockMetamaskState,
+      ...overrides,
+    },
+  });
+}
+
+export function createRampsTestWrapper(store = createRampsMockStore()) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </Provider>
+  );
+}

--- a/ui/hooks/ramps/useRampsController.test.tsx
+++ b/ui/hooks/ramps/useRampsController.test.tsx
@@ -1,0 +1,29 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useRampsController } from './useRampsController';
+import { createRampsTestWrapper } from './test-utils';
+
+jest.mock('../../store/controller-actions/ramps-controller', () => ({
+  setRampsUserRegion: jest.fn(),
+  setRampsSelectedProvider: jest.fn(),
+  setRampsSelectedToken: jest.fn(),
+  setRampsSelectedPaymentMethod: jest.fn(),
+  getRampsProviders: jest.fn().mockResolvedValue({ providers: [] }),
+  getRampsPaymentMethods: jest.fn().mockResolvedValue({ paymentMethods: [] }),
+  getRampsQuotes: jest.fn(),
+  getRampsBuyWidgetData: jest.fn(),
+  addRampsOrder: jest.fn(),
+  addRampsPrecreatedOrder: jest.fn(),
+  removeRampsOrder: jest.fn(),
+  refreshRampsOrder: jest.fn(),
+  getRampsOrderFromCallback: jest.fn(),
+}));
+
+describe('useRampsController', () => {
+  it('matches snapshot', () => {
+    const { result } = renderHook(() => useRampsController(), {
+      wrapper: createRampsTestWrapper(),
+    });
+
+    expect(result.current).toMatchSnapshot();
+  });
+});

--- a/ui/hooks/ramps/useRampsController.ts
+++ b/ui/hooks/ramps/useRampsController.ts
@@ -1,0 +1,122 @@
+import { useRampsUserRegion, type UseRampsUserRegionResult } from './useRampsUserRegion';
+import { useRampsProviders, type UseRampsProvidersResult } from './useRampsProviders';
+import { useRampsTokens, type UseRampsTokensResult } from './useRampsTokens';
+import { useRampsCountries, type UseRampsCountriesResult } from './useRampsCountries';
+import {
+  useRampsPaymentMethods,
+  type UseRampsPaymentMethodsResult,
+} from './useRampsPaymentMethods';
+import { useRampsQuotes, type UseRampsQuotesResult } from './useRampsQuotes';
+import { useRampsOrders, type UseRampsOrdersResult } from './useRampsOrders';
+
+export interface UseRampsControllerResult {
+  userRegion: UseRampsUserRegionResult['userRegion'];
+  setUserRegion: UseRampsUserRegionResult['setUserRegion'];
+  selectedProvider: UseRampsProvidersResult['selectedProvider'];
+  setSelectedProvider: UseRampsProvidersResult['setSelectedProvider'];
+  providers: UseRampsProvidersResult['providers'];
+  providersLoading: UseRampsProvidersResult['isLoading'];
+  providersError: UseRampsProvidersResult['error'];
+  tokens: UseRampsTokensResult['tokens'];
+  selectedToken: UseRampsTokensResult['selectedToken'];
+  setSelectedToken: UseRampsTokensResult['setSelectedToken'];
+  tokensLoading: UseRampsTokensResult['isLoading'];
+  tokensError: UseRampsTokensResult['error'];
+  countries: UseRampsCountriesResult['countries'];
+  countriesLoading: UseRampsCountriesResult['isLoading'];
+  countriesError: UseRampsCountriesResult['error'];
+  paymentMethods: UseRampsPaymentMethodsResult['paymentMethods'];
+  selectedPaymentMethod: UseRampsPaymentMethodsResult['selectedPaymentMethod'];
+  setSelectedPaymentMethod: UseRampsPaymentMethodsResult['setSelectedPaymentMethod'];
+  paymentMethodsLoading: UseRampsPaymentMethodsResult['isLoading'];
+  paymentMethodsFetching: UseRampsPaymentMethodsResult['isFetching'];
+  paymentMethodsStatus: UseRampsPaymentMethodsResult['status'];
+  paymentMethodsError: UseRampsPaymentMethodsResult['error'];
+  getQuotes: UseRampsQuotesResult['getQuotes'];
+  getBuyWidgetData: UseRampsQuotesResult['getBuyWidgetData'];
+  orders: UseRampsOrdersResult['orders'];
+  getOrderById: UseRampsOrdersResult['getOrderById'];
+  addOrder: UseRampsOrdersResult['addOrder'];
+  addPrecreatedOrder: UseRampsOrdersResult['addPrecreatedOrder'];
+  removeOrder: UseRampsOrdersResult['removeOrder'];
+  refreshOrder: UseRampsOrdersResult['refreshOrder'];
+  getOrderFromCallback: UseRampsOrdersResult['getOrderFromCallback'];
+}
+
+export function useRampsController(): UseRampsControllerResult {
+  const { userRegion, setUserRegion } = useRampsUserRegion();
+  const {
+    providers,
+    selectedProvider,
+    setSelectedProvider,
+    isLoading: providersLoading,
+    error: providersError,
+  } = useRampsProviders();
+  const {
+    tokens,
+    selectedToken,
+    setSelectedToken,
+    isLoading: tokensLoading,
+    error: tokensError,
+  } = useRampsTokens();
+  const {
+    countries,
+    isLoading: countriesLoading,
+    error: countriesError,
+  } = useRampsCountries();
+  const {
+    paymentMethods,
+    selectedPaymentMethod,
+    setSelectedPaymentMethod,
+    isLoading: paymentMethodsLoading,
+    isFetching: paymentMethodsFetching,
+    status: paymentMethodsStatus,
+    error: paymentMethodsError,
+  } = useRampsPaymentMethods();
+  const { getQuotes, getBuyWidgetData } = useRampsQuotes();
+  const {
+    orders,
+    getOrderById,
+    addOrder,
+    addPrecreatedOrder,
+    removeOrder,
+    refreshOrder,
+    getOrderFromCallback,
+  } = useRampsOrders();
+
+  return {
+    userRegion,
+    setUserRegion,
+    selectedProvider,
+    setSelectedProvider,
+    providers,
+    providersLoading,
+    providersError,
+    tokens,
+    selectedToken,
+    setSelectedToken,
+    tokensLoading,
+    tokensError,
+    countries,
+    countriesLoading,
+    countriesError,
+    paymentMethods,
+    selectedPaymentMethod,
+    setSelectedPaymentMethod,
+    paymentMethodsLoading,
+    paymentMethodsFetching,
+    paymentMethodsStatus,
+    paymentMethodsError,
+    getQuotes,
+    getBuyWidgetData,
+    orders,
+    getOrderById,
+    addOrder,
+    addPrecreatedOrder,
+    removeOrder,
+    refreshOrder,
+    getOrderFromCallback,
+  };
+}
+
+export default useRampsController;

--- a/ui/hooks/ramps/useRampsCountries.test.tsx
+++ b/ui/hooks/ramps/useRampsCountries.test.tsx
@@ -1,0 +1,13 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useRampsCountries } from './useRampsCountries';
+import { createRampsTestWrapper } from './test-utils';
+
+describe('useRampsCountries', () => {
+  it('matches snapshot', () => {
+    const { result } = renderHook(() => useRampsCountries(), {
+      wrapper: createRampsTestWrapper(),
+    });
+
+    expect(result.current).toMatchSnapshot();
+  });
+});

--- a/ui/hooks/ramps/useRampsCountries.ts
+++ b/ui/hooks/ramps/useRampsCountries.ts
@@ -1,0 +1,25 @@
+import { useSelector } from 'react-redux';
+import { type Country } from '@metamask/ramps-controller';
+import { selectCountries } from '../../selectors/rampsController';
+import { parseUserFacingError } from './utils/parseUserFacingError';
+
+export interface UseRampsCountriesResult {
+  countries: Country[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function useRampsCountries(): UseRampsCountriesResult {
+  const countriesState = useSelector(selectCountries);
+  const { data: countries, isLoading, error } = countriesState;
+
+  return {
+    countries,
+    isLoading,
+    error: error
+      ? parseUserFacingError(countriesState, 'Failed to load countries')
+      : null,
+  };
+}
+
+export default useRampsCountries;

--- a/ui/hooks/ramps/useRampsOrders.test.tsx
+++ b/ui/hooks/ramps/useRampsOrders.test.tsx
@@ -1,0 +1,21 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useRampsOrders } from './useRampsOrders';
+import { createRampsTestWrapper } from './test-utils';
+
+jest.mock('../../store/controller-actions/ramps-controller', () => ({
+  addRampsOrder: jest.fn(),
+  addRampsPrecreatedOrder: jest.fn(),
+  removeRampsOrder: jest.fn(),
+  refreshRampsOrder: jest.fn(),
+  getRampsOrderFromCallback: jest.fn(),
+}));
+
+describe('useRampsOrders', () => {
+  it('matches snapshot', () => {
+    const { result } = renderHook(() => useRampsOrders(), {
+      wrapper: createRampsTestWrapper(),
+    });
+
+    expect(result.current).toMatchSnapshot();
+  });
+});

--- a/ui/hooks/ramps/useRampsOrders.ts
+++ b/ui/hooks/ramps/useRampsOrders.ts
@@ -1,0 +1,92 @@
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import type { RampsOrder } from '@metamask/ramps-controller';
+import { selectRampsOrdersForSelectedAccount } from '../../selectors/rampsController';
+import {
+  addRampsOrder,
+  addRampsPrecreatedOrder,
+  getRampsOrderFromCallback,
+  refreshRampsOrder,
+  removeRampsOrder,
+} from '../../store/controller-actions/ramps-controller';
+
+export interface AddPrecreatedOrderParams {
+  orderId: string;
+  providerCode: string;
+  walletAddress: string;
+  chainId?: string;
+}
+
+export interface UseRampsOrdersResult {
+  orders: RampsOrder[];
+  getOrderById: (providerOrderId: string) => RampsOrder | undefined;
+  addOrder: (order: RampsOrder) => Promise<void>;
+  addPrecreatedOrder: (params: AddPrecreatedOrderParams) => Promise<void>;
+  removeOrder: (providerOrderId: string) => Promise<void>;
+  refreshOrder: (
+    providerCode: string,
+    orderCode: string,
+    wallet: string,
+  ) => Promise<RampsOrder>;
+  getOrderFromCallback: (
+    providerCode: string,
+    callbackUrl: string,
+    wallet: string,
+  ) => Promise<RampsOrder>;
+}
+
+function extractOrderCode(providerOrderId: string): string {
+  const parts = providerOrderId.split('/');
+  return parts[parts.length - 1] ?? providerOrderId;
+}
+
+export function useRampsOrders(): UseRampsOrdersResult {
+  const orders = useSelector(selectRampsOrdersForSelectedAccount);
+
+  const getOrderById = useCallback(
+    (providerOrderId: string) => {
+      const orderCode = extractOrderCode(providerOrderId);
+      return orders.find((order) => order.providerOrderId === orderCode);
+    },
+    [orders],
+  );
+
+  const addOrder = useCallback(
+    (order: RampsOrder) => addRampsOrder(order),
+    [],
+  );
+
+  const addPrecreatedOrder = useCallback(
+    (params: AddPrecreatedOrderParams) => addRampsPrecreatedOrder(params),
+    [],
+  );
+
+  const removeOrder = useCallback(
+    (providerOrderId: string) => removeRampsOrder(providerOrderId),
+    [],
+  );
+
+  const refreshOrder = useCallback(
+    (providerCode: string, orderCode: string, wallet: string) =>
+      refreshRampsOrder(providerCode, orderCode, wallet),
+    [],
+  );
+
+  const getOrderFromCallback = useCallback(
+    (providerCode: string, callbackUrl: string, wallet: string) =>
+      getRampsOrderFromCallback(providerCode, callbackUrl, wallet),
+    [],
+  );
+
+  return {
+    orders,
+    getOrderById,
+    addOrder,
+    addPrecreatedOrder,
+    removeOrder,
+    refreshOrder,
+    getOrderFromCallback,
+  };
+}
+
+export default useRampsOrders;

--- a/ui/hooks/ramps/useRampsPaymentMethods.test.tsx
+++ b/ui/hooks/ramps/useRampsPaymentMethods.test.tsx
@@ -1,0 +1,18 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useRampsPaymentMethods } from './useRampsPaymentMethods';
+import { createRampsTestWrapper } from './test-utils';
+
+jest.mock('../../store/controller-actions/ramps-controller', () => ({
+  setRampsSelectedPaymentMethod: jest.fn(),
+  getRampsPaymentMethods: jest.fn(),
+}));
+
+describe('useRampsPaymentMethods', () => {
+  it('matches snapshot', () => {
+    const { result } = renderHook(() => useRampsPaymentMethods(), {
+      wrapper: createRampsTestWrapper(),
+    });
+
+    expect(result.current).toMatchSnapshot();
+  });
+});

--- a/ui/hooks/ramps/useRampsPaymentMethods.ts
+++ b/ui/hooks/ramps/useRampsPaymentMethods.ts
@@ -1,0 +1,129 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useSelector } from 'react-redux';
+import { type PaymentMethod } from '@metamask/ramps-controller';
+import {
+  selectPaymentMethods,
+  selectProviders,
+  selectTokens,
+  selectUserRegion,
+} from '../../selectors/rampsController';
+import { setRampsSelectedPaymentMethod } from '../../store/controller-actions/ramps-controller';
+import { rampsQueries } from './queries';
+import { normalizeAssetIdForApi } from './utils/normalizeAssetIdForApi';
+import { parseUserFacingError } from './utils/parseUserFacingError';
+
+export type RampsQueryStatus = 'idle' | 'loading' | 'success' | 'error';
+
+export interface UseRampsPaymentMethodsResult {
+  paymentMethods: PaymentMethod[];
+  selectedPaymentMethod: PaymentMethod | null;
+  setSelectedPaymentMethod: (
+    paymentMethod: PaymentMethod | null,
+  ) => Promise<void>;
+  isLoading: boolean;
+  isFetching: boolean;
+  status: RampsQueryStatus;
+  isSuccess: boolean;
+  error: string | null;
+}
+
+export function useRampsPaymentMethods(): UseRampsPaymentMethodsResult {
+  const { selected: selectedPaymentMethod } = useSelector(selectPaymentMethods);
+  const { selected: selectedProvider } = useSelector(selectProviders);
+  const { selected: selectedToken } = useSelector(selectTokens);
+  const userRegion = useSelector(selectUserRegion);
+
+  const queryEnabled = Boolean(
+    userRegion?.regionCode &&
+      userRegion?.country?.currency &&
+      selectedProvider?.id,
+  );
+
+  const paymentMethodsQuery = useQuery({
+    ...rampsQueries.paymentMethods.options({
+      regionCode: userRegion?.regionCode ?? '',
+      fiat: userRegion?.country?.currency ?? '',
+      assetId: normalizeAssetIdForApi(selectedToken?.assetId),
+      providerId: selectedProvider?.id ?? '',
+    }),
+    enabled: queryEnabled,
+  });
+
+  const setSelectedPaymentMethod = useCallback(
+    (paymentMethod: PaymentMethod | null) =>
+      setRampsSelectedPaymentMethod(paymentMethod),
+    [],
+  );
+
+  useEffect(() => {
+    const methods = paymentMethodsQuery.data;
+    if (!methods || methods.length === 0) {
+      return;
+    }
+
+    let target: PaymentMethod | null = null;
+
+    if (selectedPaymentMethod) {
+      target =
+        methods.find((method) => method.id === selectedPaymentMethod.id) ??
+        null;
+    }
+
+    if (!target) {
+      target = methods[0];
+    }
+
+    if (target.id !== selectedPaymentMethod?.id) {
+      setSelectedPaymentMethod(target);
+    }
+  }, [
+    paymentMethodsQuery.data,
+    selectedPaymentMethod,
+    setSelectedPaymentMethod,
+  ]);
+
+  const isAutoSelecting = Boolean(
+    paymentMethodsQuery.data?.length &&
+      (!selectedPaymentMethod ||
+        paymentMethodsQuery.data.every(
+          (method) => method.id !== selectedPaymentMethod.id,
+        )),
+  );
+
+  const status = useMemo<RampsQueryStatus>(() => {
+    if (!queryEnabled) {
+      return 'idle';
+    }
+    if (paymentMethodsQuery.isLoading) {
+      return 'loading';
+    }
+    if (paymentMethodsQuery.isError) {
+      return 'error';
+    }
+    return 'success';
+  }, [
+    paymentMethodsQuery.isError,
+    paymentMethodsQuery.isLoading,
+    queryEnabled,
+  ]);
+
+  return {
+    paymentMethods: paymentMethodsQuery.data ?? [],
+    selectedPaymentMethod,
+    setSelectedPaymentMethod,
+    isLoading: status === 'loading' || isAutoSelecting,
+    isFetching: paymentMethodsQuery.isFetching,
+    status,
+    isSuccess: status === 'success',
+    error:
+      paymentMethodsQuery.error != null
+        ? parseUserFacingError(
+            paymentMethodsQuery.error,
+            'Failed to load payment methods',
+          )
+        : null,
+  };
+}
+
+export default useRampsPaymentMethods;

--- a/ui/hooks/ramps/useRampsProviders.test.tsx
+++ b/ui/hooks/ramps/useRampsProviders.test.tsx
@@ -1,0 +1,18 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useRampsProviders } from './useRampsProviders';
+import { createRampsTestWrapper } from './test-utils';
+
+jest.mock('../../store/controller-actions/ramps-controller', () => ({
+  setRampsSelectedProvider: jest.fn(),
+  getRampsProviders: jest.fn().mockResolvedValue({ providers: [] }),
+}));
+
+describe('useRampsProviders', () => {
+  it('matches snapshot', () => {
+    const { result } = renderHook(() => useRampsProviders(), {
+      wrapper: createRampsTestWrapper(),
+    });
+
+    expect(result.current).toMatchSnapshot();
+  });
+});

--- a/ui/hooks/ramps/useRampsProviders.ts
+++ b/ui/hooks/ramps/useRampsProviders.ts
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useSelector } from 'react-redux';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { type Provider } from '@metamask/ramps-controller';
+import {
+  selectProviders,
+  selectRampsOrdersForSelectedAccount,
+  selectUserRegion,
+} from '../../selectors/rampsController';
+import { setRampsSelectedProvider } from '../../store/controller-actions/ramps-controller';
+import {
+  completedOrdersFromRampsOrders,
+  determinePreferredProvider,
+} from './utils/determinePreferredProvider';
+import { parseUserFacingError } from './utils/parseUserFacingError';
+import { rampsQueries } from './queries';
+
+export interface UseRampsProvidersResult {
+  providers: Provider[];
+  selectedProvider: Provider | null;
+  setSelectedProvider: (
+    provider: Provider | null,
+    options?: { autoSelected?: boolean },
+  ) => Promise<void>;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function useRampsProviders(options?: {
+  enableSideEffects?: boolean;
+}): UseRampsProvidersResult {
+  const enableSideEffects = options?.enableSideEffects ?? false;
+  const providersState = useSelector(selectProviders);
+  const {
+    data: providersStateData,
+    selected: selectedProvider,
+    isLoading: providersStateIsLoading,
+    error: providersStateError,
+  } = providersState;
+
+  const userRegion = useSelector(selectUserRegion);
+  const regionCode = userRegion?.regionCode ?? '';
+  const queryClient = useQueryClient();
+
+  const prevRegionRef = useRef(regionCode);
+  useEffect(() => {
+    if (
+      enableSideEffects &&
+      regionCode &&
+      prevRegionRef.current !== regionCode
+    ) {
+      prevRegionRef.current = regionCode;
+      queryClient.invalidateQueries({
+        queryKey: ['ramps'],
+        refetchType: 'none',
+      });
+    }
+  }, [enableSideEffects, regionCode, queryClient]);
+
+  const providersQuery = useQuery({
+    ...rampsQueries.providers.options({ regionCode }),
+    enabled: Boolean(regionCode),
+  });
+
+  const providers = useMemo(
+    () => providersQuery?.data ?? providersStateData ?? [],
+    [providersQuery?.data, providersStateData],
+  );
+
+  const controllerOrders = useSelector(selectRampsOrdersForSelectedAccount);
+  const completedOrders = useMemo(
+    () => completedOrdersFromRampsOrders(controllerOrders),
+    [controllerOrders],
+  );
+
+  const setSelectedProvider = useCallback(
+    (provider: Provider | null, setOptions?: { autoSelected?: boolean }) =>
+      setRampsSelectedProvider(provider?.id ?? null, setOptions),
+    [],
+  );
+
+  useEffect(() => {
+    if (
+      enableSideEffects &&
+      providers &&
+      providers.length > 0 &&
+      !selectedProvider
+    ) {
+      const result = determinePreferredProvider(completedOrders, providers);
+      if (result) {
+        setSelectedProvider(result.provider, {
+          autoSelected: result.autoSelected,
+        });
+      }
+    }
+  }, [
+    enableSideEffects,
+    providers,
+    selectedProvider,
+    completedOrders,
+    setSelectedProvider,
+  ]);
+
+  let error: string | null = null;
+  if (providersQuery?.error != null) {
+    error = parseUserFacingError(
+      providersQuery.error,
+      'Failed to load providers',
+    );
+  } else if (providersStateError) {
+    error = parseUserFacingError(
+      providersState,
+      'Failed to load providers',
+    );
+  }
+
+  return {
+    providers,
+    selectedProvider,
+    setSelectedProvider,
+    isLoading: providersQuery?.isLoading ?? providersStateIsLoading,
+    error,
+  };
+}
+
+export default useRampsProviders;

--- a/ui/hooks/ramps/useRampsQuotes.test.tsx
+++ b/ui/hooks/ramps/useRampsQuotes.test.tsx
@@ -1,0 +1,18 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useRampsQuotes } from './useRampsQuotes';
+import { createRampsTestWrapper } from './test-utils';
+
+jest.mock('../../store/controller-actions/ramps-controller', () => ({
+  getRampsQuotes: jest.fn(),
+  getRampsBuyWidgetData: jest.fn(),
+}));
+
+describe('useRampsQuotes', () => {
+  it('matches snapshot when query is disabled', () => {
+    const { result } = renderHook(() => useRampsQuotes(), {
+      wrapper: createRampsTestWrapper(),
+    });
+
+    expect(result.current).toMatchSnapshot();
+  });
+});

--- a/ui/hooks/ramps/useRampsQuotes.ts
+++ b/ui/hooks/ramps/useRampsQuotes.ts
@@ -1,0 +1,77 @@
+import { useCallback, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { BuyWidget, Quote, QuotesResponse } from '@metamask/ramps-controller';
+import {
+  getRampsBuyWidgetData,
+  getRampsQuotes,
+  type GetRampsQuotesParams,
+} from '../../store/controller-actions/ramps-controller';
+import { rampsQueries } from './queries';
+import type { RampsQueryStatus } from './useRampsPaymentMethods';
+
+export interface UseRampsQuotesResult {
+  getQuotes: (options: GetRampsQuotesParams) => Promise<QuotesResponse>;
+  getBuyWidgetData: (quote: Quote) => Promise<BuyWidget | null>;
+  data: QuotesResponse | null;
+  loading: boolean;
+  status: RampsQueryStatus;
+  isSuccess: boolean;
+  error: unknown | null;
+}
+
+export function useRampsQuotes(
+  options?: GetRampsQuotesParams | null,
+): UseRampsQuotesResult {
+  const getQuotes = useCallback(
+    (opts: GetRampsQuotesParams) => getRampsQuotes(opts),
+    [],
+  );
+
+  const getBuyWidgetData = useCallback(
+    (quote: Quote) => getRampsBuyWidgetData(quote),
+    [],
+  );
+
+  const queryEnabled = Boolean(
+    options?.assetId && options.walletAddress && options.amount > 0,
+  );
+
+  const quotesQuery = useQuery({
+    ...rampsQueries.quotes.options({
+      assetId: options?.assetId,
+      amount: options?.amount ?? 0,
+      walletAddress: options?.walletAddress ?? '',
+      redirectUrl: options?.redirectUrl,
+      paymentMethods: options?.paymentMethods,
+      providers: options?.providers,
+      forceRefresh: options?.forceRefresh,
+      ttl: options?.ttl,
+    }),
+    enabled: queryEnabled,
+  });
+
+  const status = useMemo<RampsQueryStatus>(() => {
+    if (!queryEnabled) {
+      return 'idle';
+    }
+    if (quotesQuery.isLoading) {
+      return 'loading';
+    }
+    if (quotesQuery.isError) {
+      return 'error';
+    }
+    return 'success';
+  }, [queryEnabled, quotesQuery.isError, quotesQuery.isLoading]);
+
+  return {
+    getQuotes,
+    getBuyWidgetData,
+    data: quotesQuery.data ?? null,
+    loading: quotesQuery.isLoading,
+    status,
+    isSuccess: status === 'success',
+    error: quotesQuery.error ?? null,
+  };
+}
+
+export default useRampsQuotes;

--- a/ui/hooks/ramps/useRampsTokens.test.tsx
+++ b/ui/hooks/ramps/useRampsTokens.test.tsx
@@ -1,0 +1,17 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useRampsTokens } from './useRampsTokens';
+import { createRampsTestWrapper } from './test-utils';
+
+jest.mock('../../store/controller-actions/ramps-controller', () => ({
+  setRampsSelectedToken: jest.fn(),
+}));
+
+describe('useRampsTokens', () => {
+  it('matches snapshot', () => {
+    const { result } = renderHook(() => useRampsTokens(), {
+      wrapper: createRampsTestWrapper(),
+    });
+
+    expect(result.current).toMatchSnapshot();
+  });
+});

--- a/ui/hooks/ramps/useRampsTokens.ts
+++ b/ui/hooks/ramps/useRampsTokens.ts
@@ -1,0 +1,44 @@
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import {
+  type RampsToken,
+  type TokensResponse,
+} from '@metamask/ramps-controller';
+import { selectTokens } from '../../selectors/rampsController';
+import { setRampsSelectedToken } from '../../store/controller-actions/ramps-controller';
+import { parseUserFacingError } from './utils/parseUserFacingError';
+
+export interface UseRampsTokensResult {
+  tokens: TokensResponse | null;
+  selectedToken: RampsToken | null;
+  setSelectedToken: (assetId: string) => Promise<void>;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function useRampsTokens(): UseRampsTokensResult {
+  const tokensState = useSelector(selectTokens);
+  const {
+    data: tokens,
+    selected: selectedToken,
+    isLoading,
+    error,
+  } = tokensState;
+
+  const setSelectedToken = useCallback(
+    (assetId: string) => setRampsSelectedToken(assetId),
+    [],
+  );
+
+  return {
+    tokens,
+    selectedToken,
+    setSelectedToken,
+    isLoading,
+    error: error
+      ? parseUserFacingError(tokensState, 'Failed to load tokens')
+      : null,
+  };
+}
+
+export default useRampsTokens;

--- a/ui/hooks/ramps/useRampsUserRegion.test.tsx
+++ b/ui/hooks/ramps/useRampsUserRegion.test.tsx
@@ -1,0 +1,17 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useRampsUserRegion } from './useRampsUserRegion';
+import { createRampsTestWrapper } from './test-utils';
+
+jest.mock('../../store/controller-actions/ramps-controller', () => ({
+  setRampsUserRegion: jest.fn(),
+}));
+
+describe('useRampsUserRegion', () => {
+  it('matches snapshot', () => {
+    const { result } = renderHook(() => useRampsUserRegion(), {
+      wrapper: createRampsTestWrapper(),
+    });
+
+    expect(result.current).toMatchSnapshot();
+  });
+});

--- a/ui/hooks/ramps/useRampsUserRegion.ts
+++ b/ui/hooks/ramps/useRampsUserRegion.ts
@@ -1,0 +1,33 @@
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import {
+  ExecuteRequestOptions,
+  type UserRegion,
+} from '@metamask/ramps-controller';
+import { selectUserRegion } from '../../selectors/rampsController';
+import { setRampsUserRegion } from '../../store/controller-actions/ramps-controller';
+
+export interface UseRampsUserRegionResult {
+  userRegion: UserRegion | null;
+  setUserRegion: (
+    region: string,
+    options?: ExecuteRequestOptions,
+  ) => Promise<UserRegion | null>;
+}
+
+export function useRampsUserRegion(): UseRampsUserRegionResult {
+  const userRegion = useSelector(selectUserRegion);
+
+  const setUserRegion = useCallback(
+    (region: string, options?: ExecuteRequestOptions) =>
+      setRampsUserRegion(region, options),
+    [],
+  );
+
+  return {
+    userRegion,
+    setUserRegion,
+  };
+}
+
+export default useRampsUserRegion;

--- a/ui/hooks/ramps/utils/determinePreferredProvider.ts
+++ b/ui/hooks/ramps/utils/determinePreferredProvider.ts
@@ -1,0 +1,61 @@
+import {
+  type Provider,
+  type RampsOrder,
+  RampsOrderStatus,
+} from '@metamask/ramps-controller';
+
+export interface CompletedOrderInfo {
+  providerId: string;
+  completedAt: number;
+}
+
+export function completedOrdersFromRampsOrders(
+  orders: RampsOrder[],
+): CompletedOrderInfo[] {
+  return orders
+    .filter((order) => order.status === RampsOrderStatus.Completed)
+    .reduce<CompletedOrderInfo[]>((acc, order) => {
+      const providerId = order.provider?.id;
+      if (providerId) {
+        acc.push({ providerId, completedAt: order.createdAt });
+      }
+      return acc;
+    }, []);
+}
+
+export interface PreferredProviderResult {
+  provider: Provider;
+  autoSelected: boolean;
+}
+
+export function determinePreferredProvider(
+  completedOrders: CompletedOrderInfo[],
+  providers: Provider[],
+): PreferredProviderResult | null {
+  if (!providers.length) {
+    return null;
+  }
+
+  const sortedOrders = [...completedOrders].sort(
+    (a, b) => b.completedAt - a.completedAt,
+  );
+  const mostRecentProviderId = sortedOrders[0]?.providerId;
+
+  if (mostRecentProviderId) {
+    const previousProvider = providers.find(
+      (provider) => provider.id === mostRecentProviderId,
+    );
+    if (previousProvider) {
+      return { provider: previousProvider, autoSelected: false };
+    }
+  }
+
+  const transakProvider = providers.find((provider) =>
+    provider.id?.toLowerCase().includes('transak'),
+  );
+  if (transakProvider) {
+    return { provider: transakProvider, autoSelected: false };
+  }
+
+  return null;
+}

--- a/ui/hooks/ramps/utils/normalizeAssetIdForApi.ts
+++ b/ui/hooks/ramps/utils/normalizeAssetIdForApi.ts
@@ -1,0 +1,9 @@
+export function normalizeAssetIdForApi(assetId: string | undefined): string {
+  if (!assetId) {
+    return '';
+  }
+  if (assetId.startsWith('eip155:')) {
+    return assetId.toLowerCase();
+  }
+  return assetId;
+}

--- a/ui/hooks/ramps/utils/parseUserFacingError.ts
+++ b/ui/hooks/ramps/utils/parseUserFacingError.ts
@@ -1,0 +1,21 @@
+export function parseUserFacingError(
+  error: unknown,
+  fallbackMessage: string,
+): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  if (typeof error === 'string' && error.trim()) {
+    return error;
+  }
+
+  if (typeof error === 'object' && error !== null && 'error' in error) {
+    const resourceError = (error as { error?: unknown }).error;
+    if (typeof resourceError === 'string' && resourceError.trim()) {
+      return resourceError;
+    }
+  }
+
+  return fallbackMessage;
+}

--- a/ui/pages/index.js
+++ b/ui/pages/index.js
@@ -17,6 +17,7 @@ import { MetamaskIdentityProvider } from '../contexts/identity';
 import { ShieldSubscriptionProvider } from '../contexts/shield/shield-subscription';
 import RiveWasmProvider from '../contexts/rive-wasm';
 import { queryClient } from '../contexts/query-client';
+import RampsBootstrap from '../hooks/ramps/RampsBootstrap';
 import { HardwareWalletErrorProvider } from '../contexts/hardware-wallets';
 import { UIMessengerProvider } from '../contexts/ui-messenger';
 import ErrorPageBase from './error-page/error-page.component';
@@ -28,6 +29,7 @@ function AppProviders() {
     <MetaMetricsProvider>
       <I18nProvider>
         <QueryClientProvider client={queryClient}>
+          <RampsBootstrap />
           <AssetPollingProvider>
             <MetamaskIdentityProvider>
               <MetamaskNotificationsProvider>

--- a/ui/selectors/rampsController/__snapshots__/index.test.ts.snap
+++ b/ui/selectors/rampsController/__snapshots__/index.test.ts.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rampsController selectors matches snapshot for selectUserRegion and selectTokens 1`] = `
+{
+  "country": {
+    "currency": "USD",
+  },
+  "regionCode": "us-ca",
+}
+`;
+
+exports[`rampsController selectors matches snapshot for selectUserRegion and selectTokens 2`] = `
+{
+  "data": {
+    "allTokens": [],
+    "topTokens": [],
+  },
+  "error": null,
+  "isLoading": false,
+  "selected": null,
+}
+`;

--- a/ui/selectors/rampsController/index.test.ts
+++ b/ui/selectors/rampsController/index.test.ts
@@ -1,0 +1,25 @@
+import { selectUserRegion, selectTokens } from './index';
+
+describe('rampsController selectors', () => {
+  it('matches snapshot for selectUserRegion and selectTokens', () => {
+    const state = {
+      metamask: {
+        RampsController: {
+          userRegion: {
+            regionCode: 'us-ca',
+            country: { currency: 'USD' },
+          },
+          tokens: {
+            data: { topTokens: [], allTokens: [] },
+            selected: null,
+            isLoading: false,
+            error: null,
+          },
+        },
+      },
+    };
+
+    expect(selectUserRegion(state)).toMatchSnapshot();
+    expect(selectTokens(state)).toMatchSnapshot();
+  });
+});

--- a/ui/selectors/rampsController/index.ts
+++ b/ui/selectors/rampsController/index.ts
@@ -1,0 +1,106 @@
+import { createSelector } from 'reselect';
+import {
+  type UserRegion,
+  type Provider,
+  type Country,
+  type PaymentMethod,
+  type RampsToken,
+  type TokensResponse,
+  type ResourceState,
+  type RampsOrder,
+} from '@metamask/ramps-controller';
+import { getSelectedInternalAccount } from '../../../shared/lib/selectors/accounts';
+
+type RampsControllerStateSlice = {
+  metamask: {
+    RampsController?: {
+      userRegion?: UserRegion | null;
+      countries?: ResourceState<Country[]>;
+      providers?: ResourceState<Provider[], Provider | null>;
+      tokens?: ResourceState<TokensResponse | null, RampsToken | null>;
+      paymentMethods?: ResourceState<PaymentMethod[], PaymentMethod | null>;
+      orders?: RampsOrder[];
+      providerAutoSelected?: boolean;
+    };
+  };
+};
+
+const createDefaultResourceState = <TData, TSelected = null>(
+  data: TData,
+  selected: TSelected = null as TSelected,
+): ResourceState<TData, TSelected> => ({
+  data,
+  selected,
+  isLoading: false,
+  error: null,
+});
+
+export const selectRampsControllerState = (state: RampsControllerStateSlice) =>
+  state.metamask.RampsController;
+
+export const selectUserRegion = createSelector(
+  selectRampsControllerState,
+  (rampsControllerState): UserRegion | null =>
+    rampsControllerState?.userRegion ?? null,
+);
+
+export const selectCountries = createSelector(
+  selectRampsControllerState,
+  (rampsControllerState): ResourceState<Country[]> =>
+    rampsControllerState?.countries ??
+    createDefaultResourceState<Country[]>([]),
+);
+
+export const selectProviders = createSelector(
+  selectRampsControllerState,
+  (rampsControllerState): ResourceState<Provider[], Provider | null> =>
+    rampsControllerState?.providers ??
+    createDefaultResourceState<Provider[], Provider | null>([], null),
+);
+
+export const selectTokens = createSelector(
+  selectRampsControllerState,
+  (
+    rampsControllerState,
+  ): ResourceState<TokensResponse | null, RampsToken | null> =>
+    rampsControllerState?.tokens ??
+    createDefaultResourceState<TokensResponse | null, RampsToken | null>(
+      null,
+      null,
+    ),
+);
+
+export const selectPaymentMethods = createSelector(
+  selectRampsControllerState,
+  (
+    rampsControllerState,
+  ): ResourceState<PaymentMethod[], PaymentMethod | null> =>
+    rampsControllerState?.paymentMethods ??
+    createDefaultResourceState<PaymentMethod[], PaymentMethod | null>([], null),
+);
+
+export const selectRampsOrders = createSelector(
+  selectRampsControllerState,
+  (rampsControllerState): RampsOrder[] => rampsControllerState?.orders ?? [],
+);
+
+export const selectRampsOrdersForSelectedAccount = createSelector(
+  [selectRampsOrders, getSelectedInternalAccount],
+  (orders, selectedAccount): RampsOrder[] => {
+    const selectedAddress = selectedAccount?.address?.toLowerCase();
+    if (!selectedAddress) {
+      return [];
+    }
+
+    return orders.filter((order) => {
+      const walletAddress = order.walletAddress?.toLowerCase();
+      return walletAddress === selectedAddress;
+    });
+  },
+);
+
+export const selectProviderAutoSelected = createSelector(
+  selectRampsControllerState,
+  (rampsControllerState): boolean =>
+    rampsControllerState?.providerAutoSelected ?? false,
+);

--- a/ui/store/controller-actions/ramps-controller.test.ts
+++ b/ui/store/controller-actions/ramps-controller.test.ts
@@ -1,0 +1,43 @@
+import * as BackgroundConnectionModule from '../background-connection';
+import {
+  getRampsQuotes,
+  setRampsUserRegion,
+} from './ramps-controller';
+
+jest.mock('../background-connection');
+
+describe('ramps-controller actions', () => {
+  const mockSubmitRequestToBackground = jest.spyOn(
+    BackgroundConnectionModule,
+    'submitRequestToBackground',
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSubmitRequestToBackground.mockResolvedValue(undefined);
+  });
+
+  it('calls submitRequestToBackground for setRampsUserRegion', async () => {
+    await setRampsUserRegion('us-ca');
+
+    expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+      'setRampsUserRegion',
+      ['us-ca', undefined],
+    );
+  });
+
+  it('calls submitRequestToBackground for getRampsQuotes', async () => {
+    const quoteParams = {
+      amount: 100,
+      walletAddress: '0xabc',
+      assetId: 'eip155:1/erc20:0x0',
+    };
+
+    await getRampsQuotes(quoteParams);
+
+    expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+      'getRampsQuotes',
+      [quoteParams],
+    );
+  });
+});

--- a/ui/store/controller-actions/ramps-controller.ts
+++ b/ui/store/controller-actions/ramps-controller.ts
@@ -1,0 +1,133 @@
+import { submitRequestToBackground } from '../background-connection';
+import type {
+  BuyWidget,
+  ExecuteRequestOptions,
+  PaymentMethod,
+  Provider,
+  Quote,
+  QuotesResponse,
+  RampsOrder,
+  UserRegion,
+} from '@metamask/ramps-controller';
+
+export async function setRampsUserRegion(
+  region: string,
+  options?: ExecuteRequestOptions,
+): Promise<UserRegion | null> {
+  return submitRequestToBackground('setRampsUserRegion', [region, options]);
+}
+
+export async function setRampsSelectedToken(assetId: string): Promise<void> {
+  return submitRequestToBackground('setRampsSelectedToken', [assetId]);
+}
+
+export async function setRampsSelectedProvider(
+  provider: Provider | string | null,
+  options?: { autoSelected?: boolean },
+): Promise<void> {
+  return submitRequestToBackground('setRampsSelectedProvider', [
+    provider,
+    options,
+  ]);
+}
+
+export async function setRampsSelectedPaymentMethod(
+  paymentMethod: PaymentMethod | string | null,
+): Promise<void> {
+  return submitRequestToBackground('setRampsSelectedPaymentMethod', [
+    paymentMethod,
+  ]);
+}
+
+export async function getRampsTokens(
+  region: string,
+  action: 'buy' | 'sell' = 'buy',
+): Promise<void> {
+  return submitRequestToBackground('getRampsTokens', [region, action]);
+}
+
+export async function getRampsProviders(region: string) {
+  return submitRequestToBackground('getRampsProviders', [region]);
+}
+
+export async function getRampsPaymentMethods(
+  region: string,
+  options: {
+    fiat: string;
+    assetId?: string;
+    provider?: string;
+  },
+) {
+  return submitRequestToBackground('getRampsPaymentMethods', [
+    region,
+    options,
+  ]);
+}
+
+export type GetRampsQuotesParams = {
+  region?: string;
+  fiat?: string;
+  assetId?: string;
+  amount: number;
+  walletAddress: string;
+  paymentMethods?: string[];
+  providers?: string[];
+  redirectUrl?: string;
+  forceRefresh?: boolean;
+  ttl?: number;
+};
+
+export async function getRampsQuotes(
+  options: GetRampsQuotesParams,
+): Promise<QuotesResponse> {
+  return submitRequestToBackground('getRampsQuotes', [options]);
+}
+
+export async function getRampsBuyWidgetData(
+  quote: Quote,
+): Promise<BuyWidget | null> {
+  return submitRequestToBackground('getRampsBuyWidgetData', [quote]);
+}
+
+export async function addRampsPrecreatedOrder(params: {
+  orderId: string;
+  providerCode: string;
+  walletAddress: string;
+  chainId?: string;
+}): Promise<void> {
+  return submitRequestToBackground('addRampsPrecreatedOrder', [params]);
+}
+
+export async function addRampsOrder(order: RampsOrder): Promise<void> {
+  return submitRequestToBackground('addRampsOrder', [order]);
+}
+
+export async function removeRampsOrder(
+  providerOrderId: string,
+): Promise<void> {
+  return submitRequestToBackground('removeRampsOrder', [providerOrderId]);
+}
+
+export async function refreshRampsOrder(
+  providerCode: string,
+  orderCode: string,
+  wallet: string,
+): Promise<RampsOrder> {
+  return submitRequestToBackground('refreshRampsOrder', [
+    providerCode,
+    orderCode,
+    wallet,
+  ]);
+}
+
+export async function getRampsOrderFromCallback(
+  providerCode: string,
+  callbackUrl: string,
+  wallet: string,
+): Promise<RampsOrder> {
+  return submitRequestToBackground('getRampsOrderFromCallback', [
+    providerCode,
+    callbackUrl,
+    wallet,
+  ]);
+}


### PR DESCRIPTION
## Summary
- Wire `RampsService` and `RampsController` into extension background via local wallet-init configs, persistence, order polling, and a background API exposed through `metamask-controller`.
- Delegate `RampsController:getQuotes` and `RampsController:getOrder` on the TransactionPay messenger.
- Port the aggregator client layer from mobile: selectors, controller actions, React Query queries, hooks, `useRampsController` facade, and `RampsBootstrap` mounted at app root.
- Add snapshot/unit tests and lavamoat policy updates for direct `@metamask/ramps-controller` usage.

## Notes
- Extension stays on `@metamask/wallet` v3 and uses local ramps init configs to avoid duplicating controllers already initialized via messenger-client-init.
- Buy UI screens and Portfolio redirect migration are out of scope; plumbing is ready for a follow-up UI PR.

## Test plan
- [x] `yarn jest ui/hooks/ramps/useRampsUserRegion.test.tsx ui/hooks/ramps/useRampsTokens.test.tsx ui/hooks/ramps/useRampsCountries.test.tsx ui/hooks/ramps/useRampsProviders.test.tsx ui/hooks/ramps/useRampsPaymentMethods.test.tsx ui/hooks/ramps/useRampsQuotes.test.tsx ui/hooks/ramps/useRampsOrders.test.tsx ui/hooks/ramps/useRampsController.test.tsx ui/selectors/rampsController/index.test.ts ui/store/controller-actions/ramps-controller.test.ts app/scripts/wallet-init/ramps-controller-api.test.ts app/scripts/wallet-init/ramps/index.test.ts`
- [ ] `yarn start` — verify extension builds and loads
- [ ] Confirm `RampsController` state appears in persisted background store after unlock


Made with [Cursor](https://cursor.com)