### PR TITLE
feat: collect split state persistence diagnostics

### DIFF
--- a/app/scripts/lib/setup-initial-state-hooks.js
+++ b/app/scripts/lib/setup-initial-state-hooks.js
@@ -16,13 +16,7 @@ import { trackEarlySegmentEvent } from './segment/custom-segment-tracking';
 
 const platform = new ExtensionPlatform();
 
-function createLocalStore() {
-  const useFixtureStore =
-    process.env.IN_TEST &&
-    getManifestFlags().testing?.forceExtensionStore !== true;
-  if (!useFixtureStore) {
-    return new ExtensionStore();
-  }
+function isBackgroundContext() {
   // Use globalThis.self (not window) so this works in both the UI and the background/service worker, where window is undefined.
   const locationHref = globalThis.self?.location?.href;
   if (!locationHref) {
@@ -30,9 +24,17 @@ function createLocalStore() {
       'setup-initial-state-hooks: globalThis.self?.location?.href is not defined; expected to run in a document or service worker context.',
     );
   }
-  const isBackground =
-    getEnvironmentType(locationHref) === ENVIRONMENT_TYPE_BACKGROUND;
-  return new FixtureExtensionStore({ initialize: isBackground });
+  return getEnvironmentType(locationHref) === ENVIRONMENT_TYPE_BACKGROUND;
+}
+
+function createLocalStore() {
+  const useFixtureStore =
+    process.env.IN_TEST &&
+    getManifestFlags().testing?.forceExtensionStore !== true;
+  if (!useFixtureStore) {
+    return new ExtensionStore();
+  }
+  return new FixtureExtensionStore({ initialize: isBackgroundContext() });
 }
 
 const localStore = createLocalStore();
@@ -68,7 +70,33 @@ export const persistenceManager = new PersistenceManager({ localStore })
  * @returns The persisted wallet state.
  */
 globalThis.stateHooks.getPersistedState = async function () {
-  return await persistenceManager.get({ validateVault: false });
+  const persistedState = await persistenceManager.get({ validateVault: false });
+
+  if (
+    persistedState?.meta?.storageKind === 'split' &&
+    persistedState.data &&
+    isBackgroundContext()
+  ) {
+    try {
+      const diagnostics =
+        await persistenceManager.getWeeklySplitStatePersistenceDiagnosticsSnapshot();
+
+      if (diagnostics) {
+        trackEarlySegmentEvent({
+          state: persistedState.data,
+          event: MetaMetricsEventName.SplitStatePersistenceBaseline,
+          category: MetaMetricsEventCategory.Background,
+          properties: {
+            split_state_persistence_diagnostics: diagnostics,
+          },
+        });
+      }
+    } catch {
+      // Diagnostics must never affect startup.
+    }
+  }
+
+  return persistedState;
 };
 
 /**

--- a/app/scripts/lib/setup-initial-state-hooks.js
+++ b/app/scripts/lib/setup-initial-state-hooks.js
@@ -44,6 +44,7 @@ export const persistenceManager = new PersistenceManager({ localStore })
       payload.backup,
       MetaMetricsEventName.VaultCorruptionDetected,
       payload.corruptionType,
+      payload.diagnostics,
     );
   })
   .on('splitStateMigrationSucceeded', (payload) => {

--- a/app/scripts/lib/setup-initial-state-hooks.js
+++ b/app/scripts/lib/setup-initial-state-hooks.js
@@ -11,6 +11,7 @@ import {
   MetaMetricsEventName,
 } from '../../../shared/constants/metametrics';
 import { PersistenceManager } from '../../../shared/lib/stores/persistence-manager';
+import { getSplitStatePersistenceDiagnosticsConfig } from '../../../shared/lib/stores/persistence-diagnostics';
 import { trackVaultCorruptionEvent } from './state-corruption/track-vault-corruption';
 import { trackEarlySegmentEvent } from './segment/custom-segment-tracking';
 
@@ -35,6 +36,18 @@ function createLocalStore() {
     return new ExtensionStore();
   }
   return new FixtureExtensionStore({ initialize: isBackgroundContext() });
+}
+
+function getRemoteFeatureFlagsFromPersistedState(persistedState) {
+  const remoteFeatureFlags =
+    persistedState?.data?.RemoteFeatureFlagController?.remoteFeatureFlags;
+
+  return {
+    ...(remoteFeatureFlags && typeof remoteFeatureFlags === 'object'
+      ? remoteFeatureFlags
+      : {}),
+    ...(getManifestFlags().remoteFeatureFlags ?? {}),
+  };
 }
 
 const localStore = createLocalStore();
@@ -71,8 +84,15 @@ export const persistenceManager = new PersistenceManager({ localStore })
  */
 globalThis.stateHooks.getPersistedState = async function () {
   const persistedState = await persistenceManager.get({ validateVault: false });
+  const diagnosticsConfig = getSplitStatePersistenceDiagnosticsConfig(
+    getRemoteFeatureFlagsFromPersistedState(persistedState),
+  );
+  persistenceManager.setSplitStatePersistenceDiagnosticsConfig(
+    diagnosticsConfig,
+  );
 
   if (
+    diagnosticsConfig?.baselineEnabled &&
     persistedState?.meta?.storageKind === 'split' &&
     persistedState.data &&
     isBackgroundContext()

--- a/app/scripts/lib/setup-initial-state-hooks.test.ts
+++ b/app/scripts/lib/setup-initial-state-hooks.test.ts
@@ -4,6 +4,7 @@ import {
   MetaMetricsEventName,
 } from '../../../shared/constants/metametrics';
 import { VaultCorruptionType } from '../../../shared/constants/state-corruption';
+import { SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_FEATURE_FLAG } from '../../../shared/lib/stores/persistence-diagnostics';
 
 const mockGet = jest.fn();
 const mockGetBackup = jest.fn();
@@ -12,6 +13,7 @@ const mockPersistenceOn = jest.fn();
 const mockTrackVaultCorruptionEvent = jest.fn();
 const mockTrackEarlySegmentEvent = jest.fn();
 const mockGetWeeklySplitStatePersistenceDiagnosticsSnapshot = jest.fn();
+const mockSetSplitStatePersistenceDiagnosticsConfig = jest.fn();
 let mockMostRecentRetrievedState: unknown = null;
 
 jest.mock('../platforms/extension', () => {
@@ -47,6 +49,8 @@ jest.mock('../../../shared/lib/stores/persistence-manager', () => ({
       getBackup: mockGetBackup,
       getWeeklySplitStatePersistenceDiagnosticsSnapshot:
         mockGetWeeklySplitStatePersistenceDiagnosticsSnapshot,
+      setSplitStatePersistenceDiagnosticsConfig:
+        mockSetSplitStatePersistenceDiagnosticsConfig,
       cleanUpMostRecentRetrievedState: mockCleanUpMostRecentRetrievedState,
       on: (...args: unknown[]) => {
         mockPersistenceOn(...args);
@@ -100,6 +104,7 @@ describe('setup-initial-state-hooks', () => {
     mockTrackVaultCorruptionEvent.mockClear();
     mockTrackEarlySegmentEvent.mockClear();
     mockGetWeeklySplitStatePersistenceDiagnosticsSnapshot.mockClear();
+    mockSetSplitStatePersistenceDiagnosticsConfig.mockClear();
     globalThis.stateHooks = {} as typeof stateHooks;
   });
 
@@ -283,6 +288,13 @@ describe('setup-initial-state-hooks', () => {
             optedIn: true,
             analyticsId: 'test-metrics-id',
           },
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              [SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_FEATURE_FLAG]: {
+                enabled: true,
+              },
+            },
+          },
           PreferencesController: {},
         },
         meta: {
@@ -310,6 +322,16 @@ describe('setup-initial-state-hooks', () => {
       expect(
         mockGetWeeklySplitStatePersistenceDiagnosticsSnapshot,
       ).toHaveBeenCalledTimes(1);
+      expect(
+        mockSetSplitStatePersistenceDiagnosticsConfig,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          enabled: true,
+          baselineEnabled: true,
+          corruptionEnabled: true,
+          wideBatchKeyThreshold: 4,
+        }),
+      );
       expect(mockTrackEarlySegmentEvent).toHaveBeenCalledWith({
         state: persistedState.data,
         event: MetaMetricsEventName.SplitStatePersistenceBaseline,
@@ -324,6 +346,13 @@ describe('setup-initial-state-hooks', () => {
     it('does not track a weekly split-state persistence baseline in UI context', async () => {
       mockGet.mockResolvedValueOnce({
         data: {
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              [SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_FEATURE_FLAG]: {
+                enabled: true,
+              },
+            },
+          },
           PreferencesController: {},
         },
         meta: {
@@ -336,6 +365,30 @@ describe('setup-initial-state-hooks', () => {
 
       await globalThis.stateHooks.getPersistedState();
 
+      expect(
+        mockGetWeeklySplitStatePersistenceDiagnosticsSnapshot,
+      ).not.toHaveBeenCalled();
+      expect(mockTrackEarlySegmentEvent).not.toHaveBeenCalled();
+    });
+
+    it('does not collect or track split-state persistence diagnostics when the remote flag is missing', async () => {
+      mockGet.mockResolvedValueOnce({
+        data: {
+          PreferencesController: {},
+        },
+        meta: {
+          storageKind: 'split',
+          version: 1,
+        },
+      });
+      setSelfHref('chrome-extension://abc123/scripts/app-init.js');
+      await importFresh();
+
+      await globalThis.stateHooks.getPersistedState();
+
+      expect(
+        mockSetSplitStatePersistenceDiagnosticsConfig,
+      ).toHaveBeenCalledWith(undefined);
       expect(
         mockGetWeeklySplitStatePersistenceDiagnosticsSnapshot,
       ).not.toHaveBeenCalled();

--- a/app/scripts/lib/setup-initial-state-hooks.test.ts
+++ b/app/scripts/lib/setup-initial-state-hooks.test.ts
@@ -1,9 +1,12 @@
 import type { PersistenceManager as PersistenceManagerType } from '../../../shared/lib/stores/persistence-manager';
+import { MetaMetricsEventName } from '../../../shared/constants/metametrics';
+import { VaultCorruptionType } from '../../../shared/constants/state-corruption';
 
 const mockGet = jest.fn();
 const mockGetBackup = jest.fn();
 const mockCleanUpMostRecentRetrievedState = jest.fn();
 const mockPersistenceOn = jest.fn();
+const mockTrackVaultCorruptionEvent = jest.fn();
 let mockMostRecentRetrievedState: unknown = null;
 
 jest.mock('../platforms/extension', () => {
@@ -51,6 +54,10 @@ jest.mock('../../../shared/lib/stores/persistence-manager', () => ({
   }),
 }));
 
+jest.mock('./state-corruption/track-vault-corruption', () => ({
+  trackVaultCorruptionEvent: mockTrackVaultCorruptionEvent,
+}));
+
 /**
  * Re-imports the module with a fresh module registry so top-level code
  * re-runs with the current `globalThis.self.location.href`.
@@ -79,6 +86,7 @@ describe('setup-initial-state-hooks', () => {
     mockMostRecentRetrievedState = null;
     mockCleanUpMostRecentRetrievedState.mockClear();
     mockPersistenceOn.mockClear();
+    mockTrackVaultCorruptionEvent.mockClear();
     globalThis.stateHooks = {} as typeof stateHooks;
   });
 
@@ -202,6 +210,37 @@ describe('setup-initial-state-hooks', () => {
       expect(mockPersistenceOn).toHaveBeenCalledWith(
         'splitStateMigrationFailed',
         expect.any(Function),
+      );
+    });
+
+    it('passes split-state diagnostics to the vault corruption tracker', async () => {
+      setSelfHref('chrome-extension://abc123/home.html');
+      await importFresh();
+
+      const vaultCorruptionListener = mockPersistenceOn.mock.calls.find(
+        ([eventName]) => eventName === 'vaultCorruptionDetected',
+      )?.[1] as (payload: unknown) => void;
+      const backup = { KeyringController: { vault: 'vault' } };
+      const diagnostics = {
+        schemaVersion: 1,
+        updatedAt: 1000,
+        totalQueuedUpdates: 1,
+        totalPersistedBatches: 1,
+        topWrittenKeys: [],
+        recentWideBatches: [],
+      };
+
+      vaultCorruptionListener({
+        backup,
+        corruptionType: VaultCorruptionType.InaccessibleDatabase,
+        diagnostics,
+      });
+
+      expect(mockTrackVaultCorruptionEvent).toHaveBeenCalledWith(
+        backup,
+        MetaMetricsEventName.VaultCorruptionDetected,
+        VaultCorruptionType.InaccessibleDatabase,
+        diagnostics,
       );
     });
   });

--- a/app/scripts/lib/setup-initial-state-hooks.test.ts
+++ b/app/scripts/lib/setup-initial-state-hooks.test.ts
@@ -1,5 +1,8 @@
 import type { PersistenceManager as PersistenceManagerType } from '../../../shared/lib/stores/persistence-manager';
-import { MetaMetricsEventName } from '../../../shared/constants/metametrics';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../shared/constants/metametrics';
 import { VaultCorruptionType } from '../../../shared/constants/state-corruption';
 
 const mockGet = jest.fn();
@@ -7,6 +10,8 @@ const mockGetBackup = jest.fn();
 const mockCleanUpMostRecentRetrievedState = jest.fn();
 const mockPersistenceOn = jest.fn();
 const mockTrackVaultCorruptionEvent = jest.fn();
+const mockTrackEarlySegmentEvent = jest.fn();
+const mockGetWeeklySplitStatePersistenceDiagnosticsSnapshot = jest.fn();
 let mockMostRecentRetrievedState: unknown = null;
 
 jest.mock('../platforms/extension', () => {
@@ -40,6 +45,8 @@ jest.mock('../../../shared/lib/stores/persistence-manager', () => ({
     const instance = {
       get: mockGet,
       getBackup: mockGetBackup,
+      getWeeklySplitStatePersistenceDiagnosticsSnapshot:
+        mockGetWeeklySplitStatePersistenceDiagnosticsSnapshot,
       cleanUpMostRecentRetrievedState: mockCleanUpMostRecentRetrievedState,
       on: (...args: unknown[]) => {
         mockPersistenceOn(...args);
@@ -56,6 +63,10 @@ jest.mock('../../../shared/lib/stores/persistence-manager', () => ({
 
 jest.mock('./state-corruption/track-vault-corruption', () => ({
   trackVaultCorruptionEvent: mockTrackVaultCorruptionEvent,
+}));
+
+jest.mock('./segment/custom-segment-tracking', () => ({
+  trackEarlySegmentEvent: mockTrackEarlySegmentEvent,
 }));
 
 /**
@@ -87,6 +98,8 @@ describe('setup-initial-state-hooks', () => {
     mockCleanUpMostRecentRetrievedState.mockClear();
     mockPersistenceOn.mockClear();
     mockTrackVaultCorruptionEvent.mockClear();
+    mockTrackEarlySegmentEvent.mockClear();
+    mockGetWeeklySplitStatePersistenceDiagnosticsSnapshot.mockClear();
     globalThis.stateHooks = {} as typeof stateHooks;
   });
 
@@ -261,6 +274,72 @@ describe('setup-initial-state-hooks', () => {
       await globalThis.stateHooks.getPersistedState();
 
       expect(mockGet).toHaveBeenCalledWith({ validateVault: false });
+    });
+
+    it('tracks a weekly split-state persistence baseline in background context', async () => {
+      const persistedState = {
+        data: {
+          AnalyticsController: {
+            optedIn: true,
+            analyticsId: 'test-metrics-id',
+          },
+          PreferencesController: {},
+        },
+        meta: {
+          storageKind: 'split',
+          version: 1,
+        },
+      };
+      const diagnostics = {
+        schemaVersion: 1,
+        updatedAt: 1000,
+        totalQueuedUpdates: 1,
+        totalPersistedBatches: 1,
+        topWrittenKeys: [],
+        recentWideBatches: [],
+      };
+      mockGet.mockResolvedValueOnce(persistedState);
+      mockGetWeeklySplitStatePersistenceDiagnosticsSnapshot.mockResolvedValueOnce(
+        diagnostics,
+      );
+      setSelfHref('chrome-extension://abc123/scripts/app-init.js');
+      await importFresh();
+
+      await globalThis.stateHooks.getPersistedState();
+
+      expect(
+        mockGetWeeklySplitStatePersistenceDiagnosticsSnapshot,
+      ).toHaveBeenCalledTimes(1);
+      expect(mockTrackEarlySegmentEvent).toHaveBeenCalledWith({
+        state: persistedState.data,
+        event: MetaMetricsEventName.SplitStatePersistenceBaseline,
+        category: MetaMetricsEventCategory.Background,
+        properties: {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          split_state_persistence_diagnostics: diagnostics,
+        },
+      });
+    });
+
+    it('does not track a weekly split-state persistence baseline in UI context', async () => {
+      mockGet.mockResolvedValueOnce({
+        data: {
+          PreferencesController: {},
+        },
+        meta: {
+          storageKind: 'split',
+          version: 1,
+        },
+      });
+      setSelfHref('chrome-extension://abc123/home.html');
+      await importFresh();
+
+      await globalThis.stateHooks.getPersistedState();
+
+      expect(
+        mockGetWeeklySplitStatePersistenceDiagnosticsSnapshot,
+      ).not.toHaveBeenCalled();
+      expect(mockTrackEarlySegmentEvent).not.toHaveBeenCalled();
     });
 
     it('registers getBackupState on globalThis.stateHooks', async () => {

--- a/app/scripts/lib/state-corruption/track-vault-corruption.test.ts
+++ b/app/scripts/lib/state-corruption/track-vault-corruption.test.ts
@@ -5,6 +5,7 @@ import {
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
 import type { Backup } from '../../../../shared/lib/stores/persistence-manager';
+import type { SplitStatePersistenceDiagnosticsSnapshot } from '../../../../shared/lib/stores/persistence-diagnostics';
 import { trackVaultCorruptionEvent } from './track-vault-corruption';
 
 jest.mock('../segment', () => ({
@@ -55,6 +56,65 @@ describe('trackVaultCorruptionEvent', () => {
         },
       },
     });
+    expect(mockSegment.flush).toHaveBeenCalledTimes(1);
+  });
+
+  it('includes split-state persistence diagnostics when provided', () => {
+    const backup: Backup = {
+      KeyringController: { vault: 'encrypted-vault-data' },
+      AnalyticsController: {
+        optedIn: true,
+        analyticsId: 'test-metrics-id-123',
+      },
+    };
+    const diagnostics: SplitStatePersistenceDiagnosticsSnapshot = {
+      schemaVersion: 1,
+      updatedAt: 1000,
+      totalQueuedUpdates: 1,
+      totalPersistedBatches: 1,
+      topWrittenKeys: [
+        {
+          key: 'PreferencesController',
+          queuedUpdates: 1,
+          persistedWrites: 1,
+          lastSizeBucket: 'lt_4kb',
+          maxSizeBucket: 'lt_4kb',
+        },
+      ],
+      recentWideBatches: [],
+      readDiagnostics: {
+        manifestStatus: 'readable',
+        manifestKeyCount: 1,
+        readableKeys: [],
+        missingKeys: [],
+        failedKeys: [
+          {
+            key: 'PreferencesController',
+            errorName: 'Error',
+            errorMessage: 'block checksum mismatch',
+          },
+        ],
+      },
+    };
+
+    trackVaultCorruptionEvent(
+      backup,
+      MetaMetricsEventName.VaultCorruptionDetected,
+      VaultCorruptionType.InaccessibleDatabase,
+      diagnostics,
+    );
+
+    expect(mockSegment.track).toHaveBeenCalledWith(
+      expect.objectContaining({
+        properties: {
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          error_type: VaultCorruptionType.InaccessibleDatabase,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          split_state_persistence_diagnostics: diagnostics,
+          category: MetaMetricsEventCategory.Error,
+        },
+      }),
+    );
     expect(mockSegment.flush).toHaveBeenCalledTimes(1);
   });
 

--- a/app/scripts/lib/state-corruption/track-vault-corruption.test.ts
+++ b/app/scripts/lib/state-corruption/track-vault-corruption.test.ts
@@ -5,7 +5,11 @@ import {
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
 import type { Backup } from '../../../../shared/lib/stores/persistence-manager';
-import type { SplitStatePersistenceDiagnosticsSnapshot } from '../../../../shared/lib/stores/persistence-diagnostics';
+import {
+  SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_FEATURE_FLAG,
+  getSplitStatePersistenceDiagnosticsConfig,
+  type SplitStatePersistenceDiagnosticsSnapshot,
+} from '../../../../shared/lib/stores/persistence-diagnostics';
 import { trackVaultCorruptionEvent } from './track-vault-corruption';
 
 jest.mock('../segment', () => ({
@@ -16,6 +20,20 @@ jest.mock('../segment', () => ({
 }));
 
 const mockSegment = segment as jest.Mocked<typeof segment>;
+
+function getDiagnosticsConfig() {
+  const config = getSplitStatePersistenceDiagnosticsConfig({
+    [SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_FEATURE_FLAG]: {
+      enabled: true,
+    },
+  });
+
+  if (!config) {
+    throw new Error('Expected diagnostics config to be enabled');
+  }
+
+  return config;
+}
 
 describe('trackVaultCorruptionEvent', () => {
   beforeEach(() => {
@@ -69,6 +87,7 @@ describe('trackVaultCorruptionEvent', () => {
     };
     const diagnostics: SplitStatePersistenceDiagnosticsSnapshot = {
       schemaVersion: 1,
+      config: getDiagnosticsConfig(),
       updatedAt: 1000,
       totalQueuedUpdates: 1,
       totalPersistedBatches: 1,

--- a/app/scripts/lib/state-corruption/track-vault-corruption.ts
+++ b/app/scripts/lib/state-corruption/track-vault-corruption.ts
@@ -1,11 +1,13 @@
 // Vault corruption events are tracked via the early Segment tracking utility,
 // which is available before MetaMetricsController is initialized.
+import type { Json } from '@metamask/utils';
 import { VaultCorruptionType } from '../../../../shared/constants/state-corruption';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
 import type { Backup } from '../../../../shared/lib/stores/persistence-manager';
+import type { SplitStatePersistenceDiagnosticsSnapshot } from '../../../../shared/lib/stores/persistence-diagnostics';
 import { trackEarlySegmentEvent } from '../segment/custom-segment-tracking';
 
 /**
@@ -17,11 +19,13 @@ import { trackEarlySegmentEvent } from '../segment/custom-segment-tracking';
  * @param backup - The backup state from IndexedDB containing MetaMetricsController state.
  * @param eventName - The MetaMetrics event name to track.
  * @param corruptionType - The type of vault corruption (missing_vault_in_database, inaccessible_database).
+ * @param diagnostics - Optional split-state persistence diagnostics.
  */
 export function trackVaultCorruptionEvent(
   backup: Backup | null,
   eventName: MetaMetricsEventName,
   corruptionType: VaultCorruptionType,
+  diagnostics?: SplitStatePersistenceDiagnosticsSnapshot,
 ): void {
   trackEarlySegmentEvent({
     state: backup,
@@ -30,6 +34,13 @@ export function trackVaultCorruptionEvent(
     properties: {
       // eslint-disable-next-line @typescript-eslint/naming-convention
       error_type: corruptionType,
+      ...(diagnostics
+        ? {
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            split_state_persistence_diagnostics:
+              diagnostics as unknown as Json,
+          }
+        : {}),
     },
   });
 }

--- a/app/scripts/lib/state-corruption/track-vault-corruption.ts
+++ b/app/scripts/lib/state-corruption/track-vault-corruption.ts
@@ -37,8 +37,7 @@ export function trackVaultCorruptionEvent(
       ...(diagnostics
         ? {
             // eslint-disable-next-line @typescript-eslint/naming-convention
-            split_state_persistence_diagnostics:
-              diagnostics as unknown as Json,
+            split_state_persistence_diagnostics: diagnostics as unknown as Json,
           }
         : {}),
     },

--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -937,6 +937,7 @@ export enum MetaMetricsEventName {
   StorageErrorToastViewed = 'Storage Error Toast Viewed',
   StorageErrorToastDismissed = 'Storage Error Toast Dismissed',
   StorageErrorToastBackupSrpButtonPressed = 'Storage Error Toast Backup SRP Button Pressed',
+  SplitStatePersistenceBaseline = 'Split State Persistence Baseline',
   StateMigrationSucceeded = 'State Migration Succeeded',
   StateMigrationFailed = 'State Migration Failed',
   VaultCorruptionDetected = 'Vault Corruption Detected',

--- a/shared/lib/stores/base-store.ts
+++ b/shared/lib/stores/base-store.ts
@@ -1,3 +1,5 @@
+import type { SplitStateReadDiagnostics } from './persistence-diagnostics';
+
 /**
  * This type is used to represent the state tree of MetaMask.
  */
@@ -63,6 +65,8 @@ export type BaseStore = {
   set: (state: Required<MetaMaskStorageStructure>) => Promise<void>;
 
   get: () => Promise<MetaMaskStorageStructure | null>;
+
+  getSplitStateReadDiagnostics?: () => Promise<SplitStateReadDiagnostics>;
 
   reset: () => Promise<void>;
 };

--- a/shared/lib/stores/extension-store.test.ts
+++ b/shared/lib/stores/extension-store.test.ts
@@ -155,9 +155,7 @@ describe('ExtensionStore', () => {
 
       expect(getMock).toHaveBeenNthCalledWith(1, ['manifest']);
       expect(getMock).toHaveBeenNthCalledWith(2, ['KeyringController']);
-      expect(getMock).toHaveBeenNthCalledWith(3, [
-        'PreferencesController',
-      ]);
+      expect(getMock).toHaveBeenNthCalledWith(3, ['PreferencesController']);
       expect(getMock).toHaveBeenNthCalledWith(4, ['MissingController']);
     });
 

--- a/shared/lib/stores/extension-store.test.ts
+++ b/shared/lib/stores/extension-store.test.ts
@@ -118,4 +118,67 @@ describe('ExtensionStore', () => {
       expect(getMock).toHaveBeenCalledWith(['data', 'meta']);
     });
   });
+
+  describe('getSplitStateReadDiagnostics', () => {
+    it('reports manifest keys that are readable, missing, or failed', async () => {
+      const getMock = jest
+        .fn()
+        .mockResolvedValueOnce({
+          manifest: [
+            'KeyringController',
+            'PreferencesController',
+            'MissingController',
+          ],
+        })
+        .mockResolvedValueOnce({
+          KeyringController: { vault: 'encrypted-vault' },
+        })
+        .mockRejectedValueOnce(new Error('block checksum mismatch'))
+        .mockResolvedValueOnce({});
+      const localStore = setup({ localMock: { get: getMock } });
+
+      await expect(
+        localStore.getSplitStateReadDiagnostics(),
+      ).resolves.toStrictEqual({
+        manifestStatus: 'readable',
+        manifestKeyCount: 3,
+        readableKeys: ['KeyringController'],
+        missingKeys: ['MissingController'],
+        failedKeys: [
+          {
+            key: 'PreferencesController',
+            errorName: 'Error',
+            errorMessage: 'block checksum mismatch',
+          },
+        ],
+      });
+
+      expect(getMock).toHaveBeenNthCalledWith(1, ['manifest']);
+      expect(getMock).toHaveBeenNthCalledWith(2, ['KeyringController']);
+      expect(getMock).toHaveBeenNthCalledWith(3, [
+        'PreferencesController',
+      ]);
+      expect(getMock).toHaveBeenNthCalledWith(4, ['MissingController']);
+    });
+
+    it('reports a failed manifest read', async () => {
+      const getMock = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('manifest block checksum mismatch'));
+      const localStore = setup({ localMock: { get: getMock } });
+
+      await expect(
+        localStore.getSplitStateReadDiagnostics(),
+      ).resolves.toStrictEqual({
+        manifestStatus: 'failed',
+        readableKeys: [],
+        missingKeys: [],
+        failedKeys: [],
+        manifestError: {
+          errorName: 'Error',
+          errorMessage: 'manifest block checksum mismatch',
+        },
+      });
+    });
+  });
 });

--- a/shared/lib/stores/extension-store.ts
+++ b/shared/lib/stores/extension-store.ts
@@ -6,6 +6,10 @@ import type {
   BaseStore,
   MetaData,
 } from './base-store';
+import {
+  getSplitStateDiagnosticError,
+  type SplitStateReadDiagnostics,
+} from './persistence-diagnostics';
 
 const { sentry } = globalThis;
 
@@ -73,6 +77,78 @@ export default class ExtensionStore implements BaseStore {
     } finally {
       console.timeEnd('[ExtensionStore]: Reading from local store');
     }
+  }
+
+  async getSplitStateReadDiagnostics(): Promise<SplitStateReadDiagnostics> {
+    const emptyDiagnostics = {
+      readableKeys: [],
+      missingKeys: [],
+      failedKeys: [],
+    };
+
+    if (!this.isSupported) {
+      return {
+        manifestStatus: 'failed',
+        ...emptyDiagnostics,
+        manifestError: {
+          errorName: 'UnsupportedStorage',
+          errorMessage: 'Storage local API not available.',
+        },
+      };
+    }
+
+    const { local } = browser.storage;
+    let manifest: unknown;
+
+    try {
+      const manifestResponse = await local.get(['manifest']);
+      manifest = isObject(manifestResponse)
+        ? manifestResponse.manifest
+        : undefined;
+    } catch (error) {
+      return {
+        manifestStatus: 'failed',
+        ...emptyDiagnostics,
+        manifestError: getSplitStateDiagnosticError(error),
+      };
+    }
+
+    if (!Array.isArray(manifest)) {
+      return {
+        manifestStatus: 'missing',
+        ...emptyDiagnostics,
+      };
+    }
+
+    const diagnostics: SplitStateReadDiagnostics = {
+      manifestStatus: 'readable',
+      manifestKeyCount: manifest.length,
+      readableKeys: [],
+      missingKeys: [],
+      failedKeys: [],
+    };
+
+    for (const key of manifest) {
+      if (typeof key !== 'string') {
+        continue;
+      }
+
+      try {
+        const response = await local.get([key]);
+        if (isObject(response) && hasProperty(response, key)) {
+          diagnostics.readableKeys.push(key);
+        } else {
+          diagnostics.missingKeys.push(key);
+        }
+      } catch (error) {
+        diagnostics.failedKeys.push({
+          key,
+          ...getSplitStateDiagnosticError(error),
+        });
+      }
+    }
+
+    return diagnostics;
   }
 
   async setKeyValues(pairs: Map<string, unknown>): Promise<void> {

--- a/shared/lib/stores/persistence-diagnostics.test.ts
+++ b/shared/lib/stores/persistence-diagnostics.test.ts
@@ -142,6 +142,48 @@ describe('SplitStatePersistenceDiagnostics', () => {
     });
   });
 
+  it('returns a baseline snapshot at most once per week', async () => {
+    diagnostics.recordQueuedUpdate('KeyringController');
+    diagnostics.recordPersistedBatch(
+      new Map<string, unknown>([['KeyringController', { vault: 'secret' }]]),
+    );
+
+    const firstSnapshot = await diagnostics.getWeeklyBaselineSnapshot(1000);
+    const secondSnapshot = await diagnostics.getWeeklyBaselineSnapshot(
+      1000 + 6 * 24 * 60 * 60 * 1000,
+    );
+    const thirdSnapshot = await diagnostics.getWeeklyBaselineSnapshot(
+      1000 + 7 * 24 * 60 * 60 * 1000,
+    );
+
+    expect(firstSnapshot).toMatchObject({
+      totalQueuedUpdates: 1,
+      totalPersistedBatches: 1,
+    });
+    expect(secondSnapshot).toBeUndefined();
+    expect(thirdSnapshot).toMatchObject({
+      totalQueuedUpdates: 1,
+      totalPersistedBatches: 1,
+    });
+  });
+
+  it('persists the weekly baseline gate across diagnostics instances', async () => {
+    diagnostics.recordQueuedUpdate('KeyringController');
+    diagnostics.recordPersistedBatch(
+      new Map<string, unknown>([['KeyringController', { vault: 'secret' }]]),
+    );
+    await diagnostics.getWeeklyBaselineSnapshot(1000);
+    diagnostics.close();
+
+    const nextDiagnostics = new SplitStatePersistenceDiagnostics();
+    const snapshot = await nextDiagnostics.getWeeklyBaselineSnapshot(
+      1000 + 6 * 24 * 60 * 60 * 1000,
+    );
+    nextDiagnostics.close();
+
+    expect(snapshot).toBeUndefined();
+  });
+
   it('can report read diagnostics even when there are no write stats', async () => {
     const readDiagnostics: SplitStateReadDiagnostics = {
       manifestStatus: 'readable',

--- a/shared/lib/stores/persistence-diagnostics.test.ts
+++ b/shared/lib/stores/persistence-diagnostics.test.ts
@@ -48,9 +48,7 @@ describe('SplitStatePersistenceDiagnostics', () => {
   function recordUnsampledPersistedBatches(count: number) {
     for (let index = 0; index < count; index++) {
       diagnostics.recordPersistedBatch(
-        new Map<string, unknown>([
-          ['UnsampledController', { value: index }],
-        ]),
+        new Map<string, unknown>([['UnsampledController', { value: index }]]),
       );
     }
   }
@@ -326,8 +324,7 @@ describe('SplitStatePersistenceDiagnostics', () => {
       ],
     };
 
-    const snapshot =
-      await diagnostics.getSnapshotForReport(readDiagnostics);
+    const snapshot = await diagnostics.getSnapshotForReport(readDiagnostics);
 
     expect(snapshot).toMatchObject({
       totalQueuedUpdates: 0,
@@ -343,9 +340,7 @@ describe('SplitStatePersistenceDiagnostics', () => {
       '4kb_16kb',
     );
 
-    const error = getSplitStateDiagnosticError(
-      new Error('a'.repeat(300)),
-    );
+    const error = getSplitStateDiagnosticError(new Error('a'.repeat(300)));
 
     expect(error.errorName).toBe('Error');
     expect(error.errorMessage).toHaveLength(200);

--- a/shared/lib/stores/persistence-diagnostics.test.ts
+++ b/shared/lib/stores/persistence-diagnostics.test.ts
@@ -2,6 +2,7 @@ import 'fake-indexeddb/auto';
 
 import {
   SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_DB_NAME,
+  SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_SIZE_SAMPLE_RATE,
   SplitStatePersistenceDiagnostics,
   getSplitStateDiagnosticError,
   getSplitStateSizeBucket,
@@ -21,6 +22,16 @@ async function deleteDiagnosticsDatabase(): Promise<void> {
 
 describe('SplitStatePersistenceDiagnostics', () => {
   let diagnostics: SplitStatePersistenceDiagnostics;
+
+  function recordUnsampledPersistedBatches(count: number) {
+    for (let index = 0; index < count; index++) {
+      diagnostics.recordPersistedBatch(
+        new Map<string, unknown>([
+          ['UnsampledController', { value: index }],
+        ]),
+      );
+    }
+  }
 
   beforeEach(async () => {
     await deleteDiagnosticsDatabase();
@@ -56,15 +67,11 @@ describe('SplitStatePersistenceDiagnostics', () => {
           key: 'AccountTreeController',
           queuedUpdates: 1,
           persistedWrites: 1,
-          lastSizeBucket: 'lt_4kb',
-          maxSizeBucket: 'lt_4kb',
         },
         {
           key: 'KeyringController',
           queuedUpdates: 1,
           persistedWrites: 1,
-          lastSizeBucket: 'lt_4kb',
-          maxSizeBucket: 'lt_4kb',
         },
       ],
       recentWideBatches: [],
@@ -73,7 +80,51 @@ describe('SplitStatePersistenceDiagnostics', () => {
     expect(JSON.stringify(snapshot)).not.toContain('0x123');
   });
 
+  it('samples persisted value sizes once every 20 batches', () => {
+    const stringifySpy = jest.spyOn(JSON, 'stringify');
+
+    try {
+      recordUnsampledPersistedBatches(
+        SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_SIZE_SAMPLE_RATE - 1,
+      );
+
+      expect(stringifySpy).not.toHaveBeenCalled();
+
+      diagnostics.recordPersistedBatch(
+        new Map<string, unknown>([
+          ['KeyringController', { vault: 'secret-vault' }],
+          ['PreferencesController', { preferences: true }],
+        ]),
+      );
+      const snapshot = diagnostics.getSnapshot(undefined, 1000);
+
+      expect(stringifySpy).toHaveBeenCalledTimes(2);
+      expect(snapshot).toMatchObject({
+        totalPersistedBatches:
+          SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_SIZE_SAMPLE_RATE,
+        topWrittenKeys: expect.arrayContaining([
+          expect.objectContaining({
+            key: 'KeyringController',
+            lastSizeBucket: 'lt_4kb',
+            maxSizeBucket: 'lt_4kb',
+          }),
+          expect.objectContaining({
+            key: 'PreferencesController',
+            lastSizeBucket: 'lt_4kb',
+            maxSizeBucket: 'lt_4kb',
+          }),
+        ]),
+      });
+    } finally {
+      stringifySpy.mockRestore();
+    }
+  });
+
   it('records recent wide batches with largest key size buckets', () => {
+    recordUnsampledPersistedBatches(
+      SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_SIZE_SAMPLE_RATE - 1,
+    );
+
     diagnostics.recordPersistedBatch(
       new Map<string, unknown>([
         ['SmallController', { value: true }],

--- a/shared/lib/stores/persistence-diagnostics.test.ts
+++ b/shared/lib/stores/persistence-diagnostics.test.ts
@@ -1,0 +1,184 @@
+import 'fake-indexeddb/auto';
+
+import {
+  SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_DB_NAME,
+  SplitStatePersistenceDiagnostics,
+  getSplitStateDiagnosticError,
+  getSplitStateSizeBucket,
+  type SplitStateReadDiagnostics,
+} from './persistence-diagnostics';
+
+async function deleteDiagnosticsDatabase(): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const request = indexedDB.deleteDatabase(
+      SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_DB_NAME,
+    );
+    request.onsuccess = () => resolve();
+    request.onerror = () => reject(request.error);
+    request.onblocked = () => reject(new Error('Database deletion blocked'));
+  });
+}
+
+describe('SplitStatePersistenceDiagnostics', () => {
+  let diagnostics: SplitStatePersistenceDiagnostics;
+
+  beforeEach(async () => {
+    await deleteDiagnosticsDatabase();
+    diagnostics = new SplitStatePersistenceDiagnostics();
+  });
+
+  afterEach(() => {
+    diagnostics.close();
+  });
+
+  it('records controller write counts and size buckets without retaining values', () => {
+    diagnostics.recordQueuedUpdate('KeyringController');
+    diagnostics.recordQueuedUpdate('AccountTreeController');
+    diagnostics.recordQueuedUpdate('meta');
+
+    diagnostics.recordPersistedBatch(
+      new Map<string, unknown>([
+        ['KeyringController', { vault: 'secret-vault' }],
+        ['AccountTreeController', { accounts: ['0x123'] }],
+        ['meta', { version: 1 }],
+      ]),
+    );
+
+    const snapshot = diagnostics.getSnapshot(undefined, 1000);
+
+    expect(snapshot).toStrictEqual({
+      schemaVersion: 1,
+      updatedAt: 1000,
+      totalQueuedUpdates: 2,
+      totalPersistedBatches: 1,
+      topWrittenKeys: [
+        {
+          key: 'AccountTreeController',
+          queuedUpdates: 1,
+          persistedWrites: 1,
+          lastSizeBucket: 'lt_4kb',
+          maxSizeBucket: 'lt_4kb',
+        },
+        {
+          key: 'KeyringController',
+          queuedUpdates: 1,
+          persistedWrites: 1,
+          lastSizeBucket: 'lt_4kb',
+          maxSizeBucket: 'lt_4kb',
+        },
+      ],
+      recentWideBatches: [],
+    });
+    expect(JSON.stringify(snapshot)).not.toContain('secret-vault');
+    expect(JSON.stringify(snapshot)).not.toContain('0x123');
+  });
+
+  it('records recent wide batches with largest key size buckets', () => {
+    diagnostics.recordPersistedBatch(
+      new Map<string, unknown>([
+        ['SmallController', { value: true }],
+        ['LargeController', { value: 'x'.repeat(5000) }],
+        ['DeletedController', undefined],
+        ['OtherController', { nested: { value: 'test' } }],
+      ]),
+    );
+
+    expect(
+      diagnostics.getSnapshot(undefined, 1000).recentWideBatches,
+    ).toStrictEqual([
+      {
+        keys: [
+          'SmallController',
+          'LargeController',
+          'DeletedController',
+          'OtherController',
+        ],
+        keyCount: 4,
+        totalSizeBucket: '4kb_16kb',
+        largestKeys: [
+          {
+            key: 'LargeController',
+            sizeBucket: '4kb_16kb',
+          },
+          {
+            key: 'OtherController',
+            sizeBucket: 'lt_4kb',
+          },
+          {
+            key: 'SmallController',
+            sizeBucket: 'lt_4kb',
+          },
+          {
+            key: 'DeletedController',
+            sizeBucket: 'undefined',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('persists and hydrates diagnostics snapshots from IndexedDB', async () => {
+    diagnostics.recordQueuedUpdate('KeyringController');
+    diagnostics.recordPersistedBatch(
+      new Map<string, unknown>([['KeyringController', { vault: 'secret' }]]),
+    );
+    await diagnostics.persistSnapshot(1000);
+    diagnostics.close();
+
+    const nextDiagnostics = new SplitStatePersistenceDiagnostics();
+    const snapshot = await nextDiagnostics.getSnapshotForReport();
+    nextDiagnostics.close();
+
+    expect(snapshot).toMatchObject({
+      totalQueuedUpdates: 1,
+      totalPersistedBatches: 1,
+      topWrittenKeys: [
+        {
+          key: 'KeyringController',
+          queuedUpdates: 1,
+          persistedWrites: 1,
+        },
+      ],
+    });
+  });
+
+  it('can report read diagnostics even when there are no write stats', async () => {
+    const readDiagnostics: SplitStateReadDiagnostics = {
+      manifestStatus: 'readable',
+      manifestKeyCount: 2,
+      readableKeys: ['KeyringController'],
+      missingKeys: [],
+      failedKeys: [
+        {
+          key: 'PreferencesController',
+          errorName: 'Error',
+          errorMessage: 'block checksum mismatch',
+        },
+      ],
+    };
+
+    const snapshot =
+      await diagnostics.getSnapshotForReport(readDiagnostics);
+
+    expect(snapshot).toMatchObject({
+      totalQueuedUpdates: 0,
+      totalPersistedBatches: 0,
+      topWrittenKeys: [],
+      recentWideBatches: [],
+      readDiagnostics,
+    });
+  });
+
+  it('returns coarse size buckets and diagnostic-safe errors', () => {
+    expect(getSplitStateSizeBucket({ value: 'x'.repeat(4096) })).toBe(
+      '4kb_16kb',
+    );
+
+    const error = getSplitStateDiagnosticError(
+      new Error('a'.repeat(300)),
+    );
+
+    expect(error.errorName).toBe('Error');
+    expect(error.errorMessage).toHaveLength(200);
+  });
+});

--- a/shared/lib/stores/persistence-diagnostics.test.ts
+++ b/shared/lib/stores/persistence-diagnostics.test.ts
@@ -2,10 +2,14 @@ import 'fake-indexeddb/auto';
 
 import {
   SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_DB_NAME,
+  SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_FEATURE_FLAG,
   SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_SIZE_SAMPLE_RATE,
   SplitStatePersistenceDiagnostics,
+  getSplitStatePersistenceDiagnosticsConfig,
   getSplitStateDiagnosticError,
   getSplitStateSizeBucket,
+  type SplitStatePersistenceDiagnosticsConfig,
+  type SplitStatePersistenceDiagnosticsSnapshot,
   type SplitStateReadDiagnostics,
 } from './persistence-diagnostics';
 
@@ -20,8 +24,26 @@ async function deleteDiagnosticsDatabase(): Promise<void> {
   });
 }
 
+function getEnabledConfig(
+  overrides: Record<string, unknown> = {},
+): SplitStatePersistenceDiagnosticsConfig {
+  const config = getSplitStatePersistenceDiagnosticsConfig({
+    [SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_FEATURE_FLAG]: {
+      enabled: true,
+      ...overrides,
+    },
+  });
+
+  if (!config) {
+    throw new Error('Expected diagnostics config to be enabled');
+  }
+
+  return config;
+}
+
 describe('SplitStatePersistenceDiagnostics', () => {
   let diagnostics: SplitStatePersistenceDiagnostics;
+  let config: SplitStatePersistenceDiagnosticsConfig;
 
   function recordUnsampledPersistedBatches(count: number) {
     for (let index = 0; index < count; index++) {
@@ -35,7 +57,9 @@ describe('SplitStatePersistenceDiagnostics', () => {
 
   beforeEach(async () => {
     await deleteDiagnosticsDatabase();
+    config = getEnabledConfig();
     diagnostics = new SplitStatePersistenceDiagnostics();
+    diagnostics.setConfig(config);
   });
 
   afterEach(() => {
@@ -59,6 +83,7 @@ describe('SplitStatePersistenceDiagnostics', () => {
 
     expect(snapshot).toStrictEqual({
       schemaVersion: 1,
+      config,
       updatedAt: 1000,
       totalQueuedUpdates: 2,
       totalPersistedBatches: 1,
@@ -80,6 +105,49 @@ describe('SplitStatePersistenceDiagnostics', () => {
     expect(JSON.stringify(snapshot)).not.toContain('0x123');
   });
 
+  it('does not collect diagnostics without the remote feature flag config', () => {
+    diagnostics.setConfig(undefined);
+
+    diagnostics.recordQueuedUpdate('KeyringController');
+    diagnostics.recordPersistedBatch(
+      new Map<string, unknown>([['KeyringController', { vault: 'secret' }]]),
+    );
+
+    expect(diagnostics.getSnapshot(undefined, 1000)).toBeUndefined();
+  });
+
+  it('normalizes and clamps remote feature flag config', () => {
+    expect(
+      getSplitStatePersistenceDiagnosticsConfig({
+        [SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_FEATURE_FLAG]: {
+          enabled: true,
+          baselineEnabled: false,
+          corruptionEnabled: true,
+          sizeSampleRate: 0,
+          baselineIntervalMs: Number.POSITIVE_INFINITY,
+          snapshotPersistIntervalMs: 1,
+          wideBatchKeyThreshold: 200,
+          topWrittenKeysLimit: 100,
+          recentWideBatchesLimit: 0,
+          largestKeysPerBatchLimit: 100,
+        },
+      }),
+    ).toStrictEqual({
+      enabled: true,
+      baselineEnabled: false,
+      corruptionEnabled: true,
+      sizeSampleRate: 1,
+      baselineIntervalMs: config.baselineIntervalMs,
+      snapshotPersistIntervalMs: 60 * 1000,
+      wideBatchKeyThreshold: 100,
+      topWrittenKeysLimit: 50,
+      recentWideBatchesLimit: 1,
+      largestKeysPerBatchLimit: 20,
+    });
+
+    expect(getSplitStatePersistenceDiagnosticsConfig({})).toBeUndefined();
+  });
+
   it('samples persisted value sizes once every 20 batches', () => {
     const stringifySpy = jest.spyOn(JSON, 'stringify');
 
@@ -96,7 +164,10 @@ describe('SplitStatePersistenceDiagnostics', () => {
           ['PreferencesController', { preferences: true }],
         ]),
       );
-      const snapshot = diagnostics.getSnapshot(undefined, 1000);
+      const snapshot = diagnostics.getSnapshot(
+        undefined,
+        1000,
+      ) as SplitStatePersistenceDiagnosticsSnapshot;
 
       expect(stringifySpy).toHaveBeenCalledTimes(2);
       expect(snapshot).toMatchObject({
@@ -135,7 +206,12 @@ describe('SplitStatePersistenceDiagnostics', () => {
     );
 
     expect(
-      diagnostics.getSnapshot(undefined, 1000).recentWideBatches,
+      (
+        diagnostics.getSnapshot(
+          undefined,
+          1000,
+        ) as SplitStatePersistenceDiagnosticsSnapshot
+      ).recentWideBatches,
     ).toStrictEqual([
       {
         keys: [

--- a/shared/lib/stores/persistence-diagnostics.ts
+++ b/shared/lib/stores/persistence-diagnostics.ts
@@ -9,8 +9,7 @@ export const SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_KEY =
   'split-state-persistence-diagnostics';
 export const SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_BASELINE_KEY =
   'split-state-persistence-diagnostics-baseline';
-export const SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_INTERVAL_MS =
-  5 * 60 * 1000;
+export const SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_INTERVAL_MS = 5 * 60 * 1000;
 export const SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_BASELINE_INTERVAL_MS =
   7 * 24 * 60 * 60 * 1000;
 export const SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_SIZE_SAMPLE_RATE = 20;
@@ -44,8 +43,7 @@ const DEFAULT_SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_CONFIG: SplitStatePersistenceD
     sizeSampleRate: SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_SIZE_SAMPLE_RATE,
     baselineIntervalMs:
       SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_BASELINE_INTERVAL_MS,
-    snapshotPersistIntervalMs:
-      SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_INTERVAL_MS,
+    snapshotPersistIntervalMs: SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_INTERVAL_MS,
     wideBatchKeyThreshold:
       SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_WIDE_BATCH_KEY_THRESHOLD,
     topWrittenKeysLimit:
@@ -185,9 +183,8 @@ function getNumericConfigValue(
 export function getSplitStatePersistenceDiagnosticsConfig(
   remoteFeatureFlags: Record<string, unknown> | null | undefined,
 ): SplitStatePersistenceDiagnosticsConfig | undefined {
-  const featureFlag = remoteFeatureFlags?.[
-    SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_FEATURE_FLAG
-  ];
+  const featureFlag =
+    remoteFeatureFlags?.[SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_FEATURE_FLAG];
 
   if (!isObject(featureFlag) || featureFlag.enabled !== true) {
     return undefined;
@@ -268,9 +265,7 @@ export function getSplitStateDiagnosticError(
  * @param value - The value to size.
  * @returns The value's size bucket.
  */
-export function getSplitStateSizeBucket(
-  value: unknown,
-): SplitStateSizeBucket {
+export function getSplitStateSizeBucket(value: unknown): SplitStateSizeBucket {
   return measureValue(value).sizeBucket;
 }
 
@@ -393,9 +388,7 @@ export class SplitStatePersistenceDiagnostics {
 
   #config: SplitStatePersistenceDiagnosticsConfig | undefined;
 
-  setConfig(
-    config: SplitStatePersistenceDiagnosticsConfig | undefined,
-  ): void {
+  setConfig(config: SplitStatePersistenceDiagnosticsConfig | undefined): void {
     this.#config = config;
 
     if (!config) {
@@ -631,9 +624,7 @@ export class SplitStatePersistenceDiagnostics {
     ]);
 
     if (
-      isSplitStatePersistenceDiagnosticsBaselineMetadata(
-        baselineMetadata,
-      ) &&
+      isSplitStatePersistenceDiagnosticsBaselineMetadata(baselineMetadata) &&
       now - baselineMetadata.lastSentAt < config.baselineIntervalMs
     ) {
       return undefined;
@@ -735,9 +726,7 @@ export class SplitStatePersistenceDiagnostics {
       SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_KEY,
     ]);
 
-    if (
-      !isSplitStatePersistenceDiagnosticsSnapshot(persistedSnapshot)
-    ) {
+    if (!isSplitStatePersistenceDiagnosticsSnapshot(persistedSnapshot)) {
       return;
     }
 
@@ -769,8 +758,10 @@ export class SplitStatePersistenceDiagnostics {
 
     this.#recentWideBatches = [
       ...snapshot.recentWideBatches.slice(
-        -(this.#config?.recentWideBatchesLimit ??
-          snapshot.config.recentWideBatchesLimit),
+        -(
+          this.#config?.recentWideBatchesLimit ??
+          snapshot.config.recentWideBatchesLimit
+        ),
       ),
       ...this.#recentWideBatches,
     ].slice(

--- a/shared/lib/stores/persistence-diagnostics.ts
+++ b/shared/lib/stores/persistence-diagnostics.ts
@@ -14,12 +14,57 @@ export const SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_INTERVAL_MS =
 export const SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_BASELINE_INTERVAL_MS =
   7 * 24 * 60 * 60 * 1000;
 export const SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_SIZE_SAMPLE_RATE = 20;
+export const SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_FEATURE_FLAG =
+  'splitStatePersistenceDiagnostics';
 
-const TOP_WRITTEN_KEYS_LIMIT = 10;
-const RECENT_WIDE_BATCHES_LIMIT = 20;
-const WIDE_BATCH_MIN_KEY_COUNT = 4;
-const LARGEST_KEYS_PER_BATCH_LIMIT = 5;
+const SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_TOP_WRITTEN_KEYS_LIMIT = 10;
+const SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_RECENT_WIDE_BATCHES_LIMIT = 20;
+const SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_WIDE_BATCH_KEY_THRESHOLD = 4;
+const SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_LARGEST_KEYS_PER_BATCH_LIMIT = 5;
 const ERROR_MESSAGE_MAX_LENGTH = 200;
+
+export type SplitStatePersistenceDiagnosticsConfig = {
+  enabled: true;
+  baselineEnabled: boolean;
+  corruptionEnabled: boolean;
+  sizeSampleRate: number;
+  baselineIntervalMs: number;
+  snapshotPersistIntervalMs: number;
+  wideBatchKeyThreshold: number;
+  topWrittenKeysLimit: number;
+  recentWideBatchesLimit: number;
+  largestKeysPerBatchLimit: number;
+};
+
+const DEFAULT_SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_CONFIG: SplitStatePersistenceDiagnosticsConfig =
+  {
+    enabled: true,
+    baselineEnabled: true,
+    corruptionEnabled: true,
+    sizeSampleRate: SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_SIZE_SAMPLE_RATE,
+    baselineIntervalMs:
+      SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_BASELINE_INTERVAL_MS,
+    snapshotPersistIntervalMs:
+      SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_INTERVAL_MS,
+    wideBatchKeyThreshold:
+      SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_WIDE_BATCH_KEY_THRESHOLD,
+    topWrittenKeysLimit:
+      SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_TOP_WRITTEN_KEYS_LIMIT,
+    recentWideBatchesLimit:
+      SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_RECENT_WIDE_BATCHES_LIMIT,
+    largestKeysPerBatchLimit:
+      SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_LARGEST_KEYS_PER_BATCH_LIMIT,
+  };
+
+const NUMERIC_CONFIG_LIMITS = {
+  sizeSampleRate: { min: 1, max: 1000 },
+  baselineIntervalMs: { min: 60 * 1000, max: 90 * 24 * 60 * 60 * 1000 },
+  snapshotPersistIntervalMs: { min: 60 * 1000, max: 24 * 60 * 60 * 1000 },
+  wideBatchKeyThreshold: { min: 2, max: 100 },
+  topWrittenKeysLimit: { min: 1, max: 50 },
+  recentWideBatchesLimit: { min: 1, max: 100 },
+  largestKeysPerBatchLimit: { min: 1, max: 20 },
+} as const;
 
 export type SplitStateSizeBucket =
   | 'unknown'
@@ -71,6 +116,7 @@ export type SplitStateWideBatchDiagnostics = {
 
 export type SplitStatePersistenceDiagnosticsSnapshot = {
   schemaVersion: 1;
+  config: SplitStatePersistenceDiagnosticsConfig;
   updatedAt: number;
   totalQueuedUpdates: number;
   totalPersistedBatches: number;
@@ -107,6 +153,99 @@ const SIZE_BUCKET_ORDER = new Map<SplitStateSizeBucket, number>([
   ['256kb_1mb', 5],
   ['gt_1mb', 6],
 ]);
+
+function getBooleanConfigValue(value: unknown, fallback: boolean): boolean {
+  return typeof value === 'boolean' ? value : fallback;
+}
+
+function getNumericConfigValue(
+  value: unknown,
+  fallback: number,
+  {
+    min,
+    max,
+  }: {
+    min: number;
+    max: number;
+  },
+): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return fallback;
+  }
+
+  return Math.min(Math.max(Math.trunc(value), min), max);
+}
+
+/**
+ * Normalizes the split-state persistence diagnostics remote feature flag.
+ *
+ * @param remoteFeatureFlags - Remote feature flags, including manifest overrides.
+ * @returns Normalized diagnostics config, or undefined when disabled/missing.
+ */
+export function getSplitStatePersistenceDiagnosticsConfig(
+  remoteFeatureFlags: Record<string, unknown> | null | undefined,
+): SplitStatePersistenceDiagnosticsConfig | undefined {
+  const featureFlag = remoteFeatureFlags?.[
+    SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_FEATURE_FLAG
+  ];
+
+  if (!isObject(featureFlag) || featureFlag.enabled !== true) {
+    return undefined;
+  }
+
+  const config: SplitStatePersistenceDiagnosticsConfig = {
+    ...DEFAULT_SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_CONFIG,
+    baselineEnabled: getBooleanConfigValue(
+      featureFlag.baselineEnabled,
+      DEFAULT_SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_CONFIG.baselineEnabled,
+    ),
+    corruptionEnabled: getBooleanConfigValue(
+      featureFlag.corruptionEnabled,
+      DEFAULT_SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_CONFIG.corruptionEnabled,
+    ),
+    sizeSampleRate: getNumericConfigValue(
+      featureFlag.sizeSampleRate,
+      DEFAULT_SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_CONFIG.sizeSampleRate,
+      NUMERIC_CONFIG_LIMITS.sizeSampleRate,
+    ),
+    baselineIntervalMs: getNumericConfigValue(
+      featureFlag.baselineIntervalMs,
+      DEFAULT_SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_CONFIG.baselineIntervalMs,
+      NUMERIC_CONFIG_LIMITS.baselineIntervalMs,
+    ),
+    snapshotPersistIntervalMs: getNumericConfigValue(
+      featureFlag.snapshotPersistIntervalMs,
+      DEFAULT_SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_CONFIG.snapshotPersistIntervalMs,
+      NUMERIC_CONFIG_LIMITS.snapshotPersistIntervalMs,
+    ),
+    wideBatchKeyThreshold: getNumericConfigValue(
+      featureFlag.wideBatchKeyThreshold,
+      DEFAULT_SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_CONFIG.wideBatchKeyThreshold,
+      NUMERIC_CONFIG_LIMITS.wideBatchKeyThreshold,
+    ),
+    topWrittenKeysLimit: getNumericConfigValue(
+      featureFlag.topWrittenKeysLimit,
+      DEFAULT_SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_CONFIG.topWrittenKeysLimit,
+      NUMERIC_CONFIG_LIMITS.topWrittenKeysLimit,
+    ),
+    recentWideBatchesLimit: getNumericConfigValue(
+      featureFlag.recentWideBatchesLimit,
+      DEFAULT_SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_CONFIG.recentWideBatchesLimit,
+      NUMERIC_CONFIG_LIMITS.recentWideBatchesLimit,
+    ),
+    largestKeysPerBatchLimit: getNumericConfigValue(
+      featureFlag.largestKeysPerBatchLimit,
+      DEFAULT_SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_CONFIG.largestKeysPerBatchLimit,
+      NUMERIC_CONFIG_LIMITS.largestKeysPerBatchLimit,
+    ),
+  };
+
+  if (!config.baselineEnabled && !config.corruptionEnabled) {
+    return undefined;
+  }
+
+  return config;
+}
 
 /**
  * Builds a small, value-free diagnostic error object.
@@ -206,6 +345,8 @@ function isSplitStatePersistenceDiagnosticsSnapshot(
     isObject(value) &&
     hasProperty(value, 'schemaVersion') &&
     value.schemaVersion === 1 &&
+    hasProperty(value, 'config') &&
+    isObject(value.config) &&
     hasProperty(value, 'updatedAt') &&
     typeof value.updatedAt === 'number' &&
     hasProperty(value, 'topWrittenKeys') &&
@@ -250,8 +391,20 @@ export class SplitStatePersistenceDiagnostics {
 
   #recentWideBatches: SplitStateWideBatchDiagnostics[] = [];
 
+  #config: SplitStatePersistenceDiagnosticsConfig | undefined;
+
+  setConfig(
+    config: SplitStatePersistenceDiagnosticsConfig | undefined,
+  ): void {
+    this.#config = config;
+
+    if (!config) {
+      this.#resetInMemory();
+    }
+  }
+
   recordQueuedUpdate(key: string): void {
-    if (!isSplitStateDataKey(key)) {
+    if (!this.#config || !isSplitStateDataKey(key)) {
       return;
     }
 
@@ -260,6 +413,11 @@ export class SplitStatePersistenceDiagnostics {
   }
 
   recordPersistedBatch(pairs: Map<string, unknown>): void {
+    const config = this.#config;
+    if (!config) {
+      return;
+    }
+
     const persistedEntries = [...pairs.entries()].filter(([key]) =>
       isSplitStateDataKey(key),
     );
@@ -270,9 +428,7 @@ export class SplitStatePersistenceDiagnostics {
 
     this.#totalPersistedBatches += 1;
     const shouldSampleSizes =
-      this.#totalPersistedBatches %
-        SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_SIZE_SAMPLE_RATE ===
-      0;
+      this.#totalPersistedBatches % config.sizeSampleRate === 0;
     const measuredEntries: (MeasuredValue & { key: string })[] = [];
 
     for (const [key, value] of persistedEntries) {
@@ -304,7 +460,7 @@ export class SplitStatePersistenceDiagnostics {
 
     if (
       !shouldSampleSizes ||
-      measuredEntries.length < WIDE_BATCH_MIN_KEY_COUNT
+      measuredEntries.length < config.wideBatchKeyThreshold
     ) {
       return;
     }
@@ -331,7 +487,7 @@ export class SplitStatePersistenceDiagnostics {
           (first, second) =>
             (second.sizeInChars ?? -1) - (first.sizeInChars ?? -1),
         )
-        .slice(0, LARGEST_KEYS_PER_BATCH_LIMIT)
+        .slice(0, config.largestKeysPerBatchLimit)
         .map(({ key, sizeBucket }) => ({
           key,
           sizeBucket,
@@ -339,7 +495,7 @@ export class SplitStatePersistenceDiagnostics {
     });
 
     this.#recentWideBatches = this.#recentWideBatches.slice(
-      -RECENT_WIDE_BATCHES_LIMIT,
+      -config.recentWideBatchesLimit,
     );
   }
 
@@ -355,9 +511,16 @@ export class SplitStatePersistenceDiagnostics {
   getSnapshot(
     readDiagnostics?: SplitStateReadDiagnostics,
     now = Date.now(),
-  ): SplitStatePersistenceDiagnosticsSnapshot {
+  ): SplitStatePersistenceDiagnosticsSnapshot | undefined {
+    const config = this.#config;
+
+    if (!config) {
+      return undefined;
+    }
+
     const snapshot: SplitStatePersistenceDiagnosticsSnapshot = {
       schemaVersion: 1,
+      config,
       updatedAt: now,
       totalQueuedUpdates: this.#totalQueuedUpdates,
       totalPersistedBatches: this.#totalPersistedBatches,
@@ -384,7 +547,7 @@ export class SplitStatePersistenceDiagnostics {
             second.queuedUpdates - first.queuedUpdates ||
             first.key.localeCompare(second.key),
         )
-        .slice(0, TOP_WRITTEN_KEYS_LIMIT),
+        .slice(0, config.topWrittenKeysLimit),
       recentWideBatches: this.#recentWideBatches,
     };
 
@@ -400,7 +563,10 @@ export class SplitStatePersistenceDiagnostics {
   ): Promise<SplitStatePersistenceDiagnosticsSnapshot | undefined> {
     await this.#openDatabase().catch(() => undefined);
 
-    if (!this.hasData() && !readDiagnostics) {
+    if (
+      !this.#config?.corruptionEnabled ||
+      (!this.hasData() && !readDiagnostics)
+    ) {
       return undefined;
     }
 
@@ -408,14 +574,14 @@ export class SplitStatePersistenceDiagnostics {
   }
 
   async persistSnapshotIfDue(now = Date.now()): Promise<void> {
-    if (!this.hasData()) {
+    const config = this.#config;
+    if (!config || !this.hasData()) {
       return;
     }
 
     if (
       this.#lastPersistedAt !== 0 &&
-      now - this.#lastPersistedAt <
-        SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_INTERVAL_MS
+      now - this.#lastPersistedAt < config.snapshotPersistIntervalMs
     ) {
       return;
     }
@@ -424,7 +590,7 @@ export class SplitStatePersistenceDiagnostics {
   }
 
   async persistSnapshot(now = Date.now()): Promise<void> {
-    if (!this.hasData()) {
+    if (!this.#config || !this.hasData()) {
       return;
     }
 
@@ -434,11 +600,13 @@ export class SplitStatePersistenceDiagnostics {
       return;
     }
 
+    const snapshot = this.getSnapshot(undefined, now);
+    if (!snapshot) {
+      return;
+    }
+
     await this.#db.set({
-      [SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_KEY]: this.getSnapshot(
-        undefined,
-        now,
-      ),
+      [SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_KEY]: snapshot,
     });
     this.#lastPersistedAt = now;
   }
@@ -446,6 +614,12 @@ export class SplitStatePersistenceDiagnostics {
   async getWeeklyBaselineSnapshot(
     now = Date.now(),
   ): Promise<SplitStatePersistenceDiagnosticsSnapshot | undefined> {
+    const config = this.#config;
+
+    if (!config?.baselineEnabled) {
+      return undefined;
+    }
+
     await this.#openDatabase();
 
     if (!this.#db || !this.hasData()) {
@@ -460,13 +634,16 @@ export class SplitStatePersistenceDiagnostics {
       isSplitStatePersistenceDiagnosticsBaselineMetadata(
         baselineMetadata,
       ) &&
-      now - baselineMetadata.lastSentAt <
-        SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_BASELINE_INTERVAL_MS
+      now - baselineMetadata.lastSentAt < config.baselineIntervalMs
     ) {
       return undefined;
     }
 
     const snapshot = this.getSnapshot(undefined, now);
+    if (!snapshot) {
+      return undefined;
+    }
+
     await this.#db.set({
       [SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_KEY]: snapshot,
       [SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_BASELINE_KEY]: {
@@ -480,11 +657,7 @@ export class SplitStatePersistenceDiagnostics {
   }
 
   async reset(): Promise<void> {
-    this.#totalQueuedUpdates = 0;
-    this.#totalPersistedBatches = 0;
-    this.#keyStats.clear();
-    this.#recentWideBatches = [];
-    this.#lastPersistedAt = 0;
+    this.#resetInMemory();
     this.#hydrated = true;
 
     await this.#openDatabase().catch(() => undefined);
@@ -509,6 +682,14 @@ export class SplitStatePersistenceDiagnostics {
       this.#keyStats.set(key, stats);
     }
     return stats;
+  }
+
+  #resetInMemory(): void {
+    this.#totalQueuedUpdates = 0;
+    this.#totalPersistedBatches = 0;
+    this.#keyStats.clear();
+    this.#recentWideBatches = [];
+    this.#lastPersistedAt = 0;
   }
 
   async #openDatabase(): Promise<void> {
@@ -570,6 +751,10 @@ export class SplitStatePersistenceDiagnostics {
     this.#totalPersistedBatches += snapshot.totalPersistedBatches;
     this.#lastPersistedAt = Math.max(this.#lastPersistedAt, snapshot.updatedAt);
 
+    if (!this.#config && snapshot.config) {
+      this.#config = snapshot.config;
+    }
+
     for (const keyDiagnostics of snapshot.topWrittenKeys) {
       const stats = this.#getStats(keyDiagnostics.key);
       stats.queuedUpdates += keyDiagnostics.queuedUpdates;
@@ -583,8 +768,16 @@ export class SplitStatePersistenceDiagnostics {
     }
 
     this.#recentWideBatches = [
-      ...snapshot.recentWideBatches.slice(-RECENT_WIDE_BATCHES_LIMIT),
+      ...snapshot.recentWideBatches.slice(
+        -(this.#config?.recentWideBatchesLimit ??
+          snapshot.config.recentWideBatchesLimit),
+      ),
       ...this.#recentWideBatches,
-    ].slice(-RECENT_WIDE_BATCHES_LIMIT);
+    ].slice(
+      -(
+        this.#config?.recentWideBatchesLimit ??
+        snapshot.config.recentWideBatchesLimit
+      ),
+    );
   }
 }

--- a/shared/lib/stores/persistence-diagnostics.ts
+++ b/shared/lib/stores/persistence-diagnostics.ts
@@ -7,8 +7,12 @@ export const SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_DB_NAME =
 export const SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_DB_VERSION = 1;
 export const SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_KEY =
   'split-state-persistence-diagnostics';
+export const SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_BASELINE_KEY =
+  'split-state-persistence-diagnostics-baseline';
 export const SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_INTERVAL_MS =
   5 * 60 * 1000;
+export const SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_BASELINE_INTERVAL_MS =
+  7 * 24 * 60 * 60 * 1000;
 
 const TOP_WRITTEN_KEYS_LIMIT = 10;
 const RECENT_WIDE_BATCHES_LIMIT = 20;
@@ -72,6 +76,11 @@ export type SplitStatePersistenceDiagnosticsSnapshot = {
   topWrittenKeys: SplitStateWrittenKeyDiagnostics[];
   recentWideBatches: SplitStateWideBatchDiagnostics[];
   readDiagnostics?: SplitStateReadDiagnostics;
+};
+
+type SplitStatePersistenceDiagnosticsBaselineMetadata = {
+  schemaVersion: 1;
+  lastSentAt: number;
 };
 
 type KeyStats = {
@@ -202,6 +211,18 @@ function isSplitStatePersistenceDiagnosticsSnapshot(
     Array.isArray(value.topWrittenKeys) &&
     hasProperty(value, 'recentWideBatches') &&
     Array.isArray(value.recentWideBatches)
+  );
+}
+
+function isSplitStatePersistenceDiagnosticsBaselineMetadata(
+  value: unknown,
+): value is SplitStatePersistenceDiagnosticsBaselineMetadata {
+  return (
+    isObject(value) &&
+    hasProperty(value, 'schemaVersion') &&
+    value.schemaVersion === 1 &&
+    hasProperty(value, 'lastSentAt') &&
+    typeof value.lastSentAt === 'number'
   );
 }
 
@@ -394,6 +415,42 @@ export class SplitStatePersistenceDiagnostics {
       ),
     });
     this.#lastPersistedAt = now;
+  }
+
+  async getWeeklyBaselineSnapshot(
+    now = Date.now(),
+  ): Promise<SplitStatePersistenceDiagnosticsSnapshot | undefined> {
+    await this.#openDatabase();
+
+    if (!this.#db || !this.hasData()) {
+      return undefined;
+    }
+
+    const [baselineMetadata] = await this.#db.get([
+      SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_BASELINE_KEY,
+    ]);
+
+    if (
+      isSplitStatePersistenceDiagnosticsBaselineMetadata(
+        baselineMetadata,
+      ) &&
+      now - baselineMetadata.lastSentAt <
+        SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_BASELINE_INTERVAL_MS
+    ) {
+      return undefined;
+    }
+
+    const snapshot = this.getSnapshot(undefined, now);
+    await this.#db.set({
+      [SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_KEY]: snapshot,
+      [SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_BASELINE_KEY]: {
+        schemaVersion: 1,
+        lastSentAt: now,
+      },
+    });
+    this.#lastPersistedAt = now;
+
+    return snapshot;
   }
 
   async reset(): Promise<void> {

--- a/shared/lib/stores/persistence-diagnostics.ts
+++ b/shared/lib/stores/persistence-diagnostics.ts
@@ -13,6 +13,7 @@ export const SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_INTERVAL_MS =
   5 * 60 * 1000;
 export const SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_BASELINE_INTERVAL_MS =
   7 * 24 * 60 * 60 * 1000;
+export const SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_SIZE_SAMPLE_RATE = 20;
 
 const TOP_WRITTEN_KEYS_LIMIT = 10;
 const RECENT_WIDE_BATCHES_LIMIT = 20;
@@ -259,36 +260,52 @@ export class SplitStatePersistenceDiagnostics {
   }
 
   recordPersistedBatch(pairs: Map<string, unknown>): void {
-    const measuredEntries = [...pairs.entries()]
-      .filter(([key]) => isSplitStateDataKey(key))
-      .map(([key, value]) => ({
-        key,
-        ...measureValue(value),
-      }));
+    const persistedEntries = [...pairs.entries()].filter(([key]) =>
+      isSplitStateDataKey(key),
+    );
 
-    if (measuredEntries.length === 0) {
+    if (persistedEntries.length === 0) {
       return;
     }
 
     this.#totalPersistedBatches += 1;
+    const shouldSampleSizes =
+      this.#totalPersistedBatches %
+        SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_SIZE_SAMPLE_RATE ===
+      0;
+    const measuredEntries: (MeasuredValue & { key: string })[] = [];
 
-    for (const entry of measuredEntries) {
-      const stats = this.#getStats(entry.key);
+    for (const [key, value] of persistedEntries) {
+      const stats = this.#getStats(key);
       stats.persistedWrites += 1;
-      stats.lastSizeBucket = entry.sizeBucket;
+
+      if (!shouldSampleSizes) {
+        continue;
+      }
+
+      const measuredEntry = {
+        key,
+        ...measureValue(value),
+      };
+      measuredEntries.push(measuredEntry);
+
+      stats.lastSizeBucket = measuredEntry.sizeBucket;
       stats.maxSizeBucket = getLargerSizeBucket(
         stats.maxSizeBucket,
-        entry.sizeBucket,
+        measuredEntry.sizeBucket,
       );
       if (
-        entry.sizeInChars !== null &&
-        entry.sizeInChars > stats.maxSizeInChars
+        measuredEntry.sizeInChars !== null &&
+        measuredEntry.sizeInChars > stats.maxSizeInChars
       ) {
-        stats.maxSizeInChars = entry.sizeInChars;
+        stats.maxSizeInChars = measuredEntry.sizeInChars;
       }
     }
 
-    if (measuredEntries.length < WIDE_BATCH_MIN_KEY_COUNT) {
+    if (
+      !shouldSampleSizes ||
+      measuredEntries.length < WIDE_BATCH_MIN_KEY_COUNT
+    ) {
       return;
     }
 
@@ -345,13 +362,22 @@ export class SplitStatePersistenceDiagnostics {
       totalQueuedUpdates: this.#totalQueuedUpdates,
       totalPersistedBatches: this.#totalPersistedBatches,
       topWrittenKeys: [...this.#keyStats.entries()]
-        .map(([key, stats]) => ({
-          key,
-          queuedUpdates: stats.queuedUpdates,
-          persistedWrites: stats.persistedWrites,
-          lastSizeBucket: stats.lastSizeBucket,
-          maxSizeBucket: stats.maxSizeBucket,
-        }))
+        .map(([key, stats]) => {
+          const keyDiagnostics: SplitStateWrittenKeyDiagnostics = {
+            key,
+            queuedUpdates: stats.queuedUpdates,
+            persistedWrites: stats.persistedWrites,
+          };
+
+          if (stats.lastSizeBucket) {
+            keyDiagnostics.lastSizeBucket = stats.lastSizeBucket;
+          }
+          if (stats.maxSizeBucket) {
+            keyDiagnostics.maxSizeBucket = stats.maxSizeBucket;
+          }
+
+          return keyDiagnostics;
+        })
         .toSorted(
           (first, second) =>
             second.persistedWrites - first.persistedWrites ||

--- a/shared/lib/stores/persistence-diagnostics.ts
+++ b/shared/lib/stores/persistence-diagnostics.ts
@@ -1,0 +1,507 @@
+import { getErrorMessage, hasProperty, isObject } from '@metamask/utils';
+
+import { IndexedDBStore } from './indexeddb-store';
+
+export const SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_DB_NAME =
+  'metamask-split-state-persistence-diagnostics';
+export const SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_DB_VERSION = 1;
+export const SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_KEY =
+  'split-state-persistence-diagnostics';
+export const SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_INTERVAL_MS =
+  5 * 60 * 1000;
+
+const TOP_WRITTEN_KEYS_LIMIT = 10;
+const RECENT_WIDE_BATCHES_LIMIT = 20;
+const WIDE_BATCH_MIN_KEY_COUNT = 4;
+const LARGEST_KEYS_PER_BATCH_LIMIT = 5;
+const ERROR_MESSAGE_MAX_LENGTH = 200;
+
+export type SplitStateSizeBucket =
+  | 'unknown'
+  | 'undefined'
+  | 'lt_4kb'
+  | '4kb_16kb'
+  | '16kb_64kb'
+  | '64kb_256kb'
+  | '256kb_1mb'
+  | 'gt_1mb';
+
+export type SplitStateDiagnosticError = {
+  errorName: string;
+  errorMessage: string;
+};
+
+export type SplitStateFailedRead = SplitStateDiagnosticError & {
+  key: string;
+};
+
+export type SplitStateReadDiagnostics = {
+  manifestStatus: 'readable' | 'missing' | 'failed';
+  manifestKeyCount?: number;
+  readableKeys: string[];
+  missingKeys: string[];
+  failedKeys: SplitStateFailedRead[];
+  manifestError?: SplitStateDiagnosticError;
+};
+
+export type SplitStateWrittenKeyDiagnostics = {
+  key: string;
+  queuedUpdates: number;
+  persistedWrites: number;
+  lastSizeBucket?: SplitStateSizeBucket;
+  maxSizeBucket?: SplitStateSizeBucket;
+};
+
+export type SplitStateLargestBatchKey = {
+  key: string;
+  sizeBucket: SplitStateSizeBucket;
+};
+
+export type SplitStateWideBatchDiagnostics = {
+  keys: string[];
+  keyCount: number;
+  totalSizeBucket: SplitStateSizeBucket;
+  largestKeys: SplitStateLargestBatchKey[];
+};
+
+export type SplitStatePersistenceDiagnosticsSnapshot = {
+  schemaVersion: 1;
+  updatedAt: number;
+  totalQueuedUpdates: number;
+  totalPersistedBatches: number;
+  topWrittenKeys: SplitStateWrittenKeyDiagnostics[];
+  recentWideBatches: SplitStateWideBatchDiagnostics[];
+  readDiagnostics?: SplitStateReadDiagnostics;
+};
+
+type KeyStats = {
+  queuedUpdates: number;
+  persistedWrites: number;
+  maxSizeInChars: number;
+  lastSizeBucket?: SplitStateSizeBucket;
+  maxSizeBucket?: SplitStateSizeBucket;
+};
+
+type MeasuredValue = {
+  sizeBucket: SplitStateSizeBucket;
+  sizeInChars: number | null;
+};
+
+const SIZE_BUCKET_ORDER = new Map<SplitStateSizeBucket, number>([
+  ['unknown', 0],
+  ['undefined', 0],
+  ['lt_4kb', 1],
+  ['4kb_16kb', 2],
+  ['16kb_64kb', 3],
+  ['64kb_256kb', 4],
+  ['256kb_1mb', 5],
+  ['gt_1mb', 6],
+]);
+
+/**
+ * Builds a small, value-free diagnostic error object.
+ *
+ * @param error - The error to summarize.
+ * @returns A diagnostic-safe error summary.
+ */
+export function getSplitStateDiagnosticError(
+  error: unknown,
+): SplitStateDiagnosticError {
+  return {
+    errorName: error instanceof Error ? error.name : typeof error,
+    errorMessage: getErrorMessage(error).slice(0, ERROR_MESSAGE_MAX_LENGTH),
+  };
+}
+
+/**
+ * Gets a coarse JSON size bucket for a value.
+ *
+ * @param value - The value to size.
+ * @returns The value's size bucket.
+ */
+export function getSplitStateSizeBucket(
+  value: unknown,
+): SplitStateSizeBucket {
+  return measureValue(value).sizeBucket;
+}
+
+function isSplitStateDataKey(key: string): boolean {
+  return key !== 'data' && key !== 'manifest' && key !== 'meta';
+}
+
+function measureValue(value: unknown): MeasuredValue {
+  if (value === undefined) {
+    return {
+      sizeBucket: 'undefined',
+      sizeInChars: 0,
+    };
+  }
+
+  try {
+    const json = JSON.stringify(value);
+    if (typeof json !== 'string') {
+      return {
+        sizeBucket: 'unknown',
+        sizeInChars: null,
+      };
+    }
+    const sizeInChars = json.length;
+    return {
+      sizeBucket: getSizeBucketForCharLength(sizeInChars),
+      sizeInChars,
+    };
+  } catch {
+    return {
+      sizeBucket: 'unknown',
+      sizeInChars: null,
+    };
+  }
+}
+
+function getSizeBucketForCharLength(sizeInChars: number): SplitStateSizeBucket {
+  if (sizeInChars < 4 * 1024) {
+    return 'lt_4kb';
+  } else if (sizeInChars < 16 * 1024) {
+    return '4kb_16kb';
+  } else if (sizeInChars < 64 * 1024) {
+    return '16kb_64kb';
+  } else if (sizeInChars < 256 * 1024) {
+    return '64kb_256kb';
+  } else if (sizeInChars < 1024 * 1024) {
+    return '256kb_1mb';
+  }
+  return 'gt_1mb';
+}
+
+function getLargerSizeBucket(
+  first?: SplitStateSizeBucket,
+  second?: SplitStateSizeBucket,
+): SplitStateSizeBucket | undefined {
+  if (!first) {
+    return second;
+  }
+  if (!second) {
+    return first;
+  }
+  return (SIZE_BUCKET_ORDER.get(first) ?? 0) >=
+    (SIZE_BUCKET_ORDER.get(second) ?? 0)
+    ? first
+    : second;
+}
+
+function isSplitStatePersistenceDiagnosticsSnapshot(
+  value: unknown,
+): value is SplitStatePersistenceDiagnosticsSnapshot {
+  return (
+    isObject(value) &&
+    hasProperty(value, 'schemaVersion') &&
+    value.schemaVersion === 1 &&
+    hasProperty(value, 'updatedAt') &&
+    typeof value.updatedAt === 'number' &&
+    hasProperty(value, 'topWrittenKeys') &&
+    Array.isArray(value.topWrittenKeys) &&
+    hasProperty(value, 'recentWideBatches') &&
+    Array.isArray(value.recentWideBatches)
+  );
+}
+
+/**
+ * Tracks split-state persistence diagnostics without retaining controller
+ * values.
+ */
+export class SplitStatePersistenceDiagnostics {
+  #db: IndexedDBStore | undefined;
+
+  #openPromise: Promise<void> | undefined;
+
+  #disabled = false;
+
+  #hydrated = false;
+
+  #lastPersistedAt = 0;
+
+  #totalQueuedUpdates = 0;
+
+  #totalPersistedBatches = 0;
+
+  #keyStats = new Map<string, KeyStats>();
+
+  #recentWideBatches: SplitStateWideBatchDiagnostics[] = [];
+
+  recordQueuedUpdate(key: string): void {
+    if (!isSplitStateDataKey(key)) {
+      return;
+    }
+
+    this.#totalQueuedUpdates += 1;
+    this.#getStats(key).queuedUpdates += 1;
+  }
+
+  recordPersistedBatch(pairs: Map<string, unknown>): void {
+    const measuredEntries = [...pairs.entries()]
+      .filter(([key]) => isSplitStateDataKey(key))
+      .map(([key, value]) => ({
+        key,
+        ...measureValue(value),
+      }));
+
+    if (measuredEntries.length === 0) {
+      return;
+    }
+
+    this.#totalPersistedBatches += 1;
+
+    for (const entry of measuredEntries) {
+      const stats = this.#getStats(entry.key);
+      stats.persistedWrites += 1;
+      stats.lastSizeBucket = entry.sizeBucket;
+      stats.maxSizeBucket = getLargerSizeBucket(
+        stats.maxSizeBucket,
+        entry.sizeBucket,
+      );
+      if (
+        entry.sizeInChars !== null &&
+        entry.sizeInChars > stats.maxSizeInChars
+      ) {
+        stats.maxSizeInChars = entry.sizeInChars;
+      }
+    }
+
+    if (measuredEntries.length < WIDE_BATCH_MIN_KEY_COUNT) {
+      return;
+    }
+
+    const totalSizeInChars = measuredEntries.reduce<number | null>(
+      (total, entry) => {
+        if (total === null || entry.sizeInChars === null) {
+          return null;
+        }
+        return total + entry.sizeInChars;
+      },
+      0,
+    );
+
+    this.#recentWideBatches.push({
+      keys: measuredEntries.map(({ key }) => key),
+      keyCount: measuredEntries.length,
+      totalSizeBucket:
+        totalSizeInChars === null
+          ? 'unknown'
+          : getSizeBucketForCharLength(totalSizeInChars),
+      largestKeys: measuredEntries
+        .toSorted(
+          (first, second) =>
+            (second.sizeInChars ?? -1) - (first.sizeInChars ?? -1),
+        )
+        .slice(0, LARGEST_KEYS_PER_BATCH_LIMIT)
+        .map(({ key, sizeBucket }) => ({
+          key,
+          sizeBucket,
+        })),
+    });
+
+    this.#recentWideBatches = this.#recentWideBatches.slice(
+      -RECENT_WIDE_BATCHES_LIMIT,
+    );
+  }
+
+  hasData(): boolean {
+    return (
+      this.#totalQueuedUpdates > 0 ||
+      this.#totalPersistedBatches > 0 ||
+      this.#keyStats.size > 0 ||
+      this.#recentWideBatches.length > 0
+    );
+  }
+
+  getSnapshot(
+    readDiagnostics?: SplitStateReadDiagnostics,
+    now = Date.now(),
+  ): SplitStatePersistenceDiagnosticsSnapshot {
+    const snapshot: SplitStatePersistenceDiagnosticsSnapshot = {
+      schemaVersion: 1,
+      updatedAt: now,
+      totalQueuedUpdates: this.#totalQueuedUpdates,
+      totalPersistedBatches: this.#totalPersistedBatches,
+      topWrittenKeys: [...this.#keyStats.entries()]
+        .map(([key, stats]) => ({
+          key,
+          queuedUpdates: stats.queuedUpdates,
+          persistedWrites: stats.persistedWrites,
+          lastSizeBucket: stats.lastSizeBucket,
+          maxSizeBucket: stats.maxSizeBucket,
+        }))
+        .toSorted(
+          (first, second) =>
+            second.persistedWrites - first.persistedWrites ||
+            second.queuedUpdates - first.queuedUpdates ||
+            first.key.localeCompare(second.key),
+        )
+        .slice(0, TOP_WRITTEN_KEYS_LIMIT),
+      recentWideBatches: this.#recentWideBatches,
+    };
+
+    if (readDiagnostics) {
+      snapshot.readDiagnostics = readDiagnostics;
+    }
+
+    return snapshot;
+  }
+
+  async getSnapshotForReport(
+    readDiagnostics?: SplitStateReadDiagnostics,
+  ): Promise<SplitStatePersistenceDiagnosticsSnapshot | undefined> {
+    await this.#openDatabase().catch(() => undefined);
+
+    if (!this.hasData() && !readDiagnostics) {
+      return undefined;
+    }
+
+    return this.getSnapshot(readDiagnostics);
+  }
+
+  async persistSnapshotIfDue(now = Date.now()): Promise<void> {
+    if (!this.hasData()) {
+      return;
+    }
+
+    if (
+      this.#lastPersistedAt !== 0 &&
+      now - this.#lastPersistedAt <
+        SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_INTERVAL_MS
+    ) {
+      return;
+    }
+
+    await this.persistSnapshot(now);
+  }
+
+  async persistSnapshot(now = Date.now()): Promise<void> {
+    if (!this.hasData()) {
+      return;
+    }
+
+    await this.#openDatabase();
+
+    if (!this.#db) {
+      return;
+    }
+
+    await this.#db.set({
+      [SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_KEY]: this.getSnapshot(
+        undefined,
+        now,
+      ),
+    });
+    this.#lastPersistedAt = now;
+  }
+
+  async reset(): Promise<void> {
+    this.#totalQueuedUpdates = 0;
+    this.#totalPersistedBatches = 0;
+    this.#keyStats.clear();
+    this.#recentWideBatches = [];
+    this.#lastPersistedAt = 0;
+    this.#hydrated = true;
+
+    await this.#openDatabase().catch(() => undefined);
+    await this.#db?.reset().catch(() => undefined);
+  }
+
+  close(): void {
+    this.#db?.close();
+    this.#db = undefined;
+    this.#openPromise = undefined;
+    this.#hydrated = false;
+  }
+
+  #getStats(key: string): KeyStats {
+    let stats = this.#keyStats.get(key);
+    if (!stats) {
+      stats = {
+        queuedUpdates: 0,
+        persistedWrites: 0,
+        maxSizeInChars: 0,
+      };
+      this.#keyStats.set(key, stats);
+    }
+    return stats;
+  }
+
+  async #openDatabase(): Promise<void> {
+    if (this.#disabled || this.#db) {
+      return;
+    }
+
+    if (!this.#openPromise) {
+      this.#openPromise = this.#doOpenDatabase();
+    }
+
+    try {
+      await this.#openPromise;
+    } finally {
+      this.#openPromise = undefined;
+    }
+  }
+
+  async #doOpenDatabase(): Promise<void> {
+    try {
+      const db = new IndexedDBStore();
+      await db.open(
+        SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_DB_NAME,
+        SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_DB_VERSION,
+      );
+      this.#db = db;
+      await this.#hydrateFromDatabase();
+    } catch {
+      this.#disabled = true;
+      this.#db?.close();
+      this.#db = undefined;
+    }
+  }
+
+  async #hydrateFromDatabase(): Promise<void> {
+    if (this.#hydrated || !this.#db) {
+      return;
+    }
+
+    this.#hydrated = true;
+
+    const [persistedSnapshot] = await this.#db.get([
+      SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_KEY,
+    ]);
+
+    if (
+      !isSplitStatePersistenceDiagnosticsSnapshot(persistedSnapshot)
+    ) {
+      return;
+    }
+
+    this.#mergePersistedSnapshot(persistedSnapshot);
+  }
+
+  #mergePersistedSnapshot(
+    snapshot: SplitStatePersistenceDiagnosticsSnapshot,
+  ): void {
+    this.#totalQueuedUpdates += snapshot.totalQueuedUpdates;
+    this.#totalPersistedBatches += snapshot.totalPersistedBatches;
+    this.#lastPersistedAt = Math.max(this.#lastPersistedAt, snapshot.updatedAt);
+
+    for (const keyDiagnostics of snapshot.topWrittenKeys) {
+      const stats = this.#getStats(keyDiagnostics.key);
+      stats.queuedUpdates += keyDiagnostics.queuedUpdates;
+      stats.persistedWrites += keyDiagnostics.persistedWrites;
+      stats.lastSizeBucket =
+        keyDiagnostics.lastSizeBucket ?? stats.lastSizeBucket;
+      stats.maxSizeBucket = getLargerSizeBucket(
+        stats.maxSizeBucket,
+        keyDiagnostics.maxSizeBucket,
+      );
+    }
+
+    this.#recentWideBatches = [
+      ...snapshot.recentWideBatches.slice(-RECENT_WIDE_BATCHES_LIMIT),
+      ...this.#recentWideBatches,
+    ].slice(-RECENT_WIDE_BATCHES_LIMIT);
+  }
+}

--- a/shared/lib/stores/persistence-manager.test.ts
+++ b/shared/lib/stores/persistence-manager.test.ts
@@ -416,9 +416,7 @@ describe('PersistenceManager', () => {
         MISSING_VAULT_ERROR,
       );
 
-      expect(
-        mockStoreGetSplitStateReadDiagnostics,
-      ).not.toHaveBeenCalled();
+      expect(mockStoreGetSplitStateReadDiagnostics).not.toHaveBeenCalled();
       expect(listener).toHaveBeenCalledWith({
         backup: {
           KeyringController: {

--- a/shared/lib/stores/persistence-manager.test.ts
+++ b/shared/lib/stores/persistence-manager.test.ts
@@ -10,7 +10,12 @@ import { PersistenceManager } from './persistence-manager';
 import { IndexedDBStore } from './indexeddb-store';
 import ExtensionStore from './extension-store';
 import { MetaMaskStateType } from './base-store';
-import type { SplitStateReadDiagnostics } from './persistence-diagnostics';
+import {
+  SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_FEATURE_FLAG,
+  getSplitStatePersistenceDiagnosticsConfig,
+  type SplitStatePersistenceDiagnosticsConfig,
+  type SplitStateReadDiagnostics,
+} from './persistence-diagnostics';
 
 const MOCK_DATA = { config: { foo: 'bar' } };
 
@@ -46,6 +51,20 @@ jest.mock('../trace', () => ({
 }));
 const mockedCaptureException = jest.mocked(captureException);
 const mockedCaptureMessage = jest.mocked(captureMessage);
+
+function getDiagnosticsConfig(): SplitStatePersistenceDiagnosticsConfig {
+  const config = getSplitStatePersistenceDiagnosticsConfig({
+    [SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_FEATURE_FLAG]: {
+      enabled: true,
+    },
+  });
+
+  if (!config) {
+    throw new Error('Expected diagnostics config to be enabled');
+  }
+
+  return config;
+}
 
 describe('PersistenceManager', () => {
   let manager: PersistenceManager;
@@ -300,6 +319,8 @@ describe('PersistenceManager', () => {
     });
 
     it('emits split-state diagnostics when storage is inaccessible and a backup exists', async () => {
+      const diagnosticsConfig = getDiagnosticsConfig();
+      manager.setSplitStatePersistenceDiagnosticsConfig(diagnosticsConfig);
       manager.setMetadata({ version: 10, storageKind: 'split' });
       manager.update('KeyringController', { vault: 'encrypted-vault' });
       manager.update('PreferencesController', { selectedAddress: '0xabc' });
@@ -329,6 +350,13 @@ describe('PersistenceManager', () => {
         KeyringController: {
           vault: 'backup-vault',
         },
+        RemoteFeatureFlagController: {
+          remoteFeatureFlags: {
+            [SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_FEATURE_FLAG]: {
+              enabled: true,
+            },
+          },
+        },
       });
 
       await expect(manager.get({ validateVault: true })).rejects.toThrow(
@@ -340,9 +368,17 @@ describe('PersistenceManager', () => {
           KeyringController: {
             vault: 'backup-vault',
           },
+          RemoteFeatureFlagController: {
+            remoteFeatureFlags: {
+              [SPLIT_STATE_PERSISTENCE_DIAGNOSTICS_FEATURE_FLAG]: {
+                enabled: true,
+              },
+            },
+          },
         },
         corruptionType: VaultCorruptionType.InaccessibleDatabase,
         diagnostics: expect.objectContaining({
+          config: diagnosticsConfig,
           totalQueuedUpdates: 2,
           totalPersistedBatches: 1,
           readDiagnostics,
@@ -359,6 +395,38 @@ describe('PersistenceManager', () => {
             }),
           ]),
         }),
+      });
+    });
+
+    it('does not collect split-state diagnostics for corruption when the remote flag is missing from the backup', async () => {
+      manager.setMetadata({ version: 10, storageKind: 'split' });
+      manager.update('KeyringController', { vault: 'encrypted-vault' });
+      await manager.persist();
+
+      const listener = jest.fn();
+      manager.on('vaultCorruptionDetected', listener);
+      mockStoreGet.mockRejectedValueOnce(new Error('Database read failed'));
+      jest.spyOn(manager, 'getBackup').mockResolvedValueOnce({
+        KeyringController: {
+          vault: 'backup-vault',
+        },
+      });
+
+      await expect(manager.get({ validateVault: true })).rejects.toThrow(
+        MISSING_VAULT_ERROR,
+      );
+
+      expect(
+        mockStoreGetSplitStateReadDiagnostics,
+      ).not.toHaveBeenCalled();
+      expect(listener).toHaveBeenCalledWith({
+        backup: {
+          KeyringController: {
+            vault: 'backup-vault',
+          },
+        },
+        corruptionType: VaultCorruptionType.InaccessibleDatabase,
+        diagnostics: undefined,
       });
     });
   });
@@ -405,6 +473,7 @@ describe('PersistenceManager', () => {
           analyticsId: '0xabc123',
           optedIn: true,
         },
+        RemoteFeatureFlagController: undefined,
         meta: {
           version: 10,
         },
@@ -453,6 +522,8 @@ describe('PersistenceManager', () => {
     });
 
     it('records split-state write diagnostics after successful persistence', async () => {
+      const diagnosticsConfig = getDiagnosticsConfig();
+      manager.setSplitStatePersistenceDiagnosticsConfig(diagnosticsConfig);
       manager.setMetadata({ version: 10, storageKind: 'split' });
       manager.update('KeyringController', { vault: 'encrypted-vault' });
       manager.update('PreferencesController', { preferences: true });
@@ -464,6 +535,7 @@ describe('PersistenceManager', () => {
       expect(
         manager.getSplitStatePersistenceDiagnosticsSnapshot(undefined, 1000),
       ).toMatchObject({
+        config: diagnosticsConfig,
         totalQueuedUpdates: 2,
         totalPersistedBatches: 1,
         topWrittenKeys: expect.arrayContaining([

--- a/shared/lib/stores/persistence-manager.test.ts
+++ b/shared/lib/stores/persistence-manager.test.ts
@@ -5,10 +5,12 @@ import log from 'loglevel';
 
 import { captureException, captureMessage } from '../sentry';
 import { MISSING_VAULT_ERROR } from '../../constants/errors';
+import { VaultCorruptionType } from '../../constants/state-corruption';
 import { PersistenceManager } from './persistence-manager';
 import { IndexedDBStore } from './indexeddb-store';
 import ExtensionStore from './extension-store';
 import { MetaMaskStateType } from './base-store';
+import type { SplitStateReadDiagnostics } from './persistence-diagnostics';
 
 const MOCK_DATA = { config: { foo: 'bar' } };
 
@@ -16,6 +18,7 @@ const mockStoreSet = jest.fn();
 const mockStoreSetKeyValues = jest.fn();
 const mockStoreGet = jest.fn();
 const mockStoreReset = jest.fn();
+const mockStoreGetSplitStateReadDiagnostics = jest.fn();
 
 jest.mock('./extension-store', () => {
   return jest.fn().mockImplementation(() => {
@@ -23,6 +26,7 @@ jest.mock('./extension-store', () => {
       set: mockStoreSet,
       setKeyValues: mockStoreSetKeyValues,
       get: mockStoreGet,
+      getSplitStateReadDiagnostics: mockStoreGetSplitStateReadDiagnostics,
       reset: mockStoreReset,
     };
   });
@@ -46,9 +50,11 @@ const mockedCaptureMessage = jest.mocked(captureMessage);
 describe('PersistenceManager', () => {
   let manager: PersistenceManager;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     jest.clearAllMocks();
     manager = new PersistenceManager({ localStore: new ExtensionStore() });
+    await manager.reset();
+    jest.clearAllMocks();
   });
 
   describe('open', () => {
@@ -292,6 +298,69 @@ describe('PersistenceManager', () => {
         MISSING_VAULT_ERROR,
       );
     });
+
+    it('emits split-state diagnostics when storage is inaccessible and a backup exists', async () => {
+      manager.setMetadata({ version: 10, storageKind: 'split' });
+      manager.update('KeyringController', { vault: 'encrypted-vault' });
+      manager.update('PreferencesController', { selectedAddress: '0xabc' });
+      await manager.persist();
+
+      const readDiagnostics: SplitStateReadDiagnostics = {
+        manifestStatus: 'readable',
+        manifestKeyCount: 2,
+        readableKeys: ['KeyringController'],
+        missingKeys: [],
+        failedKeys: [
+          {
+            key: 'PreferencesController',
+            errorName: 'Error',
+            errorMessage: 'block checksum mismatch',
+          },
+        ],
+      };
+      const storageError = new Error('Database read failed');
+      const listener = jest.fn();
+      manager.on('vaultCorruptionDetected', listener);
+      mockStoreGet.mockRejectedValueOnce(storageError);
+      mockStoreGetSplitStateReadDiagnostics.mockResolvedValueOnce(
+        readDiagnostics,
+      );
+      jest.spyOn(manager, 'getBackup').mockResolvedValueOnce({
+        KeyringController: {
+          vault: 'backup-vault',
+        },
+      });
+
+      await expect(manager.get({ validateVault: true })).rejects.toThrow(
+        MISSING_VAULT_ERROR,
+      );
+
+      expect(listener).toHaveBeenCalledWith({
+        backup: {
+          KeyringController: {
+            vault: 'backup-vault',
+          },
+        },
+        corruptionType: VaultCorruptionType.InaccessibleDatabase,
+        diagnostics: expect.objectContaining({
+          totalQueuedUpdates: 2,
+          totalPersistedBatches: 1,
+          readDiagnostics,
+          topWrittenKeys: expect.arrayContaining([
+            expect.objectContaining({
+              key: 'KeyringController',
+              queuedUpdates: 1,
+              persistedWrites: 1,
+            }),
+            expect.objectContaining({
+              key: 'PreferencesController',
+              queuedUpdates: 1,
+              persistedWrites: 1,
+            }),
+          ]),
+        }),
+      });
+    });
   });
 
   describe('getBackup', () => {
@@ -381,6 +450,35 @@ describe('PersistenceManager', () => {
       /* eslint-enable jest/prefer-strict-equal */
       expect(passedMap.has('BarController')).toBe(true);
       expect(passedMap.get('BarController')).toBeUndefined();
+    });
+
+    it('records split-state write diagnostics after successful persistence', async () => {
+      manager.setMetadata({ version: 10, storageKind: 'split' });
+      manager.update('KeyringController', { vault: 'encrypted-vault' });
+      manager.update('PreferencesController', { preferences: true });
+
+      const [result, error] = await manager.persist();
+
+      expect(result).toBe(true);
+      expect(error).toBeUndefined();
+      expect(
+        manager.getSplitStatePersistenceDiagnosticsSnapshot(undefined, 1000),
+      ).toMatchObject({
+        totalQueuedUpdates: 2,
+        totalPersistedBatches: 1,
+        topWrittenKeys: expect.arrayContaining([
+          expect.objectContaining({
+            key: 'KeyringController',
+            queuedUpdates: 1,
+            persistedWrites: 1,
+          }),
+          expect.objectContaining({
+            key: 'PreferencesController',
+            queuedUpdates: 1,
+            persistedWrites: 1,
+          }),
+        ]),
+      });
     });
 
     it('logs error and captures exception if store.setKeyValues throws', async () => {

--- a/shared/lib/stores/persistence-manager.ts
+++ b/shared/lib/stores/persistence-manager.ts
@@ -10,7 +10,9 @@ import { StorageWriteErrorType } from '../../constants/app-state';
 import { IndexedDBStore } from './indexeddb-store';
 import {
   getSplitStateDiagnosticError,
+  getSplitStatePersistenceDiagnosticsConfig,
   SplitStatePersistenceDiagnostics,
+  type SplitStatePersistenceDiagnosticsConfig,
   type SplitStatePersistenceDiagnosticsSnapshot,
   type SplitStateReadDiagnostics,
 } from './persistence-diagnostics';
@@ -29,6 +31,7 @@ export const backedUpStateKeys = [
   'AppMetadataController',
   'MetaMetricsController',
   'AnalyticsController',
+  'RemoteFeatureFlagController',
 ] as const;
 
 export type BackedUpStateKey = (typeof backedUpStateKeys)[number];
@@ -127,6 +130,26 @@ function makeBackup(state: MetaMaskStateType, meta: MetaData): Backup {
   }
   backup.meta = meta;
   return backup;
+}
+
+function getRemoteFeatureFlagsFromState(
+  state: MetaMaskStateType | Backup | null | undefined,
+): Record<string, unknown> {
+  const remoteFeatureFlagController =
+    isObject(state) && hasProperty(state, 'RemoteFeatureFlagController')
+      ? state.RemoteFeatureFlagController
+      : undefined;
+  const remoteFeatureFlags =
+    isObject(remoteFeatureFlagController) &&
+    hasProperty(remoteFeatureFlagController, 'remoteFeatureFlags') &&
+    isObject(remoteFeatureFlagController.remoteFeatureFlags)
+      ? remoteFeatureFlagController.remoteFeatureFlags
+      : {};
+
+  return {
+    ...remoteFeatureFlags,
+    ...(getManifestFlags().remoteFeatureFlags ?? {}),
+  };
 }
 
 /**
@@ -368,8 +391,14 @@ export class PersistenceManager extends EventEmitter<PersistenceManagerEventMap>
   getSplitStatePersistenceDiagnosticsSnapshot(
     readDiagnostics?: SplitStateReadDiagnostics,
     now = Date.now(),
-  ): SplitStatePersistenceDiagnosticsSnapshot {
+  ): SplitStatePersistenceDiagnosticsSnapshot | undefined {
     return this.#splitStateDiagnostics.getSnapshot(readDiagnostics, now);
+  }
+
+  setSplitStatePersistenceDiagnosticsConfig(
+    config: SplitStatePersistenceDiagnosticsConfig | undefined,
+  ) {
+    this.#splitStateDiagnostics.setConfig(config);
   }
 
   async getWeeklySplitStatePersistenceDiagnosticsSnapshot(
@@ -471,9 +500,15 @@ export class PersistenceManager extends EventEmitter<PersistenceManagerEventMap>
     }
   }
 
-  async #getSplitStatePersistenceDiagnosticsSnapshotForReport(): Promise<
-    SplitStatePersistenceDiagnosticsSnapshot | undefined
-  > {
+  async #getSplitStatePersistenceDiagnosticsSnapshotForReport(
+    config: SplitStatePersistenceDiagnosticsConfig | undefined,
+  ): Promise<SplitStatePersistenceDiagnosticsSnapshot | undefined> {
+    if (!config?.corruptionEnabled) {
+      return undefined;
+    }
+
+    this.#splitStateDiagnostics.setConfig(config);
+
     let readDiagnostics: SplitStateReadDiagnostics | undefined;
 
     try {
@@ -819,11 +854,17 @@ export class PersistenceManager extends EventEmitter<PersistenceManagerEventMap>
               const corruptionType = localStoreError
                 ? VaultCorruptionType.InaccessibleDatabase
                 : VaultCorruptionType.MissingVaultInDatabase;
+              const diagnosticsConfig =
+                getSplitStatePersistenceDiagnosticsConfig(
+                  getRemoteFeatureFlagsFromState(backup),
+                );
               const shouldCollectSplitStateDiagnostics = localStoreError
                 ? this.storageKind === 'split'
                 : (result?.meta?.storageKind ?? 'data') === 'split';
               const diagnostics = shouldCollectSplitStateDiagnostics
-                ? await this.#getSplitStatePersistenceDiagnosticsSnapshotForReport()
+                ? await this.#getSplitStatePersistenceDiagnosticsSnapshotForReport(
+                    diagnosticsConfig,
+                  )
                 : undefined;
               this.emit('vaultCorruptionDetected', {
                 backup,

--- a/shared/lib/stores/persistence-manager.ts
+++ b/shared/lib/stores/persistence-manager.ts
@@ -8,6 +8,12 @@ import { getManifestFlags } from '../manifestFlags';
 import { VaultCorruptionType } from '../../constants/state-corruption';
 import { StorageWriteErrorType } from '../../constants/app-state';
 import { IndexedDBStore } from './indexeddb-store';
+import {
+  getSplitStateDiagnosticError,
+  SplitStatePersistenceDiagnostics,
+  type SplitStatePersistenceDiagnosticsSnapshot,
+  type SplitStateReadDiagnostics,
+} from './persistence-diagnostics';
 import type {
   MetaMaskStateType,
   MetaMaskStorageStructure,
@@ -41,6 +47,7 @@ export type Backup = {
 export type VaultCorruptionDetectedEvent = {
   backup: Backup;
   corruptionType: VaultCorruptionType;
+  diagnostics?: SplitStatePersistenceDiagnosticsSnapshot;
 };
 
 export type SplitStateMigrationSucceededEvent = {
@@ -217,6 +224,8 @@ export class PersistenceManager extends EventEmitter<PersistenceManagerEventMap>
 
   #backupDb: IndexedDBStore | null = null;
 
+  #splitStateDiagnostics = new SplitStatePersistenceDiagnostics();
+
   #backup?: string;
 
   #open: boolean = false;
@@ -356,6 +365,13 @@ export class PersistenceManager extends EventEmitter<PersistenceManagerEventMap>
     return structuredClone(this.#metadata);
   }
 
+  getSplitStatePersistenceDiagnosticsSnapshot(
+    readDiagnostics?: SplitStateReadDiagnostics,
+    now = Date.now(),
+  ): SplitStatePersistenceDiagnosticsSnapshot {
+    return this.#splitStateDiagnostics.getSnapshot(readDiagnostics, now);
+  }
+
   setMetadata(metadata: MetaData) {
     // don't rewrite if nothing has changed
     // this is a cheap comparison since metadata is small.
@@ -439,6 +455,37 @@ export class PersistenceManager extends EventEmitter<PersistenceManagerEventMap>
   async #setKeyValuesInLocalStore(pairs: Map<string, unknown>): Promise<void> {
     this.#maybeSimulateSetFailure();
     await this.#localStore.setKeyValues(pairs);
+  }
+
+  async #persistSplitStateDiagnosticsSnapshot(): Promise<void> {
+    try {
+      await this.#splitStateDiagnostics.persistSnapshotIfDue();
+    } catch {
+      // Diagnostics must never affect persistence success.
+    }
+  }
+
+  async #getSplitStatePersistenceDiagnosticsSnapshotForReport(): Promise<
+    SplitStatePersistenceDiagnosticsSnapshot | undefined
+  > {
+    let readDiagnostics: SplitStateReadDiagnostics | undefined;
+
+    try {
+      readDiagnostics =
+        await this.#localStore.getSplitStateReadDiagnostics?.();
+    } catch (error) {
+      readDiagnostics = {
+        manifestStatus: 'failed',
+        readableKeys: [],
+        missingKeys: [],
+        failedKeys: [],
+        manifestError: getSplitStateDiagnosticError(error),
+      };
+    }
+
+    return await this.#splitStateDiagnostics.getSnapshotForReport(
+      readDiagnostics,
+    );
   }
 
   /**
@@ -567,6 +614,7 @@ export class PersistenceManager extends EventEmitter<PersistenceManagerEventMap>
       );
     }
     this.#pendingPairs.set(key, value);
+    this.#splitStateDiagnostics.recordQueuedUpdate(String(key));
   }
 
   async persist(): Promise<[boolean, Error | undefined]> {
@@ -612,6 +660,8 @@ export class PersistenceManager extends EventEmitter<PersistenceManagerEventMap>
           try {
             // save the pairs (includes test simulation check)
             await this.#setKeyValuesInLocalStore(clone);
+            this.#splitStateDiagnostics.recordPersistedBatch(clone);
+            await this.#persistSplitStateDiagnosticsSnapshot();
           } catch (err) {
             // merge the clone with the pending pairs again
             for (const [key, value] of clone.entries()) {
@@ -763,9 +813,16 @@ export class PersistenceManager extends EventEmitter<PersistenceManagerEventMap>
               const corruptionType = localStoreError
                 ? VaultCorruptionType.InaccessibleDatabase
                 : VaultCorruptionType.MissingVaultInDatabase;
+              const shouldCollectSplitStateDiagnostics = localStoreError
+                ? this.storageKind === 'split'
+                : (result?.meta?.storageKind ?? 'data') === 'split';
+              const diagnostics = shouldCollectSplitStateDiagnostics
+                ? await this.#getSplitStatePersistenceDiagnosticsSnapshotForReport()
+                : undefined;
               this.emit('vaultCorruptionDetected', {
                 backup,
                 corruptionType,
+                diagnostics,
               });
 
               // We've got some data (we haven't checked for a vault, as the
@@ -824,6 +881,7 @@ export class PersistenceManager extends EventEmitter<PersistenceManagerEventMap>
         await Promise.all([
           this.#localStore.reset(),
           await this.#backupDb?.reset(),
+          this.#splitStateDiagnostics.reset(),
         ]);
         this.#backup = undefined;
         this.#isExtensionInitialized = false;

--- a/shared/lib/stores/persistence-manager.ts
+++ b/shared/lib/stores/persistence-manager.ts
@@ -512,8 +512,7 @@ export class PersistenceManager extends EventEmitter<PersistenceManagerEventMap>
     let readDiagnostics: SplitStateReadDiagnostics | undefined;
 
     try {
-      readDiagnostics =
-        await this.#localStore.getSplitStateReadDiagnostics?.();
+      readDiagnostics = await this.#localStore.getSplitStateReadDiagnostics?.();
     } catch (error) {
       readDiagnostics = {
         manifestStatus: 'failed',

--- a/shared/lib/stores/persistence-manager.ts
+++ b/shared/lib/stores/persistence-manager.ts
@@ -372,6 +372,12 @@ export class PersistenceManager extends EventEmitter<PersistenceManagerEventMap>
     return this.#splitStateDiagnostics.getSnapshot(readDiagnostics, now);
   }
 
+  async getWeeklySplitStatePersistenceDiagnosticsSnapshot(
+    now = Date.now(),
+  ): Promise<SplitStatePersistenceDiagnosticsSnapshot | undefined> {
+    return await this.#splitStateDiagnostics.getWeeklyBaselineSnapshot(now);
+  }
+
   setMetadata(metadata: MetaData) {
     // don't rewrite if nothing has changed
     // this is a cheap comparison since metadata is small.


### PR DESCRIPTION
## **Description**

Adds split-state-only persistence diagnostics to help identify which controller keys are most likely involved when extension storage becomes unreadable.

The implementation records compact, value-free write pressure diagnostics for split state updates, including queued update counts, persisted batch counts, coarse JSON size buckets, top written keys, and recent wide batches. These snapshots are persisted to a separate IndexedDB database so they can survive startup corruption of `storage.local`.

All collection and reporting is gated by the `splitStatePersistenceDiagnostics` remote feature flag. If the flag is missing, invalid, or not enabled, diagnostics are not collected and are not attached to events. The normalized flag config is included in every diagnostics payload so dashboards can group and filter results when thresholds or frequencies change.

A weekly, consent-gated baseline event is emitted from the background startup path after a successful split-state read. When vault corruption recovery is triggered, `ExtensionStore` also attempts per-key reads from the split-state manifest so the existing `VaultCorruptionDetected` Segment event can include which keys were readable, missing, or failed. Reporting remains gated through the existing backup/persisted-state AnalyticsController consent path.

## Remote flag shape

```json
{
  "splitStatePersistenceDiagnostics": {
    "enabled": true,
    "baselineEnabled": true,
    "corruptionEnabled": true,
    "sizeSampleRate": 20,
    "baselineIntervalMs": 604800000,
    "snapshotPersistIntervalMs": 300000,
    "wideBatchKeyThreshold": 4,
    "topWrittenKeysLimit": 10,
    "recentWideBatchesLimit": 20,
    "largestKeysPerBatchLimit": 5
  }
}
```

Only `enabled: true` is required to use the default values above. Numeric values are clamped locally to keep payload size and runtime cost bounded. If both `baselineEnabled` and `corruptionEnabled` are false, diagnostics are treated as disabled.

## Example payloads

The diagnostics are attached under `split_state_persistence_diagnostics`. Controller values are not included; the payload contains key names, exact write counts, coarse size buckets sampled on one in twenty persisted batches, sanitized error summaries, and the normalized config that produced the payload. Size bucket fields are present after a key has been included in a sampled batch; unsampled keys still report counts.

Example weekly baseline event properties for `Split State Persistence Baseline`:

```json
{
  "split_state_persistence_diagnostics": {
    "schemaVersion": 1,
    "config": {
      "enabled": true,
      "baselineEnabled": true,
      "corruptionEnabled": true,
      "sizeSampleRate": 20,
      "baselineIntervalMs": 604800000,
      "snapshotPersistIntervalMs": 300000,
      "wideBatchKeyThreshold": 4,
      "topWrittenKeysLimit": 10,
      "recentWideBatchesLimit": 20,
      "largestKeysPerBatchLimit": 5
    },
    "updatedAt": 1782760000000,
    "totalQueuedUpdates": 2480,
    "totalPersistedBatches": 620,
    "topWrittenKeys": [
      {
        "key": "PreferencesController",
        "queuedUpdates": 620,
        "persistedWrites": 620,
        "lastSizeBucket": "lt_4kb",
        "maxSizeBucket": "lt_4kb"
      },
      {
        "key": "MultichainBalancesController",
        "queuedUpdates": 496,
        "persistedWrites": 496,
        "lastSizeBucket": "16kb_64kb",
        "maxSizeBucket": "64kb_256kb"
      },
      {
        "key": "KeyringController",
        "queuedUpdates": 3,
        "persistedWrites": 3,
        "lastSizeBucket": "4kb_16kb",
        "maxSizeBucket": "4kb_16kb"
      }
    ],
    "recentWideBatches": [
      {
        "keys": [
          "PreferencesController",
          "MultichainBalancesController",
          "AccountTreeController",
          "SubjectMetadataController"
        ],
        "keyCount": 4,
        "totalSizeBucket": "64kb_256kb",
        "largestKeys": [
          {
            "key": "MultichainBalancesController",
            "sizeBucket": "64kb_256kb"
          },
          {
            "key": "SubjectMetadataController",
            "sizeBucket": "16kb_64kb"
          },
          {
            "key": "AccountTreeController",
            "sizeBucket": "4kb_16kb"
          },
          {
            "key": "PreferencesController",
            "sizeBucket": "lt_4kb"
          }
        ]
      }
    ]
  }
}
```

Example corruption event properties for `Vault Corruption Detected` when one split-state key fails individual reads during startup:

```json
{
  "error_type": "inaccessible_database",
  "split_state_persistence_diagnostics": {
    "schemaVersion": 1,
    "config": {
      "enabled": true,
      "baselineEnabled": true,
      "corruptionEnabled": true,
      "sizeSampleRate": 20,
      "baselineIntervalMs": 604800000,
      "snapshotPersistIntervalMs": 300000,
      "wideBatchKeyThreshold": 4,
      "topWrittenKeysLimit": 10,
      "recentWideBatchesLimit": 20,
      "largestKeysPerBatchLimit": 5
    },
    "updatedAt": 1782760000000,
    "totalQueuedUpdates": 2480,
    "totalPersistedBatches": 620,
    "topWrittenKeys": [
      {
        "key": "PreferencesController",
        "queuedUpdates": 620,
        "persistedWrites": 620,
        "lastSizeBucket": "lt_4kb",
        "maxSizeBucket": "lt_4kb"
      },
      {
        "key": "MultichainBalancesController",
        "queuedUpdates": 496,
        "persistedWrites": 496,
        "lastSizeBucket": "16kb_64kb",
        "maxSizeBucket": "64kb_256kb"
      },
      {
        "key": "KeyringController",
        "queuedUpdates": 3,
        "persistedWrites": 3,
        "lastSizeBucket": "4kb_16kb",
        "maxSizeBucket": "4kb_16kb"
      }
    ],
    "recentWideBatches": [
      {
        "keys": [
          "PreferencesController",
          "MultichainBalancesController",
          "AccountTreeController",
          "SubjectMetadataController"
        ],
        "keyCount": 4,
        "totalSizeBucket": "64kb_256kb",
        "largestKeys": [
          {
            "key": "MultichainBalancesController",
            "sizeBucket": "64kb_256kb"
          },
          {
            "key": "SubjectMetadataController",
            "sizeBucket": "16kb_64kb"
          },
          {
            "key": "AccountTreeController",
            "sizeBucket": "4kb_16kb"
          },
          {
            "key": "PreferencesController",
            "sizeBucket": "lt_4kb"
          }
        ]
      }
    ],
    "readDiagnostics": {
      "manifestStatus": "readable",
      "manifestKeyCount": 42,
      "readableKeys": [
        "KeyringController",
        "PreferencesController",
        "AccountTreeController"
      ],
      "missingKeys": [],
      "failedKeys": [
        {
          "key": "MultichainBalancesController",
          "errorName": "Error",
          "errorMessage": "IO error: ... block checksum mismatch ..."
        }
      ]
    }
  }
}
```

Example corruption event properties if the manifest itself cannot be read:

```json
{
  "error_type": "inaccessible_database",
  "split_state_persistence_diagnostics": {
    "schemaVersion": 1,
    "config": {
      "enabled": true,
      "baselineEnabled": true,
      "corruptionEnabled": true,
      "sizeSampleRate": 20,
      "baselineIntervalMs": 604800000,
      "snapshotPersistIntervalMs": 300000,
      "wideBatchKeyThreshold": 4,
      "topWrittenKeysLimit": 10,
      "recentWideBatchesLimit": 20,
      "largestKeysPerBatchLimit": 5
    },
    "updatedAt": 1782760000000,
    "totalQueuedUpdates": 2480,
    "totalPersistedBatches": 620,
    "topWrittenKeys": [
      {
        "key": "PreferencesController",
        "queuedUpdates": 620,
        "persistedWrites": 620,
        "lastSizeBucket": "lt_4kb",
        "maxSizeBucket": "lt_4kb"
      }
    ],
    "recentWideBatches": [],
    "readDiagnostics": {
      "manifestStatus": "failed",
      "readableKeys": [],
      "missingKeys": [],
      "failedKeys": [],
      "manifestError": {
        "errorName": "Error",
        "errorMessage": "IO error: ... block checksum mismatch ..."
      }
    }
  }
}
```

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Configure the `splitStatePersistenceDiagnostics` remote feature flag with `enabled: true`.
2. Run the extension and create or unlock a wallet with MetaMetrics enabled.
3. Make at least one split-state controller update, then wait for persistence to complete.
4. Reload the extension after the weekly baseline gate is eligible.
5. Verify the `Split State Persistence Baseline` Segment event includes `split_state_persistence_diagnostics` with write stats, the normalized `config`, and no controller values.
6. Simulate startup corruption by making one manifest-listed split-state key unreadable or unavailable, then reload the extension.
7. Verify the vault corruption recovery path is shown and the `Vault Corruption Detected` Segment event includes `split_state_persistence_diagnostics` with write stats, the normalized `config`, and per-key read diagnostics.
8. Disable or remove the remote feature flag and verify diagnostics are no longer collected or attached to events.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## Validation

- `yarn lint:changed:fix`
- `yarn test:unit shared/lib/stores/persistence-diagnostics.test.ts shared/lib/stores/extension-store.test.ts shared/lib/stores/persistence-manager.test.ts app/scripts/lib/state-corruption/track-vault-corruption.test.ts app/scripts/lib/setup-initial-state-hooks.test.ts --runInBand`
