### PR TITLE
fix(mv3): extend install event until background scripts load

### DIFF
--- a/app/scripts/app-init.js
+++ b/app/scripts/app-init.js
@@ -148,6 +148,8 @@ function importAllScripts() {
 // eslint-disable-next-line no-undef
 self.addEventListener('install', (event) => {
   // Extend the install event lifetime until background scripts finish loading.
+  // Without waitUntil, Chrome may finish the install event before the async
+  // dynamic import of background.js completes.
   event.waitUntil(Promise.resolve(importAllScripts()));
 });
 

--- a/app/scripts/app-init.js
+++ b/app/scripts/app-init.js
@@ -146,12 +146,7 @@ function importAllScripts() {
 
 // Ref: https://stackoverflow.com/questions/66406672/chrome-extension-mv3-modularize-service-worker-js-file
 // eslint-disable-next-line no-undef
-self.addEventListener('install', (event) => {
-  // Extend the install event lifetime until background scripts finish loading.
-  // Without waitUntil, Chrome may finish the install event before the async
-  // dynamic import of background.js completes.
-  event.waitUntil(importAllScripts());
-});
+self.addEventListener('install', importAllScripts);
 
 // listen for connection events from other contexts, and respond to liveness
 // checks, and ping them to let them know we're listening.

--- a/app/scripts/app-init.js
+++ b/app/scripts/app-init.js
@@ -146,7 +146,10 @@ function importAllScripts() {
 
 // Ref: https://stackoverflow.com/questions/66406672/chrome-extension-mv3-modularize-service-worker-js-file
 // eslint-disable-next-line no-undef
-self.addEventListener('install', importAllScripts);
+self.addEventListener('install', (event) => {
+  // Extend the install event lifetime until background scripts finish loading.
+  event.waitUntil(Promise.resolve(importAllScripts()));
+});
 
 // listen for connection events from other contexts, and respond to liveness
 // checks, and ping them to let them know we're listening.

--- a/app/scripts/app-init.js
+++ b/app/scripts/app-init.js
@@ -150,7 +150,7 @@ self.addEventListener('install', (event) => {
   // Extend the install event lifetime until background scripts finish loading.
   // Without waitUntil, Chrome may finish the install event before the async
   // dynamic import of background.js completes.
-  event.waitUntil(Promise.resolve(importAllScripts()));
+  event.waitUntil(Promise.resolve().then(() => importAllScripts()));
 });
 
 // listen for connection events from other contexts, and respond to liveness

--- a/app/scripts/app-init.js
+++ b/app/scripts/app-init.js
@@ -150,7 +150,7 @@ self.addEventListener('install', (event) => {
   // Extend the install event lifetime until background scripts finish loading.
   // Without waitUntil, Chrome may finish the install event before the async
   // dynamic import of background.js completes.
-  event.waitUntil(Promise.resolve().then(() => importAllScripts()));
+  event.waitUntil(importAllScripts());
 });
 
 // listen for connection events from other contexts, and respond to liveness

--- a/app/service-worker.ts
+++ b/app/service-worker.ts
@@ -44,8 +44,8 @@ async function runImportScripts() {
 // eslint-disable-next-line no-undef
 self.addEventListener('install', (event) => {
   // Extend the install event lifetime until background scripts finish loading.
-  // Without waitUntil, Chrome may terminate the service worker before the async
-  // dynamic import completes (see https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers).
+  // Without waitUntil, Chrome may finish the install event before the async
+  // dynamic import of background.js completes.
   (event as ExtendableEvent).waitUntil(runImportScripts());
 });
 

--- a/app/service-worker.ts
+++ b/app/service-worker.ts
@@ -42,12 +42,15 @@ async function runImportScripts() {
 
 // Ref: https://stackoverflow.com/questions/66406672/chrome-extension-mv3-modularize-service-worker-js-file
 // eslint-disable-next-line no-undef
-self.addEventListener('install', (event) => {
-  // Extend the install event lifetime until background scripts finish loading.
-  // Without waitUntil, Chrome may finish the install event before the async
-  // dynamic import of background.js completes.
-  (event as ExtendableEvent).waitUntil(runImportScripts());
-});
+self.addEventListener(
+  'install',
+  ((event: ExtendableEvent) => {
+    // Extend the install event lifetime until background scripts finish loading.
+    // Without waitUntil, Chrome may finish the install event before the async
+    // dynamic import of background.js completes.
+    event.waitUntil(runImportScripts());
+  }) as EventListener,
+);
 
 // listen for connection events from other contexts, and respond to liveness
 // checks, and ping them to let them know we're listening.

--- a/app/service-worker.ts
+++ b/app/service-worker.ts
@@ -42,15 +42,12 @@ async function runImportScripts() {
 
 // Ref: https://stackoverflow.com/questions/66406672/chrome-extension-mv3-modularize-service-worker-js-file
 // eslint-disable-next-line no-undef
-self.addEventListener(
-  'install',
-  ((event: ExtendableEvent) => {
-    // Extend the install event lifetime until background scripts finish loading.
-    // Without waitUntil, Chrome may finish the install event before the async
-    // dynamic import of background.js completes.
-    event.waitUntil(runImportScripts());
-  }) as EventListener,
-);
+self.addEventListener('install', ((event: ExtendableEvent) => {
+  // Extend the install event lifetime until background scripts finish loading.
+  // Without waitUntil, Chrome may finish the install event before the async
+  // dynamic import of background.js completes.
+  event.waitUntil(runImportScripts());
+}) as EventListener);
 
 // listen for connection events from other contexts, and respond to liveness
 // checks, and ping them to let them know we're listening.

--- a/app/service-worker.ts
+++ b/app/service-worker.ts
@@ -42,7 +42,12 @@ async function runImportScripts() {
 
 // Ref: https://stackoverflow.com/questions/66406672/chrome-extension-mv3-modularize-service-worker-js-file
 // eslint-disable-next-line no-undef
-self.addEventListener('install', runImportScripts);
+self.addEventListener('install', (event) => {
+  // Extend the install event lifetime until background scripts finish loading.
+  // Without waitUntil, Chrome may terminate the service worker before the async
+  // dynamic import completes (see https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers).
+  (event as ExtendableEvent).waitUntil(runImportScripts());
+});
 
 // listen for connection events from other contexts, and respond to liveness
 // checks, and ping them to let them know we're listening.

--- a/app/service-worker.ts
+++ b/app/service-worker.ts
@@ -18,12 +18,35 @@ globalThis.stateHooks.lazyListener = lazyListener;
 
 let runImportScriptsInitiated = false;
 
+async function maybeApplyServiceWorkerStartupDelay() {
+  if (!process.env.IN_TEST) {
+    return;
+  }
+
+  const manifest = chrome.runtime.getManifest() as {
+    _flags?: {
+      testing?: {
+        simulateServiceWorkerStartupDelayMs?: number;
+      };
+    };
+  };
+  const delayMs = manifest._flags?.testing?.simulateServiceWorkerStartupDelayMs;
+
+  if (typeof delayMs !== 'number' || delayMs <= 0) {
+    return;
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, delayMs));
+}
+
 async function runImportScripts() {
   // Bail if we've already run importScripts
   if (runImportScriptsInitiated) {
     return;
   }
   runImportScriptsInitiated = true;
+
+  await maybeApplyServiceWorkerStartupDelay();
 
   const startImportScriptsTime = performance.now();
 

--- a/shared/lib/manifestFlags.ts
+++ b/shared/lib/manifestFlags.ts
@@ -102,6 +102,11 @@ export type ManifestFlags = {
      */
     simulatedSlowBackgroundLoadingTimeout?: number;
     /**
+     * Number of milliseconds to wait before importing the background script
+     * during service worker installation.
+     */
+    simulateServiceWorkerStartupDelayMs?: number;
+    /**
      * Simulate background initialization hang for testing the initialization
      * timeout error screen. Only triggers when a vault backup exists in IndexedDB,
      * so tests can onboard first, then reload to trigger the timeout.

--- a/test/e2e/tests/critical-errors/critical-errors.spec.ts
+++ b/test/e2e/tests/critical-errors/critical-errors.spec.ts
@@ -211,4 +211,28 @@ describe('Critical errors', function (this: Suite) {
       },
     );
   });
+
+  it('loads the login page when service worker install delays background script import', async function () {
+    if (getManifestVersion() === 2) {
+      this.skip();
+    }
+
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilderV2().build(),
+        manifestFlags: {
+          testing: {
+            simulateServiceWorkerStartupDelayMs: 5000,
+          },
+        },
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }) => {
+        await driver.navigate(PAGES.HOME, { waitForControllers: false });
+
+        const loginPage = new LoginPage(driver);
+        await loginPage.checkPageIsLoaded();
+      },
+    );
+  });
 });


### PR DESCRIPTION
## **Description**

On MV3, the service worker loads `background.js` asynchronously during the `install` event. Today that work is started from the install handler but not tied to the event lifetime, so Chrome can consider install finished before the import completes.

We reproduced this by adding a short artificial delay before the background import on a fresh install. Without `event.waitUntil()`, the delay causes a console error such as:

`NetworkError: Failed to execute 'importScripts' on 'WorkerGlobalScope': The script at 'chrome-extension://…/8955.js' failed to load.`

The background never loads and the extension cannot start.

This PR wraps install-time startup in `event.waitUntil()`, which is [Chrome's recommended pattern](https://developer.chrome.com/docs/extensions/develop/migrate/to-service-workers) for async work during service worker lifecycle events. The same change is applied in `app-init.js` for the browserify build path.

This change is intentionally minimal. It does not add custom keep-alive logic or periodic API polling.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related to: #43773

## **Manual testing steps**

### How to make the error reproducible and easy to see?

Add a temporary 5-second delay by adding this line in `app/service-worker.ts`, inside `runImportScripts()`, **immediately before** `await import('./scripts/background.js')`:

   ```typescript
   await new Promise((resolve) => setTimeout(resolve, 5000));
   ```

### Part A — Reproduce the bug (without the fix)

1. Check out `main`.
2. Manually add the 5-second delay.
3. Run `yarn start` and wait for a successful compile.
4. Go to `chrome://extensions`, and load unpacked from `dist/chrome`, but do not open the extension popup yet.
5. Open the service worker console.
6. After ~5 seconds, confirm the console shows a `NetworkError` for `importScripts` (a numbered chunk such as `8955.js` failed to load).
7. Confirm `importScripts completed in ... seconds` does **not** appear.
8. Open the MetaMask popup and confirm it shows the critical error screen with "Background connection unresponsive" message.

<img width="388" height="448" alt="Screenshot 2026-07-06 at 07 22 36" src="https://github.com/user-attachments/assets/28cdfebb-3332-462c-8b8f-bcef26e290aa" />

### Part B — Verify the fix (with this PR)

1. Check out this PR branch with the `event.waitUntil(...)` install handler in place.
2. Manually add the 5-second delay.
3. Run `yarn start` and wait for a successful compile.
4. Go to `chrome://extensions`, and load unpacked from `dist/chrome`, but do not open the extension popup yet.
5. Open the service worker console.
5. After ~5 seconds, confirm `importScripts completed in ... seconds` appears and there is no `NetworkError`.
6. Open the MetaMask popup and confirm it loads normally.

## **Screenshots/Recordings**

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core MV3 service worker install/background bootstrap timing; behavior change is small but affects extension startup on every fresh install or SW update.
> 
> **Overview**
> Fixes MV3 startup failures when background script import takes longer than the service worker **install** event: the install listener now calls **`event.waitUntil(runImportScripts())`** so Chrome keeps the install lifecycle open until the dynamic `background.js` import finishes, instead of firing install completion early and surfacing `importScripts` / chunk load errors.
> 
> For e2e, adds **`simulateServiceWorkerStartupDelayMs`** under manifest testing flags and **`maybeApplyServiceWorkerStartupDelay()`** (test builds only) before the import, plus an MV3 test that asserts the login page still loads when a 5s install-time delay is simulated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cbf726305fcc217dbfd0592a0c06921da6abb2ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->