### PR TITLE
feat(ramps): intent routing in goToBuy + stub buy pages

### DIFF
--- a/ui/components/app/modals/add-funds-modal/add-funds-modal.test.tsx
+++ b/ui/components/app/modals/add-funds-modal/add-funds-modal.test.tsx
@@ -1,10 +1,21 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
+import { fireEvent } from '@testing-library/react';
 import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import mockState from '../../../../../test/data/mock-state.json';
 import { CHAIN_IDS } from '../../../../../shared/constants/network';
 import { mockNetworkState } from '../../../../../test/stub/networks';
 import AddFundsModal from './add-funds-modal';
+
+const mockGoToBuy = jest.fn().mockResolvedValue(true);
+jest.mock(
+  '../../../../hooks/ramps/useRampsNavigation/useRampsNavigation',
+  () => ({
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    __esModule: true,
+    default: () => ({ goToBuy: mockGoToBuy }),
+  }),
+);
 
 const mockTrackEvent = jest.fn();
 
@@ -58,5 +69,25 @@ describe('Add funds modal Component', () => {
     );
 
     expect(container).toMatchSnapshot();
+  });
+
+  it('routes the Buy row through useRampsNavigation.goToBuy', () => {
+    const { getByTestId } = renderWithProvider(
+      <AddFundsModal
+        onClose={jest.fn()}
+        token={{
+          address: '0x0',
+          decimals: 18,
+          symbol: 'USDC',
+          conversionRate: { usd: '1' },
+        }}
+        chainId="0x1"
+        payerAddress="0x0"
+      />,
+      mockStore,
+    );
+
+    fireEvent.click(getByTestId('add-funds-modal-buy-crypto-button'));
+    expect(mockGoToBuy).toHaveBeenCalledWith();
   });
 });

--- a/ui/components/app/modals/add-funds-modal/add-funds-modal.test.tsx
+++ b/ui/components/app/modals/add-funds-modal/add-funds-modal.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import mockState from '../../../../../test/data/mock-state.json';
 import { CHAIN_IDS } from '../../../../../shared/constants/network';
@@ -50,6 +50,8 @@ describe('Add funds modal Component', () => {
 
   const mockStore = configureMockStore()(defaultState);
 
+  beforeEach(() => jest.clearAllMocks());
+
   it('should match snapshot', () => {
     const { container } = renderWithProvider(
       <AddFundsModal
@@ -89,5 +91,29 @@ describe('Add funds modal Component', () => {
 
     fireEvent.click(getByTestId('add-funds-modal-buy-crypto-button'));
     expect(mockGoToBuy).toHaveBeenCalledWith();
+  });
+
+  it('does not track or close when the ramps gate blocks the buy', async () => {
+    mockGoToBuy.mockResolvedValueOnce(false);
+    const onClose = jest.fn();
+    const { getByTestId } = renderWithProvider(
+      <AddFundsModal
+        onClose={onClose}
+        token={{
+          address: '0x0',
+          decimals: 18,
+          symbol: 'USDC',
+          conversionRate: { usd: '1' },
+        }}
+        chainId="0x1"
+        payerAddress="0x0"
+      />,
+      mockStore,
+    );
+
+    fireEvent.click(getByTestId('add-funds-modal-buy-crypto-button'));
+    await waitFor(() => expect(mockGoToBuy).toHaveBeenCalled());
+    expect(mockTrackEvent).not.toHaveBeenCalled();
+    expect(onClose).not.toHaveBeenCalled();
   });
 });

--- a/ui/components/app/modals/add-funds-modal/add-funds-modal.tsx
+++ b/ui/components/app/modals/add-funds-modal/add-funds-modal.tsx
@@ -66,14 +66,7 @@ const AddFundsModal = ({
         .build(),
     );
     onClose();
-  }, [
-    chainId,
-    onClose,
-    goToBuy,
-    token.symbol,
-    createEventBuilder,
-    trackEvent,
-  ]);
+  }, [chainId, onClose, goToBuy, token.symbol, createEventBuilder, trackEvent]);
 
   const handleReceiveOnClick = useCallback(() => {
     trace({ name: TraceName.ReceiveModal });

--- a/ui/components/app/modals/add-funds-modal/add-funds-modal.tsx
+++ b/ui/components/app/modals/add-funds-modal/add-funds-modal.tsx
@@ -18,7 +18,7 @@ import {
   ModalHeader,
   ModalOverlay,
 } from '../../../component-library';
-import useRamps from '../../../../hooks/ramps/useRamps/useRamps';
+import useRampsNavigation from '../../../../hooks/ramps/useRampsNavigation/useRampsNavigation';
 import { ReceiveModal } from '../../../multichain/receive-modal';
 import useBridging from '../../../../hooks/bridge/useBridging';
 import {
@@ -41,15 +41,15 @@ const AddFundsModal = ({
   payerAddress: Hex;
 }) => {
   const t = useI18nContext();
-  const { openBuyCryptoInPdapp } = useRamps();
+  const { goToBuy } = useRampsNavigation();
   const { trackEvent, createEventBuilder } = useAnalytics();
 
   const { openBridgeExperience } = useBridging();
 
   const [showReceiveModal, setShowReceiveModal] = useState(false);
 
-  const handleBuyAndSellOnClick = useCallback(() => {
-    openBuyCryptoInPdapp();
+  const handleBuyAndSellOnClick = useCallback(async () => {
+    await goToBuy();
     trackEvent(
       createEventBuilder(MetaMetricsEventName.NavBuyButtonClicked)
         .addCategory(MetaMetricsEventCategory.Navigation)
@@ -69,7 +69,7 @@ const AddFundsModal = ({
   }, [
     chainId,
     onClose,
-    openBuyCryptoInPdapp,
+    goToBuy,
     token.symbol,
     createEventBuilder,
     trackEvent,

--- a/ui/components/app/modals/add-funds-modal/add-funds-modal.tsx
+++ b/ui/components/app/modals/add-funds-modal/add-funds-modal.tsx
@@ -49,7 +49,13 @@ const AddFundsModal = ({
   const [showReceiveModal, setShowReceiveModal] = useState(false);
 
   const handleBuyAndSellOnClick = useCallback(async () => {
-    await goToBuy();
+    const opened = await goToBuy();
+    // The ramps gate can block the buy (e.g. service disruption, unsupported
+    // region) and show its own modal; don't report a buy click or close this
+    // modal in that case.
+    if (!opened) {
+      return;
+    }
     trackEvent(
       createEventBuilder(MetaMetricsEventName.NavBuyButtonClicked)
         .addCategory(MetaMetricsEventCategory.Navigation)

--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -64,6 +64,7 @@ import {
 } from '../../component-library';
 import IconButton from '../../ui/icon-button';
 import useRampsNavigation from '../../../hooks/ramps/useRampsNavigation/useRampsNavigation';
+import { getIsRampsEnabled } from '../../../selectors/ramps-feature-flags';
 import useBridging from '../../../hooks/bridge/useBridging';
 import { ReceiveModal } from '../../multichain/receive-modal';
 import { Toast, ToastContainer } from '../../multichain/toast';
@@ -363,6 +364,7 @@ const CoinButtons = ({
   };
 
   const { goToBuy } = useRampsNavigation();
+  const isRampsEnabled = useSelector(getIsRampsEnabled);
 
   const { openBridgeExperience } = useBridging();
 
@@ -426,7 +428,12 @@ const CoinButtons = ({
     if (!opened) {
       return;
     }
-    setShowTabOpenedToast(true);
+    // Only the flag-off path opens a Portfolio browser tab; with the ramps
+    // flow enabled, goToBuy navigates in-app, so the "tab opened" toast would
+    // be misleading.
+    if (!isRampsEnabled) {
+      setShowTabOpenedToast(true);
+    }
     trackEvent(
       createEventBuilder(MetaMetricsEventName.NavBuyButtonClicked)
         .addCategory(MetaMetricsEventCategory.Navigation)
@@ -446,7 +453,7 @@ const CoinButtons = ({
         })
         .build(),
     );
-  }, [chainId, defaultSwapsToken, buyAssetId, goToBuy]);
+  }, [chainId, defaultSwapsToken, buyAssetId, goToBuy, isRampsEnabled]);
 
   const handleSwapOnClick = useCallback(async () => {
     // Determine the chainId to use in the Swap experience using the url

--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -5,6 +5,7 @@ import { toHex } from '@metamask/controller-utils';
 import {
   isCaipChainId,
   CaipChainId,
+  CaipAssetType,
   isCaipAssetType,
   parseCaipAssetType,
 } from '@metamask/utils';
@@ -223,6 +224,11 @@ type CoinButtonsProps = {
   classPrefix?: string;
   /** When true, disables the send button for non-EVM chains (used on asset page) */
   disableSendForNonEvm?: boolean;
+  /**
+   * CAIP-19 asset to pre-select when buying (asset-page native tokens). When
+   * omitted (e.g. wallet overview), Buy opens the token-selection page instead.
+   */
+  buyAssetId?: CaipAssetType;
 };
 
 const CoinButtons = ({
@@ -233,6 +239,7 @@ const CoinButtons = ({
   isSigningEnabled,
   classPrefix = 'coin',
   disableSendForNonEvm = false,
+  buyAssetId,
 }: CoinButtonsProps) => {
   const t = useContext(I18nContext);
   const dispatch = useDispatch();
@@ -412,7 +419,7 @@ const CoinButtons = ({
   }, [chainId, account, setCorrectChain, handleSendNonEvm, trackingLocation]);
 
   const handleBuyAndSellOnClick = useCallback(async () => {
-    const opened = await goToBuy(getChainId());
+    const opened = await goToBuy({ assetId: buyAssetId, chainId: getChainId() });
     if (!opened) {
       return;
     }
@@ -436,7 +443,7 @@ const CoinButtons = ({
         })
         .build(),
     );
-  }, [chainId, defaultSwapsToken, goToBuy]);
+  }, [chainId, defaultSwapsToken, buyAssetId, goToBuy]);
 
   const handleSwapOnClick = useCallback(async () => {
     // Determine the chainId to use in the Swap experience using the url

--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -419,7 +419,10 @@ const CoinButtons = ({
   }, [chainId, account, setCorrectChain, handleSendNonEvm, trackingLocation]);
 
   const handleBuyAndSellOnClick = useCallback(async () => {
-    const opened = await goToBuy({ assetId: buyAssetId, chainId: getChainId() });
+    const opened = await goToBuy({
+      assetId: buyAssetId,
+      chainId: getChainId(),
+    });
     if (!opened) {
       return;
     }

--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -64,7 +64,6 @@ import {
 } from '../../component-library';
 import IconButton from '../../ui/icon-button';
 import useRampsNavigation from '../../../hooks/ramps/useRampsNavigation/useRampsNavigation';
-import { getIsRampsEnabled } from '../../../selectors/ramps-feature-flags';
 import useBridging from '../../../hooks/bridge/useBridging';
 import { ReceiveModal } from '../../multichain/receive-modal';
 import { Toast, ToastContainer } from '../../multichain/toast';
@@ -363,8 +362,7 @@ const CoinButtons = ({
     return {};
   };
 
-  const { goToBuy } = useRampsNavigation();
-  const isRampsEnabled = useSelector(getIsRampsEnabled);
+  const { goToBuy, isRampsEnabled } = useRampsNavigation();
 
   const { openBridgeExperience } = useBridging();
 

--- a/ui/helpers/constants/routes.ts
+++ b/ui/helpers/constants/routes.ts
@@ -181,6 +181,11 @@ export const BASIC_FUNCTIONALITY_OFF_ROUTE = '/basic-functionality-off';
 
 export const DEFI_ROUTE = '/defi';
 
+// Ramps (native buy) routes
+export const RAMPS_ROUTE = '/ramps';
+export const RAMPS_BUILD_QUOTE_ROUTE = '/ramps/build-quote';
+export const RAMPS_TOKEN_SELECTION_ROUTE = '/ramps/token-selection';
+
 // Perps routes
 export const PERPS_ROUTE = '/perps';
 export const PERPS_MARKET_DETAIL_ROUTE = '/perps/market';

--- a/ui/hooks/ramps/useRampsNavigation/useRampsNavigation.test.tsx
+++ b/ui/hooks/ramps/useRampsNavigation/useRampsNavigation.test.tsx
@@ -11,14 +11,27 @@ import { act } from '@testing-library/react';
 import { renderHookWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import { mockNetworkState } from '../../../../test/stub/networks';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
+import {
+  RAMPS_BUILD_QUOTE_ROUTE,
+  RAMPS_TOKEN_SELECTION_ROUTE,
+} from '../../../helpers/constants/routes';
 import { submitRequestToBackground } from '../../../store/background-connection';
-import useRampsNavigation from './useRampsNavigation';
+import useRampsNavigation, { type RampIntent } from './useRampsNavigation';
 
 jest.mock('../../../store/background-connection', () => ({
   submitRequestToBackground: jest.fn(),
 }));
 
-const mockGetGeolocation = submitRequestToBackground as jest.Mock;
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => ({
+  ...jest.requireActual('react-router-dom'),
+  useNavigate: () => mockNavigate,
+}));
+
+const mockBackground = submitRequestToBackground as jest.Mock;
+// `submitRequestToBackground` backs both the geolocation lookup and
+// `setRampsSelectedToken`; the geolocation result is what the gate reads.
+const mockGetGeolocation = mockBackground;
 const openTab = jest.fn();
 
 const region: UserRegion = {
@@ -79,12 +92,13 @@ const run = (state: ReturnType<typeof buildState>) => {
   return { result, getModalName };
 };
 
-const goToBuy = async (result: {
-  current: ReturnType<typeof useRampsNavigation>;
-}): Promise<boolean | undefined> => {
+const goToBuy = async (
+  result: { current: ReturnType<typeof useRampsNavigation> },
+  intent: RampIntent = { chainId: '0x1' },
+): Promise<boolean | undefined> => {
   let opened: boolean | undefined;
   await act(async () => {
-    opened = await result.current.goToBuy('0x1');
+    opened = await result.current.goToBuy(intent);
   });
   return opened;
 };
@@ -179,14 +193,16 @@ describe('useRampsNavigation goToBuy', () => {
     expect(getModalName()).toBe('RAMPS_UNSUPPORTED');
   });
 
-  it('supported + providers → proceeds (opens Portfolio for now)', async () => {
-    const { result } = run(buildState());
+  it('gate passes, no assetId → navigates to token selection', async () => {
+    const { result, getModalName } = run(buildState());
     const opened = await goToBuy(result);
     expect(opened).toBe(true);
-    expect(openTab).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith(RAMPS_TOKEN_SELECTION_ROUTE);
+    expect(openTab).not.toHaveBeenCalled();
+    expect(getModalName()).toBeNull();
   });
 
-  it('providers fetch errored → fails open and proceeds', async () => {
+  it('providers fetch errored → fails open and navigates to token selection', async () => {
     const { result, getModalName } = run(
       buildState({
         providers: {
@@ -198,11 +214,11 @@ describe('useRampsNavigation goToBuy', () => {
       }),
     );
     await goToBuy(result);
-    expect(openTab).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith(RAMPS_TOKEN_SELECTION_ROUTE);
     expect(getModalName()).toBeNull();
   });
 
-  it('tokens fetch errored → fails open and proceeds', async () => {
+  it('tokens fetch errored → fails open and navigates to token selection', async () => {
     const { result, getModalName } = run(
       buildState({
         tokens: {
@@ -214,11 +230,11 @@ describe('useRampsNavigation goToBuy', () => {
       }),
     );
     await goToBuy(result);
-    expect(openTab).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith(RAMPS_TOKEN_SELECTION_ROUTE);
     expect(getModalName()).toBeNull();
   });
 
-  it('providers/tokens never fetched (default state) → fails open and proceeds', async () => {
+  it('providers/tokens never fetched (default state) → fails open and navigates', async () => {
     // RampsController's never-fetched default: providers.data === [] and
     // tokens.data === null. This must NOT be treated as "fetched and empty".
     const { result, getModalName } = run(
@@ -228,7 +244,118 @@ describe('useRampsNavigation goToBuy', () => {
       }),
     );
     await goToBuy(result);
-    expect(openTab).toHaveBeenCalled();
+    expect(mockNavigate).toHaveBeenCalledWith(RAMPS_TOKEN_SELECTION_ROUTE);
+    expect(getModalName()).toBeNull();
+  });
+
+  it('intent with supported assetId → pre-selects token and navigates to build quote', async () => {
+    const assetId = 'eip155:1/erc20:0xabc';
+    const { result, getModalName } = run(
+      buildState({
+        tokens: {
+          data: {
+            topTokens: [],
+            allTokens: [{ assetId, tokenSupported: true } as RampsToken],
+          },
+          selected: null,
+          isLoading: false,
+          error: null,
+        },
+      }),
+    );
+    const opened = await goToBuy(result, { assetId });
+    expect(opened).toBe(true);
+    expect(mockBackground).toHaveBeenCalledWith('setRampsSelectedToken', [
+      assetId,
+    ]);
+    expect(mockNavigate).toHaveBeenCalledWith(RAMPS_BUILD_QUOTE_ROUTE);
+    expect(getModalName()).toBeNull();
+  });
+
+  it('intent with supported assetId matches case-insensitively', async () => {
+    const catalogAssetId = 'eip155:1/erc20:0xAbC';
+    const { result } = run(
+      buildState({
+        tokens: {
+          data: {
+            topTokens: [],
+            allTokens: [
+              { assetId: catalogAssetId, tokenSupported: true } as RampsToken,
+            ],
+          },
+          selected: null,
+          isLoading: false,
+          error: null,
+        },
+      }),
+    );
+    const opened = await goToBuy(result, { assetId: 'eip155:1/erc20:0xabc' });
+    expect(opened).toBe(true);
+    expect(mockNavigate).toHaveBeenCalledWith(RAMPS_BUILD_QUOTE_ROUTE);
+  });
+
+  it('intent with assetId absent from a settled catalog → shows RAMPS_UNSUPPORTED', async () => {
+    const { result, getModalName } = run(
+      buildState({
+        tokens: {
+          data: {
+            topTokens: [],
+            allTokens: [
+              {
+                assetId: 'eip155:1/erc20:0xother',
+                tokenSupported: true,
+              } as RampsToken,
+            ],
+          },
+          selected: null,
+          isLoading: false,
+          error: null,
+        },
+      }),
+    );
+    const opened = await goToBuy(result, {
+      assetId: 'eip155:1/erc20:0xmissing',
+    });
+    expect(opened).toBe(false);
+    expect(getModalName()).toBe('RAMPS_UNSUPPORTED');
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('intent with assetId flagged tokenSupported:false → shows RAMPS_UNSUPPORTED', async () => {
+    const assetId = 'eip155:1/erc20:0xabc';
+    const { result, getModalName } = run(
+      buildState({
+        tokens: {
+          data: {
+            topTokens: [],
+            allTokens: [{ assetId, tokenSupported: false } as RampsToken],
+          },
+          selected: null,
+          isLoading: false,
+          error: null,
+        },
+      }),
+    );
+    const opened = await goToBuy(result, { assetId });
+    expect(opened).toBe(false);
+    expect(getModalName()).toBe('RAMPS_UNSUPPORTED');
+  });
+
+  it('intent with assetId but catalog not settled → fails open to build quote', async () => {
+    // tokens.data === null (never fetched): cannot verify the token, so fail
+    // open and proceed with it pre-selected rather than blocking.
+    const assetId = 'eip155:1/erc20:0xabc';
+    const { result, getModalName } = run(
+      buildState({
+        tokens: { data: null, selected: null, isLoading: false, error: null },
+      }),
+    );
+    const opened = await goToBuy(result, { assetId });
+    expect(opened).toBe(true);
+    expect(mockBackground).toHaveBeenCalledWith('setRampsSelectedToken', [
+      assetId,
+    ]);
+    expect(mockNavigate).toHaveBeenCalledWith(RAMPS_BUILD_QUOTE_ROUTE);
     expect(getModalName()).toBeNull();
   });
 });

--- a/ui/hooks/ramps/useRampsNavigation/useRampsNavigation.ts
+++ b/ui/hooks/ramps/useRampsNavigation/useRampsNavigation.ts
@@ -206,5 +206,7 @@ export default function useRampsNavigation() {
     ],
   );
 
-  return { goToBuy };
+  // Expose the rollout flag so callers can gate follow-up UI (e.g. the flag-off
+  // "tab opened" toast) without re-reading the selector themselves.
+  return { goToBuy, isRampsEnabled: isEnabled };
 }

--- a/ui/hooks/ramps/useRampsNavigation/useRampsNavigation.ts
+++ b/ui/hooks/ramps/useRampsNavigation/useRampsNavigation.ts
@@ -3,6 +3,11 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import type { CaipAssetType, CaipChainId, Hex } from '@metamask/utils';
 import { UNKNOWN_LOCATION } from '@metamask/geolocation-controller';
+import type {
+  Provider,
+  ResourceState,
+  TokensResponse,
+} from '@metamask/ramps-controller';
 import type { ChainId } from '../../../../shared/constants/network';
 import {
   RAMPS_BUILD_QUOTE_ROUTE,
@@ -30,6 +35,67 @@ export type RampIntent = {
   /** Chain for the flag-off Portfolio fallback deeplink only. */
   chainId?: Hex | CaipChainId;
 };
+
+type ProvidersState = ResourceState<Provider[], Provider | null>;
+type TokensState = ResourceState<TokensResponse | null, unknown>;
+
+// Resolve geolocation on demand; a failed lookup fails closed (undefined).
+async function resolveGeolocation(): Promise<string | undefined> {
+  try {
+    return await submitRequestToBackground<string>('getGeolocation');
+  } catch {
+    return undefined;
+  }
+}
+
+// True once providers/tokens have finished fetching without error.
+function isCatalogSettled(
+  providers: ProvidersState,
+  tokens: TokensState,
+): boolean {
+  return (
+    !providers.isLoading &&
+    !tokens.isLoading &&
+    !providers.error &&
+    !tokens.error
+  );
+}
+
+// True when a settled catalog has no providers or no tokens.
+function isCatalogEmpty(
+  providers: ProvidersState,
+  tokensData: TokensResponse,
+): boolean {
+  const providersEmpty = providers.data.length === 0;
+  const tokensEmpty =
+    (tokensData.topTokens?.length ?? 0) === 0 &&
+    (tokensData.allTokens?.length ?? 0) === 0;
+  return providersEmpty || tokensEmpty;
+}
+
+// True when `assetId` is present in a settled catalog and not flagged off.
+function isAssetSupported(
+  tokensData: TokensResponse,
+  assetId: CaipAssetType,
+): boolean {
+  const catalog = [
+    ...(tokensData.topTokens ?? []),
+    ...(tokensData.allTokens ?? []),
+  ];
+  const match = catalog.find(
+    (token) => token.assetId.toLowerCase() === assetId.toLowerCase(),
+  );
+  return Boolean(match) && match?.tokenSupported !== false;
+}
+
+// Pre-select the token; a failed pre-selection fails open (non-fatal).
+async function preselectToken(assetId: CaipAssetType): Promise<void> {
+  try {
+    await submitRequestToBackground('setRampsSelectedToken', [assetId]);
+  } catch {
+    // Fail open — the build-quote page can re-resolve the token itself.
+  }
+}
 
 /**
  * Provides the `goToBuy` navigation gate for the Ramps buy entry point.
@@ -85,12 +151,7 @@ export default function useRampsNavigation() {
       // (it does not fetch at startup, so reading synced state alone would
       // report UNKNOWN and fail closed). A settled `UNKNOWN`/failed lookup means
       // we cannot verify the user's location → EligibilityFailed.
-      let location: string | undefined;
-      try {
-        location = await submitRequestToBackground<string>('getGeolocation');
-      } catch {
-        location = undefined;
-      }
+      const location = await resolveGeolocation();
       if (!location || location === UNKNOWN_LOCATION) {
         dispatch(showModal({ name: 'RAMPS_ELIGIBILITY_FAILED' }));
         return false;
@@ -107,53 +168,30 @@ export default function useRampsNavigation() {
       // native flow), so fail open and skip this check entirely until then.
       // A fetch error also fails open (mobile parity) — an empty result only
       // counts once the catalog has actually settled, not on a failed fetch.
-      const catalogSettled =
-        !providers.isLoading &&
-        !tokens.isLoading &&
-        !providers.error &&
-        !tokens.error;
-      if (catalogSettled && tokens.data !== null) {
-        const providersEmpty = providers.data.length === 0;
-        const tokensEmpty =
-          (tokens.data.topTokens?.length ?? 0) === 0 &&
-          (tokens.data.allTokens?.length ?? 0) === 0;
-        if (providersEmpty || tokensEmpty) {
-          dispatch(showModal({ name: 'RAMPS_UNSUPPORTED' }));
-          return false;
-        }
+      const catalogSettled = isCatalogSettled(providers, tokens);
+      const catalogData = catalogSettled ? tokens.data : null;
+      if (catalogData && isCatalogEmpty(providers, catalogData)) {
+        dispatch(showModal({ name: 'RAMPS_UNSUPPORTED' }));
+        return false;
       }
 
       // 5. Route into the native buy flow.
       const assetId = intent?.assetId;
-      if (assetId) {
-        // Resolve against the catalog. Only block on a settled catalog that
-        // definitively lacks/unsupports the token — an unsettled catalog fails
-        // open (proceed with it selected, page re-resolves).
-        if (catalogSettled && tokens.data !== null) {
-          const catalog = [
-            ...(tokens.data.topTokens ?? []),
-            ...(tokens.data.allTokens ?? []),
-          ];
-          const match = catalog.find(
-            (token) => token.assetId.toLowerCase() === assetId.toLowerCase(),
-          );
-          if (!match || match.tokenSupported === false) {
-            dispatch(showModal({ name: 'RAMPS_UNSUPPORTED' }));
-            return false;
-          }
-        }
-        try {
-          await submitRequestToBackground('setRampsSelectedToken', [assetId]);
-        } catch {
-          // Fail open — a failed pre-selection is non-fatal; the build-quote
-          // page can re-resolve the token itself.
-        }
-        navigate(RAMPS_BUILD_QUOTE_ROUTE);
+      if (!assetId) {
+        // No specific asset → token selection page.
+        navigate(RAMPS_TOKEN_SELECTION_ROUTE);
         return true;
       }
 
-      // 6. No specific asset → token selection page.
-      navigate(RAMPS_TOKEN_SELECTION_ROUTE);
+      // Resolve against the catalog. Only block on a settled catalog that
+      // definitively lacks/unsupports the token — an unsettled catalog fails
+      // open (proceed with it selected, page re-resolves).
+      if (catalogData && !isAssetSupported(catalogData, assetId)) {
+        dispatch(showModal({ name: 'RAMPS_UNSUPPORTED' }));
+        return false;
+      }
+      await preselectToken(assetId);
+      navigate(RAMPS_BUILD_QUOTE_ROUTE);
       return true;
     },
     [

--- a/ui/hooks/ramps/useRampsNavigation/useRampsNavigation.ts
+++ b/ui/hooks/ramps/useRampsNavigation/useRampsNavigation.ts
@@ -1,8 +1,13 @@
 import { useCallback } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import type { CaipChainId } from '@metamask/utils';
+import { useNavigate } from 'react-router-dom';
+import type { CaipAssetType, CaipChainId, Hex } from '@metamask/utils';
 import { UNKNOWN_LOCATION } from '@metamask/geolocation-controller';
 import type { ChainId } from '../../../../shared/constants/network';
+import {
+  RAMPS_BUILD_QUOTE_ROUTE,
+  RAMPS_TOKEN_SELECTION_ROUTE,
+} from '../../../helpers/constants/routes';
 import { showModal } from '../../../store/actions';
 import { submitRequestToBackground } from '../../../store/background-connection';
 import {
@@ -17,25 +22,40 @@ import {
 import useRamps from '../useRamps/useRamps';
 
 /**
+ * A buy intent, mirroring mobile's `RampIntent` (buy-only subset).
+ */
+export type RampIntent = {
+  /** CAIP-19 asset to pre-select, e.g. `eip155:1/erc20:0x...`. */
+  assetId?: CaipAssetType;
+  /** Chain for the flag-off Portfolio fallback deeplink only. */
+  chainId?: Hex | CaipChainId;
+};
+
+/**
  * Provides the `goToBuy` navigation gate for the Ramps buy entry point.
  *
  * Runs a fixed geo-block gate (service disruption, geolocation unknown, region
- * unsupported, providers/tokens fetched-but-empty, proceed) before falling
- * through to the existing Portfolio redirect. The gate is skipped entirely when
- * the `rampsEnabled` rollout flag is off.
+ * unsupported, providers/tokens fetched-but-empty) and then routes into the
+ * native buy flow: an intent with a supported `assetId` pre-selects the token
+ * and opens the build-quote page; without one it opens the token-selection
+ * page; an unsupported `assetId` raises the unsupported modal. The gate is
+ * skipped entirely when the `rampsEnabled` rollout flag is off (unchanged
+ * Portfolio redirect).
  *
  * Geolocation is resolved on demand via the background `GeolocationController`
  * (mobile parity — it does not fetch at startup, so reading synced state alone
  * would fail closed). Any loading/indeterminate state fails open; only a
  * settled, definitively-blocking state raises a modal.
  *
- * @returns An object with `goToBuy`, an async callback that runs the gate and
- * either shows a blocking modal or opens the buy destination. Resolves to
- * `true` when it proceeded (buy destination opened) and `false` when a blocking
- * modal was shown, so callers can gate follow-up UI (e.g. a "tab opened" toast).
+ * @returns An object with `goToBuy`, an async callback taking an optional
+ * {@link RampIntent}. It runs the gate and either shows a blocking modal or
+ * opens the buy destination. Resolves to `true` when it proceeded and `false`
+ * when a blocking modal was shown, so callers can gate follow-up UI (e.g. a
+ * "tab opened" toast).
  */
 export default function useRampsNavigation() {
   const dispatch = useDispatch();
+  const navigate = useNavigate();
   const { openBuyCryptoInPdapp } = useRamps();
 
   const isEnabled = useSelector(getIsRampsEnabled);
@@ -45,10 +65,12 @@ export default function useRampsNavigation() {
   const tokens = useSelector(selectTokens);
 
   const goToBuy = useCallback(
-    async (chainId?: ChainId | CaipChainId): Promise<boolean> => {
+    async (intent?: RampIntent): Promise<boolean> => {
       // Rollout gate off → unchanged Portfolio behavior.
       if (!isEnabled) {
-        openBuyCryptoInPdapp(chainId);
+        // `getBuyURI` accepts any hex chain id; the narrower `ChainId` param is
+        // just an over-tight annotation.
+        openBuyCryptoInPdapp(intent?.chainId as ChainId | CaipChainId);
         return true;
       }
 
@@ -101,8 +123,37 @@ export default function useRampsNavigation() {
         }
       }
 
-      // 5. Proceed. Destination stays Portfolio until native pages (TRAM-3714+).
-      openBuyCryptoInPdapp(chainId);
+      // 5. Route into the native buy flow.
+      const assetId = intent?.assetId;
+      if (assetId) {
+        // Resolve against the catalog. Only block on a settled catalog that
+        // definitively lacks/unsupports the token — an unsettled catalog fails
+        // open (proceed with it selected, page re-resolves).
+        if (catalogSettled && tokens.data !== null) {
+          const catalog = [
+            ...(tokens.data.topTokens ?? []),
+            ...(tokens.data.allTokens ?? []),
+          ];
+          const match = catalog.find(
+            (token) => token.assetId.toLowerCase() === assetId.toLowerCase(),
+          );
+          if (!match || match.tokenSupported === false) {
+            dispatch(showModal({ name: 'RAMPS_UNSUPPORTED' }));
+            return false;
+          }
+        }
+        try {
+          await submitRequestToBackground('setRampsSelectedToken', [assetId]);
+        } catch {
+          // Fail open — a failed pre-selection is non-fatal; the build-quote
+          // page can re-resolve the token itself.
+        }
+        navigate(RAMPS_BUILD_QUOTE_ROUTE);
+        return true;
+      }
+
+      // 6. No specific asset → token selection page.
+      navigate(RAMPS_TOKEN_SELECTION_ROUTE);
       return true;
     },
     [
@@ -112,6 +163,7 @@ export default function useRampsNavigation() {
       providers,
       tokens,
       dispatch,
+      navigate,
       openBuyCryptoInPdapp,
     ],
   );

--- a/ui/pages/asset/components/asset-page.tsx
+++ b/ui/pages/asset/components/asset-page.tsx
@@ -360,6 +360,7 @@ const AssetPage = ({
               isBridgeChain,
               chainId,
               disableSendForNonEvm: true,
+              buyAssetId: caipAssetId,
             }}
           />
         ) : null}

--- a/ui/pages/asset/components/token-buttons.test.tsx
+++ b/ui/pages/asset/components/token-buttons.test.tsx
@@ -10,14 +10,11 @@ import { Asset } from '../types/asset';
 import TokenButtons from './token-buttons';
 
 const mockGoToBuy = jest.fn().mockResolvedValue(true);
-jest.mock(
-  '../../../hooks/ramps/useRampsNavigation/useRampsNavigation',
-  () => ({
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    __esModule: true,
-    default: () => ({ goToBuy: mockGoToBuy }),
-  }),
-);
+jest.mock('../../../hooks/ramps/useRampsNavigation/useRampsNavigation', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  __esModule: true,
+  default: () => ({ goToBuy: mockGoToBuy }),
+}));
 
 jest.mock('../../../hooks/bridge/useBridging', () => ({
   // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/ui/pages/asset/components/token-buttons.test.tsx
+++ b/ui/pages/asset/components/token-buttons.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
 import { mockNetworkState } from '../../../../test/stub/networks';
@@ -22,12 +22,13 @@ jest.mock('../../../hooks/bridge/useBridging', () => ({
   default: () => ({ openBridgeExperience: jest.fn() }),
 }));
 
+const mockTrackEvent = jest.fn();
 jest.mock('../../../hooks/useAnalytics', () => {
   const { createEventBuilder } = jest.requireActual(
     '../../../../shared/lib/analytics/create-event-builder',
   );
   return {
-    useAnalytics: () => ({ trackEvent: jest.fn(), createEventBuilder }),
+    useAnalytics: () => ({ trackEvent: mockTrackEvent, createEventBuilder }),
   };
 });
 
@@ -61,5 +62,17 @@ describe('TokenButtons buy wiring', () => {
       assetId: toAssetId(token.address, token.chainId),
       chainId: token.chainId,
     });
+  });
+
+  it('does not track a buy click when the ramps gate blocks the buy', async () => {
+    mockGoToBuy.mockResolvedValueOnce(false);
+    const { getByTestId } = renderWithProvider(
+      <TokenButtons token={token} />,
+      store,
+    );
+
+    fireEvent.click(getByTestId('token-overview-buy'));
+    await waitFor(() => expect(mockGoToBuy).toHaveBeenCalled());
+    expect(mockTrackEvent).not.toHaveBeenCalled();
   });
 });

--- a/ui/pages/asset/components/token-buttons.test.tsx
+++ b/ui/pages/asset/components/token-buttons.test.tsx
@@ -1,0 +1,68 @@
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+import { fireEvent } from '@testing-library/react';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import { CHAIN_IDS } from '../../../../shared/constants/network';
+import { mockNetworkState } from '../../../../test/stub/networks';
+import { AssetType } from '../../../../shared/constants/transaction';
+import { toAssetId } from '../../../../shared/lib/asset-utils';
+import { Asset } from '../types/asset';
+import TokenButtons from './token-buttons';
+
+const mockGoToBuy = jest.fn().mockResolvedValue(true);
+jest.mock(
+  '../../../hooks/ramps/useRampsNavigation/useRampsNavigation',
+  () => ({
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    __esModule: true,
+    default: () => ({ goToBuy: mockGoToBuy }),
+  }),
+);
+
+jest.mock('../../../hooks/bridge/useBridging', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  __esModule: true,
+  default: () => ({ openBridgeExperience: jest.fn() }),
+}));
+
+jest.mock('../../../hooks/useAnalytics', () => {
+  const { createEventBuilder } = jest.requireActual(
+    '../../../../shared/lib/analytics/create-event-builder',
+  );
+  return {
+    useAnalytics: () => ({ trackEvent: jest.fn(), createEventBuilder }),
+  };
+});
+
+const token = {
+  type: AssetType.token,
+  address: '0x6b175474e89094c44da98b954eedeac495271d0f',
+  chainId: CHAIN_IDS.MAINNET,
+  decimals: 18,
+  symbol: 'DAI',
+  image: '',
+} as Asset & { type: AssetType.token };
+
+const store = configureMockStore()({
+  metamask: {
+    ...mockNetworkState({ chainId: CHAIN_IDS.MAINNET }),
+    useExternalServices: true,
+  },
+});
+
+describe('TokenButtons buy wiring', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('routes the Buy button through goToBuy with the token as intent assetId', () => {
+    const { getByTestId } = renderWithProvider(
+      <TokenButtons token={token} />,
+      store,
+    );
+
+    fireEvent.click(getByTestId('token-overview-buy'));
+    expect(mockGoToBuy).toHaveBeenCalledWith({
+      assetId: toAssetId(token.address, token.chainId),
+      chainId: token.chainId,
+    });
+  });
+});

--- a/ui/pages/asset/components/token-buttons.tsx
+++ b/ui/pages/asset/components/token-buttons.tsx
@@ -66,10 +66,15 @@ const TokenButtons = ({
   }, [token.isERC721, token.address, dispatch]);
 
   const handleBuyAndSellOnClick = useCallback(async () => {
-    await goToBuy({
+    const opened = await goToBuy({
       assetId: toAssetId(token.address, token.chainId),
       chainId: token.chainId,
     });
+    // The ramps gate can block the buy and show its own modal; don't report a
+    // buy click in that case.
+    if (!opened) {
+      return;
+    }
     trackEvent(
       createEventBuilder(MetaMetricsEventName.NavBuyButtonClicked)
         .addCategory(MetaMetricsEventCategory.Navigation)

--- a/ui/pages/asset/components/token-buttons.tsx
+++ b/ui/pages/asset/components/token-buttons.tsx
@@ -3,7 +3,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import { Box, BoxJustifyContent } from '@metamask/design-system-react';
 import { I18nContext } from '../../../contexts/i18n';
-import useRamps from '../../../hooks/ramps/useRamps/useRamps';
+import useRampsNavigation from '../../../hooks/ramps/useRampsNavigation/useRampsNavigation';
 import { getUseExternalServices } from '../../../selectors';
 import useBridging from '../../../hooks/bridge/useBridging';
 
@@ -26,7 +26,7 @@ import {
 import { Asset } from '../types/asset';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0021): route-isolation backlog
 import { navigateToSendRoute } from '../../confirmations/utils/send';
-import { isEvmChainId } from '../../../../shared/lib/asset-utils';
+import { isEvmChainId, toAssetId } from '../../../../shared/lib/asset-utils';
 
 const TokenButtons = ({
   token,
@@ -51,7 +51,7 @@ const TokenButtons = ({
 
   const currentChainId = token.chainId;
 
-  const { openBuyCryptoInPdapp } = useRamps();
+  const { goToBuy } = useRampsNavigation();
   const { openBridgeExperience } = useBridging();
 
   useEffect(() => {
@@ -65,8 +65,11 @@ const TokenButtons = ({
     }
   }, [token.isERC721, token.address, dispatch]);
 
-  const handleBuyAndSellOnClick = useCallback(() => {
-    openBuyCryptoInPdapp();
+  const handleBuyAndSellOnClick = useCallback(async () => {
+    await goToBuy({
+      assetId: toAssetId(token.address, token.chainId),
+      chainId: token.chainId,
+    });
     trackEvent(
       createEventBuilder(MetaMetricsEventName.NavBuyButtonClicked)
         .addCategory(MetaMetricsEventCategory.Navigation)
@@ -84,10 +87,12 @@ const TokenButtons = ({
     );
   }, [
     currentChainId,
+    token.address,
+    token.chainId,
     token.symbol,
     trackEvent,
     createEventBuilder,
-    openBuyCryptoInPdapp,
+    goToBuy,
   ]);
 
   const handleSendOnClick = useCallback(async () => {

--- a/ui/pages/ramps/build-quote/build-quote.test.tsx
+++ b/ui/pages/ramps/build-quote/build-quote.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import BuildQuote from './build-quote';
+
+describe('Ramps BuildQuote (stub)', () => {
+  it('renders the placeholder page', () => {
+    const { getByTestId } = renderWithProvider(
+      <BuildQuote />,
+      configureMockStore()({ metamask: {} }),
+    );
+    expect(getByTestId('ramps-build-quote-page')).toBeInTheDocument();
+  });
+});

--- a/ui/pages/ramps/build-quote/build-quote.tsx
+++ b/ui/pages/ramps/build-quote/build-quote.tsx
@@ -1,0 +1,43 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  ButtonIcon,
+  ButtonIconSize,
+  IconName,
+} from '@metamask/design-system-react';
+import { Header, Page, Content } from '../../../components/multichain/pages/page';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
+
+/**
+ * Placeholder for the native ramps build-quote page.
+ *
+ * `useRampsNavigation.goToBuy` routes here once a supported token has been
+ * pre-selected. The real quote UI lands in a follow-up ticket (TRAM-3714+).
+ *
+ * bare stub — body is intentionally empty until TRAM-3714+.
+ */
+export default function BuildQuote() {
+  const t = useI18nContext();
+  const navigate = useNavigate();
+
+  return (
+    <Page data-testid="ramps-build-quote-page">
+      <Header
+        startAccessory={
+          <ButtonIcon
+            iconName={IconName.ArrowLeft}
+            size={ButtonIconSize.Md}
+            ariaLabel={t('back')}
+            onClick={() => navigate(DEFAULT_ROUTE)}
+          />
+        }
+      >
+        {t('buy')}
+      </Header>
+      <Content>
+        <div className="w-full text-center">Build Quote Stub</div>
+      </Content>
+    </Page>
+  );
+}

--- a/ui/pages/ramps/build-quote/build-quote.tsx
+++ b/ui/pages/ramps/build-quote/build-quote.tsx
@@ -5,7 +5,11 @@ import {
   ButtonIconSize,
   IconName,
 } from '@metamask/design-system-react';
-import { Header, Page, Content } from '../../../components/multichain/pages/page';
+import {
+  Header,
+  Page,
+  Content,
+} from '../../../components/multichain/pages/page';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 

--- a/ui/pages/ramps/build-quote/index.ts
+++ b/ui/pages/ramps/build-quote/index.ts
@@ -1,0 +1,1 @@
+export { default } from './build-quote';

--- a/ui/pages/ramps/token-selection/index.ts
+++ b/ui/pages/ramps/token-selection/index.ts
@@ -1,0 +1,1 @@
+export { default } from './token-selection';

--- a/ui/pages/ramps/token-selection/token-selection.test.tsx
+++ b/ui/pages/ramps/token-selection/token-selection.test.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import TokenSelection from './token-selection';
+
+describe('Ramps TokenSelection (stub)', () => {
+  it('renders the placeholder page', () => {
+    const { getByTestId } = renderWithProvider(
+      <TokenSelection />,
+      configureMockStore()({ metamask: {} }),
+    );
+    expect(getByTestId('ramps-token-selection-page')).toBeInTheDocument();
+  });
+});

--- a/ui/pages/ramps/token-selection/token-selection.tsx
+++ b/ui/pages/ramps/token-selection/token-selection.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  ButtonIcon,
+  ButtonIconSize,
+  IconName,
+} from '@metamask/design-system-react';
+import { Header, Page, Content} from '../../../components/multichain/pages/page';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
+
+/**
+ * Placeholder for the native ramps token-selection page.
+ *
+ * `useRampsNavigation.goToBuy` routes here when the buy intent carries no
+ * specific token. The real token picker lands in a follow-up ticket
+ * (TRAM-3714+).
+ *
+ * bare stub — body is intentionally empty until TRAM-3714+.
+ */
+export default function TokenSelection() {
+  const t = useI18nContext();
+  const navigate = useNavigate();
+
+  return (
+    <Page data-testid="ramps-token-selection-page">
+      <Header
+        startAccessory={
+          <ButtonIcon
+            iconName={IconName.ArrowLeft}
+            size={ButtonIconSize.Md}
+            ariaLabel={t('back')}
+            onClick={() => navigate(DEFAULT_ROUTE)}
+          />
+        }
+      >
+        {t('buy')}
+      </Header>
+      <Content>
+        <div className="w-full text-center">Token Selection Stub</div>
+      </Content>
+    </Page>
+  );
+}

--- a/ui/pages/ramps/token-selection/token-selection.tsx
+++ b/ui/pages/ramps/token-selection/token-selection.tsx
@@ -5,7 +5,11 @@ import {
   ButtonIconSize,
   IconName,
 } from '@metamask/design-system-react';
-import { Header, Page, Content} from '../../../components/multichain/pages/page';
+import {
+  Header,
+  Page,
+  Content,
+} from '../../../components/multichain/pages/page';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -46,6 +46,8 @@ import {
   IMPORT_SRP_ROUTE,
   BASIC_FUNCTIONALITY_OFF_ROUTE,
   DEFI_ROUTE,
+  RAMPS_BUILD_QUOTE_ROUTE,
+  RAMPS_TOKEN_SELECTION_ROUTE,
   DEEP_LINK_ROUTE,
   ACCOUNT_LIST_PAGE_ROUTE,
   MULTICHAIN_ACCOUNT_ADDRESS_LIST_PAGE_ROUTE,
@@ -202,6 +204,10 @@ const NftFullImage = mmLazy(
 );
 const Asset = mmLazy(() => import('../asset/index.js'));
 const DeFiPage = mmLazy(() => import('../defi/index.ts'));
+const RampsBuildQuote = mmLazy(() => import('../ramps/build-quote/index.ts'));
+const RampsTokenSelection = mmLazy(
+  () => import('../ramps/token-selection/index.ts'),
+);
 const PermissionsPage = mmLazy(
   () =>
     import('../../components/multichain/pages/permissions-page/permissions-page.js'),
@@ -528,6 +534,14 @@ export const routeConfig = [
           {
             path: `${DEFI_ROUTE}/:chainId/:protocolId`,
             element: <DeFiPage />,
+          },
+          {
+            path: RAMPS_BUILD_QUOTE_ROUTE,
+            element: <RampsBuildQuote />,
+          },
+          {
+            path: RAMPS_TOKEN_SELECTION_ROUTE,
+            element: <RampsTokenSelection />,
           },
           {
             path: `${MUSD_CONVERSION_ROUTE}/*`,


### PR DESCRIPTION
## **Description**

Extends the ramps buy flow with intent-based routing, stacked on top of #44351.

1. **Reason for the change:** #44351 added the geo-block gate to `useRampsNavigation.goToBuy` but, once the gate passed, still fell through to the Portfolio redirect and only wired the wallet Buy button. To move toward the native buy flow, `goToBuy` needs to route into in-extension pages and cover the remaining entry points.
2. **Improvement/solution:** `goToBuy` now takes a `RampIntent` and, after the geo-block gate passes, routes into the native buy flow:
   1. Intent has a supported `assetId` → pre-select the token (`setRampsSelectedToken`) and open the **build-quote** page.
   2. Intent `assetId` absent/unsupported on a **settled** catalog → `RAMPS_UNSUPPORTED` modal.
   3. No `assetId` → open the **token-selection** page.

   Fail-open is preserved: an unsettled/loading/errored catalog never blocks — with an `assetId` it proceeds to build-quote (token still pre-selected). With `rampsEnabled` off, behavior is unchanged (Portfolio redirect).

**What's included:**
- `RampIntent` type + steps 6–7 routing in `useRampsNavigation.goToBuy`
- `/ramps/build-quote` and `/ramps/token-selection` **stub pages** + route constants + router registration (page bodies land in TRAM-3714+)
- Entry-point wiring for all four buy CTAs:
  - Wallet overview Buy (`coin-buttons.tsx`) — already gated by #44351; now no-asset → token selection
  - Asset page **token** Buy (`token-buttons.tsx`) — passes the token as intent `assetId`
  - Asset page **native** Buy (ETH/BTC/Tron render `CoinButtons`, not `TokenButtons`) — new optional `buyAssetId` prop threaded from `asset-page.tsx`'s `caipAssetId`, so native pages pre-select and open build-quote
  - Add-funds modal Buy row (`add-funds-modal.tsx`)

**Notes:**
- Step destinations are **stub pages** — they render a titled placeholder only. The real build-quote / token-selection UIs are delivered by subsequent tickets (TRAM-3714+).
- Aggregator, sell, and `overrideUnifiedRouting` are mobile-only and intentionally excluded (per ticket).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TRAM-3711](https://consensyssoftware.atlassian.net/browse/TRAM-3711)

Stacked on: #44351 (TRAM-3710)

## **Manual testing steps**

1. Check out this branch and run `yarn start`.
2. Enable the feature flag: create `.manifest-overrides.json` at the repo root with
   `{ "_flags": { "remoteFeatureFlags": { "rampsEnabled": true } } }` and set `MANIFEST_OVERRIDES=.manifest-overrides.json` in `.metamaskrc` (or edit `dist/chrome/manifest.json` `_flags` directly and reload).
3. Load `dist/chrome` as an unpacked extension, unlock.
4. **Flag on, no specific asset:** click the wallet **Buy** button (supported region) → lands on the `/ramps/token-selection` stub page.
5. **Flag on, token asset page:** open an ERC-20 asset page and click **Buy** → lands on the `/ramps/build-quote` stub page (token pre-selected in `RampsController` state).
6. **Flag on, native asset page:** open the ETH (or native BTC / Tron) asset page and click **Buy** → lands on the `/ramps/build-quote` stub page (native token pre-selected).
7. **Flag on, add-funds modal:** open the add-funds modal and click the **Buy** row → lands on `/ramps/token-selection`.
8. **Flag off:** with `rampsEnabled` unset/false, any of the above Buy buttons opens the Portfolio buy tab (unchanged).
9. Run unit tests (all seven routing branches + fail-open cases are covered deterministically):
   `yarn jest ui/hooks/ramps/useRampsNavigation/useRampsNavigation.test.tsx ui/pages/asset/components/token-buttons.test.tsx ui/components/app/modals/add-funds-modal/add-funds-modal.test.tsx ui/pages/ramps/build-quote/build-quote.test.tsx ui/pages/ramps/token-selection/token-selection.test.tsx`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- Buy CTAs redirect to the Portfolio buy tab. -->

### **After**


https://github.com/user-attachments/assets/eb273e57-a758-4c8b-a7cf-fa4e4f290c8b



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[TRAM-3711]: https://consensyssoftware.atlassian.net/browse/TRAM-3711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes buy navigation across several high-traffic entry points and eligibility/catalog gating, but behavior is feature-flagged and heavily tested; stub destinations limit user impact until follow-up UI ships.
> 
> **Overview**
> With **`rampsEnabled` on**, **`goToBuy`** no longer opens Portfolio after the geo gate—it takes an optional **`RampIntent`** and navigates in-extension: no **`assetId`** → **`/ramps/token-selection`**; supported **`assetId`** → **`setRampsSelectedToken`** then **`/ramps/build-quote`**; unsupported/missing token on a settled catalog → **`RAMPS_UNSUPPORTED`**. Flag off still uses the Portfolio deeplink. **`isRampsEnabled`** is exposed so wallet Buy only shows the “tab opened” toast on that fallback path.
> 
> **Buy CTAs** are aligned on this hook: wallet/native asset **`CoinButtons`** (optional **`buyAssetId`** from the asset page), token **`TokenButtons`**, and **Add funds** modal. When the gate returns **`false`**, those handlers skip analytics and (for add-funds) skip closing the modal.
> 
> Stub **build-quote** and **token-selection** pages plus route constants and router entries land now; real UI is deferred (TRAM-3714+). Tests cover routing branches, fail-open catalog behavior, and entry-point wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6cd8d0b30b882d800993a988f53c77d80cd8b16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->