### PR TITLE
chore: remove unused `setSelectedAddress` from `getApi`

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2994,14 +2994,6 @@ export default class MetamaskController extends EventEmitter {
           this.networkController,
         ),
       // PreferencesController
-      setSelectedAddress: (address) => {
-        const account = this.accountsController.getAccountByAddress(address);
-        if (account) {
-          this.accountsController.setSelectedAccount(account.id);
-        } else {
-          throw new Error(`No account found for address: ${address}`);
-        }
-      },
       toggleExternalServices: this.toggleExternalServices.bind(this),
       addToken: async ({
         address,


### PR DESCRIPTION
## **Description**

`setSelectedAddress` is unused — the `getApi` method has no client caller (no `submitRequestToBackground('setSelectedAddress')`, no E2E usage; the UI `setSelectedAddress` references are a local `useState` setter and a component prop that dispatches `setSelectedAccount`). Removing the dead method rather than migrating it to `LegacyBackgroundApiService`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Progresses: https://consensyssoftware.atlassian.net/browse/WPC-1086

## **Manual testing steps**

1. No manual testing needed — this removes dead, uncalled code.

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Removes uncalled background API surface only; no callers and no change to active account-selection flows.
> 
> **Overview**
> Removes **`setSelectedAddress`** from the object returned by **`getApi`** in `metamamask-controller.js`. That handler resolved an address via **`AccountsController`** and called **`setSelectedAccount`**, but nothing invoked it through the background API (no `submitRequestToBackground('setSelectedAddress')`).
> 
> Account switching in the UI still uses local **`setSelectedAddress`** props that dispatch **`setSelectedAccount`** / **`switchToAccount`**—unchanged by this deletion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55dcae4d38b4cc0e4ee3fb6e2711994836eceb1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->