### PR TITLE
chore: migrate `captureTestError` to `LegacyBackgroundApiService`

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -3876,7 +3876,10 @@ export default class MetamaskController extends EventEmitter {
         this.controllerMessenger,
         'LegacyBackgroundApiService:throwTestError',
       ),
-      captureTestError: this.captureTestError.bind(this),
+      captureTestError: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'LegacyBackgroundApiService:captureTestError',
+      ),
 
       // NameController
       updateProposedNames: this.nameController.updateProposedNames.bind(
@@ -8079,21 +8082,6 @@ export default class MetamaskController extends EventEmitter {
 
     releaseLock();
     return pendingNonce;
-  }
-
-  /**
-   * Capture an artificial error in a timeout handler for testing purposes.
-   *
-   * @param message - The error message.
-   * @deprecated This is only meant to facilitate manual and E2E tests testing. We should not
-   * use this for handling errors.
-   */
-  captureTestError(message) {
-    setTimeout(() => {
-      const error = new Error(message);
-      error.name = 'TestError';
-      captureException(error);
-    });
   }
 
   getTransactionUIMetricsFragmentId(transactionId) {

--- a/app/scripts/services/legacy-background-api-service-method-action-types.ts
+++ b/app/scripts/services/legacy-background-api-service-method-action-types.ts
@@ -462,6 +462,18 @@ export type LegacyBackgroundApiServiceAcceptPermissionsRequestAction = {
 };
 
 /**
+ * Capture an artificial error in a timeout handler for testing purposes.
+ *
+ * @param message - The error message.
+ * @deprecated This is only meant to facilitate manual and E2E tests testing. We should not
+ * use this for handling errors.
+ */
+export type LegacyBackgroundApiServiceCaptureTestErrorAction = {
+  type: `LegacyBackgroundApiService:captureTestError`;
+  handler: LegacyBackgroundApiService['captureTestError'];
+};
+
+/**
  * Throw an artificial error in a timeout handler for testing purposes.
  *
  * @param message - The error message.
@@ -527,5 +539,6 @@ export type LegacyBackgroundApiServiceMethodActions =
   | LegacyBackgroundApiServiceRejectAllPendingApprovalsAction
   | LegacyBackgroundApiServiceToggleExternalServicesAction
   | LegacyBackgroundApiServiceAcceptPermissionsRequestAction
+  | LegacyBackgroundApiServiceCaptureTestErrorAction
   | LegacyBackgroundApiServiceThrowTestErrorAction
   | LegacyBackgroundApiServiceIsRelaySupportedAction;

--- a/app/scripts/services/legacy-background-api-service.test.ts
+++ b/app/scripts/services/legacy-background-api-service.test.ts
@@ -33,6 +33,7 @@ import {
 } from '../../../shared/constants/app';
 import { MetaMetricsEventCategory } from '../../../shared/constants/metametrics';
 import { createSentryError } from '../../../shared/lib/error';
+import { captureException } from '../../../shared/lib/sentry';
 import { getIsShieldSubscriptionActive } from '../../../shared/lib/shield/subscription-utils';
 import { TraceName, TraceOperation } from '../../../shared/lib/trace';
 import { PASSKEY_AUTO_UNLOCK_SUPPRESSION_DURATION_MS } from '../../../shared/constants/passkey';
@@ -62,6 +63,7 @@ const mockGetIsShieldSubscriptionActive = jest.mocked(
 jest.mock('../lib/transaction/sentinel-api');
 jest.mock('../lib/transaction/transaction-relay');
 jest.mock('../lib/transaction/decode/util');
+jest.mock('../../../shared/lib/sentry');
 
 describe('LegacyBackgroundApiService', () => {
   it('initializes a new instance of LegacyBackgroundApiService', async () => {
@@ -3463,6 +3465,31 @@ describe('LegacyBackgroundApiService', () => {
         rootMessenger.call('LegacyBackgroundApiService:throwTestError', 'boom');
 
         expect(() => jest.runAllTimers()).toThrow(
+          expect.objectContaining({ name: 'TestError', message: 'boom' }),
+        );
+      });
+    });
+  });
+
+  describe('captureTestError', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('captures a TestError with the given message from a timeout handler', async () => {
+      await withService(({ rootMessenger }) => {
+        rootMessenger.call(
+          'LegacyBackgroundApiService:captureTestError',
+          'boom',
+        );
+
+        jest.runAllTimers();
+
+        expect(captureException).toHaveBeenCalledWith(
           expect.objectContaining({ name: 'TestError', message: 'boom' }),
         );
       });

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -145,6 +145,7 @@ import {
 import { getIsAssetsUnifiedStateIncludedInBuild } from '../../../shared/lib/environment';
 import { getIsShieldSubscriptionActive } from '../../../shared/lib/shield/subscription-utils';
 import { DecodedTransactionDataResponse } from '../../../shared/types/transaction-decode';
+import { captureException } from '../../../shared/lib/sentry';
 import {
   ASSETS_UNIFY_STATE_VERSION_1,
   AssetsUnifyStateFeatureFlag,
@@ -199,6 +200,7 @@ const serviceName = 'LegacyBackgroundApiService';
 const MESSENGER_EXPOSED_METHODS = [
   'acceptPermissionsRequest',
   'applyTransactionContainersExisting',
+  'captureTestError',
   'changePassword',
   'checkDelegationDisabled',
   'checkIsSeedlessPasswordOutdated',
@@ -1747,6 +1749,21 @@ export class LegacyBackgroundApiService {
         throw error;
       }
     }
+  }
+
+  /**
+   * Capture an artificial error in a timeout handler for testing purposes.
+   *
+   * @param message - The error message.
+   * @deprecated This is only meant to facilitate manual and E2E tests testing. We should not
+   * use this for handling errors.
+   */
+  captureTestError(message: string): void {
+    setTimeout(() => {
+      const error = new Error(message);
+      error.name = 'TestError';
+      captureException(error);
+    });
   }
 
   /**


### PR DESCRIPTION
## **Description**

Part of the ongoing effort to migrate `getApi()` methods from `MetamaskController` into `LegacyBackgroundApiService`, exposed via the controller messenger.

This PR migrates the test-only `captureTestError(message)` method. It is a self-contained helper (no controller/messenger dependencies) that captures an artificial `TestError` via Sentry from within a timeout handler, used only for manual and E2E testing.

The method was moved verbatim into `LegacyBackgroundApiService`, added to `MESSENGER_EXPOSED_METHODS`, and its `getApi()` entry now delegates to `LegacyBackgroundApiService:captureTestError` via the controller messenger. The old controller method was removed. The UI thunk (`submitRequestToBackground('captureTestError', [message])`) is unchanged as the argument shape is preserved.

This mirrors the already-merged `throwTestError` migration.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Progresses: https://consensyssoftware.atlassian.net/browse/WPC-1108

## **Manual testing steps**

1. Build and run the extension.
2. From the background/E2E test harness, invoke `captureTestError('some message')`.
3. Confirm a `TestError` with the given message is captured by Sentry, identical to the previous behavior.

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only Sentry helper with unchanged behavior and argument shape; no production error-handling or security paths affected.
> 
> **Overview**
> Moves the deprecated test-only **`captureTestError`** helper out of **`MetamaskController`** into **`LegacyBackgroundApiService`**, continuing the **`getApi()`** → messenger migration (same pattern as **`throwTestError`**).
> 
> **`getApi()`** now routes **`captureTestError`** through **`LegacyBackgroundApiService:captureTestError`** on the controller messenger instead of binding a controller method. The implementation (timeout + **`TestError`** + **`captureException`**) lives on the service, is registered in **`MESSENGER_EXPOSED_METHODS`**, and is typed in the legacy background API action union. Unit tests cover messenger invocation and Sentry capture with fake timers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ca72bc2309f865fed20728ed03349832a791b41. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->