### PR TITLE
feat(ramps): add ramps controller hooks and selectors

### DIFF
--- a/lavamoat/webpack/mv3/beta/policy.json
+++ b/lavamoat/webpack/mv3/beta/policy.json
@@ -1380,6 +1380,24 @@
         "@metamask/providers>readable-stream": true
       }
     },
+    "@metamask/ramps-controller": {
+      "globals": {
+        "AbortController": true,
+        "URL": true,
+        "clearInterval": true,
+        "setInterval": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/controller-utils' reexports from 'cockatiel' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
+        "cockatiel": true
+      }
+    },
     "@metamask/react-data-query": {
       "packages": {
         "@metamask/utils": true,

--- a/lavamoat/webpack/mv3/beta/policy.json
+++ b/lavamoat/webpack/mv3/beta/policy.json
@@ -1382,20 +1382,10 @@
     },
     "@metamask/ramps-controller": {
       "globals": {
-        "AbortController": true,
-        "URL": true,
-        "clearInterval": true,
-        "setInterval": true
-      },
-      "meta": {
-        "webpack-optimization": [
-          "Dependency '@metamask/controller-utils' reexports from 'cockatiel' and webpack collapsed that to a direct import."
-        ]
+        "URL": true
       },
       "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/controller-utils": true,
-        "cockatiel": true
+        "@metamask/controller-utils": true
       }
     },
     "@metamask/react-data-query": {

--- a/lavamoat/webpack/mv3/experimental/policy.json
+++ b/lavamoat/webpack/mv3/experimental/policy.json
@@ -1380,6 +1380,24 @@
         "@metamask/providers>readable-stream": true
       }
     },
+    "@metamask/ramps-controller": {
+      "globals": {
+        "AbortController": true,
+        "URL": true,
+        "clearInterval": true,
+        "setInterval": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/controller-utils' reexports from 'cockatiel' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
+        "cockatiel": true
+      }
+    },
     "@metamask/react-data-query": {
       "packages": {
         "@metamask/utils": true,

--- a/lavamoat/webpack/mv3/experimental/policy.json
+++ b/lavamoat/webpack/mv3/experimental/policy.json
@@ -1382,20 +1382,10 @@
     },
     "@metamask/ramps-controller": {
       "globals": {
-        "AbortController": true,
-        "URL": true,
-        "clearInterval": true,
-        "setInterval": true
-      },
-      "meta": {
-        "webpack-optimization": [
-          "Dependency '@metamask/controller-utils' reexports from 'cockatiel' and webpack collapsed that to a direct import."
-        ]
+        "URL": true
       },
       "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/controller-utils": true,
-        "cockatiel": true
+        "@metamask/controller-utils": true
       }
     },
     "@metamask/react-data-query": {

--- a/lavamoat/webpack/mv3/flask/policy.json
+++ b/lavamoat/webpack/mv3/flask/policy.json
@@ -1380,6 +1380,24 @@
         "@metamask/providers>readable-stream": true
       }
     },
+    "@metamask/ramps-controller": {
+      "globals": {
+        "AbortController": true,
+        "URL": true,
+        "clearInterval": true,
+        "setInterval": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/controller-utils' reexports from 'cockatiel' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
+        "cockatiel": true
+      }
+    },
     "@metamask/react-data-query": {
       "packages": {
         "@metamask/utils": true,

--- a/lavamoat/webpack/mv3/flask/policy.json
+++ b/lavamoat/webpack/mv3/flask/policy.json
@@ -1382,20 +1382,10 @@
     },
     "@metamask/ramps-controller": {
       "globals": {
-        "AbortController": true,
-        "URL": true,
-        "clearInterval": true,
-        "setInterval": true
-      },
-      "meta": {
-        "webpack-optimization": [
-          "Dependency '@metamask/controller-utils' reexports from 'cockatiel' and webpack collapsed that to a direct import."
-        ]
+        "URL": true
       },
       "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/controller-utils": true,
-        "cockatiel": true
+        "@metamask/controller-utils": true
       }
     },
     "@metamask/react-data-query": {

--- a/lavamoat/webpack/mv3/main/policy.json
+++ b/lavamoat/webpack/mv3/main/policy.json
@@ -1380,6 +1380,24 @@
         "@metamask/providers>readable-stream": true
       }
     },
+    "@metamask/ramps-controller": {
+      "globals": {
+        "AbortController": true,
+        "URL": true,
+        "clearInterval": true,
+        "setInterval": true
+      },
+      "meta": {
+        "webpack-optimization": [
+          "Dependency '@metamask/controller-utils' reexports from 'cockatiel' and webpack collapsed that to a direct import."
+        ]
+      },
+      "packages": {
+        "@metamask/base-controller": true,
+        "@metamask/controller-utils": true,
+        "cockatiel": true
+      }
+    },
     "@metamask/react-data-query": {
       "packages": {
         "@metamask/utils": true,

--- a/lavamoat/webpack/mv3/main/policy.json
+++ b/lavamoat/webpack/mv3/main/policy.json
@@ -1382,20 +1382,10 @@
     },
     "@metamask/ramps-controller": {
       "globals": {
-        "AbortController": true,
-        "URL": true,
-        "clearInterval": true,
-        "setInterval": true
-      },
-      "meta": {
-        "webpack-optimization": [
-          "Dependency '@metamask/controller-utils' reexports from 'cockatiel' and webpack collapsed that to a direct import."
-        ]
+        "URL": true
       },
       "packages": {
-        "@metamask/base-controller": true,
-        "@metamask/controller-utils": true,
-        "cockatiel": true
+        "@metamask/controller-utils": true
       }
     },
     "@metamask/react-data-query": {

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -557,27 +557,6 @@
     "ui/hooks/musd/useMusdGeoBlocking.test.ts": {
       "React: Act warnings (component updates not wrapped)": 2
     },
-    "ui/hooks/ramps/useRampsController.test.tsx": {
-      "Reselect: Identity function warnings": 6
-    },
-    "ui/hooks/ramps/useRampsCountries.test.tsx": {
-      "Reselect: Identity function warnings": 1
-    },
-    "ui/hooks/ramps/useRampsOrders.test.tsx": {
-      "Reselect: Identity function warnings": 1
-    },
-    "ui/hooks/ramps/useRampsPaymentMethods.test.tsx": {
-      "Reselect: Identity function warnings": 4
-    },
-    "ui/hooks/ramps/useRampsProviders.test.tsx": {
-      "Reselect: Identity function warnings": 3
-    },
-    "ui/hooks/ramps/useRampsTokens.test.tsx": {
-      "Reselect: Identity function warnings": 1
-    },
-    "ui/hooks/ramps/useRampsUserRegion.test.tsx": {
-      "Reselect: Identity function warnings": 1
-    },
     "ui/hooks/rewards/useValidateReferralCode.test.tsx": {
       "React: Act warnings (component updates not wrapped)": 1
     },
@@ -1158,9 +1137,6 @@
     },
     "ui/selectors/nonce-sorted-transactions-selector.test.js": {
       "Reselect: Identity function warnings": 1
-    },
-    "ui/selectors/rampsController/index.test.ts": {
-      "Reselect: Identity function warnings": 2
     },
     "ui/selectors/transactions.test.js": {
       "Reselect: Identity function warnings": 3

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -557,6 +557,27 @@
     "ui/hooks/musd/useMusdGeoBlocking.test.ts": {
       "React: Act warnings (component updates not wrapped)": 2
     },
+    "ui/hooks/ramps/useRampsController.test.tsx": {
+      "Reselect: Identity function warnings": 6
+    },
+    "ui/hooks/ramps/useRampsCountries.test.tsx": {
+      "Reselect: Identity function warnings": 1
+    },
+    "ui/hooks/ramps/useRampsOrders.test.tsx": {
+      "Reselect: Identity function warnings": 1
+    },
+    "ui/hooks/ramps/useRampsPaymentMethods.test.tsx": {
+      "Reselect: Identity function warnings": 4
+    },
+    "ui/hooks/ramps/useRampsProviders.test.tsx": {
+      "Reselect: Identity function warnings": 3
+    },
+    "ui/hooks/ramps/useRampsTokens.test.tsx": {
+      "Reselect: Identity function warnings": 1
+    },
+    "ui/hooks/ramps/useRampsUserRegion.test.tsx": {
+      "Reselect: Identity function warnings": 1
+    },
     "ui/hooks/rewards/useValidateReferralCode.test.tsx": {
       "React: Act warnings (component updates not wrapped)": 1
     },
@@ -1137,6 +1158,9 @@
     },
     "ui/selectors/nonce-sorted-transactions-selector.test.js": {
       "Reselect: Identity function warnings": 1
+    },
+    "ui/selectors/rampsController/index.test.ts": {
+      "Reselect: Identity function warnings": 2
     },
     "ui/selectors/transactions.test.js": {
       "Reselect: Identity function warnings": 3

--- a/ui/hooks/ramps/RampsBootstrap.test.tsx
+++ b/ui/hooks/ramps/RampsBootstrap.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { getRampsTokens } from '../../store/controller-actions/ramps-controller';
+import RampsBootstrap from './RampsBootstrap';
+import { createRampsTestWrapper } from './test-utils';
+
+jest.mock('../../store/controller-actions/ramps-controller', () => ({
+  getRampsTokens: jest.fn().mockResolvedValue(undefined),
+  setRampsSelectedProvider: jest.fn().mockResolvedValue(undefined),
+  setRampsSelectedPaymentMethod: jest.fn().mockResolvedValue(undefined),
+  getRampsProviders: jest.fn().mockResolvedValue({ providers: [] }),
+  getRampsPaymentMethods: jest.fn().mockResolvedValue({ payments: [] }),
+}));
+
+jest.mock('@tanstack/react-query', () => {
+  const actual = jest.requireActual('@tanstack/react-query');
+  return {
+    ...actual,
+    useQuery: jest.fn(() => ({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      error: null,
+    })),
+  };
+});
+
+describe('RampsBootstrap', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('loads tokens for the current region', () => {
+    render(<RampsBootstrap />, {
+      wrapper: createRampsTestWrapper(),
+    });
+
+    expect(getRampsTokens).toHaveBeenCalledWith('us-ca', 'buy');
+  });
+});

--- a/ui/hooks/ramps/RampsBootstrap.tsx
+++ b/ui/hooks/ramps/RampsBootstrap.tsx
@@ -1,0 +1,22 @@
+import { useEffect } from 'react';
+import { useSelector } from 'react-redux';
+import { selectUserRegion } from '../../selectors/rampsController';
+import { getRampsTokens } from '../../store/controller-actions/ramps-controller';
+import useRampsProviders from './useRampsProviders';
+import useRampsPaymentMethods from './useRampsPaymentMethods';
+
+function RampsBootstrap(): null {
+  useRampsProviders({ enableSideEffects: true });
+  useRampsPaymentMethods();
+
+  const userRegion = useSelector(selectUserRegion);
+  useEffect(() => {
+    if (userRegion?.regionCode) {
+      getRampsTokens(userRegion.regionCode, 'buy');
+    }
+  }, [userRegion?.regionCode]);
+
+  return null;
+}
+
+export default RampsBootstrap;

--- a/ui/hooks/ramps/__snapshots__/useRampsController.test.tsx.snap
+++ b/ui/hooks/ramps/__snapshots__/useRampsController.test.tsx.snap
@@ -1,0 +1,47 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useRampsController matches snapshot 1`] = `
+{
+  "addOrder": [Function],
+  "addPrecreatedOrder": [Function],
+  "countries": [],
+  "countriesError": null,
+  "countriesLoading": false,
+  "getBuyWidgetData": [Function],
+  "getOrderById": [Function],
+  "getOrderFromCallback": [Function],
+  "getQuotes": [Function],
+  "orders": [],
+  "paymentMethods": [],
+  "paymentMethodsError": null,
+  "paymentMethodsFetching": false,
+  "paymentMethodsLoading": false,
+  "paymentMethodsStatus": "idle",
+  "providers": [],
+  "providersError": null,
+  "providersLoading": true,
+  "refreshOrder": [Function],
+  "removeOrder": [Function],
+  "selectedPaymentMethod": null,
+  "selectedProvider": null,
+  "selectedToken": null,
+  "setSelectedPaymentMethod": [Function],
+  "setSelectedProvider": [Function],
+  "setSelectedToken": [Function],
+  "setUserRegion": [Function],
+  "tokens": {
+    "allTokens": [],
+    "topTokens": [],
+  },
+  "tokensError": null,
+  "tokensLoading": false,
+  "userRegion": {
+    "country": {
+      "currency": "USD",
+      "isoCode": "US",
+      "name": "United States",
+    },
+    "regionCode": "us-ca",
+  },
+}
+`;

--- a/ui/hooks/ramps/__snapshots__/useRampsCountries.test.tsx.snap
+++ b/ui/hooks/ramps/__snapshots__/useRampsCountries.test.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useRampsCountries matches snapshot 1`] = `
+{
+  "countries": [],
+  "error": null,
+  "isLoading": false,
+}
+`;

--- a/ui/hooks/ramps/__snapshots__/useRampsOrders.test.tsx.snap
+++ b/ui/hooks/ramps/__snapshots__/useRampsOrders.test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useRampsOrders matches snapshot 1`] = `
+{
+  "addOrder": [Function],
+  "addPrecreatedOrder": [Function],
+  "getOrderById": [Function],
+  "getOrderFromCallback": [Function],
+  "orders": [],
+  "refreshOrder": [Function],
+  "removeOrder": [Function],
+}
+`;

--- a/ui/hooks/ramps/__snapshots__/useRampsPaymentMethods.test.tsx.snap
+++ b/ui/hooks/ramps/__snapshots__/useRampsPaymentMethods.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`useRampsPaymentMethods matches snapshot 1`] = `
+exports[`useRampsPaymentMethods matches snapshot when idle 1`] = `
 {
   "error": null,
   "isFetching": false,

--- a/ui/hooks/ramps/__snapshots__/useRampsPaymentMethods.test.tsx.snap
+++ b/ui/hooks/ramps/__snapshots__/useRampsPaymentMethods.test.tsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useRampsPaymentMethods matches snapshot 1`] = `
+{
+  "error": null,
+  "isFetching": false,
+  "isLoading": false,
+  "isSuccess": false,
+  "paymentMethods": [],
+  "selectedPaymentMethod": null,
+  "setSelectedPaymentMethod": [Function],
+  "status": "idle",
+}
+`;

--- a/ui/hooks/ramps/__snapshots__/useRampsProviders.test.tsx.snap
+++ b/ui/hooks/ramps/__snapshots__/useRampsProviders.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`useRampsProviders matches snapshot 1`] = `
 {
   "error": null,
-  "isLoading": true,
+  "isLoading": false,
   "providers": [],
   "selectedProvider": null,
   "setSelectedProvider": [Function],

--- a/ui/hooks/ramps/__snapshots__/useRampsProviders.test.tsx.snap
+++ b/ui/hooks/ramps/__snapshots__/useRampsProviders.test.tsx.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useRampsProviders matches snapshot 1`] = `
+{
+  "error": null,
+  "isLoading": true,
+  "providers": [],
+  "selectedProvider": null,
+  "setSelectedProvider": [Function],
+}
+`;

--- a/ui/hooks/ramps/__snapshots__/useRampsQuotes.test.tsx.snap
+++ b/ui/hooks/ramps/__snapshots__/useRampsQuotes.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`useRampsQuotes matches snapshot when query is disabled 1`] = `
   "getBuyWidgetData": [Function],
   "getQuotes": [Function],
   "isSuccess": false,
-  "loading": true,
+  "loading": false,
   "status": "idle",
 }
 `;

--- a/ui/hooks/ramps/__snapshots__/useRampsQuotes.test.tsx.snap
+++ b/ui/hooks/ramps/__snapshots__/useRampsQuotes.test.tsx.snap
@@ -1,0 +1,13 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useRampsQuotes matches snapshot when query is disabled 1`] = `
+{
+  "data": null,
+  "error": null,
+  "getBuyWidgetData": [Function],
+  "getQuotes": [Function],
+  "isSuccess": false,
+  "loading": true,
+  "status": "idle",
+}
+`;

--- a/ui/hooks/ramps/__snapshots__/useRampsTokens.test.tsx.snap
+++ b/ui/hooks/ramps/__snapshots__/useRampsTokens.test.tsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useRampsTokens matches snapshot 1`] = `
+{
+  "error": null,
+  "isLoading": false,
+  "selectedToken": null,
+  "setSelectedToken": [Function],
+  "tokens": {
+    "allTokens": [],
+    "topTokens": [],
+  },
+}
+`;

--- a/ui/hooks/ramps/__snapshots__/useRampsUserRegion.test.tsx.snap
+++ b/ui/hooks/ramps/__snapshots__/useRampsUserRegion.test.tsx.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useRampsUserRegion matches snapshot 1`] = `
+{
+  "setUserRegion": [Function],
+  "userRegion": {
+    "country": {
+      "currency": "USD",
+      "isoCode": "US",
+      "name": "United States",
+    },
+    "regionCode": "us-ca",
+  },
+}
+`;

--- a/ui/hooks/ramps/queries/__snapshots__/paymentMethods.test.ts.snap
+++ b/ui/hooks/ramps/queries/__snapshots__/paymentMethods.test.ts.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rampsPaymentMethodsKeys includes fiat and assetId in the detail key 1`] = `
+[
+  "ramps",
+  "paymentMethods",
+  "us",
+  "usd",
+  "eip155:1/slip44:60",
+  "transak",
+]
+`;

--- a/ui/hooks/ramps/queries/__snapshots__/paymentMethods.test.ts.snap
+++ b/ui/hooks/ramps/queries/__snapshots__/paymentMethods.test.ts.snap
@@ -10,3 +10,12 @@ exports[`rampsPaymentMethodsKeys includes fiat and assetId in the detail key 1`]
   "transak",
 ]
 `;
+
+exports[`rampsPaymentMethodsOptions loads payment methods from the controller action 1`] = `
+[
+  {
+    "id": "credit_debit_card",
+    "name": "Card",
+  },
+]
+`;

--- a/ui/hooks/ramps/queries/__snapshots__/quotes.test.ts.snap
+++ b/ui/hooks/ramps/queries/__snapshots__/quotes.test.ts.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rampsQuotesKeys includes forceRefresh, ttl, and redirectUrl in the detail key 1`] = `
+[
+  "ramps",
+  "quotes",
+  "eip155:1/slip44:60",
+  100,
+  "0xabc",
+  "credit_debit_card",
+  "transak",
+  "https://metamask.io/callback",
+  true,
+  15000,
+]
+`;

--- a/ui/hooks/ramps/queries/index.ts
+++ b/ui/hooks/ramps/queries/index.ts
@@ -1,4 +1,7 @@
-import { rampsPaymentMethodsKeys, rampsPaymentMethodsOptions } from './paymentMethods';
+import {
+  rampsPaymentMethodsKeys,
+  rampsPaymentMethodsOptions,
+} from './paymentMethods';
 import { rampsProvidersKeys, rampsProvidersOptions } from './providers';
 import { rampsQuotesKeys, rampsQuotesOptions } from './quotes';
 

--- a/ui/hooks/ramps/queries/index.ts
+++ b/ui/hooks/ramps/queries/index.ts
@@ -1,0 +1,18 @@
+import { rampsPaymentMethodsKeys, rampsPaymentMethodsOptions } from './paymentMethods';
+import { rampsProvidersKeys, rampsProvidersOptions } from './providers';
+import { rampsQuotesKeys, rampsQuotesOptions } from './quotes';
+
+export const rampsQueries = {
+  paymentMethods: {
+    keys: rampsPaymentMethodsKeys,
+    options: rampsPaymentMethodsOptions,
+  },
+  providers: {
+    keys: rampsProvidersKeys,
+    options: rampsProvidersOptions,
+  },
+  quotes: {
+    keys: rampsQuotesKeys,
+    options: rampsQuotesOptions,
+  },
+};

--- a/ui/hooks/ramps/queries/paymentMethods.test.ts
+++ b/ui/hooks/ramps/queries/paymentMethods.test.ts
@@ -1,0 +1,33 @@
+import { rampsPaymentMethodsKeys } from './paymentMethods';
+
+describe('rampsPaymentMethodsKeys', () => {
+  it('includes fiat and assetId in the detail key', () => {
+    expect(
+      rampsPaymentMethodsKeys.detail({
+        regionCode: 'US',
+        fiat: 'USD',
+        assetId: 'eip155:1/slip44:60',
+        providerId: 'transak',
+      }),
+    ).toMatchSnapshot();
+  });
+
+  it('changes when fiat or assetId changes', () => {
+    const base = {
+      regionCode: 'us',
+      fiat: 'usd',
+      assetId: 'eip155:1/slip44:60',
+      providerId: 'transak',
+    };
+
+    expect(rampsPaymentMethodsKeys.detail(base)).not.toEqual(
+      rampsPaymentMethodsKeys.detail({ ...base, fiat: 'eur' }),
+    );
+    expect(rampsPaymentMethodsKeys.detail(base)).not.toEqual(
+      rampsPaymentMethodsKeys.detail({
+        ...base,
+        assetId: 'eip155:1/erc20:0xabc',
+      }),
+    );
+  });
+});

--- a/ui/hooks/ramps/queries/paymentMethods.test.ts
+++ b/ui/hooks/ramps/queries/paymentMethods.test.ts
@@ -54,7 +54,10 @@ describe('rampsPaymentMethodsOptions', () => {
       providerId: 'transak',
     };
 
-    const result = await rampsPaymentMethodsOptions(params).queryFn();
+    const options = rampsPaymentMethodsOptions(params);
+    const result = await (
+      options.queryFn as () => ReturnType<NonNullable<typeof options.queryFn>>
+    )();
 
     expect(result).toMatchSnapshot();
     expect(getRampsPaymentMethods).toHaveBeenCalledWith('US', {

--- a/ui/hooks/ramps/queries/paymentMethods.test.ts
+++ b/ui/hooks/ramps/queries/paymentMethods.test.ts
@@ -1,4 +1,7 @@
-import { rampsPaymentMethodsKeys, rampsPaymentMethodsOptions } from './paymentMethods';
+import {
+  rampsPaymentMethodsKeys,
+  rampsPaymentMethodsOptions,
+} from './paymentMethods';
 
 jest.mock('../../../store/controller-actions/ramps-controller', () => ({
   getRampsPaymentMethods: jest.fn().mockResolvedValue({

--- a/ui/hooks/ramps/queries/paymentMethods.test.ts
+++ b/ui/hooks/ramps/queries/paymentMethods.test.ts
@@ -1,4 +1,14 @@
-import { rampsPaymentMethodsKeys } from './paymentMethods';
+import { rampsPaymentMethodsKeys, rampsPaymentMethodsOptions } from './paymentMethods';
+
+jest.mock('../../../store/controller-actions/ramps-controller', () => ({
+  getRampsPaymentMethods: jest.fn().mockResolvedValue({
+    payments: [{ id: 'credit_debit_card', name: 'Card' }],
+  }),
+}));
+
+const { getRampsPaymentMethods } = jest.requireMock(
+  '../../../store/controller-actions/ramps-controller',
+);
 
 describe('rampsPaymentMethodsKeys', () => {
   it('includes fiat and assetId in the detail key', () => {
@@ -29,5 +39,25 @@ describe('rampsPaymentMethodsKeys', () => {
         assetId: 'eip155:1/erc20:0xabc',
       }),
     );
+  });
+});
+
+describe('rampsPaymentMethodsOptions', () => {
+  it('loads payment methods from the controller action', async () => {
+    const params = {
+      regionCode: 'US',
+      fiat: 'USD',
+      assetId: 'eip155:1/slip44:60',
+      providerId: 'transak',
+    };
+
+    const result = await rampsPaymentMethodsOptions(params).queryFn();
+
+    expect(result).toMatchSnapshot();
+    expect(getRampsPaymentMethods).toHaveBeenCalledWith('US', {
+      fiat: 'USD',
+      assetId: 'eip155:1/slip44:60',
+      provider: 'transak',
+    });
   });
 });

--- a/ui/hooks/ramps/queries/paymentMethods.ts
+++ b/ui/hooks/ramps/queries/paymentMethods.ts
@@ -5,7 +5,7 @@ import type {
 } from '@metamask/ramps-controller';
 import { getRampsPaymentMethods } from '../../../store/controller-actions/ramps-controller';
 
-interface PaymentMethodsQueryParams {
+type PaymentMethodsQueryParams = {
   regionCode: string;
   fiat: string;
   assetId: string;
@@ -16,11 +16,15 @@ export const rampsPaymentMethodsKeys = {
   all: () => ['ramps', 'paymentMethods'] as const,
   detail: ({
     regionCode,
+    fiat,
+    assetId,
     providerId,
-  }: Pick<PaymentMethodsQueryParams, 'regionCode' | 'providerId'>) =>
+  }: PaymentMethodsQueryParams) =>
     [
       ...rampsPaymentMethodsKeys.all(),
       regionCode.trim().toLowerCase(),
+      fiat.trim().toLowerCase(),
+      assetId,
       providerId,
     ] as const,
 };

--- a/ui/hooks/ramps/queries/paymentMethods.ts
+++ b/ui/hooks/ramps/queries/paymentMethods.ts
@@ -10,7 +10,7 @@ type PaymentMethodsQueryParams = {
   fiat: string;
   assetId: string;
   providerId: string;
-}
+};
 
 export const rampsPaymentMethodsKeys = {
   all: () => ['ramps', 'paymentMethods'] as const,

--- a/ui/hooks/ramps/queries/paymentMethods.ts
+++ b/ui/hooks/ramps/queries/paymentMethods.ts
@@ -1,0 +1,41 @@
+import { queryOptions } from '@tanstack/react-query';
+import type {
+  PaymentMethod,
+  PaymentMethodsResponse,
+} from '@metamask/ramps-controller';
+import { getRampsPaymentMethods } from '../../../store/controller-actions/ramps-controller';
+
+interface PaymentMethodsQueryParams {
+  regionCode: string;
+  fiat: string;
+  assetId: string;
+  providerId: string;
+}
+
+export const rampsPaymentMethodsKeys = {
+  all: () => ['ramps', 'paymentMethods'] as const,
+  detail: ({
+    regionCode,
+    providerId,
+  }: Pick<PaymentMethodsQueryParams, 'regionCode' | 'providerId'>) =>
+    [
+      ...rampsPaymentMethodsKeys.all(),
+      regionCode.trim().toLowerCase(),
+      providerId,
+    ] as const,
+};
+
+export const rampsPaymentMethodsOptions = (params: PaymentMethodsQueryParams) =>
+  queryOptions({
+    queryKey: rampsPaymentMethodsKeys.detail(params),
+    queryFn: async (): Promise<PaymentMethod[]> => {
+      const response = (await getRampsPaymentMethods(params.regionCode, {
+        fiat: params.fiat,
+        assetId: params.assetId,
+        provider: params.providerId,
+      })) as PaymentMethodsResponse;
+
+      return response.payments;
+    },
+    staleTime: 5 * 60 * 1000,
+  });

--- a/ui/hooks/ramps/queries/providers.ts
+++ b/ui/hooks/ramps/queries/providers.ts
@@ -2,9 +2,9 @@ import { queryOptions } from '@tanstack/react-query';
 import type { Provider } from '@metamask/ramps-controller';
 import { getRampsProviders } from '../../../store/controller-actions/ramps-controller';
 
-interface ProvidersQueryParams {
+type ProvidersQueryParams = {
   regionCode: string;
-}
+};
 
 export const rampsProvidersKeys = {
   all: () => ['ramps', 'providers'] as const,

--- a/ui/hooks/ramps/queries/providers.ts
+++ b/ui/hooks/ramps/queries/providers.ts
@@ -1,0 +1,23 @@
+import { queryOptions } from '@tanstack/react-query';
+import type { Provider } from '@metamask/ramps-controller';
+import { getRampsProviders } from '../../../store/controller-actions/ramps-controller';
+
+interface ProvidersQueryParams {
+  regionCode: string;
+}
+
+export const rampsProvidersKeys = {
+  all: () => ['ramps', 'providers'] as const,
+  detail: ({ regionCode }: ProvidersQueryParams) =>
+    [...rampsProvidersKeys.all(), regionCode.trim().toLowerCase()] as const,
+};
+
+export const rampsProvidersOptions = (params: ProvidersQueryParams) =>
+  queryOptions({
+    queryKey: rampsProvidersKeys.detail(params),
+    queryFn: async (): Promise<Provider[]> => {
+      const response = await getRampsProviders(params.regionCode);
+      return response.providers;
+    },
+    staleTime: 15 * 60 * 1000,
+  });

--- a/ui/hooks/ramps/queries/providers.ts
+++ b/ui/hooks/ramps/queries/providers.ts
@@ -6,6 +6,10 @@ type ProvidersQueryParams = {
   regionCode: string;
 };
 
+type ProvidersResponse = {
+  providers: Provider[];
+};
+
 export const rampsProvidersKeys = {
   all: () => ['ramps', 'providers'] as const,
   detail: ({ regionCode }: ProvidersQueryParams) =>
@@ -16,7 +20,9 @@ export const rampsProvidersOptions = (params: ProvidersQueryParams) =>
   queryOptions({
     queryKey: rampsProvidersKeys.detail(params),
     queryFn: async (): Promise<Provider[]> => {
-      const response = await getRampsProviders(params.regionCode);
+      const response = (await getRampsProviders(
+        params.regionCode,
+      )) as ProvidersResponse;
       return response.providers;
     },
     staleTime: 15 * 60 * 1000,

--- a/ui/hooks/ramps/queries/quotes.test.ts
+++ b/ui/hooks/ramps/queries/quotes.test.ts
@@ -1,0 +1,33 @@
+import { rampsQuotesKeys } from './quotes';
+
+describe('rampsQuotesKeys', () => {
+  it('includes forceRefresh, ttl, and redirectUrl in the detail key', () => {
+    expect(
+      rampsQuotesKeys.detail({
+        assetId: 'eip155:1/slip44:60',
+        amount: 100,
+        walletAddress: '0xabc',
+        paymentMethods: ['credit_debit_card'],
+        providers: ['transak'],
+        redirectUrl: 'https://metamask.io/callback',
+        forceRefresh: true,
+        ttl: 15_000,
+      }),
+    ).toMatchSnapshot();
+  });
+
+  it('changes when forceRefresh changes', () => {
+    const base = {
+      assetId: 'eip155:1/slip44:60',
+      amount: 100,
+      walletAddress: '0xabc',
+      paymentMethods: ['credit_debit_card'],
+      providers: ['transak'],
+      forceRefresh: false,
+    };
+
+    expect(rampsQuotesKeys.detail(base)).not.toEqual(
+      rampsQuotesKeys.detail({ ...base, forceRefresh: true }),
+    );
+  });
+});

--- a/ui/hooks/ramps/queries/quotes.ts
+++ b/ui/hooks/ramps/queries/quotes.ts
@@ -29,6 +29,9 @@ export const rampsQuotesKeys = {
       params.walletAddress,
       (params.paymentMethods ?? []).join(','),
       (params.providers ?? []).join(','),
+      params.redirectUrl ?? '',
+      Boolean(params.forceRefresh),
+      params.ttl ?? null,
     ] as const,
 };
 

--- a/ui/hooks/ramps/queries/quotes.ts
+++ b/ui/hooks/ramps/queries/quotes.ts
@@ -1,0 +1,40 @@
+import { queryOptions } from '@tanstack/react-query';
+import type { QuotesResponse } from '@metamask/ramps-controller';
+import {
+  getRampsQuotes,
+  type GetRampsQuotesParams,
+} from '../../../store/controller-actions/ramps-controller';
+
+export const RAMPS_QUOTES_STALE_TIME_MS = 15_000;
+
+type RampsQuotesQueryParams = Pick<
+  GetRampsQuotesParams,
+  | 'assetId'
+  | 'amount'
+  | 'walletAddress'
+  | 'redirectUrl'
+  | 'forceRefresh'
+  | 'ttl'
+  | 'paymentMethods'
+  | 'providers'
+>;
+
+export const rampsQuotesKeys = {
+  all: () => ['ramps', 'quotes'] as const,
+  detail: (params: RampsQuotesQueryParams) =>
+    [
+      ...rampsQuotesKeys.all(),
+      params.assetId ?? '',
+      params.amount,
+      params.walletAddress,
+      (params.paymentMethods ?? []).join(','),
+      (params.providers ?? []).join(','),
+    ] as const,
+};
+
+export const rampsQuotesOptions = (params: RampsQuotesQueryParams) =>
+  queryOptions({
+    queryKey: rampsQuotesKeys.detail(params),
+    queryFn: async (): Promise<QuotesResponse> => getRampsQuotes(params),
+    staleTime: RAMPS_QUOTES_STALE_TIME_MS,
+  });

--- a/ui/hooks/ramps/test-utils.tsx
+++ b/ui/hooks/ramps/test-utils.tsx
@@ -47,9 +47,7 @@ export const rampsMockMetamaskState = {
 
 const mockStoreFactory = configureStore([]);
 
-export function createRampsMockStore(
-  overrides: Record<string, unknown> = {},
-) {
+export function createRampsMockStore(overrides: Record<string, unknown> = {}) {
   return mockStoreFactory({
     metamask: {
       ...rampsMockMetamaskState,

--- a/ui/hooks/ramps/test-utils.tsx
+++ b/ui/hooks/ramps/test-utils.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+import { Provider } from 'react-redux';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import configureStore from 'redux-mock-store';
+
+export const rampsMockMetamaskState = {
+  RampsController: {
+    userRegion: {
+      regionCode: 'us-ca',
+      country: { currency: 'USD', isoCode: 'US', name: 'United States' },
+    },
+    countries: {
+      data: [],
+      selected: null,
+      isLoading: false,
+      error: null,
+    },
+    providers: {
+      data: [],
+      selected: null,
+      isLoading: false,
+      error: null,
+    },
+    tokens: {
+      data: { topTokens: [], allTokens: [] },
+      selected: null,
+      isLoading: false,
+      error: null,
+    },
+    paymentMethods: {
+      data: [],
+      selected: null,
+      isLoading: false,
+      error: null,
+    },
+    orders: [],
+  },
+  internalAccounts: {
+    selectedAccount: 'account-1',
+    accounts: {
+      'account-1': {
+        id: 'account-1',
+        address: '0xabc123',
+        metadata: { name: 'Account 1' },
+      },
+    },
+  },
+};
+
+const mockStoreFactory = configureStore([]);
+
+export function createRampsMockStore(
+  overrides: Record<string, unknown> = {},
+) {
+  return mockStoreFactory({
+    metamask: {
+      ...rampsMockMetamaskState,
+      ...overrides,
+    },
+  });
+}
+
+export function createRampsTestWrapper(store = createRampsMockStore()) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return ({ children }: { children: React.ReactNode }) => (
+    <Provider store={store}>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </Provider>
+  );
+}

--- a/ui/hooks/ramps/test-utils.tsx
+++ b/ui/hooks/ramps/test-utils.tsx
@@ -4,37 +4,35 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import configureStore from 'redux-mock-store';
 
 export const rampsMockMetamaskState = {
-  RampsController: {
-    userRegion: {
-      regionCode: 'us-ca',
-      country: { currency: 'USD', isoCode: 'US', name: 'United States' },
-    },
-    countries: {
-      data: [],
-      selected: null,
-      isLoading: false,
-      error: null,
-    },
-    providers: {
-      data: [],
-      selected: null,
-      isLoading: false,
-      error: null,
-    },
-    tokens: {
-      data: { topTokens: [], allTokens: [] },
-      selected: null,
-      isLoading: false,
-      error: null,
-    },
-    paymentMethods: {
-      data: [],
-      selected: null,
-      isLoading: false,
-      error: null,
-    },
-    orders: [],
+  userRegion: {
+    regionCode: 'us-ca',
+    country: { currency: 'USD', isoCode: 'US', name: 'United States' },
   },
+  countries: {
+    data: [],
+    selected: null,
+    isLoading: false,
+    error: null,
+  },
+  providers: {
+    data: [],
+    selected: null,
+    isLoading: false,
+    error: null,
+  },
+  tokens: {
+    data: { topTokens: [], allTokens: [] },
+    selected: null,
+    isLoading: false,
+    error: null,
+  },
+  paymentMethods: {
+    data: [],
+    selected: null,
+    isLoading: false,
+    error: null,
+  },
+  orders: [],
   internalAccounts: {
     selectedAccount: 'account-1',
     accounts: {

--- a/ui/hooks/ramps/useRampsController.test.tsx
+++ b/ui/hooks/ramps/useRampsController.test.tsx
@@ -1,0 +1,29 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useRampsController } from './useRampsController';
+import { createRampsTestWrapper } from './test-utils';
+
+jest.mock('../../store/controller-actions/ramps-controller', () => ({
+  setRampsUserRegion: jest.fn(),
+  setRampsSelectedProvider: jest.fn(),
+  setRampsSelectedToken: jest.fn(),
+  setRampsSelectedPaymentMethod: jest.fn(),
+  getRampsProviders: jest.fn().mockResolvedValue({ providers: [] }),
+  getRampsPaymentMethods: jest.fn().mockResolvedValue({ paymentMethods: [] }),
+  getRampsQuotes: jest.fn(),
+  getRampsBuyWidgetData: jest.fn(),
+  addRampsOrder: jest.fn(),
+  addRampsPrecreatedOrder: jest.fn(),
+  removeRampsOrder: jest.fn(),
+  refreshRampsOrder: jest.fn(),
+  getRampsOrderFromCallback: jest.fn(),
+}));
+
+describe('useRampsController', () => {
+  it('matches snapshot', () => {
+    const { result } = renderHook(() => useRampsController(), {
+      wrapper: createRampsTestWrapper(),
+    });
+
+    expect(result.current).toMatchSnapshot();
+  });
+});

--- a/ui/hooks/ramps/useRampsController.ts
+++ b/ui/hooks/ramps/useRampsController.ts
@@ -1,7 +1,16 @@
-import { useRampsUserRegion, type UseRampsUserRegionResult } from './useRampsUserRegion';
-import { useRampsProviders, type UseRampsProvidersResult } from './useRampsProviders';
+import {
+  useRampsUserRegion,
+  type UseRampsUserRegionResult,
+} from './useRampsUserRegion';
+import {
+  useRampsProviders,
+  type UseRampsProvidersResult,
+} from './useRampsProviders';
 import { useRampsTokens, type UseRampsTokensResult } from './useRampsTokens';
-import { useRampsCountries, type UseRampsCountriesResult } from './useRampsCountries';
+import {
+  useRampsCountries,
+  type UseRampsCountriesResult,
+} from './useRampsCountries';
 import {
   useRampsPaymentMethods,
   type UseRampsPaymentMethodsResult,
@@ -9,7 +18,7 @@ import {
 import { useRampsQuotes, type UseRampsQuotesResult } from './useRampsQuotes';
 import { useRampsOrders, type UseRampsOrdersResult } from './useRampsOrders';
 
-export interface UseRampsControllerResult {
+export type UseRampsControllerResult = {
   userRegion: UseRampsUserRegionResult['userRegion'];
   setUserRegion: UseRampsUserRegionResult['setUserRegion'];
   selectedProvider: UseRampsProvidersResult['selectedProvider'];
@@ -41,7 +50,7 @@ export interface UseRampsControllerResult {
   removeOrder: UseRampsOrdersResult['removeOrder'];
   refreshOrder: UseRampsOrdersResult['refreshOrder'];
   getOrderFromCallback: UseRampsOrdersResult['getOrderFromCallback'];
-}
+};
 
 export function useRampsController(): UseRampsControllerResult {
   const { userRegion, setUserRegion } = useRampsUserRegion();

--- a/ui/hooks/ramps/useRampsController.ts
+++ b/ui/hooks/ramps/useRampsController.ts
@@ -1,0 +1,122 @@
+import { useRampsUserRegion, type UseRampsUserRegionResult } from './useRampsUserRegion';
+import { useRampsProviders, type UseRampsProvidersResult } from './useRampsProviders';
+import { useRampsTokens, type UseRampsTokensResult } from './useRampsTokens';
+import { useRampsCountries, type UseRampsCountriesResult } from './useRampsCountries';
+import {
+  useRampsPaymentMethods,
+  type UseRampsPaymentMethodsResult,
+} from './useRampsPaymentMethods';
+import { useRampsQuotes, type UseRampsQuotesResult } from './useRampsQuotes';
+import { useRampsOrders, type UseRampsOrdersResult } from './useRampsOrders';
+
+export interface UseRampsControllerResult {
+  userRegion: UseRampsUserRegionResult['userRegion'];
+  setUserRegion: UseRampsUserRegionResult['setUserRegion'];
+  selectedProvider: UseRampsProvidersResult['selectedProvider'];
+  setSelectedProvider: UseRampsProvidersResult['setSelectedProvider'];
+  providers: UseRampsProvidersResult['providers'];
+  providersLoading: UseRampsProvidersResult['isLoading'];
+  providersError: UseRampsProvidersResult['error'];
+  tokens: UseRampsTokensResult['tokens'];
+  selectedToken: UseRampsTokensResult['selectedToken'];
+  setSelectedToken: UseRampsTokensResult['setSelectedToken'];
+  tokensLoading: UseRampsTokensResult['isLoading'];
+  tokensError: UseRampsTokensResult['error'];
+  countries: UseRampsCountriesResult['countries'];
+  countriesLoading: UseRampsCountriesResult['isLoading'];
+  countriesError: UseRampsCountriesResult['error'];
+  paymentMethods: UseRampsPaymentMethodsResult['paymentMethods'];
+  selectedPaymentMethod: UseRampsPaymentMethodsResult['selectedPaymentMethod'];
+  setSelectedPaymentMethod: UseRampsPaymentMethodsResult['setSelectedPaymentMethod'];
+  paymentMethodsLoading: UseRampsPaymentMethodsResult['isLoading'];
+  paymentMethodsFetching: UseRampsPaymentMethodsResult['isFetching'];
+  paymentMethodsStatus: UseRampsPaymentMethodsResult['status'];
+  paymentMethodsError: UseRampsPaymentMethodsResult['error'];
+  getQuotes: UseRampsQuotesResult['getQuotes'];
+  getBuyWidgetData: UseRampsQuotesResult['getBuyWidgetData'];
+  orders: UseRampsOrdersResult['orders'];
+  getOrderById: UseRampsOrdersResult['getOrderById'];
+  addOrder: UseRampsOrdersResult['addOrder'];
+  addPrecreatedOrder: UseRampsOrdersResult['addPrecreatedOrder'];
+  removeOrder: UseRampsOrdersResult['removeOrder'];
+  refreshOrder: UseRampsOrdersResult['refreshOrder'];
+  getOrderFromCallback: UseRampsOrdersResult['getOrderFromCallback'];
+}
+
+export function useRampsController(): UseRampsControllerResult {
+  const { userRegion, setUserRegion } = useRampsUserRegion();
+  const {
+    providers,
+    selectedProvider,
+    setSelectedProvider,
+    isLoading: providersLoading,
+    error: providersError,
+  } = useRampsProviders();
+  const {
+    tokens,
+    selectedToken,
+    setSelectedToken,
+    isLoading: tokensLoading,
+    error: tokensError,
+  } = useRampsTokens();
+  const {
+    countries,
+    isLoading: countriesLoading,
+    error: countriesError,
+  } = useRampsCountries();
+  const {
+    paymentMethods,
+    selectedPaymentMethod,
+    setSelectedPaymentMethod,
+    isLoading: paymentMethodsLoading,
+    isFetching: paymentMethodsFetching,
+    status: paymentMethodsStatus,
+    error: paymentMethodsError,
+  } = useRampsPaymentMethods();
+  const { getQuotes, getBuyWidgetData } = useRampsQuotes();
+  const {
+    orders,
+    getOrderById,
+    addOrder,
+    addPrecreatedOrder,
+    removeOrder,
+    refreshOrder,
+    getOrderFromCallback,
+  } = useRampsOrders();
+
+  return {
+    userRegion,
+    setUserRegion,
+    selectedProvider,
+    setSelectedProvider,
+    providers,
+    providersLoading,
+    providersError,
+    tokens,
+    selectedToken,
+    setSelectedToken,
+    tokensLoading,
+    tokensError,
+    countries,
+    countriesLoading,
+    countriesError,
+    paymentMethods,
+    selectedPaymentMethod,
+    setSelectedPaymentMethod,
+    paymentMethodsLoading,
+    paymentMethodsFetching,
+    paymentMethodsStatus,
+    paymentMethodsError,
+    getQuotes,
+    getBuyWidgetData,
+    orders,
+    getOrderById,
+    addOrder,
+    addPrecreatedOrder,
+    removeOrder,
+    refreshOrder,
+    getOrderFromCallback,
+  };
+}
+
+export default useRampsController;

--- a/ui/hooks/ramps/useRampsCountries.test.tsx
+++ b/ui/hooks/ramps/useRampsCountries.test.tsx
@@ -1,0 +1,13 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useRampsCountries } from './useRampsCountries';
+import { createRampsTestWrapper } from './test-utils';
+
+describe('useRampsCountries', () => {
+  it('matches snapshot', () => {
+    const { result } = renderHook(() => useRampsCountries(), {
+      wrapper: createRampsTestWrapper(),
+    });
+
+    expect(result.current).toMatchSnapshot();
+  });
+});

--- a/ui/hooks/ramps/useRampsCountries.ts
+++ b/ui/hooks/ramps/useRampsCountries.ts
@@ -1,0 +1,25 @@
+import { useSelector } from 'react-redux';
+import { type Country } from '@metamask/ramps-controller';
+import { selectCountries } from '../../selectors/rampsController';
+import { parseUserFacingError } from './utils/parseUserFacingError';
+
+export interface UseRampsCountriesResult {
+  countries: Country[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function useRampsCountries(): UseRampsCountriesResult {
+  const countriesState = useSelector(selectCountries);
+  const { data: countries, isLoading, error } = countriesState;
+
+  return {
+    countries,
+    isLoading,
+    error: error
+      ? parseUserFacingError(countriesState, 'Failed to load countries')
+      : null,
+  };
+}
+
+export default useRampsCountries;

--- a/ui/hooks/ramps/useRampsCountries.ts
+++ b/ui/hooks/ramps/useRampsCountries.ts
@@ -3,11 +3,11 @@ import { type Country } from '@metamask/ramps-controller';
 import { selectCountries } from '../../selectors/rampsController';
 import { parseUserFacingError } from './utils/parseUserFacingError';
 
-export interface UseRampsCountriesResult {
+export type UseRampsCountriesResult = {
   countries: Country[];
   isLoading: boolean;
   error: string | null;
-}
+};
 
 export function useRampsCountries(): UseRampsCountriesResult {
   const countriesState = useSelector(selectCountries);

--- a/ui/hooks/ramps/useRampsOrders.test.tsx
+++ b/ui/hooks/ramps/useRampsOrders.test.tsx
@@ -1,0 +1,21 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useRampsOrders } from './useRampsOrders';
+import { createRampsTestWrapper } from './test-utils';
+
+jest.mock('../../store/controller-actions/ramps-controller', () => ({
+  addRampsOrder: jest.fn(),
+  addRampsPrecreatedOrder: jest.fn(),
+  removeRampsOrder: jest.fn(),
+  refreshRampsOrder: jest.fn(),
+  getRampsOrderFromCallback: jest.fn(),
+}));
+
+describe('useRampsOrders', () => {
+  it('matches snapshot', () => {
+    const { result } = renderHook(() => useRampsOrders(), {
+      wrapper: createRampsTestWrapper(),
+    });
+
+    expect(result.current).toMatchSnapshot();
+  });
+});

--- a/ui/hooks/ramps/useRampsOrders.test.tsx
+++ b/ui/hooks/ramps/useRampsOrders.test.tsx
@@ -1,21 +1,86 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react-hooks';
+import {
+  addRampsOrder,
+  addRampsPrecreatedOrder,
+  getRampsOrderFromCallback,
+  refreshRampsOrder,
+  removeRampsOrder,
+} from '../../store/controller-actions/ramps-controller';
 import { useRampsOrders } from './useRampsOrders';
-import { createRampsTestWrapper } from './test-utils';
+import { createRampsMockStore, createRampsTestWrapper } from './test-utils';
 
 jest.mock('../../store/controller-actions/ramps-controller', () => ({
-  addRampsOrder: jest.fn(),
-  addRampsPrecreatedOrder: jest.fn(),
-  removeRampsOrder: jest.fn(),
-  refreshRampsOrder: jest.fn(),
-  getRampsOrderFromCallback: jest.fn(),
+  addRampsOrder: jest.fn().mockResolvedValue(undefined),
+  addRampsPrecreatedOrder: jest.fn().mockResolvedValue(undefined),
+  removeRampsOrder: jest.fn().mockResolvedValue(undefined),
+  refreshRampsOrder: jest.fn().mockResolvedValue({ id: 'order-1' }),
+  getRampsOrderFromCallback: jest.fn().mockResolvedValue({ id: 'order-1' }),
 }));
 
+const order = {
+  id: '1',
+  providerOrderId: 'order-1',
+  walletAddress: '0xabc123',
+  status: 'COMPLETED',
+  createdAt: 1,
+} as never;
+
 describe('useRampsOrders', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('matches snapshot', () => {
     const { result } = renderHook(() => useRampsOrders(), {
       wrapper: createRampsTestWrapper(),
     });
 
     expect(result.current).toMatchSnapshot();
+  });
+
+  it('finds orders by provider order id and forwards write actions', async () => {
+    const store = createRampsMockStore({
+      orders: [order],
+    });
+
+    const { result } = renderHook(() => useRampsOrders(), {
+      wrapper: createRampsTestWrapper(store),
+    });
+
+    expect(result.current.getOrderById('transak/order-1')).toEqual(order);
+
+    await act(async () => {
+      await result.current.addOrder(order);
+      await result.current.addPrecreatedOrder({
+        orderId: 'order-1',
+        providerCode: 'transak',
+        walletAddress: '0xabc123',
+      });
+      await result.current.removeOrder('order-1');
+      await result.current.refreshOrder('transak', 'order-1', '0xabc123');
+      await result.current.getOrderFromCallback(
+        'transak',
+        'https://callback',
+        '0xabc123',
+      );
+    });
+
+    expect(addRampsOrder).toHaveBeenCalledWith(order);
+    expect(addRampsPrecreatedOrder).toHaveBeenCalledWith({
+      orderId: 'order-1',
+      providerCode: 'transak',
+      walletAddress: '0xabc123',
+    });
+    expect(removeRampsOrder).toHaveBeenCalledWith('order-1');
+    expect(refreshRampsOrder).toHaveBeenCalledWith(
+      'transak',
+      'order-1',
+      '0xabc123',
+    );
+    expect(getRampsOrderFromCallback).toHaveBeenCalledWith(
+      'transak',
+      'https://callback',
+      '0xabc123',
+    );
   });
 });

--- a/ui/hooks/ramps/useRampsOrders.test.tsx
+++ b/ui/hooks/ramps/useRampsOrders.test.tsx
@@ -47,7 +47,10 @@ describe('useRampsOrders', () => {
       wrapper: createRampsTestWrapper(store),
     });
 
-    expect(result.current.getOrderById('transak/order-1')).toEqual(order);
+    expect(
+      result.current.getOrderById('/providers/transak/orders/order-1'),
+    ).toEqual(order);
+    expect(result.current.getOrderById('order-1')).toEqual(order);
 
     await act(async () => {
       await result.current.addOrder(order);
@@ -56,7 +59,7 @@ describe('useRampsOrders', () => {
         providerCode: 'transak',
         walletAddress: '0xabc123',
       });
-      await result.current.removeOrder('order-1');
+      await result.current.removeOrder('/providers/transak/orders/order-1');
       await result.current.refreshOrder('transak', 'order-1', '0xabc123');
       await result.current.getOrderFromCallback(
         'transak',

--- a/ui/hooks/ramps/useRampsOrders.ts
+++ b/ui/hooks/ramps/useRampsOrders.ts
@@ -44,9 +44,7 @@ export function useRampsOrders(): UseRampsOrdersResult {
   const getOrderById = useCallback(
     (providerOrderId: string) => {
       const orderCode = getInternalOrderCode(providerOrderId);
-      return orders.find(
-        (order) => getInternalOrderCode(order) === orderCode,
-      );
+      return orders.find((order) => getInternalOrderCode(order) === orderCode);
     },
     [orders],
   );

--- a/ui/hooks/ramps/useRampsOrders.ts
+++ b/ui/hooks/ramps/useRampsOrders.ts
@@ -10,14 +10,14 @@ import {
   removeRampsOrder,
 } from '../../store/controller-actions/ramps-controller';
 
-export interface AddPrecreatedOrderParams {
+export type AddPrecreatedOrderParams = {
   orderId: string;
   providerCode: string;
   walletAddress: string;
   chainId?: string;
-}
+};
 
-export interface UseRampsOrdersResult {
+export type UseRampsOrdersResult = {
   orders: RampsOrder[];
   getOrderById: (providerOrderId: string) => RampsOrder | undefined;
   addOrder: (order: RampsOrder) => Promise<void>;
@@ -33,7 +33,7 @@ export interface UseRampsOrdersResult {
     callbackUrl: string,
     wallet: string,
   ) => Promise<RampsOrder>;
-}
+};
 
 function extractOrderCode(providerOrderId: string): string {
   const parts = providerOrderId.split('/');
@@ -51,10 +51,7 @@ export function useRampsOrders(): UseRampsOrdersResult {
     [orders],
   );
 
-  const addOrder = useCallback(
-    (order: RampsOrder) => addRampsOrder(order),
-    [],
-  );
+  const addOrder = useCallback((order: RampsOrder) => addRampsOrder(order), []);
 
   const addPrecreatedOrder = useCallback(
     (params: AddPrecreatedOrderParams) => addRampsPrecreatedOrder(params),

--- a/ui/hooks/ramps/useRampsOrders.ts
+++ b/ui/hooks/ramps/useRampsOrders.ts
@@ -1,0 +1,92 @@
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import type { RampsOrder } from '@metamask/ramps-controller';
+import { selectRampsOrdersForSelectedAccount } from '../../selectors/rampsController';
+import {
+  addRampsOrder,
+  addRampsPrecreatedOrder,
+  getRampsOrderFromCallback,
+  refreshRampsOrder,
+  removeRampsOrder,
+} from '../../store/controller-actions/ramps-controller';
+
+export interface AddPrecreatedOrderParams {
+  orderId: string;
+  providerCode: string;
+  walletAddress: string;
+  chainId?: string;
+}
+
+export interface UseRampsOrdersResult {
+  orders: RampsOrder[];
+  getOrderById: (providerOrderId: string) => RampsOrder | undefined;
+  addOrder: (order: RampsOrder) => Promise<void>;
+  addPrecreatedOrder: (params: AddPrecreatedOrderParams) => Promise<void>;
+  removeOrder: (providerOrderId: string) => Promise<void>;
+  refreshOrder: (
+    providerCode: string,
+    orderCode: string,
+    wallet: string,
+  ) => Promise<RampsOrder>;
+  getOrderFromCallback: (
+    providerCode: string,
+    callbackUrl: string,
+    wallet: string,
+  ) => Promise<RampsOrder>;
+}
+
+function extractOrderCode(providerOrderId: string): string {
+  const parts = providerOrderId.split('/');
+  return parts[parts.length - 1] ?? providerOrderId;
+}
+
+export function useRampsOrders(): UseRampsOrdersResult {
+  const orders = useSelector(selectRampsOrdersForSelectedAccount);
+
+  const getOrderById = useCallback(
+    (providerOrderId: string) => {
+      const orderCode = extractOrderCode(providerOrderId);
+      return orders.find((order) => order.providerOrderId === orderCode);
+    },
+    [orders],
+  );
+
+  const addOrder = useCallback(
+    (order: RampsOrder) => addRampsOrder(order),
+    [],
+  );
+
+  const addPrecreatedOrder = useCallback(
+    (params: AddPrecreatedOrderParams) => addRampsPrecreatedOrder(params),
+    [],
+  );
+
+  const removeOrder = useCallback(
+    (providerOrderId: string) => removeRampsOrder(providerOrderId),
+    [],
+  );
+
+  const refreshOrder = useCallback(
+    (providerCode: string, orderCode: string, wallet: string) =>
+      refreshRampsOrder(providerCode, orderCode, wallet),
+    [],
+  );
+
+  const getOrderFromCallback = useCallback(
+    (providerCode: string, callbackUrl: string, wallet: string) =>
+      getRampsOrderFromCallback(providerCode, callbackUrl, wallet),
+    [],
+  );
+
+  return {
+    orders,
+    getOrderById,
+    addOrder,
+    addPrecreatedOrder,
+    removeOrder,
+    refreshOrder,
+    getOrderFromCallback,
+  };
+}
+
+export default useRampsOrders;

--- a/ui/hooks/ramps/useRampsOrders.ts
+++ b/ui/hooks/ramps/useRampsOrders.ts
@@ -1,6 +1,9 @@
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
-import type { RampsOrder } from '@metamask/ramps-controller';
+import {
+  getInternalOrderCode,
+  type RampsOrder,
+} from '@metamask/ramps-controller';
 import { selectRampsOrdersForSelectedAccount } from '../../selectors/rampsController';
 import {
   addRampsOrder,
@@ -35,18 +38,15 @@ export type UseRampsOrdersResult = {
   ) => Promise<RampsOrder>;
 };
 
-function extractOrderCode(providerOrderId: string): string {
-  const parts = providerOrderId.split('/');
-  return parts[parts.length - 1] ?? providerOrderId;
-}
-
 export function useRampsOrders(): UseRampsOrdersResult {
   const orders = useSelector(selectRampsOrdersForSelectedAccount);
 
   const getOrderById = useCallback(
     (providerOrderId: string) => {
-      const orderCode = extractOrderCode(providerOrderId);
-      return orders.find((order) => order.providerOrderId === orderCode);
+      const orderCode = getInternalOrderCode(providerOrderId);
+      return orders.find(
+        (order) => getInternalOrderCode(order) === orderCode,
+      );
     },
     [orders],
   );
@@ -59,7 +59,8 @@ export function useRampsOrders(): UseRampsOrdersResult {
   );
 
   const removeOrder = useCallback(
-    (providerOrderId: string) => removeRampsOrder(providerOrderId),
+    (providerOrderId: string) =>
+      removeRampsOrder(getInternalOrderCode(providerOrderId)),
     [],
   );
 

--- a/ui/hooks/ramps/useRampsPaymentMethods.test.tsx
+++ b/ui/hooks/ramps/useRampsPaymentMethods.test.tsx
@@ -99,6 +99,22 @@ describe('useRampsPaymentMethods', () => {
     expect(setRampsSelectedPaymentMethod).toHaveBeenCalledWith(paymentMethod);
   });
 
+  it('preserves selected payment method while the query is loading', () => {
+    mockedUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isFetching: true,
+      isError: false,
+      error: null,
+    } as never);
+
+    renderHook(() => useRampsPaymentMethods(), {
+      wrapper: createRampsTestWrapper(enabledStore),
+    });
+
+    expect(setRampsSelectedPaymentMethod).not.toHaveBeenCalled();
+  });
+
   it('clears selected payment method when the query returns no methods', () => {
     mockedUseQuery.mockReturnValue({
       data: [],

--- a/ui/hooks/ramps/useRampsPaymentMethods.test.tsx
+++ b/ui/hooks/ramps/useRampsPaymentMethods.test.tsx
@@ -1,18 +1,118 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useQuery } from '@tanstack/react-query';
+import { setRampsSelectedPaymentMethod } from '../../store/controller-actions/ramps-controller';
 import { useRampsPaymentMethods } from './useRampsPaymentMethods';
-import { createRampsTestWrapper } from './test-utils';
+import { createRampsMockStore, createRampsTestWrapper } from './test-utils';
+
+jest.mock('@tanstack/react-query', () => {
+  const actual = jest.requireActual('@tanstack/react-query');
+  return {
+    ...actual,
+    useQuery: jest.fn(),
+  };
+});
 
 jest.mock('../../store/controller-actions/ramps-controller', () => ({
-  setRampsSelectedPaymentMethod: jest.fn(),
+  setRampsSelectedPaymentMethod: jest.fn().mockResolvedValue(undefined),
   getRampsPaymentMethods: jest.fn(),
 }));
 
+const mockedUseQuery = jest.mocked(useQuery);
+
+const paymentMethod = {
+  id: 'credit_debit_card',
+  name: 'Debit or Credit',
+} as never;
+
+const enabledStore = createRampsMockStore({
+  providers: {
+    data: [],
+    selected: { id: 'transak' },
+    isLoading: false,
+    error: null,
+  },
+  paymentMethods: {
+    data: [paymentMethod],
+    selected: paymentMethod,
+    isLoading: false,
+    error: null,
+  },
+});
+
 describe('useRampsPaymentMethods', () => {
-  it('matches snapshot', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      error: null,
+    } as never);
+  });
+
+  it('matches snapshot when idle', () => {
     const { result } = renderHook(() => useRampsPaymentMethods(), {
       wrapper: createRampsTestWrapper(),
     });
 
     expect(result.current).toMatchSnapshot();
+  });
+
+  it('returns loading status while the query is loading', () => {
+    mockedUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isFetching: true,
+      isError: false,
+      error: null,
+    } as never);
+
+    const { result } = renderHook(() => useRampsPaymentMethods(), {
+      wrapper: createRampsTestWrapper(enabledStore),
+    });
+
+    expect(result.current.status).toBe('loading');
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('returns loaded payment methods and exposes write helper', async () => {
+    mockedUseQuery.mockReturnValue({
+      data: [paymentMethod],
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      error: null,
+    } as never);
+
+    const { result } = renderHook(() => useRampsPaymentMethods(), {
+      wrapper: createRampsTestWrapper(enabledStore),
+    });
+
+    expect(result.current.status).toBe('success');
+    expect(result.current.paymentMethods).toEqual([paymentMethod]);
+
+    await act(async () => {
+      await result.current.setSelectedPaymentMethod(paymentMethod);
+    });
+
+    expect(setRampsSelectedPaymentMethod).toHaveBeenCalledWith(paymentMethod);
+  });
+
+  it('returns error status when the query fails', () => {
+    mockedUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isFetching: false,
+      isError: true,
+      error: new Error('network down'),
+    } as never);
+
+    const { result } = renderHook(() => useRampsPaymentMethods(), {
+      wrapper: createRampsTestWrapper(enabledStore),
+    });
+
+    expect(result.current.status).toBe('error');
+    expect(result.current.error).toContain('network down');
   });
 });

--- a/ui/hooks/ramps/useRampsPaymentMethods.test.tsx
+++ b/ui/hooks/ramps/useRampsPaymentMethods.test.tsx
@@ -99,6 +99,22 @@ describe('useRampsPaymentMethods', () => {
     expect(setRampsSelectedPaymentMethod).toHaveBeenCalledWith(paymentMethod);
   });
 
+  it('clears selected payment method when the query returns no methods', () => {
+    mockedUseQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isFetching: false,
+      isError: false,
+      error: null,
+    } as never);
+
+    renderHook(() => useRampsPaymentMethods(), {
+      wrapper: createRampsTestWrapper(enabledStore),
+    });
+
+    expect(setRampsSelectedPaymentMethod).toHaveBeenCalledWith(null);
+  });
+
   it('returns error status when the query fails', () => {
     mockedUseQuery.mockReturnValue({
       data: undefined,

--- a/ui/hooks/ramps/useRampsPaymentMethods.test.tsx
+++ b/ui/hooks/ramps/useRampsPaymentMethods.test.tsx
@@ -1,0 +1,18 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useRampsPaymentMethods } from './useRampsPaymentMethods';
+import { createRampsTestWrapper } from './test-utils';
+
+jest.mock('../../store/controller-actions/ramps-controller', () => ({
+  setRampsSelectedPaymentMethod: jest.fn(),
+  getRampsPaymentMethods: jest.fn(),
+}));
+
+describe('useRampsPaymentMethods', () => {
+  it('matches snapshot', () => {
+    const { result } = renderHook(() => useRampsPaymentMethods(), {
+      wrapper: createRampsTestWrapper(),
+    });
+
+    expect(result.current).toMatchSnapshot();
+  });
+});

--- a/ui/hooks/ramps/useRampsPaymentMethods.ts
+++ b/ui/hooks/ramps/useRampsPaymentMethods.ts
@@ -59,6 +59,9 @@ export function useRampsPaymentMethods(): UseRampsPaymentMethodsResult {
   useEffect(() => {
     const methods = paymentMethodsQuery.data;
     if (!methods || methods.length === 0) {
+      if (selectedPaymentMethod !== null) {
+        setSelectedPaymentMethod(null);
+      }
       return;
     }
 

--- a/ui/hooks/ramps/useRampsPaymentMethods.ts
+++ b/ui/hooks/ramps/useRampsPaymentMethods.ts
@@ -58,7 +58,11 @@ export function useRampsPaymentMethods(): UseRampsPaymentMethodsResult {
 
   useEffect(() => {
     const methods = paymentMethodsQuery.data;
-    if (!methods || methods.length === 0) {
+    if (methods === undefined) {
+      return;
+    }
+
+    if (methods.length === 0) {
       if (selectedPaymentMethod !== null) {
         setSelectedPaymentMethod(null);
       }

--- a/ui/hooks/ramps/useRampsPaymentMethods.ts
+++ b/ui/hooks/ramps/useRampsPaymentMethods.ts
@@ -1,0 +1,129 @@
+import { useCallback, useEffect, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useSelector } from 'react-redux';
+import { type PaymentMethod } from '@metamask/ramps-controller';
+import {
+  selectPaymentMethods,
+  selectProviders,
+  selectTokens,
+  selectUserRegion,
+} from '../../selectors/rampsController';
+import { setRampsSelectedPaymentMethod } from '../../store/controller-actions/ramps-controller';
+import { rampsQueries } from './queries';
+import { normalizeAssetIdForApi } from './utils/normalizeAssetIdForApi';
+import { parseUserFacingError } from './utils/parseUserFacingError';
+
+export type RampsQueryStatus = 'idle' | 'loading' | 'success' | 'error';
+
+export interface UseRampsPaymentMethodsResult {
+  paymentMethods: PaymentMethod[];
+  selectedPaymentMethod: PaymentMethod | null;
+  setSelectedPaymentMethod: (
+    paymentMethod: PaymentMethod | null,
+  ) => Promise<void>;
+  isLoading: boolean;
+  isFetching: boolean;
+  status: RampsQueryStatus;
+  isSuccess: boolean;
+  error: string | null;
+}
+
+export function useRampsPaymentMethods(): UseRampsPaymentMethodsResult {
+  const { selected: selectedPaymentMethod } = useSelector(selectPaymentMethods);
+  const { selected: selectedProvider } = useSelector(selectProviders);
+  const { selected: selectedToken } = useSelector(selectTokens);
+  const userRegion = useSelector(selectUserRegion);
+
+  const queryEnabled = Boolean(
+    userRegion?.regionCode &&
+      userRegion?.country?.currency &&
+      selectedProvider?.id,
+  );
+
+  const paymentMethodsQuery = useQuery({
+    ...rampsQueries.paymentMethods.options({
+      regionCode: userRegion?.regionCode ?? '',
+      fiat: userRegion?.country?.currency ?? '',
+      assetId: normalizeAssetIdForApi(selectedToken?.assetId),
+      providerId: selectedProvider?.id ?? '',
+    }),
+    enabled: queryEnabled,
+  });
+
+  const setSelectedPaymentMethod = useCallback(
+    (paymentMethod: PaymentMethod | null) =>
+      setRampsSelectedPaymentMethod(paymentMethod),
+    [],
+  );
+
+  useEffect(() => {
+    const methods = paymentMethodsQuery.data;
+    if (!methods || methods.length === 0) {
+      return;
+    }
+
+    let target: PaymentMethod | null = null;
+
+    if (selectedPaymentMethod) {
+      target =
+        methods.find((method) => method.id === selectedPaymentMethod.id) ??
+        null;
+    }
+
+    if (!target) {
+      target = methods[0];
+    }
+
+    if (target.id !== selectedPaymentMethod?.id) {
+      setSelectedPaymentMethod(target);
+    }
+  }, [
+    paymentMethodsQuery.data,
+    selectedPaymentMethod,
+    setSelectedPaymentMethod,
+  ]);
+
+  const isAutoSelecting = Boolean(
+    paymentMethodsQuery.data?.length &&
+      (!selectedPaymentMethod ||
+        paymentMethodsQuery.data.every(
+          (method) => method.id !== selectedPaymentMethod.id,
+        )),
+  );
+
+  const status = useMemo<RampsQueryStatus>(() => {
+    if (!queryEnabled) {
+      return 'idle';
+    }
+    if (paymentMethodsQuery.isLoading) {
+      return 'loading';
+    }
+    if (paymentMethodsQuery.isError) {
+      return 'error';
+    }
+    return 'success';
+  }, [
+    paymentMethodsQuery.isError,
+    paymentMethodsQuery.isLoading,
+    queryEnabled,
+  ]);
+
+  return {
+    paymentMethods: paymentMethodsQuery.data ?? [],
+    selectedPaymentMethod,
+    setSelectedPaymentMethod,
+    isLoading: status === 'loading' || isAutoSelecting,
+    isFetching: paymentMethodsQuery.isFetching,
+    status,
+    isSuccess: status === 'success',
+    error:
+      paymentMethodsQuery.error != null
+        ? parseUserFacingError(
+            paymentMethodsQuery.error,
+            'Failed to load payment methods',
+          )
+        : null,
+  };
+}
+
+export default useRampsPaymentMethods;

--- a/ui/hooks/ramps/useRampsPaymentMethods.ts
+++ b/ui/hooks/ramps/useRampsPaymentMethods.ts
@@ -15,7 +15,7 @@ import { parseUserFacingError } from './utils/parseUserFacingError';
 
 export type RampsQueryStatus = 'idle' | 'loading' | 'success' | 'error';
 
-export interface UseRampsPaymentMethodsResult {
+export type UseRampsPaymentMethodsResult = {
   paymentMethods: PaymentMethod[];
   selectedPaymentMethod: PaymentMethod | null;
   setSelectedPaymentMethod: (
@@ -26,7 +26,7 @@ export interface UseRampsPaymentMethodsResult {
   status: RampsQueryStatus;
   isSuccess: boolean;
   error: string | null;
-}
+};
 
 export function useRampsPaymentMethods(): UseRampsPaymentMethodsResult {
   const { selected: selectedPaymentMethod } = useSelector(selectPaymentMethods);
@@ -36,8 +36,8 @@ export function useRampsPaymentMethods(): UseRampsPaymentMethodsResult {
 
   const queryEnabled = Boolean(
     userRegion?.regionCode &&
-      userRegion?.country?.currency &&
-      selectedProvider?.id,
+    userRegion?.country?.currency &&
+    selectedProvider?.id,
   );
 
   const paymentMethodsQuery = useQuery({
@@ -85,10 +85,10 @@ export function useRampsPaymentMethods(): UseRampsPaymentMethodsResult {
 
   const isAutoSelecting = Boolean(
     paymentMethodsQuery.data?.length &&
-      (!selectedPaymentMethod ||
-        paymentMethodsQuery.data.every(
-          (method) => method.id !== selectedPaymentMethod.id,
-        )),
+    (!selectedPaymentMethod ||
+      paymentMethodsQuery.data.every(
+        (method) => method.id !== selectedPaymentMethod.id,
+      )),
   );
 
   const status = useMemo<RampsQueryStatus>(() => {
@@ -116,13 +116,12 @@ export function useRampsPaymentMethods(): UseRampsPaymentMethodsResult {
     isFetching: paymentMethodsQuery.isFetching,
     status,
     isSuccess: status === 'success',
-    error:
-      paymentMethodsQuery.error != null
-        ? parseUserFacingError(
-            paymentMethodsQuery.error,
-            'Failed to load payment methods',
-          )
-        : null,
+    error: paymentMethodsQuery.error
+      ? parseUserFacingError(
+          paymentMethodsQuery.error,
+          'Failed to load payment methods',
+        )
+      : null,
   };
 }
 

--- a/ui/hooks/ramps/useRampsProviders.test.tsx
+++ b/ui/hooks/ramps/useRampsProviders.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { renderHook } from '@testing-library/react-hooks';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import {
@@ -53,27 +54,30 @@ describe('useRampsProviders', () => {
   });
 
   it('clears selected provider and payment method when region changes', () => {
-    let store = createRampsMockStore({
-      userRegion: {
-        regionCode: 'us-ca',
-        country: { currency: 'USD', isoCode: 'US', name: 'United States' },
-      },
-      providers: {
-        data: [],
-        selected: transakProvider,
-        isLoading: false,
-        error: null,
-      },
-    });
+    const storeRef = {
+      current: createRampsMockStore({
+        userRegion: {
+          regionCode: 'us-ca',
+          country: { currency: 'USD', isoCode: 'US', name: 'United States' },
+        },
+        providers: {
+          data: [],
+          selected: transakProvider,
+          isLoading: false,
+          error: null,
+        },
+      }),
+    };
 
     const { rerender } = renderHook(
       () => useRampsProviders({ enableSideEffects: true }),
       {
-        wrapper: ({ children }) => createRampsTestWrapper(store)({ children }),
+        wrapper: ({ children }: { children: React.ReactNode }) =>
+          createRampsTestWrapper(storeRef.current)({ children }),
       },
     );
 
-    store = createRampsMockStore({
+    storeRef.current = createRampsMockStore({
       userRegion: {
         regionCode: 'gb',
         country: {

--- a/ui/hooks/ramps/useRampsProviders.test.tsx
+++ b/ui/hooks/ramps/useRampsProviders.test.tsx
@@ -1,18 +1,125 @@
 import { renderHook } from '@testing-library/react-hooks';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  setRampsSelectedPaymentMethod,
+  setRampsSelectedProvider,
+} from '../../store/controller-actions/ramps-controller';
 import { useRampsProviders } from './useRampsProviders';
-import { createRampsTestWrapper } from './test-utils';
+import { createRampsMockStore, createRampsTestWrapper } from './test-utils';
+
+jest.mock('@tanstack/react-query', () => {
+  const actual = jest.requireActual('@tanstack/react-query');
+  return {
+    ...actual,
+    useQuery: jest.fn(),
+    useQueryClient: jest.fn(),
+  };
+});
 
 jest.mock('../../store/controller-actions/ramps-controller', () => ({
-  setRampsSelectedProvider: jest.fn(),
+  setRampsSelectedProvider: jest.fn().mockResolvedValue(undefined),
+  setRampsSelectedPaymentMethod: jest.fn().mockResolvedValue(undefined),
   getRampsProviders: jest.fn().mockResolvedValue({ providers: [] }),
 }));
 
+const mockedUseQuery = jest.mocked(useQuery);
+const mockedUseQueryClient = jest.mocked(useQueryClient);
+
+const transakProvider = {
+  id: 'transak',
+  name: 'Transak',
+};
+
 describe('useRampsProviders', () => {
+  const invalidateQueries = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseQueryClient.mockReturnValue({
+      invalidateQueries,
+    } as never);
+    mockedUseQuery.mockReturnValue({
+      data: [],
+      isLoading: false,
+    } as never);
+  });
+
   it('matches snapshot', () => {
     const { result } = renderHook(() => useRampsProviders(), {
       wrapper: createRampsTestWrapper(),
     });
 
     expect(result.current).toMatchSnapshot();
+  });
+
+  it('clears selected provider and payment method when region changes', () => {
+    let store = createRampsMockStore({
+      userRegion: {
+        regionCode: 'us-ca',
+        country: { currency: 'USD', isoCode: 'US', name: 'United States' },
+      },
+      providers: {
+        data: [],
+        selected: transakProvider,
+        isLoading: false,
+        error: null,
+      },
+    });
+
+    const { rerender } = renderHook(
+      () => useRampsProviders({ enableSideEffects: true }),
+      {
+        wrapper: ({ children }) =>
+          createRampsTestWrapper(store)({ children }),
+      },
+    );
+
+    store = createRampsMockStore({
+      userRegion: {
+        regionCode: 'gb',
+        country: {
+          currency: 'GBP',
+          isoCode: 'GB',
+          name: 'United Kingdom',
+        },
+      },
+      providers: {
+        data: [],
+        selected: transakProvider,
+        isLoading: false,
+        error: null,
+      },
+    });
+
+    rerender();
+
+    expect(invalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['ramps'],
+      refetchType: 'none',
+    });
+    expect(setRampsSelectedProvider).toHaveBeenCalledWith(null, undefined);
+    expect(setRampsSelectedPaymentMethod).toHaveBeenCalledWith(null);
+  });
+
+  it('clears a stale selected provider that is not in the current provider list', () => {
+    mockedUseQuery.mockReturnValue({
+      data: [transakProvider],
+      isLoading: false,
+    } as never);
+
+    renderHook(() => useRampsProviders({ enableSideEffects: true }), {
+      wrapper: createRampsTestWrapper(
+        createRampsMockStore({
+          providers: {
+            data: [transakProvider],
+            selected: { id: 'moonpay', name: 'MoonPay' },
+            isLoading: false,
+            error: null,
+          },
+        }),
+      ),
+    });
+
+    expect(setRampsSelectedProvider).toHaveBeenCalledWith(null, undefined);
   });
 });

--- a/ui/hooks/ramps/useRampsProviders.test.tsx
+++ b/ui/hooks/ramps/useRampsProviders.test.tsx
@@ -124,6 +124,7 @@ describe('useRampsProviders', () => {
     });
 
     expect(setRampsSelectedProvider).toHaveBeenCalledWith(null, undefined);
+    expect(setRampsSelectedPaymentMethod).toHaveBeenCalledWith(null);
   });
 
   it('auto-selects a provider when none is selected', () => {

--- a/ui/hooks/ramps/useRampsProviders.test.tsx
+++ b/ui/hooks/ramps/useRampsProviders.test.tsx
@@ -69,8 +69,7 @@ describe('useRampsProviders', () => {
     const { rerender } = renderHook(
       () => useRampsProviders({ enableSideEffects: true }),
       {
-        wrapper: ({ children }) =>
-          createRampsTestWrapper(store)({ children }),
+        wrapper: ({ children }) => createRampsTestWrapper(store)({ children }),
       },
     );
 

--- a/ui/hooks/ramps/useRampsProviders.test.tsx
+++ b/ui/hooks/ramps/useRampsProviders.test.tsx
@@ -121,4 +121,42 @@ describe('useRampsProviders', () => {
 
     expect(setRampsSelectedProvider).toHaveBeenCalledWith(null, undefined);
   });
+
+  it('auto-selects a provider when none is selected', () => {
+    mockedUseQuery.mockReturnValue({
+      data: [transakProvider],
+      isLoading: false,
+    } as never);
+
+    renderHook(() => useRampsProviders({ enableSideEffects: true }), {
+      wrapper: createRampsTestWrapper(),
+    });
+
+    expect(setRampsSelectedProvider).toHaveBeenCalledWith('transak', {
+      autoSelected: true,
+    });
+  });
+
+  it('returns a providers state error when the query is unavailable', () => {
+    mockedUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: null,
+    } as never);
+
+    const { result } = renderHook(() => useRampsProviders(), {
+      wrapper: createRampsTestWrapper(
+        createRampsMockStore({
+          providers: {
+            data: [],
+            selected: null,
+            isLoading: false,
+            error: 'Failed to load providers',
+          },
+        }),
+      ),
+    });
+
+    expect(result.current.error).toBe('Failed to load providers');
+  });
 });

--- a/ui/hooks/ramps/useRampsProviders.test.tsx
+++ b/ui/hooks/ramps/useRampsProviders.test.tsx
@@ -1,0 +1,18 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useRampsProviders } from './useRampsProviders';
+import { createRampsTestWrapper } from './test-utils';
+
+jest.mock('../../store/controller-actions/ramps-controller', () => ({
+  setRampsSelectedProvider: jest.fn(),
+  getRampsProviders: jest.fn().mockResolvedValue({ providers: [] }),
+}));
+
+describe('useRampsProviders', () => {
+  it('matches snapshot', () => {
+    const { result } = renderHook(() => useRampsProviders(), {
+      wrapper: createRampsTestWrapper(),
+    });
+
+    expect(result.current).toMatchSnapshot();
+  });
+});

--- a/ui/hooks/ramps/useRampsProviders.ts
+++ b/ui/hooks/ramps/useRampsProviders.ts
@@ -97,6 +97,7 @@ export function useRampsProviders(options?: {
       !providers.some((provider) => provider.id === selectedProvider.id)
     ) {
       setSelectedProvider(null);
+      setRampsSelectedPaymentMethod(null);
       return;
     }
 

--- a/ui/hooks/ramps/useRampsProviders.ts
+++ b/ui/hooks/ramps/useRampsProviders.ts
@@ -15,7 +15,7 @@ import {
 import { parseUserFacingError } from './utils/parseUserFacingError';
 import { rampsQueries } from './queries';
 
-export interface UseRampsProvidersResult {
+export type UseRampsProvidersResult = {
   providers: Provider[];
   selectedProvider: Provider | null;
   setSelectedProvider: (
@@ -24,7 +24,7 @@ export interface UseRampsProvidersResult {
   ) => Promise<void>;
   isLoading: boolean;
   error: string | null;
-}
+};
 
 export function useRampsProviders(options?: {
   enableSideEffects?: boolean;
@@ -102,16 +102,13 @@ export function useRampsProviders(options?: {
   ]);
 
   let error: string | null = null;
-  if (providersQuery?.error != null) {
+  if (providersQuery?.error) {
     error = parseUserFacingError(
       providersQuery.error,
       'Failed to load providers',
     );
   } else if (providersStateError) {
-    error = parseUserFacingError(
-      providersState,
-      'Failed to load providers',
-    );
+    error = parseUserFacingError(providersState, 'Failed to load providers');
   }
 
   return {

--- a/ui/hooks/ramps/useRampsProviders.ts
+++ b/ui/hooks/ramps/useRampsProviders.ts
@@ -1,0 +1,126 @@
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { useSelector } from 'react-redux';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { type Provider } from '@metamask/ramps-controller';
+import {
+  selectProviders,
+  selectRampsOrdersForSelectedAccount,
+  selectUserRegion,
+} from '../../selectors/rampsController';
+import { setRampsSelectedProvider } from '../../store/controller-actions/ramps-controller';
+import {
+  completedOrdersFromRampsOrders,
+  determinePreferredProvider,
+} from './utils/determinePreferredProvider';
+import { parseUserFacingError } from './utils/parseUserFacingError';
+import { rampsQueries } from './queries';
+
+export interface UseRampsProvidersResult {
+  providers: Provider[];
+  selectedProvider: Provider | null;
+  setSelectedProvider: (
+    provider: Provider | null,
+    options?: { autoSelected?: boolean },
+  ) => Promise<void>;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function useRampsProviders(options?: {
+  enableSideEffects?: boolean;
+}): UseRampsProvidersResult {
+  const enableSideEffects = options?.enableSideEffects ?? false;
+  const providersState = useSelector(selectProviders);
+  const {
+    data: providersStateData,
+    selected: selectedProvider,
+    isLoading: providersStateIsLoading,
+    error: providersStateError,
+  } = providersState;
+
+  const userRegion = useSelector(selectUserRegion);
+  const regionCode = userRegion?.regionCode ?? '';
+  const queryClient = useQueryClient();
+
+  const prevRegionRef = useRef(regionCode);
+  useEffect(() => {
+    if (
+      enableSideEffects &&
+      regionCode &&
+      prevRegionRef.current !== regionCode
+    ) {
+      prevRegionRef.current = regionCode;
+      queryClient.invalidateQueries({
+        queryKey: ['ramps'],
+        refetchType: 'none',
+      });
+    }
+  }, [enableSideEffects, regionCode, queryClient]);
+
+  const providersQuery = useQuery({
+    ...rampsQueries.providers.options({ regionCode }),
+    enabled: Boolean(regionCode),
+  });
+
+  const providers = useMemo(
+    () => providersQuery?.data ?? providersStateData ?? [],
+    [providersQuery?.data, providersStateData],
+  );
+
+  const controllerOrders = useSelector(selectRampsOrdersForSelectedAccount);
+  const completedOrders = useMemo(
+    () => completedOrdersFromRampsOrders(controllerOrders),
+    [controllerOrders],
+  );
+
+  const setSelectedProvider = useCallback(
+    (provider: Provider | null, setOptions?: { autoSelected?: boolean }) =>
+      setRampsSelectedProvider(provider?.id ?? null, setOptions),
+    [],
+  );
+
+  useEffect(() => {
+    if (
+      enableSideEffects &&
+      providers &&
+      providers.length > 0 &&
+      !selectedProvider
+    ) {
+      const result = determinePreferredProvider(completedOrders, providers);
+      if (result) {
+        setSelectedProvider(result.provider, {
+          autoSelected: result.autoSelected,
+        });
+      }
+    }
+  }, [
+    enableSideEffects,
+    providers,
+    selectedProvider,
+    completedOrders,
+    setSelectedProvider,
+  ]);
+
+  let error: string | null = null;
+  if (providersQuery?.error != null) {
+    error = parseUserFacingError(
+      providersQuery.error,
+      'Failed to load providers',
+    );
+  } else if (providersStateError) {
+    error = parseUserFacingError(
+      providersState,
+      'Failed to load providers',
+    );
+  }
+
+  return {
+    providers,
+    selectedProvider,
+    setSelectedProvider,
+    isLoading: providersQuery?.isLoading ?? providersStateIsLoading,
+    error,
+  };
+}
+
+export default useRampsProviders;

--- a/ui/hooks/ramps/useRampsProviders.ts
+++ b/ui/hooks/ramps/useRampsProviders.ts
@@ -7,7 +7,10 @@ import {
   selectRampsOrdersForSelectedAccount,
   selectUserRegion,
 } from '../../selectors/rampsController';
-import { setRampsSelectedProvider } from '../../store/controller-actions/ramps-controller';
+import {
+  setRampsSelectedPaymentMethod,
+  setRampsSelectedProvider,
+} from '../../store/controller-actions/ramps-controller';
 import {
   completedOrdersFromRampsOrders,
   determinePreferredProvider,
@@ -42,6 +45,12 @@ export function useRampsProviders(options?: {
   const regionCode = userRegion?.regionCode ?? '';
   const queryClient = useQueryClient();
 
+  const setSelectedProvider = useCallback(
+    (provider: Provider | null, setOptions?: { autoSelected?: boolean }) =>
+      setRampsSelectedProvider(provider?.id ?? null, setOptions),
+    [],
+  );
+
   const prevRegionRef = useRef(regionCode);
   useEffect(() => {
     if (
@@ -49,13 +58,18 @@ export function useRampsProviders(options?: {
       regionCode &&
       prevRegionRef.current !== regionCode
     ) {
+      const previousRegion = prevRegionRef.current;
       prevRegionRef.current = regionCode;
       queryClient.invalidateQueries({
         queryKey: ['ramps'],
         refetchType: 'none',
       });
+      if (previousRegion) {
+        setSelectedProvider(null);
+        setRampsSelectedPaymentMethod(null);
+      }
     }
-  }, [enableSideEffects, regionCode, queryClient]);
+  }, [enableSideEffects, regionCode, queryClient, setSelectedProvider]);
 
   const providersQuery = useQuery({
     ...rampsQueries.providers.options({ regionCode }),
@@ -73,19 +87,20 @@ export function useRampsProviders(options?: {
     [controllerOrders],
   );
 
-  const setSelectedProvider = useCallback(
-    (provider: Provider | null, setOptions?: { autoSelected?: boolean }) =>
-      setRampsSelectedProvider(provider?.id ?? null, setOptions),
-    [],
-  );
-
   useEffect(() => {
+    if (!enableSideEffects || !providers?.length) {
+      return;
+    }
+
     if (
-      enableSideEffects &&
-      providers &&
-      providers.length > 0 &&
-      !selectedProvider
+      selectedProvider &&
+      !providers.some((provider) => provider.id === selectedProvider.id)
     ) {
+      setSelectedProvider(null);
+      return;
+    }
+
+    if (!selectedProvider) {
       const result = determinePreferredProvider(completedOrders, providers);
       if (result) {
         setSelectedProvider(result.provider, {

--- a/ui/hooks/ramps/useRampsQuotes.test.tsx
+++ b/ui/hooks/ramps/useRampsQuotes.test.tsx
@@ -1,0 +1,18 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useRampsQuotes } from './useRampsQuotes';
+import { createRampsTestWrapper } from './test-utils';
+
+jest.mock('../../store/controller-actions/ramps-controller', () => ({
+  getRampsQuotes: jest.fn(),
+  getRampsBuyWidgetData: jest.fn(),
+}));
+
+describe('useRampsQuotes', () => {
+  it('matches snapshot when query is disabled', () => {
+    const { result } = renderHook(() => useRampsQuotes(), {
+      wrapper: createRampsTestWrapper(),
+    });
+
+    expect(result.current).toMatchSnapshot();
+  });
+});

--- a/ui/hooks/ramps/useRampsQuotes.test.tsx
+++ b/ui/hooks/ramps/useRampsQuotes.test.tsx
@@ -17,7 +17,9 @@ jest.mock('@tanstack/react-query', () => {
 
 jest.mock('../../store/controller-actions/ramps-controller', () => ({
   getRampsQuotes: jest.fn().mockResolvedValue({ quotes: [] }),
-  getRampsBuyWidgetData: jest.fn().mockResolvedValue({ url: 'https://example.com' }),
+  getRampsBuyWidgetData: jest
+    .fn()
+    .mockResolvedValue({ url: 'https://example.com' }),
 }));
 
 const mockedUseQuery = jest.mocked(useQuery);

--- a/ui/hooks/ramps/useRampsQuotes.test.tsx
+++ b/ui/hooks/ramps/useRampsQuotes.test.tsx
@@ -1,18 +1,106 @@
-import { renderHook } from '@testing-library/react-hooks';
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useQuery } from '@tanstack/react-query';
+import {
+  getRampsBuyWidgetData,
+  getRampsQuotes,
+} from '../../store/controller-actions/ramps-controller';
 import { useRampsQuotes } from './useRampsQuotes';
 import { createRampsTestWrapper } from './test-utils';
 
+jest.mock('@tanstack/react-query', () => {
+  const actual = jest.requireActual('@tanstack/react-query');
+  return {
+    ...actual,
+    useQuery: jest.fn(),
+  };
+});
+
 jest.mock('../../store/controller-actions/ramps-controller', () => ({
-  getRampsQuotes: jest.fn(),
-  getRampsBuyWidgetData: jest.fn(),
+  getRampsQuotes: jest.fn().mockResolvedValue({ quotes: [] }),
+  getRampsBuyWidgetData: jest.fn().mockResolvedValue({ url: 'https://example.com' }),
 }));
 
+const mockedUseQuery = jest.mocked(useQuery);
+
+const quoteOptions = {
+  assetId: 'eip155:1/slip44:60',
+  amount: 100,
+  walletAddress: '0xabc',
+};
+
 describe('useRampsQuotes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as never);
+  });
+
   it('matches snapshot when query is disabled', () => {
     const { result } = renderHook(() => useRampsQuotes(), {
       wrapper: createRampsTestWrapper(),
     });
 
     expect(result.current).toMatchSnapshot();
+  });
+
+  it('returns loading status while quotes are fetching', () => {
+    mockedUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+    } as never);
+
+    const { result } = renderHook(() => useRampsQuotes(quoteOptions), {
+      wrapper: createRampsTestWrapper(),
+    });
+
+    expect(result.current.status).toBe('loading');
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('returns loaded quotes and exposes write helpers', async () => {
+    const quotesResponse = { quotes: [{ id: 'q1' }] };
+    mockedUseQuery.mockReturnValue({
+      data: quotesResponse,
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as never);
+
+    const { result } = renderHook(() => useRampsQuotes(quoteOptions), {
+      wrapper: createRampsTestWrapper(),
+    });
+
+    expect(result.current.status).toBe('success');
+    expect(result.current.data).toEqual(quotesResponse);
+
+    await act(async () => {
+      await result.current.getQuotes(quoteOptions);
+      await result.current.getBuyWidgetData({ id: 'q1' } as never);
+    });
+
+    expect(getRampsQuotes).toHaveBeenCalledWith(quoteOptions);
+    expect(getRampsBuyWidgetData).toHaveBeenCalledWith({ id: 'q1' });
+  });
+
+  it('returns error status when the query fails', () => {
+    mockedUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error('quote failed'),
+    } as never);
+
+    const { result } = renderHook(() => useRampsQuotes(quoteOptions), {
+      wrapper: createRampsTestWrapper(),
+    });
+
+    expect(result.current.status).toBe('error');
+    expect(result.current.error).toEqual(new Error('quote failed'));
   });
 });

--- a/ui/hooks/ramps/useRampsQuotes.test.tsx
+++ b/ui/hooks/ramps/useRampsQuotes.test.tsx
@@ -49,6 +49,22 @@ describe('useRampsQuotes', () => {
     expect(result.current).toMatchSnapshot();
   });
 
+  it('returns idle loading state when the query is disabled', () => {
+    mockedUseQuery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      error: null,
+    } as never);
+
+    const { result } = renderHook(() => useRampsQuotes(), {
+      wrapper: createRampsTestWrapper(),
+    });
+
+    expect(result.current.status).toBe('idle');
+    expect(result.current.loading).toBe(false);
+  });
+
   it('returns loading status while quotes are fetching', () => {
     mockedUseQuery.mockReturnValue({
       data: undefined,

--- a/ui/hooks/ramps/useRampsQuotes.ts
+++ b/ui/hooks/ramps/useRampsQuotes.ts
@@ -71,7 +71,7 @@ export function useRampsQuotes(
     getQuotes,
     getBuyWidgetData,
     data: quotesQuery.data ?? null,
-    loading: quotesQuery.isLoading,
+    loading: queryEnabled && quotesQuery.isLoading,
     status,
     isSuccess: status === 'success',
     error: quotesQuery.error ?? null,

--- a/ui/hooks/ramps/useRampsQuotes.ts
+++ b/ui/hooks/ramps/useRampsQuotes.ts
@@ -1,6 +1,10 @@
 import { useCallback, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import type { BuyWidget, Quote, QuotesResponse } from '@metamask/ramps-controller';
+import type {
+  BuyWidget,
+  Quote,
+  QuotesResponse,
+} from '@metamask/ramps-controller';
 import {
   getRampsBuyWidgetData,
   getRampsQuotes,
@@ -9,7 +13,7 @@ import {
 import { rampsQueries } from './queries';
 import type { RampsQueryStatus } from './useRampsPaymentMethods';
 
-export interface UseRampsQuotesResult {
+export type UseRampsQuotesResult = {
   getQuotes: (options: GetRampsQuotesParams) => Promise<QuotesResponse>;
   getBuyWidgetData: (quote: Quote) => Promise<BuyWidget | null>;
   data: QuotesResponse | null;
@@ -17,7 +21,7 @@ export interface UseRampsQuotesResult {
   status: RampsQueryStatus;
   isSuccess: boolean;
   error: unknown | null;
-}
+};
 
 export function useRampsQuotes(
   options?: GetRampsQuotesParams | null,

--- a/ui/hooks/ramps/useRampsQuotes.ts
+++ b/ui/hooks/ramps/useRampsQuotes.ts
@@ -1,0 +1,77 @@
+import { useCallback, useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { BuyWidget, Quote, QuotesResponse } from '@metamask/ramps-controller';
+import {
+  getRampsBuyWidgetData,
+  getRampsQuotes,
+  type GetRampsQuotesParams,
+} from '../../store/controller-actions/ramps-controller';
+import { rampsQueries } from './queries';
+import type { RampsQueryStatus } from './useRampsPaymentMethods';
+
+export interface UseRampsQuotesResult {
+  getQuotes: (options: GetRampsQuotesParams) => Promise<QuotesResponse>;
+  getBuyWidgetData: (quote: Quote) => Promise<BuyWidget | null>;
+  data: QuotesResponse | null;
+  loading: boolean;
+  status: RampsQueryStatus;
+  isSuccess: boolean;
+  error: unknown | null;
+}
+
+export function useRampsQuotes(
+  options?: GetRampsQuotesParams | null,
+): UseRampsQuotesResult {
+  const getQuotes = useCallback(
+    (opts: GetRampsQuotesParams) => getRampsQuotes(opts),
+    [],
+  );
+
+  const getBuyWidgetData = useCallback(
+    (quote: Quote) => getRampsBuyWidgetData(quote),
+    [],
+  );
+
+  const queryEnabled = Boolean(
+    options?.assetId && options.walletAddress && options.amount > 0,
+  );
+
+  const quotesQuery = useQuery({
+    ...rampsQueries.quotes.options({
+      assetId: options?.assetId,
+      amount: options?.amount ?? 0,
+      walletAddress: options?.walletAddress ?? '',
+      redirectUrl: options?.redirectUrl,
+      paymentMethods: options?.paymentMethods,
+      providers: options?.providers,
+      forceRefresh: options?.forceRefresh,
+      ttl: options?.ttl,
+    }),
+    enabled: queryEnabled,
+  });
+
+  const status = useMemo<RampsQueryStatus>(() => {
+    if (!queryEnabled) {
+      return 'idle';
+    }
+    if (quotesQuery.isLoading) {
+      return 'loading';
+    }
+    if (quotesQuery.isError) {
+      return 'error';
+    }
+    return 'success';
+  }, [queryEnabled, quotesQuery.isError, quotesQuery.isLoading]);
+
+  return {
+    getQuotes,
+    getBuyWidgetData,
+    data: quotesQuery.data ?? null,
+    loading: quotesQuery.isLoading,
+    status,
+    isSuccess: status === 'success',
+    error: quotesQuery.error ?? null,
+  };
+}
+
+export default useRampsQuotes;

--- a/ui/hooks/ramps/useRampsTokens.test.tsx
+++ b/ui/hooks/ramps/useRampsTokens.test.tsx
@@ -1,0 +1,17 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useRampsTokens } from './useRampsTokens';
+import { createRampsTestWrapper } from './test-utils';
+
+jest.mock('../../store/controller-actions/ramps-controller', () => ({
+  setRampsSelectedToken: jest.fn(),
+}));
+
+describe('useRampsTokens', () => {
+  it('matches snapshot', () => {
+    const { result } = renderHook(() => useRampsTokens(), {
+      wrapper: createRampsTestWrapper(),
+    });
+
+    expect(result.current).toMatchSnapshot();
+  });
+});

--- a/ui/hooks/ramps/useRampsTokens.ts
+++ b/ui/hooks/ramps/useRampsTokens.ts
@@ -8,13 +8,13 @@ import { selectTokens } from '../../selectors/rampsController';
 import { setRampsSelectedToken } from '../../store/controller-actions/ramps-controller';
 import { parseUserFacingError } from './utils/parseUserFacingError';
 
-export interface UseRampsTokensResult {
+export type UseRampsTokensResult = {
   tokens: TokensResponse | null;
   selectedToken: RampsToken | null;
   setSelectedToken: (assetId: string) => Promise<void>;
   isLoading: boolean;
   error: string | null;
-}
+};
 
 export function useRampsTokens(): UseRampsTokensResult {
   const tokensState = useSelector(selectTokens);

--- a/ui/hooks/ramps/useRampsTokens.ts
+++ b/ui/hooks/ramps/useRampsTokens.ts
@@ -1,0 +1,44 @@
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import {
+  type RampsToken,
+  type TokensResponse,
+} from '@metamask/ramps-controller';
+import { selectTokens } from '../../selectors/rampsController';
+import { setRampsSelectedToken } from '../../store/controller-actions/ramps-controller';
+import { parseUserFacingError } from './utils/parseUserFacingError';
+
+export interface UseRampsTokensResult {
+  tokens: TokensResponse | null;
+  selectedToken: RampsToken | null;
+  setSelectedToken: (assetId: string) => Promise<void>;
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function useRampsTokens(): UseRampsTokensResult {
+  const tokensState = useSelector(selectTokens);
+  const {
+    data: tokens,
+    selected: selectedToken,
+    isLoading,
+    error,
+  } = tokensState;
+
+  const setSelectedToken = useCallback(
+    (assetId: string) => setRampsSelectedToken(assetId),
+    [],
+  );
+
+  return {
+    tokens,
+    selectedToken,
+    setSelectedToken,
+    isLoading,
+    error: error
+      ? parseUserFacingError(tokensState, 'Failed to load tokens')
+      : null,
+  };
+}
+
+export default useRampsTokens;

--- a/ui/hooks/ramps/useRampsUserRegion.test.tsx
+++ b/ui/hooks/ramps/useRampsUserRegion.test.tsx
@@ -1,0 +1,17 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useRampsUserRegion } from './useRampsUserRegion';
+import { createRampsTestWrapper } from './test-utils';
+
+jest.mock('../../store/controller-actions/ramps-controller', () => ({
+  setRampsUserRegion: jest.fn(),
+}));
+
+describe('useRampsUserRegion', () => {
+  it('matches snapshot', () => {
+    const { result } = renderHook(() => useRampsUserRegion(), {
+      wrapper: createRampsTestWrapper(),
+    });
+
+    expect(result.current).toMatchSnapshot();
+  });
+});

--- a/ui/hooks/ramps/useRampsUserRegion.ts
+++ b/ui/hooks/ramps/useRampsUserRegion.ts
@@ -7,13 +7,13 @@ import {
 import { selectUserRegion } from '../../selectors/rampsController';
 import { setRampsUserRegion } from '../../store/controller-actions/ramps-controller';
 
-export interface UseRampsUserRegionResult {
+export type UseRampsUserRegionResult = {
   userRegion: UserRegion | null;
   setUserRegion: (
     region: string,
     options?: ExecuteRequestOptions,
   ) => Promise<UserRegion | null>;
-}
+};
 
 export function useRampsUserRegion(): UseRampsUserRegionResult {
   const userRegion = useSelector(selectUserRegion);

--- a/ui/hooks/ramps/useRampsUserRegion.ts
+++ b/ui/hooks/ramps/useRampsUserRegion.ts
@@ -1,0 +1,33 @@
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import {
+  ExecuteRequestOptions,
+  type UserRegion,
+} from '@metamask/ramps-controller';
+import { selectUserRegion } from '../../selectors/rampsController';
+import { setRampsUserRegion } from '../../store/controller-actions/ramps-controller';
+
+export interface UseRampsUserRegionResult {
+  userRegion: UserRegion | null;
+  setUserRegion: (
+    region: string,
+    options?: ExecuteRequestOptions,
+  ) => Promise<UserRegion | null>;
+}
+
+export function useRampsUserRegion(): UseRampsUserRegionResult {
+  const userRegion = useSelector(selectUserRegion);
+
+  const setUserRegion = useCallback(
+    (region: string, options?: ExecuteRequestOptions) =>
+      setRampsUserRegion(region, options),
+    [],
+  );
+
+  return {
+    userRegion,
+    setUserRegion,
+  };
+}
+
+export default useRampsUserRegion;

--- a/ui/hooks/ramps/utils/__snapshots__/normalizeAssetIdForApi.test.ts.snap
+++ b/ui/hooks/ramps/utils/__snapshots__/normalizeAssetIdForApi.test.ts.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`normalizeAssetIdForApi matches snapshot for asset id inputs 1`] = `
+{
+  "eip155": "EIP155:1/ERC20:0xABC",
+  "empty": "",
+  "other": "solana:5eykt.../token:ABC",
+  "undefined": "",
+}
+`;

--- a/ui/hooks/ramps/utils/__snapshots__/parseUserFacingError.test.ts.snap
+++ b/ui/hooks/ramps/utils/__snapshots__/parseUserFacingError.test.ts.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`parseUserFacingError matches snapshot for supported error shapes 1`] = `
+{
+  "emptyErrorMessage": "fallback",
+  "emptyResourceError": "fallback",
+  "emptyString": "fallback",
+  "errorWithMessage": "network down",
+  "nullError": "fallback",
+  "resourceError": "invalid region",
+  "stringError": " provider unavailable ",
+  "unknownError": "fallback",
+}
+`;

--- a/ui/hooks/ramps/utils/determinePreferredProvider.test.ts
+++ b/ui/hooks/ramps/utils/determinePreferredProvider.test.ts
@@ -1,4 +1,8 @@
-import { RampsOrderStatus, type Provider, type RampsOrder } from '@metamask/ramps-controller';
+import {
+  RampsOrderStatus,
+  type Provider,
+  type RampsOrder,
+} from '@metamask/ramps-controller';
 import {
   completedOrdersFromRampsOrders,
   determinePreferredProvider,

--- a/ui/hooks/ramps/utils/determinePreferredProvider.test.ts
+++ b/ui/hooks/ramps/utils/determinePreferredProvider.test.ts
@@ -1,4 +1,4 @@
-import { RampsOrderStatus } from '@metamask/ramps-controller';
+import { RampsOrderStatus, type Provider, type RampsOrder } from '@metamask/ramps-controller';
 import {
   completedOrdersFromRampsOrders,
   determinePreferredProvider,
@@ -7,12 +7,12 @@ import {
 const transakProvider = {
   id: 'transak',
   name: 'Transak',
-};
+} as Provider;
 
 const moonpayProvider = {
   id: 'moonpay',
   name: 'MoonPay',
-};
+} as Provider;
 
 describe('determinePreferredProvider', () => {
   it('auto-selects Transak when there is no completed order history', () => {
@@ -65,7 +65,7 @@ describe('completedOrdersFromRampsOrders', () => {
         createdAt: 3000,
         provider: undefined,
       },
-    ]);
+    ] as RampsOrder[]);
 
     expect(orders).toEqual([{ providerId: 'moonpay', completedAt: 1000 }]);
   });

--- a/ui/hooks/ramps/utils/determinePreferredProvider.test.ts
+++ b/ui/hooks/ramps/utils/determinePreferredProvider.test.ts
@@ -1,0 +1,72 @@
+import { RampsOrderStatus } from '@metamask/ramps-controller';
+import {
+  completedOrdersFromRampsOrders,
+  determinePreferredProvider,
+} from './determinePreferredProvider';
+
+const transakProvider = {
+  id: 'transak',
+  name: 'Transak',
+};
+
+const moonpayProvider = {
+  id: 'moonpay',
+  name: 'MoonPay',
+};
+
+describe('determinePreferredProvider', () => {
+  it('auto-selects Transak when there is no completed order history', () => {
+    const result = determinePreferredProvider(
+      [],
+      [moonpayProvider, transakProvider],
+    );
+
+    expect(result).toEqual({
+      provider: transakProvider,
+      autoSelected: true,
+    });
+  });
+
+  it('prefers the most recent completed order provider without auto-selecting', () => {
+    const result = determinePreferredProvider(
+      [{ providerId: 'moonpay', completedAt: 1000 }],
+      [moonpayProvider, transakProvider],
+    );
+
+    expect(result).toEqual({
+      provider: moonpayProvider,
+      autoSelected: false,
+    });
+  });
+
+  it('returns null when providers are empty', () => {
+    expect(determinePreferredProvider([], [])).toBeNull();
+  });
+});
+
+describe('completedOrdersFromRampsOrders', () => {
+  it('includes only completed orders with provider ids', () => {
+    const orders = completedOrdersFromRampsOrders([
+      {
+        id: '1',
+        status: RampsOrderStatus.Completed,
+        createdAt: 1000,
+        provider: moonpayProvider,
+      },
+      {
+        id: '2',
+        status: RampsOrderStatus.Pending,
+        createdAt: 2000,
+        provider: transakProvider,
+      },
+      {
+        id: '3',
+        status: RampsOrderStatus.Completed,
+        createdAt: 3000,
+        provider: undefined,
+      },
+    ]);
+
+    expect(orders).toEqual([{ providerId: 'moonpay', completedAt: 1000 }]);
+  });
+});

--- a/ui/hooks/ramps/utils/determinePreferredProvider.ts
+++ b/ui/hooks/ramps/utils/determinePreferredProvider.ts
@@ -1,0 +1,61 @@
+import {
+  type Provider,
+  type RampsOrder,
+  RampsOrderStatus,
+} from '@metamask/ramps-controller';
+
+export interface CompletedOrderInfo {
+  providerId: string;
+  completedAt: number;
+}
+
+export function completedOrdersFromRampsOrders(
+  orders: RampsOrder[],
+): CompletedOrderInfo[] {
+  return orders
+    .filter((order) => order.status === RampsOrderStatus.Completed)
+    .reduce<CompletedOrderInfo[]>((acc, order) => {
+      const providerId = order.provider?.id;
+      if (providerId) {
+        acc.push({ providerId, completedAt: order.createdAt });
+      }
+      return acc;
+    }, []);
+}
+
+export interface PreferredProviderResult {
+  provider: Provider;
+  autoSelected: boolean;
+}
+
+export function determinePreferredProvider(
+  completedOrders: CompletedOrderInfo[],
+  providers: Provider[],
+): PreferredProviderResult | null {
+  if (!providers.length) {
+    return null;
+  }
+
+  const sortedOrders = [...completedOrders].sort(
+    (a, b) => b.completedAt - a.completedAt,
+  );
+  const mostRecentProviderId = sortedOrders[0]?.providerId;
+
+  if (mostRecentProviderId) {
+    const previousProvider = providers.find(
+      (provider) => provider.id === mostRecentProviderId,
+    );
+    if (previousProvider) {
+      return { provider: previousProvider, autoSelected: false };
+    }
+  }
+
+  const transakProvider = providers.find((provider) =>
+    provider.id?.toLowerCase().includes('transak'),
+  );
+  if (transakProvider) {
+    return { provider: transakProvider, autoSelected: false };
+  }
+
+  return null;
+}

--- a/ui/hooks/ramps/utils/determinePreferredProvider.ts
+++ b/ui/hooks/ramps/utils/determinePreferredProvider.ts
@@ -7,7 +7,7 @@ import {
 export type CompletedOrderInfo = {
   providerId: string;
   completedAt: number;
-}
+};
 
 export function completedOrdersFromRampsOrders(
   orders: RampsOrder[],
@@ -26,7 +26,7 @@ export function completedOrdersFromRampsOrders(
 export type PreferredProviderResult = {
   provider: Provider;
   autoSelected: boolean;
-}
+};
 
 export function determinePreferredProvider(
   completedOrders: CompletedOrderInfo[],

--- a/ui/hooks/ramps/utils/determinePreferredProvider.ts
+++ b/ui/hooks/ramps/utils/determinePreferredProvider.ts
@@ -4,7 +4,7 @@ import {
   RampsOrderStatus,
 } from '@metamask/ramps-controller';
 
-export interface CompletedOrderInfo {
+export type CompletedOrderInfo = {
   providerId: string;
   completedAt: number;
 }
@@ -23,7 +23,7 @@ export function completedOrdersFromRampsOrders(
     }, []);
 }
 
-export interface PreferredProviderResult {
+export type PreferredProviderResult = {
   provider: Provider;
   autoSelected: boolean;
 }
@@ -54,7 +54,7 @@ export function determinePreferredProvider(
     provider.id?.toLowerCase().includes('transak'),
   );
   if (transakProvider) {
-    return { provider: transakProvider, autoSelected: false };
+    return { provider: transakProvider, autoSelected: true };
   }
 
   return null;

--- a/ui/hooks/ramps/utils/normalizeAssetIdForApi.test.ts
+++ b/ui/hooks/ramps/utils/normalizeAssetIdForApi.test.ts
@@ -1,0 +1,12 @@
+import { normalizeAssetIdForApi } from './normalizeAssetIdForApi';
+
+describe('normalizeAssetIdForApi', () => {
+  it('matches snapshot for asset id inputs', () => {
+    expect({
+      undefined: normalizeAssetIdForApi(undefined),
+      empty: normalizeAssetIdForApi(''),
+      eip155: normalizeAssetIdForApi('EIP155:1/ERC20:0xABC'),
+      other: normalizeAssetIdForApi('solana:5eykt.../token:ABC'),
+    }).toMatchSnapshot();
+  });
+});

--- a/ui/hooks/ramps/utils/normalizeAssetIdForApi.ts
+++ b/ui/hooks/ramps/utils/normalizeAssetIdForApi.ts
@@ -1,0 +1,9 @@
+export function normalizeAssetIdForApi(assetId: string | undefined): string {
+  if (!assetId) {
+    return '';
+  }
+  if (assetId.startsWith('eip155:')) {
+    return assetId.toLowerCase();
+  }
+  return assetId;
+}

--- a/ui/hooks/ramps/utils/parseUserFacingError.test.ts
+++ b/ui/hooks/ramps/utils/parseUserFacingError.test.ts
@@ -1,0 +1,22 @@
+import { parseUserFacingError } from './parseUserFacingError';
+
+describe('parseUserFacingError', () => {
+  it('matches snapshot for supported error shapes', () => {
+    expect({
+      errorWithMessage: parseUserFacingError(
+        new Error('network down'),
+        'fallback',
+      ),
+      emptyErrorMessage: parseUserFacingError(new Error(''), 'fallback'),
+      stringError: parseUserFacingError(' provider unavailable ', 'fallback'),
+      emptyString: parseUserFacingError('   ', 'fallback'),
+      resourceError: parseUserFacingError(
+        { error: 'invalid region' },
+        'fallback',
+      ),
+      emptyResourceError: parseUserFacingError({ error: '  ' }, 'fallback'),
+      unknownError: parseUserFacingError({ code: 500 }, 'fallback'),
+      nullError: parseUserFacingError(null, 'fallback'),
+    }).toMatchSnapshot();
+  });
+});

--- a/ui/hooks/ramps/utils/parseUserFacingError.ts
+++ b/ui/hooks/ramps/utils/parseUserFacingError.ts
@@ -1,0 +1,21 @@
+export function parseUserFacingError(
+  error: unknown,
+  fallbackMessage: string,
+): string {
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  if (typeof error === 'string' && error.trim()) {
+    return error;
+  }
+
+  if (typeof error === 'object' && error !== null && 'error' in error) {
+    const resourceError = (error as { error?: unknown }).error;
+    if (typeof resourceError === 'string' && resourceError.trim()) {
+      return resourceError;
+    }
+  }
+
+  return fallbackMessage;
+}

--- a/ui/pages/index.js
+++ b/ui/pages/index.js
@@ -17,6 +17,7 @@ import { MetamaskIdentityProvider } from '../contexts/identity';
 import { ShieldSubscriptionProvider } from '../contexts/shield/shield-subscription';
 import RiveWasmProvider from '../contexts/rive-wasm';
 import { queryClient } from '../contexts/query-client';
+import RampsBootstrap from '../hooks/ramps/RampsBootstrap';
 import { HardwareWalletErrorProvider } from '../contexts/hardware-wallets';
 import { UIMessengerProvider } from '../contexts/ui-messenger';
 import ErrorPageBase from './error-page/error-page.component';
@@ -28,6 +29,7 @@ function AppProviders() {
     <MetaMetricsProvider>
       <I18nProvider>
         <QueryClientProvider client={queryClient}>
+          <RampsBootstrap />
           <AssetPollingProvider>
             <MetamaskIdentityProvider>
               <MetamaskNotificationsProvider>

--- a/ui/selectors/rampsController/__snapshots__/index.test.ts.snap
+++ b/ui/selectors/rampsController/__snapshots__/index.test.ts.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`rampsController selectors matches snapshot for selectUserRegion and selectTokens 1`] = `
+{
+  "country": {
+    "currency": "USD",
+  },
+  "regionCode": "us-ca",
+}
+`;
+
+exports[`rampsController selectors matches snapshot for selectUserRegion and selectTokens 2`] = `
+{
+  "data": {
+    "allTokens": [],
+    "topTokens": [],
+  },
+  "error": null,
+  "isLoading": false,
+  "selected": null,
+}
+`;

--- a/ui/selectors/rampsController/__snapshots__/index.test.ts.snap
+++ b/ui/selectors/rampsController/__snapshots__/index.test.ts.snap
@@ -1,22 +1,225 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`rampsController selectors matches snapshot for selectUserRegion and selectTokens 1`] = `
+exports[`rampsController selectors matches snapshot for default state 1`] = `
 {
-  "country": {
-    "currency": "USD",
+  "selectCountries": {
+    "data": [],
+    "error": null,
+    "isLoading": false,
+    "selected": null,
   },
-  "regionCode": "us-ca",
+  "selectPaymentMethods": {
+    "data": [],
+    "error": null,
+    "isLoading": false,
+    "selected": null,
+  },
+  "selectProviderAutoSelected": false,
+  "selectProviders": {
+    "data": [],
+    "error": null,
+    "isLoading": false,
+    "selected": null,
+  },
+  "selectRampsControllerState": {
+    "countries": {
+      "data": [],
+      "error": null,
+      "isLoading": false,
+      "selected": null,
+    },
+    "orders": [],
+    "paymentMethods": {
+      "data": [],
+      "error": null,
+      "isLoading": false,
+      "selected": null,
+    },
+    "providerAutoSelected": false,
+    "providers": {
+      "data": [],
+      "error": null,
+      "isLoading": false,
+      "selected": null,
+    },
+    "tokens": {
+      "data": null,
+      "error": null,
+      "isLoading": false,
+      "selected": null,
+    },
+    "userRegion": null,
+  },
+  "selectRampsOrders": [],
+  "selectRampsOrdersForSelectedAccount": [],
+  "selectTokens": {
+    "data": null,
+    "error": null,
+    "isLoading": false,
+    "selected": null,
+  },
+  "selectUserRegion": null,
 }
 `;
 
-exports[`rampsController selectors matches snapshot for selectUserRegion and selectTokens 2`] = `
+exports[`rampsController selectors matches snapshot for populated state 1`] = `
 {
-  "data": {
-    "allTokens": [],
-    "topTokens": [],
+  "selectCountries": {
+    "data": [
+      {
+        "isoCode": "US",
+        "name": "United States",
+      },
+    ],
+    "error": null,
+    "isLoading": false,
+    "selected": null,
   },
-  "error": null,
-  "isLoading": false,
-  "selected": null,
+  "selectPaymentMethods": {
+    "data": [
+      {
+        "id": "credit_debit_card",
+        "name": "Card",
+      },
+    ],
+    "error": null,
+    "isLoading": false,
+    "selected": {
+      "id": "credit_debit_card",
+      "name": "Card",
+    },
+  },
+  "selectProviderAutoSelected": true,
+  "selectProviders": {
+    "data": [
+      {
+        "id": "transak",
+        "name": "Transak",
+      },
+    ],
+    "error": null,
+    "isLoading": false,
+    "selected": {
+      "id": "transak",
+      "name": "Transak",
+    },
+  },
+  "selectRampsControllerState": {
+    "countries": {
+      "data": [
+        {
+          "isoCode": "US",
+          "name": "United States",
+        },
+      ],
+      "error": null,
+      "isLoading": false,
+      "selected": null,
+    },
+    "orders": [
+      {
+        "createdAt": 1,
+        "id": "1",
+        "providerOrderId": "order-1",
+        "status": "COMPLETED",
+        "walletAddress": "0xAbC123",
+      },
+      {
+        "createdAt": 2,
+        "id": "2",
+        "providerOrderId": "order-2",
+        "status": "COMPLETED",
+        "walletAddress": "0xother",
+      },
+    ],
+    "paymentMethods": {
+      "data": [
+        {
+          "id": "credit_debit_card",
+          "name": "Card",
+        },
+      ],
+      "error": null,
+      "isLoading": false,
+      "selected": {
+        "id": "credit_debit_card",
+        "name": "Card",
+      },
+    },
+    "providerAutoSelected": true,
+    "providers": {
+      "data": [
+        {
+          "id": "transak",
+          "name": "Transak",
+        },
+      ],
+      "error": null,
+      "isLoading": false,
+      "selected": {
+        "id": "transak",
+        "name": "Transak",
+      },
+    },
+    "tokens": {
+      "data": {
+        "allTokens": [],
+        "topTokens": [],
+      },
+      "error": null,
+      "isLoading": false,
+      "selected": null,
+    },
+    "userRegion": {
+      "country": {
+        "currency": "USD",
+        "isoCode": "US",
+        "name": "United States",
+      },
+      "regionCode": "us-ca",
+    },
+  },
+  "selectRampsOrders": [
+    {
+      "createdAt": 1,
+      "id": "1",
+      "providerOrderId": "order-1",
+      "status": "COMPLETED",
+      "walletAddress": "0xAbC123",
+    },
+    {
+      "createdAt": 2,
+      "id": "2",
+      "providerOrderId": "order-2",
+      "status": "COMPLETED",
+      "walletAddress": "0xother",
+    },
+  ],
+  "selectRampsOrdersForSelectedAccount": [
+    {
+      "createdAt": 1,
+      "id": "1",
+      "providerOrderId": "order-1",
+      "status": "COMPLETED",
+      "walletAddress": "0xAbC123",
+    },
+  ],
+  "selectTokens": {
+    "data": {
+      "allTokens": [],
+      "topTokens": [],
+    },
+    "error": null,
+    "isLoading": false,
+    "selected": null,
+  },
+  "selectUserRegion": {
+    "country": {
+      "currency": "USD",
+      "isoCode": "US",
+      "name": "United States",
+    },
+    "regionCode": "us-ca",
+  },
 }
 `;

--- a/ui/selectors/rampsController/index.test.ts
+++ b/ui/selectors/rampsController/index.test.ts
@@ -1,3 +1,4 @@
+import type { AccountsState } from '../../../shared/lib/selectors/accounts';
 import {
   selectCountries,
   selectPaymentMethods,
@@ -8,6 +9,7 @@ import {
   selectRampsOrdersForSelectedAccount,
   selectTokens,
   selectUserRegion,
+  type RampsState,
 } from '.';
 
 const populatedState = {
@@ -68,7 +70,7 @@ const populatedState = {
       },
     },
   },
-};
+} as unknown as RampsState & AccountsState;
 
 describe('rampsController selectors', () => {
   it('matches snapshot for populated state', () => {
@@ -87,7 +89,7 @@ describe('rampsController selectors', () => {
   });
 
   it('matches snapshot for default state', () => {
-    const emptyMetamask = { metamask: {} };
+    const emptyMetamask = { metamask: {} } as unknown as RampsState;
     const emptyAccountState = {
       metamask: {
         internalAccounts: {
@@ -95,7 +97,7 @@ describe('rampsController selectors', () => {
           accounts: {},
         },
       },
-    };
+    } as unknown as RampsState & AccountsState;
 
     expect({
       selectUserRegion: selectUserRegion(emptyMetamask),

--- a/ui/selectors/rampsController/index.test.ts
+++ b/ui/selectors/rampsController/index.test.ts
@@ -1,0 +1,25 @@
+import { selectUserRegion, selectTokens } from './index';
+
+describe('rampsController selectors', () => {
+  it('matches snapshot for selectUserRegion and selectTokens', () => {
+    const state = {
+      metamask: {
+        RampsController: {
+          userRegion: {
+            regionCode: 'us-ca',
+            country: { currency: 'USD' },
+          },
+          tokens: {
+            data: { topTokens: [], allTokens: [] },
+            selected: null,
+            isLoading: false,
+            error: null,
+          },
+        },
+      },
+    };
+
+    expect(selectUserRegion(state)).toMatchSnapshot();
+    expect(selectTokens(state)).toMatchSnapshot();
+  });
+});

--- a/ui/selectors/rampsController/index.test.ts
+++ b/ui/selectors/rampsController/index.test.ts
@@ -1,23 +1,113 @@
-import { selectUserRegion, selectTokens } from '.';
+import {
+  selectCountries,
+  selectPaymentMethods,
+  selectProviderAutoSelected,
+  selectProviders,
+  selectRampsControllerState,
+  selectRampsOrders,
+  selectRampsOrdersForSelectedAccount,
+  selectTokens,
+  selectUserRegion,
+} from '.';
+
+const populatedState = {
+  metamask: {
+    userRegion: {
+      regionCode: 'us-ca',
+      country: { currency: 'USD', isoCode: 'US', name: 'United States' },
+    },
+    countries: {
+      data: [{ isoCode: 'US', name: 'United States' }],
+      selected: null,
+      isLoading: false,
+      error: null,
+    },
+    providers: {
+      data: [{ id: 'transak', name: 'Transak' }],
+      selected: { id: 'transak', name: 'Transak' },
+      isLoading: false,
+      error: null,
+    },
+    tokens: {
+      data: { topTokens: [], allTokens: [] },
+      selected: null,
+      isLoading: false,
+      error: null,
+    },
+    paymentMethods: {
+      data: [{ id: 'credit_debit_card', name: 'Card' }],
+      selected: { id: 'credit_debit_card', name: 'Card' },
+      isLoading: false,
+      error: null,
+    },
+    orders: [
+      {
+        id: '1',
+        providerOrderId: 'order-1',
+        walletAddress: '0xAbC123',
+        status: 'COMPLETED',
+        createdAt: 1,
+      },
+      {
+        id: '2',
+        providerOrderId: 'order-2',
+        walletAddress: '0xother',
+        status: 'COMPLETED',
+        createdAt: 2,
+      },
+    ],
+    providerAutoSelected: true,
+    internalAccounts: {
+      selectedAccount: 'account-1',
+      accounts: {
+        'account-1': {
+          id: 'account-1',
+          address: '0xabc123',
+          metadata: { name: 'Account 1' },
+        },
+      },
+    },
+  },
+};
 
 describe('rampsController selectors', () => {
-  it('matches snapshot for selectUserRegion and selectTokens', () => {
-    const state = {
+  it('matches snapshot for populated state', () => {
+    expect({
+      selectUserRegion: selectUserRegion(populatedState),
+      selectCountries: selectCountries(populatedState),
+      selectProviders: selectProviders(populatedState),
+      selectTokens: selectTokens(populatedState),
+      selectPaymentMethods: selectPaymentMethods(populatedState),
+      selectRampsOrders: selectRampsOrders(populatedState),
+      selectRampsOrdersForSelectedAccount:
+        selectRampsOrdersForSelectedAccount(populatedState),
+      selectProviderAutoSelected: selectProviderAutoSelected(populatedState),
+      selectRampsControllerState: selectRampsControllerState(populatedState),
+    }).toMatchSnapshot();
+  });
+
+  it('matches snapshot for default state', () => {
+    const emptyMetamask = { metamask: {} };
+    const emptyAccountState = {
       metamask: {
-        userRegion: {
-          regionCode: 'us-ca',
-          country: { currency: 'USD' },
-        },
-        tokens: {
-          data: { topTokens: [], allTokens: [] },
-          selected: null,
-          isLoading: false,
-          error: null,
+        internalAccounts: {
+          selectedAccount: 'missing',
+          accounts: {},
         },
       },
     };
 
-    expect(selectUserRegion(state)).toMatchSnapshot();
-    expect(selectTokens(state)).toMatchSnapshot();
+    expect({
+      selectUserRegion: selectUserRegion(emptyMetamask),
+      selectCountries: selectCountries(emptyMetamask),
+      selectProviders: selectProviders(emptyMetamask),
+      selectTokens: selectTokens(emptyMetamask),
+      selectPaymentMethods: selectPaymentMethods(emptyMetamask),
+      selectRampsOrders: selectRampsOrders(emptyMetamask),
+      selectRampsOrdersForSelectedAccount:
+        selectRampsOrdersForSelectedAccount(emptyAccountState),
+      selectProviderAutoSelected: selectProviderAutoSelected(emptyMetamask),
+      selectRampsControllerState: selectRampsControllerState(emptyMetamask),
+    }).toMatchSnapshot();
   });
 });

--- a/ui/selectors/rampsController/index.test.ts
+++ b/ui/selectors/rampsController/index.test.ts
@@ -4,17 +4,15 @@ describe('rampsController selectors', () => {
   it('matches snapshot for selectUserRegion and selectTokens', () => {
     const state = {
       metamask: {
-        RampsController: {
-          userRegion: {
-            regionCode: 'us-ca',
-            country: { currency: 'USD' },
-          },
-          tokens: {
-            data: { topTokens: [], allTokens: [] },
-            selected: null,
-            isLoading: false,
-            error: null,
-          },
+        userRegion: {
+          regionCode: 'us-ca',
+          country: { currency: 'USD' },
+        },
+        tokens: {
+          data: { topTokens: [], allTokens: [] },
+          selected: null,
+          isLoading: false,
+          error: null,
         },
       },
     };

--- a/ui/selectors/rampsController/index.test.ts
+++ b/ui/selectors/rampsController/index.test.ts
@@ -1,4 +1,4 @@
-import { selectUserRegion, selectTokens } from './index';
+import { selectUserRegion, selectTokens } from '.';
 
 describe('rampsController selectors', () => {
   it('matches snapshot for selectUserRegion and selectTokens', () => {

--- a/ui/selectors/rampsController/index.ts
+++ b/ui/selectors/rampsController/index.ts
@@ -31,70 +31,57 @@ const createDefaultResourceState = <TData, TSelected = null>(
   error: null,
 });
 
+const EMPTY_ORDERS: RampsOrder[] = [];
+const DEFAULT_COUNTRIES = createDefaultResourceState<Country[]>([]);
+const DEFAULT_PROVIDERS = createDefaultResourceState<
+  Provider[],
+  Provider | null
+>([], null);
+const DEFAULT_TOKENS = createDefaultResourceState<
+  TokensResponse | null,
+  RampsToken | null
+>(null, null);
+const DEFAULT_PAYMENT_METHODS = createDefaultResourceState<
+  PaymentMethod[],
+  PaymentMethod | null
+>([], null);
+
 export const selectRampsControllerState = createSelector(
   (state: RampsState) => state.metamask,
   (metamask): Partial<RampsControllerState> => ({
     userRegion: metamask.userRegion ?? null,
-    countries: metamask.countries ?? createDefaultResourceState<Country[]>([]),
-    providers:
-      metamask.providers ??
-      createDefaultResourceState<Provider[], Provider | null>([], null),
-    tokens:
-      metamask.tokens ??
-      createDefaultResourceState<TokensResponse | null, RampsToken | null>(
-        null,
-        null,
-      ),
-    paymentMethods:
-      metamask.paymentMethods ??
-      createDefaultResourceState<PaymentMethod[], PaymentMethod | null>(
-        [],
-        null,
-      ),
-    orders: metamask.orders ?? [],
+    countries: metamask.countries ?? DEFAULT_COUNTRIES,
+    providers: metamask.providers ?? DEFAULT_PROVIDERS,
+    tokens: metamask.tokens ?? DEFAULT_TOKENS,
+    paymentMethods: metamask.paymentMethods ?? DEFAULT_PAYMENT_METHODS,
+    orders: metamask.orders ?? EMPTY_ORDERS,
     providerAutoSelected: metamask.providerAutoSelected ?? false,
   }),
 );
 
-export const selectUserRegion = createSelector(
-  (state: RampsState) => state.metamask.userRegion,
-  (userRegion): UserRegion | null => userRegion ?? null,
-);
+export const selectUserRegion = (state: RampsState): UserRegion | null =>
+  state.metamask.userRegion ?? null;
 
-export const selectCountries = createSelector(
-  (state: RampsState) => state.metamask.countries,
-  (countries): ResourceState<Country[]> =>
-    countries ?? createDefaultResourceState<Country[]>([]),
-);
+export const selectCountries = (state: RampsState): ResourceState<Country[]> =>
+  state.metamask.countries ?? DEFAULT_COUNTRIES;
 
-export const selectProviders = createSelector(
-  (state: RampsState) => state.metamask.providers,
-  (providers): ResourceState<Provider[], Provider | null> =>
-    providers ??
-    createDefaultResourceState<Provider[], Provider | null>([], null),
-);
+export const selectProviders = (
+  state: RampsState,
+): ResourceState<Provider[], Provider | null> =>
+  state.metamask.providers ?? DEFAULT_PROVIDERS;
 
-export const selectTokens = createSelector(
-  (state: RampsState) => state.metamask.tokens,
-  (tokens): ResourceState<TokensResponse | null, RampsToken | null> =>
-    tokens ??
-    createDefaultResourceState<TokensResponse | null, RampsToken | null>(
-      null,
-      null,
-    ),
-);
+export const selectTokens = (
+  state: RampsState,
+): ResourceState<TokensResponse | null, RampsToken | null> =>
+  state.metamask.tokens ?? DEFAULT_TOKENS;
 
-export const selectPaymentMethods = createSelector(
-  (state: RampsState) => state.metamask.paymentMethods,
-  (paymentMethods): ResourceState<PaymentMethod[], PaymentMethod | null> =>
-    paymentMethods ??
-    createDefaultResourceState<PaymentMethod[], PaymentMethod | null>([], null),
-);
+export const selectPaymentMethods = (
+  state: RampsState,
+): ResourceState<PaymentMethod[], PaymentMethod | null> =>
+  state.metamask.paymentMethods ?? DEFAULT_PAYMENT_METHODS;
 
-export const selectRampsOrders = createSelector(
-  (state: RampsState) => state.metamask.orders,
-  (orders): RampsOrder[] => orders ?? [],
-);
+export const selectRampsOrders = (state: RampsState): RampsOrder[] =>
+  state.metamask.orders ?? EMPTY_ORDERS;
 
 export const selectRampsOrdersForSelectedAccount = createSelector(
   [selectRampsOrders, getSelectedInternalAccount],
@@ -111,7 +98,5 @@ export const selectRampsOrdersForSelectedAccount = createSelector(
   },
 );
 
-export const selectProviderAutoSelected = createSelector(
-  (state: RampsState) => state.metamask.providerAutoSelected,
-  (providerAutoSelected): boolean => providerAutoSelected ?? false,
-);
+export const selectProviderAutoSelected = (state: RampsState): boolean =>
+  state.metamask.providerAutoSelected ?? false;

--- a/ui/selectors/rampsController/index.ts
+++ b/ui/selectors/rampsController/index.ts
@@ -35,8 +35,7 @@ export const selectRampsControllerState = createSelector(
   (state: RampsState) => state.metamask,
   (metamask): Partial<RampsControllerState> => ({
     userRegion: metamask.userRegion ?? null,
-    countries:
-      metamask.countries ?? createDefaultResourceState<Country[]>([]),
+    countries: metamask.countries ?? createDefaultResourceState<Country[]>([]),
     providers:
       metamask.providers ??
       createDefaultResourceState<Provider[], Provider | null>([], null),
@@ -89,10 +88,7 @@ export const selectPaymentMethods = createSelector(
   (state: RampsState) => state.metamask.paymentMethods,
   (paymentMethods): ResourceState<PaymentMethod[], PaymentMethod | null> =>
     paymentMethods ??
-    createDefaultResourceState<PaymentMethod[], PaymentMethod | null>(
-      [],
-      null,
-    ),
+    createDefaultResourceState<PaymentMethod[], PaymentMethod | null>([], null),
 );
 
 export const selectRampsOrders = createSelector(

--- a/ui/selectors/rampsController/index.ts
+++ b/ui/selectors/rampsController/index.ts
@@ -1,0 +1,106 @@
+import { createSelector } from 'reselect';
+import {
+  type UserRegion,
+  type Provider,
+  type Country,
+  type PaymentMethod,
+  type RampsToken,
+  type TokensResponse,
+  type ResourceState,
+  type RampsOrder,
+} from '@metamask/ramps-controller';
+import { getSelectedInternalAccount } from '../../../shared/lib/selectors/accounts';
+
+type RampsControllerStateSlice = {
+  metamask: {
+    RampsController?: {
+      userRegion?: UserRegion | null;
+      countries?: ResourceState<Country[]>;
+      providers?: ResourceState<Provider[], Provider | null>;
+      tokens?: ResourceState<TokensResponse | null, RampsToken | null>;
+      paymentMethods?: ResourceState<PaymentMethod[], PaymentMethod | null>;
+      orders?: RampsOrder[];
+      providerAutoSelected?: boolean;
+    };
+  };
+};
+
+const createDefaultResourceState = <TData, TSelected = null>(
+  data: TData,
+  selected: TSelected = null as TSelected,
+): ResourceState<TData, TSelected> => ({
+  data,
+  selected,
+  isLoading: false,
+  error: null,
+});
+
+export const selectRampsControllerState = (state: RampsControllerStateSlice) =>
+  state.metamask.RampsController;
+
+export const selectUserRegion = createSelector(
+  selectRampsControllerState,
+  (rampsControllerState): UserRegion | null =>
+    rampsControllerState?.userRegion ?? null,
+);
+
+export const selectCountries = createSelector(
+  selectRampsControllerState,
+  (rampsControllerState): ResourceState<Country[]> =>
+    rampsControllerState?.countries ??
+    createDefaultResourceState<Country[]>([]),
+);
+
+export const selectProviders = createSelector(
+  selectRampsControllerState,
+  (rampsControllerState): ResourceState<Provider[], Provider | null> =>
+    rampsControllerState?.providers ??
+    createDefaultResourceState<Provider[], Provider | null>([], null),
+);
+
+export const selectTokens = createSelector(
+  selectRampsControllerState,
+  (
+    rampsControllerState,
+  ): ResourceState<TokensResponse | null, RampsToken | null> =>
+    rampsControllerState?.tokens ??
+    createDefaultResourceState<TokensResponse | null, RampsToken | null>(
+      null,
+      null,
+    ),
+);
+
+export const selectPaymentMethods = createSelector(
+  selectRampsControllerState,
+  (
+    rampsControllerState,
+  ): ResourceState<PaymentMethod[], PaymentMethod | null> =>
+    rampsControllerState?.paymentMethods ??
+    createDefaultResourceState<PaymentMethod[], PaymentMethod | null>([], null),
+);
+
+export const selectRampsOrders = createSelector(
+  selectRampsControllerState,
+  (rampsControllerState): RampsOrder[] => rampsControllerState?.orders ?? [],
+);
+
+export const selectRampsOrdersForSelectedAccount = createSelector(
+  [selectRampsOrders, getSelectedInternalAccount],
+  (orders, selectedAccount): RampsOrder[] => {
+    const selectedAddress = selectedAccount?.address?.toLowerCase();
+    if (!selectedAddress) {
+      return [];
+    }
+
+    return orders.filter((order) => {
+      const walletAddress = order.walletAddress?.toLowerCase();
+      return walletAddress === selectedAddress;
+    });
+  },
+);
+
+export const selectProviderAutoSelected = createSelector(
+  selectRampsControllerState,
+  (rampsControllerState): boolean =>
+    rampsControllerState?.providerAutoSelected ?? false,
+);

--- a/ui/selectors/rampsController/index.ts
+++ b/ui/selectors/rampsController/index.ts
@@ -8,21 +8,17 @@ import {
   type TokensResponse,
   type ResourceState,
   type RampsOrder,
+  type RampsControllerState,
 } from '@metamask/ramps-controller';
 import { getSelectedInternalAccount } from '../../../shared/lib/selectors/accounts';
 
-type RampsControllerStateSlice = {
-  metamask: {
-    RampsController?: {
-      userRegion?: UserRegion | null;
-      countries?: ResourceState<Country[]>;
-      providers?: ResourceState<Provider[], Provider | null>;
-      tokens?: ResourceState<TokensResponse | null, RampsToken | null>;
-      paymentMethods?: ResourceState<PaymentMethod[], PaymentMethod | null>;
-      orders?: RampsOrder[];
-      providerAutoSelected?: boolean;
-    };
-  };
+/**
+ * RampsController state is flattened into state.metamask by
+ * ComposableObservableStore.getFlatState(). All properties live directly
+ * on state.metamask, NOT nested under state.metamask.RampsController.
+ */
+export type RampsState = {
+  metamask: Partial<RampsControllerState>;
 };
 
 const createDefaultResourceState = <TData, TSelected = null>(
@@ -35,35 +31,54 @@ const createDefaultResourceState = <TData, TSelected = null>(
   error: null,
 });
 
-export const selectRampsControllerState = (state: RampsControllerStateSlice) =>
-  state.metamask.RampsController;
+export const selectRampsControllerState = createSelector(
+  (state: RampsState) => state.metamask,
+  (metamask): Partial<RampsControllerState> => ({
+    userRegion: metamask.userRegion ?? null,
+    countries:
+      metamask.countries ?? createDefaultResourceState<Country[]>([]),
+    providers:
+      metamask.providers ??
+      createDefaultResourceState<Provider[], Provider | null>([], null),
+    tokens:
+      metamask.tokens ??
+      createDefaultResourceState<TokensResponse | null, RampsToken | null>(
+        null,
+        null,
+      ),
+    paymentMethods:
+      metamask.paymentMethods ??
+      createDefaultResourceState<PaymentMethod[], PaymentMethod | null>(
+        [],
+        null,
+      ),
+    orders: metamask.orders ?? [],
+    providerAutoSelected: metamask.providerAutoSelected ?? false,
+  }),
+);
 
 export const selectUserRegion = createSelector(
-  selectRampsControllerState,
-  (rampsControllerState): UserRegion | null =>
-    rampsControllerState?.userRegion ?? null,
+  (state: RampsState) => state.metamask.userRegion,
+  (userRegion): UserRegion | null => userRegion ?? null,
 );
 
 export const selectCountries = createSelector(
-  selectRampsControllerState,
-  (rampsControllerState): ResourceState<Country[]> =>
-    rampsControllerState?.countries ??
-    createDefaultResourceState<Country[]>([]),
+  (state: RampsState) => state.metamask.countries,
+  (countries): ResourceState<Country[]> =>
+    countries ?? createDefaultResourceState<Country[]>([]),
 );
 
 export const selectProviders = createSelector(
-  selectRampsControllerState,
-  (rampsControllerState): ResourceState<Provider[], Provider | null> =>
-    rampsControllerState?.providers ??
+  (state: RampsState) => state.metamask.providers,
+  (providers): ResourceState<Provider[], Provider | null> =>
+    providers ??
     createDefaultResourceState<Provider[], Provider | null>([], null),
 );
 
 export const selectTokens = createSelector(
-  selectRampsControllerState,
-  (
-    rampsControllerState,
-  ): ResourceState<TokensResponse | null, RampsToken | null> =>
-    rampsControllerState?.tokens ??
+  (state: RampsState) => state.metamask.tokens,
+  (tokens): ResourceState<TokensResponse | null, RampsToken | null> =>
+    tokens ??
     createDefaultResourceState<TokensResponse | null, RampsToken | null>(
       null,
       null,
@@ -71,17 +86,18 @@ export const selectTokens = createSelector(
 );
 
 export const selectPaymentMethods = createSelector(
-  selectRampsControllerState,
-  (
-    rampsControllerState,
-  ): ResourceState<PaymentMethod[], PaymentMethod | null> =>
-    rampsControllerState?.paymentMethods ??
-    createDefaultResourceState<PaymentMethod[], PaymentMethod | null>([], null),
+  (state: RampsState) => state.metamask.paymentMethods,
+  (paymentMethods): ResourceState<PaymentMethod[], PaymentMethod | null> =>
+    paymentMethods ??
+    createDefaultResourceState<PaymentMethod[], PaymentMethod | null>(
+      [],
+      null,
+    ),
 );
 
 export const selectRampsOrders = createSelector(
-  selectRampsControllerState,
-  (rampsControllerState): RampsOrder[] => rampsControllerState?.orders ?? [],
+  (state: RampsState) => state.metamask.orders,
+  (orders): RampsOrder[] => orders ?? [],
 );
 
 export const selectRampsOrdersForSelectedAccount = createSelector(
@@ -100,7 +116,6 @@ export const selectRampsOrdersForSelectedAccount = createSelector(
 );
 
 export const selectProviderAutoSelected = createSelector(
-  selectRampsControllerState,
-  (rampsControllerState): boolean =>
-    rampsControllerState?.providerAutoSelected ?? false,
+  (state: RampsState) => state.metamask.providerAutoSelected,
+  (providerAutoSelected): boolean => providerAutoSelected ?? false,
 );

--- a/ui/store/controller-actions/__snapshots__/ramps-controller.test.ts.snap
+++ b/ui/store/controller-actions/__snapshots__/ramps-controller.test.ts.snap
@@ -1,0 +1,126 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ramps-controller actions matches snapshot for background action calls 1`] = `
+[
+  [
+    "setRampsUserRegion",
+    [
+      "us-ca",
+      {
+        "forceRefresh": true,
+      },
+    ],
+  ],
+  [
+    "setRampsSelectedToken",
+    [
+      "eip155:1/erc20:0x0",
+    ],
+  ],
+  [
+    "setRampsSelectedProvider",
+    [
+      "transak",
+      {
+        "autoSelected": true,
+      },
+    ],
+  ],
+  [
+    "setRampsSelectedPaymentMethod",
+    [
+      "credit_debit_card",
+    ],
+  ],
+  [
+    "getRampsTokens",
+    [
+      "us-ca",
+      "buy",
+    ],
+  ],
+  [
+    "getRampsTokens",
+    [
+      "us-ca",
+      "sell",
+    ],
+  ],
+  [
+    "getRampsProviders",
+    [
+      "us-ca",
+    ],
+  ],
+  [
+    "getRampsPaymentMethods",
+    [
+      "us-ca",
+      {
+        "assetId": "eip155:1/erc20:0x0",
+        "fiat": "USD",
+        "provider": "transak",
+      },
+    ],
+  ],
+  [
+    "getRampsQuotes",
+    [
+      {
+        "amount": 100,
+        "assetId": "eip155:1/erc20:0x0",
+        "walletAddress": "0xabc",
+      },
+    ],
+  ],
+  [
+    "getRampsBuyWidgetData",
+    [
+      {
+        "id": "quote-1",
+      },
+    ],
+  ],
+  [
+    "addRampsPrecreatedOrder",
+    [
+      {
+        "orderId": "order-1",
+        "providerCode": "transak",
+        "walletAddress": "0xabc",
+      },
+    ],
+  ],
+  [
+    "addRampsOrder",
+    [
+      {
+        "id": "order-1",
+        "providerOrderId": "abc",
+      },
+    ],
+  ],
+  [
+    "removeRampsOrder",
+    [
+      "order-1",
+    ],
+  ],
+  [
+    "refreshRampsOrder",
+    [
+      "transak",
+      "order-1",
+      "0xabc",
+    ],
+  ],
+  [
+    "getRampsOrderFromCallback",
+    [
+      "transak",
+      "https://callback",
+      "0xabc",
+    ],
+  ],
+]
+`;

--- a/ui/store/controller-actions/ramps-controller.test.ts
+++ b/ui/store/controller-actions/ramps-controller.test.ts
@@ -1,5 +1,20 @@
 import * as BackgroundConnectionModule from '../background-connection';
-import { getRampsQuotes, setRampsUserRegion } from './ramps-controller';
+import {
+  addRampsOrder,
+  addRampsPrecreatedOrder,
+  getRampsBuyWidgetData,
+  getRampsOrderFromCallback,
+  getRampsPaymentMethods,
+  getRampsProviders,
+  getRampsQuotes,
+  getRampsTokens,
+  refreshRampsOrder,
+  removeRampsOrder,
+  setRampsSelectedPaymentMethod,
+  setRampsSelectedProvider,
+  setRampsSelectedToken,
+  setRampsUserRegion,
+} from './ramps-controller';
 
 jest.mock('../background-connection');
 
@@ -14,27 +29,40 @@ describe('ramps-controller actions', () => {
     mockSubmitRequestToBackground.mockResolvedValue(undefined);
   });
 
-  it('calls submitRequestToBackground for setRampsUserRegion', async () => {
-    await setRampsUserRegion('us-ca');
-
-    expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
-      'setRampsUserRegion',
-      ['us-ca', undefined],
-    );
-  });
-
-  it('calls submitRequestToBackground for getRampsQuotes', async () => {
+  it('matches snapshot for background action calls', async () => {
     const quoteParams = {
       amount: 100,
       walletAddress: '0xabc',
       assetId: 'eip155:1/erc20:0x0',
     };
+    const quote = { id: 'quote-1' } as never;
+    const order = { id: 'order-1', providerOrderId: 'abc' } as never;
+    const precreatedOrderParams = {
+      orderId: 'order-1',
+      providerCode: 'transak',
+      walletAddress: '0xabc',
+    };
 
+    await setRampsUserRegion('us-ca', { forceRefresh: true });
+    await setRampsSelectedToken('eip155:1/erc20:0x0');
+    await setRampsSelectedProvider('transak', { autoSelected: true });
+    await setRampsSelectedPaymentMethod('credit_debit_card');
+    await getRampsTokens('us-ca');
+    await getRampsTokens('us-ca', 'sell');
+    await getRampsProviders('us-ca');
+    await getRampsPaymentMethods('us-ca', {
+      fiat: 'USD',
+      assetId: 'eip155:1/erc20:0x0',
+      provider: 'transak',
+    });
     await getRampsQuotes(quoteParams);
+    await getRampsBuyWidgetData(quote);
+    await addRampsPrecreatedOrder(precreatedOrderParams);
+    await addRampsOrder(order);
+    await removeRampsOrder('order-1');
+    await refreshRampsOrder('transak', 'order-1', '0xabc');
+    await getRampsOrderFromCallback('transak', 'https://callback', '0xabc');
 
-    expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
-      'getRampsQuotes',
-      [quoteParams],
-    );
+    expect(mockSubmitRequestToBackground.mock.calls).toMatchSnapshot();
   });
 });

--- a/ui/store/controller-actions/ramps-controller.test.ts
+++ b/ui/store/controller-actions/ramps-controller.test.ts
@@ -1,0 +1,43 @@
+import * as BackgroundConnectionModule from '../background-connection';
+import {
+  getRampsQuotes,
+  setRampsUserRegion,
+} from './ramps-controller';
+
+jest.mock('../background-connection');
+
+describe('ramps-controller actions', () => {
+  const mockSubmitRequestToBackground = jest.spyOn(
+    BackgroundConnectionModule,
+    'submitRequestToBackground',
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSubmitRequestToBackground.mockResolvedValue(undefined);
+  });
+
+  it('calls submitRequestToBackground for setRampsUserRegion', async () => {
+    await setRampsUserRegion('us-ca');
+
+    expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+      'setRampsUserRegion',
+      ['us-ca', undefined],
+    );
+  });
+
+  it('calls submitRequestToBackground for getRampsQuotes', async () => {
+    const quoteParams = {
+      amount: 100,
+      walletAddress: '0xabc',
+      assetId: 'eip155:1/erc20:0x0',
+    };
+
+    await getRampsQuotes(quoteParams);
+
+    expect(mockSubmitRequestToBackground).toHaveBeenCalledWith(
+      'getRampsQuotes',
+      [quoteParams],
+    );
+  });
+});

--- a/ui/store/controller-actions/ramps-controller.test.ts
+++ b/ui/store/controller-actions/ramps-controller.test.ts
@@ -1,8 +1,5 @@
 import * as BackgroundConnectionModule from '../background-connection';
-import {
-  getRampsQuotes,
-  setRampsUserRegion,
-} from './ramps-controller';
+import { getRampsQuotes, setRampsUserRegion } from './ramps-controller';
 
 jest.mock('../background-connection');
 

--- a/ui/store/controller-actions/ramps-controller.ts
+++ b/ui/store/controller-actions/ramps-controller.ts
@@ -1,0 +1,133 @@
+import { submitRequestToBackground } from '../background-connection';
+import type {
+  BuyWidget,
+  ExecuteRequestOptions,
+  PaymentMethod,
+  Provider,
+  Quote,
+  QuotesResponse,
+  RampsOrder,
+  UserRegion,
+} from '@metamask/ramps-controller';
+
+export async function setRampsUserRegion(
+  region: string,
+  options?: ExecuteRequestOptions,
+): Promise<UserRegion | null> {
+  return submitRequestToBackground('setRampsUserRegion', [region, options]);
+}
+
+export async function setRampsSelectedToken(assetId: string): Promise<void> {
+  return submitRequestToBackground('setRampsSelectedToken', [assetId]);
+}
+
+export async function setRampsSelectedProvider(
+  provider: Provider | string | null,
+  options?: { autoSelected?: boolean },
+): Promise<void> {
+  return submitRequestToBackground('setRampsSelectedProvider', [
+    provider,
+    options,
+  ]);
+}
+
+export async function setRampsSelectedPaymentMethod(
+  paymentMethod: PaymentMethod | string | null,
+): Promise<void> {
+  return submitRequestToBackground('setRampsSelectedPaymentMethod', [
+    paymentMethod,
+  ]);
+}
+
+export async function getRampsTokens(
+  region: string,
+  action: 'buy' | 'sell' = 'buy',
+): Promise<void> {
+  return submitRequestToBackground('getRampsTokens', [region, action]);
+}
+
+export async function getRampsProviders(region: string) {
+  return submitRequestToBackground('getRampsProviders', [region]);
+}
+
+export async function getRampsPaymentMethods(
+  region: string,
+  options: {
+    fiat: string;
+    assetId?: string;
+    provider?: string;
+  },
+) {
+  return submitRequestToBackground('getRampsPaymentMethods', [
+    region,
+    options,
+  ]);
+}
+
+export type GetRampsQuotesParams = {
+  region?: string;
+  fiat?: string;
+  assetId?: string;
+  amount: number;
+  walletAddress: string;
+  paymentMethods?: string[];
+  providers?: string[];
+  redirectUrl?: string;
+  forceRefresh?: boolean;
+  ttl?: number;
+};
+
+export async function getRampsQuotes(
+  options: GetRampsQuotesParams,
+): Promise<QuotesResponse> {
+  return submitRequestToBackground('getRampsQuotes', [options]);
+}
+
+export async function getRampsBuyWidgetData(
+  quote: Quote,
+): Promise<BuyWidget | null> {
+  return submitRequestToBackground('getRampsBuyWidgetData', [quote]);
+}
+
+export async function addRampsPrecreatedOrder(params: {
+  orderId: string;
+  providerCode: string;
+  walletAddress: string;
+  chainId?: string;
+}): Promise<void> {
+  return submitRequestToBackground('addRampsPrecreatedOrder', [params]);
+}
+
+export async function addRampsOrder(order: RampsOrder): Promise<void> {
+  return submitRequestToBackground('addRampsOrder', [order]);
+}
+
+export async function removeRampsOrder(
+  providerOrderId: string,
+): Promise<void> {
+  return submitRequestToBackground('removeRampsOrder', [providerOrderId]);
+}
+
+export async function refreshRampsOrder(
+  providerCode: string,
+  orderCode: string,
+  wallet: string,
+): Promise<RampsOrder> {
+  return submitRequestToBackground('refreshRampsOrder', [
+    providerCode,
+    orderCode,
+    wallet,
+  ]);
+}
+
+export async function getRampsOrderFromCallback(
+  providerCode: string,
+  callbackUrl: string,
+  wallet: string,
+): Promise<RampsOrder> {
+  return submitRequestToBackground('getRampsOrderFromCallback', [
+    providerCode,
+    callbackUrl,
+    wallet,
+  ]);
+}

--- a/ui/store/controller-actions/ramps-controller.ts
+++ b/ui/store/controller-actions/ramps-controller.ts
@@ -1,4 +1,3 @@
-import { submitRequestToBackground } from '../background-connection';
 import type {
   BuyWidget,
   ExecuteRequestOptions,
@@ -9,6 +8,7 @@ import type {
   RampsOrder,
   UserRegion,
 } from '@metamask/ramps-controller';
+import { submitRequestToBackground } from '../background-connection';
 
 export async function setRampsUserRegion(
   region: string,
@@ -58,10 +58,7 @@ export async function getRampsPaymentMethods(
     provider?: string;
   },
 ) {
-  return submitRequestToBackground('getRampsPaymentMethods', [
-    region,
-    options,
-  ]);
+  return submitRequestToBackground('getRampsPaymentMethods', [region, options]);
 }
 
 export type GetRampsQuotesParams = {
@@ -102,9 +99,7 @@ export async function addRampsOrder(order: RampsOrder): Promise<void> {
   return submitRequestToBackground('addRampsOrder', [order]);
 }
 
-export async function removeRampsOrder(
-  providerOrderId: string,
-): Promise<void> {
+export async function removeRampsOrder(providerOrderId: string): Promise<void> {
   return submitRequestToBackground('removeRampsOrder', [providerOrderId]);
 }
 


### PR DESCRIPTION
## **Description**

Stacked on #43962.

1. **Reason for the change:** The extension needs a client layer to read `RampsController` state and call background actions from React, matching the aggregator hooks pattern used on mobile.
2. **Improvement/solution:** This PR adds Redux selectors, controller-action wrappers, React Query hooks, a `useRampsController` facade, and `RampsBootstrap` (mounted in `ui/pages/index.js`) so UI code can load providers, tokens, payment methods, quotes, and orders from the wired background controller.

Example usage:

```tsx
const {
  providers,
  selectedProvider,
  setSelectedProvider,
  tokens,
  selectedToken,
  setSelectedToken,
  paymentMethods,
  selectedPaymentMethod,
  setSelectedPaymentMethod,
  getQuotes,
  providersLoading,
  paymentMethodsLoading,
} = useRampsController();
```

Demo app showing data availability and controller logic:

<img width="320" height="544" alt="extension ramps demo app" src="https://github.com/user-attachments/assets/f5c5c6b0-c9d2-46d1-a4fe-de46a4b5a93e" />

**Notes:**
- Buy screens and Portfolio redirect migration remain out of scope.
- After #43962 merges, retarget this PR to `main` (or rebase onto updated `main`).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TRAM-3712

## **Manual testing steps**

1. Check out this branch and run `yarn start`.
2. Unlock the extension and confirm there are no runtime errors from `RampsBootstrap` or the ramps hooks on load.
3. Run unit tests: `yarn jest ui/selectors/rampsController/index.test.ts ui/store/controller-actions/ramps-controller.test.ts ui/hooks/ramps/useRampsUserRegion.test.tsx ui/hooks/ramps/useRampsTokens.test.tsx ui/hooks/ramps/useRampsCountries.test.tsx ui/hooks/ramps/useRampsProviders.test.tsx ui/hooks/ramps/useRampsPaymentMethods.test.tsx ui/hooks/ramps/useRampsQuotes.test.tsx ui/hooks/ramps/useRampsOrders.test.tsx ui/hooks/ramps/useRampsController.test.tsx`
4. Verify hooks can load providers, tokens, and payment methods when the background controller is available.

## **Screenshots/Recordings**

### **Before**

N/A — new internal client layer; no prior UI behavior.

### **After**

See demo screenshot in Description.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches fiat on-ramp data paths (quotes, orders, provider callbacks) and runs background RPC on every app load via bootstrap, but changes are mostly new isolated hooks with tests and no production buy UI yet.
> 
> **Overview**
> Adds a **React client layer** for on-ramp/buy flows: Redux selectors over flattened `RampsController` state on `state.metamask`, thin `submitRequestToBackground` wrappers for ramps actions, and TanStack Query options for providers, payment methods, and quotes.
> 
> **`useRampsController`** composes domain hooks (region, tokens, countries, providers, payment methods, quotes, orders). Providers and payment methods use React Query with side effects for **auto-selection**, **region-change resets**, and **invalidation**; orders and selections still go through the background controller.
> 
> **`RampsBootstrap`** is mounted under `QueryClientProvider` in `ui/pages/index.js` so the app eagerly loads buy tokens for the current region and runs provider bootstrap logic on every session. LavaMoat MV3 policies gain **`@metamask/ramps-controller`** (`URL` + `@metamask/controller-utils`).
> 
> Buy screens are not in this PR; this is infrastructure plus broad unit/snapshot tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 354086736662411f18ca0d966976548215331000. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->