### PR TITLE
chore: migrate `setAccountLabel` to `LegacyBackgroundApiService`

### DIFF
--- a/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
@@ -47,6 +47,7 @@ export function getLegacyBackgroundApiServiceMessenger(
       'KeyringController:withKeyringV2',
       'KeyringController:removeAccount',
       'AccountsController:getAccountByAddress',
+      'AccountsController:setAccountName',
       'AccountsController:setSelectedAccount',
       'SeedlessOnboardingController:addNewSecretData',
       'SeedlessOnboardingController:changePassword',

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3095,13 +3095,10 @@ export default class MetamaskController extends EventEmitter {
       setAccountName:
         accountsController.setAccountName.bind(accountsController),
 
-      setAccountLabel: (address, label) => {
-        const account = this.accountsController.getAccountByAddress(address);
-        if (account === undefined) {
-          throw new Error(`No account found for address: ${address}`);
-        }
-        this.accountsController.setAccountName(account.id, label);
-      },
+      setAccountLabel: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'LegacyBackgroundApiService:setAccountLabel',
+      ),
 
       // AccountTreeController
       setSelectedMultichainAccount: (accountGroupId) => {

--- a/app/scripts/services/legacy-background-api-service-method-action-types.ts
+++ b/app/scripts/services/legacy-background-api-service-method-action-types.ts
@@ -148,6 +148,17 @@ export type LegacyBackgroundApiServiceRemoveAccountAction = {
 };
 
 /**
+ * Sets the label for the account at the given address.
+ *
+ * @param address - The address of the account to set the label for.
+ * @param label - The label to set for the account.
+ */
+export type LegacyBackgroundApiServiceSetAccountLabelAction = {
+  type: `LegacyBackgroundApiService:setAccountLabel`;
+  handler: LegacyBackgroundApiService['setAccountLabel'];
+};
+
+/**
  * Execute side effects of a removed account.
  *
  * @param address - The address of the account to remove.
@@ -359,6 +370,7 @@ export type LegacyBackgroundApiServiceMethodActions =
   | LegacyBackgroundApiServiceResetAccountAction
   | LegacyBackgroundApiServiceGetGlobalChainIdAction
   | LegacyBackgroundApiServiceRemoveAccountAction
+  | LegacyBackgroundApiServiceSetAccountLabelAction
   | LegacyBackgroundApiServiceOnAccountRemovedAction
   | LegacyBackgroundApiServiceRejectPermissionsRequestAction
   | LegacyBackgroundApiServiceRemovePermissionsForAction

--- a/app/scripts/services/legacy-background-api-service.test.ts
+++ b/app/scripts/services/legacy-background-api-service.test.ts
@@ -1217,6 +1217,50 @@ describe('LegacyBackgroundApiService', () => {
     });
   });
 
+  describe('setAccountLabel', () => {
+    it('sets the account name for the account at the given address', async () => {
+      await withService(async ({ rootMessenger }) => {
+        const setAccountNameHandler = jest.fn();
+        rootMessenger.registerActionHandler(
+          'AccountsController:getAccountByAddress',
+          jest.fn().mockReturnValue({ id: 'account-id' }),
+        );
+        rootMessenger.registerActionHandler(
+          'AccountsController:setAccountName',
+          setAccountNameHandler,
+        );
+
+        rootMessenger.call(
+          'LegacyBackgroundApiService:setAccountLabel',
+          '0x123',
+          'New Label',
+        );
+
+        expect(setAccountNameHandler).toHaveBeenCalledWith(
+          'account-id',
+          'New Label',
+        );
+      });
+    });
+
+    it('throws if no account is found for the given address', async () => {
+      await withService(async ({ rootMessenger }) => {
+        rootMessenger.registerActionHandler(
+          'AccountsController:getAccountByAddress',
+          jest.fn().mockReturnValue(undefined),
+        );
+
+        expect(() =>
+          rootMessenger.call(
+            'LegacyBackgroundApiService:setAccountLabel',
+            '0x123',
+            'New Label',
+          ),
+        ).toThrow('No account found for address: 0x123');
+      });
+    });
+  });
+
   describe('exportAccount', () => {
     it('verifies the password and returns the private key', async () => {
       const address = '0xAddress';
@@ -2803,6 +2847,7 @@ function getMessenger(
       'KeyringController:withKeyringV2',
       'KeyringController:removeAccount',
       'AccountsController:getAccountByAddress',
+      'AccountsController:setAccountName',
       'AccountsController:setSelectedAccount',
       'SeedlessOnboardingController:addNewSecretData',
       'SeedlessOnboardingController:updateBackupMetadataState',

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -29,6 +29,7 @@ import {
 import {
   AccountsControllerGetAccountByAddressAction,
   AccountsControllerGetSelectedAccountAction,
+  AccountsControllerSetAccountNameAction,
   AccountsControllerSetSelectedAccountAction,
   AccountsControllerUpdateAccountsAction,
 } from '@metamask/accounts-controller';
@@ -173,6 +174,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'removeAccount',
   'removePermissionsFor',
   'resetAccount',
+  'setAccountLabel',
   'setCurrentCurrency',
   'setLocked',
   'submitPasswordOrEncryptionKey',
@@ -193,6 +195,7 @@ type AllowedActions =
   | AccountTreeControllerInitAction
   | AccountsControllerGetAccountByAddressAction
   | AccountsControllerGetSelectedAccountAction
+  | AccountsControllerSetAccountNameAction
   | AccountsControllerSetSelectedAccountAction
   | AccountsControllerUpdateAccountsAction
   | ApprovalControllerGetStateAction
@@ -610,6 +613,27 @@ export class LegacyBackgroundApiService {
     await this.#messenger.call('KeyringController:removeAccount', address);
 
     return address;
+  }
+
+  /**
+   * Sets the label for the account at the given address.
+   *
+   * @param address - The address of the account to set the label for.
+   * @param label - The label to set for the account.
+   */
+  setAccountLabel(address: string, label: string): void {
+    const account = this.#messenger.call(
+      'AccountsController:getAccountByAddress',
+      address,
+    );
+    if (account === undefined) {
+      throw new Error(`No account found for address: ${address}`);
+    }
+    this.#messenger.call(
+      'AccountsController:setAccountName',
+      account.id,
+      label,
+    );
   }
 
   /**


### PR DESCRIPTION
## **Description**

This moves `setAccountLabel` from `MetamaskController` to `LegacyBackgroundApiService`.

## **Related issues**

Progresses: https://consensyssoftware.atlassian.net/browse/WPC-1088

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only move of display-name logic with unchanged behavior and new unit tests; no auth or transaction impact.
> 
> **Overview**
> Moves **account label renaming** out of `MetamaskController` into `LegacyBackgroundApiService`, continuing the background API migration (WPC-1088).
> 
> `MetamaskController`’s `setAccountLabel` now forwards through `controllerMessenger` to `LegacyBackgroundApiService:setAccountLabel` instead of resolving the address and calling `AccountsController:setAccountName` locally. The service implements the same flow: `getAccountByAddress`, error if missing, then `setAccountName` by account id. Messenger wiring adds `AccountsController:setAccountName` to the legacy service delegate list and registers the new action type.
> 
> Unit tests cover successful rename and the missing-address error path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd2e7072f914787f3b22ebd4b71d206a0989af57. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->