### PR TITLE
fix: render in flight perps deposit/withdraw activity details

### DIFF
--- a/ui/pages/details/templates/perps-deposit-details.tsx
+++ b/ui/pages/details/templates/perps-deposit-details.tsx
@@ -41,17 +41,12 @@ function useTransactionMeta(hash: string | undefined) {
   return localTransactions.get(hash || '')?.initialTransaction;
 }
 
-export function PerpsDepositDetails({ item }: Props) {
+export function PerpsDepositDetails({ item }: Readonly<Props>) {
   const t = useI18nContext();
   const navigate = useNavigate();
   const { formatDateTime, formatCurrencyWithMinThreshold } = useFormatters();
   const transactionMeta = useTransactionMeta(item.hash);
-
-  if (!transactionMeta) {
-    return null;
-  }
-
-  const { metamaskPay } = transactionMeta;
+  const { metamaskPay } = transactionMeta ?? {};
   const { targetFiat, networkFeeFiat, bridgeFeeFiat, totalFiat } =
     metamaskPay || {};
 
@@ -71,7 +66,7 @@ export function PerpsDepositDetails({ item }: Props) {
         >
           <ActivityAvatar tokens={[PERPS_USDC_ASSET_ID]} />
           <Text variant="heading-lg" color="text-success-default">
-            +{formattedTargetFiat}
+            {formattedTargetFiat ? `+${formattedTargetFiat}` : null}
           </Text>
         </div>
 
@@ -104,15 +99,17 @@ export function PerpsDepositDetails({ item }: Props) {
           />
         </Section>
 
-        <Section>
-          <TransactionDetailsProvider transactionMeta={transactionMeta}>
-            <TransactionDetailsSummary />
-          </TransactionDetailsProvider>
-        </Section>
+        {transactionMeta ? (
+          <Section>
+            <TransactionDetailsProvider transactionMeta={transactionMeta}>
+              <TransactionDetailsSummary />
+            </TransactionDetailsProvider>
+          </Section>
+        ) : null}
       </div>
 
       <Footer>
-        {transactionMeta.status === TransactionMetaStatus.confirmed && (
+        {transactionMeta?.status === TransactionMetaStatus.confirmed && (
           <Button
             className="w-full"
             size={ButtonSize.Lg}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The activity details screen for Perps deposit/withdraw rendered null before the transaction finalised, meaning the details page flashed info then showed an empty screen. This fix shows the details items available when in the pending state. 

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix perps deposit/withdraw activity details missing info bug

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CEUX-1175

## **Manual testing steps**

1. Make a perps deposit and withdrawal
2. Each time click into the activity item when the tx is pending and check the details show the available info

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

empty pending screen:
<img width="460" height="595" alt="image" src="https://github.com/user-attachments/assets/6b9a6b35-5a36-4251-aba0-8cb4cb3253fb" />


### **After**

withdraw pending:
<img width="459" height="592" alt="image" src="https://github.com/user-attachments/assets/d4184e59-a939-4eb4-8d68-5309c6e92cf6" />

withdraw confirmed:
<img width="568" height="731" alt="image" src="https://github.com/user-attachments/assets/9e53e422-b2ea-478e-b199-48bec3b46bff" />

deposit pending:
<img width="459" height="593" alt="image" src="https://github.com/user-attachments/assets/1d881461-305b-47ff-92d6-caa4a8e30cb1" />


deposit confirmed:
<img width="457" height="594" alt="image" src="https://github.com/user-attachments/assets/af385a74-cfa9-447c-92a1-c4c950ae9034" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change to one activity details template with optional chaining; no auth, data, or transaction submission logic touched.
> 
> **Overview**
> Fixes **Perps deposit/withdraw activity details** going blank when local transaction meta is not yet available (e.g. in-flight / pending).
> 
> `PerpsDepositDetails` no longer returns `null` when `useTransactionMeta` has no entry. It always renders status, date, and fee rows from `item` and optional `metamaskPay` data, and only shows the hero amount when fiat formatting is available.
> 
> **Transaction details summary** and the **Fund again** footer are gated on `transactionMeta` (and confirmed status for the button) so those blocks stay off until meta exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da1aecb761688ca23df893c0806118b11ac752d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->