### PR TITLE
fix(perps): mask open order size and value in privacy mode

### DIFF
--- a/ui/components/app/perps/order-card/order-card.test.tsx
+++ b/ui/components/app/perps/order-card/order-card.test.tsx
@@ -315,4 +315,61 @@ describe('OrderCard', () => {
     expect(onClick).toHaveBeenCalledTimes(1);
     expect(onClick).toHaveBeenCalledWith(order);
   });
+
+  describe('privacy mode', () => {
+    const privacyStore = configureStore({
+      metamask: {
+        ...mockState.metamask,
+        preferences: {
+          ...mockState.metamask.preferences,
+          privacyMode: true,
+        },
+      },
+    });
+
+    it('masks the order size when privacy mode is enabled', () => {
+      const order = createMockOrder({ symbol: 'ETH', size: '2.5' });
+      renderWithProvider(<OrderCard order={order} />, privacyStore);
+
+      expect(screen.queryByText('2.5 ETH')).not.toBeInTheDocument();
+      expect(screen.getAllByText('••••••').length).toBeGreaterThan(0);
+    });
+
+    it('masks the order USD value when privacy mode is enabled', () => {
+      const order = createMockOrder({
+        orderType: 'limit',
+        size: '1.0',
+        price: '3500.00',
+      });
+      renderWithProvider(<OrderCard order={order} />, privacyStore);
+
+      expect(screen.queryByText('$3,500')).not.toBeInTheDocument();
+    });
+
+    it('does not mask the "Market" label when the order has no price (privacy mode enabled)', () => {
+      const order = createMockOrder({
+        orderType: 'market',
+        price: '0',
+        size: '1.0',
+      });
+      renderWithProvider(<OrderCard order={order} />, privacyStore);
+
+      expect(
+        screen.getByText(messages.perpsMarket.message),
+      ).toBeInTheDocument();
+    });
+
+    it('shows the order size and USD value when privacy mode is disabled', () => {
+      const order = createMockOrder({
+        symbol: 'ETH',
+        size: '2.5',
+        orderType: 'limit',
+        price: '3500.00',
+      });
+      renderWithProvider(<OrderCard order={order} />, mockStore);
+
+      expect(screen.getByText('2.5 ETH')).toBeInTheDocument();
+      expect(screen.getByText('$3,500')).toBeInTheDocument();
+    });
+  });
 });

--- a/ui/components/app/perps/order-card/order-card.tsx
+++ b/ui/components/app/perps/order-card/order-card.tsx
@@ -6,6 +6,7 @@ import {
   BoxAlignItems,
   ButtonBase,
   Text,
+  SensitiveText,
   TextVariant,
   TextColor,
   FontWeight,
@@ -15,6 +16,7 @@ import { useNavigate } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { getIsPerpsShowFullAssetNamesEnabled } from '../../../../selectors/perps/feature-flags';
+import { getPreferences } from '../../../../../shared/lib/selectors/preferences';
 import { PerpsTokenLogo } from '../perps-token-logo';
 import { formatPerpsFiatUniversal } from '../utils/formatPerpsDisplayPrice';
 import { getDisplayName } from '../utils';
@@ -50,6 +52,7 @@ export const OrderCard = ({
   const navigate = useNavigate();
   const t = useI18nContext();
   const showFullAssetNames = useSelector(getIsPerpsShowFullAssetNamesEnabled);
+  const { privacyMode } = useSelector(getPreferences);
   // Title uses the full asset name when enabled; the size line keeps the ticker
   // as its unit. When the flag is off, fall back to the ticker.
   const displayName = getDisplayName(
@@ -152,9 +155,13 @@ export const OrderCard = ({
             </Text>
           </Box>
         )}
-        <Text variant={TextVariant.BodySm} color={TextColor.TextAlternative}>
-          {order.size} {displaySymbol}
-        </Text>
+        <SensitiveText
+          variant={TextVariant.BodySm}
+          color={TextColor.TextAlternative}
+          isHidden={privacyMode}
+        >
+          {`${order.size} ${displaySymbol}`}
+        </SensitiveText>
       </Box>
       {/* Right side: USD value */}
       <Box
@@ -163,12 +170,13 @@ export const OrderCard = ({
         alignItems={BoxAlignItems.End}
         gap={1}
       >
-        <Text
+        <SensitiveText
           fontWeight={FontWeight.Medium}
           className="text-s-body-md @compact:text-s-body-sm"
+          isHidden={privacyMode && Boolean(orderValueUsd)}
         >
           {orderValueUsd ?? t('perpsMarket')}
-        </Text>
+        </SensitiveText>
         {isTriggerBasedOrder && orderValueUsd && (
           <Text variant={TextVariant.BodyXs} color={TextColor.TextAlternative}>
             {t('perpsTriggerPrice')}


### PR DESCRIPTION
## **Description**

The size and USD notional/trigger value of open orders were not masked when Privacy Mode is enabled, on either the Perps home tab or the Perps market detail page.

Both surfaces render open orders through the shared `OrderCard` component (`ui/components/app/perps/order-card/order-card.tsx`), which previously rendered order size and USD value as plain, always-visible text. This PR updates `OrderCard` to read the user's `privacyMode` preference and render those two values with `SensitiveText`, mirroring the pattern already used by the sibling `PositionCard` component for positions. The non-sensitive "Market" fallback label (shown for orders with no price) is intentionally left unmasked, since it carries no sensitive amount.

## **Changelog**

CHANGELOG entry: Fixed a bug where open order size and value were not hidden when Privacy Mode was enabled.

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Enable Privacy Mode (Settings > Security & Privacy, or the eye icon on the wallet balance).
2. Open the Perps home tab and place or view at least one open order.
3. Verify the order's size (e.g. "2.5 ETH") and USD/trigger value (e.g. "$3,500") are shown as `••••••` instead of the real numbers.
4. Verify a market order with no price still shows the "Market" label (not masked).
5. Tap the order to open its market detail page, and verify the same masking behavior in the orders list there.
6. Disable Privacy Mode and confirm the real size/value are shown again on both pages.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)