### PR TITLE
fix(mv3): move keep-alive polling to service worker startup

### DIFF
--- a/app/scripts/app-init.js
+++ b/app/scripts/app-init.js
@@ -8,6 +8,19 @@ import { ExtensionLazyListener } from './lib/extension-lazy-listener/extension-l
 
 const { chrome } = globalThis;
 
+const SAVE_TIMESTAMP_INTERVAL_MS = 2 * 1000;
+
+function saveTimestamp() {
+  const timestamp = new Date().toISOString();
+
+  chrome.storage.session.set({ timestamp });
+}
+
+// Save the timestamp immediately and then every `SAVE_TIMESTAMP_INTERVAL_MS`.
+// This keeps the service worker alive.
+saveTimestamp();
+setInterval(saveTimestamp, SAVE_TIMESTAMP_INTERVAL_MS);
+
 // this needs to be run early so we can begin listening to these browser events
 // as soon as possible
 const lazyListener = new ExtensionLazyListener(chrome, {

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -746,12 +746,6 @@ browser.runtime.onConnectExternal.addListener(async (...args) => {
   connectExternallyConnectable(...args);
 });
 
-function saveTimestamp() {
-  const timestamp = new Date().toISOString();
-
-  browser.storage.session.set({ timestamp });
-}
-
 /**
  * @typedef {import('@metamask/transaction-controller').TransactionMeta} TransactionMeta
  */
@@ -846,13 +840,6 @@ async function initialize(backup) {
   }
 
   if (isManifestV3) {
-    // Save the timestamp immediately and then every `SAVE_TIMESTAMP_INTERVAL`
-    // miliseconds. This keeps the service worker alive.
-    const SAVE_TIMESTAMP_INTERVAL_MS = 2 * 1000;
-
-    saveTimestamp();
-    setInterval(saveTimestamp, SAVE_TIMESTAMP_INTERVAL_MS);
-
     const sessionData = await browser.storage.session.get([
       'isFirstMetaMaskControllerSetup',
     ]);

--- a/app/service-worker.ts
+++ b/app/service-worker.ts
@@ -55,12 +55,7 @@ async function runImportScripts() {
 
 // Ref: https://stackoverflow.com/questions/66406672/chrome-extension-mv3-modularize-service-worker-js-file
 // eslint-disable-next-line no-undef
-self.addEventListener('install', ((event: ExtendableEvent) => {
-  // Extend the install event lifetime until background scripts finish loading.
-  // Without waitUntil, Chrome may finish the install event before the async
-  // dynamic import of background.js completes.
-  event.waitUntil(runImportScripts());
-}) as EventListener);
+self.addEventListener('install', runImportScripts);
 
 // listen for connection events from other contexts, and respond to liveness
 // checks, and ping them to let them know we're listening.

--- a/app/service-worker.ts
+++ b/app/service-worker.ts
@@ -6,6 +6,19 @@ import { ExtensionLazyListener } from './scripts/lib/extension-lazy-listener/ext
 
 const { chrome } = globalThis;
 
+const SAVE_TIMESTAMP_INTERVAL_MS = 2 * 1000;
+
+function saveTimestamp() {
+  const timestamp = new Date().toISOString();
+
+  chrome.storage.session.set({ timestamp });
+}
+
+// Save the timestamp immediately and then every `SAVE_TIMESTAMP_INTERVAL_MS`.
+// This keeps the service worker alive.
+saveTimestamp();
+setInterval(saveTimestamp, SAVE_TIMESTAMP_INTERVAL_MS);
+
 // this needs to be run early so we can begin listening to these browser events
 // as soon as possible
 const lazyListener = new ExtensionLazyListener(chrome, {
@@ -42,7 +55,12 @@ async function runImportScripts() {
 
 // Ref: https://stackoverflow.com/questions/66406672/chrome-extension-mv3-modularize-service-worker-js-file
 // eslint-disable-next-line no-undef
-self.addEventListener('install', runImportScripts);
+self.addEventListener('install', ((event: ExtendableEvent) => {
+  // Extend the install event lifetime until background scripts finish loading.
+  // Without waitUntil, Chrome may finish the install event before the async
+  // dynamic import of background.js completes.
+  event.waitUntil(runImportScripts());
+}) as EventListener);
 
 // listen for connection events from other contexts, and respond to liveness
 // checks, and ping them to let them know we're listening.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

MV3 keep-alive timestamp polling previously started in `background.js`, only after persisted state was loaded. That left a gap during early service worker startup, before the dynamic `background.js` import finished.

This change moves the existing `saveTimestamp` + `setInterval` logic into the MV3 service worker entry points (`service-worker.ts` for webpack dev, `app-init.js` for browserify prod/E2E) so polling starts at module load.

Install `event.waitUntil` for background script loading is handled separately in #44189.

Removal of the obsolete `enableMV3TimestampSave` debug preference is tracked in #44373.

1. What is the reason for the change?
   - Keep-alive activity should begin as early as possible in the MV3 service worker lifecycle.
2. What is the improvement/solution?
   - Inline the existing keep-alive polling in both service worker entry points.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/43773

## **Manual testing steps**

1. Run `yarn start` and load the extension in Chrome.
2. Open `chrome://extensions`, click **Service worker** for MetaMask, and run:
   `let { timestamp } = await chrome.storage.session.get('timestamp'); console.log(timestamp)`
3. Verify a recent ISO timestamp is logged immediately after startup.
4. Reload the extension and confirm the timestamp continues updating every ~2 seconds.
5. Unlock MetaMask and perform basic actions (open popup, switch accounts) to confirm normal background behavior is unchanged.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is unchanged aside from earlier polling start; no auth, vault, or transaction logic is touched—only duplicated keep-alive code in known MV3 entry files.
> 
> **Overview**
> **MV3 keep-alive** now starts at service worker module load instead of waiting until `background.js` finishes loading persisted state.
> 
> The existing `saveTimestamp` + 2s `setInterval` that writes an ISO `timestamp` to `chrome.storage.session` is **inlined** in both MV3 entry points (`service-worker.ts` for webpack dev, `app-init.js` for browserify prod/E2E) and **removed** from `background.js` / `initialize()`.
> 
> That closes the early-startup window where the worker could idle before the dynamic `background.js` import completed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a73c7117fe7b8a92d4a18085c71ecbd822de979. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->