### PR TITLE
ci: remove requirement for "auto-rc-builds" label

### DIFF
--- a/.github/workflows/rc-slack-notify.yml
+++ b/.github/workflows/rc-slack-notify.yml
@@ -1,5 +1,5 @@
 # Posts a Slack Block Kit message after a successful Main workflow run on release/X.Y.Z,
-# when the release PR (into stable) has the `auto-rc-builds` label — parity with Mobile RC Slack.
+# when there is a release PR into stable for the release branch.
 # See .github/scripts/slack-rc-notification.mts
 #
 # Test without waiting for Main:
@@ -52,7 +52,7 @@ jobs:
           startsWith(github.event.workflow_run.head_branch, 'release/'))
       }}
     steps:
-      - name: Gate — release PR must have auto-rc-builds (workflow_run only)
+      - name: Find release PR (workflow_run only)
         id: gate
         if: github.event_name == 'workflow_run'
         env:
@@ -66,13 +66,9 @@ jobs:
             echo "Not release/x.y.z: $BRANCH — skipping Slack."
             exit 0
           fi
-          PR_JSON="$(gh pr list --repo "$GH_REPO" --head "$BRANCH" --base stable --json number,labels --jq '.[0]' 2>/dev/null || true)"
+          PR_JSON="$(gh pr list --repo "$GH_REPO" --head "$BRANCH" --base stable --json number --jq '.[0]' 2>/dev/null || true)"
           if [[ -z "$PR_JSON" || "$PR_JSON" == "null" ]]; then
             echo "No PR with base stable for head $BRANCH — skipping Slack."
-            exit 0
-          fi
-          if ! echo "$PR_JSON" | jq -r '.labels[].name' | grep -qx 'auto-rc-builds'; then
-            echo "PR exists but missing auto-rc-builds label — skipping Slack."
             exit 0
           fi
           PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
@@ -81,7 +77,7 @@ jobs:
             echo "semver=${BRANCH#release/}"
             echo "pr_number=${PR_NUMBER}"
           } >> "$GITHUB_OUTPUT"
-          echo "Proceeding: release PR has auto-rc-builds."
+          echo "Proceeding: found release PR #${PR_NUMBER}."
 
       - name: Set notification variables
         id: notif


### PR DESCRIPTION
## **Description**

I made a mistake in #42960 where we required the `auto-rc-builds` label for the Slack message to show up.

There was no good reason to do that, because Extension **always** generates RC builds.

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI notification gating only; makes Slack posts more permissive with no auth or product runtime impact.
> 
> **Overview**
> **RC Slack notifications** now fire whenever a successful Main run on `release/X.Y.Z` has an open PR into `stable`, without requiring the `auto-rc-builds` label.
> 
> The workflow gate step is renamed to **Find release PR** and only checks for that PR (and semver branch shape). The `gh pr list` query no longer fetches labels, and the jq check that skipped when `auto-rc-builds` was missing is removed. Header comments are updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3403b9e8954624aa77164e66a351e6e864452998. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->