### PR TITLE
chore: nav to perps funding screen on perps funded activity details

### DIFF
--- a/ui/pages/details/templates/perps-deposit-details.tsx
+++ b/ui/pages/details/templates/perps-deposit-details.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { useSelector } from 'react-redux';
-import { useNavigate } from 'react-router-dom';
 import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
 import {
   Button,
@@ -12,6 +11,7 @@ import { TransactionStatus as TransactionMetaStatus } from '@metamask/transactio
 import type { ActivityListItem } from '../../../../shared/lib/activity/types';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
 import { ActivityAvatar } from '../../../components/app/activity-list-item-avatar';
+import { usePerpsDepositConfirmation } from '../../../components/app/perps/hooks/usePerpsDepositConfirmation';
 import { selectLocalTransactionsByHash } from '../../../selectors/activity';
 // eslint-disable-next-line import-x/no-restricted-paths
 import { TransactionDetailsProvider } from '../../confirmations/components/activity/transaction-details-context';
@@ -43,7 +43,7 @@ function useTransactionMeta(hash: string | undefined) {
 
 export function PerpsDepositDetails({ item }: Props) {
   const t = useI18nContext();
-  const navigate = useNavigate();
+  const { trigger: triggerDeposit } = usePerpsDepositConfirmation();
   const { formatDateTime, formatCurrencyWithMinThreshold } = useFormatters();
   const transactionMeta = useTransactionMeta(item.hash);
 
@@ -117,7 +117,7 @@ export function PerpsDepositDetails({ item }: Props) {
             className="w-full"
             size={ButtonSize.Lg}
             variant={ButtonVariant.Primary}
-            onClick={() => navigate({ pathname: '/', search: 'tab=perps' })}
+            onClick={() => triggerDeposit()}
           >
             {t('perpsFundAgain')}
           </Button>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

On the activity details for Perps Funded, we show a 'Fund again' button. Previously it linked to the home screen perps tab. Now it goes directly to the Perps deposit page.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: navigate directly to the Perps deposit screen from the Perps Funded activity details 'Fund again' CTA

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/CEUX-1174

## **Manual testing steps**

1. Click the 'Fund again' button from a Perps funded activity details screen
2. Confirm you land on a /confirm-transaction screen for a Perps deposit

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized navigation change on a single activity-details button; reuses the existing Perps deposit confirmation hook with no auth or data-model changes.
> 
> **Overview**
> On **Perps funded** activity details, the confirmed **Fund again** CTA no longer navigates to `/?tab=perps`. It calls **`usePerpsDepositConfirmation`** so users go straight into creating and confirming another Perps deposit (e.g. `/confirm-transaction` with the custom amount loader), with back navigation preserved via the hook’s `goBackTo` behavior.
> 
> The details screen drops direct **`useNavigate`** in favor of this shared Perps deposit entrypoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0f1a627ad06972f25489ccc5e0c0484f0a58e611. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->