### PR TITLE
fix: disable CTA swap button for Tron when no network fees retrieved

### DIFF
--- a/package.json
+++ b/package.json
@@ -454,7 +454,7 @@
     "@metamask/subscription-controller": "^6.2.0",
     "@metamask/transaction-controller": "^68.1.1",
     "@metamask/transaction-pay-controller": "^23.17.2",
-    "@metamask/tron-wallet-snap": "^1.28.0",
+    "@metamask/tron-wallet-snap": "^1.29.0",
     "@metamask/user-operation-controller": "^41.2.5",
     "@metamask/utils": "^11.11.0",
     "@metamask/wallet": "^6.0.0",

--- a/test/e2e/flask/tron-connect/mocks/security-api.ts
+++ b/test/e2e/flask/tron-connect/mocks/security-api.ts
@@ -2,11 +2,17 @@ import { Mockttp } from 'mockttp';
 
 const PRICE_API_URL = 'https://security-alerts.api.cx.metamask.io';
 
+// The snap validates this response against its `SecurityAlertResponseStruct`,
+// which requires `validation` and `simulation` objects. A benign, successful
+// simulation keeps the Confirm button enabled and avoids the scan-error banner.
 export const mockScanTransaction = (mockServer: Mockttp) =>
   mockServer.forPost(`${PRICE_API_URL}/tron/transaction/scan`).thenJson(200, {
-    status: 'SUCCESS',
-    block: '78465629',
-    chain: 'tron',
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    account_address: 'TJ3QZbBREK1Xybe1jf4nR9Attb8i54vGS3',
+    validation: {
+      status: 'Success',
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      result_type: 'Benign',
+    },
+    simulation: {
+      status: 'Success',
+    },
   });

--- a/test/e2e/flask/tron-connect/mocks/trongrid.ts
+++ b/test/e2e/flask/tron-connect/mocks/trongrid.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'crypto';
 import { Mockttp } from 'mockttp';
 import { TRANSACTION_HASH_MOCK } from '../common-tron';
 
@@ -156,11 +157,17 @@ const accountResourcesResponse = {
   TotalEnergyWeight: 19125511029,
 };
 
+// The block number and blockID must stay consistent with the transaction's
+// TAPOS reference (`ref_block_bytes` / `ref_block_hash`) returned by
+// `mockTriggerSmartContract`, otherwise the snap's `isTransactionExpired` check
+// treats the transaction as expired and disables the Confirm button:
+//   - number % 65536 === 0x8b15  → getRefBlockBytes(number) === '8b15'
+//   - blockID.slice(16, 32)      === '5fca48bd51bf3f1d' (ref_block_hash)
 const blockResponse = {
-  blockID: 'xxxxxxxx',
+  blockID: '00000000039d8b155fca48bd51bf3f1d00000000000000000000000000000000',
   block_header: {
     raw_data: {
-      number: 60677731,
+      number: 60656405,
       txTrieRoot:
         '0000000000000000000000000000000000000000000000000000000000000000',
       witness_address: '41ce9b5acfce023822bcdf302333668cce2ba60bca',
@@ -206,40 +213,97 @@ export const mockBroadcastTransaction = (mockServer: Mockttp) =>
       txid: TRANSACTION_HASH_MOCK,
     });
 
+/**
+ * Encodes an unsigned integer as a protobuf LEB128 varint hex string.
+ *
+ * @param value - The value to encode.
+ * @returns The lowercase hex encoding of the varint.
+ */
+/* eslint-disable no-bitwise */
+const encodeVarintHex = (value: number): string => {
+  let remaining = BigInt(value);
+  const bytes: number[] = [];
+  do {
+    let byte = Number(remaining & 0x7fn);
+    remaining >>= 7n;
+    if (remaining > 0n) {
+      byte |= 0x80;
+    }
+    bytes.push(byte);
+  } while (remaining > 0n);
+  return bytes.map((byte) => byte.toString(16).padStart(2, '0')).join('');
+};
+/* eslint-enable no-bitwise */
+
+// The original hardcoded timestamps baked into the static `raw_data_hex` below.
+// They are rewritten to fresh values on every request so the snap's TAPOS/
+// expiration check (`isTransactionExpired`) does not reject the transaction as
+// expired — which would disable the confirmation's Confirm button and surface
+// the "This transaction was reverted during simulation" banner.
+const STATIC_EXPIRATION_MS = 1768469721000;
+const STATIC_TIMESTAMP_MS = 1768469664343;
+const STATIC_RAW_DATA_HEX =
+  '0a028b1522085fca48bd51bf3f1d40a8df8988bc335aae01081f12a9010a31747970652e676f6f676c65617069732e636f6d2f70726f746f636f6c2e54726967676572536d617274436f6e747261637412740a1541588c5216750cceaad16cf5a757e3f7b32835a5e1121541a614f803b6fd780986a42c78ec9c7f77e6ded13c2244a9059cbb00000000000000000000000032f9c0c487f21716b7a8f12906b7528899026558000000000000000000000000000000000000000000000000000000000754d4c070d7a48688bc33900180c2d72f';
+
 export const mockTriggerSmartContract = (mockServer: Mockttp) =>
   mockServer
     .forPost(`${TRONGRID_API_URL}/wallet/triggersmartcontract`)
-    .thenJson(200, {
-      result: {
-        result: true,
-      },
-      transaction: {
-        visible: false,
-        txID: 'c58a836f6a2a06f56b3fa35cc64513499c7b3ee4b1045760a66128842868f49c',
-        raw_data: {
-          contract: [
-            {
-              parameter: {
-                value: {
-                  data: 'a9059cbb00000000000000000000000032f9c0c487f21716b7a8f12906b7528899026558000000000000000000000000000000000000000000000000000000000754d4c0',
-                  owner_address: '41588c5216750cceaad16cf5a757e3f7b32835a5e1',
-                  contract_address:
-                    '41a614f803b6fd780986a42c78ec9c7f77e6ded13c',
+    .thenCallback(() => {
+      const now = Date.now();
+      const timestamp = now;
+      // Keep well within Tron's TAPOS validity window (< 24h ahead, > the
+      // snap's ~9s freshness buffer). Both timestamps stay 6-byte varints for
+      // realistic dates, so the in-place hex rewrite preserves byte length.
+      const expiration = now + 10 * 60 * 1000;
+
+      const rawDataHex = STATIC_RAW_DATA_HEX.replace(
+        encodeVarintHex(STATIC_EXPIRATION_MS),
+        encodeVarintHex(expiration),
+      ).replace(
+        encodeVarintHex(STATIC_TIMESTAMP_MS),
+        encodeVarintHex(timestamp),
+      );
+
+      const txID = createHash('sha256')
+        .update(Buffer.from(rawDataHex, 'hex'))
+        .digest('hex');
+
+      return {
+        statusCode: 200,
+        json: {
+          result: {
+            result: true,
+          },
+          transaction: {
+            visible: false,
+            txID,
+            raw_data: {
+              contract: [
+                {
+                  parameter: {
+                    value: {
+                      data: 'a9059cbb00000000000000000000000032f9c0c487f21716b7a8f12906b7528899026558000000000000000000000000000000000000000000000000000000000754d4c0',
+                      owner_address:
+                        '41588c5216750cceaad16cf5a757e3f7b32835a5e1',
+                      contract_address:
+                        '41a614f803b6fd780986a42c78ec9c7f77e6ded13c',
+                    },
+                    type_url:
+                      'type.googleapis.com/protocol.TriggerSmartContract',
+                  },
+                  type: 'TriggerSmartContract',
                 },
-                type_url: 'type.googleapis.com/protocol.TriggerSmartContract',
-              },
-              type: 'TriggerSmartContract',
+              ],
+              ref_block_bytes: '8b15',
+              ref_block_hash: '5fca48bd51bf3f1d',
+              expiration,
+              fee_limit: 100000000,
+              timestamp,
             },
-          ],
-          ref_block_bytes: '8b15',
-          ref_block_hash: '5fca48bd51bf3f1d',
-          expiration: 1768469721000,
-          fee_limit: 100000000,
-          timestamp: 1768469664343,
+            raw_data_hex: rawDataHex,
+          },
         },
-        raw_data_hex:
-          '0a028b1522085fca48bd51bf3f1d40a8df8988bc335aae01081f12a9010a31747970652e676f6f676c65617069732e636f6d2f70726f746f636f6c2e54726967676572536d617274436f6e747261637412740a1541588c5216750cceaad16cf5a757e3f7b32835a5e1121541a614f803b6fd780986a42c78ec9c7f77e6ded13c2244a9059cbb00000000000000000000000032f9c0c487f21716b7a8f12906b7528899026558000000000000000000000000000000000000000000000000000000000754d4c070d7a48688bc33900180c2d72f',
-      },
+      };
     });
 
 export const mockAccountRequest = (mockServer: Mockttp) =>

--- a/test/e2e/flask/tron-connect/mocks/trongrid.ts
+++ b/test/e2e/flask/tron-connect/mocks/trongrid.ts
@@ -163,7 +163,7 @@ const accountResourcesResponse = {
 // treats the transaction as expired and disables the Confirm button:
 //   - number % 65536 === 0x8b15  → getRefBlockBytes(number) === '8b15'
 //   - blockID.slice(16, 32)      === '5fca48bd51bf3f1d' (ref_block_hash)
-const blockResponse = {
+const buildBlockResponse = () => ({
   blockID: '00000000039d8b155fca48bd51bf3f1d00000000000000000000000000000000',
   block_header: {
     raw_data: {
@@ -180,22 +180,22 @@ const blockResponse = {
     witness_signature:
       '354261801bf88973cc144d74d81f90e3ebeb8ea6029b42412757e7e996df6d3a2ad22db54675d77be3774cc067e47f374a9bc8ffbdeb0cb62c6057be26201c9000',
   },
-};
+});
 
 export const mockGetBlock = (mockServer: Mockttp) =>
   mockServer
     .forPost(`${TRONGRID_API_URL}/wallet/getblock`)
-    .thenJson(200, blockResponse);
+    .thenCallback(() => ({ statusCode: 200, json: buildBlockResponse() }));
 
 export const mockGetNowBlock = (mockServer: Mockttp) =>
   mockServer
     .forPost(`${TRONGRID_API_URL}/wallet/getnowblock`)
-    .thenJson(200, blockResponse);
+    .thenCallback(() => ({ statusCode: 200, json: buildBlockResponse() }));
 
 export const mockGetBlockByNum = (mockServer: Mockttp) =>
   mockServer
     .forPost(`${TRONGRID_API_URL}/wallet/getblockbynum`)
-    .thenJson(200, blockResponse);
+    .thenCallback(() => ({ statusCode: 200, json: buildBlockResponse() }));
 
 // TODO: Check why we had to mock this. Do we intend this call to be routed through Infura
 // instead of Trongrid ?
@@ -203,7 +203,7 @@ export const mockGetNowBlockInfura = (mockServer: Mockttp) =>
   mockServer
     .forGet(/tron-mainnet\.infura\.io\/v3\/.*\/wallet\/getnowblock/u)
     .always()
-    .thenJson(200, blockResponse);
+    .thenCallback(() => ({ statusCode: 200, json: buildBlockResponse() }));
 
 export const mockBroadcastTransaction = (mockServer: Mockttp) =>
   mockServer

--- a/test/e2e/page-objects/pages/swap/swap-page.ts
+++ b/test/e2e/page-objects/pages/swap/swap-page.ts
@@ -85,6 +85,11 @@ class SwapPage {
     text: 'Swap',
   };
 
+  private readonly insufficientFundsButton = {
+    text: 'Insufficient funds',
+    css: '[data-testid="bridge-cta-button"]',
+  };
+
   private readonly transactionHeader = '[data-testid="awaiting-swap-header"]';
 
   private readonly networkFees = '[data-testid="network-fees"]';
@@ -249,6 +254,22 @@ class SwapPage {
       [this.networkFees, this.slippageEditButton, this.minimumReceived],
       options,
     );
+  }
+
+  async checkQuoteIsDisplayedWithoutNetworkFee(options?: {
+    timeout?: number;
+  }): Promise<void> {
+    await this.driver.waitForMultipleSelectors(
+      [this.slippageEditButton, this.minimumReceived, this.reviewToAmount],
+      options,
+    );
+  }
+
+  async checkInsufficientFundsButtonIsDisplayed(): Promise<void> {
+    await this.driver.waitForSelector(this.insufficientFundsButton);
+    await this.driver.waitForSelector(this.submitSwapButton, {
+      state: 'disabled',
+    });
   }
 
   async checkQuoteIsGasIncluded(): Promise<void> {

--- a/test/e2e/tests/tron/check-balance.spec.ts
+++ b/test/e2e/tests/tron/check-balance.spec.ts
@@ -54,10 +54,10 @@ describe('Check balance', function (this: Suite) {
         // Refresh re-hydrates the UI from background state so the asynchronously-fetched Snap balance is shown reliably.
         await driver.refresh();
 
-        // TRX_BALANCE = 6072392 SUN = ~6.07 TRX * $0.29469 = ~$1.79
-        // Total Fiat = TRX $1.79, HTX DAO $5.30, USDT $2.80, USDD $0.29 = $10.18
+        // TRX_BALANCE = 106072392 SUN = ~106.07 TRX * $0.29469 = ~$31.26
+        // Total Fiat = TRX $31.26, HTX DAO $5.30, USDT $2.80, USDD $0.29 = $39.65
         await homePage.checkExpectedBalanceIsDisplayed({
-          expectedBalance: '$10.18',
+          expectedBalance: '$39.65',
           timeout: HOMEPAGE_BALANCE_ASSERTION_TIMEOUT_MS,
         });
       },
@@ -81,9 +81,9 @@ describe('Check balance', function (this: Suite) {
         // Refresh re-hydrates the UI from background state so the asynchronously-fetched Snap balance is shown reliably.
         await driver.refresh();
 
-        // TRX_BALANCE = 6072392 SUN = ~6.07 TRX
+        // TRX_BALANCE = 106072392 SUN = ~106.07 TRX
         await homePage.checkExpectedBalanceIsDisplayed({
-          expectedBalance: '6.072 TRX',
+          expectedBalance: '106.072 TRX',
           timeout: HOMEPAGE_BALANCE_ASSERTION_TIMEOUT_MS,
         });
       },

--- a/test/e2e/tests/tron/mocks/common-tron.ts
+++ b/test/e2e/tests/tron/mocks/common-tron.ts
@@ -1403,3 +1403,14 @@ export async function mockTronSwapApisNoQuotes(
     await mockBridgeGetTronQuoteEmpty(mockServer),
   ];
 }
+
+export async function mockTronSwapApisWithoutFeeEstimation(
+  mockServer: Mockttp,
+  mockZeroBalance?: boolean,
+): Promise<MockedEndpoint[]> {
+  return [
+    ...(await mockTronApis(mockServer, mockZeroBalance)),
+    await mockBridgeGetTronTokens(mockServer),
+    await mockBridgeGetTronQuote(mockServer),
+  ];
+}

--- a/test/e2e/tests/tron/mocks/common-tron.ts
+++ b/test/e2e/tests/tron/mocks/common-tron.ts
@@ -16,7 +16,7 @@ const MOCK_TRON_BLOCK_TIMESTAMP_NOW_PLUS_A_YEAR = new Date(
 ).getTime();
 
 // TRX balance in SUN (1 TRX = 1,000,000 SUN)
-export const TRX_BALANCE = 6072392; // ~6.07 TRX
+export const TRX_BALANCE = 106072392; // ~106.07 TRX
 export const TRX_TO_USD_RATE = 0.29469;
 export const SUN_PER_TRX = 1_000_000;
 

--- a/test/e2e/tests/tron/mocks/common-tron.ts
+++ b/test/e2e/tests/tron/mocks/common-tron.ts
@@ -1257,7 +1257,7 @@ export async function mockTronTriggerConstantContract(
       statusCode: 200,
       json: {
         result: { result: true },
-        energy_used: 200000,
+        energy_used: 1000,
         energy_penalty: 0,
         constant_result: [
           '0000000000000000000000000000000000000000000000000000000000000001',

--- a/test/e2e/tests/tron/mocks/common-tron.ts
+++ b/test/e2e/tests/tron/mocks/common-tron.ts
@@ -1208,6 +1208,89 @@ export async function mockBridgeGetTronQuoteEmpty(
     }));
 }
 
+export async function mockTronGetChainParameters(
+  mockServer: Mockttp,
+): Promise<MockedEndpoint> {
+  return mockServer
+    .forPost(tronInfuraUrl('/wallet/getchainparameters'))
+    .always()
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: {
+        chainParameter: [
+          { key: 'getMaintenanceTimeInterval', value: 21600000 },
+          { key: 'getAccountUpgradeCost', value: 9999000000 },
+          { key: 'getCreateNewAccountFeeInSystemContract', value: 1000000 },
+          { key: 'getCreateAccountFee', value: 100000 },
+          { key: 'getTransactionFee', value: 1000 },
+          { key: 'getAssetIssueFee', value: 1024000000 },
+          { key: 'getEnergyFee', value: 420 },
+          { key: 'getTotalEnergyLimit', value: 180000000000 },
+          { key: 'getAllowTvmTransferTrc10', value: 1 },
+          { key: 'getTotalEnergyCurrentLimit', value: 180000000000 },
+          { key: 'getAllowMultiSign', value: 1 },
+          { key: 'getAllowAdaptivEnergy', value: 1 },
+        ],
+      },
+    }));
+}
+
+export async function mockTronGetNextMaintenanceTime(
+  mockServer: Mockttp,
+): Promise<MockedEndpoint> {
+  return mockServer
+    .forPost(tronInfuraUrl('/wallet/getnextmaintenancetime'))
+    .always()
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: { num: MOCK_TRON_BLOCK_TIMESTAMP_NOW_PLUS_A_YEAR },
+    }));
+}
+
+export async function mockTronTriggerConstantContract(
+  mockServer: Mockttp,
+): Promise<MockedEndpoint> {
+  return mockServer
+    .forPost(tronInfuraUrl('/wallet/triggerconstantcontract'))
+    .always()
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: {
+        result: { result: true },
+        energy_used: 200000,
+        energy_penalty: 0,
+        constant_result: [
+          '0000000000000000000000000000000000000000000000000000000000000001',
+        ],
+        transaction: {
+          ret: [{}],
+          visible: false,
+          txID: 'mock_trigger_constant_txid',
+          raw_data: {
+            contract: [],
+            ref_block_bytes: 'f733',
+            ref_block_hash: 'ff89d72ddc1ce1ea',
+            expiration: MOCK_TRON_BLOCK_TIMESTAMP_NOW_PLUS_A_YEAR,
+            timestamp: MOCK_TRON_BLOCK_TIMESTAMP_NOW_PLUS_A_YEAR,
+          },
+          raw_data_hex: '',
+        },
+      },
+    }));
+}
+
+export async function mockTronGetContract(
+  mockServer: Mockttp,
+): Promise<MockedEndpoint> {
+  return mockServer
+    .forPost(tronInfuraUrl('/wallet/getcontract'))
+    .always()
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: {},
+    }));
+}
+
 /**
  * Mocks the accounts API v2 supportedNetworks (**EVM only**).
  *
@@ -1303,6 +1386,10 @@ export async function mockTronSwapApis(
     ...(await mockTronApis(mockServer, mockZeroBalance)),
     await mockBridgeGetTronTokens(mockServer),
     await mockBridgeGetTronQuote(mockServer),
+    await mockTronGetChainParameters(mockServer),
+    await mockTronGetNextMaintenanceTime(mockServer),
+    await mockTronTriggerConstantContract(mockServer),
+    await mockTronGetContract(mockServer),
   ];
 }
 

--- a/test/e2e/tests/tron/mocks/common-tron.ts
+++ b/test/e2e/tests/tron/mocks/common-tron.ts
@@ -1212,7 +1212,7 @@ export async function mockTronGetChainParameters(
   mockServer: Mockttp,
 ): Promise<MockedEndpoint> {
   return mockServer
-    .forPost(tronInfuraUrl('/wallet/getchainparameters'))
+    .forGet(tronInfuraUrl('/wallet/getchainparameters'))
     .always()
     .thenCallback(() => ({
       statusCode: 200,

--- a/test/e2e/tests/tron/swap.spec.ts
+++ b/test/e2e/tests/tron/swap.spec.ts
@@ -34,7 +34,7 @@ describe('Swap on Tron', function () {
 
         const homePage = new HomePage(driver);
         await homePage.checkPageIsLoaded();
-        await homePage.checkExpectedBalanceIsDisplayed('6.07');
+        await homePage.checkExpectedBalanceIsDisplayed('106.07');
 
         const swapPage = new SwapPage(driver);
         await homePage.clickOnSwapButton();
@@ -74,7 +74,7 @@ describe('Swap on Tron', function () {
 
         const homePage = new HomePage(driver);
         await homePage.checkPageIsLoaded();
-        await homePage.checkExpectedBalanceIsDisplayed('6.07');
+        await homePage.checkExpectedBalanceIsDisplayed('106.07');
 
         const swapPage = new SwapPage(driver);
         await homePage.clickOnSwapButton();

--- a/test/e2e/tests/tron/swap.spec.ts
+++ b/test/e2e/tests/tron/swap.spec.ts
@@ -8,6 +8,7 @@ import SwapPage from '../../page-objects/pages/swap/swap-page';
 import {
   mockTronSwapApis,
   mockTronSwapApisNoQuotes,
+  mockTronSwapApisWithoutFeeEstimation,
   TRON_MOCK_TRANSACTION_EXPIRATION_MESSAGE,
 } from './mocks/common-tron';
 import { buildTronFixtures } from './unified-tron-assets';
@@ -52,6 +53,41 @@ describe('Swap on Tron', function () {
           swapTo: 'USDT',
           swapFromAmount: '1',
         });
+      },
+    );
+  });
+
+  it('Swap disabled when Tron network fees cannot be estimated', async function () {
+    await withFixtures(
+      {
+        fixtures: buildTronFixtures(),
+        localNodeOptions: [{ type: 'none' as const }],
+        title: this.test?.fullTitle(),
+        testSpecificMock: mockTronSwapApisWithoutFeeEstimation,
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await login(driver);
+
+        const networkManager = new NetworkManager(driver);
+        await networkManager.openNetworkManager();
+        await networkManager.selectTab('Popular');
+        await networkManager.selectNetworkByNameWithWait('Tron');
+
+        const homePage = new HomePage(driver);
+        await homePage.checkPageIsLoaded();
+        await homePage.checkExpectedBalanceIsDisplayed('106.07');
+
+        const swapPage = new SwapPage(driver);
+        await homePage.clickOnSwapButton();
+        await swapPage.createSwap({
+          amount: 1,
+          swapTo: 'USDT',
+          swapFrom: 'TRX',
+          network: 'Tron',
+        });
+
+        await swapPage.checkQuoteIsDisplayedWithoutNetworkFee();
+        await swapPage.checkInsufficientFundsButtonIsDisplayed();
       },
     );
   });

--- a/ui/ducks/bridge/selectors.test.ts
+++ b/ui/ducks/bridge/selectors.test.ts
@@ -216,6 +216,7 @@ describe('Bridge selectors', () => {
               steps: [],
             },
             trade: {
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               raw_data_hex: 'deadbeef',
             },
             estimatedProcessingTimeInSeconds: 120,

--- a/ui/ducks/bridge/selectors.test.ts
+++ b/ui/ducks/bridge/selectors.test.ts
@@ -21,6 +21,7 @@ import {
   MOCK_LEDGER_ACCOUNT,
   MOCK_SOLANA_ACCOUNT,
 } from '../../../test/data/bridge/mock-bridge-store';
+import { MOCK_ACCOUNT_TRON_MAINNET } from '../../../test/data/mock-accounts';
 import { CHAIN_IDS, FEATURED_RPCS } from '../../../shared/constants/network';
 import { mockNetworkState } from '../../../test/stub/networks';
 import mockErc20Erc20Quotes from '../../../test/data/bridge/mock-quotes-erc20-erc20.json';
@@ -175,6 +176,87 @@ describe('Bridge selectors', () => {
 
   const createBtcZeroNetworkFeeQuoteState = () =>
     createBtcBridgeState({ nonEvmFeesInNative: '0' });
+
+  const createTronBridgeState = ({
+    fromTokenInputValue = '1',
+    fromNativeBalance = '100',
+    nonEvmFeesInNative,
+    srcTokenAmount = '1000000',
+  }: {
+    fromTokenInputValue?: string;
+    fromNativeBalance?: string;
+    nonEvmFeesInNative?: string;
+    srcTokenAmount?: string;
+  } = {}) => {
+    const tronAsset = getNativeAssetForChainId(ChainId.TRON);
+    const ethAsset = getNativeAssetForChainId(ChainId.ETH);
+    const tronQuote =
+      nonEvmFeesInNative === undefined
+        ? undefined
+        : {
+            quote: {
+              requestId: 'tron-quote',
+              bridgeId: 'rango',
+              aggregator: 'rango',
+              srcChainId: ChainId.TRON,
+              srcTokenAmount,
+              srcAsset: tronAsset,
+              destChainId: ChainId.ETH,
+              destTokenAmount: '1000000000000000000',
+              destAsset: ethAsset,
+              minDestTokenAmount: '990000000000000000',
+              feeData: {
+                metabridge: {
+                  amount: '0',
+                  asset: tronAsset,
+                },
+              },
+              bridges: ['rango'],
+              protocols: ['rango'],
+              steps: [],
+            },
+            trade: {
+              raw_data_hex: 'deadbeef',
+            },
+            estimatedProcessingTimeInSeconds: 120,
+            nonEvmFeesInNative,
+          };
+
+    return createBridgeMockStore({
+      bridgeSliceOverrides: {
+        fromTokenInputValue,
+        fromToken: toBridgeToken(tronAsset),
+        toToken: toBridgeToken(ethAsset),
+      },
+      bridgeStateOverrides: {
+        quotesLastFetched: Date.now(),
+        quoteRequest: {
+          srcChainId: ChainId.TRON,
+          srcTokenAmount,
+        },
+        quotes: tronQuote ? ([tronQuote] as unknown as QuoteResponse[]) : [],
+      },
+      metamaskStateOverrides: {
+        internalAccounts: {
+          accounts: {
+            [MOCK_ACCOUNT_TRON_MAINNET.id]: MOCK_ACCOUNT_TRON_MAINNET,
+          },
+          selectedAccount: MOCK_ACCOUNT_TRON_MAINNET.id,
+        },
+        balances: {
+          [MOCK_ACCOUNT_TRON_MAINNET.id]: {
+            [tronAsset.assetId]: {
+              amount: fromNativeBalance,
+              unit: 'TRX',
+            },
+          },
+        },
+      },
+    });
+  };
+
+  const createTronZeroNetworkFeeQuoteState = () =>
+    createTronBridgeState({ nonEvmFeesInNative: '0' });
 
   describe('getFromChain', () => {
     it('returns the fromChain from the multichain network controller', () => {
@@ -2155,6 +2237,27 @@ describe('Bridge selectors', () => {
       ).toStrictEqual('0');
       expect(result.isNetworkFeeUnavailable).toBe(true);
       expect(result.isInsufficientGasForQuote).toBe(false);
+    });
+
+    it('should return isNetworkFeeUnavailable=true for a Tron quote with zero network fee', () => {
+      const state = createTronZeroNetworkFeeQuoteState();
+      const result = getValidationErrors(state as never);
+
+      expect(
+        getBridgeQuotes(state as never).activeQuote?.totalNetworkFee.amount,
+      ).toStrictEqual('0');
+      expect(result.isNetworkFeeUnavailable).toBe(true);
+      expect(result.isInsufficientGasForQuote).toBe(false);
+    });
+
+    it('should return isNetworkFeeUnavailable=false for a Tron quote with a valid network fee', () => {
+      const state = createTronBridgeState({ nonEvmFeesInNative: '1' });
+      const result = getValidationErrors(state as never);
+
+      expect(
+        getBridgeQuotes(state as never).activeQuote?.totalNetworkFee.amount,
+      ).toStrictEqual('1');
+      expect(result.isNetworkFeeUnavailable).toBe(false);
     });
 
     it('should return isEstimatedReturnLow=true return value is less than 65% of sent funds', () => {
@@ -4299,6 +4402,13 @@ describe('Bridge selectors', () => {
 
     it('returns network_fee_unavailable when BTC network fee is unavailable', () => {
       const state = createBtcZeroNetworkFeeQuoteState();
+      const result = getWarningLabels(state as never);
+
+      expect(result).toContain('network_fee_unavailable');
+    });
+
+    it('returns network_fee_unavailable when Tron network fee is unavailable', () => {
+      const state = createTronZeroNetworkFeeQuoteState();
       const result = getWarningLabels(state as never);
 
       expect(result).toContain('network_fee_unavailable');

--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -3,6 +3,7 @@ import type { InternalAccount } from '@metamask/keyring-internal-api';
 import {
   isSolanaChainId,
   isBitcoinChainId,
+  isTronChainId,
   isNativeAddress,
   formatChainIdToCaip,
   BRIDGE_QUOTE_MAX_RETURN_DIFFERENCE_PERCENTAGE,
@@ -111,7 +112,6 @@ import {
   getDefaultToToken,
   toBridgeToken,
   isNonEvmChain,
-  isTronChainId,
   getMaybeHexChainId,
   isSupportedBridgeChain,
   getDefaultFromToken,
@@ -1046,7 +1046,7 @@ export const computeQuoteValidationErrors = (
   const isNetworkFeeUnavailable = Boolean(
     quote &&
     srcChainId &&
-    isBitcoinChainId(srcChainId) &&
+    (isBitcoinChainId(srcChainId) || isTronChainId(srcChainId)) &&
     !isGasless &&
     (quote.totalNetworkFee?.amount === undefined ||
       new BigNumber(quote.totalNetworkFee?.amount ?? '0').lte(0)),

--- a/yarn.lock
+++ b/yarn.lock
@@ -8362,10 +8362,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/tron-wallet-snap@npm:^1.28.0":
-  version: 1.28.0
-  resolution: "@metamask/tron-wallet-snap@npm:1.28.0"
-  checksum: 10/e8fe563735e0fca306cd1caa2cde45b193d0f09f7a3da545be24eee55a64f1ff239a7460ad9c4a0c6b67552a1423ef18328350a4b76a2409a1fbe609f69b8769
+"@metamask/tron-wallet-snap@npm:@metamask-previews/tron-wallet-snap@1.28.0-preview-9726947":
+  version: 1.28.0-preview-9726947
+  resolution: "@metamask-previews/tron-wallet-snap@npm:1.28.0-preview-9726947"
+  checksum: 10/de9bdcb7c8c7cd75009c6765145b7eecde3ba01d535fe793344a7a316f5af92e4386814f698b77aec4dcd167314bda9c08afa4a580064515f2ae34ff56541efa
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8362,10 +8362,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/tron-wallet-snap@npm:@metamask-previews/tron-wallet-snap@1.28.0-preview-e5e1c78":
-  version: 1.28.0-preview-e5e1c78
-  resolution: "@metamask-previews/tron-wallet-snap@npm:1.28.0-preview-e5e1c78"
-  checksum: 10/b406795b1e2523259707f4ee69040574066ce069af9557cdc68d5d39f571bf482d53c8dcc7be1a01c0ecc9921b9b634db4036f2540b66ebf9bff887fdc3bc10d
+"@metamask/tron-wallet-snap@npm:^1.28.0":
+  version: 1.28.0
+  resolution: "@metamask/tron-wallet-snap@npm:1.28.0"
+  checksum: 10/e8fe563735e0fca306cd1caa2cde45b193d0f09f7a3da545be24eee55a64f1ff239a7460ad9c4a0c6b67552a1423ef18328350a4b76a2409a1fbe609f69b8769
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8362,10 +8362,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/tron-wallet-snap@npm:^1.28.0":
-  version: 1.28.0
-  resolution: "@metamask/tron-wallet-snap@npm:1.28.0"
-  checksum: 10/e8fe563735e0fca306cd1caa2cde45b193d0f09f7a3da545be24eee55a64f1ff239a7460ad9c4a0c6b67552a1423ef18328350a4b76a2409a1fbe609f69b8769
+"@metamask/tron-wallet-snap@npm:@metamask-previews/tron-wallet-snap@1.28.0-preview-e5e1c78":
+  version: 1.28.0-preview-e5e1c78
+  resolution: "@metamask-previews/tron-wallet-snap@npm:1.28.0-preview-e5e1c78"
+  checksum: 10/b406795b1e2523259707f4ee69040574066ce069af9557cdc68d5d39f571bf482d53c8dcc7be1a01c0ecc9921b9b634db4036f2540b66ebf9bff887fdc3bc10d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8362,10 +8362,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/tron-wallet-snap@npm:@metamask-previews/tron-wallet-snap@1.28.0-preview-9726947":
-  version: 1.28.0-preview-9726947
-  resolution: "@metamask-previews/tron-wallet-snap@npm:1.28.0-preview-9726947"
-  checksum: 10/de9bdcb7c8c7cd75009c6765145b7eecde3ba01d535fe793344a7a316f5af92e4386814f698b77aec4dcd167314bda9c08afa4a580064515f2ae34ff56541efa
+"@metamask/tron-wallet-snap@npm:^1.29.0":
+  version: 1.29.0
+  resolution: "@metamask/tron-wallet-snap@npm:1.29.0"
+  checksum: 10/8afc50c84215f63ae1d8ab985ff682f2a5d3b16cf15bb50f12c7d1d95df8e60d29881dbe13858941655e2163410dccba6b609307a4a3fb85458c042f799a6bb8
   languageName: node
   linkType: hard
 
@@ -33150,7 +33150,7 @@ __metadata:
     "@metamask/test-snaps": "npm:^3.4.2"
     "@metamask/transaction-controller": "npm:^68.1.1"
     "@metamask/transaction-pay-controller": "npm:^23.17.2"
-    "@metamask/tron-wallet-snap": "npm:^1.28.0"
+    "@metamask/tron-wallet-snap": "npm:^1.29.0"
     "@metamask/user-operation-controller": "npm:^41.2.5"
     "@metamask/utils": "npm:^11.11.0"
     "@metamask/wallet": "npm:^6.0.0"


### PR DESCRIPTION
## **Description**

This pull request introduces significant improvements to the Tron integration, primarily focusing on enhancing test reliability and coverage for Tron swaps, updating mock data, and improving the handling of network fee estimation. The changes ensure that test scenarios for Tron swaps are more robust and realistic, and that the application correctly handles cases where network fees cannot be estimated.

**Tron Swap Testing and Mock Improvements:**

- Enhanced the Tron swap end-to-end tests to cover scenarios where network fees cannot be estimated, ensuring the swap button is disabled and an "Insufficient funds" message is displayed, improving user safety and error handling.
- Added new and improved mock API handlers for Tron, including mocks for chain parameters, maintenance time, constant contract triggers, and contract retrieval, providing more realistic and up-to-date test data for swap and fee estimation flows.

**Test Data and Balance Updates:**

- Updated the default mocked TRX balance from ~6.07 TRX to ~106.07 TRX across all relevant test files, ensuring consistency and reflecting more realistic user balances in both fiat and TRX units.

**Mock API and Transaction Handling Enhancements:**

- Improved mock implementations for TronGrid and security API responses, including dynamic timestamp handling and validation/simulation objects, to prevent test flakiness due to transaction expiration and to better match the snap’s expected response structure.

**Selector and Store Test Utilities:**

- Added utilities for creating Tron-specific bridge state in selector tests, enabling more comprehensive and accurate testing of bridge logic for Tron swaps.

**Dependency Updates:**

- Updated the `@metamask/tron-wallet-snap` dependency from version 1.28.0 to 1.29.0 to ensure compatibility with the latest features and fixes.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: disable CTA swap button for Tron when no network fees retrieved

## **Related issues**

Fixes: submit Tron swaps without network fees

## **Manual testing steps**

1. Go to swap page
2. Try a quote for Tron
3. If the network fees are not reachable, the CTA button of the quote should not be enabled

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes swap submission gating for Tron when fee estimation fails—user-facing bridge behavior on a non-EVM chain, with targeted selector and E2E coverage.
> 
> **Overview**
> **Tron swaps** now follow the same rule as Bitcoin: if a quote has no usable native network fee (`totalNetworkFee` missing or ≤ 0), validation sets `isNetworkFeeUnavailable` and the swap CTA stays disabled with the **Insufficient funds** / `network_fee_unavailable` path instead of allowing submit without fees.
> 
> Bridge selectors treat **Tron** like Bitcoin for that check (`isTronChainId` added alongside `isBitcoinChainId`). Unit tests cover Tron zero vs valid fees and warning labels.
> 
> **E2E:** New Tron swap case uses `mockTronSwapApisWithoutFeeEstimation` (no fee-estimation RPC mocks) and asserts quote UI without network fees plus disabled CTA. Swap page object gains helpers for that flow. Mock TRX balance is raised to ~106 TRX across balance/swap specs; Tron swap mocks add chain parameters, maintenance time, constant contract, and contract endpoints. Flask TronGrid/security mocks use dynamic block/TAPOS timestamps and structured security scan responses to reduce flakiness.
> 
> **Dependency:** `@metamask/tron-wallet-snap` **1.28.0 → 1.29.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f28b4d16c4aa7370774e344556edd434743cb03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->