### PR TITLE
refactor(6925): remove legacy route messenger and migrate defaultProps

### DIFF
--- a/.storybook/i18n.js
+++ b/.storybook/i18n.js
@@ -5,18 +5,14 @@ import { I18nContext } from '../ui/contexts/i18n';
 
 export { I18nContext };
 
-export const I18nProvider = (props) => {
-  const { currentLocale, current, en } = props;
-
+export const I18nProvider = ({ currentLocale, current, en, children }) => {
   const t = useMemo(() => {
     return (key, ...args) =>
       getMessage(currentLocale, current, key, ...args) ||
       getMessage(currentLocale, en, key, ...args);
   }, [currentLocale, current, en]);
 
-  return (
-    <I18nContext.Provider value={t}>{props.children}</I18nContext.Provider>
-  );
+  return <I18nContext.Provider value={t}>{children}</I18nContext.Provider>;
 };
 
 I18nProvider.propTypes = {
@@ -24,8 +20,4 @@ I18nProvider.propTypes = {
   current: PropTypes.object,
   en: PropTypes.object,
   children: PropTypes.node,
-};
-
-I18nProvider.defaultProps = {
-  children: undefined,
 };

--- a/test/jest/console-baseline-reporter.js
+++ b/test/jest/console-baseline-reporter.js
@@ -48,7 +48,6 @@ const prettier = require('prettier');
 const {
   categorizeUnitTestMessage,
   categorizeIntegrationTestMessage,
-  createFallbackCategory,
 } = require('./console-categorizer');
 
 /**
@@ -285,7 +284,7 @@ class ConsoleBaselineReporter {
    *
    * @param {string} type - Console message type (log, warn, error, etc.)
    * @param {string} text - Console message text
-   * @returns {string} Category name for this message
+   * @returns {string|null} Category name, or null if the rule set suppressed this message
    */
   #categorizeMessage(type, text) {
     let categorizer;
@@ -301,10 +300,7 @@ class ConsoleBaselineReporter {
 
     const category = categorizer(type, text);
 
-    // If category is null (suppressed by rules), use fallback for baseline tracking
-    if (category === null) {
-      return createFallbackCategory(type, text);
-    }
+    // group: null rules suppress this message — skip baseline tracking.
     return category;
   }
 
@@ -333,6 +329,11 @@ class ConsoleBaselineReporter {
       for (const msg of testResult.console) {
         if (msg.type === 'warn' || msg.type === 'error') {
           const category = this.#categorizeMessage(msg.type, msg.message);
+
+          // Suppressed by a group: null rule — do not track in baseline.
+          if (category === null) {
+            continue;
+          }
 
           if (!this.warningsByFile[filePath][category]) {
             this.warningsByFile[filePath][category] = 0;

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -243,6 +243,9 @@
       "React: Act warnings (component updates not wrapped)": 10,
       "React: componentWill* lifecycle deprecations": 1
     },
+    "ui/components/app/connected-accounts-permissions/connected-accounts-permissions.test.tsx": {
+      "React: DOM nesting violations": 1
+    },
     "ui/components/app/identity/backup-and-sync-features-toggles/backup-and-sync-features-toggles.test.tsx": {
       "React: componentWill* lifecycle deprecations": 1,
       "error: Error: MetaMetrics context trackEvent was": 4

--- a/test/jest/console-reporter-rules-integration.js
+++ b/test/jest/console-reporter-rules-integration.js
@@ -145,6 +145,26 @@ module.exports = [
   },
 
   // ===========================================================================
+  // REACT 18 MIGRATION (temporary — will be removed by
+  // https://github.com/MetaMask/MetaMask-planning/issues/6934)
+  // ===========================================================================
+
+  {
+    match: /Warning: ReactDOM\.render is no longer/u,
+    group: null,
+  },
+
+  {
+    match: /Warning: `ReactDOMTestUtils\.act` is deprecated/u,
+    group: null,
+  },
+
+  {
+    match: /Warning: unmountComponentAtNode is deprecated/u,
+    group: null,
+  },
+
+  // ===========================================================================
   // DEPRECATION WARNINGS
   // ===========================================================================
 

--- a/test/jest/console-reporter-rules-unit.js
+++ b/test/jest/console-reporter-rules-unit.js
@@ -279,6 +279,26 @@ module.exports = [
   },
 
   // ===========================================================================
+  // REACT 18 MIGRATION (temporary — will be removed by
+  // https://github.com/MetaMask/MetaMask-planning/issues/6934)
+  // ===========================================================================
+
+  {
+    match: /Warning: ReactDOM\.render is no longer/u,
+    group: null,
+  },
+
+  {
+    match: /Warning: `ReactDOMTestUtils\.act` is deprecated/u,
+    group: null,
+  },
+
+  {
+    match: /Warning: unmountComponentAtNode is deprecated/u,
+    group: null,
+  },
+
+  // ===========================================================================
   // DEPRECATION WARNINGS
   // ===========================================================================
 

--- a/test/lib/render-helpers-navigate.js
+++ b/test/lib/render-helpers-navigate.js
@@ -13,10 +13,7 @@ import { I18nContext } from '../../ui/contexts/i18n';
 import { MetaMetricsContext } from '../../ui/contexts/metametrics';
 import { getMessage } from '../../ui/helpers/utils/i18n-helper';
 import * as enLocaleMessages from '../../app/_locales/en/messages.json';
-import {
-  LegacyRouteMessengerProvider,
-  RouteMessengerContext,
-} from '../../ui/contexts/route-messenger';
+import { RouteMessengerContext } from '../../ui/contexts/route-messenger';
 import { UIMessengerProvider } from '../../ui/contexts/ui-messenger';
 import { MetaMaskTestReduxProvider } from './redux-test-provider';
 import { createMockUIMessenger } from './mock-ui-messenger';
@@ -41,28 +38,21 @@ const createMockMetaMetricsContext = (
  * @param {object} [props.en]
  * @param {import('react').ReactNode} [props.children]
  */
-export const I18nProvider = (props) => {
-  const { currentLocale, current, en: eng } = props;
-
+export const I18nProvider = ({ currentLocale, current, en: eng, children }) => {
   const t = useMemo(() => {
     return (key, ...args) =>
       getMessage(currentLocale, current, key, ...args) ||
       getMessage(currentLocale, eng, key, ...args);
   }, [currentLocale, current, eng]);
 
-  return (
-    <I18nContext.Provider value={t}>{props.children}</I18nContext.Provider>
-  );
+  return <I18nContext.Provider value={t}>{children}</I18nContext.Provider>;
 };
 
 I18nProvider.propTypes = {
   currentLocale: PropTypes.string,
   current: PropTypes.object,
   en: PropTypes.object,
-};
-
-I18nProvider.defaultProps = {
-  children: undefined,
+  children: PropTypes.node,
 };
 
 /**
@@ -128,7 +118,7 @@ export function createProviderWrapper(
   function Wrapper({ children }) {
     const content = routeMessenger ? (
       <RouteMessengerContext.Provider value={routeMessenger}>
-        <LegacyRouteMessengerProvider>{children}</LegacyRouteMessengerProvider>
+        {children}
       </RouteMessengerContext.Provider>
     ) : (
       children

--- a/test/lib/render-helpers.js
+++ b/test/lib/render-helpers.js
@@ -10,18 +10,14 @@ import { setupInitialStore, connectToBackground } from '../../ui';
 import Root from '../../ui/pages';
 
 /** @type {import('react').FC<{ currentLocale?: string; current?: object; en?: object; children?: import('react').ReactNode }>} */
-export const I18nProvider = (props) => {
-  const { currentLocale, current, en: eng } = props;
-
+export const I18nProvider = ({ currentLocale, current, en: eng, children }) => {
   const t = useMemo(() => {
     return (key, ...args) =>
       getMessage(currentLocale, current, key, ...args) ||
       getMessage(currentLocale, eng, key, ...args);
   }, [currentLocale, current, eng]);
 
-  return (
-    <I18nContext.Provider value={t}>{props.children}</I18nContext.Provider>
-  );
+  return <I18nContext.Provider value={t}>{children}</I18nContext.Provider>;
 };
 
 I18nProvider.propTypes = {
@@ -29,10 +25,6 @@ I18nProvider.propTypes = {
   current: PropTypes.object,
   en: PropTypes.object,
   children: PropTypes.node,
-};
-
-I18nProvider.defaultProps = {
-  children: undefined,
 };
 
 export function renderWithLocalization(component) {

--- a/ui/components/app/connected-accounts-permissions/connected-accounts-permissions.js
+++ b/ui/components/app/connected-accounts-permissions/connected-accounts-permissions.js
@@ -34,7 +34,7 @@ const ConnectedAccountsPermissions = ({ permissions }) => {
     setExpanded((_expanded) => !_expanded);
   };
 
-  if (!permissions.length) {
+  if (!permissions?.length) {
     return null;
   }
 
@@ -78,6 +78,7 @@ const ConnectedAccountsPermissions = ({ permissions }) => {
             'connected-accounts-permissions__list-container-expanded',
           )}
           marginTop={4}
+          data-testid="connected-accounts-permissions-list"
         >
           <Text as="h6" variant={TextVariant.bodySm}>
             {t('authorizedPermissions')}:
@@ -109,10 +110,6 @@ ConnectedAccountsPermissions.propTypes = {
       key: PropTypes.string.isRequired,
     }),
   ),
-};
-
-ConnectedAccountsPermissions.defaultProps = {
-  permissions: [],
 };
 
 ConnectedAccountsPermissions.displayName = 'ConnectedAccountsPermissions';

--- a/ui/components/app/connected-accounts-permissions/connected-accounts-permissions.test.tsx
+++ b/ui/components/app/connected-accounts-permissions/connected-accounts-permissions.test.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import configureMockStore from 'redux-mock-store';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import mockState from '../../../../test/data/mock-state.json';
+import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
+import ConnectedAccountsPermissions from './connected-accounts-permissions';
+
+jest.mock('../../../helpers/utils/permission', () => ({
+  getPermissionDescription: jest.fn(
+    ({ permissionName }: { permissionName: string }) => [
+      { label: `Permission: ${permissionName}` },
+    ],
+  ),
+}));
+
+describe('ConnectedAccountsPermissions', () => {
+  const mockStore = configureMockStore()(mockState);
+  const permissionsListTestId = 'connected-accounts-permissions-list';
+
+  it('renders nothing when permissions is empty', () => {
+    const { container } = renderWithProvider(
+      <ConnectedAccountsPermissions permissions={[]} />,
+      mockStore,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders nothing when permissions prop is not provided', () => {
+    const { container } = renderWithProvider(
+      <ConnectedAccountsPermissions />,
+      mockStore,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders the permissions header when permissions are provided', () => {
+    const permissions = [{ key: 'eth_accounts', value: {} }];
+    const { getByText } = renderWithProvider(
+      <ConnectedAccountsPermissions permissions={permissions} />,
+      mockStore,
+    );
+    expect(getByText(messages.permissions.message)).toBeInTheDocument();
+  });
+
+  it('does not show permission list when collapsed (default state)', () => {
+    const permissions = [{ key: 'eth_accounts', value: {} }];
+    const { queryByTestId } = renderWithProvider(
+      <ConnectedAccountsPermissions permissions={permissions} />,
+      mockStore,
+    );
+    expect(queryByTestId(permissionsListTestId)).not.toBeInTheDocument();
+  });
+
+  it('shows permission list when expanded', () => {
+    const permissions = [{ key: 'eth_accounts', value: {} }];
+    const { getByText, getByTestId } = renderWithProvider(
+      <ConnectedAccountsPermissions permissions={permissions} />,
+      mockStore,
+    );
+
+    const header = getByText(messages.permissions.message).closest('button');
+    fireEvent.click(header as HTMLElement);
+
+    expect(getByTestId(permissionsListTestId)).toBeInTheDocument();
+  });
+
+  it('shows permission labels when expanded', () => {
+    const permissions = [{ key: 'eth_accounts', value: {} }];
+    const { getByText } = renderWithProvider(
+      <ConnectedAccountsPermissions permissions={permissions} />,
+      mockStore,
+    );
+
+    const header = getByText(messages.permissions.message).closest('button');
+    fireEvent.click(header as HTMLElement);
+
+    expect(getByText('Permission: eth_accounts')).toBeInTheDocument();
+  });
+
+  it('collapses the permission list when clicked again', () => {
+    const permissions = [{ key: 'eth_accounts', value: {} }];
+    const { getByText, getByTestId, queryByTestId } = renderWithProvider(
+      <ConnectedAccountsPermissions permissions={permissions} />,
+      mockStore,
+    );
+
+    const header = getByText(messages.permissions.message).closest('button');
+    fireEvent.click(header as HTMLElement);
+    expect(getByTestId(permissionsListTestId)).toBeInTheDocument();
+
+    fireEvent.click(header as HTMLElement);
+    expect(queryByTestId(permissionsListTestId)).not.toBeInTheDocument();
+  });
+
+  it('renders multiple permissions when expanded', () => {
+    const permissions = [
+      { key: 'eth_accounts', value: {} },
+      { key: 'snap_getBip44Entropy', value: {} },
+    ];
+    const { getByText } = renderWithProvider(
+      <ConnectedAccountsPermissions permissions={permissions} />,
+      mockStore,
+    );
+
+    const header = getByText(messages.permissions.message).closest('button');
+    fireEvent.click(header as HTMLElement);
+
+    expect(getByText('Permission: eth_accounts')).toBeInTheDocument();
+    expect(getByText('Permission: snap_getBip44Entropy')).toBeInTheDocument();
+  });
+});

--- a/ui/components/app/modals/loading-network-error/loading-network-error.component.js
+++ b/ui/components/app/modals/loading-network-error/loading-network-error.component.js
@@ -1,20 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Modal, { ModalContent } from '../../modal';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
 
-const LoadingNetworkError = (props, context) => {
-  const { t } = context;
-  const { hideModal } = props;
+const LoadingNetworkError = ({ hideModal }) => {
+  const t = useI18nContext();
 
   return (
     <Modal onSubmit={() => hideModal()} submitText={t('tryAgain')}>
       <ModalContent description={t('somethingWentWrong')} />
     </Modal>
   );
-};
-
-LoadingNetworkError.contextTypes = {
-  t: PropTypes.func,
 };
 
 LoadingNetworkError.propTypes = {

--- a/ui/components/app/modals/loading-network-error/loading-network-error.component.test.tsx
+++ b/ui/components/app/modals/loading-network-error/loading-network-error.component.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
+import { enLocale as messages } from '../../../../../test/lib/i18n-helpers';
+import LoadingNetworkError from './loading-network-error.component';
+
+describe('LoadingNetworkError Component', () => {
+  const props = {
+    hideModal: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders without crashing', () => {
+    const { container } = renderWithProvider(
+      <LoadingNetworkError {...props} />,
+    );
+    expect(container).toBeInTheDocument();
+  });
+
+  it('renders the "Try again" submit button', () => {
+    const { getByText } = renderWithProvider(
+      <LoadingNetworkError {...props} />,
+    );
+    expect(getByText(messages.tryAgain.message)).toBeInTheDocument();
+  });
+
+  it('renders the description text', () => {
+    const { getByText } = renderWithProvider(
+      <LoadingNetworkError {...props} />,
+    );
+    expect(getByText(messages.somethingWentWrong.message)).toBeInTheDocument();
+  });
+
+  it('calls hideModal when submit button is clicked', () => {
+    const { getByText } = renderWithProvider(
+      <LoadingNetworkError {...props} />,
+    );
+    fireEvent.click(getByText(messages.tryAgain.message));
+    expect(props.hideModal).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/components/ui/check-box/check-box.component.js
+++ b/ui/components/ui/check-box/check-box.component.js
@@ -21,7 +21,7 @@ export const { CHECKED, INDETERMINATE, UNCHECKED } = CHECKBOX_STATE;
 
 const CheckBox = ({
   className,
-  disabled,
+  disabled = false,
   id,
   onClick,
   checked,
@@ -96,12 +96,6 @@ CheckBox.propTypes = {
    * Data test ID for checkbox Component
    */
   dataTestId: PropTypes.string,
-};
-
-CheckBox.defaultProps = {
-  className: undefined,
-  disabled: false,
-  id: undefined,
 };
 
 export default CheckBox;

--- a/ui/components/ui/check-box/check-box.component.test.tsx
+++ b/ui/components/ui/check-box/check-box.component.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import CheckBox, {
+  CHECKED,
+  INDETERMINATE,
+  UNCHECKED,
+} from './check-box.component';
+
+describe('CheckBox Component', () => {
+  it('renders with CHECKED state', () => {
+    const { getByRole } = render(
+      <CheckBox checked={CHECKED} onClick={jest.fn()} />,
+    );
+    const checkbox = getByRole('checkbox');
+    expect(checkbox).toBeChecked();
+    expect(checkbox).toHaveClass('check-box__checked');
+  });
+
+  it('renders with UNCHECKED state', () => {
+    const { getByRole } = render(
+      <CheckBox checked={UNCHECKED} onClick={jest.fn()} />,
+    );
+    const checkbox = getByRole('checkbox');
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it('renders with INDETERMINATE state', () => {
+    const { getByRole } = render(
+      <CheckBox checked={INDETERMINATE} onClick={jest.fn()} />,
+    );
+    const checkbox = getByRole('checkbox') as HTMLInputElement;
+    expect(checkbox).toHaveProperty('indeterminate', true);
+  });
+
+  it('renders with boolean true for checked', () => {
+    const { getByRole } = render(
+      <CheckBox checked={true} onClick={jest.fn()} />,
+    );
+    const checkbox = getByRole('checkbox');
+    expect(checkbox).toBeChecked();
+  });
+
+  it('renders with boolean false for checked', () => {
+    const { getByRole } = render(
+      <CheckBox checked={false} onClick={jest.fn()} />,
+    );
+    const checkbox = getByRole('checkbox');
+    expect(checkbox).not.toBeChecked();
+  });
+
+  it('calls onClick when clicked', () => {
+    const mockOnClick = jest.fn();
+    const { getByRole } = render(
+      <CheckBox checked={UNCHECKED} onClick={mockOnClick} />,
+    );
+    fireEvent.click(getByRole('checkbox'));
+    expect(mockOnClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not propagate event when onClick is provided', () => {
+    const mockOnClick = jest.fn();
+    const { getByRole } = render(
+      <CheckBox checked={UNCHECKED} onClick={mockOnClick} />,
+    );
+    const checkbox = getByRole('checkbox');
+    const clickEvent = new MouseEvent('click', { bubbles: true });
+    const preventDefaultSpy = jest.spyOn(clickEvent, 'preventDefault');
+    fireEvent(checkbox, clickEvent);
+    expect(preventDefaultSpy).toHaveBeenCalled();
+    expect(mockOnClick).toHaveBeenCalled();
+  });
+
+  it('renders as disabled when disabled prop is true', () => {
+    const { getByRole } = render(
+      <CheckBox checked={UNCHECKED} onClick={jest.fn()} disabled />,
+    );
+    expect(getByRole('checkbox')).toBeDisabled();
+  });
+
+  it('applies custom className', () => {
+    const { getByRole } = render(
+      <CheckBox checked={UNCHECKED} onClick={jest.fn()} className="my-class" />,
+    );
+    expect(getByRole('checkbox')).toHaveClass('my-class');
+  });
+
+  it('renders with id when provided', () => {
+    const { getByRole } = render(
+      <CheckBox checked={UNCHECKED} onClick={jest.fn()} id="my-checkbox" />,
+    );
+    expect(getByRole('checkbox')).toHaveAttribute('id', 'my-checkbox');
+  });
+
+  it('renders with title when provided', () => {
+    const { getByRole } = render(
+      <CheckBox checked={UNCHECKED} onClick={jest.fn()} title="My Title" />,
+    );
+    expect(getByRole('checkbox')).toHaveAttribute('title', 'My Title');
+  });
+
+  it('renders with data-testid when dataTestId is provided', () => {
+    const { getByTestId } = render(
+      <CheckBox
+        checked={UNCHECKED}
+        onClick={jest.fn()}
+        dataTestId="my-checkbox"
+      />,
+    );
+    expect(getByTestId('my-checkbox')).toBeInTheDocument();
+  });
+
+  it('renders with null onClick handler when no onClick is provided', () => {
+    const { getByRole } = render(<CheckBox checked={UNCHECKED} />);
+    const checkbox = getByRole('checkbox');
+    expect(() => fireEvent.click(checkbox)).not.toThrow();
+  });
+});

--- a/ui/components/ui/icon/approve-icon.component.js
+++ b/ui/components/ui/icon/approve-icon.component.js
@@ -28,10 +28,6 @@ const Approve = ({ className, size, color }) => (
   </svg>
 );
 
-Approve.defaultProps = {
-  className: undefined,
-};
-
 Approve.propTypes = {
   /**
    * Additional className

--- a/ui/components/ui/icon/approve-icon.component.test.tsx
+++ b/ui/components/ui/icon/approve-icon.component.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Approve from './approve-icon.component';
+
+describe('Approve Icon Component', () => {
+  const defaultProps = {
+    size: 24,
+    color: '#000000',
+  };
+
+  it('renders without crashing', () => {
+    const { container } = render(<Approve {...defaultProps} />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('applies size to svg width and height', () => {
+    const { container } = render(<Approve {...defaultProps} size={32} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '32');
+    expect(svg).toHaveAttribute('height', '32');
+  });
+
+  it('applies color to stroke and fill paths', () => {
+    const { container } = render(<Approve {...defaultProps} color="#ff0000" />);
+    const svg = container.querySelector('svg');
+    const strokePath = svg?.querySelector('[stroke="#ff0000"]');
+    const fillPath = svg?.querySelector('[fill="#ff0000"]');
+    expect(strokePath).toBeInTheDocument();
+    expect(fillPath).toBeInTheDocument();
+  });
+
+  it('applies className when provided', () => {
+    const { container } = render(
+      <Approve {...defaultProps} className="custom-class" />,
+    );
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveClass('custom-class');
+  });
+
+  it('renders without className when not provided', () => {
+    const { container } = render(<Approve {...defaultProps} />);
+    const svg = container.querySelector('svg');
+    expect(svg).not.toHaveAttribute('class');
+  });
+});

--- a/ui/components/ui/icon/interaction-icon.component.js
+++ b/ui/components/ui/icon/interaction-icon.component.js
@@ -28,10 +28,6 @@ const Interaction = ({ className, size, color }) => (
   </svg>
 );
 
-Interaction.defaultProps = {
-  className: undefined,
-};
-
 Interaction.propTypes = {
   /**
    * Additional className

--- a/ui/components/ui/icon/interaction-icon.component.test.tsx
+++ b/ui/components/ui/icon/interaction-icon.component.test.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Interaction from './interaction-icon.component';
+
+describe('Interaction Icon Component', () => {
+  const defaultProps = {
+    size: 24,
+    color: '#000000',
+  };
+
+  it('renders without crashing', () => {
+    const { container } = render(<Interaction {...defaultProps} />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('applies size to svg width and height', () => {
+    const { container } = render(<Interaction {...defaultProps} size={32} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '32');
+    expect(svg).toHaveAttribute('height', '32');
+  });
+
+  it('applies color to stroke and fill paths', () => {
+    const { container } = render(
+      <Interaction {...defaultProps} color="#ff0000" />,
+    );
+    const svg = container.querySelector('svg');
+    const strokePath = svg?.querySelector('[stroke="#ff0000"]');
+    const fillPath = svg?.querySelector('[fill="#ff0000"]');
+    expect(strokePath).toBeInTheDocument();
+    expect(fillPath).toBeInTheDocument();
+  });
+
+  it('applies className when provided', () => {
+    const { container } = render(
+      <Interaction {...defaultProps} className="custom-class" />,
+    );
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveClass('custom-class');
+  });
+
+  it('renders without className when not provided', () => {
+    const { container } = render(<Interaction {...defaultProps} />);
+    const svg = container.querySelector('svg');
+    expect(svg).not.toHaveAttribute('class');
+  });
+});

--- a/ui/components/ui/icon/preloader/preloader-icon.component.js
+++ b/ui/components/ui/icon/preloader/preloader-icon.component.js
@@ -43,10 +43,6 @@ const Preloader = ({ className, size }) => (
   </svg>
 );
 
-Preloader.defaultProps = {
-  className: undefined,
-};
-
 Preloader.propTypes = {
   className: PropTypes.string,
   size: PropTypes.number.isRequired,

--- a/ui/components/ui/icon/preloader/preloader-icon.component.test.tsx
+++ b/ui/components/ui/icon/preloader/preloader-icon.component.test.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Preloader from './preloader-icon.component';
+
+describe('Preloader Icon Component', () => {
+  it('renders without crashing', () => {
+    const { container } = render(<Preloader size={16} />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('applies size to svg width and height', () => {
+    const { container } = render(<Preloader size={24} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '24');
+    expect(svg).toHaveAttribute('height', '24');
+  });
+
+  it('applies the preloader icon class', () => {
+    const { container } = render(<Preloader size={16} />);
+    expect(container.querySelector('svg')).toHaveClass('preloader__icon');
+  });
+
+  it('applies custom className when provided', () => {
+    const { container } = render(
+      <Preloader size={16} className="custom-class" />,
+    );
+    expect(container.querySelector('svg')).toHaveClass('custom-class');
+  });
+});

--- a/ui/components/ui/icon/receive-icon.component.js
+++ b/ui/components/ui/icon/receive-icon.component.js
@@ -31,10 +31,6 @@ const Receive = ({ className, size, color }) => (
   </svg>
 );
 
-Receive.defaultProps = {
-  className: undefined,
-};
-
 Receive.propTypes = {
   /**
    * Additional className

--- a/ui/components/ui/icon/receive-icon.component.test.tsx
+++ b/ui/components/ui/icon/receive-icon.component.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Receive from './receive-icon.component';
+
+describe('Receive Icon Component', () => {
+  const defaultProps = {
+    size: 24,
+    color: '#000000',
+  };
+
+  it('renders without crashing', () => {
+    const { container } = render(<Receive {...defaultProps} />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('applies size to svg width and height', () => {
+    const { container } = render(<Receive {...defaultProps} size={32} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '32');
+    expect(svg).toHaveAttribute('height', '32');
+  });
+
+  it('applies color to stroke and fill elements', () => {
+    const { container } = render(<Receive {...defaultProps} color="#ff0000" />);
+    const svg = container.querySelector('svg');
+    const strokeElement = svg?.querySelector('[stroke="#ff0000"]');
+    const fillElement = svg?.querySelector('[fill="#ff0000"]');
+    expect(strokeElement).toBeInTheDocument();
+    expect(fillElement).toBeInTheDocument();
+  });
+
+  it('applies className when provided', () => {
+    const { container } = render(
+      <Receive {...defaultProps} className="custom-class" />,
+    );
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveClass('custom-class');
+  });
+
+  it('renders without className when not provided', () => {
+    const { container } = render(<Receive {...defaultProps} />);
+    const svg = container.querySelector('svg');
+    expect(svg).not.toHaveAttribute('class');
+  });
+});

--- a/ui/components/ui/icon/send-icon.component.js
+++ b/ui/components/ui/icon/send-icon.component.js
@@ -23,10 +23,6 @@ const Send = ({ className, size, color }) => (
   </svg>
 );
 
-Send.defaultProps = {
-  className: undefined,
-};
-
 Send.propTypes = {
   /**
    * Additional className

--- a/ui/components/ui/icon/send-icon.component.test.tsx
+++ b/ui/components/ui/icon/send-icon.component.test.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Send from './send-icon.component';
+
+describe('Send Icon Component', () => {
+  const defaultProps = {
+    size: 24,
+    color: '#000000',
+  };
+
+  it('renders without crashing', () => {
+    const { container } = render(<Send {...defaultProps} />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('applies size to svg width and height', () => {
+    const { container } = render(<Send {...defaultProps} size={32} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '32');
+    expect(svg).toHaveAttribute('height', '32');
+  });
+
+  it('applies color to stroke and fill paths', () => {
+    const { container } = render(<Send {...defaultProps} color="#ff0000" />);
+    const svg = container.querySelector('svg');
+    expect(svg?.querySelector('[stroke="#ff0000"]')).toBeInTheDocument();
+    expect(svg?.querySelector('[fill="#ff0000"]')).toBeInTheDocument();
+  });
+
+  it('applies className when provided', () => {
+    const { container } = render(
+      <Send {...defaultProps} className="custom-class" />,
+    );
+    expect(container.querySelector('svg')).toHaveClass('custom-class');
+  });
+
+  it('renders without className when not provided', () => {
+    const { container } = render(<Send {...defaultProps} />);
+    expect(container.querySelector('svg')).not.toHaveAttribute('class');
+  });
+});

--- a/ui/components/ui/icon/swap-icon-for-list.component.js
+++ b/ui/components/ui/icon/swap-icon-for-list.component.js
@@ -28,10 +28,6 @@ const Swap = ({ className, size, color }) => (
   </svg>
 );
 
-Swap.defaultProps = {
-  className: undefined,
-};
-
 Swap.propTypes = {
   /**
    * Additional className

--- a/ui/components/ui/icon/swap-icon-for-list.component.test.tsx
+++ b/ui/components/ui/icon/swap-icon-for-list.component.test.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import Swap from './swap-icon-for-list.component';
+
+describe('Swap Icon For List Component', () => {
+  const defaultProps = {
+    size: 24,
+    color: '#000000',
+  };
+
+  it('renders without crashing', () => {
+    const { container } = render(<Swap {...defaultProps} />);
+    expect(container.querySelector('svg')).toBeInTheDocument();
+  });
+
+  it('applies size to svg width and height', () => {
+    const { container } = render(<Swap {...defaultProps} size={32} />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '32');
+    expect(svg).toHaveAttribute('height', '32');
+  });
+
+  it('applies color to stroke and fill paths', () => {
+    const { container } = render(<Swap {...defaultProps} color="#ff0000" />);
+    const svg = container.querySelector('svg');
+    const strokePath = svg?.querySelector('[stroke="#ff0000"]');
+    const fillPath = svg?.querySelector('[fill="#ff0000"]');
+    expect(strokePath).toBeInTheDocument();
+    expect(fillPath).toBeInTheDocument();
+  });
+
+  it('applies className when provided', () => {
+    const { container } = render(
+      <Swap {...defaultProps} className="custom-class" />,
+    );
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveClass('custom-class');
+  });
+
+  it('renders without className when not provided', () => {
+    const { container } = render(<Swap {...defaultProps} />);
+    const svg = container.querySelector('svg');
+    expect(svg).not.toHaveAttribute('class');
+  });
+});

--- a/ui/components/ui/menu/menu.js
+++ b/ui/components/ui/menu/menu.js
@@ -59,13 +59,7 @@ Menu.propTypes = {
   className: PropTypes.string,
   onHide: PropTypes.func.isRequired,
   popperOptions: PropTypes.object,
-  dataTestId: PropTypes.string,
-};
-
-Menu.defaultProps = {
-  anchorElement: undefined,
-  className: undefined,
-  popperOptions: undefined,
+  'data-testid': PropTypes.string,
 };
 
 export default Menu;

--- a/ui/components/ui/menu/menu.test.tsx
+++ b/ui/components/ui/menu/menu.test.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import Menu from './menu';
+
+jest.mock('react-popper', () => ({
+  usePopper: jest.fn(() => ({
+    attributes: { popper: {} },
+    styles: { popper: {} },
+  })),
+}));
+
+describe('Menu Component', () => {
+  let portalContainer: HTMLDivElement;
+
+  beforeEach(() => {
+    portalContainer = document.createElement('div');
+    portalContainer.setAttribute('id', 'popover-content');
+    document.body.appendChild(portalContainer);
+  });
+
+  afterEach(() => {
+    document.body.removeChild(portalContainer);
+  });
+
+  const defaultProps = {
+    onHide: jest.fn(),
+    children: <div data-testid="menu-child">Menu Content</div>,
+  } as React.ComponentProps<typeof Menu>;
+
+  it('renders children in the portal', () => {
+    const { getByTestId } = render(<Menu {...defaultProps} />);
+    expect(getByTestId('menu-child')).toBeInTheDocument();
+  });
+
+  it('renders the backdrop element', () => {
+    render(<Menu {...defaultProps} />);
+    const backdrop = document.body.querySelector('.menu__background');
+    expect(backdrop).toBeInTheDocument();
+  });
+
+  it('calls onHide when backdrop is clicked', () => {
+    const mockOnHide = jest.fn();
+    render(<Menu {...defaultProps} onHide={mockOnHide} />);
+    const backdrop = document.body.querySelector('.menu__background');
+    fireEvent.click(backdrop as Element);
+    expect(mockOnHide).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders the menu container with default class', () => {
+    render(<Menu {...defaultProps} />);
+    const menuContainer = document.body.querySelector('.menu__container');
+    expect(menuContainer).toBeInTheDocument();
+  });
+
+  it('applies className to menu container', () => {
+    render(<Menu {...defaultProps} className="custom-menu" />);
+    const menuContainer = document.body.querySelector('.menu__container');
+    expect(menuContainer).toHaveClass('custom-menu');
+  });
+
+  it('sets data-testid on backdrop when provided', () => {
+    const { getByTestId } = render(
+      <Menu {...defaultProps} data-testid="test-menu" />,
+    );
+    expect(getByTestId('test-menu')).toBeInTheDocument();
+  });
+});

--- a/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
+++ b/ui/components/ui/sender-to-recipient/sender-to-recipient.component.js
@@ -112,8 +112,8 @@ export default function SenderToRecipient({
   addressOnly,
   senderName,
   recipientAddress,
-  variant,
-  warnUserOnAccountMismatch,
+  variant = DEFAULT_VARIANT,
+  warnUserOnAccountMismatch = true,
   chainId,
 }) {
   const t = useI18nContext();
@@ -148,11 +148,6 @@ export default function SenderToRecipient({
     </div>
   );
 }
-
-SenderToRecipient.defaultProps = {
-  variant: DEFAULT_VARIANT,
-  warnUserOnAccountMismatch: true,
-};
 
 SenderToRecipient.propTypes = {
   senderName: PropTypes.string,

--- a/ui/components/ui/sender-to-recipient/sender-to-recipient.component.test.tsx
+++ b/ui/components/ui/sender-to-recipient/sender-to-recipient.component.test.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
+import SenderToRecipient from './sender-to-recipient.component';
+import { CARDS_VARIANT } from './sender-to-recipient.constants';
+
+jest.mock('../../app/name/name', () => () => (
+  <div data-testid="recipient-name" />
+));
+
+jest.mock('../../app/preferred-avatar', () => ({
+  PreferredAvatar: () => <div data-testid="preferred-avatar" />,
+}));
+
+jest.mock(
+  '../account-mismatch-warning/account-mismatch-warning.component',
+  () => () => <div data-testid="account-mismatch-warning" />,
+);
+
+const SENDER_ADDRESS = '0x1234567890123456789012345678901234567890';
+const RECIPIENT_ADDRESS = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+
+describe('SenderToRecipient', () => {
+  it('uses default variant and mismatch warning when props are omitted', () => {
+    const { getByTestId, container } = renderWithProvider(
+      <SenderToRecipient
+        senderAddress={SENDER_ADDRESS}
+        recipientAddress={RECIPIENT_ADDRESS}
+        senderName="Alice"
+      />,
+    );
+
+    expect(getByTestId('sender-to-recipient')).toHaveClass(
+      'sender-to-recipient--default',
+    );
+    expect(getByTestId('account-mismatch-warning')).toBeInTheDocument();
+    expect(
+      container.querySelector('.sender-to-recipient__arrow-circle'),
+    ).toBeInTheDocument();
+    expect(getByTestId('recipient-name')).toBeInTheDocument();
+  });
+
+  it('renders non-default variant and new contract when recipient is missing', () => {
+    const { getByTestId, getByText, queryByTestId } = renderWithProvider(
+      <SenderToRecipient
+        senderAddress={SENDER_ADDRESS}
+        senderName="Alice"
+        variant={CARDS_VARIANT}
+        warnUserOnAccountMismatch={false}
+      />,
+    );
+
+    expect(getByTestId('sender-to-recipient')).toHaveClass(
+      'sender-to-recipient--cards',
+    );
+    expect(queryByTestId('account-mismatch-warning')).not.toBeInTheDocument();
+    expect(getByText(messages.newContract.message)).toBeInTheDocument();
+  });
+});

--- a/ui/components/ui/slider/slider.component.js
+++ b/ui/components/ui/slider/slider.component.js
@@ -49,7 +49,7 @@ const sliderSx = {
 };
 
 const Slider = ({
-  editText,
+  editText = 'Edit',
   infoText,
   onEdit,
   titleDetail,
@@ -103,10 +103,6 @@ const Slider = ({
     </div>
   </div>
 );
-
-Slider.defaultProps = {
-  editText: 'Edit',
-};
 
 Slider.propTypes = {
   /**

--- a/ui/components/ui/text-field/text-field.component.js
+++ b/ui/components/ui/text-field/text-field.component.js
@@ -160,12 +160,12 @@ const themeToInputProps = {
 
 const TextField = ({
   'data-testid': dataTestId,
-  error,
-  theme,
+  error = null,
+  theme = 'bordered',
   startAdornment,
   endAdornment,
   largeLabel,
-  dir,
+  dir = 'auto',
   min,
   max,
   autoComplete,
@@ -201,12 +201,6 @@ const TextField = ({
       {...textFieldProps}
     />
   );
-};
-
-TextField.defaultProps = {
-  error: null,
-  dir: 'auto',
-  theme: 'bordered',
 };
 
 TextField.propTypes = {

--- a/ui/components/ui/token-balance/token-balance.js
+++ b/ui/components/ui/token-balance/token-balance.js
@@ -11,7 +11,7 @@ import {
 } from '../../../helpers/constants/design-system';
 
 export default function TokenBalance({
-  className,
+  className = undefined,
   token,
   showFiat,
   ...restProps
@@ -46,8 +46,4 @@ TokenBalance.propTypes = {
     symbol: PropTypes.string,
   }).isRequired,
   showFiat: PropTypes.bool,
-};
-
-TokenBalance.defaultProps = {
-  className: undefined,
 };

--- a/ui/contexts/route-messenger.ts
+++ b/ui/contexts/route-messenger.ts
@@ -1,5 +1,4 @@
-import React, { Component, createContext, useContext } from 'react';
-import PropTypes from 'prop-types';
+import { createContext, useContext } from 'react';
 
 import { RouteMessenger } from '../messengers/route-messenger';
 
@@ -26,38 +25,4 @@ export function useRouteMessenger(): RouteMessenger {
   }
 
   return messenger;
-}
-
-/**
- * Utility component which provides messengers to routes. Designed specifically
- * for legacy class components.
- *
- * @see {@link RouteWithMessenger}
- */
-export class LegacyRouteMessengerProvider extends Component<{
-  children?: React.ReactNode;
-}> {
-  static propTypes = {
-    children: PropTypes.node,
-  };
-
-  static defaultProps = {
-    children: undefined,
-  };
-
-  static contextType = RouteMessengerContext;
-
-  static childContextTypes = {
-    messenger: PropTypes.object,
-  };
-
-  getChildContext() {
-    return {
-      messenger: this.context,
-    };
-  }
-
-  render() {
-    return this.props.children;
-  }
 }

--- a/ui/layouts/route-with-messenger.tsx
+++ b/ui/layouts/route-with-messenger.tsx
@@ -3,10 +3,7 @@ import {
   UIMessengerActions,
   UIMessengerEvents,
 } from '../messengers/ui-messenger';
-import {
-  LegacyRouteMessengerProvider,
-  RouteMessengerContext,
-} from '../contexts/route-messenger';
+import { RouteMessengerContext } from '../contexts/route-messenger';
 import { useUIMessenger } from '../contexts/ui-messenger';
 import {
   createRouteMessenger,
@@ -57,7 +54,7 @@ export const RouteWithMessenger = ({
 
   return (
     <RouteMessengerContext.Provider value={routeMessenger}>
-      <LegacyRouteMessengerProvider>{children}</LegacyRouteMessengerProvider>
+      {children}
     </RouteMessengerContext.Provider>
   );
 };


### PR DESCRIPTION
Code review comment: https://github.com/MetaMask/metamask-extension/pull/42997/#pullrequestreview-4595280940


Extract pre-React 18 cleanup into a standalone PR: drop `LegacyRouteMessengerProvider`, replace function-component `defaultProps` with default parameters, add colocated unit tests, and suppress React 18 migration console warnings via reporter rules until createRoot lands

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: Partial https://github.com/MetaMask/MetaMask-planning/issues/6925

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly test infrastructure and React API modernization with behavior-preserving default handling; route messenger removal only affects legacy childContext consumers, which were removed from the tree.
> 
> **Overview**
> Pre–React 18 cleanup: removes **`LegacyRouteMessengerProvider`** and its usage in **`RouteWithMessenger`** and test render helpers, so routes rely only on **`RouteMessengerContext`** and **`useRouteMessenger`**.
> 
> **Function components** drop **`defaultProps`** in favor of **default parameters** (e.g. **`CheckBox`**, **`TextField`**, **`SenderToRecipient`**, icons, **`Slider`**, **`TokenBalance`**). **`LoadingNetworkError`** moves from legacy **`contextTypes`** to **`useI18nContext`**. **`ConnectedAccountsPermissions`** treats missing **`permissions`** safely (`permissions?.length`) and adds a list **`data-testid`**.
> 
> **Jest console baselines** now **skip** messages matched by rules with **`group: null`** (instead of inventing fallback categories); temporary **React 18 deprecation** rules (`ReactDOM.render`, **`ReactDOMTestUtils.act`**, **`unmountComponentAtNode`**) are added for unit and integration tests. **Colocated unit tests** are added for the touched UI components and helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ed5c5f3187e96e6effabc7c11f6aa1cef09ed10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->