### PR TITLE
fix(analytics): decouple srpSessionData typing from background state proxy

### DIFF
--- a/app/scripts/controllers/analytics/analytics.ts
+++ b/app/scripts/controllers/analytics/analytics.ts
@@ -5,6 +5,7 @@ import type {
   AnalyticsUserTraits,
 } from '@metamask/analytics-controller';
 import type { NetworkClientId } from '@metamask/network-controller';
+import type { AuthenticationController } from '@metamask/profile-sync-controller';
 import type { Hex, Json } from '@metamask/utils';
 import { omit, omitBy } from 'lodash';
 import type {
@@ -12,7 +13,6 @@ import type {
   AnalyticsEventBuildOptions,
 } from '../../../../shared/lib/analytics/create-event-builder';
 import { captureException as sentryCaptureException } from '../../../../shared/lib/sentry';
-import type { FlattenedBackgroundStateProxy } from '../../../../shared/types';
 import {
   ENVIRONMENT_TYPE_BACKGROUND,
   PLATFORM_FIREFOX,
@@ -99,7 +99,7 @@ export function configureAnalytics({
  * @param srpSessionData - Current SRP session data from MetaMask state.
  */
 export function updateProfileSessionData(
-  srpSessionData: FlattenedBackgroundStateProxy['srpSessionData'],
+  srpSessionData: AuthenticationController.AuthenticationControllerState['srpSessionData'],
 ): void {
   const profile = Object.entries(srpSessionData ?? {})?.[0]?.[1]?.profile;
 

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -14,6 +14,7 @@ import type {
 } from '@metamask/network-controller';
 import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import type { MultichainNetworkControllerGetStateAction } from '@metamask/multichain-network-controller';
+import type { AuthenticationController } from '@metamask/profile-sync-controller';
 import type {
   SeedlessOnboardingControllerGetStateAction,
   SeedlessOnboardingControllerState,
@@ -119,7 +120,6 @@ export type MetaMaskState = Pick<
   | 'names'
   | 'addressBook'
   | 'currentCurrency'
-  | 'srpSessionData'
   | 'keyrings'
   | 'multichainNetworkConfigurationsByChainId'
   | 'firstTimeFlowType'
@@ -129,6 +129,7 @@ export type MetaMaskState = Pick<
   // TODO: Remove as this is no longer a top-level property of the flattened background state object.
   // | 'security_providers'
 > & {
+  srpSessionData?: AuthenticationController.AuthenticationControllerState['srpSessionData'];
   preferences: Pick<
     FlattenedBackgroundStateProxy['preferences'],
     | 'privacyMode'

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -14,7 +14,6 @@ import type {
 } from '@metamask/network-controller';
 import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import type { MultichainNetworkControllerGetStateAction } from '@metamask/multichain-network-controller';
-import type { AuthenticationController } from '@metamask/profile-sync-controller';
 import type {
   SeedlessOnboardingControllerGetStateAction,
   SeedlessOnboardingControllerState,
@@ -120,6 +119,7 @@ export type MetaMaskState = Pick<
   | 'names'
   | 'addressBook'
   | 'currentCurrency'
+  | 'srpSessionData'
   | 'keyrings'
   | 'multichainNetworkConfigurationsByChainId'
   | 'firstTimeFlowType'
@@ -129,7 +129,6 @@ export type MetaMaskState = Pick<
   // TODO: Remove as this is no longer a top-level property of the flattened background state object.
   // | 'security_providers'
 > & {
-  srpSessionData?: AuthenticationController.AuthenticationControllerState['srpSessionData'];
   preferences: Pick<
     FlattenedBackgroundStateProxy['preferences'],
     | 'privacyMode'


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

PR #43846 added profile identity properties to MetaMetrics events by reading `srpSessionData` from wallet state. The new `updateProfileSessionData` helper was typed using `FlattenedBackgroundStateProxy['srpSessionData']`.

`FlattenedBackgroundStateProxy` is a strict proof type over the entire background state. When unrelated `@metamask/*` dependency bumps cause that proof to fail, analytics code fails type-checking even though the runtime behavior is unchanged. This was reported on PR #44006.

This PR decouples `srpSessionData` typing from the background state proxy and uses `AuthenticationController.AuthenticationControllerState['srpSessionData']` directly, which is the canonical source for sign-in session data.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run the extension locally with `yarn start`.
2. Unlock the wallet and trigger any analytics event (for example, navigate between pages or approve a permission).
3. Confirm the extension loads and analytics events still emit without console errors in the background page.

## **Screenshots/Recordings**

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

NA

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-parameter type and import swap in analytics with no logic changes.
> 
> **Overview**
> **`updateProfileSessionData`** no longer takes `FlattenedBackgroundStateProxy['srpSessionData']`. It now uses **`AuthenticationController.AuthenticationControllerState['srpSessionData']`** from `@metamask/profile-sync-controller`, and the unused **`FlattenedBackgroundStateProxy`** import was removed.
> 
> This is a compile-time-only change so analytics typing does not break when unrelated dependency bumps invalidate the full background state proof type; runtime profile ID caching for MetaMetrics events is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f77063af103673cfa0d8ccd698cdefd21c39a0b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->