### PR TITLE
feat(ci): verify release attestation before CWS upload (INFRA-3661)

### DIFF
--- a/.github/workflows/upload-extension-to-cws.yml
+++ b/.github/workflows/upload-extension-to-cws.yml
@@ -32,6 +32,7 @@ on:
 permissions:
   contents: read
   id-token: write
+  attestations: read # Required for gh attestation verify (INFRA-3661)
 
 jobs:
   upload:
@@ -229,6 +230,36 @@ jobs:
             --pattern "${ZIP_NAME}"
           ls -lh "${ZIP_NAME}"
 
+      - name: Verify artifact attestation
+        if: ${{ !inputs.dry-run }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ZIP_NAME: ${{ env.ZIP_NAME }}
+        run: |
+          set -euo pipefail
+          echo "=== Verifying build provenance attestation ==="
+          gh attestation verify "${ZIP_NAME}" \
+            --repo "${{ github.repository }}" \
+            --signer-workflow "${{ github.repository }}/.github/workflows/publish-release-from-release-head.yml"
+          echo "Attestation verified for ${ZIP_NAME}"
+
+      - name: Verify SHA256SUMS
+        if: ${{ !inputs.dry-run }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ZIP_NAME: ${{ env.ZIP_NAME }}
+        run: |
+          set -euo pipefail
+          echo "=== Downloading SHA256SUMS from release ==="
+          gh release download "${RELEASE_TAG}" \
+            --repo "${{ github.repository }}" \
+            --pattern "SHA256SUMS"
+          cat SHA256SUMS
+          echo ""
+          echo "=== Verifying ${ZIP_NAME} digest ==="
+          grep -F "${ZIP_NAME}" SHA256SUMS | sha256sum -c -
+          echo "SHA256SUMS check: PASSED"
+
       # Dev listing rejects manifest.key tied to production extension ID (POC lesson).
       - name: Strip manifest key from zip (dev only)
         if: inputs.target == 'dev' && !inputs.dry-run
@@ -340,6 +371,8 @@ jobs:
             echo "|-------|-------|"
             echo "| HTTP status | \`${{ steps.cws-upload.outputs.http_code || 'n/a' }}\` |"
             echo "| CWS uploadState | \`${{ steps.cws-upload.outputs.upload_state || 'n/a' }}\` |"
+            echo "| Attestation verified | ✅ |"
+            echo "| SHA256SUMS verified | ✅ |"
             echo "| Published to users | no (upload only) |"
             echo "| Workflow run | ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} |"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/upload-extension-to-cws.yml
+++ b/.github/workflows/upload-extension-to-cws.yml
@@ -232,6 +232,7 @@ jobs:
 
       - name: Verify artifact attestation
         if: ${{ !inputs.dry-run }}
+        id: verify-attestation
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ZIP_NAME: ${{ env.ZIP_NAME }}
@@ -245,6 +246,7 @@ jobs:
 
       - name: Verify SHA256SUMS
         if: ${{ !inputs.dry-run }}
+        id: verify-sha256sums
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ZIP_NAME: ${{ env.ZIP_NAME }}
@@ -371,8 +373,8 @@ jobs:
             echo "|-------|-------|"
             echo "| HTTP status | \`${{ steps.cws-upload.outputs.http_code || 'n/a' }}\` |"
             echo "| CWS uploadState | \`${{ steps.cws-upload.outputs.upload_state || 'n/a' }}\` |"
-            echo "| Attestation verified | ✅ |"
-            echo "| SHA256SUMS verified | ✅ |"
+            echo "| Attestation verified | ${{ steps.verify-attestation.outcome == 'success' && '✅' || '❌' }} |"
+            echo "| SHA256SUMS verified | ${{ steps.verify-sha256sums.outcome == 'success' && '✅' || '❌' }} |"
             echo "| Published to users | no (upload only) |"
             echo "| Workflow run | ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} |"
           } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/upload-extension-to-cws.yml
+++ b/.github/workflows/upload-extension-to-cws.yml
@@ -241,7 +241,8 @@ jobs:
           echo "=== Verifying build provenance attestation ==="
           gh attestation verify "${ZIP_NAME}" \
             --repo "${{ github.repository }}" \
-            --signer-workflow "${{ github.repository }}/.github/workflows/publish-release-from-release-head.yml"
+            --signer-workflow "${{ github.repository }}/.github/workflows/publish-release-from-release-head.yml" \
+            --source-ref "refs/heads/release/${VERSION}"
           echo "Attestation verified for ${ZIP_NAME}"
 
       - name: Verify SHA256SUMS
@@ -259,7 +260,10 @@ jobs:
           cat SHA256SUMS
           echo ""
           echo "=== Verifying ${ZIP_NAME} digest ==="
-          grep -F "${ZIP_NAME}" SHA256SUMS | sha256sum -c -
+          if ! awk -v zip="${ZIP_NAME}" '$2 == zip {print; found=1; exit} END {exit !found}' SHA256SUMS | sha256sum -c -; then
+            echo "::error::SHA256SUMS verification failed for ${ZIP_NAME}"
+            exit 1
+          fi
           echo "SHA256SUMS check: PASSED"
 
       # Dev listing rejects manifest.key tied to production extension ID (POC lesson).

--- a/.github/workflows/upload-extension-to-cws.yml
+++ b/.github/workflows/upload-extension-to-cws.yml
@@ -260,7 +260,10 @@ jobs:
           cat SHA256SUMS
           echo ""
           echo "=== Verifying ${ZIP_NAME} digest ==="
-          if ! awk -v zip="${ZIP_NAME}" '$2 == zip {print; found=1; exit} END {exit !found}' SHA256SUMS | sha256sum -c -; then
+          if ! awk -v zip="${ZIP_NAME}" '{
+            f = $2; sub(/^\*/, "", f);
+            if (f == zip) { print; found = 1; exit }
+          } END { exit !found }' SHA256SUMS | sha256sum -c -; then
             echo "::error::SHA256SUMS verification failed for ${ZIP_NAME}"
             exit 1
           fi


### PR DESCRIPTION
## **Description**

Verify SLSA attestation and `SHA256SUMS` on downloaded release zips before any Chrome Web Store API call.

**Why:** Closes upload-side gap — reject tampered or swapped release assets before `chromewebstore` API calls.

**Changes:**
- `gh attestation verify` with signer-workflow pin on `upload-extension-to-cws.yml`
- `SHA256SUMS` check after download, before dev manifest strip (M6 ordering)
- `attestations: read` workflow permission
- Result summary reflects actual verify step outcomes (not hardcoded checkmarks)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: INFRA-3661

## **Manual testing steps**

1. Merge **after** #44122 — uploads fail closed until releases include attestations + `SHA256SUMS`.
2. After #44122 merge + release cut: positive path on `upload-extension-to-cws` with `dry-run=false`.
3. Negative: replace a release asset post-cut → verify step fails before CWS upload.

## **Screenshots/Recordings**

N/A (CI only)

## **Pre-merge author checklist**

- [x] Followed MetaMask contributor and coding guidelines
- [x] Completed the PR template
- [x] Bugbot/Copilot review comments addressed

## **Pre-merge reviewer checklist**

- [ ] Verify runs before dev manifest mutation
- [ ] Merge order with #44122 understood (fail-closed until attestations ship)
- [ ] Infra toggle in va-mmc-extension-submission-infra #11 coordinated if needed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only supply-chain gates on release assets; uploads fail until attestations and SHA256SUMS exist on releases (per merge order with #44122).
> 
> **Overview**
> The Chrome Web Store upload workflow now **fails closed** on release zip integrity before any `chromewebstore` API work (skipped on `dry-run`).
> 
> After downloading the release zip, it runs **`gh attestation verify`** pinned to `publish-release-from-release-head.yml` and `refs/heads/release/${VERSION}`, then downloads **`SHA256SUMS`** and checks the zip digest—both steps run **before** the dev-only manifest strip. Workflow permissions add **`attestations: read`**, and the job summary reports attestation/SHA256 outcomes from step results instead of static checkmarks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b31a47f386a21394cdf6a43f74654a2a154286d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->