### PR TITLE
fix(perps): hide perps balance and position data when privacy mode is enabled

### DIFF
--- a/ui/components/app/perps/edit-margin/edit-margin-modal-content.test.tsx
+++ b/ui/components/app/perps/edit-margin/edit-margin-modal-content.test.tsx
@@ -255,7 +255,10 @@ describe('EditMarginModalContent', () => {
     });
 
     it('masks the liquidation price and available amount when privacy mode is enabled', () => {
-      renderWithProvider(<EditMarginModalContent {...defaultProps} />, privacyStore);
+      renderWithProvider(
+        <EditMarginModalContent {...defaultProps} />,
+        privacyStore,
+      );
 
       expect(
         screen.getByTestId('perps-edit-margin-liquidation-price-value'),
@@ -266,7 +269,10 @@ describe('EditMarginModalContent', () => {
     });
 
     it('masks the liquidation price comparison values when privacy mode is enabled', () => {
-      renderWithProvider(<EditMarginModalContent {...defaultProps} />, privacyStore);
+      renderWithProvider(
+        <EditMarginModalContent {...defaultProps} />,
+        privacyStore,
+      );
 
       const amountInput = screen.getByPlaceholderText('0.00');
       fireEvent.change(amountInput, { target: { value: '100' } });

--- a/ui/components/app/perps/edit-margin/edit-margin-modal-content.test.tsx
+++ b/ui/components/app/perps/edit-margin/edit-margin-modal-content.test.tsx
@@ -242,4 +242,38 @@ describe('EditMarginModalContent', () => {
       expect(mockSubmitRequestToBackground).not.toHaveBeenCalled();
     });
   });
+
+  describe('privacy mode', () => {
+    const privacyStore = configureStore({
+      metamask: {
+        ...mockState.metamask,
+        preferences: {
+          ...mockState.metamask.preferences,
+          privacyMode: true,
+        },
+      },
+    });
+
+    it('masks the liquidation price and available amount when privacy mode is enabled', () => {
+      renderWithProvider(<EditMarginModalContent {...defaultProps} />, privacyStore);
+
+      expect(
+        screen.getByTestId('perps-edit-margin-liquidation-price-value'),
+      ).toHaveTextContent('••••••');
+      expect(
+        screen.getByTestId('perps-edit-margin-available-value'),
+      ).toHaveTextContent('••••••');
+    });
+
+    it('masks the liquidation price comparison values when privacy mode is enabled', () => {
+      renderWithProvider(<EditMarginModalContent {...defaultProps} />, privacyStore);
+
+      const amountInput = screen.getByPlaceholderText('0.00');
+      fireEvent.change(amountInput, { target: { value: '100' } });
+
+      expect(
+        screen.getByTestId('perps-edit-margin-liquidation-price-value'),
+      ).toHaveTextContent('••••••');
+    });
+  });
 });

--- a/ui/components/app/perps/edit-margin/edit-margin-modal-content.tsx
+++ b/ui/components/app/perps/edit-margin/edit-margin-modal-content.tsx
@@ -1,10 +1,12 @@
 import React, { useState, useCallback, useEffect, useMemo } from 'react';
+import { useSelector } from 'react-redux';
 import {
   Box,
   BoxFlexDirection,
   BoxAlignItems,
   BoxJustifyContent,
   Text,
+  SensitiveText,
   TextVariant,
   TextColor,
   FontWeight,
@@ -22,6 +24,7 @@ import {
   PRICE_RANGES_MINIMAL_VIEW,
   PRICE_RANGES_UNIVERSAL,
 } from '../../../../../shared/lib/perps-formatters';
+import { getPreferences } from '../../../../../shared/lib/selectors/preferences';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { TextField, TextFieldSize } from '../../../component-library';
 import {
@@ -107,6 +110,7 @@ export const EditMarginModalContent = ({
   const { gate } = useSelectedAccountComplianceGate();
   const { replacePerpsToastByKey } = usePerpsToast();
   const { track } = usePerpsEventTracking();
+  const { privacyMode } = useSelector(getPreferences);
   const [isGeoBlockModalOpen, setIsGeoBlockModalOpen] = useState(false);
 
   const [marginAmount, setMarginAmount] = useState<string>('');
@@ -146,13 +150,14 @@ export const EditMarginModalContent = ({
     const displayAnchorLiquidationPrice = anchorLiquidationPrice ?? 0;
     if (!hasValidAnchorLiquidationPrice) {
       return (
-        <Text
+        <SensitiveText
           variant={TextVariant.BodySm}
           fontWeight={FontWeight.Medium}
+          isHidden={privacyMode}
           data-testid="perps-edit-margin-liquidation-price-value"
         >
           {PERPS_LIQUIDATION_PRICE_FALLBACK}
-        </Text>
+        </SensitiveText>
       );
     }
     if (showLiquidationComparison && hasValidEstimatedLiquidationPrice) {
@@ -163,30 +168,36 @@ export const EditMarginModalContent = ({
           gap={1}
           className="max-w-[65%] flex-wrap justify-end"
         >
-          <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
+          <SensitiveText
+            variant={TextVariant.BodySm}
+            color={TextColor.TextAlternative}
+            isHidden={privacyMode}
+          >
             {formatPerpsFiat(displayAnchorLiquidationPrice, {
               ranges: PRICE_RANGES_UNIVERSAL,
             })}
-          </Text>
+          </SensitiveText>
           <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
             →
           </Text>
-          <Text
+          <SensitiveText
             variant={TextVariant.BodySm}
             color={TextColor.TextDefault}
             fontWeight={FontWeight.Medium}
+            isHidden={privacyMode}
             data-testid="perps-edit-margin-liquidation-price-value"
           >
             {formatPerpsLiquidationPrice(estimatedLiquidationPrice)}
-          </Text>
+          </SensitiveText>
         </Box>
       );
     }
     return (
-      <Text
+      <SensitiveText
         variant={TextVariant.BodySm}
         color={TextColor.TextDefault}
         fontWeight={FontWeight.Medium}
+        isHidden={privacyMode}
         data-testid="perps-edit-margin-liquidation-price-value"
       >
         {formatPerpsLiquidationPrice(
@@ -194,7 +205,7 @@ export const EditMarginModalContent = ({
             ? estimatedLiquidationPrice
             : anchorLiquidationPrice,
         )}
-      </Text>
+      </SensitiveText>
     );
   }, [
     anchorLiquidationPrice,
@@ -202,6 +213,7 @@ export const EditMarginModalContent = ({
     hasValidAnchorLiquidationPrice,
     hasValidEstimatedLiquidationPrice,
     showLiquidationComparison,
+    privacyMode,
   ]);
 
   const marginPercent = useMemo(() => {
@@ -418,16 +430,17 @@ export const EditMarginModalContent = ({
         <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
           {availableLabel}
         </Text>
-        <Text
+        <SensitiveText
           variant={TextVariant.BodySm}
           fontWeight={FontWeight.Medium}
           color={TextColor.TextAlternative}
+          isHidden={privacyMode}
           data-testid="perps-edit-margin-available-value"
         >
           {`${formatPerpsFiat(maxAmount, {
             ranges: PRICE_RANGES_MINIMAL_VIEW,
           })} USDC`}
-        </Text>
+        </SensitiveText>
       </Box>
 
       <Box flexDirection={BoxFlexDirection.Column} gap={2}>

--- a/ui/components/app/perps/order-entry/components/amount-input/amount-input.test.tsx
+++ b/ui/components/app/perps/order-entry/components/amount-input/amount-input.test.tsx
@@ -104,6 +104,22 @@ describe('AmountInput', () => {
       expect(input).toHaveValue('25');
       expect(screen.getByText('%')).toBeInTheDocument();
     });
+
+    it('masks the available-to-trade balance when privacy mode is enabled', () => {
+      const privacyStore = configureStore({
+        metamask: {
+          ...mockState.metamask,
+          preferences: {
+            ...mockState.metamask.preferences,
+            privacyMode: true,
+          },
+        },
+      });
+
+      renderWithProvider(<AmountInput {...defaultProps} />, privacyStore);
+
+      expect(screen.getByText('••••••')).toBeInTheDocument();
+    });
   });
 
   describe('denomination toggle', () => {

--- a/ui/components/app/perps/order-entry/components/amount-input/amount-input.tsx
+++ b/ui/components/app/perps/order-entry/components/amount-input/amount-input.tsx
@@ -1,6 +1,7 @@
 import {
   Box,
   Text,
+  SensitiveText,
   TextVariant,
   TextColor,
   BoxFlexDirection,
@@ -12,6 +13,7 @@ import {
   IconColor,
 } from '@metamask/design-system-react';
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
 
 import {
   BorderRadius,
@@ -20,6 +22,7 @@ import {
 import { useFormatters } from '../../../../../../hooks/useFormatters';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
 import { formatPositionSize } from '../../../../../../../shared/lib/perps-formatters';
+import { getPreferences } from '../../../../../../../shared/lib/selectors/preferences';
 import { TextField, TextFieldSize } from '../../../../../component-library';
 import { PerpsSlider } from '../../../perps-slider';
 import { getDisplaySymbol } from '../../../utils';
@@ -81,6 +84,7 @@ export const AmountInput = ({
 }: AmountInputProps) => {
   const t = useI18nContext();
   const { formatNumber } = useFormatters();
+  const { privacyMode } = useSelector(getPreferences);
   const [percentInputValue, setPercentInputValue] = useState<string>(
     String(balancePercent),
   );
@@ -379,9 +383,9 @@ export const AmountInput = ({
           alignItems={BoxAlignItems.Center}
           gap={2}
         >
-          <Text variant={TextVariant.BodySm}>
+          <SensitiveText variant={TextVariant.BodySm} isHidden={privacyMode}>
             {`${formatNumber(availableBalance, { minimumFractionDigits: 2, maximumFractionDigits: 2 })} USDC`}
-          </Text>
+          </SensitiveText>
           <ButtonIcon
             iconName={IconName.AddCircle}
             size={ButtonIconSize.Xs}

--- a/ui/components/app/perps/order-entry/components/order-summary/order-summary.test.tsx
+++ b/ui/components/app/perps/order-entry/components/order-summary/order-summary.test.tsx
@@ -199,4 +199,36 @@ describe('OrderSummary', () => {
       ).toHaveTextContent('-');
     });
   });
+
+  describe('privacy mode', () => {
+    const privacyStore = configureStore({
+      metamask: {
+        ...mockState.metamask,
+        preferences: {
+          ...mockState.metamask.preferences,
+          privacyMode: true,
+        },
+      },
+    });
+
+    it('masks liquidation price and margin when privacy mode is enabled', () => {
+      renderWithProvider(
+        <OrderSummary
+          marginRequired="$1,000.00"
+          estimatedFees={0.5}
+          liquidationPrice="$42,500.00"
+        />,
+        privacyStore,
+      );
+
+      expect(screen.queryByText('$1,000.00')).not.toBeInTheDocument();
+      expect(screen.queryByText('$42,500.00')).not.toBeInTheDocument();
+      expect(
+        screen.getByTestId('perps-order-summary-margin-required'),
+      ).toHaveTextContent('••••••');
+      expect(
+        screen.getByTestId('perps-order-summary-liquidation-price'),
+      ).toHaveTextContent('••••••');
+    });
+  });
 });

--- a/ui/components/app/perps/order-entry/components/order-summary/order-summary.tsx
+++ b/ui/components/app/perps/order-entry/components/order-summary/order-summary.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
+import { useSelector } from 'react-redux';
 import {
   Box,
   Text,
+  SensitiveText,
   TextVariant,
   TextColor,
   BoxFlexDirection,
@@ -13,6 +15,7 @@ import {
   IconSize,
   twMerge,
 } from '@metamask/design-system-react';
+import { getPreferences } from '../../../../../../../shared/lib/selectors/preferences';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
 import { PerpsFeesDisplay } from '../../../perps-fees-display';
 import type { OrderSummaryProps } from '../../order-entry.types';
@@ -45,6 +48,7 @@ export const OrderSummary = ({
   isSlippageRowDisabled = false,
 }: OrderSummaryProps) => {
   const t = useI18nContext();
+  const { privacyMode } = useSelector(getPreferences);
 
   return (
     <Box flexDirection={BoxFlexDirection.Column} gap={2}>
@@ -57,13 +61,14 @@ export const OrderSummary = ({
         <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
           {t('perpsLiquidationPrice')}
         </Text>
-        <Text
+        <SensitiveText
           variant={TextVariant.BodySm}
           color={TextColor.TextDefault}
+          isHidden={privacyMode}
           data-testid="perps-order-summary-liquidation-price"
         >
           {liquidationPrice ?? '-'}
-        </Text>
+        </SensitiveText>
       </Box>
 
       {showSlippageRow && (
@@ -126,13 +131,14 @@ export const OrderSummary = ({
         <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
           {t('perpsMargin')}
         </Text>
-        <Text
+        <SensitiveText
           variant={TextVariant.BodySm}
           color={TextColor.TextDefault}
+          isHidden={privacyMode}
           data-testid="perps-order-summary-margin-required"
         >
           {marginRequired ?? '-'}
-        </Text>
+        </SensitiveText>
       </Box>
 
       {/* Fees */}

--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx
@@ -270,4 +270,31 @@ describe('PerpsBalanceDropdown', () => {
       expect(screen.getByTestId('perps-geo-block-modal')).toBeInTheDocument();
     });
   });
+
+  describe('privacy mode', () => {
+    const privacyStore = configureStore({
+      metamask: {
+        ...mockState.metamask,
+        preferences: {
+          ...mockState.metamask.preferences,
+          privacyMode: true,
+        },
+      },
+    });
+
+    it('masks the total balance when privacy mode is enabled', () => {
+      renderWithProvider(<PerpsBalanceDropdown />, privacyStore);
+
+      expect(screen.queryByText('$15,250')).not.toBeInTheDocument();
+      expect(screen.getByText('••••••')).toBeInTheDocument();
+    });
+
+    it('masks the P&L and RoE when privacy mode is enabled', () => {
+      renderWithProvider(<PerpsBalanceDropdown hasPositions />, privacyStore);
+
+      expect(screen.queryByText(/\+\$375/u)).not.toBeInTheDocument();
+      expect(screen.queryByText(/7\.32%/u)).not.toBeInTheDocument();
+      expect(screen.getAllByText('••••••')).toHaveLength(3);
+    });
+  });
 });

--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx
@@ -296,5 +296,26 @@ describe('PerpsBalanceDropdown', () => {
       expect(screen.queryByText(/7\.32%/u)).not.toBeInTheDocument();
       expect(screen.getAllByText('••••••')).toHaveLength(3);
     });
+
+    it('uses the default text color instead of green/red for P&L and RoE when privacy mode is enabled', () => {
+      renderWithProvider(<PerpsBalanceDropdown hasPositions />, privacyStore);
+
+      const pnl = screen.getByTestId('perps-balance-dropdown-pnl-value');
+      const roe = screen.getByTestId('perps-balance-dropdown-roe-value');
+      expect(pnl).toHaveClass('text-default');
+      expect(pnl).not.toHaveClass('text-success-default');
+      expect(pnl).not.toHaveClass('text-error-default');
+      expect(roe).toHaveClass('text-default');
+      expect(roe).not.toHaveClass('text-success-default');
+      expect(roe).not.toHaveClass('text-error-default');
+    });
+  });
+
+  it('uses the success color for a profitable P&L outside of privacy mode', () => {
+    renderWithProvider(<PerpsBalanceDropdown hasPositions />, mockStore);
+
+    expect(screen.getByTestId('perps-balance-dropdown-pnl-value')).toHaveClass(
+      'text-success-default',
+    );
   });
 });

--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useRef, useState } from 'react';
+import { useSelector } from 'react-redux';
 import {
   twMerge,
   TextVariant,
@@ -9,6 +10,7 @@ import {
   IconName,
   IconSize,
   Text,
+  SensitiveText,
   BoxFlexDirection,
   BoxJustifyContent,
   BoxAlignItems,
@@ -20,6 +22,7 @@ import {
   formatPerpsFiat,
   PRICE_RANGES_MINIMAL_VIEW,
 } from '../../../../../shared/lib/perps-formatters';
+import { getPreferences } from '../../../../../shared/lib/selectors/preferences';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { useFormatters } from '../../../../hooks/useFormatters';
 import { usePerpsEligibility } from '../../../../hooks/perps';
@@ -79,6 +82,7 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
   const { formatPercentWithMinThreshold } = useFormatters();
   const { isEligible } = usePerpsEligibility();
   const { gate } = useSelectedAccountComplianceGate();
+  const { privacyMode } = useSelector(getPreferences);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isGeoBlockModalOpen, setIsGeoBlockModalOpen] = useState(false);
 
@@ -176,11 +180,15 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
               alignItems={BoxAlignItems.Center}
               gap={2}
             >
-              <Text variant={TextVariant.BodySm} fontWeight={FontWeight.Medium}>
+              <SensitiveText
+                variant={TextVariant.BodySm}
+                fontWeight={FontWeight.Medium}
+                isHidden={privacyMode}
+              >
                 {formatPerpsFiat(accountValue, {
                   ranges: PRICE_RANGES_MINIMAL_VIEW,
                 })}
-              </Text>
+              </SensitiveText>
               <Icon
                 name={isDropdownOpen ? IconName.ArrowUp : IconName.ArrowDown}
                 size={IconSize.Xs}
@@ -232,13 +240,32 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
           <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
             {t('perpsUnrealizedPnl')}
           </Text>
-          <Text
-            variant={TextVariant.BodySm}
-            fontWeight={FontWeight.Medium}
-            color={isProfit ? TextColor.SuccessDefault : TextColor.ErrorDefault}
+          <Box
+            flexDirection={BoxFlexDirection.Row}
+            alignItems={BoxAlignItems.Baseline}
+            gap={1}
           >
-            {formattedPnl} ({formattedRoe})
-          </Text>
+            <SensitiveText
+              variant={TextVariant.BodySm}
+              fontWeight={FontWeight.Medium}
+              color={
+                isProfit ? TextColor.SuccessDefault : TextColor.ErrorDefault
+              }
+              isHidden={privacyMode}
+            >
+              {formattedPnl}
+            </SensitiveText>
+            <SensitiveText
+              variant={TextVariant.BodySm}
+              fontWeight={FontWeight.Medium}
+              color={
+                isProfit ? TextColor.SuccessDefault : TextColor.ErrorDefault
+              }
+              isHidden={privacyMode}
+            >
+              {`(${formattedRoe})`}
+            </SensitiveText>
+          </Box>
         </Box>
       )}
       <PerpsGeoBlockModal

--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
@@ -31,6 +31,7 @@ import { useSelectedAccountComplianceGate } from '../../compliance';
 import { PerpsGeoBlockModal } from '../perps-geo-block-modal';
 import { PerpsControlBarSkeleton } from '../perps-skeletons';
 import { useOnClickOutside } from '../hooks/useClickOutside';
+import { getPrivacyAwareColor } from '../utils';
 
 /** Handler from perps triggers (e.g. deposit / withdraw); may return a Promise. */
 export type PerpsBalanceActionHandler = () => void | Promise<unknown>;
@@ -97,6 +98,10 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
   const pnlNum = Number.parseFloat(unrealizedPnl);
   const isProfit = pnlNum >= 0;
   const pnlPrefix = isProfit ? '+' : '-';
+  const pnlColor = getPrivacyAwareColor(
+    isProfit ? TextColor.SuccessDefault : TextColor.ErrorDefault,
+    privacyMode,
+  );
   const formattedPnl = `${pnlPrefix}${formatPerpsFiat(Math.abs(pnlNum), {
     ranges: PRICE_RANGES_MINIMAL_VIEW,
   })}`;
@@ -248,20 +253,18 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
             <SensitiveText
               variant={TextVariant.BodySm}
               fontWeight={FontWeight.Medium}
-              color={
-                isProfit ? TextColor.SuccessDefault : TextColor.ErrorDefault
-              }
+              color={pnlColor}
               isHidden={privacyMode}
+              data-testid="perps-balance-dropdown-pnl-value"
             >
               {formattedPnl}
             </SensitiveText>
             <SensitiveText
               variant={TextVariant.BodySm}
               fontWeight={FontWeight.Medium}
-              color={
-                isProfit ? TextColor.SuccessDefault : TextColor.ErrorDefault
-              }
+              color={pnlColor}
               isHidden={privacyMode}
+              data-testid="perps-balance-dropdown-roe-value"
             >
               {`(${formattedRoe})`}
             </SensitiveText>

--- a/ui/components/app/perps/position-card/position-card.test.tsx
+++ b/ui/components/app/perps/position-card/position-card.test.tsx
@@ -175,6 +175,9 @@ describe('PositionCard', () => {
     expect(screen.getByTestId('position-card-roe-ETH')).toHaveTextContent(
       '(15.79%)',
     );
+    expect(screen.getByTestId('position-card-roe-ETH')).toHaveClass(
+      'text-success-default',
+    );
   });
 
   it('displays ROE percentage for a losing position', () => {
@@ -187,6 +190,9 @@ describe('PositionCard', () => {
 
     expect(screen.getByTestId('position-card-roe-BTC')).toHaveTextContent(
       '(-16.67%)',
+    );
+    expect(screen.getByTestId('position-card-roe-BTC')).toHaveClass(
+      'text-error-default',
     );
   });
 
@@ -224,6 +230,19 @@ describe('PositionCard', () => {
         '••••••',
       );
       expect(screen.getAllByText('••••••')).toHaveLength(4);
+    });
+
+    it('uses the default text color instead of green/red for P&L and RoE when privacy mode is enabled', () => {
+      const position = createMockPosition({
+        symbol: 'ETH',
+        unrealizedPnl: '375.00',
+      });
+      renderWithProvider(<PositionCard position={position} />, privacyStore);
+
+      const roe = screen.getByTestId('position-card-roe-ETH');
+      expect(roe).toHaveClass('text-default');
+      expect(roe).not.toHaveClass('text-success-default');
+      expect(roe).not.toHaveClass('text-error-default');
     });
   });
 });

--- a/ui/components/app/perps/position-card/position-card.test.tsx
+++ b/ui/components/app/perps/position-card/position-card.test.tsx
@@ -201,4 +201,29 @@ describe('PositionCard', () => {
       screen.queryByTestId('position-card-roe-ETH'),
     ).not.toBeInTheDocument();
   });
+
+  describe('privacy mode', () => {
+    const privacyStore = configureStore({
+      metamask: {
+        ...mockState.metamask,
+        preferences: {
+          ...mockState.metamask.preferences,
+          privacyMode: true,
+        },
+      },
+    });
+
+    it('masks size, value, P&L and RoE when privacy mode is enabled', () => {
+      const position = createMockPosition({ symbol: 'ETH', size: '2.5' });
+      renderWithProvider(<PositionCard position={position} />, privacyStore);
+
+      expect(screen.queryByText('2.5 ETH')).not.toBeInTheDocument();
+      expect(screen.queryByText('$7,125')).not.toBeInTheDocument();
+      expect(screen.queryByText('+$375.00')).not.toBeInTheDocument();
+      expect(screen.getByTestId('position-card-roe-ETH')).toHaveTextContent(
+        '••••••',
+      );
+      expect(screen.getAllByText('••••••')).toHaveLength(4);
+    });
+  });
 });

--- a/ui/components/app/perps/position-card/position-card.tsx
+++ b/ui/components/app/perps/position-card/position-card.tsx
@@ -20,7 +20,11 @@ import { formatPnl } from '../../../../../shared/lib/perps-formatters';
 import { getPreferences } from '../../../../../shared/lib/selectors/preferences';
 import { formatPerpsFiatMinimal } from '../utils/formatPerpsDisplayPrice';
 import { PerpsTokenLogo } from '../perps-token-logo';
-import { getDisplayName, getPositionDirection } from '../utils';
+import {
+  getDisplayName,
+  getPositionDirection,
+  getPrivacyAwareColor,
+} from '../utils';
 import { PERPS_MARKET_DETAIL_ROUTE } from '../../../../helpers/constants/routes';
 
 export type PositionCardProps = {
@@ -51,6 +55,10 @@ export const PositionCard = ({
   const direction = getPositionDirection(position.size);
   const pnlNum = parseFloat(position.unrealizedPnl);
   const isProfit = pnlNum >= 0;
+  const pnlColor = getPrivacyAwareColor(
+    isProfit ? TextColor.SuccessDefault : TextColor.ErrorDefault,
+    privacyMode,
+  );
   const absSize = Math.abs(parseFloat(position.size)).toString();
   // Title uses the full asset name; the size line keeps the ticker as its unit.
   const displayName = assetName || getDisplayName(position.symbol);
@@ -146,7 +154,7 @@ export const PositionCard = ({
         >
           <SensitiveText
             variant={TextVariant.BodySm}
-            color={isProfit ? TextColor.SuccessDefault : TextColor.ErrorDefault}
+            color={pnlColor}
             isHidden={privacyMode}
           >
             {formattedPnl}
@@ -154,9 +162,7 @@ export const PositionCard = ({
           {formattedRoe !== null && (
             <SensitiveText
               variant={TextVariant.BodySm}
-              color={
-                isProfit ? TextColor.SuccessDefault : TextColor.ErrorDefault
-              }
+              color={pnlColor}
               isHidden={privacyMode}
               data-testid={`position-card-roe-${position.symbol}`}
             >

--- a/ui/components/app/perps/position-card/position-card.tsx
+++ b/ui/components/app/perps/position-card/position-card.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback } from 'react';
+import { useSelector } from 'react-redux';
 import {
   twMerge,
   Box,
@@ -6,6 +7,7 @@ import {
   BoxAlignItems,
   ButtonBase,
   Text,
+  SensitiveText,
   TextVariant,
   TextColor,
   FontWeight,
@@ -15,6 +17,7 @@ import { useNavigate } from 'react-router-dom';
 import type { Position } from '@metamask/perps-controller';
 import { useFormatters } from '../../../../hooks/useFormatters';
 import { formatPnl } from '../../../../../shared/lib/perps-formatters';
+import { getPreferences } from '../../../../../shared/lib/selectors/preferences';
 import { formatPerpsFiatMinimal } from '../utils/formatPerpsDisplayPrice';
 import { PerpsTokenLogo } from '../perps-token-logo';
 import { getDisplayName, getPositionDirection } from '../utils';
@@ -43,6 +46,7 @@ export const PositionCard = ({
   assetName,
 }: PositionCardProps) => {
   const navigate = useNavigate();
+  const { privacyMode } = useSelector(getPreferences);
   const { formatPercentWithMinThreshold } = useFormatters();
   const direction = getPositionDirection(position.size);
   const pnlNum = parseFloat(position.unrealizedPnl);
@@ -112,9 +116,13 @@ export const PositionCard = ({
             {position.leverage.value}x {direction}
           </Text>
         </Box>
-        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-          {absSize} {displaySymbol}
-        </Text>
+        <SensitiveText
+          variant={TextVariant.BodySm}
+          color={TextColor.TextAlternative}
+          isHidden={privacyMode}
+        >
+          {`${absSize} ${displaySymbol}`}
+        </SensitiveText>
       </Box>
 
       {/* Right side: Position value and P&L */}
@@ -124,33 +132,36 @@ export const PositionCard = ({
         alignItems={BoxAlignItems.End}
         gap={1}
       >
-        <Text
+        <SensitiveText
           fontWeight={FontWeight.Medium}
           className="text-s-body-md @compact:text-s-body-sm"
+          isHidden={privacyMode}
         >
           {formatPerpsFiatMinimal(parseFloat(position.positionValue))}
-        </Text>
+        </SensitiveText>
         <Box
           flexDirection={BoxFlexDirection.Row}
           alignItems={BoxAlignItems.Baseline}
           gap={1}
         >
-          <Text
+          <SensitiveText
             variant={TextVariant.BodySm}
             color={isProfit ? TextColor.SuccessDefault : TextColor.ErrorDefault}
+            isHidden={privacyMode}
           >
             {formattedPnl}
-          </Text>
+          </SensitiveText>
           {formattedRoe !== null && (
-            <Text
+            <SensitiveText
               variant={TextVariant.BodySm}
               color={
                 isProfit ? TextColor.SuccessDefault : TextColor.ErrorDefault
               }
+              isHidden={privacyMode}
               data-testid={`position-card-roe-${position.symbol}`}
             >
               ({formattedRoe})
-            </Text>
+            </SensitiveText>
           )}
         </Box>
       </Box>

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.test.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.test.tsx
@@ -419,6 +419,49 @@ describe('UpdateTPSLModalContent', () => {
     });
   });
 
+  describe('privacy mode', () => {
+    const privacyStore = configureStore({
+      metamask: {
+        ...mockState.metamask,
+        preferences: {
+          ...mockState.metamask.preferences,
+          privacyMode: true,
+        },
+      },
+    });
+
+    it('masks entry price, liquidation price, and estimated P&L when privacy mode is enabled', () => {
+      renderWithProvider(
+        <TpslContentWithTestFooter {...defaultProps} />,
+        privacyStore,
+      );
+
+      expect(
+        screen.getByTestId('perps-update-tpsl-entry-price-value'),
+      ).toHaveTextContent('••••••');
+      expect(
+        screen.getByTestId('perps-update-tpsl-liquidation-price-value'),
+      ).toHaveTextContent('••••••');
+      expect(
+        screen.getByTestId('perps-update-tpsl-estimated-tp-pnl-value'),
+      ).toHaveTextContent('••••••');
+      expect(
+        screen.getByTestId('perps-update-tpsl-estimated-sl-pnl-value'),
+      ).toHaveTextContent('••••••');
+    });
+
+    it('does not mask the current price, which is public market data', () => {
+      renderWithProvider(
+        <TpslContentWithTestFooter {...defaultProps} currentPrice={2900} />,
+        privacyStore,
+      );
+
+      expect(
+        screen.getByTestId('perps-update-tpsl-current-price-value'),
+      ).toHaveTextContent(formatPerpsFiatUniversal(2900));
+    });
+  });
+
   describe('presets (RoE% with leverage)', () => {
     it('sets TP price correctly for a +25% RoE preset on a long position', () => {
       // ETH: entry=2850, leverage=3 (long)

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.test.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.test.tsx
@@ -460,6 +460,26 @@ describe('UpdateTPSLModalContent', () => {
         screen.getByTestId('perps-update-tpsl-current-price-value'),
       ).toHaveTextContent(formatPerpsFiatUniversal(2900));
     });
+
+    it('uses the default text color instead of green/red for estimated P&L when privacy mode is enabled', () => {
+      renderWithProvider(
+        <TpslContentWithTestFooter {...defaultProps} />,
+        privacyStore,
+      );
+
+      const tpPnl = screen.getByTestId(
+        'perps-update-tpsl-estimated-tp-pnl-value',
+      );
+      const slPnl = screen.getByTestId(
+        'perps-update-tpsl-estimated-sl-pnl-value',
+      );
+      expect(tpPnl).toHaveClass('text-default');
+      expect(tpPnl).not.toHaveClass('text-success-default');
+      expect(tpPnl).not.toHaveClass('text-error-default');
+      expect(slPnl).toHaveClass('text-default');
+      expect(slPnl).not.toHaveClass('text-success-default');
+      expect(slPnl).not.toHaveClass('text-error-default');
+    });
   });
 
   describe('presets (RoE% with leverage)', () => {

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
@@ -56,6 +56,7 @@ import {
   deriveTpslType,
   formatRoePercent,
   getPnlDisplayColor,
+  getPrivacyAwareColor,
 } from '../utils';
 import { PerpsGeoBlockModal } from '../perps-geo-block-modal';
 import {
@@ -783,7 +784,10 @@ export const UpdateTPSLModalContent = ({
             <SensitiveText
               variant={TextVariant.BodySm}
               fontWeight={FontWeight.Medium}
-              color={getPnlDisplayColor(estimatedPnlAtTp)}
+              color={getPrivacyAwareColor(
+                getPnlDisplayColor(estimatedPnlAtTp),
+                privacyMode,
+              )}
               isHidden={privacyMode}
               data-testid="perps-update-tpsl-estimated-tp-pnl-value"
             >
@@ -921,7 +925,10 @@ export const UpdateTPSLModalContent = ({
             <SensitiveText
               variant={TextVariant.BodySm}
               fontWeight={FontWeight.Medium}
-              color={getPnlDisplayColor(estimatedPnlAtSl)}
+              color={getPrivacyAwareColor(
+                getPnlDisplayColor(estimatedPnlAtSl),
+                privacyMode,
+              )}
               isHidden={privacyMode}
               data-testid="perps-update-tpsl-estimated-sl-pnl-value"
             >

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
@@ -6,12 +6,14 @@ import React, {
   useLayoutEffect,
   useRef,
 } from 'react';
+import { useSelector } from 'react-redux';
 import {
   Box,
   BoxAlignItems,
   BoxFlexDirection,
   BoxJustifyContent,
   Text,
+  SensitiveText,
   TextVariant,
   TextColor,
   FontWeight,
@@ -22,6 +24,7 @@ import {
   PRICE_RANGES_MINIMAL_VIEW,
   PRICE_RANGES_UNIVERSAL,
 } from '../../../../../shared/lib/perps-formatters';
+import { getPreferences } from '../../../../../shared/lib/selectors/preferences';
 import {
   formatPerpsFiatUniversal,
   formatPerpsLiquidationPrice,
@@ -114,6 +117,7 @@ export const UpdateTPSLModalContent = ({
   const { isEligible } = usePerpsEligibility();
   const { gate } = useSelectedAccountComplianceGate();
   const { replacePerpsToastByKey } = usePerpsToast();
+  const { privacyMode } = useSelector(getPreferences);
   const { feeRate: closingFeeRate } = usePerpsOrderFees({
     symbol: position.symbol,
     orderType: 'market',
@@ -619,13 +623,14 @@ export const UpdateTPSLModalContent = ({
           <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
             {t('perpsEntryPrice')}
           </Text>
-          <Text
+          <SensitiveText
             variant={TextVariant.BodySm}
             fontWeight={FontWeight.Medium}
+            isHidden={privacyMode}
             data-testid="perps-update-tpsl-entry-price-value"
           >
             {formatPerpsFiatUniversal(position.entryPrice)}
-          </Text>
+          </SensitiveText>
         </Box>
         <Box
           flexDirection={BoxFlexDirection.Row}
@@ -653,13 +658,14 @@ export const UpdateTPSLModalContent = ({
           <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
             {t('perpsLiquidationPrice')}
           </Text>
-          <Text
+          <SensitiveText
             variant={TextVariant.BodySm}
             fontWeight={FontWeight.Medium}
+            isHidden={privacyMode}
             data-testid="perps-update-tpsl-liquidation-price-value"
           >
             {formatPerpsLiquidationPrice(position.liquidationPrice)}
-          </Text>
+          </SensitiveText>
         </Box>
       </Box>
       {/* Take Profit */}
@@ -774,16 +780,18 @@ export const UpdateTPSLModalContent = ({
             >
               {t('perpsEstimatedPnlAtTakeProfit')}
             </Text>
-            <Text
+            <SensitiveText
               variant={TextVariant.BodySm}
               fontWeight={FontWeight.Medium}
               color={getPnlDisplayColor(estimatedPnlAtTp)}
+              isHidden={privacyMode}
+              data-testid="perps-update-tpsl-estimated-tp-pnl-value"
             >
               {estimatedPnlAtTp >= 0 ? '+' : '-'}
               {formatPerpsFiat(Math.abs(estimatedPnlAtTp), {
                 ranges: PRICE_RANGES_MINIMAL_VIEW,
               })}
-            </Text>
+            </SensitiveText>
           </Box>
         )}
         {isTpInvalid && (
@@ -910,16 +918,18 @@ export const UpdateTPSLModalContent = ({
             >
               {t('perpsEstimatedPnlAtStopLoss')}
             </Text>
-            <Text
+            <SensitiveText
               variant={TextVariant.BodySm}
               fontWeight={FontWeight.Medium}
               color={getPnlDisplayColor(estimatedPnlAtSl)}
+              isHidden={privacyMode}
+              data-testid="perps-update-tpsl-estimated-sl-pnl-value"
             >
               {estimatedPnlAtSl >= 0 ? '+' : '-'}
               {formatPerpsFiat(Math.abs(estimatedPnlAtSl), {
                 ranges: PRICE_RANGES_MINIMAL_VIEW,
               })}
-            </Text>
+            </SensitiveText>
           </Box>
         )}
         {(isSlInvalid || isSlLiquidationInvalid) && (

--- a/ui/components/app/perps/utils.test.ts
+++ b/ui/components/app/perps/utils.test.ts
@@ -18,6 +18,7 @@ import {
   getTransactionStatusColor,
   getTransactionAmountColor,
   getPnlDisplayColor,
+  getPrivacyAwareColor,
   parseVolume,
   hasVolume,
   formatRoePercent,
@@ -604,6 +605,32 @@ describe('Perps Utils', () => {
 
     it('returns TextDefault for zero PnL', () => {
       expect(getPnlDisplayColor(0)).toBe(TextColor.TextDefault);
+    });
+  });
+
+  describe('getPrivacyAwareColor', () => {
+    it('returns the given color when the value is not hidden', () => {
+      expect(getPrivacyAwareColor(TextColor.SuccessDefault, false)).toBe(
+        TextColor.SuccessDefault,
+      );
+      expect(getPrivacyAwareColor(TextColor.ErrorDefault, false)).toBe(
+        TextColor.ErrorDefault,
+      );
+    });
+
+    it('returns TextDefault when the value is hidden, regardless of the given color', () => {
+      expect(getPrivacyAwareColor(TextColor.SuccessDefault, true)).toBe(
+        TextColor.TextDefault,
+      );
+      expect(getPrivacyAwareColor(TextColor.ErrorDefault, true)).toBe(
+        TextColor.TextDefault,
+      );
+    });
+
+    it('treats an undefined isHidden as not hidden', () => {
+      expect(getPrivacyAwareColor(TextColor.SuccessDefault, undefined)).toBe(
+        TextColor.SuccessDefault,
+      );
     });
   });
 

--- a/ui/components/app/perps/utils.ts
+++ b/ui/components/app/perps/utils.ts
@@ -512,6 +512,26 @@ export function getPnlDisplayColor(pnl: number): TextColor {
 }
 
 /**
+ * Neutralizes a semantic (success/error) text color when the value it's
+ * applied to is currently masked (e.g. by privacy mode). This prevents the
+ * color itself from leaking whether a P&L/return figure is positive or
+ * negative while the value is hidden behind dots.
+ *
+ * @param color - The color to use when the value is visible
+ * @param isHidden - Whether the value is currently masked
+ * @returns `TextColor.TextDefault` when hidden, otherwise the given color
+ * @example
+ * getPrivacyAwareColor(TextColor.SuccessDefault, true) // → TextColor.TextDefault
+ * getPrivacyAwareColor(TextColor.SuccessDefault, false) // → TextColor.SuccessDefault
+ */
+export function getPrivacyAwareColor(
+  color: TextColor,
+  isHidden: boolean | undefined,
+): TextColor {
+  return isHidden ? TextColor.TextDefault : color;
+}
+
+/**
  * Format a RoE% value for display in TP/SL inputs.
  * Always returns the absolute value: integers with no decimal ("25"),
  * non-integers with 2 decimal places ("25.50").

--- a/ui/pages/confirmations/components/perps-confirmations/perps-withdraw-balance/perps-withdraw-balance.test.tsx
+++ b/ui/pages/confirmations/components/perps-confirmations/perps-withdraw-balance/perps-withdraw-balance.test.tsx
@@ -7,6 +7,20 @@ import { enLocale as messages } from '../../../../../../test/lib/i18n-helpers';
 import { usePerpsLiveAccount } from '../../../../../hooks/perps/stream';
 import { PerpsWithdrawBalance } from './perps-withdraw-balance';
 
+const renderWithPrivacyMode = (privacyMode: boolean) => {
+  const store = configureStore({
+    ...mockState,
+    metamask: {
+      ...mockState.metamask,
+      preferences: {
+        ...mockState.metamask.preferences,
+        privacyMode,
+      },
+    },
+  });
+  return renderWithProvider(<PerpsWithdrawBalance />, store);
+};
+
 jest.mock('../../../../../hooks/perps/stream', () => ({
   usePerpsLiveAccount: jest.fn(),
 }));
@@ -32,13 +46,11 @@ describe('PerpsWithdrawBalance', () => {
     renderBalance();
 
     expect(
-      screen.getByText(
-        new RegExp(
-          `${messages.perpsAvailableBalance.message}\\$1,232\\.39`,
-          'u',
-        ),
-      ),
+      screen.getByText(messages.perpsAvailableBalance.message.trim()),
     ).toBeInTheDocument();
+    expect(
+      screen.getByTestId('perps-withdraw-balance-value'),
+    ).toHaveTextContent('$1,232.39');
   });
 
   it('prefers available-to-trade balance when provided', () => {
@@ -53,10 +65,8 @@ describe('PerpsWithdrawBalance', () => {
     renderBalance();
 
     expect(
-      screen.getByText(
-        new RegExp(`${messages.perpsAvailableBalance.message}\\$456\\.78`, 'u'),
-      ),
-    ).toBeInTheDocument();
+      screen.getByTestId('perps-withdraw-balance-value'),
+    ).toHaveTextContent('$456.78');
   });
 
   it('renders $0.00 when the live account has no balance', () => {
@@ -68,9 +78,20 @@ describe('PerpsWithdrawBalance', () => {
     renderBalance();
 
     expect(
-      screen.getByText(
-        new RegExp(`${messages.perpsAvailableBalance.message}\\$0\\.00`, 'u'),
-      ),
-    ).toBeInTheDocument();
+      screen.getByTestId('perps-withdraw-balance-value'),
+    ).toHaveTextContent('$0.00');
+  });
+
+  it('masks the balance when privacy mode is enabled', () => {
+    usePerpsLiveAccountMock.mockReturnValue({
+      account: { spendableBalance: '1232.39' } as never,
+      isInitialLoading: false,
+    });
+
+    renderWithPrivacyMode(true);
+
+    expect(
+      screen.getByTestId('perps-withdraw-balance-value'),
+    ).toHaveTextContent('••••••');
   });
 });

--- a/ui/pages/confirmations/components/perps-confirmations/perps-withdraw-balance/perps-withdraw-balance.tsx
+++ b/ui/pages/confirmations/components/perps-confirmations/perps-withdraw-balance/perps-withdraw-balance.tsx
@@ -1,6 +1,11 @@
 import React, { useMemo } from 'react';
+import { useSelector } from 'react-redux';
 
-import { Box, Text } from '../../../../../components/component-library';
+import {
+  Box,
+  Text,
+  SensitiveText,
+} from '../../../../../components/component-library';
 import {
   AlignItems,
   Display,
@@ -13,11 +18,13 @@ import { useI18nContext } from '../../../../../hooks/useI18nContext';
 import { useFormatters } from '../../../../../hooks/useFormatters';
 import { usePerpsLiveAccount } from '../../../../../hooks/perps/stream';
 import { getTradeableBalance } from '../../../../../hooks/perps/getTradeableBalance';
+import { getPreferences } from '../../../../../../shared/lib/selectors/preferences';
 
 export const PerpsWithdrawBalance = () => {
   const t = useI18nContext();
   const { formatCurrency } = useFormatters();
   const { account } = usePerpsLiveAccount();
+  const { privacyMode } = useSelector(getPreferences);
 
   const balanceFormatted = useMemo(() => {
     const value = parseFloat(getTradeableBalance(account)) || 0;
@@ -36,8 +43,16 @@ export const PerpsWithdrawBalance = () => {
         variant={TextVariant.bodyMdMedium}
         color={TextColor.textAlternative}
       >
-        {`${t('perpsAvailableBalance')}${balanceFormatted}`}
+        {t('perpsAvailableBalance')}
       </Text>
+      <SensitiveText
+        variant={TextVariant.bodyMdMedium}
+        color={TextColor.textAlternative}
+        isHidden={privacyMode}
+        data-testid="perps-withdraw-balance-value"
+      >
+        {balanceFormatted}
+      </SensitiveText>
     </Box>
   );
 };

--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -485,6 +485,38 @@ describe('PerpsMarketDetailPage', () => {
       ).toHaveTextContent('••••••');
     });
 
+    it('masks entry price, liquidation price, funding payments, and auto close TP/SL when privacy mode is enabled', async () => {
+      const state = createMockState(true);
+      const store = mockStore({
+        ...state,
+        metamask: {
+          ...state.metamask,
+          preferences: {
+            ...state.metamask.preferences,
+            privacyMode: true,
+          },
+        },
+      });
+
+      await renderPage(store);
+
+      expect(
+        screen.getByTestId('perps-position-entry-value'),
+      ).toHaveTextContent('••••••');
+      expect(
+        screen.getByTestId('perps-position-liquidation-value'),
+      ).toHaveTextContent('••••••');
+      expect(
+        screen.getByTestId('perps-position-funding-value'),
+      ).toHaveTextContent('••••••');
+      expect(
+        screen.getByTestId('perps-auto-close-tp-value'),
+      ).toHaveTextContent('••••••');
+      expect(
+        screen.getByTestId('perps-auto-close-sl-value'),
+      ).toHaveTextContent('••••••');
+    });
+
     it('shows order filled toast when route state has pendingOrderSymbol and matching position exists', async () => {
       mockUseLocation.mockReturnValue({
         pathname: '/perps/market/ETH',

--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -509,12 +509,12 @@ describe('PerpsMarketDetailPage', () => {
       expect(
         screen.getByTestId('perps-position-funding-value'),
       ).toHaveTextContent('••••••');
-      expect(
-        screen.getByTestId('perps-auto-close-tp-value'),
-      ).toHaveTextContent('••••••');
-      expect(
-        screen.getByTestId('perps-auto-close-sl-value'),
-      ).toHaveTextContent('••••••');
+      expect(screen.getByTestId('perps-auto-close-tp-value')).toHaveTextContent(
+        '••••••',
+      );
+      expect(screen.getByTestId('perps-auto-close-sl-value')).toHaveTextContent(
+        '••••••',
+      );
     });
 
     it('shows order filled toast when route state has pendingOrderSymbol and matching position exists', async () => {

--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -485,6 +485,41 @@ describe('PerpsMarketDetailPage', () => {
       ).toHaveTextContent('••••••');
     });
 
+    it('uses the default text color instead of green/red for P&L and return when privacy mode is enabled', async () => {
+      const state = createMockState(true);
+      const store = mockStore({
+        ...state,
+        metamask: {
+          ...state.metamask,
+          preferences: {
+            ...state.metamask.preferences,
+            privacyMode: true,
+          },
+        },
+      });
+
+      await renderPage(store);
+
+      const pnl = screen.getByTestId('perps-position-pnl-value');
+      const returnValue = screen.getByTestId('perps-position-return-value');
+      expect(pnl).toHaveClass('text-default');
+      expect(pnl).not.toHaveClass('text-success-default');
+      expect(pnl).not.toHaveClass('text-error-default');
+      expect(returnValue).toHaveClass('text-default');
+      expect(returnValue).not.toHaveClass('text-success-default');
+      expect(returnValue).not.toHaveClass('text-error-default');
+    });
+
+    it('uses the success color for a profitable P&L outside of privacy mode', async () => {
+      const store = mockStore(createMockState(true));
+
+      await renderPage(store);
+
+      expect(screen.getByTestId('perps-position-pnl-value')).toHaveClass(
+        'text-success-default',
+      );
+    });
+
     it('masks entry price, liquidation price, funding payments, and auto close TP/SL when privacy mode is enabled', async () => {
       const state = createMockState(true);
       const store = mockStore({

--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -477,9 +477,9 @@ describe('PerpsMarketDetailPage', () => {
       expect(
         screen.getByTestId('perps-position-return-value'),
       ).toHaveTextContent('••••••');
-      expect(
-        screen.getByTestId('perps-position-size-value'),
-      ).toHaveTextContent('••••••');
+      expect(screen.getByTestId('perps-position-size-value')).toHaveTextContent(
+        '••••••',
+      );
       expect(
         screen.getByTestId('perps-position-margin-value'),
       ).toHaveTextContent('••••••');

--- a/ui/pages/perps/perps-market-detail-page.test.tsx
+++ b/ui/pages/perps/perps-market-detail-page.test.tsx
@@ -456,6 +456,35 @@ describe('PerpsMarketDetailPage', () => {
       expect(screen.getByText(/15\.79%/u)).toBeInTheDocument();
     });
 
+    it('masks position P&L, return, size, and margin when privacy mode is enabled', async () => {
+      const state = createMockState(true);
+      const store = mockStore({
+        ...state,
+        metamask: {
+          ...state.metamask,
+          preferences: {
+            ...state.metamask.preferences,
+            privacyMode: true,
+          },
+        },
+      });
+
+      await renderPage(store);
+
+      expect(screen.getByTestId('perps-position-pnl-value')).toHaveTextContent(
+        '••••••',
+      );
+      expect(
+        screen.getByTestId('perps-position-return-value'),
+      ).toHaveTextContent('••••••');
+      expect(
+        screen.getByTestId('perps-position-size-value'),
+      ).toHaveTextContent('••••••');
+      expect(
+        screen.getByTestId('perps-position-margin-value'),
+      ).toHaveTextContent('••••••');
+    });
+
     it('shows order filled toast when route state has pendingOrderSymbol and matching position exists', async () => {
       mockUseLocation.mockReturnValue({
         pathname: '/perps/market/ETH',

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -19,6 +19,7 @@ import {
   BoxAlignItems,
   BoxJustifyContent,
   Text,
+  SensitiveText,
   TextVariant,
   TextColor,
   FontWeight,
@@ -515,9 +516,11 @@ const PerpsMarketDetailPage = () => {
 
   // Candle period: persisted in PreferencesController across sessions/markets.
   // Local override gives instant UI feedback; background save persists for next visit.
-  const { perpsSelectedCandlePeriod: persistedCandlePeriod } = useSelector(
-    getPreferences,
-  ) as { perpsSelectedCandlePeriod?: string };
+  const { perpsSelectedCandlePeriod: persistedCandlePeriod, privacyMode } =
+    useSelector(getPreferences) as {
+      perpsSelectedCandlePeriod?: string;
+      privacyMode?: boolean;
+    };
   const resolvedPersistedPeriod =
     persistedCandlePeriod &&
     Object.values(CandlePeriod).includes(persistedCandlePeriod as CandlePeriod)
@@ -1315,7 +1318,7 @@ const PerpsMarketDetailPage = () => {
                       {t('perpsPnl')}
                     </Text>
                   </Box>
-                  <Text
+                  <SensitiveText
                     variant={TextVariant.BodyMd}
                     fontWeight={FontWeight.Medium}
                     color={
@@ -1323,9 +1326,11 @@ const PerpsMarketDetailPage = () => {
                         ? TextColor.SuccessDefault
                         : TextColor.ErrorDefault
                     }
+                    isHidden={privacyMode}
+                    data-testid="perps-position-pnl-value"
                   >
                     {formatPnl(position.unrealizedPnl)}
-                  </Text>
+                  </SensitiveText>
                 </Box>
 
                 {/* Return Card */}
@@ -1338,7 +1343,7 @@ const PerpsMarketDetailPage = () => {
                       {t('perpsReturn')}
                     </Text>
                   </Box>
-                  <Text
+                  <SensitiveText
                     variant={TextVariant.BodyMd}
                     fontWeight={FontWeight.Medium}
                     color={
@@ -1346,12 +1351,14 @@ const PerpsMarketDetailPage = () => {
                         ? TextColor.SuccessDefault
                         : TextColor.ErrorDefault
                     }
+                    isHidden={privacyMode}
+                    data-testid="perps-position-return-value"
                   >
                     {/* Controller/mobile ROE is a ratio (e.g. 0.1579), same as what the formatter expects. */}
                     {formatPercentWithMinThreshold(
                       Number.parseFloat(position.returnOnEquity),
                     )}
-                  </Text>
+                  </SensitiveText>
                 </Box>
               </Box>
 
@@ -1373,9 +1380,10 @@ const PerpsMarketDetailPage = () => {
                       {t('perpsSize')}
                     </Text>
                   </Box>
-                  <Text
+                  <SensitiveText
                     variant={TextVariant.BodyMd}
                     fontWeight={FontWeight.Medium}
+                    isHidden={privacyMode}
                     data-testid="perps-position-size-value"
                   >
                     {showSizeInFiat && Boolean(position.entryPrice)
@@ -1387,7 +1395,7 @@ const PerpsMarketDetailPage = () => {
                           Math.abs(parseFloat(position.size)),
                           marketInfo?.szDecimals,
                         )} ${getDisplayName(position.symbol)}`}
-                  </Text>
+                  </SensitiveText>
                 </Box>
 
                 {/* Margin Card - click to open Add/Remove margin popover */}
@@ -1406,13 +1414,14 @@ const PerpsMarketDetailPage = () => {
                       {t('perpsMargin')}
                     </Text>
                   </Box>
-                  <Text
+                  <SensitiveText
                     variant={TextVariant.BodyMd}
                     fontWeight={FontWeight.Medium}
+                    isHidden={privacyMode}
                     data-testid="perps-position-margin-value"
                   >
                     {formatPerpsFiatMinimal(position.marginUsed)}
-                  </Text>
+                  </SensitiveText>
                   <Popover
                     referenceElement={marginMenuRef.current}
                     isOpen={isMarginMenuOpen}

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -1487,28 +1487,32 @@ const PerpsMarketDetailPage = () => {
                     >
                       TP{' '}
                     </Text>
-                    <Text
+                    <SensitiveText
                       variant={TextVariant.BodyMd}
                       fontWeight={FontWeight.Medium}
+                      isHidden={privacyMode}
+                      data-testid="perps-auto-close-tp-value"
                     >
                       {effectiveTakeProfitPrice
                         ? formatPerpsFiatUniversal(effectiveTakeProfitPrice)
                         : '-'}
-                    </Text>
+                    </SensitiveText>
                     <Text
                       variant={TextVariant.BodyMd}
                       fontWeight={FontWeight.Medium}
                     >
                       , SL{' '}
                     </Text>
-                    <Text
+                    <SensitiveText
                       variant={TextVariant.BodyMd}
                       fontWeight={FontWeight.Medium}
+                      isHidden={privacyMode}
+                      data-testid="perps-auto-close-sl-value"
                     >
                       {effectiveStopLossPrice
                         ? formatPerpsFiatUniversal(effectiveStopLossPrice)
                         : '-'}
-                    </Text>
+                    </SensitiveText>
                   </Box>
                 </Box>
                 <Icon
@@ -1571,13 +1575,14 @@ const PerpsMarketDetailPage = () => {
                   >
                     {t('perpsEntryPrice')}
                   </Text>
-                  <Text
+                  <SensitiveText
                     variant={TextVariant.BodySm}
                     fontWeight={FontWeight.Medium}
+                    isHidden={privacyMode}
                     data-testid="perps-position-entry-value"
                   >
                     {formatPerpsFiatUniversal(position.entryPrice)}
-                  </Text>
+                  </SensitiveText>
                 </Box>
 
                 {/* Liquidation Price Row */}
@@ -1593,13 +1598,14 @@ const PerpsMarketDetailPage = () => {
                   >
                     {t('perpsLiquidationPrice')}
                   </Text>
-                  <Text
+                  <SensitiveText
                     variant={TextVariant.BodySm}
                     fontWeight={FontWeight.Medium}
+                    isHidden={privacyMode}
                     data-testid="perps-position-liquidation-value"
                   >
                     {formatPerpsLiquidationPrice(position.liquidationPrice)}
-                  </Text>
+                  </SensitiveText>
                 </Box>
 
                 {/* Funding Payments Row */}
@@ -1615,9 +1621,10 @@ const PerpsMarketDetailPage = () => {
                   >
                     {t('perpsFundingPayments')}
                   </Text>
-                  <Text
+                  <SensitiveText
                     variant={TextVariant.BodySm}
                     fontWeight={FontWeight.Medium}
+                    isHidden={privacyMode}
                     data-testid="perps-position-funding-value"
                   >
                     {(() => {
@@ -1635,7 +1642,7 @@ const PerpsMarketDetailPage = () => {
                         { ranges: PRICE_RANGES_MINIMAL_VIEW },
                       )}`;
                     })()}
-                  </Text>
+                  </SensitiveText>
                 </Box>
               </Box>
             </Box>

--- a/ui/pages/perps/perps-market-detail-page.tsx
+++ b/ui/pages/perps/perps-market-detail-page.tsx
@@ -92,6 +92,7 @@ import {
   safeDecodeURIComponent,
   getChangeColor,
   formatSignedChangePercent,
+  getPrivacyAwareColor,
 } from '../../components/app/perps/utils';
 import {
   parsePerpsDisplayPrice,
@@ -521,6 +522,19 @@ const PerpsMarketDetailPage = () => {
       perpsSelectedCandlePeriod?: string;
       privacyMode?: boolean;
     };
+
+  const positionPnlColor = getPrivacyAwareColor(
+    position && parseFloat(position.unrealizedPnl) < 0
+      ? TextColor.ErrorDefault
+      : TextColor.SuccessDefault,
+    privacyMode,
+  );
+  const positionReturnColor = getPrivacyAwareColor(
+    position && parseFloat(position.returnOnEquity) < 0
+      ? TextColor.ErrorDefault
+      : TextColor.SuccessDefault,
+    privacyMode,
+  );
   const resolvedPersistedPeriod =
     persistedCandlePeriod &&
     Object.values(CandlePeriod).includes(persistedCandlePeriod as CandlePeriod)
@@ -1321,11 +1335,7 @@ const PerpsMarketDetailPage = () => {
                   <SensitiveText
                     variant={TextVariant.BodyMd}
                     fontWeight={FontWeight.Medium}
-                    color={
-                      parseFloat(position.unrealizedPnl) >= 0
-                        ? TextColor.SuccessDefault
-                        : TextColor.ErrorDefault
-                    }
+                    color={positionPnlColor}
                     isHidden={privacyMode}
                     data-testid="perps-position-pnl-value"
                   >
@@ -1346,11 +1356,7 @@ const PerpsMarketDetailPage = () => {
                   <SensitiveText
                     variant={TextVariant.BodyMd}
                     fontWeight={FontWeight.Medium}
-                    color={
-                      parseFloat(position.returnOnEquity) >= 0
-                        ? TextColor.SuccessDefault
-                        : TextColor.ErrorDefault
-                    }
+                    color={positionReturnColor}
                     isHidden={privacyMode}
                     data-testid="perps-position-return-value"
                   >


### PR DESCRIPTION
## **Description**

When a user hides their global wallet balance (privacy mode), the Perps tab balance, P&L, position sizes, margin, and related values remain visible in plaintext — unlike mobile, which correctly hides this data. This is a regression report from [TAT-3268](https://consensyssoftware.atlassian.net/browse/TAT-3268).

This PR wraps the sensitive Perps monetary/percentage values in `SensitiveText` (from `@metamask/design-system-react`, which is already used throughout the Perps UI), driven by the existing global `privacyMode` preference — the same preference and pattern already used for the wallet balance, token list, and DeFi list.

A follow-up pass cross-checked `metamask-mobile`'s `PerpsPositionCard`, which also masks Entry price, Liquidation price, Auto Close (TP/SL), and Funding payments. Those fields have been added here for parity, along with the same Liquidation/Entry price masking (plus already-established categories: margin, available balance, and P&L) extended to the order-entry summary, edit-margin modal, and update-TP/SL modal for consistency, even though mobile does not mask those particular surfaces.

Surfaces covered:
- Perps tab total balance + unrealized P&L (`PerpsBalanceDropdown`)
- Position list cards: size, value, P&L, RoE (`PositionCard`)
- Market detail page position section: P&L, Return, Size, Margin, Entry Price, Liquidation Price, Auto Close (TP/SL), Funding Payments (`PerpsMarketDetailPage`)
- Order entry "Available to trade" (`AmountInput`)
- Order entry summary: Liquidation price, Margin (`OrderSummary`)
- Edit margin modal: Liquidation price, Available to add/subtract (`EditMarginModalContent`)
- Update TP/SL modal: Entry price, Liquidation price, Estimated P&L at Take Profit/Stop Loss (`UpdateTPSLModalContent`)
- Withdraw confirmation "Available balance" (`PerpsWithdrawBalance`)

## **Changelog**

CHANGELOG entry: Fixed a bug where the Perps balance, P&L, and position details remained visible when the wallet balance privacy mode was enabled

## **Related issues**

Fixes: [TAT-3268](https://consensyssoftware.atlassian.net/browse/TAT-3268)

## **Manual testing steps**

1. Open the extension and unlock the wallet.
2. Click the total wallet balance on the home screen to enable privacy mode.
3. Go to the Perps tab.
4. Verify the total balance and P&L are shown as bullets instead of numbers.
5. Open the market detail page for a market with an existing position.
6. Verify the position's P&L, Return, Size, Margin, Entry Price, Liquidation Price, Auto Close (TP/SL), and Funding Payments are all masked.
7. Open the order entry page for a market, enter an amount, and verify "Available to trade" and the order summary's Liquidation price and Margin are masked.
8. Open the "Add margin" or "Remove margin" modal on an existing position and verify the Liquidation price and Available amount are masked.
9. Open the "Edit TP/SL" modal on an existing position and verify Entry price, Liquidation price, and the Estimated P&L (once a TP/SL price is set) are masked.
10. Start a Perps withdrawal and verify "Available balance" is masked.
11. Click the wallet balance again to disable privacy mode and verify all the above values reappear correctly.


## **Screenshots/Recordings**

### **Before**

### **After**
<img width="487" height="970" alt="Screenshot 2026-07-08 at 17 30 29" src="https://github.com/user-attachments/assets/ce5aaeaf-7bbf-4940-8bb4-785994ea2f7f" />



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

[TAT-3268]: https://consensyssoftware.atlassian.net/browse/TAT-3268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
