### PR TITLE
chore: update CODEOWNERS for engagement team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -55,17 +55,19 @@ development/circular-deps.ts         @MetaMask/extension-security-team
 ui/components/component-library      @MetaMask/design-system-engineers
 tailwind.config.js                   @MetaMask/design-system-engineers
 
-# The Notifications team is responsible for code related to notifications
+# The Engagement team is responsible for code related to notifications.
 
-# Controllers
-**/controllers/metamask-notifications/**            @MetaMask/notifications
-**/controllers/push-platform-notifications/**       @MetaMask/notifications
+# Notifications - controllers and services
+app/scripts/controllers/push-notifications/**                     @MetaMask/engagement
+app/scripts/messenger-client-init/messengers/notifications/**    @MetaMask/engagement
+app/scripts/messenger-client-init/notifications/**               @MetaMask/engagement
 
-# UI
-**/metamask-notifications/**                        @MetaMask/notifications
-**/multichain/notification*/**                      @MetaMask/notifications
-**/pages/notification*/**                           @MetaMask/notifications
-**/utils/notification.util.ts                       @MetaMask/notifications
+# Notifications - UI
+**/metamask-notifications/**                                @MetaMask/engagement
+ui/pages/notifications/**                                         @MetaMask/engagement
+ui/pages/notification-details/**                                  @MetaMask/engagement
+ui/pages/notifications-settings/**                                @MetaMask/engagement
+ui/helpers/utils/notification.util.ts                             @MetaMask/engagement
 
 # Accounts team is responsible for code related with: Snap accounts,
 # Multichain accounts, Authentication, Backup and sync, Hardware Wallets
@@ -131,6 +133,9 @@ ui/components/multichain/                       @MetaMask/core-extension-ux
 ui/components/app/transaction-list              @MetaMask/core-extension-ux
 ui/components/app/transaction-list-item-details @MetaMask/core-extension-ux
 ui/components/app/transaction-list-item         @MetaMask/core-extension-ux
+ui/pages/settings/notifications-tab/**          @MetaMask/core-extension-ux @MetaMask/engagement
+ui/components/multichain/notification*/**       @MetaMask/core-extension-ux @MetaMask/engagement
+ui/components/multichain/notifications*/**      @MetaMask/core-extension-ux @MetaMask/engagement
 
 # Co-owned by accounts and core-extension-ux
 ui/components/multichain/multi-srp/              @MetaMask/accounts-engineers @MetaMask/core-extension-ux


### PR DESCRIPTION
## **Description**

Updates `.github/CODEOWNERS` to align extension notification ownership with the mobile ownership direction:
- replaces `@MetaMask/notifications` with `@MetaMask/engagement`
- updates stale notification controller patterns to current extension paths
- adds explicit co-ownership with `@MetaMask/core-extension-ux` for notification surfaces under Settings and multichain components

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Open `.github/CODEOWNERS` on this branch.
2. Verify the old `@MetaMask/notifications` notification block is replaced by `@MetaMask/engagement`.
3. Verify `ui/pages/settings/notifications-tab/**` and `ui/components/multichain/notification*/**` / `ui/components/multichain/notifications*/**` are co-owned by `@MetaMask/core-extension-ux @MetaMask/engagement`.

<!--
## **Screenshots/Recordings**

### **Before**

N/A (CODEOWNERS-only change)

### **After**

N/A (CODEOWNERS-only change)
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)