### PR TITLE
refactor: migrate delete metametrics toast

### DIFF
--- a/ui/pages/settings/privacy-tab/delete-metametrics-data-item.tsx
+++ b/ui/pages/settings/privacy-tab/delete-metametrics-data-item.tsx
@@ -1,11 +1,6 @@
 import React, { useState } from 'react';
 import { useSelector } from 'react-redux';
-import {
-  Button,
-  Icon,
-  IconColor,
-  IconName,
-} from '@metamask/design-system-react';
+import { Button } from '@metamask/design-system-react';
 import {
   DeleteRegulationStatus,
   DATA_DELETION_REQUESTED_STATUSES,
@@ -17,8 +12,7 @@ import {
   getCompletedMetaMetricsOnboarding,
   getOptedIn,
 } from '../../../selectors';
-import { Toast, ToastContainer } from '../../../components/multichain/toast';
-import { BorderRadius } from '../../../helpers/constants/design-system';
+import { toast, ToastContent } from '../../../components/ui/toast/toast';
 import { PRIVACY_ITEMS } from '../search-config';
 import DeleteMetametricsModal from './delete-metametrics-modal';
 import DeletionInProgressModal from './deletion-in-progress-modal';
@@ -28,10 +22,6 @@ export const DeleteMetametricsDataItem = () => {
 
   const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showDeletionInProgressModal, setShowDeletionInProgressModal] =
-    useState(false);
-  const [showDataDeletionErrorToast, setShowDataDeletionErrorToast] =
-    useState(false);
-  const [showDataDeletionSuccessToast, setShowDataDeletionSuccessToast] =
     useState(false);
   const [deletionRequestedThisSession, setDeletionRequestedThisSession] =
     useState(false);
@@ -71,49 +61,25 @@ export const DeleteMetametricsDataItem = () => {
           onClose={() => setShowDeleteModal(false)}
           onSuccess={() => {
             setDeletionRequestedThisSession(true);
-            setShowDataDeletionSuccessToast(true);
+            toast.success(t('deleteMetaMetricsDataToast'), {
+              id: 'delete-metametrics-data-success-toast',
+            });
           }}
-          onError={() => setShowDataDeletionErrorToast(true)}
+          onError={() => {
+            toast.error(
+              <ToastContent
+                title={t('deleteMetaMetricsDataErrorToast')}
+                description={t('deleteMetaMetricsDataErrorDesc')}
+              />,
+              { id: 'delete-metametrics-data-error-toast' },
+            );
+          }}
         />
       )}
       {showDeletionInProgressModal && (
         <DeletionInProgressModal
           onClose={() => setShowDeletionInProgressModal(false)}
         />
-      )}
-      {showDataDeletionErrorToast && (
-        <ToastContainer>
-          <Toast
-            startAdornment={
-              <Icon name={IconName.Warning} color={IconColor.WarningDefault} />
-            }
-            text={t('deleteMetaMetricsDataErrorToast')}
-            description={t('deleteMetaMetricsDataErrorDesc')}
-            onClose={() => setShowDataDeletionErrorToast(false)}
-            borderRadius={BorderRadius.LG}
-            textClassName="text-base"
-            data-testid="delete-metametrics-data-error-toast"
-          />
-        </ToastContainer>
-      )}
-      {showDataDeletionSuccessToast && (
-        <ToastContainer>
-          <Toast
-            startAdornment={
-              <Icon
-                name={IconName.CheckBold}
-                color={IconColor.SuccessDefault}
-              />
-            }
-            text={t('deleteMetaMetricsDataToast')}
-            onClose={() => setShowDataDeletionSuccessToast(false)}
-            autoHideTime={2500}
-            onAutoHideToast={() => setShowDataDeletionSuccessToast(false)}
-            borderRadius={BorderRadius.LG}
-            textClassName="text-base"
-            data-testid="delete-metametrics-data-success-toast"
-          />
-        </ToastContainer>
       )}
     </>
   );


### PR DESCRIPTION
Migrate privacy delete MetaMetrics success/error toasts from the deprecated multichain Toast to react-hot-toast via ui/toast.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: CEUX-1181

## **Manual testing steps**

1. Go to Settings > Privacy
2. Click Delete MetaMetrics data

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only toast migration in a settings privacy flow; behavior and copy stay the same with no auth or data-path changes.
> 
> **Overview**
> Replaces inline **multichain** `Toast`/`ToastContainer` feedback on Settings → Privacy **Delete MetaMetrics data** with the shared **`ui/toast`** API (`toast.success` / `toast.error` + `ToastContent`).
> 
> Success and error toasts are now triggered from `DeleteMetametricsModal` callbacks with stable toast `id`s, and the two boolean state flags plus ~40 lines of conditional toast JSX are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44a00fb64b98c581451acc6276c8013dbe086416. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->