### PR TITLE
feat(ci): attest webpack release zips at publish (INFRA-2665)

### DIFF
--- a/.github/scripts/release-create-gh-release.sh
+++ b/.github/scripts/release-create-gh-release.sh
@@ -148,7 +148,7 @@ fi
 printf '%s\n' "Creating GitHub Release for ${tag}..."
 
 if [[ ! -f SHA256SUMS ]]; then
-    echo "::error::SHA256SUMS file not found — attestation step may have failed"
+    echo "::error::SHA256SUMS file not found — Generate SHA256SUMS workflow step may have failed"
     exit 1
 fi
 

--- a/.github/scripts/release-create-gh-release.sh
+++ b/.github/scripts/release-create-gh-release.sh
@@ -147,6 +147,11 @@ fi
 
 printf '%s\n' "Creating GitHub Release for ${tag}..."
 
+if [[ ! -f SHA256SUMS ]]; then
+    echo "::error::SHA256SUMS file not found — attestation step may have failed"
+    exit 1
+fi
+
 # Collect and validate webpack artifacts
 webpack_artifacts=()
 for artifact in build-dist-webpack/builds/metamask-chrome-*.zip \
@@ -185,6 +190,7 @@ release_body="$(awk -v version="[${VERSION}]" -f .github/scripts/show-changelog.
 gh release create "${tag}" \
     "${webpack_artifacts[@]}" \
     "${browserify_artifacts[@]}" \
+    SHA256SUMS \
     --title "Version ${VERSION}" \
     --notes "${release_body}" \
     --target "${RELEASE_SHA}"

--- a/.github/workflows/publish-release-from-release-head.yml
+++ b/.github/workflows/publish-release-from-release-head.yml
@@ -11,7 +11,8 @@ permissions:
   contents: read # publish-release uses EXTENSION_PUBLISH_TOKEN for write operations
   statuses: read # Required by verify-ci-checks.sh to read commit statuses
   actions: read # Required to download artifacts from build jobs
-  id-token: write # Required for OIDC authentication in S3 uploads
+  id-token: write # Required for OIDC authentication in S3 uploads and build provenance attestation
+  attestations: write # Required for actions/attest-build-provenance (INFRA-2665)
 
 jobs:
   validate-branch:
@@ -314,6 +315,39 @@ jobs:
       - name: Publish Flask MV2 webpack release to Sentry
         run: yarn sentry:publish --build-type flask --dist mv2 --dist-directory build-flask-mv2-webpack/dist
 
+      # SLSA build provenance attestation (INFRA-2665). Webpack zips only — browserify assets are deprecated fallbacks.
+      - name: Attest webpack chrome artifact
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
+        with:
+          subject-path: build-dist-webpack/builds/metamask-chrome-*.zip
+
+      - name: Attest webpack firefox artifact
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
+        with:
+          subject-path: build-dist-mv2-webpack/builds/metamask-firefox-*.zip
+
+      - name: Attest webpack flask chrome artifact
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
+        with:
+          subject-path: build-flask-webpack/builds/metamask-chrome-*.zip
+
+      - name: Attest webpack flask firefox artifact
+        uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
+        with:
+          subject-path: build-flask-mv2-webpack/builds/metamask-firefox-*.zip
+
+      - name: Generate SHA256SUMS
+        run: |
+          set -euo pipefail
+          sha256sum \
+            build-dist-webpack/builds/metamask-chrome-*.zip \
+            build-dist-mv2-webpack/builds/metamask-firefox-*.zip \
+            build-flask-webpack/builds/metamask-chrome-*.zip \
+            build-flask-mv2-webpack/builds/metamask-firefox-*.zip \
+            > SHA256SUMS
+          echo "=== SHA256SUMS ==="
+          cat SHA256SUMS
+
       - name: Create tags and GitHub release
         run: .github/scripts/release-create-gh-release.sh
 
@@ -344,6 +378,8 @@ jobs:
             echo "| Sentry (main MV2 webpack) | ✅ Published |"
             echo "| Sentry (Flask webpack) | ✅ Published |"
             echo "| Sentry (Flask MV2 webpack) | ✅ Published |"
+            echo "| Attestation (4 webpack artifacts) | ✅ Attested |"
+            echo "| SHA256SUMS | ✅ Generated |"
             echo "| GitHub Release | ✅ Created |"
             echo "| Firefox Bundle | ✅ Pushed |"
             if [[ "${{ steps.amo-reviewer-s3.conclusion }}" == "success" ]]; then

--- a/.github/workflows/publish-release-from-release-head.yml
+++ b/.github/workflows/publish-release-from-release-head.yml
@@ -339,12 +339,18 @@ jobs:
       - name: Generate SHA256SUMS
         run: |
           set -euo pipefail
-          sha256sum \
+          # Emit bare filenames (no directory prefix) so `sha256sum -c SHA256SUMS`
+          # works when release assets are downloaded into a single directory
+          # (INFRA-3661 CWS upload verify). Release assets are published under
+          # bare zip names, not their workspace-relative build paths.
+          : > SHA256SUMS
+          for zip in \
             build-dist-webpack/builds/metamask-chrome-*.zip \
             build-dist-mv2-webpack/builds/metamask-firefox-*.zip \
             build-flask-webpack/builds/metamask-chrome-*.zip \
-            build-flask-mv2-webpack/builds/metamask-firefox-*.zip \
-            > SHA256SUMS
+            build-flask-mv2-webpack/builds/metamask-firefox-*.zip; do
+            ( cd "$(dirname "${zip}")" && sha256sum "$(basename "${zip}")" ) >> "${GITHUB_WORKSPACE}/SHA256SUMS"
+          done
           echo "=== SHA256SUMS ==="
           cat SHA256SUMS
 

--- a/.github/workflows/publish-release-from-release-head.yml
+++ b/.github/workflows/publish-release-from-release-head.yml
@@ -350,7 +350,7 @@ jobs:
             build-dist-mv2-webpack/builds/metamask-firefox-*.zip \
             build-flask-webpack/builds/metamask-chrome-*.zip \
             build-flask-mv2-webpack/builds/metamask-firefox-*.zip; do
-            ( cd "$(dirname "${zip}")" && sha256sum "$(basename "${zip}")" ) >> "${SHA256SUMS}"
+            ( cd "$(dirname "${zip}")" && sha256sum --text "$(basename "${zip}")" ) >> "${SHA256SUMS}"
           done
           echo "=== SHA256SUMS ==="
           cat "${SHA256SUMS}"

--- a/.github/workflows/publish-release-from-release-head.yml
+++ b/.github/workflows/publish-release-from-release-head.yml
@@ -11,8 +11,7 @@ permissions:
   contents: read # publish-release uses EXTENSION_PUBLISH_TOKEN for write operations
   statuses: read # Required by verify-ci-checks.sh to read commit statuses
   actions: read # Required to download artifacts from build jobs
-  id-token: write # Required for OIDC authentication in S3 uploads and build provenance attestation
-  attestations: write # Required for actions/attest-build-provenance (INFRA-2665)
+  id-token: write # Required for OIDC in build-job S3 uploads (run-build.yml) and publish-release
 
 jobs:
   validate-branch:
@@ -173,6 +172,12 @@ jobs:
 
   publish-release:
     name: Publish release
+    permissions:
+      contents: read
+      statuses: read
+      actions: read
+      id-token: write # Required for actions/attest-build-provenance OIDC
+      attestations: write # Required for actions/attest-build-provenance (INFRA-2665)
     needs:
       - validate-branch
       - approve-release

--- a/.github/workflows/publish-release-from-release-head.yml
+++ b/.github/workflows/publish-release-from-release-head.yml
@@ -343,16 +343,17 @@ jobs:
           # works when release assets are downloaded into a single directory
           # (INFRA-3661 CWS upload verify). Release assets are published under
           # bare zip names, not their workspace-relative build paths.
-          : > SHA256SUMS
+          SHA256SUMS="${GITHUB_WORKSPACE}/SHA256SUMS"
+          : > "${SHA256SUMS}"
           for zip in \
             build-dist-webpack/builds/metamask-chrome-*.zip \
             build-dist-mv2-webpack/builds/metamask-firefox-*.zip \
             build-flask-webpack/builds/metamask-chrome-*.zip \
             build-flask-mv2-webpack/builds/metamask-firefox-*.zip; do
-            ( cd "$(dirname "${zip}")" && sha256sum "$(basename "${zip}")" ) >> "${GITHUB_WORKSPACE}/SHA256SUMS"
+            ( cd "$(dirname "${zip}")" && sha256sum "$(basename "${zip}")" ) >> "${SHA256SUMS}"
           done
           echo "=== SHA256SUMS ==="
-          cat SHA256SUMS
+          cat "${SHA256SUMS}"
 
       - name: Create tags and GitHub release
         run: .github/scripts/release-create-gh-release.sh


### PR DESCRIPTION
## **Description**

Add SLSA build provenance attestation and `SHA256SUMS` to production release publish workflow so store-upload verify gates can fail closed on tampered zips.

**Changes:**
- `actions/attest-build-provenance@v4` on four primary webpack zips in `publish-release-from-release-head.yml`
- Generate and attach `SHA256SUMS` with bare zip filenames (compatible with downstream `sha256sum -c`)
- Workflow `attestations: write` permission

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: INFRA-2665

## **Manual testing steps**

1. Merge after review; validate on next release cut from `release/*`.
2. Confirm release assets include `SHA256SUMS` and attestations for the four webpack zips.
3. Run `gh attestation verify metamask-chrome-{version}.zip --repo MetaMask/metamask-extension`.
4. Download release assets into one directory and run `sha256sum -c SHA256SUMS`.

## **Screenshots/Recordings**

N/A (CI/release only)

## **Pre-merge author checklist**

- [x] Followed MetaMask contributor and coding guidelines
- [x] Completed the PR template
- [x] Bugbot/Copilot review comments addressed

## **Pre-merge reviewer checklist**

- [ ] Attestation scope (four webpack zips) matches threat model intent
- [ ] SHA256SUMS format works with INFRA-3661 verify in #44123

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the production release publish path; mistakes could block releases or mis-attach checksums, but changes are additive CI/supply-chain steps rather than extension runtime logic.
> 
> **Overview**
> Extends the **release publish** workflow so primary webpack store zips get **SLSA build provenance** and a **`SHA256SUMS`** asset for downstream verify gates (e.g. CWS upload checks).
> 
> In `publish-release-from-release-head.yml`, the `publish-release` job now runs `actions/attest-build-provenance@v4` on the four webpack zips (main/Flask × Chrome/Firefox), generates `SHA256SUMS` using **bare zip filenames** so `sha256sum -c` works when assets are downloaded flat, and grants **`attestations: write`** plus job-scoped OIDC permissions for attestation. The publish summary table reflects attestation and checksum generation.
> 
> `release-create-gh-release.sh` **requires** `SHA256SUMS` before `gh release create` and **uploads** it alongside the zip artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9db776bdc9a653b2a4aff1c1922a8a0f70f11ef. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->