### PR TITLE
fix: only trigger Snaps registry update when onboarding is complete

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -8210,7 +8210,11 @@ export default class MetamaskController extends EventEmitter {
       // unlocked.
       this.controllerMessenger.call('SnapController:setClientActive', open);
 
-      if (open) {
+      const { completedOnboarding } = this.controllerMessenger.call(
+        'OnboardingController:getState',
+      );
+
+      if (open && completedOnboarding) {
         // If the client is open and unlocked, request a periodic update of the
         // Snaps registry.
         this.controllerMessenger


### PR DESCRIPTION
## **Description**

When the client is opened and unlocked, MetaMask schedules a periodic update of the Snaps registry. This was potentially happening during onboarding, before the user had fully set up their wallet. This PR adds a check for `completedOnboarding` from `OnboardingController` state before requesting the registry update.

Follow up to #43922.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Start onboarding and unlock the wallet mid-flow.
2. Verify the Snaps registry update is not triggered during onboarding.
3. Complete onboarding and re-open the extension.
4. Verify the Snaps registry update is triggered as expected.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single conditional guard on a non-critical background registry fetch; no auth or data-path changes.
> 
> **Overview**
> **Snaps registry updates** no longer run when the UI opens during onboarding. The `isClientOpen` path still notifies Snaps of client active state when unlocked; it now also reads `completedOnboarding` from `OnboardingController` before calling `SnapRegistryController:requestPeriodicUpdate`.
> 
> Previously, an unlocked wallet mid-onboarding could schedule periodic registry updates; that check is gated so updates only happen after onboarding is finished.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b6348fffbc5865f4d09dfade014b9cfa93c7e9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->