### PR TITLE
refactor: migrate download state logs toast (CEUX-1180)

### DIFF
--- a/ui/components/ui/toast/toast.test.tsx
+++ b/ui/components/ui/toast/toast.test.tsx
@@ -1,10 +1,28 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
-import { ToastContent } from './toast';
+import { toast as hotToast } from 'react-hot-toast';
+import { ToastContent, toast } from './toast';
 
 jest.mock('../status-icon/status-icon', () => ({
   StatusIcon: () => null,
 }));
+
+jest.mock('react-hot-toast', () => {
+  const actual =
+    jest.requireActual<typeof import('react-hot-toast')>('react-hot-toast');
+  return {
+    ...actual,
+    toast: {
+      ...actual.toast,
+      success: jest.fn(() => 'toast-id'),
+      error: jest.fn(() => 'toast-id'),
+      loading: jest.fn(() => 'toast-id'),
+      promise: jest.fn((promise) => promise),
+      dismiss: jest.fn(),
+      remove: jest.fn(),
+    },
+  };
+});
 
 describe('ToastContent', () => {
   it('renders the title', () => {
@@ -43,5 +61,152 @@ describe('ToastContent', () => {
       <ToastContent title="Transaction confirmed" actionText="test-action" />,
     );
     expect(screen.queryByText('test-action')).not.toBeInTheDocument();
+  });
+});
+
+describe('toast', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('toast.success builds ToastContent from params', () => {
+    toast.success(
+      {
+        title: 'Networks updated',
+        id: 'network-permission-toast',
+      },
+      {
+        duration: Infinity,
+      },
+    );
+
+    expect(hotToast.success).toHaveBeenCalledWith(
+      expect.objectContaining({
+        props: {
+          title: 'Networks updated',
+          description: undefined,
+          actionText: undefined,
+          onActionClick: undefined,
+          dataTestId: 'network-permission-toast',
+        },
+      }),
+      {
+        id: 'network-permission-toast',
+        duration: Infinity,
+      },
+    );
+  });
+
+  it('toast.error passes through options without forcing a duration', () => {
+    toast.error({
+      title: 'Failed',
+      description: 'Try again',
+      id: 'error-toast',
+    });
+
+    expect(hotToast.error).toHaveBeenCalledWith(
+      expect.objectContaining({
+        props: expect.objectContaining({
+          title: 'Failed',
+          description: 'Try again',
+          dataTestId: 'error-toast',
+        }),
+      }),
+      {
+        id: 'error-toast',
+      },
+    );
+  });
+
+  it('toast.loading accepts an icon override', () => {
+    toast.loading(
+      {
+        title: 'Loading',
+        id: 'loading-toast',
+      },
+      {
+        icon: null,
+      },
+    );
+
+    expect(hotToast.loading).toHaveBeenCalledWith(
+      expect.objectContaining({
+        props: expect.objectContaining({
+          title: 'Loading',
+          dataTestId: 'loading-toast',
+        }),
+      }),
+      {
+        id: 'loading-toast',
+        icon: null,
+      },
+    );
+  });
+
+  it('toast.promise builds ToastContent for each stage', async () => {
+    const work = Promise.resolve({ amount: '10' });
+
+    await toast.promise(
+      work,
+      {
+        loading: {
+          title: 'Sending',
+          id: 'send-toast',
+        },
+        success: (data) => ({
+          title: 'Sent',
+          description: data.amount,
+          id: 'send-toast',
+        }),
+        error: {
+          title: 'Failed',
+          id: 'send-toast',
+        },
+      },
+      {
+        success: {
+          duration: 5_000,
+        },
+      },
+    );
+
+    expect(hotToast.promise).toHaveBeenCalledWith(
+      work,
+      {
+        loading: expect.objectContaining({
+          props: expect.objectContaining({
+            title: 'Sending',
+            dataTestId: 'send-toast',
+          }),
+        }),
+        success: expect.any(Function),
+        error: expect.any(Function),
+      },
+      {
+        id: 'send-toast',
+        success: {
+          duration: 5_000,
+        },
+      },
+    );
+
+    const msgs = jest.mocked(hotToast.promise).mock.calls[0][1];
+    expect(msgs.success?.({ amount: '10' } as never)).toEqual(
+      expect.objectContaining({
+        props: expect.objectContaining({
+          title: 'Sent',
+          description: '10',
+          dataTestId: 'send-toast',
+        }),
+      }),
+    );
+    expect(msgs.error?.(new Error('nope'))).toEqual(
+      expect.objectContaining({
+        props: expect.objectContaining({
+          title: 'Failed',
+          dataTestId: 'send-toast',
+        }),
+      }),
+    );
   });
 });

--- a/ui/components/ui/toast/toast.tsx
+++ b/ui/components/ui/toast/toast.tsx
@@ -1,5 +1,11 @@
 import React, { type CSSProperties } from 'react';
-import { toast, ToastBar, Toaster as ToasterBase } from 'react-hot-toast';
+import {
+  toast as hotToast,
+  ToastBar,
+  Toaster as ToasterBase,
+  type DefaultToastOptions,
+  type ToastOptions,
+} from 'react-hot-toast';
 import {
   ButtonIcon,
   ButtonIconSize,
@@ -9,11 +15,10 @@ import {
   ButtonVariant,
   TextVariant,
 } from '@metamask/design-system-react';
+import { SECOND } from '../../../../shared/constants/time';
 import { isInteractiveUI } from '../../../../shared/lib/environment-type';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { StatusIcon } from '../status-icon/status-icon';
-
-export { toast } from 'react-hot-toast';
 
 const statusMap = {
   loading: 'loading',
@@ -21,61 +26,14 @@ const statusMap = {
   error: 'fail',
 } as const;
 
-export function Toaster() {
-  const t = useI18nContext();
-
-  if (!isInteractiveUI()) {
-    return null;
-  }
-
-  return (
-    <ToasterBase
-      position="bottom-center"
-      containerClassName="toast-container"
-      containerStyle={{
-        bottom: 'var(--toaster-bottom-offset, 16px)',
-      }}
-      toastOptions={{
-        className: 'w-[360px] max-w-[360px] border border-border-muted',
-        style: {
-          background: 'var(--color-background-section)',
-          color: 'var(--color-text-default)',
-          borderRadius: 12,
-          padding: 12,
-          visibility:
-            'var(--toast-visibility, visible)' as CSSProperties['visibility'],
-        },
-      }}
-    >
-      {(item) => (
-        <ToastBar toast={item} position={item.position ?? 'bottom-center'}>
-          {({ message }) => (
-            <>
-              {item.icon ?? (
-                <StatusIcon
-                  className="shrink-0"
-                  state={
-                    statusMap[item.type as keyof typeof statusMap] ??
-                    statusMap.loading
-                  }
-                />
-              )}
-
-              {message}
-
-              <ButtonIcon
-                ariaLabel={t('close')}
-                iconName={IconName.Close}
-                size={ButtonIconSize.Sm}
-                onClick={() => toast.dismiss(item.id)}
-              />
-            </>
-          )}
-        </ToastBar>
-      )}
-    </ToasterBase>
-  );
-}
+type ToastParams = {
+  title: string;
+  description?: string;
+  actionText?: string;
+  onActionClick?: () => void;
+  dataTestId?: string;
+  id?: string;
+};
 
 export const ToastContent = ({
   title,
@@ -118,3 +76,138 @@ export const ToastContent = ({
     </div>
   );
 };
+
+function toToastContent({
+  title,
+  description,
+  actionText,
+  onActionClick,
+  dataTestId,
+  id,
+}: ToastParams) {
+  return (
+    <ToastContent
+      title={title}
+      description={description}
+      actionText={actionText}
+      onActionClick={onActionClick}
+      dataTestId={dataTestId ?? id}
+    />
+  );
+}
+
+function showToast(
+  variant: 'success' | 'error' | 'loading',
+  params: ToastParams,
+  options?: ToastOptions,
+) {
+  return hotToast[variant](toToastContent(params), {
+    id: params.id,
+    ...options,
+  });
+}
+
+type ToastPromiseMessages<T> = {
+  loading: ToastParams;
+  success?: ToastParams | ((data: T) => ToastParams);
+  error?: ToastParams | ((error: unknown) => ToastParams);
+};
+
+export const toast = {
+  success: (params: ToastParams, options?: ToastOptions) =>
+    showToast('success', params, options),
+  error: (params: ToastParams, options?: ToastOptions) =>
+    showToast('error', params, options),
+  loading: (params: ToastParams, options?: ToastOptions) =>
+    showToast('loading', params, options),
+  promise: <T,>(
+    promise: Promise<T> | (() => Promise<T>),
+    msgs: ToastPromiseMessages<T>,
+    options?: DefaultToastOptions,
+  ) => {
+    const { success, error } = msgs;
+
+    return hotToast.promise(
+      promise,
+      {
+        loading: toToastContent(msgs.loading),
+        success: success
+          ? (data) =>
+              toToastContent(
+                typeof success === 'function' ? success(data) : success,
+              )
+          : undefined,
+        error: error
+          ? (err) =>
+              toToastContent(typeof error === 'function' ? error(err) : error)
+          : undefined,
+      },
+      {
+        id: msgs.loading.id,
+        ...options,
+      },
+    );
+  },
+  dismiss: hotToast.dismiss,
+  remove: hotToast.remove,
+};
+
+export function Toaster() {
+  const t = useI18nContext();
+
+  if (!isInteractiveUI()) {
+    return null;
+  }
+
+  return (
+    <ToasterBase
+      position="bottom-center"
+      containerClassName="toast-container"
+      containerStyle={{
+        bottom: 'var(--toaster-bottom-offset, 16px)',
+      }}
+      toastOptions={{
+        duration: 5 * SECOND,
+        loading: {
+          duration: Infinity,
+        },
+        className: 'w-[360px] max-w-[360px] border border-border-muted',
+        style: {
+          background: 'var(--color-background-section)',
+          color: 'var(--color-text-default)',
+          borderRadius: 12,
+          padding: 12,
+          visibility:
+            'var(--toast-visibility, visible)' as CSSProperties['visibility'],
+        },
+      }}
+    >
+      {(item) => (
+        <ToastBar toast={item} position={item.position ?? 'bottom-center'}>
+          {({ message }) => (
+            <>
+              {item.icon ?? (
+                <StatusIcon
+                  className="shrink-0"
+                  state={
+                    statusMap[item.type as keyof typeof statusMap] ??
+                    statusMap.loading
+                  }
+                />
+              )}
+
+              {message}
+
+              <ButtonIcon
+                ariaLabel={t('close')}
+                iconName={IconName.Close}
+                size={ButtonIconSize.Sm}
+                onClick={() => hotToast.dismiss(item.id)}
+              />
+            </>
+          )}
+        </ToastBar>
+      )}
+    </ToasterBase>
+  );
+}

--- a/ui/pages/settings/privacy-tab/download-state-logs-item.test.tsx
+++ b/ui/pages/settings/privacy-tab/download-state-logs-item.test.tsx
@@ -6,6 +6,7 @@ import mockState from '../../../../test/data/mock-state.json';
 import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import * as exportUtils from '../../../helpers/utils/export-utils';
+import { toast } from '../../../components/ui/toast/toast';
 import { DownloadStateLogsItem } from './download-state-logs-item';
 
 jest.mock('../../../helpers/utils/export-utils', () => ({
@@ -17,6 +18,20 @@ jest.mock('../../../../shared/lib/sentry', () => ({
   ...jest.requireActual('../../../../shared/lib/sentry'),
   captureException: jest.fn(),
 }));
+
+jest.mock('../../../components/ui/toast/toast', () => {
+  const actual = jest.requireActual<
+    typeof import('../../../components/ui/toast/toast')
+  >('../../../components/ui/toast/toast');
+  return {
+    ...actual,
+    toast: {
+      ...actual.toast,
+      error: jest.fn(),
+    },
+    ToastContent: actual.ToastContent,
+  };
+});
 
 const mockExportAsFile = exportUtils.exportAsFile as jest.Mock;
 
@@ -101,12 +116,17 @@ describe('DownloadStateLogsItem', () => {
     });
 
     await waitFor(() => {
-      expect(
-        screen.getByTestId('download-state-logs-error-toast'),
-      ).toBeInTheDocument();
-      expect(
-        screen.getByText(messages.stateLogError.message),
-      ).toBeInTheDocument();
+      expect(jest.mocked(toast.error)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: messages.unableToDownload.message,
+            description: messages.stateLogError.message,
+            dataTestId: 'download-state-logs-error-toast',
+          id: 'download-state-logs-error-toast',
+        }),
+        expect.objectContaining({
+          duration: Infinity,
+        }),
+      );
     });
   });
 
@@ -127,9 +147,15 @@ describe('DownloadStateLogsItem', () => {
     });
 
     await waitFor(() => {
-      expect(
-        screen.getByTestId('download-state-logs-error-toast'),
-      ).toBeInTheDocument();
+      expect(jest.mocked(toast.error)).toHaveBeenCalledWith(
+        expect.objectContaining({
+          dataTestId: 'download-state-logs-error-toast',
+          id: 'download-state-logs-error-toast',
+        }),
+        expect.objectContaining({
+          duration: Infinity,
+        }),
+      );
     });
   });
 });

--- a/ui/pages/settings/privacy-tab/download-state-logs-item.tsx
+++ b/ui/pages/settings/privacy-tab/download-state-logs-item.tsx
@@ -1,20 +1,29 @@
 import React, { useState } from 'react';
-import {
-  Button,
-  Icon,
-  IconColor,
-  IconName,
-} from '@metamask/design-system-react';
+import { Button } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+import { toast } from '../../../components/ui/toast/toast';
 import { PRIVACY_ITEMS } from '../search-config';
-import { Toast, ToastContainer } from '../../../components/multichain/toast';
-import { BorderRadius } from '../../../helpers/constants/design-system';
 import DownloadStateLogsModal from './download-state-logs-modal';
+
+const TOAST_ID = 'download-state-logs-error-toast';
 
 export const DownloadStateLogsItem = () => {
   const t = useI18nContext();
   const [showModal, setShowModal] = useState(false);
-  const [showErrorToast, setShowErrorToast] = useState(false);
+
+  const showErrorToast = () => {
+    toast.error(
+      {
+        title: t('unableToDownload'),
+        description: t('stateLogError'),
+        dataTestId: TOAST_ID,
+        id: TOAST_ID,
+      },
+      {
+        duration: Infinity,
+      },
+    );
+  };
 
   return (
     <>
@@ -28,23 +37,8 @@ export const DownloadStateLogsItem = () => {
       {showModal && (
         <DownloadStateLogsModal
           onClose={() => setShowModal(false)}
-          onError={() => setShowErrorToast(true)}
+          onError={showErrorToast}
         />
-      )}
-      {showErrorToast && (
-        <ToastContainer>
-          <Toast
-            startAdornment={
-              <Icon name={IconName.Warning} color={IconColor.WarningDefault} />
-            }
-            text={t('unableToDownload')}
-            description={t('stateLogError')}
-            onClose={() => setShowErrorToast(false)}
-            borderRadius={BorderRadius.LG}
-            textClassName="text-base"
-            dataTestId="download-state-logs-error-toast"
-          />
-        </ToastContainer>
       )}
     </>
   );


### PR DESCRIPTION
Migrate the privacy download state logs error toast from the deprecated multichain Toast to react-hot-toast via ui/toast.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI/toast refactor and one settings error path; no auth, data export logic, or backend changes beyond how errors are surfaced.
> 
> **Overview**
> Introduces a **structured `toast` API** in `ui/components/ui/toast/toast` instead of re-exporting `react-hot-toast` directly. Callers pass `title` / `description` / `id` (and optional actions) via `ToastParams`; the module maps those to `ToastContent` and forwards to `hotToast` for **success**, **error**, **loading**, **promise**, plus **dismiss** / **remove**.
> 
> **Toaster defaults** now set a **5s** duration for normal toasts and **infinite** duration for loading toasts; the close button dismisses via `hotToast.dismiss`.
> 
> **Privacy → download state logs** drops the deprecated multichain `Toast` / local error state and shows failures with `toast.error` (stable id, `duration: Infinity`). Tests assert the wrapper’s `toast.error` calls instead of DOM toasts, and **new unit tests** cover the wrapper behavior (including `promise` stage mapping).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5375e215d22741e8fd1a575baa2dccd45f5a8fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->