### PR TITLE
chore: setup codeownership of `metamask-controller`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -109,7 +109,7 @@ app/scripts/services/legacy-background-api-service.test.ts @MetaMask/core-platfo
 
 
 # Co-owned by Extension Platform and Core Platform
-app/scripts/metamask-controller.js @Metamask/extension-platform @MetaMask/core-platform
+app/scripts/metamask-controller.js @MetaMask/extension-platform @MetaMask/core-platform
 
 # Co-owned by Confirmations and Core Platform
 ui/components/app/metamask-template-renderer @MetaMask/confirmations @MetaMask/core-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -108,7 +108,10 @@ app/scripts/services/legacy-background-api-service.ts      @MetaMask/core-platfo
 app/scripts/services/legacy-background-api-service.test.ts @MetaMask/core-platform
 
 
-# Co-owned by Confirmations and Snaps
+# Co-owned by Extension Platform and Core Platform
+app/scripts/metamask-controller.js @Metamask/extension-platform @MetaMask/core-platform
+
+# Co-owned by Confirmations and Core Platform
 ui/components/app/metamask-template-renderer @MetaMask/confirmations @MetaMask/core-platform
 
 # Core Extension UX


### PR DESCRIPTION
## **Description**

This sets the codeowners of `app/scripts/metamask-controller.js` to `core-platform` and `extension-platform`

## **Changelog**

CHANGELOG entry:null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Process-only change to review requirements; no runtime or build behavior is modified.
> 
> **Overview**
> Updates **`.github/CODEOWNERS`** so changes to **`app/scripts/metamask-controller.js`** require review from **@MetaMask/extension-platform** and **@MetaMask/core-platform**, with a new co-ownership comment for that path.
> 
> The **metamask-template-renderer** entry comment is updated from Snaps to **Core Platform** (owners unchanged). A prior **Confirmations and Snaps** comment block is removed in favor of these sections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9219389c71e049d8339c2d41005f65c478e83f74. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->