### PR TITLE
chore: migrate `rejectPendingApproval` to `LegacyBackgroundApiService`

### DIFF
--- a/app/scripts/metamask-controller.actions.test.js
+++ b/app/scripts/metamask-controller.actions.test.js
@@ -656,40 +656,6 @@ describe('MetaMaskController', function () {
     });
   });
 
-  describe('#rejectPendingApproval', function () {
-    it('should not propagate ApprovalRequestNotFoundError', function () {
-      const error = new ApprovalRequestNotFoundError('123');
-      metamaskController.approvalController = {
-        rejectRequest: () => {
-          throw error;
-        },
-      };
-      expect(() =>
-        metamaskController.rejectPendingApproval('DUMMY_ID', {
-          code: 1,
-          message: 'DUMMY_MESSAGE',
-          data: 'DUMMY_DATA',
-        }),
-      ).not.toThrow(error);
-    });
-
-    it('should propagate Error other than ApprovalRequestNotFoundError', function () {
-      const error = new Error();
-      metamaskController.approvalController = {
-        rejectRequest: () => {
-          throw error;
-        },
-      };
-      expect(() =>
-        metamaskController.rejectPendingApproval('DUMMY_ID', {
-          code: 1,
-          message: 'DUMMY_MESSAGE',
-          data: 'DUMMY_DATA',
-        }),
-      ).toThrow(error);
-    });
-  });
-
   describe('passkey methods', function () {
     const registrationResponse = { id: 'credential-id' };
     const authenticationResponse = { id: 'assertion-id' };

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3628,7 +3628,10 @@ export default class MetamaskController extends EventEmitter {
 
       // ApprovalController
       rejectAllPendingApprovals: this.rejectAllPendingApprovals.bind(this),
-      rejectPendingApproval: this.rejectPendingApproval,
+      rejectPendingApproval: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'LegacyBackgroundApiService:rejectPendingApproval',
+      ),
       requestUserApproval:
         approvalController.addAndShowApprovalRequest.bind(approvalController),
       resolvePendingApproval: this.resolvePendingApproval,
@@ -8480,19 +8483,6 @@ export default class MetamaskController extends EventEmitter {
       }
 
       throw error;
-    }
-  };
-
-  rejectPendingApproval = (id, error) => {
-    try {
-      this.approvalController.rejectRequest(
-        id,
-        new JsonRpcError(error.code, error.message, error.data),
-      );
-    } catch (exp) {
-      if (!(exp instanceof ApprovalRequestNotFoundError)) {
-        throw exp;
-      }
     }
   };
 

--- a/app/scripts/services/legacy-background-api-service-method-action-types.ts
+++ b/app/scripts/services/legacy-background-api-service-method-action-types.ts
@@ -318,6 +318,20 @@ export type LegacyBackgroundApiServiceUpsertTransactionUIMetricsFragmentAction =
   };
 
 /**
+ * Rejects a pending approval request.
+ *
+ * @param id - The ID of the approval request to reject.
+ * @param error - The error to reject the approval request with.
+ * @param error.code - The error code.
+ * @param error.message - The error message.
+ * @param error.data - The error data.
+ */
+export type LegacyBackgroundApiServiceRejectPendingApprovalAction = {
+  type: `LegacyBackgroundApiService:rejectPendingApproval`;
+  handler: LegacyBackgroundApiService['rejectPendingApproval'];
+};
+
+/**
  * Union of all LegacyBackgroundApiService action types.
  */
 export type LegacyBackgroundApiServiceMethodActions =
@@ -348,4 +362,5 @@ export type LegacyBackgroundApiServiceMethodActions =
   | LegacyBackgroundApiServiceSyncKeyringEncryptionKeyAction
   | LegacyBackgroundApiServiceExportAccountAction
   | LegacyBackgroundApiServiceApplyTransactionContainersExistingAction
-  | LegacyBackgroundApiServiceUpsertTransactionUIMetricsFragmentAction;
+  | LegacyBackgroundApiServiceUpsertTransactionUIMetricsFragmentAction
+  | LegacyBackgroundApiServiceRejectPendingApprovalAction;

--- a/app/scripts/services/legacy-background-api-service.test.ts
+++ b/app/scripts/services/legacy-background-api-service.test.ts
@@ -21,6 +21,7 @@ import {
 } from '@metamask/seedless-onboarding-controller';
 import { Caip25CaveatType } from '@metamask/chain-agnostic-permission';
 import { PermissionsRequestNotFoundError } from '@metamask/permission-controller';
+import { ApprovalRequestNotFoundError } from '@metamask/approval-controller';
 import { SnapId } from '@metamask/snaps-sdk';
 import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
 import { SMART_TRANSACTION_CONFIRMATION_TYPES } from '../../../shared/constants/app';
@@ -2580,6 +2581,77 @@ describe('LegacyBackgroundApiService', () => {
             gas: ESTIMATE_GAS_MOCK,
           }),
         );
+      });
+    });
+  });
+
+  describe('rejectPendingApproval', () => {
+    it('rejects the approval request with a JSON-RPC error', async () => {
+      await withService(async ({ rootMessenger, serviceMessenger }) => {
+        const callSpy = jest.spyOn(serviceMessenger, 'call');
+
+        rootMessenger.registerActionHandler(
+          'ApprovalController:rejectRequest',
+          jest.fn(),
+        );
+
+        rootMessenger.call(
+          'LegacyBackgroundApiService:rejectPendingApproval',
+          'DUMMY_ID',
+          { code: 1, message: 'DUMMY_MESSAGE', data: 'DUMMY_DATA' },
+        );
+
+        expect(callSpy).toHaveBeenCalledWith(
+          'ApprovalController:rejectRequest',
+          'DUMMY_ID',
+          expect.objectContaining({
+            code: 1,
+            message: 'DUMMY_MESSAGE',
+            data: 'DUMMY_DATA',
+          }),
+        );
+      });
+    });
+
+    it('does not propagate ApprovalRequestNotFoundError', async () => {
+      await withService(async ({ rootMessenger }) => {
+        const error = new ApprovalRequestNotFoundError('123');
+
+        rootMessenger.registerActionHandler(
+          'ApprovalController:rejectRequest',
+          jest.fn().mockImplementation(() => {
+            throw error;
+          }),
+        );
+
+        expect(() =>
+          rootMessenger.call(
+            'LegacyBackgroundApiService:rejectPendingApproval',
+            'DUMMY_ID',
+            { code: 1, message: 'DUMMY_MESSAGE', data: 'DUMMY_DATA' },
+          ),
+        ).not.toThrow(error);
+      });
+    });
+
+    it('propagates errors other than ApprovalRequestNotFoundError', async () => {
+      await withService(async ({ rootMessenger }) => {
+        const error = new Error('boom');
+
+        rootMessenger.registerActionHandler(
+          'ApprovalController:rejectRequest',
+          jest.fn().mockImplementation(() => {
+            throw error;
+          }),
+        );
+
+        expect(() =>
+          rootMessenger.call(
+            'LegacyBackgroundApiService:rejectPendingApproval',
+            'DUMMY_ID',
+            { code: 1, message: 'DUMMY_MESSAGE', data: 'DUMMY_DATA' },
+          ),
+        ).toThrow(error);
       });
     });
   });

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -165,6 +165,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'isPublicEndpointUrl',
   'markPasswordForgotten',
   'onAccountRemoved',
+  'rejectPendingApproval',
   'rejectPermissionsRequest',
   'removeAccount',
   'removePermissionsFor',
@@ -1359,5 +1360,31 @@ export class LegacyBackgroundApiService {
       properties: payload.properties ?? {},
       sensitiveProperties: payload.sensitiveProperties ?? {},
     });
+  }
+
+  /**
+   * Rejects a pending approval request.
+   *
+   * @param id - The ID of the approval request to reject.
+   * @param error - The error to reject the approval request with.
+   * @param error.code - The error code.
+   * @param error.message - The error message.
+   * @param error.data - The error data.
+   */
+  rejectPendingApproval(
+    id: string,
+    error: { code: number; message: string; data?: Json },
+  ): void {
+    try {
+      this.#messenger.call(
+        'ApprovalController:rejectRequest',
+        id,
+        new JsonRpcError(error.code, error.message, error.data),
+      );
+    } catch (err) {
+      if (!(err instanceof ApprovalRequestNotFoundError)) {
+        throw err;
+      }
+    }
   }
 }


### PR DESCRIPTION
## **Description**

This moves `rejectPendingApproval` from `MetamaskController` to `LegacyBackgroundApiService`.

## **Related issues**

Progresses: https://consensyssoftware.atlassian.net/browse/WPC-1084

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor with preserved approval-rejection behavior and moved tests; no new auth or data paths.
> 
> **Overview**
> Moves **`rejectPendingApproval`** out of `MetamaskController` into **`LegacyBackgroundApiService`**, as part of the legacy background API migration (WPC-1084).
> 
> The background API still exposes **`rejectPendingApproval`**, but `getApi()` now forwards through **`controllerMessenger.call('LegacyBackgroundApiService:rejectPendingApproval', …)`** instead of calling a controller method directly. The service implementation still calls **`ApprovalController:rejectRequest`** with a **`JsonRpcError`** and **swallows `ApprovalRequestNotFoundError`**.
> 
> Tests for that behavior move from **`metamask-controller.actions.test.js`** to **`legacy-background-api-service.test.ts`**, with a new messenger action type registered in **`legacy-background-api-service-method-action-types.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66071295554b10139a1603449d617d63b631eec9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->