### PR TITLE
perf(6915): memoize getApprovalFlows Selector

### DIFF
--- a/ui/pages/confirmations/confirmation/confirmation.js
+++ b/ui/pages/confirmations/confirmation/confirmation.js
@@ -10,7 +10,6 @@ import React, {
 import PropTypes from 'prop-types';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
-import { isEqual } from 'lodash';
 import { produce } from 'immer';
 import log from 'loglevel';
 import {
@@ -239,7 +238,7 @@ export default function ConfirmationPage({
   const navigate = useNavigate();
   const pendingConfirmations = useSelector(getUnapprovedTemplatedConfirmations);
   const unapprovedTxsCount = useSelector(getUnapprovedTxCount);
-  const approvalFlows = useSelector(getApprovalFlows, isEqual);
+  const approvalFlows = useSelector(getApprovalFlows);
   const totalUnapprovedCount = useSelector(getTotalUnapprovedCount);
   const isHardwareWalletErrorModalVisible = useSelector(
     getIsHardwareWalletErrorModalVisible,

--- a/ui/pages/confirmations/hooks/useConfirmationNavigation.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationNavigation.ts
@@ -2,7 +2,6 @@ import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate, useLocation, useSearchParams } from 'react-router-dom';
 import { ApprovalType } from '@metamask/controller-utils';
-import { isEqual } from 'lodash';
 import { ApprovalRequest } from '@metamask/approval-controller';
 import { Json } from '@metamask/utils';
 
@@ -44,7 +43,7 @@ export type ConfirmationNavigationOptions = {
 
 export function useConfirmationNavigation() {
   const confirmations = useSelector(selectPendingApprovalsForNavigation);
-  const approvalFlows = useSelector(getApprovalFlows, isEqual);
+  const approvalFlows = useSelector(getApprovalFlows);
   const navigate = useNavigate();
   const { search: queryString } = useLocation();
   const count = confirmations.length;

--- a/ui/selectors/approvals.test.ts
+++ b/ui/selectors/approvals.test.ts
@@ -71,6 +71,13 @@ describe('approval selectors', () => {
 
       expect(result).toStrictEqual(mockedState.metamask.approvalFlows);
     });
+
+    it('should return same reference when state has not changed (memoization)', () => {
+      const result1 = getApprovalFlows(mockedState);
+      const result2 = getApprovalFlows(mockedState);
+
+      expect(result1).toBe(result2);
+    });
   });
 
   describe('getPendingApprovals', () => {

--- a/ui/selectors/approvals.ts
+++ b/ui/selectors/approvals.ts
@@ -5,8 +5,14 @@ import {
 import { ApprovalType } from '@metamask/controller-utils';
 import { createSelector } from 'reselect';
 import { Json } from '@metamask/utils';
+import {
+  createDeepEqualSelector,
+  createShallowResultSelector,
+} from '../../shared/lib/selectors/selector-creators';
 import { SMART_TRANSACTION_CONFIRMATION_TYPES } from '../../shared/constants/app';
-import { EMPTY_OBJECT } from './shared';
+import { getBooleanFeatureFlag } from '../../shared/lib/remote-feature-flag-utils';
+import { getRemoteFeatureFlags } from '../../shared/lib/selectors/remote-feature-flags';
+import { EMPTY_ARRAY, EMPTY_OBJECT } from './shared';
 
 export type ApprovalsMetaMaskState = {
   metamask: {
@@ -52,9 +58,19 @@ export const getApprovalRequestsByType = (
   return pendingApprovalRequests;
 };
 
-export function getApprovalFlows(state: ApprovalsMetaMaskState) {
-  return state.metamask.approvalFlows;
-}
+const getApprovalFlowsFromState = (state: ApprovalsMetaMaskState) =>
+  state.metamask.approvalFlows;
+
+export const getApprovalFlows = createShallowResultSelector(
+  getApprovalFlowsFromState,
+  (approvalFlows) => {
+    if (!approvalFlows?.length) {
+      return EMPTY_ARRAY;
+    }
+
+    return [...approvalFlows];
+  },
+);
 
 export function selectHasApprovalFlows(state: ApprovalsMetaMaskState) {
   return (state.metamask.approvalFlows?.length ?? 0) > 0;
@@ -73,17 +89,28 @@ export const pendingApprovalsSortedSelector = createSelector(
   (approvals) => [...approvals].sort((a1, a2) => a1.time - a2.time),
 );
 
+const getSkipSmartTransactionStatusPage = createSelector(
+  getRemoteFeatureFlags,
+  (remoteFeatureFlags) =>
+    getBooleanFeatureFlag(
+      remoteFeatureFlags?.extensionSkipTransactionStatusPage,
+      true,
+    ),
+);
+
 /**
  * Returns pending approvals sorted by time for use in confirmation navigation.
  * Excludes duplicate watch asset approvals as they are combined into a single confirmation.
  */
-export const selectPendingApprovalsForNavigation = createSelector(
+export const selectPendingApprovalsForNavigation = createDeepEqualSelector(
   pendingApprovalsSortedSelector,
-  (sortedPendingApprovals) =>
+  getSkipSmartTransactionStatusPage,
+  (sortedPendingApprovals, skipSmartTransactionStatusPage) =>
     sortedPendingApprovals.filter((approval, index) => {
       if (
+        skipSmartTransactionStatusPage &&
         approval.type ===
-        SMART_TRANSACTION_CONFIRMATION_TYPES.showSmartTransactionStatusPage
+          SMART_TRANSACTION_CONFIRMATION_TYPES.showSmartTransactionStatusPage
       ) {
         return false;
       }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
To avoid unnecessary re-renders in confirmation flows without relying on `lodash` deep equality on every update, this PRF has now made `getApprovalFlows` a memoized `createSelector` instead of a plain function that returns `state.metamask.approvalFlows` directly. Therefore `confirmation.js` and `useConfirmationNavigation.ts` no longer use `isEqual` with `useSelector` as the memoized selector handles that.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6915

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Selector memoization and removal of per-render deep equality are low-risk performance changes; navigation filtering for smart-transaction status pages now depends on a remote feature flag with a conservative default.
> 
> **Overview**
> Reduces unnecessary re-renders in confirmation flows by **memoizing `getApprovalFlows`** with `createShallowResultSelector` (stable empty array via `EMPTY_ARRAY`, shallow-copied flow list when present) instead of returning Redux state directly. **`confirmation.js`** and **`useConfirmationNavigation`** no longer pass `lodash` `isEqual` into `useSelector`; they rely on the selector’s shallow result equality.
> 
> **`selectPendingApprovalsForNavigation`** is switched to **`createDeepEqualSelector`** and only hides smart-transaction status-page approvals when the remote flag **`extensionSkipTransactionStatusPage`** is true (default **true** via `getBooleanFeatureFlag`). A unit test asserts **`getApprovalFlows`** returns the same reference when state is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e90b2571321598078cf0a59e28e1cb81e96e2fdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->