### PR TITLE
fix: extra pending row from local state cp-13.40.0

### DIFF
--- a/ui/helpers/constants/transactions.js
+++ b/ui/helpers/constants/transactions.js
@@ -28,6 +28,7 @@ export const EXCLUDED_TRANSACTION_TYPES = new Set([
   TransactionType.incoming,
   TransactionType.gasPayment,
   TransactionType.relayDeposit,
+  TransactionType.musdRelayDeposit,
 ]);
 
 // EVM transaction types excluded from toast notifications

--- a/ui/selectors/activity.ts
+++ b/ui/selectors/activity.ts
@@ -47,6 +47,7 @@ import { selectCurrentAccountNonEvmTransactions } from './multichain-transaction
 import {
   selectOrderedTransactions,
   selectRequiredTransactionHashes,
+  selectRequiredTransactionIds,
 } from './transactionController';
 import type { TokenScanCacheResults } from './token-scan';
 import {
@@ -84,11 +85,13 @@ export const selectLocalTransactions = createSelector(
   selectOrderedTransactions,
   getSelectedInternalAccount,
   smartTransactionsListSelector,
+  selectRequiredTransactionIds,
   selectRequiredTransactionHashes,
   (
     transactions,
     selectedAccount,
     smartTransactions,
+    requiredTransactionIds,
     internalTxHashes,
   ): TransactionGroup[] => {
     if (!selectedAccount?.address) {
@@ -97,18 +100,30 @@ export const selectLocalTransactions = createSelector(
 
     const selectedAddress = selectedAccount.address.toLowerCase();
 
+    const isRequiredChildTx = (tx: { id?: string; hash?: string }) => {
+      if (tx.id && requiredTransactionIds.has(tx.id)) {
+        return true;
+      }
+      if (tx.hash && internalTxHashes.has(tx.hash.toLowerCase())) {
+        return true;
+      }
+      return false;
+    };
+
     const filtered = (transactions ?? []).filter((tx) => {
       if (!isFromSelectedAccount(tx, selectedAddress)) {
         return false;
       }
-
-      if (tx.hash && internalTxHashes.has(tx.hash.toLowerCase())) {
-        return false;
-      }
-      return true;
+      return !isRequiredChildTx(tx);
     });
 
-    const combined = [...filtered, ...smartTransactions];
+    const filteredSmartTransactions = smartTransactions.filter(
+      (tx) =>
+        !(tx.type && EXCLUDED_TRANSACTION_TYPES.has(tx.type)) &&
+        !isRequiredChildTx(tx),
+    );
+
+    const combined = [...filtered, ...filteredSmartTransactions];
 
     if (!combined.length) {
       return EMPTY_ARRAY as unknown as TransactionGroup[];

--- a/ui/selectors/activity.ts
+++ b/ui/selectors/activity.ts
@@ -91,7 +91,7 @@ export const selectLocalTransactions = createSelector(
     transactions,
     selectedAccount,
     smartTransactions,
-    requiredTransactionIds,
+    internalTxIds,
     internalTxHashes,
   ): TransactionGroup[] => {
     if (!selectedAccount?.address) {
@@ -100,8 +100,10 @@ export const selectLocalTransactions = createSelector(
 
     const selectedAddress = selectedAccount.address.toLowerCase();
 
-    const isRequiredChildTx = (tx: { id?: string; hash?: string }) => {
-      if (tx.id && requiredTransactionIds.has(tx.id)) {
+    const isInternalRequiredTransaction = (
+      tx: Pick<Partial<TransactionMeta>, 'id' | 'hash'>,
+    ) => {
+      if (tx.id && internalTxIds.has(tx.id)) {
         return true;
       }
       if (tx.hash && internalTxHashes.has(tx.hash.toLowerCase())) {
@@ -110,17 +112,16 @@ export const selectLocalTransactions = createSelector(
       return false;
     };
 
-    const filtered = (transactions ?? []).filter((tx) => {
-      if (!isFromSelectedAccount(tx, selectedAddress)) {
-        return false;
-      }
-      return !isRequiredChildTx(tx);
-    });
+    const filtered = (transactions ?? []).filter(
+      (tx) =>
+        isFromSelectedAccount(tx, selectedAddress) &&
+        !isInternalRequiredTransaction(tx),
+    );
 
     const filteredSmartTransactions = smartTransactions.filter(
       (tx) =>
         !(tx.type && EXCLUDED_TRANSACTION_TYPES.has(tx.type)) &&
-        !isRequiredChildTx(tx),
+        !isInternalRequiredTransaction(tx),
     );
 
     const combined = [...filtered, ...filteredSmartTransactions];

--- a/ui/selectors/transactions.js
+++ b/ui/selectors/transactions.js
@@ -158,7 +158,21 @@ export const unapprovedEncryptionPublicKeyMsgsSelector = (state) =>
 export const unapprovedTypedMessagesSelector = (state) =>
   state.metamask.unapprovedTypedMessages;
 
-// Memoized to prevent new array creation on every render
+/**
+ * Smart transaction
+ *
+ * @typedef {object} SmartTransaction
+ * @property {string} [id] - Transaction id
+ * @property {string} [hash] - Transaction hash
+ * @property {import('@metamask/transaction-controller').TransactionType} [type] - Transaction type
+ * @property {boolean} [isSmartTransaction] - Whether this entry came from smart transactions state
+ */
+
+/**
+ * Memoized to prevent new array creation on every render.
+ *
+ * @type {(state: object) => SmartTransaction[]}
+ */
 export const smartTransactionsListSelector = createSelector(
   getSelectedInternalAccount,
   (state) => state.metamask.smartTransactionsState?.smartTransactions,


### PR DESCRIPTION
## **Description**

During custom mUSD convert, pending child transactions are created alongside the parent “Converting to mUSD” row.

This PR hides these internal transactions, so only the top-level convert row shows while the flow is pending.

## **Changelog**

CHANGELOG entry: Fixed extra pending row during mUSD conversion flow

## **Related issues**

Fixes:
https://consensyssoftware.atlassian.net/browse/CEUX-1170

## **Manual testing steps**

1. Open the extension Activity list (redesign).
2. Start a custom convert to mUSD flow and leave it pending/signing.
3. Confirm only one row appears: “Converting to mUSD” (no “Interaction in progress” / “With USDC” sibling).
4. Confirm the convert details Summary still shows the internal send/receive steps as before.

## **Screenshots/Recordings**

### **Before**
<img width="259" height="202" alt="image" src="https://github.com/user-attachments/assets/97616dd9-0916-48fb-b8a9-f94bb8ab5999" />


### **After**

<img width="222" height="147" alt="image" src="https://github.com/user-attachments/assets/1f24906b-7d5d-4e80-8a50-19ccda333475" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Activity-list filtering only; convert details still use required-transaction data elsewhere. Low risk of hiding unrelated txs unless they are linked via `requiredTransactionIds`.
> 
> **Overview**
> Fixes duplicate pending rows during **mUSD convert** by treating required child transactions as internal-only in the Activity list.
> 
> **`selectLocalTransactions`** now drops entries whose **id** or **hash** appears in the parent’s `requiredTransactionIds` set (not just hash), so unsigned/pending relay steps no longer show as separate rows while the parent “Converting to mUSD” row is still pending. The same internal-required filter is applied to **smart transactions**, including type exclusions via `EXCLUDED_TRANSACTION_TYPES`.
> 
> **`musdRelayDeposit`** is added to `EXCLUDED_TRANSACTION_TYPES` so relay deposit steps stay out of unified lists. Minor JSDoc was added for `smartTransactionsListSelector`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fd16c18dfff78bd449618a22840580bc3ac5ff2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->