### PR TITLE
fix(sentry): Drop `sentry-tracing-init` mark spans in `beforeSendTransaction`

### DIFF
--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -405,8 +405,10 @@ export function sanitizeBreadcrumbsInReport(report) {
   }
 }
 
-// `op: 'mark'` span names with no diagnostic value, dropped from transactions.
-const LOW_VALUE_TRACE_MARKS = new Set(['sentry-tracing-init']);
+// `op: 'mark'` span names with no Sentry-side consumer, dropped from transactions.
+// (`mm-hero-painted` is a benchmark LCP marker read locally via the Performance
+// API; its Sentry span is incidental.)
+const LOW_VALUE_TRACE_MARKS = new Set(['sentry-tracing-init', 'mm-hero-painted']);
 
 /**
  * Removes zero-diagnostic-value `op: 'mark'` child spans from a transaction

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -403,15 +403,55 @@ export function sanitizeBreadcrumbsInReport(report) {
 }
 
 /**
- * Scrubs breadcrumb payloads on performance transaction events before send.
- * {@link rewriteReport} handles errors via `beforeSend`; transactions use
- * `beforeSendTransaction` instead.
+ * Browser `performance.mark()` entries that `browserTracingIntegration` captures
+ * as `op: 'mark'` child spans but that carry no diagnostic value — the parent
+ * transaction's own existence already evidences them, so they are pure span
+ * volume. Listed here so {@link dropLowValueMarkSpans} can trim them.
+ *
+ * - `sentry-tracing-init`: emitted once per root transaction by the Sentry
+ *   browser SDK when tracing initializes (`@sentry-internal/browser-utils`).
+ *   ~30M/7d (~25M on `/service-worker.js` cold-starts); zero diagnostic value,
+ *   since a transaction existing already proves tracing initialized.
+ *
+ * Extend as further zero-value marks are identified. App marks that carry real
+ * signal (e.g. `mm-hero-painted`) are intentionally absent.
+ */
+const LOW_VALUE_TRACE_MARKS = new Set(['sentry-tracing-init']);
+
+/**
+ * Removes zero / low-diagnostic-value `op: 'mark'` child spans from a
+ * transaction event in place. Child-span trimming only: the root transaction
+ * and every non-mark span — and every meaningful mark — are retained. No
+ * transaction-level sampling.
+ *
+ * The mark name is read from both `description` (Sentry v8 `spanToJSON`
+ * serializes a span's `name` to `description`) and `name`, so the filter keeps
+ * working across the in-flight v8 -> v10 SDK upgrade (#42867) whichever field
+ * the transaction payload ends up using.
+ *
+ * @param {object} report - A Sentry transaction event object.
+ */
+function dropLowValueMarkSpans(report) {
+  if (!Array.isArray(report.spans)) {
+    return;
+  }
+  report.spans = report.spans.filter((span) => {
+    const markName = span?.description ?? span?.name;
+    return !(span?.op === 'mark' && LOW_VALUE_TRACE_MARKS.has(markName));
+  });
+}
+
+/**
+ * Scrubs breadcrumb payloads and drops low-diagnostic-value `op: 'mark'` spans
+ * on performance transaction events before send. {@link rewriteReport} handles
+ * errors via `beforeSend`; transactions use `beforeSendTransaction` instead.
  *
  * @param {object} report - A Sentry transaction event object.
  * @returns {object} The modified report (same reference).
  */
 export function rewriteTransactionReport(report) {
   sanitizeBreadcrumbsInReport(report);
+  dropLowValueMarkSpans(report);
   return report;
 }
 

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -402,32 +402,12 @@ export function sanitizeBreadcrumbsInReport(report) {
   }
 }
 
-/**
- * Browser `performance.mark()` entries that `browserTracingIntegration` captures
- * as `op: 'mark'` child spans but that carry no diagnostic value — the parent
- * transaction's own existence already evidences them, so they are pure span
- * volume. Listed here so {@link dropLowValueMarkSpans} can trim them.
- *
- * - `sentry-tracing-init`: emitted once per root transaction by the Sentry
- *   browser SDK when tracing initializes (`@sentry-internal/browser-utils`).
- *   ~30M/7d (~25M on `/service-worker.js` cold-starts); zero diagnostic value,
- *   since a transaction existing already proves tracing initialized.
- *
- * Extend as further zero-value marks are identified. App marks that carry real
- * signal (e.g. `mm-hero-painted`) are intentionally absent.
- */
+// `op: 'mark'` span names with no diagnostic value, dropped from transactions.
 const LOW_VALUE_TRACE_MARKS = new Set(['sentry-tracing-init']);
 
 /**
- * Removes zero / low-diagnostic-value `op: 'mark'` child spans from a
- * transaction event in place. Child-span trimming only: the root transaction
- * and every non-mark span — and every meaningful mark — are retained. No
- * transaction-level sampling.
- *
- * The mark name is read from both `description` (Sentry v8 `spanToJSON`
- * serializes a span's `name` to `description`) and `name`, so the filter keeps
- * working across the in-flight v8 -> v10 SDK upgrade (#42867) whichever field
- * the transaction payload ends up using.
+ * Removes zero-diagnostic-value `op: 'mark'` child spans from a transaction
+ * event in place. Child-span trimming only; no transaction-level sampling.
  *
  * @param {object} report - A Sentry transaction event object.
  */
@@ -436,6 +416,7 @@ function dropLowValueMarkSpans(report) {
     return;
   }
   report.spans = report.spans.filter((span) => {
+    // The mark name serializes to `description` (SDK v8) or `name`.
     const markName = span?.description ?? span?.name;
     return !(span?.op === 'mark' && LOW_VALUE_TRACE_MARKS.has(markName));
   });

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -103,7 +103,7 @@ function getClientOptions() {
     beforeSend: (report) => rewriteReport(safeCloneReport(report)),
     beforeSendTransaction: (report) => {
       const transaction = rewriteTransactionReport(safeCloneReport(report));
-      dropMarkSpans(transaction);
+      dropLowValueMarkSpans(transaction);
       return transaction;
     },
     debug: METAMASK_DEBUG,
@@ -405,18 +405,26 @@ export function sanitizeBreadcrumbsInReport(report) {
   }
 }
 
+// `op: 'mark'` span names with no Sentry-side consumer, dropped from transactions.
+const LOW_VALUE_TRACE_MARKS = new Set([
+  'sentry-tracing-init',
+  'mm-hero-painted',
+]);
+
 /**
- * Removes `op: 'mark'` child spans (captured `performance.mark()` annotations
- * with no Sentry-side consumer) from a transaction event in place. Measures and
- * all other spans are kept.
+ * Removes the {@link LOW_VALUE_TRACE_MARKS} `op: 'mark'` child spans from a
+ * transaction event in place. Measures and all other spans are kept.
  *
  * @param {object} report - A Sentry transaction event object.
  */
-export function dropMarkSpans(report) {
+export function dropLowValueMarkSpans(report) {
   if (!Array.isArray(report.spans)) {
     return;
   }
-  report.spans = report.spans.filter((span) => span?.op !== 'mark');
+  report.spans = report.spans.filter((span) => {
+    const markName = span?.description ?? span?.name;
+    return !(span?.op === 'mark' && LOW_VALUE_TRACE_MARKS.has(markName));
+  });
 }
 
 /**

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -101,8 +101,11 @@ function getClientOptions() {
     // which would otherwise make the next error look like a different stack (background timers
     // usually run after beforeSend finished; rapid UI captures often dedupe first).
     beforeSend: (report) => rewriteReport(safeCloneReport(report)),
-    beforeSendTransaction: (report) =>
-      rewriteTransactionReport(safeCloneReport(report)),
+    beforeSendTransaction: (report) => {
+      const transaction = rewriteTransactionReport(safeCloneReport(report));
+      dropLowValueMarkSpans(transaction);
+      return transaction;
+    },
     debug: METAMASK_DEBUG,
     dist: isManifestV3 ? 'mv3' : 'mv2',
     dsn: sentryTarget,
@@ -411,7 +414,7 @@ const LOW_VALUE_TRACE_MARKS = new Set(['sentry-tracing-init']);
  *
  * @param {object} report - A Sentry transaction event object.
  */
-function dropLowValueMarkSpans(report) {
+export function dropLowValueMarkSpans(report) {
   if (!Array.isArray(report.spans)) {
     return;
   }
@@ -423,16 +426,15 @@ function dropLowValueMarkSpans(report) {
 }
 
 /**
- * Scrubs breadcrumb payloads and drops low-diagnostic-value `op: 'mark'` spans
- * on performance transaction events before send. {@link rewriteReport} handles
- * errors via `beforeSend`; transactions use `beforeSendTransaction` instead.
+ * Scrubs breadcrumb payloads on performance transaction events before send.
+ * {@link rewriteReport} handles errors via `beforeSend`; transactions use
+ * `beforeSendTransaction` instead.
  *
  * @param {object} report - A Sentry transaction event object.
  * @returns {object} The modified report (same reference).
  */
 export function rewriteTransactionReport(report) {
   sanitizeBreadcrumbsInReport(report);
-  dropLowValueMarkSpans(report);
   return report;
 }
 

--- a/app/scripts/lib/setupSentry.js
+++ b/app/scripts/lib/setupSentry.js
@@ -103,7 +103,7 @@ function getClientOptions() {
     beforeSend: (report) => rewriteReport(safeCloneReport(report)),
     beforeSendTransaction: (report) => {
       const transaction = rewriteTransactionReport(safeCloneReport(report));
-      dropLowValueMarkSpans(transaction);
+      dropMarkSpans(transaction);
       return transaction;
     },
     debug: METAMASK_DEBUG,
@@ -405,26 +405,18 @@ export function sanitizeBreadcrumbsInReport(report) {
   }
 }
 
-// `op: 'mark'` span names with no Sentry-side consumer, dropped from transactions.
-// (`mm-hero-painted` is a benchmark LCP marker read locally via the Performance
-// API; its Sentry span is incidental.)
-const LOW_VALUE_TRACE_MARKS = new Set(['sentry-tracing-init', 'mm-hero-painted']);
-
 /**
- * Removes zero-diagnostic-value `op: 'mark'` child spans from a transaction
- * event in place. Child-span trimming only; no transaction-level sampling.
+ * Removes `op: 'mark'` child spans (captured `performance.mark()` annotations
+ * with no Sentry-side consumer) from a transaction event in place. Measures and
+ * all other spans are kept.
  *
  * @param {object} report - A Sentry transaction event object.
  */
-export function dropLowValueMarkSpans(report) {
+export function dropMarkSpans(report) {
   if (!Array.isArray(report.spans)) {
     return;
   }
-  report.spans = report.spans.filter((span) => {
-    // The mark name serializes to `description` (SDK v8) or `name`.
-    const markName = span?.description ?? span?.name;
-    return !(span?.op === 'mark' && LOW_VALUE_TRACE_MARKS.has(markName));
-  });
+  report.spans = report.spans.filter((span) => span?.op !== 'mark');
 }
 
 /**

--- a/app/scripts/lib/setupSentry.test.js
+++ b/app/scripts/lib/setupSentry.test.js
@@ -1,5 +1,6 @@
 import { cloneDeep } from 'lodash';
 import {
+  dropLowValueMarkSpans,
   removeUrlsFromBreadCrumb,
   rewriteReport,
   rewriteTransactionReport,
@@ -344,7 +345,9 @@ describe('Setup Sentry', () => {
       rewriteTransactionReport(testReport);
       expect(testReport.breadcrumbs[0].data.url).toStrictEqual('');
     });
+  });
 
+  describe('dropLowValueMarkSpans', () => {
     it('drops the sentry-tracing-init mark span while keeping the transaction and meaningful spans', () => {
       const testReport = {
         type: 'transaction',
@@ -355,7 +358,7 @@ describe('Setup Sentry', () => {
           { op: 'http.client', description: 'GET /foo' },
         ],
       };
-      rewriteTransactionReport(testReport);
+      dropLowValueMarkSpans(testReport);
       expect(testReport.transaction).toBe('ui.popup');
       expect(testReport.spans).toStrictEqual([
         { op: 'mark', description: 'mm-hero-painted' },
@@ -373,7 +376,7 @@ describe('Setup Sentry', () => {
         transaction: 'ui.popup',
         spans,
       };
-      rewriteTransactionReport(testReport);
+      dropLowValueMarkSpans(testReport);
       expect(testReport.spans).toStrictEqual(spans);
     });
 
@@ -383,7 +386,7 @@ describe('Setup Sentry', () => {
         transaction: 'ui.popup',
         spans: [{ op: 'http.client', description: 'sentry-tracing-init' }],
       };
-      rewriteTransactionReport(testReport);
+      dropLowValueMarkSpans(testReport);
       expect(testReport.spans).toStrictEqual([
         { op: 'http.client', description: 'sentry-tracing-init' },
       ]);
@@ -391,7 +394,7 @@ describe('Setup Sentry', () => {
 
     it('does not throw when the transaction has no spans array', () => {
       const testReport = { type: 'transaction', transaction: 'ui.popup' };
-      expect(() => rewriteTransactionReport(testReport)).not.toThrow();
+      expect(() => dropLowValueMarkSpans(testReport)).not.toThrow();
       expect(testReport.spans).toBeUndefined();
     });
 
@@ -404,7 +407,7 @@ describe('Setup Sentry', () => {
           { op: 'mark', name: 'mm-hero-painted' },
         ],
       };
-      rewriteTransactionReport(testReport);
+      dropLowValueMarkSpans(testReport);
       expect(testReport.spans).toStrictEqual([
         { op: 'mark', name: 'mm-hero-painted' },
       ]);

--- a/app/scripts/lib/setupSentry.test.js
+++ b/app/scripts/lib/setupSentry.test.js
@@ -1,6 +1,6 @@
 import { cloneDeep } from 'lodash';
 import {
-  dropLowValueMarkSpans,
+  dropMarkSpans,
   removeUrlsFromBreadCrumb,
   rewriteReport,
   rewriteTransactionReport,
@@ -347,8 +347,8 @@ describe('Setup Sentry', () => {
     });
   });
 
-  describe('dropLowValueMarkSpans', () => {
-    it('drops low-value mark spans while keeping the transaction and meaningful spans', () => {
+  describe('dropMarkSpans', () => {
+    it('drops all op:mark spans while keeping the transaction, measures, and other spans', () => {
       const testReport = {
         type: 'transaction',
         transaction: 'ui.popup',
@@ -356,20 +356,33 @@ describe('Setup Sentry', () => {
           { op: 'mark', description: 'sentry-tracing-init' },
           { op: 'mark', description: 'mm-hero-painted' },
           { op: 'mark', description: 'first-contentful-paint' },
+          { op: 'measure', description: 'boot' },
           { op: 'http.client', description: 'GET /foo' },
         ],
       };
-      dropLowValueMarkSpans(testReport);
+      dropMarkSpans(testReport);
       expect(testReport.transaction).toBe('ui.popup');
       expect(testReport.spans).toStrictEqual([
-        { op: 'mark', description: 'first-contentful-paint' },
+        { op: 'measure', description: 'boot' },
         { op: 'http.client', description: 'GET /foo' },
       ]);
     });
 
-    it('leaves a transaction without a low-value mark unchanged', () => {
+    it('keeps a non-mark span even if its description matches a mark name', () => {
+      const testReport = {
+        type: 'transaction',
+        transaction: 'ui.popup',
+        spans: [{ op: 'http.client', description: 'sentry-tracing-init' }],
+      };
+      dropMarkSpans(testReport);
+      expect(testReport.spans).toStrictEqual([
+        { op: 'http.client', description: 'sentry-tracing-init' },
+      ]);
+    });
+
+    it('leaves a transaction with no mark spans unchanged', () => {
       const spans = [
-        { op: 'mark', description: 'first-contentful-paint' },
+        { op: 'measure', description: 'boot' },
         { op: 'http.client', description: 'GET /foo' },
       ];
       const testReport = {
@@ -377,42 +390,14 @@ describe('Setup Sentry', () => {
         transaction: 'ui.popup',
         spans,
       };
-      dropLowValueMarkSpans(testReport);
+      dropMarkSpans(testReport);
       expect(testReport.spans).toStrictEqual(spans);
-    });
-
-    it('keeps a non-mark span even if its description matches a low-value mark name', () => {
-      const testReport = {
-        type: 'transaction',
-        transaction: 'ui.popup',
-        spans: [{ op: 'http.client', description: 'sentry-tracing-init' }],
-      };
-      dropLowValueMarkSpans(testReport);
-      expect(testReport.spans).toStrictEqual([
-        { op: 'http.client', description: 'sentry-tracing-init' },
-      ]);
     });
 
     it('does not throw when the transaction has no spans array', () => {
       const testReport = { type: 'transaction', transaction: 'ui.popup' };
-      expect(() => dropLowValueMarkSpans(testReport)).not.toThrow();
+      expect(() => dropMarkSpans(testReport)).not.toThrow();
       expect(testReport.spans).toBeUndefined();
-    });
-
-    it('drops the mark when the name is on the `name` field (SDK v10 forward-compat)', () => {
-      const testReport = {
-        type: 'transaction',
-        transaction: 'ui.popup',
-        spans: [
-          { op: 'mark', name: 'sentry-tracing-init' },
-          { op: 'mark', name: 'mm-hero-painted' },
-          { op: 'mark', name: 'first-contentful-paint' },
-        ],
-      };
-      dropLowValueMarkSpans(testReport);
-      expect(testReport.spans).toStrictEqual([
-        { op: 'mark', name: 'first-contentful-paint' },
-      ]);
     });
   });
 

--- a/app/scripts/lib/setupSentry.test.js
+++ b/app/scripts/lib/setupSentry.test.js
@@ -344,6 +344,71 @@ describe('Setup Sentry', () => {
       rewriteTransactionReport(testReport);
       expect(testReport.breadcrumbs[0].data.url).toStrictEqual('');
     });
+
+    it('drops the sentry-tracing-init mark span while keeping the transaction and meaningful spans', () => {
+      const testReport = {
+        type: 'transaction',
+        transaction: 'ui.popup',
+        spans: [
+          { op: 'mark', description: 'sentry-tracing-init' },
+          { op: 'mark', description: 'mm-hero-painted' },
+          { op: 'http.client', description: 'GET /foo' },
+        ],
+      };
+      rewriteTransactionReport(testReport);
+      expect(testReport.transaction).toBe('ui.popup');
+      expect(testReport.spans).toStrictEqual([
+        { op: 'mark', description: 'mm-hero-painted' },
+        { op: 'http.client', description: 'GET /foo' },
+      ]);
+    });
+
+    it('leaves a transaction without the low-value mark unchanged', () => {
+      const spans = [
+        { op: 'mark', description: 'mm-hero-painted' },
+        { op: 'http.client', description: 'GET /foo' },
+      ];
+      const testReport = {
+        type: 'transaction',
+        transaction: 'ui.popup',
+        spans,
+      };
+      rewriteTransactionReport(testReport);
+      expect(testReport.spans).toStrictEqual(spans);
+    });
+
+    it('keeps a non-mark span even if its description matches a low-value mark name', () => {
+      const testReport = {
+        type: 'transaction',
+        transaction: 'ui.popup',
+        spans: [{ op: 'http.client', description: 'sentry-tracing-init' }],
+      };
+      rewriteTransactionReport(testReport);
+      expect(testReport.spans).toStrictEqual([
+        { op: 'http.client', description: 'sentry-tracing-init' },
+      ]);
+    });
+
+    it('does not throw when the transaction has no spans array', () => {
+      const testReport = { type: 'transaction', transaction: 'ui.popup' };
+      expect(() => rewriteTransactionReport(testReport)).not.toThrow();
+      expect(testReport.spans).toBeUndefined();
+    });
+
+    it('drops the mark when the name is on the `name` field (SDK v10 forward-compat)', () => {
+      const testReport = {
+        type: 'transaction',
+        transaction: 'ui.popup',
+        spans: [
+          { op: 'mark', name: 'sentry-tracing-init' },
+          { op: 'mark', name: 'mm-hero-painted' },
+        ],
+      };
+      rewriteTransactionReport(testReport);
+      expect(testReport.spans).toStrictEqual([
+        { op: 'mark', name: 'mm-hero-painted' },
+      ]);
+    });
   });
 
   describe('shouldCreateSpanForRequest', () => {

--- a/app/scripts/lib/setupSentry.test.js
+++ b/app/scripts/lib/setupSentry.test.js
@@ -348,27 +348,28 @@ describe('Setup Sentry', () => {
   });
 
   describe('dropLowValueMarkSpans', () => {
-    it('drops the sentry-tracing-init mark span while keeping the transaction and meaningful spans', () => {
+    it('drops low-value mark spans while keeping the transaction and meaningful spans', () => {
       const testReport = {
         type: 'transaction',
         transaction: 'ui.popup',
         spans: [
           { op: 'mark', description: 'sentry-tracing-init' },
           { op: 'mark', description: 'mm-hero-painted' },
+          { op: 'mark', description: 'first-contentful-paint' },
           { op: 'http.client', description: 'GET /foo' },
         ],
       };
       dropLowValueMarkSpans(testReport);
       expect(testReport.transaction).toBe('ui.popup');
       expect(testReport.spans).toStrictEqual([
-        { op: 'mark', description: 'mm-hero-painted' },
+        { op: 'mark', description: 'first-contentful-paint' },
         { op: 'http.client', description: 'GET /foo' },
       ]);
     });
 
-    it('leaves a transaction without the low-value mark unchanged', () => {
+    it('leaves a transaction without a low-value mark unchanged', () => {
       const spans = [
-        { op: 'mark', description: 'mm-hero-painted' },
+        { op: 'mark', description: 'first-contentful-paint' },
         { op: 'http.client', description: 'GET /foo' },
       ];
       const testReport = {
@@ -405,11 +406,12 @@ describe('Setup Sentry', () => {
         spans: [
           { op: 'mark', name: 'sentry-tracing-init' },
           { op: 'mark', name: 'mm-hero-painted' },
+          { op: 'mark', name: 'first-contentful-paint' },
         ],
       };
       dropLowValueMarkSpans(testReport);
       expect(testReport.spans).toStrictEqual([
-        { op: 'mark', name: 'mm-hero-painted' },
+        { op: 'mark', name: 'first-contentful-paint' },
       ]);
     });
   });

--- a/app/scripts/lib/setupSentry.test.js
+++ b/app/scripts/lib/setupSentry.test.js
@@ -1,6 +1,6 @@
 import { cloneDeep } from 'lodash';
 import {
-  dropMarkSpans,
+  dropLowValueMarkSpans,
   removeUrlsFromBreadCrumb,
   rewriteReport,
   rewriteTransactionReport,
@@ -347,8 +347,8 @@ describe('Setup Sentry', () => {
     });
   });
 
-  describe('dropMarkSpans', () => {
-    it('drops all op:mark spans while keeping the transaction, measures, and other spans', () => {
+  describe('dropLowValueMarkSpans', () => {
+    it('drops the listed low-value mark spans, keeping the transaction and other marks/spans', () => {
       const testReport = {
         type: 'transaction',
         transaction: 'ui.popup',
@@ -356,33 +356,32 @@ describe('Setup Sentry', () => {
           { op: 'mark', description: 'sentry-tracing-init' },
           { op: 'mark', description: 'mm-hero-painted' },
           { op: 'mark', description: 'first-contentful-paint' },
-          { op: 'measure', description: 'boot' },
           { op: 'http.client', description: 'GET /foo' },
         ],
       };
-      dropMarkSpans(testReport);
+      dropLowValueMarkSpans(testReport);
       expect(testReport.transaction).toBe('ui.popup');
       expect(testReport.spans).toStrictEqual([
-        { op: 'measure', description: 'boot' },
+        { op: 'mark', description: 'first-contentful-paint' },
         { op: 'http.client', description: 'GET /foo' },
       ]);
     });
 
-    it('keeps a non-mark span even if its description matches a mark name', () => {
+    it('keeps a non-mark span even if its description matches a low-value mark name', () => {
       const testReport = {
         type: 'transaction',
         transaction: 'ui.popup',
         spans: [{ op: 'http.client', description: 'sentry-tracing-init' }],
       };
-      dropMarkSpans(testReport);
+      dropLowValueMarkSpans(testReport);
       expect(testReport.spans).toStrictEqual([
         { op: 'http.client', description: 'sentry-tracing-init' },
       ]);
     });
 
-    it('leaves a transaction with no mark spans unchanged', () => {
+    it('leaves a transaction without a low-value mark unchanged', () => {
       const spans = [
-        { op: 'measure', description: 'boot' },
+        { op: 'mark', description: 'first-contentful-paint' },
         { op: 'http.client', description: 'GET /foo' },
       ];
       const testReport = {
@@ -390,14 +389,29 @@ describe('Setup Sentry', () => {
         transaction: 'ui.popup',
         spans,
       };
-      dropMarkSpans(testReport);
+      dropLowValueMarkSpans(testReport);
       expect(testReport.spans).toStrictEqual(spans);
     });
 
     it('does not throw when the transaction has no spans array', () => {
       const testReport = { type: 'transaction', transaction: 'ui.popup' };
-      expect(() => dropMarkSpans(testReport)).not.toThrow();
+      expect(() => dropLowValueMarkSpans(testReport)).not.toThrow();
       expect(testReport.spans).toBeUndefined();
+    });
+
+    it('matches the mark name on the `name` field (SDK v10 forward-compat)', () => {
+      const testReport = {
+        type: 'transaction',
+        transaction: 'ui.popup',
+        spans: [
+          { op: 'mark', name: 'sentry-tracing-init' },
+          { op: 'mark', name: 'first-contentful-paint' },
+        ],
+      };
+      dropLowValueMarkSpans(testReport);
+      expect(testReport.spans).toStrictEqual([
+        { op: 'mark', name: 'first-contentful-paint' },
+      ]);
     });
   });
 


### PR DESCRIPTION
## **Description**

`browserTracingIntegration` captures browser `performance.mark()` entries as `op: 'mark'` child spans on every root transaction. The `sentry-tracing-init` mark — emitted once per root transaction by the Sentry browser SDK on tracing init — adds **~30M spans/7d** (~25M on `/service-worker.js` cold-starts, ~5M across notification / sidepanel / popup / home / background) with **zero diagnostic value**: a transaction existing already proves tracing initialized.

This adds `dropLowValueMarkSpans()` to `rewriteTransactionReport` (the `beforeSendTransaction` path): it filters `event.spans` to drop `op: 'mark'` spans whose name is in the identified `LOW_VALUE_TRACE_MARKS` set, keeping the transaction and every meaningful span. **Child-span trimming only — no root / transaction sampling.**

## **Reviewer notes**

- The mark name is read from both `description` (v8 `spanToJSON` serializes a span's `name` → `description`) and `name`, so the filter is unaffected by the v8 → v10 SDK upgrade (#42867, merged 2026-07-17). Verified against `@sentry-internal/browser-utils@10.38.0` / `@sentry/core@10.38.0`: the mark, the `op:'mark'` span, and the `description` field all persist in v10.
- Independent of the structural SW root work (`MetaMask/MetaMask-planning#7354` — now *bound the SW root*, not remove it): this drops the marks on the remaining transactions for immediate relief.
- **Scope (Sentry, 30d, prod, `transaction:/service-worker.js`):** the `sentry-tracing-init` marks are **6.7%** (145.76M ≈ one per cold-start) of the 2.18B `/service-worker.js` spans — so this trim is a cheap stopgap, not the structural fix. The volume splits ~**55% operational `http.client`** (usage-driven RPC, count invariant to the SW lifecycle — preserved by bounding the root, MetaMask/MetaMask-planning#7355), ~**30% boot `http.client`** re-run per cold-start (the MV3 multiplier — the real volume lever, reduced only by caching/persistence, MetaMask/MetaMask-planning#7366), and ~**13%** per-cold-start `pageload`/mark overhead (this PR + the marks). `http.client` is `browserTracingIntegration`'s fetch auto-instrumentation, not #39891 (ruled out, #43629).

## **Changelog**

CHANGELOG entry: Drops the zero-diagnostic-value `sentry-tracing-init` mark span from Sentry performance transactions.

## **Related issues**

Closes: #43654
Parent epic: #43410
Re: #43235, MetaMask/MetaMask-planning#7354

## **Manual testing steps**

1. Build and run with Sentry enabled; trigger any UI transaction (e.g. open the popup).
2. In Sentry, open a resulting performance transaction and confirm **no** `op: mark` span named `sentry-tracing-init` appears, while the transaction itself and all other spans (incl. `mm-hero-painted`, `http.client`, etc.) are unchanged.
3. Post-merge: `sentry-tracing-init` mark volume → ~0; transaction / pageload counts unchanged.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Telemetry-only preprocessing in Sentry send hooks; no user-facing or auth/data paths, with behavior locked by new unit tests.
> 
> **Overview**
> Adds **`dropLowValueMarkSpans`** on the Sentry **`beforeSendTransaction`** path (after `rewriteTransactionReport`) so outbound performance transactions no longer include selected **`op: 'mark'`** child spans. Marks are matched by name on **`description`** or **`name`** (v10-compat); only **`op === 'mark'`** entries in **`LOW_VALUE_TRACE_MARKS`** are removed—root transactions, measures, and other span types are unchanged.
> 
> The filter set currently includes **`sentry-tracing-init`** and **`mm-hero-painted`**. Unit tests cover mixed spans, non-mark collisions, missing `spans`, and the `name` field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a15b794982323f5f7aed536be0b65fcae09e1042. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

