### PR TITLE
feat: ux improvemnets for add via chainlist feature

### DIFF
--- a/ui/components/multichain/networks-form/networks-form.tsx
+++ b/ui/components/multichain/networks-form/networks-form.tsx
@@ -583,7 +583,9 @@ export const NetworksForm = ({
             return url.length > (isList ? 37 : 35) ? url : undefined;
           }}
           addButtonText={t('addRpcUrl')}
-          itemIsDeletable={(item) => item.type !== RpcEndpointType.Infura}
+          itemIsDeletable={(item, items) =>
+            items.length > 1 && item.type !== RpcEndpointType.Infura
+          }
           onItemAdd={onRpcAdd}
           onItemSelected={(index) =>
             setRpcUrls((state) => ({

--- a/ui/pages/networks/chainlist-network-picker.tsx
+++ b/ui/pages/networks/chainlist-network-picker.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
 import {
   AvatarNetwork,
   BannerAlert,
@@ -11,13 +12,17 @@ import {
   TextFieldSize,
   TextVariant,
 } from '@metamask/design-system-react';
-import { CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP } from '../../../shared/constants/network';
+import {
+  CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP,
+  TEST_CHAINS,
+} from '../../../shared/constants/network';
 import ZENDESK_URLS from '../../helpers/constants/zendesk-url';
 import {
   type SafeChain,
   useSafeChains,
 } from '../../components/multichain/networks-form/use-safe-chains';
 import { useI18nContext } from '../../hooks/useI18nContext';
+import { getShowTestNetworks } from '../../selectors/selectors';
 import { NoSearchResult } from './no-search-result';
 
 export type ChainlistNetwork = SafeChain & {
@@ -45,6 +50,9 @@ export const getUsableUrls = (urls: string[] = []) =>
 
 const CHAINLIST_PAGE_SIZE = 100;
 const CHAINLIST_SCROLL_THRESHOLD_PX = 120;
+const BUILT_IN_TEST_CHAIN_IDS = new Set(
+  TEST_CHAINS.map((chainId) => chainId.toLowerCase()),
+);
 
 type ChainlistNetworkPickerProps = {
   existingNetworkChainIds: Set<string>;
@@ -62,14 +70,19 @@ export const ChainlistNetworkPicker = ({
   const [visibleNetworkCount, setVisibleNetworkCount] =
     useState(CHAINLIST_PAGE_SIZE);
   const { safeChains } = useSafeChains();
+  const showTestNetworks = useSelector(getShowTestNetworks);
 
   const chainlistNetworks = useMemo(() => {
     const normalizedSearchValue = searchValue.trim().toLowerCase();
 
     return ((safeChains ?? []) as ChainlistNetwork[]).filter((network) => {
-      const existingNetworkName =
-        existingNetworkNamesByChainId[getHexChainId(network.chainId)];
+      const chainId = getHexChainId(network.chainId);
+      const existingNetworkName = existingNetworkNamesByChainId[chainId];
       if (getUsableUrls(network.rpc).length === 0) {
+        return false;
+      }
+
+      if (!showTestNetworks && BUILT_IN_TEST_CHAIN_IDS.has(chainId)) {
         return false;
       }
 
@@ -83,7 +96,12 @@ export const ChainlistNetworkPicker = ({
         String(network.chainId).includes(normalizedSearchValue)
       );
     });
-  }, [existingNetworkNamesByChainId, safeChains, searchValue]);
+  }, [
+    existingNetworkNamesByChainId,
+    safeChains,
+    searchValue,
+    showTestNetworks,
+  ]);
 
   const visibleChainlistNetworks = useMemo(
     () => chainlistNetworks.slice(0, visibleNetworkCount),
@@ -118,36 +136,36 @@ export const ChainlistNetworkPicker = ({
 
   return (
     <Box className="flex min-h-0 flex-1 flex-col overflow-hidden bg-background-default">
-      <Box className="px-4 pb-4">
-        <TextFieldSearch
-          clearButtonOnClick={() => setSearchValue('')}
-          clearButtonProps={{ ariaLabel: t('clear') }}
-          className="mm-text-field-search w-full rounded-full border border-border-muted bg-background-default"
-          data-testid="networks-page-chainlist-search"
-          onChange={(event) => setSearchValue(event.target.value)}
-          placeholder={t('searchNetworkNameOrChainId')}
-          size={TextFieldSize.Lg}
-          value={searchValue}
-        />
-        <BannerAlert
-          className="mt-4"
-          severity={BannerAlertSeverity.Info}
-          data-testid="networks-page-chainlist-source-banner"
-          description={t('chainlistNetworkDataSourceBanner', [
-            <TextButton
-              key="chainlist-learn-how-to-stay-safe"
-              onClick={handleLearnHowToStaySafe}
-            >
-              {t('chainlistLearnHowToStaySafe')}
-            </TextButton>,
-          ])}
-        />
-      </Box>
       <Box
         className="min-h-0 flex-1 overflow-y-auto"
         data-testid="networks-page-chainlist-network-list"
         onScroll={handleChainlistScroll}
       >
+        <Box className="px-4 pb-4">
+          <TextFieldSearch
+            clearButtonOnClick={() => setSearchValue('')}
+            clearButtonProps={{ ariaLabel: t('clear') }}
+            className="mm-text-field-search w-full rounded-full border border-border-muted bg-background-default"
+            data-testid="networks-page-chainlist-search"
+            onChange={(event) => setSearchValue(event.target.value)}
+            placeholder={t('searchNetworkNameOrChainId')}
+            size={TextFieldSize.Lg}
+            value={searchValue}
+          />
+          <BannerAlert
+            className="mt-4"
+            severity={BannerAlertSeverity.Info}
+            data-testid="networks-page-chainlist-source-banner"
+            description={t('chainlistNetworkDataSourceBanner', [
+              <TextButton
+                key="chainlist-learn-how-to-stay-safe"
+                onClick={handleLearnHowToStaySafe}
+              >
+                {t('chainlistLearnHowToStaySafe')}
+              </TextButton>,
+            ])}
+          />
+        </Box>
         {showNoSearchResults ? (
           <NoSearchResult dataTestId="networks-page-chainlist-no-results" />
         ) : null}

--- a/ui/pages/networks/networks-page.test.tsx
+++ b/ui/pages/networks/networks-page.test.tsx
@@ -25,6 +25,13 @@ const mockSafeChains = [
     explorers: [{ url: 'https://cronoscan.com' }],
   },
   {
+    name: 'Sepolia',
+    chainId: 11155111,
+    nativeCurrency: { symbol: 'SepoliaETH' },
+    rpc: ['https://sepolia.infura.io/v3/123'],
+    explorers: [{ url: 'https://sepolia.etherscan.io' }],
+  },
+  {
     name: 'HTTP Only Network',
     chainId: 200,
     nativeCurrency: { symbol: 'HTTP' },
@@ -370,6 +377,54 @@ describe('NetworksPage', () => {
     expect(screen.getByTestId('network-form-ticker-input')).toHaveValue('xDAI');
   });
 
+  it('hides built-in test networks from Chainlist when test networks are hidden', async () => {
+    renderNetworksPage({
+      pathname: `${NETWORKS_ROUTE}?view=add-from-chainlist`,
+      networkConfigurationsByChainId: {
+        ...mockNetworkConfigurations,
+        ...testNetworkConfiguration,
+      },
+      remoteFeatureFlags: { extensionUxChainlist: true },
+      showTestNetworks: false,
+    });
+
+    await userEvent.type(
+      await screen.findByPlaceholderText(
+        messages.searchNetworkNameOrChainId.message,
+      ),
+      'Sepolia',
+    );
+
+    expect(screen.queryByText('Sepolia')).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('networks-page-chainlist-added-pill'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('shows built-in test networks in Chainlist when test networks are shown', async () => {
+    renderNetworksPage({
+      pathname: `${NETWORKS_ROUTE}?view=add-from-chainlist`,
+      networkConfigurationsByChainId: {
+        ...mockNetworkConfigurations,
+        ...testNetworkConfiguration,
+      },
+      remoteFeatureFlags: { extensionUxChainlist: true },
+      showTestNetworks: true,
+    });
+
+    await userEvent.type(
+      await screen.findByPlaceholderText(
+        messages.searchNetworkNameOrChainId.message,
+      ),
+      'Sepolia',
+    );
+
+    expect(await screen.findByText('Sepolia')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('networks-page-chainlist-added-pill'),
+    ).toHaveTextContent(messages.added.message);
+  });
+
   it('prefills only the top Chainlist RPC URL in the add network form', async () => {
     renderNetworksPage({
       pathname: `${NETWORKS_ROUTE}?view=add-from-chainlist`,
@@ -400,6 +455,10 @@ describe('NetworksPage', () => {
     expect(
       screen.queryByText('rpc-tertiary.example.com'),
     ).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByTestId('test-add-rpc-drop-down'));
+
+    expect(screen.queryByTestId('delete-item-0')).not.toBeInTheDocument();
   });
 
   it('prefills Chainlist network name from the canonical network name when available', async () => {

--- a/ui/pages/networks/networks-page.test.tsx
+++ b/ui/pages/networks/networks-page.test.tsx
@@ -455,10 +455,6 @@ describe('NetworksPage', () => {
     expect(
       screen.queryByText('rpc-tertiary.example.com'),
     ).not.toBeInTheDocument();
-
-    await userEvent.click(screen.getByTestId('test-add-rpc-drop-down'));
-
-    expect(screen.queryByTestId('delete-item-0')).not.toBeInTheDocument();
   });
 
   it('prefills Chainlist network name from the canonical network name when available', async () => {


### PR DESCRIPTION
This PR is to:
1. Make the warning banner scrollable
2. Don't show built in test nets in the list if test net toggle is disabled
3. Hide the delete button if only one RPC URL is available

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
4. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to Chainlist
2. Make sure the banner scrolls
3. If testnet is disabled, it should not show built in test nets in the list
4. If there is only one RPC URL. Don't show the delete button

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/f8c66148-d403-455d-8de0-a847508a0e0c


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only filtering and layout changes with a small guard on RPC deletion; no auth or transaction logic.
> 
> **Overview**
> Improves the **add via Chainlist** flow and network form RPC list behavior in three areas.
> 
> **Chainlist picker:** The search field and Chainlist source **info banner** are moved inside the scrollable network list so they scroll with the list instead of staying fixed above it. Built-in test networks from `TEST_CHAINS` are **filtered out** of Chainlist results when the user’s **show test networks** preference is off, using `getShowTestNetworks` from Redux.
> 
> **Network form:** RPC URL rows can only be deleted when there is **more than one** endpoint (Infura endpoints remain non-deletable as before), so a lone RPC cannot be removed.
> 
> **Tests:** Coverage for hiding vs showing Sepolia in Chainlist based on `showTestNetworks`, plus Sepolia in mock Chainlist data.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f993ff7224a61eda31ba7e77cd15f6dcd2bd1a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->