### PR TITLE
feat(e2e): wire Tron local node into fixtures

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "test:api-specs-multichain": "SELENIUM_BROWSER=chrome tsx test/e2e/run-api-specs-multichain.ts",
     "test:e2e:benchmark": "yarn tsx test/e2e/benchmarks/run-benchmark.ts",
     "test:e2e:pw:report": "yarn playwright show-report public/playwright/playwright-reports/html",
+    "test:e2e:smoke:local-node-ports": "tsx test/e2e/scripts/smoke-local-node-ports.ts",
     "test:e2e:feature-flag:coverage": "tsx test/e2e/scripts/feature-flag-coverage-report.ts",
     "test:e2e:chrome:rpc": "SELENIUM_BROWSER=chrome tsx test/e2e/run-all.mts --rpc",
     "test:e2e:chrome:multi-provider": "MULTIPROVIDER=true SELENIUM_BROWSER=chrome tsx test/e2e/run-all.mts --multi-provider",

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -415,7 +415,7 @@ async function withFixtures(options, testSuite) {
     let effectiveUnifiedEvmAccountsApiBalances =
       unifiedEvmAccountsApiBalances ?? {};
     const localChainId = localNodeOptsNormalized[0]?.options.chainId ?? 1337;
-    if (localNodes[0]) {
+    if (localNodes[0] && localNodeOptsNormalized[0]?.type === 'anvil') {
       const nodeBalance = Number(
         (await localNodes[0].getBalance()).toFixed(3),
       ).toString();

--- a/test/e2e/helpers.js
+++ b/test/e2e/helpers.js
@@ -284,6 +284,14 @@ async function withFixtures(options, testSuite) {
           localNodes.push(localNode);
           break;
 
+        case 'tron':
+          // eslint-disable-next-line n/global-require, no-case-declarations -- load this module conditionally
+          const { TronNode } = require('./seeder/tron/node');
+          localNode = new TronNode();
+          await localNode.start(nodeOptions);
+          localNodes.push(localNode);
+          break;
+
         case 'none':
           break;
 

--- a/test/e2e/scripts/smoke-local-node-ports.ts
+++ b/test/e2e/scripts/smoke-local-node-ports.ts
@@ -1,0 +1,104 @@
+import { getAvailablePorts } from '../seeder/ports';
+import { TronNode } from '../seeder/tron/node';
+
+type TronBlockResponse = Partial<
+  Record<
+    'block_header',
+    Partial<Record<'raw_data', { number?: number | string }>>
+  >
+>;
+
+async function main(): Promise<void> {
+  const [firstFullNodePort, secondFullNodePort] =
+    await getAvailablePortsWithGaps(2);
+  const ports = [
+    { fullNodePort: firstFullNodePort },
+    { fullNodePort: secondFullNodePort },
+  ] as const;
+  const nodes = [new TronNode(), new TronNode()] as const;
+
+  console.log(
+    `Starting two java-tron private networks on ${formatNodeUrls(
+      ports.map(({ fullNodePort }) => fullNodePort),
+    )}`,
+  );
+
+  try {
+    await startAll(
+      nodes.map((node, index) => () => node.start({ ports: ports[index] })),
+    );
+
+    const blocks = await Promise.all(
+      nodes.map(
+        (node) =>
+          node.fetchJson('/wallet/getnowblock', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: '{}',
+          }) as Promise<TronBlockResponse>,
+      ),
+    );
+    console.log(
+      `Tron smoke passed: ${blocks
+        .map(
+          (block, index) =>
+            `node ${index + 1} block ${
+              block.block_header?.raw_data?.number ?? 'unknown'
+            }`,
+        )
+        .join(', ')}`,
+    );
+  } finally {
+    await quitAll(nodes);
+  }
+}
+
+async function getAvailablePortsWithGaps(
+  count: number,
+  gapSize = 8,
+): Promise<number[]> {
+  const ports: number[] = [];
+  const excludedPorts = new Set<number>();
+
+  while (ports.length < count) {
+    const [port] = await getAvailablePorts(1, excludedPorts);
+    ports.push(port);
+
+    for (let offset = -gapSize; offset <= gapSize; offset += 1) {
+      const excludedPort = port + offset;
+      if (excludedPort >= 1 && excludedPort <= 65_535) {
+        excludedPorts.add(excludedPort);
+      }
+    }
+  }
+
+  return ports;
+}
+
+async function startAll(starts: (() => Promise<void>)[]): Promise<void> {
+  for (const start of starts) {
+    await start();
+  }
+}
+
+async function quitAll(
+  nodes: readonly { quit: () => Promise<void> }[],
+): Promise<void> {
+  const results = await Promise.allSettled(nodes.map((node) => node.quit()));
+  const failure = results.find(
+    (result): result is PromiseRejectedResult => result.status === 'rejected',
+  );
+
+  if (failure) {
+    throw failure.reason;
+  }
+}
+
+function formatNodeUrls(ports: readonly number[]): string {
+  return ports.map((port) => `127.0.0.1:${port}`).join(' and ');
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});


### PR DESCRIPTION
## **Description**

This PR wires the `'tron'` case into `withFixtures` and adds a smoke script so a Tron local node can be started and consumed from a test fixture. It is one reviewable step of a linear stack and replaces #44139. Together with PRs 03-05 it supersedes #43722. Based on a fresh `main` and under 1000 changed lines.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of the local-blockchain E2E initiative (WPN-536).
Replaces #44139; together with the preceding Tron node PRs (config, seeder, bootstrap) supersedes #43722.

## **Manual testing steps**

1. `yarn build:test`
2. Run the Tron fixtures smoke script and confirm the `'tron'` fixture case boots a local node and tears it down cleanly.

## **Screenshots/Recordings**

N/A — test infrastructure only, no user-facing UI change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only fixture and smoke tooling; the Anvil guard is a small behavioral fix for mixed local-node fixtures.
> 
> **Overview**
> E2E fixtures can now boot a **Tron** local node via `localNodeOptions: 'tron'` (or `{ type: 'tron', options: ... }`), using the existing `TronNode` seeder alongside the Anvil path.
> 
> **Accounts API v5** native-balance sync from `localNodes[0]` is limited to **Anvil** only, so a Tron-first fixture no longer calls `getBalance()` on a non-EVM node.
> 
> A new **`test:e2e:smoke:local-node-ports`** script starts two java-tron networks on spaced ports, hits `getnowblock`, and tears down—sanity check for port allocation and multi-node startup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c91ac63a58e9c832ce638b424f0d033f4bf17bd1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->