### PR TITLE
feat: replace use metametrics with useAnalytics hook for networks page

### DIFF
--- a/ui/pages/networks/networks-page.tsx
+++ b/ui/pages/networks/networks-page.tsx
@@ -6,7 +6,6 @@ import {
 import { NETWORKS_BYPASSING_VALIDATION } from '@metamask/controller-utils';
 import React, {
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useState,
@@ -52,7 +51,7 @@ import { getEditedNetwork } from '../../selectors/selectors';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0021): route-isolation backlog
 import { SettingsHeader } from '../settings/shared/settings-header';
 import { useGlobalMenuRouteTransition } from '../routes/global-menu-route-transition';
-import { MetaMetricsContext } from '../../contexts/metametrics';
+import { useAnalytics } from '../../hooks/useAnalytics';
 import { AddRpcUrlPageForm } from './add-rpc-url-page-form';
 import {
   ChainlistNetworkPicker,
@@ -129,7 +128,7 @@ const NetworksPageFormBody = ({ children }: { children: React.ReactNode }) => (
 export const NetworksPage = () => {
   const dispatch = useDispatch();
   const t = useI18nContext();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const navigate = useNavigate();
   const runCloseTransition = useGlobalMenuRouteTransition();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -213,12 +212,13 @@ export const NetworksPage = () => {
   }, [setView]);
 
   const handleAddFromChainlist = useCallback(() => {
-    trackEvent({
-      event: MetaMetricsEventName.ChainlistAddClicked,
-      category: MetaMetricsEventCategory.Network,
-    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.ChainlistAddClicked)
+        .addCategory(MetaMetricsEventCategory.Network)
+        .build(),
+    );
     setView('add-from-chainlist');
-  }, [setView, trackEvent]);
+  }, [createEventBuilder, setView, trackEvent]);
 
   const handleChainlistNetworkSelect = useCallback(
     (network: ChainlistNetwork, searchQuery?: string) => {
@@ -226,17 +226,19 @@ export const NetworksPage = () => {
       const existingNetwork =
         evmNetworks[chainIdHex as keyof typeof evmNetworks];
       const networkName = existingNetwork?.name ?? network.name;
-      trackEvent({
-        event: MetaMetricsEventName.ChainlistNetworkSelected,
-        category: MetaMetricsEventCategory.Network,
-        /* eslint-disable @typescript-eslint/naming-convention */
-        properties: {
-          chain_id: chainIdHex,
-          network_name: networkName,
-          already_added: Boolean(existingNetwork),
-          ...(searchQuery ? { search_query: searchQuery } : {}),
-        },
-      });
+      /* eslint-disable @typescript-eslint/naming-convention */
+      trackEvent(
+        createEventBuilder(MetaMetricsEventName.ChainlistNetworkSelected)
+          .addCategory(MetaMetricsEventCategory.Network)
+          .addProperties({
+            chain_id: chainIdHex,
+            network_name: networkName,
+            already_added: Boolean(existingNetwork),
+            ...(searchQuery ? { search_query: searchQuery } : {}),
+          })
+          .build(),
+      );
+      /* eslint-enable @typescript-eslint/naming-convention */
 
       if (existingNetwork) {
         dispatch(
@@ -276,7 +278,14 @@ export const NetworksPage = () => {
       });
       setView('add');
     },
-    [dispatch, evmNetworks, networkFormState, setView, trackEvent],
+    [
+      createEventBuilder,
+      dispatch,
+      evmNetworks,
+      networkFormState,
+      setView,
+      trackEvent,
+    ],
   );
 
   const handleAddRPC = useCallback(

--- a/ui/pages/networks/networks-page.tsx
+++ b/ui/pages/networks/networks-page.tsx
@@ -4,12 +4,7 @@ import {
   UpdateNetworkFields,
 } from '@metamask/network-controller';
 import { NETWORKS_BYPASSING_VALIDATION } from '@metamask/controller-utils';
-import React, {
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   Box,
   BoxFlexDirection,


### PR DESCRIPTION
This PR is to replace the hook for metametrics

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. No change

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

No UI change
## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics instrumentation refactor only; event names and properties are preserved with no network or security logic changes.
> 
> **Overview**
> **Networks page** analytics now go through **`useAnalytics`** instead of **`MetaMetricsContext`**, matching the pattern used elsewhere (e.g. rewards, passkey, unlock).
> 
> Chainlist flows still emit the same events: **`ChainlistAddClicked`** when opening add-from-chainlist, and **`ChainlistNetworkSelected`** with `chain_id`, `network_name`, `already_added`, and optional `search_query`. Those calls now use **`createEventBuilder(...).addCategory(...).addProperties(...).build()`** rather than raw `trackEvent({ event, category, properties })`.
> 
> React imports drop **`useContext`**; callback dependency arrays include **`createEventBuilder`** where needed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c422e512b18b0b98be588d374197f4e1bd888b87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->