### PR TITLE
test(e2e): add Tron send E2E cluster with local node

### DIFF
--- a/test/e2e/page-objects/flows/tron-network.flow.ts
+++ b/test/e2e/page-objects/flows/tron-network.flow.ts
@@ -1,0 +1,19 @@
+import { Driver } from '../../webdriver/driver';
+import NetworkManager from '../pages/network-manager';
+
+/**
+ * Selects the Tron network from the Network Manager Popular tab and waits for
+ * any leftover modal backdrop to clear so subsequent clicks are not blocked.
+ *
+ * @param driver - WebDriver instance
+ */
+export async function selectTronNetwork(driver: Driver): Promise<void> {
+  const networkManager = new NetworkManager(driver);
+  await networkManager.openNetworkManager();
+  await networkManager.selectTab('Popular');
+  await networkManager.selectNetworkByNameWithWait('Tron');
+
+  // Network Manager close transitions can leave an orphan backdrop that blocks
+  // Selenium clicks even after the modal itself has gone away.
+  await driver.assertElementNotPresent('.modal__backdrop');
+}

--- a/test/e2e/page-objects/flows/tron-network.flow.ts
+++ b/test/e2e/page-objects/flows/tron-network.flow.ts
@@ -1,8 +1,8 @@
-import { Driver } from "../../webdriver/driver";
+import { Driver } from '../../webdriver/driver';
 import {
   switchToNetworkFromNetworkSelect,
   waitForNetworkManagerBackdropToClear,
-} from "./network.flow";
+} from './network.flow';
 
 /**
  * Selects the Tron network from the Network Manager Popular tab and waits for
@@ -14,6 +14,6 @@ import {
  * @param driver - WebDriver instance
  */
 export async function selectTronNetwork(driver: Driver): Promise<void> {
-  await switchToNetworkFromNetworkSelect(driver, "Popular", "Tron");
+  await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Tron');
   await waitForNetworkManagerBackdropToClear(driver);
 }

--- a/test/e2e/page-objects/flows/tron-send.flow.ts
+++ b/test/e2e/page-objects/flows/tron-send.flow.ts
@@ -1,0 +1,45 @@
+import { Driver } from '../../webdriver/driver';
+import NonEvmHomepage from '../pages/home/non-evm-homepage';
+import SendPage from '../pages/send/send-page';
+import { TRON_CHAIN_ID } from '../../tests/tron/mocks/common-tron';
+import { login } from './login.flow';
+import { selectTronNetwork } from './tron-network.flow';
+
+export async function landOnTronSendScreen({
+  driver,
+  symbol,
+  assetId,
+  expectedNativeBalance = '6.072',
+}: {
+  driver: Driver;
+  symbol: 'TRX' | 'USDT' | 'USDD' | 'HTX' | 'SEED';
+  assetId?: string;
+  expectedNativeBalance?: string | null;
+}): Promise<SendPage> {
+  await login(driver, { validateBalance: false });
+  await selectTronNetwork(driver);
+
+  const home = new NonEvmHomepage(driver);
+  await home.checkPageIsLoaded();
+  // Wait for the live TRX balance to land on the homepage before navigating to
+  // Send. Without this gate, Send opens with the cached "0 TRX available" and
+  // every amount renders "Insufficient funds", leaving the Continue button
+  // disabled. The local Tron node is seeded with 6.072 TRX in profiles.ts.
+  if (expectedNativeBalance) {
+    await home.checkExpectedTokenBalanceIsDisplayed(
+      expectedNativeBalance,
+      'TRX',
+    );
+  }
+
+  const sendPage = new SendPage(driver);
+  const searchParams = new URLSearchParams({ chainId: TRON_CHAIN_ID });
+  if (assetId) {
+    searchParams.set('asset', assetId);
+  }
+  await driver.openNewURL(
+    `${driver.extensionUrl}/home.html#/send/amount-recipient?${searchParams.toString()}`,
+  );
+  await sendPage.checkSendFormIsLoaded();
+  return sendPage;
+}

--- a/test/e2e/page-objects/flows/tron-send.flow.ts
+++ b/test/e2e/page-objects/flows/tron-send.flow.ts
@@ -1,4 +1,7 @@
 import { Driver } from '../../webdriver/driver';
+import SnapTransactionConfirmation from '../pages/confirmations/snap-transaction-confirmation';
+import ActivityTab from '../pages/home/activity-tab';
+import HomePage from '../pages/home/homepage';
 import NonEvmHomepage from '../pages/home/non-evm-homepage';
 import SendPage from '../pages/send/send-page';
 import { TRON_CHAIN_ID } from '../../tests/tron/mocks/common-tron';
@@ -46,4 +49,28 @@ export async function landOnTronSendScreen({
   );
   await sendPage.checkSendFormIsLoaded();
   return sendPage;
+}
+
+export async function confirmTronSendAndAssertActivity({
+  driver,
+  expectedAmount,
+}: {
+  driver: Driver;
+  expectedAmount?: string;
+}): Promise<void> {
+  const snapConfirmation = new SnapTransactionConfirmation(driver);
+  await snapConfirmation.checkPageIsLoaded();
+  await snapConfirmation.clickFooterConfirmButton();
+
+  const homePage = new HomePage(driver);
+  // Same mitigation as BTC Bug #43641: confirm may leave Assets/Home selected.
+  await homePage.goToActivityList();
+
+  const activityList = new ActivityTab(driver);
+  await activityList.checkPendingTxNumberDisplayedInActivity(1);
+  await activityList.checkConfirmedTxNumberDisplayedInActivity(1);
+  if (expectedAmount) {
+    await activityList.checkTxAmountInActivity(expectedAmount, 1);
+  }
+  await activityList.checkNoFailedTransactions();
 }

--- a/test/e2e/page-objects/flows/tron-send.flow.ts
+++ b/test/e2e/page-objects/flows/tron-send.flow.ts
@@ -91,10 +91,7 @@ export async function confirmTronSendAndAssertActivity({
   let usingDialog = false;
 
   try {
-    await driver.waitForWindowWithTitleToBePresent(
-      WINDOW_TITLES.Dialog,
-      5_000,
-    );
+    await driver.waitForWindowWithTitleToBePresent(WINDOW_TITLES.Dialog, 5_000);
     await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
     usingDialog = true;
   } catch {

--- a/test/e2e/page-objects/flows/tron-send.flow.ts
+++ b/test/e2e/page-objects/flows/tron-send.flow.ts
@@ -1,18 +1,18 @@
-import { Driver } from "../../webdriver/driver";
-import NonEvmHomepage from "../pages/home/non-evm-homepage";
-import SendPage from "../pages/send/send-page";
-import { TRON_CHAIN_ID } from "../../tests/tron/mocks/common-tron";
-import { login } from "./login.flow";
-import { selectTronNetwork } from "./tron-network.flow";
+import { Driver } from '../../webdriver/driver';
+import NonEvmHomepage from '../pages/home/non-evm-homepage';
+import SendPage from '../pages/send/send-page';
+import { TRON_CHAIN_ID } from '../../tests/tron/mocks/common-tron';
+import { login } from './login.flow';
+import { selectTronNetwork } from './tron-network.flow';
 
 export async function landOnTronSendScreen({
   driver,
   symbol,
   assetId,
-  expectedNativeBalance = "6.072",
+  expectedNativeBalance = '6.072',
 }: {
   driver: Driver;
-  symbol: "TRX" | "USDT" | "USDD" | "HTX" | "SEED";
+  symbol: 'TRX' | 'USDT' | 'USDD' | 'HTX' | 'SEED';
   assetId?: string;
   expectedNativeBalance?: string | null;
 }): Promise<SendPage> {
@@ -30,13 +30,16 @@ export async function landOnTronSendScreen({
   // every amount renders "Insufficient funds", leaving the Continue button
   // disabled. The local Tron node is seeded with 6.072 TRX in profiles.ts.
   if (expectedNativeBalance) {
-    await home.checkExpectedTokenBalanceIsDisplayed(expectedNativeBalance, "TRX");
+    await home.checkExpectedTokenBalanceIsDisplayed(
+      expectedNativeBalance,
+      'TRX',
+    );
   }
 
   const sendPage = new SendPage(driver);
   const searchParams = new URLSearchParams({ chainId: TRON_CHAIN_ID });
   if (assetId) {
-    searchParams.set("asset", assetId);
+    searchParams.set('asset', assetId);
   }
   await driver.openNewURL(
     `${driver.extensionUrl}/home.html#/send/amount-recipient?${searchParams.toString()}`,

--- a/test/e2e/page-objects/flows/tron-send.flow.ts
+++ b/test/e2e/page-objects/flows/tron-send.flow.ts
@@ -1,3 +1,4 @@
+import { WINDOW_TITLES } from '../../constants';
 import { Driver } from '../../webdriver/driver';
 import SnapTransactionConfirmation from '../pages/confirmations/snap-transaction-confirmation';
 import ActivityTab from '../pages/home/activity-tab';
@@ -8,16 +9,22 @@ import { TRON_CHAIN_ID } from '../../tests/tron/mocks/common-tron';
 import { login } from './login.flow';
 import { selectTronNetwork } from './tron-network.flow';
 
+const TRON_CONFIRM_TIMEOUT_MS = 30_000;
+const TRON_ACTIVITY_PENDING_OR_CONFIRMED_SELECTOR =
+  '[data-tx-status="submitted"], [data-tx-status="approved"], [data-tx-status="unapproved"], [data-tx-status="pending"], [data-tx-status="confirmed"]';
+
 export async function landOnTronSendScreen({
   driver,
   symbol,
   assetId,
   expectedNativeBalance = '6.072',
+  expectedTokenBalance,
 }: {
   driver: Driver;
   symbol: 'TRX' | 'USDT' | 'USDD' | 'HTX' | 'SEED';
   assetId?: string;
   expectedNativeBalance?: string | null;
+  expectedTokenBalance?: string;
 }): Promise<SendPage> {
   await login(driver, { validateBalance: false });
   await selectTronNetwork(driver);
@@ -38,6 +45,12 @@ export async function landOnTronSendScreen({
       'TRX',
     );
   }
+  if (expectedTokenBalance) {
+    await home.checkExpectedTokenBalanceIsDisplayed(
+      expectedTokenBalance,
+      symbol,
+    );
+  }
 
   const sendPage = new SendPage(driver);
   const searchParams = new URLSearchParams({ chainId: TRON_CHAIN_ID });
@@ -51,6 +64,21 @@ export async function landOnTronSendScreen({
   return sendPage;
 }
 
+async function waitForTronSendActivity(driver: Driver): Promise<void> {
+  // Local java-tron can confirm before a pending row is observable.
+  console.log('Waiting for Tron send activity (pending or confirmed)');
+  await driver.wait(async () => {
+    try {
+      const activityItems = await driver.findElements(
+        TRON_ACTIVITY_PENDING_OR_CONFIRMED_SELECTOR,
+      );
+      return activityItems.length >= 1;
+    } catch {
+      return false;
+    }
+  }, 30_000);
+}
+
 export async function confirmTronSendAndAssertActivity({
   driver,
   expectedAmount,
@@ -59,15 +87,37 @@ export async function confirmTronSendAndAssertActivity({
   expectedAmount?: string;
 }): Promise<void> {
   const snapConfirmation = new SnapTransactionConfirmation(driver);
-  await snapConfirmation.checkPageIsLoaded();
-  await snapConfirmation.clickFooterConfirmButton();
+  const extensionHandle = await driver.driver.getWindowHandle();
+  let usingDialog = false;
+
+  try {
+    await driver.waitForWindowWithTitleToBePresent(
+      WINDOW_TITLES.Dialog,
+      5_000,
+    );
+    await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
+    usingDialog = true;
+  } catch {
+    // Unified send may render confirmation inline in the extension popup.
+  }
+
+  await snapConfirmation.checkPageIsLoaded({
+    timeout: TRON_CONFIRM_TIMEOUT_MS,
+  });
+
+  if (usingDialog) {
+    await snapConfirmation.clickFooterConfirmButtonAndWaitForWindowToClose();
+    await driver.switchToWindow(extensionHandle);
+  } else {
+    await snapConfirmation.clickFooterConfirmButton();
+  }
 
   const homePage = new HomePage(driver);
   // Same mitigation as BTC Bug #43641: confirm may leave Assets/Home selected.
   await homePage.goToActivityList();
 
   const activityList = new ActivityTab(driver);
-  await activityList.checkPendingTxNumberDisplayedInActivity(1);
+  await waitForTronSendActivity(driver);
   await activityList.checkConfirmedTxNumberDisplayedInActivity(1);
   if (expectedAmount) {
     await activityList.checkTxAmountInActivity(expectedAmount, 1);

--- a/test/e2e/page-objects/pages/confirmations/snap-transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/snap-transaction-confirmation.ts
@@ -49,8 +49,7 @@ class SnapTransactionConfirmation {
     timeout,
   }: { timeout?: number } = {}): Promise<void> {
     try {
-      const waitOptions =
-        timeout === undefined ? undefined : { timeout };
+      const waitOptions = timeout === undefined ? undefined : { timeout };
       await this.driver.waitForMultipleSelectors(
         [this.header, this.cancelButton, this.confirmButton],
         waitOptions,

--- a/test/e2e/page-objects/pages/confirmations/snap-transaction-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/snap-transaction-confirmation.ts
@@ -45,13 +45,16 @@ class SnapTransactionConfirmation {
     );
   }
 
-  async checkPageIsLoaded(): Promise<void> {
+  async checkPageIsLoaded({
+    timeout,
+  }: { timeout?: number } = {}): Promise<void> {
     try {
-      await this.driver.waitForMultipleSelectors([
-        this.header,
-        this.cancelButton,
-        this.confirmButton,
-      ]);
+      const waitOptions =
+        timeout === undefined ? undefined : { timeout };
+      await this.driver.waitForMultipleSelectors(
+        [this.header, this.cancelButton, this.confirmButton],
+        waitOptions,
+      );
     } catch (e) {
       console.log(
         'Timeout while waiting for snap transaction confirmation page to be loaded',

--- a/test/e2e/page-objects/pages/send/send-page.ts
+++ b/test/e2e/page-objects/pages/send/send-page.ts
@@ -16,6 +16,11 @@ class SendPage {
   private readonly continueButtonEnabled =
     '[data-testid="send-continue-button"]:not([disabled])';
 
+  private readonly continueButtonError = (errorText: string) => ({
+    css: '[data-testid="send-continue-button"]',
+    text: errorText,
+  });
+
   private readonly driver: Driver;
 
   private readonly header = {
@@ -82,6 +87,10 @@ class SendPage {
     return {
       testId: `token-asset-${chainId}-${symbol}`,
     };
+  };
+
+  private readonly transactionError = {
+    text: 'Transaction error. Exception thrown in contract code.',
   };
 
   constructor(driver: Driver) {
@@ -235,6 +244,18 @@ class SendPage {
   async checkSolanaNetworkIsPresent(): Promise<void> {
     console.log('Checking if Solana network is present');
     await this.driver.findElement(this.solanaNetwork);
+  }
+
+  /**
+   * Waits for a non-EVM submit validation error on the Continue button after
+   * Continue is pressed with an invalid amount (Tron shows transactionError
+   * copy on the button rather than inline "Required").
+   */
+  async checkTransactionError(): Promise<void> {
+    console.log('Checking for transaction error');
+    await this.driver.waitForSelector(
+      this.continueButtonError(this.transactionError.text),
+    );
   }
 
   async checkWarningMessage(warningText: string): Promise<void> {

--- a/test/e2e/page-objects/pages/send/send-page.ts
+++ b/test/e2e/page-objects/pages/send/send-page.ts
@@ -1,52 +1,53 @@
-import { Driver } from "../../../webdriver/driver";
+import { Driver } from '../../../webdriver/driver';
 
 class SendPage {
-  private readonly amountBalance = { testId: "send-amount-balance" };
+  private readonly amountBalance = { testId: 'send-amount-balance' };
 
-  private readonly amountFiatValue = { testId: "send-amount-fiat-value" };
+  private readonly amountFiatValue = { testId: 'send-amount-fiat-value' };
 
-  private readonly amountInput = { testId: "send-amount-input" };
+  private readonly amountInput = { testId: 'send-amount-input' };
 
   private readonly amountRequiredError = {
-    text: "Required",
+    text: 'Required',
   };
 
-  private readonly continueButton = { testId: "send-continue-button" };
+  private readonly continueButton = { testId: 'send-continue-button' };
 
-  private readonly continueButtonEnabled = '[data-testid="send-continue-button"]:not([disabled])';
+  private readonly continueButtonEnabled =
+    '[data-testid="send-continue-button"]:not([disabled])';
 
   private readonly driver: Driver;
 
   private readonly header = {
-    tag: "h4",
-    text: "Send",
+    tag: 'h4',
+    text: 'Send',
   };
 
   private readonly hexDataInput = '[placeholder="Enter hex data (optional)"]';
 
   private readonly inputRecipient = {
-    testId: "recipient-address-input",
+    testId: 'recipient-address-input',
   };
 
   private readonly insufficientBalanceToCoverFeesError = {
-    text: "Insufficient balance to cover fees",
+    text: 'Insufficient balance to cover fees',
   };
 
   private readonly insufficientFundsError = {
-    text: "Insufficient funds",
+    text: 'Insufficient funds',
   };
 
   private readonly insufficientFundsErrorDetailed = {
-    text: "Insufficient funds",
+    text: 'Insufficient funds',
   };
 
   private readonly invalidAddressError = {
-    text: "Invalid address",
+    text: 'Invalid address',
   };
 
   private readonly maxButton = {
-    text: "Max",
-    tag: "button",
+    text: 'Max',
+    tag: 'button',
   };
 
   private readonly networkName = (networkName: string) => {
@@ -56,17 +57,17 @@ class SendPage {
   };
 
   private readonly networkPicker = {
-    testId: "send-network-filter-toggle",
+    testId: 'send-network-filter-toggle',
   };
 
-  private readonly recipientClassRendered = ".break-all";
+  private readonly recipientClassRendered = '.break-all';
 
   private readonly recipientModalButton = {
-    testId: "open-recipient-modal-btn",
+    testId: 'open-recipient-modal-btn',
   };
 
   private readonly recipientValidationError = (errorText: string) => ({
-    css: ".mm-help-text",
+    css: '.mm-help-text',
     text: errorText,
   });
 
@@ -74,7 +75,7 @@ class SendPage {
     '[data-testid="send-alert-modal-acknowledge-button"]';
 
   private readonly solanaNetwork = {
-    text: "Solana",
+    text: 'Solana',
   };
 
   private readonly tokenAsset = (chainId: string, symbol: string) => {
@@ -97,13 +98,13 @@ class SendPage {
         timeout: 2000,
       });
     } catch (error) {
-      if ((error as { name?: string }).name === "TimeoutError") {
-        console.log("No send alert modal to acknowledge");
+      if ((error as { name?: string }).name === 'TimeoutError') {
+        console.log('No send alert modal to acknowledge');
         return;
       }
       throw error;
     }
-    console.log("Acknowledging send alert modal");
+    console.log('Acknowledging send alert modal');
     await this.driver.clickElement(this.sendAlertAcknowledgeButton);
   }
 
@@ -118,7 +119,7 @@ class SendPage {
     await this.driver.waitUntil(
       async () => {
         const inputElement = await this.driver.findElement(this.amountInput);
-        const value = await inputElement.getAttribute("value");
+        const value = await inputElement.getAttribute('value');
         return parseFloat(value) === parseFloat(expectedAmount);
       },
       { interval: 100, timeout: 5000 },
@@ -126,7 +127,7 @@ class SendPage {
   }
 
   async checkAmountRequiredError(): Promise<void> {
-    console.log("Checking for amount required error");
+    console.log('Checking for amount required error');
     await this.driver.waitForSelector(this.amountRequiredError);
   }
 
@@ -136,7 +137,11 @@ class SendPage {
    * @param options - Wait options.
    * @param options.state - Expected button state (`enabled` or `disabled`).
    */
-  async checkContinueButton({ state }: { state: "enabled" | "disabled" }): Promise<void> {
+  async checkContinueButton({
+    state,
+  }: {
+    state: 'enabled' | 'disabled';
+  }): Promise<void> {
     console.log(`Waiting for continue button to be ${state}`);
     await this.driver.waitForSelector(this.continueButton, {
       state,
@@ -144,8 +149,8 @@ class SendPage {
   }
 
   async checkContinueButtonIsDisabled(): Promise<void> {
-    console.log("Checking that Continue button is disabled");
-    await this.checkContinueButton({ state: "disabled" });
+    console.log('Checking that Continue button is disabled');
+    await this.checkContinueButton({ state: 'disabled' });
   }
 
   /**
@@ -155,7 +160,10 @@ class SendPage {
    * @param address - The Ethereum address to which the ENS domain is expected to resolve.
    * @returns A promise that resolves if the ENS domain successfully resolves to the specified address on send token screen.
    */
-  async checkEnsAddressResolution(ensDomain: string, address: string): Promise<void> {
+  async checkEnsAddressResolution(
+    ensDomain: string,
+    address: string,
+  ): Promise<void> {
     console.log(
       `Check ENS domain resolution: '${ensDomain}' should resolve to address '${address}' on the send token screen.`,
     );
@@ -173,17 +181,17 @@ class SendPage {
   }
 
   async checkInsufficientFundsError(): Promise<void> {
-    console.log("Checking for insufficient funds error");
+    console.log('Checking for insufficient funds error');
     await this.driver.waitForSelector(this.insufficientFundsError);
   }
 
   async checkInsufficientFundsErrorDetailed(): Promise<void> {
-    console.log("Checking for detailed insufficient funds error");
+    console.log('Checking for detailed insufficient funds error');
     await this.driver.waitForSelector(this.insufficientFundsErrorDetailed);
   }
 
   async checkInvalidAddressError(): Promise<void> {
-    console.log("Checking for invalid address error");
+    console.log('Checking for invalid address error');
     await this.driver.waitForSelector(this.invalidAddressError);
   }
 
@@ -192,14 +200,17 @@ class SendPage {
   }
 
   async checkPageIsLoaded(): Promise<void> {
-    console.log("Checking if send page is loaded");
+    console.log('Checking if send page is loaded');
     try {
-      await this.driver.waitForMultipleSelectors([this.header, this.networkPicker]);
+      await this.driver.waitForMultipleSelectors([
+        this.header,
+        this.networkPicker,
+      ]);
     } catch (e) {
-      console.log("Timeout while waiting for send page to be loaded", e);
+      console.log('Timeout while waiting for send page to be loaded', e);
       throw e;
     }
-    console.log("Send page is loaded");
+    console.log('Send page is loaded');
   }
 
   /**
@@ -215,11 +226,14 @@ class SendPage {
   }
 
   async checkSendFormIsLoaded(): Promise<void> {
-    await this.driver.waitForMultipleSelectors([this.amountInput, this.inputRecipient]);
+    await this.driver.waitForMultipleSelectors([
+      this.amountInput,
+      this.inputRecipient,
+    ]);
   }
 
   async checkSolanaNetworkIsPresent(): Promise<void> {
-    console.log("Checking if Solana network is present");
+    console.log('Checking if Solana network is present');
     await this.driver.findElement(this.solanaNetwork);
   }
 
@@ -228,11 +242,11 @@ class SendPage {
     await this.driver.waitForSelector({
       text: warningText,
     });
-    console.log("Warning message validation successful");
+    console.log('Warning message validation successful');
   }
 
   async clickMaxButton(): Promise<void> {
-    console.log("Clicking max button");
+    console.log('Clicking max button');
     await this.driver.clickElement(this.maxButton);
   }
 
@@ -247,7 +261,7 @@ class SendPage {
     recipientAddress?: string;
     recipientName?: string;
   }): Promise<void> {
-    console.log("Creating max send request");
+    console.log('Creating max send request');
     await this.selectToken(chainId, symbol);
     if (recipientAddress) {
       await this.fillRecipient({ recipientAddress });
@@ -257,7 +271,7 @@ class SendPage {
     }
     await this.clickMaxButton();
     await this.waitForSendAmountBalance();
-    await this.checkContinueButton({ state: "enabled" });
+    await this.checkContinueButton({ state: 'enabled' });
     await this.pressContinueButton();
   }
 
@@ -266,7 +280,7 @@ class SendPage {
     symbol,
     recipientAddress,
     recipientName,
-    amount = "0",
+    amount = '0',
   }: {
     chainId: string;
     symbol: string;
@@ -274,7 +288,7 @@ class SendPage {
     recipientName?: string;
     amount: string;
   }): Promise<void> {
-    console.log("Creating send request");
+    console.log('Creating send request');
     await this.selectToken(chainId, symbol);
     if (recipientAddress) {
       await this.fillRecipient({ recipientAddress });
@@ -285,12 +299,12 @@ class SendPage {
     await this.fillAmount(amount);
     await this.checkAmountInputValue(amount);
     await this.waitForSendAmountBalance();
-    await this.checkContinueButton({ state: "enabled" });
+    await this.checkContinueButton({ state: 'enabled' });
     await this.pressContinueButton();
   }
 
   async editAmountByKeys(keys: string[]): Promise<void> {
-    console.log("Editing amount value by key presses");
+    console.log('Editing amount value by key presses');
     for (const key of keys) {
       await this.driver.press(this.amountInput, key);
     }
@@ -306,7 +320,7 @@ class SendPage {
     console.log(`Filling hex data`);
     await this.driver.fill(this.hexDataInput, hexData);
     // Tab out of the hex data field to trigger onBlur and ensure React commits the value to state
-    await this.driver.press(this.hexDataInput, "\uE004");
+    await this.driver.press(this.hexDataInput, '\uE004');
   }
 
   async fillRecipient({
@@ -331,7 +345,7 @@ class SendPage {
    * optional send-alert modal when present.
    */
   async pressContinueButton(): Promise<void> {
-    console.log("Pressing continue button");
+    console.log('Pressing continue button');
     await this.waitForContinueButtonStablyEnabled();
     await this.driver.clickElement(this.continueButton);
     await this.acknowledgeSendAlertIfPresent();
@@ -339,7 +353,10 @@ class SendPage {
 
   async pressOnAmountInput(key: string): Promise<void> {
     console.log(`Pressing ${key} on amount input`);
-    await this.driver.press(this.amountInput, this.driver.Key[key as keyof typeof this.driver.Key]);
+    await this.driver.press(
+      this.amountInput,
+      this.driver.Key[key as keyof typeof this.driver.Key],
+    );
   }
 
   async selectAccountFromRecipientModal(accountName: string): Promise<void> {
@@ -372,22 +389,27 @@ class SendPage {
    * enough to avoid clicking during enable/disable flicker from validation.
    */
   async waitForContinueButtonStablyEnabled(): Promise<void> {
-    console.log("Waiting for continue button to be stably enabled");
+    console.log('Waiting for continue button to be stably enabled');
     await this.driver.waitUntil(
       async () => {
-        return await this.driver.isElementPresentAndVisible(this.continueButtonEnabled, 1000);
+        return await this.driver.isElementPresentAndVisible(
+          this.continueButtonEnabled,
+          1000,
+        );
       },
       { timeout: 30000, interval: 500, stableFor: 2000 },
     );
   }
 
   async waitForSendAmountBalance(): Promise<void> {
-    console.log("Waiting for send amount balance to be displayed");
+    console.log('Waiting for send amount balance to be displayed');
     await this.driver.waitForSelector(this.amountBalance);
   }
 
   async waitForSendAmountFiatValue(expectedValue: string): Promise<void> {
-    console.log(`Waiting for send amount fiat value "${expectedValue}" to be displayed`);
+    console.log(
+      `Waiting for send amount fiat value "${expectedValue}" to be displayed`,
+    );
     await this.driver.waitForSelector({
       ...this.amountFiatValue,
       text: expectedValue,

--- a/test/e2e/page-objects/pages/send/send-page.ts
+++ b/test/e2e/page-objects/pages/send/send-page.ts
@@ -7,6 +7,10 @@ class SendPage {
 
   private readonly amountInput = { testId: 'send-amount-input' };
 
+  private readonly amountRequiredError = {
+    text: 'Required',
+  };
+
   private readonly continueButton = { testId: 'send-continue-button' };
 
   private readonly continueButtonEnabled =
@@ -23,6 +27,10 @@ class SendPage {
 
   private readonly inputRecipient = {
     testId: 'recipient-address-input',
+  };
+
+  private readonly insufficientBalanceToCoverFeesError = {
+    text: 'Insufficient balance to cover fees',
   };
 
   private readonly insufficientFundsError = {
@@ -118,6 +126,11 @@ class SendPage {
     );
   }
 
+  async checkAmountRequiredError(): Promise<void> {
+    console.log('Checking for amount required error');
+    await this.driver.waitForSelector(this.amountRequiredError);
+  }
+
   /**
    * Waits for the continue button to reach the expected enabled/disabled state.
    *
@@ -133,6 +146,11 @@ class SendPage {
     await this.driver.waitForSelector(this.continueButton, {
       state,
     });
+  }
+
+  async checkContinueButtonIsDisabled(): Promise<void> {
+    console.log('Checking that Continue button is disabled');
+    await this.checkContinueButton({ state: 'disabled' });
   }
 
   /**
@@ -158,9 +176,13 @@ class SendPage {
     });
   }
 
+  async checkInsufficientBalanceToCoverFeesError(): Promise<void> {
+    await this.driver.waitForSelector(this.insufficientBalanceToCoverFeesError);
+  }
+
   async checkInsufficientFundsError(): Promise<void> {
     console.log('Checking for insufficient funds error');
-    await this.driver.findElement(this.insufficientFundsError);
+    await this.driver.waitForSelector(this.insufficientFundsError);
   }
 
   async checkInsufficientFundsErrorDetailed(): Promise<void> {
@@ -170,7 +192,7 @@ class SendPage {
 
   async checkInvalidAddressError(): Promise<void> {
     console.log('Checking for invalid address error');
-    await this.driver.findElement(this.invalidAddressError);
+    await this.driver.waitForSelector(this.invalidAddressError);
   }
 
   async checkNetworkFilterToggleIsDisplayed(): Promise<void> {
@@ -318,6 +340,7 @@ class SendPage {
     }
   }
 
+
   /**
    * Clicks Continue once the button is stably enabled, then acknowledges the
    * optional send-alert modal when present.
@@ -357,7 +380,9 @@ class SendPage {
 
   async selectToken(chainId: string, symbol: string): Promise<void> {
     console.log(`Selecting token ${symbol} on chain ${chainId}`);
-    await this.driver.clickElement(this.tokenAsset(chainId, symbol));
+    const tokenAsset = this.tokenAsset(chainId, symbol);
+    await this.driver.waitForSelector(tokenAsset);
+    await this.driver.clickElement(tokenAsset);
   }
 
   /**

--- a/test/e2e/tests/send/send-tron-local.spec.ts
+++ b/test/e2e/tests/send/send-tron-local.spec.ts
@@ -1,3 +1,4 @@
+import { Suite } from 'mocha';
 import { Mockttp } from 'mockttp';
 import { withFixtures } from '../../helpers';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
@@ -21,10 +22,10 @@ import { proxyTronBlockchainCalls } from '../tron/mocks/local-tron-node-mocks';
 import { TronNode } from '../../seeder/tron/node';
 import { createTronPortfolioNodeOptions } from '../../seeder/tron/profiles';
 
-describe('Send Tron', function () {
-  this.timeout(180_000);
+describe('Send Tron (local blockchain)', function (this: Suite) {
+  this.timeout(180_000); // covers Docker startup and the test run
 
-  it('sends TRX using a local Tron node', async function () {
+  it('should be possible to send TRX using a real local blockchain', async function () {
     // Captured in afterLocalNodesStart (which runs before the network mocks
     // are set up) so the mock builder can proxy calls to the local node.
     // testSpecificMock itself keeps its single-argument contract.
@@ -52,11 +53,13 @@ describe('Send Tron', function () {
           }
 
           return [
+            // ── External service mocks (unchanged from original test) ──────────
             await mockTronFeatureFlags(mockServer),
             await mockExchangeRates(mockServer),
             await mockFiatExchangeRates(mockServer),
             await mockTrxNativeSpotPrices(mockServer),
             await mockTronAssets(mockServer, tronNode),
+            // ── Blockchain calls proxied to local Tron node ───────────────────
             ...(await proxyTronBlockchainCalls(mockServer, tronNode, [
               TRON_ACCOUNT_ADDRESS,
               TRON_RECIPIENT_ADDRESS,
@@ -67,36 +70,39 @@ describe('Send Tron', function () {
       async ({ driver }: { driver: Driver }) => {
         await login(driver);
 
-        // Switch to Tron via the UI. Enabling it through fixtures causes a redirect
-        // back to the default network because the snap is not yet initialized
         const networkManager = new NetworkManager(driver);
         await networkManager.openNetworkManager();
         await networkManager.selectTab('Popular');
         await networkManager.selectNetworkByNameWithWait('Tron');
 
         const nonEvmHomepage = new NonEvmHomepage(driver);
+        // Real balance from local node: 6,072,392 SUN ≈ 6.072 TRX
         await nonEvmHomepage.checkExpectedTokenBalanceIsDisplayed(
           '6.072',
           'TRX',
         );
-        const snapTransactionConfirmation = new SnapTransactionConfirmation(
-          driver,
-        );
+
         await nonEvmHomepage.clickOnSendButton();
+
         const sendPage = new SendPage(driver);
         await sendPage.selectToken('tron:728126428', 'TRX');
-
-        // Wait for the send page to load
         await sendPage.fillRecipient({
           recipientAddress: TRON_RECIPIENT_ADDRESS,
         });
         await sendPage.fillAmount('1');
         await sendPage.pressContinueButton();
+
+        const snapTransactionConfirmation = new SnapTransactionConfirmation(
+          driver,
+        );
         await snapTransactionConfirmation.checkPageIsLoaded();
         await snapTransactionConfirmation.clickFooterConfirmButton();
+
         const activityList = new ActivityTab(driver);
-        await activityList.checkTxAmountInActivity('-1 TRX', 1);
+        // The broadcast reached the real local node — no failed transaction should appear
         await activityList.checkNoFailedTransactions();
+        // The snap tracks the submitted transaction locally and renders it immediately
+        await activityList.checkTxAmountInActivity('-1 TRX', 1);
       },
     );
   });

--- a/test/e2e/tests/send/send-tron-local.spec.ts
+++ b/test/e2e/tests/send/send-tron-local.spec.ts
@@ -1,89 +1,25 @@
 import { Suite } from 'mocha';
-import { Mockttp } from 'mockttp';
-import { withFixtures } from '../../helpers';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { Driver } from '../../webdriver/driver';
-import { login } from '../../page-objects/flows/login.flow';
-import { selectTronNetwork } from '../../page-objects/flows/tron-network.flow';
-import NonEvmHomepage from '../../page-objects/pages/home/non-evm-homepage';
-import SendPage from '../../page-objects/pages/send/send-page';
 import SnapTransactionConfirmation from '../../page-objects/pages/confirmations/snap-transaction-confirmation';
 import ActivityTab from '../../page-objects/pages/home/activity-tab';
-import {
-  mockTronFeatureFlags,
-  mockExchangeRates,
-  mockFiatExchangeRates,
-  mockTrxNativeSpotPrices,
-  mockTronAssets,
-  TRON_ACCOUNT_ADDRESS,
-  TRON_RECIPIENT_ADDRESS,
-} from '../tron/mocks/common-tron';
-import { proxyTronBlockchainCalls } from '../tron/mocks/local-tron-node-mocks';
-import { TronNode } from '../../seeder/tron/node';
-import { createTronPortfolioNodeOptions } from '../../seeder/tron/profiles';
+import { landOnTronSendScreen } from '../../page-objects/flows/tron-send.flow';
+import { TRON_RECIPIENT_ADDRESS } from '../tron/mocks/common-tron';
+import { TRON_PORTFOLIO_ACCOUNT } from '../tron/fixtures/environments';
+import { withTronFixtures } from '../tron/fixtures/with-tron-fixtures';
 
 describe('Send Tron (local blockchain)', function (this: Suite) {
-  this.timeout(180_000); // covers Docker startup and the test run
+  this.timeout(180_000);
 
   it('should be possible to send TRX using a real local blockchain', async function () {
-    // Captured in afterLocalNodesStart (which runs before the network mocks
-    // are set up) so the mock builder can proxy calls to the local node.
-    // testSpecificMock itself keeps its single-argument contract.
-    let localNodes: unknown[] = [];
-    await withFixtures(
+    await withTronFixtures(
       {
+        accounts: [TRON_PORTFOLIO_ACCOUNT],
         fixtures: new FixtureBuilderV2().build(),
         title: this.test?.fullTitle(),
-        localNodeOptions: [
-          'anvil',
-          {
-            type: 'tron',
-            options: createTronPortfolioNodeOptions(TRON_ACCOUNT_ADDRESS),
-          },
-        ],
-        afterLocalNodesStart: (nodeContext: { localNodes: unknown[] }) => {
-          localNodes = nodeContext.localNodes;
-        },
-        testSpecificMock: async (mockServer: Mockttp) => {
-          const tronNode = localNodes.find(
-            (node): node is TronNode => node instanceof TronNode,
-          );
-          if (!tronNode) {
-            throw new Error('Tron local node was not started');
-          }
-
-          return [
-            // ── External service mocks (unchanged from original test) ──────────
-            await mockTronFeatureFlags(mockServer),
-            await mockExchangeRates(mockServer),
-            await mockFiatExchangeRates(mockServer),
-            await mockTrxNativeSpotPrices(mockServer),
-            await mockTronAssets(mockServer, tronNode),
-            // ── Blockchain calls proxied to local Tron node ───────────────────
-            ...(await proxyTronBlockchainCalls(mockServer, tronNode, [
-              TRON_ACCOUNT_ADDRESS,
-              TRON_RECIPIENT_ADDRESS,
-            ])),
-          ];
-        },
       },
       async ({ driver }: { driver: Driver }) => {
-        await login(driver);
-        await selectTronNetwork(driver);
-        await driver.refresh();
-
-        const nonEvmHomepage = new NonEvmHomepage(driver);
-        await nonEvmHomepage.checkPageIsLoaded();
-        // Real balance from local node: 6,072,392 SUN ≈ 6.072 TRX
-        await nonEvmHomepage.checkExpectedTokenBalanceIsDisplayed(
-          '6.072',
-          'TRX',
-        );
-
-        await nonEvmHomepage.clickOnSendButton();
-
-        const sendPage = new SendPage(driver);
-        await sendPage.selectToken('tron:728126428', 'TRX');
+        const sendPage = await landOnTronSendScreen({ driver, symbol: 'TRX' });
         await sendPage.fillRecipient({
           recipientAddress: TRON_RECIPIENT_ADDRESS,
         });
@@ -97,9 +33,7 @@ describe('Send Tron (local blockchain)', function (this: Suite) {
         await snapTransactionConfirmation.clickFooterConfirmButton();
 
         const activityList = new ActivityTab(driver);
-        // The broadcast reached the real local node — no failed transaction should appear
         await activityList.checkNoFailedTransactions();
-        // The snap tracks the submitted transaction locally and renders it immediately
         await activityList.checkTxAmountInActivity('-1 TRX', 1);
       },
     );

--- a/test/e2e/tests/send/send-tron-local.spec.ts
+++ b/test/e2e/tests/send/send-tron-local.spec.ts
@@ -1,14 +1,14 @@
-import { Suite } from "mocha";
-import { Mockttp } from "mockttp";
-import { withFixtures } from "../../helpers";
-import FixtureBuilderV2 from "../../fixtures/fixture-builder-v2";
-import { Driver } from "../../webdriver/driver";
-import { login } from "../../page-objects/flows/login.flow";
-import { selectTronNetwork } from "../../page-objects/flows/tron-network.flow";
-import NonEvmHomepage from "../../page-objects/pages/home/non-evm-homepage";
-import SendPage from "../../page-objects/pages/send/send-page";
-import SnapTransactionConfirmation from "../../page-objects/pages/confirmations/snap-transaction-confirmation";
-import ActivityTab from "../../page-objects/pages/home/activity-tab";
+import { Suite } from 'mocha';
+import { Mockttp } from 'mockttp';
+import { withFixtures } from '../../helpers';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
+import { Driver } from '../../webdriver/driver';
+import { login } from '../../page-objects/flows/login.flow';
+import { selectTronNetwork } from '../../page-objects/flows/tron-network.flow';
+import NonEvmHomepage from '../../page-objects/pages/home/non-evm-homepage';
+import SendPage from '../../page-objects/pages/send/send-page';
+import SnapTransactionConfirmation from '../../page-objects/pages/confirmations/snap-transaction-confirmation';
+import ActivityTab from '../../page-objects/pages/home/activity-tab';
 import {
   mockTronFeatureFlags,
   mockExchangeRates,
@@ -17,15 +17,15 @@ import {
   mockTronAssets,
   TRON_ACCOUNT_ADDRESS,
   TRON_RECIPIENT_ADDRESS,
-} from "../tron/mocks/common-tron";
-import { proxyTronBlockchainCalls } from "../tron/mocks/local-tron-node-mocks";
-import { TronNode } from "../../seeder/tron/node";
-import { createTronPortfolioNodeOptions } from "../../seeder/tron/profiles";
+} from '../tron/mocks/common-tron';
+import { proxyTronBlockchainCalls } from '../tron/mocks/local-tron-node-mocks';
+import { TronNode } from '../../seeder/tron/node';
+import { createTronPortfolioNodeOptions } from '../../seeder/tron/profiles';
 
-describe("Send Tron (local blockchain)", function (this: Suite) {
+describe('Send Tron (local blockchain)', function (this: Suite) {
   this.timeout(180_000); // covers Docker startup and the test run
 
-  it("should be possible to send TRX using a real local blockchain", async function () {
+  it('should be possible to send TRX using a real local blockchain', async function () {
     // Captured in afterLocalNodesStart (which runs before the network mocks
     // are set up) so the mock builder can proxy calls to the local node.
     // testSpecificMock itself keeps its single-argument contract.
@@ -35,9 +35,9 @@ describe("Send Tron (local blockchain)", function (this: Suite) {
         fixtures: new FixtureBuilderV2().build(),
         title: this.test?.fullTitle(),
         localNodeOptions: [
-          "anvil",
+          'anvil',
           {
-            type: "tron",
+            type: 'tron',
             options: createTronPortfolioNodeOptions(TRON_ACCOUNT_ADDRESS),
           },
         ],
@@ -45,9 +45,11 @@ describe("Send Tron (local blockchain)", function (this: Suite) {
           localNodes = nodeContext.localNodes;
         },
         testSpecificMock: async (mockServer: Mockttp) => {
-          const tronNode = localNodes.find((node): node is TronNode => node instanceof TronNode);
+          const tronNode = localNodes.find(
+            (node): node is TronNode => node instanceof TronNode,
+          );
           if (!tronNode) {
-            throw new Error("Tron local node was not started");
+            throw new Error('Tron local node was not started');
           }
 
           return [
@@ -73,19 +75,24 @@ describe("Send Tron (local blockchain)", function (this: Suite) {
         const nonEvmHomepage = new NonEvmHomepage(driver);
         await nonEvmHomepage.checkPageIsLoaded();
         // Real balance from local node: 6,072,392 SUN ≈ 6.072 TRX
-        await nonEvmHomepage.checkExpectedTokenBalanceIsDisplayed("6.072", "TRX");
+        await nonEvmHomepage.checkExpectedTokenBalanceIsDisplayed(
+          '6.072',
+          'TRX',
+        );
 
         await nonEvmHomepage.clickOnSendButton();
 
         const sendPage = new SendPage(driver);
-        await sendPage.selectToken("tron:728126428", "TRX");
+        await sendPage.selectToken('tron:728126428', 'TRX');
         await sendPage.fillRecipient({
           recipientAddress: TRON_RECIPIENT_ADDRESS,
         });
-        await sendPage.fillAmount("1");
+        await sendPage.fillAmount('1');
         await sendPage.pressContinueButton();
 
-        const snapTransactionConfirmation = new SnapTransactionConfirmation(driver);
+        const snapTransactionConfirmation = new SnapTransactionConfirmation(
+          driver,
+        );
         await snapTransactionConfirmation.checkPageIsLoaded();
         await snapTransactionConfirmation.clickFooterConfirmButton();
 
@@ -93,7 +100,7 @@ describe("Send Tron (local blockchain)", function (this: Suite) {
         // The broadcast reached the real local node — no failed transaction should appear
         await activityList.checkNoFailedTransactions();
         // The snap tracks the submitted transaction locally and renders it immediately
-        await activityList.checkTxAmountInActivity("-1 TRX", 1);
+        await activityList.checkTxAmountInActivity('-1 TRX', 1);
       },
     );
   });

--- a/test/e2e/tests/send/send-tron-local.spec.ts
+++ b/test/e2e/tests/send/send-tron-local.spec.ts
@@ -32,9 +32,13 @@ describe('Send Tron (local blockchain)', function (this: Suite) {
         await snapTransactionConfirmation.checkPageIsLoaded();
         await snapTransactionConfirmation.clickFooterConfirmButton();
 
+        // Wait for the snap-tracked tx to land before asserting amount. Otherwise
+        // the activity tab can still show the static TronGrid HTX history mock.
         const activityList = new ActivityTab(driver);
-        await activityList.checkNoFailedTransactions();
+        await activityList.checkPendingTxNumberDisplayedInActivity(1);
+        await activityList.checkConfirmedTxNumberDisplayedInActivity(1);
         await activityList.checkTxAmountInActivity('-1 TRX', 1);
+        await activityList.checkNoFailedTransactions();
       },
     );
   });

--- a/test/e2e/tests/send/send-tron-local.spec.ts
+++ b/test/e2e/tests/send/send-tron-local.spec.ts
@@ -1,9 +1,10 @@
 import { Suite } from 'mocha';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { Driver } from '../../webdriver/driver';
-import SnapTransactionConfirmation from '../../page-objects/pages/confirmations/snap-transaction-confirmation';
-import ActivityTab from '../../page-objects/pages/home/activity-tab';
-import { landOnTronSendScreen } from '../../page-objects/flows/tron-send.flow';
+import {
+  confirmTronSendAndAssertActivity,
+  landOnTronSendScreen,
+} from '../../page-objects/flows/tron-send.flow';
 import { TRON_RECIPIENT_ADDRESS } from '../tron/mocks/common-tron';
 import { TRON_PORTFOLIO_ACCOUNT } from '../tron/fixtures/environments';
 import { withTronFixtures } from '../tron/fixtures/with-tron-fixtures';
@@ -26,19 +27,10 @@ describe('Send Tron (local blockchain)', function (this: Suite) {
         await sendPage.fillAmount('1');
         await sendPage.pressContinueButton();
 
-        const snapTransactionConfirmation = new SnapTransactionConfirmation(
+        await confirmTronSendAndAssertActivity({
           driver,
-        );
-        await snapTransactionConfirmation.checkPageIsLoaded();
-        await snapTransactionConfirmation.clickFooterConfirmButton();
-
-        // Wait for the snap-tracked tx to land before asserting amount. Otherwise
-        // the activity tab can still show the static TronGrid HTX history mock.
-        const activityList = new ActivityTab(driver);
-        await activityList.checkPendingTxNumberDisplayedInActivity(1);
-        await activityList.checkConfirmedTxNumberDisplayedInActivity(1);
-        await activityList.checkTxAmountInActivity('-1 TRX', 1);
-        await activityList.checkNoFailedTransactions();
+          expectedAmount: '-1 TRX',
+        });
       },
     );
   });

--- a/test/e2e/tests/send/send-tron.spec.ts
+++ b/test/e2e/tests/send/send-tron.spec.ts
@@ -1,13 +1,13 @@
-import { Mockttp } from "mockttp";
-import { withFixtures } from "../../helpers";
-import FixtureBuilderV2 from "../../fixtures/fixture-builder-v2";
-import { Driver } from "../../webdriver/driver";
-import NonEvmHomepage from "../../page-objects/pages/home/non-evm-homepage";
-import SendPage from "../../page-objects/pages/send/send-page";
-import SnapTransactionConfirmation from "../../page-objects/pages/confirmations/snap-transaction-confirmation";
-import ActivityTab from "../../page-objects/pages/home/activity-tab";
-import { selectTronNetwork } from "../../page-objects/flows/tron-network.flow";
-import { login } from "../../page-objects/flows/login.flow";
+import { Mockttp } from 'mockttp';
+import { withFixtures } from '../../helpers';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
+import { Driver } from '../../webdriver/driver';
+import NonEvmHomepage from '../../page-objects/pages/home/non-evm-homepage';
+import SendPage from '../../page-objects/pages/send/send-page';
+import SnapTransactionConfirmation from '../../page-objects/pages/confirmations/snap-transaction-confirmation';
+import ActivityTab from '../../page-objects/pages/home/activity-tab';
+import { selectTronNetwork } from '../../page-objects/flows/tron-network.flow';
+import { login } from '../../page-objects/flows/login.flow';
 import {
   mockTronFeatureFlags,
   mockExchangeRates,
@@ -16,15 +16,15 @@ import {
   mockTronAssets,
   TRON_ACCOUNT_ADDRESS,
   TRON_RECIPIENT_ADDRESS,
-} from "../tron/mocks/common-tron";
-import { proxyTronBlockchainCalls } from "../tron/mocks/local-tron-node-mocks";
-import { TronNode } from "../../seeder/tron/node";
-import { createTronPortfolioNodeOptions } from "../../seeder/tron/profiles";
+} from '../tron/mocks/common-tron';
+import { proxyTronBlockchainCalls } from '../tron/mocks/local-tron-node-mocks';
+import { TronNode } from '../../seeder/tron/node';
+import { createTronPortfolioNodeOptions } from '../../seeder/tron/profiles';
 
-describe("Send Tron", function () {
+describe('Send Tron', function () {
   this.timeout(180_000);
 
-  it("sends TRX using a local Tron node", async function () {
+  it('sends TRX using a local Tron node', async function () {
     // Captured in afterLocalNodesStart (which runs before the network mocks
     // are set up) so the mock builder can proxy calls to the local node.
     // testSpecificMock itself keeps its single-argument contract.
@@ -34,9 +34,9 @@ describe("Send Tron", function () {
         fixtures: new FixtureBuilderV2().build(),
         title: this.test?.fullTitle(),
         localNodeOptions: [
-          "anvil",
+          'anvil',
           {
-            type: "tron",
+            type: 'tron',
             options: createTronPortfolioNodeOptions(TRON_ACCOUNT_ADDRESS),
           },
         ],
@@ -44,9 +44,11 @@ describe("Send Tron", function () {
           localNodes = nodeContext.localNodes;
         },
         testSpecificMock: async (mockServer: Mockttp) => {
-          const tronNode = localNodes.find((node): node is TronNode => node instanceof TronNode);
+          const tronNode = localNodes.find(
+            (node): node is TronNode => node instanceof TronNode,
+          );
           if (!tronNode) {
-            throw new Error("Tron local node was not started");
+            throw new Error('Tron local node was not started');
           }
 
           return [
@@ -69,21 +71,26 @@ describe("Send Tron", function () {
 
         const nonEvmHomepage = new NonEvmHomepage(driver);
         await nonEvmHomepage.checkPageIsLoaded();
-        await nonEvmHomepage.checkExpectedTokenBalanceIsDisplayed("6.072", "TRX");
-        const snapTransactionConfirmation = new SnapTransactionConfirmation(driver);
+        await nonEvmHomepage.checkExpectedTokenBalanceIsDisplayed(
+          '6.072',
+          'TRX',
+        );
+        const snapTransactionConfirmation = new SnapTransactionConfirmation(
+          driver,
+        );
         await nonEvmHomepage.clickOnSendButton();
         const sendPage = new SendPage(driver);
-        await sendPage.selectToken("tron:728126428", "TRX");
+        await sendPage.selectToken('tron:728126428', 'TRX');
 
         await sendPage.fillRecipient({
           recipientAddress: TRON_RECIPIENT_ADDRESS,
         });
-        await sendPage.fillAmount("1");
+        await sendPage.fillAmount('1');
         await sendPage.pressContinueButton();
         await snapTransactionConfirmation.checkPageIsLoaded();
         await snapTransactionConfirmation.clickFooterConfirmButton();
         const activityList = new ActivityTab(driver);
-        await activityList.checkTxAmountInActivity("-1 TRX", 1);
+        await activityList.checkTxAmountInActivity('-1 TRX', 1);
         await activityList.checkNoFailedTransactions();
       },
     );

--- a/test/e2e/tests/send/send-tron.spec.ts
+++ b/test/e2e/tests/send/send-tron.spec.ts
@@ -1,87 +1,44 @@
-import { Mockttp } from 'mockttp';
 import { withFixtures } from '../../helpers';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { Driver } from '../../webdriver/driver';
-import NonEvmHomepage from '../../page-objects/pages/home/non-evm-homepage';
+import { login } from '../../page-objects/flows/login.flow';
+import { switchToNetworkFromNetworkSelect } from '../../page-objects/flows/network.flow';
+import HomePage from '../../page-objects/pages/home/homepage';
+import TokensTab from '../../page-objects/pages/home/tokens-tab';
 import SendPage from '../../page-objects/pages/send/send-page';
 import SnapTransactionConfirmation from '../../page-objects/pages/confirmations/snap-transaction-confirmation';
 import ActivityTab from '../../page-objects/pages/home/activity-tab';
-import { selectTronNetwork } from '../../page-objects/flows/tron-network.flow';
-import { login } from '../../page-objects/flows/login.flow';
 import {
-  mockTronFeatureFlags,
-  mockExchangeRates,
-  mockFiatExchangeRates,
-  mockTrxNativeSpotPrices,
-  mockTronAssets,
-  TRON_ACCOUNT_ADDRESS,
+  mockTronApis,
   TRON_RECIPIENT_ADDRESS,
 } from '../tron/mocks/common-tron';
-import { proxyTronBlockchainCalls } from '../tron/mocks/local-tron-node-mocks';
-import { TronNode } from '../../seeder/tron/node';
-import { createTronPortfolioNodeOptions } from '../../seeder/tron/profiles';
 
 describe('Send Tron', function () {
-  this.timeout(180_000);
-
-  it('sends TRX using a local Tron node', async function () {
-    // Captured in afterLocalNodesStart (which runs before the network mocks
-    // are set up) so the mock builder can proxy calls to the local node.
-    // testSpecificMock itself keeps its single-argument contract.
-    let localNodes: unknown[] = [];
+  it('it should be possible to send TRX', async function () {
     await withFixtures(
       {
         fixtures: new FixtureBuilderV2().build(),
         title: this.test?.fullTitle(),
-        localNodeOptions: [
-          'anvil',
-          {
-            type: 'tron',
-            options: createTronPortfolioNodeOptions(TRON_ACCOUNT_ADDRESS),
-          },
-        ],
-        afterLocalNodesStart: (nodeContext: { localNodes: unknown[] }) => {
-          localNodes = nodeContext.localNodes;
-        },
-        testSpecificMock: async (mockServer: Mockttp) => {
-          const tronNode = localNodes.find(
-            (node): node is TronNode => node instanceof TronNode,
-          );
-          if (!tronNode) {
-            throw new Error('Tron local node was not started');
-          }
-
-          return [
-            await mockTronFeatureFlags(mockServer),
-            await mockExchangeRates(mockServer),
-            await mockFiatExchangeRates(mockServer),
-            await mockTrxNativeSpotPrices(mockServer),
-            await mockTronAssets(mockServer, tronNode),
-            ...(await proxyTronBlockchainCalls(mockServer, tronNode, [
-              TRON_ACCOUNT_ADDRESS,
-              TRON_RECIPIENT_ADDRESS,
-            ])),
-          ];
-        },
+        testSpecificMock: mockTronApis,
       },
       async ({ driver }: { driver: Driver }) => {
         await login(driver);
-        await selectTronNetwork(driver);
-        await driver.refresh();
 
-        const nonEvmHomepage = new NonEvmHomepage(driver);
-        await nonEvmHomepage.checkPageIsLoaded();
-        await nonEvmHomepage.checkExpectedTokenBalanceIsDisplayed(
-          '6.072',
-          'TRX',
-        );
+        // Switch to Tron via the UI. Enabling it through fixtures causes a redirect
+        // back to the default network because the snap is not yet initialized
+        await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Tron');
+
+        const homePage = new HomePage(driver);
+        const tokensTab = new TokensTab(driver);
+        await tokensTab.checkExpectedTokenBalanceIsDisplayed('6.072', 'TRX');
         const snapTransactionConfirmation = new SnapTransactionConfirmation(
           driver,
         );
-        await nonEvmHomepage.clickOnSendButton();
+        await homePage.clickOnSendButton();
         const sendPage = new SendPage(driver);
         await sendPage.selectToken('tron:728126428', 'TRX');
 
+        // Wait for the send page to load
         await sendPage.fillRecipient({
           recipientAddress: TRON_RECIPIENT_ADDRESS,
         });
@@ -89,9 +46,9 @@ describe('Send Tron', function () {
         await sendPage.pressContinueButton();
         await snapTransactionConfirmation.checkPageIsLoaded();
         await snapTransactionConfirmation.clickFooterConfirmButton();
-        const activityList = new ActivityTab(driver);
-        await activityList.checkTxAmountInActivity('-1 TRX', 1);
-        await activityList.checkNoFailedTransactions();
+        const activityTab = new ActivityTab(driver);
+        await activityTab.checkTxAmountInActivity('-50,000 HTX', 1); // mocked activity
+        await activityTab.checkNoFailedTransactions();
       },
     );
   });

--- a/test/e2e/tests/tron/fixtures/with-tron-fixtures.ts
+++ b/test/e2e/tests/tron/fixtures/with-tron-fixtures.ts
@@ -24,8 +24,6 @@ import {
   mockTronGetBlockByNum,
   mockTronGetNowBlock,
   mockTronGetReward,
-  mockTronGetTransactions,
-  mockTronGetTrc20Transactions,
 } from '../mocks/common-tron';
 import { proxyTronBlockchainCalls } from '../mocks/local-tron-node-mocks';
 
@@ -251,8 +249,6 @@ async function mockTronFixtureApis(
     await mockTronGetBlock(mockServer),
     await mockTronGetNowBlock(mockServer),
     await mockTronGetBlockByNum(mockServer),
-    await mockTronGetTransactions(mockServer),
-    await mockTronGetTrc20Transactions(mockServer),
     // NOTE: no static `broadcasttransaction` mock here. mockttp serves the
     // first matching *unused* rule, so a static broadcast mock would swallow
     // each test's single broadcast with a fake txid that the local node never

--- a/test/e2e/tests/tron/fixtures/with-tron-fixtures.ts
+++ b/test/e2e/tests/tron/fixtures/with-tron-fixtures.ts
@@ -20,9 +20,6 @@ import {
   mockExchangeRates,
   mockFiatExchangeRates,
   mockTronFeatureFlags,
-  mockTronGetBlock,
-  mockTronGetBlockByNum,
-  mockTronGetNowBlock,
   mockTronGetReward,
 } from '../mocks/common-tron';
 import { proxyTronBlockchainCalls } from '../mocks/local-tron-node-mocks';
@@ -246,15 +243,12 @@ async function mockTronFixtureApis(
     await mockTronFixtureSpotPrices(mockServer, accounts, tronNode),
     await mockTronFixtureAssets(mockServer, accounts, tronNode),
     await mockTronGetReward(mockServer),
-    await mockTronGetBlock(mockServer),
-    await mockTronGetNowBlock(mockServer),
-    await mockTronGetBlockByNum(mockServer),
-    // NOTE: no static `broadcasttransaction` mock here. mockttp serves the
-    // first matching *unused* rule, so a static broadcast mock would swallow
-    // each test's single broadcast with a fake txid that the local node never
-    // sees — the tx then polls as pending forever. `proxyTronBlockchainCalls`
-    // below proxies broadcasts to the local Tron node and replays them as
-    // confirmed history.
+    // NOTE: do not register static getblock/getnowblock/getblockbynum or
+    // broadcasttransaction mocks here. mockttp serves the first matching
+    // `.always()` rule, so a static block mock makes the snap sign against a
+    // stale ref block and java-tron rejects the broadcast with TAPOS_ERROR.
+    // `proxyTronBlockchainCalls` proxies those endpoints to the local node and
+    // replays successful broadcasts as confirmed history.
     ...fixtureHistoryEndpoints,
     ...(await proxyTronBlockchainCalls(mockServer, tronNode, allAddresses)),
     await mockWildcardTronAccountApis(mockServer, tronNode, accountByAddress),

--- a/test/e2e/tests/tron/mocks/local-tron-node-mocks.ts
+++ b/test/e2e/tests/tron/mocks/local-tron-node-mocks.ts
@@ -81,15 +81,6 @@ type CapturedTxFields = Pick<
   | 'value'
 >;
 
-type TriggerSmartContractRequest = {
-  call_value?: number;
-  contract_address?: string;
-  fee_limit?: number;
-  function_selector?: string;
-  owner_address?: string;
-  parameter?: string;
-};
-
 function normalizeMaybeTronAddress(address?: string): string | undefined {
   if (!address) {
     return undefined;
@@ -114,61 +105,6 @@ function buildSeededTrc20ContractAddressSet(
       .map((address) => normalizeMaybeTronAddress(address))
       .filter((address): address is string => Boolean(address)),
   );
-}
-
-function getFunctionSelectorPrefix(functionSelector?: string): string {
-  // transfer(address,uint256)
-  if (functionSelector === 'transfer(address,uint256)') {
-    return 'a9059cbb';
-  }
-  return '';
-}
-
-function buildTriggerSmartContractTransaction(
-  request: TriggerSmartContractRequest,
-): Record<string, unknown> {
-  const timestamp = Date.now();
-  const ownerAddress = request.owner_address
-    ? normalizeTronHexAddress(request.owner_address)
-    : '';
-  const contractAddress = request.contract_address
-    ? normalizeTronHexAddress(request.contract_address)
-    : '';
-  const data = `${getFunctionSelectorPrefix(request.function_selector)}${
-    request.parameter ?? ''
-  }`;
-
-  return {
-    result: { result: true },
-    transaction: {
-      txID: '0'.repeat(64),
-      raw_data: {
-        contract: [
-          {
-            parameter: {
-              value: {
-                data,
-                owner_address: ownerAddress,
-                contract_address: contractAddress,
-                call_value: request.call_value ?? 0,
-              },
-              type_url: 'type.googleapis.com/protocol.TriggerSmartContract',
-            },
-            type: 'TriggerSmartContract',
-          },
-        ],
-        ref_block_bytes: '0000',
-        ref_block_hash: '0000000000000000',
-        expiration: timestamp + 60_000,
-        fee_limit: request.fee_limit,
-        timestamp,
-      },
-      // Large enough to force a realistic bandwidth cost when the account has
-      // no free bandwidth. The exact bytes are not semantically parsed in tests.
-      raw_data_hex: '00'.repeat(250),
-      visible: false,
-    },
-  };
 }
 
 async function fetchTxFromLocalNode(
@@ -425,6 +361,9 @@ export async function proxyTronBlockchainCalls(
   await proxyPostPath('/wallet/getcontract');
   await proxyPostPath('/wallet/gettransactionbyid');
   await proxyPostPath('/wallet/createtransaction');
+  // Must proxy real java-tron builds: TronWeb validates txID/raw_data_hex.
+  // A synthetic trigger response fails Continuetrial with generic transactionError.
+  await proxyPostPath('/wallet/triggersmartcontract');
   await proxyPostPath('/wallet/getblockbynum');
   await proxyPostPath('/wallet/getaccount');
   await proxyGetPath('/wallet/getnowblock');
@@ -467,29 +406,9 @@ export async function proxyTronBlockchainCalls(
         return proxyPost(localNodeUrl, '/wallet/gettransactioninfobyid', body);
       }),
 
-    await mockServer
-      .forPost(tronProviderUrl('/wallet/triggersmartcontract'))
-      .always()
-      .thenCallback(async (req) => {
-        const body = await req.body.getText();
-        const parsed = body
-          ? (JSON.parse(body) as TriggerSmartContractRequest)
-          : {};
-        const contractAddress = normalizeMaybeTronAddress(
-          parsed.contract_address,
-        );
-        if (
-          contractAddress &&
-          seededTrc20ContractAddresses.has(contractAddress)
-        ) {
-          return {
-            statusCode: 200,
-            json: buildTriggerSmartContractTransaction(parsed),
-          };
-        }
-        return proxyPost(localNodeUrl, '/wallet/triggersmartcontract', body);
-      }),
-
+    // Keep constant-contract energy short-circuit so TRC20 fee estimates stay
+    // under the seeded ~6.072 TRX portfolio balance; real first-transfer energy
+    // can exceed that and block Continuetrial on fee checks.
     await mockServer
       .forPost(tronProviderUrl('/wallet/triggerconstantcontract'))
       .always()

--- a/test/e2e/tests/tron/mocks/local-tron-node-mocks.ts
+++ b/test/e2e/tests/tron/mocks/local-tron-node-mocks.ts
@@ -566,10 +566,10 @@ export async function proxyTronBlockchainCalls(
         .forGet(tronProviderUrl(`/v1/accounts/${accountAddress}/transactions`))
         .always()
         .thenCallback(async () => {
-          const nativeTxs = captured.filter(
-            (tx) =>
-              tx.contractType !== 'TriggerSmartContract' &&
-              txInvolvesAccount(tx, accountAddress),
+          // Include TriggerSmartContract too: the snap confirms from native
+          // /transactions only, then joins /transactions/trc20 by txID.
+          const nativeTxs = captured.filter((tx) =>
+            txInvolvesAccount(tx, accountAddress),
           );
           const data = nativeTxs.map((tx) => {
             tx.pollsObserved += 1;

--- a/test/e2e/tests/tron/mocks/local-tron-node-mocks.ts
+++ b/test/e2e/tests/tron/mocks/local-tron-node-mocks.ts
@@ -242,6 +242,13 @@ function txInvolvesAccount(tx: CapturedTx, accountAddress: string): boolean {
   const ownerHex = normalizeMaybeTronAddress(tx.ownerAddress);
   const toHex = normalizeMaybeTronAddress(tx.toAddress);
 
+  // When capture could not recover addresses from the broadcast body / local
+  // node, still surface the tx on every registered account history endpoint so
+  // confirmation isn't lost (E2E fixtures only register sender + recipient).
+  if (!ownerHex && !toHex) {
+    return true;
+  }
+
   return ownerHex === accountHex || toHex === accountHex;
 }
 
@@ -414,6 +421,7 @@ export async function proxyTronBlockchainCalls(
 
   await proxyPostPath('/wallet/getblock');
   await proxyPostPath('/wallet/getaccountresource');
+  await proxyPostPath('/wallet/getaccountnet');
   await proxyPostPath('/wallet/getcontract');
   await proxyPostPath('/wallet/gettransactionbyid');
   await proxyPostPath('/wallet/createtransaction');

--- a/test/e2e/tests/tron/send.spec.ts
+++ b/test/e2e/tests/tron/send.spec.ts
@@ -1,0 +1,259 @@
+import { Suite } from 'mocha';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
+import { Driver } from '../../webdriver/driver';
+import SnapTransactionConfirmation from '../../page-objects/pages/confirmations/snap-transaction-confirmation';
+import ActivityTab from '../../page-objects/pages/home/activity-tab';
+import { TronNode } from '../../seeder/tron/node';
+import { landOnTronSendScreen } from '../../page-objects/flows/tron-send.flow';
+import { TRON_CHAIN_ID, TRON_RECIPIENT_ADDRESS } from './mocks/common-tron';
+import {
+  TRON_LOW_TRX_WITH_USDT_ACCOUNT,
+  TRON_PORTFOLIO_ACCOUNT,
+  TRON_PORTFOLIO_TRX_BALANCE_IN_SUN,
+} from './fixtures/environments';
+import { withTronFixtures } from './fixtures/with-tron-fixtures';
+
+const TRON_SEND_FEE_BUFFER_IN_SUN = 1_000_000;
+
+function formatSunAmount(amountInSun: number): string {
+  const whole = Math.floor(amountInSun / 1_000_000);
+  const fraction = String(amountInSun % 1_000_000).padStart(6, '0');
+  return `${whole}.${fraction}`.replace(/\.?0+$/u, '');
+}
+
+function getTronTrc20AssetId(
+  localNodes: unknown[],
+  symbol: 'USDT' | 'USDD' | 'HTX' | 'SEED',
+): string {
+  const tronNode = localNodes.find(
+    (node): node is TronNode => node instanceof TronNode,
+  );
+  const token = tronNode?.trc20Tokens[symbol];
+  if (!token) {
+    throw new Error(`Seeded ${symbol} token was not found on the Tron node`);
+  }
+  return `${TRON_CHAIN_ID}/trc20:${token.address}`;
+}
+
+describe('Tron Send', function (this: Suite) {
+  this.timeout(180_000);
+
+  // ── Validation tests ────────────────────────────────────────────────────────
+
+  it('blocks Continue when a bad address is entered', async function () {
+    await withTronFixtures(
+      {
+        accounts: [TRON_PORTFOLIO_ACCOUNT],
+        fixtures: new FixtureBuilderV2().build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        const sendPage = await landOnTronSendScreen({ driver, symbol: 'TRX' });
+        await sendPage.fillRecipient({
+          recipientAddress: 'not-a-valid-address',
+          // The formatted recipient element never renders for an invalid
+          // address, so skip the post-paste re-render wait.
+          validAddress: false,
+        });
+        await sendPage.checkInvalidAddressError();
+        await sendPage.checkContinueButtonIsDisabled();
+      },
+    );
+  });
+
+  it('blocks Continue when amount is empty', async function () {
+    await withTronFixtures(
+      {
+        accounts: [TRON_PORTFOLIO_ACCOUNT],
+        fixtures: new FixtureBuilderV2().build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        const sendPage = await landOnTronSendScreen({ driver, symbol: 'TRX' });
+        await sendPage.fillRecipient({ recipientAddress: TRON_RECIPIENT_ADDRESS });
+        await sendPage.checkAmountRequiredError();
+        await sendPage.checkContinueButtonIsDisabled();
+      },
+    );
+  });
+
+  it('blocks Continue when amount exceeds balance', async function () {
+    await withTronFixtures(
+      {
+        accounts: [TRON_PORTFOLIO_ACCOUNT],
+        fixtures: new FixtureBuilderV2().build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        const sendPage = await landOnTronSendScreen({ driver, symbol: 'TRX' });
+        await sendPage.fillRecipient({ recipientAddress: TRON_RECIPIENT_ADDRESS });
+        await sendPage.fillAmount('999999');
+        await sendPage.checkInsufficientFundsError();
+        await sendPage.checkContinueButtonIsDisabled();
+      },
+    );
+  });
+
+  it('blocks USDT send when TRX balance cannot cover energy fee', async function () {
+    await withTronFixtures(
+      {
+        accounts: [TRON_LOW_TRX_WITH_USDT_ACCOUNT],
+        fixtures: new FixtureBuilderV2().build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({
+        driver,
+        localNodes,
+      }: {
+        driver: Driver;
+        localNodes: unknown[];
+      }) => {
+        const sendPage = await landOnTronSendScreen({
+          driver,
+          symbol: 'USDT',
+          assetId: getTronTrc20AssetId(localNodes, 'USDT'),
+          expectedNativeBalance: null,
+        });
+        await sendPage.fillRecipient({ recipientAddress: TRON_RECIPIENT_ADDRESS });
+        await sendPage.fillAmount('1');
+        await sendPage.checkInsufficientBalanceToCoverFeesError();
+        await sendPage.checkContinueButtonIsDisabled();
+      },
+    );
+  });
+
+  // ── TRX partial send ────────────────────────────────────────────────────────
+
+  it('sends part of TRX balance and shows it pending then confirmed', async function () {
+    await withTronFixtures(
+      {
+        accounts: [TRON_PORTFOLIO_ACCOUNT],
+        fixtures: new FixtureBuilderV2().build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        const sendPage = await landOnTronSendScreen({ driver, symbol: 'TRX' });
+        await sendPage.fillRecipient({ recipientAddress: TRON_RECIPIENT_ADDRESS });
+        await sendPage.fillAmount('1');
+        await sendPage.pressContinueButton();
+
+        const snapConfirmation = new SnapTransactionConfirmation(driver);
+        await snapConfirmation.checkPageIsLoaded();
+        await snapConfirmation.clickFooterConfirmButton();
+
+        const activityList = new ActivityTab(driver);
+        await activityList.checkPendingTxNumberDisplayedInActivity(1);
+        await activityList.checkConfirmedTxNumberDisplayedInActivity(1);
+        await activityList.checkTxAmountInActivity('-1 TRX', 1);
+        await activityList.checkNoFailedTransactions();
+      },
+    );
+  });
+
+  // ── TRX total send (Max) ────────────────────────────────────────────────────
+
+  it('sends fee-buffered TRX balance via manual full-amount entry', async function () {
+    await withTronFixtures(
+      {
+        accounts: [TRON_PORTFOLIO_ACCOUNT],
+        fixtures: new FixtureBuilderV2().build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        const sendPage = await landOnTronSendScreen({ driver, symbol: 'TRX' });
+        await sendPage.fillRecipient({ recipientAddress: TRON_RECIPIENT_ADDRESS });
+        const sendAmount = formatSunAmount(
+          TRON_PORTFOLIO_TRX_BALANCE_IN_SUN - TRON_SEND_FEE_BUFFER_IN_SUN,
+        );
+        await sendPage.fillAmount(sendAmount);
+        await sendPage.pressContinueButton();
+
+        const snapConfirmation = new SnapTransactionConfirmation(driver);
+        await snapConfirmation.checkPageIsLoaded();
+        await snapConfirmation.clickFooterConfirmButton();
+
+        const activityList = new ActivityTab(driver);
+        await activityList.checkPendingTxNumberDisplayedInActivity(1);
+        await activityList.checkConfirmedTxNumberDisplayedInActivity(1);
+        await activityList.checkNoFailedTransactions();
+      },
+    );
+  });
+
+  // ── USDT partial send ───────────────────────────────────────────────────────
+
+  it('sends part of USDT balance and shows it pending then confirmed', async function () {
+    await withTronFixtures(
+      {
+        accounts: [TRON_PORTFOLIO_ACCOUNT],
+        fixtures: new FixtureBuilderV2().build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({
+        driver,
+        localNodes,
+      }: {
+        driver: Driver;
+        localNodes: unknown[];
+      }) => {
+        const sendPage = await landOnTronSendScreen({
+          driver,
+          symbol: 'USDT',
+          assetId: getTronTrc20AssetId(localNodes, 'USDT'),
+        });
+        await sendPage.fillRecipient({ recipientAddress: TRON_RECIPIENT_ADDRESS });
+        await sendPage.fillAmount('1');
+        await sendPage.pressContinueButton();
+
+        const snapConfirmation = new SnapTransactionConfirmation(driver);
+        await snapConfirmation.checkPageIsLoaded();
+        await snapConfirmation.clickFooterConfirmButton();
+
+        const activityList = new ActivityTab(driver);
+        await activityList.checkPendingTxNumberDisplayedInActivity(1);
+        await activityList.checkConfirmedTxNumberDisplayedInActivity(1);
+        await activityList.checkTxAmountInActivity('-1 USDT', 1);
+        await activityList.checkNoFailedTransactions();
+      },
+    );
+  });
+
+  // ── USDT total send (Max) ───────────────────────────────────────────────────
+
+  it('sends total USDT balance via manual full-amount entry', async function () {
+    await withTronFixtures(
+      {
+        accounts: [TRON_PORTFOLIO_ACCOUNT],
+        fixtures: new FixtureBuilderV2().build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({
+        driver,
+        localNodes,
+      }: {
+        driver: Driver;
+        localNodes: unknown[];
+      }) => {
+        const sendPage = await landOnTronSendScreen({
+          driver,
+          symbol: 'USDT',
+          assetId: getTronTrc20AssetId(localNodes, 'USDT'),
+        });
+        await sendPage.fillRecipient({ recipientAddress: TRON_RECIPIENT_ADDRESS });
+        // Seeded USDT balance is 2_804_595 raw = 2.804595 USDT.
+        // TRC20 has no fee buffer (fee paid in TRX).
+        await sendPage.fillAmount('2.804595');
+        await sendPage.pressContinueButton();
+
+        const snapConfirmation = new SnapTransactionConfirmation(driver);
+        await snapConfirmation.checkPageIsLoaded();
+        await snapConfirmation.clickFooterConfirmButton();
+
+        const activityList = new ActivityTab(driver);
+        await activityList.checkPendingTxNumberDisplayedInActivity(1);
+        await activityList.checkConfirmedTxNumberDisplayedInActivity(1);
+        await activityList.checkNoFailedTransactions();
+      },
+    );
+  });
+});

--- a/test/e2e/tests/tron/send.spec.ts
+++ b/test/e2e/tests/tron/send.spec.ts
@@ -1,31 +1,33 @@
-import { Suite } from "mocha";
-import FixtureBuilderV2 from "../../fixtures/fixture-builder-v2";
-import { Driver } from "../../webdriver/driver";
-import SnapTransactionConfirmation from "../../page-objects/pages/confirmations/snap-transaction-confirmation";
-import ActivityTab from "../../page-objects/pages/home/activity-tab";
-import { TronNode } from "../../seeder/tron/node";
-import { landOnTronSendScreen } from "../../page-objects/flows/tron-send.flow";
-import { TRON_CHAIN_ID, TRON_RECIPIENT_ADDRESS } from "./mocks/common-tron";
+import { Suite } from 'mocha';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
+import { Driver } from '../../webdriver/driver';
+import SnapTransactionConfirmation from '../../page-objects/pages/confirmations/snap-transaction-confirmation';
+import ActivityTab from '../../page-objects/pages/home/activity-tab';
+import { TronNode } from '../../seeder/tron/node';
+import { landOnTronSendScreen } from '../../page-objects/flows/tron-send.flow';
+import { TRON_CHAIN_ID, TRON_RECIPIENT_ADDRESS } from './mocks/common-tron';
 import {
   TRON_LOW_TRX_WITH_USDT_ACCOUNT,
   TRON_PORTFOLIO_ACCOUNT,
   TRON_PORTFOLIO_TRX_BALANCE_IN_SUN,
-} from "./fixtures/environments";
-import { withTronFixtures } from "./fixtures/with-tron-fixtures";
+} from './fixtures/environments';
+import { withTronFixtures } from './fixtures/with-tron-fixtures';
 
 const TRON_SEND_FEE_BUFFER_IN_SUN = 1_000_000;
 
 function formatSunAmount(amountInSun: number): string {
   const whole = Math.floor(amountInSun / 1_000_000);
-  const fraction = String(amountInSun % 1_000_000).padStart(6, "0");
-  return `${whole}.${fraction}`.replace(/\.?0+$/u, "");
+  const fraction = String(amountInSun % 1_000_000).padStart(6, '0');
+  return `${whole}.${fraction}`.replace(/\.?0+$/u, '');
 }
 
 function getTronTrc20AssetId(
   localNodes: unknown[],
-  symbol: "USDT" | "USDD" | "HTX" | "SEED",
+  symbol: 'USDT' | 'USDD' | 'HTX' | 'SEED',
 ): string {
-  const tronNode = localNodes.find((node): node is TronNode => node instanceof TronNode);
+  const tronNode = localNodes.find(
+    (node): node is TronNode => node instanceof TronNode,
+  );
   const token = tronNode?.trc20Tokens[symbol];
   if (!token) {
     throw new Error(`Seeded ${symbol} token was not found on the Tron node`);
@@ -33,12 +35,12 @@ function getTronTrc20AssetId(
   return `${TRON_CHAIN_ID}/trc20:${token.address}`;
 }
 
-describe("Tron Send", function (this: Suite) {
+describe('Tron Send', function (this: Suite) {
   this.timeout(180_000);
 
   // ── Validation tests ────────────────────────────────────────────────────────
 
-  it("blocks Continue when a bad address is entered", async function () {
+  it('blocks Continue when a bad address is entered', async function () {
     await withTronFixtures(
       {
         accounts: [TRON_PORTFOLIO_ACCOUNT],
@@ -46,9 +48,9 @@ describe("Tron Send", function (this: Suite) {
         title: this.test?.fullTitle(),
       },
       async ({ driver }: { driver: Driver }) => {
-        const sendPage = await landOnTronSendScreen({ driver, symbol: "TRX" });
+        const sendPage = await landOnTronSendScreen({ driver, symbol: 'TRX' });
         await sendPage.fillRecipient({
-          recipientAddress: "not-a-valid-address",
+          recipientAddress: 'not-a-valid-address',
           // The formatted recipient element never renders for an invalid
           // address, so skip the post-paste re-render wait.
           validAddress: false,
@@ -59,7 +61,7 @@ describe("Tron Send", function (this: Suite) {
     );
   });
 
-  it("blocks Continue when amount is empty", async function () {
+  it('blocks Continue when amount is empty', async function () {
     await withTronFixtures(
       {
         accounts: [TRON_PORTFOLIO_ACCOUNT],
@@ -67,15 +69,17 @@ describe("Tron Send", function (this: Suite) {
         title: this.test?.fullTitle(),
       },
       async ({ driver }: { driver: Driver }) => {
-        const sendPage = await landOnTronSendScreen({ driver, symbol: "TRX" });
-        await sendPage.fillRecipient({ recipientAddress: TRON_RECIPIENT_ADDRESS });
+        const sendPage = await landOnTronSendScreen({ driver, symbol: 'TRX' });
+        await sendPage.fillRecipient({
+          recipientAddress: TRON_RECIPIENT_ADDRESS,
+        });
         await sendPage.checkAmountRequiredError();
         await sendPage.checkContinueButtonIsDisabled();
       },
     );
   });
 
-  it("blocks Continue when amount exceeds balance", async function () {
+  it('blocks Continue when amount exceeds balance', async function () {
     await withTronFixtures(
       {
         accounts: [TRON_PORTFOLIO_ACCOUNT],
@@ -83,31 +87,41 @@ describe("Tron Send", function (this: Suite) {
         title: this.test?.fullTitle(),
       },
       async ({ driver }: { driver: Driver }) => {
-        const sendPage = await landOnTronSendScreen({ driver, symbol: "TRX" });
-        await sendPage.fillRecipient({ recipientAddress: TRON_RECIPIENT_ADDRESS });
-        await sendPage.fillAmount("999999");
+        const sendPage = await landOnTronSendScreen({ driver, symbol: 'TRX' });
+        await sendPage.fillRecipient({
+          recipientAddress: TRON_RECIPIENT_ADDRESS,
+        });
+        await sendPage.fillAmount('999999');
         await sendPage.checkInsufficientFundsError();
         await sendPage.checkContinueButtonIsDisabled();
       },
     );
   });
 
-  it("blocks USDT send when TRX balance cannot cover energy fee", async function () {
+  it('blocks USDT send when TRX balance cannot cover energy fee', async function () {
     await withTronFixtures(
       {
         accounts: [TRON_LOW_TRX_WITH_USDT_ACCOUNT],
         fixtures: new FixtureBuilderV2().build(),
         title: this.test?.fullTitle(),
       },
-      async ({ driver, localNodes }: { driver: Driver; localNodes: unknown[] }) => {
+      async ({
+        driver,
+        localNodes,
+      }: {
+        driver: Driver;
+        localNodes: unknown[];
+      }) => {
         const sendPage = await landOnTronSendScreen({
           driver,
-          symbol: "USDT",
-          assetId: getTronTrc20AssetId(localNodes, "USDT"),
+          symbol: 'USDT',
+          assetId: getTronTrc20AssetId(localNodes, 'USDT'),
           expectedNativeBalance: null,
         });
-        await sendPage.fillRecipient({ recipientAddress: TRON_RECIPIENT_ADDRESS });
-        await sendPage.fillAmount("1");
+        await sendPage.fillRecipient({
+          recipientAddress: TRON_RECIPIENT_ADDRESS,
+        });
+        await sendPage.fillAmount('1');
         await sendPage.checkInsufficientBalanceToCoverFeesError();
         await sendPage.checkContinueButtonIsDisabled();
       },
@@ -116,7 +130,7 @@ describe("Tron Send", function (this: Suite) {
 
   // ── TRX partial send ────────────────────────────────────────────────────────
 
-  it("sends part of TRX balance and shows it pending then confirmed", async function () {
+  it('sends part of TRX balance and shows it pending then confirmed', async function () {
     await withTronFixtures(
       {
         accounts: [TRON_PORTFOLIO_ACCOUNT],
@@ -124,9 +138,11 @@ describe("Tron Send", function (this: Suite) {
         title: this.test?.fullTitle(),
       },
       async ({ driver }: { driver: Driver }) => {
-        const sendPage = await landOnTronSendScreen({ driver, symbol: "TRX" });
-        await sendPage.fillRecipient({ recipientAddress: TRON_RECIPIENT_ADDRESS });
-        await sendPage.fillAmount("1");
+        const sendPage = await landOnTronSendScreen({ driver, symbol: 'TRX' });
+        await sendPage.fillRecipient({
+          recipientAddress: TRON_RECIPIENT_ADDRESS,
+        });
+        await sendPage.fillAmount('1');
         await sendPage.pressContinueButton();
 
         const snapConfirmation = new SnapTransactionConfirmation(driver);
@@ -136,7 +152,7 @@ describe("Tron Send", function (this: Suite) {
         const activityList = new ActivityTab(driver);
         await activityList.checkPendingTxNumberDisplayedInActivity(1);
         await activityList.checkConfirmedTxNumberDisplayedInActivity(1);
-        await activityList.checkTxAmountInActivity("-1 TRX", 1);
+        await activityList.checkTxAmountInActivity('-1 TRX', 1);
         await activityList.checkNoFailedTransactions();
       },
     );
@@ -144,7 +160,7 @@ describe("Tron Send", function (this: Suite) {
 
   // ── TRX total send (Max) ────────────────────────────────────────────────────
 
-  it("sends fee-buffered TRX balance via manual full-amount entry", async function () {
+  it('sends fee-buffered TRX balance via manual full-amount entry', async function () {
     await withTronFixtures(
       {
         accounts: [TRON_PORTFOLIO_ACCOUNT],
@@ -152,8 +168,10 @@ describe("Tron Send", function (this: Suite) {
         title: this.test?.fullTitle(),
       },
       async ({ driver }: { driver: Driver }) => {
-        const sendPage = await landOnTronSendScreen({ driver, symbol: "TRX" });
-        await sendPage.fillRecipient({ recipientAddress: TRON_RECIPIENT_ADDRESS });
+        const sendPage = await landOnTronSendScreen({ driver, symbol: 'TRX' });
+        await sendPage.fillRecipient({
+          recipientAddress: TRON_RECIPIENT_ADDRESS,
+        });
         const sendAmount = formatSunAmount(
           TRON_PORTFOLIO_TRX_BALANCE_IN_SUN - TRON_SEND_FEE_BUFFER_IN_SUN,
         );
@@ -174,21 +192,29 @@ describe("Tron Send", function (this: Suite) {
 
   // ── USDT partial send ───────────────────────────────────────────────────────
 
-  it("sends part of USDT balance and shows it pending then confirmed", async function () {
+  it('sends part of USDT balance and shows it pending then confirmed', async function () {
     await withTronFixtures(
       {
         accounts: [TRON_PORTFOLIO_ACCOUNT],
         fixtures: new FixtureBuilderV2().build(),
         title: this.test?.fullTitle(),
       },
-      async ({ driver, localNodes }: { driver: Driver; localNodes: unknown[] }) => {
+      async ({
+        driver,
+        localNodes,
+      }: {
+        driver: Driver;
+        localNodes: unknown[];
+      }) => {
         const sendPage = await landOnTronSendScreen({
           driver,
-          symbol: "USDT",
-          assetId: getTronTrc20AssetId(localNodes, "USDT"),
+          symbol: 'USDT',
+          assetId: getTronTrc20AssetId(localNodes, 'USDT'),
         });
-        await sendPage.fillRecipient({ recipientAddress: TRON_RECIPIENT_ADDRESS });
-        await sendPage.fillAmount("1");
+        await sendPage.fillRecipient({
+          recipientAddress: TRON_RECIPIENT_ADDRESS,
+        });
+        await sendPage.fillAmount('1');
         await sendPage.pressContinueButton();
 
         const snapConfirmation = new SnapTransactionConfirmation(driver);
@@ -198,7 +224,7 @@ describe("Tron Send", function (this: Suite) {
         const activityList = new ActivityTab(driver);
         await activityList.checkPendingTxNumberDisplayedInActivity(1);
         await activityList.checkConfirmedTxNumberDisplayedInActivity(1);
-        await activityList.checkTxAmountInActivity("-1 USDT", 1);
+        await activityList.checkTxAmountInActivity('-1 USDT', 1);
         await activityList.checkNoFailedTransactions();
       },
     );
@@ -206,23 +232,31 @@ describe("Tron Send", function (this: Suite) {
 
   // ── USDT total send (Max) ───────────────────────────────────────────────────
 
-  it("sends total USDT balance via manual full-amount entry", async function () {
+  it('sends total USDT balance via manual full-amount entry', async function () {
     await withTronFixtures(
       {
         accounts: [TRON_PORTFOLIO_ACCOUNT],
         fixtures: new FixtureBuilderV2().build(),
         title: this.test?.fullTitle(),
       },
-      async ({ driver, localNodes }: { driver: Driver; localNodes: unknown[] }) => {
+      async ({
+        driver,
+        localNodes,
+      }: {
+        driver: Driver;
+        localNodes: unknown[];
+      }) => {
         const sendPage = await landOnTronSendScreen({
           driver,
-          symbol: "USDT",
-          assetId: getTronTrc20AssetId(localNodes, "USDT"),
+          symbol: 'USDT',
+          assetId: getTronTrc20AssetId(localNodes, 'USDT'),
         });
-        await sendPage.fillRecipient({ recipientAddress: TRON_RECIPIENT_ADDRESS });
+        await sendPage.fillRecipient({
+          recipientAddress: TRON_RECIPIENT_ADDRESS,
+        });
         // Seeded USDT balance is 2_804_595 raw = 2.804595 USDT.
         // TRC20 has no fee buffer (fee paid in TRX).
-        await sendPage.fillAmount("2.804595");
+        await sendPage.fillAmount('2.804595');
         await sendPage.pressContinueButton();
 
         const snapConfirmation = new SnapTransactionConfirmation(driver);

--- a/test/e2e/tests/tron/send.spec.ts
+++ b/test/e2e/tests/tron/send.spec.ts
@@ -1,10 +1,11 @@
 import { Suite } from 'mocha';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { Driver } from '../../webdriver/driver';
-import SnapTransactionConfirmation from '../../page-objects/pages/confirmations/snap-transaction-confirmation';
-import ActivityTab from '../../page-objects/pages/home/activity-tab';
 import { TronNode } from '../../seeder/tron/node';
-import { landOnTronSendScreen } from '../../page-objects/flows/tron-send.flow';
+import {
+  confirmTronSendAndAssertActivity,
+  landOnTronSendScreen,
+} from '../../page-objects/flows/tron-send.flow';
 import { TRON_CHAIN_ID, TRON_RECIPIENT_ADDRESS } from './mocks/common-tron';
 import {
   TRON_LOW_TRX_WITH_USDT_ACCOUNT,
@@ -145,15 +146,10 @@ describe('Tron Send', function (this: Suite) {
         await sendPage.fillAmount('1');
         await sendPage.pressContinueButton();
 
-        const snapConfirmation = new SnapTransactionConfirmation(driver);
-        await snapConfirmation.checkPageIsLoaded();
-        await snapConfirmation.clickFooterConfirmButton();
-
-        const activityList = new ActivityTab(driver);
-        await activityList.checkPendingTxNumberDisplayedInActivity(1);
-        await activityList.checkConfirmedTxNumberDisplayedInActivity(1);
-        await activityList.checkTxAmountInActivity('-1 TRX', 1);
-        await activityList.checkNoFailedTransactions();
+        await confirmTronSendAndAssertActivity({
+          driver,
+          expectedAmount: '-1 TRX',
+        });
       },
     );
   });
@@ -178,14 +174,7 @@ describe('Tron Send', function (this: Suite) {
         await sendPage.fillAmount(sendAmount);
         await sendPage.pressContinueButton();
 
-        const snapConfirmation = new SnapTransactionConfirmation(driver);
-        await snapConfirmation.checkPageIsLoaded();
-        await snapConfirmation.clickFooterConfirmButton();
-
-        const activityList = new ActivityTab(driver);
-        await activityList.checkPendingTxNumberDisplayedInActivity(1);
-        await activityList.checkConfirmedTxNumberDisplayedInActivity(1);
-        await activityList.checkNoFailedTransactions();
+        await confirmTronSendAndAssertActivity({ driver });
       },
     );
   });
@@ -217,15 +206,10 @@ describe('Tron Send', function (this: Suite) {
         await sendPage.fillAmount('1');
         await sendPage.pressContinueButton();
 
-        const snapConfirmation = new SnapTransactionConfirmation(driver);
-        await snapConfirmation.checkPageIsLoaded();
-        await snapConfirmation.clickFooterConfirmButton();
-
-        const activityList = new ActivityTab(driver);
-        await activityList.checkPendingTxNumberDisplayedInActivity(1);
-        await activityList.checkConfirmedTxNumberDisplayedInActivity(1);
-        await activityList.checkTxAmountInActivity('-1 USDT', 1);
-        await activityList.checkNoFailedTransactions();
+        await confirmTronSendAndAssertActivity({
+          driver,
+          expectedAmount: '-1 USDT',
+        });
       },
     );
   });
@@ -259,14 +243,7 @@ describe('Tron Send', function (this: Suite) {
         await sendPage.fillAmount('2.804595');
         await sendPage.pressContinueButton();
 
-        const snapConfirmation = new SnapTransactionConfirmation(driver);
-        await snapConfirmation.checkPageIsLoaded();
-        await snapConfirmation.clickFooterConfirmButton();
-
-        const activityList = new ActivityTab(driver);
-        await activityList.checkPendingTxNumberDisplayedInActivity(1);
-        await activityList.checkConfirmedTxNumberDisplayedInActivity(1);
-        await activityList.checkNoFailedTransactions();
+        await confirmTronSendAndAssertActivity({ driver });
       },
     );
   });

--- a/test/e2e/tests/tron/send.spec.ts
+++ b/test/e2e/tests/tron/send.spec.ts
@@ -204,11 +204,14 @@ describe('Tron Send', function (this: Suite) {
           driver,
           symbol: 'USDT',
           assetId: getTronTrc20AssetId(localNodes, 'USDT'),
+          // Homepage rounds 2.804595 → 2.805 (same as assets.spec.ts).
+          expectedTokenBalance: '2.805',
         });
         await sendPage.fillRecipient({
           recipientAddress: TRON_RECIPIENT_ADDRESS,
         });
         await sendPage.fillAmount('1');
+        await sendPage.waitForSendAmountBalance();
         await sendPage.pressContinueButton();
 
         await confirmTronSendAndAssertActivity({
@@ -239,6 +242,8 @@ describe('Tron Send', function (this: Suite) {
           driver,
           symbol: 'USDT',
           assetId: getTronTrc20AssetId(localNodes, 'USDT'),
+          // Homepage rounds 2.804595 → 2.805 (same as assets.spec.ts).
+          expectedTokenBalance: '2.805',
         });
         await sendPage.fillRecipient({
           recipientAddress: TRON_RECIPIENT_ADDRESS,
@@ -246,8 +251,10 @@ describe('Tron Send', function (this: Suite) {
         // Seeded USDT balance is 2_804_595 raw = 2.804595 USDT.
         // TRC20 has no fee buffer (fee paid in TRX).
         await sendPage.fillAmount('2.804595');
+        await sendPage.waitForSendAmountBalance();
         await sendPage.pressContinueButton();
 
+        // Activity may round the amount; presence + confirmed status is enough.
         await confirmTronSendAndAssertActivity({ driver });
       },
     );

--- a/test/e2e/tests/tron/send.spec.ts
+++ b/test/e2e/tests/tron/send.spec.ts
@@ -74,7 +74,10 @@ describe('Tron Send', function (this: Suite) {
         await sendPage.fillRecipient({
           recipientAddress: TRON_RECIPIENT_ADDRESS,
         });
-        await sendPage.checkAmountRequiredError();
+        // Empty amount leaves Continue enabled; Tron snap rejects on submit and
+        // surfaces transactionError on the Continue button.
+        await sendPage.pressContinueButton();
+        await sendPage.checkTransactionError();
         await sendPage.checkContinueButtonIsDisabled();
       },
     );
@@ -123,7 +126,9 @@ describe('Tron Send', function (this: Suite) {
           recipientAddress: TRON_RECIPIENT_ADDRESS,
         });
         await sendPage.fillAmount('1');
-        await sendPage.checkInsufficientBalanceToCoverFeesError();
+        // Fee validation runs on Continue; Tron surfaces transactionError on the button.
+        await sendPage.pressContinueButton();
+        await sendPage.checkTransactionError();
         await sendPage.checkContinueButtonIsDisabled();
       },
     );

--- a/test/e2e/tests/tron/send.spec.ts
+++ b/test/e2e/tests/tron/send.spec.ts
@@ -126,9 +126,9 @@ describe('Tron Send', function (this: Suite) {
           recipientAddress: TRON_RECIPIENT_ADDRESS,
         });
         await sendPage.fillAmount('1');
-        // Fee validation runs on Continue; Tron surfaces transactionError on the button.
+        // With 1 sun TRX, Continuetrial builds the TRC20 tx then fails fee cover.
         await sendPage.pressContinueButton();
-        await sendPage.checkTransactionError();
+        await sendPage.checkInsufficientBalanceToCoverFeesError();
         await sendPage.checkContinueButtonIsDisabled();
       },
     );


### PR DESCRIPTION
# test(e2e): add Tron send E2E cluster with local node

## What

Adds the Tron send E2E cluster. `test/e2e/tests/tron/send.spec.ts` covers mocked send scenarios, and `test/e2e/tests/send/send-tron-local.spec.ts` runs the send flow against the real local java-tron node via the proxy. Adds a `tron-send.flow.ts` flow, a `tron-network.flow.ts` helper (so this PR does not depend on #44165), extends `send-page.ts`, and updates the existing `send-tron.spec.ts`.

Folds in the `pr-43663` cleanup branch (the WPN-402 tip was a superset of it). The original specs' `testSpecificMock(server, localNodes)` two-argument usage is converted to the `afterLocalNodesStart` pattern, avoiding the second-positional-argument collision.

## Stack

Base: `main`. Independent of #44165, #44166, and #44167.

## Relationship to previous PRs

New, extracted from #43663 (E2E only). Together with prior stack PRs, this supersedes #43663 (will be closed).

## Testing

- `send-tron-local.spec.ts` run locally against a real java-tron node (boot → fund via seeder → send → observe on-chain).
- `send.spec.ts` and the updated `send-tron.spec.ts` run locally against the mock stack.

CHANGELOG entry: null