### PR TITLE
feat(e2e): wire Tron node into fixtures [WPN-536]

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "test:api-specs-multichain": "SELENIUM_BROWSER=chrome tsx test/e2e/run-api-specs-multichain.ts",
     "test:e2e:benchmark": "yarn tsx test/e2e/benchmarks/run-benchmark.ts",
     "test:e2e:pw:report": "yarn playwright show-report public/playwright/playwright-reports/html",
+    "test:e2e:smoke:local-node-ports": "tsx test/e2e/scripts/smoke-local-node-ports.ts",
     "test:e2e:feature-flag:coverage": "tsx test/e2e/scripts/feature-flag-coverage-report.ts",
     "test:e2e:chrome:rpc": "SELENIUM_BROWSER=chrome tsx test/e2e/run-all.mts --rpc",
     "test:e2e:chrome:multi-provider": "MULTIPROVIDER=true SELENIUM_BROWSER=chrome tsx test/e2e/run-all.mts --multi-provider",

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -227,6 +227,14 @@ async function withFixtures(options, testSuite) {
           localNodes.push(localNode);
           break;
 
+        case 'tron':
+          // eslint-disable-next-line n/global-require, no-case-declarations -- load this module conditionally
+          const { TronNode } = require('./seeder/tron/node');
+          localNode = new TronNode();
+          await localNode.start(nodeOptions);
+          localNodes.push(localNode);
+          break;
+
         case 'none':
           break;
 

--- a/test/e2e/scripts/smoke-local-node-ports.ts
+++ b/test/e2e/scripts/smoke-local-node-ports.ts
@@ -1,0 +1,104 @@
+import { getAvailablePorts } from '../seeder/ports';
+import { TronNode } from '../seeder/tron/node';
+
+type TronBlockResponse = Partial<
+  Record<
+    'block_header',
+    Partial<Record<'raw_data', { number?: number | string }>>
+  >
+>;
+
+async function main(): Promise<void> {
+  const [firstFullNodePort, secondFullNodePort] =
+    await getAvailablePortsWithGaps(2);
+  const ports = [
+    { fullNodePort: firstFullNodePort },
+    { fullNodePort: secondFullNodePort },
+  ] as const;
+  const nodes = [new TronNode(), new TronNode()] as const;
+
+  console.log(
+    `Starting two java-tron private networks on ${formatNodeUrls(
+      ports.map(({ fullNodePort }) => fullNodePort),
+    )}`,
+  );
+
+  try {
+    await startAll(
+      nodes.map((node, index) => () => node.start({ ports: ports[index] })),
+    );
+
+    const blocks = await Promise.all(
+      nodes.map(
+        (node) =>
+          node.fetchJson('/wallet/getnowblock', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: '{}',
+          }) as Promise<TronBlockResponse>,
+      ),
+    );
+    console.log(
+      `Tron smoke passed: ${blocks
+        .map(
+          (block, index) =>
+            `node ${index + 1} block ${
+              block.block_header?.raw_data?.number ?? 'unknown'
+            }`,
+        )
+        .join(', ')}`,
+    );
+  } finally {
+    await quitAll(nodes);
+  }
+}
+
+async function getAvailablePortsWithGaps(
+  count: number,
+  gapSize = 8,
+): Promise<number[]> {
+  const ports: number[] = [];
+  const excludedPorts = new Set<number>();
+
+  while (ports.length < count) {
+    const [port] = await getAvailablePorts(1, excludedPorts);
+    ports.push(port);
+
+    for (let offset = -gapSize; offset <= gapSize; offset += 1) {
+      const excludedPort = port + offset;
+      if (excludedPort >= 1 && excludedPort <= 65_535) {
+        excludedPorts.add(excludedPort);
+      }
+    }
+  }
+
+  return ports;
+}
+
+async function startAll(starts: (() => Promise<void>)[]): Promise<void> {
+  for (const start of starts) {
+    await start();
+  }
+}
+
+async function quitAll(
+  nodes: readonly { quit: () => Promise<void> }[],
+): Promise<void> {
+  const results = await Promise.allSettled(nodes.map((node) => node.quit()));
+  const failure = results.find(
+    (result): result is PromiseRejectedResult => result.status === 'rejected',
+  );
+
+  if (failure) {
+    throw failure.reason;
+  }
+}
+
+function formatNodeUrls(ports: readonly number[]): string {
+  return ports.map((port) => `127.0.0.1:${port}`).join(' and ');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## **Description**

Stacked on #44140. Split from #43722. This is PR 4 of 4 in the WPN-536 stacked split.

This PR wires the Tron local node into `withFixtures` and adds the local-node port smoke script plus package script.

Stack sequence:
1. #44138 - config/dependency foundations, 664 changed lines against `main`
2. #44141 - Tron seeder asset helpers/tests, 928 changed lines against `WPN-536a-tron-node-config`
3. #44140 - TronNode bootstrap, 994 changed lines against `WPN-536b-tron-seeder-helpers`
4. #44139 - `withFixtures` wiring and smoke script, 113 changed lines against `WPN-536c-tron-node-bootstrap`

The tip of the stack was verified to match the rebased #43722 content.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Check out this branch: `WPN-536d-tron-fixtures-smoke`.
2. Use Node 24.13.x.
3. Run `yarn jest test/e2e/helpers/tron-assets.test.ts test/e2e/helpers/tron-seeder.test.ts --runInBand`.
4. Optionally run `yarn test:e2e:smoke:local-node-ports` to smoke-test two java-tron local nodes.

## **Screenshots/Recordings**

N/A - test infrastructure only.

### **Before**

N/A

### **After**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
