### PR TITLE
feat(networks): add Robinhood Chain as featured network

### DIFF
--- a/shared/constants/network.test.ts
+++ b/shared/constants/network.test.ts
@@ -42,6 +42,7 @@ describe('NetworkConstants', () => {
         MegaETH: CHAIN_IDS.MEGAETH_MAINNET,
         Tempo: CHAIN_IDS.TEMPO_MAINNET,
         Arc: CHAIN_IDS.ARC,
+        'Robinhood Chain': CHAIN_IDS.ROBINHOOD_CHAIN,
       };
 
       FEATURED_RPCS.forEach((rpc) => {

--- a/shared/constants/network.ts
+++ b/shared/constants/network.ts
@@ -229,6 +229,7 @@ export const CHAIN_IDS = {
   MANTLE: '0x1388',
   KONET: '0x4341',
   ARC: '0x13b2',
+  ROBINHOOD_CHAIN: '0x1237',
 } as const;
 
 export const CHAINLIST_CHAIN_IDS_MAP = {
@@ -405,6 +406,7 @@ export const STABLE_DISPLAY_NAME = 'Stable';
 export const MANTLE_DISPLAY_NAME = 'Mantle';
 export const KONET_DISPLAY_NAME = 'KONET Mainnet';
 export const ARC_DISPLAY_NAME = 'Arc';
+export const ROBINHOOD_CHAIN_DISPLAY_NAME = 'Robinhood Chain';
 
 /**
  * The Arc USDC ERC20 token contract. On Arc the native gas token is USDC, so
@@ -747,6 +749,7 @@ export const MSU_IMAGE_URL = './images/msu.svg';
 export const MSU_NATIVE_TOKEN_IMAGE_URL = './images/msu-native.svg';
 export const BOB_IMAGE_URL = './images/bob.svg';
 export const ROOTSTOCK_IMAGE_URL = './images/rootstock.svg';
+export const ROBINHOOD_CHAIN_IMAGE_URL = './images/robinhood.svg';
 export const ROOTSTOCK_NATIVE_TOKEN_IMAGE_URL = './images/rootstock-native.svg';
 export const TEMPO_TESTNET_IMAGE_URL = './images/tempo.svg';
 export const TEMPO_MAINNET_IMAGE_URL = './images/tempo.svg';
@@ -945,6 +948,7 @@ export const NETWORK_TO_NAME_MAP = {
   [CHAIN_IDS.MANTLE]: MANTLE_DISPLAY_NAME,
   [CHAIN_IDS.KONET]: KONET_DISPLAY_NAME,
   [CHAIN_IDS.ARC]: ARC_DISPLAY_NAME,
+  [CHAIN_IDS.ROBINHOOD_CHAIN]: ROBINHOOD_CHAIN_DISPLAY_NAME,
 } as const;
 
 export const CHAIN_ID_TO_CURRENCY_SYMBOL_MAP = {
@@ -1117,6 +1121,7 @@ export const CHAIN_ID_TO_CURRENCY_SYMBOL_MAP = {
   [CHAIN_IDS.STABLE_MAINNET]: CURRENCY_SYMBOLS.STABLE,
   [CHAIN_IDS.KONET]: CURRENCY_SYMBOLS.KONET,
   [CHAIN_IDS.ARC]: CURRENCY_SYMBOLS.ARC,
+  [CHAIN_IDS.ROBINHOOD_CHAIN]: CURRENCY_SYMBOLS.ETH,
 } as const;
 
 /**
@@ -1310,6 +1315,7 @@ export const CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP: Record<string, string> = {
   [CHAIN_IDS.STABLE_MAINNET]: STABLE_IMAGE_URL,
   [CHAIN_IDS.KONET]: KONET_IMAGE_URL,
   [CHAIN_IDS.ARC]: ARC_NETWORK_IMAGE_URL,
+  [CHAIN_IDS.ROBINHOOD_CHAIN]: ROBINHOOD_CHAIN_IMAGE_URL,
 } as const;
 
 export const CHAIN_ID_TO_ETHERS_NETWORK_NAME_MAP = {
@@ -1409,6 +1415,7 @@ export const CHAIN_ID_TOKEN_IMAGE_MAP = {
   [CHAIN_IDS.TEMPO_TESTNET]: TEMPO_NATIVE_TOKEN_IMAGE_URL,
   [CHAIN_IDS.ARC]: ARC_NATIVE_TOKEN_IMAGE_URL,
   [CHAIN_IDS.KONET]: KONET_IMAGE_URL,
+  [CHAIN_IDS.ROBINHOOD_CHAIN]: ETH_TOKEN_IMAGE_URL,
   [MultichainNetworks.SOLANA]: SOLANA_IMAGE_URL,
   [MultichainNetworks.SOLANA_TESTNET]: SOLANA_TESTNET_IMAGE_URL,
   [MultichainNetworks.SOLANA_DEVNET]: SOLANA_DEVNET_IMAGE_URL,
@@ -1785,6 +1792,21 @@ export const FEATURED_RPCS: AddNetworkFields[] = [
     ],
     defaultRpcEndpointIndex: 0,
     blockExplorerUrls: ['https://explorer.arc.io'],
+    defaultBlockExplorerUrlIndex: 0,
+  },
+  {
+    chainId: CHAIN_IDS.ROBINHOOD_CHAIN,
+    name: ROBINHOOD_CHAIN_DISPLAY_NAME,
+    nativeCurrency: CURRENCY_SYMBOLS.ETH,
+    rpcEndpoints: [
+      {
+        url: 'https://rpc.mainnet.chain.robinhood.com',
+        failoverUrls: [],
+        type: RpcEndpointType.Custom,
+      },
+    ],
+    defaultRpcEndpointIndex: 0,
+    blockExplorerUrls: ['https://robinhoodchain.blockscout.com'],
     defaultBlockExplorerUrlIndex: 0,
   },
 ];

--- a/ui/components/multichain/network-list-menu/__snapshots__/network-list-menu.test.tsx.snap
+++ b/ui/components/multichain/network-list-menu/__snapshots__/network-list-menu.test.tsx.snap
@@ -905,6 +905,53 @@ exports[`NetworkListMenu renders properly 1`] = `
                   </div>
                   <div
                     class="mm-box new-network-list__list-of-networks mm-box--padding-top-4 mm-box--padding-bottom-4 mm-box--display-flex mm-box--justify-content-space-between mm-box--align-items-center"
+                    data-testid="popular-network-0x1237"
+                  >
+                    <div
+                      class="mm-box mm-box--display-flex mm-box--align-items-center"
+                    >
+                      <div
+                        class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+                      >
+                        <img
+                          alt="Robinhood Chain logo"
+                          class="mm-avatar-network__network-image"
+                          src="./images/robinhood.svg"
+                        />
+                      </div>
+                      <div
+                        class="mm-box mm-box--margin-left-4"
+                      >
+                        <p
+                          class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
+                        >
+                          Robinhood Chain
+                        </p>
+                      </div>
+                    </div>
+                    <div
+                      class="mm-box"
+                      data-testid="test-add-button"
+                    >
+                      <button
+                        aria-label="Add"
+                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+                      >
+                        <svg
+                          class="inline-block w-6 h-6 text-inherit"
+                          fill="currentColor"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 13H5v-2h6V5h2v6h6v2h-6v6h-2z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="mm-box new-network-list__list-of-networks mm-box--padding-top-4 mm-box--padding-bottom-4 mm-box--display-flex mm-box--justify-content-space-between mm-box--align-items-center"
                     data-testid="popular-network-0x531"
                   >
                     <div
@@ -2241,6 +2288,53 @@ exports[`NetworkListMenu should match snapshot when editing a network 1`] = `
                           class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
                         >
                           Polygon
+                        </p>
+                      </div>
+                    </div>
+                    <div
+                      class="mm-box"
+                      data-testid="test-add-button"
+                    >
+                      <button
+                        aria-label="Add"
+                        class="inline-flex items-center justify-center p-0 h-8 w-8 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+                      >
+                        <svg
+                          class="inline-block w-6 h-6 text-inherit"
+                          fill="currentColor"
+                          viewBox="0 0 24 24"
+                          xmlns="http://www.w3.org/2000/svg"
+                        >
+                          <path
+                            d="M11 13H5v-2h6V5h2v6h6v2h-6v6h-2z"
+                          />
+                        </svg>
+                      </button>
+                    </div>
+                  </div>
+                  <div
+                    class="mm-box new-network-list__list-of-networks mm-box--padding-top-4 mm-box--padding-bottom-4 mm-box--display-flex mm-box--justify-content-space-between mm-box--align-items-center"
+                    data-testid="popular-network-0x1237"
+                  >
+                    <div
+                      class="mm-box mm-box--display-flex mm-box--align-items-center"
+                    >
+                      <div
+                        class="mm-box mm-text mm-avatar-base mm-avatar-base--size-sm mm-avatar-network mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-md mm-box--border-color-background-default mm-box--border-width-1 box--border-style-solid"
+                      >
+                        <img
+                          alt="Robinhood Chain logo"
+                          class="mm-avatar-network__network-image"
+                          src="./images/robinhood.svg"
+                        />
+                      </div>
+                      <div
+                        class="mm-box mm-box--margin-left-4"
+                      >
+                        <p
+                          class="mm-box mm-text mm-text--body-md mm-text--ellipsis mm-box--color-text-default mm-box--background-color-transparent"
+                        >
+                          Robinhood Chain
                         </p>
                       </div>
                     </div>


### PR DESCRIPTION
## **Description**

Adds Robinhood Chain (chain ID `0x1237` / 4663) as a featured network in MetaMask Extension. Users can discover and add Robinhood Chain from the network list without manually entering RPC details.

Changes in `shared/constants/network.ts`:
- Added `CHAIN_IDS.ROBINHOOD_CHAIN`
- Added `ROBINHOOD_CHAIN_DISPLAY_NAME` and `ROBINHOOD_CHAIN_IMAGE_URL`
- Wired display name, currency (ETH), and image maps
- Added `FEATURED_RPCS` entry with Robinhood mainnet RPC and Blockscout explorer

## **Changelog**

CHANGELOG entry: Added Robinhood Chain as a featured network

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open MetaMask Extension
2. Click the network selector dropdown
3. Browse the featured/popular network list
4. Verify Robinhood Chain appears with the Robinhood logo and ETH as the currency symbol
5. Add Robinhood Chain and verify the RPC connects and the block explorer link works

## **Screenshots/Recordings**

### **Before**

Robinhood Chain not present in featured networks list.

### **After**

Robinhood Chain appears in featured networks list with correct logo, ETH ticker, and chain ID `0x1237`.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)).

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Routine featured-network constants and UI list wiring; no changes to auth, signing, or transaction logic beyond exposing a new default RPC URL.
> 
> **Overview**
> Adds **Robinhood Chain** (`0x1237`) as a discoverable featured network so users can add it from the network list without manual RPC setup.
> 
> In `shared/constants/network.ts`, the PR introduces `CHAIN_IDS.ROBINHOOD_CHAIN`, display name and `robinhood.svg` branding, and hooks the chain into the usual display name, currency (**ETH**), network image, and native token image maps. A new `FEATURED_RPCS` entry points at `https://rpc.mainnet.chain.robinhood.com` and Blockscout at `https://robinhoodchain.blockscout.com` (custom RPC, no Infura failover).
> 
> `shared/constants/network.test.ts` expects Robinhood in the featured RPC chain ID map, and the network list menu snapshots include the **Additional networks** row for `popular-network-0x1237`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 094a758edf3892ecbedb25745858ebe818b1e3db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->