### PR TITLE
fix: update `trackImportEvent` usage to use correct params and string comparison

### DIFF
--- a/ui/components/multichain/import-account/import-account.js
+++ b/ui/components/multichain/import-account/import-account.js
@@ -68,7 +68,7 @@ export const ImportAccount = ({ onActionComplete }) => {
       }
     } catch (error) {
       const message = getErrorMessage(error);
-      trackImportEvent(strategy, message);
+      trackImportEvent(strategy, false);
 
       if (handleKeyringControllerError(error)) {
         return false;
@@ -83,7 +83,7 @@ export const ImportAccount = ({ onActionComplete }) => {
 
   function trackImportEvent(strategy, wasSuccessful) {
     const accountImportType =
-      strategy === 'Private Key'
+      strategy === 'privateKey'
         ? MetaMetricsEventAccountImportType.PrivateKey
         : MetaMetricsEventAccountImportType.Json;
 

--- a/ui/components/multichain/import-account/import-account.test.tsx
+++ b/ui/components/multichain/import-account/import-account.test.tsx
@@ -5,6 +5,12 @@ import { fireEvent, waitFor } from '@testing-library/react';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import mockState from '../../../../test/data/mock-state.json';
 import * as actions from '../../../store/actions';
+import {
+  MetaMetricsEventAccountImportType,
+  MetaMetricsEventAccountType,
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../shared/constants/metametrics';
 import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import { ImportAccount } from './import-account';
 
@@ -20,11 +26,17 @@ const mockStore = configureMockStore(middlewares);
 
 const mockOnActionComplete = jest.fn();
 
-const renderImportAccount = (storeState: typeof mockState = mockState) => {
+const renderImportAccount = (
+  storeState: typeof mockState = mockState,
+  getMockTrackEvent?: () => jest.Mock,
+) => {
   const store = mockStore(storeState);
   return renderWithProvider(
     <ImportAccount onActionComplete={mockOnActionComplete} />,
     store,
+    '/',
+    undefined,
+    getMockTrackEvent,
   );
 };
 
@@ -197,6 +209,92 @@ describe('ImportAccount', () => {
       await waitFor(() => {
         expect(queryByText('Invalid private key')).toBeInTheDocument();
       });
+    });
+
+    it('tracks a failed private key import with the private key import type', async () => {
+      const mockTrackEvent = jest.fn();
+      mockedActions.importNewAccount.mockReturnValue(() =>
+        Promise.reject(new Error('Invalid private key')),
+      );
+
+      const { getByLabelText, getByText } = renderImportAccount(
+        mockState,
+        () => mockTrackEvent,
+      );
+
+      const privateKeyInput = getByLabelText(messages.pastePrivateKey.message);
+      fireEvent.change(privateKeyInput, {
+        target: { value: 'invalid-key' },
+      });
+
+      fireEvent.click(getByText(messages.import.message));
+
+      await waitFor(() => {
+        expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+      });
+
+      const trackedEvent = mockTrackEvent.mock.calls[0]?.[0];
+
+      expect(trackedEvent).toMatchObject({
+        category: MetaMetricsEventCategory.Accounts,
+        event: MetaMetricsEventName.AccountAddFailed,
+      });
+      expect(trackedEvent.properties.account_type).toBe(
+        MetaMetricsEventAccountType.Imported,
+      );
+      expect(trackedEvent.properties.account_import_type).toBe(
+        MetaMetricsEventAccountImportType.PrivateKey,
+      );
+      expect(trackedEvent.properties.hd_entropy_index).toBe(0);
+      expect(trackedEvent.properties.is_suggested_name).toBe(true);
+    });
+
+    it('tracks a failed json import with the json import type', async () => {
+      const mockTrackEvent = jest.fn();
+      mockedActions.importNewAccount.mockReturnValue(() =>
+        Promise.reject(new Error('Invalid JSON file')),
+      );
+
+      const { getByRole, getByTestId, getByText } = renderImportAccount(
+        mockState,
+        () => mockTrackEvent,
+      );
+
+      fireEvent.change(getByRole('combobox'), {
+        target: { value: 'JSON File' },
+      });
+
+      const fileInput = getByTestId('file-input');
+      const mockFile = new File(['0'], 'test.json');
+
+      fireEvent.change(fileInput, {
+        target: { files: [mockFile] },
+      });
+
+      await waitFor(() => {
+        expect(getByText(messages.import.message)).not.toBeDisabled();
+      });
+
+      fireEvent.click(getByText(messages.import.message));
+
+      await waitFor(() => {
+        expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+      });
+
+      const trackedEvent = mockTrackEvent.mock.calls[0]?.[0];
+
+      expect(trackedEvent).toMatchObject({
+        category: MetaMetricsEventCategory.Accounts,
+        event: MetaMetricsEventName.AccountAddFailed,
+      });
+      expect(trackedEvent.properties.account_type).toBe(
+        MetaMetricsEventAccountType.Imported,
+      );
+      expect(trackedEvent.properties.account_import_type).toBe(
+        MetaMetricsEventAccountImportType.Json,
+      );
+      expect(trackedEvent.properties.hd_entropy_index).toBe(0);
+      expect(trackedEvent.properties.is_suggested_name).toBe(true);
     });
 
     it('disables import button when private key input is empty', () => {


### PR DESCRIPTION
## **Description**

`trackImportEvent` was not being used properly in failure scenarios and it's string comparison against strategy type was wrong.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

1. Run tests
2. Confirm they pass

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [x] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [x] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics-only fix in the import account UI with no auth or import logic changes beyond event payloads.
> 
> **Overview**
> Fixes **MetaMetrics** tracking when account import fails in `import-account.js`. On catch, `trackImportEvent` now receives **`false`** instead of the error message string, so failures emit **`AccountAddFailed`** instead of being misclassified as success.
> 
> **`trackImportEvent`** now compares `strategy` to **`'privateKey'`** (not `'Private Key'`), matching the values passed from the import flow, so **`account_import_type`** is **`PrivateKey`** vs **Json** on failures.
> 
> Tests inject a mock **`trackEvent`** and assert failed private-key and JSON imports fire **`AccountAddFailed`** with the expected **`account_import_type`** and related properties.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a65c69db4f5cf219ea1a89ffc63a94d01064799d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->