### PR TITLE
fix: use the normal app translation path for networks tab

### DIFF
--- a/ui/components/multichain/network-manager/network-tabs.tsx
+++ b/ui/components/multichain/network-manager/network-tabs.tsx
@@ -3,7 +3,7 @@ import { useDispatch } from 'react-redux';
 import { hideModal } from '../../../store/actions';
 import { ModalHeader, ModalBody, Box } from '../../component-library';
 import { Tab, Tabs } from '../../ui/tabs';
-import { t } from '../../../../shared/lib/translate';
+import { useI18nContext } from '../../../hooks/useI18nContext';
 import { CustomNetworks } from './components/custom-networks';
 import { DefaultNetworks } from './components/default-networks';
 
@@ -22,6 +22,7 @@ export const NetworkTabs = ({
   isPage = false,
 }: NetworkTabsProps) => {
   const dispatch = useDispatch();
+  const t = useI18nContext();
   const [activeTab, setActiveTab] = useState(initialTab);
   const handleClose = useCallback(() => {
     if (onClose) {
@@ -38,7 +39,7 @@ export const NetworkTabs = ({
           onClose={handleClose}
           closeButtonProps={{ 'data-testid': 'modal-header-close-button' }}
         >
-          {t('bridgeSelectNetwork') ?? 'Select network'}
+          {t('bridgeSelectNetwork')}
         </ModalHeader>
       ) : null}
       <ModalBody style={{ padding: 0 }}>
@@ -57,14 +58,14 @@ export const NetworkTabs = ({
         >
           <Tab
             tabKey="networks"
-            name={t('networkTabPopular') ?? 'Popular'}
+            name={t('networkTabPopular')}
             className="flex-1"
           >
             <DefaultNetworks />
           </Tab>
           <Tab
             tabKey="custom-networks"
-            name={t('networkTabCustom') ?? 'Custom'}
+            name={t('networkTabCustom')}
             className="flex-1"
           >
             <CustomNetworks />


### PR DESCRIPTION
This PR is to use the normal app translation path, so that it can pick up the translated text properly.

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Turn networkManagemnet flag off locally, Switch the language from English to any other language
2. Check the popup renders correct translated string and not English 


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="1206" height="776" alt="Screenshot 2026-07-01 at 9 58 06 AM" src="https://github.com/user-attachments/assets/97652a91-526b-46cb-aa80-493dac4a1373" />

### **After**


<img width="1316" height="1120" alt="Screenshot 2026-07-01 at 9 51 58 AM" src="https://github.com/user-attachments/assets/06ed88f3-6074-4944-97bf-6226836b559e" />



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-component i18n wiring change with no auth, data, or business-logic impact.
> 
> **Overview**
> Fixes **network manager** modal/popup labels staying in English when the app locale is changed.
> 
> **NetworkTabs** now uses **`useI18nContext()`** for `bridgeSelectNetwork`, `networkTabPopular`, and `networkTabCustom` instead of the **`shared/lib/translate`** import, matching how other UI code resolves translations. The **`?? 'English fallback'`** strings were removed so copy comes only from the normal locale pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9624d861ae8e2b1de190dfccfbad83599733a0d5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->