### PR TITLE
test: fix update-fixtures script permissions

### DIFF
--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -54,6 +54,9 @@ jobs:
     needs: is-cross-repo-pr
     if: ${{ needs.is-cross-repo-pr.outputs.IS_CROSS_REPO_PR == 'false' }}
     environment: default-branch
+    permissions:
+      contents: read
+      actions: write
     outputs:
       COMMIT_SHA: ${{ steps.commit-sha.outputs.COMMIT_SHA }}
       BRANCH: ${{ steps.branch.outputs.BRANCH }}
@@ -138,6 +141,11 @@ jobs:
     timeout-minutes: 30
     needs:
       - prepare
+    # actions: write gives the job token a writable scope so actions/cache/save
+    # can write the updated-fixtures cache (see the prepare job for details).
+    permissions:
+      contents: read
+      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6

--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -141,8 +141,6 @@ jobs:
     timeout-minutes: 30
     needs:
       - prepare
-    # actions: write gives the job token a writable scope so actions/cache/save
-    # can write the updated-fixtures cache (see the prepare job for details).
     permissions:
       contents: read
       actions: write


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
The update-fixture script was broken due to the new cache build logic. This issue was fixed here:

https://github.com/MetaMask/metamask-extension/pull/43194 

However, this has unmasked an issue with permissions in the repo (cannot fully test in the fork, that's why it was not catched there):


1. In prepare, the Cache dist artifact step failed because of this error `##[warning]Failed to save: Unable to reserve cache with key dist-f2a11c162c. cache write denied: token has no writable scopes`

https://github.com/MetaMask/metamask-extension/actions/runs/28595056443/job/84790275152

<img width="1074" height="138" alt="image" src="https://github.com/user-attachments/assets/fc4a041d-ad76-4f58-9c3c-9f617be5d719" />

2. In update-fixtures, Restore dist artifact has fail-on-cache-miss: true, so it hard-failed, the cache was never written.

<img width="875" height="244" alt="image" src="https://github.com/user-attachments/assets/930526d4-788f-4cd1-80af-6728cb65bee6" />


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Not easy manual steps. Best effort: look into the failure and see fix

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow permission tweak with no application or runtime behavior changes.
> 
> **Overview**
> Fixes the **Update E2E fixtures** workflow by giving the `prepare` and `update-fixtures` jobs explicit token scopes.
> 
> Each job now declares `permissions: contents: read` and `actions: write` so steps that **download** build artifacts from another run (`gh run download`), **save/restore** cache entries, and **upload** test artifacts can run under the default `GITHUB_TOKEN` instead of failing on missing `actions` access. Commit/push behavior is unchanged and still relies on `FIXTURE_UPDATE_TOKEN` in later jobs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 654d27afde9b6482ab8a500798c830431de1d046. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->