### PR TITLE
fix: align LavaMoat development module graph

### DIFF
--- a/development/webpack/webpack.config.ts
+++ b/development/webpack/webpack.config.ts
@@ -57,6 +57,7 @@ const nodeModules = join(__dirname, '../../node_modules');
 const root = join(context, '..');
 const isDevelopment = args.mode === MODES.DEVELOPMENT;
 const isDevelopmentWatchMode = isDevelopment && args.watch;
+const useOptimizedModuleGraph = !isDevelopment || args.lavamoat;
 const MANIFEST_VERSION = args.manifestVersion;
 const browsersListPath = join(root, '.browserslistrc');
 // read .browserslist now to stop it from searching for the file over and over
@@ -598,12 +599,13 @@ const config = {
     global: true,
   },
   optimization: {
-    // only enable sideEffects, providedExports, removeAvailableModules, and
-    // usedExports for production, as these options slow down the build
-    sideEffects: !isDevelopment,
-    providedExports: !isDevelopment,
+    // Enable tree shaking for production and LavaMoat builds. LavaMoat
+    // policies are generated from the optimized production graph, so LavaMoat
+    // development builds must use the same graph.
+    sideEffects: useOptimizedModuleGraph,
+    providedExports: useOptimizedModuleGraph,
     removeAvailableModules: !isDevelopment,
-    usedExports: !isDevelopment,
+    usedExports: useOptimizedModuleGraph,
     // 'deterministic' results in faster recompilations in cases where a child
     // chunk changes, but the parent chunk does not.
     moduleIds: 'deterministic',


### PR DESCRIPTION
## **Description**

Stacked on #44456. Enable `sideEffects`, `providedExports`, and `usedExports` for LavaMoat development builds so policy analysis sees the same optimized module graph used for production policy generation. `removeAvailableModules` remains production-only.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Parent PR: #44456

## **Manual testing steps**

1. Build and load the Chrome MV3 development extension with LavaMoat enabled.
2. Open the extension service-worker console.
3. Verify the service worker starts and the extension unlocks without LavaMoat policy errors.

<!-- ## **Screenshots/Recordings**: Not applicable; build configuration only. -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.