### PR TITLE
fix(mv3): keep service worker alive during startup with waitUntil

### DIFF
--- a/app/scripts/app-init.js
+++ b/app/scripts/app-init.js
@@ -5,6 +5,7 @@ import { APP_INIT_LIVENESS_METHOD } from '../../shared/constants/ui-initializati
 // "chunks" via `importScripts`; but in this case `ExtensionLazyListener` is so
 // small we won't ever have a problem with these two files being "split".
 import { ExtensionLazyListener } from './lib/extension-lazy-listener/extension-lazy-listener';
+import { waitUntil } from './lib/service-worker-wait-until';
 
 const { chrome } = globalThis;
 
@@ -28,9 +29,18 @@ globalThis.stateHooks.lazyListener = lazyListener;
 let scriptsLoadInitiated = false;
 const testMode = process.env.IN_TEST;
 
+const keepAliveEstablished = Promise.withResolvers();
+
+globalThis.stateHooks.notifyServiceWorkerKeepAliveEstablished =
+  keepAliveEstablished.resolve;
+
 const loadTimeLogs = [];
 // eslint-disable-next-line import-x/unambiguous
 function tryImport(...fileNames) {
+  if (fileNames.length === 0) {
+    return;
+  }
+
   try {
     const startTime = new Date().getTime();
     // eslint-disable-next-line
@@ -43,13 +53,10 @@ function tryImport(...fileNames) {
       startTime,
       endTime,
     });
-
-    return true;
   } catch (e) {
     console.error(e);
+    throw e;
   }
-
-  return false;
 }
 
 function importAllScripts() {
@@ -57,7 +64,6 @@ function importAllScripts() {
   if (scriptsLoadInitiated) {
     return;
   }
-  scriptsLoadInitiated = true;
   const files = [];
 
   // In testMode individual files are imported, this is to help capture load time stats
@@ -116,6 +122,8 @@ function importAllScripts() {
   // Import all required resources
   tryImport(...files);
 
+  scriptsLoadInitiated = true;
+
   const endImportScriptsTime = Date.now();
 
   // for performance metrics/reference
@@ -144,9 +152,24 @@ function importAllScripts() {
   }
 }
 
+function waitUntilImportAllScripts() {
+  return waitUntil(
+    (async () => {
+      if (!scriptsLoadInitiated) {
+        importAllScripts();
+      }
+      await keepAliveEstablished.promise;
+    })(),
+  ).catch((error) => {
+    console.error('MetaMask service worker startup failed', error);
+  });
+}
+
 // Ref: https://stackoverflow.com/questions/66406672/chrome-extension-mv3-modularize-service-worker-js-file
 // eslint-disable-next-line no-undef
-self.addEventListener('install', importAllScripts);
+self.addEventListener('install', (event) => {
+  event.waitUntil(waitUntilImportAllScripts());
+});
 
 // listen for connection events from other contexts, and respond to liveness
 // checks, and ping them to let them know we're listening.
@@ -185,5 +208,5 @@ chrome.runtime.onConnect.addListener((port) => {
  */
 // eslint-disable-next-line no-undef
 if (self.serviceWorker.state === 'activated') {
-  importAllScripts();
+  waitUntilImportAllScripts();
 }

--- a/app/scripts/app-init.js
+++ b/app/scripts/app-init.js
@@ -4,6 +4,7 @@ import { APP_INIT_LIVENESS_METHOD } from '../../shared/constants/ui-initializati
 // We don't usually `import` files into `app-init.js` because we need to load
 // "chunks" via `importScripts`; but in this case `ExtensionLazyListener` is so
 // small we won't ever have a problem with these two files being "split".
+import { withResolvers } from '../../shared/lib/promise-with-resolvers';
 import { ExtensionLazyListener } from './lib/extension-lazy-listener/extension-lazy-listener';
 import { waitUntil } from './lib/service-worker-wait-until';
 
@@ -29,7 +30,7 @@ globalThis.stateHooks.lazyListener = lazyListener;
 let scriptsLoadInitiated = false;
 const testMode = process.env.IN_TEST;
 
-const keepAliveEstablished = Promise.withResolvers();
+const keepAliveEstablished = withResolvers();
 
 globalThis.stateHooks.notifyServiceWorkerKeepAliveEstablished =
   keepAliveEstablished.resolve;

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -755,6 +755,25 @@ function saveTimestamp() {
   browser.storage.session.set({ timestamp });
 }
 
+function notifyServiceWorkerKeepAliveEstablished() {
+  globalThis.stateHooks.notifyServiceWorkerKeepAliveEstablished?.();
+}
+
+function startServiceWorkerKeepAlive(enableTimestampSave) {
+  if (!isManifestV3) {
+    return;
+  }
+
+  if (enableTimestampSave !== false) {
+    const SAVE_TIMESTAMP_INTERVAL_MS = 2 * 1000;
+
+    saveTimestamp();
+    setInterval(saveTimestamp, SAVE_TIMESTAMP_INTERVAL_MS);
+  }
+
+  notifyServiceWorkerKeepAliveEstablished();
+}
+
 /**
  * @typedef {import('@metamask/transaction-controller').TransactionMeta} TransactionMeta
  */
@@ -849,14 +868,9 @@ async function initialize(backup) {
   }
 
   if (isManifestV3) {
-    // Save the timestamp immediately and then every `SAVE_TIMESTAMP_INTERVAL`
-    // miliseconds. This keeps the service worker alive.
-    if (initState.PreferencesController?.enableMV3TimestampSave !== false) {
-      const SAVE_TIMESTAMP_INTERVAL_MS = 2 * 1000;
-
-      saveTimestamp();
-      setInterval(saveTimestamp, SAVE_TIMESTAMP_INTERVAL_MS);
-    }
+    startServiceWorkerKeepAlive(
+      initState.PreferencesController?.enableMV3TimestampSave,
+    );
 
     const sessionData = await browser.storage.session.get([
       'isFirstMetaMaskControllerSetup',
@@ -2598,6 +2612,7 @@ async function initBackground(backup) {
   } catch (error) {
     log.error(error);
     rejectInitialization(error);
+    notifyServiceWorkerKeepAliveEstablished();
   }
 }
 /**
@@ -2606,6 +2621,7 @@ async function initBackground(backup) {
  */
 async function initOrRestoreBackground() {
   if (process.env.SKIP_BACKGROUND_INITIALIZATION) {
+    notifyServiceWorkerKeepAliveEstablished();
     return;
   }
 

--- a/app/scripts/lib/service-worker-wait-until.test.ts
+++ b/app/scripts/lib/service-worker-wait-until.test.ts
@@ -1,0 +1,53 @@
+import { waitUntil } from './service-worker-wait-until';
+
+describe('waitUntil', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    globalThis.chrome = {
+      runtime: {
+        getPlatformInfo: jest.fn().mockResolvedValue({}),
+      },
+    } as unknown as typeof chrome;
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('resolves when the promise resolves', async () => {
+    const waitUntilPromise = waitUntil(Promise.resolve());
+
+    await expect(waitUntilPromise).resolves.toBeUndefined();
+  });
+
+  it('rejects when the promise rejects', async () => {
+    const waitUntilPromise = waitUntil(
+      Promise.reject(new Error('startup failed')),
+    );
+
+    await expect(waitUntilPromise).rejects.toThrow('startup failed');
+  });
+
+  it('calls getPlatformInfo periodically while waiting', async () => {
+    const getPlatformInfo = jest.fn().mockResolvedValue({});
+    globalThis.chrome = {
+      runtime: { getPlatformInfo },
+    } as unknown as typeof chrome;
+
+    let resolveDeferred!: () => void;
+    const deferred = new Promise<void>((resolve) => {
+      resolveDeferred = resolve;
+    });
+
+    const waitUntilPromise = waitUntil(deferred);
+
+    jest.advanceTimersByTime(25 * 1000);
+    expect(getPlatformInfo).toHaveBeenCalledTimes(1);
+
+    resolveDeferred();
+    await waitUntilPromise;
+
+    jest.advanceTimersByTime(25 * 1000);
+    expect(getPlatformInfo).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/scripts/lib/service-worker-wait-until.ts
+++ b/app/scripts/lib/service-worker-wait-until.ts
@@ -1,0 +1,25 @@
+const KEEP_ALIVE_INTERVAL_MS = 25 * 1000;
+
+/**
+ * Keeps the extension service worker alive until the given promise settles.
+ *
+ * During long-running startup work that does not call extension APIs, Chrome
+ * may terminate the service worker. Calling a trivial extension API on an
+ * interval resets the idle timer until startup completes.
+ *
+ * @param promise
+ * @see https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers#keep_the_service_worker_alive
+ */
+export async function waitUntil(promise: Promise<unknown>): Promise<void> {
+  const keepAlive = setInterval(() => {
+    chrome.runtime.getPlatformInfo().catch(() => {
+      // Ignore errors. This call only resets the idle timer.
+    });
+  }, KEEP_ALIVE_INTERVAL_MS);
+
+  try {
+    await promise;
+  } finally {
+    clearInterval(keepAlive);
+  }
+}

--- a/app/service-worker.ts
+++ b/app/service-worker.ts
@@ -3,6 +3,7 @@
 import './scripts/load/bootstrap';
 import { APP_INIT_LIVENESS_METHOD } from '../shared/constants/ui-initialization';
 import { ExtensionLazyListener } from './scripts/lib/extension-lazy-listener/extension-lazy-listener';
+import { waitUntil } from './scripts/lib/service-worker-wait-until';
 
 const { chrome } = globalThis;
 
@@ -18,17 +19,23 @@ globalThis.stateHooks.lazyListener = lazyListener;
 
 let runImportScriptsInitiated = false;
 
+const keepAliveEstablished = Promise.withResolvers<void>();
+globalThis.stateHooks.notifyServiceWorkerKeepAliveEstablished =
+  keepAliveEstablished.resolve;
+
 async function runImportScripts() {
   // Bail if we've already run importScripts
   if (runImportScriptsInitiated) {
+    await keepAliveEstablished.promise;
     return;
   }
-  runImportScriptsInitiated = true;
 
   const startImportScriptsTime = performance.now();
 
   // eslint-disable-next-line import-x/extensions
   await import('./scripts/background.js');
+
+  runImportScriptsInitiated = true;
 
   const endImportScriptsTime = performance.now();
 
@@ -38,11 +45,21 @@ async function runImportScripts() {
       (endImportScriptsTime - startImportScriptsTime) / 1000
     } seconds`,
   );
+
+  await keepAliveEstablished.promise;
+}
+
+function waitUntilRunImportScripts() {
+  return waitUntil(runImportScripts()).catch((error) => {
+    console.error('MetaMask service worker startup failed', error);
+  });
 }
 
 // Ref: https://stackoverflow.com/questions/66406672/chrome-extension-mv3-modularize-service-worker-js-file
 // eslint-disable-next-line no-undef
-self.addEventListener('install', runImportScripts);
+self.addEventListener('install', (event) => {
+  event.waitUntil(waitUntilRunImportScripts());
+});
 
 // listen for connection events from other contexts, and respond to liveness
 // checks, and ping them to let them know we're listening.
@@ -82,5 +99,5 @@ chrome.runtime.onConnect.addListener((port) => {
 // @ts-expect-error - typescript doesn't know about this
 // eslint-disable-next-line no-undef
 if (self.serviceWorker.state === 'activated') {
-  runImportScripts();
+  waitUntilRunImportScripts();
 }

--- a/app/service-worker.ts
+++ b/app/service-worker.ts
@@ -59,7 +59,7 @@ function waitUntilRunImportScripts() {
 // Ref: https://stackoverflow.com/questions/66406672/chrome-extension-mv3-modularize-service-worker-js-file
 // eslint-disable-next-line no-undef
 self.addEventListener('install', (event) => {
-  event.waitUntil(waitUntilRunImportScripts());
+  (event as ExtendableEvent).waitUntil(waitUntilRunImportScripts());
 });
 
 // listen for connection events from other contexts, and respond to liveness

--- a/app/service-worker.ts
+++ b/app/service-worker.ts
@@ -2,6 +2,7 @@
 
 import './scripts/load/bootstrap';
 import { APP_INIT_LIVENESS_METHOD } from '../shared/constants/ui-initialization';
+import { withResolvers } from '../shared/lib/promise-with-resolvers';
 import { ExtensionLazyListener } from './scripts/lib/extension-lazy-listener/extension-lazy-listener';
 import { waitUntil } from './scripts/lib/service-worker-wait-until';
 
@@ -19,7 +20,7 @@ globalThis.stateHooks.lazyListener = lazyListener;
 
 let runImportScriptsInitiated = false;
 
-const keepAliveEstablished = Promise.withResolvers<void>();
+const keepAliveEstablished = withResolvers<void>();
 globalThis.stateHooks.notifyServiceWorkerKeepAliveEstablished =
   keepAliveEstablished.resolve;
 

--- a/types/global.d.ts
+++ b/types/global.d.ts
@@ -287,6 +287,12 @@ type StateHooks = {
    */
   lazyListener?: ExtensionLazyListener<typeof globalThis.chrome>;
   /**
+   * Called by `background.js` once MV3 keep-alive has started (or when startup
+   * will not start keep-alive). Used by the service worker entry to extend its
+   * lifetime until keep-alive is established.
+   */
+  notifyServiceWorkerKeepAliveEstablished?: () => void;
+  /**
    * Reload the extension. This is used to trigger extension reload from a page context by E2E
    * tests.
    */


### PR DESCRIPTION
## **Description**

The MV3 service worker can be terminated by Chrome during long startup work that does not call extension APIs. That can interrupt script loading and background initialization, leaving users unable to open the extension.

This change keeps the service worker alive from install through background keep-alive setup by:

1. Wrapping startup in `event.waitUntil()` with a new `waitUntil()` helper that periodically calls `chrome.runtime.getPlatformInfo()` (per [Chrome MV3 guidance](https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers#keep_the_service_worker_alive))
2. Coordinating between the service worker entry scripts and `background.js` via `notifyServiceWorkerKeepAliveEstablished` so startup waits until the existing session timestamp keep-alive is running
3. Propagating import errors and deferring the "scripts loaded" flag until imports succeed, so failed startups can retry instead of hanging

Fixes startup reliability issues described in #43773.

## **Changelog**

CHANGELOG entry: Fixed a bug where the MV3 service worker could terminate during startup and prevent the extension from opening

## **Related issues**

Fixes: #43773

## **Manual testing steps**

1. Build and load the extension with `yarn start` (Chrome MV3 webpack).
2. Open the extension popup and confirm it loads normally after a cold start.
3. In `chrome://serviceworker-internals`, locate the MetaMask service worker and use "Stop" to terminate it.
4. Open the extension popup again and confirm it recovers and loads without a stuck or blank state.
5. Optionally disable "Keep service worker alive" in Advanced Settings (debug) and repeat steps 3-4 to confirm startup still completes when timestamp keep-alive is disabled.
6. Re-build and re-load the extension with `yarn dist` (Chrome MV3 browserify) and go trough steps 2-5 again.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)