### PR TITLE
test: fix flaky test `Send NFT ERC1155 Wallet initiated sends ERC1155`

### DIFF
--- a/test/e2e/benchmarks/flows/user-journey/send-transactions.ts
+++ b/test/e2e/benchmarks/flows/user-journey/send-transactions.ts
@@ -104,7 +104,7 @@ export async function runSendTransactionsBenchmark(): Promise<BenchmarkRunResult
         );
 
         // Measure: Review transaction
-        await sendPage.fillRecipient(RECIPIENT_ADDRESS);
+        await sendPage.fillRecipient({ recipientAddress: RECIPIENT_ADDRESS });
         await sendPage.fillAmount('0.00001');
         await sendPage.pressContinueButton();
         steps.push(

--- a/test/e2e/page-objects/pages/send/send-page.ts
+++ b/test/e2e/page-objects/pages/send/send-page.ts
@@ -43,6 +43,8 @@ class SendPage {
     testId: 'send-network-filter-toggle',
   };
 
+  private readonly recipientClassRendered = '.break-all';
+
   private readonly recipientModalButton = {
     testId: 'open-recipient-modal-btn',
   };
@@ -194,6 +196,7 @@ class SendPage {
   async fillRecipient(recipientAddress: string): Promise<void> {
     console.log(`Filling recipient with ${recipientAddress}`);
     await this.driver.pasteIntoField(this.inputRecipient, recipientAddress);
+    await this.driver.waitForSelector(this.recipientClassRendered);
   }
 
   async getAmountInputValue(): Promise<string> {

--- a/test/e2e/page-objects/pages/send/send-page.ts
+++ b/test/e2e/page-objects/pages/send/send-page.ts
@@ -139,7 +139,7 @@ class SendPage {
     console.log('Creating max send request');
     await this.selectToken(chainId, symbol);
     if (recipientAddress) {
-      await this.fillRecipient(recipientAddress);
+      await this.fillRecipient({ recipientAddress });
     }
     if (recipientName) {
       await this.selectAccountFromRecipientModal(recipientName);
@@ -164,7 +164,7 @@ class SendPage {
     console.log('Creating send request');
     await this.selectToken(chainId, symbol);
     if (recipientAddress) {
-      await this.fillRecipient(recipientAddress);
+      await this.fillRecipient({ recipientAddress });
     }
     if (recipientName) {
       await this.selectAccountFromRecipientModal(recipientName);
@@ -193,10 +193,21 @@ class SendPage {
     await this.driver.press(this.hexDataInput, '\uE004');
   }
 
-  async fillRecipient(recipientAddress: string): Promise<void> {
+  async fillRecipient({
+    recipientAddress,
+    validAddress = true,
+  }: {
+    recipientAddress: string;
+    validAddress?: boolean;
+  }): Promise<void> {
     console.log(`Filling recipient with ${recipientAddress}`);
     await this.driver.pasteIntoField(this.inputRecipient, recipientAddress);
-    await this.driver.waitForSelector(this.recipientClassRendered);
+    // After we add the recipient, a new re-render happens which formats the recipient element.
+    // We wait for that to happen before proceeding with the next step to prevent flakiness.
+    // When the address is invalid the formatted element never renders, so we skip the wait.
+    if (validAddress) {
+      await this.driver.waitForSelector(this.recipientClassRendered);
+    }
   }
 
   async getAmountInputValue(): Promise<string> {

--- a/test/e2e/snaps/test-snap-namelookup.spec.ts
+++ b/test/e2e/snaps/test-snap-namelookup.spec.ts
@@ -103,7 +103,7 @@ describe('Name lookup', function () {
         await homePage.startSendFlow();
 
         await sendPage.selectToken('0x1', 'ETH');
-        await sendPage.fillRecipient('metamask.domain');
+        await sendPage.fillRecipient({ recipientAddress: 'metamask.domain' });
 
         await driver.findElement({ text: '0xc0ffe...54979' });
       },

--- a/test/e2e/tests/multichain/asset-list.spec.ts
+++ b/test/e2e/tests/multichain/asset-list.spec.ts
@@ -141,9 +141,9 @@ describe('Multichain Asset List', function (this: Suite) {
 
         await homePage.startSendFlow();
         await sendPage.selectToken('0x89', 'TST');
-        await sendPage.fillRecipient(
-          '0x2f318C334780961FB129D2a6c30D0763d9a5C970',
-        );
+        await sendPage.fillRecipient({
+          recipientAddress: '0x2f318C334780961FB129D2a6c30D0763d9a5C970',
+        });
       },
     );
   });

--- a/test/e2e/tests/send/btc-send.spec.ts
+++ b/test/e2e/tests/send/btc-send.spec.ts
@@ -65,7 +65,10 @@ describe('BTC Account - Send', function (this: Suite) {
         await homePage.startSendFlow();
         await sendPage.selectToken(bitcoinChainId, 'BTC');
 
-        await sendPage.fillRecipient('invalidBTCAddress');
+        await sendPage.fillRecipient({
+          recipientAddress: 'invalidBTCAddress',
+          validAddress: false,
+        });
         await sendPage.checkInvalidAddressError();
       },
     );
@@ -95,7 +98,7 @@ describe('BTC Account - Send', function (this: Suite) {
         await homePage.startSendFlow();
         await sendPage.selectToken(bitcoinChainId, 'BTC');
 
-        await sendPage.fillRecipient(recipientAddress);
+        await sendPage.fillRecipient({ recipientAddress });
 
         await sendPage.fillAmount('5');
         await sendPage.checkInsufficientFundsError();
@@ -133,7 +136,7 @@ describe('BTC Account - Send', function (this: Suite) {
         await homePage.startSendFlow();
 
         await sendPage.selectToken(bitcoinChainId, 'BTC');
-        await sendPage.fillRecipient(recipientAddress);
+        await sendPage.fillRecipient({ recipientAddress });
         await sendPage.fillAmount(sendAmount);
         await sendPage.isContinueButtonEnabled();
         await sendPage.pressContinueButton();

--- a/test/e2e/tests/send/send-erc20-gas.spec.ts
+++ b/test/e2e/tests/send/send-erc20-gas.spec.ts
@@ -66,7 +66,7 @@ describe('Send ERC20 - Gas Customization', function () {
         await tokensTab.openTokenDetails(symbol);
         await tokensTab.startSendFlow();
 
-        await sendPage.fillRecipient(recipientAddress);
+        await sendPage.fillRecipient({ recipientAddress });
         await sendPage.fillAmount('1');
         await sendPage.pressContinueButton();
 

--- a/test/e2e/tests/send/send-erc20-mainnet.spec.ts
+++ b/test/e2e/tests/send/send-erc20-mainnet.spec.ts
@@ -122,9 +122,9 @@ describe('Send ERC20 - Mainnet', function () {
         await tokenOverviewPage.clickSend();
 
         const sendPage = new SendPage(driver);
-        await sendPage.fillRecipient(
-          '0x5cfe73b6021e818b776b421b1c4db2474086a7e1',
-        );
+        await sendPage.fillRecipient({
+          recipientAddress: '0x5cfe73b6021e818b776b421b1c4db2474086a7e1',
+        });
         await sendPage.fillAmount('10');
         await sendPage.pressContinueButton();
 

--- a/test/e2e/tests/send/send-erc20-to-contract.spec.ts
+++ b/test/e2e/tests/send/send-erc20-to-contract.spec.ts
@@ -67,7 +67,10 @@ describe('Send ERC20 - Contract Warning', function () {
         await tokenOverviewPage.clickSend();
 
         const sendPage = new SendPage(driver);
-        await sendPage.fillRecipient(contractAddress);
+        await sendPage.fillRecipient({
+          recipientAddress: contractAddress,
+          validAddress: false,
+        });
 
         // Verify warning
         const warningText =

--- a/test/e2e/tests/send/send-erc20.spec.ts
+++ b/test/e2e/tests/send/send-erc20.spec.ts
@@ -107,7 +107,7 @@ describe('Send ERC20', function () {
 
           await homePage.startSendFlow();
           await sendPage.selectToken('0x539', 'TST');
-          await sendPage.fillRecipient(DEFAULT_RECIPIENT);
+          await sendPage.fillRecipient({ recipientAddress: DEFAULT_RECIPIENT });
           await sendPage.fillAmount('1');
           await sendPage.pressContinueButton();
 

--- a/test/e2e/tests/send/send-eth-advanced.spec.ts
+++ b/test/e2e/tests/send/send-eth-advanced.spec.ts
@@ -225,9 +225,9 @@ describe('Send ETH - Advanced', function () {
 
           await sendPage.selectToken('0x539', 'ETH');
 
-          await sendPage.fillRecipient(
-            '0xc427D562164062a23a5cFf596A4a3208e72Acd28',
-          );
+          await sendPage.fillRecipient({
+            recipientAddress: '0xc427D562164062a23a5cFf596A4a3208e72Acd28',
+          });
 
           await sendPage.fillHexData(
             '0xa9059cbb0000000000000000000000002f318C334780961FB129D2a6c30D0763d9a5C970000000000000000000000000000000000000000000000000000000000000000a',

--- a/test/e2e/tests/send/send-eth.spec.ts
+++ b/test/e2e/tests/send/send-eth.spec.ts
@@ -60,7 +60,7 @@ describe('Send ETH', function () {
 
           await homePage.startSendFlow();
           await sendPage.selectToken('0x539', 'ETH');
-          await sendPage.fillRecipient(DEFAULT_RECIPIENT);
+          await sendPage.fillRecipient({ recipientAddress: DEFAULT_RECIPIENT });
           await sendPage.fillAmount('1');
           await sendPage.pressContinueButton();
 
@@ -198,7 +198,7 @@ describe('Send ETH', function () {
 
           await homePage.startSendFlow();
           await sendPage.selectToken('0x1', 'ETH');
-          await sendPage.fillRecipient('test.eth');
+          await sendPage.fillRecipient({ recipientAddress: 'test.eth' });
 
           await driver.findElement({ text: '0xc0ffe...54979' });
         },

--- a/test/e2e/tests/send/send-hex-address.spec.ts
+++ b/test/e2e/tests/send/send-hex-address.spec.ts
@@ -79,7 +79,9 @@ describe('Send - Hex Address Normalization', function () {
           await homePage.clickOnSendButton();
           // Paste address without hex prefix
           const sendPage = new SendPage(driver);
-          await sendPage.fillRecipient(nonHexPrefixedAddress);
+          await sendPage.fillRecipient({
+            recipientAddress: nonHexPrefixedAddress,
+          });
           await sendPage.pressContinueButton();
 
           // Verify address on confirmation screen
@@ -110,7 +112,9 @@ describe('Send - Hex Address Normalization', function () {
 
           // Type address without hex prefix
           const sendPage = new SendPage(driver);
-          await sendPage.fillRecipient(nonHexPrefixedAddress);
+          await sendPage.fillRecipient({
+            recipientAddress: nonHexPrefixedAddress,
+          });
           await sendPage.fillAmount('0');
           await sendPage.pressContinueButton();
 

--- a/test/e2e/tests/send/send-nft-filtering.spec.ts
+++ b/test/e2e/tests/send/send-nft-filtering.spec.ts
@@ -49,9 +49,9 @@ describe('Send NFT - Filtering', function () {
         const sendPage = new SendPage(driver);
         await sendPage.checkPageIsLoaded();
         await sendPage.selectNft('Test Dapp NFTs #1');
-        await sendPage.fillRecipient(
-          '0x1234567890123456789012345678901234567890',
-        );
+        await sendPage.fillRecipient({
+          recipientAddress: '0x1234567890123456789012345678901234567890',
+        });
       },
     );
   });

--- a/test/e2e/tests/send/send-nft.spec.ts
+++ b/test/e2e/tests/send/send-nft.spec.ts
@@ -231,7 +231,7 @@ describe('Send NFT', function () {
     });
   });
 
-  describe('ERC1155', function () {
+  describe('ERC1155 TEST', function () {
     const smartContract = SMART_CONTRACTS.ERC1155;
 
     describe('Wallet initiated', function () {

--- a/test/e2e/tests/send/send-nft.spec.ts
+++ b/test/e2e/tests/send/send-nft.spec.ts
@@ -154,7 +154,9 @@ describe('Send NFT', function () {
             await nftDetailsPage.clickNFTSendButton();
 
             const sendPage = new SendPage(driver);
-            await sendPage.fillRecipient(DEFAULT_RECIPIENT);
+            await sendPage.fillRecipient({
+              recipientAddress: DEFAULT_RECIPIENT,
+            });
             await sendPage.pressContinueButton();
 
             const tokenTransferConfirmation =
@@ -231,7 +233,7 @@ describe('Send NFT', function () {
     });
   });
 
-  describe('ERC1155 TEST', function () {
+  describe('ERC1155', function () {
     const smartContract = SMART_CONTRACTS.ERC1155;
 
     describe('Wallet initiated', function () {
@@ -289,7 +291,9 @@ describe('Send NFT', function () {
             await nftDetailsPage.clickNFTSendButton();
 
             const sendPage = new SendPage(driver);
-            await sendPage.fillRecipient(DEFAULT_RECIPIENT);
+            await sendPage.fillRecipient({
+              recipientAddress: DEFAULT_RECIPIENT,
+            });
             await sendPage.fillAmount('1');
             await sendPage.pressContinueButton();
 

--- a/test/e2e/tests/send/send-tron.spec.ts
+++ b/test/e2e/tests/send/send-tron.spec.ts
@@ -42,7 +42,9 @@ describe('Send Tron', function () {
         await sendPage.selectToken('tron:728126428', 'TRX');
 
         // Wait for the send page to load
-        await sendPage.fillRecipient(TRON_RECIPIENT_ADDRESS);
+        await sendPage.fillRecipient({
+          recipientAddress: TRON_RECIPIENT_ADDRESS,
+        });
         await sendPage.fillAmount('1');
         await sendPage.pressContinueButton();
         await snapTransactionConfirmation.checkPageIsLoaded();

--- a/test/e2e/tests/settings/preferences-and-display-language.spec.ts
+++ b/test/e2e/tests/settings/preferences-and-display-language.spec.ts
@@ -160,7 +160,10 @@ describe('Settings - Preferences and display', function (this: Suite) {
 
         const sendPage = new SendPage(driver);
         await sendPage.selectToken('0x539', 'ETH');
-        await sendPage.fillRecipient('0xAAA');
+        await sendPage.fillRecipient({
+          recipientAddress: '0xAAA',
+          validAddress: false,
+        });
 
         // Recipient validation is debounced (~500ms); waitForSelector waits for the German error.
         await driver.waitForSelector(selectors.dialogTextDeutsch);

--- a/test/e2e/tests/solana/send-flow.spec.ts
+++ b/test/e2e/tests/solana/send-flow.spec.ts
@@ -35,10 +35,13 @@ describe('Send flow', function (this: Suite) {
         await sendPage.checkSolanaNetworkIsPresent();
         await sendPage.selectToken(SOLANA_MAINNET_SCOPE, 'SOL');
 
-        await sendPage.fillRecipient('2433asd');
+        await sendPage.fillRecipient({
+          recipientAddress: '2433asd',
+          validAddress: false,
+        });
         await sendPage.checkInvalidAddressError();
 
-        await sendPage.fillRecipient(commonSolanaAddress);
+        await sendPage.fillRecipient({ recipientAddress: commonSolanaAddress });
         await sendPage.fillAmount('1');
         await sendPage.checkInsufficientFundsError();
         assert.equal(
@@ -77,7 +80,7 @@ describe('Send flow', function (this: Suite) {
           false,
           'Continue button is enabled when no address nor amount',
         );
-        await sendPage.fillRecipient(commonSolanaAddress);
+        await sendPage.fillRecipient({ recipientAddress: commonSolanaAddress });
         await sendPage.fillAmount('0.1');
         await sendPage.waitForSendAmountBalance();
         await sendPage.waitForSendAmountFiatValue(solSendAmountFiatValue);
@@ -129,7 +132,7 @@ describe('Send flow', function (this: Suite) {
           false,
           'Continue button is enabled when no address nor amount',
         );
-        await sendPage.fillRecipient(commonSolanaAddress);
+        await sendPage.fillRecipient({ recipientAddress: commonSolanaAddress });
         await sendPage.fillAmount('0.1');
         assert.equal(
           await sendPage.isContinueButtonEnabled(),

--- a/test/e2e/tests/solana/send-spl-token.spec.ts
+++ b/test/e2e/tests/solana/send-spl-token.spec.ts
@@ -311,7 +311,7 @@ describe('Send flow - SPL Token', function (this: Suite) {
           false,
           'Continue button is enabled when no address nor amount',
         );
-        await sendPage.fillRecipient(commonSolanaAddress);
+        await sendPage.fillRecipient({ recipientAddress: commonSolanaAddress });
         await sendPage.fillAmount('0.1');
         assert.equal(
           await sendPage.isContinueButtonEnabled(),
@@ -395,7 +395,7 @@ describe('Send flow - SPL Token', function (this: Suite) {
           false,
           'Continue button is enabled when no address nor amount',
         );
-        await sendPage.fillRecipient(commonSolanaAddress);
+        await sendPage.fillRecipient({ recipientAddress: commonSolanaAddress });
         await sendPage.fillAmount('0.1');
         assert.equal(
           await sendPage.isContinueButtonEnabled(),

--- a/test/e2e/tests/transaction/ens.spec.ts
+++ b/test/e2e/tests/transaction/ens.spec.ts
@@ -70,7 +70,7 @@ describe('ENS', function (this: Suite) {
         // fill ens address as recipient when user lands on send token screen
         const sendToPage = new SendPage(driver);
         await sendToPage.selectToken('0x1', 'ETH');
-        await sendToPage.fillRecipient(sampleEnsDomain);
+        await sendToPage.fillRecipient({ recipientAddress: sampleEnsDomain });
 
         // Verify that ens is resolved to the correct address
         await sendToPage.checkEnsAddressResolution(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
After adding an address into the recipient To field from the Send screen, this address is 'parsed/computed' and formatted (if valid).

Now, we wait until the format is applied (if valid) after adding a recipient.



## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**
See after adding address, it takes some time until the input is parsed/formatted


https://github.com/user-attachments/assets/45ba0826-75ae-4f69-a9da-0794910a0fe6





### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2E page-object and test call-site changes only; no extension product code paths are modified.
> 
> **Overview**
> Reduces flaky send-flow E2E tests (including ERC1155 NFT sends) by synchronizing on the recipient UI after paste.
> 
> **`SendPage.fillRecipient`** now takes an options object (`recipientAddress`, optional `validAddress` defaulting to `true`) instead of a bare string. After pasting into the recipient field, it **waits for** the `.break-all` formatted recipient element when the address is treated as valid, so the next step runs only after React finishes re-rendering. For invalid-address cases, callers pass **`validAddress: false`** so the wait is skipped (that formatted node never appears).
> 
> All send-related specs, benchmarks, and helpers that called `fillRecipient` were updated to the new API; invalid-address, contract-warning, and localization error tests set `validAddress: false` where appropriate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38e18f45ba6819b64ddbf9c8f56c909e0532a226. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->