### PR TITLE
chore: bind `updateAccountsList` directly to `AccountOrderController:updateAccountsList`

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3464,7 +3464,10 @@ export default class MetamaskController extends EventEmitter {
         this.controllerMessenger,
         'NetworkOrderController:updateNetworksList',
       ),
-      updateAccountsList: this.updateAccountsList.bind(this),
+      updateAccountsList: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'AccountOrderController:updateAccountsList',
+      ),
       setEnabledNetworks: this.setEnabledNetworks.bind(this),
       setEnabledAllPopularNetworks:
         this.setEnabledAllPopularNetworks.bind(this),
@@ -8459,22 +8462,6 @@ export default class MetamaskController extends EventEmitter {
       if (!(exp instanceof PermissionsRequestNotFoundError)) {
         throw exp;
       }
-    }
-  };
-
-  /**
-   * Updates the pinned accounts list
-   *
-   * @deprecated This method is deprecated and will be removed in the future.
-   * use AccountTreeController.setAccountGroupPinned instead
-   * @param {AccountAddress[]} pinnedAccountList - The list of accounts to update in the state.
-   */
-  updateAccountsList = (pinnedAccountList) => {
-    try {
-      this.accountOrderController.updateAccountsList(pinnedAccountList);
-    } catch (err) {
-      log.error(err.message);
-      throw err;
     }
   };
 


### PR DESCRIPTION
## **Description**

Part of the WPC-418 effort to slim down `MetamaskController.getApi()`.

The `updateAccountsList` getApi entry was a thin pass-through over `accountOrderController.updateAccountsList`, wrapped only in a `try/catch` that logged and rethrew. Since the `AccountOrderController:updateAccountsList` messenger action already exists (the method is in the controller's `MESSENGER_EXPOSED_METHODS`), the getApi entry is now bound directly to that action via the controller messenger and the redundant `MetamaskController` wrapper method is removed.

No behavior change for the client: the UI thunk still calls `submitRequestToBackground('updateAccountsList', [pinnedAccountList])` with the same argument shape.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/WPC-1097

## **Manual testing steps**

1. Open the account list in the UI and pin/unpin an account.
2. Confirm the pinned order persists after reload (state is updated).

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only API wiring for account pinning order; no auth or transaction logic, with only minor error-logging behavior change if the controller throws.
> 
> **Overview**
> Part of slimming down `MetamaskController.getApi()`, **`updateAccountsList`** is now wired like **`updateNetworksList`**: the background API entry calls **`AccountOrderController:updateAccountsList`** through the controller messenger instead of a **`MetamaskController`** wrapper.
> 
> The removed wrapper only delegated to **`accountOrderController.updateAccountsList`** with a log-and-rethrow **`try/catch`**. Callers still use the same **`updateAccountsList`** background method and pinned-account argument shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e6adbf775c2940d4a921f860634300a827371d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->