### PR TITLE
chore: set bottom nav bar conditional rendering

### DIFF
--- a/ui/components/app/bottom-nav-bar/bottom-nav-bar.test.tsx
+++ b/ui/components/app/bottom-nav-bar/bottom-nav-bar.test.tsx
@@ -7,7 +7,6 @@ import {
   ACTIVITY_ROUTE,
   DEFAULT_ROUTE,
   PERPS_HOME_PAGE_ROUTE,
-  PERPS_ROUTE,
   SWAP_PATH,
 } from '../../../helpers/constants/routes';
 import { BottomNavBar } from './bottom-nav-bar';
@@ -124,18 +123,6 @@ describe('BottomNavBar', () => {
       );
       expect(getByTestId('bottom-nav-home')).not.toHaveAttribute(
         'aria-current',
-      );
-    });
-
-    it('marks Perps as active on /perps/* sub-routes', () => {
-      const { getByTestId } = renderBottomNavBar(
-        baseState,
-        `${PERPS_ROUTE}/market-list`,
-      );
-
-      expect(getByTestId('bottom-nav-perps')).toHaveAttribute(
-        'aria-current',
-        'page',
       );
     });
 

--- a/ui/components/app/bottom-nav-bar/bottom-nav-bar.tsx
+++ b/ui/components/app/bottom-nav-bar/bottom-nav-bar.tsx
@@ -123,7 +123,7 @@ export function BottomNavBar() {
       />
       <NavTab
         isActive={isActivity}
-        icon={IconName.Activity}
+        icon={isActivity ? IconName.ClockFilled : IconName.Clock}
         label={t('activity')}
         onClick={handleActivityClick}
         data-testid="bottom-nav-activity"

--- a/ui/components/app/bottom-nav-bar/bottom-nav-bar.tsx
+++ b/ui/components/app/bottom-nav-bar/bottom-nav-bar.tsx
@@ -70,7 +70,8 @@ export function BottomNavBar() {
   const isPerpsAvailable = useSelector(getIsPerpsExperienceAvailable);
   const lastActiveTab = useSelector(getDefaultHomeActiveTabName);
 
-  const { isHome, isPerps, isSwaps, isActivity } = getActiveBottomNavTabs(pathname);
+  const { isHome, isPerps, isSwaps, isActivity } =
+    getActiveBottomNavTabs(pathname);
 
   const handleHomeClick = useCallback(
     () =>

--- a/ui/components/app/bottom-nav-bar/bottom-nav-bar.tsx
+++ b/ui/components/app/bottom-nav-bar/bottom-nav-bar.tsx
@@ -16,11 +16,11 @@ import {
   ACTIVITY_ROUTE,
   DEFAULT_ROUTE,
   PERPS_HOME_PAGE_ROUTE,
-  PERPS_ROUTE,
   SWAP_PATH,
 } from '../../../helpers/constants/routes';
 import { getIsPerpsExperienceAvailable } from '../../../selectors/perps/feature-flags';
 import { getDefaultHomeActiveTabName } from '../../../selectors';
+import { getActiveBottomNavTabs } from './bottom-nav-bar.utils';
 
 type NavTabProps = {
   isActive: boolean;
@@ -70,11 +70,7 @@ export function BottomNavBar() {
   const isPerpsAvailable = useSelector(getIsPerpsExperienceAvailable);
   const lastActiveTab = useSelector(getDefaultHomeActiveTabName);
 
-  const isHome = pathname === DEFAULT_ROUTE;
-  const isPerps =
-    pathname === PERPS_HOME_PAGE_ROUTE || pathname.startsWith(PERPS_ROUTE);
-  const isSwaps = pathname.startsWith(SWAP_PATH);
-  const isActivity = pathname === ACTIVITY_ROUTE;
+  const { isHome, isPerps, isSwaps, isActivity } = getActiveBottomNavTabs(pathname);
 
   const handleHomeClick = useCallback(
     () =>
@@ -97,7 +93,11 @@ export function BottomNavBar() {
   );
 
   return (
-    <nav className="bottom-nav-bar w-full bg-background-default border-t border-border-muted flex flex-row justify-between p-2 gap-2">
+    <nav
+      data-testid="bottom-nav-bar"
+      className="bottom-nav-bar w-full bg-background-default border-t border-border-muted flex flex-row justify-between p-2 gap-2 z-[100]"
+      style={{ viewTransitionName: 'bottom-nav-bar' }}
+    >
       <NavTab
         isActive={isHome}
         icon={isHome ? IconName.HomeFilled : IconName.Home}

--- a/ui/components/app/bottom-nav-bar/bottom-nav-bar.utils.test.ts
+++ b/ui/components/app/bottom-nav-bar/bottom-nav-bar.utils.test.ts
@@ -1,0 +1,76 @@
+import { it } from '@jest/globals';
+import {
+  ACTIVITY_ROUTE,
+  DEFAULT_ROUTE,
+  PERPS_HOME_PAGE_ROUTE,
+  SWAP_PATH,
+} from '../../../helpers/constants/routes';
+import {
+  getActiveBottomNavTabs,
+  isBottomNavRoute,
+} from './bottom-nav-bar.utils';
+
+describe('getActiveBottomNavTabs', () => {
+  it('marks isHome active on the default route', () => {
+    expect(getActiveBottomNavTabs(DEFAULT_ROUTE)).toStrictEqual({
+      isHome: true,
+      isPerps: false,
+      isSwaps: false,
+      isActivity: false,
+    });
+  });
+
+  it('marks isPerps active on the perps home route', () => {
+    expect(getActiveBottomNavTabs(PERPS_HOME_PAGE_ROUTE)).toStrictEqual({
+      isHome: false,
+      isPerps: true,
+      isSwaps: false,
+      isActivity: false,
+    });
+  });
+
+  it('marks isSwaps active on the swap path', () => {
+    expect(getActiveBottomNavTabs(SWAP_PATH)).toStrictEqual({
+      isHome: false,
+      isPerps: false,
+      isSwaps: true,
+      isActivity: false,
+    });
+  });
+
+  it('marks isActivity active on the activity route', () => {
+    expect(getActiveBottomNavTabs(ACTIVITY_ROUTE)).toStrictEqual({
+      isHome: false,
+      isPerps: false,
+      isSwaps: false,
+      isActivity: true,
+    });
+  });
+
+  it('returns all false for an unrelated route', () => {
+    expect(getActiveBottomNavTabs('/settings')).toStrictEqual({
+      isHome: false,
+      isPerps: false,
+      isSwaps: false,
+      isActivity: false,
+    });
+  });
+});
+
+describe('isBottomNavRoute', () => {
+  it.each([
+    ['default route', DEFAULT_ROUTE],
+    ['perps home route', PERPS_HOME_PAGE_ROUTE],
+    ['swap path', SWAP_PATH],
+    ['activity route', ACTIVITY_ROUTE],
+  ])('returns true for the %s', (_label, route) => {
+    expect(isBottomNavRoute(route)).toBe(true);
+  });
+
+  it.each([['/settings'], ['/send'], ['/confirm-transaction'], ['/unknown']])(
+    'returns false for %s',
+    (route) => {
+      expect(isBottomNavRoute(route)).toBe(false);
+    },
+  );
+});

--- a/ui/components/app/bottom-nav-bar/bottom-nav-bar.utils.ts
+++ b/ui/components/app/bottom-nav-bar/bottom-nav-bar.utils.ts
@@ -17,14 +17,16 @@ export type ActiveBottomNavTabs = {
  *
  * @param pathname - The current location pathname.
  */
-export function getActiveBottomNavTabs(pathname: string): ActiveBottomNavTabs {
+export const getActiveBottomNavTabs = (
+  pathname: string,
+): ActiveBottomNavTabs => {
   return {
     isHome: pathname === DEFAULT_ROUTE,
     isPerps: pathname === PERPS_HOME_PAGE_ROUTE,
     isSwaps: pathname === SWAP_PATH,
     isActivity: pathname === ACTIVITY_ROUTE,
   };
-}
+};
 
 /**
  * Returns true when the pathname corresponds to one of the bottom nav
@@ -32,7 +34,7 @@ export function getActiveBottomNavTabs(pathname: string): ActiveBottomNavTabs {
  *
  * @param pathname - The current location pathname.
  */
-export function isBottomNavRoute(pathname: string): boolean {
+export const isBottomNavRoute = (pathname: string): boolean => {
   const activeBottomNavTabs = getActiveBottomNavTabs(pathname);
   return Object.values(activeBottomNavTabs).some(Boolean);
-}
+};

--- a/ui/components/app/bottom-nav-bar/bottom-nav-bar.utils.ts
+++ b/ui/components/app/bottom-nav-bar/bottom-nav-bar.utils.ts
@@ -1,0 +1,38 @@
+import {
+  ACTIVITY_ROUTE,
+  DEFAULT_ROUTE,
+  PERPS_HOME_PAGE_ROUTE,
+  SWAP_PATH,
+} from '../../../helpers/constants/routes';
+
+export type ActiveBottomNavTabs = {
+  isHome: boolean;
+  isPerps: boolean;
+  isSwaps: boolean;
+  isActivity: boolean;
+};
+
+/**
+ * Returns the active state of each bottom nav tab based on the pathname.
+ *
+ * @param pathname - The current location pathname.
+ */
+export function getActiveBottomNavTabs(pathname: string): ActiveBottomNavTabs {
+  return {
+    isHome: pathname === DEFAULT_ROUTE,
+    isPerps: pathname === PERPS_HOME_PAGE_ROUTE,
+    isSwaps: pathname === SWAP_PATH,
+    isActivity: pathname === ACTIVITY_ROUTE,
+  };
+}
+
+/**
+ * Returns true when the pathname corresponds to one of the bottom nav
+ * bar tabs (Home, Activity, Perps, Swaps).
+ *
+ * @param pathname - The current location pathname.
+ */
+export function isBottomNavRoute(pathname: string): boolean {
+  const activeBottomNavTabs = getActiveBottomNavTabs(pathname);
+  return Object.values(activeBottomNavTabs).some(Boolean);
+}

--- a/ui/components/multichain/toast/index.scss
+++ b/ui/components/multichain/toast/index.scss
@@ -46,6 +46,11 @@
 }
 
 /* Lift the toaster above fixed CTA footers */
-:root:has(.cta-footer, .multichain-page-footer, .dapp-connection-control-bar) {
+:root:has(.cta-footer, .multichain-page-footer, .dapp-connection-control-bar, .bottom-nav-bar) {
   --toaster-bottom-offset: 80px;
+}
+
+/* Lift above both the bottom nav bar and the dapp connection bar */
+:root:has(.bottom-nav-bar):has(.dapp-connection-control-bar) {
+  --toaster-bottom-offset: 148px;
 }

--- a/ui/hooks/useBottomNavBar.ts
+++ b/ui/hooks/useBottomNavBar.ts
@@ -1,0 +1,7 @@
+/**
+ * Skeleton implementation — always returns true.
+ * TODO: implement full eligibility check, route gating, and A/B test variant.
+ */
+export function useBottomNavBar(): boolean {
+  return false;
+}

--- a/ui/hooks/useBottomNavBar.ts
+++ b/ui/hooks/useBottomNavBar.ts
@@ -1,5 +1,5 @@
 /**
- * Skeleton implementation — always returns true.
+ * Skeleton implementation — always returns false.
  * TODO: implement full eligibility check, route gating, and A/B test variant.
  */
 export function useBottomNavBar(): boolean {

--- a/ui/layouts/root-layout.tsx
+++ b/ui/layouts/root-layout.tsx
@@ -1,14 +1,21 @@
 import React from 'react';
 import cn from 'clsx';
 import { Outlet } from 'react-router-dom';
+import { BottomNavBar } from '../components/app/bottom-nav-bar/bottom-nav-bar';
+import { useBottomNavBar } from '../hooks/useBottomNavBar';
 
 const width = 'max-w-[clamp(var(--width-sm),85vw,var(--width-max))]';
 const sidepanel = 'group-[.app--sidepanel]:max-w-[var(--width-max-sidepanel)]';
 
 export const RootLayout = () => {
+  const showBottomNav = useBottomNavBar();
+
   return (
     <div className={cn('w-full h-full flex flex-col', width, sidepanel)}>
-      <Outlet />
+      <div className="flex-1 min-h-0 overflow-y-auto flex flex-col">
+        <Outlet />
+      </div>
+      {showBottomNav && <BottomNavBar />}
     </div>
   );
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

No UI changes, just sets up more stuff for bottom nav.

- sets the bottom nav bar to conditionally render in root layout
- makes some nav bar route utils and tests
- adds a style so that toasts sit above the bottom nav bar, or both it and the dapp connection bar when relevant
- creates dummy useBottomNavBar hook that returns false right now (switch to true to test locally)

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Relates: https://consensyssoftware.atlassian.net/browse/CEUX-1141

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

Example: toast on top of dapp connection bar and bottom nav bar
<img width="370" height="626" alt="image" src="https://github.com/user-attachments/assets/e16a02da-b41b-42f4-99ce-124e660b3c8d" />

Example: toast on top of bottom nav bar
<img width="364" height="626" alt="image" src="https://github.com/user-attachments/assets/1e36e6ef-ba2b-427f-9913-bd049e11326b" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No production UI until the hook is implemented; the main follow-up risk is stricter Perps/Swaps active-state matching on sub-routes when the nav is enabled.
> 
> **Overview**
> Sets up **conditional bottom nav** in `RootLayout`: main content scrolls in a flex column and `BottomNavBar` renders only when `useBottomNavBar()` is true (stub always returns **false**, so no user-visible nav yet).
> 
> **Route matching** moves into `bottom-nav-bar.utils` (`getActiveBottomNavTabs`, `isBottomNavRoute`) with dedicated unit tests. Active-tab logic **narrows** vs the previous inline checks: Perps is active only on `PERPS_HOME_PAGE_ROUTE` (not `/perps/*` sub-routes), and Swaps only on an exact `SWAP_PATH` match (no longer `startsWith`). The component test for Perps sub-routes is removed accordingly.
> 
> **Bottom nav polish**: `data-testid`, higher z-index, view-transition name, and Activity uses filled/clock icons when active. **Toasts** gain CSS so `--toaster-bottom-offset` accounts for `.bottom-nav-bar` alone or together with the dapp connection bar.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f10b6c3395a4cb04c4e17ced92f3aa49956a678. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->