### PR TITLE
feat(assets): show Tron daily resources on asset page

### DIFF
--- a/shared/lib/asset-utils.test.ts
+++ b/shared/lib/asset-utils.test.ts
@@ -21,6 +21,7 @@ import {
   getNativeAssetId,
   isEvmChainId,
   isTronSpecialAsset,
+  isTronStakedAsset,
 } from './asset-utils';
 
 jest.mock('@metamask/multichain-network-controller');
@@ -605,6 +606,40 @@ describe('asset-utils', () => {
       expect(isTronSpecialAsset('0xabc123')).toBe(false);
       expect(isTronSpecialAsset('')).toBe(false);
       expect(isTronSpecialAsset('not-a-caip-id')).toBe(false);
+    });
+  });
+
+  describe('isTronStakedAsset', () => {
+    const tronMainnet = MultichainNetworks.TRON;
+
+    it('returns true for staked-for-energy', () => {
+      expect(
+        isTronStakedAsset(
+          `${tronMainnet}/${TRON_SPECIAL_ASSET_CAIP_TYPES.STAKED_FOR_ENERGY}` as CaipAssetType,
+        ),
+      ).toBe(true);
+    });
+
+    it('returns true for staked-for-bandwidth', () => {
+      expect(
+        isTronStakedAsset(
+          `${tronMainnet}/${TRON_SPECIAL_ASSET_CAIP_TYPES.STAKED_FOR_BANDWIDTH}` as CaipAssetType,
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false for energy resource assets', () => {
+      expect(
+        isTronStakedAsset(
+          `${tronMainnet}/${TRON_SPECIAL_ASSET_CAIP_TYPES.ENERGY}` as CaipAssetType,
+        ),
+      ).toBe(false);
+    });
+
+    it('returns false for native TRX', () => {
+      expect(
+        isTronStakedAsset(`${tronMainnet}/slip44:195` as CaipAssetType),
+      ).toBe(false);
     });
   });
 });

--- a/shared/lib/asset-utils.ts
+++ b/shared/lib/asset-utils.ts
@@ -22,6 +22,7 @@ import {
 
 import { MultichainNetworks } from '../constants/multichain/networks';
 import {
+  TRON_SPECIAL_ASSET_CAIP_TYPES,
   TRON_SPECIAL_ASSET_CAIP_TYPES_SET,
   type TronSpecialAssetCaipType,
 } from '../constants/multichain/assets';
@@ -325,16 +326,31 @@ export const isTronSpecialAsset = (
   );
 };
 
+const TRON_STAKED_ASSET_CAIP_TYPES_SET: ReadonlySet<TronSpecialAssetCaipType> =
+  new Set([
+    TRON_SPECIAL_ASSET_CAIP_TYPES.STAKED_FOR_ENERGY,
+    TRON_SPECIAL_ASSET_CAIP_TYPES.STAKED_FOR_BANDWIDTH,
+  ]);
+
 /**
- * Returns the chain ID from a CAIP asset ID
- *
- * @param assetId - The CAIP asset ID to get the chain ID from.
- * @returns The chain ID from the CAIP asset ID.
+ * Checks if the given CAIP asset ID represents staked TRX (frozen for energy
+ * or bandwidth). These are shown on the native TRX asset details page but
+ * filtered from portfolio lists.
+ * @param assetId
  */
-export function getChainIdFromAssetId(
-  assetId: CaipAssetType,
-): CaipChainId | undefined {
-  return CaipAssetTypeStruct.is(assetId)
-    ? parseCaipAssetType(assetId).chainId
-    : undefined;
-}
+export const isTronStakedAsset = (
+  assetId: CaipAssetType | string | undefined,
+): boolean => {
+  if (!assetId || !isCaipAssetType(assetId)) {
+    return false;
+  }
+  const { chain, assetNamespace, assetReference } = parseCaipAssetType(assetId);
+
+  if (chain.namespace !== KnownCaipNamespace.Tron) {
+    return false;
+  }
+
+  return TRON_STAKED_ASSET_CAIP_TYPES_SET.has(
+    `${assetNamespace}:${assetReference}` as TronSpecialAssetCaipType,
+  );
+};

--- a/ui/pages/asset/components/asset-page.tsx
+++ b/ui/pages/asset/components/asset-page.tsx
@@ -35,7 +35,8 @@ import React, { ReactNode, useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
 import { AssetType } from '../../../../shared/constants/transaction';
-import { isEvmChainId, toAssetId } from '../../../../shared/lib/asset-utils';
+import { TRON_SPECIAL_ASSET_CAIP_TYPES } from '../../../../shared/constants/multichain/assets';
+import { isEvmChainId, isTronStakedAsset, toAssetId } from '../../../../shared/lib/asset-utils';
 import { endTrace, TraceName } from '../../../../shared/lib/trace';
 import { hexToDecimal } from '../../../../shared/lib/conversion.utils';
 import { toChecksumHexAddress } from '../../../../shared/lib/hexstring-utils';
@@ -69,6 +70,7 @@ import {
 import {
   getAsset,
   getAssetsBySelectedAccountGroup,
+  getAssetsBySelectedAccountGroupWithTronSpecialAssets,
   getMultichainNativeAssetType,
 } from '../../../selectors/assets';
 import {
@@ -104,6 +106,20 @@ import { MusdBonusSection } from './musd-bonus-section';
 import { MusdConvertSection } from './musd-convert-section';
 import { MusdPositionSection } from './musd-position-section';
 
+const getTronStakedBalanceRowTestId = (assetId: CaipAssetType): string => {
+  const { assetNamespace, assetReference } = parseCaipAssetType(assetId);
+  const caipType = `${assetNamespace}:${assetReference}`;
+
+  switch (caipType) {
+    case TRON_SPECIAL_ASSET_CAIP_TYPES.STAKED_FOR_ENERGY:
+      return 'tron-staked-balance-row-energy';
+    case TRON_SPECIAL_ASSET_CAIP_TYPES.STAKED_FOR_BANDWIDTH:
+      return 'tron-staked-balance-row-bandwidth';
+    default:
+      return 'tron-staked-balance-row';
+  }
+};
+
 // TODO BIP44 Refactor: BIP-44 has been enabled and is stable, this page needs a significant refactor to remove confusing branching logic
 const AssetPage = ({
   asset,
@@ -120,6 +136,9 @@ const AssetPage = ({
   // TODO BIP44 Refactor: This selector does not work with BIP44 enabled, pass the information in the asset object
   const nativeAssetType = useSelector(getMultichainNativeAssetType);
   const accountGroupIdAssets = useSelector(getAssetsBySelectedAccountGroup);
+  const accountGroupAssetsWithTronSpecial = useSelector(
+    getAssetsBySelectedAccountGroupWithTronSpecialAssets,
+  );
   const caipChainId = isCaipChainId(asset.chainId)
     ? asset.chainId
     : formatChainIdToCaip(asset.chainId);
@@ -286,6 +305,19 @@ const AssetPage = ({
   const isTron = useMultichainSelector(getMultichainIsTron, selectedAccount);
   const showTronResources = isTron && type === AssetType.native;
 
+  const tronStakedBalanceAssets = useMemo(() => {
+    if (!showTronResources) {
+      return [];
+    }
+
+    return (accountGroupAssetsWithTronSpecial[chainId] ?? []).filter(
+      (groupAsset) =>
+        isTronStakedAsset(groupAsset.assetId) &&
+        groupAsset.balance !== '0' &&
+        groupAsset.balance !== undefined,
+    );
+  }, [showTronResources, accountGroupAssetsWithTronSpecial, chainId]);
+
   const isUpdatedAssetNative = isNativeAsset(updatedAsset);
   const tokenAsset = isUpdatedAssetNative ? null : updatedAsset;
   const isMusdAssetPage =
@@ -443,6 +475,39 @@ const AssetPage = ({
                 musd={ASSET_OVERVIEW_TOKEN_CELL_MUSD_OPTIONS}
               />
             )}
+            {tronStakedBalanceAssets.map((stakedAsset) => {
+              const stakedBalance = stakedAsset.balance ?? '0';
+              const stakedFiatAmount = stakedAsset.fiat?.balance ?? 0;
+
+              return (
+                <Box
+                  key={stakedAsset.assetId}
+                  data-testid={getTronStakedBalanceRowTestId(
+                    stakedAsset.assetId as CaipAssetType,
+                  )}
+                >
+                  <TokenCell
+                    token={{
+                      address: stakedAsset.assetId as Hex,
+                      chainId,
+                      symbol: stakedAsset.symbol,
+                      image: stakedAsset.image,
+                      title: stakedAsset.name ?? stakedAsset.symbol,
+                      tokenFiatAmount: showFiat ? stakedFiatAmount : null,
+                      string: stakedBalance ? stakedBalance.toString() : '',
+                      decimals: stakedAsset.decimals,
+                      aggregators: [],
+                      isNative: false,
+                      balance: stakedBalance,
+                      secondary: stakedBalance ? Number(stakedBalance) : 0,
+                      accountType: stakedAsset.accountType,
+                      assetId: stakedAsset.assetId,
+                    }}
+                    safeChains={safeChains}
+                  />
+                </Box>
+              );
+            })}
           </>
         )}
         {/* mUSD Conversion CTA - shows for eligible stablecoins */}

--- a/ui/pages/asset/components/asset-page.tsx
+++ b/ui/pages/asset/components/asset-page.tsx
@@ -36,7 +36,11 @@ import { useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
 import { AssetType } from '../../../../shared/constants/transaction';
 import { TRON_SPECIAL_ASSET_CAIP_TYPES } from '../../../../shared/constants/multichain/assets';
-import { isEvmChainId, isTronStakedAsset, toAssetId } from '../../../../shared/lib/asset-utils';
+import {
+  isEvmChainId,
+  isTronStakedAsset,
+  toAssetId,
+} from '../../../../shared/lib/asset-utils';
 import { endTrace, TraceName } from '../../../../shared/lib/trace';
 import { hexToDecimal } from '../../../../shared/lib/conversion.utils';
 import { toChecksumHexAddress } from '../../../../shared/lib/hexstring-utils';


### PR DESCRIPTION
## **Description**

Adds production UI support for Tron daily resources on the asset page (`asset-utils`, `asset-page`). This is the first step of a linear stack that adds the Tron assets E2E cluster; together with the follow-up E2E PRs it supersedes #43662.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of the local-blockchain E2E initiative (WPN-536).
Together with the Tron assets E2E PRs supersedes #43662.

## **Manual testing steps**

1. Run the extension with a Tron account that has daily resources.
2. Open the TRX asset page.
3. Verify the daily resources section renders with energy and bandwidth values.

## **Screenshots/Recordings**

N/A — production UI support for E2E coverage.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.