### PR TITLE
chore: use delay on the global spinner

### DIFF
--- a/ui/hooks/useSpinDelay.test.ts
+++ b/ui/hooks/useSpinDelay.test.ts
@@ -1,0 +1,131 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { act } from '@testing-library/react';
+import { useSpinDelay } from './useSpinDelay';
+
+describe('useSpinDelay', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.clearAllTimers();
+  });
+
+  afterEach(() => {
+    act(() => {
+      jest.runOnlyPendingTimers();
+    });
+    jest.useRealTimers();
+  });
+
+  it('does not show the spinner while idle', () => {
+    const { result } = renderHook(() => useSpinDelay(false));
+    expect(result.current).toBe(false);
+  });
+
+  it('does not show the spinner before the delay elapses', () => {
+    const { result } = renderHook(() =>
+      useSpinDelay(true, { delay: 300, minDuration: 400 }),
+    );
+
+    expect(result.current).toBe(false);
+
+    act(() => {
+      jest.advanceTimersByTime(299);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('never shows the spinner when loading resolves before the delay', () => {
+    const { result, rerender } = renderHook(
+      ({ loading }: { loading: boolean }) =>
+        useSpinDelay(loading, { delay: 300, minDuration: 400 }),
+      { initialProps: { loading: true } },
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(200);
+    });
+    rerender({ loading: false });
+
+    act(() => {
+      jest.advanceTimersByTime(1000);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('shows the spinner once the delay elapses while still loading', () => {
+    const { result } = renderHook(() =>
+      useSpinDelay(true, { delay: 300, minDuration: 400 }),
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('keeps the spinner visible for at least minDuration after it appears', () => {
+    const { result, rerender } = renderHook(
+      ({ loading }: { loading: boolean }) =>
+        useSpinDelay(loading, { delay: 300, minDuration: 400 }),
+      { initialProps: { loading: true } },
+    );
+
+    // Cross the delay threshold: spinner now shown.
+    act(() => {
+      jest.advanceTimersByTime(300);
+    });
+    expect(result.current).toBe(true);
+
+    // Loading resolves almost immediately after the spinner appears.
+    rerender({ loading: false });
+    act(() => {
+      jest.advanceTimersByTime(399);
+    });
+    expect(result.current).toBe(true);
+
+    // Once the minimum duration elapses, the spinner hides.
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe(false);
+  });
+
+  it('hides the spinner immediately once loading ends after minDuration', () => {
+    const { result, rerender } = renderHook(
+      ({ loading }: { loading: boolean }) =>
+        useSpinDelay(loading, { delay: 300, minDuration: 400 }),
+      { initialProps: { loading: true } },
+    );
+
+    act(() => {
+      jest.advanceTimersByTime(700);
+    });
+    expect(result.current).toBe(true);
+
+    rerender({ loading: false });
+    expect(result.current).toBe(false);
+  });
+
+  it('uses default options when none are provided', () => {
+    const { result } = renderHook(() => useSpinDelay(true));
+
+    act(() => {
+      jest.advanceTimersByTime(299);
+    });
+    expect(result.current).toBe(false);
+
+    act(() => {
+      jest.advanceTimersByTime(1);
+    });
+    expect(result.current).toBe(true);
+  });
+
+  it('cleans up timeouts on unmount', () => {
+    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+
+    const { unmount } = renderHook(() => useSpinDelay(true));
+    unmount();
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockRestore();
+  });
+});

--- a/ui/hooks/useSpinDelay.ts
+++ b/ui/hooks/useSpinDelay.ts
@@ -1,0 +1,54 @@
+import { useEffect, useRef, useState } from 'react';
+
+// Adapted from `spin-delay` by Stephan Meijer
+// Source: https://github.com/smeijer/spin-delay
+
+export type SpinDelayOptions = {
+  delay?: number;
+  minDuration?: number;
+};
+
+type State = 'idle' | 'delay' | 'display' | 'expire';
+
+const defaultOptions = {
+  delay: 300,
+  minDuration: 400,
+};
+
+/**
+ * Defer showing loading so quick operations (e.g. account switching) don't flash a spinner,
+ * and pin it briefly once shown so it doesn't flicker out
+ * @param loading - Whether the loading state is active
+ * @param options - Optional configuration for delay and minimum duration
+ * @returns A boolean indicating whether the spinner should be displayed
+ */
+export function useSpinDelay(loading: boolean, options?: SpinDelayOptions) {
+  const { delay, minDuration } = {
+    ...defaultOptions,
+    ...options,
+  };
+  const [state, setState] = useState<State>('idle');
+  const timeout = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    if (loading && state === 'idle') {
+      clearTimeout(timeout.current);
+
+      timeout.current = setTimeout(() => {
+        timeout.current = setTimeout(() => setState('expire'), minDuration);
+        setState('display');
+      }, delay);
+
+      setState('delay');
+    }
+
+    if (!loading && state !== 'display') {
+      clearTimeout(timeout.current);
+      setState('idle');
+    }
+  }, [loading, state, delay, minDuration]);
+
+  useEffect(() => () => clearTimeout(timeout.current), []);
+
+  return state === 'display' || state === 'expire';
+}

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -123,6 +123,7 @@ import { MultichainAccountAddressListPage } from '../multichain-accounts/multich
 import { MultichainAccountPrivateKeyListPage } from '../multichain-accounts/multichain-account-private-key-list-page';
 import MultichainAccountIntroModalContainer from '../../components/app/modals/multichain-accounts/intro-modal';
 import { useMultichainAccountsIntroModal } from '../../hooks/useMultichainAccountsIntroModal';
+import { useSpinDelay } from '../../hooks/useSpinDelay';
 import { AccountList } from '../multichain-accounts/account-list';
 import { AddWalletPage } from '../multichain-accounts/add-wallet-page';
 import { ChooseNewWalletTypePage } from '../multichain-accounts/choose-new-wallet-type';
@@ -584,6 +585,7 @@ export default function Routes() {
   const alertOpen = useAppSelector((state) => state.appState.alertOpen);
   const alertMessage = useAppSelector((state) => state.appState.alertMessage);
   const isLoading = useAppSelector((state) => state.appState.isLoading);
+  const showLoadingOverlay = useSpinDelay(isLoading);
   const loadingMessage = useAppSelector(
     (state) => state.appState.loadingMessage,
   );
@@ -722,7 +724,7 @@ export default function Routes() {
   const isShowingDeepLinkRoute = location.pathname === DEEP_LINK_ROUTE;
 
   const isLoadingShown =
-    isLoading &&
+    showLoadingOverlay &&
     completedOnboarding &&
     !pendingConfirmations.some(
       (confirmation) =>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Switching accounts (and many other quick operations) **always** briefly flashed the full-screen loading overlay. For operations that resolve in a few milliseconds, the spinner makes the app feel slower

This PR adds a `useSpinDelay` hook that withholds the spinner until loading has run for at least a certain duration, and once shown pins it for a minimum duration to prevent flicker on the way out. 

Summary:
- fast operations no longer flash a spinner
- genuinely slow operations still show one


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: chore: defer global spinners

## **Related issues**

Fixes:

## **Manual testing steps**

1.Unlock the wallet and open the account list
2. Switch between accounts several times
3. Verify no loading spinner flashes during the switch
4. Open Settings and toggle a few preferences


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/35785229-a9c5-4e82-978a-ad2fac88bd8d

https://github.com/user-attachments/assets/aac6568c-51f4-44df-854c-bc1fdcd51a87





<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/ce2a590d-2d56-4a53-a4f6-a8ecacf94c16


https://github.com/user-attachments/assets/ce3025aa-cdac-4098-adc6-389a679b56ac




<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only timing change on the global loading overlay with no auth, data, or API impact; behavior is covered by unit tests.
> 
> **Overview**
> Adds **`useSpinDelay`** so the full-screen loading overlay no longer appears on very short `appState.isLoading` bursts (e.g. account switching).
> 
> The hook waits **300ms** before showing a spinner and, once visible, keeps it up for at least **400ms** to avoid flicker. **`Routes`** now gates the overlay with `showLoadingOverlay = useSpinDelay(isLoading)` instead of tying visibility directly to `isLoading`; existing guards (onboarding, confirmations, redesigned flows, deep link) are unchanged.
> 
> Unit tests cover delay, min duration, early resolution, defaults, and unmount cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2a85916d356b4f05f74c9bf20285828ddd46813. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->