### PR TITLE
feat(ramps): update remaining entrypoints to use goToBuy

### DIFF
--- a/shared/lib/asset-utils.test.ts
+++ b/shared/lib/asset-utils.test.ts
@@ -18,6 +18,7 @@ import {
   fetchAssetMetadata,
   toAssetId,
   fetchAssetMetadataForAssetIds,
+  getNativeAssetId,
   isEvmChainId,
   isTronSpecialAsset,
 } from './asset-utils';
@@ -37,6 +38,23 @@ jest.mock('./fetch-with-timeout', () => ({
 describe('asset-utils', () => {
   const STATIC_METAMASK_BASE_URL = 'https://static.cx.metamask.io';
   const TOKEN_API_V3_BASE_URL = 'https://tokens.api.cx.metamask.io/v3';
+
+  describe('getNativeAssetId', () => {
+    it('returns the native asset id for a supported chain', () => {
+      expect(getNativeAssetId('eip155:1')).toBe(
+        getNativeAssetForChainId('eip155:1').assetId,
+      );
+    });
+
+    it('returns undefined when no chainId is given', () => {
+      expect(getNativeAssetId(undefined)).toBeUndefined();
+    });
+
+    it('returns undefined for a chain unknown to the asset map', () => {
+      // getNativeAssetForChainId throws on custom/unsupported networks.
+      expect(getNativeAssetId('0x123456' as Hex)).toBeUndefined();
+    });
+  });
 
   describe('toAssetId', () => {
     beforeEach(() => {

--- a/shared/lib/asset-utils.ts
+++ b/shared/lib/asset-utils.ts
@@ -78,6 +78,27 @@ export const toAssetId = (
 };
 
 /**
+ * Resolve a chain's native asset as a CAIP-19 asset id, or `undefined` for
+ * chains unknown to the bridge asset map (`getNativeAssetForChainId` throws on
+ * custom/unsupported networks).
+ *
+ * @param chainId - The chain id in caip or hex format.
+ * @returns The native asset id, or `undefined` when it can't be resolved.
+ */
+export const getNativeAssetId = (
+  chainId?: CaipChainId | Hex,
+): CaipAssetType | undefined => {
+  if (!chainId) {
+    return undefined;
+  }
+  try {
+    return getNativeAssetForChainId(chainId).assetId;
+  } catch {
+    return undefined;
+  }
+};
+
+/**
  * Returns the image url for a caip-formatted asset
  *
  * @param assetId - The hex address or caip-formatted asset id

--- a/ui/components/app/musd/musd-buy-get-cta.test.tsx
+++ b/ui/components/app/musd/musd-buy-get-cta.test.tsx
@@ -56,15 +56,12 @@ jest.mock('../../../hooks/musd', () => ({
 }));
 
 const mockGoToBuy = jest.fn().mockResolvedValue(true);
-jest.mock(
-  '../../../hooks/ramps/useRampsNavigation/useRampsNavigation',
-  () => ({
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    __esModule: true,
-    default: () => ({ goToBuy: mockGoToBuy }),
-  }),
-);
+jest.mock('../../../hooks/ramps/useRampsNavigation/useRampsNavigation', () => ({
+  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  __esModule: true,
+  default: () => ({ goToBuy: mockGoToBuy }),
+}));
 
 const createMockStore = (overrides = {}) => {
   return configureStore({

--- a/ui/components/app/musd/musd-buy-get-cta.test.tsx
+++ b/ui/components/app/musd/musd-buy-get-cta.test.tsx
@@ -240,7 +240,10 @@ describe('MusdBuyGetCta', () => {
 
       // goToBuy owns the flag-off Portfolio fallback (with this chain) and the
       // flag-on in-app routing.
-      expect(mockGoToBuy).toHaveBeenCalledWith({ chainId: '0x1' });
+      expect(mockGoToBuy).toHaveBeenCalledWith({
+        assetId: 'eip155:1/erc20:0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
+        chainId: '0x1',
+      });
     });
 
     it('routes through goToBuy when inner CTA button is clicked for BUY variant', () => {
@@ -257,7 +260,10 @@ describe('MusdBuyGetCta', () => {
         screen.getByRole('button', { name: messages.musdBuyMusd.message }),
       );
 
-      expect(mockGoToBuy).toHaveBeenCalledWith({ chainId: '0x1' });
+      expect(mockGoToBuy).toHaveBeenCalledWith({
+        assetId: 'eip155:1/erc20:0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
+        chainId: '0x1',
+      });
     });
 
     it('does not route to buy for the GET variant', () => {

--- a/ui/components/app/musd/musd-buy-get-cta.test.tsx
+++ b/ui/components/app/musd/musd-buy-get-cta.test.tsx
@@ -55,15 +55,16 @@ jest.mock('../../../hooks/musd', () => ({
   }),
 }));
 
-const mockOpenBuyCryptoInPdapp = jest.fn();
-jest.mock('../../../hooks/ramps/useRamps/useRamps', () => ({
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  __esModule: true,
-  default: jest.fn(() => ({
-    openBuyCryptoInPdapp: mockOpenBuyCryptoInPdapp,
-  })),
-}));
+const mockGoToBuy = jest.fn().mockResolvedValue(true);
+jest.mock(
+  '../../../hooks/ramps/useRampsNavigation/useRampsNavigation',
+  () => ({
+    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    __esModule: true,
+    default: () => ({ goToBuy: mockGoToBuy }),
+  }),
+);
 
 const createMockStore = (overrides = {}) => {
   return configureStore({
@@ -227,7 +228,7 @@ describe('MusdBuyGetCta', () => {
       ).toBeInTheDocument();
     });
 
-    it('opens buy crypto page when row is clicked for BUY variant', () => {
+    it('routes through goToBuy with the selected chain when row is clicked for BUY variant', () => {
       const store = createMockStore();
       renderWithProvider(
         <MusdBuyGetCta
@@ -240,10 +241,12 @@ describe('MusdBuyGetCta', () => {
       const ctaElement = screen.getByTestId('multichain-token-list-button');
       fireEvent.click(ctaElement);
 
-      expect(mockOpenBuyCryptoInPdapp).toHaveBeenCalledWith('0x1');
+      // goToBuy owns the flag-off Portfolio fallback (with this chain) and the
+      // flag-on in-app routing.
+      expect(mockGoToBuy).toHaveBeenCalledWith({ chainId: '0x1' });
     });
 
-    it('opens buy crypto page when inner CTA button is clicked for BUY variant', () => {
+    it('routes through goToBuy when inner CTA button is clicked for BUY variant', () => {
       const store = createMockStore();
       renderWithProvider(
         <MusdBuyGetCta
@@ -257,7 +260,25 @@ describe('MusdBuyGetCta', () => {
         screen.getByRole('button', { name: messages.musdBuyMusd.message }),
       );
 
-      expect(mockOpenBuyCryptoInPdapp).toHaveBeenCalledWith('0x1');
+      expect(mockGoToBuy).toHaveBeenCalledWith({ chainId: '0x1' });
+    });
+
+    it('does not route to buy for the GET variant', () => {
+      const store = createMockStore();
+      renderWithProvider(
+        <MusdBuyGetCta
+          variant={BuyGetMusdCtaVariant.GET}
+          selectedChainId="0x1"
+        />,
+        store,
+      );
+
+      fireEvent.click(
+        screen.getByRole('button', { name: messages.musdGetMusd.message }),
+      );
+
+      expect(mockGoToBuy).not.toHaveBeenCalled();
+      expect(mockStartConversionFlow).toHaveBeenCalled();
     });
   });
 

--- a/ui/components/app/musd/musd-buy-get-cta.tsx
+++ b/ui/components/app/musd/musd-buy-get-cta.tsx
@@ -9,7 +9,7 @@
 
 import React, { useCallback, useMemo } from 'react';
 import { useSelector } from 'react-redux';
-import type { Hex } from '@metamask/utils';
+import type { CaipAssetType, Hex } from '@metamask/utils';
 import {
   Box,
   BoxAlignItems,
@@ -47,6 +47,7 @@ import { getAssetImageUrl } from '../../../../shared/lib/asset-utils';
 import useRampsNavigation from '../../../hooks/ramps/useRampsNavigation/useRampsNavigation';
 import { ASSET_CELL_HEIGHT } from '../assets/constants';
 import {
+  getMusdAssetIdForChain,
   MUSD_CONVERSION_APY,
   MUSD_CONVERSION_DEFAULT_CHAIN_ID,
   MUSD_TOKEN_ADDRESS,
@@ -160,7 +161,18 @@ export const MusdBuyGetCta = ({
     );
 
     if (variant === BuyGetMusdCtaVariant.BUY) {
-      goToBuy({ chainId: selectedChainId ?? undefined });
+      const buyChainId = selectedChainId ?? MUSD_CONVERSION_DEFAULT_CHAIN_ID;
+      goToBuy({
+        // Pre-select mUSD so the in-app flow lands on build-quote instead of
+        // the token-selection page. Fall back to mainnet mUSD when the current
+        // chain has no mUSD route. chainId is only used for the flag-off
+        // Portfolio fallback.
+        assetId: (getMusdAssetIdForChain(buyChainId) ??
+          getMusdAssetIdForChain(MUSD_CONVERSION_DEFAULT_CHAIN_ID)) as
+          | CaipAssetType
+          | undefined,
+        chainId: selectedChainId ?? undefined,
+      });
     } else if (variant === BuyGetMusdCtaVariant.GET) {
       if (!defaultPaymentToken) {
         console.error(

--- a/ui/components/app/musd/musd-buy-get-cta.tsx
+++ b/ui/components/app/musd/musd-buy-get-cta.tsx
@@ -28,7 +28,6 @@ import {
   BadgeWrapper,
 } from '../../component-library';
 import { BackgroundColor } from '../../../helpers/constants/design-system';
-import type { ChainId } from '../../../../shared/constants/network';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
@@ -45,7 +44,7 @@ import {
   getImageForChainId,
 } from '../../../selectors/multichain';
 import { getAssetImageUrl } from '../../../../shared/lib/asset-utils';
-import useRamps from '../../../hooks/ramps/useRamps/useRamps';
+import useRampsNavigation from '../../../hooks/ramps/useRampsNavigation/useRampsNavigation';
 import { ASSET_CELL_HEIGHT } from '../assets/constants';
 import {
   MUSD_CONVERSION_APY,
@@ -92,7 +91,7 @@ export const MusdBuyGetCta = ({
   const { trackEvent, createEventBuilder } = useAnalytics();
   const { startConversionFlow, educationSeen } = useMusdConversion();
   const { defaultPaymentToken } = useMusdConversionTokens();
-  const { openBuyCryptoInPdapp } = useRamps();
+  const { goToBuy } = useRampsNavigation();
 
   // Get network configuration for icon
   const networkConfigurationsByChainId = useSelector(
@@ -161,7 +160,7 @@ export const MusdBuyGetCta = ({
     );
 
     if (variant === BuyGetMusdCtaVariant.BUY) {
-      openBuyCryptoInPdapp((selectedChainId as ChainId) ?? undefined);
+      goToBuy({ chainId: selectedChainId ?? undefined });
     } else if (variant === BuyGetMusdCtaVariant.GET) {
       if (!defaultPaymentToken) {
         console.error(
@@ -185,7 +184,7 @@ export const MusdBuyGetCta = ({
     educationSeen,
     createEventBuilder,
     trackEvent,
-    openBuyCryptoInPdapp,
+    goToBuy,
     startConversionFlow,
     defaultPaymentToken,
   ]);

--- a/ui/components/multichain/funding-method-modal/funding-method-modal.test.tsx
+++ b/ui/components/multichain/funding-method-modal/funding-method-modal.test.tsx
@@ -5,26 +5,26 @@ import thunk from 'redux-thunk';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import mockState from '../../../../test/data/mock-state.json';
-import useRamps from '../../../hooks/ramps/useRamps/useRamps';
 import { FundingMethodModal } from './funding-method-modal';
 
-jest.mock('../../../hooks/ramps/useRamps/useRamps', () => ({
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  __esModule: true,
-  default: jest.fn(),
-}));
+const mockGoToBuy = jest.fn().mockResolvedValue(true);
+jest.mock(
+  '../../../hooks/ramps/useRampsNavigation/useRampsNavigation',
+  () => ({
+    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    __esModule: true,
+    default: () => ({ goToBuy: mockGoToBuy }),
+  }),
+);
 
 const mockStore = configureMockStore([thunk]);
 
 describe('FundingMethodModal', () => {
   let store = configureMockStore([thunk])(mockState);
-  let openBuyCryptoInPdapp: jest.Mock<() => void>;
 
   beforeEach(() => {
     store = mockStore(mockState);
-    openBuyCryptoInPdapp = jest.fn();
-    (useRamps as jest.Mock).mockReturnValue({ openBuyCryptoInPdapp });
   });
 
   afterEach(() => {
@@ -62,7 +62,7 @@ describe('FundingMethodModal', () => {
     expect(queryByTestId('funding-method-modal')).toBeNull();
   });
 
-  it('should call openBuyCryptoInPdapp when the Token Marketplace item is clicked', () => {
+  it('routes the Token Marketplace item through goToBuy with the current chain', () => {
     const { getByText } = renderWithProvider(
       <FundingMethodModal
         isOpen={true}
@@ -75,7 +75,9 @@ describe('FundingMethodModal', () => {
     );
 
     fireEvent.click(getByText(messages.tokenMarketplace.message));
-    expect(openBuyCryptoInPdapp).toHaveBeenCalled();
+    // Preserves the chain context it passed to the Portfolio deeplink today;
+    // goToBuy handles the flag-off Portfolio fallback internally.
+    expect(mockGoToBuy).toHaveBeenCalledWith({ chainId: '0x5' });
   });
 
   it('should call onClickReceive when the Receive Crypto item is clicked', () => {

--- a/ui/components/multichain/funding-method-modal/funding-method-modal.test.tsx
+++ b/ui/components/multichain/funding-method-modal/funding-method-modal.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent } from '@testing-library/react';
+import { fireEvent, waitFor } from '@testing-library/react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
@@ -14,6 +14,19 @@ jest.mock('../../../hooks/ramps/useRampsNavigation/useRampsNavigation', () => ({
   __esModule: true,
   default: () => ({ goToBuy: mockGoToBuy }),
 }));
+
+const mockTrackEvent = jest.fn();
+jest.mock('../../../hooks/useAnalytics', () => {
+  const { createEventBuilder } = jest.requireActual(
+    '../../../../shared/lib/analytics/create-event-builder',
+  );
+  return {
+    useAnalytics: () => ({
+      trackEvent: mockTrackEvent,
+      createEventBuilder,
+    }),
+  };
+});
 
 const mockStore = configureMockStore([thunk]);
 
@@ -75,6 +88,24 @@ describe('FundingMethodModal', () => {
     // Preserves the chain context it passed to the Portfolio deeplink today;
     // goToBuy handles the flag-off Portfolio fallback internally.
     expect(mockGoToBuy).toHaveBeenCalledWith({ chainId: '0x5' });
+  });
+
+  it('does not track the buy click when the ramps gate blocks it', async () => {
+    mockGoToBuy.mockResolvedValueOnce(false);
+    const { getByText } = renderWithProvider(
+      <FundingMethodModal
+        isOpen={true}
+        onClose={jest.fn()}
+        title="Test Modal"
+        onClickReceive={jest.fn()}
+        data-testid="funding-method-modal"
+      />,
+      store,
+    );
+
+    fireEvent.click(getByText(messages.tokenMarketplace.message));
+    await waitFor(() => expect(mockGoToBuy).toHaveBeenCalled());
+    expect(mockTrackEvent).not.toHaveBeenCalled();
   });
 
   it('should call onClickReceive when the Receive Crypto item is clicked', () => {

--- a/ui/components/multichain/funding-method-modal/funding-method-modal.test.tsx
+++ b/ui/components/multichain/funding-method-modal/funding-method-modal.test.tsx
@@ -8,15 +8,12 @@ import mockState from '../../../../test/data/mock-state.json';
 import { FundingMethodModal } from './funding-method-modal';
 
 const mockGoToBuy = jest.fn().mockResolvedValue(true);
-jest.mock(
-  '../../../hooks/ramps/useRampsNavigation/useRampsNavigation',
-  () => ({
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    __esModule: true,
-    default: () => ({ goToBuy: mockGoToBuy }),
-  }),
-);
+jest.mock('../../../hooks/ramps/useRampsNavigation/useRampsNavigation', () => ({
+  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  __esModule: true,
+  default: () => ({ goToBuy: mockGoToBuy }),
+}));
 
 const mockStore = configureMockStore([thunk]);
 

--- a/ui/components/multichain/funding-method-modal/funding-method-modal.tsx
+++ b/ui/components/multichain/funding-method-modal/funding-method-modal.tsx
@@ -102,7 +102,13 @@ export const FundingMethodModal = ({
     createEventBuilder,
   ]);
 
-  const handleBuyCryptoClick = useCallback(() => {
+  const handleBuyCryptoClick = useCallback(async () => {
+    const opened = await goToBuy({ chainId: chainId as Hex | CaipChainId });
+    // The ramps gate can block the buy (e.g. service disruption, unsupported
+    // region) and show its own modal; don't report a buy click in that case.
+    if (!opened) {
+      return;
+    }
     trackEvent(
       createEventBuilder(MetaMetricsEventName.NavBuyButtonClicked)
         .addCategory(MetaMetricsEventCategory.Navigation)
@@ -118,7 +124,6 @@ export const FundingMethodModal = ({
         })
         .build(),
     );
-    goToBuy({ chainId: chainId as Hex | CaipChainId });
   }, [chainId, symbol, trackEvent, createEventBuilder, goToBuy]);
 
   return (

--- a/ui/components/multichain/funding-method-modal/funding-method-modal.tsx
+++ b/ui/components/multichain/funding-method-modal/funding-method-modal.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback } from 'react';
 import { useSelector } from 'react-redux';
-import { CaipChainId } from '@metamask/utils';
+import { CaipChainId, Hex } from '@metamask/utils';
 import { useAnalytics } from '../../../hooks/useAnalytics';
 import {
   Modal,
@@ -19,9 +19,8 @@ import {
   getMultichainCurrentNetwork,
   getMultichainDefaultToken,
 } from '../../../selectors/multichain';
-import useRamps, {
-  RampsMetaMaskEntry,
-} from '../../../hooks/ramps/useRamps/useRamps';
+import { RampsMetaMaskEntry } from '../../../hooks/ramps/useRamps/useRamps';
+import useRampsNavigation from '../../../hooks/ramps/useRampsNavigation/useRampsNavigation';
 import { getPortfolioUrl } from '../../../helpers/utils/portfolio';
 import {
   getAnalyticsId,
@@ -31,7 +30,6 @@ import {
   getSelectedAccount,
 } from '../../../selectors';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { ChainId } from '../../../../shared/constants/network';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
@@ -54,7 +52,7 @@ export const FundingMethodModal = ({
 }: FundingMethodModalProps) => {
   const t = useI18nContext();
   const { trackEvent, createEventBuilder } = useAnalytics();
-  const { openBuyCryptoInPdapp } = useRamps();
+  const { goToBuy } = useRampsNavigation();
   const { address: accountAddress } = useSelector(getSelectedAccount);
   const { chainId } = useSelector(getMultichainCurrentNetwork);
   const { symbol } = useSelector(getMultichainDefaultToken);
@@ -120,8 +118,8 @@ export const FundingMethodModal = ({
         })
         .build(),
     );
-    openBuyCryptoInPdapp(chainId as ChainId | CaipChainId);
-  }, [chainId, symbol, trackEvent, createEventBuilder, openBuyCryptoInPdapp]);
+    goToBuy({ chainId: chainId as Hex | CaipChainId });
+  }, [chainId, symbol, trackEvent, createEventBuilder, goToBuy]);
 
   return (
     <Modal isOpen={isOpen} onClose={onClose} {...props}>

--- a/ui/hooks/ramps/useRamps/useRamps.test.tsx
+++ b/ui/hooks/ramps/useRamps/useRamps.test.tsx
@@ -144,6 +144,23 @@ describe('useRamps', () => {
     expect(buyURI).toBe(mockBuyURI);
   });
 
+  it('should handle EVM chain IDs passed in CAIP format', () => {
+    const metaMaskEntry = 'ext_buy_sell_button';
+    const caipChainId = 'eip155:1';
+    (isEvmChainId as jest.Mock).mockReturnValueOnce(true);
+    mockStoreState = {
+      ...mockStoreState,
+      metamask: {
+        ...mockStoreState.metamask,
+        ...mockNetworkState({ chainId: '0x1' }),
+      },
+    };
+    const mockBuyURI = `${process.env.PORTFOLIO_URL}/buy?metamaskEntry=${metaMaskEntry}&chainId=1&metametricsId=${mockedMetametricsId}&metricsEnabled=false`;
+    const { result } = renderHook(() => useRamps(), { wrapper });
+    const buyURI = result.current.getBuyURI(caipChainId);
+    expect(buyURI).toBe(mockBuyURI);
+  });
+
   it('should handle non-EVM chain IDs correctly (like Bitcoin)', () => {
     const metaMaskEntry = 'ext_buy_sell_button';
     const bitcoinChainId = 'bip122:000000000019d6689c085ae165831e93';

--- a/ui/hooks/ramps/useRamps/useRamps.ts
+++ b/ui/hooks/ramps/useRamps/useRamps.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react';
 import { useSelector } from 'react-redux';
 import { CaipChainId, Hex, hexToNumber } from '@metamask/utils';
+import { formatChainIdToHex } from '@metamask/bridge-controller';
 import { ChainId } from '../../../../shared/constants/network';
 import { getCurrentChainId } from '../../../../shared/lib/selectors/networks';
 import {
@@ -46,7 +47,9 @@ const useRamps = (
 
         let numericChainId = '';
         if (isEvmChainId(_chainId)) {
-          numericChainId = hexToNumber(_chainId).toString();
+          // EVM chain ids may arrive as hex or CAIP (`eip155:1`); normalize to
+          // hex first so callers can pass whichever format they already have.
+          numericChainId = hexToNumber(formatChainIdToHex(_chainId)).toString();
         } else {
           numericChainId = _chainId;
         }

--- a/ui/pages/bridge/hooks/useBridgeAlerts.test.ts
+++ b/ui/pages/bridge/hooks/useBridgeAlerts.test.ts
@@ -618,9 +618,11 @@ describe('useBridgeAlerts', () => {
         'insufficient-gas'
       ]?.bannerAlertProps?.actionButtonOnClick?.();
 
+      // chainId is normalized to hex so the flag-off Portfolio fallback
+      // (getBuyURI -> hexToNumber) accepts it; assetId stays CAIP.
       expect(mockGoToBuy).toHaveBeenCalledWith({
         assetId: getNativeAssetForChainId(MOCK_FROM_CHAIN_ID).assetId,
-        chainId: MOCK_FROM_CHAIN_ID,
+        chainId: '0x1',
       });
     });
 

--- a/ui/pages/bridge/hooks/useBridgeAlerts.test.ts
+++ b/ui/pages/bridge/hooks/useBridgeAlerts.test.ts
@@ -1,7 +1,8 @@
+import { getNativeAssetForChainId } from '@metamask/bridge-controller';
 import { renderHookWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
-import useRamps from '../../../hooks/ramps/useRamps/useRamps';
+import useRampsNavigation from '../../../hooks/ramps/useRampsNavigation/useRampsNavigation';
 import {
   getActiveQuoteInsufficientNativeReserveError,
   getActiveQuotePriceData,
@@ -9,6 +10,7 @@ import {
   getBridgeUnavailableQuoteReason,
   getFormattedPriceImpactFiat,
   getFormattedPriceImpactPercentage,
+  getFromChain,
   getToToken,
   getValidationErrors,
 } from '../../../ducks/bridge/selectors';
@@ -21,7 +23,7 @@ import { useBridgeAlerts } from './useBridgeAlerts';
 
 jest.mock('../../../hooks/useI18nContext');
 jest.mock('../../../hooks/useMultichainSelector');
-jest.mock('../../../hooks/ramps/useRamps/useRamps');
+jest.mock('../../../hooks/ramps/useRampsNavigation/useRampsNavigation');
 jest.mock('./useSecurityAlerts');
 jest.mock('./useAssetSecurityData');
 jest.mock('../utils/quote');
@@ -36,7 +38,10 @@ jest.mock('../../../ducks/bridge/selectors', () => ({
   getFormattedPriceImpactFiat: jest.fn(),
   getActiveQuoteInsufficientNativeReserveError: jest.fn(),
   getBridgeQuotes: jest.fn(),
+  getFromChain: jest.fn(),
 }));
+
+const MOCK_FROM_CHAIN_ID = 'eip155:1';
 
 const mockT = jest.fn((key: string, args?: string[]) =>
   args ? `${key}:${args.join(',')}` : key,
@@ -69,7 +74,7 @@ const DEFAULT_VALIDATION_ERRORS = {
 };
 
 describe('useBridgeAlerts', () => {
-  const mockOpenBuyCryptoInPdapp = jest.fn();
+  const mockGoToBuy = jest.fn();
 
   const renderHook = () =>
     renderHookWithProvider(() => useBridgeAlerts(), { metamask: {} });
@@ -79,9 +84,12 @@ describe('useBridgeAlerts', () => {
 
     jest.mocked(useI18nContext).mockReturnValue(mockT as never);
     jest.mocked(useMultichainSelector).mockReturnValue('ETH');
-    jest.mocked(useRamps).mockReturnValue({
-      openBuyCryptoInPdapp: mockOpenBuyCryptoInPdapp,
+    jest.mocked(useRampsNavigation).mockReturnValue({
+      goToBuy: mockGoToBuy,
     } as never);
+    jest
+      .mocked(getFromChain)
+      .mockReturnValue({ chainId: MOCK_FROM_CHAIN_ID } as never);
     jest
       .mocked(useSecurityAlerts)
       .mockReturnValue({ txAlert: null, securityWarnings: [] });
@@ -603,14 +611,17 @@ describe('useBridgeAlerts', () => {
       );
     });
 
-    it('calls openBuyCryptoInPdapp when the action button is clicked', () => {
+    it('routes through goToBuy with the source chain native gas token when the action button is clicked', () => {
       const { result } = renderHook();
 
       result.current.alertsById[
         'insufficient-gas'
       ]?.bannerAlertProps?.actionButtonOnClick?.();
 
-      expect(mockOpenBuyCryptoInPdapp).toHaveBeenCalledTimes(1);
+      expect(mockGoToBuy).toHaveBeenCalledWith({
+        assetId: getNativeAssetForChainId(MOCK_FROM_CHAIN_ID).assetId,
+        chainId: MOCK_FROM_CHAIN_ID,
+      });
     });
 
     it('does not add insufficient-gas when isLoading is true', () => {

--- a/ui/pages/bridge/hooks/useBridgeAlerts.test.ts
+++ b/ui/pages/bridge/hooks/useBridgeAlerts.test.ts
@@ -618,11 +618,11 @@ describe('useBridgeAlerts', () => {
         'insufficient-gas'
       ]?.bannerAlertProps?.actionButtonOnClick?.();
 
-      // chainId is normalized to hex so the flag-off Portfolio fallback
-      // (getBuyURI -> hexToNumber) accepts it; assetId stays CAIP.
+      // Passes the source chain as-is (CAIP); getBuyURI normalizes it for the
+      // flag-off Portfolio fallback.
       expect(mockGoToBuy).toHaveBeenCalledWith({
         assetId: getNativeAssetForChainId(MOCK_FROM_CHAIN_ID).assetId,
-        chainId: '0x1',
+        chainId: MOCK_FROM_CHAIN_ID,
       });
     });
 

--- a/ui/pages/bridge/hooks/useBridgeAlerts.ts
+++ b/ui/pages/bridge/hooks/useBridgeAlerts.ts
@@ -1,11 +1,6 @@
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useMemo } from 'react';
-import type { CaipChainId, Hex } from '@metamask/utils';
-import { formatChainIdToHex } from '@metamask/bridge-controller';
-import {
-  getNativeAssetId,
-  isEvmChainId,
-} from '../../../../shared/lib/asset-utils';
+import { getNativeAssetId } from '../../../../shared/lib/asset-utils';
 import {
   getActiveQuoteInsufficientNativeReserveError,
   type BridgeAppState,
@@ -28,20 +23,6 @@ import { isQuoteExpiredOrInvalid } from '../utils/quote';
 import { type BridgeAlert } from '../prepare/types';
 import { useSecurityAlerts } from './useSecurityAlerts';
 import { useAssetSecurityData } from './useAssetSecurityData';
-
-/**
- * Normalize the source chain id for the flag-off Portfolio fallback.
- * `getBuyURI` runs `hexToNumber` on EVM chain ids, so it needs hex — bridge
- * state stores them as CAIP (`eip155:1`). Non-EVM caip ids pass through.
- *
- * @param chainId - The bridge source chain id.
- */
-function getBuyFallbackChainId(chainId?: Hex | CaipChainId) {
-  if (!chainId) {
-    return undefined;
-  }
-  return isEvmChainId(chainId) ? formatChainIdToHex(chainId) : chainId;
-}
 
 /**
  * Merges tx, token, and validation alert data used for displaying {@link BannerAlert}
@@ -239,7 +220,7 @@ export const useBridgeAlerts = () => {
           actionButtonOnClick: () =>
             goToBuy({
               assetId: getNativeAssetId(fromChain?.chainId),
-              chainId: getBuyFallbackChainId(fromChain?.chainId),
+              chainId: fromChain?.chainId,
             }),
         },
       });

--- a/ui/pages/bridge/hooks/useBridgeAlerts.ts
+++ b/ui/pages/bridge/hooks/useBridgeAlerts.ts
@@ -1,11 +1,11 @@
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useMemo } from 'react';
 import type { CaipChainId, Hex } from '@metamask/utils';
+import { formatChainIdToHex } from '@metamask/bridge-controller';
 import {
-  formatChainIdToHex,
-  getNativeAssetForChainId,
-} from '@metamask/bridge-controller';
-import { isEvmChainId } from '../../../../shared/lib/asset-utils';
+  getNativeAssetId,
+  isEvmChainId,
+} from '../../../../shared/lib/asset-utils';
 import {
   getActiveQuoteInsufficientNativeReserveError,
   type BridgeAppState,
@@ -28,24 +28,6 @@ import { isQuoteExpiredOrInvalid } from '../utils/quote';
 import { type BridgeAlert } from '../prepare/types';
 import { useSecurityAlerts } from './useSecurityAlerts';
 import { useAssetSecurityData } from './useAssetSecurityData';
-
-/**
- * Resolve a chain's native gas token as a CAIP-19 asset id, or `undefined` when
- * the chain is unknown to the bridge asset map (`getNativeAssetForChainId`
- * throws on those).
- *
- * @param chainId - The source chain the gas is paid on.
- */
-function getNativeGasAssetId(chainId?: Hex | CaipChainId) {
-  if (!chainId) {
-    return undefined;
-  }
-  try {
-    return getNativeAssetForChainId(chainId).assetId;
-  } catch {
-    return undefined;
-  }
-}
 
 /**
  * Normalize the source chain id for the flag-off Portfolio fallback.
@@ -256,7 +238,7 @@ export const useBridgeAlerts = () => {
           // Portfolio fallback.
           actionButtonOnClick: () =>
             goToBuy({
-              assetId: getNativeGasAssetId(fromChain?.chainId),
+              assetId: getNativeAssetId(fromChain?.chainId),
               chainId: getBuyFallbackChainId(fromChain?.chainId),
             }),
         },

--- a/ui/pages/bridge/hooks/useBridgeAlerts.ts
+++ b/ui/pages/bridge/hooks/useBridgeAlerts.ts
@@ -1,5 +1,7 @@
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useMemo } from 'react';
+import type { CaipChainId, Hex } from '@metamask/utils';
+import { getNativeAssetForChainId } from '@metamask/bridge-controller';
 import {
   getActiveQuoteInsufficientNativeReserveError,
   type BridgeAppState,
@@ -7,6 +9,7 @@ import {
   getBridgeUnavailableQuoteReason,
   getFormattedPriceImpactFiat,
   getFormattedPriceImpactPercentage,
+  getFromChain,
   getToToken,
   getValidationErrors,
 } from '../../../ducks/bridge/selectors';
@@ -16,11 +19,29 @@ import { BannerAlertSeverity } from '../../../components/component-library';
 import { getBridgeQuotes } from '../../../ducks/bridge/selectors';
 import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
 import { getMultichainNativeCurrency } from '../../../selectors/multichain';
-import useRamps from '../../../hooks/ramps/useRamps/useRamps';
+import useRampsNavigation from '../../../hooks/ramps/useRampsNavigation/useRampsNavigation';
 import { isQuoteExpiredOrInvalid } from '../utils/quote';
 import { type BridgeAlert } from '../prepare/types';
 import { useSecurityAlerts } from './useSecurityAlerts';
 import { useAssetSecurityData } from './useAssetSecurityData';
+
+/**
+ * Resolve a chain's native gas token as a CAIP-19 asset id, or `undefined` when
+ * the chain is unknown to the bridge asset map (`getNativeAssetForChainId`
+ * throws on those).
+ *
+ * @param chainId - The source chain the gas is paid on.
+ */
+function getNativeGasAssetId(chainId?: Hex | CaipChainId) {
+  if (!chainId) {
+    return undefined;
+  }
+  try {
+    return getNativeAssetForChainId(chainId).assetId;
+  } catch {
+    return undefined;
+  }
+}
 
 /**
  * Merges tx, token, and validation alert data used for displaying {@link BannerAlert}
@@ -65,7 +86,8 @@ export const useBridgeAlerts = () => {
   } = useAssetSecurityData(toToken);
 
   const { txAlert } = useSecurityAlerts(toToken);
-  const { openBuyCryptoInPdapp } = useRamps();
+  const { goToBuy } = useRampsNavigation();
+  const fromChain = useSelector(getFromChain);
 
   const activeQuotePriceData = useSelector(getActiveQuotePriceData);
 
@@ -211,7 +233,14 @@ export const useBridgeAlerts = () => {
         bannerAlertProps: {
           severity: BannerAlertSeverity.Danger,
           actionButtonLabel: t('buyMoreAsset', [ticker]),
-          actionButtonOnClick: () => openBuyCryptoInPdapp(),
+          // Pre-select the source chain's native gas token so the buy flow
+          // lands on build-quote for it; chainId also drives the flag-off
+          // Portfolio fallback.
+          actionButtonOnClick: () =>
+            goToBuy({
+              assetId: getNativeGasAssetId(fromChain?.chainId),
+              chainId: fromChain?.chainId,
+            }),
         },
       });
     }
@@ -307,7 +336,8 @@ export const useBridgeAlerts = () => {
     isSwap,
     insufficientNativeReserveError,
     dispatch,
-    openBuyCryptoInPdapp,
+    goToBuy,
+    fromChain,
     ticker,
     toToken,
     assetIsMalicious,

--- a/ui/pages/bridge/hooks/useBridgeAlerts.ts
+++ b/ui/pages/bridge/hooks/useBridgeAlerts.ts
@@ -1,7 +1,11 @@
 import { shallowEqual, useDispatch, useSelector } from 'react-redux';
 import { useMemo } from 'react';
 import type { CaipChainId, Hex } from '@metamask/utils';
-import { getNativeAssetForChainId } from '@metamask/bridge-controller';
+import {
+  formatChainIdToHex,
+  getNativeAssetForChainId,
+} from '@metamask/bridge-controller';
+import { isEvmChainId } from '../../../../shared/lib/asset-utils';
 import {
   getActiveQuoteInsufficientNativeReserveError,
   type BridgeAppState,
@@ -41,6 +45,20 @@ function getNativeGasAssetId(chainId?: Hex | CaipChainId) {
   } catch {
     return undefined;
   }
+}
+
+/**
+ * Normalize the source chain id for the flag-off Portfolio fallback.
+ * `getBuyURI` runs `hexToNumber` on EVM chain ids, so it needs hex — bridge
+ * state stores them as CAIP (`eip155:1`). Non-EVM caip ids pass through.
+ *
+ * @param chainId - The bridge source chain id.
+ */
+function getBuyFallbackChainId(chainId?: Hex | CaipChainId) {
+  if (!chainId) {
+    return undefined;
+  }
+  return isEvmChainId(chainId) ? formatChainIdToHex(chainId) : chainId;
 }
 
 /**
@@ -239,7 +257,7 @@ export const useBridgeAlerts = () => {
           actionButtonOnClick: () =>
             goToBuy({
               assetId: getNativeGasAssetId(fromChain?.chainId),
-              chainId: fromChain?.chainId,
+              chainId: getBuyFallbackChainId(fromChain?.chainId),
             }),
         },
       });

--- a/ui/pages/confirmations/hooks/useConfirmationAlertActions.test.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationAlertActions.test.ts
@@ -1,8 +1,10 @@
 import { TransactionEnvelopeType } from '@metamask/transaction-controller';
+import { getNativeAssetForChainId } from '@metamask/bridge-controller';
+import { CHAIN_IDS } from '../../../../shared/constants/network';
 import { renderHookWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import mockState from '../../../../test/data/mock-state.json';
 import { AlertActionKey } from '../../../components/app/confirm/info/row/constants';
-import useRamps from '../../../hooks/ramps/useRamps/useRamps';
+import useRampsNavigation from '../../../hooks/ramps/useRampsNavigation/useRampsNavigation';
 import { useGasFeeModalContext } from '../context/gas-fee-modal';
 import { useConfirmContext } from '../context/confirm';
 import { GasModalType } from '../constants/gas';
@@ -16,9 +18,9 @@ jest.mock('../context/confirm', () => ({
   useConfirmContext: jest.fn(),
 }));
 
-jest.mock('../../../hooks/ramps/useRamps/useRamps');
+jest.mock('../../../hooks/ramps/useRampsNavigation/useRampsNavigation');
 
-const mockOpenBuyCryptoInPdapp = jest.fn();
+const mockGoToBuy = jest.fn();
 
 function processAlertActionKey(actionKey: string) {
   const { result } = renderHookWithProvider(
@@ -38,10 +40,9 @@ describe('useConfirmationAlertActions', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    jest.mocked(useRamps).mockReturnValue({
-      openBuyCryptoInPdapp: mockOpenBuyCryptoInPdapp,
-      getBuyURI: jest.fn(),
-    } as ReturnType<typeof useRamps>);
+    jest.mocked(useRampsNavigation).mockReturnValue({
+      goToBuy: mockGoToBuy,
+    } as unknown as ReturnType<typeof useRampsNavigation>);
 
     useGasFeeModalContextMock.mockReturnValue({
       openGasFeeModal: openGasFeeModalMock,
@@ -52,6 +53,7 @@ describe('useConfirmationAlertActions', () => {
 
     useConfirmContextMock.mockReturnValue({
       currentConfirmation: {
+        chainId: CHAIN_IDS.MAINNET,
         txParams: {
           type: TransactionEnvelopeType.feeMarket,
         },
@@ -62,10 +64,13 @@ describe('useConfirmationAlertActions', () => {
     });
   });
 
-  it('opens in-extension buy flow if action key is Buy', () => {
+  it('routes Buy through goToBuy with the native gas token and chain', () => {
     processAlertActionKey(AlertActionKey.Buy);
 
-    expect(mockOpenBuyCryptoInPdapp).toHaveBeenCalledTimes(1);
+    expect(mockGoToBuy).toHaveBeenCalledWith({
+      assetId: getNativeAssetForChainId(CHAIN_IDS.MAINNET).assetId,
+      chainId: CHAIN_IDS.MAINNET,
+    });
   });
 
   it('opens advanced EIP-1559 gas fee modal if action key is ShowAdvancedGasFeeModal for fee market transactions', () => {

--- a/ui/pages/confirmations/hooks/useConfirmationAlertActions.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationAlertActions.ts
@@ -1,32 +1,14 @@
 import { useCallback } from 'react';
-import type { Hex } from '@metamask/utils';
-import { getNativeAssetForChainId } from '@metamask/bridge-controller';
 import {
   TransactionEnvelopeType,
   TransactionMeta,
 } from '@metamask/transaction-controller';
 import { AlertActionKey } from '../../../components/app/confirm/info/row/constants';
+import { getNativeAssetId } from '../../../../shared/lib/asset-utils';
 import useRampsNavigation from '../../../hooks/ramps/useRampsNavigation/useRampsNavigation';
 import { useGasFeeModalContext } from '../context/gas-fee-modal';
 import { useConfirmContext } from '../context/confirm';
 import { GasModalType } from '../constants/gas';
-
-/**
- * Resolve the chain's native gas token as a CAIP-19 asset id, or `undefined`
- * for custom/unsupported networks (`getNativeAssetForChainId` throws on those).
- *
- * @param chainId - The confirmation's chain id.
- */
-function getNativeGasAssetId(chainId?: Hex) {
-  if (!chainId) {
-    return undefined;
-  }
-  try {
-    return getNativeAssetForChainId(chainId).assetId;
-  } catch {
-    return undefined;
-  }
-}
 
 const useConfirmationAlertActions = () => {
   const { goToBuy } = useRampsNavigation();
@@ -41,7 +23,7 @@ const useConfirmationAlertActions = () => {
           // Pre-select the native gas token so the buy flow lands on
           // build-quote for it; chainId also drives the flag-off Portfolio
           // fallback.
-          goToBuy({ assetId: getNativeGasAssetId(chainId), chainId });
+          goToBuy({ assetId: getNativeAssetId(chainId), chainId });
           break;
         }
 

--- a/ui/pages/confirmations/hooks/useConfirmationAlertActions.ts
+++ b/ui/pages/confirmations/hooks/useConfirmationAlertActions.ts
@@ -1,25 +1,49 @@
 import { useCallback } from 'react';
+import type { Hex } from '@metamask/utils';
+import { getNativeAssetForChainId } from '@metamask/bridge-controller';
 import {
   TransactionEnvelopeType,
   TransactionMeta,
 } from '@metamask/transaction-controller';
 import { AlertActionKey } from '../../../components/app/confirm/info/row/constants';
-import useRamps from '../../../hooks/ramps/useRamps/useRamps';
+import useRampsNavigation from '../../../hooks/ramps/useRampsNavigation/useRampsNavigation';
 import { useGasFeeModalContext } from '../context/gas-fee-modal';
 import { useConfirmContext } from '../context/confirm';
 import { GasModalType } from '../constants/gas';
 
+/**
+ * Resolve the chain's native gas token as a CAIP-19 asset id, or `undefined`
+ * for custom/unsupported networks (`getNativeAssetForChainId` throws on those).
+ *
+ * @param chainId - The confirmation's chain id.
+ */
+function getNativeGasAssetId(chainId?: Hex) {
+  if (!chainId) {
+    return undefined;
+  }
+  try {
+    return getNativeAssetForChainId(chainId).assetId;
+  } catch {
+    return undefined;
+  }
+}
+
 const useConfirmationAlertActions = () => {
-  const { openBuyCryptoInPdapp } = useRamps();
+  const { goToBuy } = useRampsNavigation();
   const { openGasFeeModal } = useGasFeeModalContext();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
 
   const processAction = useCallback(
     (actionKey: string) => {
       switch (actionKey) {
-        case AlertActionKey.Buy:
-          openBuyCryptoInPdapp();
+        case AlertActionKey.Buy: {
+          const chainId = currentConfirmation?.chainId;
+          // Pre-select the native gas token so the buy flow lands on
+          // build-quote for it; chainId also drives the flag-off Portfolio
+          // fallback.
+          goToBuy({ assetId: getNativeGasAssetId(chainId), chainId });
           break;
+        }
 
         case AlertActionKey.ShowAdvancedGasFeeModal: {
           const advancedModalType =
@@ -40,7 +64,7 @@ const useConfirmationAlertActions = () => {
           break;
       }
     },
-    [openBuyCryptoInPdapp, openGasFeeModal, currentConfirmation],
+    [goToBuy, openGasFeeModal, currentConfirmation],
   );
 
   return processAction;

--- a/ui/pages/musd/screens/education.test.tsx
+++ b/ui/pages/musd/screens/education.test.tsx
@@ -50,14 +50,11 @@ jest.mock('../../../hooks/musd', () => ({
 }));
 
 const mockGoToBuy = jest.fn().mockResolvedValue(true);
-jest.mock(
-  '../../../hooks/ramps/useRampsNavigation/useRampsNavigation',
-  () => ({
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    __esModule: true,
-    default: () => ({ goToBuy: mockGoToBuy }),
-  }),
-);
+jest.mock('../../../hooks/ramps/useRampsNavigation/useRampsNavigation', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  __esModule: true,
+  default: () => ({ goToBuy: mockGoToBuy }),
+}));
 
 // Mock useTheme
 jest.mock('../../../hooks/useTheme', () => ({

--- a/ui/pages/musd/screens/education.test.tsx
+++ b/ui/pages/musd/screens/education.test.tsx
@@ -312,7 +312,10 @@ describe('MusdEducationScreen', () => {
 
       expect(mockDispatch).toHaveBeenCalled();
       // Deeplink buy branch pins the fallback chain to mainnet.
-      expect(mockGoToBuy).toHaveBeenCalledWith({ chainId: '0x1' });
+      expect(mockGoToBuy).toHaveBeenCalledWith({
+        assetId: 'eip155:1/erc20:0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
+        chainId: '0x1',
+      });
       // Flag off opens Portfolio in a new tab, so the screen returns home.
       await waitFor(() =>
         expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE),
@@ -332,7 +335,10 @@ describe('MusdEducationScreen', () => {
       fireEvent.click(button);
 
       await waitFor(() =>
-        expect(mockGoToBuy).toHaveBeenCalledWith({ chainId: '0x1' }),
+        expect(mockGoToBuy).toHaveBeenCalledWith({
+          assetId: 'eip155:1/erc20:0xacA92E438df0B2401fF60dA7E4337B687a2435DA',
+          chainId: '0x1',
+        }),
       );
       // goToBuy navigates in-app itself; the screen must not override it home.
       expect(mockNavigate).not.toHaveBeenCalledWith(DEFAULT_ROUTE);

--- a/ui/pages/musd/screens/education.test.tsx
+++ b/ui/pages/musd/screens/education.test.tsx
@@ -50,10 +50,11 @@ jest.mock('../../../hooks/musd', () => ({
 }));
 
 const mockGoToBuy = jest.fn().mockResolvedValue(true);
+let mockIsRampsEnabled = false;
 jest.mock('../../../hooks/ramps/useRampsNavigation/useRampsNavigation', () => ({
   // eslint-disable-next-line @typescript-eslint/naming-convention
   __esModule: true,
-  default: () => ({ goToBuy: mockGoToBuy }),
+  default: () => ({ goToBuy: mockGoToBuy, isRampsEnabled: mockIsRampsEnabled }),
 }));
 
 // Mock useTheme
@@ -82,12 +83,11 @@ jest.mock('react-router-dom', () => ({
   ],
 }));
 
-const createMockStore = (remoteFeatureFlags = {}) => {
+const createMockStore = () => {
   return configureStore({
     metamask: {
       remoteFeatureFlags: {
         earnMusdConversionFlowEnabled: true,
-        ...remoteFeatureFlags,
       },
       selectedNetworkClientId: 'mainnet',
       networkConfigurationsByChainId: {
@@ -125,6 +125,7 @@ describe('MusdEducationScreen', () => {
       canBuyMusdInRegion: true,
       isLoading: false,
     });
+    mockIsRampsEnabled = false;
   });
 
   it('renders the headline with the bonus percentage', () => {
@@ -328,7 +329,8 @@ describe('MusdEducationScreen', () => {
         canBuyMusdInRegion: true,
         isLoading: false,
       });
-      const store = createMockStore({ rampsEnabled: true });
+      mockIsRampsEnabled = true;
+      const store = createMockStore();
       renderWithProvider(<MusdEducationScreen />, store);
 
       const button = screen.getByTestId('musd-education-continue-button');

--- a/ui/pages/musd/screens/education.test.tsx
+++ b/ui/pages/musd/screens/education.test.tsx
@@ -2,7 +2,7 @@
  * @jest-environment jsdom
  */
 import React from 'react';
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 import configureStore from '../../../store/store';
@@ -49,12 +49,15 @@ jest.mock('../../../hooks/musd', () => ({
   useCanBuyMusd: () => mockUseCanBuyMusd(),
 }));
 
-const mockOpenBuyCryptoInPdapp = jest.fn();
-jest.mock('../../../hooks/ramps/useRamps/useRamps', () => ({
-  // eslint-disable-next-line @typescript-eslint/naming-convention
-  __esModule: true,
-  default: () => ({ openBuyCryptoInPdapp: mockOpenBuyCryptoInPdapp }),
-}));
+const mockGoToBuy = jest.fn().mockResolvedValue(true);
+jest.mock(
+  '../../../hooks/ramps/useRampsNavigation/useRampsNavigation',
+  () => ({
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    __esModule: true,
+    default: () => ({ goToBuy: mockGoToBuy }),
+  }),
+);
 
 // Mock useTheme
 jest.mock('../../../hooks/useTheme', () => ({
@@ -82,11 +85,12 @@ jest.mock('react-router-dom', () => ({
   ],
 }));
 
-const createMockStore = () => {
+const createMockStore = (remoteFeatureFlags = {}) => {
   return configureStore({
     metamask: {
       remoteFeatureFlags: {
         earnMusdConversionFlowEnabled: true,
+        ...remoteFeatureFlags,
       },
       selectedNetworkClientId: 'mainnet',
       networkConfigurationsByChainId: {
@@ -281,7 +285,7 @@ describe('MusdEducationScreen', () => {
 
     expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE);
     expect(mockStartConversionFlow).not.toHaveBeenCalled();
-    expect(mockOpenBuyCryptoInPdapp).not.toHaveBeenCalled();
+    expect(mockGoToBuy).not.toHaveBeenCalled();
   });
 
   // -------------------------------------------------------------------
@@ -297,7 +301,7 @@ describe('MusdEducationScreen', () => {
       });
     });
 
-    it('shows "Buy mUSD" and opens buy flow when user can buy', () => {
+    it('routes through goToBuy (mainnet) and returns home when the ramps flag is off', async () => {
       mockUseCanBuyMusd.mockReturnValue({
         canBuyMusdInRegion: true,
         isLoading: false,
@@ -310,8 +314,31 @@ describe('MusdEducationScreen', () => {
       fireEvent.click(button);
 
       expect(mockDispatch).toHaveBeenCalled();
-      expect(mockOpenBuyCryptoInPdapp).toHaveBeenCalledWith('0x1');
-      expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE);
+      // Deeplink buy branch pins the fallback chain to mainnet.
+      expect(mockGoToBuy).toHaveBeenCalledWith({ chainId: '0x1' });
+      // Flag off opens Portfolio in a new tab, so the screen returns home.
+      await waitFor(() =>
+        expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE),
+      );
+      expect(mockStartConversionFlow).not.toHaveBeenCalled();
+    });
+
+    it('routes through goToBuy and stays put (in-app routing) when the ramps flag is on', async () => {
+      mockUseCanBuyMusd.mockReturnValue({
+        canBuyMusdInRegion: true,
+        isLoading: false,
+      });
+      const store = createMockStore({ rampsEnabled: true });
+      renderWithProvider(<MusdEducationScreen />, store);
+
+      const button = screen.getByTestId('musd-education-continue-button');
+      fireEvent.click(button);
+
+      await waitFor(() =>
+        expect(mockGoToBuy).toHaveBeenCalledWith({ chainId: '0x1' }),
+      );
+      // goToBuy navigates in-app itself; the screen must not override it home.
+      expect(mockNavigate).not.toHaveBeenCalledWith(DEFAULT_ROUTE);
       expect(mockStartConversionFlow).not.toHaveBeenCalled();
     });
 
@@ -334,7 +361,7 @@ describe('MusdEducationScreen', () => {
 
       expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE);
       expect(mockStartConversionFlow).not.toHaveBeenCalled();
-      expect(mockOpenBuyCryptoInPdapp).not.toHaveBeenCalled();
+      expect(mockGoToBuy).not.toHaveBeenCalled();
     });
 
     it('shows "Continue" and navigates home when ramp unavailable in region', () => {
@@ -351,7 +378,7 @@ describe('MusdEducationScreen', () => {
 
       expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE);
       expect(mockStartConversionFlow).not.toHaveBeenCalled();
-      expect(mockOpenBuyCryptoInPdapp).not.toHaveBeenCalled();
+      expect(mockGoToBuy).not.toHaveBeenCalled();
     });
   });
 
@@ -382,7 +409,7 @@ describe('MusdEducationScreen', () => {
         skipEducation: true,
         entryPoint: 'deeplink',
       });
-      expect(mockOpenBuyCryptoInPdapp).not.toHaveBeenCalled();
+      expect(mockGoToBuy).not.toHaveBeenCalled();
     });
 
     it('shows "Get started" and starts conversion flow even when user cannot buy in region', async () => {
@@ -403,7 +430,7 @@ describe('MusdEducationScreen', () => {
         skipEducation: true,
         entryPoint: 'deeplink',
       });
-      expect(mockOpenBuyCryptoInPdapp).not.toHaveBeenCalled();
+      expect(mockGoToBuy).not.toHaveBeenCalled();
     });
   });
 });

--- a/ui/pages/musd/screens/education.tsx
+++ b/ui/pages/musd/screens/education.tsx
@@ -7,7 +7,7 @@
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import type { CaipAssetType } from '@metamask/utils';
 import {
   Box,
@@ -51,7 +51,6 @@ import {
   useCanBuyMusd,
 } from '../../../hooks/musd';
 import useRampsNavigation from '../../../hooks/ramps/useRampsNavigation/useRampsNavigation';
-import { getIsRampsEnabled } from '../../../selectors/ramps-feature-flags';
 import {
   getMusdAssetIdForChain,
   MUSD_CONVERSION_APY,
@@ -111,8 +110,7 @@ const MusdEducationScreen = () => {
   const { tokens: conversionTokens, defaultPaymentToken } =
     useMusdConversionTokens();
   const { canBuyMusdInRegion } = useCanBuyMusd();
-  const { goToBuy } = useRampsNavigation();
-  const isRampsEnabled = useSelector(getIsRampsEnabled);
+  const { goToBuy, isRampsEnabled } = useRampsNavigation();
   const [isLoading, setIsLoading] = useState(false);
 
   const hasEligibleConversionTokens = conversionTokens.length > 0;

--- a/ui/pages/musd/screens/education.tsx
+++ b/ui/pages/musd/screens/education.tsx
@@ -7,7 +7,7 @@
 
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
-import { useDispatch } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
 import {
   Box,
   Text,
@@ -49,7 +49,8 @@ import {
   useMusdConversionTokens,
   useCanBuyMusd,
 } from '../../../hooks/musd';
-import useRamps from '../../../hooks/ramps/useRamps/useRamps';
+import useRampsNavigation from '../../../hooks/ramps/useRampsNavigation/useRampsNavigation';
+import { getIsRampsEnabled } from '../../../selectors/ramps-feature-flags';
 import {
   MUSD_CONVERSION_APY,
   MUSD_CONVERSION_BONUS_TERMS_OF_USE,
@@ -108,7 +109,8 @@ const MusdEducationScreen = () => {
   const { tokens: conversionTokens, defaultPaymentToken } =
     useMusdConversionTokens();
   const { canBuyMusdInRegion } = useCanBuyMusd();
-  const { openBuyCryptoInPdapp } = useRamps();
+  const { goToBuy } = useRampsNavigation();
+  const isRampsEnabled = useSelector(getIsRampsEnabled);
   const [isLoading, setIsLoading] = useState(false);
 
   const hasEligibleConversionTokens = conversionTokens.length > 0;
@@ -184,8 +186,13 @@ const MusdEducationScreen = () => {
     dispatch(setMusdConversionEducationSeen(true));
 
     if (isDeeplinkNoTokensGoToBuy) {
-      openBuyCryptoInPdapp(MUSD_CONVERSION_DEFAULT_CHAIN_ID);
-      navigate(DEFAULT_ROUTE);
+      await goToBuy({ chainId: MUSD_CONVERSION_DEFAULT_CHAIN_ID });
+      // Flag off opens Portfolio in a new tab, so send the user home; flag on
+      // navigates in-app (build-quote, or a blocking modal on the education
+      // screen), so leave routing to goToBuy.
+      if (!isRampsEnabled) {
+        navigate(DEFAULT_ROUTE);
+      }
       return;
     }
 
@@ -226,7 +233,8 @@ const MusdEducationScreen = () => {
     isDeeplinkNoTokensContinueHome,
     isDeeplink,
     isGeoBlocked,
-    openBuyCryptoInPdapp,
+    goToBuy,
+    isRampsEnabled,
     startConversionFlow,
     defaultPaymentToken,
     createEventBuilder,

--- a/ui/pages/musd/screens/education.tsx
+++ b/ui/pages/musd/screens/education.tsx
@@ -8,6 +8,7 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
+import type { CaipAssetType } from '@metamask/utils';
 import {
   Box,
   Text,
@@ -52,6 +53,7 @@ import {
 import useRampsNavigation from '../../../hooks/ramps/useRampsNavigation/useRampsNavigation';
 import { getIsRampsEnabled } from '../../../selectors/ramps-feature-flags';
 import {
+  getMusdAssetIdForChain,
   MUSD_CONVERSION_APY,
   MUSD_CONVERSION_BONUS_TERMS_OF_USE,
   MUSD_CONVERSION_DEFAULT_CHAIN_ID,
@@ -186,7 +188,15 @@ const MusdEducationScreen = () => {
     dispatch(setMusdConversionEducationSeen(true));
 
     if (isDeeplinkNoTokensGoToBuy) {
-      await goToBuy({ chainId: MUSD_CONVERSION_DEFAULT_CHAIN_ID });
+      await goToBuy({
+        // Pre-select mUSD (mainnet) so the in-app flow lands on build-quote
+        // instead of the token-selection page; chainId is only used for the
+        // flag-off Portfolio fallback.
+        assetId: getMusdAssetIdForChain(MUSD_CONVERSION_DEFAULT_CHAIN_ID) as
+          | CaipAssetType
+          | undefined,
+        chainId: MUSD_CONVERSION_DEFAULT_CHAIN_ID,
+      });
       // Flag off opens Portfolio in a new tab, so send the user home; flag on
       // navigates in-app (build-quote, or a blocking modal on the education
       // screen), so leave routing to goToBuy.


### PR DESCRIPTION
## **Description**

Follow-up to TRAM-3711, which introduced the `useRampsNavigation` hook and its `goToBuy` method (feature-flag gating, regional eligibility, service-disruption kill-switch, in-extension routing). This PR migrates **all remaining buy CTAs** off the direct `openBuyCryptoInPdapp` Portfolio deeplink and onto `goToBuy`, so every entry point runs the same eligibility gate and in-extension routing when the ramps flag is on — while preserving the existing Portfolio behavior (with the same chain context) when the flag is off.

The wallet-overview, non-EVM-overview, token-asset-page, and add-funds CTAs were already migrated as part of TRAM-3711. This PR covers the remaining call sites:

- **Funding method modal** (`funding-method-modal.tsx`) — passes the current chain. The `NavBuyButtonClicked` metric is now gated on `goToBuy` succeeding, so it no longer fires when the gate blocks the buy.
- **mUSD BUY CTA** (`musd-buy-get-cta.tsx`) — `BUY` variant only. Passes the mUSD `assetId` (falling back to mainnet mUSD when the current chain has no mUSD route) so the flow lands directly on build-quote with mUSD pre-selected, plus `selectedChainId` for the flag-off Portfolio fallback. The `GET` variant (in-app conversion) is unchanged.
- **mUSD education deeplink branch** (`education.tsx`) — the `isDeeplinkNoTokensGoToBuy` branch only. Passes the mainnet mUSD `assetId` + chain. It now only returns the user home when the ramps flag is off (Portfolio opens in a new tab); with the flag on, in-app routing is left to `goToBuy`. Other education branches are unchanged.
- **Bridge insufficient-gas alert** (`useBridgeAlerts.ts`) — the "Buy more {ticker}" banner action. Pre-selects the **source chain's native gas token** as `assetId` and passes the source chain for the fallback.
- **Confirmation insufficient-funds alert** (`useConfirmationAlertActions.ts`) — `AlertActionKey.Buy`. Pre-selects the **confirmation chain's native gas token** as `assetId` and passes that chain for the fallback.

The bridge and confirmation alerts were originally scoped as a follow-up in TRAM-3756 (they fire mid-flow and target the native gas token). **Product confirmed the in-app buy navigation is the desired behavior**, so they are included here, pre-selecting the native token so the flow lands on build-quote for the right asset. `getNativeAssetForChainId` throws on custom networks, so it is guarded to fall back to no pre-selected asset (token-selection page).

`goToBuy` keeps the flag-off Portfolio fallback internally by delegating to `openBuyCryptoInPdapp`, so both `openBuyCryptoInPdapp` and the `useRamps` hook are retained — those remain the only two references to it (the hook definition and the `goToBuy` flag-off fallback).

Two supporting changes so callers stay simple:

- **`getBuyURI` normalizes chain-id format at the root** (`useRamps.ts`). It now accepts EVM chain ids as either hex or CAIP (`eip155:1`) and normalizes internally via `formatChainIdToHex`, so every `goToBuy` caller can pass whatever format it already has instead of formatting at each call site. Non-EVM caip ids are unchanged.
- **Shared `getNativeAssetId` helper** added in `shared/lib/asset-utils.ts` (safe wrapper around `getNativeAssetForChainId` that returns `undefined` on custom/unsupported networks), replacing the two identical local copies in the bridge and confirmation hooks.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [TRAM-3756](https://consensyssoftware.atlassian.net/browse/TRAM-3756)

## **Manual testing steps**

With the `rampsEnabled` flag **on**, each of these lands on the in-extension buy flow (build-quote with the expected token pre-selected where applicable):
1. Funding-method modal → tap "Token marketplace".
2. Empty wallet → tap the mUSD "Buy mUSD" CTA → build-quote with mUSD pre-selected.
3. mUSD education screen via deeplink, no eligible tokens (buyable region) → tap "Buy mUSD" → build-quote with mUSD pre-selected, and stays there (does not bounce home).
4. Bridge with insufficient gas → tap "Buy more {ticker}" → build-quote with the source-chain native token pre-selected.
5. Transaction confirmation with insufficient funds → tap Buy → build-quote with the confirmation-chain native token pre-selected.

With the flag **off**, each of the above still opens the Portfolio buy deeplink in a new tab with the same chain context as before.

## **Screenshots/Recordings**

N/A — routing change, no visual change.

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[TRAM-3756]: https://consensyssoftware.atlassian.net/browse/TRAM-3756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple user-facing buy paths and analytics gating; behavior changes when ramps flag is on vs off, but scope is navigation/eligibility rather than transaction signing.
> 
> **Overview**
> Remaining **buy** entry points now call **`useRampsNavigation`’s `goToBuy`** instead of **`openBuyCryptoInPdapp`**, so they share the same ramps feature flag, eligibility gates, and in-extension routing when enabled, while flag-off behavior still falls back to Portfolio via `goToBuy`.
> 
> **Funding method modal**, **mUSD BUY CTA**, **mUSD education deeplink (no tokens → buy)**, **bridge insufficient-gas**, and **confirmation Buy** pass **`chainId`** and, where relevant, a pre-selected **`assetId`** (mUSD or the source/confirmation chain’s native gas token) so in-app buy lands on build-quote instead of token selection. The funding modal only fires **`NavBuyButtonClicked`** when `goToBuy` succeeds; education only navigates home after buy when ramps are flag-off (Portfolio tab).
> 
> Adds **`getNativeAssetId`** in `shared/lib/asset-utils` (safe wrapper around `getNativeAssetForChainId`) and normalizes **EVM CAIP chain IDs** in **`getBuyURI`** via `formatChainIdToHex`. Tests updated across touched surfaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0e87232f25be2748d750d84d50ee680921e9e5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
