### PR TITLE
feat(perps): [Extension] Spike: de-risk performance impact of the expanded (extended) view [NOT-READY]

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -7008,6 +7008,9 @@
     "message": "Est. P&L at take profit",
     "description": "Label for estimated profit or loss when take profit is hit"
   },
+  "perpsExpandView": {
+    "message": "Open expanded view"
+  },
   "perpsExploreMarkets": {
     "message": "Explore markets"
   },
@@ -7152,6 +7155,9 @@
   "perpsNoMarketsFound": {
     "message": "No markets found"
   },
+  "perpsNoOpenPositions": {
+    "message": "No open positions or orders"
+  },
   "perpsNoTransactions": {
     "message": "No transactions yet"
   },
@@ -7177,6 +7183,12 @@
   },
   "perpsOraclePriceTooltip": {
     "message": "The median of external prices reported by validators, used for computing funding rate"
+  },
+  "perpsOrderBook": {
+    "message": "Order book"
+  },
+  "perpsOrderBookSpread": {
+    "message": "Spread"
   },
   "perpsOrderDate": {
     "message": "Date"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -7008,6 +7008,9 @@
     "message": "Est. P&L at take profit",
     "description": "Label for estimated profit or loss when take profit is hit"
   },
+  "perpsExpandView": {
+    "message": "Open expanded view"
+  },
   "perpsExploreMarkets": {
     "message": "Explore markets"
   },
@@ -7152,6 +7155,9 @@
   "perpsNoMarketsFound": {
     "message": "No markets found"
   },
+  "perpsNoOpenPositions": {
+    "message": "No open positions or orders"
+  },
   "perpsNoTransactions": {
     "message": "No transactions yet"
   },
@@ -7177,6 +7183,12 @@
   },
   "perpsOraclePriceTooltip": {
     "message": "The median of external prices reported by validators, used for computing funding rate"
+  },
+  "perpsOrderBook": {
+    "message": "Order book"
+  },
+  "perpsOrderBookSpread": {
+    "message": "Spread"
   },
   "perpsOrderDate": {
     "message": "Date"

--- a/ui/components/app/perps/order-entry/index.ts
+++ b/ui/components/app/perps/order-entry/index.ts
@@ -1,6 +1,9 @@
 // Main component export
 export { OrderEntry } from './order-entry';
 
+// Order params conversion (shared by order entry page + expanded view)
+export { formStateToOrderParams } from './order-params';
+
 // Type exports
 export type {
   OrderEntryProps,

--- a/ui/components/app/perps/order-entry/order-entry.test.tsx
+++ b/ui/components/app/perps/order-entry/order-entry.test.tsx
@@ -617,6 +617,15 @@ describe('OrderEntry', () => {
         mockStore,
       );
 
+      // A limit order needs a price before submit is enabled, mirroring the
+      // order-entry page's isLimitPriceInvalid guard.
+      const limitInput = screen
+        .getByTestId('limit-price-input')
+        .querySelector('input');
+      fireEvent.change(limitInput as HTMLInputElement, {
+        target: { value: '45000' },
+      });
+
       const submitButton = screen.getByTestId('order-entry-submit-button');
       fireEvent.click(submitButton);
 
@@ -625,6 +634,87 @@ describe('OrderEntry', () => {
           type: 'limit',
         }),
       );
+    });
+  });
+
+  describe('submit guards (parity with order-entry page)', () => {
+    const setAmount = (value: string) => {
+      const input = screen
+        .getByTestId('amount-input-field')
+        .querySelector('input') as HTMLInputElement;
+      fireEvent.change(input, { target: { value } });
+    };
+
+    it('disables submit and advertises the minimum for a below-min amount like "09"', () => {
+      const onSubmit = jest.fn();
+      renderWithProvider(
+        <OrderEntry {...defaultProps} onSubmit={onSubmit} />,
+        mockStore,
+      );
+
+      setAmount('09');
+
+      const submitButton = screen.getByTestId('order-entry-submit-button');
+      expect(submitButton).toBeDisabled();
+      // perpsMinOrderSize: "Order size must be at least $1" → "$10" substituted.
+      expect(submitButton).toHaveTextContent(/at least \$10/u);
+
+      fireEvent.click(submitButton);
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('disables submit when the amount is zero', () => {
+      const onSubmit = jest.fn();
+      renderWithProvider(
+        <OrderEntry {...defaultProps} onSubmit={onSubmit} />,
+        mockStore,
+      );
+
+      setAmount('0');
+
+      const submitButton = screen.getByTestId('order-entry-submit-button');
+      expect(submitButton).toBeDisabled();
+      fireEvent.click(submitButton);
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('disables submit and shows insufficient funds when margin exceeds balance', () => {
+      const onSubmit = jest.fn();
+      renderWithProvider(
+        <OrderEntry
+          {...defaultProps}
+          availableBalance={5}
+          onSubmit={onSubmit}
+        />,
+        mockStore,
+      );
+
+      // $100 at the default 3x leverage requires ~$33 margin > $5 balance.
+      setAmount('100');
+
+      const submitButton = screen.getByTestId('order-entry-submit-button');
+      expect(submitButton).toBeDisabled();
+      expect(submitButton).toHaveTextContent(
+        messages.insufficientFundsSend.message,
+      );
+      fireEvent.click(submitButton);
+      expect(onSubmit).not.toHaveBeenCalled();
+    });
+
+    it('enables submit for a valid amount at or above the minimum', () => {
+      const onSubmit = jest.fn();
+      renderWithProvider(
+        <OrderEntry {...defaultProps} onSubmit={onSubmit} />,
+        mockStore,
+      );
+
+      setAmount('100');
+
+      const submitButton = screen.getByTestId('order-entry-submit-button');
+      expect(submitButton).not.toBeDisabled();
+      expect(submitButton).toHaveTextContent('Open long BTC');
+      fireEvent.click(submitButton);
+      expect(onSubmit).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/ui/components/app/perps/order-entry/order-entry.tsx
+++ b/ui/components/app/perps/order-entry/order-entry.tsx
@@ -230,7 +230,10 @@ export const OrderEntry = ({
       return false;
     }
     // Modify with an empty amount is the TP/SL-only path — exempt.
-    if (mode === 'modify' && formState.amount.replace(/,/gu, '').trim() === '') {
+    if (
+      mode === 'modify' &&
+      formState.amount.replace(/,/gu, '').trim() === ''
+    ) {
       return false;
     }
     return orderUsdAmount < PERPS_MIN_MARKET_ORDER_USD;

--- a/ui/components/app/perps/order-entry/order-entry.tsx
+++ b/ui/components/app/perps/order-entry/order-entry.tsx
@@ -19,6 +19,7 @@ import {
   TextColor,
 } from '../../../../helpers/constants/design-system';
 import { getDisplaySymbol } from '../utils';
+import { PERPS_MIN_MARKET_ORDER_USD } from '../constants';
 import type { OrderEntryProps, OrderCalculations } from './order-entry.types';
 
 import { AmountInput } from './components/amount-input';
@@ -211,6 +212,76 @@ export const OrderEntry = ({
           : t('perpsOpenShort', [getDisplaySymbol(asset)]);
     }
   }, [mode, isLong, asset, t]);
+
+  // Submit guards for the in-form submit button (used by the expanded trade
+  // view). The full order-entry page renders OrderEntry with
+  // showSubmitButton={false} and owns its own disabled button, so without these
+  // the expanded view's internal button had no validation and could submit an
+  // invalid size — e.g. a $9 ("09") order the order-entry page would reject.
+  // These mirror the page's isBelowMinOrderSize / isInsufficientFunds /
+  // isLimitPriceInvalid checks so both surfaces behave the same.
+  const orderUsdAmount = useMemo(
+    () => Number.parseFloat(formState.amount.replace(/,/gu, '')) || 0,
+    [formState.amount],
+  );
+
+  const isBelowMinOrderSize = useMemo(() => {
+    if (formState.type !== 'market' || (mode !== 'new' && mode !== 'modify')) {
+      return false;
+    }
+    // Modify with an empty amount is the TP/SL-only path — exempt.
+    if (mode === 'modify' && formState.amount.replace(/,/gu, '').trim() === '') {
+      return false;
+    }
+    return orderUsdAmount < PERPS_MIN_MARKET_ORDER_USD;
+  }, [formState.type, formState.amount, mode, orderUsdAmount]);
+
+  const isInsufficientFunds = useMemo(() => {
+    if (mode === 'close' || orderUsdAmount <= 0 || formState.leverage <= 0) {
+      return false;
+    }
+    return orderUsdAmount / formState.leverage > availableBalance;
+  }, [mode, orderUsdAmount, formState.leverage, availableBalance]);
+
+  const isLimitPriceInvalid = useMemo(() => {
+    if (formState.type !== 'limit') {
+      return false;
+    }
+    const cleaned = formState.limitPrice?.replaceAll(',', '') ?? '';
+    const parsed = Number.parseFloat(cleaned);
+    return !cleaned || Number.isNaN(parsed) || parsed <= 0;
+  }, [formState.type, formState.limitPrice]);
+
+  const isSubmitDisabled = useMemo(() => {
+    if (mode === 'close') {
+      return currentPrice <= 0 || (closePercent ?? 100) <= 0;
+    }
+    return (
+      currentPrice <= 0 ||
+      isBelowMinOrderSize ||
+      isInsufficientFunds ||
+      isLimitPriceInvalid
+    );
+  }, [
+    mode,
+    currentPrice,
+    closePercent,
+    isBelowMinOrderSize,
+    isInsufficientFunds,
+    isLimitPriceInvalid,
+  ]);
+
+  const resolvedSubmitButtonText = useMemo(() => {
+    if (mode !== 'close') {
+      if (isBelowMinOrderSize) {
+        return t('perpsMinOrderSize', [`$${PERPS_MIN_MARKET_ORDER_USD}`]);
+      }
+      if (isInsufficientFunds) {
+        return t('insufficientFundsSend');
+      }
+    }
+    return submitButtonText;
+  }, [mode, isBelowMinOrderSize, isInsufficientFunds, submitButtonText, t]);
 
   // Get position size for close mode
   const positionSize = existingPosition?.size ?? '0';
@@ -432,15 +503,17 @@ export const OrderEntry = ({
             variant={ButtonVariant.Primary}
             size={ButtonSize.Md}
             onClick={handleSubmit}
+            disabled={isSubmitDisabled}
             className={twMerge(
               'w-full',
               isLong
                 ? 'bg-success-default hover:bg-success-hover active:bg-success-pressed'
                 : 'bg-error-default hover:bg-error-hover active:bg-error-pressed',
+              isSubmitDisabled && 'opacity-70 cursor-not-allowed',
             )}
             data-testid="order-entry-submit-button"
           >
-            {submitButtonText}
+            {resolvedSubmitButtonText}
           </Button>
         </Box>
       )}

--- a/ui/components/app/perps/order-entry/order-params.test.ts
+++ b/ui/components/app/perps/order-entry/order-params.test.ts
@@ -1,0 +1,291 @@
+import { ORDER_SLIPPAGE_CONFIG } from '@metamask/perps-controller';
+import { formStateToOrderParams } from './order-params';
+import type { OrderFormState } from './order-entry.types';
+
+const baseFormState: OrderFormState = {
+  asset: 'ETH',
+  direction: 'long',
+  closePercent: 100,
+  amount: '100',
+  leverage: 3,
+  balancePercent: 0,
+  takeProfitPrice: '',
+  stopLossPrice: '',
+  limitPrice: '',
+  type: 'market',
+  autoCloseEnabled: false,
+};
+
+describe('formStateToOrderParams', () => {
+  describe('market orders', () => {
+    it('sets isBuy to true for long direction', () => {
+      const result = formStateToOrderParams(baseFormState, 2000);
+      expect(result.isBuy).toBe(true);
+    });
+
+    it('sets isBuy to false for short direction', () => {
+      const state: OrderFormState = { ...baseFormState, direction: 'short' };
+      const result = formStateToOrderParams(state, 2000);
+      expect(result.isBuy).toBe(false);
+    });
+
+    it('calculates position size from margin, leverage, and price', () => {
+      // size = (100 * 3) / 2000 = 0.15
+      const result = formStateToOrderParams(baseFormState, 2000);
+      expect(result.size).toBe('0.15');
+    });
+
+    it('sets size to 0 when currentPrice is 0', () => {
+      const result = formStateToOrderParams(baseFormState, 0);
+      expect(result.size).toBe('0');
+    });
+
+    it('uses DefaultMarketSlippageBps when no override provided', () => {
+      const result = formStateToOrderParams(baseFormState, 2000);
+      expect(result.maxSlippageBps).toBe(
+        ORDER_SLIPPAGE_CONFIG.DefaultMarketSlippageBps,
+      );
+    });
+
+    it('uses provided maxSlippageBps override for market orders', () => {
+      const result = formStateToOrderParams(
+        baseFormState,
+        2000,
+        'new',
+        undefined,
+        500,
+      );
+      expect(result.maxSlippageBps).toBe(500);
+    });
+
+    it('does not set price field for market orders', () => {
+      const result = formStateToOrderParams(baseFormState, 2000);
+      expect(result.price).toBeUndefined();
+    });
+
+    it('strips commas from amount and exposes as usdAmount', () => {
+      const state: OrderFormState = { ...baseFormState, amount: '1,000' };
+      const result = formStateToOrderParams(state, 2000);
+      expect(result.usdAmount).toBe('1000');
+    });
+
+    it('sets symbol from formState asset', () => {
+      const result = formStateToOrderParams(baseFormState, 2000);
+      expect(result.symbol).toBe('ETH');
+    });
+
+    it('sets orderType from formState type', () => {
+      const result = formStateToOrderParams(baseFormState, 2000);
+      expect(result.orderType).toBe('market');
+    });
+
+    it('sets leverage and currentPrice', () => {
+      const result = formStateToOrderParams(baseFormState, 2000);
+      expect(result.leverage).toBe(3);
+      expect(result.currentPrice).toBe(2000);
+      expect(result.priceAtCalculation).toBe(2000);
+    });
+
+    it('treats non-numeric amount as 0 margin for size calculation', () => {
+      const state: OrderFormState = { ...baseFormState, amount: '' };
+      const result = formStateToOrderParams(state, 2000);
+      expect(result.size).toBe('0');
+    });
+  });
+
+  describe('limit orders', () => {
+    const limitFormState: OrderFormState = {
+      ...baseFormState,
+      type: 'limit',
+      limitPrice: '1950',
+    };
+
+    it('uses DefaultLimitSlippageBps for limit orders', () => {
+      const result = formStateToOrderParams(limitFormState, 2000);
+      expect(result.maxSlippageBps).toBe(
+        ORDER_SLIPPAGE_CONFIG.DefaultLimitSlippageBps,
+      );
+    });
+
+    it('sets price from limitPrice for limit orders', () => {
+      const result = formStateToOrderParams(limitFormState, 2000);
+      expect(result.price).toBe('1950');
+    });
+
+    it('strips commas from limitPrice', () => {
+      const state: OrderFormState = {
+        ...limitFormState,
+        limitPrice: '1,950.50',
+      };
+      const result = formStateToOrderParams(state, 2000);
+      expect(result.price).toBe('1950.50');
+    });
+
+    it('does not set price when limitPrice is empty', () => {
+      const state: OrderFormState = { ...limitFormState, limitPrice: '' };
+      const result = formStateToOrderParams(state, 2000);
+      expect(result.price).toBeUndefined();
+    });
+
+    it('ignores maxSlippageBps override for limit orders', () => {
+      const result = formStateToOrderParams(
+        limitFormState,
+        2000,
+        'new',
+        undefined,
+        999,
+      );
+      expect(result.maxSlippageBps).toBe(
+        ORDER_SLIPPAGE_CONFIG.DefaultLimitSlippageBps,
+      );
+    });
+  });
+
+  describe('close mode', () => {
+    it('uses existingPositionSize as size in close mode', () => {
+      const result = formStateToOrderParams(
+        baseFormState,
+        2000,
+        'close',
+        '2.5',
+      );
+      expect(result.size).toBe('2.5');
+    });
+
+    it('uses absolute value of existingPositionSize for short positions', () => {
+      const result = formStateToOrderParams(
+        baseFormState,
+        2000,
+        'close',
+        '-0.5',
+      );
+      expect(result.size).toBe('0.5');
+    });
+
+    it('sets reduceOnly to true in close mode', () => {
+      const result = formStateToOrderParams(
+        baseFormState,
+        2000,
+        'close',
+        '2.5',
+      );
+      expect(result.reduceOnly).toBe(true);
+    });
+
+    it('sets isFullClose to true in close mode', () => {
+      const result = formStateToOrderParams(
+        baseFormState,
+        2000,
+        'close',
+        '2.5',
+      );
+      expect(result.isFullClose).toBe(true);
+    });
+
+    it('falls back to calculated size when existingPositionSize is not provided in close mode', () => {
+      // (100 * 3) / 2000 = 0.15
+      const result = formStateToOrderParams(baseFormState, 2000, 'close');
+      expect(result.size).toBe('0.15');
+    });
+  });
+
+  describe('TP/SL when autoCloseEnabled', () => {
+    it('includes takeProfitPrice when autoCloseEnabled and takeProfitPrice is set', () => {
+      const state: OrderFormState = {
+        ...baseFormState,
+        autoCloseEnabled: true,
+        takeProfitPrice: '2500',
+      };
+      const result = formStateToOrderParams(state, 2000);
+      expect(result.takeProfitPrice).toBe('2500');
+    });
+
+    it('strips commas from takeProfitPrice', () => {
+      const state: OrderFormState = {
+        ...baseFormState,
+        autoCloseEnabled: true,
+        takeProfitPrice: '2,500.00',
+      };
+      const result = formStateToOrderParams(state, 2000);
+      expect(result.takeProfitPrice).toBe('2500.00');
+    });
+
+    it('includes stopLossPrice when autoCloseEnabled and stopLossPrice is set', () => {
+      const state: OrderFormState = {
+        ...baseFormState,
+        autoCloseEnabled: true,
+        stopLossPrice: '1800',
+      };
+      const result = formStateToOrderParams(state, 2000);
+      expect(result.stopLossPrice).toBe('1800');
+    });
+
+    it('strips commas from stopLossPrice', () => {
+      const state: OrderFormState = {
+        ...baseFormState,
+        autoCloseEnabled: true,
+        stopLossPrice: '1,800.00',
+      };
+      const result = formStateToOrderParams(state, 2000);
+      expect(result.stopLossPrice).toBe('1800.00');
+    });
+
+    it('does not include takeProfitPrice when autoCloseEnabled is false', () => {
+      const state: OrderFormState = {
+        ...baseFormState,
+        autoCloseEnabled: false,
+        takeProfitPrice: '2500',
+      };
+      const result = formStateToOrderParams(state, 2000);
+      expect(result.takeProfitPrice).toBeUndefined();
+    });
+
+    it('does not include stopLossPrice when autoCloseEnabled is false', () => {
+      const state: OrderFormState = {
+        ...baseFormState,
+        autoCloseEnabled: false,
+        stopLossPrice: '1800',
+      };
+      const result = formStateToOrderParams(state, 2000);
+      expect(result.stopLossPrice).toBeUndefined();
+    });
+
+    it('does not include takeProfitPrice when it is an empty string', () => {
+      const state: OrderFormState = {
+        ...baseFormState,
+        autoCloseEnabled: true,
+        takeProfitPrice: '',
+      };
+      const result = formStateToOrderParams(state, 2000);
+      expect(result.takeProfitPrice).toBeUndefined();
+    });
+
+    it('does not include stopLossPrice when it is an empty string', () => {
+      const state: OrderFormState = {
+        ...baseFormState,
+        autoCloseEnabled: true,
+        stopLossPrice: '',
+      };
+      const result = formStateToOrderParams(state, 2000);
+      expect(result.stopLossPrice).toBeUndefined();
+    });
+  });
+
+  describe('mode defaults', () => {
+    it('defaults to new mode when mode is not provided', () => {
+      const result = formStateToOrderParams(baseFormState, 2000);
+      expect(result.reduceOnly).toBeUndefined();
+      expect(result.isFullClose).toBeUndefined();
+    });
+
+    it('does not set reduceOnly in new mode', () => {
+      const result = formStateToOrderParams(baseFormState, 2000, 'new');
+      expect(result.reduceOnly).toBeUndefined();
+    });
+
+    it('does not set isFullClose in new mode', () => {
+      const result = formStateToOrderParams(baseFormState, 2000, 'new');
+      expect(result.isFullClose).toBeUndefined();
+    });
+  });
+});

--- a/ui/components/app/perps/order-entry/order-params.ts
+++ b/ui/components/app/perps/order-entry/order-params.ts
@@ -1,0 +1,65 @@
+import { ORDER_SLIPPAGE_CONFIG } from '@metamask/perps-controller';
+import type { OrderParams } from '@metamask/perps-controller';
+import type { OrderFormState, OrderMode } from './order-entry.types';
+
+/**
+ * Convert UI `OrderFormState` into a PerpsController `OrderParams` payload.
+ *
+ * Shared by the order entry page and the expanded trading view so the two
+ * surfaces submit identical order shapes.
+ *
+ * @param formState - Current order form state.
+ * @param currentPrice - Current asset price in USD.
+ * @param mode - Order mode (new, modify, close). Defaults to `'new'`.
+ * @param existingPositionSize - Size of the existing position when closing.
+ * @param maxSlippageBps - Optional slippage override (market orders only).
+ * @returns The controller order params.
+ */
+export function formStateToOrderParams(
+  formState: OrderFormState,
+  currentPrice: number,
+  mode: OrderMode = 'new',
+  existingPositionSize?: string,
+  maxSlippageBps?: number,
+): OrderParams {
+  const isBuy = formState.direction === 'long';
+  const marginAmount = Number.parseFloat(formState.amount) || 0;
+  const positionSize =
+    currentPrice > 0 ? (marginAmount * formState.leverage) / currentPrice : 0;
+  const size =
+    mode === 'close' && existingPositionSize
+      ? Math.abs(Number.parseFloat(existingPositionSize)).toString()
+      : positionSize.toString();
+  const cleanAmount = formState.amount.replaceAll(',', '');
+
+  const params: OrderParams = {
+    symbol: formState.asset,
+    isBuy,
+    size,
+    orderType: formState.type,
+    leverage: formState.leverage,
+    currentPrice,
+    usdAmount: cleanAmount,
+    priceAtCalculation: currentPrice,
+    maxSlippageBps:
+      formState.type === 'limit'
+        ? ORDER_SLIPPAGE_CONFIG.DefaultLimitSlippageBps
+        : (maxSlippageBps ?? ORDER_SLIPPAGE_CONFIG.DefaultMarketSlippageBps),
+  };
+
+  if (formState.type === 'limit' && formState.limitPrice) {
+    params.price = formState.limitPrice.replaceAll(',', '');
+  }
+  if (formState.autoCloseEnabled && formState.takeProfitPrice) {
+    params.takeProfitPrice = formState.takeProfitPrice.replaceAll(',', '');
+  }
+  if (formState.autoCloseEnabled && formState.stopLossPrice) {
+    params.stopLossPrice = formState.stopLossPrice.replaceAll(',', '');
+  }
+  if (mode === 'close') {
+    params.reduceOnly = true;
+    params.isFullClose = true;
+  }
+
+  return params;
+}

--- a/ui/components/app/perps/perps-market-expanded/index.ts
+++ b/ui/components/app/perps/perps-market-expanded/index.ts
@@ -1,0 +1,11 @@
+export { PerpsExpandedHeader } from './perps-expanded-header';
+export type { PerpsExpandedHeaderProps } from './perps-expanded-header';
+export { PerpsExpandedChartPanel } from './perps-expanded-chart-panel';
+export type { PerpsExpandedChartPanelProps } from './perps-expanded-chart-panel';
+export { PerpsExpandedOrderBookPanel } from './perps-expanded-order-book-panel';
+export type { PerpsExpandedOrderBookPanelProps } from './perps-expanded-order-book-panel';
+export { PerpsExpandedTradePanel } from './perps-expanded-trade-panel';
+export type { PerpsExpandedTradePanelProps } from './perps-expanded-trade-panel';
+export { PerpsExpandedPositionsPanel } from './perps-expanded-positions-panel';
+export type { PerpsExpandedPositionsPanelProps } from './perps-expanded-positions-panel';
+export { PerpsExpandedSkeleton } from './perps-expanded-skeleton';

--- a/ui/components/app/perps/perps-market-expanded/perps-expanded-chart-panel.tsx
+++ b/ui/components/app/perps/perps-market-expanded/perps-expanded-chart-panel.tsx
@@ -1,0 +1,122 @@
+import React, { useCallback, useMemo, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { Box, BoxFlexDirection, Skeleton } from '@metamask/design-system-react';
+import { getPreferences } from '../../../../../shared/lib/selectors/preferences';
+import { useTheme } from '../../../../hooks/useTheme';
+import { usePerpsLiveCandles } from '../../../../hooks/perps/stream';
+import { submitRequestToBackground } from '../../../../store/background-connection';
+import {
+  PerpsCandlestickChart,
+  type PerpsCandlestickChartRef,
+  type ChartPriceLine,
+} from '../perps-candlestick-chart';
+import { PerpsCandlePeriodSelector } from '../perps-candle-period-selector';
+import {
+  CandlePeriod,
+  TimeDuration,
+  ZOOM_CONFIG,
+} from '../constants/chartConfig';
+
+const CHART_THROTTLE_MS = 1000;
+
+export type PerpsExpandedChartPanelProps = {
+  /** Market symbol being charted (e.g. 'BTC'). */
+  symbol: string;
+};
+
+/**
+ * Chart panel for the expanded perps view.
+ *
+ * Owns its candle subscription (throttled to {@link CHART_THROTTLE_MS}) and
+ * derives the current price from the latest candle locally. The price is never
+ * lifted to the page, so a candle tick re-renders only this panel.
+ */
+export const PerpsExpandedChartPanel = React.memo(
+  ({ symbol }: PerpsExpandedChartPanelProps) => {
+    const isDark = useTheme() === 'dark';
+    const { perpsSelectedCandlePeriod: persistedCandlePeriod } = useSelector(
+      getPreferences,
+    ) as { perpsSelectedCandlePeriod?: string };
+    const resolvedPersistedPeriod =
+      persistedCandlePeriod &&
+      Object.values(CandlePeriod).includes(
+        persistedCandlePeriod as CandlePeriod,
+      )
+        ? (persistedCandlePeriod as CandlePeriod)
+        : CandlePeriod.FiveMinutes;
+    const [localPeriodOverride, setLocalPeriodOverride] =
+      useState<CandlePeriod | null>(null);
+    const selectedPeriod = localPeriodOverride ?? resolvedPersistedPeriod;
+    const chartRef = useRef<PerpsCandlestickChartRef>(null);
+
+    const { candleData, isInitialLoading, fetchMoreHistory } =
+      usePerpsLiveCandles({
+        symbol,
+        interval: selectedPeriod,
+        duration: TimeDuration.YearToDate,
+        throttleMs: CHART_THROTTLE_MS,
+      });
+
+    const currentPrice = useMemo(() => {
+      const lastClose = candleData?.candles?.at(-1)?.close;
+      return lastClose ? parseFloat(lastClose) : 0;
+    }, [candleData]);
+
+    const priceLines = useMemo<ChartPriceLine[]>(() => {
+      if (currentPrice <= 0) {
+        return [];
+      }
+      return [
+        {
+          price: currentPrice,
+          label: '',
+          // Matches the detail page's muted current-price line.
+          color: isDark ? '#ffffff0a' : '#b4b4b528',
+          lineStyle: 2,
+          lineWidth: 2,
+        },
+      ];
+    }, [currentPrice, isDark]);
+
+    const handlePeriodChange = useCallback((period: CandlePeriod) => {
+      setLocalPeriodOverride(period);
+      submitRequestToBackground('setPreference', [
+        'perpsSelectedCandlePeriod',
+        period,
+      ]).catch(() => {
+        // best-effort; chart still updates via local state
+      });
+      chartRef.current?.applyZoom(ZOOM_CONFIG.DEFAULT_CANDLES, true);
+    }, []);
+
+    return (
+      <Box
+        flexDirection={BoxFlexDirection.Column}
+        className="min-h-0 min-w-0 border-r border-muted"
+        data-testid="perps-expanded-chart-panel"
+      >
+        <Box className="min-h-0 flex-1 p-2">
+          {isInitialLoading && !candleData ? (
+            <Skeleton className="h-full w-full rounded-lg" />
+          ) : (
+            <PerpsCandlestickChart
+              ref={chartRef}
+              height={420}
+              selectedPeriod={selectedPeriod}
+              candleData={candleData}
+              currentPrice={currentPrice}
+              priceLines={priceLines}
+              onNeedMoreHistory={fetchMoreHistory}
+            />
+          )}
+        </Box>
+        <PerpsCandlePeriodSelector
+          selectedPeriod={selectedPeriod}
+          onPeriodChange={handlePeriodChange}
+        />
+      </Box>
+    );
+  },
+);
+
+PerpsExpandedChartPanel.displayName = 'PerpsExpandedChartPanel';

--- a/ui/components/app/perps/perps-market-expanded/perps-expanded-header.test.tsx
+++ b/ui/components/app/perps/perps-market-expanded/perps-expanded-header.test.tsx
@@ -1,0 +1,119 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { PerpsExpandedHeader } from './perps-expanded-header';
+
+jest.mock('../../../../hooks/useI18nContext', () => ({
+  useI18nContext: () => (key: string) => key,
+}));
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+const mockUsePerpsLivePrices = jest.fn(() => ({
+  prices: {},
+  isInitialLoading: false,
+}));
+
+jest.mock('../../../../hooks/perps/stream', () => ({
+  usePerpsLivePrices: (...args: unknown[]) => mockUsePerpsLivePrices(...args),
+}));
+
+jest.mock('../perps-token-logo', () => ({
+  PerpsTokenLogo: ({ symbol }: { symbol: string }) => (
+    <div data-testid="perps-token-logo" data-symbol={symbol} />
+  ),
+}));
+
+describe('PerpsExpandedHeader', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePerpsLivePrices.mockReturnValue({
+      prices: {},
+      isInitialLoading: false,
+    });
+  });
+
+  it('renders the header container', () => {
+    const { getByTestId } = render(
+      <PerpsExpandedHeader symbol="ETH" />,
+    );
+    expect(getByTestId('perps-expanded-header')).toBeInTheDocument();
+  });
+
+  it('renders the symbol name with USD suffix', () => {
+    render(<PerpsExpandedHeader symbol="ETH" />);
+    expect(screen.getByText('ETH-USD')).toBeInTheDocument();
+  });
+
+  it('renders maxLeverageLabel when provided', () => {
+    render(<PerpsExpandedHeader symbol="ETH" maxLeverageLabel="20x" />);
+    expect(screen.getByText('20x')).toBeInTheDocument();
+  });
+
+  it('does not render maxLeverageLabel when not provided', () => {
+    render(<PerpsExpandedHeader symbol="ETH" />);
+    expect(screen.queryByText(/\d+x/u)).not.toBeInTheDocument();
+  });
+
+  it('renders the price element', () => {
+    mockUsePerpsLivePrices.mockReturnValue({
+      prices: {
+        ETH: { price: '2850.00', percentChange24h: '+2.56%', symbol: 'ETH' },
+      },
+      isInitialLoading: false,
+    });
+
+    render(<PerpsExpandedHeader symbol="ETH" />);
+
+    expect(screen.getByTestId('perps-expanded-price')).toBeInTheDocument();
+  });
+
+  it('renders the change element', () => {
+    mockUsePerpsLivePrices.mockReturnValue({
+      prices: {
+        ETH: { price: '2850.00', percentChange24h: '+2.56%', symbol: 'ETH' },
+      },
+      isInitialLoading: false,
+    });
+
+    render(<PerpsExpandedHeader symbol="ETH" />);
+
+    expect(screen.getByTestId('perps-expanded-change')).toBeInTheDocument();
+  });
+
+  it('renders the back button', () => {
+    render(<PerpsExpandedHeader symbol="ETH" />);
+    expect(screen.getByTestId('perps-expanded-back-button')).toBeInTheDocument();
+  });
+
+  it('navigates to the perps tab when back button is clicked', () => {
+    render(<PerpsExpandedHeader symbol="ETH" />);
+    fireEvent.click(screen.getByTestId('perps-expanded-back-button'));
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({ search: 'tab=perps' }),
+    );
+  });
+
+  it('renders the token logo for the symbol', () => {
+    const { getByTestId } = render(<PerpsExpandedHeader symbol="BTC" />);
+    const logo = getByTestId('perps-token-logo');
+    expect(logo).toHaveAttribute('data-symbol', 'BTC');
+  });
+
+  it('passes symbols array to usePerpsLivePrices', () => {
+    render(<PerpsExpandedHeader symbol="ETH" />);
+    expect(mockUsePerpsLivePrices).toHaveBeenCalledWith(
+      expect.objectContaining({ symbols: ['ETH'] }),
+    );
+  });
+
+  it('activates the price stream', () => {
+    render(<PerpsExpandedHeader symbol="ETH" />);
+    expect(mockUsePerpsLivePrices).toHaveBeenCalledWith(
+      expect.objectContaining({ activateStream: true }),
+    );
+  });
+});

--- a/ui/components/app/perps/perps-market-expanded/perps-expanded-header.test.tsx
+++ b/ui/components/app/perps/perps-market-expanded/perps-expanded-header.test.tsx
@@ -12,10 +12,14 @@ jest.mock('react-router-dom', () => ({
   useNavigate: () => mockNavigate,
 }));
 
-const mockUsePerpsLivePrices = jest.fn(() => ({
-  prices: {},
-  isInitialLoading: false,
-}));
+const mockUsePerpsLivePrices = jest.fn(
+  (
+    ..._args: unknown[]
+  ): { prices: Record<string, unknown>; isInitialLoading: boolean } => ({
+    prices: {},
+    isInitialLoading: false,
+  }),
+);
 
 jest.mock('../../../../hooks/perps/stream', () => ({
   usePerpsLivePrices: (...args: unknown[]) => mockUsePerpsLivePrices(...args),

--- a/ui/components/app/perps/perps-market-expanded/perps-expanded-header.test.tsx
+++ b/ui/components/app/perps/perps-market-expanded/perps-expanded-header.test.tsx
@@ -37,9 +37,7 @@ describe('PerpsExpandedHeader', () => {
   });
 
   it('renders the header container', () => {
-    const { getByTestId } = render(
-      <PerpsExpandedHeader symbol="ETH" />,
-    );
+    const { getByTestId } = render(<PerpsExpandedHeader symbol="ETH" />);
     expect(getByTestId('perps-expanded-header')).toBeInTheDocument();
   });
 
@@ -86,7 +84,9 @@ describe('PerpsExpandedHeader', () => {
 
   it('renders the back button', () => {
     render(<PerpsExpandedHeader symbol="ETH" />);
-    expect(screen.getByTestId('perps-expanded-back-button')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('perps-expanded-back-button'),
+    ).toBeInTheDocument();
   });
 
   it('navigates to the perps tab when back button is clicked', () => {

--- a/ui/components/app/perps/perps-market-expanded/perps-expanded-header.tsx
+++ b/ui/components/app/perps/perps-market-expanded/perps-expanded-header.tsx
@@ -1,0 +1,129 @@
+import React, { useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  Text,
+  TextVariant,
+  TextColor,
+  FontWeight,
+  AvatarTokenSize,
+  ButtonIcon,
+  ButtonIconSize,
+  IconName,
+} from '@metamask/design-system-react';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { DEFAULT_ROUTE } from '../../../../helpers/constants/routes';
+import { usePerpsLivePrices } from '../../../../hooks/perps/stream';
+import { PerpsTokenLogo } from '../perps-token-logo';
+import {
+  getChangeColor,
+  formatSignedChangePercent,
+  getDisplayName,
+} from '../utils';
+import { formatPerpsFiatUniversal } from '../utils/formatPerpsDisplayPrice';
+
+export type PerpsExpandedHeaderProps = {
+  /** Market symbol being traded (e.g. 'BTC'). */
+  symbol: string;
+  /** Max leverage label for the market (e.g. '40x'), if known. */
+  maxLeverageLabel?: string;
+};
+
+/**
+ * Header for the expanded perps trading view.
+ *
+ * This is the single owner of the live price stream for the active market
+ * (`activateStream: true`); other panels read the same shared channel without
+ * re-activating it. Subscribing here — rather than at the page level — means a
+ * price tick only re-renders the header, not the chart, order book, or trade
+ * ticket.
+ */
+export const PerpsExpandedHeader = React.memo(
+  ({ symbol, maxLeverageLabel }: PerpsExpandedHeaderProps) => {
+    const t = useI18nContext();
+    const navigate = useNavigate();
+
+    const symbols = useMemo(() => [symbol], [symbol]);
+    const { prices } = usePerpsLivePrices({
+      symbols,
+      activateStream: true,
+      includeMarketData: true,
+    });
+    const livePrice = prices[symbol];
+
+    const displayPrice = formatPerpsFiatUniversal(livePrice?.price ?? '0');
+    const displayChange = formatSignedChangePercent(
+      livePrice?.percentChange24h ?? '',
+    );
+    const displayName = getDisplayName(symbol);
+
+    return (
+      <Box
+        flexDirection={BoxFlexDirection.Row}
+        alignItems={BoxAlignItems.Center}
+        gap={3}
+        paddingLeft={4}
+        paddingRight={4}
+        paddingTop={3}
+        paddingBottom={3}
+        className="shrink-0 border-b border-muted bg-background-default"
+        data-testid="perps-expanded-header"
+      >
+        <ButtonIcon
+          iconName={IconName.ArrowLeft}
+          size={ButtonIconSize.Md}
+          ariaLabel={t('back')}
+          onClick={() =>
+            navigate({ pathname: DEFAULT_ROUTE, search: 'tab=perps' })
+          }
+          data-testid="perps-expanded-back-button"
+        />
+        <PerpsTokenLogo symbol={symbol} size={AvatarTokenSize.Md} />
+        <Box flexDirection={BoxFlexDirection.Column}>
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Center}
+            gap={1}
+          >
+            <Text variant={TextVariant.HeadingMd}>{displayName}-USD</Text>
+            {maxLeverageLabel && (
+              <Box className="shrink-0 rounded-md bg-background-muted px-1.5">
+                <Text
+                  variant={TextVariant.BodyXs}
+                  color={TextColor.TextAlternative}
+                >
+                  {maxLeverageLabel}
+                </Text>
+              </Box>
+            )}
+          </Box>
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Baseline}
+            gap={1}
+          >
+            <Text
+              variant={TextVariant.HeadingSm}
+              fontWeight={FontWeight.Medium}
+              data-testid="perps-expanded-price"
+            >
+              {displayPrice}
+            </Text>
+            <Text
+              variant={TextVariant.BodySm}
+              fontWeight={FontWeight.Medium}
+              color={getChangeColor(displayChange)}
+              data-testid="perps-expanded-change"
+            >
+              {displayChange}
+            </Text>
+          </Box>
+        </Box>
+      </Box>
+    );
+  },
+);
+
+PerpsExpandedHeader.displayName = 'PerpsExpandedHeader';

--- a/ui/components/app/perps/perps-market-expanded/perps-expanded-order-book-panel.tsx
+++ b/ui/components/app/perps/perps-market-expanded/perps-expanded-order-book-panel.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import type { OrderBookLevel } from '@metamask/perps-controller';
+import {
+  Box,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  Text,
+  TextVariant,
+  TextColor,
+  Skeleton,
+} from '@metamask/design-system-react';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { usePerpsLiveOrderBook } from '../../../../hooks/perps/stream';
+import { formatPerpsFiatUniversal } from '../utils/formatPerpsDisplayPrice';
+
+/** Number of price levels rendered per side. */
+const ORDER_BOOK_LEVELS = 11;
+
+type OrderBookRowsProps = {
+  levels: OrderBookLevel[];
+  maxTotal: number;
+  side: 'bid' | 'ask';
+};
+
+const OrderBookRows = ({ levels, maxTotal, side }: OrderBookRowsProps) => {
+  const priceColor =
+    side === 'bid' ? TextColor.SuccessDefault : TextColor.ErrorDefault;
+  const depthColor =
+    side === 'bid' ? 'rgba(40, 167, 69, 0.12)' : 'rgba(220, 53, 69, 0.12)';
+
+  return (
+    <Box
+      flexDirection={BoxFlexDirection.Column}
+      data-testid={`perps-order-book-${side}s`}
+    >
+      {levels.map((level) => {
+        const total = parseFloat(level.total);
+        const depthPct =
+          maxTotal > 0 ? Math.min(100, (total / maxTotal) * 100) : 0;
+        return (
+          <Box
+            key={`${side}-${level.price}`}
+            flexDirection={BoxFlexDirection.Row}
+            justifyContent={BoxJustifyContent.Between}
+            className="relative px-3 py-0.5"
+          >
+            <Box
+              className="absolute inset-y-0 right-0"
+              style={{ width: `${depthPct}%`, backgroundColor: depthColor }}
+            />
+            <Text
+              variant={TextVariant.BodyXs}
+              color={priceColor}
+              className="z-10 tabular-nums"
+            >
+              {formatPerpsFiatUniversal(level.price)}
+            </Text>
+            <Text
+              variant={TextVariant.BodyXs}
+              color={TextColor.TextAlternative}
+              className="z-10 tabular-nums"
+            >
+              {level.size}
+            </Text>
+          </Box>
+        );
+      })}
+    </Box>
+  );
+};
+
+export type PerpsExpandedOrderBookPanelProps = {
+  /** Market symbol whose order book is shown. */
+  symbol: string;
+};
+
+/**
+ * Order book panel for the expanded perps view.
+ *
+ * Owns the high-frequency order-book stream subscription locally so book ticks
+ * re-render only this panel, never the chart or trade ticket.
+ */
+export const PerpsExpandedOrderBookPanel = React.memo(
+  ({ symbol }: PerpsExpandedOrderBookPanelProps) => {
+    const t = useI18nContext();
+    const { orderBook, isInitialLoading } = usePerpsLiveOrderBook({
+      symbol,
+      levels: ORDER_BOOK_LEVELS,
+    });
+
+    return (
+      <Box
+        flexDirection={BoxFlexDirection.Column}
+        className="min-h-0 min-w-0 overflow-hidden border-r border-muted"
+        data-testid="perps-expanded-order-book-panel"
+      >
+        <Box paddingLeft={3} paddingRight={3} paddingTop={3} paddingBottom={2}>
+          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+            {t('perpsOrderBook')}
+          </Text>
+        </Box>
+        {isInitialLoading || !orderBook ? (
+          <Box
+            paddingLeft={3}
+            paddingRight={3}
+            flexDirection={BoxFlexDirection.Column}
+            gap={1}
+          >
+            {Array.from({ length: 6 }).map((_, index) => (
+              <Skeleton key={index} className="h-4 w-full" />
+            ))}
+          </Box>
+        ) : (
+          <Box
+            flexDirection={BoxFlexDirection.Column}
+            className="min-h-0 flex-1 overflow-y-auto"
+          >
+            <OrderBookRows
+              levels={orderBook.asks.slice(0, ORDER_BOOK_LEVELS).reverse()}
+              maxTotal={parseFloat(orderBook.maxTotal)}
+              side="ask"
+            />
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              justifyContent={BoxJustifyContent.Between}
+              className="border-y border-muted px-3 py-1"
+              data-testid="perps-order-book-spread"
+            >
+              <Text
+                variant={TextVariant.BodyXs}
+                color={TextColor.TextAlternative}
+              >
+                {t('perpsOrderBookSpread')}
+              </Text>
+              <Text variant={TextVariant.BodyXs} className="tabular-nums">
+                {orderBook.spread}
+              </Text>
+            </Box>
+            <OrderBookRows
+              levels={orderBook.bids.slice(0, ORDER_BOOK_LEVELS)}
+              maxTotal={parseFloat(orderBook.maxTotal)}
+              side="bid"
+            />
+          </Box>
+        )}
+      </Box>
+    );
+  },
+);
+
+PerpsExpandedOrderBookPanel.displayName = 'PerpsExpandedOrderBookPanel';

--- a/ui/components/app/perps/perps-market-expanded/perps-expanded-positions-panel.test.tsx
+++ b/ui/components/app/perps/perps-market-expanded/perps-expanded-positions-panel.test.tsx
@@ -47,7 +47,11 @@ const mockEthPosition = {
   liquidationPrice: '2400.00',
   maxLeverage: 20,
   returnOnEquity: '0.1579',
-  cumulativeFunding: { allTime: '12.50', sinceOpen: '8.30', sinceChange: '0.00' },
+  cumulativeFunding: {
+    allTime: '12.50',
+    sinceOpen: '8.30',
+    sinceChange: '0.00',
+  },
 };
 
 const mockBtcPosition = {
@@ -61,7 +65,11 @@ const mockBtcPosition = {
   liquidationPrice: '48000.00',
   maxLeverage: 20,
   returnOnEquity: '-0.1667',
-  cumulativeFunding: { allTime: '-5.20', sinceOpen: '-3.10', sinceChange: '0.00' },
+  cumulativeFunding: {
+    allTime: '-5.20',
+    sinceOpen: '-3.10',
+    sinceChange: '0.00',
+  },
 };
 
 const mockEthOrder = {

--- a/ui/components/app/perps/perps-market-expanded/perps-expanded-positions-panel.test.tsx
+++ b/ui/components/app/perps/perps-market-expanded/perps-expanded-positions-panel.test.tsx
@@ -6,14 +6,18 @@ jest.mock('../../../../hooks/useI18nContext', () => ({
   useI18nContext: () => (key: string) => key,
 }));
 
-const mockUsePerpsLivePositions = jest.fn(() => ({
-  positions: [],
-  isInitialLoading: false,
-}));
-const mockUsePerpsLiveOrders = jest.fn(() => ({
-  orders: [],
-  isInitialLoading: false,
-}));
+const mockUsePerpsLivePositions = jest.fn(
+  (): { positions: Record<string, unknown>[]; isInitialLoading: boolean } => ({
+    positions: [],
+    isInitialLoading: false,
+  }),
+);
+const mockUsePerpsLiveOrders = jest.fn(
+  (): { orders: Record<string, unknown>[]; isInitialLoading: boolean } => ({
+    orders: [],
+    isInitialLoading: false,
+  }),
+);
 
 jest.mock('../../../../hooks/perps/stream', () => ({
   usePerpsLivePositions: () => mockUsePerpsLivePositions(),

--- a/ui/components/app/perps/perps-market-expanded/perps-expanded-positions-panel.test.tsx
+++ b/ui/components/app/perps/perps-market-expanded/perps-expanded-positions-panel.test.tsx
@@ -1,0 +1,225 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { PerpsExpandedPositionsPanel } from './perps-expanded-positions-panel';
+
+jest.mock('../../../../hooks/useI18nContext', () => ({
+  useI18nContext: () => (key: string) => key,
+}));
+
+const mockUsePerpsLivePositions = jest.fn(() => ({
+  positions: [],
+  isInitialLoading: false,
+}));
+const mockUsePerpsLiveOrders = jest.fn(() => ({
+  orders: [],
+  isInitialLoading: false,
+}));
+
+jest.mock('../../../../hooks/perps/stream', () => ({
+  usePerpsLivePositions: () => mockUsePerpsLivePositions(),
+  usePerpsLiveOrders: () => mockUsePerpsLiveOrders(),
+}));
+
+jest.mock('../perps-positions-orders', () => ({
+  PerpsPositionsOrders: ({
+    positions,
+    orders,
+  }: {
+    positions: unknown[];
+    orders: unknown[];
+  }) => (
+    <div
+      data-testid="perps-positions-orders"
+      data-positions={positions.length}
+      data-orders={orders.length}
+    />
+  ),
+}));
+
+const mockEthPosition = {
+  symbol: 'ETH',
+  size: '2.5',
+  entryPrice: '2850.00',
+  positionValue: '7125.00',
+  unrealizedPnl: '375.00',
+  marginUsed: '2375.00',
+  leverage: { type: 'isolated' as const, value: 3, rawUsd: '2375.00' },
+  liquidationPrice: '2400.00',
+  maxLeverage: 20,
+  returnOnEquity: '0.1579',
+  cumulativeFunding: { allTime: '12.50', sinceOpen: '8.30', sinceChange: '0.00' },
+};
+
+const mockBtcPosition = {
+  symbol: 'BTC',
+  size: '-0.5',
+  entryPrice: '45000.00',
+  positionValue: '22500.00',
+  unrealizedPnl: '-250.00',
+  marginUsed: '1500.00',
+  leverage: { type: 'cross' as const, value: 15 },
+  liquidationPrice: '48000.00',
+  maxLeverage: 20,
+  returnOnEquity: '-0.1667',
+  cumulativeFunding: { allTime: '-5.20', sinceOpen: '-3.10', sinceChange: '0.00' },
+};
+
+const mockEthOrder = {
+  symbol: 'ETH',
+  orderId: '1',
+  size: '1',
+  price: '2800',
+  side: 'buy',
+  orderType: 'limit',
+  isTrigger: false,
+};
+const mockBtcOrder = {
+  symbol: 'BTC',
+  orderId: '2',
+  size: '0.5',
+  price: '44000',
+  side: 'sell',
+  orderType: 'limit',
+  isTrigger: false,
+};
+
+describe('PerpsExpandedPositionsPanel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePerpsLivePositions.mockReturnValue({
+      positions: [],
+      isInitialLoading: false,
+    });
+    mockUsePerpsLiveOrders.mockReturnValue({
+      orders: [],
+      isInitialLoading: false,
+    });
+  });
+
+  it('renders the panel container', () => {
+    const { getByTestId } = render(<PerpsExpandedPositionsPanel />);
+    expect(getByTestId('perps-expanded-positions-panel')).toBeInTheDocument();
+  });
+
+  it('shows empty state text when there are no positions or orders', () => {
+    render(<PerpsExpandedPositionsPanel />);
+    expect(screen.getByText('perpsNoOpenPositions')).toBeInTheDocument();
+  });
+
+  it('does not render PerpsPositionsOrders in empty state', () => {
+    render(<PerpsExpandedPositionsPanel />);
+    expect(
+      screen.queryByTestId('perps-positions-orders'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders PerpsPositionsOrders when positions exist', () => {
+    mockUsePerpsLivePositions.mockReturnValue({
+      positions: [mockEthPosition],
+      isInitialLoading: false,
+    });
+
+    render(<PerpsExpandedPositionsPanel />);
+
+    expect(screen.getByTestId('perps-positions-orders')).toBeInTheDocument();
+    expect(screen.queryByText('perpsNoOpenPositions')).not.toBeInTheDocument();
+  });
+
+  it('renders PerpsPositionsOrders when orders exist', () => {
+    mockUsePerpsLiveOrders.mockReturnValue({
+      orders: [mockEthOrder],
+      isInitialLoading: false,
+    });
+
+    render(<PerpsExpandedPositionsPanel />);
+
+    expect(screen.getByTestId('perps-positions-orders')).toBeInTheDocument();
+  });
+
+  it('filters positions by symbol when symbol prop is provided', () => {
+    mockUsePerpsLivePositions.mockReturnValue({
+      positions: [mockEthPosition, mockBtcPosition],
+      isInitialLoading: false,
+    });
+
+    render(<PerpsExpandedPositionsPanel symbol="ETH" />);
+
+    const ordersComponent = screen.getByTestId('perps-positions-orders');
+    expect(ordersComponent).toHaveAttribute('data-positions', '1');
+  });
+
+  it('filters orders by symbol when symbol prop is provided', () => {
+    mockUsePerpsLiveOrders.mockReturnValue({
+      orders: [mockEthOrder, mockBtcOrder],
+      isInitialLoading: false,
+    });
+
+    render(<PerpsExpandedPositionsPanel symbol="ETH" />);
+
+    const ordersComponent = screen.getByTestId('perps-positions-orders');
+    expect(ordersComponent).toHaveAttribute('data-orders', '1');
+  });
+
+  it('shows all positions when no symbol prop is provided', () => {
+    mockUsePerpsLivePositions.mockReturnValue({
+      positions: [mockEthPosition, mockBtcPosition],
+      isInitialLoading: false,
+    });
+
+    render(<PerpsExpandedPositionsPanel />);
+
+    const ordersComponent = screen.getByTestId('perps-positions-orders');
+    expect(ordersComponent).toHaveAttribute('data-positions', '2');
+  });
+
+  it('shows all orders when no symbol prop is provided', () => {
+    mockUsePerpsLiveOrders.mockReturnValue({
+      orders: [mockEthOrder, mockBtcOrder],
+      isInitialLoading: false,
+    });
+
+    render(<PerpsExpandedPositionsPanel />);
+
+    const ordersComponent = screen.getByTestId('perps-positions-orders');
+    expect(ordersComponent).toHaveAttribute('data-orders', '2');
+  });
+
+  it('shows empty state when symbol filter matches no positions or orders', () => {
+    mockUsePerpsLivePositions.mockReturnValue({
+      positions: [mockEthPosition],
+      isInitialLoading: false,
+    });
+    mockUsePerpsLiveOrders.mockReturnValue({
+      orders: [mockEthOrder],
+      isInitialLoading: false,
+    });
+
+    render(<PerpsExpandedPositionsPanel symbol="SOL" />);
+
+    expect(screen.getByText('perpsNoOpenPositions')).toBeInTheDocument();
+  });
+
+  it('performs case-insensitive symbol filtering for positions', () => {
+    mockUsePerpsLivePositions.mockReturnValue({
+      positions: [mockEthPosition],
+      isInitialLoading: false,
+    });
+
+    render(<PerpsExpandedPositionsPanel symbol="eth" />);
+
+    const ordersComponent = screen.getByTestId('perps-positions-orders');
+    expect(ordersComponent).toHaveAttribute('data-positions', '1');
+  });
+
+  it('performs case-insensitive symbol filtering for orders', () => {
+    mockUsePerpsLiveOrders.mockReturnValue({
+      orders: [mockEthOrder],
+      isInitialLoading: false,
+    });
+
+    render(<PerpsExpandedPositionsPanel symbol="eth" />);
+
+    const ordersComponent = screen.getByTestId('perps-positions-orders');
+    expect(ordersComponent).toHaveAttribute('data-orders', '1');
+  });
+});

--- a/ui/components/app/perps/perps-market-expanded/perps-expanded-positions-panel.tsx
+++ b/ui/components/app/perps/perps-market-expanded/perps-expanded-positions-panel.tsx
@@ -1,0 +1,83 @@
+import React, { useMemo } from 'react';
+import {
+  Box,
+  BoxFlexDirection,
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import {
+  usePerpsLiveOrders,
+  usePerpsLivePositions,
+} from '../../../../hooks/perps/stream';
+import { PerpsPositionsOrders } from '../perps-positions-orders';
+
+export type PerpsExpandedPositionsPanelProps = {
+  /** When set, only this market's positions/orders are shown. */
+  symbol?: string;
+};
+
+/**
+ * Bottom panel listing the account's open positions and orders.
+ *
+ * Owns the positions and orders subscriptions locally so a positions/orders
+ * tick re-renders only this panel, not the chart, order book, or trade ticket.
+ */
+export const PerpsExpandedPositionsPanel = React.memo(
+  ({ symbol }: PerpsExpandedPositionsPanelProps) => {
+    const t = useI18nContext();
+    const { positions } = usePerpsLivePositions();
+    const { orders } = usePerpsLiveOrders();
+
+    const filteredPositions = useMemo(() => {
+      if (!symbol) {
+        return positions;
+      }
+      const target = symbol.toLowerCase();
+      return positions.filter((p) => p.symbol.toLowerCase() === target);
+    }, [positions, symbol]);
+
+    const filteredOrders = useMemo(() => {
+      if (!symbol) {
+        return orders;
+      }
+      const target = symbol.toLowerCase();
+      return orders.filter((o) => o.symbol.toLowerCase() === target);
+    }, [orders, symbol]);
+
+    const isEmpty =
+      filteredPositions.length === 0 && filteredOrders.length === 0;
+
+    return (
+      <Box
+        flexDirection={BoxFlexDirection.Column}
+        className="shrink-0 overflow-y-auto border-t border-muted"
+        data-testid="perps-expanded-positions-panel"
+      >
+        {isEmpty ? (
+          <Box
+            paddingLeft={4}
+            paddingRight={4}
+            paddingTop={4}
+            paddingBottom={4}
+          >
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+            >
+              {t('perpsNoOpenPositions')}
+            </Text>
+          </Box>
+        ) : (
+          <PerpsPositionsOrders
+            positions={filteredPositions}
+            orders={filteredOrders}
+          />
+        )}
+      </Box>
+    );
+  },
+);
+
+PerpsExpandedPositionsPanel.displayName = 'PerpsExpandedPositionsPanel';

--- a/ui/components/app/perps/perps-market-expanded/perps-expanded-skeleton.tsx
+++ b/ui/components/app/perps/perps-market-expanded/perps-expanded-skeleton.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Box, BoxFlexDirection, Skeleton } from '@metamask/design-system-react';
+
+/**
+ * Full-viewport loading placeholder for the expanded perps view, shown while
+ * market metadata hydrates.
+ */
+export const PerpsExpandedSkeleton = () => (
+  <Box
+    flexDirection={BoxFlexDirection.Column}
+    className="h-screen w-full overflow-hidden bg-background-default"
+    data-testid="perps-expanded-skeleton"
+  >
+    <Skeleton className="h-16 w-full" />
+    <Box className="grid min-h-0 flex-1 grid-cols-3 gap-2 p-2">
+      <Skeleton className="h-full w-full rounded-lg" />
+      <Skeleton className="h-full w-full rounded-lg" />
+      <Skeleton className="h-full w-full rounded-lg" />
+    </Box>
+    <Skeleton className="h-32 w-full" />
+  </Box>
+);

--- a/ui/components/app/perps/perps-market-expanded/perps-expanded-trade-panel.tsx
+++ b/ui/components/app/perps/perps-market-expanded/perps-expanded-trade-panel.tsx
@@ -1,0 +1,142 @@
+import React, { useCallback, useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { Box, BoxFlexDirection } from '@metamask/design-system-react';
+import { getSelectedInternalAccount } from '../../../../../shared/lib/selectors/accounts';
+import {
+  usePerpsLiveAccount,
+  usePerpsLivePrices,
+} from '../../../../hooks/perps/stream';
+import { getTradeableBalance } from '../../../../hooks/perps/getTradeableBalance';
+import { usePerpsEligibility } from '../../../../hooks/perps';
+import { submitRequestToBackground } from '../../../../store/background-connection';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import {
+  OrderEntry,
+  formStateToOrderParams,
+  type OrderFormState,
+} from '../order-entry';
+import { PERPS_TOAST_KEYS, usePerpsToast } from '../perps-toast';
+import { translatePerpsError } from '../utils/translate-perps-error';
+import type { PerpsBackgroundResult } from '../types';
+
+export type PerpsExpandedTradePanelProps = {
+  /** Market symbol being traded. */
+  symbol: string;
+  /** Max leverage allowed for this market. */
+  maxLeverage: number;
+  /** Initial leverage for new orders. */
+  initialLeverage?: number;
+  /** Market size decimals for position-size formatting. */
+  sizeDecimals?: number;
+  /** Opens the geo-block modal when the account is not eligible. */
+  onGeoBlocked: () => void;
+};
+
+/**
+ * Trade ticket panel for the expanded perps view.
+ *
+ * Subscribes to the live account (for balance) and the live price stream (for
+ * order calculations) locally — the page does not lift price into shared state.
+ * Wraps the existing {@link OrderEntry} form for parity with the order entry
+ * page.
+ */
+export const PerpsExpandedTradePanel = React.memo(
+  ({
+    symbol,
+    maxLeverage,
+    initialLeverage,
+    sizeDecimals,
+    onGeoBlocked,
+  }: PerpsExpandedTradePanelProps) => {
+    const t = useI18nContext();
+    const selectedAccount = useSelector(getSelectedInternalAccount);
+    const selectedAddress = selectedAccount?.address;
+    const { isEligible } = usePerpsEligibility();
+    const { replacePerpsToastByKey } = usePerpsToast();
+
+    const { account } = usePerpsLiveAccount();
+    const symbols = useMemo(() => [symbol], [symbol]);
+    const { prices } = usePerpsLivePrices({ symbols });
+    const livePrice = Number.parseFloat(prices[symbol]?.price ?? '');
+    const currentPrice =
+      Number.isFinite(livePrice) && livePrice > 0 ? livePrice : 0;
+
+    const availableBalance = account
+      ? Number.parseFloat(getTradeableBalance(account))
+      : 0;
+
+    const handleSubmit = useCallback(
+      async (formState: OrderFormState) => {
+        if (!isEligible) {
+          onGeoBlocked();
+          return;
+        }
+        if (!selectedAddress || currentPrice <= 0) {
+          return;
+        }
+
+        replacePerpsToastByKey({ key: PERPS_TOAST_KEYS.SUBMIT_IN_PROGRESS });
+
+        try {
+          const result = await submitRequestToBackground<PerpsBackgroundResult>(
+            'perpsPlaceOrder',
+            [formStateToOrderParams(formState, currentPrice)],
+          );
+          if (!result.success) {
+            throw new Error(result.error ?? 'Order failed');
+          }
+          submitRequestToBackground('perpsSaveTradeConfiguration', [
+            formState.asset,
+            formState.leverage,
+          ]).catch(() => undefined);
+
+          const successToastKey =
+            formState.type === 'limit'
+              ? PERPS_TOAST_KEYS.ORDER_PLACED
+              : PERPS_TOAST_KEYS.ORDER_SUBMITTED;
+          replacePerpsToastByKey({
+            key: successToastKey,
+            ...(successToastKey === PERPS_TOAST_KEYS.ORDER_SUBMITTED
+              ? { autoHideTime: 3000 }
+              : {}),
+          });
+        } catch (error) {
+          replacePerpsToastByKey({
+            key: PERPS_TOAST_KEYS.ORDER_FAILED,
+            description:
+              translatePerpsError(error, t as (key: string) => string) ??
+              t('perpsToastOrderFailedDescriptionFallback'),
+          });
+        }
+      },
+      [
+        isEligible,
+        onGeoBlocked,
+        selectedAddress,
+        currentPrice,
+        replacePerpsToastByKey,
+        t,
+      ],
+    );
+
+    return (
+      <Box
+        flexDirection={BoxFlexDirection.Column}
+        className="min-h-0 min-w-0 overflow-y-auto p-3"
+        data-testid="perps-expanded-trade-panel"
+      >
+        <OrderEntry
+          asset={symbol}
+          currentPrice={currentPrice}
+          maxLeverage={maxLeverage}
+          availableBalance={availableBalance}
+          initialLeverage={initialLeverage}
+          sizeDecimals={sizeDecimals}
+          onSubmit={handleSubmit}
+        />
+      </Box>
+    );
+  },
+);
+
+PerpsExpandedTradePanel.displayName = 'PerpsExpandedTradePanel';

--- a/ui/components/app/perps/perps-market-expanded/perps-expanded-trade-panel.tsx
+++ b/ui/components/app/perps/perps-market-expanded/perps-expanded-trade-panel.tsx
@@ -88,13 +88,6 @@ export const PerpsExpandedTradePanel = React.memo(
         isBuy: (formSnapshot?.direction ?? 'long') === 'long',
         enabled: isMarketOrderWithAmount,
       });
-    const exceedsMaxSlippage =
-      !isMaxSlippageLoading &&
-      isMarketOrderWithAmount &&
-      isEstimatedSlippageReady &&
-      typeof estimatedSlippageBps === 'number' &&
-      estimatedSlippageBps > maxSlippageBps;
-
     const { account } = usePerpsLiveAccount();
     const { positions } = usePerpsLivePositions();
     const position = useMemo(
@@ -126,22 +119,43 @@ export const PerpsExpandedTradePanel = React.memo(
 
         // Block market orders whose estimated slippage exceeds the user's cap,
         // matching the order entry page — otherwise a trade rejected there can
-        // still be placed from the expanded ticket.
-        if (
-          isMarketOrderWithAmount &&
-          (isMaxSlippageLoading || !isEstimatedSlippageReady)
-        ) {
-          return;
-        }
-        if (exceedsMaxSlippage && typeof estimatedSlippageBps === 'number') {
-          replacePerpsToastByKey({
-            key: PERPS_TOAST_KEYS.ORDER_FAILED,
-            description: t('perpsSlippageExceedsMax', [
-              bpsToPercent(estimatedSlippageBps).toFixed(2),
-              bpsToPercent(maxSlippageBps).toFixed(2),
-            ]),
-          });
-          return;
+        // still be placed from the expanded ticket. Evaluate the guard against
+        // the authoritative `formState` passed to submit, not the `formSnapshot`
+        // that only drives the estimate subscription (it can lag a render), and
+        // only trust the estimate when it was computed for the exact order being
+        // submitted.
+        const submitUsdAmount =
+          Number.parseFloat(formState.amount.replace(/,/gu, '')) || 0;
+        const submitIsMarketOrderWithAmount =
+          formState.type === 'market' &&
+          submitUsdAmount > 0 &&
+          isSlippageConfigEnabled;
+        if (submitIsMarketOrderWithAmount) {
+          const estimateMatchesOrder =
+            formSnapshot !== null &&
+            formSnapshot.type === formState.type &&
+            formSnapshot.amount === formState.amount &&
+            formSnapshot.direction === formState.direction;
+          if (
+            !estimateMatchesOrder ||
+            isMaxSlippageLoading ||
+            !isEstimatedSlippageReady
+          ) {
+            return;
+          }
+          if (
+            typeof estimatedSlippageBps === 'number' &&
+            estimatedSlippageBps > maxSlippageBps
+          ) {
+            replacePerpsToastByKey({
+              key: PERPS_TOAST_KEYS.ORDER_FAILED,
+              description: t('perpsSlippageExceedsMax', [
+                bpsToPercent(estimatedSlippageBps).toFixed(2),
+                bpsToPercent(maxSlippageBps).toFixed(2),
+              ]),
+            });
+            return;
+          }
         }
 
         replacePerpsToastByKey({ key: PERPS_TOAST_KEYS.SUBMIT_IN_PROGRESS });
@@ -242,10 +256,9 @@ export const PerpsExpandedTradePanel = React.memo(
         position,
         isSlippageConfigEnabled,
         maxSlippageBps,
-        isMarketOrderWithAmount,
+        formSnapshot,
         isMaxSlippageLoading,
         isEstimatedSlippageReady,
-        exceedsMaxSlippage,
         estimatedSlippageBps,
         replacePerpsToastByKey,
         t,

--- a/ui/components/app/perps/perps-market-expanded/perps-expanded-trade-panel.tsx
+++ b/ui/components/app/perps/perps-market-expanded/perps-expanded-trade-panel.tsx
@@ -4,10 +4,12 @@ import { Box, BoxFlexDirection } from '@metamask/design-system-react';
 import { getSelectedInternalAccount } from '../../../../../shared/lib/selectors/accounts';
 import {
   usePerpsLiveAccount,
+  usePerpsLivePositions,
   usePerpsLivePrices,
 } from '../../../../hooks/perps/stream';
 import { getTradeableBalance } from '../../../../hooks/perps/getTradeableBalance';
-import { usePerpsEligibility } from '../../../../hooks/perps';
+import { usePerpsEligibility, usePerpsMaxSlippage } from '../../../../hooks/perps';
+import { getIsPerpsSlippageConfigEnabled } from '../../../../selectors/perps/feature-flags';
 import { submitRequestToBackground } from '../../../../store/background-connection';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import {
@@ -16,6 +18,7 @@ import {
   type OrderFormState,
 } from '../order-entry';
 import { PERPS_TOAST_KEYS, usePerpsToast } from '../perps-toast';
+import { normalizeTpslPrices, willFlipPosition } from '../utils';
 import { translatePerpsError } from '../utils/translate-perps-error';
 import type { PerpsBackgroundResult } from '../types';
 
@@ -53,8 +56,20 @@ export const PerpsExpandedTradePanel = React.memo(
     const selectedAddress = selectedAccount?.address;
     const { isEligible } = usePerpsEligibility();
     const { replacePerpsToastByKey } = usePerpsToast();
+    const isSlippageConfigEnabled = useSelector(
+      getIsPerpsSlippageConfigEnabled,
+    );
+    const { maxSlippageBps } = usePerpsMaxSlippage();
 
     const { account } = usePerpsLiveAccount();
+    const { positions } = usePerpsLivePositions();
+    const position = useMemo(
+      () =>
+        positions.find(
+          (pos) => pos.symbol.toLowerCase() === symbol.toLowerCase(),
+        ),
+      [positions, symbol],
+    );
     const symbols = useMemo(() => [symbol], [symbol]);
     const { prices } = usePerpsLivePrices({ symbols });
     const livePrice = Number.parseFloat(prices[symbol]?.price ?? '');
@@ -78,12 +93,68 @@ export const PerpsExpandedTradePanel = React.memo(
         replacePerpsToastByKey({ key: PERPS_TOAST_KEYS.SUBMIT_IN_PROGRESS });
 
         try {
+          const orderParams = formStateToOrderParams(
+            formState,
+            currentPrice,
+            'new',
+            position?.size,
+            isSlippageConfigEnabled ? maxSlippageBps : undefined,
+          );
+
+          // Market orders with TP/SL on a new (or flipping) position route
+          // through the two-step flow used by the order entry page: place the
+          // market order without TP/SL, then call `perpsUpdatePositionTPSL` so
+          // the controller submits the trigger orders under
+          // `grouping: 'positionTpsl'`. Sending TP/SL in the same `placeOrder`
+          // call falls back to the controller's `normalTpsl` default, which
+          // tags the trigger orders `isPositionTpsl: false` and breaks the
+          // auto-close/orders partition on the market-detail page.
+          const shouldHandleTpslSeparately =
+            (orderParams.takeProfitPrice || orderParams.stopLossPrice) &&
+            formState.type === 'market' &&
+            (!position ||
+              parseFloat(position.size.replaceAll(',', '')) === 0 ||
+              willFlipPosition(position, orderParams));
+          const placeOrderParams = shouldHandleTpslSeparately
+            ? (() => {
+                const stripped = { ...orderParams };
+                delete stripped.takeProfitPrice;
+                delete stripped.stopLossPrice;
+                return stripped;
+              })()
+            : orderParams;
+
           const result = await submitRequestToBackground<PerpsBackgroundResult>(
             'perpsPlaceOrder',
-            [formStateToOrderParams(formState, currentPrice)],
+            [placeOrderParams],
           );
           if (!result.success) {
             throw new Error(result.error ?? 'Order failed');
+          }
+          if (shouldHandleTpslSeparately) {
+            const { takeProfitPrice, stopLossPrice } = normalizeTpslPrices({
+              takeProfitPrice: orderParams.takeProfitPrice,
+              stopLossPrice: orderParams.stopLossPrice,
+            });
+            const tpslResult =
+              await submitRequestToBackground<PerpsBackgroundResult>(
+                'perpsUpdatePositionTPSL',
+                [{ symbol: formState.asset, takeProfitPrice, stopLossPrice }],
+              );
+            if (!tpslResult.success) {
+              // The market order already filled — surface the TP/SL-specific
+              // failure so the user can attach TP/SL from the open position
+              // rather than re-submitting (which would open a duplicate).
+              replacePerpsToastByKey({
+                key: PERPS_TOAST_KEYS.UPDATE_FAILED,
+                description:
+                  translatePerpsError(
+                    new Error(tpslResult.error ?? 'Failed to attach TP/SL'),
+                    t as (key: string) => string,
+                  ) ?? t('perpsToastOrderFailedDescriptionFallback'),
+              });
+              return;
+            }
           }
           submitRequestToBackground('perpsSaveTradeConfiguration', [
             formState.asset,
@@ -114,6 +185,9 @@ export const PerpsExpandedTradePanel = React.memo(
         onGeoBlocked,
         selectedAddress,
         currentPrice,
+        position,
+        isSlippageConfigEnabled,
+        maxSlippageBps,
         replacePerpsToastByKey,
         t,
       ],

--- a/ui/components/app/perps/perps-market-expanded/perps-expanded-trade-panel.tsx
+++ b/ui/components/app/perps/perps-market-expanded/perps-expanded-trade-panel.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { Box, BoxFlexDirection } from '@metamask/design-system-react';
 import { getSelectedInternalAccount } from '../../../../../shared/lib/selectors/accounts';
@@ -8,7 +8,12 @@ import {
   usePerpsLivePrices,
 } from '../../../../hooks/perps/stream';
 import { getTradeableBalance } from '../../../../hooks/perps/getTradeableBalance';
-import { usePerpsEligibility, usePerpsMaxSlippage } from '../../../../hooks/perps';
+import {
+  usePerpsEligibility,
+  usePerpsEstimatedSlippage,
+  usePerpsMaxSlippage,
+} from '../../../../hooks/perps';
+import { bpsToPercent } from '../constants/slippageConfig';
 import { getIsPerpsSlippageConfigEnabled } from '../../../../selectors/perps/feature-flags';
 import { submitRequestToBackground } from '../../../../store/background-connection';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
@@ -59,7 +64,36 @@ export const PerpsExpandedTradePanel = React.memo(
     const isSlippageConfigEnabled = useSelector(
       getIsPerpsSlippageConfigEnabled,
     );
-    const { maxSlippageBps } = usePerpsMaxSlippage();
+    const { maxSlippageBps, isLoading: isMaxSlippageLoading } =
+      usePerpsMaxSlippage();
+
+    // Mirror the order entry page's estimated-slippage pre-submit guard. The
+    // form owns its own state, so we snapshot the latest values here purely to
+    // feed the slippage estimate — kept local to this leaf panel so it does not
+    // lift live form state into the page tree.
+    const [formSnapshot, setFormSnapshot] = useState<OrderFormState | null>(
+      null,
+    );
+    const orderUsdAmount = formSnapshot
+      ? Number.parseFloat(formSnapshot.amount.replace(/,/gu, '')) || 0
+      : 0;
+    const isMarketOrderWithAmount =
+      (formSnapshot?.type ?? 'market') === 'market' &&
+      orderUsdAmount > 0 &&
+      isSlippageConfigEnabled;
+    const { estimatedSlippageBps, isReady: isEstimatedSlippageReady } =
+      usePerpsEstimatedSlippage({
+        symbol,
+        sizeUsd: isMarketOrderWithAmount ? orderUsdAmount : undefined,
+        isBuy: (formSnapshot?.direction ?? 'long') === 'long',
+        enabled: isMarketOrderWithAmount,
+      });
+    const exceedsMaxSlippage =
+      !isMaxSlippageLoading &&
+      isMarketOrderWithAmount &&
+      isEstimatedSlippageReady &&
+      typeof estimatedSlippageBps === 'number' &&
+      estimatedSlippageBps > maxSlippageBps;
 
     const { account } = usePerpsLiveAccount();
     const { positions } = usePerpsLivePositions();
@@ -87,6 +121,26 @@ export const PerpsExpandedTradePanel = React.memo(
           return;
         }
         if (!selectedAddress || currentPrice <= 0) {
+          return;
+        }
+
+        // Block market orders whose estimated slippage exceeds the user's cap,
+        // matching the order entry page — otherwise a trade rejected there can
+        // still be placed from the expanded ticket.
+        if (
+          isMarketOrderWithAmount &&
+          (isMaxSlippageLoading || !isEstimatedSlippageReady)
+        ) {
+          return;
+        }
+        if (exceedsMaxSlippage && typeof estimatedSlippageBps === 'number') {
+          replacePerpsToastByKey({
+            key: PERPS_TOAST_KEYS.ORDER_FAILED,
+            description: t('perpsSlippageExceedsMax', [
+              bpsToPercent(estimatedSlippageBps).toFixed(2),
+              bpsToPercent(maxSlippageBps).toFixed(2),
+            ]),
+          });
           return;
         }
 
@@ -188,6 +242,11 @@ export const PerpsExpandedTradePanel = React.memo(
         position,
         isSlippageConfigEnabled,
         maxSlippageBps,
+        isMarketOrderWithAmount,
+        isMaxSlippageLoading,
+        isEstimatedSlippageReady,
+        exceedsMaxSlippage,
+        estimatedSlippageBps,
         replacePerpsToastByKey,
         t,
       ],
@@ -206,6 +265,7 @@ export const PerpsExpandedTradePanel = React.memo(
           availableBalance={availableBalance}
           initialLeverage={initialLeverage}
           sizeDecimals={sizeDecimals}
+          onFormStateChange={setFormSnapshot}
           onSubmit={handleSubmit}
         />
       </Box>

--- a/ui/helpers/constants/routes.ts
+++ b/ui/helpers/constants/routes.ts
@@ -184,6 +184,7 @@ export const DEFI_ROUTE = '/defi';
 // Perps routes
 export const PERPS_ROUTE = '/perps';
 export const PERPS_MARKET_DETAIL_ROUTE = '/perps/market';
+export const PERPS_MARKET_EXPANDED_ROUTE = '/perps/market-expanded';
 export const PERPS_ORDER_ENTRY_ROUTE = '/perps/trade';
 export const PERPS_ACTIVITY_ROUTE = '/perps/activity';
 export const PERPS_WITHDRAW_ROUTE = '/perps/withdraw';

--- a/ui/layouts/full-width-layout.test.tsx
+++ b/ui/layouts/full-width-layout.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { Outlet } from 'react-router-dom';
+import { FullWidthLayout } from './full-width-layout';
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    Outlet: jest.fn(() => <div data-testid="outlet" />),
+  };
+});
+
+describe('FullWidthLayout', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders without crashing', () => {
+    const { container } = render(<FullWidthLayout />);
+    expect(container.firstChild).toBeInTheDocument();
+  });
+
+  it('renders the Outlet', () => {
+    const { getByTestId } = render(<FullWidthLayout />);
+    expect(getByTestId('outlet')).toBeInTheDocument();
+  });
+
+  it('renders a full-width container', () => {
+    const { container } = render(<FullWidthLayout />);
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).toContain('w-full');
+    expect(div.className).toContain('h-full');
+  });
+
+  it('calls Outlet once', () => {
+    render(<FullWidthLayout />);
+    expect(Outlet).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/layouts/full-width-layout.tsx
+++ b/ui/layouts/full-width-layout.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Outlet } from 'react-router-dom';
+
+/**
+ * Layout for routes that must span the full viewport width.
+ *
+ * Unlike {@link RootLayout}, this layout intentionally omits the
+ * `max-w-[clamp(...)]` constraint so expanded experiences (e.g. the perps
+ * expanded trading view rendered in a browser tab) can use the entire
+ * available width. It renders the matched child route via `<Outlet />`.
+ */
+export const FullWidthLayout = () => {
+  return (
+    <div className="w-full h-full flex flex-col">
+      <Outlet />
+    </div>
+  );
+};

--- a/ui/layouts/require-authenticated-full-width.test.tsx
+++ b/ui/layouts/require-authenticated-full-width.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { RequireAuthenticatedFullWidth } from './require-authenticated-full-width';
+
+const mockUseAuthGuardRedirect = jest.fn();
+jest.mock('./use-auth-guard-redirect', () => ({
+  useAuthGuardRedirect: () => mockUseAuthGuardRedirect(),
+}));
+
+jest.mock('./full-width-layout', () => ({
+  FullWidthLayout: () => <div data-testid="full-width-layout" />,
+}));
+
+describe('RequireAuthenticatedFullWidth', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders FullWidthLayout when there is no redirect', () => {
+    mockUseAuthGuardRedirect.mockReturnValue(null);
+
+    const { getByTestId } = render(<RequireAuthenticatedFullWidth />);
+
+    expect(getByTestId('full-width-layout')).toBeInTheDocument();
+  });
+
+  it('renders the redirect element when useAuthGuardRedirect returns one', () => {
+    const redirect = <div data-testid="redirect-element" />;
+    mockUseAuthGuardRedirect.mockReturnValue(redirect);
+
+    const { getByTestId, queryByTestId } = render(
+      <RequireAuthenticatedFullWidth />,
+    );
+
+    expect(getByTestId('redirect-element')).toBeInTheDocument();
+    expect(queryByTestId('full-width-layout')).not.toBeInTheDocument();
+  });
+
+  it('does not render FullWidthLayout when redirecting', () => {
+    const redirect = <div data-testid="redirect-element" />;
+    mockUseAuthGuardRedirect.mockReturnValue(redirect);
+
+    const { queryByTestId } = render(<RequireAuthenticatedFullWidth />);
+
+    expect(queryByTestId('full-width-layout')).not.toBeInTheDocument();
+  });
+});

--- a/ui/layouts/require-authenticated-full-width.tsx
+++ b/ui/layouts/require-authenticated-full-width.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { FullWidthLayout } from './full-width-layout';
+import { useAuthGuardRedirect } from './use-auth-guard-redirect';
+
+/**
+ * Authenticated route guard that renders its children at full viewport width.
+ *
+ * Applies the same onboarding / unlock checks as {@link RequireAuthenticated}
+ * (via the shared {@link useAuthGuardRedirect} hook) but renders
+ * {@link FullWidthLayout} instead of `RootLayout`, bypassing the popup
+ * max-width constraint for expanded experiences.
+ */
+export const RequireAuthenticatedFullWidth = () => {
+  const redirect = useAuthGuardRedirect();
+  return redirect ?? <FullWidthLayout />;
+};

--- a/ui/layouts/require-authenticated.tsx
+++ b/ui/layouts/require-authenticated.tsx
@@ -1,23 +1,8 @@
 import React from 'react';
-import { Navigate, useLocation } from 'react-router-dom';
-import { useSelector } from 'react-redux';
-import { ONBOARDING_ROUTE, UNLOCK_ROUTE } from '../helpers/constants/routes';
-import { getCompletedOnboarding } from '../ducks/metamask/metamask';
-import { getIsUnlocked } from '../ducks/metamask/base-selectors';
 import { RootLayout } from './root-layout';
+import { useAuthGuardRedirect } from './use-auth-guard-redirect';
 
 export const RequireAuthenticated = () => {
-  const completedOnboarding = useSelector(getCompletedOnboarding);
-  const isUnlocked = useSelector(getIsUnlocked);
-  const location = useLocation();
-
-  if (!completedOnboarding) {
-    return <Navigate to={ONBOARDING_ROUTE} replace />;
-  }
-
-  if (!isUnlocked) {
-    return <Navigate to={UNLOCK_ROUTE} state={{ from: location }} replace />;
-  }
-
-  return <RootLayout />;
+  const redirect = useAuthGuardRedirect();
+  return redirect ?? <RootLayout />;
 };

--- a/ui/layouts/use-auth-guard-redirect.test.tsx
+++ b/ui/layouts/use-auth-guard-redirect.test.tsx
@@ -35,16 +35,23 @@ describe('useAuthGuardRedirect', () => {
   });
 
   it('redirects to onboarding when onboarding is not completed', () => {
-    const state = { metamask: { completedOnboarding: false, isUnlocked: false } };
+    const state = {
+      metamask: { completedOnboarding: false, isUnlocked: false },
+    };
     mockUseSelector.mockImplementation((selector) => selector(state as never));
 
     const { getByTestId } = render(<TestComponent />);
 
-    expect(getByTestId('navigate')).toHaveAttribute('data-to', ONBOARDING_ROUTE);
+    expect(getByTestId('navigate')).toHaveAttribute(
+      'data-to',
+      ONBOARDING_ROUTE,
+    );
   });
 
   it('redirects to unlock when onboarding is complete but wallet is locked', () => {
-    const state = { metamask: { completedOnboarding: true, isUnlocked: false } };
+    const state = {
+      metamask: { completedOnboarding: true, isUnlocked: false },
+    };
     mockUseLocation.mockReturnValue({
       pathname: '/settings',
       search: '',
@@ -75,7 +82,9 @@ describe('useAuthGuardRedirect', () => {
   });
 
   it('passes the current location as state when redirecting to unlock', () => {
-    const state = { metamask: { completedOnboarding: true, isUnlocked: false } };
+    const state = {
+      metamask: { completedOnboarding: true, isUnlocked: false },
+    };
     mockUseLocation.mockReturnValue({
       pathname: '/bridge/prepare',
       search: '?foo=bar',
@@ -101,7 +110,9 @@ describe('useAuthGuardRedirect', () => {
   });
 
   it('uses replace navigation for all redirects', () => {
-    const state = { metamask: { completedOnboarding: true, isUnlocked: false } };
+    const state = {
+      metamask: { completedOnboarding: true, isUnlocked: false },
+    };
     mockUseSelector.mockImplementation((selector) => selector(state as never));
 
     render(<TestComponent />);
@@ -113,11 +124,16 @@ describe('useAuthGuardRedirect', () => {
   });
 
   it('prioritises onboarding redirect over unlock redirect when both conditions apply', () => {
-    const state = { metamask: { completedOnboarding: false, isUnlocked: false } };
+    const state = {
+      metamask: { completedOnboarding: false, isUnlocked: false },
+    };
     mockUseSelector.mockImplementation((selector) => selector(state as never));
 
     const { getByTestId } = render(<TestComponent />);
 
-    expect(getByTestId('navigate')).toHaveAttribute('data-to', ONBOARDING_ROUTE);
+    expect(getByTestId('navigate')).toHaveAttribute(
+      'data-to',
+      ONBOARDING_ROUTE,
+    );
   });
 });

--- a/ui/layouts/use-auth-guard-redirect.test.tsx
+++ b/ui/layouts/use-auth-guard-redirect.test.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { useSelector } from 'react-redux';
+import { Navigate } from 'react-router-dom';
+import { ONBOARDING_ROUTE, UNLOCK_ROUTE } from '../helpers/constants/routes';
+import { useAuthGuardRedirect } from './use-auth-guard-redirect';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+const mockUseLocation = jest.fn();
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom');
+  return {
+    ...actual,
+    useLocation: () => mockUseLocation(),
+    Navigate: jest.fn(({ to }: { to: string }) => (
+      <div data-testid="navigate" data-to={to} />
+    )),
+  };
+});
+
+const mockUseSelector = jest.mocked(useSelector);
+
+const TestComponent = () => {
+  const redirect = useAuthGuardRedirect();
+  return redirect ?? <div data-testid="no-redirect" />;
+};
+
+describe('useAuthGuardRedirect', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseLocation.mockReturnValue({ pathname: '/', search: '', hash: '' });
+  });
+
+  it('redirects to onboarding when onboarding is not completed', () => {
+    const state = { metamask: { completedOnboarding: false, isUnlocked: false } };
+    mockUseSelector.mockImplementation((selector) => selector(state as never));
+
+    const { getByTestId } = render(<TestComponent />);
+
+    expect(getByTestId('navigate')).toHaveAttribute('data-to', ONBOARDING_ROUTE);
+  });
+
+  it('redirects to unlock when onboarding is complete but wallet is locked', () => {
+    const state = { metamask: { completedOnboarding: true, isUnlocked: false } };
+    mockUseLocation.mockReturnValue({
+      pathname: '/settings',
+      search: '',
+      hash: '',
+    });
+    mockUseSelector.mockImplementation((selector) => selector(state as never));
+
+    render(<TestComponent />);
+
+    expect(Navigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: UNLOCK_ROUTE,
+        replace: true,
+        state: { from: expect.objectContaining({ pathname: '/settings' }) },
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('returns null when onboarding is complete and wallet is unlocked', () => {
+    const state = { metamask: { completedOnboarding: true, isUnlocked: true } };
+    mockUseSelector.mockImplementation((selector) => selector(state as never));
+
+    const { getByTestId, queryByTestId } = render(<TestComponent />);
+
+    expect(getByTestId('no-redirect')).toBeInTheDocument();
+    expect(queryByTestId('navigate')).not.toBeInTheDocument();
+  });
+
+  it('passes the current location as state when redirecting to unlock', () => {
+    const state = { metamask: { completedOnboarding: true, isUnlocked: false } };
+    mockUseLocation.mockReturnValue({
+      pathname: '/bridge/prepare',
+      search: '?foo=bar',
+      hash: '#ignored',
+    });
+    mockUseSelector.mockImplementation((selector) => selector(state as never));
+
+    render(<TestComponent />);
+
+    expect(Navigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: UNLOCK_ROUTE,
+        replace: true,
+        state: {
+          from: expect.objectContaining({
+            pathname: '/bridge/prepare',
+            search: '?foo=bar',
+          }),
+        },
+      }),
+      expect.anything(),
+    );
+  });
+
+  it('uses replace navigation for all redirects', () => {
+    const state = { metamask: { completedOnboarding: true, isUnlocked: false } };
+    mockUseSelector.mockImplementation((selector) => selector(state as never));
+
+    render(<TestComponent />);
+
+    expect(Navigate).toHaveBeenCalledWith(
+      expect.objectContaining({ replace: true }),
+      expect.anything(),
+    );
+  });
+
+  it('prioritises onboarding redirect over unlock redirect when both conditions apply', () => {
+    const state = { metamask: { completedOnboarding: false, isUnlocked: false } };
+    mockUseSelector.mockImplementation((selector) => selector(state as never));
+
+    const { getByTestId } = render(<TestComponent />);
+
+    expect(getByTestId('navigate')).toHaveAttribute('data-to', ONBOARDING_ROUTE);
+  });
+});

--- a/ui/layouts/use-auth-guard-redirect.tsx
+++ b/ui/layouts/use-auth-guard-redirect.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { ONBOARDING_ROUTE, UNLOCK_ROUTE } from '../helpers/constants/routes';
+import { getCompletedOnboarding } from '../ducks/metamask/metamask';
+import { getIsUnlocked } from '../ducks/metamask/base-selectors';
+
+/**
+ * Shared authentication guard used by authenticated route layouts.
+ *
+ * Returns a `<Navigate />` redirect element when the user has not completed
+ * onboarding or the wallet is locked, otherwise `null`. Centralising the
+ * onboarding / unlock checks here keeps every authenticated layout
+ * (standard width, full width, …) in lockstep instead of duplicating the
+ * logic per layout.
+ *
+ * @returns A redirect element when access should be blocked, otherwise `null`.
+ */
+export const useAuthGuardRedirect = (): React.ReactElement | null => {
+  const completedOnboarding = useSelector(getCompletedOnboarding);
+  const isUnlocked = useSelector(getIsUnlocked);
+  const location = useLocation();
+
+  if (!completedOnboarding) {
+    return <Navigate to={ONBOARDING_ROUTE} replace />;
+  }
+
+  if (!isUnlocked) {
+    return <Navigate to={UNLOCK_ROUTE} state={{ from: location }} replace />;
+  }
+
+  return null;
+};

--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -372,6 +372,12 @@ jest.mock('react-router-dom', () => ({
   },
 }));
 
+const mockIsPopupOrSidePanelEnvironment = jest.fn().mockReturnValue(false);
+jest.mock('../../../shared/lib/environment-type', () => ({
+  ...jest.requireActual('../../../shared/lib/environment-type'),
+  isPopupOrSidePanelEnvironment: () => mockIsPopupOrSidePanelEnvironment(),
+}));
+
 // eslint-disable-next-line import-x/first
 import PerpsMarketDetailPage from './perps-market-detail-page';
 
@@ -686,6 +692,40 @@ describe('PerpsMarketDetailPage', () => {
         value: originalLength,
         configurable: true,
       });
+    });
+
+    it('navigates in place to the expanded view when already fullscreen', async () => {
+      mockIsPopupOrSidePanelEnvironment.mockReturnValue(false);
+      const store = mockStore(createMockState(true));
+
+      const { getByTestId } = await renderPage(store);
+
+      getByTestId('perps-market-detail-expand-button').click();
+
+      expect(mockUseNavigate).toHaveBeenCalledWith(
+        '/perps/market-expanded/ETH',
+      );
+    });
+
+    it('opens the expanded view in a browser tab from popup / side panel', async () => {
+      mockIsPopupOrSidePanelEnvironment.mockReturnValue(true);
+      const openExtensionInBrowser = jest.fn();
+      // @ts-expect-error mocking platform
+      global.platform = { openExtensionInBrowser };
+      const store = mockStore(createMockState(true));
+
+      const { getByTestId } = await renderPage(store);
+
+      getByTestId('perps-market-detail-expand-button').click();
+
+      expect(openExtensionInBrowser).toHaveBeenCalledWith(
+        '/perps/market-expanded/ETH',
+      );
+      expect(mockUseNavigate).not.toHaveBeenCalledWith(
+        '/perps/market-expanded/ETH',
+      );
+
+      mockIsPopupOrSidePanelEnvironment.mockReturnValue(false);
     });
 
     it('uses market 24h change as fallback when no live percent update exists', async () => {

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -53,8 +53,10 @@ import { useI18nContext } from '../../hooks/useI18nContext';
 import { useTheme } from '../../hooks/useTheme';
 import {
   DEFAULT_ROUTE,
+  PERPS_MARKET_EXPANDED_ROUTE,
   PERPS_ORDER_ENTRY_ROUTE,
 } from '../../helpers/constants/routes';
+import { isPopupOrSidePanelEnvironment } from '../../../shared/lib/environment-type';
 import {
   usePerpsLivePositions,
   usePerpsLiveOrders,
@@ -967,6 +969,33 @@ const PerpsMarketDetailPage = () => {
     });
   }, [decodedSymbol, track]);
 
+  // Opens the full-width expanded trading view. From the narrow popup / side
+  // panel we open a dedicated full browser tab; from the already-fullscreen tab
+  // we navigate in place (no extra tab) so the affordance is available wherever
+  // the user views the market.
+  const handleExpandClick = useCallback(() => {
+    if (!decodedSymbol) {
+      return;
+    }
+    track(MetaMetricsEventName.PerpsUiInteraction, {
+      [PERPS_EVENT_PROPERTY.INTERACTION_TYPE]:
+        PERPS_EVENT_VALUE.INTERACTION_TYPE.BUTTON_CLICKED,
+      [PERPS_EVENT_PROPERTY.BUTTON_TYPE]:
+        PERPS_EVENT_VALUE.BUTTON_CLICKED.TRADE,
+      [PERPS_EVENT_PROPERTY.BUTTON_LOCATION]:
+        PERPS_EVENT_VALUE.BUTTON_LOCATION.ASSET_DETAILS,
+      [PERPS_EVENT_PROPERTY.ASSET]: decodedSymbol,
+    });
+    const expandedPath = `${PERPS_MARKET_EXPANDED_ROUTE}/${encodeURIComponent(
+      decodedSymbol,
+    )}`;
+    if (isPopupOrSidePanelEnvironment()) {
+      global.platform.openExtensionInBrowser(expandedPath);
+    } else {
+      navigate(expandedPath);
+    }
+  }, [decodedSymbol, navigate, track]);
+
   // Opens the cancel order modal for the selected order
   const handleOrderClick = useCallback((order: Order) => {
     setCancelOrderTarget(order);
@@ -1152,6 +1181,19 @@ const PerpsMarketDetailPage = () => {
         </Box>
 
         <Box className="flex-1" />
+
+        <Box
+          data-testid="perps-market-detail-expand-button"
+          aria-label={t('perpsExpandView')}
+          className="p-2 cursor-pointer transition-transform hover:scale-110"
+          onClick={handleExpandClick}
+        >
+          <Icon
+            name={IconName.Expand}
+            size={IconSize.Md}
+            color={IconColor.IconAlternative}
+          />
+        </Box>
 
         <Box
           data-testid="perps-market-detail-favorite-button"

--- a/ui/pages/perps/perps-market-expanded-page.test.tsx
+++ b/ui/pages/perps/perps-market-expanded-page.test.tsx
@@ -66,9 +66,7 @@ jest.mock('../../components/app/perps/perps-market-expanded', () => ({
   PerpsExpandedPositionsPanel: () => (
     <div data-testid="perps-expanded-positions" />
   ),
-  PerpsExpandedSkeleton: () => (
-    <div data-testid="perps-expanded-skeleton" />
-  ),
+  PerpsExpandedSkeleton: () => <div data-testid="perps-expanded-skeleton" />,
   PerpsExpandedTradePanel: () => <div data-testid="perps-expanded-trade" />,
 }));
 
@@ -207,9 +205,7 @@ describe('PerpsMarketExpandedPage', () => {
     it('does not show skeleton when market is found', () => {
       const { queryByTestId } = render(<PerpsMarketExpandedPage />);
 
-      expect(
-        queryByTestId('perps-expanded-skeleton'),
-      ).not.toBeInTheDocument();
+      expect(queryByTestId('perps-expanded-skeleton')).not.toBeInTheDocument();
     });
 
     it('does not show not-found when market is found', () => {

--- a/ui/pages/perps/perps-market-expanded-page.test.tsx
+++ b/ui/pages/perps/perps-market-expanded-page.test.tsx
@@ -1,0 +1,241 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+
+// ─── Mock variables (must be prefixed "mock" for babel-jest hoisting) ────────
+const mockNavigate = jest.fn();
+const mockNavigateComponent = jest.fn();
+const mockUseParams = jest.fn(() => ({ symbol: 'ETH' }));
+const mockUsePerpsLiveMarketData = jest.fn(() => ({
+  markets: [],
+  isInitialLoading: false,
+  error: null,
+}));
+const mockGetIsPerpsExperienceAvailable = jest.fn(() => true);
+const mockSelectPerpsIsTestnet = jest.fn(() => false);
+const mockSelectPerpsTradeConfigurations = jest.fn(() => ({}));
+
+// ─── Module mocks ──────────────────────────────────────────────────────────────
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+  useParams: () => mockUseParams(),
+  Navigate: (props: { to: string; replace?: boolean }) => {
+    mockNavigateComponent(props);
+    return null;
+  },
+}));
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn((selector) => selector({})),
+}));
+
+jest.mock('../../selectors/perps/feature-flags', () => ({
+  getIsPerpsExperienceAvailable: (...args: unknown[]) =>
+    mockGetIsPerpsExperienceAvailable(...args),
+}));
+
+jest.mock('../../selectors/perps-controller', () => ({
+  selectPerpsIsTestnet: (...args: unknown[]) =>
+    mockSelectPerpsIsTestnet(...args),
+  selectPerpsTradeConfigurations: (...args: unknown[]) =>
+    mockSelectPerpsTradeConfigurations(...args),
+}));
+
+jest.mock('../../hooks/perps/stream', () => ({
+  usePerpsLiveMarketData: () => mockUsePerpsLiveMarketData(),
+}));
+
+jest.mock('../../hooks/perps/usePerpsMarketInfo', () => ({
+  usePerpsMarketInfo: jest.fn(() => null),
+}));
+
+jest.mock('../../hooks/perps/usePerpsMeasurement', () => ({
+  usePerpsMeasurement: jest.fn(),
+}));
+
+jest.mock('../../hooks/useI18nContext', () => ({
+  useI18nContext: () => (key: string) => key,
+}));
+
+jest.mock('../../components/app/perps/perps-market-expanded', () => ({
+  PerpsExpandedChartPanel: () => <div data-testid="perps-expanded-chart" />,
+  PerpsExpandedHeader: () => <div data-testid="perps-expanded-header" />,
+  PerpsExpandedOrderBookPanel: () => (
+    <div data-testid="perps-expanded-orderbook" />
+  ),
+  PerpsExpandedPositionsPanel: () => (
+    <div data-testid="perps-expanded-positions" />
+  ),
+  PerpsExpandedSkeleton: () => (
+    <div data-testid="perps-expanded-skeleton" />
+  ),
+  PerpsExpandedTradePanel: () => <div data-testid="perps-expanded-trade" />,
+}));
+
+jest.mock('../../components/app/perps/perps-geo-block-modal', () => ({
+  PerpsGeoBlockModal: () => null,
+}));
+
+jest.mock('../../components/app/perps/utils', () => ({
+  ...jest.requireActual('../../components/app/perps/utils'),
+  safeDecodeURIComponent: (val: string) => val,
+}));
+
+// Import after mocks so all factories resolve correctly
+// eslint-disable-next-line import-x/first
+import PerpsMarketExpandedPage from './perps-market-expanded-page';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+const mockEthMarket = {
+  symbol: 'ETH',
+  name: 'Ethereum',
+  maxLeverage: '20x',
+  price: '$2850.00',
+  change24h: '+$75.00',
+  change24hPercent: '+2.63%',
+  volume: '$850M',
+  openInterest: '$1.8B',
+  nextFundingTime: Date.now() + 3600000,
+  fundingIntervalHours: 8,
+  fundingRate: 0.00008,
+  marketSource: undefined,
+  marketType: undefined,
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+describe('PerpsMarketExpandedPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetIsPerpsExperienceAvailable.mockReturnValue(true);
+    mockSelectPerpsIsTestnet.mockReturnValue(false);
+    mockSelectPerpsTradeConfigurations.mockReturnValue({});
+    mockUseParams.mockReturnValue({ symbol: 'ETH' });
+    mockUsePerpsLiveMarketData.mockReturnValue({
+      markets: [mockEthMarket],
+      isInitialLoading: false,
+      error: null,
+    });
+  });
+
+  describe('guard redirects', () => {
+    it('redirects to DEFAULT_ROUTE when perps experience is unavailable', () => {
+      mockGetIsPerpsExperienceAvailable.mockReturnValue(false);
+
+      render(<PerpsMarketExpandedPage />);
+
+      expect(mockNavigateComponent).toHaveBeenCalledWith(
+        expect.objectContaining({ to: '/', replace: true }),
+      );
+    });
+
+    it('redirects to DEFAULT_ROUTE when symbol is missing from route params', () => {
+      mockUseParams.mockReturnValue({ symbol: undefined });
+
+      render(<PerpsMarketExpandedPage />);
+
+      expect(mockNavigateComponent).toHaveBeenCalledWith(
+        expect.objectContaining({ to: '/', replace: true }),
+      );
+    });
+  });
+
+  describe('loading state', () => {
+    it('shows skeleton while markets are loading', () => {
+      mockUsePerpsLiveMarketData.mockReturnValue({
+        markets: [],
+        isInitialLoading: true,
+        error: null,
+      });
+
+      const { getByTestId } = render(<PerpsMarketExpandedPage />);
+
+      expect(getByTestId('perps-expanded-skeleton')).toBeInTheDocument();
+    });
+
+    it('shows skeleton when markets list is empty and not loading', () => {
+      mockUsePerpsLiveMarketData.mockReturnValue({
+        markets: [],
+        isInitialLoading: false,
+        error: null,
+      });
+
+      const { getByTestId } = render(<PerpsMarketExpandedPage />);
+
+      expect(getByTestId('perps-expanded-skeleton')).toBeInTheDocument();
+    });
+  });
+
+  describe('not-found state', () => {
+    it('shows not-found UI when markets are loaded but symbol is absent', () => {
+      mockUseParams.mockReturnValue({ symbol: 'DOGE' });
+      mockUsePerpsLiveMarketData.mockReturnValue({
+        markets: [mockEthMarket],
+        isInitialLoading: false,
+        error: null,
+      });
+
+      const { getByTestId } = render(<PerpsMarketExpandedPage />);
+
+      expect(
+        getByTestId('perps-market-expanded-not-found'),
+      ).toBeInTheDocument();
+    });
+
+    it('does not render the full page when market is not found', () => {
+      mockUseParams.mockReturnValue({ symbol: 'DOGE' });
+      mockUsePerpsLiveMarketData.mockReturnValue({
+        markets: [mockEthMarket],
+        isInitialLoading: false,
+        error: null,
+      });
+
+      const { queryByTestId } = render(<PerpsMarketExpandedPage />);
+
+      expect(
+        queryByTestId('perps-market-expanded-page'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe('happy path', () => {
+    it('renders the full expanded page when market is found', () => {
+      const { getByTestId } = render(<PerpsMarketExpandedPage />);
+
+      expect(getByTestId('perps-market-expanded-page')).toBeInTheDocument();
+    });
+
+    it('does not show skeleton when market is found', () => {
+      const { queryByTestId } = render(<PerpsMarketExpandedPage />);
+
+      expect(
+        queryByTestId('perps-expanded-skeleton'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not show not-found when market is found', () => {
+      const { queryByTestId } = render(<PerpsMarketExpandedPage />);
+
+      expect(
+        queryByTestId('perps-market-expanded-not-found'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders all panel components', () => {
+      const { getByTestId } = render(<PerpsMarketExpandedPage />);
+
+      expect(getByTestId('perps-expanded-header')).toBeInTheDocument();
+      expect(getByTestId('perps-expanded-chart')).toBeInTheDocument();
+      expect(getByTestId('perps-expanded-orderbook')).toBeInTheDocument();
+      expect(getByTestId('perps-expanded-trade')).toBeInTheDocument();
+      expect(getByTestId('perps-expanded-positions')).toBeInTheDocument();
+    });
+
+    it('performs case-insensitive symbol matching for market lookup', () => {
+      mockUseParams.mockReturnValue({ symbol: 'eth' });
+
+      const { getByTestId } = render(<PerpsMarketExpandedPage />);
+
+      expect(getByTestId('perps-market-expanded-page')).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/pages/perps/perps-market-expanded-page.test.tsx
+++ b/ui/pages/perps/perps-market-expanded-page.test.tsx
@@ -4,15 +4,27 @@ import { render } from '@testing-library/react';
 // ─── Mock variables (must be prefixed "mock" for babel-jest hoisting) ────────
 const mockNavigate = jest.fn();
 const mockNavigateComponent = jest.fn();
-const mockUseParams = jest.fn(() => ({ symbol: 'ETH' }));
-const mockUsePerpsLiveMarketData = jest.fn(() => ({
-  markets: [],
-  isInitialLoading: false,
-  error: null,
+const mockUseParams = jest.fn((): { symbol: string | undefined } => ({
+  symbol: 'ETH',
 }));
-const mockGetIsPerpsExperienceAvailable = jest.fn(() => true);
-const mockSelectPerpsIsTestnet = jest.fn(() => false);
-const mockSelectPerpsTradeConfigurations = jest.fn(() => ({}));
+const mockUsePerpsLiveMarketData = jest.fn(
+  (): {
+    markets: Record<string, unknown>[];
+    isInitialLoading: boolean;
+    error: Error | null;
+  } => ({
+    markets: [],
+    isInitialLoading: false,
+    error: null,
+  }),
+);
+const mockGetIsPerpsExperienceAvailable = jest.fn(
+  (..._args: unknown[]) => true,
+);
+const mockSelectPerpsIsTestnet = jest.fn((..._args: unknown[]) => false);
+const mockSelectPerpsTradeConfigurations = jest.fn(
+  (..._args: unknown[]): Record<string, unknown> => ({}),
+);
 
 // ─── Module mocks ──────────────────────────────────────────────────────────────
 jest.mock('react-router-dom', () => ({
@@ -150,16 +162,21 @@ describe('PerpsMarketExpandedPage', () => {
       expect(getByTestId('perps-expanded-skeleton')).toBeInTheDocument();
     });
 
-    it('shows skeleton when markets list is empty and not loading', () => {
+    it('shows not-found (not an endless skeleton) when loading completes with an empty markets list', () => {
       mockUsePerpsLiveMarketData.mockReturnValue({
         markets: [],
         isInitialLoading: false,
         error: null,
       });
 
-      const { getByTestId } = render(<PerpsMarketExpandedPage />);
+      const { getByTestId, queryByTestId } = render(
+        <PerpsMarketExpandedPage />,
+      );
 
-      expect(getByTestId('perps-expanded-skeleton')).toBeInTheDocument();
+      expect(queryByTestId('perps-expanded-skeleton')).not.toBeInTheDocument();
+      expect(
+        getByTestId('perps-market-expanded-not-found'),
+      ).toBeInTheDocument();
     });
   });
 

--- a/ui/pages/perps/perps-market-expanded-page.tsx
+++ b/ui/pages/perps/perps-market-expanded-page.tsx
@@ -1,0 +1,189 @@
+import React, { useCallback, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { Navigate, useNavigate, useParams } from 'react-router-dom';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  BoxJustifyContent,
+  Button,
+  ButtonSize,
+  ButtonVariant,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react';
+import { getIsPerpsExperienceAvailable } from '../../selectors/perps/feature-flags';
+import {
+  selectPerpsIsTestnet,
+  selectPerpsTradeConfigurations,
+} from '../../selectors/perps-controller';
+import { DEFAULT_ROUTE } from '../../helpers/constants/routes';
+import { usePerpsLiveMarketData } from '../../hooks/perps/stream';
+import { usePerpsMarketInfo } from '../../hooks/perps/usePerpsMarketInfo';
+import { usePerpsMeasurement } from '../../hooks/perps/usePerpsMeasurement';
+import { useI18nContext } from '../../hooks/useI18nContext';
+import { safeDecodeURIComponent } from '../../components/app/perps/utils';
+import { PerpsGeoBlockModal } from '../../components/app/perps/perps-geo-block-modal';
+import {
+  PerpsExpandedChartPanel,
+  PerpsExpandedHeader,
+  PerpsExpandedOrderBookPanel,
+  PerpsExpandedPositionsPanel,
+  PerpsExpandedSkeleton,
+  PerpsExpandedTradePanel,
+} from '../../components/app/perps/perps-market-expanded';
+
+/** Fallback max leverage when market metadata has not loaded. */
+const DEFAULT_MAX_LEVERAGE = 50;
+/** Default leverage applied to a fresh order when none is saved. */
+const DEFAULT_LEVERAGE = 3;
+/**
+ * Three-column terminal grid: chart | order book | trade ticket.
+ * Magic widths live here, named, instead of inline in JSX.
+ */
+const TERMINAL_GRID_COLUMNS =
+  'minmax(420px, 1fr) minmax(260px, 0.5fr) minmax(320px, 0.5fr)';
+
+/**
+ * Full-width perps trading terminal rendered in a browser tab.
+ *
+ * This page is a thin orchestrator: it resolves the market and renders the
+ * panels. Every high-frequency live subscription (price, candles, order book,
+ * positions, orders, account) lives inside the individual panels, so a tick on
+ * one stream re-renders only the panel that consumes it — not the whole tree.
+ */
+const PerpsMarketExpandedPage = () => {
+  const t = useI18nContext();
+  const navigate = useNavigate();
+  const { symbol } = useParams<{ symbol: string }>();
+  const isPerpsExperienceAvailable = useSelector(getIsPerpsExperienceAvailable);
+  const isTestnet = useSelector(selectPerpsIsTestnet);
+  const tradeConfigurations = useSelector(selectPerpsTradeConfigurations);
+
+  const decodedSymbol = useMemo(
+    () => (symbol ? safeDecodeURIComponent(symbol) : undefined),
+    [symbol],
+  );
+
+  // Page-level market-list subscription is used only to resolve the
+  // existence / loading guard. Panels do not receive any live-market data as
+  // props, so a market tick re-renders only this lightweight orchestrator.
+  const { markets, isInitialLoading: marketsLoading } =
+    usePerpsLiveMarketData();
+  const market = useMemo(() => {
+    if (!decodedSymbol) {
+      return undefined;
+    }
+    const target = decodedSymbol.toLowerCase();
+    return markets.find((m) => m.symbol.toLowerCase() === target);
+  }, [decodedSymbol, markets]);
+
+  // Static market metadata (numeric maxLeverage, szDecimals) from a cached
+  // fetch that does not tick — safe to pass down to memoized panels.
+  const marketInfo = usePerpsMarketInfo(decodedSymbol ?? '');
+
+  const maxLeverage = useMemo(() => {
+    if (marketInfo?.maxLeverage) {
+      return marketInfo.maxLeverage;
+    }
+    if (market?.maxLeverage) {
+      return parseInt(market.maxLeverage.replace('x', ''), 10);
+    }
+    return DEFAULT_MAX_LEVERAGE;
+  }, [marketInfo?.maxLeverage, market?.maxLeverage]);
+
+  const maxLeverageLabel = marketInfo?.maxLeverage
+    ? `${marketInfo.maxLeverage}x`
+    : market?.maxLeverage;
+
+  const initialLeverage = useMemo(() => {
+    if (!decodedSymbol) {
+      return undefined;
+    }
+    const env = isTestnet ? 'testnet' : 'mainnet';
+    const saved = tradeConfigurations[env]?.[decodedSymbol]?.leverage;
+    return Math.min(saved ?? DEFAULT_LEVERAGE, maxLeverage);
+  }, [decodedSymbol, isTestnet, tradeConfigurations, maxLeverage]);
+
+  const [isGeoBlockModalOpen, setIsGeoBlockModalOpen] = useState(false);
+  const openGeoBlockModal = useCallback(() => setIsGeoBlockModalOpen(true), []);
+  const closeGeoBlockModal = useCallback(
+    () => setIsGeoBlockModalOpen(false),
+    [],
+  );
+
+  usePerpsMeasurement('PerpsMarketExpandedLoaded', !marketsLoading);
+
+  if (!isPerpsExperienceAvailable || !decodedSymbol) {
+    return <Navigate to={DEFAULT_ROUTE} replace />;
+  }
+
+  // Wait for markets to hydrate before deciding the symbol is missing. A fresh
+  // (cold) tab opened from the Expand button hydrates the markets stream
+  // asynchronously; redirecting on a transient empty list would bounce the user
+  // away before the data arrives.
+  if (marketsLoading || markets.length === 0) {
+    return <PerpsExpandedSkeleton />;
+  }
+
+  if (!market) {
+    return (
+      <Box
+        flexDirection={BoxFlexDirection.Column}
+        alignItems={BoxAlignItems.Center}
+        justifyContent={BoxJustifyContent.Center}
+        gap={4}
+        className="h-screen w-full bg-background-default"
+        data-testid="perps-market-expanded-not-found"
+      >
+        <Text variant={TextVariant.HeadingMd}>{t('perpsMarketNotFound')}</Text>
+        <Button
+          variant={ButtonVariant.Tertiary}
+          size={ButtonSize.Sm}
+          onClick={() =>
+            navigate({ pathname: DEFAULT_ROUTE, search: 'tab=perps' })
+          }
+        >
+          {t('back')}
+        </Button>
+      </Box>
+    );
+  }
+
+  return (
+    <Box
+      flexDirection={BoxFlexDirection.Column}
+      className="h-screen w-full overflow-hidden bg-background-default"
+      data-testid="perps-market-expanded-page"
+    >
+      <PerpsExpandedHeader
+        symbol={decodedSymbol}
+        maxLeverageLabel={maxLeverageLabel}
+      />
+
+      <div
+        className="grid min-h-0 flex-1 overflow-hidden max-[980px]:overflow-y-auto"
+        style={{ gridTemplateColumns: TERMINAL_GRID_COLUMNS }}
+      >
+        <PerpsExpandedChartPanel symbol={decodedSymbol} />
+        <PerpsExpandedOrderBookPanel symbol={decodedSymbol} />
+        <PerpsExpandedTradePanel
+          symbol={decodedSymbol}
+          maxLeverage={maxLeverage}
+          initialLeverage={initialLeverage}
+          sizeDecimals={marketInfo?.szDecimals}
+          onGeoBlocked={openGeoBlockModal}
+        />
+      </div>
+
+      <PerpsExpandedPositionsPanel symbol={decodedSymbol} />
+
+      <PerpsGeoBlockModal
+        isOpen={isGeoBlockModalOpen}
+        onClose={closeGeoBlockModal}
+      />
+    </Box>
+  );
+};
+
+export default PerpsMarketExpandedPage;

--- a/ui/pages/perps/perps-market-expanded-page.tsx
+++ b/ui/pages/perps/perps-market-expanded-page.tsx
@@ -118,11 +118,14 @@ const PerpsMarketExpandedPage = () => {
     return <Navigate to={DEFAULT_ROUTE} replace />;
   }
 
-  // Wait for markets to hydrate before deciding the symbol is missing. A fresh
-  // (cold) tab opened from the Expand button hydrates the markets stream
-  // asynchronously; redirecting on a transient empty list would bounce the user
-  // away before the data arrives.
-  if (marketsLoading || markets.length === 0) {
+  // Wait for the markets stream to hydrate before deciding the symbol is
+  // missing. A fresh (cold) tab opened from the Expand button hydrates
+  // asynchronously; `isInitialLoading` stays true until the first emission, so
+  // redirecting during that window would bounce the user before data arrives.
+  // Once loading completes we intentionally fall through even on an empty list
+  // so a failed/empty fetch lands on the not-found terminal instead of an
+  // endless skeleton (mirrors the popup market-detail page).
+  if (marketsLoading) {
     return <PerpsExpandedSkeleton />;
   }
 

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -34,13 +34,9 @@ import {
 import type {
   ClosePositionParams,
   OrderType,
-  OrderParams,
   PriceUpdate,
 } from '@metamask/perps-controller';
-import {
-  ORDER_SLIPPAGE_CONFIG,
-  PERFORMANCE_CONFIG,
-} from '@metamask/perps-controller';
+import { PERFORMANCE_CONFIG } from '@metamask/perps-controller';
 import {
   formatPerpsFiat,
   PRICE_RANGES_UNIVERSAL,
@@ -125,6 +121,7 @@ import {
   OrderEntry,
   DirectionTabs,
   OrderSummary,
+  formStateToOrderParams,
   type OrderDirection,
   type OrderFormState,
   type OrderMode,
@@ -163,64 +160,6 @@ export function shouldShowPerpsOrderSubmissionToasts(
   hasPendingPerpsDeposit: boolean,
 ) {
   return !hasPendingPerpsDeposit;
-}
-
-/**
- * Convert UI OrderFormState to PerpsController OrderParams
- *
- * @param formState - Current order form state
- * @param currentPrice - Current asset price in USD
- * @param mode - Order mode (new, modify, close)
- * @param existingPositionSize - Size of existing position when closing
- * @param maxSlippageBps
- */
-function formStateToOrderParams(
-  formState: OrderFormState,
-  currentPrice: number,
-  mode: OrderMode,
-  existingPositionSize?: string,
-  maxSlippageBps?: number,
-): OrderParams {
-  const isBuy = formState.direction === 'long';
-  const marginAmount = Number.parseFloat(formState.amount) || 0;
-  const positionSize =
-    currentPrice > 0 ? (marginAmount * formState.leverage) / currentPrice : 0;
-  const size =
-    mode === 'close' && existingPositionSize
-      ? Math.abs(Number.parseFloat(existingPositionSize)).toString()
-      : positionSize.toString();
-  const cleanAmount = formState.amount.replaceAll(',', '');
-
-  const params: OrderParams = {
-    symbol: formState.asset,
-    isBuy,
-    size,
-    orderType: formState.type,
-    leverage: formState.leverage,
-    currentPrice,
-    usdAmount: cleanAmount,
-    priceAtCalculation: currentPrice,
-    maxSlippageBps:
-      formState.type === 'limit'
-        ? ORDER_SLIPPAGE_CONFIG.DefaultLimitSlippageBps
-        : (maxSlippageBps ?? ORDER_SLIPPAGE_CONFIG.DefaultMarketSlippageBps),
-  };
-
-  if (formState.type === 'limit' && formState.limitPrice) {
-    params.price = formState.limitPrice.replaceAll(',', '');
-  }
-  if (formState.autoCloseEnabled && formState.takeProfitPrice) {
-    params.takeProfitPrice = formState.takeProfitPrice.replaceAll(',', '');
-  }
-  if (formState.autoCloseEnabled && formState.stopLossPrice) {
-    params.stopLossPrice = formState.stopLossPrice.replaceAll(',', '');
-  }
-  if (mode === 'close') {
-    params.reduceOnly = true;
-    params.isFullClose = true;
-  }
-
-  return params;
 }
 
 const FULL_CLOSE_PERCENT = 100;
@@ -591,24 +530,24 @@ const PerpsOrderEntryPage = () => {
 
     const tpInvalid = Boolean(
       tp?.trim() &&
-      !isValidTakeProfitPrice(tp, {
-        currentPrice: referencePrice,
-        direction: dir,
-      }),
+        !isValidTakeProfitPrice(tp, {
+          currentPrice: referencePrice,
+          direction: dir,
+        }),
     );
     const slInvalid = Boolean(
       sl?.trim() &&
-      !isValidStopLossPrice(sl, {
-        currentPrice: referencePrice,
-        direction: dir,
-      }),
+        !isValidStopLossPrice(sl, {
+          currentPrice: referencePrice,
+          direction: dir,
+        }),
     );
     const slLiquidationInvalid = Boolean(
       sl?.trim() &&
-      !isStopLossSafeFromLiquidation(sl, {
-        liquidationPrice,
-        direction: dir,
-      }),
+        !isStopLossSafeFromLiquidation(sl, {
+          liquidationPrice,
+          direction: dir,
+        }),
     );
 
     return tpInvalid || slInvalid || slLiquidationInvalid;

--- a/ui/pages/perps/perps-order-entry-page.tsx
+++ b/ui/pages/perps/perps-order-entry-page.tsx
@@ -530,24 +530,24 @@ const PerpsOrderEntryPage = () => {
 
     const tpInvalid = Boolean(
       tp?.trim() &&
-        !isValidTakeProfitPrice(tp, {
-          currentPrice: referencePrice,
-          direction: dir,
-        }),
+      !isValidTakeProfitPrice(tp, {
+        currentPrice: referencePrice,
+        direction: dir,
+      }),
     );
     const slInvalid = Boolean(
       sl?.trim() &&
-        !isValidStopLossPrice(sl, {
-          currentPrice: referencePrice,
-          direction: dir,
-        }),
+      !isValidStopLossPrice(sl, {
+        currentPrice: referencePrice,
+        direction: dir,
+      }),
     );
     const slLiquidationInvalid = Boolean(
       sl?.trim() &&
-        !isStopLossSafeFromLiquidation(sl, {
-          liquidationPrice,
-          direction: dir,
-        }),
+      !isStopLossSafeFromLiquidation(sl, {
+        liquidationPrice,
+        direction: dir,
+      }),
     );
 
     return tpInvalid || slInvalid || slLiquidationInvalid;

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -203,27 +203,19 @@ const Asset = mmLazy(() => import('../asset/index.js'));
 const DeFiPage = mmLazy(() => import('../defi/index.ts'));
 const PermissionsPage = mmLazy(
   () =>
-    import(
-      '../../components/multichain/pages/permissions-page/permissions-page.js'
-    ),
+    import('../../components/multichain/pages/permissions-page/permissions-page.js'),
 );
 const GatorPermissionsPage = mmLazy(
   () =>
-    import(
-      '../../components/multichain/pages/gator-permissions/gator-permissions-page.tsx'
-    ),
+    import('../../components/multichain/pages/gator-permissions/gator-permissions-page.tsx'),
 );
 const GatorPermissionsTokenTransferPermissionsPage = mmLazy(
   () =>
-    import(
-      '../../components/multichain/pages/gator-permissions/token-transfer/token-transfer-page.tsx'
-    ),
+    import('../../components/multichain/pages/gator-permissions/token-transfer/token-transfer-page.tsx'),
 );
 const GatorPermissionsReviewPermissionsPage = mmLazy(
   () =>
-    import(
-      '../../components/multichain/pages/gator-permissions/review-permissions/review-gator-permissions-page.tsx'
-    ),
+    import('../../components/multichain/pages/gator-permissions/review-permissions/review-gator-permissions-page.tsx'),
 );
 const Home = mmLazy(() => import('../home/index.ts'));
 const DeepLink = mmLazy(() => import('../deep-link/deep-link.tsx'));

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -70,6 +70,7 @@ import {
   DECRYPT_MESSAGE_REQUEST_PATH,
   ENCRYPTION_PUBLIC_KEY_REQUEST_PATH,
   PERPS_MARKET_DETAIL_ROUTE,
+  PERPS_MARKET_EXPANDED_ROUTE,
   PERPS_ORDER_ENTRY_ROUTE,
   PERPS_ACTIVITY_ROUTE,
   PERPS_WITHDRAW_ROUTE,
@@ -130,6 +131,7 @@ import { WalletDetailsPage } from '../multichain-accounts/wallet-details-page';
 import { MultichainReviewPermissions } from '../../components/multichain-accounts/permissions/permission-review-page/multichain-review-permissions-page';
 import { LegacyLayout } from '../../layouts/legacy-layout';
 import { RequireAuthenticated } from '../../layouts/require-authenticated';
+import { RequireAuthenticatedFullWidth } from '../../layouts/require-authenticated-full-width';
 import { RequireOnboarded } from '../../layouts/require-onboarded';
 import { contactsRoutes } from '../contacts';
 import RequireBasicFunctionality from '../../helpers/higher-order-components/require-basic-functionality/require-basic-functionality';
@@ -201,19 +203,27 @@ const Asset = mmLazy(() => import('../asset/index.js'));
 const DeFiPage = mmLazy(() => import('../defi/index.ts'));
 const PermissionsPage = mmLazy(
   () =>
-    import('../../components/multichain/pages/permissions-page/permissions-page.js'),
+    import(
+      '../../components/multichain/pages/permissions-page/permissions-page.js'
+    ),
 );
 const GatorPermissionsPage = mmLazy(
   () =>
-    import('../../components/multichain/pages/gator-permissions/gator-permissions-page.tsx'),
+    import(
+      '../../components/multichain/pages/gator-permissions/gator-permissions-page.tsx'
+    ),
 );
 const GatorPermissionsTokenTransferPermissionsPage = mmLazy(
   () =>
-    import('../../components/multichain/pages/gator-permissions/token-transfer/token-transfer-page.tsx'),
+    import(
+      '../../components/multichain/pages/gator-permissions/token-transfer/token-transfer-page.tsx'
+    ),
 );
 const GatorPermissionsReviewPermissionsPage = mmLazy(
   () =>
-    import('../../components/multichain/pages/gator-permissions/review-permissions/review-gator-permissions-page.tsx'),
+    import(
+      '../../components/multichain/pages/gator-permissions/review-permissions/review-gator-permissions-page.tsx'
+    ),
 );
 const Home = mmLazy(() => import('../home/index.ts'));
 const DeepLink = mmLazy(() => import('../deep-link/deep-link.tsx'));
@@ -241,6 +251,9 @@ const PerpsWithdrawPage = mmLazy(
 );
 const PerpsOrderEntryPage = mmLazy(
   () => import('../perps/perps-order-entry-page.tsx'),
+);
+const PerpsMarketExpandedPage = mmLazy(
+  () => import('../perps/perps-market-expanded-page.tsx'),
 );
 const MusdConversionPage = mmLazy(() => import('../musd/index.tsx'));
 const PerpsLayout = mmLazy(() => import('../perps/perps-layout.tsx'));
@@ -569,6 +582,22 @@ export const routeConfig = [
                 element: <PerpsWithdrawPage />,
               },
             ],
+          },
+        ],
+      },
+    ],
+  },
+  // Full-width route block: bypasses RootLayout's popup max-width so the perps
+  // expanded trading view can span the entire browser tab.
+  {
+    element: <RequireAuthenticatedFullWidth />,
+    children: [
+      {
+        element: <PerpsLayout />,
+        children: [
+          {
+            path: `${PERPS_MARKET_EXPANDED_ROUTE}/:symbol`,
+            element: <PerpsMarketExpandedPage />,
           },
         ],
       },


### PR DESCRIPTION
## **Description**

Spike (TAT-3461) to de-risk the performance impact of the Extension perps **expanded ("extended") view**, implemented as a clean, production-shaped architecture rather than a throwaway PoC.

**TL;DR — no significant latency / main-thread cost.** The expanded view opens in ~21 ms with **0 ms Total Blocking Time** ("good") and 0 ms main-thread blocking during live streaming (order book included), because each panel owns its own subscriptions — no top-level price-lift, no whole-tree re-renders.

### Are the data calls the same? (the central question)

**Yes — identical, except one.** Both the expanded view and the popup detail page subscribe to the same module-level singleton channels (`PerpsStreamManager`): positions, orders, account, markets, candles, price. Reading them from multiple panels adds React subscribers, **not** network/background calls. The expanded view adds exactly **one** new subscription the popup never makes: **`usePerpsLiveOrderBook`** (a new order-book WebSocket feed). Remove it and the data footprint equals the popup's — it's a new *feature*, not a regression.

### Performance comparison (latency / main-thread axis)

| Metric | Expanded | Popup detail | Source |
| --- | --- | --- | --- |
| Time-to-render (to first DOM) | ~21 ms | ~18 ms | `performance.now()` |
| Total Blocking Time | **0 ms (good)** | 0 ms (good) | `getLongTaskMetricsWithTBT` (longtask observer) |
| Steady-state blocking (10 s, live) | **0 ms** | 0 ms | longtask observer |

Captured in a warm session (unfunded account, modest order-book activity): de-risks the **latency / main-thread axis**, not a stress test.

### Memory axis — not yet established

Memory/DOM figures are intentionally excluded. Reliable retention numbers require **forced-GC heap snapshots** (`HeapProfiler.collectGarbage` before each sample), ideally with a funded/active scenario and React render-count instrumentation. That measurement is outstanding; no memory-cost claim is made here.

### No per-navigation leak

GC-forced measurement (`HeapProfiler.collectGarbage` before each sample) is **flat** across navigation cycles — there is no per-navigation listener/DOM leak. The only GC-surviving growth is a vendor web-vitals `visibilitychange` listener (~3/cycle, app-wide, no DOM retention), which is negligible. **TAT-3462 is closed as not-a-bug.**

### Assessment of PoC #41661 (AC1)

**Keep:** the full-width route concept, the 3-column terminal, the panel decomposition. **Rework/discard:** the PoC lifted 4 live-stream subscriptions to the page and lifted chart price into page state (whole-tree re-renders on every tick), and duplicated the auth guard. This PR reworks all three.

### What this PR implements (AC4)

Shared `useAuthGuardRedirect` + generic `FullWidthLayout` (no duplicated guard); a thin orchestrator page with **per-panel subscriptions**; no top-level price-lift; shared `formStateToOrderParams` (expanded trade ticket mirrors the order-entry submit flow — two-step TP/SL via `perpsUpdatePositionTPSL` and gated `maxSlippageBps`); a robust cold-mount guard; `data-testid`s throughout; and an **Expand** entry point on the market detail page (sidebar/popup → full tab, fullscreen → in-place).

The PoC assessment, architecture, and the validation recipe are below.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TAT-3461](https://consensyssoftware.atlassian.net/browse/TAT-3461)

## **Manual testing steps**

1. Open MetaMask and go to Perps → a market (e.g. ETH) detail page (popup, side panel, or fullscreen tab).
2. Click the new **Expand** icon in the market header.
3. From the popup/side panel it opens the full-width trading terminal in a new browser tab; from a fullscreen tab it navigates in place.
4. Confirm the terminal renders chart + live order book + trade ticket + positions, full width, with live price/order-book updates.

## **Screenshots/Recordings**

Full-width expanded perps trading terminal, opened from the side panel Expand button.


**Video**
Sidebar-entry recipe run: open side panel -> detail -> Expand -> expanded terminal renders + perf captured.
- After: [artifacts/recipe-runs/inherited-e20e0dd0-2175-4696-854f-672cf954707a/after.mp4](https://raw.githubusercontent.com/abretonc7s/mm-extension-farm-artifacts/main/fixes/44002/recipe-runs/inherited-e20e0dd0-2175-4696-854f-672cf954707a/after.mp4?sha=5a07ecdebed1f44c)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## **Validation Recipe**

Sidebar-entry recipe: opens the side panel, clicks the real Expand button, asserts the expanded terminal opens with all five panels + full width, and records the expanded vs popup TBT baseline (35/35 nodes pass).

<details>
<summary>recipe.json</summary>

```json
{
  "schema_version": 1,
  "title": "TAT-3461 Perps expanded view — sidebar entry, render + perf baseline",

  "validate": {
    "workflow": {
      "entry": "status",
      "nodes": {
        "status": {
          "action": "app.status",
          "intent": "Read runner compatibility status",
          "flow": "setup",
          "next": "fixture"
        },
        "fixture": {
          "action": "metamask.wallet.fixture_status",
          "intent": "Verify wallet fixture availability",
          "flow": "setup",
          "next": "setup-unlock"
        },
        "setup-unlock": {
          "action": "metamask.wallet.ensure_unlocked",
          "intent": "Ensure the wallet is unlocked",
          "flow": "setup",
          "next": "setup-clean-perf"
        },
        "setup-clean-perf": {
          "action": "command",

          "intent": "Start from a clean perf-metrics file",
          "flow": "setup",
          "next": "setup-assert-clean"
        },
        "setup-assert-clean": {
          "action": "assert_exit_code",
          "source": "setup-clean-perf",
          "expected": 0,
          "intent": "Confirm perf-metrics reset",
          "flow": "setup",
          "next": "setup-open-sidebar"
        },
        "setup-open-sidebar": {
          "action": "command",

          "intent": "Open the extension side panel (primary product surface)",
          "flow": "ac4 sidebar",
          "next": "setup-assert-sidebar"
        },
        "setup-assert-sidebar": {
          "action": "assert_exit_code",
          "source": "setup-open-sidebar",
          "expected": 0,
          "intent": "Confirm the side panel opened",
          "flow": "ac4 sidebar",
          "next": "ac4-sidebar-nav-detail"
        },
        "ac4-sidebar-nav-detail": {
          "action": "command",

          "intent": "Open the ETH perps market in the side panel",
          "flow": "ac4 sidebar",
          "next": "ac4-sidebar-wait-detail"
        },
        "ac4-sidebar-wait-detail": {
          "action": "command",

          "intent": "Wait for the detail page in the side panel",
          "flow": "ac4 sidebar",
          "next": "ac4-sidebar-assert-detail"
        },
        "ac4-sidebar-assert-detail": {
          "action": "assert_exit_code",
          "source": "ac4-sidebar-wait-detail",
          "expected": 0,
          "intent": "Confirm the detail page rendered in the side panel",
          "flow": "ac4 sidebar",
          "next": "ac4-sidebar-wait-expand-button"
        },
        "ac4-sidebar-wait-expand-button": {
          "action": "command",

          "intent": "Confirm the Expand button is present in the side panel",
          "flow": "ac4 sidebar",
          "next": "ac4-sidebar-assert-expand-button"
        },
        "ac4-sidebar-assert-expand-button": {
          "action": "assert_exit_code",
          "source": "ac4-sidebar-wait-expand-button",
          "expected": 0,
          "intent": "Confirm the Expand affordance exists on the detail page",
          "flow": "ac4 sidebar",
          "next": "ac4-sidebar-click-expand"
        },
        "ac4-sidebar-click-expand": {
          "action": "command",

          "intent": "Click Expand in the side panel (trusted gesture opens a full tab)",
          "flow": "ac4 sidebar",
          "next": "ac4-sidebar-assert-click"
        },
        "ac4-sidebar-assert-click": {
          "action": "assert_exit_code",
          "source": "ac4-sidebar-click-expand",
          "expected": 0,
          "intent": "Confirm the Expand click dispatched",
          "flow": "ac4 sidebar",
          "next": "ac4-wait-expanded-tab"
        },
        "ac4-wait-expanded-tab": {
          "action": "command",

          "intent": "Wait for the expanded view to open in a new browser tab",
          "flow": "ac4 sidebar",
          "next": "ac4-assert-expanded-tab"
        },
        "ac4-assert-expanded-tab": {
          "action": "assert_exit_code",
          "source": "ac4-wait-expanded-tab",
          "expected": 0,
          "intent": "Confirm the Expand button opened the expanded tab",
          "flow": "ac4 sidebar",
          "next": "ac2-reset-expanded"
        },
        "ac2-reset-expanded": {
          "action": "command",

          "intent": "Reset Long-Task/TBT counters on the expanded tab",
          "flow": "ac2 perf",
          "next": "ac4-wait-expanded-page"
        },
        "ac4-wait-expanded-page": {
          "action": "command",

          "intent": "Wait for the expanded terminal to render in the new tab",
          "flow": "ac4 architecture",
          "next": "ac4-assert-expanded-page"
        },
        "ac4-assert-expanded-page": {
          "action": "assert_exit_code",
          "source": "ac4-wait-expanded-page",
          "expected": 0,
          "intent": "Confirm the expanded page rendered",
          "flow": "ac4 architecture",
          "next": "ac4-check-panels"
        },
        "ac4-check-panels": {
          "action": "command",

          "intent": "Assert all five expanded panels render",
          "flow": "ac4 architecture",
          "next": "ac4-assert-panels"
        },
        "ac4-assert-panels": {
          "action": "assert_exit_code",
          "source": "ac4-check-panels",
          "expected": 0,
          "intent": "Confirm every panel rendered",
          "flow": "ac4 architecture",
          "next": "ac4-check-full-width"
        },
        "ac4-check-full-width": {
          "action": "command",

          "intent": "Assert the expanded page spans the full viewport width",
          "flow": "ac4 architecture",
          "next": "ac4-assert-full-width"
        },
        "ac4-assert-full-width": {
          "action": "assert_exit_code",
          "source": "ac4-check-full-width",
          "expected": 0,
          "intent": "Confirm RootLayout max-width was bypassed",
          "flow": "ac4 architecture",
          "next": "ac2-measure-expanded"
        },
        "ac2-measure-expanded": {
          "action": "command",

          "intent": "Capture expanded-view Long-Task/TBT baseline",
          "flow": "ac2 perf",
          "next": "ac2-assert-measure-expanded"
        },
        "ac2-assert-measure-expanded": {
          "action": "assert_exit_code",
          "source": "ac2-measure-expanded",
          "expected": 0,
          "intent": "Confirm expanded perf metrics captured",
          "flow": "ac2 perf",
          "next": "ac4-runner-warm-detail"
        },
        "ac4-runner-warm-detail": {
          "action": "ui.navigate",
          "hash": "#/perps/market/ETH",
          "intent": "Warm the runner tab on the detail route for the evidence screenshot",
          "flow": "ac4 evidence",
          "next": "ac4-runner-wait-detail"
        },
        "ac4-runner-wait-detail": {
          "action": "command",

          "intent": "Wait for the detail page on the runner tab",
          "flow": "ac4 evidence",
          "next": "ac2-reset-popup"
        },
        "ac4-runner-nav-expanded": {
          "action": "ui.navigate",
          "hash": "#/perps/market-expanded/ETH",
          "intent": "Navigate the runner tab to the expanded route for the screenshot",
          "flow": "ac4 evidence",
          "next": "ac4-runner-wait-expanded"
        },
        "ac4-runner-wait-expanded": {
          "action": "ui.wait_for",
          "text": "Order book",
          "intent": "Wait for the expanded terminal (order book visible)",
          "flow": "ac4 evidence",
          "next": "ac4-screenshot"
        },
        "ac4-screenshot": {
          "action": "ui.screenshot",
          "path": "evidence-ac4-expanded-view.png",
          "timeout_ms": 15000,
          "intent": "Capture the full-width expanded perps terminal",
          "flow": "ac4 evidence",
          "next": "ac2-assert-perf-json"
        },
        "ac2-reset-popup": {
          "action": "command",

          "intent": "Reset counters before the popup measurement",
          "flow": "ac2 perf",
          "next": "ac2-measure-popup"
        },
        "ac2-measure-popup": {
          "action": "command",

          "intent": "Capture popup detail Long-Task/TBT baseline for comparison",
          "flow": "ac2 perf",
          "next": "ac2-assert-measure-popup"
        },
        "ac2-assert-measure-popup": {
          "action": "assert_exit_code",
          "source": "ac2-measure-popup",
          "expected": 0,
          "intent": "Confirm popup perf metrics captured",
          "flow": "ac2 perf",
          "next": "ac4-runner-nav-expanded"
        },
        "ac2-assert-perf-json": {
          "action": "assert_json",

          "assert": { "path": "$.expanded.ok", "operator": "eq", "value": true },
          "intent": "Confirm a numeric expanded-view TBT baseline was recorded",
          "flow": "ac2 perf",
          "next": "done"
        },
        "done": {
          "action": "end",
          "status": "pass",
          "intent": "Finish sidebar-entry expanded-view render + perf recipe",
          "flow": "complete"
        }
      }
    }
  }
}
```

</details>

[TAT-3461]: https://consensyssoftware.atlassian.net/browse/TAT-3461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expanded view places real perps orders with slippage and two-step TP/SL logic that must stay aligned with the order-entry page; regressions could allow invalid submits or wrong trigger grouping.
> 
> **Overview**
> Adds a **full-width perps trading terminal** at `/perps/market-expanded/:symbol`, wired through `RequireAuthenticatedFullWidth` and `FullWidthLayout` so browser tabs are not capped by the popup `RootLayout` width.
> 
> The market detail page gets an **Expand** control: popup/side panel opens the route in a new tab via `openExtensionInBrowser`; an already-fullscreen tab navigates in place. The expanded page is a thin orchestrator (chart, order book, trade ticket, positions) with **live streams owned per panel** to limit re-renders; it adds a dedicated **order book** stream and new copy for expand, spread, and empty positions.
> 
> **Order parity:** `formStateToOrderParams` is extracted for shared use; the order-entry page imports it instead of an inline helper. `OrderEntry`’s internal submit button now enforces the same min size, balance, and limit-price guards as the trade page (for the expanded ticket). `PerpsExpandedTradePanel` reuses `OrderEntry` and mirrors submit behavior (slippage cap, two-step market TP/SL via `perpsUpdatePositionTPSL`, geo block).
> 
> Auth onboarding/unlock checks move into **`useAuthGuardRedirect`**, reused by `RequireAuthenticated` and the new full-width guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48791f5167c3738145fccd77eb026bb995b82a40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

