### PR TITLE
test: ignore notifications log in refresh-auth-token spec

### DIFF
--- a/test/e2e/tests/seedless-onboarding/refresh-auth-tokens.spec.ts
+++ b/test/e2e/tests/seedless-onboarding/refresh-auth-tokens.spec.ts
@@ -50,6 +50,7 @@ describe('Refresh Auth Tokens (Seedless Onboarding)', function () {
         fixtures: new FixtureBuilderV2({ onboarding: true }).build(),
         ignoredConsoleErrors: [
           'The operation cannot be completed while the controller is locked.',
+          'Unable to enable notifications',
         ],
         title: this.test?.fullTitle(),
         testSpecificMock: (server: Mockttp) => {
@@ -143,6 +144,7 @@ describe('Refresh Auth Tokens (Seedless Onboarding)', function () {
         fixtures: new FixtureBuilderV2({ onboarding: true }).build(),
         ignoredConsoleErrors: [
           'The operation cannot be completed while the controller is locked.',
+          'Unable to enable notifications',
         ],
         title: this.test?.fullTitle(),
         testSpecificMock: (server: Mockttp) => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Flakyness of the spec seems related to a race condition with profile-sync.

Auto-enable is driven by React effects (ui/contexts/metamask-notifications/metamask-notifications.tsx:91-179) keyed on isUnlocked/isSignedIn/isBasicFunctionalityEnabled. When enable throws during the brief window where the wallet has just unlocked but profile-sync auth hasn't settled, the effect simply re-runs onthe next state change and succeeds. Nothing is permanently broken.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/GE-318

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2e test configuration only; no production or auth logic changes.
> 
> **Overview**
> Reduces flakiness in seedless **Refresh Auth Tokens** e2e coverage by treating a transient MetaMask notifications auto-enable failure as an allowed console error.
> 
> Both cases in `refresh-auth-tokens.spec.ts` now add `'Unable to enable notifications'` to `ignoredConsoleErrors` alongside the existing controller-locked message. That matches the pattern used elsewhere (e.g. responsive UI specs) when unlock/profile-sync timing can briefly cause notification enable to throw before auth settles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73c8d4c43c62082188340b042b623cb661e698ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->