### PR TITLE
feat: sync-accounts use image for qr code

### DIFF
--- a/ui/pages/settings/sync-accounts/components/qr-code-scan.test.tsx
+++ b/ui/pages/settings/sync-accounts/components/qr-code-scan.test.tsx
@@ -11,12 +11,11 @@ import { submitRequestToBackground } from '../../../../store/background-connecti
 import { selectQrSyncQrPayload } from '../../../../selectors/qr-sync/qr-sync';
 import QrCodeScan from './qr-code-scan';
 
-jest.mock(
-  '../../../../components/app/deeplink-qr-code/deeplink-qr-code',
-  () => ({
-    QRCodeImage: () => <div data-testid="qr-code-image" />,
-  }),
-);
+jest.mock('qrcode-generator', () => () => ({
+  addData: jest.fn(),
+  make: jest.fn(),
+  createDataURL: jest.fn(() => 'data:image/gif;base64,mock-qr'),
+}));
 
 jest.mock('../../../../store/background-connection', () => ({
   submitRequestToBackground: jest.fn().mockResolvedValue(undefined),

--- a/ui/pages/settings/sync-accounts/components/qr-code-scan.tsx
+++ b/ui/pages/settings/sync-accounts/components/qr-code-scan.tsx
@@ -1,4 +1,11 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import qrCode from 'qrcode-generator';
 import {
   Box,
   Text,
@@ -13,13 +20,23 @@ import {
 import { useSelector } from 'react-redux';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { Skeleton } from '../../../../components/component-library/skeleton';
-import { QRCodeImage } from '../../../../components/app/deeplink-qr-code/deeplink-qr-code';
 import { submitRequestToBackground } from '../../../../store/background-connection';
 import { selectQrSyncQrPayload } from '../../../../selectors/qr-sync/qr-sync';
 import { QR_SYNC_TIMEOUT_MS } from '../../../../../shared/constants/qr-sync';
 
 const MWP_SESSION_REQUEST_EXPIRY_SECONDS =
   QR_SYNC_TIMEOUT_MS.MWP_SESSION_TIMEOUT / 1000;
+
+/** Minimal type for qrcode-generator instance (no @types package) */
+type QRCodeInstance = {
+  addData: (data: string) => void;
+  make: () => void;
+  createDataURL: (cellSize?: number, margin?: number) => string;
+};
+
+const QR_CODE_CELL_SIZE = 5;
+const QR_CODE_MARGIN = 16;
+const QR_CODE_SIZE = 340;
 
 const QrCodeScan = () => {
   const t = useI18nContext();
@@ -29,6 +46,15 @@ const QrCodeScan = () => {
     lastQrPayloadRef.current = qrPayload;
   }
   const displayedPayload = qrPayload ?? lastQrPayloadRef.current;
+  const qrDataUrl = useMemo(() => {
+    if (!displayedPayload) {
+      return null;
+    }
+    const qrImage = qrCode(0, 'M') as QRCodeInstance;
+    qrImage.addData(displayedPayload);
+    qrImage.make();
+    return qrImage.createDataURL(QR_CODE_CELL_SIZE, QR_CODE_MARGIN);
+  }, [displayedPayload]);
   const [secondsLeft, setSecondsLeft] = useState(
     MWP_SESSION_REQUEST_EXPIRY_SECONDS,
   );
@@ -96,17 +122,46 @@ const QrCodeScan = () => {
         alignItems={BoxAlignItems.Center}
         justifyContent={BoxJustifyContent.Center}
         marginTop={4}
+        gap={4}
       >
         <Box
+          className="relative inline-flex"
+          justifyContent={BoxJustifyContent.Center}
+          alignItems={BoxAlignItems.Center}
           style={{
             opacity: shouldDimQr ? 0.3 : 1,
             filter: shouldDimQr ? 'blur(4px)' : 'none',
           }}
         >
-          {displayedPayload ? (
-            <QRCodeImage data={displayedPayload} />
+          {qrDataUrl ? (
+            <>
+              <img
+                data-testid="qr-code-image"
+                src={qrDataUrl}
+                alt={t('scanQrCode')}
+                width={QR_CODE_SIZE}
+                height={QR_CODE_SIZE}
+                className="rounded-2xl"
+              />
+              <Box
+                // Background must remain white regardless of theme
+                className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-white rounded-lg flex overflow-hidden"
+                justifyContent={BoxJustifyContent.Center}
+                alignItems={BoxAlignItems.Center}
+                style={{ height: 40, width: 45 }}
+              >
+                <img
+                  src="images/logo/metamask-fox.svg"
+                  alt="Logo"
+                  width={35}
+                  height={35}
+                />
+              </Box>
+            </>
           ) : (
-            <Skeleton width={240} height={240} />
+            <Box padding={4}>
+              <Skeleton width={QR_CODE_SIZE} height={QR_CODE_SIZE} />
+            </Box>
           )}
         </Box>
         {statusContent}

--- a/ui/pages/settings/sync-accounts/components/qr-code-scan.tsx
+++ b/ui/pages/settings/sync-accounts/components/qr-code-scan.tsx
@@ -159,9 +159,7 @@ const QrCodeScan = () => {
               </Box>
             </>
           ) : (
-            <Box padding={4}>
-              <Skeleton width={QR_CODE_SIZE} height={QR_CODE_SIZE} />
-            </Box>
+            <Skeleton width={QR_CODE_SIZE} height={QR_CODE_SIZE} />
           )}
         </Box>
         {statusContent}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Renders the QR sync code as an `<img>` generated from a data URL instead of the table-based `QRCode` component. This ensures the QR code displays correctly on small viewports such as the side-panel view, where the previous rendering did not scale reliably. The Skeleton loader now matches the QR code's dimensions so there is no layout shift while the payload loads.

## Changes

- **`qr-code-scan.tsx`**
  - Replaced the `QRCodeImage` component with a QR data URL generated directly via `qrcode-generator`, rendered as an `<img>` (340×340) so it displays properly on small screens like the side panel.
  - Memoized QR generation with `useMemo` keyed on the displayed payload to avoid regenerating on every render.
  - Sized the `Skeleton` loader to the same 340×340 dimensions as the QR code to prevent layout shift between the loading and loaded states.
  - Added a centered MetaMask fox logo overlay on a fixed white background (theme-independent) over the QR code.
- **`qr-code-scan.test.tsx`**
  - Updated mocks to stub `qrcode-generator` (returning a mock data URL) instead of mocking the removed `QRCodeImage` component.

## Motivation

The table-based `QRCode` did not render/scale reliably in the constrained side-panel viewport. Using an image sourced from a generated data URL renders consistently across screen sizes.


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: display 1:1 proportion of qr code for smaller screen

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open MetaMask extension on side panel mode
2. Go to Menu > Settings > Sync with mobile
3. Check QR code image 

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="357" height="694" alt="Screenshot 2026-07-14 at 1 01 28 PM" src="https://github.com/user-attachments/assets/0cf23a6b-551e-4d34-b494-01bd302c6b6a" />


<!-- [screenshots/recordings] -->

### **After**
<img width="355" height="577" alt="Screenshot 2026-07-14 at 1 08 29 PM" src="https://github.com/user-attachments/assets/84b8a8a7-6284-49a6-919d-5474ba3549a6" />


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI change on the sync-accounts QR screen with no auth or persistence impact; deeplink QR still uses the existing table-based component.
> 
> **Overview**
> **Sync-with-mobile QR** no longer uses the shared `QRCodeImage` table renderer; it builds a **data URL** with `qrcode-generator` (`createDataURL` instead of `createTableTag`) and shows a fixed **340×340** `<img>` so the code scales reliably in the side panel.
> 
> QR generation is **memoized** on the displayed payload, the loading **skeleton** matches the same size to avoid layout shift, and a **centered MetaMask fox** sits on a theme-independent white badge over the code. Tests now mock **`qrcode-generator`** instead of `QRCodeImage`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bdfe05e7468a4277df6ba7aca4108b04b22e85a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->