### PR TITLE
feat: refactor non-zero native custom networks

### DIFF
--- a/app/images/gnosis-native.svg
+++ b/app/images/gnosis-native.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+<rect height="100%" width="100%" fill="white" />
+<g transform="translate(-3.84375 2.4616265860680073)">
+<line x1="63.188" y1="138.125" x2="140.916" y2="60.396" stroke="#01795B" stroke-width="33.125" stroke-linecap="round"/>
+<line x1="63.188" y1="138.125" x2="115.461" y2="85.851" stroke="#09E33A" stroke-width="33.125"/>
+<line x1="63.188" y1="57.000" x2="144.452" y2="138.264" stroke="#0DB50A" stroke-width="33.125" stroke-linecap="round"/>
+<line x1="63.188" y1="57.000" x2="115.461" y2="109.274" stroke="#09E33A" stroke-width="33.125"/>
+<circle cx="63.188" cy="57.000" r="16.562" fill="#09E33A"/>
+<circle cx="63.188" cy="138.125" r="16.562" fill="#09E33A"/>
+<circle cx="144.375" cy="56.938" r="16.688" fill="#09E33A"/>
+</g>
+</svg>

--- a/app/images/gnosis.svg
+++ b/app/images/gnosis.svg
@@ -7,7 +7,7 @@
 <g transform="matrix(1 0 0 1 540 540)" id="6d236122-bb3d-4e42-9c6b-8d2a0958998c"  >
 </g>
 <g transform="matrix(1 0 0 1 540 540)" id="e68d71f6-858d-496f-973e-8d82de5e6bfb"  >
-<rect style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(255,255,255); fill-rule: nonzero; opacity: 1; visibility: hidden;" vector-effect="non-scaling-stroke"  x="-540" y="-540" rx="0" ry="0" width="1080" height="1080" />
+<rect style="stroke: none; stroke-width: 1; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(240,235,222);" vector-effect="non-scaling-stroke"  x="-540" y="-540" rx="0" ry="0" width="1080" height="1080" />
 </g>
 <g transform="matrix(12.89 0 0 12.89 539.9 539.9)" id="fc2f5ed2-9b97-4553-a90e-ba5317325e12"  >
 <circle style="stroke: rgb(0,0,0); stroke-opacity: 0; stroke-width: 0; stroke-dasharray: none; stroke-linecap: butt; stroke-dashoffset: 0; stroke-linejoin: miter; stroke-miterlimit: 4; fill: rgb(240,235,222); fill-rule: nonzero; opacity: 1;" vector-effect="non-scaling-stroke"  cx="0" cy="0" r="35" />

--- a/shared/constants/network.ts
+++ b/shared/constants/network.ts
@@ -230,6 +230,7 @@ export const CHAIN_IDS = {
   KONET: '0x4341',
   ARC: '0x13b2',
   ROBINHOOD_CHAIN: '0x1237',
+  STABLE: '0x3dc',
 } as const;
 
 export const CHAINLIST_CHAIN_IDS_MAP = {
@@ -615,7 +616,8 @@ export const HARMONY_ONE_TOKEN_IMAGE_URL = './images/harmony-one.svg';
 export const OPTIMISM_TOKEN_IMAGE_URL = './images/optimism.svg';
 export const PALM_TOKEN_IMAGE_URL = './images/palm.svg';
 export const CELO_TOKEN_IMAGE_URL = './images/celo.svg';
-export const GNOSIS_TOKEN_IMAGE_URL = './images/gnosis.svg';
+export const GNOSIS_NETWORK_IMAGE_URL = './images/gnosis.svg';
+export const GNOSIS_TOKEN_IMAGE_URL = './images/gnosis-native.svg';
 export const ZK_SYNC_ERA_TOKEN_IMAGE_URL = './images/zk-sync.svg';
 export const BASE_TOKEN_IMAGE_URL = './images/base.svg';
 export const ARBITRUM_NOVA_IMAGE_URL = './images/arbitrum-nova-logo.svg';
@@ -1186,7 +1188,7 @@ export const CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP: Record<string, string> = {
   [CHAIN_IDS.OPTIMISM]: OPTIMISM_TOKEN_IMAGE_URL,
   [CHAIN_IDS.PALM]: PALM_TOKEN_IMAGE_URL,
   [CHAIN_IDS.CELO]: CELO_TOKEN_IMAGE_URL,
-  [CHAIN_IDS.GNOSIS]: GNOSIS_TOKEN_IMAGE_URL,
+  [CHAIN_IDS.GNOSIS]: GNOSIS_NETWORK_IMAGE_URL,
   [CHAIN_IDS.ZKSYNC_ERA]: ZK_SYNC_ERA_TOKEN_IMAGE_URL,
   [CHAIN_IDS.MEGAETH_TESTNET]: MEGAETH_TESTNET_IMAGE_URL,
   [CHAIN_IDS.MEGAETH_TESTNET_V2]: MEGAETH_TESTNET_V2_IMAGE_URL,

--- a/ui/components/app/assets/enablement/arc.test.ts
+++ b/ui/components/app/assets/enablement/arc.test.ts
@@ -1,9 +1,4 @@
-import { AssetsControllerState } from '@metamask/assets-controller';
-import {
-  ARC_ERC20_USDC_ASSET_ID,
-  augmentAssetControllersState,
-  filterOutArcNativeAsset,
-} from './arc';
+import { filterOutArcNativeAsset } from './arc';
 
 const ARC_NATIVE_CAIP_CHAIN_ID = 'eip155:5042';
 const ARC_NATIVE_HEX_CHAIN_ID = '0x13b2';
@@ -122,58 +117,4 @@ describe('filterOutArcNativeAsset', () => {
       expect(filterOutArcNativeAsset(assets)).toStrictEqual(expected);
     },
   );
-});
-
-describe('augmentAssetControllersState', () => {
-  const buildState = (
-    assetsBalance: Record<string, Record<string, { amount: string }>>,
-  ) => ({ assetsBalance }) as unknown as AssetsControllerState;
-
-  it('removes the ERC20 USDC asset from every account', () => {
-    const state = buildState({
-      'account-1': {
-        [ARC_NATIVE_ASSET_ID]: { amount: '5' },
-        [ARC_ERC20_USDC_ASSET_ID]: { amount: '5' },
-      },
-      'account-2': {
-        [ARC_ERC20_USDC_ASSET_ID]: { amount: '0' },
-      },
-    });
-
-    expect(augmentAssetControllersState(state).assetsBalance).toStrictEqual({
-      'account-1': { [ARC_NATIVE_ASSET_ID]: { amount: '5' } },
-      'account-2': {},
-    });
-  });
-
-  it('leaves accounts without the ERC20 USDC asset untouched', () => {
-    const assetsBalance = {
-      'account-1': { [ARC_NATIVE_ASSET_ID]: { amount: '5' } },
-    };
-
-    expect(
-      augmentAssetControllersState(buildState(assetsBalance)).assetsBalance,
-    ).toStrictEqual(assetsBalance);
-  });
-
-  it('does not mutate the original state', () => {
-    const state = buildState({
-      'account-1': { [ARC_ERC20_USDC_ASSET_ID]: { amount: '5' } },
-    });
-
-    augmentAssetControllersState(state);
-
-    expect(state.assetsBalance['account-1']).toHaveProperty(
-      ARC_ERC20_USDC_ASSET_ID,
-    );
-  });
-
-  it('preserves other top-level state keys', () => {
-    const state = {
-      assetsBalance: {},
-      assetsMetadata: { foo: 'bar' },
-    } as unknown as AssetsControllerState;
-
-    expect(augmentAssetControllersState(state)).toStrictEqual(state);
-  });
 });

--- a/ui/components/app/assets/enablement/arc.ts
+++ b/ui/components/app/assets/enablement/arc.ts
@@ -1,6 +1,5 @@
 import { BridgeAsset } from '@metamask/bridge-controller';
 import { hexToNumber, CaipAssetType } from '@metamask/utils';
-import { AssetsControllerState } from '@metamask/assets-controller';
 import {
   ARC_USDC_TOKEN_ADDRESS,
   CHAIN_IDS,
@@ -104,26 +103,4 @@ export function filterOutArcNativeAsset<
  */
 export function isArcTokenUSDC(assetId: CaipAssetType): boolean {
   return assetId === ARC_ERC20_USDC_BRIDGE_ASSET.assetId;
-}
-
-/**
- * Augments the Asset Controller state for Arc-related concerns.
- * Precisely for Arc: Removing ERC20 USDC balances to avoid double counting in balance total.
- * @param assetsControllerState
- * @returns altered (copy) version of assetsControllerState with no ERC20 USDC balance
- */
-export function augmentAssetControllersState(
-  assetsControllerState: AssetsControllerState,
-): AssetsControllerState {
-  return {
-    ...assetsControllerState,
-    assetsBalance: Object.fromEntries(
-      Object.entries(assetsControllerState.assetsBalance).map(
-        ([accountId, assets]) => {
-          const { [ARC_ERC20_USDC_ASSET_ID]: _omit, ...rest } = assets;
-          return [accountId, rest];
-        },
-      ),
-    ),
-  };
 }

--- a/ui/components/app/assets/enablement/networks-customization.test.ts
+++ b/ui/components/app/assets/enablement/networks-customization.test.ts
@@ -1,0 +1,205 @@
+import { AccountGroupAssets } from '@metamask/assets-controllers';
+import { AssetsControllerState } from '@metamask/assets-controller';
+import { CHAIN_IDS } from '../../../../../shared/constants/network';
+import {
+  ARC_USDC_ERC20_TOKEN_ADDRESS,
+  STABLE_USDT0_ERC20_ADDRESS,
+  filterExcludedAssetList,
+  filterExcludedAssets,
+  filterExcludedTokenBalances,
+  augmentAssetControllersState,
+  TokenBalances,
+} from './networks-customization';
+
+const { ARC, STABLE } = CHAIN_IDS;
+const OTHER_TOKEN = '0x1111111111111111111111111111111111111111';
+
+// Independently written (not derived from the module) so a regression in the
+// hex → CAIP conversion is caught rather than mirrored.
+const ARC_USDC_ASSET_ID = `eip155:5042/erc20:${ARC_USDC_ERC20_TOKEN_ADDRESS}`;
+const ARC_NATIVE_ASSET_ID = 'eip155:5042/slip44:60';
+const STABLE_USDT0_ASSET_ID = `eip155:988/erc20:${STABLE_USDT0_ERC20_ADDRESS}`;
+
+describe('networks-customization', () => {
+  describe('filterExcludedAssets', () => {
+    it('removes the excluded ERC-20 on Arc and Stable, keeps other assets', () => {
+      const assets = {
+        [ARC]: [
+          { address: ARC_USDC_ERC20_TOKEN_ADDRESS },
+          { address: OTHER_TOKEN },
+          { symbol: 'USDC' }, // native-style asset without address
+        ],
+        [STABLE]: [{ address: STABLE_USDT0_ERC20_ADDRESS }],
+        '0x1': [{ address: ARC_USDC_ERC20_TOKEN_ADDRESS }],
+      } as unknown as AccountGroupAssets;
+
+      const result = filterExcludedAssets(assets);
+
+      expect(result[ARC]).toStrictEqual([
+        { address: OTHER_TOKEN },
+        { symbol: 'USDC' },
+      ]);
+      expect(result[STABLE]).toStrictEqual([]);
+      // Same address on an unrelated chain is untouched
+      expect(result['0x1']).toStrictEqual([
+        { address: ARC_USDC_ERC20_TOKEN_ADDRESS },
+      ]);
+    });
+
+    it('is case-insensitive on address and chain id', () => {
+      const assets = {
+        [ARC.toUpperCase()]: [
+          { address: ARC_USDC_ERC20_TOKEN_ADDRESS.toUpperCase() },
+        ],
+      } as unknown as AccountGroupAssets;
+
+      expect(Object.values(filterExcludedAssets(assets))[0]).toStrictEqual([]);
+    });
+
+    it('returns the same reference when no chain has exclusions', () => {
+      const assets = {
+        '0x1': [{ address: OTHER_TOKEN }],
+      } as unknown as AccountGroupAssets;
+
+      expect(filterExcludedAssets(assets)).toBe(assets);
+    });
+  });
+
+  describe('filterExcludedTokenBalances', () => {
+    it('strips the excluded balance key only on excluded chains', () => {
+      const tokenBalances = {
+        '0xaccount': {
+          [ARC]: {
+            [ARC_USDC_ERC20_TOKEN_ADDRESS]: '0x1',
+            [OTHER_TOKEN]: '0x2',
+          },
+          '0x1': { [ARC_USDC_ERC20_TOKEN_ADDRESS]: '0x3' },
+        },
+      } as TokenBalances;
+
+      const result = filterExcludedTokenBalances(tokenBalances);
+
+      expect(result['0xaccount'][ARC]).toStrictEqual({ [OTHER_TOKEN]: '0x2' });
+      expect(result['0xaccount']['0x1']).toStrictEqual({
+        [ARC_USDC_ERC20_TOKEN_ADDRESS]: '0x3',
+      });
+    });
+
+    it('is case-insensitive on the balance address key', () => {
+      const tokenBalances = {
+        '0xaccount': {
+          [ARC]: { [ARC_USDC_ERC20_TOKEN_ADDRESS.toUpperCase()]: '0x1' },
+        },
+      } as TokenBalances;
+
+      expect(
+        filterExcludedTokenBalances(tokenBalances)['0xaccount'][ARC],
+      ).toStrictEqual({});
+    });
+
+    it('does not mutate the input', () => {
+      const tokenBalances = {
+        '0xaccount': { [ARC]: { [ARC_USDC_ERC20_TOKEN_ADDRESS]: '0x1' } },
+      } as TokenBalances;
+
+      filterExcludedTokenBalances(tokenBalances);
+
+      expect(tokenBalances['0xaccount'][ARC]).toHaveProperty(
+        ARC_USDC_ERC20_TOKEN_ADDRESS,
+      );
+    });
+  });
+
+  describe('filterExcludedAssetList', () => {
+    it('filters by hex chainId + address', () => {
+      const assets = [
+        { chainId: ARC, address: ARC_USDC_ERC20_TOKEN_ADDRESS },
+        { chainId: ARC, address: OTHER_TOKEN },
+        { chainId: '0x1', address: ARC_USDC_ERC20_TOKEN_ADDRESS },
+      ];
+
+      expect(filterExcludedAssetList(assets)).toStrictEqual([
+        { chainId: ARC, address: OTHER_TOKEN },
+        { chainId: '0x1', address: ARC_USDC_ERC20_TOKEN_ADDRESS },
+      ]);
+    });
+
+    it('filters by CAIP chainId, and by assetId when fields are absent', () => {
+      const assets = [
+        { chainId: 'eip155:5042', address: ARC_USDC_ERC20_TOKEN_ADDRESS },
+        { assetId: ARC_USDC_ASSET_ID },
+        { assetId: STABLE_USDT0_ASSET_ID },
+        { assetId: ARC_NATIVE_ASSET_ID },
+      ];
+
+      expect(filterExcludedAssetList(assets)).toStrictEqual([
+        { assetId: ARC_NATIVE_ASSET_ID },
+      ]);
+    });
+
+    it('passes through non-EVM, unparseable, and chainless assets', () => {
+      const assets = [
+        { assetId: 'bip122:000000000019d6689c085ae165831e93/slip44:0' },
+        { chainId: 'not-a-chain-id', address: ARC_USDC_ERC20_TOKEN_ADDRESS },
+        { address: ARC_USDC_ERC20_TOKEN_ADDRESS }, // no chain info at all
+        { chainId: ARC }, // excluded chain but no resolvable address
+      ];
+
+      expect(filterExcludedAssetList(assets)).toStrictEqual(assets);
+    });
+  });
+
+  describe('augmentAssetControllersState', () => {
+    const buildState = (
+      assetsBalance: Record<string, Record<string, { amount: string }>>,
+    ) => ({ assetsBalance }) as unknown as AssetsControllerState;
+
+    it('removes excluded asset ids (Arc + Stable) from every account', () => {
+      const state = buildState({
+        'account-1': {
+          [ARC_NATIVE_ASSET_ID]: { amount: '5' },
+          [ARC_USDC_ASSET_ID]: { amount: '5' },
+        },
+        'account-2': {
+          [STABLE_USDT0_ASSET_ID]: { amount: '0' },
+        },
+      });
+
+      expect(augmentAssetControllersState(state).assetsBalance).toStrictEqual({
+        'account-1': { [ARC_NATIVE_ASSET_ID]: { amount: '5' } },
+        'account-2': {},
+      });
+    });
+
+    it('is case-insensitive on the asset id', () => {
+      const state = buildState({
+        'account-1': { [ARC_USDC_ASSET_ID.toUpperCase()]: { amount: '5' } },
+      });
+
+      expect(augmentAssetControllersState(state).assetsBalance).toStrictEqual({
+        'account-1': {},
+      });
+    });
+
+    it('does not mutate the original state', () => {
+      const state = buildState({
+        'account-1': { [ARC_USDC_ASSET_ID]: { amount: '5' } },
+      });
+
+      augmentAssetControllersState(state);
+
+      expect(state.assetsBalance['account-1']).toHaveProperty(
+        ARC_USDC_ASSET_ID,
+      );
+    });
+
+    it('preserves other top-level state keys', () => {
+      const state = {
+        assetsBalance: {},
+        assetsMetadata: { foo: 'bar' },
+      } as unknown as AssetsControllerState;
+
+      expect(augmentAssetControllersState(state)).toStrictEqual(state);
+    });
+  });
+});

--- a/ui/components/app/assets/enablement/networks-customization.ts
+++ b/ui/components/app/assets/enablement/networks-customization.ts
@@ -1,0 +1,197 @@
+import { isCaipAssetType, parseCaipAssetType } from '@metamask/utils';
+import { formatChainIdToHex } from '@metamask/bridge-controller';
+import {
+  AccountGroupAssets,
+  TokenBalancesControllerState,
+} from '@metamask/assets-controllers';
+import { AssetsControllerState } from '@metamask/assets-controller';
+import { CHAIN_IDS } from '../../../../../shared/constants/network';
+
+/**
+ * The Arc USDC ERC-20 token contract. On Arc, USDC is the native gas token
+ * and is also exposed through this ERC-20 interface; both share the same
+ * underlying balance. It is hidden across the UI (token list, aggregated
+ * balance, send asset picker) in favour of the native representation to
+ * avoid double-counting.
+ */
+export const ARC_USDC_ERC20_TOKEN_ADDRESS =
+  '0x3600000000000000000000000000000000000000';
+
+/**
+ * The Stable USDT0 ERC-20 token contract. Since Stable v1.2.0, USDT0
+ * (replacing gUSDT) is the native gas token and is also exposed as this
+ * ERC-20. It is hidden across the UI (token list, aggregated balance, send
+ * asset picker) in favour of the native representation to avoid
+ * double-counting.
+ */
+export const STABLE_USDT0_ERC20_ADDRESS =
+  '0x779ded0c9e1022225f8e0630b35a9b54be713736';
+
+// For token visibility in the Asset List + Send picker.
+// Keys and values are normalized to lowercase at module load so all lookups
+// and comparisons are case-insensitive.
+const EXCLUDED_ASSETS_FROM_ASSET_LIST: Record<string, string> =
+  Object.fromEntries(
+    Object.entries({
+      [CHAIN_IDS.ARC]: ARC_USDC_ERC20_TOKEN_ADDRESS,
+      [CHAIN_IDS.STABLE]: STABLE_USDT0_ERC20_ADDRESS,
+    }).map(([chainId, address]) => [
+      chainId.toLowerCase(),
+      address.toLowerCase(),
+    ]),
+  );
+
+const EXCLUDED_ASSET_IDS = new Set(
+  Object.entries(EXCLUDED_ASSETS_FROM_ASSET_LIST).map(
+    ([hexChainId, address]) =>
+      `eip155:${Number.parseInt(hexChainId, 16)}/erc20:${address}`,
+  ),
+);
+
+export function isExcludedAsset(
+  chainId: string,
+  address: string | undefined,
+): boolean {
+  if (!address) {
+    return false;
+  }
+  return getExcludedAddress(chainId) === address.toLowerCase();
+}
+
+function getExcludedAddress(chainId: string): string | undefined {
+  return EXCLUDED_ASSETS_FROM_ASSET_LIST[chainId.toLowerCase()];
+}
+
+export type TokenBalances = TokenBalancesControllerState['tokenBalances'];
+
+/**
+ * Removes excluded homonym ERC-20s (ex: Arc USDC at 0x3600..., Stable USDT0)
+ * from the per-chain asset map so they never appear as duplicates of the
+ * native token. The native token (zero address) is kept, as it is the source
+ * of truth for display on those chains.
+ *
+ * @param assets - Per-chain map of assets keyed by chain ID.
+ * @returns The asset map with excluded ERC-20s removed from affected chains.
+ */
+export function filterExcludedAssets(
+  assets: AccountGroupAssets,
+): AccountGroupAssets {
+  return Object.entries(assets).reduce((acc, [chainId, chainAssets]) => {
+    if (!chainAssets || !getExcludedAddress(chainId)) {
+      return acc;
+    }
+    return {
+      ...acc,
+      [chainId]: chainAssets.filter(
+        (asset) =>
+          !('address' in asset) || !isExcludedAsset(chainId, asset.address),
+      ),
+    };
+  }, assets);
+}
+
+/**
+ * Strips excluded ERC-20s (ex: Arc USDC at 0x3600...) from the nested
+ * account > chain > address balance map - the native token already reflects
+ * those balances, so counting both would double the aggregated balance.
+ * @param tokenBalances
+ */
+export function filterExcludedTokenBalances(
+  tokenBalances: TokenBalances,
+): TokenBalances {
+  return Object.fromEntries(
+    Object.entries(tokenBalances).map(([account, chainMap]) => [
+      account,
+      Object.fromEntries(
+        Object.entries(chainMap).map(([chainId, addressMap]) => {
+          if (!getExcludedAddress(chainId)) {
+            return [chainId, addressMap];
+          }
+          return [
+            chainId,
+            Object.fromEntries(
+              Object.entries(addressMap).filter(
+                ([address]) => !isExcludedAsset(chainId, address),
+              ),
+            ),
+          ];
+        }),
+      ),
+    ]),
+  );
+}
+
+type AssetLike = {
+  chainId?: string | number;
+  assetId?: string;
+  address?: string;
+};
+
+/**
+ * Filters out excluded homonym ERC-20s (ex: Arc USDC at 0x3600...) - display
+ * duplicates of their chain's native gas token.
+ *
+ * Handles hex (0x13b2) and CAIP (eip155:5042) chain ids - falling back to the
+ * assetId's chain part when no chainId field is present - and resolves the
+ * address from the `address` field or the assetId reference.
+ * @param assets
+ */
+export function filterExcludedAssetList<AssetGeneric extends AssetLike>(
+  assets: AssetGeneric[],
+): AssetGeneric[] {
+  return assets.filter((asset) => {
+    const parsed =
+      typeof asset.assetId === 'string' && isCaipAssetType(asset.assetId)
+        ? parseCaipAssetType(asset.assetId)
+        : undefined;
+
+    const rawChainId = asset.chainId ?? parsed?.chainId;
+    if (rawChainId === undefined) {
+      return true;
+    }
+
+    let hexChainId: string;
+    try {
+      hexChainId = formatChainIdToHex(String(rawChainId));
+    } catch {
+      return true; // unparseable chain id → not an excluded chain
+    }
+
+    if (!getExcludedAddress(hexChainId)) {
+      return true;
+    }
+
+    return !isExcludedAsset(
+      hexChainId,
+      asset.address ?? parsed?.assetReference,
+    );
+  });
+}
+
+/**
+ * Augments the Asset Controller state for network customization concerns.
+ * Removes excluded homonym ERC-20 balances (ex: Arc USDC, Stable USDT0) to
+ * avoid double counting in the balance total - the native token already
+ * reflects those balances.
+ * @param assetsControllerState
+ * @returns altered (copy) version of assetsControllerState without excluded balances
+ */
+export function augmentAssetControllersState(
+  assetsControllerState: AssetsControllerState,
+): AssetsControllerState {
+  return {
+    ...assetsControllerState,
+    assetsBalance: Object.fromEntries(
+      Object.entries(assetsControllerState.assetsBalance).map(
+        ([accountId, assets]) => [
+          accountId,
+          Object.fromEntries(
+            Object.entries(assets).filter(
+              ([assetId]) => !EXCLUDED_ASSET_IDS.has(assetId.toLowerCase()),
+            ),
+          ),
+        ],
+      ),
+    ),
+  };
+}

--- a/ui/components/app/assets/token-cell/cells/token-cell-percent-change.tsx
+++ b/ui/components/app/assets/token-cell/cells/token-cell-percent-change.tsx
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { CaipAssetType, Hex } from '@metamask/utils';
 import { Skeleton } from '@metamask/design-system-react';
+import { toChecksumHexAddress } from '@metamask/controller-utils';
 import { getMarketData } from '../../../../../selectors';
 import { TokenFiatDisplayInfo } from '../../types';
 import { PercentageChange } from '../../../../multichain/token-list-item/price/percentage-change';
@@ -23,7 +24,8 @@ export const TokenCellPercentChange = React.memo(
 
     const tokenAddress =
       token.isNative && isEvm
-        ? getNativeTokenAddress(token.chainId as Hex)
+        ? // For custom networks with a slip44, this will be `0x0000...` instead of slip44.
+          getNativeTokenAddress(token.chainId as Hex)
         : token.address;
 
     if (token.isFiatLoading) {
@@ -43,8 +45,9 @@ export const TokenCellPercentChange = React.memo(
       tokenPercentageChange = ((price - comparePrice) / comparePrice) * 100;
     } else {
       tokenPercentageChange = isEvm
-        ? multiChainMarketData?.[token.chainId as Hex]?.[tokenAddress as Hex]
-            ?.pricePercentChange1d
+        ? multiChainMarketData?.[token.chainId as Hex]?.[
+            toChecksumHexAddress(tokenAddress) as Hex
+          ]?.pricePercentChange1d
         : nonEvmConversionRates?.[tokenAddress as CaipAssetType]?.marketData
             ?.pricePercentChange?.P1D;
     }

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.test.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.test.tsx
@@ -13,6 +13,7 @@ import { renderWithProvider } from '../../../../../test/lib/render-helpers-navig
 import mockState from '../../../../../test/data/mock-send-state.json';
 import { AssetType } from '../../../../../shared/constants/transaction';
 import {
+  getAllTokens,
   getNativeCurrencyImage,
   getSelectedAccountCachedBalance,
   getSelectedEvmInternalAccount,
@@ -37,6 +38,11 @@ import {
 import { MultichainNetworks } from '../../../../../shared/constants/multichain/networks';
 import { useMultichainBalances } from '../../../../hooks/useMultichainBalances';
 import { enLocale as messages } from '../../../../../test/lib/i18n-helpers';
+import { CHAIN_IDS } from '../../../../../shared/constants/network';
+import {
+  ARC_USDC_ERC20_TOKEN_ADDRESS,
+  STABLE_USDT0_ERC20_ADDRESS,
+} from '../../../app/assets/enablement/networks-customization';
 import { AssetPickerModal } from './asset-picker-modal';
 import { ERC20Asset } from './types';
 
@@ -330,6 +336,63 @@ describe('AssetPickerModal', () => {
     expect(modalTitle).toBeInTheDocument();
 
     expect(getAllByRole('img')).toHaveLength(1);
+  });
+
+  it('should hide excluded ERC-20 coming from detected tokens', () => {
+    useSelectorMock.mockImplementation((selector) => {
+      switch (selector) {
+        case getMultichainCurrentChainId:
+          return CHAIN_IDS.ARC;
+        case getMultichainNetworkConfigurationsByChainId:
+          return { [CHAIN_IDS.ARC]: { chainId: CHAIN_IDS.ARC } };
+        case getAllTokens:
+          return {
+            [CHAIN_IDS.ARC]: {
+              '0xAddress': [
+                {
+                  address: ARC_USDC_ERC20_TOKEN_ADDRESS,
+                  symbol: 'USDC',
+                  decimals: 6,
+                },
+                { address: '0xother', symbol: 'OTHER', decimals: 18 },
+              ],
+            },
+          };
+        case getSelectedEvmInternalAccount:
+          return { address: '0xAddress' };
+        case getMultichainCurrentCurrency:
+          return 'USD';
+        case getTokenExchangeRates:
+          return {};
+        case getConversionRate:
+          return 1;
+        default:
+          return {};
+      }
+    });
+
+    renderWithProvider(
+      <AssetPickerModal
+        {...defaultProps}
+        onNetworkPickerClick={undefined}
+        isMultiselectEnabled={false}
+        network={
+          {
+            chainId: CHAIN_IDS.ARC,
+            name: 'Arc',
+          } as unknown as NetworkConfiguration
+        }
+        selectedChainIds={[CHAIN_IDS.ARC]}
+      />,
+      store,
+    );
+
+    const { tokenList } = mockAssetList.mock.calls.at(-1)[0];
+    const addresses = tokenList.map((t: { address?: string }) =>
+      t.address?.toLowerCase(),
+    );
+    expect(addresses).not.toContain(ARC_USDC_ERC20_TOKEN_ADDRESS.toLowerCase());
+    expect(addresses).toContain('0xother');
   });
 });
 
@@ -690,5 +753,97 @@ describe('AssetPickerModal token filtering', () => {
 
     expect(mockUseAssetMetadata.mock.calls.at(-1)).toMatchSnapshot();
     expect(mockAssetList.mock.calls.at(-1)).toMatchSnapshot();
+  });
+
+  it('should hide excluded homonym ERC-20s (Arc USDC, Stable USDT0)', () => {
+    mockUseMultichainBalances.mockReturnValue({
+      assetsWithBalance: [
+        {
+          address: '',
+          balance: '100',
+          chainId: CHAIN_IDS.STABLE,
+          decimals: 6,
+          isNative: true,
+          symbol: 'USDT0',
+          type: 'NATIVE',
+        },
+        {
+          address: STABLE_USDT0_ERC20_ADDRESS,
+          balance: '100',
+          chainId: CHAIN_IDS.STABLE,
+          decimals: 6,
+          isNative: false,
+          symbol: 'USDT0',
+          type: 'TOKEN',
+        },
+        {
+          address: ARC_USDC_ERC20_TOKEN_ADDRESS,
+          balance: '50',
+          chainId: CHAIN_IDS.ARC,
+          decimals: 6,
+          isNative: false,
+          symbol: 'USDC',
+          type: 'TOKEN',
+        },
+      ],
+    });
+
+    mockUseAssetMetadata.mockReturnValue(undefined);
+
+    renderWithProvider(
+      <AssetPickerModal
+        {...defaultProps}
+        selectedChainIds={[CHAIN_IDS.STABLE, CHAIN_IDS.ARC]}
+      />,
+    );
+
+    const { tokenList } = mockAssetList.mock.calls.at(-1)[0];
+    const addresses = tokenList.map((token: { address: string }) =>
+      token.address?.toLowerCase(),
+    );
+    expect(addresses).not.toContain(STABLE_USDT0_ERC20_ADDRESS);
+    expect(addresses).not.toContain(ARC_USDC_ERC20_TOKEN_ADDRESS.toLowerCase());
+    expect(
+      tokenList.some(
+        (token: { isNative?: boolean; symbol: string }) =>
+          token.isNative && token.symbol === 'USDT0',
+      ),
+    ).toBe(true);
+  });
+
+  it('should not filter excluded ERC-20s supplied by customTokenListGenerator (bridge/swap exception)', () => {
+    renderWithProvider(
+      <AssetPickerModal
+        {...defaultProps}
+        isMultiselectEnabled={false}
+        network={
+          {
+            chainId: CHAIN_IDS.ARC,
+            name: 'Arc',
+          } as unknown as NetworkConfiguration
+        }
+        selectedChainIds={[CHAIN_IDS.ARC]}
+        customTokenListGenerator={function* () {
+          yield {
+            address: ARC_USDC_ERC20_TOKEN_ADDRESS,
+            balance: '50',
+            chainId: CHAIN_IDS.ARC,
+            decimals: 6,
+            isNative: false,
+            symbol: 'USDC',
+            type: AssetType.token,
+          } as never;
+        }}
+      />,
+    );
+
+    const { tokenList } = mockAssetList.mock.calls.at(-1)[0];
+    expect(
+      tokenList.some(
+        (t: { address?: string }) =>
+          t.address?.toLowerCase() ===
+          ARC_USDC_ERC20_TOKEN_ADDRESS.toLowerCase(),
+      ),
+    ).toBe(true);
   });
 });

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
@@ -39,9 +39,7 @@ import {
 } from '../../../../selectors';
 import { getRenderableTokenData } from '../../../../hooks/useTokensToSearch';
 import {
-  ARC_USDC_TOKEN_ADDRESS,
   CHAIN_ID_TOKEN_IMAGE_MAP,
-  CHAIN_IDS,
   NETWORK_TO_NAME_MAP,
 } from '../../../../../shared/constants/network';
 import { useMultichainBalances } from '../../../../hooks/useMultichainBalances';
@@ -63,6 +61,7 @@ import {
 import { Numeric } from '../../../../../shared/lib/Numeric';
 import { isTronSpecialAsset } from '../../../../../shared/lib/asset-utils';
 
+import { isExcludedAsset } from '../../../app/assets/enablement/networks-customization';
 import { useAssetMetadata } from './hooks/useAssetMetadata';
 import type { ERC20Asset, NativeAsset, AssetWithDisplayData } from './types';
 import AssetList from './AssetList';
@@ -216,19 +215,17 @@ export function AssetPickerModal({
           string?: string;
         })
     > {
-      // On Arc the native gas token IS USDC, so the USDC ERC20 (0x3600…) is a
-      // display duplicate. Hide it from the picker so only the native token is
-      // selectable; native tokens (empty/zero address) are never affected.
+      // Excluded homonym ERC-20s (Arc USDC, Stable USDT0) are display
+      // duplicates of their chain's native gas token. Hide them so only the
+      // native token is selectable. Native tokens (empty address) are never
+      // affected.
       const addToken = (
         symbol: string,
         address?: null | string,
         tokenChainId?: string,
       ) =>
         shouldAddToken(symbol, address, tokenChainId) &&
-        !(
-          tokenChainId === CHAIN_IDS.ARC &&
-          (address ?? '').toLowerCase() === ARC_USDC_TOKEN_ADDRESS
-        );
+        !(tokenChainId && isExcludedAsset(tokenChainId, address ?? undefined));
 
       // Yield multichain tokens with balances
       for (const token of multichainTokensWithBalance) {

--- a/ui/pages/asset/hooks/useHistoricalPrices.test.ts
+++ b/ui/pages/asset/hooks/useHistoricalPrices.test.ts
@@ -266,6 +266,38 @@ describe('useHistoricalPrices', () => {
     });
   });
 
+  describe('when no CAIP asset id can be derived', () => {
+    const currency = 'usd';
+    const timeRange = 'P7D';
+    const state = {
+      ...mockBaseState,
+      metamask: {
+        ...mockBaseState.metamask,
+        internalAccounts: {
+          ...mockBaseState.metamask.internalAccounts,
+          selectedAccount: '81b1ead4-334c-4921-9adf-282fde539752',
+        },
+      },
+    };
+
+    it('does not fetch when the chain id cannot be parsed', async () => {
+      const { result } = renderHookWithProvider(
+        () =>
+          useHistoricalPrices({
+            // @ts-expect-error intentionally malformed chain id
+            chainId: 'garbage',
+            address: '0x458036e7Bc0612e9b207640Dc07Ca7711346AAE5',
+            currency,
+            timeRange,
+          }),
+        state,
+      );
+
+      await waitFor(() => expect(result.current.isFetching).toBe(false));
+      expect(mockPricesFetch).not.toHaveBeenCalled();
+    });
+  });
+
   describe('non-EVM chain (Solana)', () => {
     const chainId = SolScope.Mainnet;
     const address = '8A4AptCThfbuknsbteHgGKXczfJpfjuVA9SLTSGaaLGC';

--- a/ui/pages/asset/hooks/useHistoricalPrices.ts
+++ b/ui/pages/asset/hooks/useHistoricalPrices.ts
@@ -1,6 +1,12 @@
 import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { CaipChainId, Hex, parseCaipAssetType } from '@metamask/utils';
+import { getAssetId } from '@metamask/assets-controllers';
+import {
+  CaipChainId,
+  Hex,
+  isStrictHexString,
+  parseCaipAssetType,
+} from '@metamask/utils';
 // @ts-expect-error suppress CommonJS vs ECMAScript error
 import { Point } from 'chart.js';
 import { API_URLS, GC_TIMES, STALE_TIMES } from '@metamask/core-backend';
@@ -119,19 +125,30 @@ function getV3HistoricalPricesCaipParams(
   chainId: Hex | CaipChainId,
   address: string,
 ): { caipChainId: CaipChainId; assetType: string } | null {
-  const caipAssetType = toAssetId(address, chainId);
-  if (!caipAssetType) {
+  try {
+    // getAssetId re-uses the assets-controllers v3 spot-prices logic and apply on V3 historical-prices
+    const caipAssetType = isStrictHexString(chainId)
+      ? (getAssetId({
+          chainId,
+          tokenAddress: address,
+        }) ?? toAssetId(address, chainId))
+      : toAssetId(address, chainId);
+
+    if (!caipAssetType) {
+      return null;
+    }
+    const {
+      chainId: caipChainId,
+      assetNamespace,
+      assetReference,
+    } = parseCaipAssetType(caipAssetType);
+    return {
+      caipChainId,
+      assetType: `${assetNamespace}:${assetReference}`,
+    };
+  } catch {
     return null;
   }
-  const {
-    chainId: caipChainId,
-    assetNamespace,
-    assetReference,
-  } = parseCaipAssetType(caipAssetType);
-  return {
-    caipChainId,
-    assetType: `${assetNamespace}:${assetReference}`,
-  };
 }
 
 /**

--- a/ui/pages/token-management/token-management.tsx
+++ b/ui/pages/token-management/token-management.tsx
@@ -109,11 +109,8 @@ import {
   AssetType,
   TokenStandard,
 } from '../../../shared/constants/transaction';
-import {
-  ARC_USDC_TOKEN_ADDRESS,
-  CHAIN_IDS,
-} from '../../../shared/constants/network';
 import { useGlobalMenuRouteTransition } from '../routes/global-menu-route-transition';
+import { filterExcludedAssetList } from '../../components/app/assets/enablement/networks-customization';
 
 type ManagedAsset = Parameters<typeof sortAssetsWithPriority>[0][number];
 
@@ -609,21 +606,7 @@ export const TokenManagementPage = () => {
       }),
     );
 
-    // On Arc the native gas token IS USDC, so the USDC ERC20 (0x3600…) is a
-    // display duplicate. Hide it here too — it can re-enter via imported tokens
-    // even though the asset selector already filters it from balances. The
-    // chain id can be hex (0x13b2) or CAIP (eip155:5042) and the address may
-    // only live inside the assetId, so normalize both before comparing.
-    const visibleAssets = dedupedAssets.filter((asset) => {
-      if (normalizeToHexChainId(String(asset.chainId)) !== CHAIN_IDS.ARC) {
-        return true;
-      }
-      const assetAddress =
-        'address' in asset && asset.address
-          ? asset.address
-          : getAssetReferenceFromAssetId(asset.assetId);
-      return assetAddress?.toLowerCase() !== ARC_USDC_TOKEN_ADDRESS;
-    });
+    const visibleAssets = filterExcludedAssetList(dedupedAssets);
 
     const accountAssets = sortAssetsWithPriority(
       visibleAssets,
@@ -691,14 +674,7 @@ export const TokenManagementPage = () => {
 
     // On Arc the native gas token IS USDC, so the USDC ERC20 (0x3600…) is a
     // display duplicate. Drop it from search/browse results too.
-    return results.filter((result) => {
-      const chainPart = String(result.assetId).split('/')[0];
-      if (normalizeToHexChainId(chainPart) !== CHAIN_IDS.ARC) {
-        return true;
-      }
-      const reference = getAssetReferenceFromAssetId(result.assetId);
-      return reference?.toLowerCase() !== ARC_USDC_TOKEN_ADDRESS;
-    });
+    return filterExcludedAssetList(results);
   }, [deferredNormalizedQuery.length, hasQuery, searchResponse?.data]);
   const searchResults = useMemo(
     () => (hasQuery ? apiTokenResults : EMPTY_TOKEN_SEARCH_RESULTS),

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -1,10 +1,8 @@
 import {
-  AccountGroupAssets,
   AssetListState,
   DeFiPositionsControllerState,
   MultichainAssetsControllerState,
   MultichainAssetsRatesControllerState,
-  calculateBalanceChangeForAllWallets,
   calculateBalanceForAllWallets,
   calculateBalanceChangeForAccountGroup,
   selectAssetsBySelectedAccountGroup,
@@ -48,11 +46,7 @@ import type {
 } from '@metamask/assets-controllers';
 import { NetworkEnablementControllerState } from '@metamask/network-enablement-controller';
 import type { RemoteFeatureFlagControllerState } from '@metamask/remote-feature-flag-controller';
-import {
-  ARC_USDC_TOKEN_ADDRESS,
-  CHAIN_IDS,
-  TEST_CHAINS,
-} from '../../shared/constants/network';
+import { TEST_CHAINS } from '../../shared/constants/network';
 import {
   createDeepEqualSelector,
   createParameterizedSelector,
@@ -91,7 +85,12 @@ import {
 } from '../../shared/lib/selectors/assets-migration';
 import { getSelectedInternalAccount } from '../../shared/lib/selectors/accounts';
 import { getPreferences } from '../../shared/lib/selectors/preferences';
-import { augmentAssetControllersState } from '../components/app/assets/enablement/arc';
+import {
+  augmentAssetControllersState,
+  filterExcludedAssets,
+  filterExcludedTokenBalances,
+  filterExcludedAssetList,
+} from '../components/app/assets/enablement/networks-customization';
 import {
   calculateBalanceForAllWallets as calculateBalanceForAllWalletsFromUnified,
   calculateBalanceChangeForAccountGroup as calculateBalanceChangeForAccountGroupFromUnified,
@@ -340,7 +339,7 @@ export const getTokenBalancesEvm = createSelector(
         });
       },
     );
-    return tokensWithBalance;
+    return filterExcludedAssetList(tokensWithBalance);
   },
 );
 
@@ -721,37 +720,14 @@ const selectAccountsStateForBalances = createSelector(
   }),
 );
 
-const ARC_USDC_ERC20_ADDRESS = ARC_USDC_TOKEN_ADDRESS.toLowerCase();
-
 /**
  * Wraps token balances for core balance computations.
  */
 const selectTokenBalancesStateForBalances = createSelector(
   [getTokenBalances],
-  (tokenBalances) => {
-    // Strip the Arc USDC ERC20 (0x3600…) so it is excluded from the aggregated
-    // balance — the native token already reflects the USDC balance on Arc and
-    // is the source of truth, so counting both would double the balance.
-    const result = Object.fromEntries(
-      Object.entries(tokenBalances).map(([account, chainMap]) => [
-        account,
-        Object.fromEntries(
-          Object.entries(chainMap).map(([chainId, addressMap]) => [
-            chainId,
-            chainId === CHAIN_IDS.ARC
-              ? Object.fromEntries(
-                  Object.entries(addressMap).filter(
-                    ([address]) =>
-                      address.toLowerCase() !== ARC_USDC_ERC20_ADDRESS,
-                  ),
-                )
-              : addressMap,
-          ]),
-        ),
-      ]),
-    ) as typeof tokenBalances;
-    return { tokenBalances: result };
-  },
+  (tokenBalances) => ({
+    tokenBalances: filterExcludedTokenBalances(tokenBalances),
+  }),
 );
 
 /**
@@ -1429,42 +1405,17 @@ const getStateForAssetSelector = createSelector(
   },
 );
 
-/**
- * Removes the Arc USDC ERC20 (0x3600…) from the per-chain asset map so it never
- * appears as a duplicate of the native token on Arc. The native token (zero
- * address) is kept, as it is the source of truth for USDC on Arc.
- *
- * @param assets - Per-chain map of assets keyed by chain ID.
- * @returns The asset map with the Arc USDC ERC20 removed from the Arc entry.
- */
-function filterArcUsdcErc20Token(
-  assets: AccountGroupAssets,
-): AccountGroupAssets {
-  const arcAssets = assets[CHAIN_IDS.ARC];
-  if (!arcAssets) {
-    return assets;
-  }
-  return {
-    ...assets,
-    [CHAIN_IDS.ARC]: arcAssets.filter(
-      (asset) =>
-        !('address' in asset) ||
-        asset.address?.toLowerCase() !== ARC_USDC_ERC20_ADDRESS,
-    ),
-  };
-}
-
 export const getAssetsBySelectedAccountGroup = createSelector(
   getStateForAssetSelector,
   (assetListState: AssetListState) =>
-    filterArcUsdcErc20Token(selectAssetsBySelectedAccountGroup(assetListState)),
+    filterExcludedAssets(selectAssetsBySelectedAccountGroup(assetListState)),
 );
 
 export const getAssetsBySelectedAccountGroupIncludingHidden =
   createDeepEqualSelector(
     getStateForAssetSelector,
     (assetListState: AssetListState) =>
-      filterArcUsdcErc20Token(
+      filterExcludedAssets(
         selectAssetsBySelectedAccountGroup({
           ...assetListState,
           allIgnoredTokens: EMPTY_OBJECT,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Primary role of this PR: Fix various issues with some Custom Networks that were enabled.
Secondary role of this PR: Refactor Arc USDC duplication logic, allowing Stable to take advantage of it too.

- Refactor the workarounds made for Arc USDC deduplication to have a set of modifiers located in a new `networks-customization.ts` maintained by Networks.
- Apply the modifiers to Stable USDT0 (same as for Arc USDC).
- (Core, already bumped on `main` but part of this) Unset custom native addresses for networks Rootstock, Stable, and Gnosis as they were pointing to ERC20 that were not actually the native asset.
- `historical-prices` endpoints to leverage `getAssetId` from Assets Controller to call Price API in the same logic as for `spot-prices`.
- Fix network and token logo for Gnosis (formerly xDai)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix multiple issues on enabled networks Rootstock, Stable, and Gnosis.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/WPN-1536

## **Manual testing steps**

For all networks listed below.
1. Check spot price for native asset.
2. Check chart for native asset (in native asset page).
3. Try to custom-add the "corresponding ERC20" in the Token Manager (corresponding to the network).
4. Observe that adding that ERC20 either doesn't work, or appears as distinct token with distinct balance.
5. Observe that the balance total remains correct even after having tried to add the ERC20.
6. Observe that prices also remain after trying to add the ERC20.

Networks to test with their ERC20:
- Arc `0x13b2` -> `0x3600000000000000000000000000000000000000` (two interfaces, one token)
- Stable `0x3dc` -> `0x779ded0c9e1022225f8e0630b35a9b54be713736` (two interfaces, one token)
- Rootstock `0x1e` -> `0x542fda317318ebf1d3deaf76e0b632741a7e677d` (distinct token, not the native)
- Gnosis `0x64` -> `0xe91d153e0b41518a2ce8dd3d7944fa863463a97d` (distinct token - wXDAI, not the native)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how aggregated balances and visible assets are computed wallet-wide; mistakes could double-count or hide the wrong token, though coverage is broad and bridge/swap paths are explicitly exempted.
> 
> **Overview**
> Introduces **`networks-customization`** to hide **homonym ERC-20s** that duplicate native gas on **Arc** (USDC at `0x3600…`) and **Stable** (USDT0 at `0x779d…`) from token lists, send picker, token management, and balance aggregation. Arc-only logic in **`arc.ts`** / **`assets` selectors** is removed in favor of shared **`filterExcludedAssetList`**, **`filterExcludedAssets`**, **`filterExcludedTokenBalances`**, and **`augmentAssetControllersState`** (moved out of `arc.ts`).
> 
> **Send/asset picker** uses **`isExcludedAsset`** for default lists but **does not** filter tokens supplied via **`customTokenListGenerator`** (bridge/swap). **Gnosis** gets separate **network** vs **native token** image URLs plus a new **`gnosis-native.svg`**; **`CHAIN_IDS.STABLE`** is added for exclusions.
> 
> Smaller fixes: **`useHistoricalPrices`** derives CAIP ids with **`getAssetId`** on EVM and skips fetch when the chain id cannot be parsed; **`TokenCellPercentChange`** checksums addresses for EVM market-data lookup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6b90beba4a4b3256e22126557b75e2406056ee0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->