### PR TITLE
chore: remove unused `endTrace` from `getApi`

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3899,7 +3899,6 @@ export default class MetamaskController extends EventEmitter {
         ),
 
       // Other
-      endTrace,
       isRelaySupported,
       isSendBundleSupported,
       openUpdateTabAndReload: () =>


### PR DESCRIPTION
## Description

The `endTrace` shorthand entry in `MetamaskController.getApi()` has no client callers: there is no `submitRequestToBackground('endTrace')` anywhere in the codebase, and every `endTrace` reference in `ui/` uses the `shared/lib/trace` function directly in the renderer. Since the `getApi` entry is dead, it is removed here instead of being migrated to `LegacyBackgroundApiService`.

This mirrors the `trackInsightSnapView` removal (#44135) from the same WPC-418 effort.

The internal `endTrace` import in `metamask-controller.js` is retained: it is still used for in-controller tracing (e.g. `discoverAndCreateAccounts`, the snaps request handler config).

## Changes

- Remove only the `endTrace,` shorthand entry from the `getApi()` return object.

## Related issues

Progresses: https://consensyssoftware.atlassian.net/browse/WPC-1104

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line removal of an unused public API surface with no callers; no behavior change for tracing.
> 
> **Overview**
> Removes the unused **`endTrace`** shorthand from **`MetamaskController.getApi()`** as part of the WPC-418 background API cleanup.
> 
> Nothing in the UI calls this via **`submitRequestToBackground('endTrace')`**; tracing in the renderer uses **`shared/lib/trace`** directly. The **`endTrace`** import and in-controller usage (e.g. account discovery, snaps request handler config, finished-transaction tracing) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 37f53023be5534be11d1711ce843d81fe6d0c353. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->