### PR TITLE
fix: remove swaps location setting for activity details

### DIFF
--- a/ui/pages/details/components/swap-again-button.test.tsx
+++ b/ui/pages/details/components/swap-again-button.test.tsx
@@ -67,21 +67,16 @@ const renderSwapAgainButton = (
   );
 
 describe('SwapAgainButton', () => {
-  let setBridgeLocationSpy: jest.SpyInstance;
   let trackUnifiedSwapBridgeEventSpy: jest.SpyInstance;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    setBridgeLocationSpy = jest
-      .spyOn(bridgeActions, 'setBridgeLocation')
-      .mockImplementation((...args: unknown[]) => jest.fn()(...args));
     trackUnifiedSwapBridgeEventSpy = jest
       .spyOn(bridgeActions, 'trackUnifiedSwapBridgeEvent')
       .mockImplementation((...args: unknown[]) => jest.fn()(...args));
   });
 
   afterEach(() => {
-    setBridgeLocationSpy.mockRestore();
     trackUnifiedSwapBridgeEventSpy.mockRestore();
   });
 
@@ -115,7 +110,7 @@ describe('SwapAgainButton', () => {
     expect(getByRole('button')).toHaveTextContent(messages.bridgeAgain.message);
   });
 
-  it('tracks button click, sets bridge location, and navigates to swap flow', async () => {
+  it('tracks button click and navigates to swap flow', async () => {
     const { getByRole } = renderSwapAgainButton(ethMainnetNative, usdcMainnet);
 
     await act(async () => {
@@ -133,10 +128,6 @@ describe('SwapAgainButton', () => {
         /* eslint-enable @typescript-eslint/naming-convention */
       },
     );
-    expect(setBridgeLocationSpy).toHaveBeenCalledWith(
-      MetaMetricsSwapsEventSource.TransactionDetails,
-    );
-
     const expectedSearchParams = new URLSearchParams();
     expectedSearchParams.set(
       BridgeQueryParams.From,
@@ -152,6 +143,6 @@ describe('SwapAgainButton', () => {
       search: expectedSearchParams,
       isEntrypoint: true,
     });
-    expect(mockDispatch).toHaveBeenCalledTimes(2);
+    expect(mockDispatch).toHaveBeenCalledTimes(1);
   });
 });

--- a/ui/pages/details/components/swap-again-button.tsx
+++ b/ui/pages/details/components/swap-again-button.tsx
@@ -12,10 +12,7 @@ import { useDispatch } from 'react-redux';
 import type { TokenAmount } from '../../../../shared/lib/activity/types';
 import { MetaMetricsSwapsEventSource } from '../../../../shared/constants/metametrics';
 import { BridgeQueryParams } from '../../../../shared/lib/deep-links/routes/swap';
-import {
-  setBridgeLocation,
-  trackUnifiedSwapBridgeEvent,
-} from '../../../ducks/bridge/actions';
+import { trackUnifiedSwapBridgeEvent } from '../../../ducks/bridge/actions';
 import { useBridgeNavigation } from '../../../hooks/bridge/useBridgeNavigation';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { transitionForward } from '../../../components/ui/transition';
@@ -71,8 +68,6 @@ export function SwapAgainButton({
     );
 
     transitionForward(() => {
-      const location = MetaMetricsSwapsEventSource.TransactionDetails;
-      dispatch(setBridgeLocation(location));
       navigateToBridgePage({
         token: null,
         search: searchParams,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR removes the explicit Transaction Details bridge location update from the Swap Again button on activity details. The button still tracks the click event from Activity Details and navigates to the swap/bridge flow with the original source and destination tokens, without overwriting bridge location state during navigation.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Follow up to https://github.com/MetaMask/metamask-extension/pull/43816

## **Manual testing steps**

1. Open an existing completed swap or bridge transaction from Activity.
2. Click the Swap Again or Bridge Again button on the transaction details page.
3. Verify the swap/bridge page opens with the original source and destination tokens populated.
4. Verify the Swap Again button click is attributed to Activity Details in metrics, without setting the bridge location to Transaction Details during navigation.

<!--
## **Screenshots/Recordings**

If applicable, add screenshots and/or recordings to visualize the before and after of your change.

### **Before**

[screenshots/recordings]

N/A

### **After**

[screenshots/recordings]
-->

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable. Not applicable: this is a small metrics/navigation state cleanup covered by manual verification.
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable. Not applicable: no public API or new code surface was added.
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavior change to bridge metrics location state on one button; no auth, payments, or broad navigation refactors.
> 
> **Overview**
> Removes the **`setBridgeLocation(TransactionDetails)`** dispatch from **`SwapAgainButton`** on activity transaction details. Clicks still fire **`trackUnifiedSwapBridgeEvent`** with **`ActivityDetails`**, and navigation still opens swap/bridge with the same **from/to** query params.
> 
> Unit tests drop the **`setBridgeLocation`** spy and expect **one** Redux dispatch (analytics only) instead of two.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3de6f74232d184404b8847e70d77c83541f550e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->