### PR TITLE
test: fix flaky `Token List Sorting should sort tokens alphabetically and by decreasing balance`

### DIFF
--- a/test/e2e/page-objects/pages/home/tokens-tab.ts
+++ b/test/e2e/page-objects/pages/home/tokens-tab.ts
@@ -268,6 +268,7 @@ class TokensTab extends HomePage {
     await this.driver.clickElement(this.sortByPopoverToggle);
     if (sortBy === 'alphabetically') {
       await this.driver.clickElement(this.sortByAlphabetically);
+      await this.driver.assertElementNotPresent(this.lowValueAssetsToggle);
     } else if (sortBy === 'decliningBalance') {
       await this.driver.clickElement(this.sortByDecliningBalance);
     }

--- a/test/e2e/tests/tokens/token-sort.spec.ts
+++ b/test/e2e/tests/tokens/token-sort.spec.ts
@@ -40,7 +40,7 @@ describe('Token List Sorting', function () {
     });
   }
 
-  it('should sort tokens alphabetically and by decreasing balance TEST', async function () {
+  it('should sort tokens alphabetically and by decreasing balance', async function () {
     await withFixtures(
       {
         ...testFixtures,

--- a/test/e2e/tests/tokens/token-sort.spec.ts
+++ b/test/e2e/tests/tokens/token-sort.spec.ts
@@ -40,7 +40,7 @@ describe('Token List Sorting', function () {
     });
   }
 
-  it('should sort tokens alphabetically and by decreasing balance', async function () {
+  it('should sort tokens alphabetically and by decreasing balance TEST', async function () {
     await withFixtures(
       {
         ...testFixtures,

--- a/test/e2e/tests/tokens/token-sort.spec.ts
+++ b/test/e2e/tests/tokens/token-sort.spec.ts
@@ -66,7 +66,7 @@ describe('Token List Sorting', function () {
         );
         await tokensTab.dismissTokenImportedMessage();
 
-        await tokensTab.checkTokenExistsInList('Ethereum');
+        await tokensTab.checkTokenExistsInList(customTokenSymbol);
         await tokensTab.sortTokenList('alphabetically');
         await tokensTab.checkTokenPositionInList({
           position: 1,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Click Sort alphabetically took no effect, which indicates there's been a re-render.

After we import the custom token, we now wait until the token is loaded (it appears in the low value section), before sorting alphabetically.

This ensures that once we sort, the token is already loaded, and then the low value section disappears


See in the artifacts how the imported token remained in the low value section and the alphabetical order click took no effect

<img width="1366" height="682" alt="image" src="https://github.com/user-attachments/assets/e8493d03-afa4-4986-9271-f691eb2a979e" />


Note: other flakiness around the custom token import is being worked on separately

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only page-object and spec changes with no production code touched.
> 
> **Overview**
> Stabilizes the flaky **Token List Sorting** e2e by waiting for the UI to finish updating after choosing alphabetical sort.
> 
> In `TokensTab.sortTokenList`, after clicking **Sort alphabetically**, the flow now asserts that `low-value-assets-toggle` is **not** present. That matches product behavior when sort is not declining balance (low-value tokens are inlined, no collapsible section), so position checks do not run while the list is still re-bucketing or the toggle is visible.
> 
> The spec title was changed to append `TEST` on the alphabetical / decreasing-balance case—likely leftover debug text and worth reverting before merge.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb4bd5334180080e46bf802d7945e9345a06b331. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->