### PR TITLE
fix(mv3): extend install waitUntil through background initialization

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -2678,9 +2678,11 @@ async function initOrRestoreBackground() {
   return isInitialized;
 }
 
-export const backgroundInitOrRestore = initOrRestoreBackground().catch((error) => {
-  log.error('initOrRestoreBackground failed', error);
-});
+export const backgroundInitOrRestore = initOrRestoreBackground().catch(
+  (error) => {
+    log.error('initOrRestoreBackground failed', error);
+  },
+);
 
 if (inTest) {
   // listen for test messages from the background

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -2593,6 +2593,18 @@ async function initBackground(backup) {
       });
     }
 
+    const backgroundInitializationDelayMs =
+      getManifestFlags().testing?.simulateBackgroundInitializationDelayMs;
+    if (
+      inTest &&
+      typeof backgroundInitializationDelayMs === 'number' &&
+      backgroundInitializationDelayMs > 0
+    ) {
+      await new Promise((resolve) =>
+        setTimeout(resolve, backgroundInitializationDelayMs),
+      );
+    }
+
     log.info('MetaMask initialization complete.');
     resolveInitialization();
   } catch (error) {
@@ -2606,7 +2618,7 @@ async function initBackground(backup) {
  */
 async function initOrRestoreBackground() {
   if (process.env.SKIP_BACKGROUND_INITIALIZATION) {
-    return;
+    return Promise.resolve();
   }
 
   const restoreSession = await readCriticalErrorRestoreSession(browser);
@@ -2650,7 +2662,7 @@ async function initOrRestoreBackground() {
         await isInitialized;
       } catch (error) {
         log.error('critical-error-restore: initialization failed', error);
-        return;
+        return Promise.resolve();
       }
 
       controller.onboardingController.setFirstTimeFlowType(
@@ -2658,14 +2670,15 @@ async function initOrRestoreBackground() {
       );
 
       await handoffRestoringTabToExtension(platform, handoffPayload);
-      return;
+      return isInitialized;
     }
   }
 
   initBackground(null);
+  return isInitialized;
 }
 
-initOrRestoreBackground().catch((error) => {
+export const backgroundInitOrRestore = initOrRestoreBackground().catch((error) => {
   log.error('initOrRestoreBackground failed', error);
 });
 

--- a/app/service-worker.ts
+++ b/app/service-worker.ts
@@ -51,7 +51,8 @@ async function runImportScripts() {
   const startImportScriptsTime = performance.now();
 
   // eslint-disable-next-line import-x/extensions
-  await import('./scripts/background.js');
+  const { backgroundInitOrRestore } = await import('./scripts/background.js');
+  await backgroundInitOrRestore;
 
   const endImportScriptsTime = performance.now();
 

--- a/shared/lib/manifestFlags.ts
+++ b/shared/lib/manifestFlags.ts
@@ -107,6 +107,10 @@ export type ManifestFlags = {
      */
     simulateServiceWorkerStartupDelayMs?: number;
     /**
+     * Number of milliseconds to wait before resolving background initialization.
+     */
+    simulateBackgroundInitializationDelayMs?: number;
+    /**
      * Simulate background initialization hang for testing the initialization
      * timeout error screen. Only triggers when a vault backup exists in IndexedDB,
      * so tests can onboard first, then reload to trigger the timeout.

--- a/test/e2e/tests/critical-errors/critical-errors.spec.ts
+++ b/test/e2e/tests/critical-errors/critical-errors.spec.ts
@@ -235,4 +235,28 @@ describe('Critical errors', function (this: Suite) {
       },
     );
   });
+
+  it('loads the login page when service worker install delays background initialization', async function () {
+    if (getManifestVersion() === 2) {
+      this.skip();
+    }
+
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilderV2().build(),
+        manifestFlags: {
+          testing: {
+            simulateBackgroundInitializationDelayMs: 5000,
+          },
+        },
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }) => {
+        await driver.navigate(PAGES.HOME, { waitForControllers: false });
+
+        const loginPage = new LoginPage(driver);
+        await loginPage.checkPageIsLoaded();
+      },
+    );
+  });
 });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

PR #44189 extends the MV3 service worker `install` event with `event.waitUntil(runImportScripts())` so Chrome does not finish install before the dynamic `background.js` import completes.

This follow-up extends that same install lifetime through **full background initialization** (storage reads, migrations, controller setup, and `isInitialized` resolution), not just the script import.

Changes:
- Export `backgroundInitOrRestore` from `background.js` and await it from `service-worker.ts` after the dynamic import
- Add `simulateBackgroundInitializationDelayMs` manifest testing flag
- Add an MV3 E2E test that verifies the login page still loads when background initialization is artificially delayed during install

**Stacked on:** #44189

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related to: #43773

## **Manual testing steps**

1. Check out this branch and run `MANIFEST_OVERRIDES=.manifest-overrides.json yarn start:test`.
2. In `.manifest-overrides.json`, set `simulateBackgroundInitializationDelayMs` to `5000` under `_flags.testing`.
3. Load the unpacked extension from `dist/chrome` and open the service worker console.
4. Confirm `importScripts completed in ... seconds` appears after roughly import time plus 5 seconds, with no `NetworkError` for chunk loading.
5. Open the MetaMask popup and confirm the login page loads normally.
6. Remove the delay flag and confirm startup returns to normal timing.

## **Screenshots/Recordings**

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes MV3 service worker install lifetime and background startup sequencing; mis-timing could affect cold-start behavior, though it follows the prior import waitUntil pattern and adds E2E coverage.
> 
> **Overview**
> **MV3 service worker install** now stays open until background initialization finishes, not only until `background.js` is dynamically imported.
> 
> `service-worker.ts` imports and **awaits** the exported `backgroundInitOrRestore` promise inside `runImportScripts()`, so `event.waitUntil` covers storage load, migrations, controller setup, and `isInitialized` resolution. `initOrRestoreBackground()` is adjusted to **return** that initialization promise (including critical-error restore paths) instead of fire-and-forget startup.
> 
> Test support adds **`simulateBackgroundInitializationDelayMs`** and an MV3 E2E case that confirms the **login page still loads** when initialization is delayed during install.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 43085492e4dd42b16c9827d5df80e3ce168d27b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->