### PR TITLE
chore: migrate `getAssets` to `LegacyBackgroundApiService`

### DIFF
--- a/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/legacy-background-api-service-messenger.ts
@@ -31,6 +31,7 @@ export function getLegacyBackgroundApiServiceMessenger(
       'NetworkController:getSelectedNetworkClient',
       'RemoteFeatureFlagController:getState',
       'CurrencyRateController:setCurrentCurrency',
+      'AssetsController:getAssets',
       'AssetsController:setSelectedCurrency',
       'KeyringController:exportSeedPhrase',
       'AccountsController:getSelectedAccount',

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3746,15 +3746,10 @@ export default class MetamaskController extends EventEmitter {
       ),
 
       // Assets Controller - accounts passed from UI; options may include chainIds, assetTypes
-      getAssets: (accounts, options) => {
-        if (!this.assetsController) {
-          return Promise.resolve();
-        }
-        return this.assetsController.getAssets(accounts, {
-          ...options,
-          forceUpdate: true,
-        });
-      },
+      getAssets: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'LegacyBackgroundApiService:getAssets',
+      ),
 
       /** Token Detection V2 */
       addDetectedTokens:

--- a/app/scripts/services/legacy-background-api-service-method-action-types.ts
+++ b/app/scripts/services/legacy-background-api-service-method-action-types.ts
@@ -26,6 +26,23 @@ export type LegacyBackgroundApiServiceSetCurrentCurrencyAction = {
 };
 
 /**
+ * Refreshes and returns the assets for the given accounts via the
+ * AssetsController (force-updating from remote sources).
+ *
+ * No-ops when the assets unify state feature is not enabled, since the
+ * AssetsController is not registered in that case.
+ *
+ * @param accounts - The accounts to fetch assets for.
+ * @param options - Options for fetching assets (e.g. `chainIds`, `assetTypes`).
+ * @returns The assets for the given accounts, or `undefined` when the feature
+ * is not enabled.
+ */
+export type LegacyBackgroundApiServiceGetAssetsAction = {
+  type: `LegacyBackgroundApiService:getAssets`;
+  handler: LegacyBackgroundApiService['getAssets'];
+};
+
+/**
  * Determines if the given endpoint URL is a public endpoint URL.
  *
  * @param endpointUrl - The endpoint URL to check.
@@ -396,6 +413,7 @@ export type LegacyBackgroundApiServiceAcceptPermissionsRequestAction = {
 export type LegacyBackgroundApiServiceMethodActions =
   | LegacyBackgroundApiServiceIsAssetsUnifyStateEnabledAction
   | LegacyBackgroundApiServiceSetCurrentCurrencyAction
+  | LegacyBackgroundApiServiceGetAssetsAction
   | LegacyBackgroundApiServiceIsPublicEndpointUrlAction
   | LegacyBackgroundApiServiceGetRequestAccountTabIdsAction
   | LegacyBackgroundApiServiceGetOpenMetamaskTabsIdsAction

--- a/app/scripts/services/legacy-background-api-service.test.ts
+++ b/app/scripts/services/legacy-background-api-service.test.ts
@@ -256,6 +256,96 @@ describe('LegacyBackgroundApiService', () => {
     });
   });
 
+  describe('getAssets', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+      jest.resetModules();
+      process.env = { ...originalEnv };
+    });
+
+    afterEach(() => {
+      process.env = originalEnv;
+    });
+
+    it('fetches assets from the AssetsController with forceUpdate when the feature is enabled', async () => {
+      const accounts = [{ id: 'account-1' }] as never;
+      const options = { chainIds: ['eip155:1'] };
+      const assets = { 'account-1': {} };
+
+      await withService(async ({ serviceMessenger, rootMessenger }) => {
+        process.env.ASSETS_UNIFIED_STATE_ENABLED = 'true';
+
+        rootMessenger.registerActionHandler(
+          'RemoteFeatureFlagController:getState',
+          jest.fn().mockReturnValue({
+            remoteFeatureFlags: {
+              assetsUnifyState: { enabled: true, featureVersion: '1' },
+            },
+          }),
+        );
+
+        const getAssetsHandler = jest.fn().mockResolvedValue(assets);
+        rootMessenger.registerActionHandler(
+          'AssetsController:getAssets',
+          getAssetsHandler,
+        );
+
+        const callSpy = jest.spyOn(serviceMessenger, 'call');
+
+        await expect(
+          rootMessenger.call(
+            'LegacyBackgroundApiService:getAssets',
+            accounts,
+            options as never,
+          ),
+        ).resolves.toStrictEqual(assets);
+
+        expect(callSpy).toHaveBeenCalledWith(
+          'AssetsController:getAssets',
+          accounts,
+          { ...options, forceUpdate: true },
+        );
+      });
+    });
+
+    it('resolves to undefined and does not call the AssetsController when the feature is not enabled', async () => {
+      const accounts = [{ id: 'account-1' }] as never;
+
+      await withService(async ({ serviceMessenger, rootMessenger }) => {
+        process.env.ASSETS_UNIFIED_STATE_ENABLED = 'false';
+
+        rootMessenger.registerActionHandler(
+          'RemoteFeatureFlagController:getState',
+          jest.fn().mockReturnValue({
+            remoteFeatureFlags: {
+              assetsUnifyState: { enabled: true, featureVersion: '1' },
+            },
+          }),
+        );
+
+        const getAssetsHandler = jest.fn();
+        rootMessenger.registerActionHandler(
+          'AssetsController:getAssets',
+          getAssetsHandler,
+        );
+
+        const callSpy = jest.spyOn(serviceMessenger, 'call');
+
+        await expect(
+          rootMessenger.call('LegacyBackgroundApiService:getAssets', accounts),
+        ).resolves.toBeUndefined();
+
+        expect(callSpy).not.toHaveBeenCalledWith(
+          'AssetsController:getAssets',
+          expect.anything(),
+          expect.anything(),
+        );
+        expect(getAssetsHandler).not.toHaveBeenCalled();
+      });
+    });
+  });
+
   describe('isPublicEndpointUrl', () => {
     it('returns true for a public endpoint URL', async () => {
       await withService(({ rootMessenger }) => {
@@ -3290,6 +3380,7 @@ function getMessenger(
       'NetworkController:getSelectedNetworkClient',
       'RemoteFeatureFlagController:getState',
       'CurrencyRateController:setCurrentCurrency',
+      'AssetsController:getAssets',
       'AssetsController:setSelectedCurrency',
       'KeyringController:exportSeedPhrase',
       'AccountsController:getSelectedAccount',

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -48,7 +48,14 @@ import {
   TokenDetectionControllerDisableAction,
   TokenDetectionControllerEnableAction,
 } from '@metamask/assets-controllers';
-import { AssetsControllerSetSelectedCurrencyAction } from '@metamask/assets-controller';
+import {
+  AccountId,
+  Asset,
+  AssetsControllerGetAssetsAction,
+  AssetsControllerSetSelectedCurrencyAction,
+  Caip19AssetId,
+} from '@metamask/assets-controller';
+import type { InternalAccount } from '@metamask/keyring-internal-api';
 import { SupportedCurrency } from '@metamask/core-backend';
 import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import {
@@ -185,6 +192,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'estimateGas',
   'exportAccount',
   'getAccountsBySnapId',
+  'getAssets',
   'getCode',
   'getGlobalChainId',
   'getNextNonce',
@@ -233,6 +241,7 @@ type AllowedActions =
   | ApprovalControllerGetStateAction
   | ApprovalControllerRejectRequestAction
   | AppStateControllerSetPasskeyAutoUnlockSuppressedAction
+  | AssetsControllerGetAssetsAction
   | AssetsControllerSetSelectedCurrencyAction
   | AuthenticationControllerGetStateAction
   | AuthenticationControllerPerformSignOutAction
@@ -432,6 +441,32 @@ export class LegacyBackgroundApiService {
         currencyCode,
       );
     }
+  }
+
+  /**
+   * Refreshes and returns the assets for the given accounts via the
+   * AssetsController (force-updating from remote sources).
+   *
+   * No-ops when the assets unify state feature is not enabled, since the
+   * AssetsController is not registered in that case.
+   *
+   * @param accounts - The accounts to fetch assets for.
+   * @param options - Options for fetching assets (e.g. `chainIds`, `assetTypes`).
+   * @returns The assets for the given accounts, or `undefined` when the feature
+   * is not enabled.
+   */
+  async getAssets(
+    accounts: InternalAccount[],
+    options?: Parameters<AssetsControllerGetAssetsAction['handler']>[1],
+  ): Promise<Record<AccountId, Record<Caip19AssetId, Asset>> | undefined> {
+    if (!this.isAssetsUnifyStateEnabled()) {
+      return undefined;
+    }
+
+    return await this.#messenger.call('AssetsController:getAssets', accounts, {
+      ...options,
+      forceUpdate: true,
+    });
   }
 
   /**


### PR DESCRIPTION
## **Description**

Migrates the `getAssets` background API method from `MetamaskController.getApi()` into `LegacyBackgroundApiService`, exposed via the controller messenger.

The `getApi` entry now binds to `LegacyBackgroundApiService:getAssets`, which delegates to the `AssetsController:getAssets` messenger action (force-updating from remote sources). The previous null-guard on `this.assetsController` is preserved via `getIsAssetsUnifiedStateIncludedInBuild()` — the same build gate that conditionally registers the `AssetsController` — so the method no-ops (resolves to `undefined`) when the assets unify state feature is not included in the build.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Progresses: https://consensyssoftware.atlassian.net/browse/WPC-1102

## **Manual testing steps**

1. With the assets unify state feature enabled, refresh assets for the selected account (e.g. via the asset list control bar) and confirm balances update.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the UI triggers asset refresh in the unified assets path, but behavior is intended to stay the same behind the existing feature gate.
> 
> **Overview**
> Moves **`getAssets`** off `MetaMaskController.getApi()` into **`LegacyBackgroundApiService`**, so the legacy background API keeps migrating onto the controller messenger pattern.
> 
> `MetaMaskController` now forwards **`getAssets`** to **`LegacyBackgroundApiService:getAssets`** instead of calling `AssetsController` directly. The new service method still **force-refreshes** assets via **`AssetsController:getAssets`** (`forceUpdate: true`) when assets unify state is enabled, and **returns `undefined` without calling the controller** when it is not—matching the old “no controller registered” no-op. Messenger wiring delegates **`AssetsController:getAssets`** to the service messenger, and unit tests cover both enabled and disabled paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a72cb3d3091ab2e2a1392c929cf590274f47a107. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->