### PR TITLE
feat: scrollable tab

### DIFF
--- a/ui/components/multichain/account-overview/account-overview-tabs.tsx
+++ b/ui/components/multichain/account-overview/account-overview-tabs.tsx
@@ -242,7 +242,8 @@ export const AccountOverviewTabs = ({
         activeTab={activeTabKey}
         onTabClick={handleTabClick}
         tabListProps={{
-          className: 'px-4',
+          className:
+            'mx-4 overflow-x-auto overscroll-x-contain [scrollbar-width:none] tablist-fade',
         }}
       >
         {showTokens && (

--- a/ui/components/ui/tabs/tabs.scss
+++ b/ui/components/ui/tabs/tabs.scss
@@ -3,6 +3,52 @@
   --tab-transition-duration: 200ms;
   --tab-transition-easing: cubic-bezier(0.4, 0, 0.2, 1);
   --tab-transition-distance: 12px;
+  --tabs-list-fade-size: 1.5rem;
+}
+
+.tablist-fade {
+  container-type: scroll-state;
+
+  &::before,
+  &::after {
+    content: '';
+    position: sticky;
+    z-index: 1;
+    flex-shrink: 0;
+    align-self: stretch;
+    width: var(--tabs-list-fade-size);
+    pointer-events: none;
+    opacity: 0;
+    transition: opacity var(--tab-transition-duration) var(--tab-transition-easing);
+  }
+
+  &::before {
+    inset-inline-start: 0;
+    margin-inline-end: calc(-1 * (1rem + var(--tabs-list-fade-size)));
+    background: linear-gradient(
+      to right,
+      var(--color-background-default),
+      transparent
+    );
+
+    @container scroll-state(scrollable: inline-start) {
+      opacity: 1;
+    }
+  }
+
+  &::after {
+    inset-inline-end: 0;
+    margin-inline-start: calc(-1 * (1rem + var(--tabs-list-fade-size)));
+    background: linear-gradient(
+      to right,
+      transparent,
+      var(--color-background-default)
+    );
+
+    @container scroll-state(scrollable: inline-end) {
+      opacity: 1;
+    }
+  }
 }
 
 /* Clip overflow and make size changes instant (don't animate height) */

--- a/ui/components/ui/tabs/tabs.scss
+++ b/ui/components/ui/tabs/tabs.scss
@@ -25,11 +25,12 @@
   &::before {
     inset-inline-start: 0;
     margin-inline-end: calc(-1 * (1rem + var(--tabs-list-fade-size)));
-    background: linear-gradient(
-      to right,
-      var(--color-background-default),
-      transparent
-    );
+    background:
+      linear-gradient(
+        to right,
+        var(--color-background-default),
+        transparent
+      );
 
     @container scroll-state(scrollable: inline-start) {
       opacity: 1;
@@ -39,11 +40,12 @@
   &::after {
     inset-inline-end: 0;
     margin-inline-start: calc(-1 * (1rem + var(--tabs-list-fade-size)));
-    background: linear-gradient(
-      to right,
-      transparent,
-      var(--color-background-default)
-    );
+    background:
+      linear-gradient(
+        to right,
+        transparent,
+        var(--color-background-default)
+      );
 
     @container scroll-state(scrollable: inline-end) {
       opacity: 1;

--- a/ui/components/ui/tabs/tabs.tsx
+++ b/ui/components/ui/tabs/tabs.tsx
@@ -97,15 +97,16 @@ export const Tabs = <TKey extends string = string>({
       : 0;
 
   useLayoutEffect(() => {
+    const childIndex = findChildByKey(activeTab);
+    const index = childIndex >= 0 ? childIndex : clampedIndex;
     const tabs = tabListRef.current?.querySelectorAll('[role="tab"]');
-    const tab = tabs?.[clampedIndex];
 
-    tab?.scrollIntoView({
+    tabs?.[index]?.scrollIntoView({
       behavior: 'smooth',
       inline: 'nearest',
       block: 'nearest',
     });
-  }, [clampedIndex]);
+  }, [activeTab, findChildByKey, clampedIndex]);
 
   const handleTabClick = (tabIndex: number, tabKey: TKey): void => {
     if (tabIndex !== clampedIndex) {

--- a/ui/components/ui/tabs/tabs.tsx
+++ b/ui/components/ui/tabs/tabs.tsx
@@ -1,4 +1,11 @@
-import React, { useState, useMemo, useEffect, useCallback } from 'react';
+import React, {
+  useState,
+  useMemo,
+  useEffect,
+  useLayoutEffect,
+  useCallback,
+  useRef,
+} from 'react';
 import {
   Box,
   BoxBackgroundColor,
@@ -44,6 +51,8 @@ export const Tabs = <TKey extends string = string>({
   animated,
   ...props
 }: TabsProps<TKey>) => {
+  const tabListRef = useRef<HTMLDivElement>(null);
+
   // Helper function to get valid children, filtering out null/undefined/false values
   const getValidChildren = useMemo((): TabChild<TKey>[] => {
     return React.Children.toArray(children).filter(
@@ -86,6 +95,17 @@ export const Tabs = <TKey extends string = string>({
     getValidChildren.length > 0
       ? clamp(activeTabIndex, 0, getValidChildren.length - 1)
       : 0;
+
+  useLayoutEffect(() => {
+    const tabs = tabListRef.current?.querySelectorAll('[role="tab"]');
+    const tab = tabs?.[clampedIndex];
+
+    tab?.scrollIntoView({
+      behavior: 'smooth',
+      inline: 'nearest',
+      block: 'nearest',
+    });
+  }, [clampedIndex]);
 
   const handleTabClick = (tabIndex: number, tabKey: TKey): void => {
     if (tabIndex !== clampedIndex) {
@@ -135,6 +155,7 @@ export const Tabs = <TKey extends string = string>({
   return (
     <Box className={twMerge('tabs', 'transform-gpu', className)} {...props}>
       <Box
+        ref={tabListRef}
         role="tablist"
         flexDirection={BoxFlexDirection.Row}
         justifyContent={BoxJustifyContent.Start}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

When there are more tabs than fit the viewport, make the tab list scrolls horizontally with left/right fades that only show when that edge is scrollable

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="373" height="65" alt="image" src="https://github.com/user-attachments/assets/4564bfc1-acdb-4a97-b00c-5302f99d10c1" />

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only tab list layout and scrolling behavior with no auth, data, or security impact; main risk is browser support for scroll-state container queries on the fade effect.
> 
> **Overview**
> **Tab lists can scroll horizontally** when there are more tabs than fit on screen, with **edge fades** that appear only when content is scrollable in that direction.
> 
> The shared `Tabs` component now **refs the tab list** and runs a **`useLayoutEffect`** that **`scrollIntoView`s the active tab** (`inline: 'nearest'`, smooth) when selection changes. New **`.tablist-fade`** styles use **`container-type: scroll-state`** and **`@container scroll-state(scrollable: …)`** to toggle left/right gradient overlays; a **`--tabs-list-fade-size`** token controls fade width.
> 
> **Account overview** tab list props change from plain `px-4` to **`mx-4 overflow-x-auto overscroll-x-contain [scrollbar-width:none] tablist-fade`** so that screen gets the scroll + fade behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9e63cfff1d66ea61cca606704d4da5ccc2d229e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->