### PR TITLE
chore: migrate `approvePermissionsRequest` to `LegacyBackgroundApiService`

### DIFF
--- a/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
@@ -96,6 +96,7 @@ export function getLegacyBackgroundApiServiceMessenger(
       'TransactionController:isAtomicBatchSupported',
       'DelegationController:signDelegation',
       'KeyringController:signEip7702Authorization',
+      'PermissionController:acceptPermissionsRequest',
     ],
   });
 

--- a/app/scripts/metamask-controller.actions.test.js
+++ b/app/scripts/metamask-controller.actions.test.js
@@ -10,7 +10,6 @@ import {
   METAMASK_HOTLIST_DIFF_FILE,
 } from '@metamask/phishing-controller';
 import { ApprovalRequestNotFoundError } from '@metamask/approval-controller';
-import { PermissionsRequestNotFoundError } from '@metamask/permission-controller';
 import nock from 'nock';
 import { PasskeyControllerErrorCode } from '@metamask/passkey-controller';
 import { MOCK_ANY_NAMESPACE, Messenger } from '@metamask/messenger';
@@ -486,32 +485,6 @@ describe('MetaMaskController', function () {
           unifyController.assetsController.addCustomAsset,
         ).not.toHaveBeenCalled();
       });
-    });
-  });
-
-  describe('#acceptPermissionsRequest', function () {
-    it('should not propagate PermissionsRequestNotFoundError', function () {
-      const error = new PermissionsRequestNotFoundError('123');
-      metamaskController.permissionController = {
-        acceptPermissionsRequest: () => {
-          throw error;
-        },
-      };
-      expect(() =>
-        metamaskController.acceptPermissionsRequest('DUMMY_ID'),
-      ).not.toThrow(error);
-    });
-
-    it('should propagate Error other than PermissionsRequestNotFoundError', function () {
-      const error = new Error();
-      metamaskController.permissionController = {
-        acceptPermissionsRequest: () => {
-          throw error;
-        },
-      };
-      expect(() =>
-        metamaskController.acceptPermissionsRequest('DUMMY_ID'),
-      ).toThrow(error);
     });
   });
 

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3454,7 +3454,10 @@ export default class MetamaskController extends EventEmitter {
         this.controllerMessenger,
         'LegacyBackgroundApiService:removePermissionsFor',
       ),
-      approvePermissionsRequest: this.acceptPermissionsRequest,
+      approvePermissionsRequest: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'LegacyBackgroundApiService:acceptPermissionsRequest',
+      ),
       rejectPermissionsRequest: this.controllerMessenger.call.bind(
         this.controllerMessenger,
         'LegacyBackgroundApiService:rejectPermissionsRequest',
@@ -8438,16 +8441,6 @@ export default class MetamaskController extends EventEmitter {
     } catch (err) {
       log.error(err.message);
       throw err;
-    }
-  };
-
-  acceptPermissionsRequest = (request) => {
-    try {
-      this.permissionController.acceptPermissionsRequest(request);
-    } catch (exp) {
-      if (!(exp instanceof PermissionsRequestNotFoundError)) {
-        throw exp;
-      }
     }
   };
 

--- a/app/scripts/services/legacy-background-api-service-method-action-types.ts
+++ b/app/scripts/services/legacy-background-api-service-method-action-types.ts
@@ -332,6 +332,17 @@ export type LegacyBackgroundApiServiceRejectPendingApprovalAction = {
 };
 
 /**
+ * Accepts a permissions request. Silently ignores the request if it can no
+ * longer be found.
+ *
+ * @param request - The permissions request to accept.
+ */
+export type LegacyBackgroundApiServiceAcceptPermissionsRequestAction = {
+  type: `LegacyBackgroundApiService:acceptPermissionsRequest`;
+  handler: LegacyBackgroundApiService['acceptPermissionsRequest'];
+};
+
+/**
  * Union of all LegacyBackgroundApiService action types.
  */
 export type LegacyBackgroundApiServiceMethodActions =
@@ -363,4 +374,5 @@ export type LegacyBackgroundApiServiceMethodActions =
   | LegacyBackgroundApiServiceExportAccountAction
   | LegacyBackgroundApiServiceApplyTransactionContainersExistingAction
   | LegacyBackgroundApiServiceUpsertTransactionUIMetricsFragmentAction
-  | LegacyBackgroundApiServiceRejectPendingApprovalAction;
+  | LegacyBackgroundApiServiceRejectPendingApprovalAction
+  | LegacyBackgroundApiServiceAcceptPermissionsRequestAction;

--- a/app/scripts/services/legacy-background-api-service.test.ts
+++ b/app/scripts/services/legacy-background-api-service.test.ts
@@ -2655,6 +2655,74 @@ describe('LegacyBackgroundApiService', () => {
       });
     });
   });
+
+  describe('acceptPermissionsRequest', () => {
+    it('accepts the permissions request', async () => {
+      await withService(async ({ rootMessenger }) => {
+        const acceptPermissionsRequestHandler = jest.fn();
+        rootMessenger.registerActionHandler(
+          'PermissionController:acceptPermissionsRequest',
+          acceptPermissionsRequestHandler,
+        );
+
+        const request = {
+          metadata: { id: 'DUMMY_ID', origin: 'https://example.com' },
+          permissions: {},
+        };
+
+        rootMessenger.call(
+          'LegacyBackgroundApiService:acceptPermissionsRequest',
+          request,
+        );
+
+        expect(acceptPermissionsRequestHandler).toHaveBeenCalledWith(request);
+      });
+    });
+
+    it('does not propagate PermissionsRequestNotFoundError', async () => {
+      await withService(async ({ rootMessenger }) => {
+        const error = new PermissionsRequestNotFoundError('123');
+        rootMessenger.registerActionHandler(
+          'PermissionController:acceptPermissionsRequest',
+          jest.fn().mockImplementation(() => {
+            throw error;
+          }),
+        );
+
+        expect(() =>
+          rootMessenger.call(
+            'LegacyBackgroundApiService:acceptPermissionsRequest',
+            {
+              metadata: { id: 'DUMMY_ID', origin: 'https://example.com' },
+              permissions: {},
+            },
+          ),
+        ).not.toThrow(error);
+      });
+    });
+
+    it('propagates errors other than PermissionsRequestNotFoundError', async () => {
+      await withService(async ({ rootMessenger }) => {
+        const error = new Error('Test error');
+        rootMessenger.registerActionHandler(
+          'PermissionController:acceptPermissionsRequest',
+          jest.fn().mockImplementation(() => {
+            throw error;
+          }),
+        );
+
+        expect(() =>
+          rootMessenger.call(
+            'LegacyBackgroundApiService:acceptPermissionsRequest',
+            {
+              metadata: { id: 'DUMMY_ID', origin: 'https://example.com' },
+              permissions: {},
+            },
+          ),
+        ).toThrow(error);
+      });
+    });
+  });
 });
 
 /**
@@ -2782,6 +2850,7 @@ function getMessenger(
       'TransactionController:isAtomicBatchSupported',
       'DelegationController:signDelegation',
       'KeyringController:signEip7702Authorization',
+      'PermissionController:acceptPermissionsRequest',
     ],
   });
 

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -75,10 +75,12 @@ import {
   CaveatSpecificationConstraint,
   ExtractPermission,
   OriginString,
+  PermissionControllerAcceptPermissionsRequestAction,
   PermissionControllerRejectPermissionsRequestAction,
   PermissionControllerRevokePermissionsAction,
   PermissionControllerUpdatePermissionsByCaveatAction,
   PermissionSpecificationConstraint,
+  PermissionsRequest,
   PermissionsRequestNotFoundError,
 } from '@metamask/permission-controller';
 import {
@@ -148,6 +150,7 @@ const serviceName = 'LegacyBackgroundApiService';
  * This is currently empty, but it can be extended in the future to replace `MetaMaskController.getApi()`.
  */
 const MESSENGER_EXPOSED_METHODS = [
+  'acceptPermissionsRequest',
   'applyTransactionContainersExisting',
   'changePassword',
   'checkIsSeedlessPasswordOutdated',
@@ -231,6 +234,7 @@ type AllowedActions =
   | NetworkControllerResetConnectionAction
   | OnboardingControllerGetIsSocialLoginFlowAction
   | OnboardingControllerGetStateAction
+  | PermissionControllerAcceptPermissionsRequestAction
   | PermissionControllerRejectPermissionsRequestAction
   | PermissionControllerRevokePermissionsAction
   | PermissionControllerUpdatePermissionsByCaveatAction
@@ -1384,6 +1388,25 @@ export class LegacyBackgroundApiService {
     } catch (err) {
       if (!(err instanceof ApprovalRequestNotFoundError)) {
         throw err;
+      }
+    }
+  }
+
+  /**
+   * Accepts a permissions request. Silently ignores the request if it can no
+   * longer be found.
+   *
+   * @param request - The permissions request to accept.
+   */
+  acceptPermissionsRequest(request: PermissionsRequest): void {
+    try {
+      this.#messenger.call(
+        'PermissionController:acceptPermissionsRequest',
+        request,
+      );
+    } catch (error) {
+      if (!(error instanceof PermissionsRequestNotFoundError)) {
+        throw error;
       }
     }
   }


### PR DESCRIPTION
## **Description**

This moves `approvePermissionsRequest` (`acceptPermissionsRequest`) from `MetamaskController` to `LegacyBackgroundApiService`, keeping the `approvePermissionsRequest` getApi key.

## **Related issues**

Progresses: https://consensyssoftware.atlassian.net/browse/WPC-1082

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches dapp permission grant flow, but behavior and error handling are preserved; risk is mainly routing/regression in a security-sensitive path.
> 
> **Overview**
> **Permission approval** is moved off `MetaMaskController` into `LegacyBackgroundApiService`, continuing the WPC-1082 background API migration.
> 
> `getApi().approvePermissionsRequest` is unchanged for callers; it now invokes `LegacyBackgroundApiService:acceptPermissionsRequest` via the controller messenger instead of a controller method. The service forwards to `PermissionController:acceptPermissionsRequest` and still **swallows** `PermissionsRequestNotFoundError` while rethrowing other errors. Messenger wiring delegates `PermissionController:acceptPermissionsRequest` to the legacy background API service messenger.
> 
> Tests for this behavior move from `metamask-controller.actions.test.js` to `legacy-background-api-service.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b44e81122e1f470f09012c5903c76092b6264ff0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->