### PR TITLE
feat(e2e): add shared local node fixture plumbing

### DIFF
--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -160,6 +160,9 @@ async function withFixtures(options, testSuite) {
     title,
     ignoredConsoleErrors = [],
     disableServerMochaToBackground = false,
+    afterLocalNodesStart = async function () {
+      // do nothing.
+    },
     testSpecificMock = function () {
       // do nothing.
     },
@@ -236,6 +239,8 @@ async function withFixtures(options, testSuite) {
           );
       }
     }
+
+    await afterLocalNodesStart({ localNodes });
 
     let contractRegistry;
     let seeder;

--- a/test/e2e/seeder/ports.ts
+++ b/test/e2e/seeder/ports.ts
@@ -1,0 +1,144 @@
+import { createServer, type Server } from 'net';
+
+export type PortRange = {
+  endPort: number;
+  startPort: number;
+};
+
+const MAX_PORT = 65535;
+const MIN_PORT = 1;
+
+export function assertValidPort(port: number, label: string): void {
+  if (!Number.isInteger(port) || port < MIN_PORT || port > MAX_PORT) {
+    throw new Error(
+      `${label} must be an integer from ${MIN_PORT} to ${MAX_PORT}`,
+    );
+  }
+}
+
+export async function getAvailablePorts(
+  count: number,
+  excludedPorts: Iterable<number> = [],
+): Promise<number[]> {
+  if (!Number.isInteger(count) || count < 0) {
+    throw new Error('Port count must be a non-negative integer');
+  }
+
+  const excluded = new Set(excludedPorts);
+  const servers: { port: number; server: Server }[] = [];
+
+  try {
+    while (servers.length < count) {
+      const allocation = await openEphemeralServer();
+      if (excluded.has(allocation.port)) {
+        await closeServer(allocation.server);
+        continue;
+      }
+
+      excluded.add(allocation.port);
+      servers.push(allocation);
+    }
+
+    return servers.map(({ port }) => port);
+  } finally {
+    await Promise.all(servers.map(({ server }) => closeServer(server)));
+  }
+}
+
+export async function isTcpPortAvailable(port: number): Promise<boolean> {
+  assertValidPort(port, 'Port');
+
+  try {
+    const server = await listenOnTcpPort(port);
+    await closeServer(server);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function isTcpPortRangeAvailable(
+  startPort: number,
+  count: number,
+): Promise<boolean> {
+  assertValidPort(startPort, 'Start port');
+  if (!Number.isInteger(count) || count < 1) {
+    throw new Error('Port range count must be a positive integer');
+  }
+
+  const endPort = startPort + count - 1;
+  assertValidPort(endPort, 'End port');
+
+  const servers: Server[] = [];
+
+  try {
+    for (let offset = 0; offset < count; offset += 1) {
+      servers.push(await listenOnTcpPort(startPort + offset));
+    }
+    return true;
+  } catch {
+    return false;
+  } finally {
+    await Promise.all(servers.map((server) => closeServer(server)));
+  }
+}
+
+export function parsePortRange(range: string): PortRange {
+  const match = range.match(/^(\d+)-(\d+)$/u);
+  if (!match) {
+    throw new Error(`Invalid port range: ${range}`);
+  }
+
+  const startPort = Number(match[1]);
+  const endPort = Number(match[2]);
+  assertValidPort(startPort, 'Start port');
+  assertValidPort(endPort, 'End port');
+
+  if (endPort < startPort) {
+    throw new Error(`Invalid port range: ${range}`);
+  }
+
+  return { endPort, startPort };
+}
+
+async function openEphemeralServer(): Promise<{
+  port: number;
+  server: Server;
+}> {
+  return await new Promise((resolvePromise, rejectPromise) => {
+    const server = createServer();
+    server.unref();
+    server.once('error', rejectPromise);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (typeof address === 'object' && address?.port) {
+        resolvePromise({ port: address.port, server });
+        return;
+      }
+
+      server.close();
+      rejectPromise(new Error('Unable to allocate an available port'));
+    });
+  });
+}
+
+async function listenOnTcpPort(port: number): Promise<Server> {
+  return await new Promise((resolvePromise, rejectPromise) => {
+    const server = createServer();
+    server.unref();
+    server.once('error', rejectPromise);
+    server.listen(port, '127.0.0.1', () => resolvePromise(server));
+  });
+}
+
+async function closeServer(server: Server): Promise<void> {
+  await new Promise<void>((resolvePromise, rejectPromise) => {
+    server.close((error) => {
+      if (error) {
+        rejectPromise(error);
+        return;
+      }
+      resolvePromise();
+    });
+  });
+}


### PR DESCRIPTION
## **Description**

This PR adds the shared plumbing that later local-node PRs build on: a central `ports.ts` registry and an `afterLocalNodesStart` hook in the fixtures flow. `testSpecificMock` is intentionally not passed `{ localNodes }` at this stage, keeping the surface minimal for this step. It is one reviewable step of a linear stack and was extracted from the earlier #43722/#43724 work. Validated by running `send-eth.spec.ts` (4/4 passing). Based on a fresh `main` and under 1000 changed lines.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of the local-blockchain E2E initiative (WPN-536).
Extracted from #43722/#43724; supersedes their fixture-plumbing portion.

## **Manual testing steps**

1. `yarn build:test`
2. `yarn test:e2e:single test/e2e/tests/transaction/send-eth.spec.ts --browser=chrome` (expect 4/4 passing).

## **Screenshots/Recordings**

N/A — test infrastructure only, no user-facing UI change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only infrastructure with a backward-compatible optional hook; `ports.ts` is unused until later stack PRs.
> 
> **Overview**
> Adds **shared E2E infrastructure** for upcoming local-blockchain work: a new `test/e2e/seeder/ports.ts` module for TCP port validation, ephemeral allocation (`getAvailablePorts`), single/range availability checks, and `parsePortRange` string parsing.
> 
> Extends **`withFixtures`** in `helpers.js` with an optional **`afterLocalNodesStart`** callback (default no-op), invoked right after local nodes are started and before contract seeding—so later tests can configure nodes without changing the core fixture flow. **`testSpecificMock`** is unchanged (still not given `{ localNodes }` in this step).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 076f0570b276952d12ad89cc6d21f934d7d5b94f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->