### PR TITLE
chore: tiny header adjustments on new bottom nav pages

### DIFF
--- a/ui/pages/activity/activity-page.tsx
+++ b/ui/pages/activity/activity-page.tsx
@@ -14,8 +14,8 @@ export const ActivityPage = () => {
     <Page data-testid="activity-page">
       <Text
         variant={TextVariant.HeadingLg}
-        fontWeight={FontWeight.Medium}
-        className="pt-6 px-4 pb-2"
+        fontWeight={FontWeight.Bold}
+        className="pt-4 px-4 pb-2"
       >
         {t('activity')}
       </Text>

--- a/ui/pages/perps/perps-home-page.tsx
+++ b/ui/pages/perps/perps-home-page.tsx
@@ -13,8 +13,8 @@ export const PerpsHomePage = () => {
     <Page data-testid="perps-home-page">
       <Text
         variant={TextVariant.HeadingLg}
-        fontWeight={FontWeight.Medium}
-        className="pt-6 px-4 pb-2"
+        fontWeight={FontWeight.Bold}
+        className="pt-4 px-4 pb-2"
       >
         {t('perps')}
       </Text>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Tiny style adjustments to the new header on Activity and Perps pages that will be shown when the bottom nav bar experiment is on. No change to current UI.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. In `useBottomNavBar` return `true`
2. Click into Perps and Activity from the bottom bar and see the page styles

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

Activity page:
<img width="492" height="235" alt="image" src="https://github.com/user-attachments/assets/dcb2c5a4-3220-4024-966e-68bcc15fd42d" />

Perps page:
<img width="494" height="188" alt="image" src="https://github.com/user-attachments/assets/be7c5a0c-d2cd-4e6a-9b85-4fa6dcb4275a" />


### **After**

Activity page:
<img width="492" height="207" alt="image" src="https://github.com/user-attachments/assets/5ae1e97e-b1d6-4f13-af73-17a0fcebb499" />


Perps page:
<img width="492" height="185" alt="image" src="https://github.com/user-attachments/assets/18f4aec1-19a2-4404-a845-63aba22c23a4" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic header styling only; no logic, routing, or data changes.
> 
> **Overview**
> Aligns the **Activity** and **Perps** bottom-nav tab headers with updated typography and spacing when the bottom navigation experiment is enabled.
> 
> On both pages, the title `Text` now uses **`FontWeight.Bold`** instead of **Medium**, and top padding is tightened from **`pt-6`** to **`pt-4`** (horizontal and bottom padding unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dd32dc06b513b5a79f90474e481fedff457f19e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->