### PR TITLE
feat: create bottom bar UI

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -4490,6 +4490,10 @@
   "holdToRevealUnlockedLabel": {
     "message": "hold to reveal circle unlocked"
   },
+  "home": {
+    "message": "Home",
+    "description": "Label for the Home tab in the bottom navigation bar"
+  },
   "honeypotDescription": {
     "message": "This token might pose a honeypot risk. It is advised to conduct due diligence before interacting to prevent any potential financial loss."
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -4490,6 +4490,10 @@
   "holdToRevealUnlockedLabel": {
     "message": "hold to reveal circle unlocked"
   },
+  "home": {
+    "message": "Home",
+    "description": "Label for the Home tab in the bottom navigation bar"
+  },
   "honeypotDescription": {
     "message": "This token might pose a honeypot risk. It is advised to conduct due diligence before interacting to prevent any potential financial loss."
   },

--- a/ui/components/app/bottom-nav-bar/bottom-nav-bar.stories.tsx
+++ b/ui/components/app/bottom-nav-bar/bottom-nav-bar.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { BottomNavBar } from './bottom-nav-bar';
+
+const meta: Meta<typeof BottomNavBar> = {
+  title: 'Components/App/BottomNavBar',
+  component: BottomNavBar,
+  parameters: {
+    initialEntries: ['/'],
+    path: '*',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof BottomNavBar>;
+
+export const Default: Story = {};

--- a/ui/components/app/bottom-nav-bar/bottom-nav-bar.test.tsx
+++ b/ui/components/app/bottom-nav-bar/bottom-nav-bar.test.tsx
@@ -113,7 +113,10 @@ describe('BottomNavBar', () => {
     });
 
     it('marks Perps as active on the /perps-home route', () => {
-      const { getByTestId } = renderBottomNavBar(baseState, PERPS_HOME_PAGE_ROUTE);
+      const { getByTestId } = renderBottomNavBar(
+        baseState,
+        PERPS_HOME_PAGE_ROUTE,
+      );
 
       expect(getByTestId('bottom-nav-perps')).toHaveAttribute(
         'aria-current',
@@ -164,9 +167,7 @@ describe('BottomNavBar', () => {
       );
 
       fireEvent.click(getByTestId('bottom-nav-home'));
-      expect(mockNavigate).toHaveBeenCalledWith(
-        `${DEFAULT_ROUTE}?tab=nfts`,
-      );
+      expect(mockNavigate).toHaveBeenCalledWith(`${DEFAULT_ROUTE}?tab=nfts`);
     });
 
     it('navigates to the perps page when Perps is clicked', () => {

--- a/ui/components/app/bottom-nav-bar/bottom-nav-bar.test.tsx
+++ b/ui/components/app/bottom-nav-bar/bottom-nav-bar.test.tsx
@@ -1,0 +1,193 @@
+import React from 'react';
+import { fireEvent } from '@testing-library/react';
+import configureStore from '../../../store/store';
+import mockState from '../../../../test/data/mock-state.json';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import {
+  ACTIVITY_ROUTE,
+  DEFAULT_ROUTE,
+  PERPS_HOME_PAGE_ROUTE,
+  PERPS_ROUTE,
+  SWAP_PATH,
+} from '../../../helpers/constants/routes';
+import { BottomNavBar } from './bottom-nav-bar';
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+jest.mock('../../../../shared/lib/environment', () => ({
+  ...jest.requireActual('../../../../shared/lib/environment'),
+  getIsPerpsIncludedInBuild: jest.fn(() => true),
+}));
+
+const baseState = {
+  metamask: {
+    ...mockState.metamask,
+    completedOnboarding: true,
+    remoteFeatureFlags: {
+      ...mockState.metamask.remoteFeatureFlags,
+      perpsEnabledVersion: { enabled: true, minimumVersion: '0.0.1' },
+    },
+  },
+};
+
+const stateWithPerpsDisabled = {
+  metamask: {
+    ...mockState.metamask,
+    completedOnboarding: true,
+    remoteFeatureFlags: {
+      ...mockState.metamask.remoteFeatureFlags,
+      perpsEnabledVersion: { enabled: false, minimumVersion: '0.0.1' },
+    },
+  },
+};
+
+const stateWithLastTab = {
+  metamask: {
+    ...baseState.metamask,
+    defaultHomeActiveTabName: 'nfts',
+  },
+};
+
+function renderBottomNavBar(state = baseState, pathname = DEFAULT_ROUTE) {
+  const store = configureStore(state);
+  return renderWithProvider(<BottomNavBar />, store, pathname);
+}
+
+describe('BottomNavBar', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('renders all tabs', () => {
+    it('renders Home, Swaps, Perps, and Activity tabs when Perps is available', () => {
+      const { getByTestId } = renderBottomNavBar();
+
+      expect(getByTestId('bottom-nav-home')).toBeInTheDocument();
+      expect(getByTestId('bottom-nav-swaps')).toBeInTheDocument();
+      expect(getByTestId('bottom-nav-perps')).toBeInTheDocument();
+      expect(getByTestId('bottom-nav-activity')).toBeInTheDocument();
+    });
+
+    it('renders Home, Swaps, and Activity tabs when Perps is unavailable', () => {
+      const { getByTestId, queryByTestId } = renderBottomNavBar(
+        stateWithPerpsDisabled,
+      );
+
+      expect(getByTestId('bottom-nav-home')).toBeInTheDocument();
+      expect(getByTestId('bottom-nav-swaps')).toBeInTheDocument();
+      expect(queryByTestId('bottom-nav-perps')).not.toBeInTheDocument();
+      expect(getByTestId('bottom-nav-activity')).toBeInTheDocument();
+    });
+  });
+
+  describe('active state', () => {
+    it('marks Home as active on the root route', () => {
+      const { getByTestId } = renderBottomNavBar(baseState, DEFAULT_ROUTE);
+
+      expect(getByTestId('bottom-nav-home')).toHaveAttribute(
+        'aria-current',
+        'page',
+      );
+      expect(getByTestId('bottom-nav-perps')).not.toHaveAttribute(
+        'aria-current',
+      );
+      expect(getByTestId('bottom-nav-activity')).not.toHaveAttribute(
+        'aria-current',
+      );
+    });
+
+    it('marks Activity as active on the /activity route', () => {
+      const { getByTestId } = renderBottomNavBar(baseState, ACTIVITY_ROUTE);
+
+      expect(getByTestId('bottom-nav-activity')).toHaveAttribute(
+        'aria-current',
+        'page',
+      );
+      expect(getByTestId('bottom-nav-home')).not.toHaveAttribute(
+        'aria-current',
+      );
+    });
+
+    it('marks Perps as active on the /perps-home route', () => {
+      const { getByTestId } = renderBottomNavBar(baseState, PERPS_HOME_PAGE_ROUTE);
+
+      expect(getByTestId('bottom-nav-perps')).toHaveAttribute(
+        'aria-current',
+        'page',
+      );
+      expect(getByTestId('bottom-nav-home')).not.toHaveAttribute(
+        'aria-current',
+      );
+    });
+
+    it('marks Perps as active on /perps/* sub-routes', () => {
+      const { getByTestId } = renderBottomNavBar(
+        baseState,
+        `${PERPS_ROUTE}/market-list`,
+      );
+
+      expect(getByTestId('bottom-nav-perps')).toHaveAttribute(
+        'aria-current',
+        'page',
+      );
+    });
+
+    it('marks Swaps as active on the swaps route', () => {
+      const { getByTestId } = renderBottomNavBar(baseState, SWAP_PATH);
+
+      expect(getByTestId('bottom-nav-swaps')).toHaveAttribute(
+        'aria-current',
+        'page',
+      );
+      expect(getByTestId('bottom-nav-home')).not.toHaveAttribute(
+        'aria-current',
+      );
+    });
+  });
+
+  describe('navigation', () => {
+    it('navigates to the root route when Home is clicked and no last tab is stored', () => {
+      const { getByTestId } = renderBottomNavBar(baseState, ACTIVITY_ROUTE);
+
+      fireEvent.click(getByTestId('bottom-nav-home'));
+      expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE);
+    });
+
+    it('navigates to the last active tab when Home is clicked and a tab is stored', () => {
+      const { getByTestId } = renderBottomNavBar(
+        stateWithLastTab,
+        ACTIVITY_ROUTE,
+      );
+
+      fireEvent.click(getByTestId('bottom-nav-home'));
+      expect(mockNavigate).toHaveBeenCalledWith(
+        `${DEFAULT_ROUTE}?tab=nfts`,
+      );
+    });
+
+    it('navigates to the perps page when Perps is clicked', () => {
+      const { getByTestId } = renderBottomNavBar();
+
+      fireEvent.click(getByTestId('bottom-nav-perps'));
+      expect(mockNavigate).toHaveBeenCalledWith(PERPS_HOME_PAGE_ROUTE);
+    });
+
+    it('navigates to the swaps route when Swaps is clicked', () => {
+      const { getByTestId } = renderBottomNavBar();
+
+      fireEvent.click(getByTestId('bottom-nav-swaps'));
+      expect(mockNavigate).toHaveBeenCalledWith(SWAP_PATH);
+    });
+
+    it('navigates to the activity route when Activity is clicked', () => {
+      const { getByTestId } = renderBottomNavBar();
+
+      fireEvent.click(getByTestId('bottom-nav-activity'));
+      expect(mockNavigate).toHaveBeenCalledWith(ACTIVITY_ROUTE);
+    });
+  });
+});

--- a/ui/components/app/bottom-nav-bar/bottom-nav-bar.tsx
+++ b/ui/components/app/bottom-nav-bar/bottom-nav-bar.tsx
@@ -15,7 +15,7 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   ACTIVITY_ROUTE,
   DEFAULT_ROUTE,
-  PERPS_MARKET_LIST_ROUTE,
+  PERPS_HOME_PAGE_ROUTE,
   PERPS_ROUTE,
   SWAP_PATH,
 } from '../../../helpers/constants/routes';
@@ -71,7 +71,8 @@ export function BottomNavBar() {
   const lastActiveTab = useSelector(getDefaultHomeActiveTabName);
 
   const isHome = pathname === DEFAULT_ROUTE;
-  const isPerps = pathname.startsWith(PERPS_ROUTE);
+  const isPerps =
+    pathname === PERPS_HOME_PAGE_ROUTE || pathname.startsWith(PERPS_ROUTE);
   const isSwaps = pathname.startsWith(SWAP_PATH);
   const isActivity = pathname === ACTIVITY_ROUTE;
 
@@ -84,7 +85,7 @@ export function BottomNavBar() {
   );
 
   const handlePerpsClick = useCallback(
-    () => navigate(PERPS_MARKET_LIST_ROUTE),
+    () => navigate(PERPS_HOME_PAGE_ROUTE),
     [navigate],
   );
 

--- a/ui/components/app/bottom-nav-bar/bottom-nav-bar.tsx
+++ b/ui/components/app/bottom-nav-bar/bottom-nav-bar.tsx
@@ -1,0 +1,132 @@
+import React, { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import { useLocation, useNavigate } from 'react-router-dom';
+import {
+  Icon,
+  IconColor,
+  IconName,
+  IconSize,
+  Text,
+  TextVariant,
+  TextColor,
+  FontWeight,
+} from '@metamask/design-system-react';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import {
+  ACTIVITY_ROUTE,
+  DEFAULT_ROUTE,
+  PERPS_MARKET_LIST_ROUTE,
+  PERPS_ROUTE,
+  SWAP_PATH,
+} from '../../../helpers/constants/routes';
+import { getIsPerpsExperienceAvailable } from '../../../selectors/perps/feature-flags';
+import { getDefaultHomeActiveTabName } from '../../../selectors';
+
+type NavTabProps = {
+  isActive: boolean;
+  icon: IconName;
+  label: string;
+  onClick: () => void;
+  'data-testid'?: string;
+};
+
+const NavTab = ({
+  isActive,
+  icon,
+  label,
+  onClick,
+  'data-testid': testId,
+}: NavTabProps) => {
+  return (
+    <button
+      data-testid={testId}
+      onClick={onClick}
+      className="group/tab flex flex-1 flex-col gap-1 items-center justify-center"
+      aria-current={isActive ? 'page' : undefined}
+      aria-label={label}
+    >
+      <Icon
+        name={icon}
+        size={IconSize.Lg}
+        color={isActive ? IconColor.IconDefault : IconColor.IconAlternative}
+        className="group-hover/tab:text-icon-default-hover"
+      />
+      <Text
+        variant={TextVariant.BodySm}
+        fontWeight={FontWeight.Medium}
+        color={isActive ? TextColor.TextDefault : TextColor.TextAlternative}
+        className="group-hover/tab:text-text-default"
+      >
+        {label}
+      </Text>
+    </button>
+  );
+};
+
+export function BottomNavBar() {
+  const t = useI18nContext();
+  const navigate = useNavigate();
+  const { pathname } = useLocation();
+  const isPerpsAvailable = useSelector(getIsPerpsExperienceAvailable);
+  const lastActiveTab = useSelector(getDefaultHomeActiveTabName);
+
+  const isHome = pathname === DEFAULT_ROUTE;
+  const isPerps = pathname.startsWith(PERPS_ROUTE);
+  const isSwaps = pathname.startsWith(SWAP_PATH);
+  const isActivity = pathname === ACTIVITY_ROUTE;
+
+  const handleHomeClick = useCallback(
+    () =>
+      navigate(
+        lastActiveTab ? `${DEFAULT_ROUTE}?tab=${lastActiveTab}` : DEFAULT_ROUTE,
+      ),
+    [navigate, lastActiveTab],
+  );
+
+  const handlePerpsClick = useCallback(
+    () => navigate(PERPS_MARKET_LIST_ROUTE),
+    [navigate],
+  );
+
+  const handleSwapsClick = useCallback(() => navigate(SWAP_PATH), [navigate]);
+
+  const handleActivityClick = useCallback(
+    () => navigate(ACTIVITY_ROUTE),
+    [navigate],
+  );
+
+  return (
+    <nav className="bottom-nav-bar w-full bg-background-default border-t border-border-muted flex flex-row justify-between p-2 gap-2">
+      <NavTab
+        isActive={isHome}
+        icon={isHome ? IconName.HomeFilled : IconName.Home}
+        label={t('home')}
+        onClick={handleHomeClick}
+        data-testid="bottom-nav-home"
+      />
+      {isPerpsAvailable && (
+        <NavTab
+          isActive={isPerps}
+          icon={IconName.Candlestick}
+          label={t('perps')}
+          onClick={handlePerpsClick}
+          data-testid="bottom-nav-perps"
+        />
+      )}
+      <NavTab
+        isActive={isSwaps}
+        icon={IconName.SwapVertical}
+        label={t('swap')}
+        onClick={handleSwapsClick}
+        data-testid="bottom-nav-swaps"
+      />
+      <NavTab
+        isActive={isActivity}
+        icon={IconName.Activity}
+        label={t('activity')}
+        onClick={handleActivityClick}
+        data-testid="bottom-nav-activity"
+      />
+    </nav>
+  );
+}

--- a/ui/helpers/constants/routes.ts
+++ b/ui/helpers/constants/routes.ts
@@ -196,9 +196,11 @@ export const PERPS_REOPEN_TTL_MS = 5 * 60 * 1000;
 
 export const SHIELD_PLAN_ROUTE = '/shield-plan';
 export const REWARDS_ROUTE = '/rewards';
+export const ACTIVITY_ROUTE = '/activity';
 
 export const ROUTES = [
   { path: DEFAULT_ROUTE, label: 'Home', trackInAnalytics: true },
+  { path: ACTIVITY_ROUTE, label: 'Activity', trackInAnalytics: true },
   { path: '', label: 'Home', trackInAnalytics: true }, // "" is an alias for the Home route
   {
     path: `${TX_DETAILS_ROUTE}/:caipChainId/:txIdentifier`,

--- a/ui/helpers/constants/routes.ts
+++ b/ui/helpers/constants/routes.ts
@@ -188,6 +188,7 @@ export const PERPS_ORDER_ENTRY_ROUTE = '/perps/trade';
 export const PERPS_ACTIVITY_ROUTE = '/perps/activity';
 export const PERPS_WITHDRAW_ROUTE = '/perps/withdraw';
 export const PERPS_MARKET_LIST_ROUTE = '/perps/market-list';
+export const PERPS_HOME_PAGE_ROUTE = '/perps-home';
 
 // Window during which reopening the extension resumes the last Perps screen
 // instead of landing on the wallet home. Keeps the cap short so stale sessions
@@ -201,6 +202,7 @@ export const ACTIVITY_ROUTE = '/activity';
 export const ROUTES = [
   { path: DEFAULT_ROUTE, label: 'Home', trackInAnalytics: true },
   { path: ACTIVITY_ROUTE, label: 'Activity', trackInAnalytics: true },
+  { path: PERPS_HOME_PAGE_ROUTE, label: 'Perps', trackInAnalytics: true },
   { path: '', label: 'Home', trackInAnalytics: true }, // "" is an alias for the Home route
   {
     path: `${TX_DETAILS_ROUTE}/:caipChainId/:txIdentifier`,

--- a/ui/pages/activity/activity-page.tsx
+++ b/ui/pages/activity/activity-page.tsx
@@ -5,6 +5,8 @@ import { ScrollContainer } from '../../contexts/scroll-container';
 import { useI18nContext } from '../../hooks/useI18nContext';
 import { ActivityList } from './activity-list';
 
+// Page shown when the Activity tab in the bottom navigation bar is clicked
+// Bottom navigation bar is shown in the A/B test coreExtensionUxCeux1141AbtestBottomNav
 export const ActivityPage = () => {
   const t = useI18nContext();
 

--- a/ui/pages/activity/activity-page.tsx
+++ b/ui/pages/activity/activity-page.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { FontWeight, Text, TextVariant } from '@metamask/design-system-react';
+import { Page } from '../../components/multichain/pages/page';
+import { ScrollContainer } from '../../contexts/scroll-container';
+import { useI18nContext } from '../../hooks/useI18nContext';
+import { ActivityList } from './activity-list';
+
+export const ActivityPage = () => {
+  const t = useI18nContext();
+
+  return (
+    <Page data-testid="activity-page">
+      <Text
+        variant={TextVariant.HeadingLg}
+        fontWeight={FontWeight.Medium}
+        className="pt-6 px-4 pb-2"
+      >
+        {t('activity')}
+      </Text>
+      <ScrollContainer className="flex-1 overflow-auto">
+        <ActivityList />
+      </ScrollContainer>
+    </Page>
+  );
+};
+
+export default ActivityPage;

--- a/ui/pages/perps/perps-home-page.tsx
+++ b/ui/pages/perps/perps-home-page.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { Page } from '../../components/multichain/pages/page';
 import { Text, FontWeight, TextVariant } from '@metamask/design-system-react';
+import { Page } from '../../components/multichain/pages/page';
 import { useI18nContext } from '../../hooks/useI18nContext';
 import { PerpsTab } from '../../components/app/perps/perps-tab';
 

--- a/ui/pages/perps/perps-home-page.tsx
+++ b/ui/pages/perps/perps-home-page.tsx
@@ -11,7 +11,11 @@ export const PerpsHomePage = () => {
 
   return (
     <Page data-testid="perps-home-page">
-      <Text variant={TextVariant.HeadingLg} fontWeight={FontWeight.Medium} className="pt-6 px-4 pb-2">
+      <Text
+        variant={TextVariant.HeadingLg}
+        fontWeight={FontWeight.Medium}
+        className="pt-6 px-4 pb-2"
+      >
         {t('perps')}
       </Text>
       <PerpsTab />

--- a/ui/pages/perps/perps-home-page.tsx
+++ b/ui/pages/perps/perps-home-page.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { Page } from '../../components/multichain/pages/page';
+import { Text, FontWeight, TextVariant } from '@metamask/design-system-react';
+import { useI18nContext } from '../../hooks/useI18nContext';
+import { PerpsTab } from '../../components/app/perps/perps-tab';
+
+// Page shown when the Perps tab in the bottom navigation bar is clicked
+// Bottom navigation bar is shown in the A/B test coreExtensionUxCeux1141AbtestBottomNav
+export const PerpsHomePage = () => {
+  const t = useI18nContext();
+
+  return (
+    <Page data-testid="perps-home-page">
+      <Text variant={TextVariant.HeadingLg} fontWeight={FontWeight.Medium} className="pt-6 px-4 pb-2">
+        {t('perps')}
+      </Text>
+      <PerpsTab />
+    </Page>
+  );
+};
+
+export default PerpsHomePage;

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -573,15 +573,15 @@ export const routeConfig = [
                 path: PERPS_WITHDRAW_ROUTE,
                 element: <PerpsWithdrawPage />,
               },
-              {
-                path: ACTIVITY_ROUTE,
-                element: <ActivityPage />,
-              },
-              {
-                path: PERPS_HOME_PAGE_ROUTE,
-                element: <PerpsPage />,
-              },
             ],
+          },
+          {
+            path: ACTIVITY_ROUTE,
+            element: <ActivityPage />,
+          },
+          {
+            path: PERPS_HOME_PAGE_ROUTE,
+            element: <PerpsPage />,
           },
         ],
       },

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -73,6 +73,7 @@ import {
   PERPS_ORDER_ENTRY_ROUTE,
   PERPS_ACTIVITY_ROUTE,
   PERPS_WITHDRAW_ROUTE,
+  ACTIVITY_ROUTE,
   CONTACTS_ROUTE,
   HARDWARE_WALLET_REPAIR_ROUTE,
   BATCH_SELL_ROOT_ROUTE,
@@ -237,6 +238,7 @@ const MarketListView = mmLazy(() => import('../perps/market-list/index.tsx'));
 const PerpsActivityPage = mmLazy(
   () => import('../perps/perps-activity-page.tsx'),
 );
+const ActivityPage = mmLazy(() => import('../activity/activity-page.tsx'));
 const PerpsWithdrawPage = mmLazy(
   () => import('../perps/perps-withdraw-page.tsx'),
 );
@@ -568,6 +570,10 @@ export const routeConfig = [
               {
                 path: PERPS_WITHDRAW_ROUTE,
                 element: <PerpsWithdrawPage />,
+              },
+              {
+                path: ACTIVITY_ROUTE,
+                element: <ActivityPage />,
               },
             ],
           },

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -74,6 +74,7 @@ import {
   PERPS_ACTIVITY_ROUTE,
   PERPS_WITHDRAW_ROUTE,
   ACTIVITY_ROUTE,
+  PERPS_HOME_PAGE_ROUTE,
   CONTACTS_ROUTE,
   HARDWARE_WALLET_REPAIR_ROUTE,
   BATCH_SELL_ROOT_ROUTE,
@@ -239,6 +240,7 @@ const PerpsActivityPage = mmLazy(
   () => import('../perps/perps-activity-page.tsx'),
 );
 const ActivityPage = mmLazy(() => import('../activity/activity-page.tsx'));
+const PerpsPage = mmLazy(() => import('../perps/perps-home-page.tsx'));
 const PerpsWithdrawPage = mmLazy(
   () => import('../perps/perps-withdraw-page.tsx'),
 );
@@ -574,6 +576,10 @@ export const routeConfig = [
               {
                 path: ACTIVITY_ROUTE,
                 element: <ActivityPage />,
+              },
+              {
+                path: PERPS_HOME_PAGE_ROUTE,
+                element: <PerpsPage />,
               },
             ],
           },


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR introduces the new BottomBarNav component which will be shown in an AB test only to new users. The component isn't being used yet but can be viewed using the story.

The tabs on the bottom bar will point to full page experiences: Home, Perps, Swap and Activity. Perps and Activity are currently tab screens, not full pages. Therefore two new page routes and page scaffolds have been created that the bottom nav will point to. The Perps one will have a new design as seen [here](https://www.figma.com/design/IZBp8tbuEAo2vqqRSckNgg/Extension-IA---bottom-nav-bar?node-id=254-2995&m=dev) in a separate PR.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Relates: https://consensyssoftware.atlassian.net/browse/CEUX-1141

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

Bottom Nav Bar is not integrated yet but when it is it will look like so:
<img width="406" height="603" alt="image" src="https://github.com/user-attachments/assets/bbadc554-f8c5-43c7-9c65-fcf1472cfee8" />

New Perps page (new design pending):
<img width="403" height="601" alt="image" src="https://github.com/user-attachments/assets/c95f19ca-c0ce-4138-83c5-9096989334c1" />

New Activity page:
<img width="403" height="601" alt="image" src="https://github.com/user-attachments/assets/fb7ddb60-8736-453d-8f90-684f94f69efa" />

Existing Swap page:
<img width="403" height="600" alt="image" src="https://github.com/user-attachments/assets/bb10538a-4584-4cd4-bae1-0230eb3c4208" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI and routing additions behind existing perps gating; no auth or transaction logic changes in this diff.
> 
> **Overview**
> Adds a **bottom navigation bar** with tabs for Home, Swaps, Activity, and optionally Perps (when the perps experience is available via feature flags/build).
> 
> The bar tracks the current route for active styling (`aria-current`), and **Home** restores the last home sub-tab from Redux (`defaultHomeActiveTabName`) when set. New top-level routes **`/activity`** and **`/perps-home`** host dedicated pages that reuse existing **`ActivityList`** and **`PerpsTab`** content, and those paths are registered for analytics in **`ROUTES`**.
> 
> Includes a **`home`** i18n string, Storybook coverage, and unit tests for tab visibility, active states, and navigation targets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19ee593d29bbf58de9ed423a01af449f2d28a3b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->