### PR TITLE
docs(agents): add Cursor Cloud dev environment setup notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1723,3 +1723,56 @@ Performance Checks (React Components):
 - **MetaMask Developer Docs:** https://docs.metamask.io/
 - **Community Forum:** https://community.metamask.io/
 - **User Support:** https://support.metamask.io/
+
+---
+
+## Cursor Cloud specific instructions
+
+Durable, non-obvious notes for cloud agents. The VM startup update script already runs
+`corepack enable` + `yarn install`; dependency installation is not needed here. Standard
+commands live in this file and the [README](./README.md) — this section only covers gotchas.
+
+### Node version (important)
+
+- This repo requires Node `>=24.13.0` (`.nvmrc` → `v24.13`) and the Yarn 4 `plugin-engines`
+  will hard-fail commands run under an older Node.
+- The VM's on-PATH `node` (`/exec-daemon/node`) is **v22** and takes precedence by default.
+  Node 24 is installed via nvm and prepended to `PATH` in `~/.bashrc`, so login shells
+  (what these agent shells use) get v24. If `node --version` ever shows v22, run:
+  `export PATH="/home/ubuntu/.nvm/versions/node/v24.13.1/bin:$PATH"`.
+
+### Config
+
+- A dev build needs `.metamaskrc` (gitignored). Create it once with `cp .metamaskrc{.dist,}`.
+  The placeholder `INFURA_PROJECT_ID=00000000000` is fine for local development and for the
+  local-node (Anvil) flows used below; real mainnet RPC calls will be rate-limited without a
+  real Infura key.
+
+### Building & running the extension
+
+- `yarn start:test` (webpack watch, LavaMoat + Snow disabled) is the fastest way to produce a
+  loadable build at `dist/chrome`; initial compile ~45s, then it watches. Use `yarn start` for
+  a normal dev build.
+- Avoid the `yarn build:test:webpack` (LavaMoat) path for a quick smoke test: it expects a
+  precompiled `development/.webpack/launch.js` and fails with `ENOENT` from a clean checkout in
+  this environment. Prefer `yarn start:test` (dev) or `yarn build:test` (browserify) to get
+  `dist/chrome`.
+
+### Visual / end-to-end smoke testing with the `mm` CLI
+
+- The `mm` CLI (`node_modules/.bin/mm`, see `test/e2e/playwright/llm-workflow/README.md`) drives
+  a **headed** Chrome with the extension loaded. Requirements already satisfied on the VM:
+  - An X display is running at `DISPLAY=:1` (Xvfb) — export `DISPLAY=:1` before `mm` commands.
+  - Playwright Chromium is installed (`yarn playwright install chromium`, cached under
+    `~/.cache/ms-playwright`). Re-run that command if the cache is missing.
+- `mm launch --state default` boots a pre-onboarded wallet with 25 ETH on local Anvil
+  (chainId 1337). Unlock password is `correct horse battery staple`.
+- `mm click <ref>` also accepts a `data-testid` directly (e.g. `mm click send-continue-button`),
+  not just the `eN` accessibility refs from `mm describe-screen`. Token list rows on the send
+  screen are only reachable via their `token-asset-<chainIdHex>-<SYMBOL>` testId.
+- Always finish with `mm cleanup` (add `--shutdown` to also stop the daemon).
+
+### QA tasks repo
+
+- The sibling `experimental-mm-qa-ai-tasks` repo is a markdown/prompt task collection only —
+  no dependencies, build, or services to run.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Sets up the development environment for this repo in a Cursor Cloud agent VM and captures the non-obvious, durable gotchas discovered during setup so future agents can start services without rediscovering them.

The only code change is a new `## Cursor Cloud specific instructions` section appended to `AGENTS.md`. No application code is modified. Environment dependency refresh is handled by the VM startup update script (`corepack enable` + `yarn install`), so this section intentionally documents only caveats, not install steps.

Key notes captured:
- **Node version:** repo requires Node `>=24.13.0`, but the VM's on-PATH `node` is v22; Node 24 (nvm) is prepended to `PATH` via `~/.bashrc`.
- **Config:** a dev build needs `.metamaskrc` (copy from `.metamaskrc.dist`); the placeholder Infura ID is fine for local/Anvil flows.
- **Building:** `yarn start:test` is the fast path to a loadable `dist/chrome`; the LavaMoat `build:test:webpack` path fails from a clean checkout (missing precompiled `launch.js`).
- **Visual/E2E smoke test:** the `mm` CLI drives headed Chrome (needs `DISPLAY=:1`, Playwright Chromium); `mm launch --state default` gives a pre-onboarded wallet (25 ETH on local Anvil, password `correct horse battery staple`).

### Environment verification performed

| Step | Command | Result |
| --- | --- | --- |
| Install | `corepack enable` + `yarn install` (Node 24) | Passed (anvil installed via foundryup) |
| Lint (styles) | `yarn lint:styles` | Passed |
| Lint (types) | `yarn lint:tsc` | Passed |
| Lint (eslint) | `eslint` on sample file | Passed |
| Unit tests | `yarn test:unit shared/lib/error-utils.test.ts` | 19/19 passed |
| Build | `yarn start:test` → `dist/chrome` | Compiled successfully |
| Run + hello-world | `mm launch` → unlock → **send 1 ETH** on local Anvil | Tx mined, balance 25→24 ETH |

**Hello-world:** launched the extension, unlocked the wallet, and sent a 1 ETH transaction on the local Anvil chain; the Activity tab confirms "Sent ETH -1 ETH".

[Wallet home 25 ETH](https://cursor.com/agents/bc-bc41398f-77a2-4f1a-a60e-bf61981db269/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmm-home-25eth.png)
[Send form 1 ETH](https://cursor.com/agents/bc-bc41398f-77a2-4f1a-a60e-bf61981db269/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmm-send-form.png)
[Activity shows sent ETH](https://cursor.com/agents/bc-bc41398f-77a2-4f1a-a60e-bf61981db269/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmm-activity-sent.png)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open `AGENTS.md` and review the new `## Cursor Cloud specific instructions` section.
2. Confirm the Node/PATH, `.metamaskrc`, build, and `mm` CLI notes match the current repo setup.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bc41398f-77a2-4f1a-a60e-bf61981db269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bc41398f-77a2-4f1a-a60e-bf61981db269"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

