### PR TITLE
feat: add `BannerDismissed` event

### DIFF
--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -857,6 +857,7 @@ export enum MetaMetricsEventName {
   AppLocked = 'App Locked',
   AppWindowExpanded = 'App Window Expanded',
   BannerDisplay = 'Banner Display',
+  BannerDismissed = 'Banner Dismissed',
   BannerCloseAll = 'Banner Close All',
   BannerSelect = 'Banner Select',
   BridgeLinkClicked = 'Bridge Link Clicked',

--- a/ui/components/multichain/account-overview/carousel.test.tsx
+++ b/ui/components/multichain/account-overview/carousel.test.tsx
@@ -1,0 +1,143 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import { useSelector, useDispatch } from 'react-redux';
+import type { CarouselSlide } from '../../../../shared/constants/app-state';
+import {
+  MetaMetricsEventName,
+  MetaMetricsEventCategory,
+} from '../../../../shared/constants/metametrics';
+import { getAppIsLoading } from '../../../selectors';
+import { getRemoteFeatureFlags } from '../../../../shared/lib/selectors/remote-feature-flags';
+import { useCarouselManagement } from '../../../hooks/useCarouselManagement';
+import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { CarouselWithEmptyState } from '../carousel';
+import { Carousel } from './carousel';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+  useDispatch: jest.fn(),
+}));
+
+jest.mock('../carousel', () => ({
+  CarouselWithEmptyState: jest.fn(() => null),
+}));
+
+jest.mock('../../../hooks/useCarouselManagement', () => ({
+  useCarouselManagement: jest.fn(),
+}));
+
+jest.mock(
+  '../../app/download-mobile-modal/download-mobile-modal',
+  () => () => null,
+);
+
+jest.mock('../../../store/actions', () => ({
+  removeSlide: jest.fn((id: string) => ({ type: 'REMOVE_SLIDE', payload: id })),
+}));
+
+const mockTrackEvent = jest.fn();
+const mockMetaMetricsContext = {
+  trackEvent: mockTrackEvent,
+  bufferedTrace: jest.fn(),
+  bufferedEndTrace: jest.fn(),
+  onboardingParentContext: { current: null },
+};
+
+const mockSlides: CarouselSlide[] = [
+  {
+    id: 'slide-1',
+    title: 'Slide 1',
+    description: 'Description 1',
+    image: 'https://example.com/1.png',
+    variableName: 'one',
+  },
+  {
+    id: 'slide-2',
+    title: 'Slide 2',
+    description: 'Description 2',
+    image: 'https://example.com/2.png',
+    variableName: 'two',
+  },
+];
+
+const getCarouselProps = () => {
+  const { calls } = jest.mocked(CarouselWithEmptyState).mock;
+  return calls[calls.length - 1][0];
+};
+
+const renderCarousel = () =>
+  render(
+    <MetaMetricsContext.Provider value={mockMetaMetricsContext}>
+      <Carousel />
+    </MetaMetricsContext.Provider>,
+  );
+
+describe('AccountOverview Carousel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(useDispatch).mockReturnValue(jest.fn());
+    jest.mocked(useSelector).mockImplementation((selector) => {
+      if (selector === getAppIsLoading) {
+        return false;
+      }
+      if (selector === getRemoteFeatureFlags) {
+        return { carouselBanners: true };
+      }
+      return undefined;
+    });
+    jest.mocked(useCarouselManagement).mockReturnValue({ slides: mockSlides });
+  });
+
+  it('tracks a Banner Dismissed event when a slide is dismissed', () => {
+    renderCarousel();
+
+    getCarouselProps().onSlideClose?.('slide-1', false);
+
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      event: MetaMetricsEventName.BannerDismissed,
+      category: MetaMetricsEventCategory.Banner,
+      properties: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        banner_name: 'slide-1',
+      },
+    });
+    expect(mockTrackEvent).not.toHaveBeenCalledWith(
+      expect.objectContaining({ event: MetaMetricsEventName.BannerCloseAll }),
+    );
+  });
+
+  it('tracks Banner Dismissed and Banner Close All when the last slide is dismissed', () => {
+    renderCarousel();
+
+    getCarouselProps().onSlideClose?.('slide-2', true);
+
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      event: MetaMetricsEventName.BannerDismissed,
+      category: MetaMetricsEventCategory.Banner,
+      properties: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        banner_name: 'slide-2',
+      },
+    });
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      event: MetaMetricsEventName.BannerCloseAll,
+      category: MetaMetricsEventCategory.Banner,
+    });
+  });
+
+  it('tracks a Banner Display event when a slide becomes active', () => {
+    renderCarousel();
+
+    getCarouselProps().onActiveSlideChange?.(mockSlides[0]);
+
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      event: MetaMetricsEventName.BannerDisplay,
+      category: MetaMetricsEventCategory.Banner,
+      properties: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        banner_name: 'slide-1',
+      },
+    });
+  });
+});

--- a/ui/components/multichain/account-overview/carousel.tsx
+++ b/ui/components/multichain/account-overview/carousel.tsx
@@ -68,6 +68,16 @@ export const Carousel = () => {
   };
 
   const handleRemoveSlide = (slideId: string, isLastSlide: boolean) => {
+    trackEvent({
+      event: MetaMetricsEventName.BannerDismissed,
+      category: MetaMetricsEventCategory.Banner,
+      properties: {
+        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        banner_name: slideId,
+      },
+    });
+
     if (isLastSlide) {
       trackEvent({
         event: MetaMetricsEventName.BannerCloseAll,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Added `BannerDismissed` event.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: add BannerDismissed event to analytics

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/GE-317

## **Manual testing steps**

1. Open Home page;
2. Dimiss a banner;
3. Make sure you see corresponding `BannerDismissed` event in MixPanel.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

N/A

### **After**

<img width="1264" height="157" alt="image" src="https://github.com/user-attachments/assets/31dac5b1-ec60-4054-a59d-545a379d6641" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only change on the account overview carousel; no auth, transactions, or persistence logic modified.
> 
> **Overview**
> Adds a **`Banner Dismissed`** MetaMetrics event so home carousel banner closes are visible in analytics (e.g. Mixpanel), alongside existing **Banner Display**, **Banner Select**, and **Banner Close All** events.
> 
> When a user dismisses a slide in the account overview carousel, **`handleRemoveSlide`** now emits **Banner Dismissed** with `banner_name` set to the slide id before removing it from state. Dismissing the **last** slide still fires **Banner Close All** as before, but now also always fires **Banner Dismissed** for that slide.
> 
> A new **`carousel.test.tsx`** suite asserts dismiss vs last-slide behavior and that active slides still trigger **Banner Display**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e13ad35e26af872241f2e0195c24e40c93d1e40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->