### PR TITLE
chore: deprecate old toast component

### DIFF
--- a/ui/components/multichain/toast/toast.tsx
+++ b/ui/components/multichain/toast/toast.tsx
@@ -21,12 +21,20 @@ import {
   TextVariant,
 } from '../../../helpers/constants/design-system';
 
+// eslint-disable-next-line jsdoc/require-param
+/**
+ * @deprecated Use the toast notification system in `ui/components/ui/toast/toast`
+ */
 export const ToastContainer = ({
   children,
 }: {
   children: React.ReactNode | string;
 }) => <Box className="toasts-container">{children}</Box>;
 
+// eslint-disable-next-line jsdoc/require-param
+/**
+ * @deprecated Use the toast notification system in `ui/components/ui/toast/toast`
+ */
 export const Toast = ({
   startAdornment,
   text,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Deprecate the old toast component to help avoid more components to migrate

It has since been replaced by `ui/components/ui/toast/toast`


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only deprecation with no behavioral changes to toast rendering or dismissal.
> 
> **Overview**
> Marks **`Toast`** and **`ToastContainer`** in `ui/components/multichain/toast/toast.tsx` as **`@deprecated`** in JSDoc, steering new work to **`ui/components/ui/toast/toast`**. Adds **`eslint-disable-next-line jsdoc/require-param`** so the deprecation blocks pass lint without full param docs.
> 
> No runtime or API changes—existing callers (e.g. MUSD, Perps, rewards toasts) behave the same until they migrate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ff400b435b64e95798318adada51571ae31411e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->