### PR TITLE
chore: remove unused `trackInsightSnapView` from `getApi`

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -1842,27 +1842,6 @@ export default class MetamaskController extends EventEmitter {
     });
   }
 
-  trackInsightSnapView(snapId) {
-    trackEvent(
-      createEventBuilder(MetaMetricsEventName.InsightSnapViewed)
-        .addCategory(MetaMetricsEventCategory.Snaps)
-        .addProperties({
-          snap_id: snapId,
-        })
-        .build(),
-    );
-  }
-
-  /**
-   * Get snap metadata from the current state without refreshing the registry database.
-   *
-   * @param {string} snapId - A snap id.
-   * @returns The available metadata for the snap, if any.
-   */
-  _getSnapMetadata(snapId) {
-    return this.snapsRegistry.state.database?.verifiedSnaps?.[snapId]?.metadata;
-  }
-
   /**
    * Sets up BaseController V2 event subscriptions. Currently, this includes
    * the subscriptions necessary to notify permission subjects of account
@@ -3623,7 +3602,6 @@ export default class MetamaskController extends EventEmitter {
       finalizeEventFragment: metaMetricsController.finalizeEventFragment.bind(
         metaMetricsController,
       ),
-      trackInsightSnapView: this.trackInsightSnapView.bind(this),
       updateMetaMetricsTraits: metaMetricsController.updateTraits.bind(
         metaMetricsController,
       ),


### PR DESCRIPTION
## **Description**

`trackInsightSnapView` was exposed via `getApi()` in `MetamaskController` but has no client callers — there is no `submitRequestToBackground('trackInsightSnapView', ...)` anywhere in the UI, and no other reference to it. Since it is dead code, it is removed rather than migrated to `LegacyBackgroundApiService`.

The private `_getSnapMetadata` helper that lived alongside it is also dead (no callers), so it is removed in the same change. (The `getSnapMetadata` used in the UI is an unrelated Redux selector and is untouched.)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Progresses: https://consensyssoftware.atlassian.net/browse/WPC-1095

## **Manual testing steps**

No user-facing behavior changes. This removes dead code:
1. Confirm there are no callers of `trackInsightSnapView` or `_getSnapMetadata` (`grep` returns only the removed definitions).
2. Run the unit tests for `metamask-controller` and `ui/store/actions` — all pass.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure removal of uncalled methods with no callers or user-facing paths affected.
> 
> **Overview**
> Removes dead Snap-related code from `MetamaskController`: the `trackInsightSnapView` handler (and its `getApi()` exposure) and the private `_getSnapMetadata` helper. Nothing in the extension called these APIs, so runtime behavior is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf566e138bf50d3419fbb86c26195d1c59d19d64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->