### PR TITLE
chore: bump `@metamask/core-backend`

### DIFF
--- a/app/scripts/messenger-client-init/messengers/core-backend/account-activity-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/core-backend/account-activity-service-messenger.ts
@@ -26,8 +26,7 @@ export function getAccountActivityServiceMessenger(
   messenger.delegate({
     messenger: serviceMessenger,
     actions: [
-      'AccountsController:getSelectedAccount',
-      'AccountsController:listMultichainAccounts',
+      'AccountTreeController:getAccountsFromSelectedAccountGroup',
       'BackendWebSocketService:connect',
       'BackendWebSocketService:forceReconnection',
       'BackendWebSocketService:subscribe',
@@ -37,10 +36,12 @@ export function getAccountActivityServiceMessenger(
       'BackendWebSocketService:findSubscriptionsByChannelPrefix',
       'BackendWebSocketService:addChannelCallback',
       'BackendWebSocketService:removeChannelCallback',
+      'RemoteFeatureFlagController:getState',
     ],
     events: [
-      'AccountsController:selectedAccountChange',
+      'AccountTreeController:selectedAccountGroupChange',
       'BackendWebSocketService:connectionStateChanged',
+      'RemoteFeatureFlagController:stateChange',
     ],
   });
   return serviceMessenger;

--- a/app/scripts/messenger-client-init/messengers/core-backend/account-activity-service-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/core-backend/account-activity-service-messenger.ts
@@ -27,6 +27,7 @@ export function getAccountActivityServiceMessenger(
     messenger: serviceMessenger,
     actions: [
       'AccountsController:getSelectedAccount',
+      'AccountsController:listMultichainAccounts',
       'BackendWebSocketService:connect',
       'BackendWebSocketService:forceReconnection',
       'BackendWebSocketService:subscribe',

--- a/package.json
+++ b/package.json
@@ -314,7 +314,7 @@
     "@metamask/assets-controller@npm:^9.1.0": "^10.1.0",
     "@metamask/messenger": "^2.0.0",
     "@metamask/network-enablement-controller@npm:^5.4.1": "patch:@metamask/network-enablement-controller@npm%3A5.4.1#~/.yarn/patches/@metamask-network-enablement-controller-npm-5.4.1-020a82a308.patch",
-    "@metamask/core-backend": "npm:@metamask-previews/core-backend@6.5.0-preview-42cce76ad"
+    "@metamask/core-backend": "npm:@metamask-previews/core-backend@6.5.0-preview-c6818385b"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.29.2#~/.yarn/patches/@babel-runtime-npm-7.29.2-b49cad1c67.patch",

--- a/package.json
+++ b/package.json
@@ -313,7 +313,8 @@
     "@pmmmwh/react-refresh-webpack-plugin@npm:^0.5.11": "patch:@pmmmwh/react-refresh-webpack-plugin@npm%3A0.5.13#~/.yarn/patches/@pmmmwh-react-refresh-webpack-plugin-npm-0.5.13-25d13d4186.patch",
     "@metamask/assets-controller@npm:^9.1.0": "^10.1.0",
     "@metamask/messenger": "^2.0.0",
-    "@metamask/network-enablement-controller@npm:^5.4.1": "patch:@metamask/network-enablement-controller@npm%3A5.4.1#~/.yarn/patches/@metamask-network-enablement-controller-npm-5.4.1-020a82a308.patch"
+    "@metamask/network-enablement-controller@npm:^5.4.1": "patch:@metamask/network-enablement-controller@npm%3A5.4.1#~/.yarn/patches/@metamask-network-enablement-controller-npm-5.4.1-020a82a308.patch",
+    "@metamask/core-backend": "npm:@metamask-previews/core-backend@6.5.0-preview-42cce76ad"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.29.2#~/.yarn/patches/@babel-runtime-npm-7.29.2-b49cad1c67.patch",

--- a/package.json
+++ b/package.json
@@ -314,7 +314,7 @@
     "@metamask/assets-controller@npm:^9.1.0": "^10.1.0",
     "@metamask/messenger": "^2.0.0",
     "@metamask/network-enablement-controller@npm:^5.4.1": "patch:@metamask/network-enablement-controller@npm%3A5.4.1#~/.yarn/patches/@metamask-network-enablement-controller-npm-5.4.1-020a82a308.patch",
-    "@metamask/core-backend": "npm:@metamask-previews/core-backend@6.5.0-preview-c6818385b"
+    "@metamask/core-backend": "npm:@metamask-previews/core-backend@6.5.0-preview-6756b9ebc"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.29.2#~/.yarn/patches/@babel-runtime-npm-7.29.2-b49cad1c67.patch",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6022,20 +6022,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/core-backend@npm:@metamask-previews/core-backend@6.5.0-preview-42cce76ad":
-  version: 6.5.0-preview-42cce76ad
-  resolution: "@metamask-previews/core-backend@npm:6.5.0-preview-42cce76ad"
+"@metamask/core-backend@npm:@metamask-previews/core-backend@6.5.0-preview-c6818385b":
+  version: 6.5.0-preview-c6818385b
+  resolution: "@metamask-previews/core-backend@npm:6.5.0-preview-c6818385b"
   dependencies:
-    "@metamask/accounts-controller": "npm:^39.0.5"
+    "@metamask/account-tree-controller": "npm:^7.5.5"
     "@metamask/controller-utils": "npm:^12.3.0"
     "@metamask/keyring-controller": "npm:^27.1.0"
     "@metamask/messenger": "npm:^2.0.0"
     "@metamask/profile-sync-controller": "npm:^28.3.0"
+    "@metamask/remote-feature-flag-controller": "npm:^4.2.2"
     "@metamask/utils": "npm:^11.11.0"
     "@tanstack/query-core": "npm:^5.62.16"
     async-mutex: "npm:^0.5.0"
     uuid: "npm:^8.3.2"
-  checksum: 10/2b11085c3d1df1302a1cfa451cdb169b1106ed59098dd5fe119833dcfd5555dfd391bd5614c12ecc6135390d67cab605190dc1fe2c7553ea588c46640b8ba4f9
+  checksum: 10/122f2676ba02fe5135b5808d4817a0016353c4e1ef412ad21447c4d860645cadff14468757552f8d719f2041e90c72e58d026d10efe7f58ef007106abdbfd44a
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6022,20 +6022,20 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/core-backend@npm:^6.2.1, @metamask/core-backend@npm:^6.2.2, @metamask/core-backend@npm:^6.4.0, @metamask/core-backend@npm:^6.5.0":
-  version: 6.5.0
-  resolution: "@metamask/core-backend@npm:6.5.0"
+"@metamask/core-backend@npm:@metamask-previews/core-backend@6.5.0-preview-42cce76ad":
+  version: 6.5.0-preview-42cce76ad
+  resolution: "@metamask-previews/core-backend@npm:6.5.0-preview-42cce76ad"
   dependencies:
-    "@metamask/accounts-controller": "npm:^39.0.4"
+    "@metamask/accounts-controller": "npm:^39.0.5"
     "@metamask/controller-utils": "npm:^12.3.0"
     "@metamask/keyring-controller": "npm:^27.1.0"
-    "@metamask/messenger": "npm:^1.2.0"
-    "@metamask/profile-sync-controller": "npm:^28.2.0"
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/profile-sync-controller": "npm:^28.3.0"
     "@metamask/utils": "npm:^11.11.0"
     "@tanstack/query-core": "npm:^5.62.16"
     async-mutex: "npm:^0.5.0"
     uuid: "npm:^8.3.2"
-  checksum: 10/d728bd8db6f832b479811288f00b8f2fd78561d42046ee08ceee6068632e72bcf2fdd229f3a7077518a2766f9eacef14b3e224dc0bdcc27d3cd5d2f6d81eb55c
+  checksum: 10/2b11085c3d1df1302a1cfa451cdb169b1106ed59098dd5fe119833dcfd5555dfd391bd5614c12ecc6135390d67cab605190dc1fe2c7553ea588c46640b8ba4f9
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6022,9 +6022,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/core-backend@npm:@metamask-previews/core-backend@6.5.0-preview-c6818385b":
-  version: 6.5.0-preview-c6818385b
-  resolution: "@metamask-previews/core-backend@npm:6.5.0-preview-c6818385b"
+"@metamask/core-backend@npm:@metamask-previews/core-backend@6.5.0-preview-6756b9ebc":
+  version: 6.5.0-preview-6756b9ebc
+  resolution: "@metamask-previews/core-backend@npm:6.5.0-preview-6756b9ebc"
   dependencies:
     "@metamask/account-tree-controller": "npm:^7.5.5"
     "@metamask/controller-utils": "npm:^12.3.0"
@@ -6036,7 +6036,7 @@ __metadata:
     "@tanstack/query-core": "npm:^5.62.16"
     async-mutex: "npm:^0.5.0"
     uuid: "npm:^8.3.2"
-  checksum: 10/122f2676ba02fe5135b5808d4817a0016353c4e1ef412ad21447c4d860645cadff14468757552f8d719f2041e90c72e58d026d10efe7f58ef007106abdbfd44a
+  checksum: 10/d7f24cf5871730b6c353937921e775586b4062732aeaf7fb5eae1b9509adde0251224a9c6e6149a02649f4ddddb910c5a90d3874afe5b737372da22039428c91
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Using preview build from https://github.com/MetaMask/core/pull/9531
```markdown
## [Unreleased]

### Changed

- **BREAKING:** `AccountActivityService` now determines which non-EVM chains to subscribe to from remote feature flags instead of a bundled list ([#9379](https://github.com/MetaMask/core/pull/9379))
  - The `AccountActivityServiceMessenger` now requires the following delegate actions and events:
    - `RemoteFeatureFlagController:getState` action and `RemoteFeatureFlagController:stateChange` event
    - `AccountTreeController:getAccountsFromSelectedAccountGroup` action and `AccountTreeController:selectedAccountGroupChange` event
  - EVM (`eip155`) subscriptions are always enabled. Solana, Tron, and Stellar subscriptions are enabled when the corresponding `networkAssetsSnapsMigrationSolana` / `networkAssetsSnapsMigrationTron` / `networkAssetsSnapsMigrationStellar` feature flag has `stage >= 1`, and disabled otherwise.
  - Accounts whose scopes do not match an enabled chain are no longer subscribed at all.
  - When the enabled chains change via a feature flag update while the websocket is connected, the service automatically resubscribes the selected account.
- **BREAKING:** `AccountActivityService.subscribe` and `AccountActivityService.unsubscribe` now require a `{ addresses: string[] }` argument ([#9531](https://github.com/MetaMask/core/pull/9531))
  - Previously, the service only allowed a single address to be subscribed and unsubscribed at a time.
- Add `@metamask/remote-feature-flag-controller` `^4.2.2` as a dependency ([#9379](https://github.com/MetaMask/core/pull/9379))
- Bump `@metamask/messenger` from `^1.2.0` to `^2.0.0` ([#9392](https://github.com/MetaMask/core/pull/9392))
- Bump `@metamask/profile-sync-controller` from `^28.2.0` to `^28.3.0` ([#9463](https://github.com/MetaMask/core/pull/9463))

### Fixed

- `AccountActivityService` subscribes to all supported scopes for a given account ([#9379](https://github.com/MetaMask/core/pull/9379))

```

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
