### PR TITLE
feat: added events for chainlist feature

### DIFF
--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -1072,6 +1072,8 @@ export enum MetaMetricsEventName {
   AccountRemoveFailed = 'Account Remove Failed',
   TestNetworksDisplayed = 'Test Networks Displayed',
   AddNetworkButtonClick = 'Add Network Button Clicked',
+  ChainlistAddClicked = 'Chainlist Add Clicked',
+  ChainlistNetworkSelected = 'Chainlist Network Selected',
   CustomNetworkAdded = 'Custom Network Added',
   TokenDetailsOpened = 'Token Details Opened',
   NftDetailsOpened = 'NFT Details Opened',

--- a/ui/pages/networks/chainlist-network-picker.tsx
+++ b/ui/pages/networks/chainlist-network-picker.tsx
@@ -45,7 +45,7 @@ const CHAINLIST_SCROLL_THRESHOLD_PX = 120;
 type ChainlistNetworkPickerProps = {
   existingNetworkChainIds: Set<string>;
   existingNetworkNamesByChainId: Record<string, string>;
-  onSelect: (network: ChainlistNetwork) => void;
+  onSelect: (network: ChainlistNetwork, searchQuery?: string) => void;
 };
 
 export const ChainlistNetworkPicker = ({
@@ -149,7 +149,7 @@ export const ChainlistNetworkPicker = ({
               className="flex w-full items-center gap-3 px-4 py-2 text-left hover:bg-hover active:bg-pressed"
               data-testid="networks-page-chainlist-network"
               key={`${network.chainId}-${network.name}`}
-              onClick={() => onSelect(network)}
+              onClick={() => onSelect(network, searchValue.trim() || undefined)}
               type="button"
             >
               {networkImageUrl ? (

--- a/ui/pages/networks/networks-page.tsx
+++ b/ui/pages/networks/networks-page.tsx
@@ -4,7 +4,13 @@ import {
   UpdateNetworkFields,
 } from '@metamask/network-controller';
 import { NETWORKS_BYPASSING_VALIDATION } from '@metamask/controller-utils';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import {
   Box,
   BoxFlexDirection,
@@ -34,6 +40,10 @@ import { Header } from '../../components/multichain/pages/page';
 import { DEFAULT_ROUTE } from '../../helpers/constants/routes';
 import { NETWORK_TO_NAME_MAP } from '../../../shared/constants/network';
 import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../shared/constants/metametrics';
+import {
   getMultichainNetworkConfigurationsByChainId,
   getSelectedMultichainNetworkChainId,
 } from '../../selectors/multichain/networks';
@@ -42,6 +52,7 @@ import { getEditedNetwork } from '../../selectors/selectors';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0021): route-isolation backlog
 import { SettingsHeader } from '../settings/shared/settings-header';
 import { useGlobalMenuRouteTransition } from '../routes/global-menu-route-transition';
+import { MetaMetricsContext } from '../../contexts/metametrics';
 import { AddRpcUrlPageForm } from './add-rpc-url-page-form';
 import {
   ChainlistNetworkPicker,
@@ -118,6 +129,7 @@ const NetworksPageFormBody = ({ children }: { children: React.ReactNode }) => (
 export const NetworksPage = () => {
   const dispatch = useDispatch();
   const t = useI18nContext();
+  const { trackEvent } = useContext(MetaMetricsContext);
   const navigate = useNavigate();
   const runCloseTransition = useGlobalMenuRouteTransition();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -201,14 +213,30 @@ export const NetworksPage = () => {
   }, [setView]);
 
   const handleAddFromChainlist = useCallback(() => {
+    trackEvent({
+      event: MetaMetricsEventName.ChainlistAddClicked,
+      category: MetaMetricsEventCategory.Network,
+    });
     setView('add-from-chainlist');
-  }, [setView]);
+  }, [setView, trackEvent]);
 
   const handleChainlistNetworkSelect = useCallback(
-    (network: ChainlistNetwork) => {
+    (network: ChainlistNetwork, searchQuery?: string) => {
       const chainIdHex = getHexChainId(network.chainId);
       const existingNetwork =
         evmNetworks[chainIdHex as keyof typeof evmNetworks];
+      const networkName = existingNetwork?.name ?? network.name;
+      trackEvent({
+        event: MetaMetricsEventName.ChainlistNetworkSelected,
+        category: MetaMetricsEventCategory.Network,
+        /* eslint-disable @typescript-eslint/naming-convention */
+        properties: {
+          chain_id: chainIdHex,
+          network_name: networkName,
+          already_added: Boolean(existingNetwork),
+          ...(searchQuery ? { search_query: searchQuery } : {}),
+        },
+      });
 
       if (existingNetwork) {
         dispatch(
@@ -228,14 +256,14 @@ export const NetworksPage = () => {
       const blockExplorerUrls = getUsableUrls(
         network.explorers?.map((explorer) => explorer.url ?? '') ?? [],
       );
-      const networkName =
+      const canonicalNetworkName =
         NETWORK_TO_NAME_MAP[chainIdHex as keyof typeof NETWORK_TO_NAME_MAP] ??
         NETWORKS_BYPASSING_VALIDATION[
           chainIdHex as keyof typeof NETWORKS_BYPASSING_VALIDATION
         ]?.name ??
         network.name;
 
-      networkFormState.setName(networkName);
+      networkFormState.setName(canonicalNetworkName);
       networkFormState.setChainId(String(network.chainId));
       networkFormState.setTicker(network.nativeCurrency.symbol);
       networkFormState.setRpcUrls({
@@ -248,7 +276,7 @@ export const NetworksPage = () => {
       });
       setView('add');
     },
-    [dispatch, evmNetworks, networkFormState, setView],
+    [dispatch, evmNetworks, networkFormState, setView, trackEvent],
   );
 
   const handleAddRPC = useCallback(


### PR DESCRIPTION
This PR adds MetaMetrics tracking for the Chainlist network flow. We now track when users click Add from Chainlist, and when they select a Chainlist network, including whether the network was already added, the selected chain ID, network name, and the search query when applicable.

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: added events for chainlist

## **Related issues**

Fixes: [issue](https://consensyssoftware.atlassian.net/browse/CEUX-1138)

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only UI changes with no changes to network configuration, auth, or persistence logic.
> 
> **Overview**
> Adds **MetaMetrics** instrumentation for the Chainlist path on the networks page so product can measure adoption and search behavior.
> 
> **Chainlist Add Clicked** fires when the user opens the add-from-Chainlist flow (`MetaMetricsEventCategory.Network`). **Chainlist Network Selected** fires when they pick a row in `ChainlistNetworkPicker`, with `chain_id`, `network_name`, `already_added`, and optional `search_query` when the picker search box was used.
> 
> `ChainlistNetworkPicker` now passes the trimmed search string into `onSelect` so selection events can attribute picks to search. Two new `MetaMetricsEventName` enum entries back these events. Network add/edit behavior is unchanged aside from renaming a local variable (`canonicalNetworkName`) for the form prefill path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ce0aba054d85406f301b2bb8b945b61df419dd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->