### PR TITLE
test: fix flaky test Vault Corruption does *not* reset metamask state when recovery is *not* confirmed

### DIFF
--- a/test/e2e/page-objects/flows/onboarding.flow.ts
+++ b/test/e2e/page-objects/flows/onboarding.flow.ts
@@ -818,6 +818,7 @@ export const completeVaultRecoveryOnboardingFlow = async ({
   // finish up onboarding screens
   const onboardingCompletePage = new OnboardingCompletePage(driver);
   await onboardingCompletePage.checkPageIsLoaded();
+  await onboardingCompletePage.checkWalletReadyMessageIsDisplayed();
 
   await onboardingCompletePage.completeOnboarding();
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Failure on test: [CI Logs ](https://github.com/MetaMask/metamask-extension/actions/runs/29259461631/job/86851356295)

`TimeoutError: Waiting for element to be located By(css selector, [data-testid="onboarding-complete-done"])
Wait timed out after 10176ms`

Possibly a race condition between the UI and the background vault restoration process. 

Displaying the login page instead of "Your wallet is ready!" page, and due to this,  `completeOnboarding() `could not click `Done`.

Added `checkWalletReadyMessageIsDisplayed()`, giving the background process enough time to finish before the test proceeds to click.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<img width="1366" height="682" alt="test-failure-screenshot-2" src="https://github.com/user-attachments/assets/a90a2283-a817-4006-96b8-d4940ae6564e" />


### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only synchronization change; no production code paths affected.
> 
> **Overview**
> Fixes a flaky vault-corruption E2E case by **waiting for the “Your wallet is ready!” UI** in `completeVaultRecoveryOnboardingFlow` before clicking **Done**.
> 
> The flow now calls `checkWalletReadyMessageIsDisplayed()` after `checkPageIsLoaded()`, matching other onboarding helpers. That blocks until the wallet-ready message appears instead of timing out on `[data-testid="onboarding-complete-done"]` when the login page still shows while background vault restoration finishes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7416ad5b70dfd2ff9b391465e6b79f9add742298. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->