### PR TITLE
refactor: migrate asset market details to MMDS

### DIFF
--- a/ui/pages/asset/components/asset-market-details.tsx
+++ b/ui/pages/asset/components/asset-market-details.tsx
@@ -7,16 +7,15 @@ import {
   BoxBorderColor,
   BoxFlexDirection,
   BoxJustifyContent,
+  FontWeight,
+  Text,
+  TextColor,
+  TextVariant,
 } from '@metamask/design-system-react';
 import { formatCurrency } from '../../../helpers/utils/confirm-tx.util';
 
 import { getPricePrecision } from '../util';
 
-import { Text } from '../../../components/component-library';
-import {
-  TextColor,
-  TextVariant,
-} from '../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { getCurrentCurrency } from '../../../ducks/metamask/metamask';
 import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
@@ -120,10 +119,8 @@ export const AssetMarketDetails = ({
         style={{ height: '1px', borderBottomWidth: 0 }}
       ></Box>
       <Text
-        variant={TextVariant.headingSm}
-        paddingInline={4}
-        paddingTop={2}
-        paddingBottom={2}
+        className="px-4 py-2"
+        variant={TextVariant.HeadingSm}
       >
         {t('marketDetails')}
       </Text>
@@ -136,7 +133,8 @@ export const AssetMarketDetails = ({
           renderRow(
             t('marketCap'),
             <Text
-              variant={TextVariant.bodyMdMedium}
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Medium}
               data-testid="asset-market-cap"
             >
               {formatCurrencyCompact(marketCap, currency)}
@@ -145,21 +143,30 @@ export const AssetMarketDetails = ({
         {totalVolume > 0 &&
           renderRow(
             t('totalVolume'),
-            <Text variant={TextVariant.bodyMdMedium}>
+            <Text
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Medium}
+            >
               {formatCurrencyCompact(totalVolume, currency)}
             </Text>,
           )}
         {circulatingSupply > 0 &&
           renderRow(
             t('circulatingSupply'),
-            <Text variant={TextVariant.bodyMdMedium}>
+            <Text
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Medium}
+            >
               {formatCompact(circulatingSupply)}
             </Text>,
           )}
         {allTimeHigh > 0 &&
           renderRow(
             t('allTimeHigh'),
-            <Text variant={TextVariant.bodyMdMedium}>
+            <Text
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Medium}
+            >
               {formatCurrency(
                 `${allTimeHigh}`,
                 currency,
@@ -170,7 +177,10 @@ export const AssetMarketDetails = ({
         {allTimeLow > 0 &&
           renderRow(
             t('allTimeLow'),
-            <Text variant={TextVariant.bodyMdMedium}>
+            <Text
+              variant={TextVariant.BodyMd}
+              fontWeight={FontWeight.Medium}
+            >
               {formatCurrency(
                 `${allTimeLow}`,
                 currency,
@@ -187,8 +197,9 @@ function renderRow(leftColumn: string, rightColumn: ReactNode) {
   return (
     <Box className="flex" justifyContent={BoxJustifyContent.Between}>
       <Text
-        color={TextColor.textAlternative}
-        variant={TextVariant.bodyMdMedium}
+        color={TextColor.TextAlternative}
+        variant={TextVariant.BodyMd}
+        fontWeight={FontWeight.Medium}
       >
         {leftColumn}
       </Text>


### PR DESCRIPTION
## **Description**

Replace the deprecated extension component-library `Text` usage in `AssetMarketDetails` with the MetaMask Design System (MMDS) `Text` component.

The migration preserves the existing heading/body variants, medium font weight, alternative text color, and spacing while removing legacy helper imports. The change is intentionally scoped to one product file as part of the evergreen migration issue.

AI assistance disclosure: This change was implemented and verified with OpenAI Codex under the contributor account owner's authorization.

Automated verification:

- `yarn jest ui/pages/asset/components/asset-market-details.test.tsx` (5/5 tests passed)
- `yarn lint:changed:fix`
- `yarn lint:tsc`
- `yarn circular-deps:check`
- `yarn build:test:webpack`

The before/after screenshots below were captured at the same 1280x800 viewport and have the same SHA-256 digest (`9878a1ebb566475e1356ce070a44db765a3afaba761ebef25a6c54650a750c01`), confirming a pixel-identical visual result.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of #43340

## **Manual testing steps**

1. Run a development wallet with an ERC-20 token that has market data, then unlock the wallet.
2. Open the **Tokens** tab, select the ERC-20 asset, and scroll to **Market details**.
3. Verify that the section heading, labels, values, spacing, and alignment render correctly.

## **Screenshots/Recordings**

### **Before**

![Asset market details before the MMDS Text migration](https://raw.githubusercontent.com/coyaSONG/metamask-extension/pr-assets/.github/pr-assets/c-0061/before.png)

### **After**

![Asset market details after the MMDS Text migration](https://raw.githubusercontent.com/coyaSONG/metamask-extension/pr-assets/.github/pr-assets/c-0061/after.png)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
