### PR TITLE
chore: migrate `isRelaySupported` to `LegacyBackgroundApiService`

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3911,7 +3911,10 @@ export default class MetamaskController extends EventEmitter {
         ),
 
       // Other
-      isRelaySupported,
+      isRelaySupported: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'LegacyBackgroundApiService:isRelaySupported',
+      ),
       isSendBundleSupported: this.controllerMessenger.call.bind(
         this.controllerMessenger,
         'LegacyBackgroundApiService:isSendBundleSupported',

--- a/app/scripts/services/legacy-background-api-service-method-action-types.ts
+++ b/app/scripts/services/legacy-background-api-service-method-action-types.ts
@@ -443,6 +443,17 @@ export type LegacyBackgroundApiServiceThrowTestErrorAction = {
 };
 
 /**
+ * Determines if the transaction relay supports the given chain.
+ *
+ * @param chainId - The chain ID to check for relay support.
+ * @returns `true` if the transaction relay supports the chain, `false` otherwise.
+ */
+export type LegacyBackgroundApiServiceIsRelaySupportedAction = {
+  type: `LegacyBackgroundApiService:isRelaySupported`;
+  handler: LegacyBackgroundApiService['isRelaySupported'];
+};
+
+/**
  * Union of all LegacyBackgroundApiService action types.
  */
 export type LegacyBackgroundApiServiceMethodActions =
@@ -483,4 +494,5 @@ export type LegacyBackgroundApiServiceMethodActions =
   | LegacyBackgroundApiServiceRejectAllPendingApprovalsAction
   | LegacyBackgroundApiServiceToggleExternalServicesAction
   | LegacyBackgroundApiServiceAcceptPermissionsRequestAction
-  | LegacyBackgroundApiServiceThrowTestErrorAction;
+  | LegacyBackgroundApiServiceThrowTestErrorAction
+  | LegacyBackgroundApiServiceIsRelaySupportedAction;

--- a/app/scripts/services/legacy-background-api-service.test.ts
+++ b/app/scripts/services/legacy-background-api-service.test.ts
@@ -38,6 +38,7 @@ import { TraceName, TraceOperation } from '../../../shared/lib/trace';
 import { PASSKEY_AUTO_UNLOCK_SUPPRESSION_DURATION_MS } from '../../../shared/constants/passkey';
 import { enforceSimulations } from '../lib/transaction/containers/enforced-simulations';
 import { isSendBundleSupported } from '../lib/transaction/sentinel-api';
+import { isRelaySupported } from '../lib/transaction/transaction-relay';
 import {
   LegacyBackgroundApiService,
   LegacyBackgroundApiServiceMessenger,
@@ -57,6 +58,7 @@ const mockGetIsShieldSubscriptionActive = jest.mocked(
 );
 
 jest.mock('../lib/transaction/sentinel-api');
+jest.mock('../lib/transaction/transaction-relay');
 
 describe('LegacyBackgroundApiService', () => {
   it('initializes a new instance of LegacyBackgroundApiService', async () => {
@@ -3381,6 +3383,24 @@ describe('LegacyBackgroundApiService', () => {
         expect(() => jest.runAllTimers()).toThrow(
           expect.objectContaining({ name: 'TestError', message: 'boom' }),
         );
+      });
+    });
+  });
+
+  describe('isRelaySupported', () => {
+    const isRelaySupportedMock = jest.mocked(isRelaySupported);
+
+    it('delegates to the transaction relay lib and returns its result', async () => {
+      isRelaySupportedMock.mockResolvedValue(true);
+
+      await withService(async ({ rootMessenger }) => {
+        const result = await rootMessenger.call(
+          'LegacyBackgroundApiService:isRelaySupported',
+          '0x1',
+        );
+
+        expect(isRelaySupportedMock).toHaveBeenCalledWith('0x1');
+        expect(result).toBe(true);
       });
     });
   });

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -162,6 +162,7 @@ import { OnboardingControllerGetIsSocialLoginFlowAction } from '../controllers/o
 import { getAccountsBySnapId } from '../lib/snap-keyring';
 import { isSendBundleSupported } from '../lib/transaction/sentinel-api';
 import { applyTransactionContainers } from '../lib/transaction/containers/util';
+import { isRelaySupported } from '../lib/transaction/transaction-relay';
 import { TransactionControllerInitMessenger } from '../wallet-init/messengers/transaction-controller-messenger';
 import {
   PreferencesControllerSetPasswordForgottenAction,
@@ -208,6 +209,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'importAccountWithStrategy',
   'isAssetsUnifyStateEnabled',
   'isPublicEndpointUrl',
+  'isRelaySupported',
   'isSendBundleSupported',
   'markPasswordForgotten',
   'onAccountRemoved',
@@ -1682,5 +1684,15 @@ export class LegacyBackgroundApiService {
       error.name = 'TestError';
       throw error;
     });
+  }
+
+  /**
+   * Determines if the transaction relay supports the given chain.
+   *
+   * @param chainId - The chain ID to check for relay support.
+   * @returns `true` if the transaction relay supports the chain, `false` otherwise.
+   */
+  async isRelaySupported(chainId: Hex): Promise<boolean> {
+    return isRelaySupported(chainId);
   }
 }


### PR DESCRIPTION
## **Description**

Migrates the `isRelaySupported` background API method into `LegacyBackgroundApiService`, exposed via the controller messenger.

`isRelaySupported` is a plain lib function (`app/scripts/lib/transaction/transaction-relay.ts`) with no controller/messenger dependencies. It is now wrapped by a thin `LegacyBackgroundApiService.isRelaySupported(chainId)` method that delegates to the imported lib function, added to `MESSENGER_EXPOSED_METHODS`, and the `getApi()` entry is repointed to `LegacyBackgroundApiService:isRelaySupported`.

The internal usage in `metamask-controller.js` (passing the imported lib function as a transaction hook) is left as-is, still using the direct import.

**Why not call the util directly from the UI instead of exposing it through the background?** `isRelaySupported` resolves the sentinel network flags, and that request is authenticated with a bearer token that is only set in the background (`setSentinelApiAuth`, wired at init from `AuthenticationController`). Calling the util directly from the UI would send the request unauthenticated (the getter is undefined in the UI module instance), so it must run in the background. This is also why its sibling `isSendBundleSupported` was migrated here rather than moved to the client.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Progresses: https://consensyssoftware.atlassian.net/browse/WPC-1105

## **Manual testing steps**

No user-facing change. This is an internal refactor; behavior is unchanged.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior-preserving API routing refactor with a new unit test; no auth, keyring, or transaction execution logic changes.
> 
> **Overview**
> **`isRelaySupported`** is moved onto the same **LegacyBackgroundApiService** + controller-messenger path as other background API methods (e.g. `isSendBundleSupported`).
> 
> `LegacyBackgroundApiService` gains a thin **`isRelaySupported(chainId)`** that delegates to `app/scripts/lib/transaction/transaction-relay`, the method is listed in **`MESSENGER_EXPOSED_METHODS`**, and **`LegacyBackgroundApiServiceIsRelaySupportedAction`** is added to the action union. **`getApi()`** in `metamask-controller.js` now binds **`LegacyBackgroundApiService:isRelaySupported`** instead of exposing the lib import directly.
> 
> Transaction-controller wiring that still passes the **direct lib import** as a hook is unchanged. A service unit test asserts messenger calls delegate to the relay lib with the given chain ID.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a9185b55efa1b40d8d010075fbce6e47988355f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
