### PR TITLE
chore: bind `alignMultichainWallets` directly to `MultichainAccountService:alignWallets`

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3116,11 +3116,10 @@ export default class MetamaskController extends EventEmitter {
         'MultichainAccountService:createNextMultichainAccountGroup',
       ),
 
-      alignMultichainWallets: async () => {
-        if (this.multichainAccountService) {
-          await this.multichainAccountService.alignWallets();
-        }
-      },
+      alignMultichainWallets: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'MultichainAccountService:alignWallets',
+      ),
 
       // AssetsContractController
       getTokenStandardAndDetails: this.getTokenStandardAndDetails.bind(this),


### PR DESCRIPTION
## **Description**


This binds the `alignMultichainWallets` `getApi()` method directly to the `MultichainAccountService:alignWallets` messenger action. Since it is a pure single-action pass-through, it skips the `LegacyBackgroundApiService` wrapper and removes the redundant `MetamaskController` method.
Migrates the `alignMultichainWallets` background API method from `MetamaskController.getApi()` into `LegacyBackgroundApiService`, exposed via the controller messenger.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Progresses: https://consensyssoftware.atlassian.net/browse/WPC-1091

## **Manual testing steps**

1. Unlock the wallet and confirm multichain accounts still align correctly.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-method wiring change with no new logic; the only behavioral nuance is losing the previous no-op when `multichainAccountService` was absent, in favor of the messenger path.
> 
> **Overview**
> **`alignMultichainWallets`** in `MetamaskController.getApi()` no longer wraps `this.multichainAccountService.alignWallets()` behind an optional service check. It is wired like **`createNextMultichainAccountGroup`**: a bound `controllerMessenger.call` to **`MultichainAccountService:alignWallets`**.
> 
> Callers still invoke the same background API name; routing goes through the controller messenger instead of a direct controller field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b0612d0aa3b60ea30df089762bf795ca57ccab5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->