### PR TITLE
chore(6930): update React Compiler target to v18

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -17,7 +17,7 @@ module.exports = function (api) {
           `^${uiPath}${slash}(?:components|contexts|hooks|layouts|pages)${slash}(?!.*(?:\\.(?:test|spec|stories|container)\\.|__mocks__${slash}|\\.d\\.[jt]s$)).*\\.(?:m?[jt]s|[jt]sx)$`,
           'u',
         ),
-        plugins: [['babel-plugin-react-compiler', { target: '17' }]],
+        plugins: [['babel-plugin-react-compiler', { target: '18' }]],
       },
     ],
     plugins: [

--- a/development/webpack/test/loaders.reactCompilerLoader.test.ts
+++ b/development/webpack/test/loaders.reactCompilerLoader.test.ts
@@ -7,7 +7,7 @@ import {
 
 describe('getReactCompilerLoader', () => {
   const baseConfig: ReactCompilerLoaderConfig = {
-    target: '17',
+    target: '18',
     verbose: false,
     debug: 'none',
     threadLoaderEnabled: false,

--- a/development/webpack/webpack.config.ts
+++ b/development/webpack/webpack.config.ts
@@ -317,7 +317,7 @@ const isChunkableAsync = (chunk: Chunk) =>
 
 const threadLoader = getThreadLoader(args);
 const reactCompiler = getReactCompilerLoader({
-  target: '17',
+  target: '18',
   verbose: args.reactCompilerVerbose,
   debug: args.reactCompilerDebug,
   threadLoaderEnabled: threadLoader !== null,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Updates the React Compiler Babel plugin and webpack loader target from 17 to 18, now that the extension runs on React 18.

Follow up work: https://github.com/MetaMask/MetaMask-planning/issues/6549

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://github.com/MetaMask/MetaMask-planning/issues/6930

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-tool configuration only; no runtime app logic changes, though a mismatched compiler target could affect compile-time optimizations if builds aren’t smoke-tested.
> 
> **Overview**
> Aligns **React Compiler** with the extension’s **React 18** runtime by changing the plugin `target` from `17` to `18` everywhere it is configured.
> 
> **Babel** (`babel.config.js`): `babel-plugin-react-compiler` on the UI components/contexts/hooks/layouts/pages override now uses `target: '18'`.
> 
> **Webpack** (`webpack.config.ts`): `getReactCompilerLoader` is called with `target: '18'` for the UI component pipeline.
> 
> **Tests** (`loaders.reactCompilerLoader.test.ts`): `baseConfig.target` is updated to `'18'` so loader tests match production config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3aa4d376612e7f014ac9bb23ac41a9c2dbb83ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->