### PR TITLE
chore: bind `syncAccountTreeWithUserStorage` directly to `AccountTreeController:syncWithUserStorage`

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3121,9 +3121,10 @@ export default class MetamaskController extends EventEmitter {
         this.accountTreeController.setAccountGroupHidden.bind(
           this.accountTreeController,
         ),
-      syncAccountTreeWithUserStorage: async () => {
-        await this.accountTreeController.syncWithUserStorage();
-      },
+      syncAccountTreeWithUserStorage: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'AccountTreeController:syncWithUserStorage',
+      ),
 
       // MultichainAccountService
       createNextMultichainAccountGroup: async (walletId) => {


### PR DESCRIPTION
## **Description**

This binds the `syncAccountTreeWithUserStorage` `getApi()` method directly to the `AccountTreeController:syncWithUserStorage` messenger action. Since the method is a pure single-controller pass-through, it skips the `LegacyBackgroundApiService` wrapper entirely and removes the redundant `MetamaskController` method.

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Progresses: https://consensyssoftware.atlassian.net/browse/WPC-1089

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line API wiring change with no new behavior; callers still trigger the same account-tree user-storage sync action.
> 
> **Overview**
> **`getApi()`** now exposes **`syncAccountTreeWithUserStorage`** as a direct **`controllerMessenger.call`** binding to **`AccountTreeController:syncWithUserStorage`**, instead of an async wrapper that called **`accountTreeController.syncWithUserStorage()`** on **`MetamaskController`**.
> 
> This matches other messenger-first API wiring and drops an unnecessary indirection layer for a single-controller pass-through (part of moving logic off **`LegacyBackgroundApiService`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2a5471be95067918ae4c24db5ed87c1943641b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->