### PR TITLE
ci: fix "All jobs pass" in cross-repo PRs

### DIFF
--- a/.github/workflows/ci-status-gate.yml
+++ b/.github/workflows/ci-status-gate.yml
@@ -166,9 +166,14 @@ jobs:
       # in the wrong suite — one the merge queue doesn't monitor. Commit
       # statuses have no suites, so they always work reliably.
       - name: Post commit status
-        # Cross-repo PRs receive a read-only token — createCommitStatus would throw
-        # "Resource not accessible by integration". Commit statuses are for
-        # the merge queue and branch protection; cross-repo PRs don't need them.
+        # Cross-repo PRs (HEAD in a different repo than the base) receive a
+        # read-only token on the pull_request event, so createCommitStatus
+        # would throw "Resource not accessible by integration". We skip it here
+        # and instead post the required "All jobs pass" status from
+        # post-cross-repo-status.yml, which runs in the base-repo context via
+        # workflow_run and therefore has a full-access statuses:write token.
+        # Without that companion workflow the required status would stay pending
+        # forever and cross-repo PRs could never merge.
         # On non-PR events (merge_group, push) this check is irrelevant.
         if: >-
           ${{

--- a/.github/workflows/post-cross-repo-status.yml
+++ b/.github/workflows/post-cross-repo-status.yml
@@ -1,0 +1,80 @@
+# Posts the required "All jobs pass" commit status for cross-repo PRs.
+#
+# Why this workflow exists
+# ------------------------
+# Because cross-repo PRs get a read-only token, main.yml's `ci-status-gate`
+# job can compute the result but CANNOT call `createCommitStatus` — its
+# "Post commit status" step is guarded off for cross-repo PRs (it would
+# throw "Resource not accessible by integration").
+#
+# The consequence: the branch-protection-required "All jobs pass" status
+# is never posted for cross-repo PRs, so it stays pending forever and the
+# PR can never be merged.
+#
+# `workflow_run` runs in the BASE repo context with a full-access token
+# (the same reason triage-and-retry-system.yml can call `gh run rerun`),
+# so it CAN post commit statuses even for cross-repo PRs. This workflow
+# fires when "Main" completes for a cross-repo PR and mirrors main.yml's
+# conclusion into the "All jobs pass" commit status.
+#
+# Scope
+# -----
+# - Only cross-repo runs: same-repo PRs and merge_group runs already get
+#   their status posted directly by ci-status-gate.yml.
+# - Only pull_request runs: a cross-repo HEAD can't open merge_group runs.
+# - Maps the workflow_run conclusion to a commit status state:
+#     success            -> success
+#     failure / timed_out / anything else -> failure
+#     cancelled          -> failure (queue reshuffle / manual cancel)
+#   Skipped/neutral shouldn't occur for a whole workflow_run, so they are
+#   treated as failure to stay safe (never leave the check green by mistake).
+
+name: Post cross-repo commit status
+
+on:
+  workflow_run:
+    workflows: ['Main']
+    types: [completed]
+
+permissions:
+  statuses: write
+
+jobs:
+  post-status:
+    name: Post "All jobs pass" status for cross-repo PRs
+    # Only cross-repo pull_request runs need this rescue. Same-repo PRs and
+    # merge_group runs get their status from ci-status-gate.yml directly.
+    if: >-
+      ${{
+        github.event.workflow_run.event == 'pull_request'
+        && github.event.workflow_run.head_repository.full_name != github.event.workflow_run.repository.full_name
+      }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+      CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+      RUN_ID: ${{ github.event.workflow_run.id }}
+    steps:
+      - name: Post commit status
+        run: |
+          if [[ "$CONCLUSION" == "success" ]]; then
+            STATE=success
+            DESCRIPTION="All CI jobs completed successfully"
+          else
+            STATE=failure
+            DESCRIPTION="CI concluded with '$CONCLUSION'"
+          fi
+
+          TARGET_URL="$GITHUB_SERVER_URL/$REPO/actions/runs/$RUN_ID"
+
+          gh api "repos/$REPO/statuses/$HEAD_SHA" \
+            --method POST \
+            -f state="$STATE" \
+            -f context="All jobs pass" \
+            -f description="$DESCRIPTION" \
+            -f target_url="$TARGET_URL"
+
+          echo "Posted '$STATE' commit status on $HEAD_SHA (main.yml conclusion: $CONCLUSION)"


### PR DESCRIPTION
## **Description**

A cross-repo PR would never post the "All jobs pass" status, which left cross-repo/external-contributors totally broken and unable to merge.

This adds a separate `workflow_run` on `Main completed` to do it, which runs in the context of the default branch with write permissions.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Progresses: MetaMask/MetaMask-planning#7456

<!--## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes merge-gating CI behavior for external contributors; mis-filtering or wrong conclusion mapping could block merges or mark failed runs green, though scope is limited to cross-repo pull_request runs.
> 
> **Overview**
> **Cross-repo PRs can satisfy the required "All jobs pass" branch protection check again.** On `pull_request`, forks get a read-only token, so `ci-status-gate` still skips `createCommitStatus` for those runs; the comments there now document that gap and point to the companion workflow.
> 
> A new **`post-cross-repo-status.yml`** runs on **`Main` `workflow_run` completed** in the **base repo** (with `statuses: write`). It only runs when the triggering event was `pull_request` and the head repo differs from the base. It posts the same **`All jobs pass`** commit status on the PR head SHA, mapping **`Main` success → success** and **any other conclusion → failure** (including cancelled), with a link back to the Actions run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 730a47593fc9743a4525e29b06fd420bb15af562. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->