### PR TITLE
fix: swap tx fails when smart account upgrade is required cp-13.38.2

### DIFF
--- a/.yarn/patches/@metamask-bridge-status-controller-npm-72.1.1-2e3e46c8d1.patch
+++ b/.yarn/patches/@metamask-bridge-status-controller-npm-72.1.1-2e3e46c8d1.patch
@@ -1,0 +1,67 @@
+diff --git a/dist/strategy/batch-strategy.cjs b/dist/strategy/batch-strategy.cjs
+index b60e7724d2ea4b8a18a6f36b30d648ce1e624067..b3a9448eac2b8c4c228e94f12da66391d2a90d8c 100644
+--- a/dist/strategy/batch-strategy.cjs
++++ b/dist/strategy/batch-strategy.cjs
+@@ -1,7 +1,6 @@
+ "use strict";
+ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.submitBatchHandler = void 0;
+-const bridge_controller_1 = require("@metamask/bridge-controller");
+ const transaction_1 = require("../utils/transaction.cjs");
+ const types_1 = require("./types.cjs");
+ /**
+@@ -16,10 +15,6 @@ async function* submitBatchHandler(args) {
+         quoteResponse,
+         isBridgeTx,
+     });
+-    const gasFeeToken = quoteResponse.quote.feeData[bridge_controller_1.FeeType.TX_FEE]?.asset?.address &&
+-        (0, bridge_controller_1.isNativeAddress)(quoteResponse.quote.feeData[bridge_controller_1.FeeType.TX_FEE].asset.address)
+-        ? undefined
+-        : quoteResponse.quote.feeData[bridge_controller_1.FeeType.TX_FEE]?.asset?.address;
+     const transactionParams = await (0, transaction_1.getAddTransactionBatchParams)({
+         tradeData,
+         requireApproval,
+@@ -29,11 +24,6 @@ async function* submitBatchHandler(args) {
+         disable7702: (0, transaction_1.shouldDisable7702)(quoteResponse.quote.gasIncluded7702, quoteResponse.quote.gasIncluded, isDelegatedAccount),
+         isGasFeeSponsored: Boolean(quoteResponse.quote.gasSponsored),
+         isGasFeeIncluded: Boolean(quoteResponse.quote.gasIncluded7702),
+-        gasFeeToken,
+-        skipInitialGasEstimate: quoteResponse.quote.gasIncluded7702
+-            ? isDelegatedAccount
+-            : Boolean(gasFeeToken),
+-        excludeNativeTokenForFee: !gasFeeToken,
+     });
+     const { batchId } = await addTransactionBatchFn(transactionParams);
+     const quoteAndTxMetas = (0, transaction_1.findAllTransactionsInBatch)({
+diff --git a/dist/strategy/batch-strategy.mjs b/dist/strategy/batch-strategy.mjs
+index 0db1331ffc2edba6341768cd8c30871440d0cab7..33ed12a6fe438b492e3521c72df5c8a63587f135 100644
+--- a/dist/strategy/batch-strategy.mjs
++++ b/dist/strategy/batch-strategy.mjs
+@@ -1,4 +1,3 @@
+-import { FeeType, isNativeAddress } from "@metamask/bridge-controller";
+ import { findAllTransactionsInBatch, getAddTransactionBatchParams, isApprovalTx, isTradeTx, shouldDisable7702, toQuoteAndTxMetadata } from "../utils/transaction.mjs";
+ import { SubmitStep } from "./types.mjs";
+ /**
+@@ -13,10 +12,6 @@ export async function* submitBatchHandler(args) {
+         quoteResponse,
+         isBridgeTx,
+     });
+-    const gasFeeToken = quoteResponse.quote.feeData[FeeType.TX_FEE]?.asset?.address &&
+-        isNativeAddress(quoteResponse.quote.feeData[FeeType.TX_FEE].asset.address)
+-        ? undefined
+-        : quoteResponse.quote.feeData[FeeType.TX_FEE]?.asset?.address;
+     const transactionParams = await getAddTransactionBatchParams({
+         tradeData,
+         requireApproval,
+@@ -26,11 +21,6 @@ export async function* submitBatchHandler(args) {
+         disable7702: shouldDisable7702(quoteResponse.quote.gasIncluded7702, quoteResponse.quote.gasIncluded, isDelegatedAccount),
+         isGasFeeSponsored: Boolean(quoteResponse.quote.gasSponsored),
+         isGasFeeIncluded: Boolean(quoteResponse.quote.gasIncluded7702),
+-        gasFeeToken,
+-        skipInitialGasEstimate: quoteResponse.quote.gasIncluded7702
+-            ? isDelegatedAccount
+-            : Boolean(gasFeeToken),
+-        excludeNativeTokenForFee: !gasFeeToken,
+     });
+     const { batchId } = await addTransactionBatchFn(transactionParams);
+     const quoteAndTxMetas = findAllTransactionsInBatch({

--- a/.yarn/patches/@metamask-bridge-status-controller-npm-73.0.0-664418b8e9.patch
+++ b/.yarn/patches/@metamask-bridge-status-controller-npm-73.0.0-664418b8e9.patch
@@ -1,0 +1,67 @@
+diff --git a/dist/strategy/batch-strategy.cjs b/dist/strategy/batch-strategy.cjs
+index b60e7724d2ea4b8a18a6f36b30d648ce1e624067..b3a9448eac2b8c4c228e94f12da66391d2a90d8c 100644
+--- a/dist/strategy/batch-strategy.cjs
++++ b/dist/strategy/batch-strategy.cjs
+@@ -1,7 +1,6 @@
+ "use strict";
+ Object.defineProperty(exports, "__esModule", { value: true });
+ exports.submitBatchHandler = void 0;
+-const bridge_controller_1 = require("@metamask/bridge-controller");
+ const transaction_1 = require("../utils/transaction.cjs");
+ const types_1 = require("./types.cjs");
+ /**
+@@ -16,10 +15,6 @@ async function* submitBatchHandler(args) {
+         quoteResponse,
+         isBridgeTx,
+     });
+-    const gasFeeToken = quoteResponse.quote.feeData[bridge_controller_1.FeeType.TX_FEE]?.asset?.address &&
+-        (0, bridge_controller_1.isNativeAddress)(quoteResponse.quote.feeData[bridge_controller_1.FeeType.TX_FEE].asset.address)
+-        ? undefined
+-        : quoteResponse.quote.feeData[bridge_controller_1.FeeType.TX_FEE]?.asset?.address;
+     const transactionParams = await (0, transaction_1.getAddTransactionBatchParams)({
+         tradeData,
+         requireApproval,
+@@ -29,11 +24,6 @@ async function* submitBatchHandler(args) {
+         disable7702: (0, transaction_1.shouldDisable7702)(quoteResponse.quote.gasIncluded7702, quoteResponse.quote.gasIncluded, isDelegatedAccount),
+         isGasFeeSponsored: Boolean(quoteResponse.quote.gasSponsored),
+         isGasFeeIncluded: Boolean(quoteResponse.quote.gasIncluded7702),
+-        gasFeeToken,
+-        skipInitialGasEstimate: quoteResponse.quote.gasIncluded7702
+-            ? isDelegatedAccount
+-            : Boolean(gasFeeToken),
+-        excludeNativeTokenForFee: !gasFeeToken,
+     });
+     const { batchId } = await addTransactionBatchFn(transactionParams);
+     const quoteAndTxMetas = (0, transaction_1.findAllTransactionsInBatch)({
+diff --git a/dist/strategy/batch-strategy.mjs b/dist/strategy/batch-strategy.mjs
+index 0db1331ffc2edba6341768cd8c30871440d0cab7..33ed12a6fe438b492e3521c72df5c8a63587f135 100644
+--- a/dist/strategy/batch-strategy.mjs
++++ b/dist/strategy/batch-strategy.mjs
+@@ -1,4 +1,3 @@
+-import { FeeType, isNativeAddress } from "@metamask/bridge-controller";
+ import { findAllTransactionsInBatch, getAddTransactionBatchParams, isApprovalTx, isTradeTx, shouldDisable7702, toQuoteAndTxMetadata } from "../utils/transaction.mjs";
+ import { SubmitStep } from "./types.mjs";
+ /**
+@@ -13,10 +12,6 @@ export async function* submitBatchHandler(args) {
+         quoteResponse,
+         isBridgeTx,
+     });
+-    const gasFeeToken = quoteResponse.quote.feeData[FeeType.TX_FEE]?.asset?.address &&
+-        isNativeAddress(quoteResponse.quote.feeData[FeeType.TX_FEE].asset.address)
+-        ? undefined
+-        : quoteResponse.quote.feeData[FeeType.TX_FEE]?.asset?.address;
+     const transactionParams = await getAddTransactionBatchParams({
+         tradeData,
+         requireApproval,
+@@ -26,11 +21,6 @@ export async function* submitBatchHandler(args) {
+         disable7702: shouldDisable7702(quoteResponse.quote.gasIncluded7702, quoteResponse.quote.gasIncluded, isDelegatedAccount),
+         isGasFeeSponsored: Boolean(quoteResponse.quote.gasSponsored),
+         isGasFeeIncluded: Boolean(quoteResponse.quote.gasIncluded7702),
+-        gasFeeToken,
+-        skipInitialGasEstimate: quoteResponse.quote.gasIncluded7702
+-            ? isDelegatedAccount
+-            : Boolean(gasFeeToken),
+-        excludeNativeTokenForFee: !gasFeeToken,
+     });
+     const { batchId } = await addTransactionBatchFn(transactionParams);
+     const quoteAndTxMetas = findAllTransactionsInBatch({

--- a/lavamoat/browserify/beta/policy.json
+++ b/lavamoat/browserify/beta/policy.json
@@ -1027,6 +1027,35 @@
         "uuid": true
       }
     },
+    "@metamask/bridge-status-controller>@metamask/bridge-controller": {
+      "globals": {
+        "AbortController": true,
+        "TextDecoder": true,
+        "URLSearchParams": true,
+        "console.error": true,
+        "console.log": true,
+        "console.warn": true
+      },
+      "packages": {
+        "ethers>@ethersproject/address": true,
+        "@ethersproject/bignumber": true,
+        "ethers>@ethersproject/constants": true,
+        "@ethersproject/contracts": true,
+        "@ethersproject/providers": true,
+        "@metamask/controller-utils": true,
+        "@metamask/keyring-api": true,
+        "@metamask/metamask-eth-abis": true,
+        "@metamask/multichain-network-controller": true,
+        "@metamask/polling-controller": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "@metamask/bridge-status-controller>bignumber.js": true,
+        "browserify>buffer": true,
+        "lodash": true,
+        "reselect": true,
+        "uuid": true
+      }
+    },
     "@metamask/transaction-pay-controller>@metamask/bridge-controller": {
       "globals": {
         "AbortController": true,
@@ -1064,7 +1093,7 @@
         "setTimeout": true
       },
       "packages": {
-        "@metamask/bridge-controller": true,
+        "@metamask/bridge-status-controller>@metamask/bridge-controller": true,
         "@metamask/controller-utils": true,
         "@metamask/keyring-controller": true,
         "@metamask/polling-controller": true,

--- a/lavamoat/browserify/experimental/policy.json
+++ b/lavamoat/browserify/experimental/policy.json
@@ -1027,6 +1027,35 @@
         "uuid": true
       }
     },
+    "@metamask/bridge-status-controller>@metamask/bridge-controller": {
+      "globals": {
+        "AbortController": true,
+        "TextDecoder": true,
+        "URLSearchParams": true,
+        "console.error": true,
+        "console.log": true,
+        "console.warn": true
+      },
+      "packages": {
+        "ethers>@ethersproject/address": true,
+        "@ethersproject/bignumber": true,
+        "ethers>@ethersproject/constants": true,
+        "@ethersproject/contracts": true,
+        "@ethersproject/providers": true,
+        "@metamask/controller-utils": true,
+        "@metamask/keyring-api": true,
+        "@metamask/metamask-eth-abis": true,
+        "@metamask/multichain-network-controller": true,
+        "@metamask/polling-controller": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "@metamask/bridge-status-controller>bignumber.js": true,
+        "browserify>buffer": true,
+        "lodash": true,
+        "reselect": true,
+        "uuid": true
+      }
+    },
     "@metamask/transaction-pay-controller>@metamask/bridge-controller": {
       "globals": {
         "AbortController": true,
@@ -1064,7 +1093,7 @@
         "setTimeout": true
       },
       "packages": {
-        "@metamask/bridge-controller": true,
+        "@metamask/bridge-status-controller>@metamask/bridge-controller": true,
         "@metamask/controller-utils": true,
         "@metamask/keyring-controller": true,
         "@metamask/polling-controller": true,

--- a/lavamoat/browserify/flask/policy.json
+++ b/lavamoat/browserify/flask/policy.json
@@ -1027,6 +1027,35 @@
         "uuid": true
       }
     },
+    "@metamask/bridge-status-controller>@metamask/bridge-controller": {
+      "globals": {
+        "AbortController": true,
+        "TextDecoder": true,
+        "URLSearchParams": true,
+        "console.error": true,
+        "console.log": true,
+        "console.warn": true
+      },
+      "packages": {
+        "ethers>@ethersproject/address": true,
+        "@ethersproject/bignumber": true,
+        "ethers>@ethersproject/constants": true,
+        "@ethersproject/contracts": true,
+        "@ethersproject/providers": true,
+        "@metamask/controller-utils": true,
+        "@metamask/keyring-api": true,
+        "@metamask/metamask-eth-abis": true,
+        "@metamask/multichain-network-controller": true,
+        "@metamask/polling-controller": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "@metamask/bridge-status-controller>bignumber.js": true,
+        "browserify>buffer": true,
+        "lodash": true,
+        "reselect": true,
+        "uuid": true
+      }
+    },
     "@metamask/transaction-pay-controller>@metamask/bridge-controller": {
       "globals": {
         "AbortController": true,
@@ -1064,7 +1093,7 @@
         "setTimeout": true
       },
       "packages": {
-        "@metamask/bridge-controller": true,
+        "@metamask/bridge-status-controller>@metamask/bridge-controller": true,
         "@metamask/controller-utils": true,
         "@metamask/keyring-controller": true,
         "@metamask/polling-controller": true,

--- a/lavamoat/browserify/main/policy.json
+++ b/lavamoat/browserify/main/policy.json
@@ -1027,6 +1027,35 @@
         "uuid": true
       }
     },
+    "@metamask/bridge-status-controller>@metamask/bridge-controller": {
+      "globals": {
+        "AbortController": true,
+        "TextDecoder": true,
+        "URLSearchParams": true,
+        "console.error": true,
+        "console.log": true,
+        "console.warn": true
+      },
+      "packages": {
+        "ethers>@ethersproject/address": true,
+        "@ethersproject/bignumber": true,
+        "ethers>@ethersproject/constants": true,
+        "@ethersproject/contracts": true,
+        "@ethersproject/providers": true,
+        "@metamask/controller-utils": true,
+        "@metamask/keyring-api": true,
+        "@metamask/metamask-eth-abis": true,
+        "@metamask/multichain-network-controller": true,
+        "@metamask/polling-controller": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "@metamask/bridge-status-controller>bignumber.js": true,
+        "browserify>buffer": true,
+        "lodash": true,
+        "reselect": true,
+        "uuid": true
+      }
+    },
     "@metamask/transaction-pay-controller>@metamask/bridge-controller": {
       "globals": {
         "AbortController": true,
@@ -1064,7 +1093,7 @@
         "setTimeout": true
       },
       "packages": {
-        "@metamask/bridge-controller": true,
+        "@metamask/bridge-status-controller>@metamask/bridge-controller": true,
         "@metamask/controller-utils": true,
         "@metamask/keyring-controller": true,
         "@metamask/polling-controller": true,

--- a/lavamoat/webpack/mv2/beta/policy.json
+++ b/lavamoat/webpack/mv2/beta/policy.json
@@ -927,6 +927,25 @@
         "uuid": true
       }
     },
+    "@metamask/bridge-status-controller>@metamask/bridge-controller": {
+      "globals": {
+        "Buffer.from": true,
+        "URLSearchParams": true,
+        "console.warn": true
+      },
+      "packages": {
+        "ethers>@ethersproject/address": true,
+        "ethers>@ethersproject/constants": true,
+        "@ethersproject/contracts": true,
+        "@metamask/controller-utils": true,
+        "@metamask/keyring-api": true,
+        "@metamask/metamask-eth-abis": true,
+        "@metamask/multichain-network-controller": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "buffer": true
+      }
+    },
     "@metamask/bridge-status-controller": {
       "globals": {
         "URLSearchParams": true,
@@ -935,7 +954,7 @@
         "setTimeout": true
       },
       "packages": {
-        "@metamask/bridge-controller": true,
+        "@metamask/bridge-status-controller>@metamask/bridge-controller": true,
         "@metamask/controller-utils": true,
         "@metamask/keyring-controller": true,
         "@metamask/polling-controller": true,

--- a/lavamoat/webpack/mv2/experimental/policy.json
+++ b/lavamoat/webpack/mv2/experimental/policy.json
@@ -927,6 +927,25 @@
         "uuid": true
       }
     },
+    "@metamask/bridge-status-controller>@metamask/bridge-controller": {
+      "globals": {
+        "Buffer.from": true,
+        "URLSearchParams": true,
+        "console.warn": true
+      },
+      "packages": {
+        "ethers>@ethersproject/address": true,
+        "ethers>@ethersproject/constants": true,
+        "@ethersproject/contracts": true,
+        "@metamask/controller-utils": true,
+        "@metamask/keyring-api": true,
+        "@metamask/metamask-eth-abis": true,
+        "@metamask/multichain-network-controller": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "buffer": true
+      }
+    },
     "@metamask/bridge-status-controller": {
       "globals": {
         "URLSearchParams": true,
@@ -935,7 +954,7 @@
         "setTimeout": true
       },
       "packages": {
-        "@metamask/bridge-controller": true,
+        "@metamask/bridge-status-controller>@metamask/bridge-controller": true,
         "@metamask/controller-utils": true,
         "@metamask/keyring-controller": true,
         "@metamask/polling-controller": true,

--- a/lavamoat/webpack/mv2/flask/policy.json
+++ b/lavamoat/webpack/mv2/flask/policy.json
@@ -927,6 +927,25 @@
         "uuid": true
       }
     },
+    "@metamask/bridge-status-controller>@metamask/bridge-controller": {
+      "globals": {
+        "Buffer.from": true,
+        "URLSearchParams": true,
+        "console.warn": true
+      },
+      "packages": {
+        "ethers>@ethersproject/address": true,
+        "ethers>@ethersproject/constants": true,
+        "@ethersproject/contracts": true,
+        "@metamask/controller-utils": true,
+        "@metamask/keyring-api": true,
+        "@metamask/metamask-eth-abis": true,
+        "@metamask/multichain-network-controller": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "buffer": true
+      }
+    },
     "@metamask/bridge-status-controller": {
       "globals": {
         "URLSearchParams": true,
@@ -935,7 +954,7 @@
         "setTimeout": true
       },
       "packages": {
-        "@metamask/bridge-controller": true,
+        "@metamask/bridge-status-controller>@metamask/bridge-controller": true,
         "@metamask/controller-utils": true,
         "@metamask/keyring-controller": true,
         "@metamask/polling-controller": true,

--- a/lavamoat/webpack/mv2/main/policy.json
+++ b/lavamoat/webpack/mv2/main/policy.json
@@ -927,6 +927,25 @@
         "uuid": true
       }
     },
+    "@metamask/bridge-status-controller>@metamask/bridge-controller": {
+      "globals": {
+        "Buffer.from": true,
+        "URLSearchParams": true,
+        "console.warn": true
+      },
+      "packages": {
+        "ethers>@ethersproject/address": true,
+        "ethers>@ethersproject/constants": true,
+        "@ethersproject/contracts": true,
+        "@metamask/controller-utils": true,
+        "@metamask/keyring-api": true,
+        "@metamask/metamask-eth-abis": true,
+        "@metamask/multichain-network-controller": true,
+        "@metamask/superstruct": true,
+        "@metamask/utils": true,
+        "buffer": true
+      }
+    },
     "@metamask/bridge-status-controller": {
       "globals": {
         "URLSearchParams": true,
@@ -935,7 +954,7 @@
         "setTimeout": true
       },
       "packages": {
-        "@metamask/bridge-controller": true,
+        "@metamask/bridge-status-controller>@metamask/bridge-controller": true,
         "@metamask/controller-utils": true,
         "@metamask/keyring-controller": true,
         "@metamask/polling-controller": true,

--- a/package.json
+++ b/package.json
@@ -307,7 +307,8 @@
     "@metamask/permission-controller@npm:^12.2.1": "^13.0.0",
     "@metamask/permission-controller@npm:^12.3.0": "^13.0.0",
     "@metamask/assets-controller@npm:^9.1.0": "patch:@metamask/assets-controller@npm%3A10.0.1#~/.yarn/patches/@metamask-assets-controller-npm-10.0.1-d3c86d8983.patch",
-    "@metamask/assets-controller@npm:^10.0.1": "patch:@metamask/assets-controller@npm%3A10.0.1#~/.yarn/patches/@metamask-assets-controller-npm-10.0.1-d3c86d8983.patch"
+    "@metamask/assets-controller@npm:^10.0.1": "patch:@metamask/assets-controller@npm%3A10.0.1#~/.yarn/patches/@metamask-assets-controller-npm-10.0.1-d3c86d8983.patch",
+    "@metamask/bridge-status-controller@npm:^73.0.0": "patch:@metamask/bridge-status-controller@npm%3A73.0.0#~/.yarn/patches/@metamask-bridge-status-controller-npm-73.0.0-664418b8e9.patch"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.29.2#~/.yarn/patches/@babel-runtime-npm-7.29.2-b49cad1c67.patch",
@@ -348,7 +349,7 @@
     "@metamask/bitcoin-wallet-snap": "^1.14.0",
     "@metamask/bitcoin-wallet-standard": "^1.1.0",
     "@metamask/bridge-controller": "^75.1.1",
-    "@metamask/bridge-status-controller": "^72.1.1",
+    "@metamask/bridge-status-controller": "patch:@metamask/bridge-status-controller@npm%3A73.0.0#~/.yarn/patches/@metamask-bridge-status-controller-npm-73.0.0-664418b8e9.patch",
     "@metamask/browser-passworder": "^6.0.0",
     "@metamask/chain-agnostic-permission": "^1.6.2",
     "@metamask/claims-controller": "^0.4.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5843,7 +5843,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bridge-controller@npm:^75.1.1, @metamask/bridge-controller@npm:^75.2.1":
+"@metamask/bridge-controller@npm:^75.1.1":
   version: 75.2.1
   resolution: "@metamask/bridge-controller@npm:75.2.1"
   dependencies:
@@ -5909,31 +5909,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/bridge-status-controller@npm:^72.1.1":
-  version: 72.1.1
-  resolution: "@metamask/bridge-status-controller@npm:72.1.1"
-  dependencies:
-    "@metamask/accounts-controller": "npm:^39.0.2"
-    "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/bridge-controller": "npm:^75.2.1"
-    "@metamask/controller-utils": "npm:^12.3.0"
-    "@metamask/gas-fee-controller": "npm:^26.2.3"
-    "@metamask/keyring-controller": "npm:^27.1.0"
-    "@metamask/messenger": "npm:^1.2.0"
-    "@metamask/network-controller": "npm:^33.0.0"
-    "@metamask/polling-controller": "npm:^16.0.7"
-    "@metamask/profile-sync-controller": "npm:^28.2.0"
-    "@metamask/snaps-controllers": "npm:^19.0.0"
-    "@metamask/superstruct": "npm:^3.1.0"
-    "@metamask/transaction-controller": "npm:^68.1.1"
-    "@metamask/utils": "npm:^11.11.0"
-    bignumber.js: "npm:^9.1.2"
-    uuid: "npm:^8.3.2"
-  checksum: 10/7a408b6e200195083ed107431c07d7db1792a4206ed1dbcd3e5a6ab3bac880ddef2ff4aabc6db475208f30ef3e65d1d986e6778cd1b92c9539a5d1aea4e1cfd4
-  languageName: node
-  linkType: hard
-
-"@metamask/bridge-status-controller@npm:^73.0.0":
+"@metamask/bridge-status-controller@npm:73.0.0":
   version: 73.0.0
   resolution: "@metamask/bridge-status-controller@npm:73.0.0"
   dependencies:
@@ -5954,6 +5930,30 @@ __metadata:
     bignumber.js: "npm:^9.1.2"
     uuid: "npm:^8.3.2"
   checksum: 10/e95224183980ba231dae62cec2297caf87f6e43973d4de082d30172adf720091f02c636aceade05d2cec11da416c305fa57a00bc28283e0b173caa7ec3746a57
+  languageName: node
+  linkType: hard
+
+"@metamask/bridge-status-controller@patch:@metamask/bridge-status-controller@npm%3A73.0.0#~/.yarn/patches/@metamask-bridge-status-controller-npm-73.0.0-664418b8e9.patch":
+  version: 73.0.0
+  resolution: "@metamask/bridge-status-controller@patch:@metamask/bridge-status-controller@npm%3A73.0.0#~/.yarn/patches/@metamask-bridge-status-controller-npm-73.0.0-664418b8e9.patch::version=73.0.0&hash=8bb7e4"
+  dependencies:
+    "@metamask/accounts-controller": "npm:^39.0.3"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/bridge-controller": "npm:^77.0.0"
+    "@metamask/controller-utils": "npm:^12.3.0"
+    "@metamask/gas-fee-controller": "npm:^26.2.3"
+    "@metamask/keyring-controller": "npm:^27.1.0"
+    "@metamask/messenger": "npm:^1.2.0"
+    "@metamask/network-controller": "npm:^33.0.0"
+    "@metamask/polling-controller": "npm:^16.0.7"
+    "@metamask/profile-sync-controller": "npm:^28.2.0"
+    "@metamask/snaps-controllers": "npm:^19.0.0"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/transaction-controller": "npm:^68.2.0"
+    "@metamask/utils": "npm:^11.11.0"
+    bignumber.js: "npm:^9.1.2"
+    uuid: "npm:^8.3.2"
+  checksum: 10/7bc8bb771eb70759b8a0f80ff7bc3e056aa2c331a673f05d0dcdd7e214c076f61b3be4572b01923f8aa5c1fbae8ba25ec207785814c49a5b5fd3f34f28cf7d68
   languageName: node
   linkType: hard
 
@@ -33278,7 +33278,7 @@ __metadata:
     "@metamask/bitcoin-wallet-snap": "npm:^1.14.0"
     "@metamask/bitcoin-wallet-standard": "npm:^1.1.0"
     "@metamask/bridge-controller": "npm:^75.1.1"
-    "@metamask/bridge-status-controller": "npm:^72.1.1"
+    "@metamask/bridge-status-controller": "patch:@metamask/bridge-status-controller@npm%3A73.0.0#~/.yarn/patches/@metamask-bridge-status-controller-npm-73.0.0-664418b8e9.patch"
     "@metamask/browser-passworder": "npm:^6.0.0"
     "@metamask/browser-playground": "npm:0.8.1"
     "@metamask/build-utils": "npm:^3.0.0"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Patches bridge-status-controller with swap batch-strategy fix in this [PR](https://github.com/MetaMask/core/pull/9431)

Fixes tx submission failures that happen when TX is enabled, account has not been upgraded, and the user receives a `gasIncluded=7702` quote

During the submission flow, passing `gasFeeToken`, `skipInitialGasEstimate`, and `excludeNativeTokenForFee` as addTransactionBatch params causes `checkGasFeeTokenBeforePublish` to throw the error. This PR removes the params so `checkGasFeeTokenBeforePublish` returns early


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: swap tx fails when smart account upgrade is required 

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/44274

## **Manual testing steps**

(extension, Base network)
1. if running extension locally, set the BRIDGE_API_BASE_URL to the prod bridge-api
2. enable smart transactions
3. disable smart account for Base
4. not sure if this matters but I have < $.02 of ETH in the account
5. try to get a swap gasIncluded7702 quote for which the txFee is an ERC20 token (i.e, base:USDC to base:USDT)
6. submit the trade
7.transactions should be published on-chain, account should get upgraded

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes bridge/swap transaction batch submission and gas-fee handling on a critical user path; scoped patch to vendored dist only, but behavior shift for ERC-20 fee + 7702 upgrade flows needs regression testing.
> 
> **Overview**
> Fixes swap submission failures when **smart transactions** are on, the account is not yet upgraded to a smart account, and the quote is **`gasIncluded7702`** with an ERC-20 **tx fee** token.
> 
> The extension moves to **`@metamask/bridge-status-controller` 73.0.0** via a **Yarn patch** (backport of MetaMask/core#9431). In `submitBatchHandler`, the patch **stops** deriving `gasFeeToken` from quote fee data and **drops** `gasFeeToken`, `skipInitialGasEstimate`, and `excludeNativeTokenForFee` from `addTransactionBatch` params so publish-time **`checkGasFeeTokenBeforePublish`** can exit early instead of throwing.
> 
> **LavaMoat** policies are updated so `@metamask/bridge-status-controller` depends on a scoped **`@metamask/bridge-status-controller>@metamask/bridge-controller`** entry rather than the top-level `@metamask/bridge-controller` package.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6ce6711f9010862ef309745065010c697888e6a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->