### PR TITLE
fix(sentry): Resolve `AggregatedBalanceSelector` transaction volume spike by not passing `trace` into `getAggregatedBalanceForAccount` cp-13.40.0

### DIFF
--- a/ui/selectors/assets.balance-utils.test.ts
+++ b/ui/selectors/assets.balance-utils.test.ts
@@ -96,24 +96,25 @@ describe('calculateBalanceForAllWallets', () => {
     expect(mockGetAggregatedBalanceForAccount).not.toHaveBeenCalled();
   });
 
-  it('forwards the optional trace callback to the aggregation selector', () => {
+  it('does not pass a trace callback to the aggregation selector', () => {
     mockGetAggregatedBalanceForAccount.mockReturnValue({
       entries: [],
       totalBalanceInFiat: 1,
       pricePercentChange1d: 0,
     });
-    const trace = jest.fn();
 
     calculateBalanceForAllWallets(
       assetsControllerState,
       accountTreeState,
       accountsById,
       undefined,
-      trace as never,
     );
 
-    // 7th positional argument of getAggregatedBalanceForAccount is the trace.
-    expect(mockGetAggregatedBalanceForAccount.mock.calls[0][6]).toBe(trace);
+    // This runs inside a Redux selector that recomputes per account group on
+    // every state change, so tracing it emits an unbounded number of
+    // transaction roots (#44447). The 7th positional argument of
+    // `getAggregatedBalanceForAccount` is the trace.
+    expect(mockGetAggregatedBalanceForAccount.mock.calls[0][6]).toBeUndefined();
   });
 });
 

--- a/ui/selectors/assets.balance-utils.ts
+++ b/ui/selectors/assets.balance-utils.ts
@@ -1,5 +1,4 @@
 import type { AccountTreeControllerState } from '@metamask/account-tree-controller';
-import type { TraceCallback } from '@metamask/controller-utils';
 import {
   getAggregatedBalanceForAccount,
   type AccountsById,
@@ -33,7 +32,6 @@ function aggregateGroupBalance(
   accountsById: AccountsById,
   enabledNetworkMap: EnabledNetworkMap,
   accountIds: string[],
-  trace?: TraceCallback,
 ): { totalBalanceInFiat: number; pricePercentChange1d: number } {
   if (accountIds.length === 0) {
     return { totalBalanceInFiat: 0, pricePercentChange1d: 0 };
@@ -45,6 +43,9 @@ function aggregateGroupBalance(
   const placeholderAccount = accountsById[accountIds[0]] ?? {
     id: accountIds[0],
   };
+  // Do not pass the optional `trace` callback. This runs inside a Redux
+  // selector that recomputes per account group on every state change, so
+  // tracing it emits an unbounded number of transaction roots (#44447).
   const { totalBalanceInFiat = 0, pricePercentChange1d = 0 } =
     getAggregatedBalanceForAccount(
       assetsControllerState,
@@ -53,7 +54,6 @@ function aggregateGroupBalance(
       undefined,
       accountIds,
       accountsById,
-      trace,
     );
   return { totalBalanceInFiat, pricePercentChange1d };
 }
@@ -107,7 +107,6 @@ function buildBalanceChangeResult(
  * @param accountTreeState - AccountTreeController state.
  * @param accountsById - Internal accounts keyed by account id.
  * @param enabledNetworkMap - Map of enabled networks keyed by namespace.
- * @param trace - Optional trace callback forwarded to the aggregation selector.
  * @returns Aggregated balances for all wallets and groups.
  */
 export function calculateBalanceForAllWallets(
@@ -115,7 +114,6 @@ export function calculateBalanceForAllWallets(
   accountTreeState: AccountTreeControllerState,
   accountsById: AccountsById,
   enabledNetworkMap: EnabledNetworkMap,
-  trace?: TraceCallback,
 ): AllWalletsBalance {
   const userCurrency = assetsControllerState.selectedCurrency ?? 'usd';
   const wallets: AllWalletsBalance['wallets'] = {};
@@ -138,7 +136,6 @@ export function calculateBalanceForAllWallets(
         accountsById,
         enabledNetworkMap,
         accountIds,
-        trace,
       );
 
       walletBalance.groups[groupId] = {
@@ -164,7 +161,6 @@ export function calculateBalanceChangeForAccountGroup(
   enabledNetworkMap: EnabledNetworkMap,
   groupId: string,
   period: BalanceChangePeriod,
-  trace?: TraceCallback,
 ): BalanceChangeResult {
   const userCurrency = assetsControllerState.selectedCurrency ?? 'usd';
   const accountIds = getAccountIdsForGroup(accountTreeState, groupId);
@@ -173,7 +169,6 @@ export function calculateBalanceChangeForAccountGroup(
     accountsById,
     enabledNetworkMap,
     accountIds,
-    trace,
   );
 
   const { current, previous } = getCurrentAndPrevious(

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -89,7 +89,6 @@ import {
   getTokensControllerAllIgnoredTokens,
   getTokensControllerAllTokens,
 } from '../../shared/lib/selectors/assets-migration';
-import { traceAsControllerCallback } from '../../shared/lib/trace';
 import { getSelectedInternalAccount } from '../../shared/lib/selectors/accounts';
 import { getPreferences } from '../../shared/lib/selectors/preferences';
 import { augmentAssetControllersState } from '../components/app/assets/enablement/arc';
@@ -908,7 +907,6 @@ export const selectBalanceForAllWallets = createSelector(
         accountTreeState,
         accountsById,
         enabledNetworkMap,
-        traceAsControllerCallback,
       );
     }
     return calculateBalanceForAllWallets(
@@ -979,7 +977,6 @@ export const selectBalanceChangeBySelectedAccountGroup = (
           enabledNetworkMap,
           groupId,
           period,
-          traceAsControllerCallback,
         );
       }
       return calculateBalanceChangeForAccountGroup(


### PR DESCRIPTION
## Motivation

`AggregatedBalanceSelector` accounts for [91% of all Sentry transaction roots](https://metamask.sentry.io/explore/traces/?aggregateField=%7B%22groupBy%22%3A%22transaction%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22count%28span.duration%29%22%5D%7D&environment=production&mode=aggregate&project=273505&sort=-count%28span.duration%29&statsPeriod=7d&query=is_transaction%3Atrue), and is growing as 13.38+ adoption climbs. Accepted transaction volume is holding at approximately 36M per week against a 3.2M per week pre-spike baseline.

`ui/selectors/assets.ts` forwards `traceAsControllerCallback` into `getAggregatedBalanceForAccount` through the `assets.balance-utils` helpers. That function runs inside a Redux selector, so it recomputes per account group on every relevant state change and re-render. Each computation emits a forced transaction root (`span.op: custom`), with no sample gate.

The same callback was removed from `assets-controller-init.ts` in #43213. That fix covered the controller entry point. The selector entry point, introduced by the same upstream changeset ([MetaMask/core#8310](https://github.com/MetaMask/core/pull/8310)), was not covered, and reached production in 13.38.0 via #43635.

`AggregatedBalanceSelector` is the only one of the seven traces added by core#8310 that is still emitting. The other six route through the controller callback removed in #43213 and are already at zero, so this call site closes core#8310 entirely.

## Description

This commit removes `traceAsControllerCallback` from the two call sites in `ui/selectors/assets.ts` that forward it into the unified balance selectors, along with the now-unused import.

The optional `trace` parameters are also removed from `aggregateGroupBalance`, `calculateBalanceForAllWallets`, and `calculateBalanceChangeForAccountGroup` in `ui/selectors/assets.balance-utils.ts`. Leaving them in place would allow the callback to be reintroduced by supplying a single argument, which is how it arrived in the first place. The test that asserted trace forwarding is inverted into a regression test asserting no trace is passed.

## Test plan

- [x] `eslint` passes on all three touched files
- [x] `tsc --noEmit` reports no errors in the touched files
- [x] `ui/selectors/assets.test.ts` and `ui/selectors/assets.balance-utils.test.ts` pass (71 tests)
- [ ] After release, [`AggregatedBalanceSelector` volume](https://metamask.sentry.io/explore/traces/?aggregateField=%7B%22groupBy%22%3A%22release%22%7D&aggregateField=%7B%22yAxes%22%3A%5B%22count%28span.duration%29%22%5D%7D&environment=production&mode=aggregate&project=273505&sort=-count%28span.duration%29&statsPeriod=30d&query=transaction%3AAggregatedBalanceSelector) drops to approximately zero on the fixed release

## Changelog

CHANGELOG entry: null

## References

Fixes #44447
Related: #43211, #43213, #43370, [MetaMask/core#8310](https://github.com/MetaMask/core/pull/8310)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only change; balance math and selector inputs are unchanged aside from omitting the optional trace argument.
> 
> **Overview**
> Stops **Sentry transaction roots** from `AggregatedBalanceSelector` by no longer forwarding `traceAsControllerCallback` into unified wallet and account-group balance calculations.
> 
> `ui/selectors/assets.ts` drops the trace import and stops passing a callback into `calculateBalanceForAllWallets` and `calculateBalanceChangeForAccountGroup` when assets-unify state is enabled. In `assets.balance-utils.ts`, optional `trace` parameters are removed end-to-end so `getAggregatedBalanceForAccount` is never given a trace callback from this Redux path (which recomputes per group on every relevant state change). The unit test now asserts the 7th argument to the aggregator stays **undefined** instead of expecting trace forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c781a10cca2c3f1ec700d7fa9ddae156619b19dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->