### PR TITLE
feat: Orders home tab for ramps sync QA (temporary)

### DIFF
--- a/shared/constants/app-state.ts
+++ b/shared/constants/app-state.ts
@@ -9,6 +9,7 @@ export enum AccountOverviewTabKey {
   Activity = 'activity',
   DeFi = 'defi',
   Perps = 'perps',
+  Orders = 'orders',
 }
 
 export type AccountOverviewTab = `${AccountOverviewTabKey}`;

--- a/ui/components/multichain/account-overview/account-overview-tabs.tsx
+++ b/ui/components/multichain/account-overview/account-overview-tabs.tsx
@@ -52,6 +52,7 @@ import {
 } from '../../../../shared/lib/ab-testing/configs/perps-tab-badge';
 import { useTokenBalances } from '../../../hooks/useTokenBalances';
 import { ActivityList as ActivityListV3 } from '../../../pages/activity/activity-list';
+import { RampsOrdersTab } from '../../../pages/activity/ramps-orders-tab';
 import { ActivityList as ActivityListV2 } from '../activity-v2/activity-list';
 import { usePrefetchTransactions } from '../activity-v2/useTransactionsQuery';
 import { getIsActivityListRedesignEnabled } from '../../../selectors/activity/feature-flags';
@@ -136,6 +137,7 @@ export const AccountOverviewTabs = ({
     ...(showDefi ? [AccountOverviewTabKey.DeFi] : []),
     ...(showNfts ? [AccountOverviewTabKey.Nfts] : []),
     ...(showActivity ? [AccountOverviewTabKey.Activity] : []),
+    AccountOverviewTabKey.Orders,
   ];
   // Perps is the effective active tab when it is explicitly selected, or when
   // the active tab isn't rendered and Tabs clamps to the first rendered tab.
@@ -351,6 +353,16 @@ export const AccountOverviewTabs = ({
             </ErrorBoundary>
           </Tab>
         )}
+
+        <Tab
+          name="Orders"
+          tabKey={AccountOverviewTabKey.Orders}
+          data-testid="account-overview__orders-tab"
+        >
+          <ErrorBoundary key="orders">
+            <RampsOrdersTab />
+          </ErrorBoundary>
+        </Tab>
       </Tabs>
     </>
   );

--- a/ui/pages/activity/__snapshots__/ramps-orders-tab.test.tsx.snap
+++ b/ui/pages/activity/__snapshots__/ramps-orders-tab.test.tsx.snap
@@ -1,0 +1,462 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`RampsOrdersTab matches snapshot when empty 1`] = `
+<div>
+  <div
+    class="flex flex-col gap-4 px-4 pb-4"
+    data-testid="ramps-orders-tab"
+  >
+    <div
+      class="rounded-xl border border-border-muted bg-background-muted p-4"
+    >
+      <p
+        class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-default font-medium"
+      >
+        Ramps order sync QA
+      </p>
+      <p
+        class="text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default mt-1 text-alternative"
+      >
+        All orders: 
+        0
+         · Selected account:
+         
+        0
+      </p>
+      <div
+        class="mt-3 flex flex-wrap items-center gap-3"
+      >
+        <button
+          class="inline-flex items-center justify-center rounded-xl px-4 font-medium overflow-hidden relative h-12 transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] bg-icon-default text-primary-inverse hover:bg-icon-default-hover active:bg-icon-default-pressed focus-visible:ring-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default"
+          data-testid="ramps-orders-sync-button"
+          role="button"
+          type="button"
+        >
+          <span
+            class="text-inherit text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
+          >
+            Sync from User Storage
+          </span>
+        </button>
+      </div>
+    </div>
+    <div
+      class="rounded-xl border border-dashed border-border-muted p-6 text-center"
+    >
+      <p
+        class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular font-default"
+      >
+        No ramps orders in controller state.
+      </p>
+      <p
+        class="text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default mt-1 text-alternative"
+      >
+        Use sync above after completing a buy flow on another client.
+      </p>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`RampsOrdersTab matches snapshot with orders 1`] = `
+<div>
+  <div
+    class="flex flex-col gap-4 px-4 pb-4"
+    data-testid="ramps-orders-tab"
+  >
+    <div
+      class="rounded-xl border border-border-muted bg-background-muted p-4"
+    >
+      <p
+        class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-default font-medium"
+      >
+        Ramps order sync QA
+      </p>
+      <p
+        class="text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default mt-1 text-alternative"
+      >
+        All orders: 
+        1
+         · Selected account:
+         
+        0
+      </p>
+      <div
+        class="mt-3 flex flex-wrap items-center gap-3"
+      >
+        <button
+          class="inline-flex items-center justify-center rounded-xl px-4 font-medium overflow-hidden relative h-12 transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] bg-icon-default text-primary-inverse hover:bg-icon-default-hover active:bg-icon-default-pressed focus-visible:ring-0 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default"
+          data-testid="ramps-orders-sync-button"
+          role="button"
+          type="button"
+        >
+          <span
+            class="text-inherit text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-medium font-default"
+          >
+            Sync from User Storage
+          </span>
+        </button>
+      </div>
+    </div>
+    <div
+      class="flex flex-col gap-3"
+    >
+      <button
+        class="w-full rounded-xl border border-border-muted bg-background-default p-4 text-left transition-colors hover:bg-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default"
+        data-testid="ramps-order-card-provider-order-1"
+        type="button"
+      >
+        <div
+          class="flex items-start justify-between gap-3"
+        >
+          <div
+            class="min-w-0 flex-1"
+          >
+            <p
+              class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-default truncate font-medium"
+            >
+              Transak
+            </p>
+            <p
+              class="text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default mt-1 truncate text-alternative"
+            >
+              provider-order-1
+            </p>
+          </div>
+          <span
+            class="shrink-0 rounded-full px-2 py-1 text-xs font-medium uppercase bg-success-muted text-success-default"
+          >
+            COMPLETED
+          </span>
+        </div>
+        <div
+          class="mt-3 grid grid-cols-2 gap-3"
+        >
+          <div>
+            <p
+              class="text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default text-alternative"
+            >
+              Fiat
+            </p>
+            <p
+              class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-default font-medium"
+            >
+              USD 100
+            </p>
+          </div>
+          <div>
+            <p
+              class="text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default text-alternative"
+            >
+              Crypto
+            </p>
+            <p
+              class="text-default text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-default font-medium"
+            >
+              0.05 ETH
+            </p>
+          </div>
+        </div>
+        <div
+          class="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-alternative"
+        >
+          <p
+            class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default"
+          >
+            1/1/2024, 12:00:00 AM
+          </p>
+          <p
+            class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default"
+          >
+            0x1234…5678
+          </p>
+        </div>
+      </button>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`RampsOrdersTab opens order details when a card is clicked 1`] = `
+<div
+  class="mm-box mm-modal-content mm-box--padding-top-4 mm-box--sm:padding-top-8 mm-box--md:padding-top-12 mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--sm:padding-bottom-8 mm-box--md:padding-bottom-12 mm-box--padding-left-4 mm-box--display-flex mm-box--justify-content-center mm-box--align-items-flex-start mm-box--width-screen mm-box--height-screen"
+  data-testid="ramps-order-detail-modal"
+>
+  <section
+    aria-modal="true"
+    class="mm-box mm-modal-content__dialog mm-modal-content__dialog--size-sm mm-box--padding-top-4 mm-box--padding-bottom-4 mm-box--display-flex mm-box--flex-direction-column mm-box--width-full mm-box--background-color-background-default mm-box--rounded-lg"
+    role="dialog"
+  >
+    <header
+      class="mm-box mm-header-base mm-modal-header mm-box--padding-right-4 mm-box--padding-bottom-4 mm-box--padding-left-4 mm-box--display-flex mm-box--justify-content-space-between"
+    >
+      <div
+        class="mm-box mm-box--width-full"
+      >
+        <h4
+          class="mm-box mm-text mm-text--heading-sm mm-text--text-align-center mm-box--color-text-default"
+        >
+          Order details
+        </h4>
+      </div>
+      <div
+        class="mm-box mm-box--display-flex mm-box--justify-content-flex-end"
+        style="min-width: 0px;"
+      >
+        <button
+          aria-label="[close]"
+          class="mm-box mm-button-icon mm-button-icon--size-md mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
+        >
+          <span
+            class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-inherit"
+            style="mask-image: url('./images/icons/close.svg');"
+          />
+        </button>
+      </div>
+    </header>
+    <div
+      class="px-4 pb-4"
+    >
+      <div
+        class="grid grid-cols-[120px_minmax(0,1fr)] gap-3 border-b border-border-muted py-2 last:border-b-0"
+      >
+        <p
+          class="text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default text-alternative"
+        >
+          Order ID
+        </p>
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default break-all"
+        >
+          provider-order-1
+        </p>
+      </div>
+      <div
+        class="grid grid-cols-[120px_minmax(0,1fr)] gap-3 border-b border-border-muted py-2 last:border-b-0"
+      >
+        <p
+          class="text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default text-alternative"
+        >
+          Provider
+        </p>
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default break-all"
+        >
+          Transak
+        </p>
+      </div>
+      <div
+        class="grid grid-cols-[120px_minmax(0,1fr)] gap-3 border-b border-border-muted py-2 last:border-b-0"
+      >
+        <p
+          class="text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default text-alternative"
+        >
+          Status
+        </p>
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default break-all"
+        >
+          COMPLETED
+        </p>
+      </div>
+      <div
+        class="grid grid-cols-[120px_minmax(0,1fr)] gap-3 border-b border-border-muted py-2 last:border-b-0"
+      >
+        <p
+          class="text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default text-alternative"
+        >
+          Type
+        </p>
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default break-all"
+        >
+          BUY
+        </p>
+      </div>
+      <div
+        class="grid grid-cols-[120px_minmax(0,1fr)] gap-3 border-b border-border-muted py-2 last:border-b-0"
+      >
+        <p
+          class="text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default text-alternative"
+        >
+          Fiat
+        </p>
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default break-all"
+        >
+          USD 100
+        </p>
+      </div>
+      <div
+        class="grid grid-cols-[120px_minmax(0,1fr)] gap-3 border-b border-border-muted py-2 last:border-b-0"
+      >
+        <p
+          class="text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default text-alternative"
+        >
+          Crypto
+        </p>
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default break-all"
+        >
+          0.05 ETH
+        </p>
+      </div>
+      <div
+        class="grid grid-cols-[120px_minmax(0,1fr)] gap-3 border-b border-border-muted py-2 last:border-b-0"
+      >
+        <p
+          class="text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default text-alternative"
+        >
+          Wallet
+        </p>
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default break-all"
+        >
+          0x1234567890abcdef1234567890abcdef12345678
+        </p>
+      </div>
+      <div
+        class="grid grid-cols-[120px_minmax(0,1fr)] gap-3 border-b border-border-muted py-2 last:border-b-0"
+      >
+        <p
+          class="text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default text-alternative"
+        >
+          Network
+        </p>
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default break-all"
+        >
+          Ethereum
+        </p>
+      </div>
+      <div
+        class="grid grid-cols-[120px_minmax(0,1fr)] gap-3 border-b border-border-muted py-2 last:border-b-0"
+      >
+        <p
+          class="text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default text-alternative"
+        >
+          Payment
+        </p>
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default break-all"
+        >
+          Debit card
+        </p>
+      </div>
+      <div
+        class="grid grid-cols-[120px_minmax(0,1fr)] gap-3 border-b border-border-muted py-2 last:border-b-0"
+      >
+        <p
+          class="text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default text-alternative"
+        >
+          Created
+        </p>
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default break-all"
+        >
+          1/1/2024, 12:00:00 AM
+        </p>
+      </div>
+      <div
+        class="grid grid-cols-[120px_minmax(0,1fr)] gap-3 border-b border-border-muted py-2 last:border-b-0"
+      >
+        <p
+          class="text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default text-alternative"
+        >
+          Tx hash
+        </p>
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default break-all"
+        >
+          —
+        </p>
+      </div>
+      <div
+        class="grid grid-cols-[120px_minmax(0,1fr)] gap-3 border-b border-border-muted py-2 last:border-b-0"
+      >
+        <p
+          class="text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default text-alternative"
+        >
+          Region
+        </p>
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default break-all"
+        >
+          —
+        </p>
+      </div>
+      <div
+        class="grid grid-cols-[120px_minmax(0,1fr)] gap-3 border-b border-border-muted py-2 last:border-b-0"
+      >
+        <p
+          class="text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default text-alternative"
+        >
+          Provider link
+        </p>
+        <p
+          class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default break-all"
+        >
+          <a
+            class="text-primary-default underline"
+            href="https://example.com/order/1"
+            rel="noopener noreferrer"
+            target="_blank"
+          >
+            Open
+          </a>
+        </p>
+      </div>
+      <div
+        class="mt-4"
+      >
+        <p
+          class="text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-regular font-default mb-2 text-alternative"
+        >
+          Raw payload
+        </p>
+        <pre
+          class="max-h-64 overflow-auto rounded-lg bg-background-muted p-3 text-xs whitespace-pre-wrap"
+        >
+          {
+  "id": "order-1",
+  "providerOrderId": "provider-order-1",
+  "walletAddress": "0x1234567890abcdef1234567890abcdef12345678",
+  "status": "COMPLETED",
+  "createdAt": 1704067200000,
+  "fiatAmount": 100,
+  "cryptoAmount": "0.05",
+  "fiatCurrency": {
+    "symbol": "USD"
+  },
+  "cryptoCurrency": {
+    "symbol": "ETH"
+  },
+  "provider": {
+    "id": "/providers/transak",
+    "name": "Transak"
+  },
+  "network": {
+    "name": "Ethereum",
+    "chainId": "eip155:1"
+  },
+  "paymentMethod": {
+    "id": "card",
+    "name": "Debit card"
+  },
+  "orderType": "BUY",
+  "providerOrderLink": "https://example.com/order/1",
+  "txHash": "",
+  "isOnlyLink": false,
+  "success": true,
+  "totalFeesFiat": 2,
+  "canBeUpdated": false,
+  "idHasExpired": false,
+  "excludeFromPurchases": false,
+  "timeDescriptionPending": ""
+}
+        </pre>
+      </div>
+    </div>
+  </section>
+</div>
+`;

--- a/ui/pages/activity/ramps-order-card.tsx
+++ b/ui/pages/activity/ramps-order-card.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import {
+  type RampsOrder,
+  RampsOrderStatus,
+  getInternalOrderCode,
+} from '@metamask/ramps-controller';
+import { Text, TextVariant } from '@metamask/design-system-react';
+
+const STATUS_LABEL_CLASS: Record<string, string> = {
+  [RampsOrderStatus.Completed]: 'bg-success-muted text-success-default',
+  [RampsOrderStatus.Pending]: 'bg-warning-muted text-warning-default',
+  [RampsOrderStatus.Created]: 'bg-info-muted text-info-default',
+  [RampsOrderStatus.Precreated]: 'bg-info-muted text-info-default',
+  [RampsOrderStatus.Failed]: 'bg-error-muted text-error-default',
+  [RampsOrderStatus.Cancelled]: 'bg-error-muted text-error-default',
+  [RampsOrderStatus.IdExpired]: 'bg-error-muted text-error-default',
+};
+
+export function getOrderKey(order: RampsOrder): string {
+  return getInternalOrderCode(order);
+}
+
+function truncateAddress(address: string): string {
+  if (address.length <= 12) {
+    return address;
+  }
+
+  return `${address.slice(0, 6)}…${address.slice(-4)}`;
+}
+
+export function formatCreatedAt(createdAt?: number): string {
+  if (!createdAt) {
+    return '—';
+  }
+
+  return new Date(createdAt).toLocaleString();
+}
+
+export function formatFiatAmount(order: RampsOrder): string {
+  const symbol = order.fiatCurrency?.symbol ?? order.fiatCurrency?.denomSymbol;
+  const amount = order.fiatAmount ?? order.fiatAmountInUsd;
+
+  if (amount === undefined || amount === null) {
+    return '—';
+  }
+
+  return symbol ? `${symbol} ${amount}` : String(amount);
+}
+
+export function formatCryptoAmount(order: RampsOrder): string {
+  const symbol = order.cryptoCurrency?.symbol;
+  const amount = order.cryptoAmount;
+
+  if (amount === undefined || amount === null || amount === '') {
+    return '—';
+  }
+
+  return symbol ? `${amount} ${symbol}` : String(amount);
+}
+
+function getStatusClassName(status: RampsOrderStatus | string): string {
+  return STATUS_LABEL_CLASS[status] ?? 'bg-background-muted text-alternative';
+}
+
+type RampsOrderCardProps = {
+  order: RampsOrder;
+  onSelect: (order: RampsOrder) => void;
+};
+
+export const RampsOrderCard = ({ order, onSelect }: RampsOrderCardProps) => {
+  const orderKey = getOrderKey(order);
+  const providerName =
+    order.provider?.name ?? order.provider?.id ?? 'Unknown provider';
+
+  return (
+    <button
+      type="button"
+      className="w-full rounded-xl border border-border-muted bg-background-default p-4 text-left transition-colors hover:bg-hover focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary-default"
+      data-testid={`ramps-order-card-${orderKey}`}
+      onClick={() => onSelect(order)}
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <Text variant={TextVariant.BodyMd} className="truncate font-medium">
+            {providerName}
+          </Text>
+          <Text
+            variant={TextVariant.BodySm}
+            className="mt-1 truncate text-alternative"
+          >
+            {orderKey}
+          </Text>
+        </div>
+        <span
+          className={`shrink-0 rounded-full px-2 py-1 text-xs font-medium uppercase ${getStatusClassName(order.status)}`}
+        >
+          {order.status}
+        </span>
+      </div>
+
+      <div className="mt-3 grid grid-cols-2 gap-3">
+        <div>
+          <Text variant={TextVariant.BodySm} className="text-alternative">
+            Fiat
+          </Text>
+          <Text variant={TextVariant.BodyMd} className="font-medium">
+            {formatFiatAmount(order)}
+          </Text>
+        </div>
+        <div>
+          <Text variant={TextVariant.BodySm} className="text-alternative">
+            Crypto
+          </Text>
+          <Text variant={TextVariant.BodyMd} className="font-medium">
+            {formatCryptoAmount(order)}
+          </Text>
+        </div>
+      </div>
+
+      <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 text-alternative">
+        <Text variant={TextVariant.BodySm}>
+          {formatCreatedAt(order.createdAt)}
+        </Text>
+        <Text variant={TextVariant.BodySm}>
+          {truncateAddress(order.walletAddress)}
+        </Text>
+      </div>
+    </button>
+  );
+};

--- a/ui/pages/activity/ramps-order-detail-modal.tsx
+++ b/ui/pages/activity/ramps-order-detail-modal.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import type { RampsOrder } from '@metamask/ramps-controller';
+import { Text, TextVariant } from '@metamask/design-system-react';
+import {
+  Modal,
+  ModalContent,
+  ModalHeader,
+  ModalOverlay,
+} from '../../components/component-library';
+import {
+  formatCreatedAt,
+  formatCryptoAmount,
+  formatFiatAmount,
+  getOrderKey,
+} from './ramps-order-card';
+
+type DetailRowProps = {
+  label: string;
+  value: React.ReactNode;
+};
+
+const DetailRow = ({ label, value }: DetailRowProps) => (
+  <div className="grid grid-cols-[120px_minmax(0,1fr)] gap-3 border-b border-border-muted py-2 last:border-b-0">
+    <Text variant={TextVariant.BodySm} className="text-alternative">
+      {label}
+    </Text>
+    <Text variant={TextVariant.BodySm} className="break-all">
+      {value}
+    </Text>
+  </div>
+);
+
+type RampsOrderDetailModalProps = {
+  order: RampsOrder;
+  onClose: () => void;
+};
+
+export const RampsOrderDetailModal = ({
+  order,
+  onClose,
+}: RampsOrderDetailModalProps) => {
+  const orderKey = getOrderKey(order);
+
+  return (
+    <Modal isOpen onClose={onClose}>
+      <ModalOverlay />
+      <ModalContent data-testid="ramps-order-detail-modal">
+        <ModalHeader onClose={onClose}>Order details</ModalHeader>
+        <div className="px-4 pb-4">
+          <DetailRow label="Order ID" value={orderKey} />
+          <DetailRow
+            label="Provider"
+            value={order.provider?.name ?? order.provider?.id ?? '—'}
+          />
+          <DetailRow label="Status" value={order.status} />
+          <DetailRow label="Type" value={order.orderType ?? '—'} />
+          <DetailRow label="Fiat" value={formatFiatAmount(order)} />
+          <DetailRow label="Crypto" value={formatCryptoAmount(order)} />
+          <DetailRow label="Wallet" value={order.walletAddress} />
+          <DetailRow
+            label="Network"
+            value={order.network?.name ?? order.network?.chainId ?? '—'}
+          />
+          <DetailRow
+            label="Payment"
+            value={order.paymentMethod?.name ?? order.paymentMethod?.id ?? '—'}
+          />
+          <DetailRow label="Created" value={formatCreatedAt(order.createdAt)} />
+          <DetailRow label="Tx hash" value={order.txHash || '—'} />
+          <DetailRow label="Region" value={order.region ?? '—'} />
+          <DetailRow
+            label="Provider link"
+            value={
+              order.providerOrderLink ? (
+                <a
+                  href={order.providerOrderLink}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary-default underline"
+                >
+                  Open
+                </a>
+              ) : (
+                '—'
+              )
+            }
+          />
+          <div className="mt-4">
+            <Text
+              variant={TextVariant.BodySm}
+              className="mb-2 text-alternative"
+            >
+              Raw payload
+            </Text>
+            <pre className="max-h-64 overflow-auto rounded-lg bg-background-muted p-3 text-xs whitespace-pre-wrap">
+              {JSON.stringify(order, null, 2)}
+            </pre>
+          </div>
+        </div>
+      </ModalContent>
+    </Modal>
+  );
+};

--- a/ui/pages/activity/ramps-orders-tab.test.tsx
+++ b/ui/pages/activity/ramps-orders-tab.test.tsx
@@ -1,0 +1,92 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { RampsOrderStatus } from '@metamask/ramps-controller';
+import { syncRampsOrdersWithUserStorage } from '../../store/controller-actions/ramps-controller';
+import {
+  createRampsMockStore,
+  createRampsTestWrapper,
+} from '../../hooks/ramps/test-utils';
+import { RampsOrdersTab } from './ramps-orders-tab';
+
+jest.mock('../../store/controller-actions/ramps-controller', () => ({
+  syncRampsOrdersWithUserStorage: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockOrder = {
+  id: 'order-1',
+  providerOrderId: 'provider-order-1',
+  walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+  status: RampsOrderStatus.Completed,
+  createdAt: 1_704_067_200_000,
+  fiatAmount: 100,
+  cryptoAmount: '0.05',
+  fiatCurrency: { symbol: 'USD' },
+  cryptoCurrency: { symbol: 'ETH' },
+  provider: { id: '/providers/transak', name: 'Transak' },
+  network: { name: 'Ethereum', chainId: 'eip155:1' },
+  paymentMethod: { id: 'card', name: 'Debit card' },
+  orderType: 'BUY',
+  providerOrderLink: 'https://example.com/order/1',
+  txHash: '',
+  isOnlyLink: false,
+  success: true,
+  totalFeesFiat: 2,
+  canBeUpdated: false,
+  idHasExpired: false,
+  excludeFromPurchases: false,
+  timeDescriptionPending: '',
+} as const;
+
+describe('RampsOrdersTab', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('matches snapshot when empty', () => {
+    const { container } = render(<RampsOrdersTab />, {
+      wrapper: createRampsTestWrapper(),
+    });
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('matches snapshot with orders', () => {
+    const store = createRampsMockStore({
+      orders: [mockOrder],
+    });
+
+    const { container } = render(<RampsOrdersTab />, {
+      wrapper: createRampsTestWrapper(store),
+    });
+
+    expect(container).toMatchSnapshot();
+  });
+
+  it('opens order details when a card is clicked', async () => {
+    const user = userEvent.setup();
+    const store = createRampsMockStore({
+      orders: [mockOrder],
+    });
+
+    render(<RampsOrdersTab />, {
+      wrapper: createRampsTestWrapper(store),
+    });
+
+    await user.click(screen.getByTestId('ramps-order-card-provider-order-1'));
+
+    expect(screen.getByTestId('ramps-order-detail-modal')).toMatchSnapshot();
+  });
+
+  it('triggers user storage sync', async () => {
+    const user = userEvent.setup();
+
+    render(<RampsOrdersTab />, {
+      wrapper: createRampsTestWrapper(),
+    });
+
+    await user.click(screen.getByTestId('ramps-orders-sync-button'));
+
+    expect(syncRampsOrdersWithUserStorage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/pages/activity/ramps-orders-tab.tsx
+++ b/ui/pages/activity/ramps-orders-tab.tsx
@@ -1,16 +1,32 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
+import type { RampsOrder } from '@metamask/ramps-controller';
+import { Button, Text, TextVariant } from '@metamask/design-system-react';
 import { useRampsOrders } from '../../hooks/ramps/useRampsOrders';
 import { useAppSelector } from '../../store/store';
 import { selectRampsOrders } from '../../selectors/rampsController';
 import { syncRampsOrdersWithUserStorage } from '../../store/controller-actions/ramps-controller';
+import { getOrderKey, RampsOrderCard } from './ramps-order-card';
+import { RampsOrderDetailModal } from './ramps-order-detail-modal';
 
 export const RampsOrdersTab = () => {
   const { orders: accountOrders } = useRampsOrders();
   const allOrders = useAppSelector(selectRampsOrders);
   const [syncStatus, setSyncStatus] = useState<string | null>(null);
+  const [selectedOrder, setSelectedOrder] = useState<RampsOrder | null>(null);
+  const [isSyncing, setIsSyncing] = useState(false);
+
+  const sortedOrders = useMemo(
+    () =>
+      [...allOrders].sort(
+        (left, right) => (right.createdAt ?? 0) - (left.createdAt ?? 0),
+      ),
+    [allOrders],
+  );
 
   const handleSync = async () => {
+    setIsSyncing(true);
     setSyncStatus('Syncing...');
+
     try {
       await syncRampsOrdersWithUserStorage();
       setSyncStatus('Sync complete');
@@ -18,42 +34,68 @@ export const RampsOrdersTab = () => {
       setSyncStatus(
         `Sync failed: ${error instanceof Error ? error.message : String(error)}`,
       );
+    } finally {
+      setIsSyncing(false);
     }
   };
 
   return (
-    <div className="px-4 pb-4 flex flex-col gap-3" data-testid="ramps-orders-tab">
-      <p>
-        All orders: {allOrders.length} · Selected account: {accountOrders.length}
-      </p>
-      <button type="button" onClick={handleSync}>
-        Sync from User Storage
-      </button>
-      {syncStatus ? <p>{syncStatus}</p> : null}
-      {allOrders.length === 0 ? (
-        <p>No ramps orders in controller state.</p>
-      ) : (
-        allOrders.map((order) => (
-          <div
-            key={order.id ?? order.providerOrderId}
-            className="mb-4 border border-default rounded p-3"
+    <div
+      className="flex flex-col gap-4 px-4 pb-4"
+      data-testid="ramps-orders-tab"
+    >
+      <div className="rounded-xl border border-border-muted bg-background-muted p-4">
+        <Text variant={TextVariant.BodyMd} className="font-medium">
+          Ramps order sync QA
+        </Text>
+        <Text variant={TextVariant.BodySm} className="mt-1 text-alternative">
+          All orders: {allOrders.length} · Selected account:{' '}
+          {accountOrders.length}
+        </Text>
+        <div className="mt-3 flex flex-wrap items-center gap-3">
+          <Button
+            type="button"
+            data-testid="ramps-orders-sync-button"
+            onClick={handleSync}
+            disabled={isSyncing}
           >
-            <p>
-              <strong>{order.id ?? order.providerOrderId}</strong> ·{' '}
-              {order.status} · {order.provider?.id ?? 'unknown provider'}
-            </p>
-            <p className="text-sm opacity-80">
-              wallet: {order.walletAddress} · created:{' '}
-              {order.createdAt
-                ? new Date(order.createdAt).toLocaleString()
-                : '—'}
-            </p>
-            <pre className="text-xs mt-2 overflow-auto whitespace-pre-wrap">
-              {JSON.stringify(order, null, 2)}
-            </pre>
-          </div>
-        ))
+            {isSyncing ? 'Syncing…' : 'Sync from User Storage'}
+          </Button>
+          {syncStatus ? (
+            <Text variant={TextVariant.BodySm} className="text-alternative">
+              {syncStatus}
+            </Text>
+          ) : null}
+        </div>
+      </div>
+
+      {sortedOrders.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-border-muted p-6 text-center">
+          <Text variant={TextVariant.BodyMd}>
+            No ramps orders in controller state.
+          </Text>
+          <Text variant={TextVariant.BodySm} className="mt-1 text-alternative">
+            Use sync above after completing a buy flow on another client.
+          </Text>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {sortedOrders.map((order) => (
+            <RampsOrderCard
+              key={getOrderKey(order)}
+              order={order}
+              onSelect={setSelectedOrder}
+            />
+          ))}
+        </div>
       )}
+
+      {selectedOrder ? (
+        <RampsOrderDetailModal
+          order={selectedOrder}
+          onClose={() => setSelectedOrder(null)}
+        />
+      ) : null}
     </div>
   );
 };

--- a/ui/pages/activity/ramps-orders-tab.tsx
+++ b/ui/pages/activity/ramps-orders-tab.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+import { useRampsOrders } from '../../hooks/ramps/useRampsOrders';
+import { useAppSelector } from '../../store/store';
+import { selectRampsOrders } from '../../selectors/rampsController';
+import { syncRampsOrdersWithUserStorage } from '../../store/controller-actions/ramps-controller';
+
+export const RampsOrdersTab = () => {
+  const { orders: accountOrders } = useRampsOrders();
+  const allOrders = useAppSelector(selectRampsOrders);
+  const [syncStatus, setSyncStatus] = useState<string | null>(null);
+
+  const handleSync = async () => {
+    setSyncStatus('Syncing...');
+    try {
+      await syncRampsOrdersWithUserStorage();
+      setSyncStatus('Sync complete');
+    } catch (error) {
+      setSyncStatus(
+        `Sync failed: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  };
+
+  return (
+    <div className="px-4 pb-4 flex flex-col gap-3" data-testid="ramps-orders-tab">
+      <p>
+        All orders: {allOrders.length} · Selected account: {accountOrders.length}
+      </p>
+      <button type="button" onClick={handleSync}>
+        Sync from User Storage
+      </button>
+      {syncStatus ? <p>{syncStatus}</p> : null}
+      {allOrders.length === 0 ? (
+        <p>No ramps orders in controller state.</p>
+      ) : (
+        allOrders.map((order) => (
+          <div
+            key={order.id ?? order.providerOrderId}
+            className="mb-4 border border-default rounded p-3"
+          >
+            <p>
+              <strong>{order.id ?? order.providerOrderId}</strong> ·{' '}
+              {order.status} · {order.provider?.id ?? 'unknown provider'}
+            </p>
+            <p className="text-sm opacity-80">
+              wallet: {order.walletAddress} · created:{' '}
+              {order.createdAt
+                ? new Date(order.createdAt).toLocaleString()
+                : '—'}
+            </p>
+            <pre className="text-xs mt-2 overflow-auto whitespace-pre-wrap">
+              {JSON.stringify(order, null, 2)}
+            </pre>
+          </div>
+        ))
+      )}
+    </div>
+  );
+};
+
+export default RampsOrdersTab;


### PR DESCRIPTION
## Summary
Temporary QA surface for cross-client ramps order sync testing. Adds an **Orders** tab on the account overview (alongside Tokens, Perps, DeFi, NFTs, Activity) that:

- Renders `RampsController.orders` via `useRampsOrders`
- Provides a manual **Sync orders** button calling `syncRampsOrdersWithUserStorage`

## Depends on
- [MetaMask/core#9474](https://github.com/MetaMask/core/pull/9474)
- [MetaMask/metamask-extension#44367](https://github.com/MetaMask/metamask-extension/pull/44367) (sync plumbing)
- [MetaMask/metamask-mobile#33148](https://github.com/MetaMask/metamask-mobile/pull/33148) (order writer)

## Notes
- **Throwaway / QA only** — not intended for production merge as-is.
- Branch is based on `feat/ramps-order-syncing` sync work; rebase onto main after #44367 lands if continuing to use it.

## Test plan
- [x] Manual: mobile V2 buy → unlock extension → Orders tab shows synced order
- [x] Manual: Sync orders button triggers pull

Made with [Cursor](https://cursor.com)