### PR TITLE
fix(release): pin firefox bundle.sh per release tag (INFRA-3753)

### DIFF
--- a/.github/actions/publish-amo-reviewer-artifacts/action.yml
+++ b/.github/actions/publish-amo-reviewer-artifacts/action.yml
@@ -3,27 +3,18 @@ description: >-
   Package Firefox reviewer source + approval notes (firefox-bundle-script) and
   upload to PRD private S3 via OIDC for production and flask AMO submission.
   Requires caller job env RELEASE_TAG, FIREFOX_BUNDLE_SCRIPT_TOKEN, and
-  id-token write for AWS OIDC.
+  id-token write for AWS OIDC. Tooling SHA is pinned in
+  publish-firefox-reviewer-artifacts.sh (INFRA-3753).
 
 # PRD platform contract (va-mmc-extension-submission-infra amo_reviewer_source.tf):
 #   bucket: prd-va-mmc-extension-submission-amo-reviewer-source
 #   role:   arn:aws:iam::363762752069:role/amo-reviewer-publisher
-
-inputs:
-  firefox_bundle_script_ref:
-    description: >-
-      Git ref for MetaMask/firefox-bundle-script (Flask packaging needs PR #9+;
-      empty uses script default SHA until merged to main)
-    required: false
-    default: ''
 
 runs:
   using: composite
   steps:
     - name: Package Firefox reviewer artifacts
       shell: bash
-      env:
-        FIREFOX_BUNDLE_SCRIPT_REF: ${{ inputs.firefox_bundle_script_ref }}
       run: bash "${GITHUB_WORKSPACE}/.github/scripts/publish-firefox-reviewer-artifacts.sh" package
 
     - name: Configure AWS credentials (PRD reviewer publisher)

--- a/.github/scripts/publish-firefox-reviewer-artifacts.sh
+++ b/.github/scripts/publish-firefox-reviewer-artifacts.sh
@@ -20,7 +20,7 @@ set -euo pipefail
 
 # Pin firefox-bundle-script tooling (prepare_release.sh + scripts). Bump via PR
 # when tooling changes; merge MetaMask/firefox-bundle-script before release use.
-# INFRA-3753: includes BUNDLE_SH_GIT_REF / per-version tag support.
+# INFRA-3753: includes FIREFOX_BUNDLE_SH_GIT_REF / per-version tag support.
 FIREFOX_BUNDLE_SCRIPT_REF="fb08f4c4515cf21846bceea83830f63e285c34fd"
 
 MODE="${1:-}"
@@ -44,7 +44,7 @@ AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-2}"
 PACKAGE_ROOT="${AMO_REVIEWER_PACKAGE_ROOT:-${RUNNER_TEMP:-/tmp}/amo-reviewer-artifacts}"
 PACKAGE_DIR="${PACKAGE_ROOT}/${raw_version}"
 S3_PREFIX="reviewer-source/${raw_version}"
-BUNDLE_SH_GIT_REF="v${raw_version}"
+FIREFOX_BUNDLE_SH_GIT_REF="v${raw_version}"
 
 ensure_mtree() {
   if command -v mtree >/dev/null 2>&1; then
@@ -109,13 +109,13 @@ package_release_variant() {
 
   mkdir -p "${PACKAGE_DIR}"
 
-  # prepare_release.sh fetches bundle.sh at BUNDLE_SH_GIT_REF (v{version} tag),
+  # prepare_release.sh fetches bundle.sh at FIREFOX_BUNDLE_SH_GIT_REF (v{version} tag),
   # runs compare_builds.sh + create_submission_package.sh, and writes packages
   # under output/. Exits non-zero when reproduced build differs from published.
   echo "Packaging ${variant} reviewer artifacts via prepare_release.sh..."
   (
     cd "${clone_dir}"
-    export BUNDLE_SH_GIT_REF
+    export FIREFOX_BUNDLE_SH_GIT_REF
     bash ./prepare_release.sh "${prepare_args[@]}" "${raw_version}" "${last_listed}"
   )
 

--- a/.github/scripts/publish-firefox-reviewer-artifacts.sh
+++ b/.github/scripts/publish-firefox-reviewer-artifacts.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 # Pin firefox-bundle-script tooling (prepare_release.sh + scripts). Bump via PR
 # when tooling changes; merge MetaMask/firefox-bundle-script before release use.
 # INFRA-3753: includes FIREFOX_BUNDLE_SH_GIT_REF / per-version tag support.
-FIREFOX_BUNDLE_SCRIPT_REF="267b42798d1e5a567c0b32e01bab73232fb8f67e"
+FIREFOX_BUNDLE_SCRIPT_REF="1cb37c0817b319d9846dbca827d533e0ae769984"
 
 MODE="${1:-}"
 if [[ "${MODE}" != "package" && "${MODE}" != "upload" ]]; then

--- a/.github/scripts/publish-firefox-reviewer-artifacts.sh
+++ b/.github/scripts/publish-firefox-reviewer-artifacts.sh
@@ -11,15 +11,17 @@
 #
 # Environment:
 #   RELEASE_TAG                  — e.g. v13.37.0 (required)
-#   FIREFOX_BUNDLE_SCRIPT_TOKEN  — clone private repo + read release branch bundle.sh
-#   FIREFOX_BUNDLE_SCRIPT_REF    — git ref (default: main)
+#   FIREFOX_BUNDLE_SCRIPT_TOKEN  — clone private repo + fetch bundle.sh tags
 #   AMO_REVIEWER_PACKAGE_ROOT    — output root (default: $RUNNER_TEMP/amo-reviewer-artifacts)
-#   AMO_REVIEWER_BUCKET            — required for upload
+#   AMO_REVIEWER_BUCKET          — required for upload
 #   AWS_DEFAULT_REGION             — default us-east-2
 
 set -euo pipefail
 
-DEFAULT_FIREFOX_BUNDLE_SCRIPT_REF="main"
+# Pin firefox-bundle-script tooling (prepare_release.sh + scripts). Bump via PR
+# when tooling changes; merge MetaMask/firefox-bundle-script before release use.
+# INFRA-3753: includes BUNDLE_SH_GIT_REF / per-version tag support.
+FIREFOX_BUNDLE_SCRIPT_REF="89582520feb136f469811c5e3dd790935bdcf188"
 
 MODE="${1:-}"
 if [[ "${MODE}" != "package" && "${MODE}" != "upload" ]]; then
@@ -42,6 +44,7 @@ AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-us-east-2}"
 PACKAGE_ROOT="${AMO_REVIEWER_PACKAGE_ROOT:-${RUNNER_TEMP:-/tmp}/amo-reviewer-artifacts}"
 PACKAGE_DIR="${PACKAGE_ROOT}/${raw_version}"
 S3_PREFIX="reviewer-source/${raw_version}"
+BUNDLE_SH_GIT_REF="v${raw_version}"
 
 ensure_mtree() {
   if command -v mtree >/dev/null 2>&1; then
@@ -106,14 +109,15 @@ package_release_variant() {
 
   mkdir -p "${PACKAGE_DIR}"
 
-  # prepare_release.sh is the canonical orchestrator: it fetches bundle.sh from
-  # origin/release, runs compare_builds.sh + create_submission_package.sh, and
-  # writes packages under output/. It also sets PRODUCTION_BUILD_FILE /
-  # FIREFOX_BUNDLE_SCRIPT_ARGS / SUBMISSION_DIR_PREFIX internally (per --flask),
-  # and exits non-zero when the reproduced build differs from the published one,
-  # which under set -e correctly fails the reviewer publish.
+  # prepare_release.sh fetches bundle.sh at BUNDLE_SH_GIT_REF (v{version} tag),
+  # runs compare_builds.sh + create_submission_package.sh, and writes packages
+  # under output/. Exits non-zero when reproduced build differs from published.
   echo "Packaging ${variant} reviewer artifacts via prepare_release.sh..."
-  ( cd "${clone_dir}" && bash ./prepare_release.sh "${prepare_args[@]}" "${raw_version}" "${last_listed}" )
+  (
+    cd "${clone_dir}"
+    export BUNDLE_SH_GIT_REF
+    bash ./prepare_release.sh "${prepare_args[@]}" "${raw_version}" "${last_listed}"
+  )
 
   local submission_dir source_zip notes_file
   submission_dir="${clone_dir}/output/${submission_dir_prefix}_v${raw_version}"
@@ -144,7 +148,7 @@ run_package() {
   local work_root script_ref clone_dir last_listed
   work_root="$(mktemp -d)"
   trap 'rm -rf "${work_root}"' EXIT
-  script_ref="${FIREFOX_BUNDLE_SCRIPT_REF:-${DEFAULT_FIREFOX_BUNDLE_SCRIPT_REF}}"
+  script_ref="${FIREFOX_BUNDLE_SCRIPT_REF}"
   clone_dir="${work_root}/firefox-bundle-script"
 
   mkdir -p "${PACKAGE_DIR}"
@@ -152,10 +156,8 @@ run_package() {
   echo "Cloning firefox-bundle-script at ref ${script_ref}..."
   clone_firefox_bundle_script "${script_ref}" "${clone_dir}"
 
-  # prepare_release.sh reads bundle.sh via `git show origin/release:bundle.sh`,
-  # so the origin/release remote-tracking ref must exist in the shallow clone.
-  echo "Fetching release branch so prepare_release.sh can read bundle.sh..."
-  git -C "${clone_dir}" fetch origin "+refs/heads/release:refs/remotes/origin/release" --depth 1
+  echo "Fetching bundle.sh tag ${BUNDLE_SH_GIT_REF}..."
+  git -C "${clone_dir}" fetch origin "+refs/tags/${BUNDLE_SH_GIT_REF}:refs/tags/${BUNDLE_SH_GIT_REF}" --depth 1
 
   last_listed="$(resolve_last_listed_version)"
   echo "Using last listed version: ${last_listed}"

--- a/.github/scripts/publish-firefox-reviewer-artifacts.sh
+++ b/.github/scripts/publish-firefox-reviewer-artifacts.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 # Pin firefox-bundle-script tooling (prepare_release.sh + scripts). Bump via PR
 # when tooling changes; merge MetaMask/firefox-bundle-script before release use.
 # INFRA-3753: includes BUNDLE_SH_GIT_REF / per-version tag support.
-FIREFOX_BUNDLE_SCRIPT_REF="89582520feb136f469811c5e3dd790935bdcf188"
+FIREFOX_BUNDLE_SCRIPT_REF="a5a5b047f0eabd0f08a7a8a26b94a19c8ede6b57"
 
 MODE="${1:-}"
 if [[ "${MODE}" != "package" && "${MODE}" != "upload" ]]; then

--- a/.github/scripts/publish-firefox-reviewer-artifacts.sh
+++ b/.github/scripts/publish-firefox-reviewer-artifacts.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 # Pin firefox-bundle-script tooling (prepare_release.sh + scripts). Bump via PR
 # when tooling changes; merge MetaMask/firefox-bundle-script before release use.
 # INFRA-3753: includes BUNDLE_SH_GIT_REF / per-version tag support.
-FIREFOX_BUNDLE_SCRIPT_REF="4bc41d91e1a9c9ccf39ea4a9338bee39db71790e"
+FIREFOX_BUNDLE_SCRIPT_REF="3c584f9e7b11d664b4b8b347f24e77aec9e7408a"
 
 MODE="${1:-}"
 if [[ "${MODE}" != "package" && "${MODE}" != "upload" ]]; then

--- a/.github/scripts/publish-firefox-reviewer-artifacts.sh
+++ b/.github/scripts/publish-firefox-reviewer-artifacts.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 # Pin firefox-bundle-script tooling (prepare_release.sh + scripts). Bump via PR
 # when tooling changes; merge MetaMask/firefox-bundle-script before release use.
 # INFRA-3753: includes BUNDLE_SH_GIT_REF / per-version tag support.
-FIREFOX_BUNDLE_SCRIPT_REF="3c584f9e7b11d664b4b8b347f24e77aec9e7408a"
+FIREFOX_BUNDLE_SCRIPT_REF="81121d4221e23a654a784ee8abc27d2daab3989d"
 
 MODE="${1:-}"
 if [[ "${MODE}" != "package" && "${MODE}" != "upload" ]]; then

--- a/.github/scripts/publish-firefox-reviewer-artifacts.sh
+++ b/.github/scripts/publish-firefox-reviewer-artifacts.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 # Pin firefox-bundle-script tooling (prepare_release.sh + scripts). Bump via PR
 # when tooling changes; merge MetaMask/firefox-bundle-script before release use.
 # INFRA-3753: includes BUNDLE_SH_GIT_REF / per-version tag support.
-FIREFOX_BUNDLE_SCRIPT_REF="a5a5b047f0eabd0f08a7a8a26b94a19c8ede6b57"
+FIREFOX_BUNDLE_SCRIPT_REF="4bc41d91e1a9c9ccf39ea4a9338bee39db71790e"
 
 MODE="${1:-}"
 if [[ "${MODE}" != "package" && "${MODE}" != "upload" ]]; then

--- a/.github/scripts/publish-firefox-reviewer-artifacts.sh
+++ b/.github/scripts/publish-firefox-reviewer-artifacts.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 # Pin firefox-bundle-script tooling (prepare_release.sh + scripts). Bump via PR
 # when tooling changes; merge MetaMask/firefox-bundle-script before release use.
 # INFRA-3753: includes FIREFOX_BUNDLE_SH_GIT_REF / per-version tag support.
-FIREFOX_BUNDLE_SCRIPT_REF="fb08f4c4515cf21846bceea83830f63e285c34fd"
+FIREFOX_BUNDLE_SCRIPT_REF="267b42798d1e5a567c0b32e01bab73232fb8f67e"
 
 MODE="${1:-}"
 if [[ "${MODE}" != "package" && "${MODE}" != "upload" ]]; then

--- a/.github/scripts/publish-firefox-reviewer-artifacts.sh
+++ b/.github/scripts/publish-firefox-reviewer-artifacts.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 # Pin firefox-bundle-script tooling (prepare_release.sh + scripts). Bump via PR
 # when tooling changes; merge MetaMask/firefox-bundle-script before release use.
 # INFRA-3753: includes BUNDLE_SH_GIT_REF / per-version tag support.
-FIREFOX_BUNDLE_SCRIPT_REF="81121d4221e23a654a784ee8abc27d2daab3989d"
+FIREFOX_BUNDLE_SCRIPT_REF="fb08f4c4515cf21846bceea83830f63e285c34fd"
 
 MODE="${1:-}"
 if [[ "${MODE}" != "package" && "${MODE}" != "upload" ]]; then
@@ -155,9 +155,6 @@ run_package() {
 
   echo "Cloning firefox-bundle-script at ref ${script_ref}..."
   clone_firefox_bundle_script "${script_ref}" "${clone_dir}"
-
-  echo "Fetching bundle.sh tag ${BUNDLE_SH_GIT_REF}..."
-  git -C "${clone_dir}" fetch origin "+refs/tags/${BUNDLE_SH_GIT_REF}:refs/tags/${BUNDLE_SH_GIT_REF}" --depth 1
 
   last_listed="$(resolve_last_listed_version)"
   echo "Using last listed version: ${last_listed}"

--- a/.github/scripts/push-firefox-bundle-script.sh
+++ b/.github/scripts/push-firefox-bundle-script.sh
@@ -65,7 +65,7 @@ remote_tag_sha="$(git ls-remote --tags origin "refs/tags/${version}^{}" | awk 'N
 if [[ -n "${remote_tag_sha}" ]]; then
   echo "Tag ${version} already exists on origin (${remote_tag_sha}); leaving immutable release tag untouched"
 else
-  git tag -f -a "${version}" -m "${version}"
+  git tag -a "${version}" -m "${version}"
   git push origin "refs/tags/${version}"
   echo "Pushed tag ${version}"
 fi

--- a/.github/scripts/push-firefox-bundle-script.sh
+++ b/.github/scripts/push-firefox-bundle-script.sh
@@ -59,6 +59,8 @@ git push origin release
 # local tag would otherwise keep pointing at an old commit. When the tag is
 # not yet on origin, create it at the commit made above and let any push
 # failure surface instead of masking it as a benign re-run.
+# Peel annotated tags to a single commit SHA (refs/tags/X^{}); without ^{},
+# ls-remote can return multiple lines for one annotated tag.
 remote_tag_sha="$(git ls-remote --tags origin "refs/tags/${version}^{}" | awk 'NR==1 { print $1; exit }')"
 if [[ -n "${remote_tag_sha}" ]]; then
   echo "Tag ${version} already exists on origin (${remote_tag_sha}); leaving immutable release tag untouched"

--- a/.github/scripts/push-firefox-bundle-script.sh
+++ b/.github/scripts/push-firefox-bundle-script.sh
@@ -59,7 +59,7 @@ git push origin release
 # local tag would otherwise keep pointing at an old commit. When the tag is
 # not yet on origin, create it at the commit made above and let any push
 # failure surface instead of masking it as a benign re-run.
-remote_tag_sha="$(git ls-remote --tags origin "refs/tags/${version}" | awk '{print $1}')"
+remote_tag_sha="$(git ls-remote --tags origin "refs/tags/${version}^{}" | awk 'NR==1 { print $1; exit }')"
 if [[ -n "${remote_tag_sha}" ]]; then
   echo "Tag ${version} already exists on origin (${remote_tag_sha}); leaving immutable release tag untouched"
 else

--- a/.github/scripts/push-firefox-bundle-script.sh
+++ b/.github/scripts/push-firefox-bundle-script.sh
@@ -52,3 +52,16 @@ done
 git add bundle.sh
 git commit --allow-empty -m "${version}"
 git push origin release
+
+# Per-release tag so prepare_release.sh can fetch bundle.sh at v{X.Y.Z}
+# instead of release branch HEAD (INFRA-3753).
+if git rev-parse "${version}^{commit}" >/dev/null 2>&1; then
+  echo "Tag ${version} already exists locally; skipping tag creation"
+else
+  git tag -a "${version}" -m "${version}"
+fi
+if git push origin "refs/tags/${version}" 2>/dev/null; then
+  echo "Pushed tag ${version}"
+else
+  echo "::warning::Tag ${version} already exists on origin (idempotent re-run)"
+fi

--- a/.github/scripts/push-firefox-bundle-script.sh
+++ b/.github/scripts/push-firefox-bundle-script.sh
@@ -54,14 +54,16 @@ git commit --allow-empty -m "${version}"
 git push origin release
 
 # Per-release tag so prepare_release.sh can fetch bundle.sh at v{X.Y.Z}
-# instead of release branch HEAD (INFRA-3753).
-if git rev-parse "${version}^{commit}" >/dev/null 2>&1; then
-  echo "Tag ${version} already exists locally; skipping tag creation"
+# instead of release branch HEAD (INFRA-3753). Check origin (the source of
+# truth) rather than a local tag that `git clone` may have pulled: a stale
+# local tag would otherwise keep pointing at an old commit. When the tag is
+# not yet on origin, create it at the commit made above and let any push
+# failure surface instead of masking it as a benign re-run.
+remote_tag_sha="$(git ls-remote --tags origin "refs/tags/${version}" | awk '{print $1}')"
+if [[ -n "${remote_tag_sha}" ]]; then
+  echo "Tag ${version} already exists on origin (${remote_tag_sha}); leaving immutable release tag untouched"
 else
-  git tag -a "${version}" -m "${version}"
-fi
-if git push origin "refs/tags/${version}" 2>/dev/null; then
+  git tag -f -a "${version}" -m "${version}"
+  git push origin "refs/tags/${version}"
   echo "Pushed tag ${version}"
-else
-  echo "::warning::Tag ${version} already exists on origin (idempotent re-run)"
 fi

--- a/.github/workflows/publish-release-from-release-head.yml
+++ b/.github/workflows/publish-release-from-release-head.yml
@@ -324,8 +324,6 @@ jobs:
         id: amo-reviewer-s3
         continue-on-error: true
         uses: ./.github/actions/publish-amo-reviewer-artifacts
-        with:
-          firefox_bundle_script_ref: ${{ vars.FIREFOX_BUNDLE_SCRIPT_REF }}
 
       - name: Summary
         env:


### PR DESCRIPTION
## **Description**

Pin `bundle.sh` to per-release tags (`v{X.Y.Z}`) instead of `release` branch HEAD, and hardcode the `firefox-bundle-script` tooling SHA in the publish path.

**Why:** `prepare_release.sh` read `bundle.sh` from `release` HEAD. If a newer release is pushed first, packaging an older version could pick up wrong secrets. Tooling also floated on `main` / a repo var.

**Changes:**
- `push-firefox-bundle-script.sh`: push annotated tag `v{X.Y.Z}` after each release commit; check origin before tagging
- `publish-firefox-reviewer-artifacts.sh`: hardcoded tooling SHA + `BUNDLE_SH_GIT_REF=v{version}`; drop `FIREFOX_BUNDLE_SCRIPT_REF` env override
- Remove `vars.FIREFOX_BUNDLE_SCRIPT_REF` from publish workflow and composite action input

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: INFRA-3753

## **Manual testing steps**

1. Merge [MetaMask/firefox-bundle-script#10](https://github.com/MetaMask/firefox-bundle-script/pull/10) first, then bump `FIREFOX_BUNDLE_SCRIPT_REF` in the publish script to the merge commit SHA if squashed.
2. On the next release (or `workflow_dispatch` publish), confirm `bundle.sh` resolves to `v{version}` tag on `firefox-bundle-script`.
3. Re-run publish for the same version and confirm the tag is not left pointing at an old commit.

## **Screenshots/Recordings**

N/A (CI/release scripting only)

## **Pre-merge author checklist**

- [x] Followed MetaMask contributor and coding guidelines
- [x] Completed the PR template
- [x] Included tests where applicable (N/A — shell/workflow changes)
- [x] Applied appropriate labels

## **Pre-merge reviewer checklist**

- [ ] Description and manual testing steps are clear
- [ ] firefox-bundle-script #10 merged or merge order agreed
- [ ] Tag immutability / idempotent re-run behavior is acceptable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Release automation now depends on per-version tags and a pinned tooling SHA; wrong tag order or an outdated SHA could break or mis-package Firefox reviewer artifacts that embed release secrets.
> 
> **Overview**
> **Pins Firefox AMO reviewer packaging to immutable per-release `bundle.sh` and fixed tooling**, so packaging version *X* cannot pick up secrets or scripts from a newer `release` branch HEAD or a floating repo variable.
> 
> `push-firefox-bundle-script.sh` now creates an annotated **`v{X.Y.Z}`** tag on origin after each release commit (idempotent: skips if the tag already exists on origin). `publish-firefox-reviewer-artifacts.sh` hardcodes the **`firefox-bundle-script`** tooling SHA, sets **`FIREFOX_BUNDLE_SH_GIT_REF=v{version}`** when calling `prepare_release.sh`, and no longer fetches `origin/release` for `bundle.sh`. The composite action and publish workflow drop the **`firefox_bundle_script_ref`** input / **`vars.FIREFOX_BUNDLE_SCRIPT_REF`** override.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4c119b9f8de6c84a4af79a88db4adfb0693161a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->