### PR TITLE
fix: hw modal showed when the selected account is hw but the request …

### DIFF
--- a/ui/contexts/hardware-wallets/HardwareWalletContext.test.tsx
+++ b/ui/contexts/hardware-wallets/HardwareWalletContext.test.tsx
@@ -135,7 +135,8 @@ describe('HardwareWalletContext', () => {
 
   describe('HardwareWalletProvider', () => {
     it('provides initial state for non-hardware wallet account', () => {
-      const store = mockStore(createMockState(KeyringTypes.hd));
+      const accountAddress = '0xabc';
+      const store = mockStore(createMockState(KeyringTypes.hd, accountAddress));
 
       const { result } = renderHook(() => useHardwareWallet(), {
         wrapper: createWrapper(store),
@@ -143,6 +144,7 @@ describe('HardwareWalletContext', () => {
 
       expect(result.current.isHardwareWalletAccount).toBe(false);
       expect(result.current.walletType).toBe(null);
+      expect(result.current.accountAddress).toBe(accountAddress);
       expect(result.current.connectionState.status).toBe(
         ConnectionStatus.Disconnected,
       );
@@ -250,7 +252,10 @@ describe('HardwareWalletContext', () => {
 
   describe('useHardwareWalletConfig hook', () => {
     it('provides config context with correct values', () => {
-      const store = mockStore(createMockState(KeyringTypes.ledger));
+      const accountAddress = '0xabc';
+      const store = mockStore(
+        createMockState(KeyringTypes.ledger, accountAddress),
+      );
 
       const { result } = renderHook(() => useHardwareWalletConfig(), {
         wrapper: createWrapper(store),
@@ -258,6 +263,7 @@ describe('HardwareWalletContext', () => {
 
       expect(result.current.isHardwareWalletAccount).toBe(true);
       expect(result.current.walletType).toBe(HardwareWalletType.Ledger);
+      expect(result.current.accountAddress).toBe(accountAddress);
       expect(result.current.hardwareConnectionPermissionState).toBe(
         HardwareConnectionPermissionState.Unknown,
       );

--- a/ui/contexts/hardware-wallets/HardwareWalletContext.tsx
+++ b/ui/contexts/hardware-wallets/HardwareWalletContext.tsx
@@ -26,6 +26,7 @@ import { isWebHidAvailable, isWebUsbAvailable } from './webConnectionUtils';
 export type HardwareWalletConfigContextType = {
   isHardwareWalletAccount: boolean;
   walletType: HardwareWalletType | null;
+  accountAddress: string | null;
   hardwareConnectionPermissionState: HardwareConnectionPermissionState;
   isWebHidAvailable: boolean;
   isWebUsbAvailable: boolean;
@@ -56,6 +57,7 @@ export type HardwareWalletContextType = {
   // State (may cause rerenders)
   isHardwareWalletAccount: boolean;
   walletType: HardwareWalletType | null;
+  accountAddress: string | null;
   connectionState: HardwareWalletConnectionState;
   hardwareConnectionPermissionState: HardwareConnectionPermissionState;
   isWebHidAvailable: boolean;
@@ -162,6 +164,7 @@ export const HardwareWalletProvider = ({
     connectionState,
     walletType,
     isHardwareWalletAccount,
+    accountAddress,
   } = state;
 
   const {
@@ -303,6 +306,7 @@ export const HardwareWalletProvider = ({
       // State
       isHardwareWalletAccount,
       walletType,
+      accountAddress,
       connectionState,
       hardwareConnectionPermissionState,
       isWebHidAvailable: isWebHidAvailableState,
@@ -322,6 +326,7 @@ export const HardwareWalletProvider = ({
     [
       isHardwareWalletAccount,
       walletType,
+      accountAddress,
       connectionState,
       hardwareConnectionPermissionState,
       isWebHidAvailableState,
@@ -335,6 +340,7 @@ export const HardwareWalletProvider = ({
     () => ({
       isHardwareWalletAccount,
       walletType,
+      accountAddress,
       hardwareConnectionPermissionState,
       isWebHidAvailable: isWebHidAvailableState,
       isWebUsbAvailable: isWebUsbAvailableState,
@@ -342,6 +348,7 @@ export const HardwareWalletProvider = ({
     [
       isHardwareWalletAccount,
       walletType,
+      accountAddress,
       hardwareConnectionPermissionState,
       isWebHidAvailableState,
       isWebUsbAvailableState,

--- a/ui/contexts/hardware-wallets/useHardwareFooter.test.ts
+++ b/ui/contexts/hardware-wallets/useHardwareFooter.test.ts
@@ -41,6 +41,9 @@ jest.mock('./rpcErrorUtils', () => ({
 }));
 
 const mockUseHardwareWalletMetrics = jest.mocked(useHardwareWalletMetrics);
+const HARDWARE_ACCOUNT_ADDRESS = '0x1111111111111111111111111111111111111111';
+const NON_HARDWARE_ACCOUNT_ADDRESS =
+  '0x2222222222222222222222222222222222222222';
 
 describe('useHardwareFooter', () => {
   let mockConnectionState: { status: ConnectionStatus };
@@ -78,6 +81,7 @@ describe('useHardwareFooter', () => {
     (useHardwareWalletConfig as jest.Mock).mockReturnValue({
       isHardwareWalletAccount: true,
       walletType: HardwareWalletType.Ledger,
+      accountAddress: HARDWARE_ACCOUNT_ADDRESS,
       hardwareConnectionPermissionState:
         HardwareConnectionPermissionState.Unknown,
     });
@@ -119,9 +123,11 @@ describe('useHardwareFooter', () => {
   const renderUseHardwareFooter = ({
     currentConfirmation = createConfirmation(TransactionType.simpleSend),
     currentConfirmationId = 'confirmation-id',
+    fromAddress = HARDWARE_ACCOUNT_ADDRESS,
   }: {
     currentConfirmation?: TransactionMeta;
     currentConfirmationId?: string;
+    fromAddress?: string;
   } = {}) =>
     renderHook(
       (props) =>
@@ -134,6 +140,7 @@ describe('useHardwareFooter', () => {
         initialProps: {
           currentConfirmation,
           currentConfirmationId,
+          fromAddress,
         },
       },
     );
@@ -143,10 +150,23 @@ describe('useHardwareFooter', () => {
       (useHardwareWalletConfig as jest.Mock).mockReturnValue({
         isHardwareWalletAccount: false,
         walletType: null,
+        accountAddress: null,
       });
       mockConnectionState.status = ConnectionStatus.Disconnected;
 
       const { result } = renderUseHardwareFooter();
+
+      expect(result.current.walletType).toBeNull();
+      expect(result.current.shouldRunHardwareWalletPreflight).toBe(false);
+      expect(result.current.isHardwareWalletReady).toBe(true);
+    });
+
+    it('returns preflight disabled when selected hardware account does not match confirmation sender', () => {
+      mockConnectionState.status = ConnectionStatus.Disconnected;
+
+      const { result } = renderUseHardwareFooter({
+        fromAddress: NON_HARDWARE_ACCOUNT_ADDRESS,
+      });
 
       expect(result.current.walletType).toBeNull();
       expect(result.current.shouldRunHardwareWalletPreflight).toBe(false);
@@ -192,6 +212,7 @@ describe('useHardwareFooter', () => {
       (useHardwareWalletConfig as jest.Mock).mockReturnValue({
         isHardwareWalletAccount: true,
         walletType: HardwareWalletType.Qr,
+        accountAddress: HARDWARE_ACCOUNT_ADDRESS,
         hardwareConnectionPermissionState:
           HardwareConnectionPermissionState.Granted,
       });
@@ -206,6 +227,7 @@ describe('useHardwareFooter', () => {
       (useHardwareWalletConfig as jest.Mock).mockReturnValue({
         isHardwareWalletAccount: true,
         walletType: HardwareWalletType.Qr,
+        accountAddress: HARDWARE_ACCOUNT_ADDRESS,
         hardwareConnectionPermissionState:
           HardwareConnectionPermissionState.Prompt,
       });
@@ -220,6 +242,7 @@ describe('useHardwareFooter', () => {
       (useHardwareWalletConfig as jest.Mock).mockReturnValue({
         isHardwareWalletAccount: true,
         walletType: HardwareWalletType.Qr,
+        accountAddress: HARDWARE_ACCOUNT_ADDRESS,
         hardwareConnectionPermissionState:
           HardwareConnectionPermissionState.Unknown,
       });
@@ -234,6 +257,7 @@ describe('useHardwareFooter', () => {
       (useHardwareWalletConfig as jest.Mock).mockReturnValue({
         isHardwareWalletAccount: true,
         walletType: HardwareWalletType.Ledger,
+        accountAddress: HARDWARE_ACCOUNT_ADDRESS,
         hardwareConnectionPermissionState:
           HardwareConnectionPermissionState.Granted,
       });
@@ -318,6 +342,7 @@ describe('useHardwareFooter', () => {
         useHardwareFooter({
           currentConfirmation: createConfirmation(TransactionType.simpleSend),
           currentConfirmationId: 'confirmation-id',
+          fromAddress: HARDWARE_ACCOUNT_ADDRESS,
           onUserRejectedHardwareWalletError:
             mockOnUserRejectedHardwareWalletError,
         }),
@@ -339,6 +364,7 @@ describe('useHardwareFooter', () => {
         useHardwareFooter({
           currentConfirmation: createConfirmation(TransactionType.simpleSend),
           currentConfirmationId: 'confirmation-id',
+          fromAddress: HARDWARE_ACCOUNT_ADDRESS,
           onUserRejectedHardwareWalletError:
             mockOnUserRejectedHardwareWalletError,
         }),
@@ -371,6 +397,7 @@ describe('useHardwareFooter', () => {
         rerender({
           currentConfirmation: createConfirmation(TransactionType.simpleSend),
           currentConfirmationId: 'confirmation-2',
+          fromAddress: HARDWARE_ACCOUNT_ADDRESS,
         });
       });
 
@@ -396,6 +423,7 @@ describe('useHardwareFooter', () => {
         rerender({
           currentConfirmation: createConfirmation(TransactionType.simpleSend),
           currentConfirmationId: 'confirmation-id',
+          fromAddress: HARDWARE_ACCOUNT_ADDRESS,
         });
       });
 

--- a/ui/contexts/hardware-wallets/useHardwareFooter.ts
+++ b/ui/contexts/hardware-wallets/useHardwareFooter.ts
@@ -94,8 +94,8 @@ export const useHardwareFooter = ({
     isSelectedHardwareWalletAccount &&
     Boolean(
       accountAddress &&
-        fromAddress &&
-        isEqualCaseInsensitive(accountAddress, fromAddress),
+      fromAddress &&
+      isEqualCaseInsensitive(accountAddress, fromAddress),
     );
   const walletType = isHardwareWalletAccount ? selectedWalletType : null;
 

--- a/ui/contexts/hardware-wallets/useHardwareFooter.ts
+++ b/ui/contexts/hardware-wallets/useHardwareFooter.ts
@@ -5,6 +5,7 @@ import {
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { isCorrectDeveloperTransactionType } from '../../../shared/lib/confirmation.utils';
 import { isFirefoxBrowser } from '../../../shared/lib/browser-runtime.utils';
+import { isEqualCaseInsensitive } from '../../../shared/lib/string-utils';
 import { isSignatureTransactionType } from '../../pages/confirmations/utils';
 import {
   useHardwareWalletActions,
@@ -26,6 +27,7 @@ import { useHardwareWalletMetrics } from './useHardwareWalletMetrics';
 type UseHardwareFooterArgs = {
   currentConfirmation?: TransactionMeta;
   currentConfirmationId?: string;
+  fromAddress?: string;
   onUserRejectedHardwareWalletError: () => Promise<void>;
 };
 
@@ -67,13 +69,18 @@ type UseHardwareFooterResult = {
 export const useHardwareFooter = ({
   currentConfirmation,
   currentConfirmationId,
+  fromAddress,
   onUserRejectedHardwareWalletError,
 }: UseHardwareFooterArgs): UseHardwareFooterResult => {
   const { trackConnectCtaClicked } = useHardwareWalletMetrics();
   const inE2e =
     process.env.IN_TEST && process.env.JEST_WORKER_ID === 'undefined';
   const { connectionState } = useHardwareWalletState();
-  const { isHardwareWalletAccount, walletType } = useHardwareWalletConfig();
+  const {
+    accountAddress,
+    isHardwareWalletAccount: isSelectedHardwareWalletAccount,
+    walletType: selectedWalletType,
+  } = useHardwareWalletConfig();
   const { ensureDeviceReady } = useHardwareWalletActions();
   const { showErrorModal } = useHardwareWalletError();
   const [hasPreflightSucceeded, setHasPreflightSucceeded] = useState(false);
@@ -82,6 +89,15 @@ export const useHardwareFooter = ({
   const isTransactionConfirmation = isCorrectDeveloperTransactionType(
     currentConfirmation?.type,
   );
+
+  const isHardwareWalletAccount =
+    isSelectedHardwareWalletAccount &&
+    Boolean(
+      accountAddress &&
+        fromAddress &&
+        isEqualCaseInsensitive(accountAddress, fromAddress),
+    );
+  const walletType = isHardwareWalletAccount ? selectedWalletType : null;
 
   const shouldRunHardwareWalletPreflight =
     !inE2e &&

--- a/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.test.tsx
@@ -14,6 +14,7 @@ import {
   getMockTypedSignConfirmStateForRequest,
 } from '../../../../../../test/data/confirmations/helper';
 import {
+  PERSONAL_SIGN_SENDER_ADDRESS,
   signatureRequestSIWE,
   unapprovedPersonalSignMsg,
 } from '../../../../../../test/data/confirmations/personal_sign';
@@ -67,6 +68,8 @@ const mockIsUserRejectedHardwareWalletError = jest.fn();
 const mockGetEnvironmentType = jest.fn();
 const mockNavigateNext = jest.fn();
 const mockNavigateToId = jest.fn();
+const HARDWARE_CONFIRMATION_SENDER =
+  '0xc42edfcc21ed14dda456aa0756c153f7985d8813';
 
 const mockTrackHardwareWalletRecoveryConnectCtaClicked = jest.mocked(
   trackHardwareWalletRecoveryConnectCtaClicked,
@@ -268,6 +271,7 @@ describe('ConfirmFooter', () => {
     mockUseHardwareWalletConfig.mockReturnValue({
       isHardwareWalletAccount: false,
       walletType: null,
+      accountAddress: null,
     });
     mockUseHardwareWalletActions.mockReturnValue({
       ensureDeviceReady: ensureDeviceReadyMock,
@@ -563,6 +567,7 @@ describe('ConfirmFooter', () => {
     mockUseHardwareWalletConfig.mockReturnValue({
       isHardwareWalletAccount: true,
       walletType: HardwareWalletType.Ledger,
+      accountAddress: PERSONAL_SIGN_SENDER_ADDRESS,
     });
     mockUseHardwareWalletState.mockReturnValue({
       connectionState: { status: ConnectionStatus.Ready },
@@ -596,6 +601,7 @@ describe('ConfirmFooter', () => {
     mockUseHardwareWalletConfig.mockReturnValue({
       isHardwareWalletAccount: true,
       walletType: HardwareWalletType.Ledger,
+      accountAddress: PERSONAL_SIGN_SENDER_ADDRESS,
     });
     mockUseHardwareWalletState.mockReturnValue({
       connectionState: { status: ConnectionStatus.Disconnected },
@@ -629,6 +635,7 @@ describe('ConfirmFooter', () => {
     mockUseHardwareWalletConfig.mockReturnValue({
       isHardwareWalletAccount: true,
       walletType: HardwareWalletType.Ledger,
+      accountAddress: PERSONAL_SIGN_SENDER_ADDRESS,
     });
     mockUseHardwareWalletState.mockReturnValue({
       connectionState: { status: ConnectionStatus.Ready },
@@ -643,6 +650,7 @@ describe('ConfirmFooter', () => {
     mockUseHardwareWalletConfig.mockReturnValue({
       isHardwareWalletAccount: true,
       walletType: HardwareWalletType.Ledger,
+      accountAddress: PERSONAL_SIGN_SENDER_ADDRESS,
     });
     mockUseHardwareWalletState.mockReturnValue({
       connectionState: { status: ConnectionStatus.Ready },
@@ -693,6 +701,7 @@ describe('ConfirmFooter', () => {
       mockUseHardwareWalletConfig.mockReturnValue({
         isHardwareWalletAccount: true,
         walletType: HardwareWalletType.Ledger,
+        accountAddress: PERSONAL_SIGN_SENDER_ADDRESS,
       });
       mockUseHardwareWalletState.mockReturnValue({
         connectionState: { status: ConnectionStatus.Connected },
@@ -713,6 +722,7 @@ describe('ConfirmFooter', () => {
       mockUseHardwareWalletConfig.mockReturnValue({
         isHardwareWalletAccount: true,
         walletType: HardwareWalletType.Ledger,
+        accountAddress: PERSONAL_SIGN_SENDER_ADDRESS,
       });
       mockUseHardwareWalletState.mockReturnValue({
         connectionState: { status: ConnectionStatus.Ready },
@@ -733,6 +743,7 @@ describe('ConfirmFooter', () => {
       mockUseHardwareWalletConfig.mockReturnValue({
         isHardwareWalletAccount: true,
         walletType: HardwareWalletType.Ledger,
+        accountAddress: PERSONAL_SIGN_SENDER_ADDRESS,
       });
       mockUseHardwareWalletState.mockReturnValue({
         connectionState: { status: ConnectionStatus.Disconnected },
@@ -752,6 +763,22 @@ describe('ConfirmFooter', () => {
       expect(queryByTestId('confirm-footer-button')).not.toBeInTheDocument();
     });
 
+    it('renders confirm button when selected hardware wallet does not match confirmation sender', () => {
+      mockUseHardwareWalletConfig.mockReturnValue({
+        isHardwareWalletAccount: true,
+        walletType: HardwareWalletType.Ledger,
+        accountAddress: HARDWARE_CONFIRMATION_SENDER,
+      });
+      mockUseHardwareWalletState.mockReturnValue({
+        connectionState: { status: ConnectionStatus.Disconnected },
+      });
+
+      const { getByTestId, queryByTestId } = render();
+
+      expect(getByTestId('confirm-footer-button')).toBeInTheDocument();
+      expect(queryByTestId('reconnect-hardware-wallet-button')).toBeNull();
+    });
+
     it('tracks hardware wallet recovery CTA when reconnect is clicked', async () => {
       const mockTrackEvent = jest.fn().mockResolvedValue(undefined);
       const connectionState = {
@@ -760,6 +787,7 @@ describe('ConfirmFooter', () => {
       mockUseHardwareWalletConfig.mockReturnValue({
         isHardwareWalletAccount: true,
         walletType: HardwareWalletType.Ledger,
+        accountAddress: PERSONAL_SIGN_SENDER_ADDRESS,
       });
       mockUseHardwareWalletState.mockReturnValue({
         connectionState,
@@ -794,6 +822,7 @@ describe('ConfirmFooter', () => {
       mockUseHardwareWalletConfig.mockReturnValue({
         isHardwareWalletAccount: true,
         walletType: HardwareWalletType.Ledger,
+        accountAddress: PERSONAL_SIGN_SENDER_ADDRESS,
       });
       mockUseHardwareWalletState.mockReturnValue({
         connectionState: { status: ConnectionStatus.Ready },
@@ -822,6 +851,7 @@ describe('ConfirmFooter', () => {
       mockUseHardwareWalletConfig.mockReturnValue({
         isHardwareWalletAccount: true,
         walletType: HardwareWalletType.Ledger,
+        accountAddress: PERSONAL_SIGN_SENDER_ADDRESS,
       });
       mockUseHardwareWalletState.mockReturnValue({
         connectionState: { status: ConnectionStatus.Disconnected },
@@ -871,6 +901,7 @@ describe('ConfirmFooter', () => {
       mockUseHardwareWalletConfig.mockReturnValue({
         isHardwareWalletAccount: true,
         walletType: HardwareWalletType.Ledger,
+        accountAddress: PERSONAL_SIGN_SENDER_ADDRESS,
       });
       mockUseHardwareWalletState.mockReturnValue({
         connectionState: { status: ConnectionStatus.Disconnected },
@@ -893,6 +924,7 @@ describe('ConfirmFooter', () => {
       mockUseHardwareWalletConfig.mockReturnValue({
         isHardwareWalletAccount: true,
         walletType: HardwareWalletType.Ledger,
+        accountAddress: HARDWARE_CONFIRMATION_SENDER,
       });
       mockUseHardwareWalletState.mockReturnValue({
         connectionState: { status: ConnectionStatus.Ready },
@@ -909,7 +941,7 @@ describe('ConfirmFooter', () => {
         getMockPersonalSignConfirmStateForRequest({
           ...unapprovedPersonalSignMsg,
           msgParams: {
-            from: '0xc42edfcc21ed14dda456aa0756c153f7985d8813',
+            from: HARDWARE_CONFIRMATION_SENDER,
           },
         } as SignatureRequestType),
       );
@@ -921,7 +953,7 @@ describe('ConfirmFooter', () => {
       });
 
       expect(resolveSpy).toHaveBeenCalledWith(expect.any(String), undefined, {
-        fromAddress: '0xc42edfcc21ed14dda456aa0756c153f7985d8813',
+        fromAddress: HARDWARE_CONFIRMATION_SENDER,
         waitForResult: true,
         walletType: HardwareWalletType.Ledger,
       });
@@ -936,6 +968,7 @@ describe('ConfirmFooter', () => {
       mockUseHardwareWalletConfig.mockReturnValue({
         isHardwareWalletAccount: true,
         walletType: HardwareWalletType.Ledger,
+        accountAddress: HARDWARE_CONFIRMATION_SENDER,
       });
       mockUseHardwareWalletState.mockReturnValue({
         connectionState: { status: ConnectionStatus.Ready },
@@ -952,7 +985,7 @@ describe('ConfirmFooter', () => {
         getMockPersonalSignConfirmStateForRequest({
           ...unapprovedPersonalSignMsg,
           msgParams: {
-            from: '0xc42edfcc21ed14dda456aa0756c153f7985d8813',
+            from: HARDWARE_CONFIRMATION_SENDER,
           },
         } as SignatureRequestType),
       );
@@ -977,6 +1010,7 @@ describe('ConfirmFooter', () => {
       mockUseHardwareWalletConfig.mockReturnValue({
         isHardwareWalletAccount: true,
         walletType: HardwareWalletType.Ledger,
+        accountAddress: HARDWARE_CONFIRMATION_SENDER,
       });
       mockUseHardwareWalletState.mockReturnValue({
         connectionState: { status: ConnectionStatus.Ready },
@@ -993,7 +1027,7 @@ describe('ConfirmFooter', () => {
         getMockPersonalSignConfirmStateForRequest({
           ...unapprovedPersonalSignMsg,
           msgParams: {
-            from: '0xc42edfcc21ed14dda456aa0756c153f7985d8813',
+            from: HARDWARE_CONFIRMATION_SENDER,
           },
         } as SignatureRequestType),
       );

--- a/ui/pages/confirmations/components/confirm/footer/footer.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/footer.tsx
@@ -289,6 +289,7 @@ const Footer = () => {
   } = useHardwareFooter({
     currentConfirmation,
     currentConfirmationId,
+    fromAddress,
     onUserRejectedHardwareWalletError,
   });
 


### PR DESCRIPTION
…is for non hardware

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This Pr fixes the bug where the hardware modal is being show for non hardware accounts when the selected account is a hardware account. 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: HW model being shown for non hardware accounts when ledger account is selected. 

## **Related issues**

Fixes: 

## **Manual testing steps**

1. Select a ledger account 
2. Go to https://metamask.github.io/test-dapp/
3. Connect only with a eoa account
4. Start a tranasction
5. See that no hw modal is being shown. 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/5fce29e5-ac3e-4a1f-a279-a72ea8ecadac



<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/c136f9cb-982f-416d-8d71-39fdfdb84d96



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes confirmation signing UX and when device preflight runs; logic is localized to useHardwareFooter with new tests, but a wrong address match could block legitimate HW sign flows.
> 
> **Overview**
> Fixes confirmation flows treating **any** pending request as hardware-wallet work when a Ledger (or other HW) account is merely **selected** in the wallet.
> 
> **`accountAddress`** is now exposed on hardware wallet context/config. **`useHardwareFooter`** accepts the confirmation **`fromAddress`** and only enables HW preflight, reconnect CTAs, and related modal suppression when the selected HW account address **matches** the request sender (case-insensitive). Mismatches behave like a normal EOA confirmation (Confirm button, no Connect Ledger).
> 
> The confirm **footer** passes **`fromAddress`** into the hook; tests cover the mismatch case end-to-end.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 910cc558819124f55f7c345fa4134269f58a8e34. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->