### PR TITLE
chore: bind `updateNetworksList` directly to `NetworkOrderController:updateNetworksList`

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3495,7 +3495,10 @@ export default class MetamaskController extends EventEmitter {
         this.controllerMessenger,
         'SnapController:disconnectOrigin',
       ),
-      updateNetworksList: this.updateNetworksList.bind(this),
+      updateNetworksList: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'NetworkOrderController:updateNetworksList',
+      ),
       updateAccountsList: this.updateAccountsList.bind(this),
       setEnabledNetworks: this.setEnabledNetworks.bind(this),
       setEnabledAllPopularNetworks:
@@ -8378,15 +8381,6 @@ export default class MetamaskController extends EventEmitter {
       if (!(exp instanceof PermissionsRequestNotFoundError)) {
         throw exp;
       }
-    }
-  };
-
-  updateNetworksList = (chainIds) => {
-    try {
-      this.networkOrderController.updateNetworksList(chainIds);
-    } catch (err) {
-      log.error(err.message);
-      throw err;
     }
   };
 


### PR DESCRIPTION
## **Description**

Part of the WPC-418 effort to slim down `MetamaskController.getApi()`.

The `updateNetworksList` getApi entry was a thin pass-through over `networkOrderController.updateNetworksList`, wrapped only in a `try/catch` that logged and rethrew. Since the `NetworkOrderController:updateNetworksList` messenger action already exists (the method is in `MESSENGER_EXPOSED_METHODS`), the getApi entry is now bound directly to that action via the controller messenger and the redundant `MetamaskController` wrapper method is removed.

No behavior change for the client: the UI thunk still calls `submitRequestToBackground('updateNetworksList', [chainIds])` with the same argument shape.

Progresses: https://consensyssoftware.atlassian.net/browse/WPC-1096

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Progresses: https://consensyssoftware.atlassian.net/browse/WPC-1096

## **Manual testing steps**

1. Open the network list in the UI and reorder networks via drag and drop.
2. Confirm the new order persists (state `orderedNetworkList` is updated) after reload.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Thin routing refactor with no intended change to network ordering logic; only error logging around the old wrapper is dropped.
> 
> **Overview**
> Part of slimming **`MetamaskController.getApi()`**, **`updateNetworksList`** is no longer implemented as a **`MetamaskController`** method that forwarded to **`networkOrderController.updateNetworksList`** inside a log-and-rethrow **`try/catch`**.
> 
> The background API entry is now **`this.controllerMessenger.call.bind(..., 'NetworkOrderController:updateNetworksList')`**, matching other controller actions already exposed on the messenger. Callers such as **`submitRequestToBackground('updateNetworksList', [chainIds])`** should still hit the same controller logic and argument shape; failures will surface from the messenger path without the extra **`log.error`** wrapper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f5e890e3de6f0ef825a02befc221db595ab037a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->