### PR TITLE
test: fix update-fixtures due to github policy change on actions cache

### DIFF
--- a/.github/workflows/update-e2e-fixtures.yml
+++ b/.github/workflows/update-e2e-fixtures.yml
@@ -54,9 +54,6 @@ jobs:
     needs: is-cross-repo-pr
     if: ${{ needs.is-cross-repo-pr.outputs.IS_CROSS_REPO_PR == 'false' }}
     environment: default-branch
-    permissions:
-      contents: read
-      actions: write
     outputs:
       COMMIT_SHA: ${{ steps.commit-sha.outputs.COMMIT_SHA }}
       BRANCH: ${{ steps.branch.outputs.BRANCH }}
@@ -129,11 +126,14 @@ jobs:
           RUN_ID: ${{ steps.find-dist.outputs.run-id }}
           GITHUB_TOKEN: ${{ secrets.FIXTURE_UPDATE_TOKEN }}
 
-      - name: Cache dist artifact
-        uses: actions/cache/save@v5
+      - name: Upload dist artifact
+        uses: actions/upload-artifact@v6
         with:
+          name: dist-${{ steps.commit-sha.outputs.COMMIT_SHA }}
           path: build-dist-webpack
-          key: dist-${{ steps.commit-sha.outputs.COMMIT_SHA }}
+          if-no-files-found: error
+          # Allow workflow re-runs to replace the artifact from a prior attempt.
+          overwrite: true
 
   update-fixtures:
     name: Update E2E fixtures
@@ -141,9 +141,6 @@ jobs:
     timeout-minutes: 30
     needs:
       - prepare
-    permissions:
-      contents: read
-      actions: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -159,12 +156,11 @@ jobs:
       - name: Install anvil
         run: yarn mm-foundryup
 
-      - name: Restore dist artifact
-        uses: actions/cache/restore@v5
+      - name: Download dist artifact
+        uses: actions/download-artifact@v7
         with:
+          name: dist-${{ needs.prepare.outputs.COMMIT_SHA }}
           path: build-dist-webpack
-          key: dist-${{ needs.prepare.outputs.COMMIT_SHA }}
-          fail-on-cache-miss: true
 
       - name: Prepare dist
         run: |
@@ -189,13 +185,16 @@ jobs:
             ./test-artifacts
             ./test/test-results/e2e
 
-      - name: Cache updated fixture
-        uses: actions/cache/save@v5
+      - name: Upload updated fixtures
+        uses: actions/upload-artifact@v6
         with:
+          name: fixtures-${{ needs.prepare.outputs.COMMIT_SHA }}
           path: |
             test/e2e/fixtures/onboarding-fixture.json
             test/e2e/fixtures/default-fixture.json
-          key: fixtures-${{ needs.prepare.outputs.COMMIT_SHA }}
+          if-no-files-found: error
+          # Allow workflow re-runs to replace the artifact from a prior attempt.
+          overwrite: true
 
   commit-updated-fixtures:
     name: Commit the updated E2E fixtures
@@ -219,14 +218,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.FIXTURE_UPDATE_TOKEN }}
           PR_NUMBER: ${{ github.event.issue.number }}
 
-      - name: Restore updated fixtures
-        uses: actions/cache/restore@v5
+      - name: Download updated fixtures
+        uses: actions/download-artifact@v7
         with:
-          path: |
-            test/e2e/fixtures/onboarding-fixture.json
-            test/e2e/fixtures/default-fixture.json
-          key: fixtures-${{ needs.prepare.outputs.COMMIT_SHA }}
-          fail-on-cache-miss: true
+          name: fixtures-${{ needs.prepare.outputs.COMMIT_SHA }}
+          path: test/e2e/fixtures
 
       - name: Check whether there are fixture changes
         id: fixture-changes


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
We still have permissions issues with the update-fixture script, after adding read/write permissions:
<img width="2148" height="276" alt="image" src="https://github.com/user-attachments/assets/32ef0098-a51f-4599-b7cd-87f58f05aae5" />

The reason is because of a github policy change in 26-06-2026, [Read-only Actions cache for untrusted triggers](https://github.blog/changelog/2026-06-26-read-only-actions-cache-for-untrusted-triggers/)
So we can no longer save caches.

This PR replaces the cache-based job-to-job handoffs in update-e2e-fixtures.yml with artifacts, and revert the permissions change (no effect)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. It's utterly complex to test the same conditions on a fork. After PR is merged we can create a test PR.
There's very low risk, as if broken, the only thing that won't work is the update-fixtures job (which is currently already broken) and only triggered by the bot comment (we have the manual alternative as workaround)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only change to a bot-triggered fixture update workflow; no application or runtime behavior changes.
> 
> **Overview**
> Restores the **@metamaskbot update-e2e-fixture** flow after GitHub’s read-only Actions cache policy for untrusted triggers (e.g. `issue_comment` on PRs), which blocked `cache/save` between jobs.
> 
> **prepare** now uploads the downloaded `build-dist-webpack` bundle as `dist-<commit-sha>`; **update-fixtures** downloads that artifact instead of restoring a cache, then uploads regenerated `onboarding-fixture.json` and `default-fixture.json` as `fixtures-<commit-sha>`. **commit-updated-fixtures** downloads those fixtures into `test/e2e/fixtures` before diffing and committing.
> 
> Job-level `contents: read` / `actions: write` permissions added for cache writes are removed. Upload steps use `if-no-files-found: error` and `overwrite: true` so re-runs can replace prior artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61a4abe6e46ae9c48b3d515228980a814af8ff2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->