### PR TITLE
chore: migrate `setSelectedInternalAccount` to `LegacyBackgroundApiService`

### DIFF
--- a/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
@@ -46,6 +46,7 @@ export function getLegacyBackgroundApiServiceMessenger(
       'OnboardingController:getIsSocialLoginFlow',
       'KeyringController:withKeyringV2',
       'KeyringController:removeAccount',
+      'AccountsController:getAccount',
       'AccountsController:getAccountByAddress',
       'AccountsController:setSelectedAccount',
       'SeedlessOnboardingController:addNewSecretData',

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3085,12 +3085,10 @@ export default class MetamaskController extends EventEmitter {
         ),
 
       // AccountsController
-      setSelectedInternalAccount: (id) => {
-        const account = this.accountsController.getAccount(id);
-        if (account) {
-          this.accountsController.setSelectedAccount(id);
-        }
-      },
+      setSelectedInternalAccount: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'LegacyBackgroundApiService:setSelectedInternalAccount',
+      ),
 
       setAccountName:
         accountsController.setAccountName.bind(accountsController),

--- a/app/scripts/services/legacy-background-api-service-method-action-types.ts
+++ b/app/scripts/services/legacy-background-api-service-method-action-types.ts
@@ -197,6 +197,16 @@ export type LegacyBackgroundApiServiceGetAccountsBySnapIdAction = {
 };
 
 /**
+ * Sets the currently selected internal account.
+ *
+ * @param id - The ID of the account to set as selected.
+ */
+export type LegacyBackgroundApiServiceSetSelectedInternalAccountAction = {
+  type: `LegacyBackgroundApiService:setSelectedInternalAccount`;
+  handler: LegacyBackgroundApiService['setSelectedInternalAccount'];
+};
+
+/**
  * Returns the next nonce according to the nonce-tracker
  *
  * @param address - The hex string address for the transaction
@@ -364,6 +374,7 @@ export type LegacyBackgroundApiServiceMethodActions =
   | LegacyBackgroundApiServiceRemovePermissionsForAction
   | LegacyBackgroundApiServiceImportAccountWithStrategyAction
   | LegacyBackgroundApiServiceGetAccountsBySnapIdAction
+  | LegacyBackgroundApiServiceSetSelectedInternalAccountAction
   | LegacyBackgroundApiServiceGetNextNonceAction
   | LegacyBackgroundApiServiceChangePasswordAction
   | LegacyBackgroundApiServiceCheckIsSeedlessPasswordOutdatedAction

--- a/app/scripts/services/legacy-background-api-service.test.ts
+++ b/app/scripts/services/legacy-background-api-service.test.ts
@@ -1451,6 +1451,66 @@ describe('LegacyBackgroundApiService', () => {
     });
   });
 
+  describe('setSelectedInternalAccount', () => {
+    it('sets the selected account when the account exists', async () => {
+      await withService(async ({ rootMessenger, serviceMessenger }) => {
+        rootMessenger.registerActionHandler(
+          'AccountsController:getAccount',
+          jest.fn().mockReturnValue({ id: 'mock-id' }),
+        );
+        rootMessenger.registerActionHandler(
+          'AccountsController:setSelectedAccount',
+          jest.fn(),
+        );
+
+        const callSpy = jest.spyOn(serviceMessenger, 'call');
+
+        rootMessenger.call(
+          'LegacyBackgroundApiService:setSelectedInternalAccount',
+          'mock-id',
+        );
+
+        expect(callSpy).toHaveBeenCalledWith(
+          'AccountsController:getAccount',
+          'mock-id',
+        );
+        expect(callSpy).toHaveBeenCalledWith(
+          'AccountsController:setSelectedAccount',
+          'mock-id',
+        );
+      });
+    });
+
+    it('does not set the selected account when the account does not exist', async () => {
+      await withService(async ({ rootMessenger, serviceMessenger }) => {
+        rootMessenger.registerActionHandler(
+          'AccountsController:getAccount',
+          jest.fn().mockReturnValue(undefined),
+        );
+        rootMessenger.registerActionHandler(
+          'AccountsController:setSelectedAccount',
+          jest.fn(),
+        );
+
+        const callSpy = jest.spyOn(serviceMessenger, 'call');
+
+        rootMessenger.call(
+          'LegacyBackgroundApiService:setSelectedInternalAccount',
+          'mock-id',
+        );
+
+        expect(callSpy).toHaveBeenCalledWith(
+          'AccountsController:getAccount',
+          'mock-id',
+        );
+        expect(callSpy).not.toHaveBeenCalledWith(
+          'AccountsController:setSelectedAccount',
+          'mock-id',
+        );
+      });
+    });
+  });
+
   describe('checkIsSeedlessPasswordOutdated', () => {
     it("returns false if it's a social login flow", async () => {
       await withService(async ({ rootMessenger }) => {
@@ -2802,6 +2862,7 @@ function getMessenger(
       'OnboardingController:getIsSocialLoginFlow',
       'KeyringController:withKeyringV2',
       'KeyringController:removeAccount',
+      'AccountsController:getAccount',
       'AccountsController:getAccountByAddress',
       'AccountsController:setSelectedAccount',
       'SeedlessOnboardingController:addNewSecretData',

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -27,6 +27,7 @@ import {
   KeyringControllerWithKeyringAction,
 } from '@metamask/keyring-controller';
 import {
+  AccountsControllerGetAccountAction,
   AccountsControllerGetAccountByAddressAction,
   AccountsControllerGetSelectedAccountAction,
   AccountsControllerSetSelectedAccountAction,
@@ -175,6 +176,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'resetAccount',
   'setCurrentCurrency',
   'setLocked',
+  'setSelectedInternalAccount',
   'submitPasswordOrEncryptionKey',
   'syncPasswordAndUnlockWallet',
   'syncKeyringEncryptionKey',
@@ -191,6 +193,7 @@ export type LegacyBackgroundApiServiceActions =
 type AllowedActions =
   | AccountTreeControllerGetSelectedAccountGroupAction
   | AccountTreeControllerInitAction
+  | AccountsControllerGetAccountAction
   | AccountsControllerGetAccountByAddressAction
   | AccountsControllerGetSelectedAccountAction
   | AccountsControllerSetSelectedAccountAction
@@ -812,6 +815,18 @@ export class LegacyBackgroundApiService {
    */
   async getAccountsBySnapId(snapId: SnapId): Promise<string[]> {
     return getAccountsBySnapId(this.#messenger, snapId);
+  }
+
+  /**
+   * Sets the currently selected internal account.
+   *
+   * @param id - The ID of the account to set as selected.
+   */
+  setSelectedInternalAccount(id: string): void {
+    const account = this.#messenger.call('AccountsController:getAccount', id);
+    if (account) {
+      this.#messenger.call('AccountsController:setSelectedAccount', id);
+    }
   }
 
   /**


### PR DESCRIPTION
## **Description**

This moves `setSelectedInternalAccount` from `MetamaskController` to `LegacyBackgroundApiService`.

## **Related issues**

Progresses: https://consensyssoftware.atlassian.net/browse/WPC-1087

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving refactor with tests; selected-account logic is unchanged, only relocated behind the messenger.
> 
> **Overview**
> Moves **`setSelectedInternalAccount`** out of `MetamaskController` into **`LegacyBackgroundApiService`**, continuing the background API consolidation (WPC-1087).
> 
> The service implements the same guard as before: it calls `AccountsController:getAccount` and only invokes `setSelectedAccount` when that account exists. The public API surface is unchanged—`MetamaskController` now forwards via `controllerMessenger.call('LegacyBackgroundApiService:setSelectedInternalAccount', …)` instead of touching `accountsController` directly.
> 
> Wiring updates include the new messenger action type, delegation of `AccountsController:getAccount` to the legacy background API messenger, and unit tests for both the success and no-op-when-missing-account paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b06c2f1bc65065b690443dfcd75ae39200de696d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->