### PR TITLE
chore: migrate `throwTestError` to `LegacyBackgroundApiService`

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3866,7 +3866,10 @@ export default class MetamaskController extends EventEmitter {
         ),
 
       // Testing
-      throwTestError: this.throwTestError.bind(this),
+      throwTestError: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'LegacyBackgroundApiService:throwTestError',
+      ),
       captureTestError: this.captureTestError.bind(this),
 
       // NameController
@@ -8048,21 +8051,6 @@ export default class MetamaskController extends EventEmitter {
 
     releaseLock();
     return pendingNonce;
-  }
-
-  /**
-   * Throw an artificial error in a timeout handler for testing purposes.
-   *
-   * @param message - The error message.
-   * @deprecated This is only meant to facilitate manual and E2E testing. We should not
-   * use this for handling errors.
-   */
-  throwTestError(message) {
-    setTimeout(() => {
-      const error = new Error(message);
-      error.name = 'TestError';
-      throw error;
-    });
   }
 
   /**

--- a/app/scripts/services/legacy-background-api-service-method-action-types.ts
+++ b/app/scripts/services/legacy-background-api-service-method-action-types.ts
@@ -391,6 +391,18 @@ export type LegacyBackgroundApiServiceAcceptPermissionsRequestAction = {
 };
 
 /**
+ * Throw an artificial error in a timeout handler for testing purposes.
+ *
+ * @param message - The error message.
+ * @deprecated This is only meant to facilitate manual and E2E testing. We should not
+ * use this for handling errors.
+ */
+export type LegacyBackgroundApiServiceThrowTestErrorAction = {
+  type: `LegacyBackgroundApiService:throwTestError`;
+  handler: LegacyBackgroundApiService['throwTestError'];
+};
+
+/**
  * Union of all LegacyBackgroundApiService action types.
  */
 export type LegacyBackgroundApiServiceMethodActions =
@@ -427,4 +439,5 @@ export type LegacyBackgroundApiServiceMethodActions =
   | LegacyBackgroundApiServiceRejectPendingApprovalAction
   | LegacyBackgroundApiServiceRejectAllPendingApprovalsAction
   | LegacyBackgroundApiServiceToggleExternalServicesAction
-  | LegacyBackgroundApiServiceAcceptPermissionsRequestAction;
+  | LegacyBackgroundApiServiceAcceptPermissionsRequestAction
+  | LegacyBackgroundApiServiceThrowTestErrorAction;

--- a/app/scripts/services/legacy-background-api-service.test.ts
+++ b/app/scripts/services/legacy-background-api-service.test.ts
@@ -3226,6 +3226,26 @@ describe('LegacyBackgroundApiService', () => {
       });
     });
   });
+
+  describe('throwTestError', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('throws a TestError with the given message from a timeout handler', async () => {
+      await withService(({ rootMessenger }) => {
+        rootMessenger.call('LegacyBackgroundApiService:throwTestError', 'boom');
+
+        expect(() => jest.runAllTimers()).toThrow(
+          expect.objectContaining({ name: 'TestError', message: 'boom' }),
+        );
+      });
+    });
+  });
 });
 
 /**

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -209,6 +209,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'submitPasswordOrEncryptionKey',
   'syncPasswordAndUnlockWallet',
   'syncKeyringEncryptionKey',
+  'throwTestError',
   'toggleExternalServices',
   'unMarkPasswordForgotten',
   'upsertTransactionUIMetricsFragment',
@@ -1597,5 +1598,20 @@ export class LegacyBackgroundApiService {
         throw error;
       }
     }
+  }
+
+  /**
+   * Throw an artificial error in a timeout handler for testing purposes.
+   *
+   * @param message - The error message.
+   * @deprecated This is only meant to facilitate manual and E2E testing. We should not
+   * use this for handling errors.
+   */
+  throwTestError(message: string): void {
+    setTimeout(() => {
+      const error = new Error(message);
+      error.name = 'TestError';
+      throw error;
+    });
   }
 }


### PR DESCRIPTION
## **Description**

Migrates the test-only `throwTestError` method from `MetamaskController` into `LegacyBackgroundApiService`, exposed via the controller messenger, as part of the WPC-418 background API migration.

The method is copied verbatim (a `setTimeout` that throws a `TestError`); it has no dependencies and no messenger calls, so no `AllowedActions` changes were needed. The `getApi()` entry now binds directly to `LegacyBackgroundApiService:throwTestError`, and the old controller method was removed (no internal callers). A service test was added.

## **Related issues**

Progresses: https://consensyssoftware.atlassian.net/browse/WPC-1107

## **Manual testing steps**

1. Open Developer Options in Settings and trigger the Sentry test error.
2. Confirm a `TestError` is thrown/reported as before.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability.
- [x] I've included tests if applicable.
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable.
- [x] I've applied the right labels on the PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only, deprecated error injection with no production behavior change and a direct move of existing logic.
> 
> **Overview**
> Moves the deprecated, test-only **`throwTestError`** helper from **`MetamaskController`** into **`LegacyBackgroundApiService`** as part of the background API migration.
> 
> **`getApi()`** now exposes it via **`controllerMessenger.call('LegacyBackgroundApiService:throwTestError', …)`** instead of binding a controller method; the controller implementation is removed. The service registers the action type, adds **`throwTestError`** to its method list, and keeps the same behavior (async **`setTimeout`** that throws a **`TestError`**). A unit test covers the messenger path with fake timers.
> 
> **`captureTestError`** is unchanged on the controller.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad05e848718137645ba561dd8316bebfdeaef72c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->