### PR TITLE
chore: migrate `isSendBundleSupported` to `LegacyBackgroundApiService`

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -386,7 +386,6 @@ import {
 } from './messenger-client-init/seedless-onboarding';
 import {
   getSendBundleSupportedChains,
-  isSendBundleSupported,
   setSentinelApiAuth,
 } from './lib/transaction/sentinel-api';
 import { ShieldControllerInit } from './messenger-client-init/shield/shield-controller-init';
@@ -3909,7 +3908,10 @@ export default class MetamaskController extends EventEmitter {
 
       // Other
       isRelaySupported,
-      isSendBundleSupported,
+      isSendBundleSupported: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'LegacyBackgroundApiService:isSendBundleSupported',
+      ),
       openUpdateTabAndReload: () =>
         openUpdateTabAndReload(this.requestSafeReload.bind(this)),
       requestSafeReload: this.requestSafeReload.bind(this),

--- a/app/scripts/services/legacy-background-api-service-method-action-types.ts
+++ b/app/scripts/services/legacy-background-api-service-method-action-types.ts
@@ -37,6 +37,17 @@ export type LegacyBackgroundApiServiceIsPublicEndpointUrlAction = {
 };
 
 /**
+ * Determines whether the sendBundle feature is supported for the given chain.
+ *
+ * @param chainId - The chain ID to check.
+ * @returns `true` if sendBundle is supported for the chain, `false` otherwise.
+ */
+export type LegacyBackgroundApiServiceIsSendBundleSupportedAction = {
+  type: `LegacyBackgroundApiService:isSendBundleSupported`;
+  handler: LegacyBackgroundApiService['isSendBundleSupported'];
+};
+
+/**
  * Gets the record of request account tab IDs.
  *
  * @returns A record of request account tab IDs.
@@ -397,6 +408,7 @@ export type LegacyBackgroundApiServiceMethodActions =
   | LegacyBackgroundApiServiceIsAssetsUnifyStateEnabledAction
   | LegacyBackgroundApiServiceSetCurrentCurrencyAction
   | LegacyBackgroundApiServiceIsPublicEndpointUrlAction
+  | LegacyBackgroundApiServiceIsSendBundleSupportedAction
   | LegacyBackgroundApiServiceGetRequestAccountTabIdsAction
   | LegacyBackgroundApiServiceGetOpenMetamaskTabsIdsAction
   | LegacyBackgroundApiServiceMarkPasswordForgottenAction

--- a/app/scripts/services/legacy-background-api-service.test.ts
+++ b/app/scripts/services/legacy-background-api-service.test.ts
@@ -37,6 +37,7 @@ import { getIsShieldSubscriptionActive } from '../../../shared/lib/shield/subscr
 import { TraceName, TraceOperation } from '../../../shared/lib/trace';
 import { PASSKEY_AUTO_UNLOCK_SUPPRESSION_DURATION_MS } from '../../../shared/constants/passkey';
 import { enforceSimulations } from '../lib/transaction/containers/enforced-simulations';
+import { isSendBundleSupported } from '../lib/transaction/sentinel-api';
 import {
   LegacyBackgroundApiService,
   LegacyBackgroundApiServiceMessenger,
@@ -54,6 +55,8 @@ jest.mock('../../../shared/lib/shield/subscription-utils', () => ({
 const mockGetIsShieldSubscriptionActive = jest.mocked(
   getIsShieldSubscriptionActive,
 );
+
+jest.mock('../lib/transaction/sentinel-api');
 
 describe('LegacyBackgroundApiService', () => {
   it('initializes a new instance of LegacyBackgroundApiService', async () => {
@@ -1225,6 +1228,22 @@ describe('LegacyBackgroundApiService', () => {
         );
 
         expect(result).toStrictEqual(['0x123']);
+      });
+    });
+  });
+
+  describe('isSendBundleSupported', () => {
+    it('returns whether the sendBundle feature is supported for the chain', async () => {
+      jest.mocked(isSendBundleSupported).mockResolvedValue(true);
+
+      await withService(async ({ rootMessenger }) => {
+        const result = await rootMessenger.call(
+          'LegacyBackgroundApiService:isSendBundleSupported',
+          '0x1',
+        );
+
+        expect(isSendBundleSupported).toHaveBeenCalledWith('0x1');
+        expect(result).toBe(true);
       });
     });
   });

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -149,6 +149,7 @@ import {
 import { isEqualCaseInsensitive } from '../../../shared/lib/string-utils';
 import { OnboardingControllerGetIsSocialLoginFlowAction } from '../controllers/onboarding-method-action-types';
 import { getAccountsBySnapId } from '../lib/snap-keyring';
+import { isSendBundleSupported } from '../lib/transaction/sentinel-api';
 import { applyTransactionContainers } from '../lib/transaction/containers/util';
 import { TransactionControllerInitMessenger } from '../messenger-client-init/messengers/transaction-controller-messenger';
 import {
@@ -194,6 +195,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'importAccountWithStrategy',
   'isAssetsUnifyStateEnabled',
   'isPublicEndpointUrl',
+  'isSendBundleSupported',
   'markPasswordForgotten',
   'onAccountRemoved',
   'rejectAllPendingApprovals',
@@ -442,6 +444,16 @@ export class LegacyBackgroundApiService {
    */
   isPublicEndpointUrl(endpointUrl: string): boolean {
     return isPublicEndpointUrl(endpointUrl, this.#infuraProjectId);
+  }
+
+  /**
+   * Determines whether the sendBundle feature is supported for the given chain.
+   *
+   * @param chainId - The chain ID to check.
+   * @returns `true` if sendBundle is supported for the chain, `false` otherwise.
+   */
+  async isSendBundleSupported(chainId: Hex): Promise<boolean> {
+    return await isSendBundleSupported(chainId);
   }
 
   /**


### PR DESCRIPTION
## **Description**

Migrates the `isSendBundleSupported` background API method from `MetamaskController.getApi()` into `LegacyBackgroundApiService`, exposed via the controller messenger, as part of the ongoing WPC-418 effort to move `getApi()` methods into the modular service.

`isSendBundleSupported` is a thin wrapper around the `isSendBundleSupported` lib function in `app/scripts/lib/transaction/sentinel-api.ts`. It is now a method on `LegacyBackgroundApiService` that delegates to that lib function, added to `MESSENGER_EXPOSED_METHODS`, and the `getApi()` entry is repointed to `this.controllerMessenger.call.bind(this.controllerMessenger, 'LegacyBackgroundApiService:isSendBundleSupported')`. Since the lib function makes no controller/messenger calls, no new `AllowedActions` were required. The argument shape (`chainId`) is unchanged, so the UI thunk needs no update.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Progresses: https://consensyssoftware.atlassian.net/browse/WPC-1106

## **Manual testing steps**

This is an internal refactor with no user-facing behavior change. To verify:

1. Build and run the extension.
2. Trigger a flow that checks sendBundle support for a chain (e.g. a smart-transaction / bundle-eligible confirmation).
3. Confirm behavior is unchanged.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal wiring refactor with unchanged `chainId` API and no new messenger dependencies; behavior should match the previous direct lib export from `getApi()`.
> 
> **Overview**
> Moves **`isSendBundleSupported`** off `MetamaskController.getApi()` into **`LegacyBackgroundApiService`**, continuing the WPC-418 pattern of routing background API methods through the messenger-backed service.
> 
> `getApi()` now exposes the same callable but forwards via `controllerMessenger.call('LegacyBackgroundApiService:isSendBundleSupported')`. The new service method still delegates to `sentinel-api`’s `isSendBundleSupported(chainId)` with the same signature. A typed messenger action is added to the union, the method is listed in `MESSENGER_EXPOSED_METHODS`, and a unit test asserts the messenger path calls the lib helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 649779263c34dfdb96aebe7b018d95743d570de9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->