### PR TITLE
chore: update @metamask/gator-permissions-snap to version 2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -389,7 +389,7 @@
     "@metamask/etherscan-link": "^3.0.0",
     "@metamask/gas-fee-controller": "^26.1.0",
     "@metamask/gator-permissions-controller": "^4.2.1",
-    "@metamask/gator-permissions-snap": "^2.3.0",
+    "@metamask/gator-permissions-snap": "^2.4.0",
     "@metamask/geolocation-controller": "^0.1.1",
     "@metamask/hw-wallet-sdk": "^0.8.0",
     "@metamask/institutional-wallet-snap": "1.5.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6668,18 +6668,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/gator-permissions-snap@npm:^2.3.0":
-  version: 2.3.0
-  resolution: "@metamask/gator-permissions-snap@npm:2.3.0"
+"@metamask/gator-permissions-snap@npm:^2.4.0":
+  version: 2.4.0
+  resolution: "@metamask/gator-permissions-snap@npm:2.4.0"
   dependencies:
     "@metamask/abi-utils": "npm:3.0.0"
     "@metamask/delegation-core": "npm:^2.2.1"
     "@metamask/delegation-deployments": "npm:^1.4.0"
-    "@metamask/profile-sync-controller": "npm:28.1.0"
-    "@metamask/snaps-sdk": "npm:11.1.0"
+    "@metamask/profile-sync-controller": "npm:28.2.0"
+    "@metamask/snaps-sdk": "npm:11.1.1"
     "@metamask/utils": "npm:11.11.0"
     zod: "npm:3.25.76"
-  checksum: 10/bf217362f4386f96a2481cd56ef27468e31673dbd28d9ed34ca371c1a31dffb28a66915df573d90f6aff9269b74c912fb0560d05fdc953aaafacb0a6d4809132
+  checksum: 10/8d0b43c5904ed2acf86f3738f19daf2605e10181c87b04ce82c100eed93bb96849f9c64cb35875332f599cd970ce593a117d68ea67c04be9246263bbfac3b8f2
   languageName: node
   linkType: hard
 
@@ -6814,7 +6814,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/keyring-controller@npm:^25.2.0, @metamask/keyring-controller@npm:^25.5.0":
+"@metamask/keyring-controller@npm:^25.2.0":
   version: 25.5.0
   resolution: "@metamask/keyring-controller@npm:25.5.0"
   dependencies:
@@ -7555,18 +7555,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/profile-sync-controller@npm:28.1.0":
-  version: 28.1.0
-  resolution: "@metamask/profile-sync-controller@npm:28.1.0"
+"@metamask/profile-sync-controller@npm:28.2.0":
+  version: 28.2.0
+  resolution: "@metamask/profile-sync-controller@npm:28.2.0"
   dependencies:
     "@metamask/address-book-controller": "npm:^7.1.2"
     "@metamask/base-controller": "npm:^9.1.0"
-    "@metamask/keyring-controller": "npm:^25.5.0"
+    "@metamask/keyring-controller": "npm:^27.0.0"
     "@metamask/messenger": "npm:^1.2.0"
     "@metamask/snaps-controllers": "npm:^19.0.0"
     "@metamask/snaps-sdk": "npm:^11.0.0"
     "@metamask/snaps-utils": "npm:^12.1.2"
-    "@metamask/utils": "npm:^11.9.0"
+    "@metamask/utils": "npm:^11.11.0"
     "@noble/ciphers": "npm:^1.3.0"
     "@noble/hashes": "npm:^1.8.0"
     immer: "npm:^9.0.6"
@@ -7575,7 +7575,7 @@ __metadata:
   peerDependencies:
     "@metamask/providers": ^22.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
-  checksum: 10/33c318fe005e55b38b4d0d603806c9303b8deaddf8f98fc04f89ecb49cf26da2189ceea20ac6a4b1be5da49060a928d6788cb465b4451aa199c8e51172366213
+  checksum: 10/49f9a69a205613dc1dab9d122048601713561c385e21cbb0d9f501925e888d3f5681f3a4a7cebdc1b3d2488f76ab6a8b2a7b9ae47ffe567245819415444f678c
   languageName: node
   linkType: hard
 
@@ -33154,7 +33154,7 @@ __metadata:
     "@metamask/foundryup": "npm:^1.0.1"
     "@metamask/gas-fee-controller": "npm:^26.1.0"
     "@metamask/gator-permissions-controller": "npm:^4.2.1"
-    "@metamask/gator-permissions-snap": "npm:^2.3.0"
+    "@metamask/gator-permissions-snap": "npm:^2.4.0"
     "@metamask/geolocation-controller": "npm:^0.1.1"
     "@metamask/hw-wallet-sdk": "npm:^0.8.0"
     "@metamask/institutional-wallet-snap": "npm:1.5.0"


### PR DESCRIPTION
## **Description**

Bumps `@metamask/gator-permissions-snap` from `^2.3.0` to `^2.4.0` to pick up the latest fixes/improvements from upstream. This also updates the transitive `@metamask/profile-sync-controller` dependency from `28.1.0` to `28.2.0`.

## **Changelog**

CHANGELOG entry: Adds Robinhood chain metadata to EIP-7715 Advanced Permissions

## **Related issues**

Fixes:

## **Manual testing steps**

1. Pull this branch and run `yarn install`
2. Build the extension (`yarn start` or `yarn dist`)
3. Verify gator permissions / smart account related flows still work as expected (e.g. granting/revoking permissions)

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only change, but it updates a preinstalled snap tied to delegation/advanced permissions and profile sync; behavior can shift without local code diffs, so manual gator permission flows are worth a quick smoke test.
> 
> **Overview**
> Bumps **`@metamask/gator-permissions-snap`** from `^2.3.0` to **`^2.4.0`** in `package.json` and refreshes **`yarn.lock`** so the extension ships the newer preinstalled Gator permissions snap (upstream fixes/improvements only—no extension source changes).
> 
> The lockfile also moves the snap’s transitive **`@metamask/profile-sync-controller`** from `28.1.0` to **`28.2.0`**, bumps **`@metamask/snaps-sdk`** for that subtree (`11.1.0` → `11.1.1`), and tidies a **`@metamask/keyring-controller`** resolution alias (drops the duplicate `^25.5.0` range on the same lock entry).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aacdbab6ce1e1e8fd5bf6df2894ae3e7280bcb23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->