### PR TITLE
fix: prevent Sentry storage read recursion

### DIFF
--- a/app/scripts/lib/sentry-get-state.test.ts
+++ b/app/scripts/lib/sentry-get-state.test.ts
@@ -70,20 +70,22 @@ describe('sentry-get-state', () => {
     });
 
     it('resolves participation from persisted state when snapshot has no state keys', async () => {
+      const getPersistedState = jest.fn().mockResolvedValue({
+        data: {
+          AnalyticsController: {
+            analyticsId: 'id-123',
+            optedIn: true,
+          },
+          MetaMetricsController: {
+            completedMetaMetricsOnboarding: true,
+          },
+        },
+      });
+
       globalThis.stateHooks = {
         ...globalThis.stateHooks,
         getSentryState: () => emptySentrySnapshot(),
-        getPersistedState: async () => ({
-          data: {
-            AnalyticsController: {
-              analyticsId: 'id-123',
-              optedIn: true,
-            },
-            MetaMetricsController: {
-              completedMetaMetricsOnboarding: true,
-            },
-          },
-        }),
+        getPersistedState,
         getBackupState: async () => ({}),
       };
 
@@ -91,6 +93,9 @@ describe('sentry-get-state', () => {
         completedMetaMetricsOnboarding: true,
         optedIn: true,
         analyticsId: 'id-123',
+      });
+      expect(getPersistedState).toHaveBeenCalledWith({
+        reportErrors: false,
       });
     });
 

--- a/app/scripts/lib/sentry-get-state.ts
+++ b/app/scripts/lib/sentry-get-state.ts
@@ -47,7 +47,9 @@ export async function getAnalyticsState(): Promise<AnalyticsParticipation> {
   }
 
   try {
-    const persistedState = await globalThis.stateHooks.getPersistedState();
+    const persistedState = await globalThis.stateHooks.getPersistedState({
+      reportErrors: false,
+    });
     return getAnalyticsStateFromPersistedState(persistedState);
   } catch (error) {
     log('Error retrieving persisted state, falling back to backup', error);

--- a/app/scripts/lib/setup-initial-state-hooks.js
+++ b/app/scripts/lib/setup-initial-state-hooks.js
@@ -64,10 +64,13 @@ export const persistenceManager = new PersistenceManager({ localStore })
 /**
  * Get the persisted wallet state.
  *
+ * @param options - Options for retrieving persisted state.
+ * @param options.reportErrors - Whether read errors should be reported to Sentry.
  * @returns The persisted wallet state.
  */
-globalThis.stateHooks.getPersistedState = async function () {
-  return await persistenceManager.get({ validateVault: false });
+globalThis.stateHooks.getPersistedState = async function (options = {}) {
+  const { reportErrors = true } = options;
+  return await persistenceManager.get({ validateVault: false, reportErrors });
 };
 
 /**

--- a/app/scripts/lib/setup-initial-state-hooks.test.ts
+++ b/app/scripts/lib/setup-initial-state-hooks.test.ts
@@ -221,7 +221,22 @@ describe('setup-initial-state-hooks', () => {
 
       await globalThis.stateHooks.getPersistedState();
 
-      expect(mockGet).toHaveBeenCalledWith({ validateVault: false });
+      expect(mockGet).toHaveBeenCalledWith({
+        validateVault: false,
+        reportErrors: true,
+      });
+    });
+
+    it('getPersistedState can disable error reporting', async () => {
+      setSelfHref('chrome-extension://abc123/home.html');
+      await importFresh();
+
+      await globalThis.stateHooks.getPersistedState({ reportErrors: false });
+
+      expect(mockGet).toHaveBeenCalledWith({
+        validateVault: false,
+        reportErrors: false,
+      });
     });
 
     it('registers getBackupState on globalThis.stateHooks', async () => {

--- a/shared/lib/stores/persistence-manager.test.ts
+++ b/shared/lib/stores/persistence-manager.test.ts
@@ -217,6 +217,21 @@ describe('PersistenceManager', () => {
       });
     });
 
+    it('does not capture exception if reporting is disabled and store.get throws', async () => {
+      const error = new Error('store.get error');
+      mockStoreGet.mockRejectedValueOnce(error);
+
+      await expect(
+        manager.get({ validateVault: false, reportErrors: false }),
+      ).rejects.toThrow(error);
+
+      expect(mockedCaptureException).not.toHaveBeenCalled();
+      expect(log.error).toHaveBeenCalledWith(
+        'Error retrieving the current state of the local store:',
+        error,
+      );
+    });
+
     it('does not overwrite mostRecentRetrievedState if already initialized', async () => {
       manager.storageKind = 'data';
       mockStoreGet.mockResolvedValueOnce({ data: MOCK_DATA });

--- a/shared/lib/stores/persistence-manager.ts
+++ b/shared/lib/stores/persistence-manager.ts
@@ -691,14 +691,17 @@ export class PersistenceManager extends EventEmitter<PersistenceManagerEventMap>
    *
    * @param options - An object containing options for the retrieval.
    * @param options.validateVault - A flag indicating whether to validate the vault
+   * @param options.reportErrors - Whether read errors should be reported to Sentry.
    * @returns The current state of the local store or null if the store is empty.
    * @throws Error if the vault is missing and a backup vault is found in IndexedDB.
    * @throws Error if the local store is not open.
    */
   async get({
     validateVault,
+    reportErrors = true,
   }: {
     validateVault: boolean;
+    reportErrors?: boolean;
   }): Promise<MetaMaskStorageStructure | undefined> {
     await this.open();
 
@@ -721,13 +724,15 @@ export class PersistenceManager extends EventEmitter<PersistenceManagerEventMap>
             'Error retrieving the current state of the local store:',
             localStoreError,
           );
-          // Custom fingerprint prevents Sentry's deduplication from dropping
-          // this event when other persistence errors with the same underlying
-          // error message (e.g., "An unexpected error occurred") are reported.
-          captureException(localStoreError, {
-            tags: { 'persistence.error': 'get-failed' },
-            fingerprint: ['persistence-error', 'get-failed'],
-          });
+          if (reportErrors) {
+            // Custom fingerprint prevents Sentry's deduplication from dropping
+            // this event when other persistence errors with the same underlying
+            // error message (e.g., "An unexpected error occurred") are reported.
+            captureException(localStoreError, {
+              tags: { 'persistence.error': 'get-failed' },
+              fingerprint: ['persistence-error', 'get-failed'],
+            });
+          }
         }
 
         if (validateVault) {

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -259,7 +259,7 @@ type StateHooks = {
   getMostRecentPersistedState?: () => any;
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  getPersistedState: () => Promise<any>;
+  getPersistedState: (options?: { reportErrors?: boolean }) => Promise<any>;
   getBackupState?: () => Promise<Backup | null>;
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
## **Description**

This PR prevents Sentry event processing from recursively reporting storage read failures. Sentry uses persisted state to determine MetaMetrics participation when no in-memory snapshot is available; if that persisted-state read failed, `PersistenceManager.get` reported the failure to Sentry, which re-entered the same persisted-state read path.

The fix adds an optional `reportErrors` flag to persisted-state reads. Normal reads still report storage failures by default, while Sentry's analytics-state lookup disables reporting and falls back to backup/null without causing another Sentry capture.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Run the extension from this branch.
2. Complete onboarding or unlock an existing test wallet.
3. Trigger an error report while the background is still initializing or while persisted state is unavailable.
4. Verify the extension does not repeatedly capture the same storage read failure.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

## Validation

- `yarn test:unit app/scripts/lib/sentry-get-state.test.ts app/scripts/lib/setup-initial-state-hooks.test.ts shared/lib/stores/persistence-manager.test.ts`
- `yarn lint:changed:fix`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches persistence error reporting and Sentry’s analytics consent path; behavior change is narrowly scoped with defaults preserved, but mis-wiring `reportErrors` could hide real storage read failures from Sentry.
> 
> **Overview**
> Adds an optional **`reportErrors`** flag on persisted-state reads so storage **`get`** failures can still be logged without always sending **`captureException`** to Sentry.
> 
> **`PersistenceManager.get`** now accepts **`reportErrors`** (default **`true`**); when **`false`**, read errors are logged but not reported. **`getPersistedState`** forwards the same option, and **`getAnalyticsState`** calls **`getPersistedState({ reportErrors: false })`** so MetaMetrics lookups during Sentry event processing do not re-trigger persisted reads that report back into Sentry.
> 
> Default behavior for normal wallet reads is unchanged (**`reportErrors: true`**). Types and unit tests cover the hook wiring and the no-capture path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1140f35c879d233e77330813f14a3a89d3d1436. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->