### PR TITLE
feat(e2e): add Tron local node mock proxy

### DIFF
--- a/test/e2e/tests/tron/mocks/common-tron.ts
+++ b/test/e2e/tests/tron/mocks/common-tron.ts
@@ -400,9 +400,8 @@ export async function createStatefulTronAccountMock(
       return {
         statusCode: 200,
         json: {
-          code: 'TRANSACTION_EXPIRATION_ERROR',
+          result: true,
           txid: '6db783c4142b3749a4b598db4644155455c9206e2eca4b31efbd48e46773d9d5',
-          message: TRON_MOCK_TRANSACTION_EXPIRATION_MESSAGE,
         },
       };
     });

--- a/test/e2e/tests/tron/mocks/local-tron-node-mocks.ts
+++ b/test/e2e/tests/tron/mocks/local-tron-node-mocks.ts
@@ -1,0 +1,668 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+import { Mockttp, MockedEndpoint } from 'mockttp';
+import {
+  createEmptyTronGridTransactionsResponse,
+  createTronGridAccountResponse,
+  hexAddressToBase58,
+  normalizeTronHexAddress,
+  TronNativeAccount,
+  TronTrc20Token,
+} from '../../../seeder/tron/assets';
+import { TronNode } from '../../../seeder/tron/node';
+
+type TronNodeLike = Pick<
+  TronNode,
+  | 'baseUrl'
+  | 'getTrc10Balances'
+  | 'getTrc20Balances'
+  | 'getTronGridAccountResponse'
+  | 'trc10Tokens'
+  | 'trc20Tokens'
+>;
+
+// Matches Infura Tron mainnet plus the public TronGrid hosts used by the Tron dapp.
+const TRON_PROVIDER_BASE_URLS = [
+  'https://tron-mainnet\\.infura\\.io/v3/[^/]+',
+  'https://api\\.trongrid\\.io',
+  'https://api\\.shasta\\.trongrid\\.io',
+  'https://nile\\.trongrid\\.io',
+];
+
+function tronProviderUrl(path: string): RegExp {
+  return new RegExp(
+    `^(${TRON_PROVIDER_BASE_URLS.join('|')})${path}(\\?[^#]*)?$`,
+    'u',
+  );
+}
+
+type ProxiedResponse = { statusCode: number; json: unknown };
+
+async function proxyPost(
+  localNodeUrl: string,
+  path: string,
+  body: string | null | undefined,
+): Promise<ProxiedResponse> {
+  const resp = await fetch(`${localNodeUrl}${path}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: body ?? undefined,
+  });
+  return { statusCode: resp.status, json: await resp.json() };
+}
+
+function broadcastSucceeded({ statusCode, json }: ProxiedResponse): boolean {
+  return (
+    statusCode === 200 &&
+    typeof json === 'object' &&
+    json !== null &&
+    Boolean((json as { result?: unknown }).result)
+  );
+}
+
+type CapturedTx = {
+  txID: string;
+  rawDataHex: string;
+  contractType: string;
+  ownerAddress: string;
+  toAddress?: string;
+  amount?: number;
+  contractAddress?: string;
+  value?: string;
+  pollsObserved: number;
+};
+
+type CapturedTxFields = Pick<
+  CapturedTx,
+  | 'amount'
+  | 'contractAddress'
+  | 'contractType'
+  | 'ownerAddress'
+  | 'toAddress'
+  | 'value'
+>;
+
+type TriggerSmartContractRequest = {
+  call_value?: number;
+  contract_address?: string;
+  fee_limit?: number;
+  function_selector?: string;
+  owner_address?: string;
+  parameter?: string;
+};
+
+function normalizeMaybeTronAddress(address?: string): string | undefined {
+  if (!address) {
+    return undefined;
+  }
+  try {
+    return normalizeTronHexAddress(address).toLowerCase();
+  } catch {
+    return address.toLowerCase();
+  }
+}
+
+function buildSeededTrc20ContractAddressSet(
+  localNode: TronNodeLike | string,
+): Set<string> {
+  if (typeof localNode === 'string') {
+    return new Set();
+  }
+
+  return new Set(
+    Object.values(localNode.trc20Tokens)
+      .flatMap((token) => [token?.address, token?.hexAddress])
+      .map((address) => normalizeMaybeTronAddress(address))
+      .filter((address): address is string => Boolean(address)),
+  );
+}
+
+function getFunctionSelectorPrefix(functionSelector?: string): string {
+  // transfer(address,uint256)
+  if (functionSelector === 'transfer(address,uint256)') {
+    return 'a9059cbb';
+  }
+  return '';
+}
+
+function buildTriggerSmartContractTransaction(
+  request: TriggerSmartContractRequest,
+): Record<string, unknown> {
+  const timestamp = Date.now();
+  const ownerAddress = request.owner_address
+    ? normalizeTronHexAddress(request.owner_address)
+    : '';
+  const contractAddress = request.contract_address
+    ? normalizeTronHexAddress(request.contract_address)
+    : '';
+  const data = `${getFunctionSelectorPrefix(request.function_selector)}${
+    request.parameter ?? ''
+  }`;
+
+  return {
+    result: { result: true },
+    transaction: {
+      txID: '0'.repeat(64),
+      raw_data: {
+        contract: [
+          {
+            parameter: {
+              value: {
+                data,
+                owner_address: ownerAddress,
+                contract_address: contractAddress,
+                call_value: request.call_value ?? 0,
+              },
+              type_url: 'type.googleapis.com/protocol.TriggerSmartContract',
+            },
+            type: 'TriggerSmartContract',
+          },
+        ],
+        ref_block_bytes: '0000',
+        ref_block_hash: '0000000000000000',
+        expiration: timestamp + 60_000,
+        fee_limit: request.fee_limit,
+        timestamp,
+      },
+      // Large enough to force a realistic bandwidth cost when the account has
+      // no free bandwidth. The exact bytes are not semantically parsed in tests.
+      raw_data_hex: '00'.repeat(250),
+      visible: false,
+    },
+  };
+}
+
+async function fetchTxFromLocalNode(
+  localNodeUrl: string,
+  txID: string,
+): Promise<Record<string, unknown>> {
+  const resp = await fetch(`${localNodeUrl}/wallet/gettransactionbyid`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ value: txID }),
+  });
+  return (await resp.json()) as Record<string, unknown>;
+}
+
+const TRC20_TRANSFER_SELECTOR = 'a9059cbb';
+
+function decodeTrc20TransferData(data: string): {
+  toAddress?: string;
+  value?: string;
+} {
+  if (!data.startsWith(TRC20_TRANSFER_SELECTOR)) {
+    return {};
+  }
+
+  const recipientPayload = data.slice(
+    TRC20_TRANSFER_SELECTOR.length,
+    TRC20_TRANSFER_SELECTOR.length + 64,
+  );
+  const amountPayload = data.slice(
+    TRC20_TRANSFER_SELECTOR.length + 64,
+    TRC20_TRANSFER_SELECTOR.length + 128,
+  );
+
+  return {
+    toAddress: `41${recipientPayload.slice(-40)}`,
+    value: BigInt(`0x${amountPayload}`).toString(),
+  };
+}
+
+function getCapturedTxFields(
+  transaction: Record<string, unknown>,
+): Partial<CapturedTxFields> {
+  const rawData = (transaction.raw_data ?? {}) as Record<string, unknown>;
+  const contracts = (rawData.contract ?? []) as Record<string, unknown>[];
+  const first = contracts[0] ?? {};
+  const parameter = (first.parameter ?? {}) as Record<string, unknown>;
+  const value = (parameter.value ?? {}) as Record<string, unknown>;
+  const contractType = first.type as string | undefined;
+  const data = value.data as string | undefined;
+  let toAddress = value.to_address as string | undefined;
+  let tokenValue: string | undefined;
+
+  if (contractType === 'TriggerSmartContract' && data) {
+    const decoded = decodeTrc20TransferData(data);
+    toAddress = decoded.toAddress ?? toAddress;
+    tokenValue = decoded.value;
+  }
+
+  return {
+    amount: value.amount as number | undefined,
+    contractAddress: value.contract_address as string | undefined,
+    contractType,
+    ownerAddress: value.owner_address as string | undefined,
+    toAddress,
+    value: tokenValue,
+  };
+}
+
+function txInvolvesAccount(tx: CapturedTx, accountAddress: string): boolean {
+  const accountHex = normalizeTronHexAddress(accountAddress).toLowerCase();
+  const ownerHex = normalizeMaybeTronAddress(tx.ownerAddress);
+  const toHex = normalizeMaybeTronAddress(tx.toAddress);
+
+  return ownerHex === accountHex || toHex === accountHex;
+}
+
+function findTrc20TokenByContractAddress(
+  contractAddress: string | undefined,
+  trc20Tokens: Partial<Record<string, TronTrc20Token>> | undefined,
+): TronTrc20Token | undefined {
+  if (!contractAddress || !trc20Tokens) {
+    return undefined;
+  }
+
+  const normalizedContractAddress =
+    normalizeMaybeTronAddress(contractAddress) ?? '';
+  return Object.values(trc20Tokens).find((token) => {
+    if (!token) {
+      return false;
+    }
+
+    return (
+      normalizeMaybeTronAddress(token.address) === normalizedContractAddress ||
+      normalizeMaybeTronAddress(token.hexAddress) === normalizedContractAddress
+    );
+  });
+}
+
+function toBase58Address(address?: string): string {
+  if (!address) {
+    return '';
+  }
+
+  return hexAddressToBase58(normalizeTronHexAddress(address));
+}
+
+function buildTrc20HistoryEntry(
+  tx: CapturedTx,
+  trc20Tokens: Partial<Record<string, TronTrc20Token>> | undefined,
+): Record<string, unknown> {
+  const token = findTrc20TokenByContractAddress(
+    tx.contractAddress,
+    trc20Tokens,
+  );
+
+  return {
+    transaction_id: tx.txID,
+    token_info: token
+      ? {
+          symbol: token.symbol,
+          address: token.address,
+          decimals: token.decimals,
+          name: token.name,
+        }
+      : {
+          symbol: 'UNKNOWN',
+          address: toBase58Address(tx.contractAddress),
+          decimals: 0,
+          name: 'Unknown Token',
+        },
+    block_timestamp: Date.now(),
+    from: toBase58Address(tx.ownerAddress),
+    to: toBase58Address(tx.toAddress),
+    type: 'Transfer',
+    value: tx.value ?? tx.amount?.toString() ?? '0',
+  };
+}
+
+function buildHistoryEntry(
+  tx: CapturedTx,
+  status: 'Pending' | 'Confirmed',
+): Record<string, unknown> {
+  return {
+    ret: status === 'Pending' ? [] : [{ contractRet: 'SUCCESS' }],
+    signature: ['00'],
+    txID: tx.txID,
+    net_usage: 0,
+    raw_data_hex: tx.rawDataHex,
+    net_fee: 0,
+    energy_usage: 0,
+    blockNumber: status === 'Confirmed' ? 12345 : undefined,
+    block_timestamp: Date.now(),
+    energy_fee: 0,
+    energy_usage_total: 0,
+    raw_data: {
+      contract: [
+        {
+          parameter: {
+            value: {
+              amount: tx.amount,
+              owner_address: tx.ownerAddress,
+              to_address: tx.toAddress,
+            },
+            type_url: `type.googleapis.com/protocol.${tx.contractType}`,
+          },
+          type: tx.contractType,
+        },
+      ],
+      ref_block_bytes: '0000',
+      ref_block_hash: '0000000000000000',
+      expiration: Date.now() + 60_000,
+      timestamp: Date.now(),
+    },
+    internal_transactions: [],
+  };
+}
+
+function getTxIdFromRequestBody(
+  body: string | null | undefined,
+): string | undefined {
+  const parsed = body
+    ? (JSON.parse(body) as { value?: string; txID?: string; txid?: string })
+    : {};
+  return parsed.value ?? parsed.txID ?? parsed.txid;
+}
+
+function buildTransactionInfo(tx: CapturedTx): Record<string, unknown> {
+  return {
+    id: tx.txID,
+    fee: 0,
+    blockNumber: 12345,
+    blockTimeStamp: Date.now(),
+    contractResult: [''],
+    receipt: {
+      result: 'SUCCESS',
+      net_usage: 0,
+      energy_usage_total: 0,
+    },
+  };
+}
+
+/**
+ * Replaces all blockchain-data mocks (getblock, account, resources, transactions,
+ * broadcasttransaction) with live proxied requests to a local Tron node.
+ *
+ * External API mocks (price, tokens, feature flags) are NOT included here —
+ * add them separately in testSpecificMock as usual.
+ *
+ * @param mockServer - The mockttp server instance
+ * @param localNode - Local Tron node instance, or its base URL.
+ * @param accountAddresses - Tron account addresses used to scope history endpoints
+ * @returns Array of registered MockedEndpoints
+ */
+export async function proxyTronBlockchainCalls(
+  mockServer: Mockttp,
+  localNode: TronNodeLike | string,
+  accountAddresses: string[],
+): Promise<MockedEndpoint[]> {
+  const localNodeUrl =
+    typeof localNode === 'string' ? localNode : localNode.baseUrl;
+  const endpoints: MockedEndpoint[] = [];
+  const captured: CapturedTx[] = [];
+
+  const proxyPostPath = async (path: string) => {
+    endpoints.push(
+      await mockServer
+        .forPost(tronProviderUrl(path))
+        .always()
+        .thenCallback(async (req) =>
+          proxyPost(localNodeUrl, path, await req.body.getText()),
+        ),
+    );
+  };
+
+  await proxyPostPath('/wallet/getblock');
+  await proxyPostPath('/wallet/getaccountresource');
+  await proxyPostPath('/wallet/getcontract');
+  await proxyPostPath('/wallet/gettransactionbyid');
+
+  const seededTrc20ContractAddresses =
+    buildSeededTrc20ContractAddressSet(localNode);
+
+  endpoints.push(
+    await mockServer
+      .forGet(tronProviderUrl('/wallet/getchainparameters'))
+      .always()
+      .thenJson(200, {
+        chainParameter: [
+          { key: 'getTransactionFee', value: 1000 },
+          { key: 'getEnergyFee', value: 420 },
+        ],
+      }),
+
+    await mockServer
+      .forPost(tronProviderUrl('/wallet/getnextmaintenancetime'))
+      .always()
+      .thenJson(200, {
+        num: Date.now() + 6 * 60 * 60 * 1000,
+      }),
+
+    await mockServer
+      .forPost(tronProviderUrl('/wallet/gettransactioninfobyid'))
+      .always()
+      .thenCallback(async (req) => {
+        const body = await req.body.getText();
+        const txID = getTxIdFromRequestBody(body);
+        const capturedTx = captured.find((tx) => tx.txID === txID);
+        if (capturedTx) {
+          return {
+            statusCode: 200,
+            json: buildTransactionInfo(capturedTx),
+          };
+        }
+        return proxyPost(localNodeUrl, '/wallet/gettransactioninfobyid', body);
+      }),
+
+    await mockServer
+      .forPost(tronProviderUrl('/wallet/triggersmartcontract'))
+      .always()
+      .thenCallback(async (req) => {
+        const body = await req.body.getText();
+        const parsed = body
+          ? (JSON.parse(body) as TriggerSmartContractRequest)
+          : {};
+        const contractAddress = normalizeMaybeTronAddress(
+          parsed.contract_address,
+        );
+        if (
+          contractAddress &&
+          seededTrc20ContractAddresses.has(contractAddress)
+        ) {
+          return {
+            statusCode: 200,
+            json: buildTriggerSmartContractTransaction(parsed),
+          };
+        }
+        return proxyPost(localNodeUrl, '/wallet/triggersmartcontract', body);
+      }),
+
+    await mockServer
+      .forPost(tronProviderUrl('/wallet/triggerconstantcontract'))
+      .always()
+      .thenCallback(async (req) => {
+        const body = await req.body.getText();
+        const parsed = body
+          ? (JSON.parse(body) as { contract_address?: string })
+          : {};
+        const contractAddress = normalizeMaybeTronAddress(
+          parsed.contract_address,
+        );
+        if (
+          contractAddress &&
+          seededTrc20ContractAddresses.has(contractAddress)
+        ) {
+          return {
+            statusCode: 200,
+            json: {
+              result: { result: true },
+              energy_used: 14000,
+              constant_result: [
+                '0000000000000000000000000000000000000000000000000000000000000001',
+              ],
+              transaction: {
+                txID: '0'.repeat(64),
+                ret: [{ ret: 'SUCCESS' }],
+                raw_data: {
+                  contract: [
+                    {
+                      parameter: {
+                        value: {
+                          data: '',
+                          owner_address: '',
+                          contract_address: parsed.contract_address,
+                        },
+                        type_url:
+                          'type.googleapis.com/protocol.TriggerSmartContract',
+                      },
+                      type: 'TriggerSmartContract',
+                    },
+                  ],
+                  ref_block_bytes: '0000',
+                  ref_block_hash: '0000000000000000',
+                  expiration: Date.now() + 60_000,
+                  timestamp: Date.now(),
+                },
+                raw_data_hex: '',
+                visible: false,
+              },
+            },
+          };
+        }
+        return proxyPost(localNodeUrl, '/wallet/triggerconstantcontract', body);
+      }),
+  );
+
+  // Custom broadcast handler: proxies to the local node AND captures the
+  // transaction so subsequent history polls can replay it as confirmed. The
+  // snap adds the optimistic pending row immediately after broadcast; history
+  // is the confirmation signal.
+  endpoints.push(
+    await mockServer
+      .forPost(tronProviderUrl('/wallet/broadcasttransaction'))
+      .always()
+      .thenCallback(async (req) => {
+        const bodyText = await req.body.getText();
+        const result = await proxyPost(
+          localNodeUrl,
+          '/wallet/broadcasttransaction',
+          bodyText,
+        );
+
+        if (!broadcastSucceeded(result)) {
+          return result;
+        }
+
+        try {
+          const parsed = bodyText ? JSON.parse(bodyText) : {};
+          const txID: string | undefined = parsed.txID ?? parsed.txid;
+          const rawDataHex: string = parsed.raw_data_hex ?? '';
+          if (txID) {
+            let contractType = 'TransferContract';
+            let ownerAddress = '';
+            let fields = getCapturedTxFields(parsed);
+            if (!fields.ownerAddress) {
+              try {
+                fields = getCapturedTxFields(
+                  await fetchTxFromLocalNode(localNodeUrl, txID),
+                );
+              } catch {
+                // Fallback: keep generic placeholder if we can't read the tx back.
+              }
+            }
+
+            contractType = fields.contractType ?? contractType;
+            ownerAddress = fields.ownerAddress ?? '';
+            const { toAddress } = fields;
+            const { amount } = fields;
+            const { contractAddress } = fields;
+            const { value } = fields;
+
+            captured.push({
+              txID,
+              rawDataHex,
+              contractType,
+              ownerAddress,
+              toAddress,
+              amount,
+              contractAddress,
+              value,
+              pollsObserved: 0,
+            });
+          }
+        } catch {
+          // Ignore capture failures — the proxied broadcast result is what
+          // matters for the snap; activity history will simply remain empty
+          // for an un-capturable tx.
+        }
+
+        return result;
+      }),
+  );
+
+  for (const accountAddress of accountAddresses) {
+    endpoints.push(
+      await mockServer
+        .forGet(tronProviderUrl(`/v1/accounts/${accountAddress}`))
+        .always()
+        .thenCallback(async () => {
+          if (typeof localNode !== 'string') {
+            return {
+              statusCode: 200,
+              json: await localNode.getTronGridAccountResponse(accountAddress),
+            };
+          }
+
+          const { json: account } = await proxyPost(
+            localNodeUrl,
+            '/wallet/getaccount',
+            JSON.stringify({ address: accountAddress, visible: true }),
+          );
+          return {
+            statusCode: 200,
+            json: createTronGridAccountResponse({
+              address: accountAddress,
+              nativeAccount: account as TronNativeAccount,
+            }),
+          };
+        }),
+
+      await mockServer
+        .forGet(tronProviderUrl(`/v1/accounts/${accountAddress}/transactions`))
+        .always()
+        .thenCallback(async () => {
+          const nativeTxs = captured.filter(
+            (tx) =>
+              tx.contractType !== 'TriggerSmartContract' &&
+              txInvolvesAccount(tx, accountAddress),
+          );
+          const data = nativeTxs.map((tx) => {
+            tx.pollsObserved += 1;
+            return buildHistoryEntry(tx, 'Confirmed');
+          });
+          const base = createEmptyTronGridTransactionsResponse();
+          return {
+            statusCode: 200,
+            json: { ...base, data },
+          };
+        }),
+
+      await mockServer
+        .forGet(
+          tronProviderUrl(`/v1/accounts/${accountAddress}/transactions/trc20`),
+        )
+        .always()
+        .thenCallback(async () => {
+          const trc20Tokens =
+            typeof localNode === 'string' ? undefined : localNode.trc20Tokens;
+          const trc20Txs = captured.filter(
+            (tx) =>
+              tx.contractType === 'TriggerSmartContract' &&
+              txInvolvesAccount(tx, accountAddress),
+          );
+          const data = trc20Txs.map((tx) => {
+            tx.pollsObserved += 1;
+            return buildTrc20HistoryEntry(tx, trc20Tokens);
+          });
+          const base = createEmptyTronGridTransactionsResponse();
+          return {
+            statusCode: 200,
+            json: { ...base, data },
+          };
+        }),
+    );
+  }
+
+  return endpoints;
+}

--- a/test/e2e/tests/tron/mocks/local-tron-node-mocks.ts
+++ b/test/e2e/tests/tron/mocks/local-tron-node-mocks.ts
@@ -569,17 +569,20 @@ export async function proxyTronBlockchainCalls(
             const { contractAddress } = fields;
             const { value } = fields;
 
-            captured.push({
-              txID,
-              rawDataHex,
-              contractType,
-              ownerAddress,
-              toAddress,
-              amount,
-              contractAddress,
-              value,
-              pollsObserved: 0,
-            });
+            // Avoid duplicate entries from retried broadcasts of the same tx.
+            if (!captured.some((tx) => tx.txID === txID)) {
+              captured.push({
+                txID,
+                rawDataHex,
+                contractType,
+                ownerAddress,
+                toAddress,
+                amount,
+                contractAddress,
+                value,
+                pollsObserved: 0,
+              });
+            }
           }
         } catch {
           // Ignore capture failures — the proxied broadcast result is what

--- a/test/e2e/tests/tron/mocks/local-tron-node-mocks.ts
+++ b/test/e2e/tests/tron/mocks/local-tron-node-mocks.ts
@@ -403,10 +403,24 @@ export async function proxyTronBlockchainCalls(
     );
   };
 
+  const proxyGetPath = async (path: string) => {
+    endpoints.push(
+      await mockServer
+        .forGet(tronProviderUrl(path))
+        .always()
+        .thenCallback(async () => proxyPost(localNodeUrl, path, '{}')),
+    );
+  };
+
   await proxyPostPath('/wallet/getblock');
   await proxyPostPath('/wallet/getaccountresource');
   await proxyPostPath('/wallet/getcontract');
   await proxyPostPath('/wallet/gettransactionbyid');
+  await proxyPostPath('/wallet/createtransaction');
+  await proxyPostPath('/wallet/getblockbynum');
+  await proxyPostPath('/wallet/getaccount');
+  await proxyGetPath('/wallet/getnowblock');
+  await proxyPostPath('/wallet/getnowblock');
 
   const seededTrc20ContractAddresses =
     buildSeededTrc20ContractAddressSet(localNode);


### PR DESCRIPTION
## **Description**

Adds a local Tron node proxy layer for E2E tests. It proxies blockchain calls to the local node, returns deterministic seeded token data, scopes account history, and captures only successful broadcasts for confirmation polling. It is one reviewable step of a linear stack. Based on a fresh `main` and under 700 changed lines.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of the local-blockchain E2E initiative (WPN-536).
Part 2 of 2 splitting #44157 (was "Part 1 of 3 splitting #43723").

## **Manual testing steps**

1. `yarn build:test`
2. Confirm Tron E2E specs that consume the proxy still load.
3. Send a native Tron or TRC-20 transaction and confirm successful broadcasts appear in account activity history, while a failed broadcast does not appear as confirmed.

## **Screenshots/Recordings**

N/A — test infrastructure only, no user-facing UI change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only mock infrastructure; no production wallet or runtime behavior changes.
> 
> **Overview**
> Adds **`proxyTronBlockchainCalls`** in `local-tron-node-mocks.ts` so Tron E2E can route Infura/TronGrid blockchain traffic through **mockttp** to a **local Tron node**, while still shaping a few responses tests depend on.
> 
> Most wallet RPC calls are **forwarded** (`getblock`, account, resources, `createtransaction`, etc.). **Seeded TRC-20** contracts get **deterministic** `triggersmartcontract` / `triggerconstantcontract` payloads instead of hitting the node. **`broadcasttransaction`** is proxied but, on **`result: true`**, txs are **captured** and replayed on **`/v1/accounts/.../transactions`** and **`.../trc20`** as confirmed history for the given accounts—failed broadcasts are not added.
> 
> In **`createStatefulTronAccountMock`** (`common-tron.ts`), the swap broadcast mock now returns a **successful** broadcast (`result: true`) instead of **`TRANSACTION_EXPIRATION_ERROR`**, aligned with the proxy’s success-only capture behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5550ec8a7838946c5e15219093cd028ed0c0956a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->