### PR TITLE
chore: migrate `checkDelegationDisabled` to `LegacyBackgroundApiService`

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3318,7 +3318,10 @@ export default class MetamaskController extends EventEmitter {
         gatorPermissionsController.submitDirectRevocation.bind(
           gatorPermissionsController,
         ),
-      checkDelegationDisabled: this.checkDelegationDisabled.bind(this),
+      checkDelegationDisabled: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'LegacyBackgroundApiService:checkDelegationDisabled',
+      ),
 
       // KeyringController
       setLocked: this.controllerMessenger.call.bind(
@@ -9059,46 +9062,6 @@ export default class MetamaskController extends EventEmitter {
     );
   }
 
-  /**
-   * Checks if a delegation is already disabled on-chain by querying the
-   * delegation manager contract's disabledDelegations mapping.
-   *
-   * @param {string} delegationManagerAddress - The delegation manager contract address.
-   * @param {string} delegationHash - The hash of the delegation to check.
-   * @param {string} networkClientId - The network client ID to use for the query.
-   * @returns {Promise<boolean>} True if the delegation is disabled, false otherwise.
-   */
-  async checkDelegationDisabled(
-    delegationManagerAddress,
-    delegationHash,
-    networkClientId,
-  ) {
-    const { encodeDisabledDelegationsCheck, decodeDisabledDelegationsResult } =
-      await import('../../shared/lib/delegation/delegation');
-
-    // Encode the call to disabledDelegations(bytes32)
-    const callData = encodeDisabledDelegationsCheck({ delegationHash });
-
-    // Make eth_call request through the network controller
-    const networkClient =
-      this.networkController.getNetworkClientById(networkClientId);
-
-    const result = await networkClient.provider.request({
-      method: 'eth_call',
-      params: [
-        {
-          to: delegationManagerAddress,
-          data: callData,
-        },
-        'latest',
-      ],
-    });
-
-    // Decode the result
-    const isDisabled = decodeDisabledDelegationsResult(result);
-
-    return isDisabled;
-  }
 
   #createEnsureOnboardingCompleteCallback() {
     return createEnsureOnboardingCompleteCallback(this.controllerMessenger);

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -9062,7 +9062,6 @@ export default class MetamaskController extends EventEmitter {
     );
   }
 
-
   #createEnsureOnboardingCompleteCallback() {
     return createEnsureOnboardingCompleteCallback(this.controllerMessenger);
   }

--- a/app/scripts/services/legacy-background-api-service-method-action-types.ts
+++ b/app/scripts/services/legacy-background-api-service-method-action-types.ts
@@ -85,6 +85,20 @@ export type LegacyBackgroundApiServiceGetCodeAction = {
 };
 
 /**
+ * Checks whether a delegation has been disabled on-chain by performing an
+ * `eth_call` against the delegation manager contract.
+ *
+ * @param delegationManagerAddress - The delegation manager contract address.
+ * @param delegationHash - The hash of the delegation to check.
+ * @param networkClientId - The ID of the network client to use for the request.
+ * @returns `true` if the delegation is disabled, `false` otherwise.
+ */
+export type LegacyBackgroundApiServiceCheckDelegationDisabledAction = {
+  type: `LegacyBackgroundApiService:checkDelegationDisabled`;
+  handler: LegacyBackgroundApiService['checkDelegationDisabled'];
+};
+
+/**
  * Estimates the gas for a given transaction using the currently selected
  * network client.
  *
@@ -402,6 +416,7 @@ export type LegacyBackgroundApiServiceMethodActions =
   | LegacyBackgroundApiServiceMarkPasswordForgottenAction
   | LegacyBackgroundApiServiceUnMarkPasswordForgottenAction
   | LegacyBackgroundApiServiceGetCodeAction
+  | LegacyBackgroundApiServiceCheckDelegationDisabledAction
   | LegacyBackgroundApiServiceEstimateGasAction
   | LegacyBackgroundApiServiceGetSeedPhraseAction
   | LegacyBackgroundApiServiceResetAccountAction

--- a/app/scripts/services/legacy-background-api-service.test.ts
+++ b/app/scripts/services/legacy-background-api-service.test.ts
@@ -12,7 +12,7 @@ import {
   TransactionContainerType,
   TransactionMeta,
 } from '@metamask/transaction-controller';
-import { add0x, hexToBytes } from '@metamask/utils';
+import { add0x, hexToBytes, type Hex } from '@metamask/utils';
 import {
   EncAccountDataType,
   SecretType,
@@ -408,6 +408,44 @@ describe('LegacyBackgroundApiService', () => {
         );
 
         expect(result).resolves.toStrictEqual('0x123');
+      });
+    });
+  });
+
+  describe('checkDelegationDisabled', () => {
+    it('performs an eth_call against the delegation manager and returns the decoded result', async () => {
+      const delegationManagerAddress: Hex =
+        '0x1234567890123456789012345678901234567890';
+      const delegationHash: Hex = `0x${'0'.repeat(63)}1`;
+      const mockRequest = jest
+        .fn()
+        .mockResolvedValue(
+          '0x0000000000000000000000000000000000000000000000000000000000000001',
+        );
+
+      await withService(async ({ rootMessenger }) => {
+        rootMessenger.registerActionHandler(
+          'NetworkController:getNetworkClientById',
+          jest.fn().mockReturnValue({
+            provider: { request: mockRequest },
+          }),
+        );
+
+        const result = await rootMessenger.call(
+          'LegacyBackgroundApiService:checkDelegationDisabled',
+          delegationManagerAddress,
+          delegationHash,
+          'networkClientId',
+        );
+
+        expect(mockRequest).toHaveBeenCalledWith({
+          method: 'eth_call',
+          params: [
+            { to: delegationManagerAddress, data: expect.any(String) },
+            'latest',
+          ],
+        });
+        expect(result).toBe(true);
       });
     });
   });

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -166,6 +166,10 @@ import {
 } from '../controllers/metametrics-controller-method-action-types';
 import { runSeedlessOnboardingMigrations } from '../lib/seedless-onboarding/run-migrations';
 import { createSentryError } from '../../../shared/lib/error';
+import {
+  encodeDisabledDelegationsCheck,
+  decodeDisabledDelegationsResult,
+} from '../../../shared/lib/delegation/delegation';
 import { TraceName, TraceOperation } from '../../../shared/lib/trace';
 import { AppStateControllerSetPasskeyAutoUnlockSuppressedAction } from '../controllers/app-state-controller-method-action-types';
 import { PASSKEY_AUTO_UNLOCK_SUPPRESSION_DURATION_MS } from '../../../shared/constants/passkey';
@@ -181,6 +185,7 @@ const MESSENGER_EXPOSED_METHODS = [
   'acceptPermissionsRequest',
   'applyTransactionContainersExisting',
   'changePassword',
+  'checkDelegationDisabled',
   'checkIsSeedlessPasswordOutdated',
   'estimateGas',
   'exportAccount',
@@ -495,6 +500,44 @@ export class LegacyBackgroundApiService {
       method: 'eth_getCode',
       params: [address],
     });
+  }
+
+  /**
+   * Checks whether a delegation has been disabled on-chain by performing an
+   * `eth_call` against the delegation manager contract.
+   *
+   * @param delegationManagerAddress - The delegation manager contract address.
+   * @param delegationHash - The hash of the delegation to check.
+   * @param networkClientId - The ID of the network client to use for the request.
+   * @returns `true` if the delegation is disabled, `false` otherwise.
+   */
+  async checkDelegationDisabled(
+    delegationManagerAddress: Hex,
+    delegationHash: Hex,
+    networkClientId: string,
+  ): Promise<boolean> {
+    // Encode the call to disabledDelegations(bytes32)
+    const callData = encodeDisabledDelegationsCheck({ delegationHash });
+
+    // Make eth_call request through the network controller
+    const { provider } = this.#messenger.call(
+      'NetworkController:getNetworkClientById',
+      networkClientId,
+    );
+
+    const result = (await provider.request({
+      method: 'eth_call',
+      params: [
+        {
+          to: delegationManagerAddress,
+          data: callData,
+        },
+        'latest',
+      ],
+    })) as Hex;
+
+    // Decode the result
+    return decodeDisabledDelegationsResult(result);
   }
 
   /**


### PR DESCRIPTION
## **Description**

Part of the WPC-418 effort to slim down `MetamaskController.getApi()`.

The `checkDelegationDisabled` method performed an `eth_call` against the delegation manager contract via `networkController`. This moves it into `LegacyBackgroundApiService`, using a messenger call (`NetworkController:getNetworkClientById`) instead of a direct controller reference, following the same pattern as the already-migrated `getCode` method.

The delegation encode/decode helpers were switched from a dynamic `import()` to a static import (matching every other consumer of that module) to satisfy the service's stricter module resolution; the module is lightweight so there is no meaningful eager-load cost.

No behavior change for the client: the UI thunk still calls `submitRequestToBackground('checkDelegationDisabled', [delegationManagerAddress, delegationHash, networkClientId])` with the same argument shape.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/WPC-1101

## **Manual testing steps**

1. Open the gator permissions revoke flow (`useRevokeGatorPermissions`).
2. Revoke a permission whose delegation is already disabled on-chain, and one that is not.
3. Confirm the flow treats each correctly, same as before.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only relocation with tests; gator revoke flows should behave the same if the messenger path matches the old direct implementation.
> 
> **Overview**
> Continues slimming **`MetamaskController.getApi()`** by relocating **`checkDelegationDisabled`** into **`LegacyBackgroundApiService`**, with the public background API still exposing the same method name and arguments via a messenger call (`LegacyBackgroundApiService:checkDelegationDisabled`).
> 
> The on-chain check is unchanged in spirit: encode `disabledDelegations(bytes32)`, **`eth_call`** through **`NetworkController:getNetworkClientById`**, then decode the result. The implementation now mirrors **`getCode`** (messenger-based network access instead of holding **`networkController`** on the controller). Delegation helpers are **statically** imported in the service instead of dynamically imported from the controller.
> 
> Typed messenger action wiring and a unit test cover the **`eth_call`** params and decoded boolean result.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a56e5c7c34246937e4f6c8ac4901549fd66a34f4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->