### PR TITLE
test: fix flaky test Ledger Hardware unlocks multiple accounts at once and removes one

### DIFF
--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -431,7 +431,6 @@ class AccountListPage {
    */
   async openMultichainAccountMenu(options: {
     accountLabel: string;
-    srpIndex?: number;
   }): Promise<void> {
     console.log(
       `Open multichain account menu in account list for account ${options.accountLabel}`,

--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -445,7 +445,9 @@ class AccountListPage {
       `${this.multichainAccountOptionsMenuButton}[aria-label="${options.accountLabel} options"]`,
     );
 
-    await multichainAccountMenuIcons[options.srpIndex ?? 0].click();
+    const icon = multichainAccountMenuIcons[options.srpIndex ?? 0];
+    await this.driver.scrollToElement(icon);
+    await icon.click();
   }
 
   /**

--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -427,7 +427,6 @@ class AccountListPage {
    *
    * @param options - Options for opening the multichain account menu
    * @param options.accountLabel - The label of the account to open the menu for
-   * @param options.srpIndex - Optional SRP index if there are multiple SRPs
    */
   async openMultichainAccountMenu(options: {
     accountLabel: string;

--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -441,13 +441,9 @@ class AccountListPage {
       waitAtLeastGuard: largeDelayMs,
     });
 
-    const multichainAccountMenuIcons = await this.driver.findElements(
+    await this.driver.clickElement(
       `${this.multichainAccountOptionsMenuButton}[aria-label="${options.accountLabel} options"]`,
     );
-
-    const icon = multichainAccountMenuIcons[options.srpIndex ?? 0];
-    await this.driver.scrollToElement(icon);
-    await icon.click();
   }
 
   /**

--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -36,6 +36,16 @@ class AccountListPage {
   private readonly multichainAccountOptionsMenuButton =
     '[data-testid="multichain-account-cell-end-accessory"]';
 
+  // Indexed XPath so the correct account is targeted when multiple accounts
+  // share the same label (e.g. "Account 1" across multiple SRPs).
+  private readonly multichainAccountOptionsMenuButtonByLabel = (
+    accountLabel: string,
+    srpIndex: number,
+  ) =>
+    `(//*[@data-testid="multichain-account-cell-end-accessory" and @aria-label=${quoteXPathText(
+      `${accountLabel} options`,
+    )}])[${srpIndex + 1}]`;
+
   private readonly addHardwareWalletButton =
     '[data-testid="choose-wallet-type-hardware-wallet"]';
 
@@ -442,11 +452,11 @@ class AccountListPage {
       waitAtLeastGuard: largeDelayMs,
     });
 
-    // Use an indexed XPath so the correct account is targeted when multiple
-    // accounts share the same label (e.g. "Account 1" across multiple SRPs).
-    // clickElement provides the visibility/enabled guards and auto-scroll.
     await this.driver.clickElement({
-      xpath: `(//*[@data-testid="multichain-account-cell-end-accessory" and @aria-label=${quoteXPathText(`${accountLabel} options`)}])[${srpIndex + 1}]`,
+      xpath: this.multichainAccountOptionsMenuButtonByLabel(
+        accountLabel,
+        srpIndex,
+      ),
     });
   }
 

--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -427,21 +427,27 @@ class AccountListPage {
    *
    * @param options - Options for opening the multichain account menu
    * @param options.accountLabel - The label of the account to open the menu for
+   * @param options.srpIndex - Optional SRP index if there are multiple SRPs
    */
   async openMultichainAccountMenu(options: {
     accountLabel: string;
+    srpIndex?: number;
   }): Promise<void> {
+    const { accountLabel, srpIndex = 0 } = options;
     console.log(
-      `Open multichain account menu in account list for account ${options.accountLabel}`,
+      `Open multichain account menu in account list for account ${accountLabel}`,
     );
     // To ensure no pending Create Account action is in progress
     await this.driver.assertElementNotPresent(this.addingAccountMessage, {
       waitAtLeastGuard: largeDelayMs,
     });
 
-    await this.driver.clickElement(
-      `${this.multichainAccountOptionsMenuButton}[aria-label="${options.accountLabel} options"]`,
-    );
+    // Use an indexed XPath so the correct account is targeted when multiple
+    // accounts share the same label (e.g. "Account 1" across multiple SRPs).
+    // clickElement provides the visibility/enabled guards and auto-scroll.
+    await this.driver.clickElement({
+      xpath: `(//*[@data-testid="multichain-account-cell-end-accessory" and @aria-label=${quoteXPathText(`${accountLabel} options`)}])[${srpIndex + 1}]`,
+    });
   }
 
   /**


### PR DESCRIPTION


<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Test is failing in CI: Ledger Account 2 was partially scrolled out of view, so clicking its options button didn't open the dropdown menu.

Added `scrollToElement()` before clicking the options button in `openMultichainAccountMenu`, ensuring the account is fully visible before the click.

CI [logs](https://github.com/MetaMask/metamask-extension/actions/runs/28572596324/job/84715535505)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<img width="780" height="493" alt="test-failure-screenshot-1" src="https://github.com/user-attachments/assets/2dcba58a-c1ad-4bb8-8ba0-ee0db027cc2d" />


### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2E page-object locator change only; no production wallet or extension runtime behavior is affected.
> 
> **Overview**
> **`openMultichainAccountMenu`** no longer uses a CSS `aria-label` selector plus `findElements` and an array index. It now clicks through a new **indexed XPath** helper that matches `multichain-account-cell-end-accessory` by quoted `"{accountLabel} options"` and picks the **(srpIndex + 1)** match when duplicate labels exist across SRPs.
> 
> `srpIndex` defaults to **0** via destructuring, and the click goes through **`driver.clickElement({ xpath })`** instead of manually indexing WebElements.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7004750d63d2d51959f85ecd84992746f81d0e8c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->