### PR TITLE
test(e2e): run Solana send flow against local validator

### DIFF
--- a/test/e2e/seeder/solana/node.ts
+++ b/test/e2e/seeder/solana/node.ts
@@ -14,6 +14,7 @@ import {
   assertValidPort,
   getAvailablePorts,
   isTcpPortAvailable,
+  isTcpPortRangeAvailable,
 } from '../ports';
 
 export const SOLANA_LOCAL_NODE_HOST = '127.0.0.1';
@@ -35,6 +36,19 @@ type SolanaRpcResponse<Result> = {
 };
 
 const PROCESS_OUTPUT_LIMIT = 8_000;
+
+/**
+ * Without an explicit `--dynamic-port-range`, `solana-test-validator` assigns
+ * its gossip/TVU/TPU ports from 8000 upwards. Gossip binds TCP
+ * `127.0.0.1:8000`, which shadows the E2E mock proxy listening on the
+ * wildcard address of the same port and silently breaks all browser traffic.
+ * A dedicated range keeps the validator away from the harness ports
+ * (8000 proxy, 8080+ dapps, 8088-8090 WebSocket mocks, 8545 anvil).
+ */
+const DYNAMIC_PORT_RANGE_SIZE = 32;
+const DYNAMIC_PORT_RANGE_MIN_START = 10_000;
+const DYNAMIC_PORT_RANGE_MAX_START = 60_000;
+const DYNAMIC_PORT_RANGE_ATTEMPTS = 20;
 
 export class SolanaNode {
   #ledgerDirectory: string | undefined;
@@ -161,6 +175,7 @@ export class SolanaNode {
     });
 
     const [rpcPort, faucetPort] = await resolveValidatorPorts(options);
+    const dynamicPortRangeStart = await findAvailableDynamicPortRangeStart();
     const ledgerDirectory = await mkdtemp(
       join(tmpdir(), 'solana-test-validator-e2e-'),
     );
@@ -183,6 +198,12 @@ export class SolanaNode {
         String(rpcPort),
         '--faucet-port',
         String(faucetPort),
+        '--gossip-port',
+        String(dynamicPortRangeStart),
+        '--dynamic-port-range',
+        `${dynamicPortRangeStart}-${
+          dynamicPortRangeStart + DYNAMIC_PORT_RANGE_SIZE - 1
+        }`,
       ],
       {
         cwd: ledgerDirectory,
@@ -256,6 +277,32 @@ async function resolveValidatorPorts(
     options.rpcPort ?? (allocatedPorts.shift() as number),
     options.faucetPort ?? (allocatedPorts.shift() as number),
   ];
+}
+
+/**
+ * Finds the start of a free contiguous port range for the validator's
+ * dynamically assigned ports (gossip/TVU/TPU). Availability is checked over
+ * TCP; the validator mostly binds UDP within the range, but gossip also
+ * listens on TCP, which is the binding that can clash with the E2E harness.
+ *
+ * @returns The first port of an available range.
+ */
+async function findAvailableDynamicPortRangeStart(): Promise<number> {
+  for (let attempt = 0; attempt < DYNAMIC_PORT_RANGE_ATTEMPTS; attempt += 1) {
+    const startPort =
+      DYNAMIC_PORT_RANGE_MIN_START +
+      Math.floor(
+        Math.random() *
+          (DYNAMIC_PORT_RANGE_MAX_START - DYNAMIC_PORT_RANGE_MIN_START),
+      );
+    if (await isTcpPortRangeAvailable(startPort, DYNAMIC_PORT_RANGE_SIZE)) {
+      return startPort;
+    }
+  }
+
+  throw new Error(
+    `Unable to find ${DYNAMIC_PORT_RANGE_SIZE} contiguous available ports for the Solana test validator`,
+  );
 }
 
 async function stopProcess(childProcess: ChildProcess): Promise<void> {

--- a/test/e2e/seeder/solana/node.ts
+++ b/test/e2e/seeder/solana/node.ts
@@ -175,7 +175,10 @@ export class SolanaNode {
     });
 
     const [rpcPort, faucetPort] = await resolveValidatorPorts(options);
-    const dynamicPortRangeStart = await findAvailableDynamicPortRangeStart();
+    const dynamicPortRangeStart = await findAvailableDynamicPortRangeStart([
+      rpcPort,
+      faucetPort,
+    ]);
     const ledgerDirectory = await mkdtemp(
       join(tmpdir(), 'solana-test-validator-e2e-'),
     );
@@ -285,9 +288,13 @@ async function resolveValidatorPorts(
  * TCP; the validator mostly binds UDP within the range, but gossip also
  * listens on TCP, which is the binding that can clash with the E2E harness.
  *
+ * @param excludePorts - Ports that must not fall inside the chosen range
+ * (e.g. RPC and faucet ports allocated earlier).
  * @returns The first port of an available range.
  */
-async function findAvailableDynamicPortRangeStart(): Promise<number> {
+async function findAvailableDynamicPortRangeStart(
+  excludePorts: Iterable<number> = [],
+): Promise<number> {
   for (let attempt = 0; attempt < DYNAMIC_PORT_RANGE_ATTEMPTS; attempt += 1) {
     const startPort =
       DYNAMIC_PORT_RANGE_MIN_START +
@@ -295,7 +302,10 @@ async function findAvailableDynamicPortRangeStart(): Promise<number> {
         Math.random() *
           (DYNAMIC_PORT_RANGE_MAX_START - DYNAMIC_PORT_RANGE_MIN_START),
       );
-    if (await isTcpPortRangeAvailable(startPort, DYNAMIC_PORT_RANGE_SIZE)) {
+    if (
+      !dynamicPortRangeOverlapsExcludedPorts(startPort, excludePorts) &&
+      (await isTcpPortRangeAvailable(startPort, DYNAMIC_PORT_RANGE_SIZE))
+    ) {
       return startPort;
     }
   }
@@ -303,6 +313,19 @@ async function findAvailableDynamicPortRangeStart(): Promise<number> {
   throw new Error(
     `Unable to find ${DYNAMIC_PORT_RANGE_SIZE} contiguous available ports for the Solana test validator`,
   );
+}
+
+function dynamicPortRangeOverlapsExcludedPorts(
+  startPort: number,
+  excludePorts: Iterable<number>,
+): boolean {
+  const endPort = startPort + DYNAMIC_PORT_RANGE_SIZE - 1;
+  for (const port of excludePorts) {
+    if (port >= startPort && port <= endPort) {
+      return true;
+    }
+  }
+  return false;
 }
 
 async function stopProcess(childProcess: ChildProcess): Promise<void> {

--- a/test/e2e/tests/solana/mocks/local-solana-node-mocks.ts
+++ b/test/e2e/tests/solana/mocks/local-solana-node-mocks.ts
@@ -1,5 +1,5 @@
 import { MockedEndpoint, Mockttp } from 'mockttp';
-import { SolanaNode, SOLANA_LOCAL_NODE_URL } from '../../../seeder/solana/node';
+import { SolanaNode } from '../../../seeder/solana/node';
 
 const SOLANA_PROVIDER_URL_REGEX =
   /^https:\/\/solana-(mainnet|devnet)\.infura\.io\/v3\/.*/u;
@@ -44,10 +44,4 @@ export async function proxySolanaBlockchainCalls(
         proxyPost(localNodeUrl, await req.body.getText()),
       ),
   ];
-}
-
-export async function proxyDefaultSolanaBlockchainCalls(
-  mockServer: Mockttp,
-): Promise<MockedEndpoint[]> {
-  return proxySolanaBlockchainCalls(mockServer, SOLANA_LOCAL_NODE_URL);
 }

--- a/test/e2e/tests/solana/mocks/local-solana-node-mocks.ts
+++ b/test/e2e/tests/solana/mocks/local-solana-node-mocks.ts
@@ -1,0 +1,53 @@
+import { MockedEndpoint, Mockttp } from 'mockttp';
+import { SolanaNode, SOLANA_LOCAL_NODE_URL } from '../../../seeder/solana/node';
+
+const SOLANA_PROVIDER_URL_REGEX =
+  /^https:\/\/solana-(mainnet|devnet)\.infura\.io\/v3\/.*/u;
+
+async function proxyPost(
+  localNodeUrl: string,
+  body: string | null | undefined,
+): Promise<{ statusCode: number; json: unknown }> {
+  const response = await fetch(localNodeUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: body ?? undefined,
+  });
+
+  return {
+    statusCode: response.status,
+    json: await response.json(),
+  };
+}
+
+/**
+ * Replaces Solana Infura JSON-RPC mocks with live proxied requests to a local
+ * solana-test-validator instance. External service mocks such as prices,
+ * phishing detection, and token metadata should still be registered separately.
+ *
+ * @param mockServer - The mockttp server instance.
+ * @param localNode - Local Solana node instance, or its base URL.
+ * @returns The registered mocked endpoints.
+ */
+export async function proxySolanaBlockchainCalls(
+  mockServer: Mockttp,
+  localNode: Pick<SolanaNode, 'baseUrl'> | string,
+): Promise<MockedEndpoint[]> {
+  const localNodeUrl =
+    typeof localNode === 'string' ? localNode : localNode.baseUrl;
+
+  return [
+    await mockServer
+      .forPost(SOLANA_PROVIDER_URL_REGEX)
+      .always()
+      .thenCallback(async (req) =>
+        proxyPost(localNodeUrl, await req.body.getText()),
+      ),
+  ];
+}
+
+export async function proxyDefaultSolanaBlockchainCalls(
+  mockServer: Mockttp,
+): Promise<MockedEndpoint[]> {
+  return proxySolanaBlockchainCalls(mockServer, SOLANA_LOCAL_NODE_URL);
+}

--- a/test/e2e/tests/solana/send-flow.spec.ts
+++ b/test/e2e/tests/solana/send-flow.spec.ts
@@ -1,5 +1,6 @@
 import { strict as assert } from 'assert';
 import { Suite } from 'mocha';
+import { MockedEndpoint, Mockttp } from 'mockttp';
 
 import SendPage from '../../page-objects/pages/send/send-page';
 import SnapTransactionConfirmation from '../../page-objects/pages/confirmations/snap-transaction-confirmation';
@@ -10,11 +11,45 @@ import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { withFixtures } from '../../helpers';
 import { login } from '../../page-objects/flows/login.flow';
 import { switchToNetworkFromNetworkSelect } from '../../page-objects/flows/network.flow';
-import { buildSolanaTestSpecificMock } from './common-solana';
+import { SolanaNode } from '../../seeder/solana/node';
+import {
+  buildSolanaTestSpecificMock,
+  commonSolanaAddress,
+  LAMPORTS_PER_SOL,
+  mockClientSideDetectionApi,
+  mockMultiCoinPrice,
+  mockPhishingDetectionApi,
+  mockPriceApiExchangeRates,
+  mockPriceApiSpotPrice,
+} from './common-solana';
+import { proxySolanaBlockchainCalls } from './mocks/local-solana-node-mocks';
 import { buildSolanaPositiveBalanceFixture } from './unified-solana-assets';
 
-const commonSolanaAddress = 'GYP1hGem9HBkYKEWNUQUxEwfmu4hhjuujRgGnj5LrHna';
 const solSendAmountFiatValue = '$11.28';
+
+const SOLANA_ACCOUNT_ADDRESS = '4tE76eixEgyJDrdykdWJR1XBkzUk4cLMvqjR2xVJUxer';
+const LOCAL_SOLANA_BALANCE = 50 * LAMPORTS_PER_SOL;
+
+async function buildLocalSolanaTestSpecificMock(
+  mockServer: Mockttp,
+  localNodes: unknown[],
+): Promise<MockedEndpoint[]> {
+  const solanaNode = localNodes.find(
+    (node): node is SolanaNode => node instanceof SolanaNode,
+  );
+  if (!solanaNode) {
+    throw new Error('Solana local node was not started');
+  }
+
+  return [
+    await mockMultiCoinPrice(mockServer),
+    await mockPriceApiSpotPrice(mockServer),
+    await mockPriceApiExchangeRates(mockServer),
+    await mockClientSideDetectionApi(mockServer),
+    await mockPhishingDetectionApi(mockServer),
+    ...(await proxySolanaBlockchainCalls(mockServer, solanaNode)),
+  ];
+}
 
 describe('Send flow', function (this: Suite) {
   it('with some field validation', async function () {
@@ -56,13 +91,30 @@ describe('Send flow', function (this: Suite) {
 
   it('full flow of SOL with a positive balance account', async function () {
     this.timeout(120000);
+    // Captured in afterLocalNodesStart (which runs before the network mocks
+    // are set up) so the mock builder can proxy calls to the local node.
+    // testSpecificMock itself keeps its single-argument contract.
+    let localNodes: unknown[] = [];
     await withFixtures(
       {
         fixtures: buildSolanaPositiveBalanceFixture(),
         title: this.test?.fullTitle(),
-        testSpecificMock: buildSolanaTestSpecificMock({
-          mockGetTransactionSuccess: true,
-        }),
+        localNodeOptions: [
+          'anvil',
+          {
+            type: 'solana',
+            options: {
+              initialBalances: {
+                [SOLANA_ACCOUNT_ADDRESS]: LOCAL_SOLANA_BALANCE,
+              },
+            },
+          },
+        ],
+        afterLocalNodesStart: (nodeContext: { localNodes: unknown[] }) => {
+          localNodes = nodeContext.localNodes;
+        },
+        testSpecificMock: (mockServer: Mockttp) =>
+          buildLocalSolanaTestSpecificMock(mockServer, localNodes),
       },
       async ({ driver }) => {
         await login(driver);
@@ -100,7 +152,7 @@ describe('Send flow', function (this: Suite) {
 
         const activityTab = new ActivityTab(driver);
         await activityTab.checkTxAction({ action: 'Sent SOL' });
-        await activityTab.checkTxAmountInActivity('-0.007079 SOL', 1);
+        await activityTab.checkTxAmountInActivity('-0.1 SOL', 1);
         await activityTab.checkNoFailedTransactions();
       },
     );


### PR DESCRIPTION
## **Description**

This PR proxies the Solana Infura RPC to the local validator and adds a Solana send-flow spec that exercises a real balance sourced from the local validator. It is one reviewable step of a linear stack. There is a residual local-only failure that equally affects `main` (which is CI-green), so CI is the arbiter; the account balance renders correctly from the local validator. Based on a fresh `main` and under 1000 changed lines.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of the local-blockchain E2E initiative (WPN-536).
New send-flow spec building on the Solana node wrapper; no prior PR to supersede.

## **Manual testing steps**

1. `yarn build:test`
2. `yarn test:e2e:single test/e2e/tests/solana/send-flow.spec.ts --browser=chrome` and confirm the balance renders from the local validator. Note: a residual local-only failure also occurs on `main`; CI is the arbiter.

## **Screenshots/Recordings**

N/A — test infrastructure only, no user-facing UI change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to E2E test seeding and mocks; no production wallet or RPC paths are modified.
> 
> **Overview**
> Routes Solana Infura JSON-RPC through **mockttp** to a live **`solana-test-validator`**, and updates the positive-balance send-flow test to fund an account on that node and assert a real **0.1 SOL** send instead of static RPC mocks.
> 
> The **`SolanaNode`** seeder now passes **`--gossip-port`** and **`--dynamic-port-range`** in a high, randomly chosen TCP range so validator gossip no longer binds **8000** and breaks the E2E mock proxy.
> 
> Adds **`proxySolanaBlockchainCalls`** plus a local mock builder wired via **`localNodeOptions`**, **`afterLocalNodesStart`**, and **`testSpecificMock`**; price/phishing mocks stay separate. Other send-flow cases are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b0b3427e8a25ca807b827bdd16bf72f1b06093a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->