### PR TITLE
test(e2e): add Tron swap negative path for unavailable network fees

### DIFF
--- a/package.json
+++ b/package.json
@@ -308,7 +308,8 @@
     "@metamask/assets-controller@npm:^8.1.0": "patch:@metamask/assets-controller@npm%3A8.3.2#~/.yarn/patches/@metamask-assets-controller-npm-8.3.2-f205cdbfee.patch",
     "@metamask/accounts-controller": "^39.0.3",
     "@metamask/multichain-account-service": "^11.0.0",
-    "@pmmmwh/react-refresh-webpack-plugin@npm:^0.5.11": "patch:@pmmmwh/react-refresh-webpack-plugin@npm%3A0.5.13#~/.yarn/patches/@pmmmwh-react-refresh-webpack-plugin-npm-0.5.13-25d13d4186.patch"
+    "@pmmmwh/react-refresh-webpack-plugin@npm:^0.5.11": "patch:@pmmmwh/react-refresh-webpack-plugin@npm%3A0.5.13#~/.yarn/patches/@pmmmwh-react-refresh-webpack-plugin-npm-0.5.13-25d13d4186.patch",
+    "@metamask/tron-wallet-snap": "npm:@metamask-previews/tron-wallet-snap@1.28.0-preview-e5e1c78"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.29.2#~/.yarn/patches/@babel-runtime-npm-7.29.2-b49cad1c67.patch",

--- a/test/e2e/page-objects/pages/swap/swap-page.ts
+++ b/test/e2e/page-objects/pages/swap/swap-page.ts
@@ -85,6 +85,11 @@ class SwapPage {
     text: 'Swap',
   };
 
+  private readonly insufficientFundsButton = {
+    text: 'Insufficient funds',
+    css: '[data-testid="bridge-cta-button"]',
+  };
+
   private readonly transactionHeader = '[data-testid="awaiting-swap-header"]';
 
   private readonly networkFees = '[data-testid="network-fees"]';
@@ -249,6 +254,22 @@ class SwapPage {
       [this.networkFees, this.slippageEditButton, this.minimumReceived],
       options,
     );
+  }
+
+  async checkQuoteIsDisplayedWithoutNetworkFee(
+    options?: { timeout?: number },
+  ): Promise<void> {
+    await this.driver.waitForMultipleSelectors(
+      [this.slippageEditButton, this.minimumReceived, this.reviewToAmount],
+      options,
+    );
+  }
+
+  async checkInsufficientFundsButtonIsDisplayed(): Promise<void> {
+    await this.driver.waitForSelector(this.insufficientFundsButton);
+    await this.driver.waitForSelector(this.submitSwapButton, {
+      state: 'disabled',
+    });
   }
 
   async checkQuoteIsGasIncluded(): Promise<void> {

--- a/test/e2e/tests/tron/check-balance.spec.ts
+++ b/test/e2e/tests/tron/check-balance.spec.ts
@@ -52,10 +52,10 @@ describe('Check balance', function (this: Suite) {
         // Refresh re-hydrates the UI from background state so the asynchronously-fetched Snap balance is shown reliably.
         await driver.refresh();
 
-        // TRX_BALANCE = 6072392 SUN = ~6.07 TRX * $0.29469 = ~$1.79
-        // Total Fiat = TRX $1.79, HTX DAO $5.30, USDT $2.80, USDD $0.29 = $10.18
+        // TRX_BALANCE = 106072392 SUN = ~106.07 TRX * $0.29469 = ~$31.26
+        // Total Fiat = TRX $31.26, HTX DAO $5.30, USDT $2.80, USDD $0.29 = $39.65
         await homePage.checkExpectedBalanceIsDisplayed({
-          expectedBalance: '$10.18',
+          expectedBalance: '$39.65',
           timeout: HOMEPAGE_BALANCE_ASSERTION_TIMEOUT_MS,
         });
       },
@@ -78,9 +78,9 @@ describe('Check balance', function (this: Suite) {
         // Refresh re-hydrates the UI from background state so the asynchronously-fetched Snap balance is shown reliably.
         await driver.refresh();
 
-        // TRX_BALANCE = 6072392 SUN = ~6.07 TRX
+        // TRX_BALANCE = 106072392 SUN = ~106.07 TRX
         await homePage.checkExpectedBalanceIsDisplayed({
-          expectedBalance: '6.072 TRX',
+          expectedBalance: '106.072 TRX',
           timeout: HOMEPAGE_BALANCE_ASSERTION_TIMEOUT_MS,
         });
       },

--- a/test/e2e/tests/tron/mocks/common-tron.ts
+++ b/test/e2e/tests/tron/mocks/common-tron.ts
@@ -1207,6 +1207,89 @@ export async function mockBridgeGetTronQuoteEmpty(
     }));
 }
 
+export async function mockTronGetChainParameters(
+  mockServer: Mockttp,
+): Promise<MockedEndpoint> {
+  return mockServer
+    .forPost(tronInfuraUrl('/wallet/getchainparameters'))
+    .always()
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: {
+        chainParameter: [
+          { key: 'getMaintenanceTimeInterval', value: 21600000 },
+          { key: 'getAccountUpgradeCost', value: 9999000000 },
+          { key: 'getCreateNewAccountFeeInSystemContract', value: 1000000 },
+          { key: 'getCreateAccountFee', value: 100000 },
+          { key: 'getTransactionFee', value: 1000 },
+          { key: 'getAssetIssueFee', value: 1024000000 },
+          { key: 'getEnergyFee', value: 420 },
+          { key: 'getTotalEnergyLimit', value: 180000000000 },
+          { key: 'getAllowTvmTransferTrc10', value: 1 },
+          { key: 'getTotalEnergyCurrentLimit', value: 180000000000 },
+          { key: 'getAllowMultiSign', value: 1 },
+          { key: 'getAllowAdaptivEnergy', value: 1 },
+        ],
+      },
+    }));
+}
+
+export async function mockTronGetNextMaintenanceTime(
+  mockServer: Mockttp,
+): Promise<MockedEndpoint> {
+  return mockServer
+    .forPost(tronInfuraUrl('/wallet/getnextmaintenancetime'))
+    .always()
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: { num: MOCK_TRON_BLOCK_TIMESTAMP_NOW_PLUS_A_YEAR },
+    }));
+}
+
+export async function mockTronTriggerConstantContract(
+  mockServer: Mockttp,
+): Promise<MockedEndpoint> {
+  return mockServer
+    .forPost(tronInfuraUrl('/wallet/triggerconstantcontract'))
+    .always()
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: {
+        result: { result: true },
+        energy_used: 200000,
+        energy_penalty: 0,
+        constant_result: [
+          '0000000000000000000000000000000000000000000000000000000000000001',
+        ],
+        transaction: {
+          ret: [{}],
+          visible: false,
+          txID: 'mock_trigger_constant_txid',
+          raw_data: {
+            contract: [],
+            ref_block_bytes: 'f733',
+            ref_block_hash: 'ff89d72ddc1ce1ea',
+            expiration: MOCK_TRON_BLOCK_TIMESTAMP_NOW_PLUS_A_YEAR,
+            timestamp: MOCK_TRON_BLOCK_TIMESTAMP_NOW_PLUS_A_YEAR,
+          },
+          raw_data_hex: '',
+        },
+      },
+    }));
+}
+
+export async function mockTronGetContract(
+  mockServer: Mockttp,
+): Promise<MockedEndpoint> {
+  return mockServer
+    .forPost(tronInfuraUrl('/wallet/getcontract'))
+    .always()
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: {},
+    }));
+}
+
 /**
  * Mocks the accounts API v2 supportedNetworks to include Tron so the
  * AccountsApiDataSource handles Tron balances via the v5 API instead of
@@ -1330,6 +1413,10 @@ export async function mockTronSwapApis(
     ...(await mockTronApis(mockServer, mockZeroBalance)),
     await mockBridgeGetTronTokens(mockServer),
     await mockBridgeGetTronQuote(mockServer),
+    await mockTronGetChainParameters(mockServer),
+    await mockTronGetNextMaintenanceTime(mockServer),
+    await mockTronTriggerConstantContract(mockServer),
+    await mockTronGetContract(mockServer),
   ];
 }
 

--- a/test/e2e/tests/tron/mocks/common-tron.ts
+++ b/test/e2e/tests/tron/mocks/common-tron.ts
@@ -275,10 +275,7 @@ export async function mockTronGetAccountResource(
 ): Promise<MockedEndpoint> {
   return mockServer
     .forPost(tronInfuraUrl('/wallet/getaccountresource'))
-    .withJsonBody({
-      address: TRON_ACCOUNT_ADDRESS,
-      visible: true,
-    })
+    .always()
     .thenCallback(() => ({
       statusCode: 200,
       json: {
@@ -1262,18 +1259,48 @@ export async function mockTronTriggerConstantContract(
           '0000000000000000000000000000000000000000000000000000000000000001',
         ],
         transaction: {
-          ret: [{}],
+          ret: [{ ret: 'SUCCESS' }],
           visible: false,
           txID: 'mock_trigger_constant_txid',
           raw_data: {
-            contract: [],
+            contract: [
+              {
+                parameter: {
+                  value: {
+                    data: '14d08fca',
+                    owner_address: '41588c5216750cceaad16cf5a757e3f7b32835a5e1',
+                    contract_address:
+                      '41f742f4589459f0923fa579600815763d1646bec3',
+                  },
+                  type_url:
+                    'type.googleapis.com/protocol.TriggerSmartContract',
+                },
+                type: 'TriggerSmartContract',
+              },
+            ],
             ref_block_bytes: 'f733',
             ref_block_hash: 'ff89d72ddc1ce1ea',
             expiration: MOCK_TRON_BLOCK_TIMESTAMP_NOW_PLUS_A_YEAR,
             timestamp: MOCK_TRON_BLOCK_TIMESTAMP_NOW_PLUS_A_YEAR,
           },
-          raw_data_hex: '',
+          raw_data_hex:
+            '0a02f7332208ff89d72ddc1ce1ea4090ad9ad68d375af40f081f12ef0f0a31747970652e676f6f676c65617069732e636f6d2f70726f746f636f6c2e54726967676572536d617274436f6e747261637412b90f',
         },
+      },
+    }));
+}
+
+export async function mockTronEstimateEnergy(
+  mockServer: Mockttp,
+): Promise<MockedEndpoint> {
+  return mockServer
+    .forPost(tronInfuraUrl('/wallet/estimateenergy'))
+    .always()
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: {
+        result: { result: true },
+        energy_required: 1000,
       },
     }));
 }
@@ -1416,6 +1443,7 @@ export async function mockTronSwapApis(
     await mockTronGetChainParameters(mockServer),
     await mockTronGetNextMaintenanceTime(mockServer),
     await mockTronTriggerConstantContract(mockServer),
+    await mockTronEstimateEnergy(mockServer),
     await mockTronGetContract(mockServer),
   ];
 }

--- a/test/e2e/tests/tron/mocks/common-tron.ts
+++ b/test/e2e/tests/tron/mocks/common-tron.ts
@@ -15,7 +15,7 @@ const MOCK_TRON_BLOCK_TIMESTAMP_NOW_PLUS_A_YEAR = new Date(
 ).getTime();
 
 // TRX balance in SUN (1 TRX = 1,000,000 SUN)
-export const TRX_BALANCE = 6072392; // ~6.07 TRX
+export const TRX_BALANCE = 106072392; // ~106.07 TRX
 export const TRX_TO_USD_RATE = 0.29469;
 export const SUN_PER_TRX = 1_000_000;
 

--- a/test/e2e/tests/tron/mocks/common-tron.ts
+++ b/test/e2e/tests/tron/mocks/common-tron.ts
@@ -1458,3 +1458,20 @@ export async function mockTronSwapApisNoQuotes(
     await mockBridgeGetTronQuoteEmpty(mockServer),
   ];
 }
+
+/**
+ * Tron swap mocks without fee-estimation RPC endpoints. The bridge quote still
+ * loads, but the Tron snap cannot compute network fees so the swap CTA stays disabled.
+ * @param mockServer
+ * @param mockZeroBalance
+ */
+export async function mockTronSwapApisWithoutFeeEstimation(
+  mockServer: Mockttp,
+  mockZeroBalance?: boolean,
+): Promise<MockedEndpoint[]> {
+  return [
+    ...(await mockTronApis(mockServer, mockZeroBalance)),
+    await mockBridgeGetTronTokens(mockServer),
+    await mockBridgeGetTronQuote(mockServer),
+  ];
+}

--- a/test/e2e/tests/tron/mocks/common-tron.ts
+++ b/test/e2e/tests/tron/mocks/common-tron.ts
@@ -1256,7 +1256,7 @@ export async function mockTronTriggerConstantContract(
       statusCode: 200,
       json: {
         result: { result: true },
-        energy_used: 200000,
+        energy_used: 1000,
         energy_penalty: 0,
         constant_result: [
           '0000000000000000000000000000000000000000000000000000000000000001',

--- a/test/e2e/tests/tron/swap.spec.ts
+++ b/test/e2e/tests/tron/swap.spec.ts
@@ -9,6 +9,7 @@ import SwapPage from '../../page-objects/pages/swap/swap-page';
 import {
   mockTronSwapApis,
   mockTronSwapApisNoQuotes,
+  mockTronSwapApisWithoutFeeEstimation,
   TRON_MOCK_TRANSACTION_EXPIRATION_MESSAGE,
 } from './mocks/common-tron';
 
@@ -51,6 +52,40 @@ describe('Swap on Tron', function () {
           swapTo: 'USDT',
           swapFromAmount: '1',
         });
+      },
+    );
+  });
+
+  it('Swap disabled when Tron network fees cannot be estimated', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilderV2().build(),
+        title: this.test?.fullTitle(),
+        testSpecificMock: mockTronSwapApisWithoutFeeEstimation,
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await login(driver);
+
+        const networkManager = new NetworkManager(driver);
+        await networkManager.openNetworkManager();
+        await networkManager.selectTab('Popular');
+        await networkManager.selectNetworkByNameWithWait('Tron');
+
+        const homePage = new HomePage(driver);
+        await homePage.checkPageIsLoaded();
+        await homePage.checkExpectedBalanceIsDisplayed('106.07');
+
+        const swapPage = new SwapPage(driver);
+        await homePage.clickOnSwapButton();
+        await swapPage.createSwap({
+          amount: 1,
+          swapTo: 'USDT',
+          swapFrom: 'TRX',
+          network: 'Tron',
+        });
+
+        await swapPage.checkQuoteIsDisplayedWithoutNetworkFee();
+        await swapPage.checkInsufficientFundsButtonIsDisplayed();
       },
     );
   });

--- a/test/e2e/tests/tron/swap.spec.ts
+++ b/test/e2e/tests/tron/swap.spec.ts
@@ -33,7 +33,7 @@ describe('Swap on Tron', function () {
 
         const homePage = new HomePage(driver);
         await homePage.checkPageIsLoaded();
-        await homePage.checkExpectedBalanceIsDisplayed('6.07');
+        await homePage.checkExpectedBalanceIsDisplayed('106.07');
 
         const swapPage = new SwapPage(driver);
         await homePage.clickOnSwapButton();
@@ -72,7 +72,7 @@ describe('Swap on Tron', function () {
 
         const homePage = new HomePage(driver);
         await homePage.checkPageIsLoaded();
-        await homePage.checkExpectedBalanceIsDisplayed('6.07');
+        await homePage.checkExpectedBalanceIsDisplayed('106.07');
 
         const swapPage = new SwapPage(driver);
         await homePage.clickOnSwapButton();

--- a/ui/ducks/bridge/selectors.test.ts
+++ b/ui/ducks/bridge/selectors.test.ts
@@ -216,6 +216,7 @@ describe('Bridge selectors', () => {
               steps: [],
             },
             trade: {
+              // eslint-disable-next-line @typescript-eslint/naming-convention
               raw_data_hex: 'deadbeef',
             },
             estimatedProcessingTimeInSeconds: 120,

--- a/ui/ducks/bridge/selectors.test.ts
+++ b/ui/ducks/bridge/selectors.test.ts
@@ -21,6 +21,7 @@ import {
   MOCK_LEDGER_ACCOUNT,
   MOCK_SOLANA_ACCOUNT,
 } from '../../../test/data/bridge/mock-bridge-store';
+import { MOCK_ACCOUNT_TRON_MAINNET } from '../../../test/data/mock-accounts';
 import { CHAIN_IDS, FEATURED_RPCS } from '../../../shared/constants/network';
 import { mockNetworkState } from '../../../test/stub/networks';
 import mockErc20Erc20Quotes from '../../../test/data/bridge/mock-quotes-erc20-erc20.json';
@@ -175,6 +176,87 @@ describe('Bridge selectors', () => {
 
   const createBtcZeroNetworkFeeQuoteState = () =>
     createBtcBridgeState({ nonEvmFeesInNative: '0' });
+
+  const createTronBridgeState = ({
+    fromTokenInputValue = '1',
+    fromNativeBalance = '100',
+    nonEvmFeesInNative,
+    srcTokenAmount = '1000000',
+  }: {
+    fromTokenInputValue?: string;
+    fromNativeBalance?: string;
+    nonEvmFeesInNative?: string;
+    srcTokenAmount?: string;
+  } = {}) => {
+    const tronAsset = getNativeAssetForChainId(ChainId.TRON);
+    const ethAsset = getNativeAssetForChainId(ChainId.ETH);
+    const tronQuote =
+      nonEvmFeesInNative === undefined
+        ? undefined
+        : {
+            quote: {
+              requestId: 'tron-quote',
+              bridgeId: 'rango',
+              aggregator: 'rango',
+              srcChainId: ChainId.TRON,
+              srcTokenAmount,
+              srcAsset: tronAsset,
+              destChainId: ChainId.ETH,
+              destTokenAmount: '1000000000000000000',
+              destAsset: ethAsset,
+              minDestTokenAmount: '990000000000000000',
+              feeData: {
+                metabridge: {
+                  amount: '0',
+                  asset: tronAsset,
+                },
+              },
+              bridges: ['rango'],
+              protocols: ['rango'],
+              steps: [],
+            },
+            trade: {
+              raw_data_hex: 'deadbeef',
+            },
+            estimatedProcessingTimeInSeconds: 120,
+            nonEvmFeesInNative,
+          };
+
+    return createBridgeMockStore({
+      bridgeSliceOverrides: {
+        fromTokenInputValue,
+        fromToken: toBridgeToken(tronAsset),
+        toToken: toBridgeToken(ethAsset),
+      },
+      bridgeStateOverrides: {
+        quotesLastFetched: Date.now(),
+        quoteRequest: {
+          srcChainId: ChainId.TRON,
+          srcTokenAmount,
+        },
+        quotes: tronQuote ? ([tronQuote] as unknown as QuoteResponse[]) : [],
+      },
+      metamaskStateOverrides: {
+        internalAccounts: {
+          accounts: {
+            [MOCK_ACCOUNT_TRON_MAINNET.id]: MOCK_ACCOUNT_TRON_MAINNET,
+          },
+          selectedAccount: MOCK_ACCOUNT_TRON_MAINNET.id,
+        },
+        balances: {
+          [MOCK_ACCOUNT_TRON_MAINNET.id]: {
+            [tronAsset.assetId]: {
+              amount: fromNativeBalance,
+              unit: 'TRX',
+            },
+          },
+        },
+      },
+    });
+  };
+
+  const createTronZeroNetworkFeeQuoteState = () =>
+    createTronBridgeState({ nonEvmFeesInNative: '0' });
 
   describe('getFromChain', () => {
     it('returns the fromChain from the multichain network controller', () => {
@@ -2155,6 +2237,27 @@ describe('Bridge selectors', () => {
       ).toStrictEqual('0');
       expect(result.isNetworkFeeUnavailable).toBe(true);
       expect(result.isInsufficientGasForQuote).toBe(false);
+    });
+
+    it('should return isNetworkFeeUnavailable=true for a Tron quote with zero network fee', () => {
+      const state = createTronZeroNetworkFeeQuoteState();
+      const result = getValidationErrors(state as never);
+
+      expect(
+        getBridgeQuotes(state as never).activeQuote?.totalNetworkFee.amount,
+      ).toStrictEqual('0');
+      expect(result.isNetworkFeeUnavailable).toBe(true);
+      expect(result.isInsufficientGasForQuote).toBe(false);
+    });
+
+    it('should return isNetworkFeeUnavailable=false for a Tron quote with a valid network fee', () => {
+      const state = createTronBridgeState({ nonEvmFeesInNative: '1' });
+      const result = getValidationErrors(state as never);
+
+      expect(
+        getBridgeQuotes(state as never).activeQuote?.totalNetworkFee.amount,
+      ).toStrictEqual('1');
+      expect(result.isNetworkFeeUnavailable).toBe(false);
     });
 
     it('should return isEstimatedReturnLow=true return value is less than 65% of sent funds', () => {
@@ -4299,6 +4402,13 @@ describe('Bridge selectors', () => {
 
     it('returns network_fee_unavailable when BTC network fee is unavailable', () => {
       const state = createBtcZeroNetworkFeeQuoteState();
+      const result = getWarningLabels(state as never);
+
+      expect(result).toContain('network_fee_unavailable');
+    });
+
+    it('returns network_fee_unavailable when Tron network fee is unavailable', () => {
+      const state = createTronZeroNetworkFeeQuoteState();
       const result = getWarningLabels(state as never);
 
       expect(result).toContain('network_fee_unavailable');

--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -3,6 +3,7 @@ import type { InternalAccount } from '@metamask/keyring-internal-api';
 import {
   isSolanaChainId,
   isBitcoinChainId,
+  isTronChainId,
   isNativeAddress,
   formatChainIdToCaip,
   BRIDGE_QUOTE_MAX_RETURN_DIFFERENCE_PERCENTAGE,
@@ -111,7 +112,6 @@ import {
   getDefaultToToken,
   toBridgeToken,
   isNonEvmChain,
-  isTronChainId,
   getMaybeHexChainId,
   isSupportedBridgeChain,
   getDefaultFromToken,
@@ -1046,7 +1046,7 @@ export const computeQuoteValidationErrors = (
   const isNetworkFeeUnavailable = Boolean(
     quote &&
     srcChainId &&
-    isBitcoinChainId(srcChainId) &&
+    (isBitcoinChainId(srcChainId) || isTronChainId(srcChainId)) &&
     !isGasless &&
     (quote.totalNetworkFee?.amount === undefined ||
       new BigNumber(quote.totalNetworkFee?.amount ?? '0').lte(0)),

--- a/yarn.lock
+++ b/yarn.lock
@@ -8531,10 +8531,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/tron-wallet-snap@npm:^1.28.0":
-  version: 1.28.0
-  resolution: "@metamask/tron-wallet-snap@npm:1.28.0"
-  checksum: 10/e8fe563735e0fca306cd1caa2cde45b193d0f09f7a3da545be24eee55a64f1ff239a7460ad9c4a0c6b67552a1423ef18328350a4b76a2409a1fbe609f69b8769
+"@metamask/tron-wallet-snap@npm:@metamask-previews/tron-wallet-snap@1.28.0-preview-e5e1c78":
+  version: 1.28.0-preview-e5e1c78
+  resolution: "@metamask-previews/tron-wallet-snap@npm:1.28.0-preview-e5e1c78"
+  checksum: 10/b406795b1e2523259707f4ee69040574066ce069af9557cdc68d5d39f571bf482d53c8dcc7be1a01c0ecc9921b9b634db4036f2540b66ebf9bff887fdc3bc10d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Adds E2E coverage for the Tron network-fee guard introduced in #44107.

**Context:** #44107 disables the swap CTA when Tron network fees cannot be retrieved. The happy-path E2E test was updated with fee-estimation mocks so swaps still work when APIs respond correctly. This PR adds the complementary negative path.

**Changes:**
- Add `mockTronSwapApisWithoutFeeEstimation` — bridge quote loads, but Tron fee-estimation RPC mocks are omitted
- Add E2E test `Swap disabled when Tron network fees cannot be estimated`
- Add swap page object helpers to assert quote UI without network fees and a disabled "Insufficient funds" CTA

**Target branch:** `fix-tron-network-fees` (stacked on #44107, not `main`)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related to: #44107

## **Manual testing steps**

1. Build the test extension: `yarn build:test`
2. Run Tron swap E2E tests: `yarn test:e2e:single test/e2e/tests/tron/swap.spec.ts --browser=chrome`
3. Verify all three cases pass:
   - Happy path: quote displayed, swap proceeds
   - **New:** quote displayed, CTA disabled when fees cannot be estimated
   - No quotes: "no trade route" message

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.