### PR TITLE
chore: migrate `rejectAllPendingApprovals` to `LegacyBackgroundApiService`

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -2131,7 +2131,7 @@ export function setupController(
       REJECT_NOTIFICATION_CLOSE,
     );
 
-    controller.rejectAllPendingApprovals();
+    controller.legacyBackgroundApiService.rejectAllPendingApprovals();
   }
 }
 

--- a/app/scripts/lib/approval/utils.test.ts
+++ b/app/scripts/lib/approval/utils.test.ts
@@ -5,20 +5,14 @@ import {
 import { Json } from '@metamask/utils';
 import { ApprovalType } from '@metamask/controller-utils';
 import { providerErrors } from '@metamask/rpc-errors';
-import { DIALOG_APPROVAL_TYPES } from '@metamask/snaps-rpc-methods';
-import {
-  SMART_TRANSACTION_CONFIRMATION_TYPES,
-  SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES,
-} from '../../../../shared/constants/app';
+import { SMART_TRANSACTION_CONFIRMATION_TYPES } from '../../../../shared/constants/app';
 import {
   getAttentionRequiredApprovalCount,
-  rejectAllApprovals,
   rejectOriginApprovals,
 } from './utils';
 
 const ID_MOCK = '123';
 const ID_MOCK_2 = '456';
-const INTERFACE_ID_MOCK = '789';
 const REJECT_ALL_APPROVALS_DATA = {
   data: {
     cause: 'rejectAllApprovals',
@@ -53,87 +47,6 @@ describe('Approval Utils', () => {
           approvalController,
         }),
       ).toBe(1);
-    });
-  });
-
-  describe('rejectAllApprovals', () => {
-    it('rejects approval requests with rejected error', () => {
-      const approvalController = createApprovalControllerMock([
-        { id: ID_MOCK, type: ApprovalType.Transaction },
-        { id: ID_MOCK_2, type: ApprovalType.EthSignTypedData },
-      ]);
-
-      rejectAllApprovals({
-        approvalController,
-      });
-
-      expect(approvalController.rejectRequest).toHaveBeenCalledTimes(2);
-      expect(approvalController.rejectRequest).toHaveBeenCalledWith(
-        ID_MOCK,
-        providerErrors.userRejectedRequest(REJECT_ALL_APPROVALS_DATA),
-      );
-      expect(approvalController.rejectRequest).toHaveBeenCalledWith(
-        ID_MOCK_2,
-        providerErrors.userRejectedRequest(REJECT_ALL_APPROVALS_DATA),
-      );
-    });
-
-    // @ts-expect-error This function is missing from the Mocha type definitions
-    it.each([
-      ApprovalType.SnapDialogAlert,
-      ApprovalType.SnapDialogPrompt,
-      DIALOG_APPROVAL_TYPES.default,
-    ])('accepts pending approval if type is %s', (type: string) => {
-      const approvalController = createApprovalControllerMock([
-        { id: ID_MOCK, type },
-      ]);
-
-      rejectAllApprovals({ approvalController });
-
-      expect(approvalController.acceptRequest).toHaveBeenCalledTimes(1);
-      expect(approvalController.acceptRequest).toHaveBeenCalledWith(
-        ID_MOCK,
-        null,
-      );
-    });
-
-    // @ts-expect-error This function is missing from the Mocha type definitions
-    it.each([
-      ApprovalType.SnapDialogConfirmation,
-      SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES.confirmAccountCreation,
-      SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES.confirmAccountRemoval,
-      SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES.showSnapAccountRedirect,
-    ])('accepts pending approval if type is %s', (type: string) => {
-      const approvalController = createApprovalControllerMock([
-        { id: ID_MOCK, type },
-      ]);
-
-      rejectAllApprovals({ approvalController });
-
-      expect(approvalController.acceptRequest).toHaveBeenCalledTimes(1);
-      expect(approvalController.acceptRequest).toHaveBeenCalledWith(
-        ID_MOCK,
-        false,
-      );
-    });
-
-    // @ts-expect-error This function is missing from the Mocha type definitions
-    it.each([
-      ApprovalType.SnapDialogAlert,
-      ApprovalType.SnapDialogPrompt,
-      DIALOG_APPROVAL_TYPES.default,
-      ApprovalType.SnapDialogConfirmation,
-    ])('deletes interface if type is %s', (type: string) => {
-      const approvalController = createApprovalControllerMock([
-        { id: ID_MOCK, type, requestData: { id: INTERFACE_ID_MOCK } },
-      ]);
-
-      const deleteInterface = jest.fn();
-
-      rejectAllApprovals({ approvalController, deleteInterface });
-
-      expect(deleteInterface).toHaveBeenCalledTimes(1);
-      expect(deleteInterface).toHaveBeenCalledWith(INTERFACE_ID_MOCK);
     });
   });
 

--- a/app/scripts/lib/approval/utils.ts
+++ b/app/scripts/lib/approval/utils.ts
@@ -28,25 +28,6 @@ export function getAttentionRequiredApprovalCount({
   ).length;
 }
 
-export function rejectAllApprovals({
-  approvalController,
-  deleteInterface,
-}: {
-  approvalController: ApprovalController;
-  deleteInterface?: (id: string) => void;
-}) {
-  const approvalRequestsById = approvalController.state.pendingApprovals;
-  const approvalRequests = Object.values(approvalRequestsById);
-
-  for (const approvalRequest of approvalRequests) {
-    rejectApproval({
-      approvalController,
-      approvalRequest,
-      deleteInterface,
-    });
-  }
-}
-
 export function rejectOriginApprovals({
   approvalController,
   deleteInterface,

--- a/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
@@ -35,6 +35,8 @@ export function getLegacyBackgroundApiServiceMessenger(
       'KeyringController:exportSeedPhrase',
       'AccountsController:getSelectedAccount',
       'ApprovalController:getState',
+      'ApprovalController:acceptRequest',
+      'SnapInterfaceController:deleteInterface',
       'TransactionController:getNonceLock',
       'TransactionController:getState',
       'ApprovalController:rejectRequest',

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -318,10 +318,7 @@ import createTracingMiddleware from './lib/createTracingMiddleware';
 import createOriginThrottlingMiddleware from './lib/createOriginThrottlingMiddleware';
 import { PatchStore } from './lib/PatchStore';
 import { sanitizeUIState } from './lib/state-utils';
-import {
-  rejectAllApprovals,
-  rejectOriginApprovals,
-} from './lib/approval/utils';
+import { rejectOriginApprovals } from './lib/approval/utils';
 import { InstitutionalSnapControllerInit } from './messenger-client-init/institutional-snap/institutional-snap-controller-init';
 import {
   MultichainAssetsControllerInit,
@@ -3630,7 +3627,10 @@ export default class MetamaskController extends EventEmitter {
       ),
 
       // ApprovalController
-      rejectAllPendingApprovals: this.rejectAllPendingApprovals.bind(this),
+      rejectAllPendingApprovals: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'LegacyBackgroundApiService:rejectAllPendingApprovals',
+      ),
       rejectPendingApproval: this.controllerMessenger.call.bind(
         this.controllerMessenger,
         'LegacyBackgroundApiService:rejectPendingApproval',
@@ -8532,19 +8532,6 @@ export default class MetamaskController extends EventEmitter {
       { waitForResult: true, walletType },
     );
   };
-
-  rejectAllPendingApprovals() {
-    const deleteInterface = (id) =>
-      this.controllerMessenger.call(
-        'SnapInterfaceController:deleteInterface',
-        id,
-      );
-
-    rejectAllApprovals({
-      approvalController: this.approvalController,
-      deleteInterface,
-    });
-  }
 
   async _onAccountChange(newAddress) {
     const permittedAccountsMap = getPermittedAccountsByOrigin(

--- a/app/scripts/services/legacy-background-api-service-method-action-types.ts
+++ b/app/scripts/services/legacy-background-api-service-method-action-types.ts
@@ -332,6 +332,18 @@ export type LegacyBackgroundApiServiceRejectPendingApprovalAction = {
 };
 
 /**
+ * Rejects all pending approval requests.
+ *
+ * Snap dialogs and account confirmations are accepted with a falsy value and
+ * their interface deleted where applicable, while all other approvals are
+ * rejected with a user-rejected-request error.
+ */
+export type LegacyBackgroundApiServiceRejectAllPendingApprovalsAction = {
+  type: `LegacyBackgroundApiService:rejectAllPendingApprovals`;
+  handler: LegacyBackgroundApiService['rejectAllPendingApprovals'];
+};
+
+/**
  * Accepts a permissions request. Silently ignores the request if it can no
  * longer be found.
  *
@@ -375,4 +387,5 @@ export type LegacyBackgroundApiServiceMethodActions =
   | LegacyBackgroundApiServiceApplyTransactionContainersExistingAction
   | LegacyBackgroundApiServiceUpsertTransactionUIMetricsFragmentAction
   | LegacyBackgroundApiServiceRejectPendingApprovalAction
+  | LegacyBackgroundApiServiceRejectAllPendingApprovalsAction
   | LegacyBackgroundApiServiceAcceptPermissionsRequestAction;

--- a/app/scripts/services/legacy-background-api-service.test.ts
+++ b/app/scripts/services/legacy-background-api-service.test.ts
@@ -22,9 +22,15 @@ import {
 import { Caip25CaveatType } from '@metamask/chain-agnostic-permission';
 import { PermissionsRequestNotFoundError } from '@metamask/permission-controller';
 import { ApprovalRequestNotFoundError } from '@metamask/approval-controller';
+import { ApprovalType } from '@metamask/controller-utils';
+import { DIALOG_APPROVAL_TYPES } from '@metamask/snaps-rpc-methods';
+import { providerErrors } from '@metamask/rpc-errors';
 import { SnapId } from '@metamask/snaps-sdk';
 import { wordlist } from '@metamask/scure-bip39/dist/wordlists/english';
-import { SMART_TRANSACTION_CONFIRMATION_TYPES } from '../../../shared/constants/app';
+import {
+  SMART_TRANSACTION_CONFIRMATION_TYPES,
+  SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES,
+} from '../../../shared/constants/app';
 import { MetaMetricsEventCategory } from '../../../shared/constants/metametrics';
 import { createSentryError } from '../../../shared/lib/error';
 import { TraceName, TraceOperation } from '../../../shared/lib/trace';
@@ -2656,6 +2662,251 @@ describe('LegacyBackgroundApiService', () => {
     });
   });
 
+  describe('rejectAllPendingApprovals', () => {
+    it('accepts snap dialog approvals with null and deletes their interface', async () => {
+      await withService(async ({ rootMessenger, serviceMessenger }) => {
+        const callSpy = jest.spyOn(serviceMessenger, 'call');
+        const acceptRequestHandler = jest.fn();
+        const deleteInterfaceHandler = jest.fn();
+
+        rootMessenger.registerActionHandler(
+          'ApprovalController:getState',
+          jest.fn().mockReturnValue({
+            pendingApprovals: {
+              '1': {
+                id: '1',
+                origin: 'npm:@metamask/snap',
+                type: ApprovalType.SnapDialogAlert,
+                requestData: { id: 'interface-1' },
+              },
+              '2': {
+                id: '2',
+                origin: 'npm:@metamask/snap',
+                type: ApprovalType.SnapDialogPrompt,
+                requestData: { id: 'interface-2' },
+              },
+              '3': {
+                id: '3',
+                origin: 'npm:@metamask/snap',
+                type: DIALOG_APPROVAL_TYPES.default,
+                requestData: { id: 'interface-3' },
+              },
+            },
+          }),
+        );
+        rootMessenger.registerActionHandler(
+          'ApprovalController:acceptRequest',
+          acceptRequestHandler,
+        );
+        rootMessenger.registerActionHandler(
+          'SnapInterfaceController:deleteInterface',
+          deleteInterfaceHandler,
+        );
+
+        rootMessenger.call(
+          'LegacyBackgroundApiService:rejectAllPendingApprovals',
+        );
+
+        expect(callSpy).toHaveBeenCalledWith(
+          'ApprovalController:acceptRequest',
+          '1',
+          null,
+        );
+        expect(callSpy).toHaveBeenCalledWith(
+          'ApprovalController:acceptRequest',
+          '2',
+          null,
+        );
+        expect(callSpy).toHaveBeenCalledWith(
+          'ApprovalController:acceptRequest',
+          '3',
+          null,
+        );
+        expect(callSpy).toHaveBeenCalledWith(
+          'SnapInterfaceController:deleteInterface',
+          'interface-1',
+        );
+        expect(callSpy).toHaveBeenCalledWith(
+          'SnapInterfaceController:deleteInterface',
+          'interface-2',
+        );
+        expect(callSpy).toHaveBeenCalledWith(
+          'SnapInterfaceController:deleteInterface',
+          'interface-3',
+        );
+      });
+    });
+
+    it('accepts snap confirmation approvals with false and deletes their interface', async () => {
+      await withService(async ({ rootMessenger, serviceMessenger }) => {
+        const callSpy = jest.spyOn(serviceMessenger, 'call');
+
+        rootMessenger.registerActionHandler(
+          'ApprovalController:getState',
+          jest.fn().mockReturnValue({
+            pendingApprovals: {
+              '1': {
+                id: '1',
+                origin: 'npm:@metamask/snap',
+                type: ApprovalType.SnapDialogConfirmation,
+                requestData: { id: 'interface-1' },
+              },
+            },
+          }),
+        );
+        rootMessenger.registerActionHandler(
+          'ApprovalController:acceptRequest',
+          jest.fn(),
+        );
+        rootMessenger.registerActionHandler(
+          'SnapInterfaceController:deleteInterface',
+          jest.fn(),
+        );
+
+        rootMessenger.call(
+          'LegacyBackgroundApiService:rejectAllPendingApprovals',
+        );
+
+        expect(callSpy).toHaveBeenCalledWith(
+          'ApprovalController:acceptRequest',
+          '1',
+          false,
+        );
+        expect(callSpy).toHaveBeenCalledWith(
+          'SnapInterfaceController:deleteInterface',
+          'interface-1',
+        );
+      });
+    });
+
+    it('accepts snap account confirmations with false without deleting an interface', async () => {
+      await withService(async ({ rootMessenger, serviceMessenger }) => {
+        const callSpy = jest.spyOn(serviceMessenger, 'call');
+        const deleteInterfaceHandler = jest.fn();
+
+        rootMessenger.registerActionHandler(
+          'ApprovalController:getState',
+          jest.fn().mockReturnValue({
+            pendingApprovals: {
+              '1': {
+                id: '1',
+                origin: 'npm:@metamask/snap',
+                type: SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES.confirmAccountCreation,
+                requestData: {},
+              },
+              '2': {
+                id: '2',
+                origin: 'npm:@metamask/snap',
+                type: SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES.confirmAccountRemoval,
+                requestData: {},
+              },
+              '3': {
+                id: '3',
+                origin: 'npm:@metamask/snap',
+                type: SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES.showSnapAccountRedirect,
+                requestData: {},
+              },
+            },
+          }),
+        );
+        rootMessenger.registerActionHandler(
+          'ApprovalController:acceptRequest',
+          jest.fn(),
+        );
+        rootMessenger.registerActionHandler(
+          'SnapInterfaceController:deleteInterface',
+          deleteInterfaceHandler,
+        );
+
+        rootMessenger.call(
+          'LegacyBackgroundApiService:rejectAllPendingApprovals',
+        );
+
+        expect(callSpy).toHaveBeenCalledWith(
+          'ApprovalController:acceptRequest',
+          '1',
+          false,
+        );
+        expect(callSpy).toHaveBeenCalledWith(
+          'ApprovalController:acceptRequest',
+          '2',
+          false,
+        );
+        expect(callSpy).toHaveBeenCalledWith(
+          'ApprovalController:acceptRequest',
+          '3',
+          false,
+        );
+        expect(deleteInterfaceHandler).not.toHaveBeenCalled();
+      });
+    });
+
+    it('rejects all other approvals with a user-rejected-request error', async () => {
+      await withService(async ({ rootMessenger, serviceMessenger }) => {
+        const callSpy = jest.spyOn(serviceMessenger, 'call');
+
+        rootMessenger.registerActionHandler(
+          'ApprovalController:getState',
+          jest.fn().mockReturnValue({
+            pendingApprovals: {
+              '1': {
+                id: '1',
+                origin: 'https://example.com',
+                type: ApprovalType.Transaction,
+                requestData: {},
+              },
+            },
+          }),
+        );
+        rootMessenger.registerActionHandler(
+          'ApprovalController:rejectRequest',
+          jest.fn(),
+        );
+
+        rootMessenger.call(
+          'LegacyBackgroundApiService:rejectAllPendingApprovals',
+        );
+
+        expect(callSpy).toHaveBeenCalledWith(
+          'ApprovalController:rejectRequest',
+          '1',
+          providerErrors.userRejectedRequest({
+            data: {
+              cause: 'rejectAllApprovals',
+            },
+          }),
+        );
+      });
+    });
+
+    it('does nothing when there are no pending approvals', async () => {
+      await withService(async ({ rootMessenger, serviceMessenger }) => {
+        const acceptRequestHandler = jest.fn();
+        const rejectRequestHandler = jest.fn();
+
+        rootMessenger.registerActionHandler(
+          'ApprovalController:getState',
+          jest.fn().mockReturnValue({ pendingApprovals: {} }),
+        );
+        rootMessenger.registerActionHandler(
+          'ApprovalController:acceptRequest',
+          acceptRequestHandler,
+        );
+        rootMessenger.registerActionHandler(
+          'ApprovalController:rejectRequest',
+          rejectRequestHandler,
+        );
+
+        rootMessenger.call(
+          'LegacyBackgroundApiService:rejectAllPendingApprovals',
+        );
+
+        expect(acceptRequestHandler).not.toHaveBeenCalled();
+        expect(rejectRequestHandler).not.toHaveBeenCalled();
+      });
+    });
+  });
+
   describe('acceptPermissionsRequest', () => {
     it('accepts the permissions request', async () => {
       await withService(async ({ rootMessenger }) => {
@@ -2791,6 +3042,8 @@ function getMessenger(
       'KeyringController:exportSeedPhrase',
       'AccountsController:getSelectedAccount',
       'ApprovalController:getState',
+      'ApprovalController:acceptRequest',
+      'SnapInterfaceController:deleteInterface',
       'TransactionController:getNonceLock',
       'TransactionController:getState',
       'ApprovalController:rejectRequest',

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -46,6 +46,7 @@ import { AssetsControllerSetSelectedCurrencyAction } from '@metamask/assets-cont
 import { SupportedCurrency } from '@metamask/core-backend';
 import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import {
+  ApprovalControllerAcceptRequestAction,
   ApprovalControllerGetStateAction,
   ApprovalControllerRejectRequestAction,
   ApprovalRequestNotFoundError,
@@ -89,6 +90,9 @@ import {
   Caip25CaveatValue,
 } from '@metamask/chain-agnostic-permission';
 import { SnapId } from '@metamask/snaps-sdk';
+import { SnapInterfaceControllerDeleteInterfaceAction } from '@metamask/snaps-controllers';
+import { DIALOG_APPROVAL_TYPES } from '@metamask/snaps-rpc-methods';
+import { ApprovalType } from '@metamask/controller-utils';
 import {
   MultichainAccountServiceResyncAccountsAction,
   MultichainAccountServiceAlignWalletsAction,
@@ -98,7 +102,7 @@ import {
   AccountTreeControllerGetSelectedAccountGroupAction,
   AccountTreeControllerInitAction,
 } from '@metamask/account-tree-controller';
-import { JsonRpcError } from '@metamask/rpc-errors';
+import { JsonRpcError, providerErrors } from '@metamask/rpc-errors';
 import {
   AuthenticationControllerGetStateAction,
   AuthenticationControllerPerformSignOutAction,
@@ -116,7 +120,10 @@ import {
   AssetsUnifyStateFeatureFlag,
   isAssetsUnifyStateFeatureEnabled as getIsAssetsUnifyStateFeatureEnabled,
 } from '../../../shared/lib/assets-unify-state/remote-feature-flag';
-import { SMART_TRANSACTION_CONFIRMATION_TYPES } from '../../../shared/constants/app';
+import {
+  SMART_TRANSACTION_CONFIRMATION_TYPES,
+  SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES,
+} from '../../../shared/constants/app';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventFragment,
@@ -168,6 +175,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'isPublicEndpointUrl',
   'markPasswordForgotten',
   'onAccountRemoved',
+  'rejectAllPendingApprovals',
   'rejectPendingApproval',
   'rejectPermissionsRequest',
   'removeAccount',
@@ -195,6 +203,7 @@ type AllowedActions =
   | AccountsControllerGetSelectedAccountAction
   | AccountsControllerSetSelectedAccountAction
   | AccountsControllerUpdateAccountsAction
+  | ApprovalControllerAcceptRequestAction
   | ApprovalControllerGetStateAction
   | ApprovalControllerRejectRequestAction
   | AppStateControllerSetPasskeyAutoUnlockSuppressedAction
@@ -254,6 +263,7 @@ type AllowedActions =
   | SeedlessOnboardingControllerSyncLatestGlobalPasswordAction
   | SeedlessOnboardingControllerUpdateBackupMetadataStateAction
   | SmartTransactionsControllerWipeSmartTransactionsAction
+  | SnapInterfaceControllerDeleteInterfaceAction
   | SubscriptionControllerStopAllPollingAction
   | TransactionControllerEstimateGasAction
   | TransactionControllerGetNonceLockAction
@@ -1388,6 +1398,77 @@ export class LegacyBackgroundApiService {
     } catch (err) {
       if (!(err instanceof ApprovalRequestNotFoundError)) {
         throw err;
+      }
+    }
+  }
+
+  /**
+   * Rejects all pending approval requests.
+   *
+   * Snap dialogs and account confirmations are accepted with a falsy value and
+   * their interface deleted where applicable, while all other approvals are
+   * rejected with a user-rejected-request error.
+   */
+  rejectAllPendingApprovals(): void {
+    const { pendingApprovals } = this.#messenger.call(
+      'ApprovalController:getState',
+    );
+
+    const approvalRequests = Object.values(pendingApprovals);
+
+    for (const approvalRequest of approvalRequests) {
+      const { id, type, origin } = approvalRequest;
+      const interfaceId = approvalRequest.requestData?.id as string;
+
+      switch (type) {
+        case ApprovalType.SnapDialogAlert:
+        case ApprovalType.SnapDialogPrompt:
+        case DIALOG_APPROVAL_TYPES.default:
+          log.debug('Rejecting snap dialog', { id, interfaceId, origin, type });
+          this.#messenger.call('ApprovalController:acceptRequest', id, null);
+          this.#messenger.call(
+            'SnapInterfaceController:deleteInterface',
+            interfaceId,
+          );
+          break;
+
+        case ApprovalType.SnapDialogConfirmation:
+          log.debug('Rejecting snap confirmation', {
+            id,
+            interfaceId,
+            origin,
+            type,
+          });
+          this.#messenger.call('ApprovalController:acceptRequest', id, false);
+          this.#messenger.call(
+            'SnapInterfaceController:deleteInterface',
+            interfaceId,
+          );
+          break;
+
+        case SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES.confirmAccountCreation:
+        case SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES.confirmAccountRemoval:
+        case SNAP_MANAGE_ACCOUNTS_CONFIRMATION_TYPES.showSnapAccountRedirect:
+          log.debug('Rejecting snap account confirmation', {
+            id,
+            origin,
+            type,
+          });
+          this.#messenger.call('ApprovalController:acceptRequest', id, false);
+          break;
+
+        default:
+          log.debug('Rejecting pending approval', { id, origin, type });
+          this.#messenger.call(
+            'ApprovalController:rejectRequest',
+            id,
+            providerErrors.userRejectedRequest({
+              data: {
+                cause: 'rejectAllApprovals',
+              },
+            }),
+          );
+          break;
       }
     }
   }


### PR DESCRIPTION
## **Description**

This moves `rejectAllPendingApprovals` from `MetamaskController` to `LegacyBackgroundApiService`. The rejection logic is inlined into the service (via messenger calls), so the now-unused `rejectAllApprovals` helper in `app/scripts/lib/approval/utils.ts` is removed along with its tests.

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Progresses: https://consensyssoftware.atlassian.net/browse/WPC-1085

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Behavior on notification close and Snap approval teardown is security-sensitive; risk is moderate because logic is relocated rather than redesigned, with service tests covering the type-specific paths.
> 
> **Overview**
> Moves **bulk dismissal of pending approvals** out of `MetamaskController` into `LegacyBackgroundApiService`, continuing the WPC-1085 background API consolidation.
> 
> `rejectAllPendingApprovals` is implemented on the service (reading pending approvals via messenger, then accepting or rejecting by type—Snap dialogs with `null`/`false` plus interface cleanup, everything else with `userRejectedRequest` and `cause: rejectAllApprovals`). The controller no longer owns that method; the public API routes through `LegacyBackgroundApiService:rejectAllPendingApprovals`, and notification close in `background.js` calls the service directly. The shared `rejectAllApprovals` helper and its unit tests are removed; coverage lives on the service tests. **`rejectOriginApprovals`** in `approval/utils.ts` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14c4bcfbb707255e3c0e73b09e72ca43adce0d83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->