### PR TITLE
chore: migrate `rejectPermissionsRequest` to `LegacyBackgroundApiService`

### DIFF
--- a/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
@@ -51,6 +51,7 @@ export function getLegacyBackgroundApiServiceMessenger(
       'SeedlessOnboardingController:addNewSecretData',
       'SeedlessOnboardingController:changePassword',
       'SeedlessOnboardingController:updateBackupMetadataState',
+      'PermissionController:rejectPermissionsRequest',
       'PermissionController:updatePermissionsByCaveat',
       'KeyringController:getKeyringsByType',
       'KeyringController:addNewKeyring',

--- a/app/scripts/metamask-controller.actions.test.js
+++ b/app/scripts/metamask-controller.actions.test.js
@@ -515,32 +515,6 @@ describe('MetaMaskController', function () {
     });
   });
 
-  describe('#rejectPermissionsRequest', function () {
-    it('should not propagate PermissionsRequestNotFoundError', function () {
-      const error = new PermissionsRequestNotFoundError('123');
-      metamaskController.permissionController = {
-        rejectPermissionsRequest: () => {
-          throw error;
-        },
-      };
-      expect(() =>
-        metamaskController.rejectPermissionsRequest('DUMMY_ID'),
-      ).not.toThrow(error);
-    });
-
-    it('should propagate Error other than PermissionsRequestNotFoundError', function () {
-      const error = new Error();
-      metamaskController.permissionController = {
-        rejectPermissionsRequest: () => {
-          throw error;
-        },
-      };
-      expect(() =>
-        metamaskController.rejectPermissionsRequest('DUMMY_ID'),
-      ).toThrow(error);
-    });
-  });
-
   describe('#acceptPermissionsRequest', function () {
     it('should not propagate PermissionsRequestNotFoundError', function () {
       const error = new PermissionsRequestNotFoundError('123');

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3532,7 +3532,10 @@ export default class MetamaskController extends EventEmitter {
       // permissions
       removePermissionsFor: this.removePermissionsFor,
       approvePermissionsRequest: this.acceptPermissionsRequest,
-      rejectPermissionsRequest: this.rejectPermissionsRequest,
+      rejectPermissionsRequest: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'LegacyBackgroundApiService:rejectPermissionsRequest',
+      ),
       ...getPermissionBackgroundApiMethods({
         permissionController,
         approvalController,
@@ -8501,16 +8504,6 @@ export default class MetamaskController extends EventEmitter {
     } catch (err) {
       log.error(err.message);
       throw err;
-    }
-  };
-
-  rejectPermissionsRequest = (requestId) => {
-    try {
-      this.permissionController.rejectPermissionsRequest(requestId);
-    } catch (exp) {
-      if (!(exp instanceof PermissionsRequestNotFoundError)) {
-        throw exp;
-      }
     }
   };
 

--- a/app/scripts/services/legacy-background-api-service-method-action-types.ts
+++ b/app/scripts/services/legacy-background-api-service-method-action-types.ts
@@ -157,6 +157,19 @@ export type LegacyBackgroundApiServiceOnAccountRemovedAction = {
   handler: LegacyBackgroundApiService['onAccountRemoved'];
 };
 
+/**
+ * Rejects a pending permissions request.
+ *
+ * Swallows `PermissionsRequestNotFoundError` so that rejecting an already
+ * resolved request does not throw.
+ *
+ * @param requestId - The ID of the permissions request to reject.
+ */
+export type LegacyBackgroundApiServiceRejectPermissionsRequestAction = {
+  type: `LegacyBackgroundApiService:rejectPermissionsRequest`;
+  handler: LegacyBackgroundApiService['rejectPermissionsRequest'];
+};
+
 export type LegacyBackgroundApiServiceImportAccountWithStrategyAction = {
   type: `LegacyBackgroundApiService:importAccountWithStrategy`;
   handler: LegacyBackgroundApiService['importAccountWithStrategy'];
@@ -288,6 +301,7 @@ export type LegacyBackgroundApiServiceMethodActions =
   | LegacyBackgroundApiServiceGetGlobalChainIdAction
   | LegacyBackgroundApiServiceRemoveAccountAction
   | LegacyBackgroundApiServiceOnAccountRemovedAction
+  | LegacyBackgroundApiServiceRejectPermissionsRequestAction
   | LegacyBackgroundApiServiceImportAccountWithStrategyAction
   | LegacyBackgroundApiServiceGetAccountsBySnapIdAction
   | LegacyBackgroundApiServiceGetNextNonceAction

--- a/app/scripts/services/legacy-background-api-service.test.ts
+++ b/app/scripts/services/legacy-background-api-service.test.ts
@@ -16,6 +16,7 @@ import {
   SeedlessOnboardingControllerErrorMessage,
 } from '@metamask/seedless-onboarding-controller';
 import { Caip25CaveatType } from '@metamask/chain-agnostic-permission';
+import { PermissionsRequestNotFoundError } from '@metamask/permission-controller';
 import { SnapId } from '@metamask/snaps-sdk';
 import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
 import { SMART_TRANSACTION_CONFIRMATION_TYPES } from '../../../shared/constants/app';
@@ -685,6 +686,66 @@ describe('LegacyBackgroundApiService', () => {
           Caip25CaveatType,
           expect.any(Function),
         );
+      });
+    });
+  });
+
+  describe('rejectPermissionsRequest', () => {
+    it('rejects the pending permissions request', async () => {
+      await withService(async ({ rootMessenger, serviceMessenger }) => {
+        rootMessenger.registerActionHandler(
+          'PermissionController:rejectPermissionsRequest',
+          jest.fn(),
+        );
+
+        const callSpy = jest.spyOn(serviceMessenger, 'call');
+
+        rootMessenger.call(
+          'LegacyBackgroundApiService:rejectPermissionsRequest',
+          'DUMMY_ID',
+        );
+
+        expect(callSpy).toHaveBeenCalledWith(
+          'PermissionController:rejectPermissionsRequest',
+          'DUMMY_ID',
+        );
+      });
+    });
+
+    it('does not propagate PermissionsRequestNotFoundError', async () => {
+      await withService(async ({ rootMessenger }) => {
+        rootMessenger.registerActionHandler(
+          'PermissionController:rejectPermissionsRequest',
+          jest.fn().mockImplementation(() => {
+            throw new PermissionsRequestNotFoundError('123');
+          }),
+        );
+
+        expect(() =>
+          rootMessenger.call(
+            'LegacyBackgroundApiService:rejectPermissionsRequest',
+            'DUMMY_ID',
+          ),
+        ).not.toThrow();
+      });
+    });
+
+    it('propagates errors other than PermissionsRequestNotFoundError', async () => {
+      await withService(async ({ rootMessenger }) => {
+        const error = new Error('Some other error');
+        rootMessenger.registerActionHandler(
+          'PermissionController:rejectPermissionsRequest',
+          jest.fn().mockImplementation(() => {
+            throw error;
+          }),
+        );
+
+        expect(() =>
+          rootMessenger.call(
+            'LegacyBackgroundApiService:rejectPermissionsRequest',
+            'DUMMY_ID',
+          ),
+        ).toThrow(error);
       });
     });
   });
@@ -2306,6 +2367,7 @@ function getMessenger(
       'AccountsController:setSelectedAccount',
       'SeedlessOnboardingController:addNewSecretData',
       'SeedlessOnboardingController:updateBackupMetadataState',
+      'PermissionController:rejectPermissionsRequest',
       'PermissionController:updatePermissionsByCaveat',
       'PreferencesController:setPasswordForgotten',
       'OnboardingController:getState',

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -66,7 +66,11 @@ import {
   SeedlessOnboardingControllerSyncLatestGlobalPasswordAction,
   SeedlessOnboardingControllerUpdateBackupMetadataStateAction,
 } from '@metamask/seedless-onboarding-controller';
-import { PermissionControllerUpdatePermissionsByCaveatAction } from '@metamask/permission-controller';
+import {
+  PermissionControllerRejectPermissionsRequestAction,
+  PermissionControllerUpdatePermissionsByCaveatAction,
+  PermissionsRequestNotFoundError,
+} from '@metamask/permission-controller';
 import {
   Caip25CaveatMutators,
   Caip25CaveatType,
@@ -139,6 +143,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'isPublicEndpointUrl',
   'markPasswordForgotten',
   'onAccountRemoved',
+  'rejectPermissionsRequest',
   'removeAccount',
   'resetAccount',
   'setCurrentCurrency',
@@ -196,6 +201,7 @@ type AllowedActions =
   | NetworkControllerResetConnectionAction
   | OnboardingControllerGetIsSocialLoginFlowAction
   | OnboardingControllerGetStateAction
+  | PermissionControllerRejectPermissionsRequestAction
   | PermissionControllerUpdatePermissionsByCaveatAction
   | PreferencesControllerSetPasswordForgottenAction
   | RemoteFeatureFlagControllerGetStateAction
@@ -585,6 +591,27 @@ export class LegacyBackgroundApiService {
           address as Hex,
         ),
     );
+  }
+
+  /**
+   * Rejects a pending permissions request.
+   *
+   * Swallows `PermissionsRequestNotFoundError` so that rejecting an already
+   * resolved request does not throw.
+   *
+   * @param requestId - The ID of the permissions request to reject.
+   */
+  rejectPermissionsRequest(requestId: string): void {
+    try {
+      this.#messenger.call(
+        'PermissionController:rejectPermissionsRequest',
+        requestId,
+      );
+    } catch (error) {
+      if (!(error instanceof PermissionsRequestNotFoundError)) {
+        throw error;
+      }
+    }
   }
 
   async importAccountWithStrategy(


### PR DESCRIPTION
## **Description**

This moves `rejectPermissionsRequest` from `MetamaskController` to `LegacyBackgroundApiService`.

## **Related issues**

Progresses: https://consensyssoftware.atlassian.net/browse/WPC-1083

## **Manual testing steps**

1. Go to a dApp and trigger a connection/permissions request.
2. Reject the request.
3. Confirm the request is dismissed and no error is surfaced.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only path change for dApp permission rejection; behavior and error swallowing are preserved and covered by moved unit tests.
> 
> **Overview**
> **`rejectPermissionsRequest`** is moved out of **`MetamaskController`** into **`LegacyBackgroundApiService`**, continuing the legacy background API consolidation.
> 
> The public background API still exposes **`rejectPermissionsRequest`**, but **`getApi()`** now forwards through **`controllerMessenger.call('LegacyBackgroundApiService:rejectPermissionsRequest', …)`** instead of a controller method. The service implementation still calls **`PermissionController:rejectPermissionsRequest`** and **ignores `PermissionsRequestNotFoundError`** when a request is already gone.
> 
> Messenger wiring adds the new service action type and delegates **`PermissionController:rejectPermissionsRequest`** to the service messenger. Tests for the swallow/propagate behavior move from **`metamask-controller.actions.test.js`** to **`legacy-background-api-service.test.ts`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32c75c734cb3a5ed4ad5612a9e160df405541ba8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->