### PR TITLE
feat: updated token management toggle button

### DIFF
--- a/ui/pages/token-management/token-management.test.tsx
+++ b/ui/pages/token-management/token-management.test.tsx
@@ -1205,6 +1205,85 @@ describe('TokenManagementPage', () => {
     });
   });
 
+  it('keeps a browse result in place when it becomes imported while the view is open', async () => {
+    const aadTokenAddress = '0x00000000000000000000000000000000000000aa';
+    const aadTokenAssetId = `eip155:1/erc20:${aadTokenAddress}`;
+    const aadToken = {
+      accountId: mainnetToken.accountId,
+      accountType: 'eip155:eoa',
+      assetId: aadTokenAssetId,
+      address: aadTokenAddress,
+      chainId: '0x1',
+      image: '',
+      name: 'Aardvark Token',
+      symbol: 'AAD',
+      decimals: 18,
+      isNative: false,
+      rawBalance: '0x0',
+      balance: '0',
+      fiat: {
+        balance: 0,
+        currency: 'usd',
+        conversionRate: 0,
+      },
+    };
+
+    setTokenSearchState({
+      results: [
+        {
+          assetId: aadTokenAssetId,
+          symbol: 'AAD',
+          decimals: 18,
+          name: 'Aardvark Token',
+        },
+      ],
+    });
+
+    const initialState = createState();
+    const { store } = renderPage(initialState);
+
+    const getRows = () =>
+      Array.from(document.querySelectorAll('[data-testid]')).filter((node) => {
+        const testId = node.getAttribute('data-testid') ?? '';
+        return (
+          testId.startsWith('token-management-cell-') &&
+          !testId.endsWith('-network-badge') &&
+          !testId.endsWith('-toggle')
+        );
+      });
+
+    const importedRow = screen.getByTestId(
+      `token-management-cell-0x1:${mainnetToken.address}`,
+    );
+    const browseRow = screen.getByTestId(
+      `token-management-cell-search-${aadTokenAssetId.toLowerCase()}`,
+    );
+    const initialRows = getRows();
+
+    expect(initialRows.indexOf(browseRow)).toBeGreaterThan(
+      initialRows.indexOf(importedRow),
+    );
+
+    const nextState = createState({
+      accountGroupAssets: {
+        '0x1': [aadToken, mainnetToken, nativeToken],
+      },
+    });
+
+    store.replaceReducer((() => nextState) as never);
+    store.dispatch({ type: 'TEST_TOKEN_IMPORTED' });
+
+    const importedAadRow = await screen.findByTestId(
+      `token-management-cell-0x1:${aadTokenAddress}`,
+    );
+    const updatedRows = getRows();
+
+    expect(importedAadRow).toBe(browseRow);
+    expect(updatedRows.indexOf(importedAadRow)).toBe(
+      initialRows.indexOf(browseRow),
+    );
+  });
+
   it('toggling ON a not-yet-imported non-EVM browse result imports via multichainAddAssets and seeds unified assets', async () => {
     const solanaResultId = `${solanaChainId}/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`;
     const solanaTokenReference = 'EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v';

--- a/ui/pages/token-management/token-management.tsx
+++ b/ui/pages/token-management/token-management.tsx
@@ -1367,11 +1367,13 @@ export const TokenManagementPage = () => {
 
     return [...nextTokenListItems].sort((itemA, itemB) => {
       const itemAOrder =
-        tokenListOrderRef.current.get(getTokenManagementListItemOrderKey(itemA)) ??
-        Number.MAX_SAFE_INTEGER;
+        tokenListOrderRef.current.get(
+          getTokenManagementListItemOrderKey(itemA),
+        ) ?? Number.MAX_SAFE_INTEGER;
       const itemBOrder =
-        tokenListOrderRef.current.get(getTokenManagementListItemOrderKey(itemB)) ??
-        Number.MAX_SAFE_INTEGER;
+        tokenListOrderRef.current.get(
+          getTokenManagementListItemOrderKey(itemB),
+        ) ?? Number.MAX_SAFE_INTEGER;
 
       return itemAOrder - itemBOrder;
     });
@@ -1422,8 +1424,7 @@ export const TokenManagementPage = () => {
   );
 
   const getTokenListItemKey = useCallback(
-    (item: TokenManagementListItem) =>
-      getTokenManagementListItemOrderKey(item),
+    (item: TokenManagementListItem) => getTokenManagementListItemOrderKey(item),
     [],
   );
 

--- a/ui/pages/token-management/token-management.tsx
+++ b/ui/pages/token-management/token-management.tsx
@@ -247,6 +247,28 @@ const normalizeToHexChainId = (chainId: string): string => {
 const getTokenAddressKey = (chainId: string, address: string) =>
   `${normalizeToHexChainId(chainId)}:${address.toLowerCase()}`;
 
+const getManagedTokenListOrderKey = (token: ManagedAsset) => {
+  if ('address' in token && token.address && token.chainId) {
+    return getTokenAddressKey(String(token.chainId), token.address);
+  }
+
+  return String(token.assetId).toLowerCase();
+};
+
+const getSearchResultListOrderKey = (result: TokenSearchResult) => {
+  const payload = convertSearchResultToImportPayload(result);
+  if (payload?.hexChainId) {
+    return getTokenAddressKey(payload.hexChainId, payload.assetReference);
+  }
+
+  return result.assetId.toLowerCase();
+};
+
+const getTokenManagementListItemOrderKey = (item: TokenManagementListItem) =>
+  item.type === 'managed'
+    ? getManagedTokenListOrderKey(item.token)
+    : getSearchResultListOrderKey(item.result);
+
 const getIgnoredTokenAddressesByChain = (
   allIgnoredTokensByChain: Record<string, Record<string, string[]>>,
   selectedAddress?: string,
@@ -419,6 +441,7 @@ export const TokenManagementPage = () => {
   >(() => new Set<string>());
   const stagedHidesRef = useRef<Map<string, StagedHidePayload>>(new Map());
   const hasTrackedScreenOpenedRef = useRef(false);
+  const tokenListOrderRef = useRef<Map<string, number>>(new Map());
 
   const stageHide = useCallback((key: string, payload: StagedHidePayload) => {
     stagedHidesRef.current.set(key, payload);
@@ -1315,23 +1338,43 @@ export const TokenManagementPage = () => {
   ]);
 
   const tokenListItems = useMemo<TokenManagementListItem[]>(() => {
-    if (hasQuery) {
-      return searchResults.map((result) => ({
-        type: 'api-result',
-        result,
-      }));
-    }
+    const nextTokenListItems = (() => {
+      if (hasQuery) {
+        return searchResults.map((result) => ({
+          type: 'api-result' as const,
+          result,
+        }));
+      }
 
-    return [
-      ...visibleTokens.map((token) => ({
-        type: 'managed' as const,
-        token,
-      })),
-      ...browseApiResults.map((result) => ({
-        type: 'api-result' as const,
-        result,
-      })),
-    ];
+      return [
+        ...visibleTokens.map((token) => ({
+          type: 'managed' as const,
+          token,
+        })),
+        ...browseApiResults.map((result) => ({
+          type: 'api-result' as const,
+          result,
+        })),
+      ];
+    })();
+
+    nextTokenListItems.forEach((item) => {
+      const itemKey = getTokenManagementListItemOrderKey(item);
+      if (!tokenListOrderRef.current.has(itemKey)) {
+        tokenListOrderRef.current.set(itemKey, tokenListOrderRef.current.size);
+      }
+    });
+
+    return [...nextTokenListItems].sort((itemA, itemB) => {
+      const itemAOrder =
+        tokenListOrderRef.current.get(getTokenManagementListItemOrderKey(itemA)) ??
+        Number.MAX_SAFE_INTEGER;
+      const itemBOrder =
+        tokenListOrderRef.current.get(getTokenManagementListItemOrderKey(itemB)) ??
+        Number.MAX_SAFE_INTEGER;
+
+      return itemAOrder - itemBOrder;
+    });
   }, [browseApiResults, hasQuery, searchResults, visibleTokens]);
   const tokenManagementViewState =
     tokenListItems.length === 0
@@ -1379,14 +1422,9 @@ export const TokenManagementPage = () => {
   );
 
   const getTokenListItemKey = useCallback(
-    (item: TokenManagementListItem, index: number) => {
-      if (item.type === 'managed') {
-        return `managed-${getTokenKey(item.token)}`;
-      }
-
-      return `${getSearchResultKey(item.result)}-${index}`;
-    },
-    [getSearchResultKey, getTokenKey],
+    (item: TokenManagementListItem) =>
+      getTokenManagementListItemOrderKey(item),
+    [],
   );
 
   const handleListScroll = useCallback(


### PR DESCRIPTION
This PR is to add a view-local order map, so when a browse/API token is toggled on and becomes an imported managed token, it stays in the same position until the Manage Tokens page is closed/remounted.

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: toggle update for manage tokens

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/005601fa-8a93-48b7-9ed1-e504bbc9d5a6



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only ordering and list keys on Manage Tokens; covered by a new regression test with no auth or persistence changes.
> 
> **Overview**
> **Manage Tokens** no longer jumps rows when a browse/API token is turned on and becomes an imported managed token. A **view-local order map** (`tokenListOrderRef`) records each row’s first-seen position and the list is sorted by that map on every recompute until the page unmounts.
> 
> Stable **order keys** tie managed tokens and search/browse results to the same identity (`chainId:address` for EVM, otherwise `assetId`), so a token keeps one slot when it switches from `api-result` to `managed`. **Virtualized list keys** now use that same order key instead of separate `managed-…` / `search-…-{index}` keys, which helps React keep the same DOM node when the row type changes.
> 
> A regression test asserts the browse row stays in place and is the same element after import.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a671fa30baa68f4f2ac5fe6bca16c2aac60d2aca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->