### PR TITLE
test: re-enable skipped benchmark tests

### DIFF
--- a/shared/constants/app.ts
+++ b/shared/constants/app.ts
@@ -223,6 +223,7 @@ export const FIREFOX_BUILD_IDS = [
   METAMASK_FLASK_FIREFOX_ID,
 ] as const;
 
+/** Placeholder ticker symbol used when a token's symbol cannot be determined. */
 export const UNKNOWN_TICKER_SYMBOL = 'UNKNOWN';
 
 export const TRACE_ENABLED_SIGN_METHODS = [

--- a/shared/constants/app.ts
+++ b/shared/constants/app.ts
@@ -223,7 +223,6 @@ export const FIREFOX_BUILD_IDS = [
   METAMASK_FLASK_FIREFOX_ID,
 ] as const;
 
-/** Placeholder ticker symbol used when a token's symbol cannot be determined. */
 export const UNKNOWN_TICKER_SYMBOL = 'UNKNOWN';
 
 export const TRACE_ENABLED_SIGN_METHODS = [

--- a/test/e2e/benchmarks/flows/user-journey/onboarding-import-wallet.ts
+++ b/test/e2e/benchmarks/flows/user-journey/onboarding-import-wallet.ts
@@ -200,15 +200,11 @@ export async function runOnboardingImportWalletBenchmark(): Promise<BenchmarkRun
           ),
         );
 
-        // BUG #42792 This test is failing with the ASSETS_UNIFIED_STATE_ENABLED='true'
-        // commenting out temporarily to unblock the release
-        /*
         try {
           webVitals = await collectWebVitals(driver);
         } catch (error) {
           console.error('Error collecting web vitals:', error);
         }
-        */
       },
     );
 

--- a/test/e2e/benchmarks/flows/user-journey/onboarding-new-wallet.ts
+++ b/test/e2e/benchmarks/flows/user-journey/onboarding-new-wallet.ts
@@ -164,15 +164,12 @@ export async function runOnboardingNewWalletBenchmark(): Promise<BenchmarkRunRes
             },
           ),
         );
-        // BUG #42792 This test is failing with the ASSETS_UNIFIED_STATE_ENABLED='true'
-        // commenting out temporarily to unblock the release
-        /*
+
         try {
           webVitals = await collectWebVitals(driver);
         } catch (error) {
           console.error('Error collecting web vitals:', error);
         }
-        */
       },
     );
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR re-enable a couple of benchmark tests that were skipped during asset controller migration as they are now passing

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that restores previously skipped benchmark instrumentation; no production code paths are modified.
> 
> **Overview**
> **Re-enables web vitals collection** in two user-journey performance benchmarks that had been commented out to unblock a release while `ASSETS_UNIFIED_STATE_ENABLED` caused failures (bug #42792).
> 
> In `onboarding-import-wallet.ts` and `onboarding-new-wallet.ts`, the `collectWebVitals(driver)` try/catch block runs again at the end of the measured flow, so benchmark results once more include `webVitals` alongside existing step timers and long-task metrics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 328c2656b4fde3821a09bf4d8759b7f71d9f3cc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->