### PR TITLE
fix: updated search handler or tokens missing a valid assetId cp-13.38.0

### DIFF
--- a/shared/lib/token-search/convert-search-result.test.ts
+++ b/shared/lib/token-search/convert-search-result.test.ts
@@ -1,3 +1,4 @@
+import type { TokenSearchResult } from './token-search-api';
 import { convertSearchResultToImportPayload } from './convert-search-result';
 
 describe('convertSearchResultToImportPayload', () => {
@@ -77,7 +78,7 @@ describe('convertSearchResultToImportPayload', () => {
       convertSearchResultToImportPayload({
         ...base,
         assetId: 'not-a-valid-caip-id',
-      }),
+      } as unknown as TokenSearchResult),
     ).toBeUndefined();
   });
 

--- a/shared/lib/token-search/token-search-api.ts
+++ b/shared/lib/token-search/token-search-api.ts
@@ -1,3 +1,4 @@
+import type { CaipAssetType } from '@metamask/utils';
 import getFetchWithTimeout from '../fetch-with-timeout';
 import { TEN_SECONDS_IN_MILLISECONDS } from '../transactions-controller-utils';
 
@@ -7,7 +8,7 @@ const DEFAULT_BROWSE_OCCURRENCE_FLOOR = 3;
 const EVM_CHAIN_NAMESPACE = 'eip155:';
 
 export type TokenSearchResult = {
-  assetId: string;
+  assetId: CaipAssetType;
   symbol: string;
   decimals: number;
   name: string;

--- a/ui/components/app/import-token/token-search/token-search.component.test.tsx
+++ b/ui/components/app/import-token/token-search/token-search.component.test.tsx
@@ -3,6 +3,7 @@ import { screen, fireEvent, act } from '@testing-library/react';
 import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import { enLocale as messages } from '../../../../../test/lib/i18n-helpers';
 import * as tokenSearchApi from '../../../../../shared/lib/token-search/token-search-api';
+import type { TokenSearchResult } from '../../../../../shared/lib/token-search/token-search-api';
 import TokenSearch from './token-search.component';
 
 jest.mock('../../../../../shared/lib/token-search/token-search-api');
@@ -16,7 +17,7 @@ const emptyResponse = {
   pageInfo: { hasNextPage: false, endCursor: '' },
 };
 
-const MOCK_AAA = {
+const MOCK_AAA: TokenSearchResult = {
   assetId: 'eip155:1/erc20:0xaaa',
   symbol: 'AAA',
   name: 'Token AAA',
@@ -24,7 +25,7 @@ const MOCK_AAA = {
   iconUrl: '',
 };
 
-const MOCK_CCC = {
+const MOCK_CCC: TokenSearchResult = {
   assetId: 'eip155:137/erc20:0xccc',
   symbol: 'CCC',
   name: 'Token CCC',

--- a/ui/pages/token-management/token-management.test.tsx
+++ b/ui/pages/token-management/token-management.test.tsx
@@ -757,24 +757,28 @@ describe('TokenManagementPage', () => {
   });
 
   it('ignores API-backed results with missing asset IDs', () => {
+    const badTokenName = 'Bad Token';
+    const missingAssetIdTokenName = 'Missing Asset ID Token';
+    const validTokenName = 'USD Coin';
+
     setTokenSearchState({
       results: [
         {
           assetId: null,
           symbol: 'BAD',
           decimals: 18,
-          name: 'Bad Token',
+          name: badTokenName,
         },
         {
           symbol: 'MISSING',
           decimals: 18,
-          name: 'Missing Asset ID Token',
+          name: missingAssetIdTokenName,
         },
         {
           assetId: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
           symbol: 'USDC',
           decimals: 6,
-          name: 'USD Coin',
+          name: validTokenName,
         },
       ],
     });
@@ -785,9 +789,9 @@ describe('TokenManagementPage', () => {
       target: { value: 'usd' },
     });
 
-    expect(screen.queryByText('Bad Token')).not.toBeInTheDocument();
-    expect(screen.queryByText('Missing Asset ID Token')).not.toBeInTheDocument();
-    expect(screen.getByText('USD Coin')).toBeInTheDocument();
+    expect(screen.queryByText(badTokenName)).not.toBeInTheDocument();
+    expect(screen.queryByText(missingAssetIdTokenName)).not.toBeInTheDocument();
+    expect(screen.getByText(validTokenName)).toBeInTheDocument();
   });
 
   it('renders imported tokens first and non-imported API browse results below as OFF', () => {

--- a/ui/pages/token-management/token-management.test.tsx
+++ b/ui/pages/token-management/token-management.test.tsx
@@ -83,7 +83,7 @@ const getMockedActions = () =>
   jest.requireMock('../../store/actions') as MockedTokenManagementActions;
 
 type MockSearchResult = {
-  assetId: string;
+  assetId?: string | null;
   symbol: string;
   decimals: number;
   name: string;
@@ -753,6 +753,40 @@ describe('TokenManagementPage', () => {
     });
 
     expect(screen.queryByText('Alpha Token')).not.toBeInTheDocument();
+    expect(screen.getByText('USD Coin')).toBeInTheDocument();
+  });
+
+  it('ignores API-backed results with missing asset IDs', () => {
+    setTokenSearchState({
+      results: [
+        {
+          assetId: null,
+          symbol: 'BAD',
+          decimals: 18,
+          name: 'Bad Token',
+        },
+        {
+          symbol: 'MISSING',
+          decimals: 18,
+          name: 'Missing Asset ID Token',
+        },
+        {
+          assetId: 'eip155:1/erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+          symbol: 'USDC',
+          decimals: 6,
+          name: 'USD Coin',
+        },
+      ],
+    });
+
+    renderPage();
+
+    fireEvent.change(screen.getByTestId('token-management-search-input'), {
+      target: { value: 'usd' },
+    });
+
+    expect(screen.queryByText('Bad Token')).not.toBeInTheDocument();
+    expect(screen.queryByText('Missing Asset ID Token')).not.toBeInTheDocument();
     expect(screen.getByText('USD Coin')).toBeInTheDocument();
   });
 

--- a/ui/pages/token-management/token-management.tsx
+++ b/ui/pages/token-management/token-management.tsx
@@ -188,8 +188,8 @@ const getAssetReferenceFromAssetId = (assetId: unknown): string | undefined => {
 
 const hasValidAssetId = (
   result: TokenSearchResult,
-): result is TokenSearchResult & { assetId: string } =>
-  typeof result.assetId === 'string' && result.assetId.length > 0;
+): result is TokenSearchResult & { assetId: CaipAssetType } =>
+  typeof result.assetId === 'string';
 
 const getManagedTokenMetricsProperties = (token: ManagedAsset) => {
   const isEvmToken = isEvmChainId(token.chainId as Hex | CaipChainId);

--- a/ui/pages/token-management/token-management.tsx
+++ b/ui/pages/token-management/token-management.tsx
@@ -186,6 +186,11 @@ const getAssetReferenceFromAssetId = (assetId: unknown): string | undefined => {
   return assetReference || assetId;
 };
 
+const hasValidAssetId = (
+  result: TokenSearchResult,
+): result is TokenSearchResult & { assetId: string } =>
+  typeof result.assetId === 'string' && result.assetId.length > 0;
+
 const getManagedTokenMetricsProperties = (token: ManagedAsset) => {
   const isEvmToken = isEvmChainId(token.chainId as Hex | CaipChainId);
   const address =
@@ -642,7 +647,9 @@ export const TokenManagementPage = () => {
       return EMPTY_TOKEN_SEARCH_RESULTS;
     }
 
-    const results = searchResponse?.data ?? EMPTY_TOKEN_SEARCH_RESULTS;
+    const results = (searchResponse?.data ?? EMPTY_TOKEN_SEARCH_RESULTS).filter(
+      hasValidAssetId,
+    );
 
     // On Arc the native gas token IS USDC, so the USDC ERC20 (0x3600…) is a
     // display duplicate. Drop it from search/browse results too.


### PR DESCRIPTION
This PR:
- Filters malformed token search API results that are missing a valid `assetId`
- Prevents Token Management from crashing on `Cannot read properties of null (reading 'toLowerCase')`
- Adds regression coverage for null/missing `assetId` search results

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fixed the Manage Tokens page from crashing when token search returns malformed results with a missing or null `assetId`.

## **Related issues**

Fixes: #43951 

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/4a6cf5b1-43a9-4d96-88b5-ac4047bcf049


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primary change is defensive filtering on search results plus UI click-target adjustments; no auth or persistence logic changes.
> 
> **Overview**
> **Manage Tokens** no longer crashes when the token search API returns rows with a **null or missing `assetId`**. API results are filtered with `hasValidAssetId` before downstream logic (including `.toLowerCase()` on asset references), and `TokenSearchResult.assetId` is typed as **`CaipAssetType`**. Regression tests cover null/missing IDs; related test mocks are aligned with that type.
> 
> **Networks UI** changes are separate: adding a popular/additional network is triggered only from the **Add** button, not the whole row (network manager modal and networks page). Row hover/cursor styling for those items is removed. Minor polish: delete-network modal header alignment (`items-start`) and slightly more top padding on the networks list scroll area.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 496c7ba9c9adea9d6ddacd921b2127a076c6149f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->