### PR TITLE
feat: make account switch referral prompt apply to all partners

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -231,8 +231,8 @@ import {
   // eslint-disable-next-line import-x/no-restricted-paths
 } from '../../ui/contexts/hardware-wallets';
 import {
-  DEFI_REFERRAL_PARTNERS,
   DefiReferralPartner,
+  getPartnerByOrigin,
 } from '../../shared/constants/defi-referrals';
 import { keyringSnapPermissionsBuilder } from './lib/snap-keyring/keyring-snaps-permissions';
 
@@ -5666,7 +5666,7 @@ export default class MetamaskController extends EventEmitter {
 
   /**
    * Runs when CAIP-25 permitted accounts are extended via the permission background API.
-   * If the origin is Hyperliquid and the globally selected account is EVM and included
+   * If the origin is a referral partner and the globally selected account is EVM and included
    * among the newly permitted accounts, it triggers the DeFi referral flow.
    *
    * @param {{ origin: string; newCaipAccountIds: import('@metamask/utils').CaipAccountId[] }} details - Added accounts payload.
@@ -5674,9 +5674,8 @@ export default class MetamaskController extends EventEmitter {
   _handleDefiReferralOnPermittedAccountsAdded(details) {
     const { origin, newCaipAccountIds } = details;
 
-    // Only run for Hyperliquid
-    const partner = DEFI_REFERRAL_PARTNERS[DefiReferralPartner.Hyperliquid];
-    if (origin !== partner.origin) {
+    const partner = getPartnerByOrigin(origin);
+    if (!partner) {
       return;
     }
 

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -5738,6 +5738,9 @@ describe('MetaMaskController', () => {
     describe('_handleDefiReferralOnPermittedAccountsAdded', () => {
       const HL_ORIGIN =
         DEFI_REFERRAL_PARTNERS[DefiReferralPartner.Hyperliquid].origin;
+      const GMX_ORIGIN = DEFI_REFERRAL_PARTNERS[DefiReferralPartner.GMX].origin;
+      const ASTER_ORIGIN =
+        DEFI_REFERRAL_PARTNERS[DefiReferralPartner.AsterDEX].origin;
 
       let mockEvmAccount;
       let mockCaipAccountId;
@@ -5770,7 +5773,14 @@ describe('MetaMaskController', () => {
           state.internalAccounts.accounts[mockEvmAccount.id] = mockEvmAccount;
           state.internalAccounts.selectedAccount = mockEvmAccount.id;
         });
+      });
 
+      afterEach(() => {
+        handleDefiReferralSpy.mockRestore();
+        jest.mocked(parseCaipAccountId).mockReset();
+      });
+
+      it('calls handleDefiReferral for Hyperliquid when selected EVM account matches a new permitted CAIP id and appActiveTab matches', () => {
         metamaskController.appStateController.update((state) => {
           state.appActiveTab = {
             id: 914,
@@ -5782,14 +5792,7 @@ describe('MetaMaskController', () => {
             href: `${HL_ORIGIN}/trade`,
           };
         });
-      });
 
-      afterEach(() => {
-        handleDefiReferralSpy.mockRestore();
-        jest.mocked(parseCaipAccountId).mockReset();
-      });
-
-      it('calls handleDefiReferral when the selected EVM account matches a new permitted CAIP id and appActiveTab matches', () => {
         metamaskController._handleDefiReferralOnPermittedAccountsAdded({
           origin: HL_ORIGIN,
           newCaipAccountIds: [mockCaipAccountId],
@@ -5806,9 +5809,67 @@ describe('MetaMaskController', () => {
         );
       });
 
-      it('does nothing when origin is not Hyperliquid', () => {
+      it('calls handleDefiReferral for GMX when selected EVM account matches a new permitted CAIP id and appActiveTab matches', () => {
+        metamaskController.appStateController.update((state) => {
+          state.appActiveTab = {
+            id: 915,
+            title: 'GMX',
+            origin: GMX_ORIGIN,
+            protocol: 'https:',
+            url: `${GMX_ORIGIN}/trade`,
+            host: 'app.gmx.io',
+            href: `${GMX_ORIGIN}/trade`,
+          };
+        });
+
         metamaskController._handleDefiReferralOnPermittedAccountsAdded({
-          origin: DEFI_REFERRAL_PARTNERS[DefiReferralPartner.GMX].origin,
+          origin: GMX_ORIGIN,
+          newCaipAccountIds: [mockCaipAccountId],
+        });
+
+        expect(handleDefiReferralSpy).toHaveBeenCalledTimes(1);
+        expect(handleDefiReferralSpy).toHaveBeenCalledWith(
+          DEFI_REFERRAL_PARTNERS[DefiReferralPartner.GMX],
+          915,
+          ReferralTriggerType.PermittedAccountAdded,
+          {
+            activePermittedAddressOverride: mockEvmAccount.address,
+          },
+        );
+      });
+
+      it('calls handleDefiReferral for AsterDEX when selected EVM account matches a new permitted CAIP id and appActiveTab matches', () => {
+        metamaskController.appStateController.update((state) => {
+          state.appActiveTab = {
+            id: 916,
+            title: 'AsterDEX',
+            origin: ASTER_ORIGIN,
+            protocol: 'https:',
+            url: `${ASTER_ORIGIN}/trade`,
+            host: 'www.asterdex.com',
+            href: `${ASTER_ORIGIN}/trade`,
+          };
+        });
+
+        metamaskController._handleDefiReferralOnPermittedAccountsAdded({
+          origin: ASTER_ORIGIN,
+          newCaipAccountIds: [mockCaipAccountId],
+        });
+
+        expect(handleDefiReferralSpy).toHaveBeenCalledTimes(1);
+        expect(handleDefiReferralSpy).toHaveBeenCalledWith(
+          DEFI_REFERRAL_PARTNERS[DefiReferralPartner.AsterDEX],
+          916,
+          ReferralTriggerType.PermittedAccountAdded,
+          {
+            activePermittedAddressOverride: mockEvmAccount.address,
+          },
+        );
+      });
+
+      it('does nothing when origin does not match any referral partner', () => {
+        metamaskController._handleDefiReferralOnPermittedAccountsAdded({
+          origin: 'https://example.com',
           newCaipAccountIds: [mockCaipAccountId],
         });
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Follows the same implementation for GMX and AsterDex as was done for Hyperliquid [here](https://github.com/MetaMask/metamask-extension/pull/41996) to make the referral prompt show when users add another permitted account for the same origin via the permission background API (e.g. “connect account” flow).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: DeFi referral flow now runs after permitting an additional account for the site from the account-picker for GMX and AsterDEX

## **Related issues**

Fixes:

## **Manual testing steps**

Follow same testing steps given here: https://github.com/MetaMask/metamask-extension/pull/41996

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/8ad50305-5090-4f22-a2bd-c0df5e951fb2


https://github.com/user-attachments/assets/b2a5c446-b26a-424d-909e-bebf5f83fd7b



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 531fb1d58d65eaff3ef71036f393af6c72fe8338. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->