### PR TITLE
feat(perps): restructure market detail header

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -7199,6 +7199,10 @@
   "perpsOrders": {
     "message": "Orders"
   },
+  "perpsPerpMarketSubtitle": {
+    "message": "$1-$2 perp",
+    "description": "$1 is the market ticker (e.g. BTC), $2 is the collateral asset (e.g. USDC). Shown as the market pair subtitle on the perps market detail header, e.g. 'BTC-USDC perp'."
+  },
   "perpsPnl": {
     "message": "P&L"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -7199,6 +7199,10 @@
   "perpsOrders": {
     "message": "Orders"
   },
+  "perpsPerpMarketSubtitle": {
+    "message": "$1-$2 perp",
+    "description": "$1 is the market ticker (e.g. BTC), $2 is the collateral asset (e.g. USDC). Shown as the market pair subtitle on the perps market detail header, e.g. 'BTC-USDC perp'."
+  },
   "perpsPnl": {
     "message": "P&L"
   },

--- a/ui/components/app/perps/constants.ts
+++ b/ui/components/app/perps/constants.ts
@@ -53,6 +53,12 @@ export const PERPS_CONSTANTS = {
 } as const;
 
 /**
+ * Collateral asset used to settle perps positions. Shown in market pair labels
+ * such as "BTC-USDC perp".
+ */
+export const PERPS_COLLATERAL_SYMBOL = 'USDC';
+
+/**
  * Minimum USD notional for market / reduce-only orders on HyperLiquid (mainnet and testnet).
  * Partial closes below this amount fail with ORDER_SIZE_MIN; full closes omit this check.
  * Duplicates TRADING_DEFAULTS.amount in @metamask/perps-controller until a shared export exists.

--- a/ui/components/app/perps/perps-skeletons/perps-detail-page-skeleton.tsx
+++ b/ui/components/app/perps/perps-skeletons/perps-detail-page-skeleton.tsx
@@ -23,49 +23,68 @@ export const PerpsDetailPageSkeleton = () => {
     >
       {/* Header */}
       <Box
-        flexDirection={BoxFlexDirection.Row}
-        alignItems={BoxAlignItems.Center}
-        paddingLeft={4}
-        paddingRight={4}
+        flexDirection={BoxFlexDirection.Column}
         paddingTop={4}
         paddingBottom={4}
         gap={2}
       >
-        {/* Back Button Placeholder */}
-        <Box className="p-2 -ml-2">
-          <Icon
-            name={IconName.ArrowLeft}
-            size={IconSize.Md}
-            color={IconColor.IconAlternative}
-          />
-        </Box>
+        {/* Top row: back chevron, logo, market identity, favorite star */}
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          paddingLeft={4}
+          paddingRight={4}
+          gap={2}
+        >
+          {/* Back Button Placeholder */}
+          <Box className="p-2 -ml-2">
+            <Icon
+              name={IconName.ArrowLeft}
+              size={IconSize.Md}
+              color={IconColor.IconAlternative}
+            />
+          </Box>
 
-        {/* Token Logo Skeleton */}
-        <Skeleton className="h-10 w-10 shrink-0 rounded-full" />
+          {/* Token Logo Skeleton */}
+          <Skeleton className="h-10 w-10 shrink-0 rounded-full" />
 
-        {/* Header Content Skeleton */}
-        <Box flexDirection={BoxFlexDirection.Column} gap={1}>
-          <Skeleton className="h-4 w-20" />
+          {/* Market Identity Skeleton */}
           <Box
-            flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Center}
-            gap={2}
+            flexDirection={BoxFlexDirection.Column}
+            className="min-w-0 flex-1"
+            gap={1}
           >
-            <Skeleton className="h-4 w-24" />
-            <Skeleton className="h-3 w-16" />
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              gap={2}
+            >
+              <Skeleton className="h-4 w-24" />
+              <Skeleton className="h-4 w-10" />
+            </Box>
+            <Skeleton className="h-3 w-20" />
+          </Box>
+
+          {/* Favorite Star Placeholder */}
+          <Box className="p-2">
+            <Icon
+              name={IconName.Star}
+              size={IconSize.Md}
+              color={IconColor.IconAlternative}
+            />
           </Box>
         </Box>
 
-        {/* Spacer */}
-        <Box className="flex-1" />
-
-        {/* Favorite Star Placeholder */}
-        <Box className="p-2">
-          <Icon
-            name={IconName.Star}
-            size={IconSize.Md}
-            color={IconColor.IconAlternative}
-          />
+        {/* Price + 24h change Skeleton */}
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          paddingLeft={4}
+          paddingRight={4}
+          gap={2}
+        >
+          <Skeleton className="h-7 w-32" />
+          <Skeleton className="h-4 w-16" />
         </Box>
       </Box>
 

--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -14,7 +14,10 @@ import {
   mockTransactions,
 } from '../../components/app/perps/mocks';
 import { PERPS_LIQUIDATION_PRICE_FALLBACK } from '../../components/app/perps/utils/formatPerpsDisplayPrice';
-import { PERPS_ACTIVITY_ROUTE } from '../../helpers/constants/routes';
+import {
+  PERPS_ACTIVITY_ROUTE,
+  PERPS_MARKET_LIST_ROUTE,
+} from '../../helpers/constants/routes';
 
 // Mobile test convention: mock the Compliance barrel so the gate hook never runs
 // (and never reaches the now-strict AccessRestrictedProvider context throw). The
@@ -588,10 +591,15 @@ describe('PerpsMarketDetailPage', () => {
     it('displays market symbol and price', async () => {
       const store = mockStore(createMockState(true));
 
-      const { getByTestId, getByText } = await renderPage(store);
+      const { getByTestId } = await renderPage(store);
 
       expect(getByTestId('perps-market-detail-price')).toBeInTheDocument();
-      expect(getByText('ETH-USD')).toBeInTheDocument();
+      expect(getByTestId('perps-market-detail-name')).toHaveTextContent(
+        'Ethereum',
+      );
+      expect(getByTestId('perps-market-detail-pair')).toHaveTextContent(
+        'ETH-USDC perp',
+      );
     });
 
     it('displays the market max leverage pill in the header', async () => {
@@ -625,10 +633,25 @@ describe('PerpsMarketDetailPage', () => {
       mockUseParams.mockReturnValue({ symbol: 'BTC' });
       const store = mockStore(createMockState(true));
 
-      const { getByTestId, getByText } = await renderPage(store);
+      const { getByTestId } = await renderPage(store);
 
       expect(getByTestId('perps-market-detail-page')).toBeInTheDocument();
-      expect(getByText('BTC-USD')).toBeInTheDocument();
+      expect(getByTestId('perps-market-detail-name')).toHaveTextContent(
+        'Bitcoin',
+      );
+      expect(getByTestId('perps-market-detail-pair')).toHaveTextContent(
+        'BTC-USDC perp',
+      );
+    });
+
+    it('navigates to the market list when the header chevron is clicked', async () => {
+      const store = mockStore(createMockState(true));
+
+      const { getByTestId } = await renderPage(store);
+
+      getByTestId('perps-market-detail-market-list-button').click();
+
+      expect(mockUseNavigate).toHaveBeenCalledWith(PERPS_MARKET_LIST_ROUTE);
     });
 
     it('displays back button', async () => {
@@ -820,11 +843,16 @@ describe('PerpsMarketDetailPage', () => {
       mockUseParams.mockReturnValue({ symbol: 'xyz:TSLA' });
       const store = mockStore(createMockState(true));
 
-      const { getByTestId, getByText } = await renderPage(store);
+      const { getByTestId } = await renderPage(store);
 
       expect(getByTestId('perps-market-detail-page')).toBeInTheDocument();
-      // Should display "TSLA-USD" with the stripped display name
-      expect(getByText('TSLA-USD')).toBeInTheDocument();
+      // Should display the full name and the ticker-collateral pair (stripped display name)
+      expect(getByTestId('perps-market-detail-name')).toHaveTextContent(
+        'Tesla',
+      );
+      expect(getByTestId('perps-market-detail-pair')).toHaveTextContent(
+        'TSLA-USDC perp',
+      );
     });
 
     it('displays position section when user has a position', async () => {

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -53,6 +53,7 @@ import { useI18nContext } from '../../hooks/useI18nContext';
 import { useTheme } from '../../hooks/useTheme';
 import {
   DEFAULT_ROUTE,
+  PERPS_MARKET_LIST_ROUTE,
   PERPS_ORDER_ENTRY_ROUTE,
 } from '../../helpers/constants/routes';
 import {
@@ -97,6 +98,7 @@ import {
   formatPerpsFiatUniversal,
   formatPerpsLiquidationPrice,
 } from '../../components/app/perps/utils/formatPerpsDisplayPrice';
+import { PERPS_COLLATERAL_SYMBOL } from '../../components/app/perps/constants';
 import {
   derivePositionTpslPricesFromOrders,
   normalizeMarketDetailsOrders,
@@ -752,6 +754,10 @@ const PerpsMarketDetailPage = () => {
     navigate({ pathname: '/', search: 'tab=perps' }, { replace: true });
   }, [navigate]);
 
+  const handleMarketListClick = useCallback(() => {
+    navigate(PERPS_MARKET_LIST_ROUTE);
+  }, [navigate]);
+
   const buildOrderEntryUrl = useCallback(
     (direction: 'long' | 'short', mode: 'new' | 'modify') => {
       if (!decodedSymbol) {
@@ -1030,6 +1036,8 @@ const PerpsMarketDetailPage = () => {
   }
 
   const displayName = getDisplayName(market.symbol);
+  // Full market name (e.g. "Bitcoin"), falling back to the ticker when unavailable.
+  const fullName = market.name || displayName;
 
   // Render the chart area: skeleton during initial load, error state on failure,
   // or the live chart once data is available.
@@ -1081,95 +1089,136 @@ const PerpsMarketDetailPage = () => {
       {/* Header */}
       <Box
         className="sticky top-0 z-10 bg-background-default"
-        flexDirection={BoxFlexDirection.Row}
-        alignItems={BoxAlignItems.Center}
-        paddingLeft={4}
-        paddingRight={4}
+        flexDirection={BoxFlexDirection.Column}
         paddingTop={4}
         paddingBottom={4}
         gap={2}
       >
-        {/* Back Button */}
+        {/* Top row: back chevron, logo, market identity, favorite star */}
         <Box
-          data-testid="perps-market-detail-back-button"
-          onClick={handleBackClick}
-          aria-label={t('back')}
-          className="p-2 -ml-2 cursor-pointer"
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Center}
+          paddingLeft={4}
+          paddingRight={4}
+          gap={2}
         >
-          <Icon
-            name={IconName.ArrowLeft}
-            size={IconSize.Md}
-            color={IconColor.IconAlternative}
-          />
-        </Box>
-
-        {/* Token Logo */}
-        <PerpsTokenLogo symbol={market.symbol} size={AvatarTokenSize.Md} />
-
-        {/* Header Content: symbol-USD, max leverage, price + change */}
-        <Box flexDirection={BoxFlexDirection.Column}>
+          {/* Back Button */}
           <Box
-            flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Center}
-            gap={1}
+            data-testid="perps-market-detail-back-button"
+            onClick={handleBackClick}
+            aria-label={t('back')}
+            className="p-2 -ml-2 cursor-pointer"
           >
-            <Text variant={TextVariant.HeadingMd}>{displayName}-USD</Text>
-            {market.maxLeverage && (
-              <Box
-                className="shrink-0 rounded-md bg-background-muted px-1.5"
-                data-testid="perps-market-max-leverage"
+            <Icon
+              name={IconName.ArrowLeft}
+              size={IconSize.Md}
+              color={IconColor.IconAlternative}
+            />
+          </Box>
+
+          {/* Token Logo */}
+          <PerpsTokenLogo symbol={market.symbol} size={AvatarTokenSize.Md} />
+
+          {/* Market identity: full name + leverage + chevron, ticker-collateral perp */}
+          <Box
+            flexDirection={BoxFlexDirection.Column}
+            className="min-w-0 flex-1"
+          >
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              gap={1}
+            >
+              <Text
+                variant={TextVariant.HeadingMd}
+                className="truncate"
+                data-testid="perps-market-detail-name"
               >
-                <Text
-                  variant={TextVariant.BodyXs}
-                  color={TextColor.TextAlternative}
+                {fullName}
+              </Text>
+              {market.maxLeverage && (
+                <Box
+                  className="shrink-0 rounded-md bg-background-muted px-1.5"
+                  data-testid="perps-market-max-leverage"
                 >
-                  {market.maxLeverage}
-                </Text>
+                  <Text
+                    variant={TextVariant.BodyXs}
+                    color={TextColor.TextAlternative}
+                  >
+                    {market.maxLeverage}
+                  </Text>
+                </Box>
+              )}
+              <Box
+                data-testid="perps-market-detail-market-list-button"
+                aria-label={t('perpsMarkets')}
+                onClick={handleMarketListClick}
+                className="shrink-0 cursor-pointer p-1 -m-1"
+              >
+                <Icon
+                  name={IconName.ArrowDown}
+                  size={IconSize.Sm}
+                  color={IconColor.IconAlternative}
+                />
               </Box>
-            )}
+            </Box>
+            <Text
+              variant={TextVariant.BodySm}
+              color={TextColor.TextAlternative}
+              data-testid="perps-market-detail-pair"
+            >
+              {t('perpsPerpMarketSubtitle', [
+                displayName,
+                PERPS_COLLATERAL_SYMBOL,
+              ])}
+            </Text>
           </Box>
+
           <Box
-            flexDirection={BoxFlexDirection.Row}
-            alignItems={BoxAlignItems.Baseline}
-            gap={1}
+            data-testid="perps-market-detail-favorite-button"
+            aria-label={
+              isInWatchlist
+                ? t('perpsRemoveFromFavorites')
+                : t('perpsAddToFavorites')
+            }
+            className="p-2 cursor-pointer transition-transform hover:scale-110"
+            onClick={handleFavoriteClick}
           >
-            <Text
-              variant={TextVariant.BodySm}
-              fontWeight={FontWeight.Medium}
-              data-testid="perps-market-detail-price"
-            >
-              {displayPrice}
-            </Text>
-            <Text
-              variant={TextVariant.BodySm}
-              fontWeight={FontWeight.Medium}
-              color={getChangeColor(displayChange)}
-              data-testid="perps-market-detail-change"
-            >
-              {displayChange}
-            </Text>
+            <Icon
+              name={isInWatchlist ? IconName.StarFilled : IconName.Star}
+              size={IconSize.Md}
+              color={
+                isInWatchlist
+                  ? IconColor.IconDefault
+                  : IconColor.IconAlternative
+              }
+            />
           </Box>
         </Box>
 
-        <Box className="flex-1" />
-
+        {/* Price + 24h change, below the header */}
         <Box
-          data-testid="perps-market-detail-favorite-button"
-          aria-label={
-            isInWatchlist
-              ? t('perpsRemoveFromFavorites')
-              : t('perpsAddToFavorites')
-          }
-          className="p-2 cursor-pointer transition-transform hover:scale-110"
-          onClick={handleFavoriteClick}
+          flexDirection={BoxFlexDirection.Row}
+          alignItems={BoxAlignItems.Baseline}
+          paddingLeft={4}
+          paddingRight={4}
+          gap={2}
         >
-          <Icon
-            name={isInWatchlist ? IconName.StarFilled : IconName.Star}
-            size={IconSize.Md}
-            color={
-              isInWatchlist ? IconColor.IconDefault : IconColor.IconAlternative
-            }
-          />
+          <Text
+            variant={TextVariant.HeadingLg}
+            fontWeight={FontWeight.Bold}
+            data-testid="perps-market-detail-price"
+          >
+            {displayPrice}
+          </Text>
+          <Text
+            variant={TextVariant.BodyMd}
+            fontWeight={FontWeight.Medium}
+            color={getChangeColor(displayChange)}
+            data-testid="perps-market-detail-change"
+          >
+            {displayChange}
+          </Text>
         </Box>
       </Box>
 


### PR DESCRIPTION
## **Description**

Reworks the perpetuals (perps) **market detail** screen header to match the
updated design.

**What changed:**

- **First row:** the market's **full name** (e.g. `Bitcoin`) with the **leverage
  pill** (e.g. `20x`) and a **chevron**.
- **Chevron behavior:** clicking the chevron navigates the user to the perps
  **market list**, so they can quickly switch markets.
- **Second row:** a `[ticker]-[collateral] perp` subtitle (e.g. `BTC-USDC perp`),
  driven by a new translatable `perpsPerpMarketSubtitle` message and a
  `PERPS_COLLATERAL_SYMBOL` constant.
- **Below the header:** the **price** and **24h price change** now render on
  their own row beneath the header, with the price shown more prominently.
- The market detail loading **skeleton** was updated to mirror the new layout.

**Why:** The previous header only showed `{symbol}-USD` with price/change inline;
the new layout aligns the extension with the agreed design and improves market
navigation via the chevron shortcut.

## **Changelog**

CHANGELOG entry: Redesigned the perps market detail header to show the full
market name, leverage, a ticker-collateral subtitle, and a chevron shortcut to
the market list.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TAT-3349

## **Manual testing steps**

```gherkin
Feature: Perps market detail header

  Scenario: Header shows the new market identity layout
    Given I have the perps experience enabled
    When I open the market detail page for a market (e.g. Bitcoin)
    Then I see the full market name with the leverage pill and a chevron on the first row
    And I see the "[ticker]-[collateral] perp" subtitle (e.g. "BTC-USDC perp") on the second row
    And I see the price and 24h price change below the header

  Scenario: Chevron navigates to the market list
    Given I am on a perps market detail page
    When I click the chevron next to the market name
    Then I am taken to the perps market list
```

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="368" height="633" alt="Screenshot 2026-07-01 at 12 33 02" src="https://github.com/user-attachments/assets/f2a1b95f-fe4e-48e0-a80b-ed549b3bbee1" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and navigation-only changes in the perps market detail UI; no auth, trading, or data-layer logic modified.
> 
> **Overview**
> Redesigns the perps **market detail** sticky header from a single row (`{symbol}-USD` with inline price/change) to a two-row identity block plus a separate price row.
> 
> The top row now shows **full market name** (from `market.name`), **max leverage** pill, and a **down chevron** that navigates to `PERPS_MARKET_LIST_ROUTE`. The subtitle uses i18n `perpsPerpMarketSubtitle` with ticker and new `PERPS_COLLATERAL_SYMBOL` (`USDC`) instead of `-USD`. **Price** and **24h change** move below the header with larger typography (`HeadingLg` for price).
> 
> `PerpsDetailPageSkeleton` mirrors the new layout. Tests assert `perps-market-detail-name`, `perps-market-detail-pair`, and chevron navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4587fb83aa8fb567b2f84c11cf2a81253071d22d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->