### PR TITLE
feat(stellar): add StellarAssetsController and wire enrichment into asset UI

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1704,6 +1704,22 @@
     "message": "Activate $1 on $2 to get started.",
     "description": "Explainer for the trustline activation card. $1 is the token symbol and $2 is the chain name."
   },
+  "assetActivationError": {
+    "message": "Something went wrong while adding this trustline. Try again.",
+    "description": "Alert when the Stellar changeTrustOpt add request fails for a reason other than user cancel"
+  },
+  "assetDeactivate": {
+    "message": "Remove",
+    "description": "Button label to deactivate an asset."
+  },
+  "assetDeactivationError": {
+    "message": "Something went wrong while removing this trustline. Try again.",
+    "description": "Alert when the Stellar changeTrustOpt delete request fails for a reason other than user cancel"
+  },
+  "assetDeactivationNonZeroBalanceError": {
+    "message": "You still have $1 $2 in this wallet. You must send or swap it all before deactivating this asset on Stellar.",
+    "description": "Alert when the Stellar changeTrustOpt delete request fails because the token balance is not zero. $1 is the formatted balance amount and $2 is the token symbol."
+  },
   "assetChartNoHistoricalPrices": {
     "message": "We could not fetch any historical data"
   },
@@ -5852,6 +5868,9 @@
   },
   "networkNameSolana": {
     "message": "Solana"
+  },
+  "networkNameStellar": {
+    "message": "Stellar"
   },
   "networkNameTron": {
     "message": "Tron"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -1704,6 +1704,22 @@
     "message": "Activate $1 on $2 to get started.",
     "description": "Explainer for the trustline activation card. $1 is the token symbol and $2 is the chain name."
   },
+  "assetActivationError": {
+    "message": "Something went wrong while adding this trustline. Try again.",
+    "description": "Alert when the Stellar changeTrustOpt add request fails for a reason other than user cancel"
+  },
+  "assetDeactivate": {
+    "message": "Remove",
+    "description": "Button label to deactivate an asset."
+  },
+  "assetDeactivationError": {
+    "message": "Something went wrong while removing this trustline. Try again.",
+    "description": "Alert when the Stellar changeTrustOpt delete request fails for a reason other than user cancel"
+  },
+  "assetDeactivationNonZeroBalanceError": {
+    "message": "You still have $1 $2 in this wallet. You must send or swap it all before deactivating this asset on Stellar.",
+    "description": "Alert when the Stellar changeTrustOpt delete request fails because the token balance is not zero. $1 is the formatted balance amount and $2 is the token symbol."
+  },
   "assetChartNoHistoricalPrices": {
     "message": "We could not fetch any historical data"
   },
@@ -5852,6 +5868,9 @@
   },
   "networkNameSolana": {
     "message": "Solana"
+  },
+  "networkNameStellar": {
+    "message": "Stellar"
   },
   "networkNameTron": {
     "message": "Tron"

--- a/app/scripts/constants/sentry-state.ts
+++ b/app/scripts/constants/sentry-state.ts
@@ -362,6 +362,9 @@ export const SENTRY_BACKGROUND_STATE: SentryBackgroundControllerMasks = {
     databaseUnavailable: false,
   },
   StaticAssetsController: {},
+  StellarAssetsController: {
+    accountAssets: false,
+  },
   SubjectMetadataController: {
     subjectMetadata: false,
   },

--- a/app/scripts/controllers/stellar-assets-controller.test.ts
+++ b/app/scripts/controllers/stellar-assets-controller.test.ts
@@ -1,0 +1,534 @@
+import type { CaipAssetType } from '@metamask/keyring-api';
+import {
+  KeyringRpcMethod,
+  XlmAccountType,
+  XlmScope,
+} from '@metamask/keyring-api';
+import { KeyringTypes } from '@metamask/keyring-controller';
+import type { InternalAccount } from '@metamask/keyring-internal-api';
+import { MOCK_ANY_NAMESPACE, Messenger } from '@metamask/messenger';
+import type {
+  MessengerActions,
+  MessengerEvents,
+  MockAnyNamespace,
+} from '@metamask/messenger';
+import { HandlerType } from '@metamask/snaps-utils';
+
+import {
+  GET_ACCOUNT_ASSET_INFO_CLIENT_METHOD,
+  StellarAssetsController,
+  getNativeAssetInfoForAsset,
+  getTrustlineAssetInfoForAsset,
+  isStellarEnrichmentEligibleAssetId,
+  type StellarAssetsControllerMessenger,
+} from './stellar-assets-controller';
+
+const STELLAR_CLASSIC_USDC =
+  'stellar:pubnet/asset:USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN' as CaipAssetType;
+
+const STELLAR_NATIVE = 'stellar:pubnet/slip44:148' as CaipAssetType;
+
+const STELLAR_INELIGIBLE_ASSET =
+  'stellar:pubnet/sep41:CBIJBDNZNF4X35BJ4FFZWCDBSCKOP5NB4PLG4SNENRMLAPYG4P5FM6VN' as CaipAssetType;
+
+const mockStellarAccount: InternalAccount = {
+  type: XlmAccountType.Account,
+  id: 'stellar-account-uuid',
+  address: 'GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX',
+  scopes: [XlmScope.Pubnet],
+  options: {},
+  methods: [],
+  metadata: {
+    name: 'Stellar Account',
+    importTime: 1737022568097,
+    keyring: {
+      type: KeyringTypes.snap,
+    },
+    snap: {
+      id: 'npm:@metamask/stellar-wallet-snap',
+      name: 'Stellar',
+      enabled: true,
+    },
+    lastSelected: 0,
+  },
+};
+
+type RootAction = MessengerActions<StellarAssetsControllerMessenger>;
+type RootEvent = MessengerEvents<StellarAssetsControllerMessenger>;
+type RootMessenger = Messenger<MockAnyNamespace, RootAction, RootEvent>;
+
+type SnapHandleRequestParams = {
+  handler: string;
+  request?: {
+    method?: string;
+    params?: { assets?: string[]; accountId?: string; scope?: string };
+  };
+};
+
+function getRootMessenger(): RootMessenger {
+  return new Messenger({ namespace: MOCK_ANY_NAMESPACE });
+}
+
+function getRestrictedMessenger(
+  messenger: RootMessenger,
+): StellarAssetsControllerMessenger {
+  const controllerMessenger = new Messenger<
+    'StellarAssetsController',
+    RootAction,
+    RootEvent,
+    RootMessenger
+  >({
+    namespace: 'StellarAssetsController',
+    parent: messenger,
+  });
+
+  messenger.delegate({
+    messenger: controllerMessenger,
+    actions: [
+      'AccountsController:listMultichainAccounts',
+      'SnapController:handleRequest',
+      'KeyringController:getState',
+    ],
+    events: [
+      'AccountsController:accountRemoved',
+      'AccountsController:accountAssetListUpdated',
+    ],
+  });
+
+  return controllerMessenger;
+}
+
+function isListAccountAssetsCall(params: SnapHandleRequestParams): boolean {
+  return (
+    params.handler === HandlerType.OnKeyringRequest &&
+    params.request?.method === KeyringRpcMethod.ListAccountAssets
+  );
+}
+
+function isGetAccountAssetInfoCall(params: SnapHandleRequestParams): boolean {
+  return (
+    params.handler === HandlerType.OnClientRequest &&
+    params.request?.method === GET_ACCOUNT_ASSET_INFO_CLIENT_METHOD
+  );
+}
+
+function buildEnrichmentForAssets(assetIds: string[]) {
+  return Object.fromEntries(
+    assetIds.map((assetId) => [
+      assetId,
+      assetId === STELLAR_NATIVE
+        ? { baseReserve: '2.5' }
+        : { limit: '100', authorized: true, sponsored: false },
+    ]),
+  );
+}
+
+async function waitForAllPromises(): Promise<void> {
+  await new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
+function publishAccountAssetListUpdated(
+  messenger: RootMessenger,
+  accountId: string,
+  {
+    added = [],
+    removed = [],
+  }: {
+    added?: CaipAssetType[];
+    removed?: CaipAssetType[];
+  } = {},
+): void {
+  messenger.publish('AccountsController:accountAssetListUpdated', {
+    assets: {
+      [accountId]: { added, removed },
+    },
+  });
+}
+
+type SetupOptions = {
+  state?: Partial<StellarAssetsController['state']>;
+  listMultichainAccounts?: InternalAccount[];
+  isUnlocked?: boolean;
+  isEnabled?: () => boolean;
+  handleRequestImplementation?: (
+    params: SnapHandleRequestParams,
+  ) => Promise<unknown>;
+};
+
+function setupController({
+  state,
+  listMultichainAccounts = [mockStellarAccount],
+  isUnlocked = true,
+  isEnabled = () => true,
+  handleRequestImplementation,
+}: SetupOptions = {}) {
+  const messenger = getRootMessenger();
+  const controllerMessenger = getRestrictedMessenger(messenger);
+
+  const mockSnapHandleRequest = jest.fn(
+    handleRequestImplementation ?? (() => Promise.resolve({})),
+  );
+  const mockListMultichainAccounts = jest.fn();
+  const mockKeyringGetState = jest.fn();
+
+  messenger.registerActionHandler(
+    'SnapController:handleRequest',
+    mockSnapHandleRequest,
+  );
+  messenger.registerActionHandler(
+    'AccountsController:listMultichainAccounts',
+    mockListMultichainAccounts,
+  );
+  messenger.registerActionHandler(
+    'KeyringController:getState',
+    mockKeyringGetState,
+  );
+
+  mockListMultichainAccounts.mockReturnValue(listMultichainAccounts);
+  mockKeyringGetState.mockReturnValue({ isUnlocked });
+
+  const controller = new StellarAssetsController({
+    messenger: controllerMessenger,
+    state,
+    isEnabled,
+  });
+
+  return {
+    controller,
+    messenger,
+    mockSnapHandleRequest,
+    mockListMultichainAccounts,
+    mockKeyringGetState,
+  };
+}
+
+describe('StellarAssetsController', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  describe('AccountsController:accountAssetListUpdated', () => {
+    it('stores native and trustline enrichment separately', async () => {
+      const { controller, messenger, mockSnapHandleRequest } = setupController({
+        handleRequestImplementation: (params) => {
+          if (isGetAccountAssetInfoCall(params)) {
+            const assets = params.request?.params?.assets ?? [];
+            return Promise.resolve(buildEnrichmentForAssets(assets));
+          }
+          if (isListAccountAssetsCall(params)) {
+            return Promise.resolve([STELLAR_CLASSIC_USDC, STELLAR_NATIVE]);
+          }
+          return Promise.resolve({});
+        },
+      });
+
+      publishAccountAssetListUpdated(messenger, mockStellarAccount.id, {
+        added: [STELLAR_NATIVE],
+      });
+      await waitForAllPromises();
+
+      expect(
+        controller.state.accountAssets[mockStellarAccount.id][
+          STELLAR_CLASSIC_USDC
+        ],
+      ).toStrictEqual({
+        limit: '100',
+        authorized: true,
+        sponsored: false,
+      });
+      expect(
+        controller.state.accountAssets[mockStellarAccount.id][STELLAR_NATIVE],
+      ).toStrictEqual({ baseReserve: '2.5' });
+      expect(mockSnapHandleRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          handler: HandlerType.OnClientRequest,
+          request: expect.objectContaining({
+            method: GET_ACCOUNT_ASSET_INFO_CLIENT_METHOD,
+            params: expect.objectContaining({
+              accountId: mockStellarAccount.id,
+              scope: XlmScope.Pubnet,
+              assets: [STELLAR_CLASSIC_USDC, STELLAR_NATIVE],
+            }),
+          }),
+        }),
+      );
+    });
+
+    it('only requests enrichment for eligible stellar assets', async () => {
+      const { messenger, mockSnapHandleRequest } = setupController({
+        handleRequestImplementation: (params) => {
+          if (isGetAccountAssetInfoCall(params)) {
+            const assets = params.request?.params?.assets ?? [];
+            return Promise.resolve(buildEnrichmentForAssets(assets));
+          }
+          if (isListAccountAssetsCall(params)) {
+            return Promise.resolve([
+              STELLAR_CLASSIC_USDC,
+              STELLAR_INELIGIBLE_ASSET,
+            ]);
+          }
+          return Promise.resolve({});
+        },
+      });
+
+      publishAccountAssetListUpdated(messenger, mockStellarAccount.id, {
+        added: [STELLAR_NATIVE],
+      });
+      await waitForAllPromises();
+
+      const enrichmentCall = mockSnapHandleRequest.mock.calls.find(([params]) =>
+        isGetAccountAssetInfoCall(params),
+      );
+
+      expect(enrichmentCall?.[0].request?.params?.assets).toStrictEqual([
+        STELLAR_CLASSIC_USDC,
+      ]);
+    });
+
+    it('stores enrichment after the snap request resolves', async () => {
+      let resolveAssetInfo: (value: unknown) => void = () => undefined;
+      const assetInfoPromise = new Promise((resolve) => {
+        resolveAssetInfo = resolve;
+      });
+
+      const { controller, messenger } = setupController({
+        handleRequestImplementation: (params) => {
+          if (isGetAccountAssetInfoCall(params)) {
+            return assetInfoPromise;
+          }
+          if (isListAccountAssetsCall(params)) {
+            return Promise.resolve([STELLAR_CLASSIC_USDC]);
+          }
+          return Promise.resolve({});
+        },
+      });
+
+      publishAccountAssetListUpdated(messenger, mockStellarAccount.id, {
+        added: [STELLAR_CLASSIC_USDC],
+      });
+      await waitForAllPromises();
+
+      expect(
+        controller.state.accountAssets[mockStellarAccount.id]?.[
+          STELLAR_CLASSIC_USDC
+        ],
+      ).toBeUndefined();
+
+      resolveAssetInfo({
+        [STELLAR_CLASSIC_USDC]: {
+          limit: '0',
+          authorized: false,
+          sponsored: false,
+        },
+      });
+      await waitForAllPromises();
+
+      expect(
+        controller.state.accountAssets[mockStellarAccount.id][
+          STELLAR_CLASSIC_USDC
+        ],
+      ).toStrictEqual({
+        limit: '0',
+        authorized: false,
+        sponsored: false,
+      });
+    });
+
+    it('does not store enrichment when the snap returns no data', async () => {
+      const { controller, messenger } = setupController({
+        handleRequestImplementation: (params) => {
+          if (isGetAccountAssetInfoCall(params)) {
+            return Promise.resolve(undefined);
+          }
+          if (isListAccountAssetsCall(params)) {
+            return Promise.resolve([STELLAR_CLASSIC_USDC]);
+          }
+          return Promise.resolve({});
+        },
+      });
+
+      publishAccountAssetListUpdated(messenger, mockStellarAccount.id, {
+        added: [STELLAR_CLASSIC_USDC],
+      });
+      await waitForAllPromises();
+
+      expect(
+        controller.state.accountAssets[mockStellarAccount.id],
+      ).toBeUndefined();
+    });
+
+    it('does not store enrichment when the snap request fails', async () => {
+      const consoleErrorSpy = jest
+        .spyOn(console, 'error')
+        .mockImplementation(() => undefined);
+
+      const { controller, messenger } = setupController({
+        handleRequestImplementation: (params) => {
+          if (isGetAccountAssetInfoCall(params)) {
+            return Promise.reject(new Error('snap failure'));
+          }
+          if (isListAccountAssetsCall(params)) {
+            return Promise.resolve([STELLAR_CLASSIC_USDC]);
+          }
+          return Promise.resolve({});
+        },
+      });
+
+      publishAccountAssetListUpdated(messenger, mockStellarAccount.id, {
+        added: [STELLAR_CLASSIC_USDC],
+      });
+      await waitForAllPromises();
+
+      expect(
+        controller.state.accountAssets[mockStellarAccount.id],
+      ).toBeUndefined();
+      expect(consoleErrorSpy).toHaveBeenCalled();
+    });
+
+    it('does not fetch when the keyring is locked', async () => {
+      const { messenger, mockSnapHandleRequest } = setupController({
+        isUnlocked: false,
+      });
+
+      publishAccountAssetListUpdated(messenger, mockStellarAccount.id, {
+        added: [STELLAR_NATIVE],
+      });
+      await waitForAllPromises();
+
+      expect(mockSnapHandleRequest).not.toHaveBeenCalled();
+    });
+
+    it('does not fetch when Stellar is disabled via isEnabled', async () => {
+      const { messenger, mockSnapHandleRequest } = setupController({
+        isEnabled: () => false,
+      });
+
+      publishAccountAssetListUpdated(messenger, mockStellarAccount.id, {
+        added: [STELLAR_NATIVE],
+      });
+      await waitForAllPromises();
+
+      expect(mockSnapHandleRequest).not.toHaveBeenCalled();
+    });
+
+    it('fetches info for all account assets and removes deleted assets', async () => {
+      const { controller, messenger, mockSnapHandleRequest } = setupController({
+        state: {
+          accountAssets: {
+            [mockStellarAccount.id]: {
+              [STELLAR_NATIVE]: {
+                baseReserve: '1',
+              },
+            },
+          },
+        },
+        handleRequestImplementation: (params) => {
+          if (isGetAccountAssetInfoCall(params)) {
+            return Promise.resolve({
+              [STELLAR_CLASSIC_USDC]: {
+                limit: '0',
+                authorized: true,
+                sponsored: false,
+              },
+            });
+          }
+          if (isListAccountAssetsCall(params)) {
+            return Promise.resolve([STELLAR_CLASSIC_USDC]);
+          }
+          return Promise.resolve({});
+        },
+      });
+
+      publishAccountAssetListUpdated(messenger, mockStellarAccount.id, {
+        added: [STELLAR_CLASSIC_USDC],
+        removed: [STELLAR_NATIVE],
+      });
+      await waitForAllPromises();
+
+      expect(
+        controller.state.accountAssets[mockStellarAccount.id][STELLAR_NATIVE],
+      ).toBeUndefined();
+      expect(
+        controller.state.accountAssets[mockStellarAccount.id][
+          STELLAR_CLASSIC_USDC
+        ],
+      ).toStrictEqual({
+        limit: '0',
+        authorized: true,
+        sponsored: false,
+      });
+      expect(mockSnapHandleRequest).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('AccountsController:accountRemoved', () => {
+    it('clears cached asset info for the removed account', () => {
+      const { controller, messenger } = setupController({
+        listMultichainAccounts: [],
+        state: {
+          accountAssets: {
+            [mockStellarAccount.id]: {
+              [STELLAR_CLASSIC_USDC]: {
+                limit: '0',
+                authorized: false,
+                sponsored: false,
+              },
+            },
+          },
+        },
+      });
+
+      messenger.publish(
+        'AccountsController:accountRemoved',
+        mockStellarAccount.id,
+      );
+
+      expect(
+        controller.state.accountAssets[mockStellarAccount.id],
+      ).toBeUndefined();
+    });
+  });
+});
+
+describe('Stellar enrichment asset id helpers', () => {
+  it('identifies supported pubnet native and classic asset ids', () => {
+    expect(isStellarEnrichmentEligibleAssetId(STELLAR_NATIVE)).toBe(true);
+    expect(isStellarEnrichmentEligibleAssetId(STELLAR_CLASSIC_USDC)).toBe(true);
+    expect(isStellarEnrichmentEligibleAssetId(STELLAR_INELIGIBLE_ASSET)).toBe(
+      false,
+    );
+    expect(
+      isStellarEnrichmentEligibleAssetId('stellar:testnet/slip44:148'),
+    ).toBe(false);
+  });
+
+  it('parses native and trustline enrichment by asset id', () => {
+    expect(
+      getNativeAssetInfoForAsset(STELLAR_NATIVE, { baseReserve: '2.5' }),
+    ).toStrictEqual({ baseReserve: '2.5' });
+    expect(
+      getNativeAssetInfoForAsset(STELLAR_CLASSIC_USDC, { baseReserve: '2.5' }),
+    ).toBeUndefined();
+    expect(
+      getTrustlineAssetInfoForAsset(STELLAR_CLASSIC_USDC, {
+        limit: '1',
+        authorized: true,
+        sponsored: false,
+      }),
+    ).toStrictEqual({
+      limit: '1',
+      authorized: true,
+      sponsored: false,
+    });
+    expect(
+      getTrustlineAssetInfoForAsset(STELLAR_NATIVE, {
+        limit: '1',
+        authorized: true,
+        sponsored: false,
+      }),
+    ).toBeUndefined();
+  });
+});

--- a/app/scripts/controllers/stellar-assets-controller.ts
+++ b/app/scripts/controllers/stellar-assets-controller.ts
@@ -1,0 +1,485 @@
+import type {
+  AccountsControllerAccountRemovedEvent,
+  AccountsControllerAccountAssetListUpdatedEvent,
+  AccountsControllerListMultichainAccountsAction,
+} from '@metamask/accounts-controller';
+import { BaseController } from '@metamask/base-controller';
+import type {
+  ControllerGetStateAction,
+  ControllerStateChangeEvent,
+  StateMetadata,
+} from '@metamask/base-controller';
+import type { AccountAssetListUpdatedEventPayload } from '@metamask/keyring-api';
+import type { KeyringControllerGetStateAction } from '@metamask/keyring-controller';
+import type { InternalAccount } from '@metamask/keyring-internal-api';
+import { KeyringClient } from '@metamask/keyring-snap-client';
+import type { Messenger } from '@metamask/messenger';
+import type { SnapControllerHandleRequestAction } from '@metamask/snaps-controllers';
+import type { SnapId } from '@metamask/snaps-sdk';
+import { HandlerType } from '@metamask/snaps-utils';
+import type {
+  CaipAssetType,
+  CaipChainId,
+  Json,
+  JsonRpcRequest,
+} from '@metamask/utils';
+import { XlmAccountType, XlmScope } from '@metamask/keyring-api';
+import {
+  type,
+  string,
+  pattern,
+  is,
+  record,
+  union,
+  type Infer,
+} from '@metamask/superstruct';
+import { Mutex } from 'async-mutex';
+
+/** Stellar pubnet native XLM CAIP-19 asset id. */
+export const StellarNativeAssetIdStruct = pattern(
+  string(),
+  /^stellar:pubnet\/slip44:148$/u,
+);
+
+/** Stellar pubnet classic asset CAIP-19 asset id. */
+export const StellarClassicAssetIdStruct = pattern(
+  string(),
+  /^stellar:pubnet\/asset:[A-Za-z0-9]{1,12}-G[A-Z2-7]{55}$/u,
+);
+
+/** Optional per-asset fields returned by snap account-asset enrichment. */
+export const TrustlineAssetInfoStruct = type({
+  limit: string(),
+});
+
+export const NativeAssetInfoStruct = type({
+  baseReserve: string(),
+});
+
+export const EnrichedAssetInfoStuct = union([
+  record(StellarNativeAssetIdStruct, NativeAssetInfoStruct),
+  record(StellarClassicAssetIdStruct, TrustlineAssetInfoStruct)
+])
+
+export type StellarNativeAssetId = Infer<typeof StellarNativeAssetIdStruct>;
+export type StellarClassicAssetId = Infer<typeof StellarClassicAssetIdStruct>;
+export type NativeAssetInfo = Infer<typeof NativeAssetInfoStruct>;
+export type TrustlineAssetInfo = Infer<typeof TrustlineAssetInfoStruct>;
+export type EnrichedAssetInfo = Infer<typeof EnrichedAssetInfoStuct>;
+
+/**
+ * Returns whether a CAIP-19 asset id is eligible for Stellar enrichment.
+ *
+ * @param assetId - CAIP-19 asset id.
+ * @returns True when the asset id is a supported pubnet native or classic asset.
+ */
+export function isStellarEnrichmentEligibleAssetId(
+  assetId: string,
+): assetId is StellarNativeAssetId | StellarClassicAssetId {
+  return (
+    is(assetId, StellarNativeAssetIdStruct) ||
+    is(assetId, StellarClassicAssetIdStruct)
+  );
+}
+
+/**
+ * Returns validated native asset enrichment for a CAIP-19 asset id.
+ *
+ * @param assetId - CAIP-19 asset id.
+ * @param info - Cached enrichment entry.
+ * @returns Native asset enrichment when valid, otherwise `undefined`.
+ */
+export function getNativeAssetInfoForAsset(
+  assetId: string,
+  info: unknown,
+): NativeAssetInfo | undefined {
+  if (!is(assetId, StellarNativeAssetIdStruct)) {
+    return undefined;
+  }
+
+  return is(info, NativeAssetInfoStruct) ? info : undefined;
+}
+
+/**
+ * Returns validated trustline asset enrichment for a CAIP-19 asset id.
+ *
+ * @param assetId - CAIP-19 asset id.
+ * @param info - Cached enrichment entry.
+ * @returns Trustline asset enrichment when valid, otherwise `undefined`.
+ */
+export function getTrustlineAssetInfoForAsset(
+  assetId: string,
+  info: unknown,
+): TrustlineAssetInfo | undefined {
+  if (!is(assetId, StellarClassicAssetIdStruct)) {
+    return undefined;
+  }
+  return is(info, TrustlineAssetInfoStruct) ? info : undefined;
+}
+
+export type StellarAssetsControllerState = {
+  accountAssets: {
+    [accountId: string]: EnrichedAssetInfo;
+  };
+};
+
+const CONTROLLER = 'StellarAssetsController' as const;
+
+export const STELLAR_CHAIN_ID = XlmScope.Pubnet;
+
+export const GET_ACCOUNT_ASSET_INFO_CLIENT_METHOD =
+  'getAccountAssetInfo' as const;
+
+export type StellarAssetsControllerGetStateAction = ControllerGetStateAction<
+  typeof CONTROLLER,
+  StellarAssetsControllerState
+>;
+
+export type StellarAssetsControllerActions =
+  StellarAssetsControllerGetStateAction;
+
+export type StellarAssetsControllerStateChangeEvent =
+  ControllerStateChangeEvent<typeof CONTROLLER, StellarAssetsControllerState>;
+
+export type StellarAssetsControllerEvents =
+  StellarAssetsControllerStateChangeEvent;
+
+type AllowedActions =
+  | SnapControllerHandleRequestAction
+  | AccountsControllerListMultichainAccountsAction
+  | KeyringControllerGetStateAction;
+
+type AllowedEvents =
+  | AccountsControllerAccountRemovedEvent
+  | AccountsControllerAccountAssetListUpdatedEvent;
+
+export type StellarAssetsControllerMessenger = Messenger<
+  typeof CONTROLLER,
+  StellarAssetsControllerActions | AllowedActions,
+  StellarAssetsControllerEvents | AllowedEvents
+>;
+
+export type StellarAssetsControllerOptions = {
+  messenger: StellarAssetsControllerMessenger;
+  state?: Partial<StellarAssetsControllerState>;
+  isEnabled: () => boolean;
+};
+
+/**
+ * Constructs the default {@link StellarAssetsController} state.
+ *
+ * @returns The default state object.
+ */
+export function getDefaultStellarAssetsControllerState(): StellarAssetsControllerState {
+  return { accountAssets: {} };
+}
+
+const stellarAssetsControllerMetadata: StateMetadata<StellarAssetsControllerState> =
+  {
+    accountAssets: {
+      includeInDebugSnapshot: true,
+      includeInStateLogs: false,
+      persist: true,
+      usedInUi: true,
+    },
+  };
+
+/**
+ * Transitional controller that caches per-account Stellar asset enrichment from
+ * the wallet snap. It bridges Stellar snap asset data until Stellar snap support
+ * is integrated with the Accounts API in the unified assets controller.
+ */
+export class StellarAssetsController extends BaseController<
+  typeof CONTROLLER,
+  StellarAssetsControllerState,
+  StellarAssetsControllerMessenger
+> {
+  readonly #isEnabled: () => boolean;
+
+  readonly #controllerOperationMutex = new Mutex();
+
+  constructor({
+    messenger,
+    state = {},
+    isEnabled = () => false,
+  }: StellarAssetsControllerOptions) {
+    super({
+      name: CONTROLLER,
+      messenger,
+      metadata: stellarAssetsControllerMetadata,
+      state: {
+        ...getDefaultStellarAssetsControllerState(),
+        ...state,
+      },
+    });
+
+    this.#isEnabled = isEnabled;
+
+    this.messenger.subscribe('AccountsController:accountRemoved', (accountId) =>
+      this.#handleOnAccountRemoved(accountId),
+    );
+
+    this.messenger.subscribe(
+      'AccountsController:accountAssetListUpdated',
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
+      async (event) => this.#handleOnAccountAssetListUpdated(event),
+    );
+  }
+
+  /**
+   * Handles asset-list updates from AccountsController.
+   *
+   * @param event - Per-account added and removed asset deltas.
+   */
+  async #handleOnAccountAssetListUpdated(
+    event: AccountAssetListUpdatedEventPayload,
+  ): Promise<void> {
+    if (!this.#isEnabled() || !this.#isKeyringUnlocked()) {
+      return;
+    }
+
+    for (const [accountId, { added, removed }] of Object.entries(
+      event.assets,
+    )) {
+      const isStellar = [...added, ...removed]
+        .some((assetId) => isStellarEnrichmentEligibleAssetId(assetId));
+
+      if (!isStellar) {
+        continue;
+      }
+
+      if (removed.length > 0) {
+        this.update((state: StellarAssetsControllerState) => {
+          const accountAssets = state.accountAssets[accountId];
+          if (!accountAssets) {
+            return;
+          }
+          for (const assetId of removed) {
+            delete accountAssets[assetId];
+          }
+          if (Object.keys(accountAssets).length === 0) {
+            delete state.accountAssets[accountId];
+          }
+        });
+      }
+
+      // Like other non-EVM snaps, the Stellar snap emits accountAssetListUpdated for
+      // the native asset even when no assets actually changed. Rather than trying to
+      // detect no-op updates, refetch enrichment for every asset on the account.
+      // This is cheap: SNAP API `getAccountAssetInfo` already batches assets and reads
+      // from the snap state store, so fetching 1 vs 100 assets costs about the same.
+      // Most accounts have fewer than 100 trustlines; imported accounts with more are rare.
+      await this.#controllerOperationMutex.runExclusive(async () => {
+        await this.#fetchAndStoreAccountAssetInfo(accountId)
+      }).catch(error => {
+        console.error(
+          `[StellarAssetsController] Failed to fetch asset info for account ${accountId}:`,
+          error,
+        );
+      });
+    }
+  }
+
+  /**
+   * Removes cached asset info for a removed account.
+   *
+   * @param accountId - The removed account id.
+   */
+  #handleOnAccountRemoved(accountId: string): void {
+    if (!(accountId in this.state.accountAssets)) {
+      return;
+    }
+
+    this.update((state: StellarAssetsControllerState) => {
+      delete state.accountAssets[accountId];
+    });
+  }
+
+  /**
+   * Fetches enrichment from the snap and stores results.
+   *
+   * @param account - Stellar account or account id.
+   */
+  async #fetchAndStoreAccountAssetInfo(
+    account: InternalAccount | string,
+  ): Promise<void> {
+    const internalAccount = typeof account === 'string' ? this.#getStellarAccount(account) : account;
+    if (!internalAccount) {
+      return;
+    }
+
+    const snapId = internalAccount.metadata.snap?.id;
+    const chainId = this.#getStellarChainId(internalAccount);
+    if (!snapId || !chainId ) {
+      return;
+    }
+    try {
+      const assets = await this.#listAccountAssets(internalAccount.id, snapId);
+      const assetsToFetch = this.#filterTrustlineEnrichmentEligibleAssets(
+        assets as CaipAssetType[],
+      );
+      const enrichment = await this.#fetchAccountAssetInfoFromSnap({
+        accountId: internalAccount.id,
+        snapId: snapId as SnapId,
+        chainId,
+        assets: assetsToFetch,
+      });
+
+      if (enrichment) {
+        this.update((state: StellarAssetsControllerState) => {
+          state.accountAssets[internalAccount.id] ??= {};
+          for (const assetId of assetsToFetch) {
+            // SNAP should guarantee that the asset info is not empty.
+            const info = enrichment?.[assetId];
+            state.accountAssets[internalAccount.id][assetId] = info;
+          }
+        });
+      }
+    } catch (error) {
+      console.error(
+        `[StellarAssetsController] Failed to fetch asset info for account ${internalAccount.id}:`,
+        error,
+      );
+    }
+  }
+
+  /**
+   * Calls the snap `getAccountAssetInfo` client request handler.
+   *
+   * @param params - Request parameters.
+   * @param params.accountId - Account id.
+   * @param params.snapId - Wallet snap id.
+   * @param params.chainId - CAIP-2 chain id.
+   * @param params.assets - CAIP-19 assets to resolve.
+   * @returns Per-asset enrichment fields.
+   */
+  async #fetchAccountAssetInfoFromSnap({
+    accountId,
+    snapId,
+    chainId,
+    assets,
+  }: {
+    accountId: string;
+    snapId: SnapId;
+    chainId: CaipChainId;
+    assets: CaipAssetType[];
+  }): Promise<EnrichedAssetInfo | undefined> {
+    return (await this.messenger.call('SnapController:handleRequest', {
+      snapId,
+      origin: 'metamask',
+      handler: HandlerType.OnClientRequest,
+      request: {
+        jsonrpc: '2.0',
+        method: GET_ACCOUNT_ASSET_INFO_CLIENT_METHOD,
+        params: {
+          accountId,
+          scope: chainId,
+          assets,
+        },
+      },
+    })) as EnrichedAssetInfo;
+  }
+
+  /**
+   * Lists assets for an account via the wallet snap keyring client.
+   *
+   * @param accountId - Account id.
+   * @param snapId - Wallet snap id.
+   * @returns Asset ids for the account.
+   */
+  async #listAccountAssets(
+    accountId: string,
+    snapId: string,
+  ): Promise<string[]> {
+    return await this.#getKeyringClient(snapId).listAccountAssets(accountId);
+  }
+
+  /**
+   * Gets a `KeyringClient` for a snap.
+   *
+   * @param snapId - Snap id.
+   * @returns Keyring client for the snap.
+   */
+  #getKeyringClient(snapId: string): KeyringClient {
+    return new KeyringClient({
+      send: async (request: JsonRpcRequest) =>
+        (await this.messenger.call('SnapController:handleRequest', {
+          snapId: snapId as SnapId,
+          origin: 'metamask',
+          handler: HandlerType.OnKeyringRequest,
+          request,
+        })) as Promise<Json>,
+    });
+  }
+
+  /**
+   * Lists Stellar accounts from AccountsController.
+   *
+   * @returns Stellar accounts backed by a snap.
+   */
+  #listStellarAccounts(): InternalAccount[] {
+    return this.messenger
+      .call('AccountsController:listMultichainAccounts')
+      .filter((account) => this.#isStellarAccount(account));
+  }
+
+  /**
+   * Returns a Stellar account by id when present.
+   *
+   * @param accountId - Account id.
+   * @returns The Stellar account, or undefined.
+   */
+  #getStellarAccount(accountId: string): InternalAccount | undefined {
+    return this.#listStellarAccounts().find(
+      (account) => account.id === accountId,
+    );
+  }
+
+  /**
+   * Returns whether the account is a Stellar snap account.
+   *
+   * @param account - Account to check.
+   * @returns True for Stellar snap accounts.
+   */
+  #isStellarAccount(account: InternalAccount): boolean {
+    return (
+      account.type === XlmAccountType.Account &&
+      account.metadata.snap !== undefined
+    );
+  }
+
+  /**
+   * Returns the Stellar chain id for an account.
+   *
+   * @param account - Stellar account.
+   * @returns Supported Stellar CAIP-2 chain id, or undefined.
+   */
+  #getStellarChainId(account: InternalAccount): CaipChainId | undefined {
+    const scope = account.scopes.find(
+      (chainId) => chainId === XlmScope.Pubnet || chainId === XlmScope.Testnet,
+    );
+    return scope as CaipChainId | undefined;
+  }
+
+  /**
+   * Returns whether the keyring is unlocked.
+   *
+   * @returns True when the keyring is unlocked.
+   */
+  #isKeyringUnlocked(): boolean {
+    const { isUnlocked } = this.messenger.call('KeyringController:getState');
+    return isUnlocked;
+  }
+
+  /**
+   * Filters asset ids to those eligible for trustline snap enrichment.
+   *
+   * @param assetIds - CAIP-19 asset ids to filter.
+   * @returns Eligible trustline asset ids.
+   */
+  #filterTrustlineEnrichmentEligibleAssets(
+    assetIds: CaipAssetType[],
+  ): CaipAssetType[] {
+    return assetIds.filter(isStellarEnrichmentEligibleAssetId);
+  }
+}

--- a/app/scripts/messenger-client-init/controller-list.ts
+++ b/app/scripts/messenger-client-init/controller-list.ts
@@ -127,6 +127,7 @@ import { EncryptionPublicKeyController } from '../controllers/encryption-public-
 import { RewardsDataService } from '../controllers/rewards/rewards-data-service';
 import { RewardsController } from '../controllers/rewards/rewards-controller';
 import { StaticAssetsController } from '../controllers/static-assets-controller';
+import { StellarAssetsController } from '../controllers/stellar-assets-controller';
 import { QrSyncController } from '../controllers/qr-sync/qr-sync-controller';
 import { QrSyncDataService } from '../controllers/qr-sync/qr-sync-data-service';
 import { DataDeletionService } from '../services/data-deletion-service';
@@ -245,6 +246,7 @@ export type MessengerClient =
   | ConfigRegistryController
   | ConfigRegistryApiService
   | StaticAssetsController
+  | StellarAssetsController
   | ProfileMetricsController
   | ProfileMetricsService
   | ProofOfOwnershipService
@@ -323,6 +325,7 @@ export type MessengerClientFlatState = AccountOrderController['state'] &
   TokenListController['state'] &
   TokensController['state'] &
   StaticAssetsController['state'] &
+  StellarAssetsController['state'] &
   TransactionController['state'] &
   TransactionPayController['state'] &
   UserOperationController['state'] &

--- a/app/scripts/messenger-client-init/messengers/index.ts
+++ b/app/scripts/messenger-client-init/messengers/index.ts
@@ -115,6 +115,10 @@ import {
   getStaticAssetsControllerInitMessenger,
   getStaticAssetsControllerMessenger,
 } from './static-assets-controller-messenger';
+import {
+  getStellarAssetsControllerInitMessenger,
+  getStellarAssetsControllerMessenger,
+} from './stellar-assets-controller-messenger';
 import { getRatesControllerMessenger } from './rates-controller-messenger';
 import {
   getCurrencyRateControllerInitMessenger,
@@ -308,6 +312,11 @@ export {
   getStaticAssetsControllerMessenger,
   getStaticAssetsControllerInitMessenger,
 } from './static-assets-controller-messenger';
+export {
+  getStellarAssetsControllerMessenger,
+  getStellarAssetsControllerInitMessenger,
+} from './stellar-assets-controller-messenger';
+export type { StellarAssetsControllerInitMessenger } from './stellar-assets-controller-messenger';
 export type { TokenDetectionControllerInitMessenger } from './token-detection-controller-messenger';
 export {
   getTokenDetectionControllerMessenger,
@@ -609,6 +618,10 @@ export const MESSENGER_FACTORIES = {
   StaticAssetsController: {
     getMessenger: getStaticAssetsControllerMessenger,
     getInitMessenger: getStaticAssetsControllerInitMessenger,
+  },
+  StellarAssetsController: {
+    getMessenger: getStellarAssetsControllerMessenger,
+    getInitMessenger: getStellarAssetsControllerInitMessenger,
   },
   SubjectMetadataController: {
     getMessenger: getSubjectMetadataControllerMessenger,

--- a/app/scripts/messenger-client-init/messengers/stellar-assets-controller-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/stellar-assets-controller-messenger.ts
@@ -1,0 +1,75 @@
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import type { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
+
+import { RootMessenger } from '../../lib/messenger';
+import type { StellarAssetsControllerMessenger } from '../../controllers/stellar-assets-controller';
+
+/**
+ * Get a restricted messenger for the Stellar Assets controller.
+ *
+ * @param messenger - The controller messenger to restrict.
+ * @returns The restricted controller messenger.
+ */
+export function getStellarAssetsControllerMessenger(
+  messenger: RootMessenger<
+    MessengerActions<StellarAssetsControllerMessenger>,
+    MessengerEvents<StellarAssetsControllerMessenger>
+  >,
+): StellarAssetsControllerMessenger {
+  const controllerMessenger: StellarAssetsControllerMessenger = new Messenger({
+    namespace: 'StellarAssetsController',
+    parent: messenger,
+  });
+
+  messenger.delegate({
+    messenger: controllerMessenger,
+    events: [
+      'AccountsController:accountRemoved',
+      'AccountsController:accountAssetListUpdated',
+    ],
+    actions: [
+      'AccountsController:listMultichainAccounts',
+      'SnapController:handleRequest',
+      'KeyringController:getState',
+    ],
+  });
+
+  return controllerMessenger;
+}
+
+type AllowedInitializationActions = RemoteFeatureFlagControllerGetStateAction;
+
+export type StellarAssetsControllerInitMessenger = ReturnType<
+  typeof getStellarAssetsControllerInitMessenger
+>;
+
+/**
+ * Get a restricted init messenger for the Stellar Assets controller.
+ *
+ * @param messenger - The root messenger to restrict.
+ * @returns The restricted init messenger.
+ */
+export function getStellarAssetsControllerInitMessenger(
+  messenger: RootMessenger<AllowedInitializationActions, never>,
+) {
+  const controllerInitMessenger = new Messenger<
+    'StellarAssetsControllerInit',
+    AllowedInitializationActions,
+    never,
+    typeof messenger
+  >({
+    namespace: 'StellarAssetsControllerInit',
+    parent: messenger,
+  });
+
+  messenger.delegate({
+    messenger: controllerInitMessenger,
+    actions: ['RemoteFeatureFlagController:getState'],
+  });
+
+  return controllerInitMessenger;
+}

--- a/app/scripts/messenger-client-init/stellar-assets-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/stellar-assets-controller-init.test.ts
@@ -1,0 +1,117 @@
+import { MOCK_ANY_NAMESPACE, Messenger } from '@metamask/messenger';
+
+import { StellarAssetsController } from '../controllers/stellar-assets-controller';
+import { getRootMessenger } from '../lib/messenger';
+import { buildControllerInitRequestMock } from './test/utils';
+import { MessengerClientInitRequest } from './types';
+import {
+  getStellarAssetsControllerInitMessenger,
+  getStellarAssetsControllerMessenger,
+  type StellarAssetsControllerInitMessenger,
+  type StellarAssetsControllerMessenger,
+} from './messengers/stellar-assets-controller-messenger';
+import { StellarAssetsControllerInit } from './stellar-assets-controller-init';
+
+jest.mock('../controllers/stellar-assets-controller');
+
+function buildInitRequestMock(
+  remoteFeatureFlags?: Record<string, unknown>,
+): jest.Mocked<
+  MessengerClientInitRequest<
+    StellarAssetsControllerMessenger,
+    StellarAssetsControllerInitMessenger
+  >
+> {
+  const baseControllerMessenger = getRootMessenger();
+  const initMessenger = getStellarAssetsControllerInitMessenger(
+    new Messenger({ namespace: MOCK_ANY_NAMESPACE }),
+  );
+
+  initMessenger.call = jest.fn().mockImplementation((action: string) => {
+    if (action === 'RemoteFeatureFlagController:getState') {
+      return { remoteFeatureFlags: remoteFeatureFlags ?? {} };
+    }
+    throw new Error(`Unexpected action: ${action}`);
+  });
+
+  return {
+    ...buildControllerInitRequestMock(),
+    controllerMessenger: getStellarAssetsControllerMessenger(
+      baseControllerMessenger,
+    ),
+    initMessenger,
+    persistedState: {
+      StellarAssetsController: { accountAssets: {} },
+    },
+  };
+}
+
+describe('StellarAssetsControllerInit', () => {
+  const stellarAssetsControllerClassMock = jest.mocked(StellarAssetsController);
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('returns controller instance', () => {
+    const requestMock = buildInitRequestMock();
+    expect(
+      StellarAssetsControllerInit(requestMock).messengerClient,
+    ).toBeInstanceOf(StellarAssetsController);
+  });
+
+  it('initializes with messenger, state, and isEnabled', () => {
+    const requestMock = buildInitRequestMock();
+    StellarAssetsControllerInit(requestMock);
+
+    expect(stellarAssetsControllerClassMock).toHaveBeenCalledWith({
+      messenger: requestMock.controllerMessenger,
+      state: requestMock.persistedState.StellarAssetsController,
+      isEnabled: expect.any(Function),
+    });
+  });
+
+  describe('isEnabled', () => {
+    it('enables stellar when stellarAccounts and assetEnrichment flags are enabled', () => {
+      const requestMock = buildInitRequestMock({
+        stellarAccounts: { enabled: true, minimumVersion: '0.0.0' },
+        assetEnrichment: { enabled: true, minimumVersion: '0.0.0' },
+      });
+
+      StellarAssetsControllerInit(requestMock);
+
+      const constructorCall = stellarAssetsControllerClassMock.mock.calls[0][0];
+      const isEnabled = constructorCall.isEnabled as () => boolean;
+
+      expect(isEnabled()).toBe(true);
+    });
+
+    it('disables stellar when stellarAccounts feature flag is disabled', () => {
+      const requestMock = buildInitRequestMock({
+        stellarAccounts: { enabled: false, minimumVersion: '0.0.0' },
+        assetEnrichment: { enabled: true, minimumVersion: '0.0.0' },
+      });
+
+      StellarAssetsControllerInit(requestMock);
+
+      const constructorCall = stellarAssetsControllerClassMock.mock.calls[0][0];
+      const isEnabled = constructorCall.isEnabled as () => boolean;
+
+      expect(isEnabled()).toBe(false);
+    });
+
+    it('disables stellar when assetEnrichment feature flag is disabled', () => {
+      const requestMock = buildInitRequestMock({
+        stellarAccounts: { enabled: true, minimumVersion: '0.0.0' },
+        assetEnrichment: { enabled: false, minimumVersion: '0.0.0' },
+      });
+
+      StellarAssetsControllerInit(requestMock);
+
+      const constructorCall = stellarAssetsControllerClassMock.mock.calls[0][0];
+      const isEnabled = constructorCall.isEnabled as () => boolean;
+
+      expect(isEnabled()).toBe(false);
+    });
+  });
+});

--- a/app/scripts/messenger-client-init/stellar-assets-controller-init.ts
+++ b/app/scripts/messenger-client-init/stellar-assets-controller-init.ts
@@ -1,0 +1,50 @@
+import {
+  StellarAssetsController,
+  type StellarAssetsControllerMessenger,
+} from '../controllers/stellar-assets-controller';
+import { isMultichainFeatureEnabled } from '../../../shared/lib/multichain-feature-flags';
+import { type StellarAssetsControllerInitMessenger } from './messengers/stellar-assets-controller-messenger';
+import { MessengerClientInitFunction } from './types';
+
+function getIsStellarEnabled(
+  initMessenger: StellarAssetsControllerInitMessenger,
+): boolean {
+  try {
+    const remoteFeatureFlagState = initMessenger.call(
+      'RemoteFeatureFlagController:getState',
+    );
+
+    return isMultichainFeatureEnabled(
+      // Individual feature flag for stellar accounts
+      remoteFeatureFlagState?.remoteFeatureFlags?.stellarAccounts,
+    ) && isMultichainFeatureEnabled(
+      // Individual feature flag for asset enrichment
+      remoteFeatureFlagState?.remoteFeatureFlags?.assetEnrichment,
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Init function for the StellarAssetsController.
+ *
+ * @param request - The request object.
+ * @param request.controllerMessenger - The messenger to use for the controller.
+ * @param request.persistedState - The persisted state of the extension.
+ * @param request.initMessenger - The init messenger for feature flag access.
+ * @returns The initialized controller.
+ */
+export const StellarAssetsControllerInit: MessengerClientInitFunction<
+  StellarAssetsController,
+  StellarAssetsControllerMessenger,
+  StellarAssetsControllerInitMessenger
+> = ({ controllerMessenger, persistedState, initMessenger }) => {
+  const messengerClient = new StellarAssetsController({
+    messenger: controllerMessenger,
+    state: persistedState.StellarAssetsController,
+    isEnabled: () => getIsStellarEnabled(initMessenger),
+  });
+
+  return { messengerClient };
+};

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -401,6 +401,7 @@ import { TokenDetectionControllerInit } from './messenger-client-init/token-dete
 import { TokensControllerInit } from './messenger-client-init/tokens-controller-init';
 import { TokenBalancesControllerInit } from './messenger-client-init/token-balances-controller-init';
 import { StaticAssetsControllerInit } from './messenger-client-init/static-assets-controller-init';
+import { StellarAssetsControllerInit } from './messenger-client-init/stellar-assets-controller-init';
 import { RatesControllerInit } from './messenger-client-init/rates-controller-init';
 import { CurrencyRateControllerInit } from './messenger-client-init/currency-rate-controller-init';
 import { EnsControllerInit } from './messenger-client-init/confirmations/ens-controller-init';
@@ -691,6 +692,7 @@ export default class MetamaskController extends EventEmitter {
       TokensController: TokensControllerInit,
       TokenBalancesController: TokenBalancesControllerInit,
       StaticAssetsController: StaticAssetsControllerInit,
+      StellarAssetsController: StellarAssetsControllerInit,
       // MultichainNetworkController and NetworkEnablementController must be initialized before TokenRatesController
       // because TokenRatesController depends on NetworkEnablementController:getState during construction.
       MultichainNetworkController: MultichainNetworkControllerInit,
@@ -842,6 +844,8 @@ export default class MetamaskController extends EventEmitter {
     this.tokenBalancesController =
       messengerClientsByName.TokenBalancesController;
     this.staticAssetsController = messengerClientsByName.StaticAssetsController;
+    this.stellarAssetsController =
+      messengerClientsByName.StellarAssetsController;
     this.tokenListController = messengerClientsByName.TokenListController;
     this.tokenDetectionController =
       messengerClientsByName.TokenDetectionController;
@@ -1445,6 +1449,7 @@ export default class MetamaskController extends EventEmitter {
       TokensController: this.tokensController,
       TokenBalancesController: this.tokenBalancesController,
       StaticAssetsController: this.staticAssetsController,
+      StellarAssetsController: this.stellarAssetsController,
       SmartTransactionsController: this.smartTransactionsController,
       NftController: this.nftController,
       ...(this.assetsController
@@ -1508,6 +1513,7 @@ export default class MetamaskController extends EventEmitter {
         TokensController: this.tokensController,
         TokenBalancesController: this.tokenBalancesController,
         StaticAssetsController: this.staticAssetsController,
+        StellarAssetsController: this.stellarAssetsController,
         SmartTransactionsController: this.smartTransactionsController,
         NftController: this.nftController,
         ...(this.assetsController

--- a/shared/lib/multichain/spendable-balance.test.ts
+++ b/shared/lib/multichain/spendable-balance.test.ts
@@ -1,6 +1,5 @@
 import { XlmScope } from '@metamask/keyring-api';
 import {
-  computeBaseReserve,
   computeSpendableBalance,
   isSupportBaseReserve,
   NATIVE_RESERVE_SLIP44_IDS,
@@ -22,58 +21,20 @@ describe('isSupportBaseReserve', () => {
   });
 });
 
-describe('computeBaseReserve', () => {
-  it('returns undefined for assets that do not support base reserve', () => {
-    expect(
-      computeBaseReserve({
-        assetId: ETHER_NATIVE_ASSET_ID,
-        assetMetadata: undefined,
-      }),
-    ).toBeUndefined();
-  });
-
-  it('extracts base reserve for supported native assets', () => {
-    expect(
-      computeBaseReserve({
-        assetId: STELLAR_NATIVE_ASSET_ID,
-        assetMetadata: { baseReserve: '0.5' },
-      }),
-    ).toStrictEqual('0.5');
-  });
-
-  it('defaults to "0" when account metadata is missing', () => {
-    expect(
-      computeBaseReserve({
-        assetId: STELLAR_NATIVE_ASSET_ID,
-        assetMetadata: undefined,
-      }),
-    ).toStrictEqual('0');
-  });
-
-  it('defaults to "0" when baseReserve is invalid', () => {
-    expect(
-      computeBaseReserve({
-        assetId: STELLAR_NATIVE_ASSET_ID,
-        assetMetadata: { baseReserve: 'not-a-number' },
-      }),
-    ).toStrictEqual('0');
-  });
-});
-
 describe('computeSpendableBalance', () => {
   it('subtracts base reserve from total balance', () => {
     expect(computeSpendableBalance('250', '2.5')).toStrictEqual('247.5');
   });
 
-  it('returns a negative spendable balance when reserve exceeds total', () => {
+  it('returns "0" when reserve exceeds total', () => {
     expect(computeSpendableBalance('1', '2.5')).toStrictEqual('0');
   });
 
-  it('throws when total balance is invalid', () => {
+  it('returns "0" when total balance is invalid', () => {
     expect(computeSpendableBalance('not-a-number', '2.5')).toStrictEqual('0');
   });
 
-  it('throws when base reserve is invalid', () => {
+  it('returns "0" when base reserve is invalid', () => {
     expect(computeSpendableBalance('250', 'not-a-number')).toStrictEqual('0');
   });
 });

--- a/shared/lib/multichain/spendable-balance.ts
+++ b/shared/lib/multichain/spendable-balance.ts
@@ -10,12 +10,6 @@ export const NATIVE_RESERVE_SLIP44_IDS: Set<string> = new Set([
 ]);
 
 /**
- * Account-scoped metadata for a multichain asset, when provided by the
- * account asset controller.
- */
-export type AssetMetadata = { baseReserve?: string } | undefined;
-
-/**
  * Validates if a string is a valid number string.
  *
  * @param value - Numeric string to validate.
@@ -31,32 +25,6 @@ function isValidNumberString(value?: string): boolean {
   } catch {
     return false;
   }
-}
-
-/**
- * Resolves the base reserve amount for a native asset that supports reserve
- * balance display.
- *
- * @param params - Parameters for computing the base reserve.
- * @param params.assetId - CAIP asset ID for the native asset.
- * @param params.assetMetadata - Optional asset metadata.
- * @returns The base reserve amount as a string, `'0'` when supported but
- * missing, or `undefined` when the asset does not support reserve balance.
- */
-export function computeBaseReserve({
-  assetId,
-  assetMetadata,
-}: {
-  assetId: string;
-  assetMetadata?: AssetMetadata;
-}): string | undefined {
-  if (!isSupportBaseReserve(assetId)) {
-    return undefined;
-  }
-
-  return isValidNumberString(assetMetadata?.baseReserve)
-    ? assetMetadata?.baseReserve
-    : '0';
 }
 
 /**

--- a/shared/types/background.ts
+++ b/shared/types/background.ts
@@ -62,6 +62,7 @@ import type { ConnectivityControllerState } from '@metamask/connectivity-control
 import type { AnalyticsControllerState } from '@metamask/analytics-controller';
 
 import type { ClaimsControllerState } from '@metamask/claims-controller';
+import type { StellarAssetsControllerState } from '../../app/scripts/controllers/stellar-assets-controller';
 import type { NetworkOrderControllerState } from '../../app/scripts/controllers/network-order';
 import type { AccountOrderControllerState } from '../../app/scripts/controllers/account-order';
 import type { PreferencesControllerState } from '../../app/scripts/controllers/preferences-controller';
@@ -204,6 +205,7 @@ export type ControllerStatePropertiesEnumerated = {
   metaMetricsDataDeletionStatus?: MetaMetricsDataDeletionState['metaMetricsDataDeletionStatus'];
   metaMetricsDataDeletionTimestamp: MetaMetricsDataDeletionState['metaMetricsDataDeletionTimestamp'];
   balances: MultichainBalancesControllerState['balances'];
+  accountAssets: StellarAssetsControllerState['accountAssets'];
   nonEvmTransactions: MultichainTransactionsControllerState['nonEvmTransactions'];
   conversionRates: MultichainAssetsRatesControllerState['conversionRates'];
   historicalPrices: MultichainAssetsRatesControllerState['historicalPrices'];
@@ -385,6 +387,7 @@ type ControllerStateTypesMerged = AccountsControllerState &
   SelectedNetworkControllerState &
   SignatureControllerState &
   SmartTransactionsControllerState &
+  StellarAssetsControllerState &
   SnapControllerState &
   SnapInterfaceControllerState &
   SnapInsightsControllerState &

--- a/ui/components/app/assets/hooks/useTokenDisplayInfo.tsx
+++ b/ui/components/app/assets/hooks/useTokenDisplayInfo.tsx
@@ -20,6 +20,8 @@ import { useFormatters } from '../../../../hooks/useFormatters';
 import { isEvmChainId } from '../../../../../shared/lib/asset-utils';
 import { getInternalAccountBySelectedAccountGroupAndCaip } from '../../../../selectors/multichain-accounts/account-tree';
 import { TEST_CHAINS } from '../../../../../shared/constants/network';
+import { isAssetRequireActivate } from '../../../../../shared/lib/multichain/trustline';
+import { getStellarTrustlineAssetInfoForAccount } from '../../../../selectors/stellar-assets';
 
 type UseTokenDisplayInfoProps = {
   token: TokenWithFiatAmount;
@@ -85,6 +87,23 @@ export const useTokenDisplayInfo = ({
   const isStakeable =
     token.isStakeable || (isEvmMainnet && isEvm && token.isNative);
 
+  const tokenRequireActivate = useSelector((state) => {
+    if (!token.assetId || !selectedAccount?.id) {
+      return false;
+    }
+
+    const assetMetadata = getStellarTrustlineAssetInfoForAccount(
+      state,
+      selectedAccount.id,
+      token.assetId,
+    );
+
+    return isAssetRequireActivate({
+      assetId: token.assetId,
+      assetMetadata,
+    });
+  });
+
   if (isEvm) {
     const tokenData = (
       Object.values(
@@ -134,6 +153,7 @@ export const useTokenDisplayInfo = ({
     secondary: showFiat ? nonEvmSecondary : null,
     isStakeable: false,
     tokenChainImage: token.image as string,
+    tokenRequireActivate,
   };
 };
 

--- a/ui/pages/asset/components/asset-activation-card.tsx
+++ b/ui/pages/asset/components/asset-activation-card.tsx
@@ -17,13 +17,16 @@ import {
 } from '@metamask/design-system-react';
 import React from 'react';
 
+import type { CaipAssetType } from '@metamask/utils';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useAssetActivation } from '../hooks/useAssetActivation';
+import { AssetType } from '../../../../shared/constants/transaction';
 import { Asset } from '../types/asset';
 import { AssetActivationErrorToast } from './asset-activation-error-toast';
 
 export type AssetActivateCardProps = {
   asset: Asset;
+  accountId?: string;
   chainName: string;
 };
 
@@ -33,16 +36,22 @@ export type AssetActivateCardProps = {
  *
  * @param params - Trustline activate card parameters
  * @param params.asset - The asset to activate
+ * @param params.accountId - Optional account id override.
  * @param params.chainName - The name of the chain
  */
 export const AssetActivateCard = ({
   asset,
+  accountId,
   chainName,
 }: AssetActivateCardProps) => {
   const t = useI18nContext();
   const { symbol } = asset;
+  const assetId =
+    asset.type === AssetType.token
+      ? (asset.address as CaipAssetType)
+      : undefined;
   const { activateAsset, isActivating, errorMessage, dismissErrorMessage } =
-    useAssetActivation({ asset });
+    useAssetActivation({ accountId, assetId, assetSymbol: symbol });
 
   return (
     <Box

--- a/ui/pages/asset/components/asset-activation-error-toast.test.tsx
+++ b/ui/pages/asset/components/asset-activation-error-toast.test.tsx
@@ -17,14 +17,12 @@ describe('AssetActivationErrorToast', () => {
 
     render(
       <AssetActivationErrorToast
-        message="Trustline activation test error"
+        message="Something went wrong"
         onClose={onClose}
       />,
     );
 
-    expect(
-      screen.getByText('Trustline activation test error'),
-    ).toBeInTheDocument();
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
 
     const closeButton = document.querySelector('.mm-banner-base__close-button');
     expect(closeButton).toBeInTheDocument();

--- a/ui/pages/asset/components/asset-page.tsx
+++ b/ui/pages/asset/components/asset-page.tsx
@@ -87,6 +87,8 @@ import {
 } from '../../../selectors/musd';
 import { useSafeChains } from '../../../components/multichain/networks-form/use-safe-chains';
 import { useCurrentPrice } from '../hooks/useCurrentPrice';
+import { isSupportBaseReserve } from '../../../../shared/lib/multichain/spendable-balance';
+import { useAssetActivation } from '../hooks/useAssetActivation';
 import { isNativeAsset, type Asset } from '../types/asset';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0021): route-isolation backlog
 import { useRWAToken } from '../../bridge/hooks/useRWAToken';
@@ -97,10 +99,13 @@ import {
 import { MusdAssetCta } from '../../../components/app/musd';
 import { isMusdToken } from '../../../components/app/musd/constants';
 import { processAssetParams } from '../util';
+import { AssetInactiveBadge } from '../../../components/app/assets/asset-inactive-badge/asset-inactive-badge';
 import { AssetMarketDetails } from './asset-market-details';
 import AssetChart from './chart/asset-chart';
 import { MarketClosedActionButton } from './market-closed-action-button';
 import TokenButtons from './token-buttons';
+import { AssetActivateCard } from './asset-activation-card';
+import { SpendableBalanceSection } from './spendable-balance-section';
 import { TronDailyResources } from './tron-daily-resources';
 import { MusdBonusSection } from './musd-bonus-section';
 import { MusdConvertSection } from './musd-convert-section';
@@ -251,6 +256,13 @@ const AssetPage = ({
     },
   };
 
+  const resolvedAssetId = (bip44Asset?.assetId ?? assetId) as CaipAssetType;
+
+  const { requiresActivate: isAssetInactive } = useAssetActivation({
+    accountId: selectedAccount?.id,
+    assetId: resolvedAssetId,
+  });
+
   const tokenWithFiatAmount = {
     address: isEvm ? address : assetId,
     chainId,
@@ -269,6 +281,9 @@ const AssetPage = ({
     assetId: bip44Asset?.assetId ?? assetId,
     rwaData,
   };
+
+  const showSpendableBalance = isSupportBaseReserve(resolvedAssetId);
+
   const { safeChains } = useSafeChains();
   const { isStockToken: checkIsStockToken, isTokenTradingOpen } = useRWAToken();
   const isStockToken = checkIsStockToken(updatedAsset);
@@ -332,11 +347,25 @@ const AssetPage = ({
         </Box>
         {optionsButton}
       </Box>
+      {isAssetInactive && (
+        <AssetActivateCard
+          asset={tokenAsset as Asset}
+          accountId={selectedAccount?.id}
+          chainName={networkName}
+        />
+      )}
       <Box paddingLeft={4}>
-        {isStockToken ? (
+        {isStockToken || isAssetInactive ? (
           <Box alignItems={BoxAlignItems.Center} gap={2}>
             {assetNameElement}
-            <StockBadge isMarketClosed={isMarketClosed} />
+            <Box
+              flexDirection={BoxFlexDirection.Row}
+              alignItems={BoxAlignItems.Center}
+              gap={2}
+            >
+              {isStockToken && <StockBadge isMarketClosed={isMarketClosed} />}
+              {isAssetInactive && <AssetInactiveBadge />}
+            </Box>
           </Box>
         ) : (
           assetNameElement
@@ -432,7 +461,17 @@ const AssetPage = ({
               className="asset-page__divider"
             />
           </>
-        ) : (
+        ) : null}
+        {!isMusdAssetPage && showSpendableBalance ? (
+          <SpendableBalanceSection
+            accountId={selectedAccount?.id}
+            assetId={resolvedAssetId}
+            totalBalance={String(balance)}
+            symbol={symbol}
+            fiatValue={tokenFiatAmount}
+          />
+        ) : null}
+        {!isMusdAssetPage && !showSpendableBalance ? (
           <>
             <Text
               variant={TextVariant.HeadingSm}
@@ -449,7 +488,7 @@ const AssetPage = ({
               />
             )}
           </>
-        )}
+        ) : null}
         {/* mUSD Conversion CTA - shows for eligible stablecoins */}
         {!isNativeAsset(updatedAsset) &&
           type === AssetType.token &&

--- a/ui/pages/asset/components/spendable-balance-section.test.tsx
+++ b/ui/pages/asset/components/spendable-balance-section.test.tsx
@@ -1,14 +1,25 @@
+import { XlmScope } from '@metamask/keyring-api';
+import type { CaipAssetType } from '@metamask/utils';
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import configureMockStore from 'redux-mock-store';
 import { I18nContext } from '../../../contexts/i18n';
 import { enLocale as messages, tEn } from '../../../../test/lib/i18n-helpers';
+import * as stellarAssetsSelectors from '../../../selectors/stellar-assets';
 import { SpendableBalanceSection } from './spendable-balance-section';
 
 jest.mock('../../../hooks/useFiatFormatter', () => ({
   useFiatFormatter: () => (n: number) => `$${n.toFixed(2)}`,
 }));
+
+jest.mock('../../../selectors/stellar-assets', () => ({
+  getStellarBaseReserveForAccountAsset: jest.fn(),
+}));
+
+const STELLAR_NATIVE_ASSET_ID =
+  `${XlmScope.Pubnet}/slip44:148` as CaipAssetType;
+const ACCOUNT_ID = 'stellar-account-id';
 
 const store = configureMockStore()({
   metamask: { currentCurrency: 'usd' },
@@ -26,12 +37,22 @@ const renderWithProviders = (component: React.ReactElement) =>
   );
 
 describe('SpendableBalanceSection', () => {
+  const getStellarBaseReserveForAccountAssetMock =
+    stellarAssetsSelectors.getStellarBaseReserveForAccountAsset as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('renders total, spendable, and reserved balances', () => {
+    getStellarBaseReserveForAccountAssetMock.mockReturnValue('2.5');
+
     renderWithProviders(
       <SpendableBalanceSection
+        accountId={ACCOUNT_ID}
+        assetId={STELLAR_NATIVE_ASSET_ID}
         totalBalance="250"
         symbol="XLM"
-        baseReserve="2.5"
         fiatValue={105}
       />,
     );
@@ -52,18 +73,34 @@ describe('SpendableBalanceSection', () => {
     ).toHaveTextContent('$105.00');
   });
 
-  it('clamps spendable balance at zero when reserve exceeds total', () => {
-    renderWithProviders(
+  it('returns null when base reserve is unavailable', () => {
+    getStellarBaseReserveForAccountAssetMock.mockReturnValue(undefined);
+
+    const { container } = renderWithProviders(
       <SpendableBalanceSection
-        totalBalance="1"
+        accountId={ACCOUNT_ID}
+        assetId={STELLAR_NATIVE_ASSET_ID}
+        totalBalance="250"
         symbol="XLM"
-        baseReserve="2.5"
         fiatValue={null}
       />,
     );
 
-    expect(
-      screen.getByTestId('spendable-balance-spendable-balance'),
-    ).toHaveTextContent('0 XLM');
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('returns null for assets that do not support base reserve', () => {
+    const { container } = renderWithProviders(
+      <SpendableBalanceSection
+        accountId={ACCOUNT_ID}
+        assetId={'eip155:1/slip44:60' as CaipAssetType}
+        totalBalance="250"
+        symbol="ETH"
+        fiatValue={null}
+      />,
+    );
+
+    expect(getStellarBaseReserveForAccountAssetMock).not.toHaveBeenCalled();
+    expect(container).toBeEmptyDOMElement();
   });
 });

--- a/ui/pages/asset/components/spendable-balance-section.tsx
+++ b/ui/pages/asset/components/spendable-balance-section.tsx
@@ -6,16 +6,18 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react';
-import React, { useMemo } from 'react';
-import { BigNumber } from 'bignumber.js';
+import type { CaipAssetType } from '@metamask/utils';
+import React from 'react';
+
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useFiatFormatter } from '../../../hooks/useFiatFormatter';
-import { computeSpendableBalance } from '../../../../shared/lib/multichain/spendable-balance';
+import { useSpendableBalance } from '../hooks/useSpendableBalance';
 
 export type SpendableBalanceSectionProps = {
+  accountId?: string;
+  assetId: CaipAssetType;
   totalBalance: string;
   symbol: string;
-  baseReserve: string;
   fiatValue: number | null;
 };
 
@@ -23,31 +25,35 @@ export type SpendableBalanceSectionProps = {
  * Spendable balance section: breakdown for a native asset (total, spendable, reserved, fiat value).
  *
  * @param params - Spendable balance section parameters
+ * @param params.accountId - Optional account id override.
+ * @param params.assetId - CAIP asset id for the native asset.
  * @param params.totalBalance - The total balance
  * @param params.symbol - The symbol of the asset
- * @param params.baseReserve - The base reserve
  * @param params.fiatValue - The fiat value
  */
 export function SpendableBalanceSection({
+  accountId,
+  assetId,
   totalBalance,
   symbol,
-  baseReserve,
   fiatValue,
 }: SpendableBalanceSectionProps) {
   const t = useI18nContext();
   const formatFiat = useFiatFormatter();
+  const { baseReserve, spendableBalance } = useSpendableBalance({
+    accountId,
+    assetId,
+    totalBalance,
+  });
 
-  const { totalDisplay, spendableDisplay, reservedDisplay } = useMemo(() => {
-    const spendable = computeSpendableBalance(totalBalance, baseReserve);
+  if (baseReserve === undefined || spendableBalance === undefined) {
+    return null;
+  }
 
-    return {
-      totalDisplay: `${totalBalance} ${symbol}`,
-      spendableDisplay: `${spendable} ${symbol}`,
-      reservedDisplay: `${baseReserve} ${symbol}`,
-    };
-  }, [baseReserve, symbol, totalBalance]);
-
-  const valueDisplay =
+  const totalDisplay = `${totalBalance} ${symbol}`;
+  const spendableDisplay = `${spendableBalance} ${symbol}`;
+  const reservedDisplay = `${baseReserve} ${symbol}`;
+  const fiatValueDisplay =
     fiatValue !== null && Number.isFinite(fiatValue)
       ? formatFiat(fiatValue)
       : '—';
@@ -100,7 +106,7 @@ export function SpendableBalanceSection({
             variant={TextVariant.BodyMd}
             data-testid="spendable-balance-fiat-value"
           >
-            {valueDisplay}
+            {fiatValueDisplay}
           </Text>
         </Box>
       </Box>

--- a/ui/pages/asset/components/token-buttons.test.tsx
+++ b/ui/pages/asset/components/token-buttons.test.tsx
@@ -13,7 +13,7 @@ import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate
 import * as storeActions from '../../../store/actions';
 import * as stellarSnapRequests from '../utils/stellar-snap-client-requests';
 import type { Asset } from '../types/asset';
-import { AssetActivateCard } from './asset-activation-card';
+import TokenButtons from './token-buttons';
 
 const PUBNET_USDC_ASSET =
   'stellar:pubnet/asset:USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN' as CaipAssetType;
@@ -25,6 +25,11 @@ const STELLAR_TOKEN = {
   symbol: 'USDC',
   decimals: 7,
   image: '',
+  balance: {
+    value: '0',
+    display: '0.00',
+    fiat: '0.00',
+  },
 } as Asset & { type: typeof AssetType.token };
 
 const STELLAR_WALLET_ID = 'entropy:stellar-test';
@@ -71,16 +76,25 @@ const stellarMockState = {
       },
     },
     selectedAccountGroup: STELLAR_GROUP_ID,
+    accountAssets: {
+      [MOCK_ACCOUNT_STELLAR_PUBNET.id]: {
+        [PUBNET_USDC_ASSET]: {
+          limit: '10',
+          authorized: true,
+          sponsored: false,
+        },
+      },
+    },
   },
 };
 
-describe('AssetActivateCard', () => {
+describe('TokenButtons', () => {
   const mockStore = configureMockStore([thunk])(stellarMockState);
 
   beforeEach(() => {
     jest
-      .spyOn(stellarSnapRequests, 'requestStellarChangeTrustOptAdd')
-      .mockResolvedValue({ status: true });
+      .spyOn(stellarSnapRequests, 'requestStellarChangeTrustOptDelete')
+      .mockResolvedValue(undefined);
     jest
       .spyOn(storeActions, 'forceUpdateMetamaskState')
       .mockResolvedValue(undefined as never);
@@ -90,33 +104,46 @@ describe('AssetActivateCard', () => {
     jest.restoreAllMocks();
   });
 
-  it('renders the activate card with asset and chain details', () => {
+  it('omits remove trustline when the token is not a trustline asset', () => {
     renderWithProvider(
-      <AssetActivateCard asset={STELLAR_TOKEN} chainName="Stellar" />,
+      <TokenButtons
+        token={{
+          ...STELLAR_TOKEN,
+          address:
+            'stellar:pubnet/sep41:CBIJBDNZNF4X35BJ4FFZWCDBSCKOP5NB4PLG4SNENRMLAPYG4P5FM6VN' as CaipAssetType,
+        }}
+        disableSendForNonEvm
+      />,
       mockStore,
     );
 
-    expect(screen.getByTestId('asset-activate-card')).toBeInTheDocument();
-    expect(screen.getByTestId('asset-activate-button')).toBeInTheDocument();
-    expect(screen.getByText(/USDC/u)).toBeInTheDocument();
-    expect(screen.getByText(/Stellar/u)).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('token-overview-deactivate-asset'),
+    ).not.toBeInTheDocument();
   });
 
-  it('submits changeTrustOpt add when the user taps Activate', async () => {
+  it('renders remove trustline for a trustline asset', () => {
     renderWithProvider(
-      <AssetActivateCard asset={STELLAR_TOKEN} chainName="Stellar" />,
+      <TokenButtons token={STELLAR_TOKEN} disableSendForNonEvm />,
       mockStore,
     );
 
-    await waitFor(() => {
-      expect(screen.getByTestId('asset-activate-button')).toBeInTheDocument();
-    });
+    expect(
+      screen.getByTestId('token-overview-deactivate-asset'),
+    ).toBeInTheDocument();
+  });
 
-    fireEvent.click(screen.getByTestId('asset-activate-button'));
+  it('submits remove trustline when tapped', async () => {
+    renderWithProvider(
+      <TokenButtons token={STELLAR_TOKEN} disableSendForNonEvm />,
+      mockStore,
+    );
+
+    fireEvent.click(screen.getByTestId('token-overview-deactivate-asset'));
 
     await waitFor(() => {
       expect(
-        stellarSnapRequests.requestStellarChangeTrustOptAdd,
+        stellarSnapRequests.requestStellarChangeTrustOptDelete,
       ).toHaveBeenCalledWith({
         accountId: MOCK_ACCOUNT_STELLAR_PUBNET.id,
         assetId: PUBNET_USDC_ASSET,
@@ -130,41 +157,17 @@ describe('AssetActivateCard', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('does not refresh state or show error toast when snap returns status false after funding prompt', async () => {
+  it('shows a dismissible error toast when remove trustline fails', async () => {
     jest
-      .spyOn(stellarSnapRequests, 'requestStellarChangeTrustOptAdd')
-      .mockResolvedValue({ status: false });
-
-    renderWithProvider(
-      <AssetActivateCard asset={STELLAR_TOKEN} chainName="Stellar" />,
-      mockStore,
-    );
-
-    fireEvent.click(screen.getByTestId('asset-activate-button'));
-
-    await waitFor(() => {
-      expect(
-        stellarSnapRequests.requestStellarChangeTrustOptAdd,
-      ).toHaveBeenCalled();
-    });
-
-    expect(storeActions.forceUpdateMetamaskState).not.toHaveBeenCalled();
-    expect(
-      screen.queryByTestId('asset-activation-error-container'),
-    ).not.toBeInTheDocument();
-  });
-
-  it('shows a dismissible error toast when changeTrustOpt fails for a reason other than user cancel', async () => {
-    jest
-      .spyOn(stellarSnapRequests, 'requestStellarChangeTrustOptAdd')
+      .spyOn(stellarSnapRequests, 'requestStellarChangeTrustOptDelete')
       .mockRejectedValue(new Error('network failure'));
 
     renderWithProvider(
-      <AssetActivateCard asset={STELLAR_TOKEN} chainName="Stellar" />,
+      <TokenButtons token={STELLAR_TOKEN} disableSendForNonEvm />,
       mockStore,
     );
 
-    fireEvent.click(screen.getByTestId('asset-activate-button'));
+    fireEvent.click(screen.getByTestId('token-overview-deactivate-asset'));
 
     await waitFor(() => {
       expect(
@@ -173,5 +176,41 @@ describe('AssetActivateCard', () => {
     });
 
     expect(storeActions.forceUpdateMetamaskState).not.toHaveBeenCalled();
+  });
+
+  it('shows a non-zero balance error when remove trustline fails with a token balance', async () => {
+    jest
+      .spyOn(stellarSnapRequests, 'requestStellarChangeTrustOptDelete')
+      .mockRejectedValue(new Error('balance must be zero'));
+
+    const storeWithBalance = configureMockStore([thunk])({
+      ...stellarMockState,
+      metamask: {
+        ...stellarMockState.metamask,
+        balances: {
+          [MOCK_ACCOUNT_STELLAR_PUBNET.id]: {
+            [PUBNET_USDC_ASSET]: {
+              amount: '25.50',
+              unit: 'USDC',
+            },
+          },
+        },
+      },
+    });
+
+    renderWithProvider(
+      <TokenButtons token={STELLAR_TOKEN} disableSendForNonEvm />,
+      storeWithBalance,
+    );
+
+    fireEvent.click(screen.getByTestId('token-overview-deactivate-asset'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByTestId('asset-activation-error-container'),
+      ).toHaveTextContent(
+        'You still have 25.50 USDC in this wallet. You must send or swap it all before deactivating this asset on Stellar.',
+      );
+    });
   });
 });

--- a/ui/pages/asset/components/token-buttons.tsx
+++ b/ui/pages/asset/components/token-buttons.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useContext, useEffect } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
+import type { CaipAssetType } from '@metamask/utils';
 import { Box, BoxJustifyContent } from '@metamask/design-system-react';
 import { I18nContext } from '../../../contexts/i18n';
 import useRamps from '../../../hooks/ramps/useRamps/useRamps';
@@ -27,6 +28,8 @@ import { Asset } from '../types/asset';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0021): route-isolation backlog
 import { navigateToSendRoute } from '../../confirmations/utils/send';
 import { isEvmChainId } from '../../../../shared/lib/asset-utils';
+import { useAssetActivation } from '../hooks/useAssetActivation';
+import { AssetActivationErrorToast } from './asset-activation-error-toast';
 
 const TokenButtons = ({
   token,
@@ -126,60 +129,94 @@ const TokenButtons = ({
     openBridgeExperience(MetaMetricsSwapsEventSource.TokenView, token);
   }, [token, openBridgeExperience]);
 
-  return (
-    <Box className="flex" gap={3} justifyContent={BoxJustifyContent.Evenly}>
-      <IconButton
-        className="token-overview__button"
-        Icon={
-          <Icon
-            name={IconName.Dollar}
-            color={IconColor.iconAlternative}
-            size={IconSize.Md}
-          />
-        }
-        label={t('buy')}
-        data-testid="token-overview-buy"
-        onClick={handleBuyAndSellOnClick}
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        disabled={token.isERC721}
-      />
+  const {
+    deactivateAsset,
+    canDeactivate,
+    dismissErrorMessage,
+    isDeactivating,
+    errorMessage,
+  } = useAssetActivation({
+    assetId: token.address as CaipAssetType,
+    assetSymbol: token.symbol,
+  });
 
-      {shouldShowSendButton ? (
+  return (
+    <>
+      <Box className="flex" gap={3} justifyContent={BoxJustifyContent.Evenly}>
         <IconButton
           className="token-overview__button"
-          onClick={handleSendOnClick}
           Icon={
             <Icon
-              name={IconName.Send}
+              name={IconName.Dollar}
               color={IconColor.iconAlternative}
               size={IconSize.Md}
             />
           }
-          label={t('send')}
-          data-testid="eth-overview-send"
-          disabled={
-            token.isERC721 ||
-            (disableSendForNonEvm && !isEvm && !isExternalServicesEnabled)
-          }
+          label={t('buy')}
+          data-testid="token-overview-buy"
+          onClick={handleBuyAndSellOnClick}
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
+          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+          disabled={token.isERC721}
         />
-      ) : null}
 
-      <IconButton
-        className="token-overview__button"
-        Icon={
-          <Icon
-            name={IconName.SwapVertical}
-            color={IconColor.iconAlternative}
-            size={IconSize.Md}
+        {shouldShowSendButton ? (
+          <IconButton
+            className="token-overview__button"
+            onClick={handleSendOnClick}
+            Icon={
+              <Icon
+                name={IconName.Send}
+                color={IconColor.iconAlternative}
+                size={IconSize.Md}
+              />
+            }
+            label={t('send')}
+            data-testid="eth-overview-send"
+            disabled={
+              token.isERC721 ||
+              (disableSendForNonEvm && !isEvm && !isExternalServicesEnabled)
+            }
           />
-        }
-        onClick={handleSwapOnClick}
-        data-testid="token-overview-swap"
-        label={t('swap')}
-        disabled={!isExternalServicesEnabled || isMarketClosed}
+        ) : null}
+
+        <IconButton
+          className="token-overview__button"
+          Icon={
+            <Icon
+              name={IconName.SwapVertical}
+              color={IconColor.iconAlternative}
+              size={IconSize.Md}
+            />
+          }
+          onClick={handleSwapOnClick}
+          data-testid="token-overview-swap"
+          label={t('swap')}
+          disabled={!isExternalServicesEnabled || isMarketClosed}
+        />
+
+        {canDeactivate ? (
+          <IconButton
+            className="token-overview__button"
+            Icon={
+              <Icon
+                name={IconName.Trash}
+                color={IconColor.iconAlternative}
+                size={IconSize.Md}
+              />
+            }
+            onClick={deactivateAsset}
+            data-testid="token-overview-deactivate-asset"
+            label={t('assetDeactivate') as string}
+            disabled={isDeactivating}
+          />
+        ) : null}
+      </Box>
+      <AssetActivationErrorToast
+        message={errorMessage}
+        onClose={dismissErrorMessage}
       />
-    </Box>
+    </>
   );
 };
 

--- a/ui/pages/asset/hooks/useAssetActivation.test.ts
+++ b/ui/pages/asset/hooks/useAssetActivation.test.ts
@@ -4,20 +4,17 @@ import { XlmScope } from '@metamask/keyring-api';
 import { errorCodes } from '@metamask/rpc-errors';
 import type { CaipAssetType } from '@metamask/utils';
 
-import { AssetType } from '../../../../shared/constants/transaction';
 import { MOCK_ACCOUNT_STELLAR_PUBNET } from '../../../../test/data/mock-accounts';
 import initializedMockState from '../../../../test/data/mock-state.json';
 import { renderHookWithProvider } from '../../../../test/lib/render-helpers-navigate';
-import { getAssetsBySelectedAccountGroup } from '../../../selectors/assets';
 import * as storeActions from '../../../store/actions';
 import * as stellarSnapRequests from '../utils/stellar-snap-client-requests';
-import { Asset } from '../types/asset';
 import { useAssetActivation } from './useAssetActivation';
 
 const PUBNET_USDC_ASSET =
   'stellar:pubnet/asset:USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN' as CaipAssetType;
 const SEP41_ASSET_ID =
-  'stellar:pubnet/sep41:CBIJBDNZNF4X35BJ4FFZWCDBSCKOP5NB4PLG4SNENRMLAPYG4P5FM6VN';
+  'stellar:pubnet/sep41:CBIJBDNZNF4X35BJ4FFZWCDBSCKOP5NB4PLG4SNENRMLAPYG4P5FM6VN' as CaipAssetType;
 const STELLAR_WALLET_ID = 'entropy:stellar-test';
 const STELLAR_GROUP_ID = 'entropy:stellar-test/0';
 const EVM_SELECTED_GROUP_ID = 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0';
@@ -27,26 +24,20 @@ const STELLAR_TRUSTLINE_ADD_ERROR =
 const STELLAR_TRUSTLINE_REMOVE_ERROR =
   'Something went wrong while removing this trustline. Try again.';
 
-describe('useAssetActivation', () => {
-  const createTrustlineAsset = (overrides: Partial<Asset> = {}): Asset =>
-    ({
-      type: AssetType.token,
-      address: PUBNET_USDC_ASSET,
-      chainId: XlmScope.Pubnet,
-      symbol: 'USDC',
-      name: 'USD Coin',
-      decimals: 7,
-      image: '',
-      balance: { value: '0', display: '0', fiat: '0' },
-      ...overrides,
-    }) as Asset;
+const DEFAULT_HOOK_PARAMS = {
+  assetId: PUBNET_USDC_ASSET,
+  assetSymbol: 'USDC',
+};
 
+describe('useAssetActivation', () => {
   const createStellarState = ({
     trustlineLimit,
+    balanceAmount,
     includeAssetInState = true,
     selectedAccountGroup = STELLAR_GROUP_ID,
   }: {
     trustlineLimit?: string;
+    balanceAmount?: string;
     includeAssetInState?: boolean;
     selectedAccountGroup?: string;
   } = {}) => ({
@@ -106,14 +97,22 @@ describe('useAssetActivation', () => {
             },
           }
         : {},
-      balances:
+      accountAssets:
         includeAssetInState && trustlineLimit !== undefined
           ? {
               [MOCK_ACCOUNT_STELLAR_PUBNET.id]: {
+                [PUBNET_USDC_ASSET]: { limit: trustlineLimit },
+              },
+            }
+          : {},
+      balances:
+        includeAssetInState &&
+        (balanceAmount !== undefined || trustlineLimit !== undefined)
+          ? {
+              [MOCK_ACCOUNT_STELLAR_PUBNET.id]: {
                 [PUBNET_USDC_ASSET]: {
-                  amount: '0',
+                  amount: balanceAmount ?? '0',
                   unit: 'USDC',
-                  accountAssetInfo: { limit: trustlineLimit },
                 },
               },
             }
@@ -123,7 +122,6 @@ describe('useAssetActivation', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    getAssetsBySelectedAccountGroup.memoizedResultFunc.clearCache();
     jest
       .spyOn(stellarSnapRequests, 'requestStellarChangeTrustOptAdd')
       .mockResolvedValue({ status: true });
@@ -141,18 +139,8 @@ describe('useAssetActivation', () => {
 
   describe('canDeactivate', () => {
     it('returns false for a native asset when the asset does not require a trustline', async () => {
-      const nativeAsset: Asset = {
-        type: AssetType.native,
-        isOriginalNativeSymbol: true,
-        chainId: XlmScope.Pubnet as unknown as `0x${string}`,
-        symbol: 'XLM',
-        name: 'Stellar',
-        decimals: 7,
-        image: '',
-      };
-
       const { result } = renderHookWithProvider(
-        () => useAssetActivation({ asset: nativeAsset }),
+        () => useAssetActivation({ assetSymbol: 'XLM' }),
         createStellarState(),
       );
 
@@ -172,12 +160,12 @@ describe('useAssetActivation', () => {
     });
 
     it('returns false for a non-trustline token when the asset does not require a trustline', async () => {
-      const asset = createTrustlineAsset({
-        address: SEP41_ASSET_ID,
-      });
-
       const { result } = renderHookWithProvider(
-        () => useAssetActivation({ asset }),
+        () =>
+          useAssetActivation({
+            assetId: SEP41_ASSET_ID,
+            assetSymbol: 'SEP41',
+          }),
         createStellarState(),
       );
 
@@ -198,7 +186,7 @@ describe('useAssetActivation', () => {
 
     it('returns false when the trustline limit is zero', () => {
       const { result } = renderHookWithProvider(
-        () => useAssetActivation({ asset: createTrustlineAsset() }),
+        () => useAssetActivation(DEFAULT_HOOK_PARAMS),
         createStellarState({ trustlineLimit: '0' }),
       );
 
@@ -207,7 +195,7 @@ describe('useAssetActivation', () => {
 
     it('returns false when trustline metadata is unavailable', () => {
       const { result } = renderHookWithProvider(
-        () => useAssetActivation({ asset: createTrustlineAsset() }),
+        () => useAssetActivation(DEFAULT_HOOK_PARAMS),
         createStellarState({ includeAssetInState: false }),
       );
 
@@ -216,7 +204,7 @@ describe('useAssetActivation', () => {
 
     it('returns true when the trustline limit is greater than zero', () => {
       const { result } = renderHookWithProvider(
-        () => useAssetActivation({ asset: createTrustlineAsset() }),
+        () => useAssetActivation(DEFAULT_HOOK_PARAMS),
         createStellarState({ trustlineLimit: '10' }),
       );
 
@@ -226,9 +214,8 @@ describe('useAssetActivation', () => {
 
   describe('activateAsset', () => {
     it('requests trustline add and refreshes state on success', async () => {
-      const asset = createTrustlineAsset();
       const { result } = renderHookWithProvider(
-        () => useAssetActivation({ asset }),
+        () => useAssetActivation(DEFAULT_HOOK_PARAMS),
         createStellarState(),
       );
 
@@ -254,7 +241,7 @@ describe('useAssetActivation', () => {
         .mockResolvedValue({ status: false });
 
       const { result } = renderHookWithProvider(
-        () => useAssetActivation({ asset: createTrustlineAsset() }),
+        () => useAssetActivation(DEFAULT_HOOK_PARAMS),
         createStellarState(),
       );
 
@@ -270,7 +257,7 @@ describe('useAssetActivation', () => {
 
     it('does nothing when account is unavailable', async () => {
       const { result } = renderHookWithProvider(
-        () => useAssetActivation({ asset: createTrustlineAsset() }),
+        () => useAssetActivation(DEFAULT_HOOK_PARAMS),
         createStellarState({ selectedAccountGroup: EVM_SELECTED_GROUP_ID }),
       );
 
@@ -289,7 +276,7 @@ describe('useAssetActivation', () => {
         .mockRejectedValue(new Error('activation failed'));
 
       const { result } = renderHookWithProvider(
-        () => useAssetActivation({ asset: createTrustlineAsset() }),
+        () => useAssetActivation(DEFAULT_HOOK_PARAMS),
         createStellarState(),
       );
 
@@ -308,7 +295,7 @@ describe('useAssetActivation', () => {
         });
 
       const { result } = renderHookWithProvider(
-        () => useAssetActivation({ asset: createTrustlineAsset() }),
+        () => useAssetActivation(DEFAULT_HOOK_PARAMS),
         createStellarState(),
       );
 
@@ -322,9 +309,8 @@ describe('useAssetActivation', () => {
 
   describe('deactivateAsset', () => {
     it('requests trustline delete and refreshes state on success', async () => {
-      const asset = createTrustlineAsset();
       const { result } = renderHookWithProvider(
-        () => useAssetActivation({ asset }),
+        () => useAssetActivation(DEFAULT_HOOK_PARAMS),
         createStellarState({ trustlineLimit: '10' }),
       );
 
@@ -346,25 +332,8 @@ describe('useAssetActivation', () => {
 
     it('does nothing when deactivation is not allowed', async () => {
       const { result } = renderHookWithProvider(
-        () => useAssetActivation({ asset: createTrustlineAsset() }),
+        () => useAssetActivation(DEFAULT_HOOK_PARAMS),
         createStellarState({ trustlineLimit: '0' }),
-      );
-
-      await act(async () => {
-        await result.current.deactivateAsset();
-      });
-
-      expect(
-        stellarSnapRequests.requestStellarChangeTrustOptDelete,
-      ).not.toHaveBeenCalled();
-    });
-
-    it('does nothing when balance display is missing', async () => {
-      const asset = createTrustlineAsset({ balance: undefined });
-
-      const { result } = renderHookWithProvider(
-        () => useAssetActivation({ asset }),
-        createStellarState({ trustlineLimit: '10' }),
       );
 
       await act(async () => {
@@ -381,12 +350,9 @@ describe('useAssetActivation', () => {
         .spyOn(stellarSnapRequests, 'requestStellarChangeTrustOptDelete')
         .mockRejectedValue(new Error('deactivation failed'));
 
-      const asset = createTrustlineAsset({
-        balance: { value: '100', display: '1', fiat: '1' },
-      });
       const { result } = renderHookWithProvider(
-        () => useAssetActivation({ asset }),
-        createStellarState({ trustlineLimit: '10' }),
+        () => useAssetActivation(DEFAULT_HOOK_PARAMS),
+        createStellarState({ trustlineLimit: '10', balanceAmount: '100' }),
       );
 
       await act(async () => {
@@ -394,7 +360,7 @@ describe('useAssetActivation', () => {
       });
 
       expect(result.current.errorMessage).toBe(
-        'You still have 1 USDC in this wallet. You must send or swap it all before deactivating this asset on Stellar.',
+        'You still have 100 USDC in this wallet. You must send or swap it all before deactivating this asset on Stellar.',
       );
     });
 
@@ -404,7 +370,7 @@ describe('useAssetActivation', () => {
         .mockRejectedValue(new Error('deactivation failed'));
 
       const { result } = renderHookWithProvider(
-        () => useAssetActivation({ asset: createTrustlineAsset() }),
+        () => useAssetActivation(DEFAULT_HOOK_PARAMS),
         createStellarState({ trustlineLimit: '10' }),
       );
 
@@ -423,7 +389,7 @@ describe('useAssetActivation', () => {
         });
 
       const { result } = renderHookWithProvider(
-        () => useAssetActivation({ asset: createTrustlineAsset() }),
+        () => useAssetActivation(DEFAULT_HOOK_PARAMS),
         createStellarState({ trustlineLimit: '10' }),
       );
 
@@ -442,7 +408,7 @@ describe('useAssetActivation', () => {
         .mockRejectedValue(new Error('activation failed'));
 
       const { result } = renderHookWithProvider(
-        () => useAssetActivation({ asset: createTrustlineAsset() }),
+        () => useAssetActivation(DEFAULT_HOOK_PARAMS),
         createStellarState(),
       );
 

--- a/ui/pages/asset/hooks/useAssetActivation.ts
+++ b/ui/pages/asset/hooks/useAssetActivation.ts
@@ -1,97 +1,109 @@
 import { useCallback, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { errorCodes } from '@metamask/rpc-errors';
-import type { InternalAccount } from '@metamask/keyring-internal-api';
 
-import type { CaipAssetType, CaipChainId } from '@metamask/utils';
-import { getAsset } from '../../../selectors/assets';
+import type { CaipAssetType } from '@metamask/utils';
+import { parseCaipAssetType } from '@metamask/utils';
 import {
   isAssetRequireActivate,
   isTrustlineAsset,
 } from '../../../../shared/lib/multichain/trustline';
+import { getStellarTrustlineAssetInfoForAccount } from '../../../selectors/stellar-assets';
+import { getMultichainBalances } from '../../../selectors/multichain';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { forceUpdateMetamaskState } from '../../../store/actions';
 import {
   requestStellarChangeTrustOptAdd,
   requestStellarChangeTrustOptDelete,
 } from '../utils/stellar-snap-client-requests';
-import { getChainIdFromAssetId } from '../../../../shared/lib/asset-utils';
 import { getInternalAccountBySelectedAccountGroupAndCaip } from '../../../selectors/multichain-accounts/account-tree';
-import { AssetType } from '../../../../shared/constants/transaction';
-import { Asset } from '../types/asset';
 
 /**
  * Manages trustline activation and deactivation for supported assets (currently Stellar classic tokens).
  *
  * @param params - Hook parameters.
- * @param params.asset - Asset to activate or deactivate.
- * @returns Trustline actions, loading flags, error state, and whether deactivation is allowed.
- * For assets that do not require a trustline, actions are inert and deactivation is disabled.
+ * @param params.accountId - Optional account id override.
+ * @param params.assetId - CAIP asset id for the trustline asset.
+ * @param params.assetSymbol - Symbol of the asset.
+ * @returns Trustline actions, loading flags, error state, activation requirement, and whether deactivation is allowed. For assets that do not require a trustline, actions are inert and deactivation is disabled.
  */
-export const useAssetActivation = ({ asset }: { asset: Asset }) => {
+export const useAssetActivation = ({
+  accountId,
+  assetId,
+  assetSymbol,
+}: {
+  accountId?: string;
+  assetId?: CaipAssetType;
+  assetSymbol?: string;
+}) => {
   const t = useI18nContext();
   const dispatch = useDispatch();
 
-  // For non trusline asset, assetId and chainId are undefined.
-  let assetId: CaipAssetType | undefined;
-  let chainId: CaipChainId | undefined;
-  let isAssetIsTrustlineAsset: boolean = false;
-  if (asset.type === AssetType.token) {
-    assetId = asset.address as CaipAssetType;
-    isAssetIsTrustlineAsset = isTrustlineAsset(assetId);
-    if (isAssetIsTrustlineAsset) {
-      chainId = getChainIdFromAssetId(assetId);
+  const isAssetIsTrustlineAsset = assetId ? isTrustlineAsset(assetId) : false;
+  const chainId = assetId ? parseCaipAssetType(assetId).chainId : undefined;
+
+  const selectedAccountId = useSelector((state) => {
+    if (accountId || !chainId) {
+      return undefined;
     }
-  }
 
-  const account = useSelector((state) =>
-    chainId
-      ? getInternalAccountBySelectedAccountGroupAndCaip(state, chainId)
-      : undefined,
-  ) as InternalAccount | undefined;
+    return getInternalAccountBySelectedAccountGroupAndCaip(state, chainId)?.id;
+  });
+  const resolvedAccountId = accountId ?? selectedAccountId;
 
-  const assetFromState = useSelector((state) =>
-    chainId && assetId ? getAsset(state, assetId, chainId) : undefined,
+  const multichainBalances = useSelector(getMultichainBalances);
+
+  const balanceAmount =
+    resolvedAccountId && assetId
+      ? multichainBalances[resolvedAccountId]?.[assetId]?.amount
+      : undefined;
+
+  const requiresActivate = useSelector((state) => {
+    if (!assetId || !isAssetIsTrustlineAsset || !resolvedAccountId) {
+      return false;
+    }
+
+    const assetMetadata = getStellarTrustlineAssetInfoForAccount(
+      state,
+      resolvedAccountId,
+      assetId,
+    );
+
+    return isAssetRequireActivate({
+      assetId,
+      assetMetadata,
+    });
+  });
+
+  const canDeactivate = Boolean(
+    assetId &&
+    isAssetIsTrustlineAsset &&
+    !requiresActivate &&
+    resolvedAccountId &&
+    chainId,
   );
 
   const [isDeactivating, setIsDeactivating] = useState(false);
   const [isActivating, setIsActivating] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
   const dismissErrorMessage = useCallback(() => {
     setErrorMessage(null);
   }, []);
 
-  const canDeactivate =
-    assetId &&
-    isAssetIsTrustlineAsset &&
-    !isAssetRequireActivate({
-      assetId,
-      assetMetadata: assetFromState?.accountAssetInfo,
-    });
-
   const deactivateAsset = useCallback(async () => {
-    if (
-      !canDeactivate ||
-      !account ||
-      !chainId ||
-      !assetId ||
-      !asset ||
-      !asset.balance?.display
-    ) {
+    if (!canDeactivate || !resolvedAccountId || !chainId || !assetId) {
       return;
     }
 
-    const hasNonZeroBalance = Boolean(
-      asset.balance?.value && asset.balance.value !== '0',
-    );
-    const balance = asset.balance?.display;
-    const { symbol } = asset;
+    const hasNonZeroBalance = Boolean(balanceAmount && balanceAmount !== '0');
+    const balanceDisplay = balanceAmount ?? '0';
 
     setErrorMessage(null);
     setIsDeactivating(true);
     try {
       await requestStellarChangeTrustOptDelete({
-        accountId: account.id,
+        accountId: resolvedAccountId,
         assetId,
         scope: chainId,
       });
@@ -103,27 +115,41 @@ export const useAssetActivation = ({ asset }: { asset: Asset }) => {
       if (!isUserRejection) {
         setErrorMessage(
           hasNonZeroBalance
-            ? (t('stellarClassicTrustlineRemoveNonZeroBalanceError', [
-                balance,
-                symbol,
+            ? (t('assetDeactivationNonZeroBalanceError', [
+                balanceDisplay,
+                assetSymbol,
               ]) as string)
-            : (t('stellarClassicTrustlineRemoveError') as string),
+            : (t('assetDeactivationError') as string),
         );
       }
     } finally {
       setIsDeactivating(false);
     }
-  }, [account, assetId, asset, canDeactivate, chainId, dispatch, t]);
+  }, [
+    assetId,
+    assetSymbol,
+    balanceAmount,
+    canDeactivate,
+    chainId,
+    dispatch,
+    resolvedAccountId,
+    t,
+  ]);
 
   const activateAsset = useCallback(async () => {
-    if (!account || !chainId || !assetId) {
+    if (
+      !resolvedAccountId ||
+      !chainId ||
+      !assetId ||
+      !isAssetIsTrustlineAsset
+    ) {
       return;
     }
     setErrorMessage(null);
     setIsActivating(true);
     try {
       const result = await requestStellarChangeTrustOptAdd({
-        accountId: account.id,
+        accountId: resolvedAccountId,
         assetId,
         scope: chainId,
       });
@@ -137,17 +163,18 @@ export const useAssetActivation = ({ asset }: { asset: Asset }) => {
       const isUserRejection =
         errorCode === errorCodes.provider.userRejectedRequest;
       if (!isUserRejection) {
-        setErrorMessage(t('stellarClassicTrustlineAddError') as string);
+        setErrorMessage(t('assetActivationError') as string);
       }
     } finally {
       setIsActivating(false);
     }
-  }, [account, assetId, chainId, dispatch, t]);
+  }, [assetId, chainId, dispatch, isAssetIsTrustlineAsset, resolvedAccountId, t]);
 
   return {
     deactivateAsset,
     activateAsset,
     canDeactivate,
+    requiresActivate,
     isDeactivating,
     isActivating,
     errorMessage,

--- a/ui/pages/asset/hooks/useSpendableBalance.test.ts
+++ b/ui/pages/asset/hooks/useSpendableBalance.test.ts
@@ -1,0 +1,94 @@
+import { XlmScope } from '@metamask/keyring-api';
+import type { CaipAssetType } from '@metamask/utils';
+import { renderHook } from '@testing-library/react-hooks';
+
+import * as stellarAssetsSelectors from '../../../selectors/stellar-assets';
+import { useSpendableBalance } from './useSpendableBalance';
+
+jest.mock('react-redux', () => ({
+  useSelector: <State, Result>(selector: (state: State) => Result): Result =>
+    selector({} as State),
+}));
+
+jest.mock('../../../selectors/stellar-assets', () => ({
+  getStellarBaseReserveForAccountAsset: jest.fn(),
+}));
+
+const ACCOUNT_ID = 'stellar-account-id';
+const STELLAR_NATIVE_ASSET_ID =
+  `${XlmScope.Pubnet}/slip44:148` as CaipAssetType;
+
+describe('useSpendableBalance', () => {
+  const getStellarBaseReserveForAccountAssetMock =
+    stellarAssetsSelectors.getStellarBaseReserveForAccountAsset as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns spendable balance data for supported native assets', () => {
+    getStellarBaseReserveForAccountAssetMock.mockReturnValue('2.5');
+
+    const { result } = renderHook(() =>
+      useSpendableBalance({
+        accountId: ACCOUNT_ID,
+        assetId: STELLAR_NATIVE_ASSET_ID,
+        totalBalance: '250',
+      }),
+    );
+
+    expect(result.current).toStrictEqual({
+      baseReserve: '2.5',
+      spendableBalance: '247.5',
+    });
+  });
+
+  it('returns undefined values when base reserve is unsupported', () => {
+    getStellarBaseReserveForAccountAssetMock.mockReturnValue(undefined);
+
+    const { result } = renderHook(() =>
+      useSpendableBalance({
+        accountId: ACCOUNT_ID,
+        assetId: STELLAR_NATIVE_ASSET_ID,
+        totalBalance: '250',
+      }),
+    );
+
+    expect(result.current).toStrictEqual({
+      baseReserve: undefined,
+      spendableBalance: undefined,
+    });
+  });
+
+  it('skips selector lookup when account id or asset id is missing', () => {
+    const { result } = renderHook(() =>
+      useSpendableBalance({
+        accountId: undefined,
+        assetId: undefined,
+        totalBalance: '250',
+      }),
+    );
+
+    expect(getStellarBaseReserveForAccountAssetMock).not.toHaveBeenCalled();
+    expect(result.current).toStrictEqual({
+      baseReserve: undefined,
+      spendableBalance: undefined,
+    });
+  });
+
+  it('skips selector lookup for assets that do not support base reserve', () => {
+    const { result } = renderHook(() =>
+      useSpendableBalance({
+        accountId: ACCOUNT_ID,
+        assetId: 'eip155:1/slip44:60' as CaipAssetType,
+        totalBalance: '250',
+      }),
+    );
+
+    expect(getStellarBaseReserveForAccountAssetMock).not.toHaveBeenCalled();
+    expect(result.current).toStrictEqual({
+      baseReserve: undefined,
+      spendableBalance: undefined,
+    });
+  });
+});

--- a/ui/pages/asset/hooks/useSpendableBalance.ts
+++ b/ui/pages/asset/hooks/useSpendableBalance.ts
@@ -1,0 +1,65 @@
+import type { CaipAssetType } from '@metamask/utils';
+import { parseCaipAssetType } from '@metamask/utils';
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+
+import {
+  computeSpendableBalance,
+  isSupportBaseReserve,
+} from '../../../../shared/lib/multichain/spendable-balance';
+import { getStellarBaseReserveForAccountAsset } from '../../../selectors/stellar-assets';
+import { getInternalAccountBySelectedAccountGroupAndCaip } from '../../../selectors/multichain-accounts/account-tree';
+
+/**
+ * Resolves native spendable balance data for an account/asset pair.
+ *
+ * @param params - Hook parameters.
+ * @param params.accountId - Optional account id override.
+ * @param params.assetId - CAIP asset id for the native asset.
+ * @param params.totalBalance - Total balance display string used to compute spendable balance.
+ * @returns Base reserve and spendable balance when available.
+ */
+export const useSpendableBalance = ({
+  accountId,
+  assetId,
+  totalBalance,
+}: {
+  accountId?: string;
+  assetId?: CaipAssetType;
+  totalBalance?: string;
+}) => {
+  const chainId = assetId ? parseCaipAssetType(assetId).chainId : undefined;
+  const selectedAccountId = useSelector((state) => {
+    if (accountId || !chainId) {
+      return undefined;
+    }
+
+    return getInternalAccountBySelectedAccountGroupAndCaip(state, chainId)?.id;
+  });
+  const resolvedAccountId = accountId ?? selectedAccountId;
+
+  const baseReserve = useSelector((state) => {
+    if (!assetId || !resolvedAccountId || !isSupportBaseReserve(assetId)) {
+      return undefined;
+    }
+
+    return getStellarBaseReserveForAccountAsset(
+      state,
+      resolvedAccountId,
+      assetId,
+    );
+  });
+
+  const spendableBalance = useMemo(() => {
+    if (baseReserve === undefined || totalBalance === undefined) {
+      return undefined;
+    }
+
+    return computeSpendableBalance(totalBalance, baseReserve);
+  }, [baseReserve, totalBalance]);
+
+  return {
+    baseReserve,
+    spendableBalance,
+  };
+};

--- a/ui/selectors/stellar-assets.test.ts
+++ b/ui/selectors/stellar-assets.test.ts
@@ -1,0 +1,115 @@
+import { XlmScope } from '@metamask/keyring-api';
+import type { CaipAssetType } from '@metamask/utils';
+
+import {
+  getStellarBaseReserveForAccountAsset,
+  getStellarTrustlineAssetInfoForAccount,
+} from './stellar-assets';
+
+const ACCOUNT_ID = 'stellar-account-id';
+const STELLAR_NATIVE_ASSET_ID =
+  `${XlmScope.Pubnet}/slip44:148` as CaipAssetType;
+const ETHER_NATIVE_ASSET_ID = 'eip155:1/slip44:60' as CaipAssetType;
+const TRUSTLINE_USDC =
+  'stellar:pubnet/asset:USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN' as CaipAssetType;
+const SEP41_ASSET_ID =
+  'stellar:pubnet/sep41:CBIJBDNZNF4X35BJ4FFZWCDBSCKOP5NB4PLG4SNENRMLAPYG4P5FM6VN' as CaipAssetType;
+
+const mockState = {
+  metamask: {
+    accountAssets: {
+      [ACCOUNT_ID]: {
+        [STELLAR_NATIVE_ASSET_ID]: {
+          baseReserve: '2.5',
+        },
+        [TRUSTLINE_USDC]: {
+          limit: '1000',
+        },
+      },
+    },
+  },
+};
+
+describe('stellar-assets selectors', () => {
+  describe('getStellarBaseReserveForAccountAsset', () => {
+    it('returns base reserve from StellarAssetsController state', () => {
+      expect(
+        getStellarBaseReserveForAccountAsset(
+          mockState,
+          ACCOUNT_ID,
+          STELLAR_NATIVE_ASSET_ID,
+        ),
+      ).toBe('2.5');
+    });
+
+    it('defaults base reserve to "0" when native enrichment is missing', () => {
+      expect(
+        getStellarBaseReserveForAccountAsset(
+          {
+            metamask: {
+              accountAssets: {
+                [ACCOUNT_ID]: {},
+              },
+            },
+          },
+          ACCOUNT_ID,
+          STELLAR_NATIVE_ASSET_ID,
+        ),
+      ).toBe('0');
+    });
+
+    it('returns undefined base reserve for unsupported assets', () => {
+      expect(
+        getStellarBaseReserveForAccountAsset(
+          mockState,
+          ACCOUNT_ID,
+          ETHER_NATIVE_ASSET_ID,
+        ),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('getStellarTrustlineAssetInfoForAccount', () => {
+    it('returns trustline metadata for an account/asset pair', () => {
+      expect(
+        getStellarTrustlineAssetInfoForAccount(
+          mockState,
+          ACCOUNT_ID,
+          TRUSTLINE_USDC,
+        ),
+      ).toStrictEqual({
+        limit: '1000',
+      });
+    });
+
+    it('returns undefined for native asset enrichment', () => {
+      expect(
+        getStellarTrustlineAssetInfoForAccount(
+          mockState,
+          ACCOUNT_ID,
+          STELLAR_NATIVE_ASSET_ID,
+        ),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when the account has no cached enrichment', () => {
+      expect(
+        getStellarTrustlineAssetInfoForAccount(
+          { metamask: { accountAssets: {} } },
+          ACCOUNT_ID,
+          TRUSTLINE_USDC,
+        ),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when the asset is missing for the account', () => {
+      expect(
+        getStellarTrustlineAssetInfoForAccount(
+          mockState,
+          ACCOUNT_ID,
+          SEP41_ASSET_ID,
+        ),
+      ).toBeUndefined();
+    });
+  });
+});

--- a/ui/selectors/stellar-assets.ts
+++ b/ui/selectors/stellar-assets.ts
@@ -1,0 +1,84 @@
+import type { CaipAssetType } from '@metamask/utils';
+import { BigNumber } from 'bignumber.js';
+
+/* eslint-disable import-x/no-restricted-paths -- controller exports enrichment helpers used by UI selectors */
+import {
+  getNativeAssetInfoForAsset,
+  getTrustlineAssetInfoForAsset,
+  type StellarAssetsControllerState,
+} from '../../app/scripts/controllers/stellar-assets-controller';
+/* eslint-enable import-x/no-restricted-paths */
+import { isSupportBaseReserve } from '../../shared/lib/multichain/spendable-balance';
+import { createParameterizedSelector } from '../../shared/lib/selectors/selector-creators';
+
+const ACCOUNT_ASSET_LRU_CACHE_SIZE = 50;
+
+type StellarAssetsSelectorState = {
+  metamask?: Pick<StellarAssetsControllerState, 'accountAssets'>;
+};
+
+function getStellarAccountAssets(
+  state: StellarAssetsSelectorState,
+): StellarAssetsControllerState['accountAssets'] {
+  return state.metamask?.accountAssets ?? {};
+}
+
+function isValidNumberString(value?: string): boolean {
+  if (value === undefined) {
+    return false;
+  }
+  try {
+    const parsed = new BigNumber(value);
+    return parsed.isFinite() && !parsed.isNegative();
+  } catch {
+    return false;
+  }
+}
+
+function resolveBaseReserve(
+  assetId: string,
+  nativeAssetInfo: ReturnType<typeof getNativeAssetInfoForAsset>,
+): string | undefined {
+  if (!isSupportBaseReserve(assetId)) {
+    return undefined;
+  }
+
+  return isValidNumberString(nativeAssetInfo?.baseReserve)
+    ? nativeAssetInfo?.baseReserve
+    : '0';
+}
+
+/**
+ * Returns the base reserve for a Stellar native asset that supports reserve balance display.
+ */
+export const getStellarBaseReserveForAccountAsset = createParameterizedSelector(
+  ACCOUNT_ASSET_LRU_CACHE_SIZE,
+)(
+  getStellarAccountAssets,
+  (_state: StellarAssetsSelectorState, accountId: string) => accountId,
+  (
+    _state: StellarAssetsSelectorState,
+    _accountId: string,
+    assetId: CaipAssetType,
+  ) => assetId,
+  (accountAssets, accountId, assetId) =>
+    resolveBaseReserve(
+      assetId,
+      getNativeAssetInfoForAsset(assetId, accountAssets[accountId]?.[assetId]),
+    ),
+);
+
+/**
+ * Returns Stellar trustline metadata for an account/asset pair.
+ */
+export const getStellarTrustlineAssetInfoForAccount =
+  createParameterizedSelector(ACCOUNT_ASSET_LRU_CACHE_SIZE)(
+    getStellarAccountAssets,
+    (_state, accountId: string) => accountId,
+    (_state, _accountId: string, assetId: CaipAssetType) => assetId,
+    (accountAssets, accountId, assetId) =>
+      getTrustlineAssetInfoForAsset(
+        assetId,
+        accountAssets[accountId]?.[assetId],
+      ),
+  );


### PR DESCRIPTION
## **Description**

Adds a transitional `StellarAssetsController` that caches per-account Stellar asset enrichment (`baseReserve` for native XLM, `limit` for classic trustlines) from the wallet snap, and wires that state into the asset details UI through selectors and hooks.

1. **Reason for the change:** Stellar trustline activation and spendable-balance display need account-scoped enrichment that is not yet available from the unified assets controller.
2. **Improvement/solution:** Introduce `StellarAssetsController` (gated by `stellarAccounts` + `assetEnrichment` remote flags), expose selectors, and update `useAssetActivation` / `useSpendableBalance` consumers to read enrichment from controller state.

## **Changelog**

CHANGELOG entry: Added Stellar asset enrichment support for trustline activation and spendable balance display.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Enable remote feature flags `stellarAccounts` and `assetEnrichment`.
2. Open a Stellar account with classic assets and native XLM.
3. On a classic trustline asset page, verify activate card / inactive badge behavior based on trustline `limit`.
4. Activate / deactivate a trustline and confirm state refreshes after the snap flow.
5. On native XLM asset page, verify spendable balance section shows total, spendable, and reserved (`baseReserve`) amounts.

## **Screenshots/Recordings**

<!--
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)