### PR TITLE
chore: migrate `removePermissionsFor` to `LegacyBackgroundApiService`

### DIFF
--- a/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
@@ -52,6 +52,7 @@ export function getLegacyBackgroundApiServiceMessenger(
       'SeedlessOnboardingController:changePassword',
       'SeedlessOnboardingController:updateBackupMetadataState',
       'PermissionController:rejectPermissionsRequest',
+      'PermissionController:revokePermissions',
       'PermissionController:updatePermissionsByCaveat',
       'KeyringController:getKeyringsByType',
       'KeyringController:addNewKeyring',

--- a/app/scripts/metamask-controller.actions.test.js
+++ b/app/scripts/metamask-controller.actions.test.js
@@ -489,32 +489,6 @@ describe('MetaMaskController', function () {
     });
   });
 
-  describe('#removePermissionsFor', function () {
-    it('should not propagate PermissionsRequestNotFoundError', function () {
-      const error = new PermissionsRequestNotFoundError('123');
-      metamaskController.permissionController = {
-        revokePermissions: () => {
-          throw error;
-        },
-      };
-      expect(() =>
-        metamaskController.removePermissionsFor({ subject: 'test_subject' }),
-      ).not.toThrow(error);
-    });
-
-    it('should propagate Error other than PermissionsRequestNotFoundError', function () {
-      const error = new Error();
-      metamaskController.permissionController = {
-        revokePermissions: () => {
-          throw error;
-        },
-      };
-      expect(() =>
-        metamaskController.removePermissionsFor({ subject: 'test_subject' }),
-      ).toThrow(error);
-    });
-  });
-
   describe('#acceptPermissionsRequest', function () {
     it('should not propagate PermissionsRequestNotFoundError', function () {
       const error = new PermissionsRequestNotFoundError('123');

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3448,7 +3448,10 @@ export default class MetamaskController extends EventEmitter {
         alertController.setWeb3ShimUsageAlertDismissed.bind(alertController),
 
       // permissions
-      removePermissionsFor: this.removePermissionsFor,
+      removePermissionsFor: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'LegacyBackgroundApiService:removePermissionsFor',
+      ),
       approvePermissionsRequest: this.acceptPermissionsRequest,
       rejectPermissionsRequest: this.controllerMessenger.call.bind(
         this.controllerMessenger,
@@ -8382,16 +8385,6 @@ export default class MetamaskController extends EventEmitter {
 
     await this.platform.switchToAnotherURL(undefined, portfolioURL);
   }
-
-  removePermissionsFor = (subjects) => {
-    try {
-      this.permissionController.revokePermissions(subjects);
-    } catch (exp) {
-      if (!(exp instanceof PermissionsRequestNotFoundError)) {
-        throw exp;
-      }
-    }
-  };
 
   updateCaveat = (origin, target, caveatType, caveatValue) => {
     try {

--- a/app/scripts/services/legacy-background-api-service-method-action-types.ts
+++ b/app/scripts/services/legacy-background-api-service-method-action-types.ts
@@ -170,6 +170,16 @@ export type LegacyBackgroundApiServiceRejectPermissionsRequestAction = {
   handler: LegacyBackgroundApiService['rejectPermissionsRequest'];
 };
 
+/**
+ * Removes the given permissions for the given subjects.
+ *
+ * @param subjects - The subjects and their permissions to remove.
+ */
+export type LegacyBackgroundApiServiceRemovePermissionsForAction = {
+  type: `LegacyBackgroundApiService:removePermissionsFor`;
+  handler: LegacyBackgroundApiService['removePermissionsFor'];
+};
+
 export type LegacyBackgroundApiServiceImportAccountWithStrategyAction = {
   type: `LegacyBackgroundApiService:importAccountWithStrategy`;
   handler: LegacyBackgroundApiService['importAccountWithStrategy'];
@@ -314,6 +324,7 @@ export type LegacyBackgroundApiServiceMethodActions =
   | LegacyBackgroundApiServiceRemoveAccountAction
   | LegacyBackgroundApiServiceOnAccountRemovedAction
   | LegacyBackgroundApiServiceRejectPermissionsRequestAction
+  | LegacyBackgroundApiServiceRemovePermissionsForAction
   | LegacyBackgroundApiServiceImportAccountWithStrategyAction
   | LegacyBackgroundApiServiceGetAccountsBySnapIdAction
   | LegacyBackgroundApiServiceGetNextNonceAction

--- a/app/scripts/services/legacy-background-api-service.test.ts
+++ b/app/scripts/services/legacy-background-api-service.test.ts
@@ -757,6 +757,70 @@ describe('LegacyBackgroundApiService', () => {
     });
   });
 
+  describe('removePermissionsFor', () => {
+    const subjects = { 'test.com': ['eth_accounts'] as [string] };
+
+    it('revokes the given permissions for the given subjects', async () => {
+      await withService(async ({ rootMessenger, serviceMessenger }) => {
+        const revokePermissions = jest.fn();
+        rootMessenger.registerActionHandler(
+          'PermissionController:revokePermissions',
+          revokePermissions,
+        );
+
+        const callSpy = jest.spyOn(serviceMessenger, 'call');
+
+        rootMessenger.call(
+          'LegacyBackgroundApiService:removePermissionsFor',
+          subjects,
+        );
+
+        expect(callSpy).toHaveBeenCalledWith(
+          'PermissionController:revokePermissions',
+          subjects,
+        );
+        expect(revokePermissions).toHaveBeenCalledWith(subjects);
+      });
+    });
+
+    it('does not propagate a PermissionsRequestNotFoundError', async () => {
+      await withService(async ({ rootMessenger }) => {
+        rootMessenger.registerActionHandler(
+          'PermissionController:revokePermissions',
+          jest.fn(() => {
+            throw new PermissionsRequestNotFoundError('123');
+          }),
+        );
+
+        expect(() =>
+          rootMessenger.call(
+            'LegacyBackgroundApiService:removePermissionsFor',
+            subjects,
+          ),
+        ).not.toThrow();
+      });
+    });
+
+    it('propagates an error other than PermissionsRequestNotFoundError', async () => {
+      await withService(async ({ rootMessenger }) => {
+        const error = new Error('some other error');
+        rootMessenger.registerActionHandler(
+          'PermissionController:revokePermissions',
+          jest.fn(() => {
+            throw error;
+          }),
+        );
+
+        expect(() =>
+          rootMessenger.call(
+            'LegacyBackgroundApiService:removePermissionsFor',
+            subjects,
+          ),
+        ).toThrow(error);
+      });
+    });
+  });
+
   describe('importAccountWithStrategy', () => {
     it('imports an account without social login', async () => {
       await withService(async ({ rootMessenger, serviceMessenger }) => {
@@ -2445,6 +2509,7 @@ function getMessenger(
       'SeedlessOnboardingController:addNewSecretData',
       'SeedlessOnboardingController:updateBackupMetadataState',
       'PermissionController:rejectPermissionsRequest',
+      'PermissionController:revokePermissions',
       'PermissionController:updatePermissionsByCaveat',
       'PreferencesController:setPasswordForgotten',
       'OnboardingController:getState',

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -6,7 +6,7 @@ import {
   NetworkControllerGetStateAction,
   NetworkControllerResetConnectionAction,
 } from '@metamask/network-controller';
-import { add0x, Hex, hexToBytes, Json } from '@metamask/utils';
+import { add0x, Hex, hexToBytes, Json, NonEmptyArray } from '@metamask/utils';
 import { Mutex } from 'async-mutex';
 import {
   AccountImportStrategy,
@@ -72,8 +72,13 @@ import {
   SeedlessOnboardingControllerUpdateBackupMetadataStateAction,
 } from '@metamask/seedless-onboarding-controller';
 import {
+  CaveatSpecificationConstraint,
+  ExtractPermission,
+  OriginString,
   PermissionControllerRejectPermissionsRequestAction,
+  PermissionControllerRevokePermissionsAction,
   PermissionControllerUpdatePermissionsByCaveatAction,
+  PermissionSpecificationConstraint,
   PermissionsRequestNotFoundError,
 } from '@metamask/permission-controller';
 import {
@@ -155,6 +160,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'onAccountRemoved',
   'rejectPermissionsRequest',
   'removeAccount',
+  'removePermissionsFor',
   'resetAccount',
   'setCurrentCurrency',
   'setLocked',
@@ -214,6 +220,7 @@ type AllowedActions =
   | OnboardingControllerGetIsSocialLoginFlowAction
   | OnboardingControllerGetStateAction
   | PermissionControllerRejectPermissionsRequestAction
+  | PermissionControllerRevokePermissionsAction
   | PermissionControllerUpdatePermissionsByCaveatAction
   | PreferencesControllerSetPasswordForgottenAction
   | RemoteFeatureFlagControllerGetStateAction
@@ -622,6 +629,31 @@ export class LegacyBackgroundApiService {
         'PermissionController:rejectPermissionsRequest',
         requestId,
       );
+    } catch (error) {
+      if (!(error instanceof PermissionsRequestNotFoundError)) {
+        throw error;
+      }
+    }
+  }
+
+  /**
+   * Removes the given permissions for the given subjects.
+   *
+   * @param subjects - The subjects and their permissions to remove.
+   */
+  removePermissionsFor(
+    subjects: Record<
+      OriginString,
+      NonEmptyArray<
+        ExtractPermission<
+          PermissionSpecificationConstraint,
+          CaveatSpecificationConstraint
+        >['parentCapability']
+      >
+    >,
+  ): void {
+    try {
+      this.#messenger.call('PermissionController:revokePermissions', subjects);
     } catch (error) {
       if (!(error instanceof PermissionsRequestNotFoundError)) {
         throw error;


### PR DESCRIPTION
## **Description**

This moves `removePermissionsFor` from `MetamaskController` to `LegacyBackgroundApiService`.

## **Related issues**

Progresses: https://consensyssoftware.atlassian.net/browse/WPC-1081

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches site permission revocation paths; behavior is intended to be unchanged but errors must still route correctly through the new messenger action.
> 
> **Overview**
> **`removePermissionsFor`** is moved off **`MetamaskController`** into **`LegacyBackgroundApiService`**, matching the pattern used for **`rejectPermissionsRequest`**.
> 
> The service implementation calls **`PermissionController:revokePermissions`** and still **swallows `PermissionsRequestNotFoundError`** while rethrowing other errors. The public background API now exposes **`removePermissionsFor`** via **`controllerMessenger.call('LegacyBackgroundApiService:removePermissionsFor', …)`**, and the legacy service messenger **delegates `PermissionController:revokePermissions`**.
> 
> Tests for revoke/error handling are **relocated** from **`metamask-controller.actions.test.js`** to **`legacy-background-api-service.test.ts`**, with typed action wiring updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aaf9952a3f87c2e7c87b2589691ca6594c542e18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->