### PR TITLE
prototype: Add Storybook stories for slider components [do-not-merge]

### DIFF
--- a/ui/components/app/perps/order-entry/components/leverage-slider/leverage-slider.stories.tsx
+++ b/ui/components/app/perps/order-entry/components/leverage-slider/leverage-slider.stories.tsx
@@ -1,0 +1,78 @@
+import React, { useState } from 'react';
+import type { Meta, StoryFn } from '@storybook/react';
+
+import { MetaMetricsContext } from '../../../../../../contexts/metametrics';
+import { LeverageSlider } from './leverage-slider';
+
+const mockMetaMetricsContext = {
+  trackEvent: () => Promise.resolve(undefined),
+  bufferedTrace: () => Promise.resolve(undefined),
+  bufferedEndTrace: () => undefined,
+  onboardingParentContext: { current: null },
+};
+
+const meta: Meta<typeof LeverageSlider> = {
+  title: 'Components/App/Perps/LeverageSlider',
+  component: LeverageSlider,
+  decorators: [
+    (Story) => (
+      <MetaMetricsContext.Provider value={mockMetaMetricsContext}>
+        <div style={{ width: 360, padding: 16 }}>
+          <Story />
+        </div>
+      </MetaMetricsContext.Provider>
+    ),
+  ],
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Leverage multiplier slider with numeric input, built on PerpsSlider.',
+      },
+    },
+  },
+  argTypes: {
+    leverage: { control: { type: 'number', min: 1 } },
+    maxLeverage: { control: { type: 'number', min: 1 } },
+    minLeverage: { control: { type: 'number', min: 1 } },
+    onLeverageChange: { action: 'onLeverageChange' },
+  },
+  args: {
+    leverage: 1,
+    maxLeverage: 20,
+    minLeverage: 1,
+  },
+};
+
+export default meta;
+
+const InteractiveTemplate: StoryFn<typeof LeverageSlider> = (args) => {
+  const [leverage, setLeverage] = useState(args.leverage);
+
+  return (
+    <LeverageSlider
+      {...args}
+      leverage={leverage}
+      onLeverageChange={(next) => {
+        setLeverage(next);
+        args.onLeverageChange?.(next);
+      }}
+    />
+  );
+};
+
+export const DefaultStory = InteractiveTemplate.bind({});
+DefaultStory.storyName = 'Default';
+
+export const MidLeverage = InteractiveTemplate.bind({});
+MidLeverage.storyName = 'MidLeverage';
+MidLeverage.args = {
+  leverage: 10,
+};
+
+export const HighMaxLeverage = InteractiveTemplate.bind({});
+HighMaxLeverage.storyName = 'HighMaxLeverage';
+HighMaxLeverage.args = {
+  leverage: 25,
+  maxLeverage: 50,
+};

--- a/ui/components/app/perps/perps-slider/perps-slider.stories.tsx
+++ b/ui/components/app/perps/perps-slider/perps-slider.stories.tsx
@@ -1,0 +1,95 @@
+import React, { useState } from 'react';
+import type { Meta, StoryFn } from '@storybook/react';
+
+import { PerpsSlider } from './perps-slider';
+
+const meta: Meta<typeof PerpsSlider> = {
+  title: 'Components/App/Perps/PerpsSlider',
+  component: PerpsSlider,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Perps-specific MUI Slider wrapper with optional header/footer chrome and tick marks.',
+      },
+    },
+  },
+  argTypes: {
+    min: { control: { type: 'number' } },
+    max: { control: { type: 'number' } },
+    step: { control: { type: 'number' } },
+    value: { control: { type: 'number' } },
+    markInterval: { control: { type: 'number' } },
+    disabled: { control: 'boolean' },
+    onChange: { action: 'onChange' },
+    onChangeCommitted: { action: 'onChangeCommitted' },
+    onEdit: { action: 'onEdit' },
+  },
+  args: {
+    min: 0,
+    max: 100,
+    step: 1,
+    value: 50,
+    disabled: false,
+  },
+};
+
+export default meta;
+
+const InteractiveTemplate: StoryFn<typeof PerpsSlider> = (args) => {
+  const [value, setValue] = useState(args.value);
+
+  return (
+    <div style={{ width: 320, padding: 16 }}>
+      <PerpsSlider
+        {...args}
+        value={value}
+        onChange={(event, newValue, activeThumb) => {
+          const next = Array.isArray(newValue) ? newValue[0] : newValue;
+          setValue(next);
+          args.onChange?.(event, newValue, activeThumb);
+        }}
+        onChangeCommitted={(event, newValue) => {
+          args.onChangeCommitted?.(event, newValue);
+        }}
+        onEdit={
+          args.onEdit
+            ? () => {
+                args.onEdit?.();
+              }
+            : undefined
+        }
+      />
+    </div>
+  );
+};
+
+export const DefaultStory = InteractiveTemplate.bind({});
+DefaultStory.storyName = 'Default';
+
+export const WithHeaderAndFooter = InteractiveTemplate.bind({});
+WithHeaderAndFooter.storyName = 'WithHeaderAndFooter';
+WithHeaderAndFooter.args = {
+  titleText: 'Amount',
+  tooltipText: 'Select a percentage of your balance to use.',
+  valueText: '50%',
+  titleDetail: 'Max 100%',
+  infoText: 'Adjust before confirming',
+  onEdit: () => undefined,
+};
+
+export const WithTickMarks = InteractiveTemplate.bind({});
+WithTickMarks.storyName = 'WithTickMarks';
+WithTickMarks.args = {
+  min: 1,
+  max: 20,
+  step: 1,
+  value: 5,
+  markInterval: 5,
+};
+
+export const Disabled = InteractiveTemplate.bind({});
+Disabled.args = {
+  disabled: true,
+  value: 75,
+};

--- a/ui/pages/confirmations/components/edit-gas-fee-popover/network-statistics/status-slider/status-slider.stories.tsx
+++ b/ui/pages/confirmations/components/edit-gas-fee-popover/network-statistics/status-slider/status-slider.stories.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import type { Meta, StoryObj } from '@storybook/react';
+
+import StatusSlider from './status-slider';
+
+const meta: Meta<typeof StatusSlider> = {
+  title: 'Pages/Confirmations/Components/StatusSlider',
+  component: StatusSlider,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Read-only network congestion indicator shown in gas fee settings. Not an interactive slider.',
+      },
+    },
+  },
+  argTypes: {
+    gasFeeEstimates: { control: 'object' },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ padding: 16 }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof StatusSlider>;
+
+export const NotBusyStory: Story = {
+  name: 'NotBusy',
+  args: {
+    gasFeeEstimates: { networkCongestion: 0.1 },
+  },
+};
+
+export const StableStory: Story = {
+  name: 'Stable',
+  args: {
+    gasFeeEstimates: { networkCongestion: 0.5 },
+  },
+};
+
+export const BusyStory: Story = {
+  name: 'Busy',
+  args: {
+    gasFeeEstimates: { networkCongestion: 0.95 },
+  },
+};
+
+export const UnknownCongestionStory: Story = {
+  name: 'UnknownCongestion',
+  args: {
+    gasFeeEstimates: undefined,
+  },
+};
+
+export const AllStatesStory: Story = {
+  name: 'AllStates',
+  render: () => (
+    <div
+      style={{
+        display: 'flex',
+        gap: 24,
+        alignItems: 'flex-end',
+      }}
+    >
+      <StatusSlider gasFeeEstimates={{ networkCongestion: 0.1 }} />
+      <StatusSlider gasFeeEstimates={{ networkCongestion: 0.5 }} />
+      <StatusSlider gasFeeEstimates={{ networkCongestion: 0.95 }} />
+      <StatusSlider gasFeeEstimates={undefined} />
+    </div>
+  ),
+};


### PR DESCRIPTION
## **Description**

Adds Storybook coverage for slider components used across the extension so they can be reviewed and iterated on in isolation. This mirrors the mobile prototype in [MetaMask/metamask-mobile#32692](https://github.com/MetaMask/metamask-mobile/pull/32692) for cross-platform design/engineering review.

**What changed:**

- New Storybook stories for **PerpsSlider**, **LeverageSlider**, and **StatusSlider**
- Interactive story templates with local state for draggable sliders
- **StatusSlider** stories cover not busy, stable, busy, unknown congestion, and an all-states comparison view

**Existing coverage (unchanged on this branch):**

- Legacy `ui/components/ui/slider` already has Storybook stories at `Components/UI/Slider`

This is a prototype branch for design/engineering review of slider behavior and visuals, not intended for production merge as-is.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-mobile/pull/32692

## **Manual testing steps**

Feature: Slider Storybook prototype

1. Check out this branch and install dependencies if needed (`yarn install`).
2. Run Storybook: `yarn storybook`
3. In the Storybook sidebar, open:
   - `Components / App / Perps / PerpsSlider`
   - `Components / App / Perps / LeverageSlider`
   - `Pages / Confirmations / Components / StatusSlider`
4. Verify each story renders correctly in light and dark theme.
5. For **PerpsSlider** and **LeverageSlider**, drag the slider thumb and confirm the value updates.
6. For **StatusSlider**, confirm the congestion label and arrow position match each story variant.

## **Screenshots/Recordings**

### **Before**

N/A

### **After**

https://github.com/user-attachments/assets/ca835e13-43da-4248-8bee-d6565906fc6b


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


Made with [Cursor](https://cursor.com)