### PR TITLE
feat: add gmx existing referral code check to defi referrals

### DIFF
--- a/app/scripts/lib/defi-referral-onchain-check.test.ts
+++ b/app/scripts/lib/defi-referral-onchain-check.test.ts
@@ -1,0 +1,118 @@
+import { CHAIN_IDS } from '../../../shared/constants/network';
+import { GMX_REFERRAL_STORAGE_ADDRESS } from '../../../shared/constants/defi-referrals';
+import { checkGmxHasReferralCode } from './defi-referral-onchain-check';
+
+const WALLET_ADDRESS = '0x1234567890abcdef1234567890abcdef12345678';
+const MOCK_NETWORK_CLIENT_ID = 'arbitrum-mainnet';
+
+// Non-zero bytes32 — represents a referral code being set
+const BYTES32_WITH_CODE =
+  '0x424c554542455252590000000000000000000000000000000000000000000000';
+// All-zero bytes32 — represents no referral code set
+const BYTES32_EMPTY =
+  '0x0000000000000000000000000000000000000000000000000000000000000000';
+
+function buildNetworkController({
+  findThrows = false,
+  rpcResult,
+  rpcThrows = false,
+}: {
+  findThrows?: boolean;
+  rpcResult?: string;
+  rpcThrows?: boolean;
+}) {
+  const mockRequest = jest.fn();
+
+  if (rpcThrows) {
+    mockRequest.mockRejectedValue(new Error('RPC error'));
+  } else {
+    mockRequest.mockResolvedValue(rpcResult);
+  }
+
+  return {
+    networkController: {
+      findNetworkClientIdByChainId: findThrows
+        ? jest.fn().mockImplementation(() => {
+            throw new Error('Chain not found');
+          })
+        : jest.fn().mockReturnValue(MOCK_NETWORK_CLIENT_ID),
+      getNetworkClientById: jest
+        .fn()
+        .mockReturnValue({ provider: { request: mockRequest } }),
+    },
+    mockRequest,
+  };
+}
+
+describe('checkGmxHasReferralCode', () => {
+  it('returns true when the wallet has a referral code set on-chain', async () => {
+    const { networkController } = buildNetworkController({
+      rpcResult: BYTES32_WITH_CODE,
+    });
+
+    const result = await checkGmxHasReferralCode(
+      networkController,
+      WALLET_ADDRESS,
+    );
+
+    expect(result).toBe(true);
+  });
+
+  it('returns false when the wallet has no referral code set on-chain', async () => {
+    const { networkController } = buildNetworkController({
+      rpcResult: BYTES32_EMPTY,
+    });
+
+    const result = await checkGmxHasReferralCode(
+      networkController,
+      WALLET_ADDRESS,
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when the RPC call throws', async () => {
+    const { networkController } = buildNetworkController({ rpcThrows: true });
+
+    const result = await checkGmxHasReferralCode(
+      networkController,
+      WALLET_ADDRESS,
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it('returns false when Arbitrum is not configured', async () => {
+    const { networkController } = buildNetworkController({ findThrows: true });
+
+    const result = await checkGmxHasReferralCode(
+      networkController,
+      WALLET_ADDRESS,
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it('queries the correct contract address and chain', async () => {
+    const { networkController, mockRequest } = buildNetworkController({
+      rpcResult: BYTES32_EMPTY,
+    });
+
+    await checkGmxHasReferralCode(networkController, WALLET_ADDRESS);
+
+    expect(networkController.findNetworkClientIdByChainId).toHaveBeenCalledWith(
+      CHAIN_IDS.ARBITRUM,
+    );
+    expect(networkController.getNetworkClientById).toHaveBeenCalledWith(
+      MOCK_NETWORK_CLIENT_ID,
+    );
+    expect(mockRequest).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'eth_call',
+        params: expect.arrayContaining([
+          expect.objectContaining({ to: GMX_REFERRAL_STORAGE_ADDRESS }),
+        ]),
+      }),
+    );
+  });
+});

--- a/app/scripts/lib/defi-referral-onchain-check.ts
+++ b/app/scripts/lib/defi-referral-onchain-check.ts
@@ -1,0 +1,57 @@
+import { CHAIN_IDS } from '../../../shared/constants/network';
+import { GMX_REFERRAL_STORAGE_ADDRESS } from '../../../shared/constants/defi-referrals';
+import { toFunctionSelector } from '../../../shared/lib/delegation/utils';
+
+/** Minimal shape of NetworkController required for the on-chain referral check. */
+type NetworkControllerLike = {
+  findNetworkClientIdByChainId: (chainId: string) => string;
+  getNetworkClientById: (
+    networkClientId: string,
+  ) => {
+    provider: {
+      request: (args: {
+        method: string;
+        params: unknown[];
+      }) => Promise<string>;
+    };
+  };
+};
+
+/**
+ * Checks if an address has a referral code set on GMX's Arbitrum ReferralStorage contract.
+ *
+ * @param networkController - NetworkController instance used to obtain the Arbitrum provider.
+ * @param walletAddress - The wallet address to check (hex string).
+ * @returns Whether the wallet has a GMX referral code on-chain.
+ */
+export async function checkGmxHasReferralCode(
+  networkController: NetworkControllerLike,
+  walletAddress: string,
+): Promise<boolean> {
+  try {
+    const networkClientId = networkController.findNetworkClientIdByChainId(
+      CHAIN_IDS.ARBITRUM,
+    );
+    const { provider } =
+      networkController.getNetworkClientById(networkClientId);
+
+    // Encode traderReferralCodes(address): selector + address zero-padded to 32 bytes
+    const selector = toFunctionSelector('traderReferralCodes(address)');
+    const paddedAddress = walletAddress
+      .toLowerCase()
+      .replace('0x', '')
+      .padStart(64, '0');
+    const callData = `${selector}${paddedAddress}`;
+
+    const result = await provider.request({
+      method: 'eth_call',
+      params: [{ to: GMX_REFERRAL_STORAGE_ADDRESS, data: callData }, 'latest'],
+    });
+
+    // Result is a bytes32; all-zero means no code is set
+    return typeof result === 'string' && BigInt(result) !== 0n;
+  } catch {
+    // If Arbitrum is not configured or the RPC call fails, default to false
+    return false;
+  }
+}

--- a/app/scripts/lib/defi-referral-onchain-check.ts
+++ b/app/scripts/lib/defi-referral-onchain-check.ts
@@ -5,14 +5,9 @@ import { toFunctionSelector } from '../../../shared/lib/delegation/utils';
 /** Minimal shape of NetworkController required for the on-chain referral check. */
 type NetworkControllerLike = {
   findNetworkClientIdByChainId: (chainId: string) => string;
-  getNetworkClientById: (
-    networkClientId: string,
-  ) => {
+  getNetworkClientById: (networkClientId: string) => {
     provider: {
-      request: (args: {
-        method: string;
-        params: unknown[];
-      }) => Promise<string>;
+      request: (args: { method: string; params: unknown[] }) => Promise<string>;
     };
   };
 };

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5848,9 +5848,15 @@ export default class MetamaskController extends EventEmitter {
       (account) => referralStatusByAccount[account] === ReferralStatus.Declined,
     );
 
+    // We should show approval screen if the account does not have a status
+    const shouldShowApproval = permittedAccountStatus === undefined;
+
+    // We should redirect to the referral url if the account is approved
+    const shouldRedirect = permittedAccountStatus === ReferralStatus.Approved;
+
     if (
       partner.id === DefiReferralPartner.GMX &&
-      permittedAccountStatus === undefined
+      (shouldShowApproval || shouldRedirect)
     ) {
       const hasExistingCode = await checkGmxHasReferralCode(
         this.networkController,
@@ -5864,12 +5870,6 @@ export default class MetamaskController extends EventEmitter {
         return;
       }
     }
-
-    // We should show approval screen if the account does not have a status
-    const shouldShowApproval = permittedAccountStatus === undefined;
-
-    // We should redirect to the referral url if the account is approved
-    const shouldRedirect = permittedAccountStatus === ReferralStatus.Approved;
 
     if (shouldShowApproval) {
       try {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -234,6 +234,7 @@ import {
   DEFI_REFERRAL_PARTNERS,
   DefiReferralPartner,
 } from '../../shared/constants/defi-referrals';
+import { checkGmxHasReferralCode } from './lib/defi-referral-onchain-check';
 import { keyringSnapPermissionsBuilder } from './lib/snap-keyring/keyring-snaps-permissions';
 
 import { AddressBookPetnamesBridge } from './lib/AddressBookPetnamesBridge';
@@ -5846,6 +5847,23 @@ export default class MetamaskController extends EventEmitter {
     const declinedAccounts = Object.keys(referralStatusByAccount).filter(
       (account) => referralStatusByAccount[account] === ReferralStatus.Declined,
     );
+
+    if (
+      partner.id === DefiReferralPartner.GMX &&
+      permittedAccountStatus === undefined
+    ) {
+      const hasExistingCode = await checkGmxHasReferralCode(
+        this.networkController,
+        activePermittedAccount,
+      );
+      if (hasExistingCode) {
+        this.preferencesController.addReferralPassedAccount(
+          partner.id,
+          activePermittedAccount,
+        );
+        return;
+      }
+    }
 
     // We should show approval screen if the account does not have a status
     const shouldShowApproval = permittedAccountStatus === undefined;

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -5546,13 +5546,18 @@ describe('MetaMaskController', () => {
       });
 
       describe('GMX on-chain referral code check', () => {
-        const GMX_ORIGIN = DEFI_REFERRAL_PARTNERS[DefiReferralPartner.GMX].origin;
+        const GMX_ORIGIN =
+          DEFI_REFERRAL_PARTNERS[DefiReferralPartner.GMX].origin;
         const GMX_APPROVAL_TYPE =
           DEFI_REFERRAL_PARTNERS[DefiReferralPartner.GMX].approvalType;
 
         beforeEach(() => {
           jest
-            .spyOn(metamaskController.remoteFeatureFlagController, 'state', 'get')
+            .spyOn(
+              metamaskController.remoteFeatureFlagController,
+              'state',
+              'get',
+            )
             .mockReturnValue({
               remoteFeatureFlags: {
                 extensionUxDefiReferralPartners: {
@@ -5623,7 +5628,9 @@ describe('MetaMaskController', () => {
             mockNewConnectionTriggerType,
           );
 
-          expect(metamaskController.approvalController.add).toHaveBeenCalledWith(
+          expect(
+            metamaskController.approvalController.add,
+          ).toHaveBeenCalledWith(
             expect.objectContaining({
               origin: GMX_ORIGIN,
               type: GMX_APPROVAL_TYPE,

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -91,6 +91,7 @@ import {
 import { forwardRequestToSnap } from './lib/forwardRequestToSnap';
 import { ReferralTriggerType } from './lib/createDefiReferralMiddleware';
 import MetaMaskController from './metamask-controller';
+import { checkGmxHasReferralCode } from './lib/defi-referral-onchain-check';
 
 // Opt out of the global `isAssetsUnifyStateFeatureEnabled` mock (see test/jest/setup.js)
 // and provide the pure flag-evaluation logic without the IN_TEST bypass
@@ -345,6 +346,10 @@ jest.mock('../../shared/lib/selectors/smart-transactions', () => {
 
 jest.mock('./lib/forwardRequestToSnap', () => ({
   forwardRequestToSnap: jest.fn().mockResolvedValue({}),
+}));
+
+jest.mock('./lib/defi-referral-onchain-check', () => ({
+  checkGmxHasReferralCode: jest.fn().mockResolvedValue(false),
 }));
 
 const TEST_SEED =
@@ -5538,6 +5543,103 @@ describe('MetaMaskController', () => {
         expect(
           metamaskController.approvalController.add,
         ).not.toHaveBeenCalled();
+      });
+
+      describe('GMX on-chain referral code check', () => {
+        const GMX_ORIGIN = DEFI_REFERRAL_PARTNERS[DefiReferralPartner.GMX].origin;
+        const GMX_APPROVAL_TYPE =
+          DEFI_REFERRAL_PARTNERS[DefiReferralPartner.GMX].approvalType;
+
+        beforeEach(() => {
+          jest
+            .spyOn(metamaskController.remoteFeatureFlagController, 'state', 'get')
+            .mockReturnValue({
+              remoteFeatureFlags: {
+                extensionUxDefiReferralPartners: {
+                  [DefiReferralPartner.GMX]: true,
+                },
+              },
+            });
+          jest
+            .spyOn(metamaskController, 'getPermittedAccounts')
+            .mockReturnValue(mockPermittedAccounts);
+          jest.spyOn(
+            metamaskController.preferencesController,
+            'addReferralPassedAccount',
+          );
+          metamaskController.preferencesController.update((state) => {
+            state.referrals[DefiReferralPartner.GMX] = {};
+          });
+        });
+
+        it('marks account as Passed and returns early when wallet has an existing code and status is undefined', async () => {
+          checkGmxHasReferralCode.mockResolvedValueOnce(true);
+
+          await metamaskController.handleDefiReferral(
+            DEFI_REFERRAL_PARTNERS[DefiReferralPartner.GMX],
+            mockTabId,
+            mockNewConnectionTriggerType,
+          );
+
+          expect(
+            metamaskController.preferencesController.addReferralPassedAccount,
+          ).toHaveBeenCalledWith(DefiReferralPartner.GMX, mockPermittedAccount);
+          expect(
+            metamaskController.approvalController.add,
+          ).not.toHaveBeenCalled();
+        });
+
+        it('marks account as Passed and returns early when wallet has an existing code and status is Approved', async () => {
+          metamaskController.preferencesController.update((state) => {
+            state.referrals[DefiReferralPartner.GMX] = {
+              [mockPermittedAccount]: ReferralStatus.Approved,
+            };
+          });
+          checkGmxHasReferralCode.mockResolvedValueOnce(true);
+
+          await metamaskController.handleDefiReferral(
+            DEFI_REFERRAL_PARTNERS[DefiReferralPartner.GMX],
+            mockTabId,
+            mockNewConnectionTriggerType,
+          );
+
+          expect(
+            metamaskController.preferencesController.addReferralPassedAccount,
+          ).toHaveBeenCalledWith(DefiReferralPartner.GMX, mockPermittedAccount);
+          expect(
+            metamaskController._handleDefiReferralRedirect,
+          ).not.toHaveBeenCalled();
+        });
+
+        it('proceeds to show the prompt when wallet has no GMX referral code', async () => {
+          checkGmxHasReferralCode.mockResolvedValueOnce(false);
+          jest
+            .spyOn(metamaskController.approvalController, 'add')
+            .mockResolvedValueOnce({});
+
+          await metamaskController.handleDefiReferral(
+            DEFI_REFERRAL_PARTNERS[DefiReferralPartner.GMX],
+            mockTabId,
+            mockNewConnectionTriggerType,
+          );
+
+          expect(metamaskController.approvalController.add).toHaveBeenCalledWith(
+            expect.objectContaining({
+              origin: GMX_ORIGIN,
+              type: GMX_APPROVAL_TYPE,
+            }),
+          );
+        });
+
+        it('does not call checkGmxHasReferralCode for non-GMX partners', async () => {
+          await metamaskController.handleDefiReferral(
+            DEFI_REFERRAL_PARTNERS[DefiReferralPartner.Hyperliquid],
+            mockTabId,
+            mockNewConnectionTriggerType,
+          );
+
+          expect(checkGmxHasReferralCode).not.toHaveBeenCalled();
+        });
       });
 
       describe('_handleDefiReferralApprovedAccount', () => {

--- a/shared/constants/defi-referrals.ts
+++ b/shared/constants/defi-referrals.ts
@@ -85,3 +85,11 @@ export function getPartnerByOrigin(
     (partner) => origin === partner.origin,
   );
 }
+
+/**
+ * GMX ReferralStorage contract address on Arbitrum
+ * Used to check whether a wallet address already has a referral code set on-chain.
+ * See https://arbiscan.io/address/0xe6fab3f0c7199b0d34d7fbe83394fc0e0d06e99d
+ */
+export const GMX_REFERRAL_STORAGE_ADDRESS =
+  '0xe6fab3f0c7199b0d34d7fbe83394fc0e0d06e99d';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

GMX requested that we check up front if a user already has a referral code set before we show them our MetaMask referral code prompt. So now when a user is connecting to GMX, we call `ReferralStorage.traderReferralCodes(walletAddress)` on Arbitrum via `eth_call`. If the wallet already has a code set on-chain, the account is silently marked as `Passed` and no prompt is shown and no redirect is performed. If the check fails for any reason, it defaults to false so the prompt proceeds as normal.

As a follow up to this I will put all the defi referral files into a folder in `scripts/lib` but this makes sense to do separately. 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Removed GMX referral code prompt when GMX users already have an existing code

## **Related issues**

Fixes:

## **Manual testing steps**

- Create a new instance of MM
- Import the QA testing account (which has a referral code already in use): 0x4f5243CeEa96Cee1DA0FdB89C756D0e999439424
- Connect to GMX
- Verify the MetaMask referral consent prompt does not appear
- Connect a different address that has no GMX referral code
- Verify the MetaMask referral consent prompt does appear as normal

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

The MM referral code prompt would show when the user connects.

### **After**

The prompt does not show for the above account. The screen recording also shows that the logged output of our new `ReferralStorage.traderReferralCodes` call matches the same output as when done directly on the contract in Arbiscan. 

https://github.com/user-attachments/assets/d579aad6-3e6d-41c6-9da5-aa4135989eb8

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
