### PR TITLE
perf(7475): adopt useDeferredValue for search and filter surfaces

### DIFF
--- a/ui/components/multichain/activity-v2/activity-list.tsx
+++ b/ui/components/multichain/activity-v2/activity-list.tsx
@@ -1,9 +1,4 @@
-import React, {
-  useCallback,
-  useMemo,
-  useEffect,
-  useState,
-} from 'react';
+import React, { useCallback, useMemo, useEffect, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { Box, Text } from '@metamask/design-system-react';
@@ -105,7 +100,9 @@ export const ActivityList = ({ filter }: Props) => {
       PENDING_STATUS_HASH,
     ).filter((group) => {
       const chainId = group.initialTransaction?.chainId;
-      return !chainId || deferredEnabledNetworks.includes(toEvmCaipChainId(chainId));
+      return (
+        !chainId || deferredEnabledNetworks.includes(toEvmCaipChainId(chainId))
+      );
     });
 
     let filteredNonEvmTransactions = nonEvmTransactions.filter((tx) =>
@@ -138,7 +135,13 @@ export const ActivityList = ({ filter }: Props) => {
       filteredLocalTransactions,
       filteredNonEvmTransactions,
     };
-  }, [data, nonEvmTransactions, localTransactions, deferredEnabledNetworks, filter]);
+  }, [
+    data,
+    nonEvmTransactions,
+    localTransactions,
+    deferredEnabledNetworks,
+    filter,
+  ]);
 
   // Merge and flatten for virtualization
   const flattenedItems = useMemo(() => {

--- a/ui/components/multichain/activity-v2/activity-list.tsx
+++ b/ui/components/multichain/activity-v2/activity-list.tsx
@@ -1,9 +1,15 @@
-import React, { useCallback, useMemo, useEffect, useState } from 'react';
+import React, {
+  useCallback,
+  useMemo,
+  useEffect,
+  useState,
+} from 'react';
 import { useSelector } from 'react-redux';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { Box, Text } from '@metamask/design-system-react';
 import type { Transaction } from '@metamask/keyring-api';
 import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
+import { useDeferredValue } from '../../../hooks/useDeferredValue';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useScrollContainer } from '../../../contexts/scroll-container';
 import { useItemInView } from '../../../hooks/useItemInView';
@@ -59,6 +65,7 @@ export const ActivityList = ({ filter }: Props) => {
 
   const evmAddress = (useSelector(selectEvmAddress) || '').toLowerCase();
   const enabledNetworks = useSelector(selectEnabledNetworksAsCaipChainIds);
+  const deferredEnabledNetworks = useDeferredValue(enabledNetworks);
 
   // Clear modal state on account switch
   useEffect(() => {
@@ -98,11 +105,11 @@ export const ActivityList = ({ filter }: Props) => {
       PENDING_STATUS_HASH,
     ).filter((group) => {
       const chainId = group.initialTransaction?.chainId;
-      return !chainId || enabledNetworks.includes(toEvmCaipChainId(chainId));
+      return !chainId || deferredEnabledNetworks.includes(toEvmCaipChainId(chainId));
     });
 
     let filteredNonEvmTransactions = nonEvmTransactions.filter((tx) =>
-      enabledNetworks.includes(tx.chain),
+      deferredEnabledNetworks.includes(tx.chain),
     );
 
     // Asset-page filtering: narrow by chain and asset scope
@@ -131,7 +138,7 @@ export const ActivityList = ({ filter }: Props) => {
       filteredLocalTransactions,
       filteredNonEvmTransactions,
     };
-  }, [data, nonEvmTransactions, localTransactions, enabledNetworks, filter]);
+  }, [data, nonEvmTransactions, localTransactions, deferredEnabledNetworks, filter]);
 
   // Merge and flatten for virtualization
   const flattenedItems = useMemo(() => {

--- a/ui/components/multichain/activity-v2/useTransactionsQuery.ts
+++ b/ui/components/multichain/activity-v2/useTransactionsQuery.ts
@@ -75,7 +75,9 @@ function useTransactionParams(caipChainId?: CaipChainId) {
     if (caipChainId) {
       return caipChainId.startsWith('eip155:') ? [caipChainId] : [];
     }
-    return deferredEnabledNetworks.filter((id: string) => id.startsWith('eip155:'));
+    return deferredEnabledNetworks.filter((id: string) =>
+      id.startsWith('eip155:'),
+    );
   }, [deferredEnabledNetworks, caipChainId]);
 
   const accountAddresses = useMemo(

--- a/ui/components/multichain/activity-v2/useTransactionsQuery.ts
+++ b/ui/components/multichain/activity-v2/useTransactionsQuery.ts
@@ -3,6 +3,7 @@ import { useSelector } from 'react-redux';
 import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query';
 import { HttpError } from '@metamask/core-backend';
 import type { CaipChainId } from '@metamask/utils';
+import { useDeferredValue } from '../../../hooks/useDeferredValue';
 import { getErrorBodyMessage } from '../../../../shared/lib/error';
 import { selectTransactions } from '../../../../shared/lib/multichain/transformations';
 import { MINUTE } from '../../../../shared/constants/time';
@@ -68,13 +69,14 @@ function useTransactionParams(caipChainId?: CaipChainId) {
   const evmAddress = (useSelector(selectEvmAddress) || '').toLowerCase();
   const locale = useSelector(getIntlLocale);
   const enabledNetworks = useSelector(selectEnabledNetworksAsCaipChainIds);
+  const deferredEnabledNetworks = useDeferredValue(enabledNetworks);
 
   const evmNetworks = useMemo(() => {
     if (caipChainId) {
       return caipChainId.startsWith('eip155:') ? [caipChainId] : [];
     }
-    return enabledNetworks.filter((id: string) => id.startsWith('eip155:'));
-  }, [enabledNetworks, caipChainId]);
+    return deferredEnabledNetworks.filter((id: string) => id.startsWith('eip155:'));
+  }, [deferredEnabledNetworks, caipChainId]);
 
   const accountAddresses = useMemo(
     () => (evmAddress ? [`eip155:0:${evmAddress}`] : []),

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.test.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.test.tsx
@@ -81,15 +81,6 @@ jest.mock('../../../../hooks/useMultichainBalances', () => ({
   useMultichainBalances: () => mockUseMultichainBalances(),
 }));
 
-jest.mock('lodash', () => ({
-  ...jest.requireActual('lodash'),
-  debounce: jest.fn().mockImplementation((fn) => {
-    const debouncedFn = fn;
-    debouncedFn.cancel = jest.fn();
-    return debouncedFn;
-  }),
-}));
-
 describe('AssetPickerModal', () => {
   const useSelectorMock = useSelector as jest.Mock;
   const useI18nContextMock = useI18nContext as jest.Mock;

--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx
@@ -13,7 +13,6 @@ import type {
 } from '@metamask/assets-controllers';
 import { isCaipChainId, isStrictHexString, type Hex } from '@metamask/utils';
 import { zeroAddress } from 'ethereumjs-util';
-import { debounce } from 'lodash';
 import {
   Modal,
   ModalContent,
@@ -34,6 +33,7 @@ import {
   JustifyContent,
 } from '../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { useDeferredValue } from '../../../../hooks/useDeferredValue';
 
 import { AssetType } from '../../../../../shared/constants/transaction';
 import {
@@ -143,29 +143,17 @@ export function AssetPickerModal({
 }: AssetPickerModalProps) {
   const t = useI18nContext();
   const [searchQuery, setSearchQuery] = useState('');
-  const [debouncedSearchQuery, setDebouncedSearchQuery] = useState(searchQuery);
-  const debouncedSetSearchQuery = useMemo(
-    () =>
-      debounce((value: string) => {
-        setDebouncedSearchQuery(value);
-      }, 200),
-    [],
-  );
+  const deferredSearchQuery = useDeferredValue(searchQuery);
 
   const abortControllerRef = useRef<AbortController | null>(null);
 
-  // Cleanup abort controller and debounce on unmount
+  // Cleanup abort controller on unmount
   useEffect(() => {
     return () => {
       abortControllerRef.current?.abort();
       abortControllerRef.current = null;
-      debouncedSetSearchQuery.cancel();
     };
-  }, [debouncedSetSearchQuery]);
-
-  useEffect(() => {
-    debouncedSetSearchQuery(searchQuery);
-  }, [searchQuery, debouncedSetSearchQuery]);
+  }, []);
 
   const handleAssetChange = useCallback(
     (newAsset: Parameters<typeof onAssetChange>[0]) => {
@@ -383,7 +371,7 @@ export function AssetPickerModal({
       address?: string | null,
       tokenChainId?: string,
     ) => {
-      const trimmedSearchQuery = debouncedSearchQuery.trim().toLowerCase();
+      const trimmedSearchQuery = deferredSearchQuery.trim().toLowerCase();
       const isSymbolMatch = symbol?.toLowerCase().includes(trimmedSearchQuery);
       // only check for matching address if search term has 6 characters or more
       // users are expected to copy and paste addresses instead of typing them
@@ -454,7 +442,7 @@ export function AssetPickerModal({
     return filteredTokens;
   }, [
     currentChainId,
-    debouncedSearchQuery,
+    deferredSearchQuery,
     isMultiselectEnabled,
     selectedChainIds,
     selectedNetwork?.chainId,

--- a/ui/hooks/useDeferredSearchQuery.test.ts
+++ b/ui/hooks/useDeferredSearchQuery.test.ts
@@ -1,0 +1,43 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { useDeferredSearchQuery } from './useDeferredSearchQuery';
+
+jest.mock('./useDeferredValue', () => ({
+  useDeferredValue: jest.fn((value: string) => value),
+}));
+
+const mockUseDeferredValue = jest.mocked(
+  jest.requireMock('./useDeferredValue').useDeferredValue,
+);
+
+describe('useDeferredSearchQuery', () => {
+  beforeEach(() => {
+    mockUseDeferredValue.mockImplementation((value: string) => value);
+  });
+
+  it('returns the initial query synchronously on first render', () => {
+    const { result } = renderHook(() => useDeferredSearchQuery('alpha'));
+
+    expect(result.current.query).toBe('alpha');
+    expect(result.current.deferredQuery).toBe('alpha');
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it('updates query immediately', () => {
+    const { result } = renderHook(() => useDeferredSearchQuery(''));
+
+    act(() => {
+      result.current.setQuery('beta');
+    });
+
+    expect(result.current.query).toBe('beta');
+  });
+
+  it('marks pending when deferred query lags behind the latest input', () => {
+    mockUseDeferredValue.mockReturnValue('stale');
+
+    const { result } = renderHook(() => useDeferredSearchQuery('live'));
+
+    expect(result.current.isPending).toBe(true);
+    expect(result.current.deferredQuery).toBe('stale');
+  });
+});

--- a/ui/hooks/useDeferredSearchQuery.ts
+++ b/ui/hooks/useDeferredSearchQuery.ts
@@ -1,0 +1,29 @@
+import { useState } from 'react';
+import { useDeferredValue } from './useDeferredValue';
+
+export type UseDeferredSearchQueryResult = {
+  query: string;
+  setQuery: (query: string) => void;
+  deferredQuery: string;
+  isPending: boolean;
+};
+
+/**
+ * Keeps search input updates on the urgent path while exposing a deferred query
+ * for expensive filtering, sorting, or network-backed search work.
+ * @param initialQuery
+ */
+export const useDeferredSearchQuery = (
+  initialQuery = '',
+): UseDeferredSearchQueryResult => {
+  const [query, setQuery] = useState(initialQuery);
+  const deferredQuery = useDeferredValue(query);
+  const isPending = query !== deferredQuery;
+
+  return {
+    query,
+    setQuery,
+    deferredQuery,
+    isPending,
+  };
+};

--- a/ui/hooks/useDeferredValue.test.ts
+++ b/ui/hooks/useDeferredValue.test.ts
@@ -1,0 +1,17 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useDeferredValue } from './useDeferredValue';
+
+describe('useDeferredValue', () => {
+  it('re-exports React.useDeferredValue', () => {
+    const { result, rerender } = renderHook(
+      ({ value }: { value: string }) => useDeferredValue(value),
+      { initialProps: { value: 'alpha' } },
+    );
+
+    expect(result.current).toBe('alpha');
+
+    rerender({ value: 'beta' });
+
+    expect(result.current).toBeDefined();
+  });
+});

--- a/ui/hooks/useDeferredValue.ts
+++ b/ui/hooks/useDeferredValue.ts
@@ -1,0 +1,1 @@
+export { useDeferredValue } from 'react';

--- a/ui/pages/activity/activity-list.tsx
+++ b/ui/pages/activity/activity-list.tsx
@@ -1,5 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { Box, Text } from '@metamask/design-system-react';
+import { useDeferredValue } from '../../hooks/useDeferredValue';
 import { PendingTransactionCancelSpeedUpProvider } from '../../components/app/pending-transaction-action-buttons/pending-transaction-cancel-speed-up-provider';
 import AssetListControlBar from '../../components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar';
 import { TransactionActivityEmptyState } from '../../components/app/transaction-activity-empty-state';
@@ -40,10 +41,11 @@ export function ActivityList({ filter }: { filter?: ActivityListFilter } = {}) {
   const scrollContainerRef = useScrollContainer();
   // null = not yet initialised by AssetListControlBar; [] = no filter applied
   const [networks, setNetworks] = useState<string[] | null>(null);
+  const deferredNetworks = useDeferredValue(networks);
   const [selectedItem, setSelectedItem] = useState<ActivityListItem | null>(
     null,
   );
-  const filters = filter ?? { networks: networks ?? [] };
+  const filters = filter ?? { networks: deferredNetworks ?? [] };
 
   const { data, isInitialLoading, fetchNextVisiblePage } =
     useTransactionsQuery(filters);

--- a/ui/pages/confirmations/components/send/asset/asset.tsx
+++ b/ui/pages/confirmations/components/send/asset/asset.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useEffect, useMemo } from 'react';
+import { useDeferredSearchQuery } from '../../../../../hooks/useDeferredSearchQuery';
 
 import {
   Display,
@@ -54,7 +55,11 @@ export const Asset = ({
   onSelectedChainIdChange,
 }: AssetProps = {}) => {
   const [selectedChainId, setSelectedChainId] = useState<string | null>(null);
-  const [searchQuery, setSearchQuery] = useState<string>('');
+  const {
+    query: searchQuery,
+    setQuery: setSearchQuery,
+    deferredQuery: deferredSearchQuery,
+  } = useDeferredSearchQuery();
   const {
     addAssetFilterMethod: addAssetFilterMethodFromMetrics,
     removeAssetFilterMethod: removeAssetFilterMethodFromMetrics,
@@ -88,7 +93,7 @@ export const Asset = ({
     tokens: filteredByCustomFilter,
     nfts: effectiveNfts,
     selectedChainId,
-    searchQuery,
+    searchQuery: deferredSearchQuery,
   });
 
   useEffect(() => {
@@ -101,7 +106,7 @@ export const Asset = ({
     setSelectedChainId(null);
     onSearchQueryChange?.('');
     onSelectedChainIdChange?.(null);
-  }, [onSearchQueryChange, onSelectedChainIdChange]);
+  }, [onSearchQueryChange, onSelectedChainIdChange, setSearchQuery]);
 
   const handleSearchQueryChange = useCallback(
     (value: string) => {
@@ -113,7 +118,7 @@ export const Asset = ({
       setSearchQuery(value);
       onSearchQueryChange?.(value);
     },
-    [addAssetFilterMethod, onSearchQueryChange, removeAssetFilterMethod],
+    [addAssetFilterMethod, onSearchQueryChange, removeAssetFilterMethod, setSearchQuery],
   );
 
   const handleSelectedChainIdChange = useCallback(

--- a/ui/pages/confirmations/components/send/asset/asset.tsx
+++ b/ui/pages/confirmations/components/send/asset/asset.tsx
@@ -118,7 +118,12 @@ export const Asset = ({
       setSearchQuery(value);
       onSearchQueryChange?.(value);
     },
-    [addAssetFilterMethod, onSearchQueryChange, removeAssetFilterMethod, setSearchQuery],
+    [
+      addAssetFilterMethod,
+      onSearchQueryChange,
+      removeAssetFilterMethod,
+      setSearchQuery,
+    ],
   );
 
   const handleSelectedChainIdChange = useCallback(

--- a/ui/pages/confirmations/components/send/recipient-list/recipient-list.tsx
+++ b/ui/pages/confirmations/components/send/recipient-list/recipient-list.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useState } from 'react';
+import React, { useCallback } from 'react';
 
 import { Recipient } from '../../UI/recipient';
 import {
@@ -11,6 +11,7 @@ import {
   TextVariant,
 } from '../../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
+import { useDeferredSearchQuery } from '../../../../../hooks/useDeferredSearchQuery';
 import { useSendRecipientFilter } from '../../../hooks/send/useSendRecipientFilter';
 import { RecipientFilterInput } from '../recipient-filter-input';
 
@@ -103,7 +104,11 @@ export const RecipientList = ({
   hideModal: () => void;
   onToChange: (address: string) => void;
 }) => {
-  const [searchQuery, setSearchQuery] = useState('');
+  const {
+    query: searchQuery,
+    setQuery: setSearchQuery,
+    deferredQuery: deferredSearchQuery,
+  } = useDeferredSearchQuery();
   const recipients = useRecipients();
   const contactRecipients = recipients.filter(
     (recipient) => recipient.contactName,
@@ -115,7 +120,7 @@ export const RecipientList = ({
     useSendRecipientFilter({
       contactRecipients,
       accountRecipients,
-      searchQuery,
+      searchQuery: deferredSearchQuery,
     });
 
   const handleSelectRecipient = useCallback(

--- a/ui/pages/token-management/token-management.test.tsx
+++ b/ui/pages/token-management/token-management.test.tsx
@@ -130,10 +130,6 @@ const mockTokenSearch = {
   spy: jest.fn(),
 };
 
-jest.mock('../../hooks/useDebouncedValue', () => ({
-  useDebouncedValue: <Value,>(value: Value) => value,
-}));
-
 jest.mock('../../hooks/useTokenSearch', () => ({
   useTokenSearch: (options: {
     query: string;

--- a/ui/pages/token-management/token-management.tsx
+++ b/ui/pages/token-management/token-management.tsx
@@ -33,6 +33,7 @@ import {
   type Hex,
 } from '@metamask/utils';
 import { ERC20 } from '@metamask/controller-utils';
+import { useDeferredValue } from '../../hooks/useDeferredValue';
 
 import { TokenManagementCell } from '../../components/multichain/token-management-cell';
 import { useI18nContext } from '../../hooks/useI18nContext';
@@ -87,7 +88,6 @@ import { Header } from '../../components/multichain/pages/page';
 import { ASSET_CELL_HEIGHT } from '../../components/app/assets/constants';
 import { HomeNetworkFilterModal } from '../../components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal';
 import { getIsNetworkManagementEnabled } from '../../selectors/multichain/feature-flags';
-import { useDebouncedValue } from '../../hooks/useDebouncedValue';
 import { useTokenSearch } from '../../hooks/useTokenSearch';
 import { type TokenSearchResult } from '../../../shared/lib/token-search/token-search-api';
 import {
@@ -124,7 +124,6 @@ type EvmToken = {
   image?: string;
 };
 
-const SEARCH_DEBOUNCE_MS = 300;
 const TOKEN_MANAGEMENT_PAGE_TOAST_DURATION_MS = 5000;
 const TOKEN_LIST_PAGINATION_THRESHOLD_PX = ASSET_CELL_HEIGHT * 4;
 const EMPTY_TOKEN_SEARCH_RESULTS: TokenSearchResult[] = [];
@@ -628,13 +627,11 @@ export const TokenManagementPage = () => {
     useExternalServices,
   ]);
 
-  const normalizedSearchQuery = searchQuery.trim();
-  const hasQuery = normalizedSearchQuery.length > 0;
-  const debouncedSearchQuery = useDebouncedValue(
-    normalizedSearchQuery,
-    SEARCH_DEBOUNCE_MS,
-  );
-  const tokenSearchQuery = hasQuery ? debouncedSearchQuery : '';
+  const deferredSearchQuery = useDeferredValue(searchQuery);
+  const immediateNormalizedQuery = searchQuery.trim();
+  const deferredNormalizedQuery = deferredSearchQuery.trim();
+  const hasQuery = immediateNormalizedQuery.length > 0;
+  const tokenSearchQuery = hasQuery ? deferredNormalizedQuery : '';
 
   const searchNetworks = useMemo(() => {
     if (enabledCaipChainIds.length === 0) {
@@ -656,11 +653,10 @@ export const TokenManagementPage = () => {
     enableTokenBrowse: !hasQuery,
   });
 
-  const isWaitingForDebounce =
-    hasQuery && normalizedSearchQuery !== debouncedSearchQuery;
+  const isSearchPending = searchQuery !== deferredSearchQuery;
 
   const apiTokenResults = useMemo(() => {
-    if (hasQuery && debouncedSearchQuery.length === 0) {
+    if (hasQuery && deferredNormalizedQuery.length === 0) {
       return EMPTY_TOKEN_SEARCH_RESULTS;
     }
 
@@ -678,15 +674,15 @@ export const TokenManagementPage = () => {
       const reference = getAssetReferenceFromAssetId(result.assetId);
       return reference?.toLowerCase() !== ARC_USDC_TOKEN_ADDRESS;
     });
-  }, [debouncedSearchQuery.length, hasQuery, searchResponse?.data]);
+  }, [deferredNormalizedQuery.length, hasQuery, searchResponse?.data]);
   const searchResults = useMemo(
     () => (hasQuery ? apiTokenResults : EMPTY_TOKEN_SEARCH_RESULTS),
     [apiTokenResults, hasQuery],
   );
   const hasResults = searchResults.length > 0;
   const isSearching =
-    isWaitingForDebounce ||
-    (hasQuery && debouncedSearchQuery.length > 0 && isSearchFetching);
+    isSearchPending ||
+    (hasQuery && deferredNormalizedQuery.length > 0 && isSearchFetching);
   const searchError = searchQueryError;
 
   const importedEvmTokensByChain = useMemo(() => {


### PR DESCRIPTION
## **Description**

Part of epic #6657 (React 18 Concurrent Rendering Adoption). Ticket #7475 consolidates four high-impact search/filter surfaces that previously blocked input responsiveness while expensive filtering, sorting, or API-backed search ran on the critical path.

React 18 is now on main (`chore(6925)`), so this PR uses native `useDeferredValue` rather than timer-based debouncing.

### Problem
- Token management search used `useDebouncedValue` (300ms delay)
- Asset picker modal used lodash debounce (200ms)
- Send asset/NFT and recipient pickers filtered synchronously on every keystroke
- Activity network filtering re-ran merge/query work immediately on every toggle

### Solution
Apply the shared deferred-search pattern:

```tsx
const [query, setQuery] = useState('');
const deferredQuery = useDeferredValue(query);
const isPending = query !== deferredQuery;
// Input binds to query; filtering/API uses deferredQuery
```

**Shared hooks**
- [`ui/hooks/useDeferredValue.ts`](ui/hooks/useDeferredValue.ts) — re-exports React 18 `useDeferredValue`
- [`ui/hooks/useDeferredSearchQuery.ts`](ui/hooks/useDeferredSearchQuery.ts) — query + deferredQuery + isPending bundle

**Surfaces updated**

| Surface | Files |
|---|---|
| Token search | [`token-management.tsx`](ui/pages/token-management/token-management.tsx), [`asset-picker-modal.tsx`](ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.tsx) |
| Transaction filtering | [`activity-list.tsx`](ui/pages/activity/activity-list.tsx), [`activity-v2/activity-list.tsx`](ui/components/multichain/activity-v2/activity-list.tsx), [`useTransactionsQuery.ts`](ui/components/multichain/activity-v2/useTransactionsQuery.ts) |
| NFT search | [`send/asset/asset.tsx`](ui/pages/confirmations/components/send/asset/asset.tsx) |
| Address book search | [`recipient-list/recipient-list.tsx`](ui/pages/confirmations/components/send/recipient-list/recipient-list.tsx) |

Token management retains existing loading UX via `isSearchPending` + `isSearchFetching`.


## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/7475

## **Manual testing steps**

1. Run `yarn start` and load the extension.
2. **Token search:** Settings → Manage tokens. Type quickly in the search field (e.g. `usdc`). Confirm input stays responsive; results update shortly after pausing. Clear search and verify browse mode still loads.
3. **Asset picker search:** Open Send → pick a token. Type in the search field; confirm list filtering does not lag keystrokes.
4. **NFT search:** Send → pick an NFT asset. Search by collection/name; confirm results filter correctly after typing.
5. **Address book search:** Send → open recipient picker. Search contacts by name/address; confirm filtering is correct and input stays responsive.
6. **Activity network filter:** Home → Activity tab. Toggle network filters rapidly; confirm list does not freeze and eventually reflects selected networks.
7. Regression: verify search/filter results match pre-change behavior (same tokens, contacts, and transactions shown for the same query/filter).

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

Not required — no visual UI changes; perf/responsiveness improvement only.

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only responsiveness and timing changes; no auth or persistence logic. Deferred updates may fire API/search slightly differently than fixed debounce windows, so regression-test search and activity network filters.
> 
> **Overview**
> Replaces timer-based debouncing and synchronous filter work with React 18 **`useDeferredValue`** so typing and network toggles stay on the urgent render path while list filtering, merges, and API-backed search catch up later.
> 
> Adds **`useDeferredValue`** (re-export) and **`useDeferredSearchQuery`** (`query`, `deferredQuery`, `isPending`). **Token management** drops **`useDebouncedValue`** (300ms) for deferred search plus **`isSearchPending`** in loading UX. **Asset picker modal** removes lodash **`debounce`** (200ms) in favor of deferred search for token list filtering. **Send** asset and **recipient** pickers filter on the deferred query via **`useDeferredSearchQuery`**. **Activity** (v1 and v2) defers enabled-network selection for transaction filtering and **`useTransactionsQuery`** EVM network params.
> 
> Tests cover the new hooks; asset-picker and token-management tests no longer mock debounce helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c6b36e567450d17c035bf6cde3225933b366cbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->