### PR TITLE
feat: refresh activity list after confirm

### DIFF
--- a/ui/components/app/toast-listener/transaction-event-toast-listener.tsx
+++ b/ui/components/app/toast-listener/transaction-event-toast-listener.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { RouteWithMessenger } from '../../../layouts/route-with-messenger';
+import { useActivityCacheInvalidation } from '../../../hooks/activity/useActivityCacheInvalidation';
 import {
   toastListenerCapabilities,
   useTransactionEventToasts,
@@ -7,6 +8,7 @@ import {
 
 const TransactionEventToastListenerInner = () => {
   useTransactionEventToasts();
+  useActivityCacheInvalidation();
   return null;
 };
 

--- a/ui/hooks/activity/useActivityCacheInvalidation.test.ts
+++ b/ui/hooks/activity/useActivityCacheInvalidation.test.ts
@@ -1,0 +1,116 @@
+import { renderHook } from '@testing-library/react-hooks';
+import {
+  TransactionStatus,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import { useActivityCacheInvalidation } from './useActivityCacheInvalidation';
+
+const mockInvalidateQueries = jest.fn();
+
+jest.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({
+    invalidateQueries: mockInvalidateQueries,
+  }),
+}));
+
+const mockSubscribe = jest.fn();
+const mockUnsubscribe = jest.fn();
+
+jest.mock('../useMessenger', () => ({
+  useMessenger: () => ({
+    subscribe: mockSubscribe,
+    unsubscribe: mockUnsubscribe,
+  }),
+}));
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn().mockReturnValue(true),
+}));
+
+jest.mock('../../selectors', () => ({
+  getUseExternalServices: jest.fn(),
+}));
+
+const { useSelector } = jest.requireMock('react-redux');
+
+const EVENT = 'TransactionController:transactionStatusUpdated';
+
+function setupHandlers() {
+  const handlers: Record<string, (raw: unknown) => void> = {};
+  mockSubscribe.mockImplementation((event: string, handler: unknown) => {
+    handlers[event] = handler as (raw: unknown) => void;
+  });
+  return handlers;
+}
+
+function makeTxPayload(
+  overrides: Partial<TransactionMeta> & Pick<TransactionMeta, 'id' | 'status'>,
+): { transactionMeta: TransactionMeta } {
+  return {
+    transactionMeta: {
+      chainId: '0x1',
+      hash: `0xhash_${overrides.id}`,
+      networkClientId: 'network-1',
+      time: 1,
+      txParams: { from: '0x0' },
+      ...overrides,
+    } as TransactionMeta,
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useSelector.mockReturnValue(true);
+});
+
+describe('useActivityCacheInvalidation', () => {
+  it('invalidates the activity query when a confirmed EVM tx event fires', () => {
+    const handlers = setupHandlers();
+    renderHook(() => useActivityCacheInvalidation());
+
+    handlers[EVENT](
+      makeTxPayload({ id: 'tx1', status: TransactionStatus.confirmed }),
+    );
+
+    expect(mockInvalidateQueries).toHaveBeenCalledWith({
+      queryKey: ['accounts', 'transactions', 'v4MultiAccount'],
+    });
+  });
+
+  it('does not fire twice for the same tx id', () => {
+    const handlers = setupHandlers();
+    renderHook(() => useActivityCacheInvalidation());
+
+    const payload = makeTxPayload({
+      id: 'tx1',
+      status: TransactionStatus.confirmed,
+    });
+    handlers[EVENT](payload);
+    handlers[EVENT](payload);
+
+    expect(mockInvalidateQueries).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not invalidate for non-confirmed statuses', () => {
+    const handlers = setupHandlers();
+    renderHook(() => useActivityCacheInvalidation());
+
+    handlers[EVENT](
+      makeTxPayload({ id: 'tx1', status: TransactionStatus.failed }),
+    );
+
+    expect(mockInvalidateQueries).not.toHaveBeenCalled();
+  });
+
+  it('does not invalidate when external services are disabled', () => {
+    useSelector.mockReturnValue(false);
+    const handlers = setupHandlers();
+    renderHook(() => useActivityCacheInvalidation());
+
+    handlers[EVENT](
+      makeTxPayload({ id: 'tx1', status: TransactionStatus.confirmed }),
+    );
+
+    expect(mockInvalidateQueries).not.toHaveBeenCalled();
+  });
+});

--- a/ui/hooks/activity/useActivityCacheInvalidation.ts
+++ b/ui/hooks/activity/useActivityCacheInvalidation.ts
@@ -1,0 +1,73 @@
+import { useEffect, useRef } from 'react';
+import { useSelector } from 'react-redux';
+import { useQueryClient } from '@tanstack/react-query';
+import {
+  TransactionStatus,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import { defineAllowedRouteCapabilities } from '../../helpers/route-messenger-helpers';
+import type { RouteMessengerFromCapabilities } from '../../messengers/route-messenger';
+import { getUseExternalServices } from '../../selectors';
+import { useMessenger } from '../useMessenger';
+import { activityQueryKey } from './useCachedEvmTransaction';
+
+const capabilities = defineAllowedRouteCapabilities({
+  actions: [],
+  events: ['TransactionController:transactionStatusUpdated'],
+});
+
+type ActivityCacheInvalidationMessenger = RouteMessengerFromCapabilities<
+  typeof capabilities
+>;
+
+export function useActivityCacheInvalidation() {
+  const queryClient = useQueryClient();
+  const messenger = useMessenger<ActivityCacheInvalidationMessenger>();
+  const useExternalServices = useSelector(getUseExternalServices);
+  const useExternalServicesRef = useRef(useExternalServices);
+  useExternalServicesRef.current = useExternalServices;
+  const firedIdsRef = useRef<Set<string>>(new Set());
+
+  useEffect(() => {
+    const handleStatusUpdated = (
+      raw:
+        | { transactionMeta: TransactionMeta }
+        | [{ transactionMeta: TransactionMeta }],
+    ) => {
+      if (!useExternalServicesRef.current) {
+        return;
+      }
+
+      const payload = Array.isArray(raw) ? raw[0] : raw;
+      const { transactionMeta } = payload;
+
+      if (!transactionMeta?.chainId?.startsWith('0x')) {
+        return;
+      }
+
+      if (transactionMeta.status !== TransactionStatus.confirmed) {
+        return;
+      }
+
+      const { id } = transactionMeta;
+      if (firedIdsRef.current.has(id)) {
+        return;
+      }
+
+      firedIdsRef.current.add(id);
+      queryClient.invalidateQueries({ queryKey: activityQueryKey });
+    };
+
+    messenger.subscribe(
+      'TransactionController:transactionStatusUpdated',
+      handleStatusUpdated,
+    );
+
+    return () => {
+      messenger.unsubscribe(
+        'TransactionController:transactionStatusUpdated',
+        handleStatusUpdated,
+      );
+    };
+  }, [messenger, queryClient]);
+}

--- a/ui/hooks/activity/useCachedEvmTransaction.ts
+++ b/ui/hooks/activity/useCachedEvmTransaction.ts
@@ -2,6 +2,12 @@ import { useMemo } from 'react';
 import { useQueryClient, type InfiniteData } from '@tanstack/react-query';
 import type { V4MultiAccountTransactionsResponse } from '@metamask/core-backend';
 
+export const activityQueryKey = [
+  'accounts',
+  'transactions',
+  'v4MultiAccount',
+] as const;
+
 export function useCachedEvmTransaction({
   chainId,
   txHash,
@@ -21,7 +27,7 @@ export function useCachedEvmTransaction({
     const cachedQueries = queryClient.getQueriesData<
       InfiniteData<V4MultiAccountTransactionsResponse>
     >({
-      queryKey: ['accounts', 'transactions', 'v4MultiAccount'],
+      queryKey: activityQueryKey,
     });
 
     for (const [, cachedData] of cachedQueries) {

--- a/ui/pages/details/transaction-details.tsx
+++ b/ui/pages/details/transaction-details.tsx
@@ -8,9 +8,9 @@ import {
   selectNonEvmActivityItemsById,
 } from '../../selectors/activity';
 import ErrorBoundary from '../../components/app/error-boundary/error-boundary';
+import { useCachedEvmTransaction } from '../../hooks/activity/useCachedEvmTransaction';
 import { Header } from './components/header';
 import { TemplateLoader } from './templates/template-loader';
-import { useCachedEvmTransaction } from './useCachedEvmTransaction';
 import { useTransactionQuery } from './useTransactionQuery';
 
 type Props = {


### PR DESCRIPTION
## **Description**

After a local EVM transaction confirms, the activity list can show local state until the API query cache is refreshed after a stale time window.

This PR invalidates the query cache on confirmation

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open the extension and ensure you have at least two accounts.
2. From Account A, send a small amount of native ETH to Account B.
3. While the tx is pending, open the Activity tab — confirm the pending row appears.
4. Wait for the tx to confirm.
5. Open the confirmed tx details — verify the **Network Fee** row is present immediately after confirmation (previously it would be missing until the next stale refetch or window focus).
6. Optionally check an older confirmed tx to confirm the Network Fee row is still present there too.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)