### PR TITLE
fix: disable gas sponsorship for hw wallets cp-13.39.0

### DIFF
--- a/test/data/confirmations/contract-interaction.ts
+++ b/test/data/confirmations/contract-interaction.ts
@@ -45,6 +45,7 @@ export const genUnapprovedContractInteractionConfirmation = ({
   selectedGasFeeToken,
   txParamsOriginal,
   isGasFeeSponsored,
+  isExternalSign,
   simulationFails,
   userFeeLevel = UserFeeLevel.MEDIUM,
   excludeNativeTokenForFee,
@@ -62,6 +63,7 @@ export const genUnapprovedContractInteractionConfirmation = ({
   simulationData?: SimulationData;
   txParamsOriginal?: TransactionParams;
   isGasFeeSponsored?: boolean;
+  isExternalSign?: boolean;
   simulationFails?: SimulationError;
   userFeeLevel?: UserFeeLevel;
   excludeNativeTokenForFee?: boolean;
@@ -211,6 +213,7 @@ export const genUnapprovedContractInteractionConfirmation = ({
     userFeeLevel,
     verifiedOnBlockchain: false,
     isGasFeeSponsored,
+    isExternalSign,
     simulationFails,
     excludeNativeTokenForFee,
   } as SignatureRequestType;

--- a/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.test.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.test.ts
@@ -87,11 +87,13 @@ function runHook({
   customNonceValue,
   gasFeeTokens,
   isGasFeeSponsored,
+  isExternalSign,
   selectedGasFeeToken,
 }: {
   customNonceValue?: string;
   gasFeeTokens?: GasFeeToken[];
   isGasFeeSponsored?: boolean;
+  isExternalSign?: boolean;
   selectedGasFeeToken?: Hex;
 } = {}) {
   const { result } = renderHookWithConfirmContextProvider(
@@ -100,6 +102,7 @@ function runHook({
       genUnapprovedContractInteractionConfirmation({
         gasFeeTokens,
         isGasFeeSponsored,
+        isExternalSign,
         selectedGasFeeToken,
       }),
       {
@@ -640,6 +643,51 @@ describe('useTransactionConfirm', () => {
 
     const actual = updateAndApproveTxMock.mock.calls[0][0];
     expect(actual.isGasFeeSponsored).toBe(false);
+  });
+
+  it('clears isExternalSign when gasless is unsupported (e.g. hardware wallet on a sponsored chain)', async () => {
+    useIsGaslessSupportedMock.mockReturnValue({
+      isSupported: false,
+      isSmartTransaction: false,
+      pending: false,
+    });
+    useGasSponsorshipPreferenceMock.mockReturnValue({
+      isSponsorshipOptedOut: false,
+      setSponsorshipOptedOut: jest.fn(),
+    });
+
+    const { onTransactionConfirm } = runHook({
+      isGasFeeSponsored: true,
+      isExternalSign: true,
+    });
+
+    await onTransactionConfirm();
+
+    const actual = updateAndApproveTxMock.mock.calls[0][0];
+    expect(actual.isExternalSign).toBe(false);
+    expect(actual.isGasFeeSponsored).toBe(false);
+  });
+
+  it('keeps isExternalSign when gasless is supported and user has not opted out', async () => {
+    useIsGaslessSupportedMock.mockReturnValue({
+      isSupported: true,
+      isSmartTransaction: false,
+      pending: false,
+    });
+    useGasSponsorshipPreferenceMock.mockReturnValue({
+      isSponsorshipOptedOut: false,
+      setSponsorshipOptedOut: jest.fn(),
+    });
+
+    const { onTransactionConfirm } = runHook({
+      isGasFeeSponsored: true,
+      isExternalSign: true,
+    });
+
+    await onTransactionConfirm();
+
+    const actual = updateAndApproveTxMock.mock.calls[0][0];
+    expect(actual.isExternalSign).toBe(true);
   });
 
   it('returns true after successful transaction in popup environment', async () => {

--- a/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.ts
+++ b/ui/pages/confirmations/hooks/transactions/useTransactionConfirm.ts
@@ -89,12 +89,20 @@ export function useTransactionConfirm() {
       transactionMeta.isGasFeeSponsored &&
       !isSponsorshipOptedOut;
 
-    // When the user opts out of gas sponsorship, clear `isExternalSign` so the
-    // transaction goes through the normal sign-and-publish flow instead of
-    // being routed to the relay. The TransactionController sets
-    // `isExternalSign = true` whenever `isGasFeeSponsored` is true during gas
-    // estimation, so we must explicitly revert it here.
-    if (isSponsorshipOptedOut && transactionMeta.isExternalSign) {
+    // Revert the controller's `isExternalSign` flag when this account cannot
+    // use an external relay — i.e. gasless is unsupported for the account/chain
+    // (such as hardware wallets, which cannot sign EIP-7702 authorization
+    // lists) — or the user has opted out of gas sponsorship. The
+    // TransactionController sets `isExternalSign = true` whenever
+    // `isGasFeeSponsored` is true during gas estimation, regardless of whether
+    // an external relay is actually eligible for this account. If we leave it
+    // set, the sign step is skipped (no keyring/device call) and, when no relay
+    // catches the publish, an unsigned/empty payload reaches
+    // `eth_sendRawTransaction` and is rejected by the node.
+    const isExternalSignSupported =
+      transactionMeta.isExternalSign &&
+      (!isGaslessSupported || isSponsorshipOptedOut);
+    if (isExternalSignSupported) {
       newTransactionMeta.isExternalSign = false;
     }
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

On gas-sponsorship networks, Monad, hardware-wallet transactions fail
instantly with no device prompt:

`eth_sendRawTransaction: Invalid parameters: transaction could not be decoded: not enough input to decode`

The `TransactionController` sets `isExternalSign = true` whenever a transaction
is gas-sponsored, regardless of account type. That flag skips the signing step,
so the device is never prompted and `rawTx` is never produced. EOA accounts are
unaffected because the EIP-7702 relay submits on their behalf; hardware wallets
cannot hold a 7702 delegation, so no relay catches the publish and an empty
payload is sent.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: disable gas sponsorship for hw wallets 

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1947?atlOrigin=eyJpIjoiOTYzMGIyOWRjNTE2NDJhZWEwM2NmYTUzNGUwOGZjOGUiLCJwIjoiaiJ9
 
## **Manual testing steps**

1. Select a **hardware-wallet account** (not an EOA).
2. Initiate a send of a **small, sponsorship-eligible** amount of native token
   (stay under Monad's gas sponsorship cap; keep gas modest). *This matters —
   if the transaction is ineligible for sponsorship, the bug does not reproduce
   and the fix cannot be verified.*
3. On the confirmation screen, confirm the transaction.
4. **Verify:** the hardware device prompts for signature (Ledger displays the
   transaction / Trezor shows the review screen). This is the key fix —
   previously the transaction failed instantly with no device prompt.
5. Approve the transaction on the device.
6. **Verify:** the transaction submits successfully and lands on chain (no
   `transaction could not be decoded` error; a transaction hash is returned).
7. **Non-regression (EOA):** switch to an EOA (HD/imported) account on the same
   network and send a transaction. Verify it is still gas-sponsored (the "Paid
   by MetaMask" indicator appears / no native gas is deducted).

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches transaction confirm approval and gasless/external-sign routing; wrong conditions could break EIP-7702 gas sponsorship for EOAs or leave HW txs broken.
> 
> **Overview**
> Fixes **instant failures on gas-sponsored networks** (e.g. Monad) when confirming with a **hardware wallet**: the device never prompted and `eth_sendRawTransaction` failed with an undecodable transaction.
> 
> On confirm, `useTransactionConfirm` now clears **`isExternalSign`** (and sponsorship flags already follow **`isGaslessSupported`**) whenever gasless is **not** supported for the account/chain—not only when the user opts out of sponsorship. Gas estimation can set `isExternalSign` for any sponsored tx; leaving it on skips signing and sends an empty raw tx when no EIP-7702 relay applies (typical for HW).
> 
> Tests cover clearing `isExternalSign` when gasless is unsupported vs keeping it when gasless is supported; confirmation test fixtures accept **`isExternalSign`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cef323c72b8f89187f1f82ebe84f7afe404f656e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->