### PR TITLE
test(storage): storage-corruption reproduction experiments

### DIFF
--- a/app/service-worker.ts
+++ b/app/service-worker.ts
@@ -10,11 +10,9 @@ const { chrome } = globalThis;
 // TEMPORARY storage-corruption investigation helpers (do not ship).
 //
 // These helpers target `chrome.storage.local`, which is where MetaMask's real
-// persisted state lives (via ExtensionStore -> PersistenceManager). An earlier
-// version of this experiment targeted `chrome.storage.session`, which is the
-// wrong surface: session storage is in-memory and is intentionally cleared on
-// extension reload, so it can never reproduce the "corrupted/missing/damaged"
-// reports, which are all about the on-disk `local` (LevelDB) database.
+// persisted state lives (via ExtensionStore -> PersistenceManager). The
+// "corrupted/missing/damaged" reports are all about that on-disk `local`
+// (LevelDB) database.
 //
 // Note on what this can and cannot prove: `chrome.storage.local.set()` hands the
 // payload to the browser process over IPC; the actual disk commit runs off the

--- a/app/service-worker.ts
+++ b/app/service-worker.ts
@@ -6,6 +6,269 @@ import { ExtensionLazyListener } from './scripts/lib/extension-lazy-listener/ext
 
 const { chrome } = globalThis;
 
+// ---------------------------------------------------------------------------
+// TEMPORARY storage-corruption investigation helpers (do not ship).
+//
+// These helpers target `chrome.storage.local`, which is where MetaMask's real
+// persisted state lives (via ExtensionStore -> PersistenceManager). An earlier
+// version of this experiment targeted `chrome.storage.session`, which is the
+// wrong surface: session storage is in-memory and is intentionally cleared on
+// extension reload, so it can never reproduce the "corrupted/missing/damaged"
+// reports, which are all about the on-disk `local` (LevelDB) database.
+//
+// Note on what this can and cannot prove: `chrome.storage.local.set()` hands the
+// payload to the browser process over IPC; the actual disk commit runs off the
+// service-worker JS thread. Chrome will not terminate a service worker with an
+// in-flight extension-API write at an unsafe point. So blocking the JS thread
+// and killing the SW does NOT tear a single `set` in half. These helpers exist
+// mainly to (a) measure the correct storage area and (b) probe QUOTA / disk
+// pressure, which is a genuine, reproducible loss vector (FILE_ERROR_NO_SPACE).
+// ---------------------------------------------------------------------------
+
+const DEBUG_STORAGE_WRITE_PAYLOAD_SIZE = 256 * 1024;
+const DEBUG_STORAGE_WRITE_BLOCK_AFTER_DISPATCH_MS = 15_000;
+
+type DebugSlowStorageWriteOptions = {
+  blockAfterDispatchMs?: number;
+  id?: string;
+  payloadSize?: number;
+};
+
+type DebugSlowStorageWriteResult = {
+  id: string;
+  keys: {
+    sentinel: string;
+    payload: string;
+    metadata: string;
+  };
+};
+
+type DebugFillStorageQuotaOptions = {
+  chunkSizeBytes?: number;
+  maxChunks?: number;
+};
+
+type DebugFillStorageQuotaResult = {
+  chunksWritten: number;
+  approxBytesWritten: number;
+  failedAtChunk: number | null;
+  lastError: string | null;
+};
+
+type DebugServiceWorkerGlobal = typeof globalThis & {
+  debugReadSlowStorageWriteExperiment?: (
+    id: string,
+  ) => Promise<Record<string, unknown>>;
+  debugSlowStorageWriteExperiment?: (
+    options?: DebugSlowStorageWriteOptions,
+  ) => DebugSlowStorageWriteResult;
+  debugFillStorageQuotaExperiment?: (
+    options?: DebugFillStorageQuotaOptions,
+  ) => Promise<DebugFillStorageQuotaResult>;
+};
+
+function blockServiceWorker(ms: number) {
+  const start = performance.now();
+
+  while (performance.now() - start < ms) {
+    // Keep the service worker JS thread busy so the storage callback cannot run.
+  }
+}
+
+function getDebugStorageKeys(id: string) {
+  return {
+    sentinel: `debugSlowStorageWrite:${id}:sentinel`,
+    payload: `debugSlowStorageWrite:${id}:payload`,
+    metadata: `debugSlowStorageWrite:${id}:metadata`,
+  };
+}
+
+function summarizeDebugStorageRead(
+  id: string,
+  result: Record<string, unknown>,
+) {
+  const keys = getDebugStorageKeys(id);
+  const storedPayload = result[keys.payload];
+  const storedMetadata = result[keys.metadata];
+
+  return {
+    id,
+    keysPresent: Object.keys(result),
+    expectedKeys: Object.values(keys),
+    hasSentinel: keys.sentinel in result,
+    hasPayload: keys.payload in result,
+    hasMetadata: keys.metadata in result,
+    payloadLength:
+      typeof storedPayload === 'string' ? storedPayload.length : undefined,
+    metadata:
+      storedMetadata && typeof storedMetadata === 'object'
+        ? storedMetadata
+        : undefined,
+  };
+}
+
+function readDebugStorageKeys(id: string): Promise<Record<string, unknown>> {
+  const keys = getDebugStorageKeys(id);
+
+  return new Promise((resolve) => {
+    chrome.storage.local.get(Object.values(keys), (result) => {
+      const summary = summarizeDebugStorageRead(id, result);
+
+      console.log('[debugSlowStorageWrite] read summary', summary);
+
+      resolve(result);
+    });
+  });
+}
+
+function runDebugSlowStorageWriteExperiment({
+  blockAfterDispatchMs,
+  id,
+  keys,
+  payloadSize,
+}: DebugSlowStorageWriteResult & Required<DebugSlowStorageWriteOptions>) {
+  const payload = 'x'.repeat(payloadSize);
+  const metadata = {
+    dispatchedAt: new Date().toISOString(),
+    id,
+    payloadLength: payload.length,
+  };
+
+  console.log('[debugSlowStorageWrite] dispatching storage write', {
+    id,
+    keys,
+    payloadSize,
+  });
+
+  chrome.storage.local.set(
+    {
+      [keys.metadata]: metadata,
+      [keys.payload]: payload,
+      [keys.sentinel]: 'written',
+    },
+    () => {
+      console.log('[debugSlowStorageWrite] storage.set callback fired', {
+        id,
+        lastError: chrome.runtime.lastError?.message,
+      });
+
+      readDebugStorageKeys(id).catch(() => undefined);
+    },
+  );
+
+  console.log('[debugSlowStorageWrite] storage.set dispatched', {
+    blockAfterDispatchMs,
+    id,
+    keys,
+    payloadSize,
+  });
+
+  if (blockAfterDispatchMs > 0) {
+    console.log('[debugSlowStorageWrite] blocking service worker', {
+      blockAfterDispatchMs,
+      id,
+    });
+
+    blockServiceWorker(blockAfterDispatchMs);
+
+    console.log('[debugSlowStorageWrite] finished blocking service worker', {
+      blockAfterDispatchMs,
+      id,
+    });
+  }
+}
+
+(globalThis as DebugServiceWorkerGlobal).debugReadSlowStorageWriteExperiment =
+  readDebugStorageKeys;
+
+(globalThis as DebugServiceWorkerGlobal).debugSlowStorageWriteExperiment = ({
+  blockAfterDispatchMs = DEBUG_STORAGE_WRITE_BLOCK_AFTER_DISPATCH_MS,
+  id = `${Date.now()}`,
+  payloadSize = DEBUG_STORAGE_WRITE_PAYLOAD_SIZE,
+}: DebugSlowStorageWriteOptions = {}) => {
+  const keys = getDebugStorageKeys(id);
+  const result = { id, keys };
+
+  console.log('[debugSlowStorageWrite] starting experiment', {
+    blockAfterDispatchMs,
+    id,
+    keys,
+    payloadSize,
+  });
+
+  runDebugSlowStorageWriteExperiment({
+    blockAfterDispatchMs,
+    id,
+    keys,
+    payloadSize,
+  });
+
+  console.log('Debug slow storage write experiment scheduled', result);
+  return result;
+};
+
+// Quota / disk-pressure experiment. Writes ever-larger chunks into
+// `chrome.storage.local` until a `set` fails. The failing `set` reports
+// `chrome.runtime.lastError` (e.g. "QUOTA_BYTES quota exceeded" or
+// "FILE_ERROR_NO_SPACE ..."). This is the realistic mechanism behind
+// StorageWriteErrorType.FileErrorNoSpace and behind the "state stops updating /
+// reverts to older state" class of reports: once a `set` starts failing,
+// PersistenceManager keeps the in-memory state advancing but the disk copy is
+// frozen, so a later reload reads stale/partial data.
+const DEBUG_FILL_CHUNK_SIZE_BYTES = 1024 * 1024; // 1 MiB per chunk
+const DEBUG_FILL_MAX_CHUNKS = 4096;
+
+function setLocal(items: Record<string, unknown>): Promise<string | null> {
+  return new Promise((resolve) => {
+    chrome.storage.local.set(items, () => {
+      resolve(chrome.runtime.lastError?.message ?? null);
+    });
+  });
+}
+
+(globalThis as DebugServiceWorkerGlobal).debugFillStorageQuotaExperiment =
+  async ({
+    chunkSizeBytes = DEBUG_FILL_CHUNK_SIZE_BYTES,
+    maxChunks = DEBUG_FILL_MAX_CHUNKS,
+  }: DebugFillStorageQuotaOptions = {}): Promise<DebugFillStorageQuotaResult> => {
+    const chunk = 'x'.repeat(chunkSizeBytes);
+    let chunksWritten = 0;
+
+    console.log('[debugFillStorageQuota] starting', {
+      chunkSizeBytes,
+      maxChunks,
+    });
+
+    for (let i = 0; i < maxChunks; i++) {
+      const lastError = await setLocal({
+        [`debugFillStorageQuota:${i}`]: chunk,
+      });
+      if (lastError) {
+        const result = {
+          chunksWritten,
+          approxBytesWritten: chunksWritten * chunkSizeBytes,
+          failedAtChunk: i,
+          lastError,
+        };
+        console.warn('[debugFillStorageQuota] write failed', result);
+        return result;
+      }
+      chunksWritten += 1;
+      if (chunksWritten % 16 === 0) {
+        console.log('[debugFillStorageQuota] progress', { chunksWritten });
+      }
+    }
+
+    const result = {
+      chunksWritten,
+      approxBytesWritten: chunksWritten * chunkSizeBytes,
+      failedAtChunk: null,
+      lastError: null,
+    };
+    console.log('[debugFillStorageQuota] completed without failure', result);
+    return result;
+  };
+
 const SAVE_TIMESTAMP_INTERVAL_MS = 2 * 1000;
 
 function saveTimestamp() {

--- a/development/storage-corruption-poc/README.md
+++ b/development/storage-corruption-poc/README.md
@@ -1,0 +1,107 @@
+# Storage-corruption investigation PoCs
+
+Temporary experiments for reproducing the "storage corrupted / missing /
+damaged" bug class (related: MetaMask/metamask-extension#43773). **Do not ship.**
+
+## Why "kill the service worker mid-write" does not reproduce it
+
+The original PoC wrote to `chrome.storage.session` and killed the service
+worker (SW) while its JS thread was blocked. The write always survived. That is
+expected, and it is a negative result, not a repro:
+
+1. **Wrong storage area.** MetaMask's persisted state (vault + controllers)
+   lives in `chrome.storage.local` (see
+   [`shared/lib/stores/extension-store.ts`](../../shared/lib/stores/extension-store.ts),
+   orchestrated by
+   [`persistence-manager.ts`](../../shared/lib/stores/persistence-manager.ts)).
+   `storage.session` is in-memory and is *intentionally* cleared on extension
+   reload — corrupting it tells you nothing about user reports.
+2. **The write isn't on the SW thread.** `storage.*.set()` posts the payload to
+   the browser process over IPC; the disk commit runs there, off the SW JS
+   thread. Chrome will not terminate a SW that has in-flight extension-API I/O
+   at an unsafe point. Blocking the JS thread and killing the SW cannot tear a
+   single `set` in half.
+
+Real corruption comes from the **browser process / disk layer** (crash, power
+loss during LevelDB compaction, aborted fsync, bad sectors, quota/disk-full) or
+from MetaMask's own **multi-step, non-atomic** write logic.
+
+## The three experiments
+
+### 1. `debugFillStorageQuotaExperiment` — quota / disk-full (highest ROI, easiest)
+
+Added to [`app/service-worker.ts`](../../app/service-worker.ts). In the SW
+console:
+
+```ts
+await globalThis.debugFillStorageQuotaExperiment({ chunkSizeBytes: 1048576 });
+```
+
+Writes 1 MiB chunks to `chrome.storage.local` until a `set` fails and reports
+`chrome.runtime.lastError` — `QUOTA_BYTES quota exceeded` or, on a genuinely
+full disk, `FILE_ERROR_NO_SPACE`. This is the mechanism behind
+`StorageWriteErrorType.FileErrorNoSpace` and the "state stops advancing / reverts
+to older state" reports: once `set` fails, `PersistenceManager` keeps the
+in-memory state moving forward while the disk copy is frozen, so a later reload
+reads stale/partial data.
+
+Cleanup:
+
+```ts
+const all = await chrome.storage.local.get(null);
+await chrome.storage.local.remove(
+  Object.keys(all).filter((k) => k.startsWith('debugFillStorageQuota:')),
+);
+```
+
+The same file also contains `debugSlowStorageWriteExperiment` /
+`debugReadSlowStorageWriteExperiment`, ported from `session` to `local` so at
+least they measure the correct surface (still expected to *not* fail on SW kill —
+kept for completeness).
+
+### 2. `corrupt-leveldb.sh` — on-disk LevelDB damage (best fidelity to reports)
+
+Directly damages the LevelDB files that back `storage.local`, simulating a crash
+/ power loss / bad sector. This is the experiment that actually reproduces
+"corrupted/damaged" and exercises the vault-recovery path in
+[`persistence-manager.ts`](../../shared/lib/stores/persistence-manager.ts)
+(`needsVaultRecovery` → IndexedDB backup → `PersistenceError` /
+`vaultCorruptionDetected`).
+
+```bash
+# Fully quit Chrome first, then:
+./corrupt-leveldb.sh list                 # find MetaMask's extension id
+./corrupt-leveldb.sh <ext-id> ldb         # flip bytes in a table file (default)
+./corrupt-leveldb.sh <ext-id> manifest    # unreadable MANIFEST -> open fails
+./corrupt-leveldb.sh <ext-id> truncate    # truncate WAL -> lost tail (power loss)
+./corrupt-leveldb.sh <ext-id> wipe-current # empty CURRENT -> hard open failure
+./corrupt-leveldb.sh restore <ext-id>      # restore from the auto-backup
+```
+
+Each run backs the DB up first. Reopen Chrome and watch the SW console and
+Sentry breadcrumbs for the `persistence.error` tags.
+
+### 3. `__DEBUG_STORAGE_FAULT_GAP_MS__` — the non-atomic `set`→`remove` gap
+
+`ExtensionStore.setKeyValues` writes new keys + manifest in one `local.set`, then
+deletes removed keys in a *separate* `local.remove`. Those two ops are not atomic
+with respect to each other. The hook in
+[`extension-store.ts`](../../shared/lib/stores/extension-store.ts) pauses between
+them when a global is set:
+
+```ts
+// in the SW console, before triggering a write that deletes keys
+// (e.g. a split-state migration or a controller that clears state):
+globalThis.__DEBUG_STORAGE_FAULT_GAP_MS__ = 20000;
+```
+
+While it's paused (`[ExtensionStore][DEBUG_FAULT] pausing …` in the console),
+kill the process / force-quit Chrome, then reopen and inspect whether the
+manifest and the physical keys agree. Note the failure mode here is *cross-op
+inconsistency* (leftover keys / manifest mismatch), not a torn single write.
+
+## Suggested order
+
+Start with **#2 (`corrupt-leveldb.sh`)** — it is the most faithful reproduction
+of the reports. **#1** is the easiest realistic loss vector. **#3** audits a
+MetaMask-owned correctness gap.

--- a/development/storage-corruption-poc/README.md
+++ b/development/storage-corruption-poc/README.md
@@ -5,22 +5,19 @@ damaged" bug class (related: MetaMask/metamask-extension#43773). **Do not ship.*
 
 ## Why "kill the service worker mid-write" does not reproduce it
 
-The original PoC wrote to `chrome.storage.session` and killed the service
-worker (SW) while its JS thread was blocked. The write always survived. That is
-expected, and it is a negative result, not a repro:
+Blocking the service-worker (SW) JS thread during a `chrome.storage.local` write
+and then killing the SW does not lose or corrupt the write — it survives. That
+is expected, and it is a negative result, not a repro:
 
-1. **Wrong storage area.** MetaMask's persisted state (vault + controllers)
-   lives in `chrome.storage.local` (see
-   [`shared/lib/stores/extension-store.ts`](../../shared/lib/stores/extension-store.ts),
-   orchestrated by
-   [`persistence-manager.ts`](../../shared/lib/stores/persistence-manager.ts)).
-   `storage.session` is in-memory and is *intentionally* cleared on extension
-   reload — corrupting it tells you nothing about user reports.
-2. **The write isn't on the SW thread.** `storage.*.set()` posts the payload to
-   the browser process over IPC; the disk commit runs there, off the SW JS
-   thread. Chrome will not terminate a SW that has in-flight extension-API I/O
-   at an unsafe point. Blocking the JS thread and killing the SW cannot tear a
-   single `set` in half.
+**The write isn't on the SW thread.** `storage.local.set()` posts the payload to
+the browser process over IPC; the disk commit runs there, off the SW JS thread.
+Chrome will not terminate a SW that has in-flight extension-API I/O at an unsafe
+point. Blocking the JS thread and killing the SW cannot tear a single `set` in
+half. (MetaMask's persisted state — vault + controllers — lives in
+`chrome.storage.local`, see
+[`shared/lib/stores/extension-store.ts`](../../shared/lib/stores/extension-store.ts),
+orchestrated by
+[`persistence-manager.ts`](../../shared/lib/stores/persistence-manager.ts).)
 
 Real corruption comes from the **browser process / disk layer** (crash, power
 loss during LevelDB compaction, aborted fsync, bad sectors, quota/disk-full) or
@@ -55,9 +52,9 @@ await chrome.storage.local.remove(
 ```
 
 The same file also contains `debugSlowStorageWriteExperiment` /
-`debugReadSlowStorageWriteExperiment`, ported from `session` to `local` so at
-least they measure the correct surface (still expected to *not* fail on SW kill —
-kept for completeness).
+`debugReadSlowStorageWriteExperiment`, which write and read back keys on
+`chrome.storage.local` (still expected to *not* fail on SW kill — kept for
+completeness).
 
 ### 2. `corrupt-leveldb.sh` — on-disk LevelDB damage (best fidelity to reports)
 

--- a/development/storage-corruption-poc/corrupt-leveldb.sh
+++ b/development/storage-corruption-poc/corrupt-leveldb.sh
@@ -5,7 +5,7 @@
 # MetaMask persists its real state (vault + controller state) to
 # chrome.storage.local, which Chrome backs with a LevelDB database on disk.
 # The "storage corrupted/missing/damaged" bug reports are corruption of THAT
-# database, not of chrome.storage.session and not of an in-flight set() call.
+# database, not of an in-flight set() call.
 #
 # You cannot reproduce this by killing the service worker (a single set() is
 # committed atomically by the browser process, off the SW JS thread). You CAN

--- a/development/storage-corruption-poc/corrupt-leveldb.sh
+++ b/development/storage-corruption-poc/corrupt-leveldb.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+#
+# TEMPORARY storage-corruption investigation tool (do not ship).
+#
+# MetaMask persists its real state (vault + controller state) to
+# chrome.storage.local, which Chrome backs with a LevelDB database on disk.
+# The "storage corrupted/missing/damaged" bug reports are corruption of THAT
+# database, not of chrome.storage.session and not of an in-flight set() call.
+#
+# You cannot reproduce this by killing the service worker (a single set() is
+# committed atomically by the browser process, off the SW JS thread). You CAN
+# reproduce it by damaging the LevelDB files directly, which is what an OS
+# crash, power loss during compaction, bad sector, or aborted fsync effectively
+# does. This script does that in a controlled way so you can then observe how
+# ExtensionStore.get() / PersistenceManager.get() and the vault-recovery path
+# behave.
+#
+# USAGE:
+#   1. Fully QUIT Chrome (not just close the window). LevelDB holds a lock and
+#      buffers writes in memory; tampering while Chrome runs proves nothing.
+#   2. ./corrupt-leveldb.sh <extension-id> [mode]
+#        mode = manifest | ldb | truncate | wipe-current   (default: ldb)
+#   3. Reopen Chrome, open MetaMask, watch the service-worker console.
+#
+# A timestamped backup of the whole LevelDB directory is taken first so you can
+# restore with:  ./corrupt-leveldb.sh restore <extension-id>
+#
+# Only tested on macOS/Linux Chrome "Default" profile. Override the profile with
+# PROFILE_DIR_OVERRIDE=".../Profile 1" for other profiles/channels.
+
+set -euo pipefail
+
+# --- locate the storage directory -----------------------------------------
+
+case "$(uname -s)" in
+  Darwin)
+    PROFILE_DIR="${HOME}/Library/Application Support/Google/Chrome/Default"
+    ;;
+  Linux)
+    PROFILE_DIR="${HOME}/.config/google-chrome/Default"
+    ;;
+  *)
+    echo "Unsupported OS. Set PROFILE_DIR_OVERRIDE manually." >&2
+    exit 1
+    ;;
+esac
+
+PROFILE_DIR="${PROFILE_DIR_OVERRIDE:-$PROFILE_DIR}"
+
+usage() {
+  echo "Usage: $0 <extension-id> [manifest|ldb|truncate|wipe-current]" >&2
+  echo "       $0 restore <extension-id>" >&2
+  echo "       $0 list" >&2
+  exit 1
+}
+
+[ $# -ge 1 ] || usage
+
+# --- list mode: help find the extension id ---------------------------------
+
+if [ "$1" = "list" ]; then
+  echo "Extensions with a Local Extension Settings LevelDB under:"
+  echo "  ${PROFILE_DIR}/Local Extension Settings"
+  ls -1 "${PROFILE_DIR}/Local Extension Settings" 2>/dev/null || \
+    echo "  (none found)"
+  exit 0
+fi
+
+# --- restore mode ----------------------------------------------------------
+
+if [ "$1" = "restore" ]; then
+  [ $# -eq 2 ] || usage
+  EXT_ID="$2"
+  DB_DIR="${PROFILE_DIR}/Local Extension Settings/${EXT_ID}"
+  LATEST_BACKUP=$(ls -1dt "${DB_DIR}".backup.* 2>/dev/null | head -n1 || true)
+  if [ -z "${LATEST_BACKUP}" ]; then
+    echo "No backup found for ${EXT_ID}" >&2
+    exit 1
+  fi
+  rm -rf "${DB_DIR}"
+  cp -R "${LATEST_BACKUP}" "${DB_DIR}"
+  echo "Restored ${DB_DIR} from ${LATEST_BACKUP}"
+  exit 0
+fi
+
+# --- corrupt mode ----------------------------------------------------------
+
+EXT_ID="$1"
+MODE="${2:-ldb}"
+DB_DIR="${PROFILE_DIR}/Local Extension Settings/${EXT_ID}"
+
+if [ ! -d "${DB_DIR}" ]; then
+  echo "LevelDB dir not found: ${DB_DIR}" >&2
+  echo "Run '$0 list' to see available extension ids." >&2
+  exit 1
+fi
+
+# Refuse to run if Chrome still holds the LevelDB lock.
+if [ -f "${DB_DIR}/LOCK" ] && command -v lsof >/dev/null 2>&1; then
+  if lsof "${DB_DIR}/LOCK" >/dev/null 2>&1; then
+    echo "Chrome appears to still hold ${DB_DIR}/LOCK. Quit Chrome first." >&2
+    exit 1
+  fi
+fi
+
+STAMP="$(date +%Y%m%d-%H%M%S)"
+BACKUP="${DB_DIR}.backup.${STAMP}"
+cp -R "${DB_DIR}" "${BACKUP}"
+echo "Backed up to ${BACKUP}"
+
+corrupt_manifest() {
+  # LevelDB refuses to open if the MANIFEST is unreadable -> get() throws ->
+  # PersistenceManager treats it as InaccessibleDatabase and attempts recovery
+  # from the IndexedDB backup.
+  local manifest
+  manifest=$(ls -1 "${DB_DIR}"/MANIFEST-* 2>/dev/null | head -n1 || true)
+  [ -n "${manifest}" ] || { echo "No MANIFEST found" >&2; exit 1; }
+  dd if=/dev/urandom of="${manifest}" bs=1 count=64 seek=16 conv=notrunc \
+    status=none
+  echo "Corrupted MANIFEST: ${manifest}"
+}
+
+corrupt_ldb() {
+  # Flip bytes inside a .ldb table file. Depending on where the vault lives,
+  # this yields either a read error or silently missing/garbled keys.
+  local table
+  table=$(ls -1 "${DB_DIR}"/*.ldb 2>/dev/null | head -n1 || true)
+  if [ -z "${table}" ]; then
+    echo "No .ldb table files yet (data may still be in the .log WAL)."
+    table=$(ls -1 "${DB_DIR}"/*.log 2>/dev/null | head -n1 || true)
+    [ -n "${table}" ] || { echo "No .ldb or .log files found" >&2; exit 1; }
+    echo "Falling back to WAL file: ${table}"
+  fi
+  dd if=/dev/urandom of="${table}" bs=1 count=128 seek=32 conv=notrunc \
+    status=none
+  echo "Corrupted table/WAL: ${table}"
+}
+
+corrupt_truncate() {
+  # Simulate an interrupted fsync / power loss mid-write: truncate the newest
+  # .log (write-ahead log) so the tail of the last transaction is lost.
+  local wal
+  wal=$(ls -1t "${DB_DIR}"/*.log 2>/dev/null | head -n1 || true)
+  [ -n "${wal}" ] || { echo "No .log WAL found" >&2; exit 1; }
+  local size
+  size=$(wc -c < "${wal}")
+  local newsize=$(( size / 2 ))
+  if command -v truncate >/dev/null 2>&1; then
+    truncate -s "${newsize}" "${wal}"
+  else
+    dd if="${wal}" of="${wal}.tmp" bs=1 count="${newsize}" status=none
+    mv "${wal}.tmp" "${wal}"
+  fi
+  echo "Truncated WAL ${wal} from ${size} to ${newsize} bytes"
+}
+
+wipe_current() {
+  # CURRENT points at the live MANIFEST. Emptying it makes LevelDB unable to
+  # find its manifest at all -> hard open failure.
+  : > "${DB_DIR}/CURRENT"
+  echo "Emptied ${DB_DIR}/CURRENT"
+}
+
+case "${MODE}" in
+  manifest)     corrupt_manifest ;;
+  ldb)          corrupt_ldb ;;
+  truncate)     corrupt_truncate ;;
+  wipe-current) wipe_current ;;
+  *)            usage ;;
+esac
+
+echo
+echo "Done. Reopen Chrome + MetaMask and watch the service-worker console."
+echo "Restore anytime with: $0 restore ${EXT_ID}"

--- a/shared/lib/stores/extension-store.ts
+++ b/shared/lib/stores/extension-store.ts
@@ -10,6 +10,38 @@ import type {
 const { sentry } = globalThis;
 
 /**
+ * TEMPORARY storage-corruption investigation hook (do not ship).
+ *
+ * `setKeyValues` performs a write in two separate, individually-atomic browser
+ * operations: `local.set(toSet)` (new/updated keys + manifest) followed by
+ * `local.remove(toRemove)` (keys marked for deletion). These are NOT atomic
+ * with respect to each other. If the service worker is suspended, or the write
+ * process is interrupted, in the window between them, the on-disk database can
+ * end up inconsistent (e.g. a manifest that no longer references a key that
+ * still physically exists, or an old monolithic `data` key surviving a split
+ * migration).
+ *
+ * When `globalThis.__DEBUG_STORAGE_FAULT_GAP_MS__` is set to a positive number,
+ * this hook pauses for that many ms between the `set` and the `remove`, giving a
+ * human (or an automated kill) a reliable window to interrupt the process at the
+ * exact non-atomic boundary. Inert unless the global is explicitly set from a
+ * console, so it is a no-op in production.
+ */
+async function maybeDebugFaultGap(label: string): Promise<void> {
+  const gapMs = (
+    globalThis as typeof globalThis & {
+      __DEBUG_STORAGE_FAULT_GAP_MS__?: number;
+    }
+  ).__DEBUG_STORAGE_FAULT_GAP_MS__;
+  if (typeof gapMs === 'number' && gapMs > 0) {
+    console.warn(
+      `[ExtensionStore][DEBUG_FAULT] pausing ${gapMs}ms at "${label}" — interrupt now to test the non-atomic write boundary`,
+    );
+    await new Promise((resolve) => setTimeout(resolve, gapMs));
+  }
+}
+
+/**
  * An implementation of the MetaMask Extension BaseStore system that uses the
  * browser.storage.local API to persist and retrieve state.
  */
@@ -129,6 +161,13 @@ export default class ExtensionStore implements BaseStore {
         // once we know the set was successful, update our in-memory manifest
         this.#manifest = newManifest;
       }
+
+      // TEMPORARY: non-atomic-write fault window (see maybeDebugFaultGap). At
+      // this point the manifest already reflects the deletions (it was written
+      // as part of `toSet`), but the keys in `toRemove` still physically exist.
+      // Interrupting here reproduces a manifest/data mismatch on disk.
+      await maybeDebugFaultGap('between set and remove');
+
       log.info(
         `[ExtensionStore]: Removing ${toRemove.length} keys from local store`,
       );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Investigation PoCs for the "storage corrupted / missing / damaged" bug class.

Blocking the service worker mid-write does not reproduce the reports: a single
`chrome.storage.local.set` is committed atomically by the browser process, off
the SW JS thread. This branch instead adds three temporary experiments that
target the surfaces that *do* produce corruption/loss:

1. **Quota / disk-full** — `debugFillStorageQuotaExperiment` in
   `app/service-worker.ts` writes 1 MiB chunks to `chrome.storage.local` until a
   `set` fails with `QUOTA_BYTES quota exceeded` / `FILE_ERROR_NO_SPACE`. This is
   the mechanism behind `StorageWriteErrorType.FileErrorNoSpace` and the "state
   stops advancing / reverts to older state" reports.
2. **On-disk LevelDB damage** — `development/storage-corruption-poc/corrupt-leveldb.sh`
   damages the LevelDB files backing `storage.local` (crash / power-loss /
   bad-sector simulation), with auto-backup + restore. Highest fidelity; also
   exercises the vault-recovery path in `PersistenceManager.get()`.
3. **Non-atomic `set`→`remove`** — a gated fault window in
   `shared/lib/stores/extension-store.ts` (`__DEBUG_STORAGE_FAULT_GAP_MS__`,
   inert in production) that pauses between the two non-atomic ops in
   `setKeyValues` so the boundary can be interrupted.

See `development/storage-corruption-poc/README.md` for the full write-up and
suggested order (start with the LevelDB script).

This is a temporary investigation PoC and is **not** intended to merge.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Related: #43773

## **Manual testing steps**

### Experiment 1 — quota / disk-full (`debugFillStorageQuotaExperiment`)

1. Run `yarn start` and load the extension in Chrome.
2. Open the MetaMask service-worker console.
3. Run:
   ```ts
   await globalThis.debugFillStorageQuotaExperiment({ chunkSizeBytes: 1024 * 1024 });
   ```
4. Confirm it stops and returns a result with `failedAtChunk` set and
   `lastError` containing `QUOTA_BYTES quota exceeded` (or `FILE_ERROR_NO_SPACE`
   on a genuinely full disk).
5. Clean up the experiment keys:
   ```ts
   const all = await chrome.storage.local.get(null);
   await chrome.storage.local.remove(
     Object.keys(all).filter((k) => k.startsWith('debugFillStorageQuota:')),
   );
   ```

### Experiment 2 — on-disk LevelDB damage (`corrupt-leveldb.sh`)

1. Onboard a wallet (so a vault exists and an IndexedDB backup has been written).
2. Fully **quit** Chrome (not just close the window).
3. Find MetaMask's extension id:
   ```bash
   ./development/storage-corruption-poc/corrupt-leveldb.sh list
   ```
4. Corrupt the LevelDB (auto-backs up first):
   ```bash
   ./development/storage-corruption-poc/corrupt-leveldb.sh <ext-id> ldb
   ```
   (Other modes: `manifest`, `truncate`, `wipe-current`.)
5. Reopen Chrome and open MetaMask. In the service-worker console, confirm the
   read path reports a storage error and, if a backup exists, the vault-recovery
   flow is triggered (`persistence.error` tags / `vaultCorruptionDetected`).
6. Restore the profile when done:
   ```bash
   ./development/storage-corruption-poc/corrupt-leveldb.sh restore <ext-id>
   ```

### Experiment 3 — non-atomic `set`→`remove` gap (`__DEBUG_STORAGE_FAULT_GAP_MS__`)

1. Run `yarn start`, load the extension, open the service-worker console.
2. Arm the fault window:
   ```ts
   globalThis.__DEBUG_STORAGE_FAULT_GAP_MS__ = 20000;
   ```
3. Trigger a state write that deletes at least one key (e.g. an action that
   clears a controller's state, or a split-state migration).
4. While the console shows `[ExtensionStore][DEBUG_FAULT] pausing 20000ms …`,
   force-quit Chrome.
5. Reopen and inspect whether the `manifest` and the physically-present keys
   agree (the expected failure mode is cross-op inconsistency, e.g. leftover
   keys / a manifest mismatch — not a torn single write).
6. Disarm the window:
   ```ts
   globalThis.__DEBUG_STORAGE_FAULT_GAP_MS__ = 0;
   ```

## **Screenshots/Recordings**

### **Before**

<!-- N/A — service-worker-console / CLI experiment, no UI. -->

### **After**

<!-- N/A — service-worker-console / CLI experiment, no UI. -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
