### PR TITLE
fix(rewards): retry silent auth when remote flags hydrate after onboarding

### DIFF
--- a/app/scripts/controllers/rewards/rewards-controller.test.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.test.ts
@@ -23,6 +23,7 @@ import {
   KeyringControllerSignPersonalMessageAction,
   KeyringControllerUnlockEvent,
 } from '@metamask/keyring-controller';
+import { RemoteFeatureFlagControllerStateChangeEvent } from '@metamask/remote-feature-flag-controller';
 import {
   RECURRING_INTERVALS,
   RecurringInterval,
@@ -242,7 +243,8 @@ async function withController<ReturnValue>(
 
   type TestAllowedEvents =
     | KeyringControllerUnlockEvent
-    | AccountTreeControllerSelectedAccountGroupChangeEvent;
+    | AccountTreeControllerSelectedAccountGroupChangeEvent
+    | RemoteFeatureFlagControllerStateChangeEvent;
 
   const messenger = getRootMessenger<
     RewardsControllerActions | TestAllowedActions,
@@ -284,6 +286,7 @@ async function withController<ReturnValue>(
     events: [
       'AccountTreeController:selectedAccountGroupChange',
       'KeyringController:unlock',
+      'RemoteFeatureFlagController:stateChange',
     ],
   });
 

--- a/app/scripts/controllers/rewards/rewards-controller.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.ts
@@ -574,6 +574,15 @@ export class RewardsController extends BaseController<
     this.messenger.subscribe('KeyringController:unlock', () =>
       this.handleAuthenticationTrigger('KeyringController unlocked'),
     );
+
+    // On a fresh install the first keyring unlock happens during onboarding,
+    // before remote feature flags (and thus `rewardsEnabled`) are available, so
+    // the unlock-triggered silent auth returns early. Retry when remote flags
+    // hydrate after onboarding completes — `handleAuthenticationTrigger` is a
+    // no-op while rewards is still disabled.
+    this.messenger.subscribe('RemoteFeatureFlagController:stateChange', () =>
+      this.handleAuthenticationTrigger('RemoteFeatureFlag changed'),
+    );
   }
 
   /**

--- a/app/scripts/controllers/rewards/rewards-controller.types.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.types.ts
@@ -13,6 +13,7 @@ import {
   KeyringControllerSignPersonalMessageAction,
   KeyringControllerUnlockEvent,
 } from '@metamask/keyring-controller';
+import { RemoteFeatureFlagControllerStateChangeEvent } from '@metamask/remote-feature-flag-controller';
 import { Messenger } from '@metamask/messenger';
 import {
   EstimatePerpsContextDto,
@@ -926,7 +927,8 @@ type AllowedActions =
 
 type AllowedEvents =
   | KeyringControllerUnlockEvent
-  | AccountTreeControllerSelectedAccountGroupChangeEvent;
+  | AccountTreeControllerSelectedAccountGroupChangeEvent
+  | RemoteFeatureFlagControllerStateChangeEvent;
 
 export type RewardsControllerMessenger = Messenger<
   'RewardsController',

--- a/app/scripts/messenger-client-init/messengers/rewards-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/rewards-controller-messenger.ts
@@ -47,6 +47,9 @@ export function getRewardsControllerMessenger(
     events: [
       'AccountTreeController:selectedAccountGroupChange',
       'KeyringController:unlock',
+      // Retry silent auth when remote flags hydrate after onboarding (fresh
+      // install unlocks during onboarding while `rewardsEnabled` is unavailable).
+      'RemoteFeatureFlagController:stateChange',
     ],
   });
   return controllerMessenger;

--- a/test/e2e/fixtures/default-fixture.json
+++ b/test/e2e/fixtures/default-fixture.json
@@ -1186,7 +1186,13 @@
           "subscriptionId": null
         }
       },
-      "rewardsActiveAccount": null,
+      "rewardsActiveAccount": {
+        "account": "eip155:0:0x5cfe73b6021e818b776b421b1c4db2474086a7e1",
+        "lastFreshOptInStatusCheck": 1783610142869,
+        "lastPerpsDiscountRateFetched": null,
+        "perpsFeeDiscount": null,
+        "subscriptionId": null
+      },
       "rewardsPointsEstimateHistory": [],
       "rewardsSeasonStatuses": {},
       "rewardsSeasons": {},

--- a/test/e2e/fixtures/fixture-validation.ts
+++ b/test/e2e/fixtures/fixture-validation.ts
@@ -115,6 +115,7 @@ const getFixtureIgnoredKeys = (): string[] => [
   'data.PerpsController',
   'data.RewardsController.rewardsAccounts.bip122:000000000019d6689c085ae165831e93:bc1qg6whd6pc0cguh6gpp3ewujm53hv32ta9hdp252.lastFreshOptInStatusCheck',
   'data.RewardsController.rewardsAccounts.eip155:0:0x5cfe73b6021e818b776b421b1c4db2474086a7e1.lastFreshOptInStatusCheck',
+  'data.RewardsController.rewardsActiveAccount.lastFreshOptInStatusCheck',
   'data.RewardsController.rewardsAccounts.solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp:4tE76eixEgyJDrdykdWJR1XBkzUk4cLMvqjR2xVJUxer.lastFreshOptInStatusCheck',
   'data.RewardsController.rewardsAccounts.tron:728126428:TJ3QZbBREK1Xybe1jf4nR9Attb8i54vGS3.lastFreshOptInStatusCheck',
 ];

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-background-state.json
@@ -258,7 +258,7 @@
     },
     "RewardsController": {
       "rewardsAccounts": "object",
-      "rewardsActiveAccount": null,
+      "rewardsActiveAccount": "object",
       "rewardsPointsEstimateHistory": "object",
       "rewardsSeasonStatuses": "object",
       "rewardsSeasons": "object",


### PR DESCRIPTION
## **Description**

### Context

On a fresh install, VIP users can see bridge fee discounts (applied server-side in the quote) but the VIP badge stays hidden. PR #43906 addressed part of this by keying `useVipTier` on `rewardsActiveAccount.subscriptionId`, but the badge still fails when silent auth never completes.

### Root cause

1. On extension fresh install, the keyring unlocks at **create-password** — before `completedOnboarding` is true.
2. While onboarding is incomplete, `RemoteFeatureFlagController` is disabled and `rewardsEnabled` is unavailable, so `isRewardsFeatureEnabled()` returns false.
3. `handleAuthenticationTrigger` (subscribed to `KeyringController:unlock`) runs on that first unlock, hits the disabled path (`performSilentAuth(null)`), and returns without establishing a rewards session.
4. The user stays unlocked through the rest of onboarding, so **no second unlock** fires and silent auth is never retried.
5. Bridge discount still works (server-side quote); badge requires client `/vip/fees` via `useVipTier`, which needs a logged-in subscription.

Mobile does not hit this path on fresh install because rewards is gated on `basicFunctionalityEnabled` (defaults on), not on remote `rewardsEnabled` + onboarding completion.

### Solution

Subscribe `RewardsController` to `RemoteFeatureFlagController:stateChange` and call `handleAuthenticationTrigger` when remote flags hydrate after onboarding completes. `handleAuthenticationTrigger` is already a no-op while rewards is disabled (same as mobile), so unrelated flag updates are harmless; once `rewardsEnabled` resolves, silent auth runs and populates `rewardsActiveAccount` for the VIP badge (complementing #43906).

## **Changelog**

CHANGELOG entry: Fixed an issue where the VIP badge could be missing on a fresh install even when VIP fee discounts were applied.

## **Related issues**

Related: #43906

## **Manual testing steps**

1. Build and load the extension (`yarn start` or `yarn build:test`).
2. Fresh install: create a new wallet through onboarding with a VIP/opted-in test address (or use an existing VIP backend account).
3. Complete onboarding without locking the wallet.
4. Open Bridge and confirm a VIP-discounted fee is shown in the quote.
5. Confirm the **VIP badge** appears next to the discounted fee (not just the discount text).
6. Optional regression: lock and unlock the wallet — badge should still appear; toggle account group — silent auth should still work.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)