### PR TITLE
refactor(analytics): migrate orphan Web3Auth onboarding events

### DIFF
--- a/ui/components/app/basic-configuration-modal/basic-configuration-modal.test.tsx
+++ b/ui/components/app/basic-configuration-modal/basic-configuration-modal.test.tsx
@@ -10,6 +10,21 @@ import {
 import { ONBOARDING_PRIVACY_SETTINGS_ROUTE } from '../../../helpers/constants/routes';
 import { BasicConfigurationModal } from './basic-configuration-modal';
 
+const mockTrackEvent = jest.fn();
+
+jest.mock('../../../hooks/useAnalytics', () => {
+  const { createEventBuilder } = jest.requireActual(
+    '../../../../shared/lib/analytics/create-event-builder',
+  );
+
+  return {
+    useAnalytics: () => ({
+      trackEvent: mockTrackEvent,
+      createEventBuilder,
+    }),
+  };
+});
+
 jest.mock('../../../store/actions', () => ({
   setDataCollectionForMarketing: jest.fn(),
   setParticipateInMetaMetrics: jest.fn(),

--- a/ui/components/app/basic-configuration-modal/basic-configuration-modal.tsx
+++ b/ui/components/app/basic-configuration-modal/basic-configuration-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useMemo } from 'react';
+import React, { useMemo } from 'react';
 import { useLocation } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import {
@@ -38,7 +38,7 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { useAnalytics } from '../../../hooks/useAnalytics';
 import { getUseExternalServices } from '../../../selectors';
 import { getIsBasicFunctionalityConsolidationEnabled } from '../../../selectors/multichain/feature-flags';
 import { selectIsMetamaskNotificationsEnabled } from '../../../selectors/metamask-notifications/metamask-notifications';
@@ -53,7 +53,7 @@ import { useBoolean } from '../../../hooks/useBoolean';
 export function BasicConfigurationModal() {
   const t = useI18nContext();
   const dispatch = useDispatch();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
 
   const isExternalServicesEnabled = useSelector(getUseExternalServices);
   const isBackupAndSyncEnabled = useSelector(selectIsBackupAndSyncEnabled);
@@ -105,7 +105,12 @@ export function BasicConfigurationModal() {
           },
         };
 
-    trackEvent(event);
+    trackEvent(
+      createEventBuilder(event.event)
+        .addCategory(event.category)
+        .addProperties(event.properties)
+        .build(),
+    );
 
     if (isExternalServicesEnabled || onboardingFlow) {
       dispatch(setParticipateInMetaMetrics(false));

--- a/ui/components/app/change-password/change-password.tsx
+++ b/ui/components/app/change-password/change-password.tsx
@@ -1,7 +1,6 @@
 import EventEmitter from 'events';
 import React, {
   useCallback,
-  useContext,
   useEffect,
   useRef,
   useState,
@@ -64,7 +63,7 @@ import {
 } from '../../../helpers/constants/routes';
 import { toast, ToastContent } from '../../ui/toast/toast';
 import ZENDESK_URLS from '../../../helpers/constants/zendesk-url';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { useAnalytics } from '../../../hooks/useAnalytics';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
@@ -100,7 +99,7 @@ const ChangePassword = ({
   const passkeyMethodLabel = t(getPasskeyAuthMethodKey());
   const dispatch = useDispatch();
   const navigate = useNavigate();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const isSocialLoginFlow = useSelector(getIsSocialLoginFlow);
   const isPasskeyActive = useIsPasskeyActive();
   const isPasskeyIncompatibleWithSidepanel =
@@ -169,16 +168,17 @@ const ChangePassword = ({
     }
 
     const startedAt = Date.now();
-    trackEvent({
-      category: MetaMetricsEventCategory.Settings,
-      event: MetaMetricsEventName.PasswordChangeWithPasskey,
-      properties: {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        status: 'started',
-        // eslint-disable-next-line @typescript-eslint/naming-convention
-        passkey_renewal_enabled: isPasskeyRenewalEnabled,
-      },
-    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.PasswordChangeWithPasskey)
+        .addCategory(MetaMetricsEventCategory.Settings)
+        .addProperties({
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          status: 'started',
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          passkey_renewal_enabled: isPasskeyRenewalEnabled,
+        })
+        .build(),
+    );
 
     let isPasskeyRenewed = false;
     try {
@@ -191,34 +191,36 @@ const ChangePassword = ({
       );
       isPasskeyRenewed = isPasskeyRenewalEnabled;
 
-      trackEvent({
-        category: MetaMetricsEventCategory.Settings,
-        event: MetaMetricsEventName.PasswordChangeWithPasskey,
-        properties: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          status: 'completed',
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          duration_ms: Date.now() - startedAt,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          passkey_renewal_enabled: isPasskeyRenewalEnabled,
-        },
-      });
+      trackEvent(
+        createEventBuilder(MetaMetricsEventName.PasswordChangeWithPasskey)
+          .addCategory(MetaMetricsEventCategory.Settings)
+          .addProperties({
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            status: 'completed',
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            duration_ms: Date.now() - startedAt,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            passkey_renewal_enabled: isPasskeyRenewalEnabled,
+          })
+          .build(),
+      );
     } catch (error) {
       const errorCode = getPasskeyErrorCode(error);
       const durationMs = Date.now() - startedAt;
-      trackEvent({
-        category: MetaMetricsEventCategory.Settings,
-        event: MetaMetricsEventName.PasswordChangeWithPasskey,
-        properties: {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          status: 'failed',
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          passkey_renewal_enabled: isPasskeyRenewalEnabled,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          duration_ms: durationMs,
-          reason: errorCode,
-        },
-      });
+      trackEvent(
+        createEventBuilder(MetaMetricsEventName.PasswordChangeWithPasskey)
+          .addCategory(MetaMetricsEventCategory.Settings)
+          .addProperties({
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            status: 'failed',
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            passkey_renewal_enabled: isPasskeyRenewalEnabled,
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            duration_ms: durationMs,
+            reason: errorCode,
+          })
+          .build(),
+      );
 
       captureException(
         createSentryError(
@@ -273,15 +275,16 @@ const ChangePassword = ({
       }
 
       // Track password changed event
-      trackEvent({
-        category: MetaMetricsEventCategory.Settings,
-        event: MetaMetricsEventName.PasswordChanged,
-        properties: {
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
-          biometrics_enabled: isPasskeyRenewalSuccessful,
-        },
-      });
+      trackEvent(
+        createEventBuilder(MetaMetricsEventName.PasswordChanged)
+          .addCategory(MetaMetricsEventCategory.Settings)
+          .addProperties({
+            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+            // eslint-disable-next-line @typescript-eslint/naming-convention
+            biometrics_enabled: isPasskeyRenewalSuccessful,
+          })
+          .build(),
+      );
 
       // upon successful password change, go back to the settings page
       navigate(redirectRoute);
@@ -307,15 +310,16 @@ const ChangePassword = ({
 
   const handleLearnMoreClick = (event: React.MouseEvent<HTMLAnchorElement>) => {
     event.stopPropagation();
-    trackEvent({
-      category: MetaMetricsEventCategory.Onboarding,
-      event: MetaMetricsEventName.ExternalLinkClicked,
-      properties: {
-        text: 'Learn More',
-        location: 'change_password',
-        url: ZENDESK_URLS.PASSWORD_ARTICLE,
-      },
-    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.ExternalLinkClicked)
+        .addCategory(MetaMetricsEventCategory.Onboarding)
+        .addProperties({
+          text: 'Learn More',
+          location: 'change_password',
+          url: ZENDESK_URLS.PASSWORD_ARTICLE,
+        })
+        .build(),
+    );
   };
 
   const createPasswordLink = (

--- a/ui/components/app/change-password/change-password.tsx
+++ b/ui/components/app/change-password/change-password.tsx
@@ -1,10 +1,5 @@
 import EventEmitter from 'events';
-import React, {
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { type PasskeyAuthenticationResponse } from '@metamask/passkey-controller';

--- a/ui/components/app/metametrics-consent/metametrics-consent-container.tsx
+++ b/ui/components/app/metametrics-consent/metametrics-consent-container.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useContext } from 'react';
+import React, { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { Text } from '@metamask/design-system-react';
 import {
@@ -6,7 +6,7 @@ import {
   MetaMetricsEventName,
   MetaMetricsUserTrait,
 } from '../../../../shared/constants/metametrics';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { useAnalytics } from '../../../hooks/useAnalytics';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   getCompletedMetaMetricsOnboarding,
@@ -36,7 +36,7 @@ import type { MetaMaskReduxState } from '../../../store/store';
 export function MetaMetricsConsentContainer() {
   const t = useI18nContext();
   const dispatch = useDispatch();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
 
   const dataCollectionForMarketing = useSelector(
     (state: MetaMaskReduxState) => state.metamask.dataCollectionForMarketing,
@@ -48,29 +48,31 @@ export function MetaMetricsConsentContainer() {
 
   const handleClose = useCallback(() => {
     dispatch(setDataCollectionForMarketing(false));
-    trackEvent({
-      category: MetaMetricsEventCategory.Home,
-      event: MetaMetricsEventName.AnalyticsPreferenceSelected,
-      properties: {
-        [MetaMetricsUserTrait.HasMarketingConsent]: false,
-        location: 'marketing_consent_modal',
-      },
-    });
-  }, [dispatch, trackEvent]);
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.AnalyticsPreferenceSelected)
+        .addCategory(MetaMetricsEventCategory.Home)
+        .addProperties({
+          [MetaMetricsUserTrait.HasMarketingConsent]: false,
+          location: 'marketing_consent_modal',
+        })
+        .build(),
+    );
+  }, [createEventBuilder, dispatch, trackEvent]);
 
   const handleConsent = useCallback(
     (consent: boolean) => {
       dispatch(setDataCollectionForMarketing(consent));
-      trackEvent({
-        category: MetaMetricsEventCategory.Home,
-        event: MetaMetricsEventName.AnalyticsPreferenceSelected,
-        properties: {
-          [MetaMetricsUserTrait.HasMarketingConsent]: consent,
-          location: 'marketing_consent_modal',
-        },
-      });
+      trackEvent(
+        createEventBuilder(MetaMetricsEventName.AnalyticsPreferenceSelected)
+          .addCategory(MetaMetricsEventCategory.Home)
+          .addProperties({
+            [MetaMetricsUserTrait.HasMarketingConsent]: consent,
+            location: 'marketing_consent_modal',
+          })
+          .build(),
+      );
     },
-    [dispatch, trackEvent],
+    [createEventBuilder, dispatch, trackEvent],
   );
 
   if (dataCollectionForMarketing !== null || !isMetaMetricsEnabled) {

--- a/ui/components/app/passkey-troubleshoot-modal/passkey-troubleshoot-modal.tsx
+++ b/ui/components/app/passkey-troubleshoot-modal/passkey-troubleshoot-modal.tsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect, useMemo, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import {
   Box,
   Button,
@@ -24,7 +24,8 @@ import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { useAnalytics } from '../../../hooks/useAnalytics';
+import { useSegmentContext } from '../../../hooks/useSegmentContext';
 
 export type PasskeyTroubleshootModalMode = 'unlock' | 'verify';
 
@@ -42,7 +43,8 @@ export default function PasskeyTroubleshootModal({
   onOpenFullScreen,
 }: PasskeyTroubleshootModalProps) {
   const t = useI18nContext();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
+  const segmentContext = useSegmentContext();
 
   const baseProperties = useMemo(
     () => ({
@@ -59,53 +61,53 @@ export default function PasskeyTroubleshootModal({
       return;
     }
     hasTrackedView.current = true;
-    trackEvent({
-      category: MetaMetricsEventCategory.Navigation,
-      event: MetaMetricsEventName.PasskeyTroubleshoot,
-      properties: {
-        ...baseProperties,
-        cta: 'modal',
-      },
-    });
-  }, [baseProperties, trackEvent]);
-
-  const handleContactSupportTrackEvent = () => {
     trackEvent(
-      {
-        category: MetaMetricsEventCategory.Navigation,
-        event: MetaMetricsEventName.SupportLinkClicked,
-        properties: {
-          url: ZENDESK_URLS.PASSKEYS,
-        },
-      },
-      {
-        contextPropsIntoEventProperties: [MetaMetricsContextProp.PageTitle],
-      },
+      createEventBuilder(MetaMetricsEventName.PasskeyTroubleshoot)
+        .addCategory(MetaMetricsEventCategory.Navigation)
+        .addProperties({
+          ...baseProperties,
+          cta: 'modal',
+        })
+        .build(),
     );
-  };
+  }, [baseProperties, createEventBuilder, trackEvent]);
+
+  const handleContactSupportTrackEvent = useCallback(() => {
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.SupportLinkClicked)
+        .addCategory(MetaMetricsEventCategory.Navigation)
+        .addProperties({
+          url: ZENDESK_URLS.PASSKEYS,
+          [MetaMetricsContextProp.PageTitle]: segmentContext.page?.title,
+        })
+        .build(),
+    );
+  }, [createEventBuilder, segmentContext.page?.title, trackEvent]);
 
   const handleOpenFullScreen = () => {
-    trackEvent({
-      category: MetaMetricsEventCategory.Navigation,
-      event: MetaMetricsEventName.PasskeyTroubleshoot,
-      properties: {
-        ...baseProperties,
-        cta: 'full_screen',
-      },
-    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.PasskeyTroubleshoot)
+        .addCategory(MetaMetricsEventCategory.Navigation)
+        .addProperties({
+          ...baseProperties,
+          cta: 'full_screen',
+        })
+        .build(),
+    );
     onOpenFullScreen();
     onClose();
   };
 
   const handleStillHavingTrouble = () => {
-    trackEvent({
-      category: MetaMetricsEventCategory.Navigation,
-      event: MetaMetricsEventName.PasskeyTroubleshoot,
-      properties: {
-        ...baseProperties,
-        cta: 'support',
-      },
-    });
+    trackEvent(
+      createEventBuilder(MetaMetricsEventName.PasskeyTroubleshoot)
+        .addCategory(MetaMetricsEventCategory.Navigation)
+        .addProperties({
+          ...baseProperties,
+          cta: 'support',
+        })
+        .build(),
+    );
     handleContactSupportTrackEvent();
     onClose();
   };

--- a/ui/pages/onboarding-flow/recovery-phrase/reveal-recovery-phrase.test.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/reveal-recovery-phrase.test.tsx
@@ -16,6 +16,21 @@ import { PLATFORM_FIREFOX } from '../../../../shared/constants/app';
 import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import RevealRecoveryPhrase from './reveal-recovery-phrase';
 
+const mockTrackEvent = jest.fn();
+
+jest.mock('../../../hooks/useAnalytics', () => {
+  const { createEventBuilder } = jest.requireActual(
+    '../../../../shared/lib/analytics/create-event-builder',
+  );
+
+  return {
+    useAnalytics: () => ({
+      trackEvent: mockTrackEvent,
+      createEventBuilder,
+    }),
+  };
+});
+
 const mockPasskeyAuthResponse = { id: 'assertion-id', type: 'public-key' };
 const mockGeneratePasskeyAuthenticationOptions = jest
   .fn()

--- a/ui/pages/onboarding-flow/recovery-phrase/reveal-recovery-phrase.test.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/reveal-recovery-phrase.test.tsx
@@ -13,6 +13,12 @@ import {
 import { getSeedPhrase } from '../../../store/actions';
 import * as BrowserRuntimeUtils from '../../../../shared/lib/browser-runtime.utils';
 import { PLATFORM_FIREFOX } from '../../../../shared/constants/app';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventKeyType,
+  MetaMetricsEventName,
+  MetaMetricsEventVerificationMethod,
+} from '../../../../shared/constants/metametrics';
 import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import RevealRecoveryPhrase from './reveal-recovery-phrase';
 
@@ -238,6 +244,32 @@ describe('RevealRecoveryPhrase', () => {
         ONBOARDING_REVIEW_SRP_ROUTE,
         { replace: true },
       );
+      expect(mockTrackEvent).toHaveBeenNthCalledWith(1, {
+        name: MetaMetricsEventName.KeyExportRequested,
+        properties: {
+          category: MetaMetricsEventCategory.Keys,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          key_type: MetaMetricsEventKeyType.Srp,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          verification_method: MetaMetricsEventVerificationMethod.Password,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          hd_entropy_index: 0,
+        },
+        sensitiveProperties: {},
+      });
+      expect(mockTrackEvent).toHaveBeenNthCalledWith(2, {
+        name: MetaMetricsEventName.KeyExportRevealed,
+        properties: {
+          category: MetaMetricsEventCategory.Keys,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          key_type: MetaMetricsEventKeyType.Srp,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          verification_method: MetaMetricsEventVerificationMethod.Password,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          hd_entropy_index: 0,
+        },
+        sensitiveProperties: {},
+      });
     });
   });
 
@@ -265,6 +297,36 @@ describe('RevealRecoveryPhrase', () => {
       messages.unlockPageIncorrectPassword.message,
     );
     expect(errorMessage).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(mockTrackEvent).toHaveBeenNthCalledWith(1, {
+        name: MetaMetricsEventName.KeyExportRequested,
+        properties: {
+          category: MetaMetricsEventCategory.Keys,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          key_type: MetaMetricsEventKeyType.Srp,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          verification_method: MetaMetricsEventVerificationMethod.Password,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          hd_entropy_index: 0,
+        },
+        sensitiveProperties: {},
+      });
+      expect(mockTrackEvent).toHaveBeenNthCalledWith(2, {
+        name: MetaMetricsEventName.KeyExportFailed,
+        properties: {
+          category: MetaMetricsEventCategory.Keys,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          key_type: MetaMetricsEventKeyType.Srp,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          verification_method: MetaMetricsEventVerificationMethod.Password,
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          hd_entropy_index: 0,
+          reason: 'Incorrect password',
+        },
+        sensitiveProperties: {},
+      });
+    });
   });
 
   it('clears error when user types after incorrect password', async () => {

--- a/ui/pages/onboarding-flow/recovery-phrase/reveal-recovery-phrase.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/reveal-recovery-phrase.tsx
@@ -1,9 +1,4 @@
-import React, {
-  FormEvent,
-  useCallback,
-  useEffect,
-  useState,
-} from 'react';
+import React, { FormEvent, useCallback, useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
 import { type PasskeyAuthenticationResponse } from '@metamask/passkey-controller';
@@ -185,11 +180,9 @@ export default function RevealRecoveryPhrase({
           createEventBuilder(MetaMetricsEventName.KeyExportFailed)
             .addCategory(MetaMetricsEventCategory.Keys)
             .addProperties(
-              getSrpExportEventProperties(
-                hdEntropyIndex,
-                verificationMethod,
-                { reason },
-              ),
+              getSrpExportEventProperties(hdEntropyIndex, verificationMethod, {
+                reason,
+              }),
             )
             .build(),
         );

--- a/ui/pages/onboarding-flow/recovery-phrase/reveal-recovery-phrase.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/reveal-recovery-phrase.tsx
@@ -1,7 +1,6 @@
 import React, {
   FormEvent,
   useCallback,
-  useContext,
   useEffect,
   useState,
 } from 'react';
@@ -34,7 +33,7 @@ import {
   MetaMetricsEventName,
   MetaMetricsEventVerificationMethod,
 } from '../../../../shared/constants/metametrics';
-import { MetaMetricsContext } from '../../../contexts/metametrics';
+import { useAnalytics } from '../../../hooks/useAnalytics';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import {
   FormTextFieldSize,
@@ -101,7 +100,7 @@ export default function RevealRecoveryPhrase({
   const navigate = useNavigate();
   const t = useI18nContext();
   const isFirefox = useIsFirefox();
-  const { trackEvent } = useContext(MetaMetricsContext);
+  const { trackEvent, createEventBuilder } = useAnalytics();
   const hdEntropyIndex = useSelector(getHDEntropyIndex);
   const { isFromSettingsSecurity, nextRouteQueryString } =
     useOnboardingSearchParams();
@@ -152,26 +151,26 @@ export default function RevealRecoveryPhrase({
       fetchSeedPhrase: () => Promise<string>,
       onFailure: (error: Error) => void,
     ) => {
-      trackEvent({
-        category: MetaMetricsEventCategory.Keys,
-        event: MetaMetricsEventName.KeyExportRequested,
-        properties: getSrpExportEventProperties(
-          hdEntropyIndex,
-          verificationMethod,
-        ),
-      });
+      trackEvent(
+        createEventBuilder(MetaMetricsEventName.KeyExportRequested)
+          .addCategory(MetaMetricsEventCategory.Keys)
+          .addProperties(
+            getSrpExportEventProperties(hdEntropyIndex, verificationMethod),
+          )
+          .build(),
+      );
 
       try {
         const seedPhrase = await fetchSeedPhrase();
 
-        trackEvent({
-          category: MetaMetricsEventCategory.Keys,
-          event: MetaMetricsEventName.KeyExportRevealed,
-          properties: getSrpExportEventProperties(
-            hdEntropyIndex,
-            verificationMethod,
-          ),
-        });
+        trackEvent(
+          createEventBuilder(MetaMetricsEventName.KeyExportRevealed)
+            .addCategory(MetaMetricsEventCategory.Keys)
+            .addProperties(
+              getSrpExportEventProperties(hdEntropyIndex, verificationMethod),
+            )
+            .build(),
+        );
 
         setSecretRecoveryPhrase(seedPhrase);
         navigateToReviewSrp();
@@ -182,19 +181,28 @@ export default function RevealRecoveryPhrase({
             ? getPasskeyErrorCode(revealError)
             : revealError.message;
 
-        trackEvent({
-          category: MetaMetricsEventCategory.Keys,
-          event: MetaMetricsEventName.KeyExportFailed,
-          properties: getSrpExportEventProperties(
-            hdEntropyIndex,
-            verificationMethod,
-            { reason },
-          ),
-        });
+        trackEvent(
+          createEventBuilder(MetaMetricsEventName.KeyExportFailed)
+            .addCategory(MetaMetricsEventCategory.Keys)
+            .addProperties(
+              getSrpExportEventProperties(
+                hdEntropyIndex,
+                verificationMethod,
+                { reason },
+              ),
+            )
+            .build(),
+        );
         onFailure(revealError);
       }
     },
-    [trackEvent, hdEntropyIndex, setSecretRecoveryPhrase, navigateToReviewSrp],
+    [
+      createEventBuilder,
+      trackEvent,
+      hdEntropyIndex,
+      setSecretRecoveryPhrase,
+      navigateToReviewSrp,
+    ],
   );
 
   const handleRevealWithPasskey = useCallback(


### PR DESCRIPTION
## **Description**

Migrates remaining legacy `MetaMetricsContext.trackEvent` / `trackMetaMetricsEvent` call sites in the **Web3Auth (recovery phrase, passkey, consent, password)** domain to `useAnalytics()` + `createEventBuilder` (or `trackAnalyticsEvent` for Redux thunks).

Part of umbrella tracker #43885 (**15d · Web3Auth onboarding gaps**).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Build and load the extension (`yarn start`).
2. Exercise the flows touched by this PR (see changed files).
3. With MetaMetrics debug enabled, confirm events still fire with the same names and properties.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics instrumentation refactor only; no changes to wallet, auth, or password/passkey business logic beyond how events are emitted.
> 
> **Overview**
> Replaces remaining **`MetaMetricsContext`** `trackEvent` usage in Web3Auth-related UI (basic functionality modal, change password, marketing consent, passkey troubleshoot, reveal SRP) with **`useAnalytics()`** and **`createEventBuilder().build()`**, keeping the same event names and properties.
> 
> **Passkey troubleshoot** now pulls **page title** for support-link events from **`useSegmentContext`** instead of the legacy second-argument context merge.
> 
> Tests for **reveal recovery phrase** (and related setup) mock **`useAnalytics`** and assert **`trackEvent`** receives the built payload shape (`name`, `properties`, `sensitiveProperties`) on SRP export success and failure paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47b7b930086dcee00e3f53a09d6b76b4ead02e49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->