### PR TITLE
fix: copy fixes for musd convert and perps  cp-13.39.1 cp-13.40.0

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -385,7 +385,7 @@
     "description": "$1 is the token symbol"
   },
   "activity_convert_success_title": {
-    "message": "Converted $1",
+    "message": "Converted to $1",
     "description": "$1 is the token symbol"
   },
   "activity_deposit_failed_description": {
@@ -3003,6 +3003,9 @@
   },
   "contractInteraction": {
     "message": "Contract interaction"
+  },
+  "convertAgain": {
+    "message": "Convert again"
   },
   "convertTokenToNFTDescription": {
     "message": "We've detected that this asset is an NFT. MetaMask now has full native support for NFTs. Would you like to remove it from your token list and add it as an NFT?"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -385,7 +385,7 @@
     "description": "$1 is the token symbol"
   },
   "activity_convert_success_title": {
-    "message": "Converted $1",
+    "message": "Converted to $1",
     "description": "$1 is the token symbol"
   },
   "activity_deposit_failed_description": {
@@ -3003,6 +3003,9 @@
   },
   "contractInteraction": {
     "message": "Contract interaction"
+  },
+  "convertAgain": {
+    "message": "Convert again"
   },
   "convertTokenToNFTDescription": {
     "message": "We've detected that this asset is an NFT. MetaMask now has full native support for NFTs. Would you like to remove it from your token list and add it as an NFT?"

--- a/ui/pages/activity/rows/useActivityRowContent.tsx
+++ b/ui/pages/activity/rows/useActivityRowContent.tsx
@@ -204,6 +204,8 @@ export function useActivityRowContent(activity: ActivityRowProps['data']) {
             signedFiatAmount !== undefined && Number.isFinite(signedFiatAmount)
               ? formatCurrencyWithMinThreshold(signedFiatAmount, PERPS_CURRENCY)
               : undefined,
+          primaryDirection:
+            activity.type === 'perpsAddFunds' ? 'in' : undefined,
         };
       }
       case 'nftBuy':

--- a/ui/pages/details/components/convert-again-button.tsx
+++ b/ui/pages/details/components/convert-again-button.tsx
@@ -1,0 +1,78 @@
+import React, { useCallback } from 'react';
+import type { Hex } from '@metamask/utils';
+import {
+  Button,
+  ButtonSize,
+  ButtonVariant,
+} from '@metamask/design-system-react';
+import type { TokenAmount } from '../../../../shared/lib/activity/types';
+import { convertCaipToHexChainId } from '../../../../shared/lib/network.utils';
+import { useMusdConversion } from '../../../hooks/musd';
+import { useBoolean } from '../../../hooks/useBoolean';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+
+function parseAssetId(
+  assetId: string,
+): { address: string; chainId: Hex } | null {
+  // assetId format: "eip155:1/erc20:0xAddress"
+  const [caipChainId, assetRef] = assetId.split('/');
+  if (!caipChainId || !assetRef) {
+    return null;
+  }
+  const address = assetRef.split(':')[1];
+  if (!address) {
+    return null;
+  }
+  try {
+    const chainId = convertCaipToHexChainId(caipChainId);
+    return { address, chainId: chainId as Hex };
+  } catch {
+    return null;
+  }
+}
+
+export function ConvertAgainButton({
+  sourceToken,
+}: {
+  sourceToken: TokenAmount | undefined;
+}) {
+  const t = useI18nContext();
+  const { startConversionFlow } = useMusdConversion();
+  const {
+    value: isLoading,
+    setTrue: setLoading,
+    setFalse: setNotLoading,
+  } = useBoolean();
+
+  const preferredToken = sourceToken?.assetId
+    ? parseAssetId(sourceToken.assetId)
+    : null;
+
+  const handleClick = useCallback(async () => {
+    if (!preferredToken || isLoading) {
+      return;
+    }
+    setLoading();
+    try {
+      await startConversionFlow({ preferredToken, skipEducation: true });
+    } finally {
+      setNotLoading();
+    }
+  }, [preferredToken, isLoading, startConversionFlow]);
+
+  if (!preferredToken) {
+    return null;
+  }
+
+  return (
+    <Button
+      className="w-full"
+      size={ButtonSize.Lg}
+      variant={ButtonVariant.Primary}
+      onClick={handleClick}
+      disabled={isLoading}
+    >
+      {t('convertAgain')}
+    </Button>
+  );
+}

--- a/ui/pages/details/components/convert-again-button.tsx
+++ b/ui/pages/details/components/convert-again-button.tsx
@@ -24,7 +24,9 @@ function parseAssetId(
     return null;
   }
   try {
-    const chainId = convertCaipToHexChainId(caipChainId);
+    const chainId = convertCaipToHexChainId(
+      caipChainId as `${string}:${string}`,
+    );
     return { address, chainId: chainId as Hex };
   } catch {
     return null;

--- a/ui/pages/details/templates/perps-deposit-details.tsx
+++ b/ui/pages/details/templates/perps-deposit-details.tsx
@@ -92,7 +92,7 @@ export function PerpsDepositDetails({ item }: Props) {
           />
           {bridgeFeeFiat ? (
             <Row
-              label={t('bridgeFee')}
+              label={t('providerFee')}
               testId="transaction-bridge-fee"
               value={formatFiat(bridgeFeeFiat)}
             />

--- a/ui/pages/details/templates/swap-details.tsx
+++ b/ui/pages/details/templates/swap-details.tsx
@@ -4,6 +4,7 @@ import { useI18nContext } from '../../../hooks/useI18nContext';
 import { FeesRows, TotalAmountRow } from '../components/amounts-section';
 import { Footer, Section } from '../components/shared';
 import { BlockExplorerButton } from '../components/block-explorer-button';
+import { ConvertAgainButton } from '../components/convert-again-button';
 import { SwapAgainButton } from '../components/swap-again-button';
 import { MetadataSection, TokensSection } from '../components/sections';
 
@@ -43,10 +44,14 @@ export function SwapDetails({
       <Footer>
         <BlockExplorerButton chainId={item.chainId} txHash={item.hash} />
 
-        <SwapAgainButton
-          sourceToken={item.data.sourceToken}
-          destinationToken={item.data.destinationToken}
-        />
+        {item.type === 'convert' ? (
+          <ConvertAgainButton sourceToken={item.data.sourceToken} />
+        ) : (
+          <SwapAgainButton
+            sourceToken={item.data.sourceToken}
+            destinationToken={item.data.destinationToken}
+          />
+        )}
       </Footer>
     </div>
   );


### PR DESCRIPTION
## **Description**

- mUSD conversion confirmed label - `"Converted $1"` -> `"Converted to $1"`
- mUSD conversion CTA: `"Swap again"` -> `"Convert again"` and into the mUSD conversion flow
- Perps deposit fee label: `"Bridge fee"` -> `"Provider fee"`
- Perps deposit amount color

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:
https://consensyssoftware.atlassian.net/browse/CEUX-1171
https://consensyssoftware.atlassian.net/browse/CEUX-1172
https://consensyssoftware.atlassian.net/browse/CEUX-1173
https://consensyssoftware.atlassian.net/browse/CEUX-1176

## **Manual testing steps**

1. Complete an mUSD conversion transaction
2. In the Activity list, confirm the confirmed row reads **"Converted to mUSD"** (not "Converted mUSD")
3. Open the mUSD conversion activity details — verify the CTA says **"Convert again"** and tapping it opens the mUSD conversion flow (not the swap/bridge flow)
4. Open a Perps deposit activity details — verify the fee row reads **"Provider fee"** (not "Bridge fee")
5. In the Activity list, confirm the Perps deposit amount is displayed in **green**

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> String and presentation-only changes in activity/details UI with no changes to transaction signing or fund movement logic.
> 
> **Overview**
> Polishes **mUSD convert** and **perps deposit** activity copy and follow-up actions.
> 
> Confirmed convert rows now use **"Converted to $1"** instead of **"Converted $1"**. On convert activity details, the footer CTA is **"Convert again"** and launches the mUSD conversion flow (`startConversionFlow` with the prior source token) instead of the generic swap-again path.
> 
> Perps deposit details rename the bridge fee row to the existing **"Provider fee"** string. Activity list rows for `perpsAddFunds` set `primaryDirection: 'in'` so the fiat amount renders as an incoming (green) amount.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a09bbe15dde933f915ef22bdf6d603770d8ef6d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->