### PR TITLE
feat: added transitions to Dapp connections pages

### DIFF
--- a/ui/components/multichain/global-menu/global-menu-list.tsx
+++ b/ui/components/multichain/global-menu/global-menu-list.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   Box,
   Text,
@@ -14,6 +15,7 @@ import {
   IconColor,
 } from '@metamask/design-system-react';
 import { MenuItem } from '../../ui/menu';
+import { transitionForward } from '../../ui/transition';
 import { GlobalMenuListProps, isRouteItem } from './global-menu-list.types';
 
 const getRouteState = (state?: object) => ({
@@ -71,6 +73,8 @@ export const GlobalMenuList = ({
   sections,
   className = '',
 }: GlobalMenuListProps) => {
+  const navigate = useNavigate();
+
   return (
     <Box
       className={`global-menu-list ${className}`}
@@ -106,6 +110,9 @@ export const GlobalMenuList = ({
           {section.items.map((item) => {
             // Show chevron for route items or when explicitly requested (e.g. notifications)
             const showChevron = isRouteItem(item) || item.showChevron === true;
+            const routeState = isRouteItem(item)
+              ? getRouteState(item.state)
+              : undefined;
 
             return (
               <MenuItem
@@ -117,10 +124,21 @@ export const GlobalMenuList = ({
                 fontWeight={FontWeight.Medium}
                 textColor={item.textColor}
                 to={isRouteItem(item) ? item.to : undefined}
-                state={
-                  isRouteItem(item) ? getRouteState(item.state) : undefined
-                }
-                onClick={item.onClick}
+                state={routeState}
+                onClick={(event) => {
+                  if (!isRouteItem(item)) {
+                    item.onClick();
+                    return;
+                  }
+
+                  event.preventDefault();
+                  item.onClick?.();
+                  transitionForward(() =>
+                    navigate(item.to, {
+                      state: routeState,
+                    }),
+                  );
+                }}
                 disabled={item.disabled}
                 showInfoDot={item.showInfoDot}
                 subtitle={item.subtitle}

--- a/ui/components/multichain/pages/gator-permissions/gator-permissions-page.tsx
+++ b/ui/components/multichain/pages/gator-permissions/gator-permissions-page.tsx
@@ -40,6 +40,7 @@ import {
   getTotalUniqueSitesCount,
 } from '../../../../selectors/gator-permissions/gator-permissions';
 import { useGlobalMenuRouteTransition } from '../../../../pages/routes/global-menu-route-transition';
+import { transitionForward } from '../../../ui/transition';
 import { PermissionListItem } from './components/permission-list-item';
 
 export const GatorPermissionsPage = () => {
@@ -74,10 +75,10 @@ export const GatorPermissionsPage = () => {
   ) => {
     switch (permissionGroupName) {
       case 'sites':
-        navigate(PERMISSIONS);
+        transitionForward(() => navigate(PERMISSIONS));
         break;
       case 'token-transfer':
-        navigate(TOKEN_TRANSFER_ROUTE);
+        transitionForward(() => navigate(TOKEN_TRANSFER_ROUTE));
         break;
       default:
         console.error('Invalid permission group name:', permissionGroupName);

--- a/ui/components/multichain/pages/permissions-page/permissions-page.js
+++ b/ui/components/multichain/pages/permissions-page/permissions-page.js
@@ -46,6 +46,7 @@ import { getMergedConnectionsListWithGatorPermissions } from '../../../../select
 import { isGatorPermissionsRevocationFeatureEnabled } from '../../../../../shared/lib/environment';
 import { removePermissionsFor } from '../../../../store/actions';
 import { useGlobalMenuRouteTransition } from '../../../../pages/routes/global-menu-route-transition';
+import { transitionForward } from '../../../ui/transition';
 import { DisconnectAllSitesModal } from '../../disconnect-all-modal';
 import { Toast, ToastContainer } from '../../toast';
 import { ConnectionListItem } from './connection-list-item';
@@ -126,12 +127,14 @@ const PermissionsPage = () => {
   }, [dispatch, mergedConnectionsList, subjects]);
 
   const handleConnectionClick = (connection) => {
-    navigate({
-      pathname: REVIEW_PERMISSIONS,
-      search: createSearchParams({
-        origin: connection.origin,
-      }).toString(),
-    });
+    transitionForward(() =>
+      navigate({
+        pathname: REVIEW_PERMISSIONS,
+        search: createSearchParams({
+          origin: connection.origin,
+        }).toString(),
+      }),
+    );
   };
 
   const renderConnectionsList = (connectionList) =>

--- a/ui/components/ui/menu/menu-item.tsx
+++ b/ui/components/ui/menu/menu-item.tsx
@@ -46,7 +46,11 @@ type MenuItemProps = {
   to?: string;
   /** React Router location state (e.g. { prevPath } for back navigation) */
   state?: object;
-  onClick?: () => void;
+  onClick?: (
+    event:
+      | React.MouseEvent<HTMLAnchorElement>
+      | React.MouseEvent<HTMLButtonElement>,
+  ) => void;
   subtitle?: string;
   disabled?: boolean;
   showInfoDot?: boolean;

--- a/ui/components/ui/transition.ts
+++ b/ui/components/ui/transition.ts
@@ -22,15 +22,7 @@ const startTransition = (
     return;
   }
   document.documentElement.dataset.pageTransition = direction;
-  const transition = document.startViewTransition(() => {
-    let callbackResult: ReturnType<TransitionCallback>;
-
-    flushSync(() => {
-      callbackResult = callback();
-    });
-
-    return callbackResult;
-  });
+  const transition = document.startViewTransition(() => flushSync(callback));
   transition.finished.finally(() => {
     delete document.documentElement.dataset.pageTransition;
   });

--- a/ui/components/ui/transition.ts
+++ b/ui/components/ui/transition.ts
@@ -1,3 +1,4 @@
+import { flushSync } from 'react-dom';
 import { getBrowserName } from '../../../shared/lib/browser-runtime.utils';
 import { PLATFORM_FIREFOX } from '../../../shared/constants/app';
 
@@ -21,7 +22,15 @@ const startTransition = (
     return;
   }
   document.documentElement.dataset.pageTransition = direction;
-  const transition = document.startViewTransition(callback);
+  const transition = document.startViewTransition(() => {
+    let callbackResult: ReturnType<TransitionCallback>;
+
+    flushSync(() => {
+      callbackResult = callback();
+    });
+
+    return callbackResult;
+  });
   transition.finished.finally(() => {
     delete document.documentElement.dataset.pageTransition;
   });

--- a/ui/components/ui/transition.ts
+++ b/ui/components/ui/transition.ts
@@ -1,4 +1,3 @@
-import { flushSync } from 'react-dom';
 import { getBrowserName } from '../../../shared/lib/browser-runtime.utils';
 import { PLATFORM_FIREFOX } from '../../../shared/constants/app';
 
@@ -22,7 +21,7 @@ const startTransition = (
     return;
   }
   document.documentElement.dataset.pageTransition = direction;
-  const transition = document.startViewTransition(() => flushSync(callback));
+  const transition = document.startViewTransition(callback);
   transition.finished.finally(() => {
     delete document.documentElement.dataset.pageTransition;
   });


### PR DESCRIPTION
This PR is to add transitions to the DApp connection Pages

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: added transitions

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to Dapp Flow
2. Check the Pages have transitions
3. No change in Functionality

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/774d7ae6-a52e-428f-85de-c41a6159e2ac




## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only navigation timing changes using the existing `transitionForward` helper (no-op in tests/Firefox); behavior should match prior routes aside from animations.
> 
> **Overview**
> Adds **forward** view transitions when navigating through DApp connection and permissions flows so page changes match the global menu’s animated navigation.
> 
> **Global menu:** Route items no longer rely on the `Link` alone for navigation. Clicks call `preventDefault`, run optional `onClick`, then `transitionForward` + `navigate` with the same `state` (including `globalMenuTransition: 'forward'`).
> 
> **Permissions / Gator:** In-app navigations to Sites, token transfer, and review-permissions are wrapped in `transitionForward` instead of calling `navigate` directly.
> 
> **MenuItem:** `onClick` now receives the click event so the global menu handler can prevent default link navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e64a52fd60eb8c30f849d5fc6d726a8fc88ae186. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->