### PR TITLE
chore: gate hl check behind useExternalServices

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5806,7 +5806,10 @@ export default class MetamaskController extends EventEmitter {
     const checkExistingCodeMap = {
       [DefiReferralPartner.GMX]: (account) =>
         checkGmxHasReferralCode(this.networkController, account),
-      [DefiReferralPartner.Hyperliquid]: checkHyperliquidHasReferralCode,
+      [DefiReferralPartner.Hyperliquid]:
+        this.preferencesController.state.useExternalServices
+          ? checkHyperliquidHasReferralCode
+          : undefined,
     };
 
     if (shouldShowApproval || shouldRedirect) {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5806,10 +5806,10 @@ export default class MetamaskController extends EventEmitter {
     const checkExistingCodeMap = {
       [DefiReferralPartner.GMX]: (account) =>
         checkGmxHasReferralCode(this.networkController, account),
-      [DefiReferralPartner.Hyperliquid]:
-        this.preferencesController.state.useExternalServices
-          ? checkHyperliquidHasReferralCode
-          : undefined,
+      [DefiReferralPartner.Hyperliquid]: this.preferencesController.state
+        .useExternalServices
+        ? checkHyperliquidHasReferralCode
+        : undefined,
     };
 
     if (shouldShowApproval || shouldRedirect) {

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -5679,6 +5679,7 @@ describe('MetaMaskController', () => {
           );
           metamaskController.preferencesController.update((state) => {
             state.referrals[DefiReferralPartner.Hyperliquid] = {};
+            state.useExternalServices = true;
           });
         });
 

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -5758,6 +5758,23 @@ describe('MetaMaskController', () => {
 
           expect(checkHyperliquidHasReferralCode).not.toHaveBeenCalled();
         });
+
+        it('does not call checkHyperliquidHasReferralCode when basic functionality is disabled', async () => {
+          metamaskController.preferencesController.update((state) => {
+            state.useExternalServices = false;
+          });
+          jest
+            .spyOn(metamaskController.approvalController, 'add')
+            .mockResolvedValueOnce({});
+
+          await metamaskController.handleDefiReferral(
+            DEFI_REFERRAL_PARTNERS[DefiReferralPartner.Hyperliquid],
+            mockTabId,
+            mockNewConnectionTriggerType,
+          );
+
+          expect(checkHyperliquidHasReferralCode).not.toHaveBeenCalled();
+        });
       });
 
       describe('_handleDefiReferralApprovedAccount', () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

As HL API is 3rd party, gate the call to HL's info referral endpoint behind a `useExternalServices` check.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Make a fresh instance of MM and import a wallet that has a HL referral code in use
2. Turn off basic functionality
3. Verify that the `info` endpoint isn't called and the HL referral prompt is shown
4. Refresh the wallet without accepting/denying the prompt
5. Turn on basic functionality
6. Verify that the `info` endpoint is called and the HL referral prompt is NOT shown

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small preference-gated change to a DeFi referral path; aligns with existing useExternalServices patterns elsewhere and is covered by new unit test behavior.
> 
> **Overview**
> Hyperliquid’s existing-referral lookup (third-party **info** API) now runs only when **`useExternalServices`** is enabled (basic functionality on). In `handleDefiReferral`, the Hyperliquid entry in `checkExistingCodeMap` is set to `checkHyperliquidHasReferralCode` when that flag is true, and **`undefined`** when it is false, so no external call is made and wallets are not auto-marked as “passed” based on an API response.
> 
> Tests set **`useExternalServices: true`** for the Hyperliquid API check suite and add a case that asserts **`checkHyperliquidHasReferralCode`** is not invoked when basic functionality is off.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eec4d97b2333c11f54b90e42211309f748f9731b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->