### PR TITLE
chore: bind `createNextMultichainAccountGroup` directly to `MultichainAccountService:createNextMultichainAccountGroup`

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3126,11 +3126,10 @@ export default class MetamaskController extends EventEmitter {
       },
 
       // MultichainAccountService
-      createNextMultichainAccountGroup: async (walletId) => {
-        await this.multichainAccountService.createNextMultichainAccountGroup({
-          entropySource: walletId,
-        });
-      },
+      createNextMultichainAccountGroup: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'MultichainAccountService:createNextMultichainAccountGroup',
+      ),
 
       alignMultichainWallets: async () => {
         if (this.multichainAccountService) {

--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -2166,7 +2166,9 @@ describe('Actions', () => {
 
       expect(createNextMultichainAccountGroup.callCount).toStrictEqual(1);
       expect(
-        createNextMultichainAccountGroup.calledWith(walletIdWithoutPrefix),
+        createNextMultichainAccountGroup.calledWith({
+          entropySource: walletIdWithoutPrefix,
+        }),
       ).toStrictEqual(true);
     });
   });

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -2589,7 +2589,7 @@ export function createNextMultichainAccountGroup(
       const walletIdWithoutTypePrefix =
         stripWalletTypePrefixFromWalletId(walletId);
       await submitRequestToBackground('createNextMultichainAccountGroup', [
-        walletIdWithoutTypePrefix,
+        { entropySource: walletIdWithoutTypePrefix },
       ]);
       // Forcing update of the state speeds up the UI update process
       // and makes UX better


### PR DESCRIPTION
## **Description**

This binds the `createNextMultichainAccountGroup` `getApi()` method directly to the `MultichainAccountService:createNextMultichainAccountGroup` messenger action, removing the redundant `MetamaskController` wrapper. The UI thunk is updated to pass `{ entropySource }` so the argument shape matches the action's signature.

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Progresses: https://consensyssoftware.atlassian.net/browse/WPC-1090

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small wiring refactor with an explicit argument-shape fix; behavior should be unchanged if the service already expected `{ entropySource }`.
> 
> **Overview**
> Removes the **`MetamaskController`** wrapper for **`createNextMultichainAccountGroup`** and exposes **`getApi()`** as a direct **`controllerMessenger.call`** to **`MultichainAccountService:createNextMultichainAccountGroup`**.
> 
> The UI thunk and its test now pass **`{ entropySource }`** (stripped wallet id) instead of a bare string, so the background RPC matches the messenger action’s expected argument shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 99e2b3122bd364bb674f953e2fe737ee7f4183fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->