### PR TITLE
chore: use candlestick filled icon when perps bottom nav active

### DIFF
--- a/ui/components/app/bottom-nav-bar/bottom-nav-bar.tsx
+++ b/ui/components/app/bottom-nav-bar/bottom-nav-bar.tsx
@@ -109,7 +109,7 @@ export function BottomNavBar() {
       {isPerpsAvailable && (
         <NavTab
           isActive={isPerps}
-          icon={IconName.Candlestick}
+          icon={isPerps ? IconName.CandlestickFilled : IconName.Candlestick}
           label={t('perps')}
           onClick={handlePerpsClick}
           data-testid="bottom-nav-perps"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Tiny PR to add the filled candlestick version icon for Perps on the bottom nav when the tab is active. Behind feature flag.

active
<img width="443" height="72" alt="image" src="https://github.com/user-attachments/assets/3080a292-929b-463b-9c5b-af4c7f3df499" />

inactive
<img width="440" height="75" alt="image" src="https://github.com/user-attachments/assets/8d42fac9-76ac-40bb-92a9-a1df2352b528" />


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
