### PR TITLE
fix: updated added to chainlist icon and padding

### DIFF
--- a/ui/components/multichain/networks-form/networks-form.tsx
+++ b/ui/components/multichain/networks-form/networks-form.tsx
@@ -5,7 +5,7 @@ import {
   Button as DSButton,
   ButtonSize as DSButtonSize,
   ButtonVariant as DSButtonVariant,
-  IconName as DSIconName,
+  IconName,
 } from '@metamask/design-system-react';
 import {
   type UpdateNetworkFields,
@@ -471,7 +471,7 @@ export const NetworksForm = ({
           <DSButton
             variant={DSButtonVariant.Secondary}
             size={DSButtonSize.Lg}
-            startIconName={DSIconName.Flash}
+            startIconName={IconName.FlashFilled}
             isFullWidth
             onClick={onAddFromChainlist}
             className="mb-4 rounded-xl"

--- a/ui/pages/networks/chainlist-network-picker.tsx
+++ b/ui/pages/networks/chainlist-network-picker.tsx
@@ -146,11 +146,10 @@ export const ChainlistNetworkPicker = ({
 
           return (
             <button
-              className="flex w-full items-center gap-3 px-4 py-2 text-left hover:bg-hover active:bg-pressed"
+              className="flex w-full items-center gap-3 px-4 py-3 text-left hover:bg-hover active:bg-pressed"
               data-testid="networks-page-chainlist-network"
               key={`${network.chainId}-${network.name}`}
               onClick={() => onSelect(network, searchValue.trim() || undefined)}
-              type="button"
             >
               {networkImageUrl ? (
                 <AvatarNetwork


### PR DESCRIPTION
This PR is to change the button icon from Flash to FlashFilled and increase paddings to 12px

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: ux changes

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to add via chainlist. Check the icon is updated

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="748" height="178" alt="Screenshot 2026-07-08 at 4 49 34 PM" src="https://github.com/user-attachments/assets/7f93317f-ab96-455e-9a8f-91dbf982ca6f" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only changes to icons and Tailwind padding with no logic, data, or security impact.
> 
> **Overview**
> Polishes the **add from Chainlist** flow to match updated design specs.
> 
> The **Add from Chainlist** button on the custom network form now uses **`IconName.FlashFilled`** instead of the outline **Flash** icon. Chainlist picker rows use **`py-3`** (12px vertical padding) instead of **`py-2`**, and the redundant **`type="button"`** attribute was removed from each network row button.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97ddc31560c2c3d162576ad58f4aef1558879708. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->