### PR TITLE
test(mv3): add storage session write experiment

### DIFF
--- a/app/service-worker.ts
+++ b/app/service-worker.ts
@@ -6,6 +6,194 @@ import { ExtensionLazyListener } from './scripts/lib/extension-lazy-listener/ext
 
 const { chrome } = globalThis;
 
+// ---------------------------------------------------------------------------
+// TEMPORARY storage-corruption investigation helpers (do not ship).
+//
+// MetaMask's persisted state (vault + controllers) lives in
+// `chrome.storage.local`, written through `ExtensionStore` and orchestrated by
+// `PersistenceManager`. This helper exercises that surface:
+//
+//   `debugSlowStorageWriteExperiment` writes a set of keys directly to
+//   `chrome.storage.local` under a caller-supplied `id`, optionally blocking the
+//   SW JS thread after dispatch. `debugReadSlowStorageWriteExperiment(id)` reads
+//   those same keys back — pass the same `id` used for the write. The write and
+//   read are separate calls so the service worker can be stopped/restarted in
+//   between.
+//
+// Important: `storage.local.set()` hands the payload to the browser process over
+// IPC; the disk commit runs there, off the SW JS thread, and Chrome won't kill a
+// SW with in-flight extension-API I/O at an unsafe point. So blocking the JS
+// thread and killing the SW does NOT tear a single write in half — expect the
+// data to survive.
+// ---------------------------------------------------------------------------
+
+const DEBUG_STORAGE_WRITE_PAYLOAD_SIZE = 256 * 1024;
+const DEBUG_STORAGE_WRITE_BLOCK_AFTER_DISPATCH_MS = 15_000;
+
+type DebugSlowStorageWriteOptions = {
+  blockAfterDispatchMs?: number;
+  id?: string;
+  payloadSize?: number;
+};
+
+type DebugSlowStorageWriteResult = {
+  id: string;
+  keys: {
+    sentinel: string;
+    payload: string;
+    metadata: string;
+  };
+};
+
+type DebugServiceWorkerGlobal = typeof globalThis & {
+  debugReadSlowStorageWriteExperiment?: (
+    id: string,
+  ) => Promise<Record<string, unknown>>;
+  debugSlowStorageWriteExperiment?: (
+    options?: DebugSlowStorageWriteOptions,
+  ) => DebugSlowStorageWriteResult;
+};
+
+function blockServiceWorker(ms: number) {
+  const start = performance.now();
+
+  while (performance.now() - start < ms) {
+    // Keep the service worker JS thread busy so the storage callback cannot run.
+  }
+}
+
+function getDebugStorageKeys(id: string) {
+  return {
+    sentinel: `debugSlowStorageWrite:${id}:sentinel`,
+    payload: `debugSlowStorageWrite:${id}:payload`,
+    metadata: `debugSlowStorageWrite:${id}:metadata`,
+  };
+}
+
+function summarizeDebugStorageRead(
+  id: string,
+  result: Record<string, unknown>,
+) {
+  const keys = getDebugStorageKeys(id);
+  const storedPayload = result[keys.payload];
+  const storedMetadata = result[keys.metadata];
+
+  return {
+    id,
+    keysPresent: Object.keys(result),
+    expectedKeys: Object.values(keys),
+    hasSentinel: keys.sentinel in result,
+    hasPayload: keys.payload in result,
+    hasMetadata: keys.metadata in result,
+    payloadLength:
+      typeof storedPayload === 'string' ? storedPayload.length : undefined,
+    metadata:
+      storedMetadata && typeof storedMetadata === 'object'
+        ? storedMetadata
+        : undefined,
+  };
+}
+
+function readDebugStorageKeys(id: string): Promise<Record<string, unknown>> {
+  const keys = getDebugStorageKeys(id);
+
+  return new Promise((resolve) => {
+    chrome.storage.local.get(Object.values(keys), (result) => {
+      const summary = summarizeDebugStorageRead(id, result);
+
+      console.log('[debugSlowStorageWrite] read summary', summary);
+
+      resolve(result);
+    });
+  });
+}
+
+function runDebugSlowStorageWriteExperiment({
+  blockAfterDispatchMs,
+  id,
+  keys,
+  payloadSize,
+}: DebugSlowStorageWriteResult & Required<DebugSlowStorageWriteOptions>) {
+  const payload = 'x'.repeat(payloadSize);
+  const metadata = {
+    dispatchedAt: new Date().toISOString(),
+    id,
+    payloadLength: payload.length,
+  };
+
+  console.log('[debugSlowStorageWrite] dispatching storage write', {
+    id,
+    keys,
+    payloadSize,
+  });
+
+  chrome.storage.local.set(
+    {
+      [keys.metadata]: metadata,
+      [keys.payload]: payload,
+      [keys.sentinel]: 'written',
+    },
+    () => {
+      console.log('[debugSlowStorageWrite] storage.set callback fired', {
+        id,
+        lastError: chrome.runtime.lastError?.message,
+      });
+
+      readDebugStorageKeys(id).catch(() => undefined);
+    },
+  );
+
+  console.log('[debugSlowStorageWrite] storage.set dispatched', {
+    blockAfterDispatchMs,
+    id,
+    keys,
+    payloadSize,
+  });
+
+  if (blockAfterDispatchMs > 0) {
+    console.log('[debugSlowStorageWrite] blocking service worker', {
+      blockAfterDispatchMs,
+      id,
+    });
+
+    blockServiceWorker(blockAfterDispatchMs);
+
+    console.log('[debugSlowStorageWrite] finished blocking service worker', {
+      blockAfterDispatchMs,
+      id,
+    });
+  }
+}
+
+(globalThis as DebugServiceWorkerGlobal).debugReadSlowStorageWriteExperiment =
+  readDebugStorageKeys;
+
+(globalThis as DebugServiceWorkerGlobal).debugSlowStorageWriteExperiment = ({
+  blockAfterDispatchMs = DEBUG_STORAGE_WRITE_BLOCK_AFTER_DISPATCH_MS,
+  id = `${Date.now()}`,
+  payloadSize = DEBUG_STORAGE_WRITE_PAYLOAD_SIZE,
+}: DebugSlowStorageWriteOptions = {}) => {
+  const keys = getDebugStorageKeys(id);
+  const result = { id, keys };
+
+  console.log('[debugSlowStorageWrite] starting experiment', {
+    blockAfterDispatchMs,
+    id,
+    keys,
+    payloadSize,
+  });
+
+  runDebugSlowStorageWriteExperiment({
+    blockAfterDispatchMs,
+    id,
+    keys,
+    payloadSize,
+  });
+
+  console.log('Debug slow storage write experiment scheduled', result);
+  return result;
+};
+
 // this needs to be run early so we can begin listening to these browser events
 // as soon as possible
 const lazyListener = new ExtensionLazyListener(chrome, {


### PR DESCRIPTION
## **Description**

Proof-of-concept experiment for the "storage corrupted / missing / damaged" bug
class (related: #43773).

MetaMask's real persisted state (vault + controllers) lives in
`chrome.storage.local`, written via `ExtensionStore` and orchestrated by
`PersistenceManager`. This PoC adds two temporary helpers on the service-worker
global that exercise that surface:

- **`debugSlowStorageWriteExperiment({ id, blockAfterDispatchMs, payloadSize })`** —
  writes a set of keys (sentinel + payload + metadata) to `chrome.storage.local`
  under the given `id`, then optionally blocks the SW JS thread for
  `blockAfterDispatchMs`.
- **`debugReadSlowStorageWriteExperiment(id)`** — reads those same keys back for
  the given `id` and logs a summary of which are present.

The write and read are separate calls sharing the same `id`, so the service
worker can be stopped and restarted in between.

Observed: `storage.local.set()` hands the payload to the browser process over
IPC; the disk commit runs there, off the SW JS thread, and Chrome won't
terminate a SW with in-flight extension-API I/O at an unsafe point. So blocking
the JS thread and killing the SW does **not** tear the write in half — the data
survives. The realistic corruption vectors (on-disk LevelDB damage,
quota/disk-full, non-atomic `set`→`remove`) are explored on the
`poc/storage-corruption-experiments` branch (#44472).

## **Related issues**

Related: #43773

## **Manual testing steps**

1. Run `yarn start` and load the extension in Chrome.
2. Open the MetaMask service-worker console.
3. Dispatch the write with an explicit `id` (reused in step 6):
   ```ts
   globalThis.debugSlowStorageWriteExperiment({
     id: 'manual-kill',
     blockAfterDispatchMs: 15000,
     payloadSize: 1024 * 1024,
   });
   ```
4. While `[debugSlowStorageWrite] blocking service worker` is visible, stop the
   service worker from `chrome://extensions`.
5. Restart the service worker by opening MetaMask. Do not reload the extension.
6. Read the keys back using the **same `id`**:
   ```ts
   await globalThis.debugReadSlowStorageWriteExperiment('manual-kill');
   ```
7. Confirm the summary reports `hasSentinel: true`, `hasPayload: true`,
   `hasMetadata: true`, and `payloadLength: 1048576`.

## **Pre-merge author checklist**

- [ ] This is a temporary investigation PoC and is **not** intended to merge.
