### PR TITLE
fix(confirmations): address enforced simulations papercuts

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1291,6 +1291,10 @@
   "addedProtectionDescription": {
     "message": "You're interacting with an unknown address. This helps prevent malicious transactions."
   },
+  "addedProtectionIncludesNetworkFee": {
+    "message": "Includes $1 for added protection",
+    "description": "$1 is the added-protection fee amount in the user's selected fiat currency."
+  },
   "addedProtectionOptionalBadge": {
     "message": "Optional"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -1291,6 +1291,10 @@
   "addedProtectionDescription": {
     "message": "You're interacting with an unknown address. This helps prevent malicious transactions."
   },
+  "addedProtectionIncludesNetworkFee": {
+    "message": "Includes $1 for added protection",
+    "description": "$1 is the added-protection fee amount in the user's selected fiat currency."
+  },
   "addedProtectionOptionalBadge": {
     "message": "Optional"
   },

--- a/ui/components/app/confirm/info/row/section.tsx
+++ b/ui/components/app/confirm/info/row/section.tsx
@@ -1,14 +1,28 @@
 import React, { CSSProperties } from 'react';
 import { Box } from '../../../../component-library';
-import type { SizeNumber } from '../../../../component-library/box/box.types';
 import {
   BackgroundColor,
   BorderRadius,
 } from '../../../../../helpers/constants/design-system';
 
+export type ConfirmInfoSectionMarginBottom =
+  | 0
+  | 1
+  | 2
+  | 3
+  | 4
+  | 5
+  | 6
+  | 7
+  | 8
+  | 9
+  | 10
+  | 11
+  | 12;
+
 export type ConfirmInfoSectionProps = {
   children: React.ReactNode | string;
-  marginBottom?: SizeNumber;
+  marginBottom?: ConfirmInfoSectionMarginBottom;
   noPadding?: boolean;
   style?: CSSProperties;
   'data-testid'?: string;

--- a/ui/components/app/confirm/info/row/section.tsx
+++ b/ui/components/app/confirm/info/row/section.tsx
@@ -1,5 +1,6 @@
 import React, { CSSProperties } from 'react';
 import { Box } from '../../../../component-library';
+import type { SizeNumber } from '../../../../component-library/box/box.types';
 import {
   BackgroundColor,
   BorderRadius,
@@ -7,6 +8,7 @@ import {
 
 export type ConfirmInfoSectionProps = {
   children: React.ReactNode | string;
+  marginBottom?: SizeNumber;
   noPadding?: boolean;
   style?: CSSProperties;
   'data-testid'?: string;
@@ -14,6 +16,7 @@ export type ConfirmInfoSectionProps = {
 
 export const ConfirmInfoSection = ({
   children,
+  marginBottom = 4,
   noPadding,
   style = {},
   'data-testid': dataTestId,
@@ -26,7 +29,7 @@ export const ConfirmInfoSection = ({
       paddingInline={noPadding ? 0 : 2}
       paddingTop={noPadding ? 0 : 1}
       paddingBottom={noPadding ? 0 : 1}
-      marginBottom={4}
+      marginBottom={marginBottom}
       style={style}
     >
       {children}

--- a/ui/pages/confirmations/components/confirm/info/batch/batch-simulation-details/batch-simulation-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/batch/batch-simulation-details/batch-simulation-details.test.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 import { BigNumber } from 'bignumber.js';
-import { BatchTransactionParams } from '@metamask/transaction-controller';
+import {
+  BatchTransactionParams,
+  TransactionContainerType,
+} from '@metamask/transaction-controller';
 import { act } from '@testing-library/react';
 import { renderWithConfirmContextProvider } from '../../../../../../../../test/lib/confirmations/render-helpers';
 import { enLocale as messages } from '../../../../../../../../test/lib/i18n-helpers';
@@ -147,10 +150,21 @@ describe('BatchSimulationDetails', () => {
       value: [BALANCE_CHANGE_ERC20_MOCK],
     });
 
-    const { getByText } = render();
+    const { getByTestId, getByText } = render(
+      genUnapprovedContractInteractionConfirmation({
+        containerTypes: [TransactionContainerType.EnforcedSimulations],
+        nestedTransactions: [NESTED_TRANSACTION_MOCK],
+        simulationData: {
+          tokenBalanceChanges: [],
+        },
+      }),
+    );
     expect(getByText(messages.youApprove.message)).toBeInTheDocument();
     expect(getByText('123.6')).toBeInTheDocument();
     expect(getByText(ADDRESS_SHORT_MOCK)).toBeInTheDocument();
+    expect(getByTestId('simulation-details-layout').parentElement).toHaveClass(
+      'mm-box--margin-bottom-2',
+    );
   });
 
   it('renders unlimited ERC-20 approve row', () => {

--- a/ui/pages/confirmations/components/confirm/info/batch/batch-simulation-details/batch-simulation-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/batch/batch-simulation-details/batch-simulation-details.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import {
+  TransactionContainerType,
   TransactionMeta,
   TransactionType,
 } from '@metamask/transaction-controller';
@@ -73,7 +74,7 @@ export function BatchSimulationDetails() {
         balanceChanges: finalBalanceChanges ?? [],
       },
     ];
-  }, [approveBalanceChanges, handleEdit]);
+  }, [approveBalanceChanges, handleEdit, t]);
 
   if (
     transactionMeta?.type === TransactionType.revokeDelegation ||
@@ -87,6 +88,9 @@ export function BatchSimulationDetails() {
     nestedTransactionIndexToEdit === undefined
       ? undefined
       : nestedTransactions?.[nestedTransactionIndexToEdit];
+  const isEnforcedSimulationsEnabled = transactionMeta.containerTypes?.includes(
+    TransactionContainerType.EnforcedSimulations,
+  );
 
   return (
     <>
@@ -107,6 +111,7 @@ export function BatchSimulationDetails() {
             transaction={transactionMeta}
             staticRows={approveRows}
             isTransactionsRedesign
+            sectionMarginBottom={isEnforcedSimulationsEnabled ? 2 : undefined}
             enableMetrics
           />
         </>

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts
@@ -48,25 +48,48 @@ describe('useFeeCalculations', () => {
   it('returns the correct estimate for a transaction', () => {
     const transactionMeta = genUnapprovedContractInteractionConfirmation({
       address: CONTRACT_INTERACTION_SENDER_ADDRESS,
+      chainId: CHAIN_IDS.SEPOLIA,
     }) as TransactionMeta;
+
+    transactionMeta.containerTypes = [
+      TransactionContainerType.EnforcedSimulations,
+    ];
+    transactionMeta.txParamsOriginal = { ...transactionMeta.txParams };
+    transactionMeta.txParams.gas = toHex(87790);
+
+    const mockStateWithSepoliaNativeTicker = merge({}, mockState, {
+      metamask: {
+        currencyRates: {
+          SepoliaETH: {
+            conversionRate: 0,
+          },
+        },
+        networkConfigurationsByChainId: {
+          [CHAIN_IDS.SEPOLIA]: {
+            nativeCurrency: 'SepoliaETH',
+            ticker: 'SepoliaETH',
+          },
+        },
+      },
+    });
 
     const { result } = renderHookWithConfirmContextProvider(
       () => useFeeCalculations(transactionMeta),
-      mockState,
+      mockStateWithSepoliaNativeTicker,
     );
 
     expect(result.current).toMatchInlineSnapshot(`
       {
-        "addedProtectionFeeFiat": null,
+        "addedProtectionFeeFiat": "$0.07",
         "calculateGasEstimate": [Function],
-        "estimatedFeeFiat": "$0.07",
+        "estimatedFeeFiat": "$0.14",
         "estimatedFeeFiatWith18SignificantDigits": null,
-        "estimatedFeeNative": "0.0001",
-        "estimatedFeeNativeHex": "0x720087dcfc95",
-        "maxFeeFiat": "$0.07",
+        "estimatedFeeNative": "0.0003",
+        "estimatedFeeNativeHex": "0xe4010fb9f92a",
+        "maxFeeFiat": "$0.14",
         "maxFeeFiatWith18SignificantDigits": null,
-        "maxFeeHex": "0x720087dcfc95",
-        "maxFeeNative": "0.0001",
+        "maxFeeHex": "0xe4010fb9f92a",
+        "maxFeeNative": "0.0003",
       }
     `);
 
@@ -221,42 +244,6 @@ describe('useFeeCalculations', () => {
 
     expect(result.current.estimatedFeeNative).toBe('< 0.0001');
     expect(result.current.maxFeeNative).toBe('< 0.0001');
-  });
-
-  it('returns added protection fee fiat for enforced simulations', () => {
-    const transactionMeta = genUnapprovedContractInteractionConfirmation({
-      address: CONTRACT_INTERACTION_SENDER_ADDRESS,
-      chainId: CHAIN_IDS.SEPOLIA,
-    }) as TransactionMeta;
-
-    transactionMeta.containerTypes = [
-      TransactionContainerType.EnforcedSimulations,
-    ];
-    transactionMeta.txParamsOriginal = { ...transactionMeta.txParams };
-    transactionMeta.txParams.gas = toHex(87790);
-
-    const mockStateWithSepoliaNativeTicker = merge({}, mockState, {
-      metamask: {
-        currencyRates: {
-          SepoliaETH: {
-            conversionRate: 0,
-          },
-        },
-        networkConfigurationsByChainId: {
-          [CHAIN_IDS.SEPOLIA]: {
-            nativeCurrency: 'SepoliaETH',
-            ticker: 'SepoliaETH',
-          },
-        },
-      },
-    });
-
-    const { result } = renderHookWithConfirmContextProvider(
-      () => useFeeCalculations(transactionMeta),
-      mockStateWithSepoliaNativeTicker,
-    );
-
-    expect(result.current.addedProtectionFeeFiat).toBe('$0.07');
   });
 
   it('returns the correct estimate if quoted swap is displayed in info', () => {

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts
@@ -1,5 +1,8 @@
 import { toHex } from '@metamask/controller-utils';
-import { TransactionMeta } from '@metamask/transaction-controller';
+import {
+  TransactionContainerType,
+  TransactionMeta,
+} from '@metamask/transaction-controller';
 import { QuoteResponse } from '@metamask/bridge-controller';
 import { merge } from 'lodash';
 
@@ -8,6 +11,7 @@ import {
   genUnapprovedContractInteractionConfirmation,
   mockBridgeQuotes,
 } from '../../../../../../../test/data/confirmations/contract-interaction';
+import { CHAIN_IDS } from '../../../../../../../shared/constants/network';
 import { renderHookWithConfirmContextProvider } from '../../../../../../../test/lib/confirmations/render-helpers';
 import mockState from '../../../../../../../test/data/mock-state.json';
 import * as DappSwapContext from '../../../../context/dapp-swap';
@@ -27,6 +31,7 @@ describe('useFeeCalculations', () => {
 
     expect(result.current).toMatchInlineSnapshot(`
       {
+        "addedProtectionFeeFiat": null,
         "calculateGasEstimate": [Function],
         "estimatedFeeFiat": "< $0.01",
         "estimatedFeeFiatWith18SignificantDigits": "0",
@@ -52,6 +57,7 @@ describe('useFeeCalculations', () => {
 
     expect(result.current).toMatchInlineSnapshot(`
       {
+        "addedProtectionFeeFiat": null,
         "calculateGasEstimate": [Function],
         "estimatedFeeFiat": "$0.07",
         "estimatedFeeFiatWith18SignificantDigits": null,
@@ -98,6 +104,7 @@ describe('useFeeCalculations', () => {
 
     expect(resultOnBNB.current).toMatchInlineSnapshot(`
       {
+        "addedProtectionFeeFiat": null,
         "calculateGasEstimate": [Function],
         "estimatedFeeFiat": "",
         "estimatedFeeFiatWith18SignificantDigits": null,
@@ -126,6 +133,7 @@ describe('useFeeCalculations', () => {
 
     expect(result.current).toMatchInlineSnapshot(`
       {
+        "addedProtectionFeeFiat": null,
         "calculateGasEstimate": [Function],
         "estimatedFeeFiat": "$0.06",
         "estimatedFeeFiatWith18SignificantDigits": null,
@@ -156,6 +164,7 @@ describe('useFeeCalculations', () => {
 
     expect(result.current).toMatchInlineSnapshot(`
       {
+        "addedProtectionFeeFiat": null,
         "calculateGasEstimate": [Function],
         "estimatedFeeFiat": "$0.06",
         "estimatedFeeFiatWith18SignificantDigits": null,
@@ -183,6 +192,7 @@ describe('useFeeCalculations', () => {
 
     expect(result.current).toMatchInlineSnapshot(`
       {
+        "addedProtectionFeeFiat": null,
         "calculateGasEstimate": [Function],
         "estimatedFeeFiat": "$2.57",
         "estimatedFeeFiatWith18SignificantDigits": null,
@@ -213,6 +223,42 @@ describe('useFeeCalculations', () => {
     expect(result.current.maxFeeNative).toBe('< 0.0001');
   });
 
+  it('returns added protection fee fiat for enforced simulations', () => {
+    const transactionMeta = genUnapprovedContractInteractionConfirmation({
+      address: CONTRACT_INTERACTION_SENDER_ADDRESS,
+      chainId: CHAIN_IDS.SEPOLIA,
+    }) as TransactionMeta;
+
+    transactionMeta.containerTypes = [
+      TransactionContainerType.EnforcedSimulations,
+    ];
+    transactionMeta.txParamsOriginal = { ...transactionMeta.txParams };
+    transactionMeta.txParams.gas = toHex(87790);
+
+    const mockStateWithSepoliaNativeTicker = merge({}, mockState, {
+      metamask: {
+        currencyRates: {
+          SepoliaETH: {
+            conversionRate: 0,
+          },
+        },
+        networkConfigurationsByChainId: {
+          [CHAIN_IDS.SEPOLIA]: {
+            nativeCurrency: 'SepoliaETH',
+            ticker: 'SepoliaETH',
+          },
+        },
+      },
+    });
+
+    const { result } = renderHookWithConfirmContextProvider(
+      () => useFeeCalculations(transactionMeta),
+      mockStateWithSepoliaNativeTicker,
+    );
+
+    expect(result.current.addedProtectionFeeFiat).toBe('$0.07');
+  });
+
   it('returns the correct estimate if quoted swap is displayed in info', () => {
     jest.spyOn(DappSwapContext, 'useDappSwapContextOptional').mockReturnValue({
       selectedQuote: mockBridgeQuotes[0] as unknown as QuoteResponse,
@@ -234,6 +280,7 @@ describe('useFeeCalculations', () => {
 
     expect(result.current).toMatchInlineSnapshot(`
       {
+        "addedProtectionFeeFiat": null,
         "calculateGasEstimate": [Function],
         "estimatedFeeFiat": "$3.24",
         "estimatedFeeFiatWith18SignificantDigits": null,

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
@@ -50,7 +50,11 @@ function getValidConversionRate(
     : undefined;
 }
 
-function shouldUseEthConversionRateFallback(chainId: Hex): boolean {
+function shouldUseEthConversionRateFallback(chainId?: Hex): boolean {
+  if (!chainId) {
+    return false;
+  }
+
   return ETH_CONVERSION_RATE_FALLBACK_CHAIN_IDS.some(
     (fallbackChainId) =>
       fallbackChainId.toLowerCase() === chainId.toLowerCase(),

--- a/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.ts
@@ -1,10 +1,17 @@
 import { GasFeeEstimates } from '@metamask/gas-fee-controller';
-import { TransactionMeta } from '@metamask/transaction-controller';
+import {
+  TransactionContainerType,
+  TransactionMeta,
+} from '@metamask/transaction-controller';
 import { Hex, add0x } from '@metamask/utils';
 import { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 
 import { EtherDenomination } from '../../../../../../../shared/constants/common';
+import {
+  CHAIN_IDS,
+  CURRENCY_SYMBOLS,
+} from '../../../../../../../shared/constants/network';
 import {
   addHexes,
   decGWEIToHexWEI,
@@ -13,7 +20,10 @@ import {
   multiplyHexes,
 } from '../../../../../../../shared/lib/conversion.utils';
 import { Numeric } from '../../../../../../../shared/lib/Numeric';
-import { getCurrentCurrency } from '../../../../../../ducks/metamask/metamask';
+import {
+  getCurrentCurrency,
+  getCurrencyRates,
+} from '../../../../../../ducks/metamask/metamask';
 import { useFiatFormatter } from '../../../../../../hooks/useFiatFormatter';
 import { useGasFeeEstimates } from '../../../../../../hooks/useGasFeeEstimates';
 import { selectConversionRateByChainId } from '../../../../../../selectors';
@@ -27,6 +37,48 @@ const EMPTY_FEE = '';
 
 const MIN_NATIVE_FEE_THRESHOLD = 0.0001;
 
+const ETH_CONVERSION_RATE_FALLBACK_CHAIN_IDS = [
+  CHAIN_IDS.SEPOLIA,
+  CHAIN_IDS.LINEA_SEPOLIA,
+];
+
+function getValidConversionRate(
+  conversionRate: number | null | undefined,
+): number | undefined {
+  return Number.isFinite(conversionRate) && Number(conversionRate) > 0
+    ? Number(conversionRate)
+    : undefined;
+}
+
+function shouldUseEthConversionRateFallback(chainId: Hex): boolean {
+  return ETH_CONVERSION_RATE_FALLBACK_CHAIN_IDS.some(
+    (fallbackChainId) =>
+      fallbackChainId.toLowerCase() === chainId.toLowerCase(),
+  );
+}
+
+function getOriginalGasLimit(
+  transactionMeta: TransactionMeta,
+  quotedGasLimit?: Hex,
+): Hex | undefined {
+  return (transactionMeta.txParamsOriginal?.gas ||
+    transactionMeta.defaultGasEstimates?.gas ||
+    transactionMeta.dappSuggestedGasFees?.gas ||
+    quotedGasLimit ||
+    transactionMeta.gasUsed ||
+    transactionMeta.gasLimitNoBuffer) as Hex | undefined;
+}
+
+function getGasLimitDelta(gasLimit: Hex, originalGasLimit: string): Hex | null {
+  const gasLimitDelta = new Numeric(gasLimit, 16).minus(originalGasLimit, 16);
+
+  if (!gasLimitDelta.greaterThan(0, 10)) {
+    return null;
+  }
+
+  return gasLimitDelta.toPrefixedHexString() as Hex;
+}
+
 function applySmallNativeFeeThreshold(nativeFee: string, hexFee: Hex): string {
   if (nativeFee === '0' && new Numeric(hexFee, 16).greaterThan(0, 10)) {
     return `< ${MIN_NATIVE_FEE_THRESHOLD}`;
@@ -39,11 +91,17 @@ export function useFeeCalculations(transactionMeta: TransactionMeta) {
   const { chainId } = transactionMeta;
   const fiatFormatter = useFiatFormatter();
 
-  const conversionRate = useSelector((state) =>
+  const chainConversionRate = useSelector((state) =>
     selectConversionRateByChainId(state, chainId),
   );
-  const hasValidConversionRate =
-    Number.isFinite(conversionRate) && Number(conversionRate) > 0;
+  const currencyRates = useSelector(getCurrencyRates);
+  const ethConversionRate = shouldUseEthConversionRateFallback(chainId)
+    ? currencyRates?.[CURRENCY_SYMBOLS.ETH]?.conversionRate
+    : undefined;
+  const conversionRate =
+    getValidConversionRate(chainConversionRate) ??
+    getValidConversionRate(ethConversionRate);
+  const hasValidConversionRate = conversionRate !== undefined;
 
   const { gasLimit: optimizedGasLimit, quotedGasLimit } =
     useTransactionGasLimit(transactionMeta);
@@ -123,6 +181,38 @@ export function useFeeCalculations(transactionMeta: TransactionMeta) {
   // Max fee
   const gasPrice = transactionMeta?.txParams?.gasPrice ?? HEX_ZERO;
 
+  const getEstimatedFeeForGasLimit = useCallback(
+    (gasLimit: Hex) => {
+      if (!supportsEIP1559) {
+        return multiplyHexes(gasPrice as Hex, gasLimit) as Hex;
+      }
+
+      let minimumFeePerGas = addHexes(
+        decGWEIToHexWEI(estimatedBaseFee) || HEX_ZERO,
+        decimalToHex(maxPriorityFeePerGas),
+      );
+
+      // `minimumFeePerGas` should never be higher than the `maxFeePerGas`
+      if (
+        new Numeric(minimumFeePerGas, 16).greaterThan(
+          decimalToHex(maxFeePerGas),
+          16,
+        )
+      ) {
+        minimumFeePerGas = decimalToHex(maxFeePerGas);
+      }
+
+      return multiplyHexes(minimumFeePerGas as Hex, gasLimit) as Hex;
+    },
+    [
+      estimatedBaseFee,
+      gasPrice,
+      maxFeePerGas,
+      maxPriorityFeePerGas,
+      supportsEIP1559,
+    ],
+  );
+
   const maxFee = useMemo(() => {
     return addHexes(
       layer1GasFee ?? HEX_ZERO,
@@ -161,39 +251,48 @@ export function useFeeCalculations(transactionMeta: TransactionMeta) {
       return getFeesFromHex(estimatedTotalFeesForL2);
     }
 
-    // Logic for any network without L1 and L2 fee components
-    let minimumFeePerGas = addHexes(
-      decGWEIToHexWEI(estimatedBaseFee) || HEX_ZERO,
-      decimalToHex(maxPriorityFeePerGas),
-    );
-
-    // `minimumFeePerGas` should never be higher than the `maxFeePerGas`
-    if (
-      new Numeric(minimumFeePerGas, 16).greaterThan(
-        decimalToHex(maxFeePerGas),
-        16,
-      )
-    ) {
-      minimumFeePerGas = decimalToHex(maxFeePerGas);
-    }
-
-    const estimatedFee = multiplyHexes(
-      supportsEIP1559 ? (minimumFeePerGas as Hex) : (gasPrice as Hex),
-      optimizedGasLimit as Hex,
-    );
-
-    return getFeesFromHex(estimatedFee);
+    return getFeesFromHex(getEstimatedFeeForGasLimit(optimizedGasLimit));
   }, [
-    estimatedBaseFee,
     gasFeeEstimate,
-    gasPrice,
+    getEstimatedFeeForGasLimit,
     getFeesFromHex,
     hasLayer1GasFee,
     layer1GasFee,
-    maxFeePerGas,
-    maxPriorityFeePerGas,
     optimizedGasLimit,
-    supportsEIP1559,
+  ]);
+
+  const hasEnforcedSimulations = Boolean(
+    transactionMeta.containerTypes?.includes(
+      TransactionContainerType.EnforcedSimulations,
+    ),
+  );
+
+  const originalGasLimit = getOriginalGasLimit(transactionMeta, quotedGasLimit);
+
+  const addedProtectionFeeFiat = useMemo(() => {
+    if (!hasEnforcedSimulations || !originalGasLimit) {
+      return null;
+    }
+
+    const gasLimitDelta = getGasLimitDelta(optimizedGasLimit, originalGasLimit);
+
+    if (!gasLimitDelta) {
+      return null;
+    }
+
+    const addedProtectionFee = getEstimatedFeeForGasLimit(gasLimitDelta);
+
+    if (!new Numeric(addedProtectionFee, 16).greaterThan(0, 10)) {
+      return null;
+    }
+
+    return getFeesFromHex(addedProtectionFee).currentCurrencyFee || null;
+  }, [
+    getEstimatedFeeForGasLimit,
+    getFeesFromHex,
+    hasEnforcedSimulations,
+    optimizedGasLimit,
+    originalGasLimit,
   ]);
 
   const calculateGasEstimateCallback = useCallback(
@@ -254,6 +353,7 @@ export function useFeeCalculations(transactionMeta: TransactionMeta) {
   );
 
   return {
+    addedProtectionFeeFiat,
     calculateGasEstimate: calculateGasEstimateCallback,
     estimatedFeeFiat: estimatedFees.currentCurrencyFee,
     estimatedFeeFiatWith18SignificantDigits:

--- a/ui/pages/confirmations/components/confirm/info/native-transfer/native-transfer.tsx
+++ b/ui/pages/confirmations/components/confirm/info/native-transfer/native-transfer.tsx
@@ -1,5 +1,8 @@
 import React from 'react';
-import { TransactionMeta } from '@metamask/transaction-controller';
+import {
+  TransactionContainerType,
+  TransactionMeta,
+} from '@metamask/transaction-controller';
 import { useConfirmContext } from '../../../../context/confirm';
 import { SimulationDetails } from '../../../simulation-details';
 import { TransactionPaySection } from '../../../rows/transaction-pay-section/transaction-pay-section';
@@ -17,6 +20,9 @@ const NativeTransferInfo = () => {
   useMaxValueRefresher();
 
   const isWalletInitiated = transactionMeta.origin === 'metamask';
+  const isEnforcedSimulationsEnabled = transactionMeta.containerTypes?.includes(
+    TransactionContainerType.EnforcedSimulations,
+  );
 
   return (
     <>
@@ -27,6 +33,7 @@ const NativeTransferInfo = () => {
         isTransactionsRedesign
         enableMetrics
         metricsOnly={isWalletInitiated}
+        sectionMarginBottom={isEnforcedSimulationsEnabled ? 2 : undefined}
       />
       <EnforcedSimulationsRow />
       <TokenDetailsSection />

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/__snapshots__/edit-gas-fees-row.test.tsx.snap
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/__snapshots__/edit-gas-fees-row.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<EditGasFeesRow /> renders component 1`] = `
+exports[`<EditGasFeesRow /> does not render added protection network fee when fiat is hidden on testnets 1`] = `
 <div>
   <div
     class="flex flex-col"
@@ -64,23 +64,12 @@ exports[`<EditGasFeesRow /> renders component 1`] = `
               />
             </svg>
           </button>
-          <div>
-            <div
-              aria-describedby="tippy-tooltip-2"
-              class=""
-              data-original-title="0.001234"
-              data-tooltipped=""
-              style="display: inline;"
-              tabindex="0"
-            >
-              <p
-                class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default"
-                data-testid="native-currency"
-              >
-                $1
-              </p>
-            </div>
-          </div>
+          <p
+            class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default"
+            data-testid="first-gas-field"
+          >
+            0.001 ETH
+          </p>
           <div
             class="gap-1 items-center inline-flex"
             data-testid="selected-gas-fee-token"

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.test.tsx
@@ -120,33 +120,16 @@ describe('<EditGasFeesRow />', () => {
       amountFiat: '',
     };
 
-    const { getByTestId } = render({
+    const { getByTestId, getByText } = render({
       chainId: CHAIN_IDS.MAINNET,
       gasFeeTokens: [gasFeeTokenWithoutFiat],
       selectedGasFeeToken: gasFeeTokenWithoutFiat.tokenAddress,
+      addedProtectionFeeFiat: '$0.07',
+      showAddedProtectionFee: true,
     });
 
     expect(getByTestId('gas-fee-token-fee')).toBeInTheDocument();
     expect(getByTestId('native-currency')).toHaveTextContent('$1');
-  });
-
-  it('renders edit gas fee button', () => {
-    const { getByTestId } = render({
-      gasFeeTokens: undefined,
-      selectedGasFeeToken: undefined,
-    });
-
-    expect(getByTestId('edit-gas-fee-icon')).toBeInTheDocument();
-  });
-
-  it('renders added protection network fee copy', () => {
-    const { getByTestId, getByText } = render({
-      addedProtectionFeeFiat: '$0.07',
-      showAddedProtectionFee: true,
-      showFiatInTestnets: true,
-    });
-
-    expect(getByTestId('added-protection-network-fee')).toBeInTheDocument();
     expect(
       getByText(
         messages.addedProtectionIncludesNetworkFee.message.replace(
@@ -157,33 +140,16 @@ describe('<EditGasFeesRow />', () => {
     ).toBeInTheDocument();
   });
 
-  it('renders added protection network fee copy with fallback fiat amount', () => {
+  it('renders edit gas fee button', () => {
     const { getByTestId, getByText } = render({
-      fiatFee: '',
-      showAddedProtectionFee: true,
-      showFiatInTestnets: true,
-    });
-
-    expect(getByTestId('added-protection-network-fee')).toBeInTheDocument();
-    expect(
-      getByText(
-        messages.addedProtectionIncludesNetworkFee.message.replace(
-          '$1',
-          '$0.00',
-        ),
-      ),
-    ).toBeInTheDocument();
-  });
-
-  it('never falls back to the full network fee for the added protection copy', () => {
-    const { getByTestId, getByText } = render({
-      addedProtectionFeeFiat: undefined,
+      gasFeeTokens: undefined,
+      selectedGasFeeToken: undefined,
       fiatFee: '$12.34',
       showAddedProtectionFee: true,
       showFiatInTestnets: true,
     });
 
-    expect(getByTestId('added-protection-network-fee')).toBeInTheDocument();
+    expect(getByTestId('edit-gas-fee-icon')).toBeInTheDocument();
     expect(
       getByText(
         messages.addedProtectionIncludesNetworkFee.message.replace(

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.test.tsx
@@ -47,6 +47,7 @@ function render({
   nativeFee = '0.001 ETH',
   estimationFailed = false,
   isGaslessSupported = false,
+  showFiatInTestnets = false,
   transactionType,
 }: {
   addedProtectionFeeFiat?: string;
@@ -58,6 +59,7 @@ function render({
   nativeFee?: string;
   estimationFailed?: boolean;
   isGaslessSupported?: boolean;
+  showFiatInTestnets?: boolean;
   transactionType?: TransactionType;
 } = {}) {
   mockUseEstimationFailed.mockReturnValue(estimationFailed);
@@ -78,7 +80,13 @@ function render({
     confirmation.type = transactionType;
   }
 
-  const state = getMockConfirmStateForTransaction(confirmation);
+  const state = getMockConfirmStateForTransaction(confirmation, {
+    metamask: {
+      preferences: {
+        showFiatInTestnets,
+      },
+    },
+  });
 
   const mockStore = configureMockStore()(state);
 
@@ -95,8 +103,14 @@ function render({
 }
 
 describe('<EditGasFeesRow />', () => {
-  it('renders component', () => {
-    const { container } = render();
+  it('does not render added protection network fee when fiat is hidden on testnets', () => {
+    const { container, queryByTestId } = render({
+      chainId: CHAIN_IDS.SEPOLIA,
+      addedProtectionFeeFiat: '$0.07',
+      showAddedProtectionFee: true,
+    });
+
+    expect(queryByTestId('added-protection-network-fee')).toBeNull();
     expect(container).toMatchSnapshot();
   });
 
@@ -129,6 +143,7 @@ describe('<EditGasFeesRow />', () => {
     const { getByTestId, getByText } = render({
       addedProtectionFeeFiat: '$0.07',
       showAddedProtectionFee: true,
+      showFiatInTestnets: true,
     });
 
     expect(getByTestId('added-protection-network-fee')).toBeInTheDocument();
@@ -146,6 +161,7 @@ describe('<EditGasFeesRow />', () => {
     const { getByTestId, getByText } = render({
       fiatFee: '',
       showAddedProtectionFee: true,
+      showFiatInTestnets: true,
     });
 
     expect(getByTestId('added-protection-network-fee')).toBeInTheDocument();
@@ -164,6 +180,7 @@ describe('<EditGasFeesRow />', () => {
       addedProtectionFeeFiat: undefined,
       fiatFee: '$12.34',
       showAddedProtectionFee: true,
+      showFiatInTestnets: true,
     });
 
     expect(getByTestId('added-protection-network-fee')).toBeInTheDocument();

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.test.tsx
@@ -159,6 +159,32 @@ describe('<EditGasFeesRow />', () => {
     ).toBeInTheDocument();
   });
 
+  it('never falls back to the full network fee for the added protection copy', () => {
+    const { getByTestId, getByText } = render({
+      addedProtectionFeeFiat: undefined,
+      fiatFee: '$12.34',
+      showAddedProtectionFee: true,
+    });
+
+    expect(getByTestId('added-protection-network-fee')).toBeInTheDocument();
+    expect(
+      getByText(
+        messages.addedProtectionIncludesNetworkFee.message.replace(
+          '$1',
+          '$0.00',
+        ),
+      ),
+    ).toBeInTheDocument();
+    expect(() =>
+      getByText(
+        messages.addedProtectionIncludesNetworkFee.message.replace(
+          '$1',
+          '$12.34',
+        ),
+      ),
+    ).toThrow();
+  });
+
   it('does not renders edit gas fee button for quote suggested swap', () => {
     jest.spyOn(DappSwapContext, 'useDappSwapContext').mockReturnValue({
       isQuotedSwapDisplayedInInfo: true,

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.test.tsx
@@ -41,12 +41,16 @@ function render({
   chainId = CHAIN_IDS.GOERLI,
   gasFeeTokens,
   selectedGasFeeToken,
+  addedProtectionFeeFiat,
+  showAddedProtectionFee,
   fiatFee = '$1',
   nativeFee = '0.001 ETH',
   estimationFailed = false,
   isGaslessSupported = false,
   transactionType,
 }: {
+  addedProtectionFeeFiat?: string;
+  showAddedProtectionFee?: boolean;
   chainId?: Hex;
   gasFeeTokens?: GasFeeToken[];
   selectedGasFeeToken?: Hex;
@@ -80,6 +84,8 @@ function render({
 
   return renderWithConfirmContextProvider(
     <EditGasFeesRow
+      addedProtectionFeeFiat={addedProtectionFeeFiat}
+      showAddedProtectionFee={showAddedProtectionFee}
       fiatFee={fiatFee}
       nativeFee={nativeFee}
       fiatFeeWith18SignificantDigits="0.001234"
@@ -117,6 +123,40 @@ describe('<EditGasFeesRow />', () => {
     });
 
     expect(getByTestId('edit-gas-fee-icon')).toBeInTheDocument();
+  });
+
+  it('renders added protection network fee copy', () => {
+    const { getByTestId, getByText } = render({
+      addedProtectionFeeFiat: '$0.07',
+      showAddedProtectionFee: true,
+    });
+
+    expect(getByTestId('added-protection-network-fee')).toBeInTheDocument();
+    expect(
+      getByText(
+        messages.addedProtectionIncludesNetworkFee.message.replace(
+          '$1',
+          '$0.07',
+        ),
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('renders added protection network fee copy with fallback fiat amount', () => {
+    const { getByTestId, getByText } = render({
+      fiatFee: '',
+      showAddedProtectionFee: true,
+    });
+
+    expect(getByTestId('added-protection-network-fee')).toBeInTheDocument();
+    expect(
+      getByText(
+        messages.addedProtectionIncludesNetworkFee.message.replace(
+          '$1',
+          '$0.00',
+        ),
+      ),
+    ).toBeInTheDocument();
   });
 
   it('does not renders edit gas fee button for quote suggested swap', () => {

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
@@ -120,9 +120,10 @@ export const EditGasFeesRow = ({
   // Only ever show the computed added-protection surcharge, or a $0.00
   // placeholder when it could not be determined. Never fall back to the
   // full network fee, which would mislabel the entire fee as the surcharge.
-  const addedProtectionFeeDisplay = showAddedProtectionFee
-    ? addedProtectionFeeFiat || fiatFormatter(0)
-    : null;
+  const addedProtectionFeeDisplay =
+    showFiat && showAddedProtectionFee
+      ? addedProtectionFeeFiat || fiatFormatter(0)
+      : null;
 
   return (
     <Box flexDirection={BoxFlexDirection.Column}>

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
@@ -24,6 +24,7 @@ import { ConfirmInfoAlertRow } from '../../../../../../../components/app/confirm
 import { RowAlertKey } from '../../../../../../../components/app/confirm/info/row/constants';
 import Tooltip from '../../../../../../../components/ui/tooltip';
 import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
+import { useFiatFormatter } from '../../../../../../../hooks/useFiatFormatter';
 import { getPreferences } from '../../../../../../../../shared/lib/selectors/preferences';
 import { useConfirmContext } from '../../../../../context/confirm';
 import { useDappSwapContext } from '../../../../../context/dapp-swap';
@@ -39,17 +40,22 @@ import { SelectedGasFeeToken } from '../selected-gas-fee-token';
 import { GasSponsorshipModal } from '../gas-sponsorship-modal';
 
 export const EditGasFeesRow = ({
+  addedProtectionFeeFiat,
+  showAddedProtectionFee,
   fiatFee,
   fiatFeeWith18SignificantDigits,
   nativeFee,
   disableUpdate,
 }: {
+  addedProtectionFeeFiat?: string | null;
+  showAddedProtectionFee?: boolean;
   fiatFee: string;
   fiatFeeWith18SignificantDigits: string | null;
   nativeFee: string;
   disableUpdate?: boolean;
 }) => {
   const t = useI18nContext();
+  const fiatFormatter = useFiatFormatter();
 
   const { currentConfirmation: transactionMeta } =
     useConfirmContext<TransactionMeta>();
@@ -111,6 +117,9 @@ export const EditGasFeesRow = ({
     !isGasFeeSponsored;
   const shouldShowPrimaryFiatValue =
     showFiat && hasFiatValue && !showAdvancedDetails && !isGasFeeSponsored;
+  const addedProtectionFeeDisplay = showAddedProtectionFee
+    ? addedProtectionFeeFiat || fiatFee || fiatFormatter(0)
+    : null;
 
   return (
     <Box flexDirection={BoxFlexDirection.Column}>
@@ -173,6 +182,19 @@ export const EditGasFeesRow = ({
                 />
               )}
             </Box>
+            {!estimationFailed &&
+              !isGasFeeSponsored &&
+              addedProtectionFeeDisplay && (
+                <Text
+                  variant={TextVariant.BodyXs}
+                  color={TextColor.TextAlternative}
+                  data-testid="added-protection-network-fee"
+                >
+                  {t('addedProtectionIncludesNetworkFee', [
+                    addedProtectionFeeDisplay,
+                  ])}
+                </Text>
+              )}
             {isGasFeeSponsored && (
               <Text
                 variant={TextVariant.BodyXs}

--- a/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.tsx
@@ -117,8 +117,11 @@ export const EditGasFeesRow = ({
     !isGasFeeSponsored;
   const shouldShowPrimaryFiatValue =
     showFiat && hasFiatValue && !showAdvancedDetails && !isGasFeeSponsored;
+  // Only ever show the computed added-protection surcharge, or a $0.00
+  // placeholder when it could not be determined. Never fall back to the
+  // full network fee, which would mislabel the entire fee as the surcharge.
   const addedProtectionFeeDisplay = showAddedProtectionFee
-    ? addedProtectionFeeFiat || fiatFee || fiatFormatter(0)
+    ? addedProtectionFeeFiat || fiatFormatter(0)
     : null;
 
   return (

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fees-details/gas-fees-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fees-details/gas-fees-details.test.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import {
   SimulationError,
   TransactionContainerType,
-  TransactionMeta,
   UserFeeLevel,
 } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
@@ -36,28 +35,40 @@ function getStore({
   selectedGasFeeToken,
   simulationFails,
   userFeeLevel,
+  chainId,
+  isEnforcedSimulations = false,
 }: {
   isAdvanced?: boolean;
   selectedGasFeeToken?: Hex;
   simulationFails?: SimulationError;
   userFeeLevel?: UserFeeLevel;
+  chainId?: Hex;
+  isEnforcedSimulations?: boolean;
 } = {}) {
+  const confirmation = genUnapprovedContractInteractionConfirmation({
+    chainId,
+    selectedGasFeeToken,
+    simulationFails,
+    userFeeLevel,
+  });
+
+  if (isEnforcedSimulations) {
+    confirmation.containerTypes = [
+      TransactionContainerType.EnforcedSimulations,
+    ];
+    confirmation.txParamsOriginal = { ...confirmation.txParams };
+    confirmation.txParams.gas = '0x156ee';
+  }
+
   return configureStore(
-    getMockConfirmStateForTransaction(
-      genUnapprovedContractInteractionConfirmation({
-        selectedGasFeeToken,
-        simulationFails,
-        userFeeLevel,
-      }),
-      {
-        metamask: {
-          preferences: {
-            showFiatInTestnets: true,
-            showConfirmationAdvancedDetails: isAdvanced ?? false,
-          },
+    getMockConfirmStateForTransaction(confirmation, {
+      metamask: {
+        preferences: {
+          showFiatInTestnets: true,
+          showConfirmationAdvancedDetails: isAdvanced ?? false,
         },
       },
-    ),
+    }),
   );
 }
 
@@ -83,44 +94,14 @@ describe('<GasFeesDetails />', () => {
     expect(getByText('$0.07')).toBeInTheDocument();
   });
 
-  it('renders added protection fee copy for enforced simulations', async () => {
-    const confirmation = genUnapprovedContractInteractionConfirmation({
-      chainId: CHAIN_IDS.SEPOLIA,
-    }) as TransactionMeta;
-    confirmation.containerTypes = [
-      TransactionContainerType.EnforcedSimulations,
-    ];
-    confirmation.txParamsOriginal = { ...confirmation.txParams };
-    confirmation.txParams.gas = '0x156ee';
-
-    const store = configureStore(
-      getMockConfirmStateForTransaction(confirmation, {
-        metamask: {
-          preferences: {
-            showFiatInTestnets: true,
-          },
-        },
-      }),
-    );
-
-    const { getByTestId } = renderWithConfirmContextProvider(
-      <GasFeesDetails />,
-      store,
-    );
-
-    await act(async () => {
-      // Intentionally empty
-    });
-
-    expect(getByTestId('added-protection-network-fee')).toHaveTextContent(
-      messages.addedProtectionIncludesNetworkFee.message.replace('$1', '$0.07'),
-    );
-  });
-
   it('renders max fee if advanced', async () => {
     const { getByTestId } = renderWithConfirmContextProvider(
       <GasFeesDetails />,
-      getStore({ isAdvanced: true }),
+      getStore({
+        isAdvanced: true,
+        chainId: CHAIN_IDS.SEPOLIA,
+        isEnforcedSimulations: true,
+      }),
     );
 
     await act(async () => {
@@ -128,6 +109,9 @@ describe('<GasFeesDetails />', () => {
     });
 
     expect(getByTestId('gas-fee-details-max-fee')).toBeInTheDocument();
+    expect(getByTestId('added-protection-network-fee')).toHaveTextContent(
+      messages.addedProtectionIncludesNetworkFee.message.replace('$1', '$0.07'),
+    );
   });
 
   it('does not render max fee if advanced and selected gas fee token', async () => {

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fees-details/gas-fees-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fees-details/gas-fees-details.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import {
   SimulationError,
   TransactionContainerType,
+  TransactionMeta,
   UserFeeLevel,
 } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
@@ -50,7 +51,7 @@ function getStore({
     selectedGasFeeToken,
     simulationFails,
     userFeeLevel,
-  });
+  }) as TransactionMeta;
 
   if (isEnforcedSimulations) {
     confirmation.containerTypes = [

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fees-details/gas-fees-details.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fees-details/gas-fees-details.test.tsx
@@ -3,9 +3,12 @@ import React from 'react';
 
 import {
   SimulationError,
+  TransactionContainerType,
+  TransactionMeta,
   UserFeeLevel,
 } from '@metamask/transaction-controller';
 import { Hex } from '@metamask/utils';
+import { CHAIN_IDS } from '../../../../../../../../shared/constants/network';
 import { getMockConfirmStateForTransaction } from '../../../../../../../../test/data/confirmations/helper';
 import { renderWithConfirmContextProvider } from '../../../../../../../../test/lib/confirmations/render-helpers';
 import { getGasFeeTimeEstimate } from '../../../../../../../store/actions';
@@ -78,6 +81,40 @@ describe('<GasFeesDetails />', () => {
     });
 
     expect(getByText('$0.07')).toBeInTheDocument();
+  });
+
+  it('renders added protection fee copy for enforced simulations', async () => {
+    const confirmation = genUnapprovedContractInteractionConfirmation({
+      chainId: CHAIN_IDS.SEPOLIA,
+    }) as TransactionMeta;
+    confirmation.containerTypes = [
+      TransactionContainerType.EnforcedSimulations,
+    ];
+    confirmation.txParamsOriginal = { ...confirmation.txParams };
+    confirmation.txParams.gas = '0x156ee';
+
+    const store = configureStore(
+      getMockConfirmStateForTransaction(confirmation, {
+        metamask: {
+          preferences: {
+            showFiatInTestnets: true,
+          },
+        },
+      }),
+    );
+
+    const { getByTestId } = renderWithConfirmContextProvider(
+      <GasFeesDetails />,
+      store,
+    );
+
+    await act(async () => {
+      // Intentionally empty
+    });
+
+    expect(getByTestId('added-protection-network-fee')).toHaveTextContent(
+      messages.addedProtectionIncludesNetworkFee.message.replace('$1', '$0.07'),
+    );
   });
 
   it('renders max fee if advanced', async () => {

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fees-details/gas-fees-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fees-details/gas-fees-details.tsx
@@ -1,4 +1,5 @@
 import {
+  TransactionContainerType,
   TransactionMeta,
   TransactionType,
 } from '@metamask/transaction-controller';
@@ -37,6 +38,7 @@ export const GasFeesDetails = (): JSX.Element | null => {
   const { supportsEIP1559 } = useSupportsEIP1559(transactionMeta);
 
   const {
+    addedProtectionFeeFiat,
     estimatedFeeFiat,
     estimatedFeeFiatWith18SignificantDigits,
     estimatedFeeNative,
@@ -62,6 +64,11 @@ export const GasFeesDetails = (): JSX.Element | null => {
     transactionMeta?.type !== TransactionType.revokeDelegation;
 
   const isGasFeeSponsored = isSponsorshipEligible && !isSponsorshipOptedOut;
+  const showAddedProtectionFee = Boolean(
+    transactionMeta?.containerTypes?.includes(
+      TransactionContainerType.EnforcedSimulations,
+    ),
+  );
 
   if (!transactionMeta?.txParams) {
     return null;
@@ -70,6 +77,8 @@ export const GasFeesDetails = (): JSX.Element | null => {
   return (
     <>
       <EditGasFeesRow
+        addedProtectionFeeFiat={addedProtectionFeeFiat}
+        showAddedProtectionFee={showAddedProtectionFee}
         fiatFee={estimatedFeeFiat}
         fiatFeeWith18SignificantDigits={estimatedFeeFiatWith18SignificantDigits}
         nativeFee={estimatedFeeNative}

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-sponsorship-modal/gas-sponsorship-modal.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-sponsorship-modal/gas-sponsorship-modal.test.tsx
@@ -76,6 +76,7 @@ describe('GasSponsorshipModal', () => {
     });
 
     useFeeCalculationsMock.mockReturnValue({
+      addedProtectionFeeFiat: null,
       calculateGasEstimate: jest.fn(),
       estimatedFeeFiat: '$1.50',
       estimatedFeeFiatWith18SignificantDigits: null,
@@ -207,6 +208,7 @@ describe('GasSponsorshipModal', () => {
 
   it('displays native fee in fiat when available', () => {
     useFeeCalculationsMock.mockReturnValue({
+      addedProtectionFeeFiat: null,
       calculateGasEstimate: jest.fn(),
       estimatedFeeFiat: '$2.75',
       estimatedFeeFiatWith18SignificantDigits: null,
@@ -228,6 +230,7 @@ describe('GasSponsorshipModal', () => {
 
   it('displays native fee in token amount when fiat is not available', () => {
     useFeeCalculationsMock.mockReturnValue({
+      addedProtectionFeeFiat: null,
       calculateGasEstimate: jest.fn(),
       estimatedFeeFiat: '',
       estimatedFeeFiatWith18SignificantDigits: null,

--- a/ui/pages/confirmations/components/confirm/info/token-transfer/token-transfer.tsx
+++ b/ui/pages/confirmations/components/confirm/info/token-transfer/token-transfer.tsx
@@ -1,4 +1,7 @@
-import { TransactionMeta } from '@metamask/transaction-controller';
+import {
+  TransactionContainerType,
+  TransactionMeta,
+} from '@metamask/transaction-controller';
 import React from 'react';
 import { useConfirmContext } from '../../../../context/confirm';
 import { SimulationDetails } from '../../../simulation-details';
@@ -15,6 +18,9 @@ const TokenTransferInfo = () => {
     useConfirmContext<TransactionMeta>();
 
   const isWalletInitiated = transactionMeta.origin === 'metamask';
+  const isEnforcedSimulationsEnabled = transactionMeta.containerTypes?.includes(
+    TransactionContainerType.EnforcedSimulations,
+  );
 
   return (
     <>
@@ -25,6 +31,7 @@ const TokenTransferInfo = () => {
         isTransactionsRedesign
         enableMetrics
         metricsOnly={isWalletInitiated}
+        sectionMarginBottom={isEnforcedSimulationsEnabled ? 2 : undefined}
       />
       <EnforcedSimulationsRow />
       <TokenDetailsSection />

--- a/ui/pages/confirmations/components/rows/enforced-simulations-row/enforced-simulations-row.tsx
+++ b/ui/pages/confirmations/components/rows/enforced-simulations-row/enforced-simulations-row.tsx
@@ -27,7 +27,7 @@ import { applyTransactionContainersExisting } from '../../../../../store/actions
 import { useIsEnforcedSimulationsEligible } from '../../../hooks/useIsEnforcedSimulationsEligible';
 
 const ADDED_PROTECTION_LEARN_MORE_URL =
-  'https://support.metamask.io/privacy-and-security/staying-safe-in-web3/what-are-enforced-simulations/';
+  'https://support.metamask.io/manage-crypto/transactions/simulations/';
 
 export function EnforcedSimulationsRow() {
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();

--- a/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
+++ b/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
@@ -26,6 +26,7 @@ import {
   IconSize,
   Text,
 } from '../../../../components/component-library';
+import type { SizeNumber } from '../../../../components/component-library/box/box.types';
 import Tooltip from '../../../../components/ui/tooltip';
 import {
   AlignItems,
@@ -57,6 +58,7 @@ export type SimulationDetailsProps = {
   readonly enableMetrics?: boolean;
   readonly isTransactionsRedesign?: boolean;
   readonly metricsOnly?: boolean;
+  readonly sectionMarginBottom?: SizeNumber;
   readonly staticRows?: StaticRow[];
   readonly transaction: TransactionMeta;
   readonly smartTransactionStatus?: string;
@@ -251,6 +253,7 @@ const HeaderLayout = ({
  * @param props.inHeader
  * @param props.isTransactionsRedesign
  * @param props.children
+ * @param props.sectionMarginBottom
  * @param props.transactionId
  */
 export const SimulationDetailsLayout = ({
@@ -258,6 +261,7 @@ export const SimulationDetailsLayout = ({
   titleTooltip,
   inHeader,
   isTransactionsRedesign,
+  sectionMarginBottom,
   transactionId,
   children,
 }: React.PropsWithChildren<{
@@ -265,10 +269,11 @@ export const SimulationDetailsLayout = ({
   titleTooltip?: string;
   inHeader?: React.ReactNode;
   isTransactionsRedesign: boolean;
+  sectionMarginBottom?: SizeNumber;
   transactionId: string;
 }>) =>
   isTransactionsRedesign ? (
-    <ConfirmInfoSection noPadding>
+    <ConfirmInfoSection noPadding marginBottom={sectionMarginBottom}>
       <Box
         data-testid="simulation-details-layout"
         className="simulation-details-layout"
@@ -375,14 +380,17 @@ const BalanceChangesAlert = ({ transactionId }: { transactionId: string }) => {
 // eslint-disable-next-line @typescript-eslint/naming-convention
 function SimulationDetailsSkeleton({
   isTransactionsRedesign,
+  sectionMarginBottom,
   transactionId,
 }: {
   isTransactionsRedesign: boolean;
+  sectionMarginBottom?: SizeNumber;
   transactionId: string;
 }) {
   return (
     <SimulationDetailsLayout
       isTransactionsRedesign={isTransactionsRedesign}
+      sectionMarginBottom={sectionMarginBottom}
       transactionId={transactionId}
     >
       <Box display={Display.Flex} flexDirection={FlexDirection.Column} gap={3}>
@@ -416,6 +424,7 @@ function SimulationDetailsSkeleton({
  * @param props.isTransactionsRedesign - Whether or not the component is being
  * used inside the transaction redesign flow.
  * @param props.metricsOnly - Whether to only track metrics and not render the UI.
+ * @param props.sectionMarginBottom - Optional bottom margin for the containing section.
  * @param props.staticRows - Optional static rows to display.
  * @param props.smartTransactionStatus - Optional Smart Transaction status to override transaction status for immediate UI updates.
  */
@@ -424,6 +433,7 @@ export const SimulationDetails = ({
   enableMetrics = false,
   isTransactionsRedesign = false,
   metricsOnly = false,
+  sectionMarginBottom,
   staticRows = [],
   smartTransactionStatus,
 }: SimulationDetailsProps) => {
@@ -462,6 +472,7 @@ export const SimulationDetails = ({
     return (
       <SimulationDetailsSkeleton
         isTransactionsRedesign={isTransactionsRedesign}
+        sectionMarginBottom={sectionMarginBottom}
         transactionId={transactionId}
       />
     );
@@ -490,6 +501,7 @@ export const SimulationDetails = ({
     return (
       <SimulationDetailsLayout
         isTransactionsRedesign={isTransactionsRedesign}
+        sectionMarginBottom={sectionMarginBottom}
         transactionId={transactionId}
         {...inHeaderProp}
       >
@@ -512,6 +524,7 @@ export const SimulationDetails = ({
     return (
       <SimulationDetailsLayout
         isTransactionsRedesign={isTransactionsRedesign}
+        sectionMarginBottom={sectionMarginBottom}
         transactionId={transactionId}
         inHeader={<EmptyContent />}
       />
@@ -568,6 +581,7 @@ export const SimulationDetails = ({
   return (
     <SimulationDetailsLayout
       isTransactionsRedesign={isTransactionsRedesign}
+      sectionMarginBottom={sectionMarginBottom}
       transactionId={transactionId}
     >
       <Box display={Display.Flex} flexDirection={FlexDirection.Column} gap={3}>

--- a/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
+++ b/ui/pages/confirmations/components/simulation-details/simulation-details.tsx
@@ -26,7 +26,7 @@ import {
   IconSize,
   Text,
 } from '../../../../components/component-library';
-import type { SizeNumber } from '../../../../components/component-library/box/box.types';
+import type { ConfirmInfoSectionMarginBottom } from '../../../../components/app/confirm/info/row/section';
 import Tooltip from '../../../../components/ui/tooltip';
 import {
   AlignItems,
@@ -58,7 +58,7 @@ export type SimulationDetailsProps = {
   readonly enableMetrics?: boolean;
   readonly isTransactionsRedesign?: boolean;
   readonly metricsOnly?: boolean;
-  readonly sectionMarginBottom?: SizeNumber;
+  readonly sectionMarginBottom?: ConfirmInfoSectionMarginBottom;
   readonly staticRows?: StaticRow[];
   readonly transaction: TransactionMeta;
   readonly smartTransactionStatus?: string;
@@ -269,7 +269,7 @@ export const SimulationDetailsLayout = ({
   titleTooltip?: string;
   inHeader?: React.ReactNode;
   isTransactionsRedesign: boolean;
-  sectionMarginBottom?: SizeNumber;
+  sectionMarginBottom?: ConfirmInfoSectionMarginBottom;
   transactionId: string;
 }>) =>
   isTransactionsRedesign ? (
@@ -384,7 +384,7 @@ function SimulationDetailsSkeleton({
   transactionId,
 }: {
   isTransactionsRedesign: boolean;
-  sectionMarginBottom?: SizeNumber;
+  sectionMarginBottom?: ConfirmInfoSectionMarginBottom;
   transactionId: string;
 }) {
   return (


### PR DESCRIPTION
## **Description**

This PR addresses enforced simulations confirmation papercuts:

- Shows `Includes $X for added protection` in the Network fee section when added protection is enabled.
- Keeps the added protection fee formatted as fiat, with a safe `$0.00` fallback when fiat rates are unavailable in the QA/testnet flow.
- Reduces spacing between Estimated changes / Balance changes and the Added protection banner from 16px to 8px so the blocks read as visually linked.
- Updates the Added protection learn-more link to the current transaction simulations support article.

Tickets covered:

- https://consensyssoftware.atlassian.net/browse/CONF-1465 — [Enforced Simulations] Show "Includes $X for added protection" in network section
- https://consensyssoftware.atlassian.net/browse/CONF-1464 — [Enforced simulations] Use design system checkbox in enforced simulations UI
- https://consensyssoftware.atlassian.net/browse/CONF-1463 — [Enforced simulations] Reduce padding between added protection banner and balance changes (8px)

## **Changelog**

CHANGELOG entry: Fixed display details and spacing for added protection in transaction confirmations.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1465
Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1464
Fixes: https://consensyssoftware.atlassian.net/browse/CONF-1463

## **Manual testing steps**

1. Build and load the extension.
2. Open the test dapp on Sepolia.
3. Trigger the enforced simulations flow with PPOM / Mint ERC20 against an unknown address.
4. Verify the Added protection banner is visible and enabled.
5. Verify the Network fee section shows `Includes $0.xx for added protection` below the fee value and token indicator.
6. Verify the spacing between Estimated changes / Balance changes and the Added protection banner is 8px.
7. Toggle Added protection off and verify the added-protection fee copy is removed from the Network fee section.

## **Screenshots/Recordings**

### **Before**

To be added before marking this draft PR ready for review.

### **After**

To be added before marking this draft PR ready for review.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes fee display and gas-limit-based surcharge math on confirmations; wrong deltas or fiat fallback could misstate costs, though scope is limited to enforced-simulations flows and tests cover key cases.
> 
> **Overview**
> **Enforced simulations** confirmations now surface how much of the network fee is the added-protection surcharge, and the simulation blocks sit closer to the added-protection banner.
> 
> `useFeeCalculations` derives **`addedProtectionFeeFiat`** when `TransactionContainerType.EnforcedSimulations` is present by comparing optimized gas to `txParamsOriginal` (and related fallbacks), pricing the delta with shared fee logic. Sepolia/Linea Sepolia can fall back to mainnet ETH conversion rates when the testnet ticker has no rate. **`EditGasFeesRow`** shows **`Includes $X for added protection`** only when fiat is shown and enforced simulations are on—using the computed surcharge or **`$0.00`**, never the full network fee. The line is hidden on testnets when fiat display is off.
> 
> **`ConfirmInfoSection`** / **`SimulationDetails`** accept optional **`sectionMarginBottom`**; native/token/batch confirm flows pass **`2`** (8px) when enforced simulations are enabled so estimated changes read as linked to the banner. Locale strings add **`addedProtectionIncludesNetworkFee`**. The added-protection learn-more URL points to the current simulations support article.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 402b41ca8e022ab8faf6ea6484ea1abd21d74d02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->