### PR TITLE
chore(preferences): remove enableMV3TimestampSave debug preference

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -848,12 +848,10 @@ async function initialize(backup) {
   if (isManifestV3) {
     // Save the timestamp immediately and then every `SAVE_TIMESTAMP_INTERVAL`
     // miliseconds. This keeps the service worker alive.
-    if (initState.PreferencesController?.enableMV3TimestampSave !== false) {
-      const SAVE_TIMESTAMP_INTERVAL_MS = 2 * 1000;
+    const SAVE_TIMESTAMP_INTERVAL_MS = 2 * 1000;
 
-      saveTimestamp();
-      setInterval(saveTimestamp, SAVE_TIMESTAMP_INTERVAL_MS);
-    }
+    saveTimestamp();
+    setInterval(saveTimestamp, SAVE_TIMESTAMP_INTERVAL_MS);
 
     const sessionData = await browser.storage.session.get([
       'isFirstMetaMaskControllerSetup',

--- a/app/scripts/constants/sentry-state.ts
+++ b/app/scripts/constants/sentry-state.ts
@@ -294,7 +294,6 @@ export const SENTRY_BACKGROUND_STATE: SentryBackgroundControllerMasks = {
     usePhishDetect: true,
     useTokenDetection: true,
     useTransactionSimulations: true,
-    enableMV3TimestampSave: true,
   },
   RemoteFeatureFlagController: {
     remoteFeatureFlags: true,

--- a/app/scripts/controllers/preferences-controller-method-action-types.ts
+++ b/app/scripts/controllers/preferences-controller-method-action-types.ts
@@ -328,11 +328,6 @@ export type PreferencesControllerSetManageInstitutionalWalletsAction = {
   handler: PreferencesController['setManageInstitutionalWallets'];
 };
 
-export type PreferencesControllerSetServiceWorkerKeepAlivePreferenceAction = {
-  type: `PreferencesController:setServiceWorkerKeepAlivePreference`;
-  handler: PreferencesController['setServiceWorkerKeepAlivePreference'];
-};
-
 export type PreferencesControllerSetUseSidePanelAsDefaultAction = {
   type: `PreferencesController:setUseSidePanelAsDefault`;
   handler: PreferencesController['setUseSidePanelAsDefault'];
@@ -422,7 +417,6 @@ export type PreferencesControllerMethodActions =
   | PreferencesControllerSetDismissSeedBackUpReminderAction
   | PreferencesControllerSetOverrideContentSecurityPolicyHeaderAction
   | PreferencesControllerSetManageInstitutionalWalletsAction
-  | PreferencesControllerSetServiceWorkerKeepAlivePreferenceAction
   | PreferencesControllerSetUseSidePanelAsDefaultAction
   | PreferencesControllerSetShowDefaultAddressAction
   | PreferencesControllerSetDefaultAddressScopeAction

--- a/app/scripts/controllers/preferences-controller.test.ts
+++ b/app/scripts/controllers/preferences-controller.test.ts
@@ -334,18 +334,6 @@ describe('preferences controller', () => {
     });
   });
 
-  describe('setServiceWorkerKeepAlivePreference', () => {
-    const { controller } = setupController({});
-    it('should default to true', () => {
-      expect(controller.state.enableMV3TimestampSave).toStrictEqual(true);
-    });
-
-    it('should set the setServiceWorkerKeepAlivePreference property in state', () => {
-      controller.setServiceWorkerKeepAlivePreference(false);
-      expect(controller.state.enableMV3TimestampSave).toStrictEqual(false);
-    });
-  });
-
   describe('globalThis.setPreference', () => {
     it('setFeatureFlags to true', () => {
       const { controller } = setupController({});
@@ -674,7 +662,6 @@ describe('preferences controller', () => {
           "advancedGasFee": {},
           "currentLocale": "",
           "dismissSeedBackUpReminder": false,
-          "enableMV3TimestampSave": true,
           "featureFlags": {},
           "forgottenPassword": false,
           "isMultiAccountBalancesEnabled": true,
@@ -741,7 +728,6 @@ describe('preferences controller', () => {
           "advancedGasFee": {},
           "currentLocale": "",
           "dismissSeedBackUpReminder": false,
-          "enableMV3TimestampSave": true,
           "featureFlags": {},
           "forgottenPassword": false,
           "ipfsGateway": "dweb.link",
@@ -825,7 +811,6 @@ describe('preferences controller', () => {
           "advancedGasFee": {},
           "currentLocale": "",
           "dismissSeedBackUpReminder": false,
-          "enableMV3TimestampSave": true,
           "featureFlags": {},
           "forgottenPassword": false,
           "ipfsGateway": "dweb.link",
@@ -910,7 +895,6 @@ describe('preferences controller', () => {
           "advancedGasFee": {},
           "currentLocale": "",
           "dismissSeedBackUpReminder": false,
-          "enableMV3TimestampSave": true,
           "featureFlags": {},
           "forgottenPassword": false,
           "ipfsGateway": "dweb.link",

--- a/app/scripts/controllers/preferences-controller.ts
+++ b/app/scripts/controllers/preferences-controller.ts
@@ -99,7 +99,6 @@ export type PreferencesControllerState = Omit<
   advancedGasFee: Record<string, Record<string, string>>;
   currentLocale: string;
   dismissSeedBackUpReminder: boolean;
-  enableMV3TimestampSave: boolean;
   forgottenPassword: boolean;
   knownMethodData: Record<string, string>;
   ledgerTransportType: LedgerTransportTypes;
@@ -134,7 +133,6 @@ export const getDefaultPreferencesControllerState =
     advancedGasFee: {},
     currentLocale: '',
     dismissSeedBackUpReminder: false,
-    enableMV3TimestampSave: true,
     featureFlags: {},
     forgottenPassword: false,
     // ENS decentralized website resolution
@@ -236,12 +234,6 @@ const controllerMetadata: StateMetadata<PreferencesControllerState> = {
     usedInUi: true,
   },
   dismissSeedBackUpReminder: {
-    includeInStateLogs: true,
-    persist: true,
-    includeInDebugSnapshot: true,
-    usedInUi: true,
-  },
-  enableMV3TimestampSave: {
     includeInStateLogs: true,
     persist: true,
     includeInDebugSnapshot: true,
@@ -461,7 +453,6 @@ const MESSENGER_EXPOSED_METHODS = [
   'setDismissSeedBackUpReminder',
   'setOverrideContentSecurityPolicyHeader',
   'setManageInstitutionalWallets',
-  'setServiceWorkerKeepAlivePreference',
   'setUseSidePanelAsDefault',
   'setShowDefaultAddress',
   'setDefaultAddressScope',
@@ -961,12 +952,6 @@ export class PreferencesController extends BaseController<
   setManageInstitutionalWallets(manageInstitutionalWallets: boolean): void {
     this.update((state) => {
       state.manageInstitutionalWallets = manageInstitutionalWallets;
-    });
-  }
-
-  setServiceWorkerKeepAlivePreference(value: boolean): void {
-    this.update((state) => {
-      state.enableMV3TimestampSave = value;
     });
   }
 

--- a/app/scripts/fixtures/with-preferences.js
+++ b/app/scripts/fixtures/with-preferences.js
@@ -31,7 +31,6 @@ export const FIXTURES_PREFERENCES = {
   theme: 'light',
   useExternalNameSources: true,
   useTransactionSimulations: true,
-  enableMV3TimestampSave: true,
   useExternalServices: true,
   isBackupAndSyncEnabled: true,
   isAccountSyncingEnabled: true,

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2722,10 +2722,6 @@ export default class MetamaskController extends EventEmitter {
       setCurrentLocale: preferencesController.setCurrentLocale.bind(
         preferencesController,
       ),
-      setServiceWorkerKeepAlivePreference:
-        preferencesController.setServiceWorkerKeepAlivePreference.bind(
-          preferencesController,
-        ),
       markPasswordForgotten: this.controllerMessenger.call.bind(
         this.controllerMessenger,
         'LegacyBackgroundApiService:markPasswordForgotten',

--- a/app/scripts/migrations/217.test.ts
+++ b/app/scripts/migrations/217.test.ts
@@ -1,0 +1,73 @@
+import { cloneDeep } from 'lodash';
+import { migrate, version } from './217';
+
+const VERSION = version;
+const OLD_VERSION = VERSION - 1;
+
+describe(`migration #${VERSION}`, () => {
+  it('removes enableMV3TimestampSave from PreferencesController', async () => {
+    const oldStorage = {
+      meta: { version: OLD_VERSION },
+      data: {
+        PreferencesController: {
+          enableMV3TimestampSave: false,
+          currentLocale: 'en',
+        },
+      },
+    };
+    const versionedData = cloneDeep(oldStorage);
+    const changedControllers = new Set<string>();
+
+    await migrate(versionedData, changedControllers);
+
+    expect(versionedData).toStrictEqual({
+      meta: { version: VERSION },
+      data: {
+        PreferencesController: {
+          currentLocale: 'en',
+        },
+      },
+    });
+    expect(changedControllers).toStrictEqual(new Set(['PreferencesController']));
+  });
+
+  it('does not mark PreferencesController changed when enableMV3TimestampSave is absent', async () => {
+    const oldStorage = {
+      meta: { version: OLD_VERSION },
+      data: {
+        PreferencesController: {
+          currentLocale: 'en',
+        },
+      },
+    };
+    const versionedData = cloneDeep(oldStorage);
+    const changedControllers = new Set<string>();
+
+    await migrate(versionedData, changedControllers);
+
+    expect(versionedData).toStrictEqual({
+      meta: { version: VERSION },
+      data: oldStorage.data,
+    });
+    expect(changedControllers).toStrictEqual(new Set([]));
+  });
+
+  it('does nothing when PreferencesController is missing', async () => {
+    const oldStorage = {
+      meta: { version: OLD_VERSION },
+      data: {
+        AppStateController: {},
+      },
+    };
+    const versionedData = cloneDeep(oldStorage);
+    const changedControllers = new Set<string>();
+
+    await migrate(versionedData, changedControllers);
+
+    expect(versionedData).toStrictEqual({
+      meta: { version: VERSION },
+      data: oldStorage.data,
+    });
+    expect(changedControllers).toStrictEqual(new Set([]));
+  });
+});

--- a/app/scripts/migrations/217.test.ts
+++ b/app/scripts/migrations/217.test.ts
@@ -28,7 +28,9 @@ describe(`migration #${VERSION}`, () => {
         },
       },
     });
-    expect(changedControllers).toStrictEqual(new Set(['PreferencesController']));
+    expect(changedControllers).toStrictEqual(
+      new Set(['PreferencesController']),
+    );
   });
 
   it('does not mark PreferencesController changed when enableMV3TimestampSave is absent', async () => {

--- a/app/scripts/migrations/217.ts
+++ b/app/scripts/migrations/217.ts
@@ -1,0 +1,38 @@
+import { hasProperty, isObject } from '@metamask/utils';
+import type { Migrate } from './types';
+
+export const version = 217;
+
+/**
+ * Removes the obsolete enableMV3TimestampSave preference from
+ * PreferencesController. MV3 keep-alive is always enabled from service worker
+ * startup and is no longer user-configurable.
+ *
+ * @param versionedData - The versioned data object to migrate.
+ * @param changedControllers - A set used to record controllers that were modified.
+ */
+export const migrate = (async (versionedData, changedControllers) => {
+  versionedData.meta.version = version;
+
+  if (removeEnableMV3TimestampSave(versionedData.data)) {
+    changedControllers.add('PreferencesController');
+  }
+}) satisfies Migrate;
+
+function removeEnableMV3TimestampSave(
+  state: Record<string, unknown>,
+): boolean {
+  if (
+    !hasProperty(state, 'PreferencesController') ||
+    !isObject(state.PreferencesController)
+  ) {
+    return false;
+  }
+
+  if (!hasProperty(state.PreferencesController, 'enableMV3TimestampSave')) {
+    return false;
+  }
+
+  delete state.PreferencesController.enableMV3TimestampSave;
+  return true;
+}

--- a/app/scripts/migrations/217.ts
+++ b/app/scripts/migrations/217.ts
@@ -19,9 +19,7 @@ export const migrate = (async (versionedData, changedControllers) => {
   }
 }) satisfies Migrate;
 
-function removeEnableMV3TimestampSave(
-  state: Record<string, unknown>,
-): boolean {
+function removeEnableMV3TimestampSave(state: Record<string, unknown>): boolean {
   if (
     !hasProperty(state, 'PreferencesController') ||
     !isObject(state.PreferencesController)

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -252,6 +252,7 @@ const migrations = [
   require('./214'),
   require('./215'),
   require('./216'),
+  require('./217'),
 ];
 
 export default migrations;

--- a/shared/types/background.ts
+++ b/shared/types/background.ts
@@ -279,7 +279,6 @@ export type ControllerStatePropertiesEnumerated = {
   theme: PreferencesControllerState['theme'];
   snapsAddSnapAccountModalDismissed?: PreferencesControllerState['snapsAddSnapAccountModalDismissed'];
   useExternalNameSources: PreferencesControllerState['useExternalNameSources'];
-  enableMV3TimestampSave: PreferencesControllerState['enableMV3TimestampSave'];
   useExternalServices: PreferencesControllerState['useExternalServices'];
   textDirection?: PreferencesControllerState['textDirection'];
   manageInstitutionalWallets: PreferencesControllerState['manageInstitutionalWallets'];

--- a/test/e2e/fixtures/default-fixture.json
+++ b/test/e2e/fixtures/default-fixture.json
@@ -178,7 +178,7 @@
       "announcements": {}
     },
     "AppMetadataController": {
-      "currentMigrationVersion": 216,
+      "currentMigrationVersion": 217,
       "firstTimeInfo": {},
       "previousAppVersion": "",
       "previousMigrationVersion": 0
@@ -1313,6 +1313,6 @@
   },
   "meta": {
     "storageKind": "split",
-    "version": 216
+    "version": 217
   }
 }

--- a/test/e2e/fixtures/default-fixture.json
+++ b/test/e2e/fixtures/default-fixture.json
@@ -1058,7 +1058,6 @@
       "advancedGasFee": {},
       "currentLocale": "en",
       "dismissSeedBackUpReminder": false,
-      "enableMV3TimestampSave": true,
       "featureFlags": {},
       "forgottenPassword": false,
       "ipfsGateway": "dweb.link",

--- a/test/e2e/fixtures/onboarding-fixture.json
+++ b/test/e2e/fixtures/onboarding-fixture.json
@@ -39,7 +39,7 @@
       "announcements": {}
     },
     "AppMetadataController": {
-      "currentMigrationVersion": 216,
+      "currentMigrationVersion": 217,
       "firstTimeInfo": {
         "date": 0,
         "version": "13.17.0"
@@ -2316,6 +2316,6 @@
   },
   "meta": {
     "storageKind": "split",
-    "version": 216
+    "version": 217
   }
 }

--- a/test/e2e/fixtures/onboarding-fixture.json
+++ b/test/e2e/fixtures/onboarding-fixture.json
@@ -2046,7 +2046,6 @@
       "advancedGasFee": {},
       "currentLocale": "en",
       "dismissSeedBackUpReminder": false,
-      "enableMV3TimestampSave": true,
       "featureFlags": {},
       "forgottenPassword": false,
       "ipfsGateway": "dweb.link",

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -277,7 +277,6 @@
     "advancedGasFee": {},
     "currentLocale": "en",
     "dismissSeedBackUpReminder": false,
-    "enableMV3TimestampSave": true,
     "featureFlags": {},
     "forgottenPassword": false,
     "ipfsGateway": "string",

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -144,7 +144,6 @@
     "dismissSeedBackUpReminder": false,
     "domains": "object",
     "drafts": "object",
-    "enableMV3TimestampSave": true,
     "enabledNetworkMap": {
       "bip122": "object",
       "eip155": "object",

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-background-state.json
@@ -193,7 +193,6 @@
       "advancedGasFee": {},
       "currentLocale": "en",
       "dismissSeedBackUpReminder": false,
-      "enableMV3TimestampSave": true,
       "featureFlags": {},
       "forgottenPassword": false,
       "ipfsGateway": "string",

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -200,7 +200,6 @@
       "advancedGasFee": {},
       "currentLocale": "en",
       "dismissSeedBackUpReminder": false,
-      "enableMV3TimestampSave": true,
       "featureFlags": {},
       "forgottenPassword": false,
       "ipfsGateway": "string",

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -319,5 +319,5 @@
     },
     "config": "object"
   },
-  "meta": { "storageKind": "split", "version": 216 }
+  "meta": { "storageKind": "split", "version": 217 }
 }

--- a/test/e2e/tests/settings/state-logs.json
+++ b/test/e2e/tests/settings/state-logs.json
@@ -762,7 +762,6 @@
       "eip155:137": "string",
       "eip155:6343": "string"
     },
-    "enableMV3TimestampSave": "boolean",
     "ensEntries": {
       "0x1": {
         ".": {

--- a/test/integration/data/onboarding-completion-route.json
+++ b/test/integration/data/onboarding-completion-route.json
@@ -118,7 +118,6 @@
   "detectedTokens": [],
   "dismissSeedBackUpReminder": false,
   "domains": {},
-  "enableMV3TimestampSave": true,
   "enabledNetworkMap": {
     "eip155": {
       "0xaa36a7": true

--- a/ui/pages/settings/debug-tab/debug-content/debug-content.test.tsx
+++ b/ui/pages/settings/debug-tab/debug-content/debug-content.test.tsx
@@ -6,10 +6,6 @@ import { renderWithProvider } from '../../../../../test/lib/render-helpers-navig
 import mockState from '../../../../../test/data/mock-state.json';
 import DebugContent from '.';
 
-const mockSetServiceWorkerKeepAlivePreference = jest.fn().mockReturnValue({
-  type: 'SET_SERVICE_WORKER_KEEP_ALIVE',
-  value: true,
-});
 const mockPerpsToggleTestnet = jest.fn().mockResolvedValue(undefined);
 const mockRemoteFeatureFlags = { feature1: 'value1' };
 // eslint-disable-next-line
@@ -30,8 +26,6 @@ jest.mock('webextension-polyfill', () => ({
 }));
 
 jest.mock('../../../../store/actions.ts', () => ({
-  setServiceWorkerKeepAlivePreference: () =>
-    mockSetServiceWorkerKeepAlivePreference,
   perpsToggleTestnet: () => mockPerpsToggleTestnet(),
 }));
 
@@ -82,16 +76,5 @@ describe('Debug tab', () => {
       fireEvent.click(getByTestId('perps-testnet-toggle'));
       expect(mockPerpsToggleTestnet).toHaveBeenCalled();
     });
-  });
-
-  it('should toggle Service Worker Keep Alive', async () => {
-    const { getByTestId } = renderWithProvider(<DebugContent />, mockStore);
-    const triggerButton = getByTestId(
-      'developer-options-service-worker-alive-toggle',
-    );
-    expect(triggerButton).toBeInTheDocument();
-    fireEvent.click(triggerButton);
-
-    expect(mockSetServiceWorkerKeepAlivePreference).toHaveBeenCalled();
   });
 });

--- a/ui/pages/settings/debug-tab/debug-content/debug-content.tsx
+++ b/ui/pages/settings/debug-tab/debug-content/debug-content.tsx
@@ -26,7 +26,6 @@ import {
   perpsToggleTestnet,
   resetOnboarding,
   resetViewedNotifications,
-  setServiceWorkerKeepAlivePreference,
 } from '../../../../store/actions';
 import { selectPerpsIsTestnet } from '../../../../selectors/perps-controller';
 import { getEnvironmentType } from '../../../../../shared/lib/environment-type';
@@ -51,8 +50,6 @@ const DebugContent = () => {
 
   const [hasResetAnnouncements, setHasResetAnnouncements] = useState(false);
   const [hasResetOnboarding, setHasResetOnboarding] = useState(false);
-  const [isServiceWorkerKeptAlive, setIsServiceWorkerKeptAlive] =
-    useState(true);
 
   const handleResetAnnouncementClick = useCallback((): void => {
     resetViewedNotifications();
@@ -75,13 +72,6 @@ const DebugContent = () => {
       navigate(backUpSRPRoute);
     }
   }, [dispatch, navigate]);
-
-  const handleToggleServiceWorkerAlive = async (
-    value: boolean,
-  ): Promise<void> => {
-    await dispatch(setServiceWorkerKeepAlivePreference(value));
-    setIsServiceWorkerKeptAlive(value);
-  };
 
   const renderAnnouncementReset = () => {
     return (
@@ -180,20 +170,6 @@ const DebugContent = () => {
     );
   };
 
-  const renderServiceWorkerKeepAliveToggle = () => {
-    return (
-      <ToggleRow
-        title="Service Worker Keep Alive"
-        description="Results in a timestamp being continuously saved to session.storage"
-        isEnabled={isServiceWorkerKeptAlive}
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
-        onToggle={(value) => handleToggleServiceWorkerAlive(!value)}
-        dataTestId="developer-options-service-worker-alive-toggle"
-      />
-    );
-  };
-
   const isPerpsTestnet = useSelector(selectPerpsIsTestnet);
   const perpsTestnetToggleRef = useRef<HTMLDivElement>(null);
 
@@ -261,7 +237,6 @@ const DebugContent = () => {
       <div className="settings-page__content-padded">
         {renderAnnouncementReset()}
         {renderOnboardingReset()}
-        {renderServiceWorkerKeepAliveToggle()}
         {process.env.METAMASK_DEBUG && (
           <ToggleRow
             title="Perps Testnet"

--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -3180,50 +3180,6 @@ describe('Actions', () => {
     });
   });
 
-  describe('#setServiceWorkerKeepAlivePreference', () => {
-    afterEach(() => {
-      sinon.restore();
-    });
-
-    it('sends a value to background', async () => {
-      const store = mockStore();
-      const setServiceWorkerKeepAlivePreferenceStub = sinon.stub().resolves();
-
-      setBackgroundConnection({
-        setServiceWorkerKeepAlivePreference:
-          setServiceWorkerKeepAlivePreferenceStub,
-      });
-
-      await store.dispatch(actions.setServiceWorkerKeepAlivePreference(true));
-      expect(setServiceWorkerKeepAlivePreferenceStub.callCount).toStrictEqual(
-        1,
-      );
-      expect(setServiceWorkerKeepAlivePreferenceStub.calledWith(true)).toBe(
-        true,
-      );
-    });
-
-    it('errors when setServiceWorkerKeepAlivePreference in background throws', async () => {
-      const store = mockStore();
-      const setServiceWorkerKeepAlivePreferenceStub = sinon
-        .stub()
-        .rejects(new Error('error'));
-
-      setBackgroundConnection({
-        setServiceWorkerKeepAlivePreference:
-          setServiceWorkerKeepAlivePreferenceStub,
-      });
-
-      const expectedActions = [
-        { type: 'SHOW_LOADING_INDICATION', payload: undefined },
-        { type: 'HIDE_LOADING_INDICATION' },
-      ];
-
-      await store.dispatch(actions.setServiceWorkerKeepAlivePreference(false));
-      expect(store.getActions()).toStrictEqual(expectedActions);
-    });
-  });
-
   describe('#setParticipateInMetaMetrics', () => {
     it('calls background with true when opting in', async () => {
       const store = mockStore();

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -4536,26 +4536,6 @@ export function resetWallet(restoreOnly = false) {
   };
 }
 
-export function setServiceWorkerKeepAlivePreference(
-  value: boolean,
-): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
-  return async (dispatch: MetaMaskReduxDispatch) => {
-    dispatch(showLoadingIndication());
-    log.debug(`background.setServiceWorkerKeepAlivePreference`);
-    try {
-      await submitRequestToBackground('setServiceWorkerKeepAlivePreference', [
-        value,
-      ]);
-    } catch {
-      // TODO: Stop suppressing this error (either log or re-throw)
-    } finally {
-      dispatch(hideLoadingIndication());
-    }
-  };
-}
-
 export async function forceUpdateMetamaskState(
   dispatch: MetaMaskReduxDispatch,
 ) {


### PR DESCRIPTION
## **Description**

The `enableMV3TimestampSave` debug preference is obsolete now that MV3 keep-alive runs unconditionally from service worker startup (see [comment](https://github.com/MetaMask/metamask-extension/pull/44348#discussion_r3559916253)). This PR removes the preference from controller state, UI, and persisted fixtures, and adds migration 217 to drop the field from existing profiles.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

Related: https://github.com/MetaMask/metamask-extension/pull/44348
Related: https://github.com/MetaMask/metamask-extension/issues/43773

## **Manual testing steps**

1. Run `yarn start` and load the extension in Chrome.
2. Open **Settings → Advanced → Developer options** and confirm the **Service worker keep-alive** toggle is no longer shown.
3. Unlock MetaMask and confirm normal background behavior is unchanged.
4. (Optional) Upgrade from a profile that had `enableMV3TimestampSave: false` and confirm migration 217 removes the field without errors.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)