### PR TITLE
chore: bind `updateHiddenAccountsList` directly to `AccountOrderController:updateHiddenAccountsList`

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3468,7 +3468,10 @@ export default class MetamaskController extends EventEmitter {
       setEnabledNetworks: this.setEnabledNetworks.bind(this),
       setEnabledAllPopularNetworks:
         this.setEnabledAllPopularNetworks.bind(this),
-      updateHiddenAccountsList: this.updateHiddenAccountsList.bind(this),
+      updateHiddenAccountsList: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'AccountOrderController:updateHiddenAccountsList',
+      ),
       getPhishingResult: async (website) => {
         await phishingController.maybeUpdateState();
 
@@ -8498,22 +8501,6 @@ export default class MetamaskController extends EventEmitter {
     }
 
     await this.lookupSelectedNetworks();
-  };
-
-  /**
-   * Updates the hidden accounts list
-   *
-   * @deprecated This method is deprecated and will be removed in the future.
-   * use AccountTreeController.setAccountGroupHidden instead
-   * @param {AccountAddress[]} hiddenAccountList - The list of accounts to update in the state.
-   */
-  updateHiddenAccountsList = (hiddenAccountList) => {
-    try {
-      this.accountOrderController.updateHiddenAccountsList(hiddenAccountList);
-    } catch (err) {
-      log.error(err.message);
-      throw err;
-    }
   };
 
   /**


### PR DESCRIPTION
## **Description**

Part of the WPC-418 effort to slim down `MetamaskController.getApi()`.

The `updateHiddenAccountsList` getApi entry was a thin pass-through over `accountOrderController.updateHiddenAccountsList`, wrapped only in a `try/catch` that logged and rethrew. Since the `AccountOrderController:updateHiddenAccountsList` messenger action already exists (the method is in the controller's `MESSENGER_EXPOSED_METHODS`), the getApi entry is now bound directly to that action via the controller messenger and the redundant `MetamaskController` wrapper method is removed.

No behavior change for the client: the UI thunk still calls `submitRequestToBackground('updateHiddenAccountsList', [...])` with the same argument shape.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/WPC-1098

## **Manual testing steps**

1. Open the account list in the UI and hide/unhide an account.
2. Confirm the hidden state persists after reload (state is updated).

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Internal refactor that routes an existing API through the messenger; no new auth or data paths, with only the removed wrapper-level error logging as a minor difference.
> 
> **Overview**
> Part of slimming **`MetamaskController.getApi()`**, the background API entry for **`updateHiddenAccountsList`** now calls **`AccountOrderController:updateHiddenAccountsList`** through **`controllerMessenger.call.bind`**, matching **`updateNetworksList`**.
> 
> The deprecated **`MetamaskController.updateHiddenAccountsList`** wrapper (delegate plus **`try/catch`** log and rethrow) is removed. Callers still use **`submitRequestToBackground('updateHiddenAccountsList', [...])`** with the same arguments; hide/unhide behavior is unchanged aside from errors no longer being logged at that wrapper layer.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a3ed2db0e6d79abc36f8fb613d4352863fc45bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->