### PR TITLE
refactor: migrate permissions disconnect-all toast

### DIFF
--- a/ui/components/multichain/pages/permissions-page/permissions-page.js
+++ b/ui/components/multichain/pages/permissions-page/permissions-page.js
@@ -48,7 +48,7 @@ import { removePermissionsFor } from '../../../../store/actions';
 import { useGlobalMenuRouteTransition } from '../../../../pages/routes/global-menu-route-transition';
 import { transitionForward } from '../../../ui/transition';
 import { DisconnectAllSitesModal } from '../../disconnect-all-modal';
-import { Toast, ToastContainer } from '../../toast';
+import { toast } from '../../../ui/toast/toast';
 import { ConnectionListItem } from './connection-list-item';
 
 const PermissionsPage = () => {
@@ -75,8 +75,6 @@ const PermissionsPage = () => {
   };
   const [totalConnections, setTotalConnections] = useState(0);
   const [showDisconnectAllModal, setShowDisconnectAllModal] = useState(false);
-  const [showSuccessToast, setShowSuccessToast] = useState(false);
-  const [showErrorToast, setShowErrorToast] = useState(false);
 
   const mergedConnectionsList = useSelector((state) => {
     if (!isGatorPermissionsRevocationFeatureEnabled()) {
@@ -120,11 +118,15 @@ const PermissionsPage = () => {
     setShowDisconnectAllModal(false);
 
     if (errors.length > 0) {
-      setShowErrorToast(true);
+      toast.error(t('disconnectAllSitesError'), {
+        id: 'disconnect-all-error-toast',
+      });
     } else {
-      setShowSuccessToast(true);
+      toast.success(t('disconnectAllSitesSuccess'), {
+        id: 'disconnect-all-success-toast',
+      });
     }
-  }, [dispatch, mergedConnectionsList, subjects]);
+  }, [dispatch, mergedConnectionsList, subjects, t]);
 
   const handleConnectionClick = (connection) => {
     transitionForward(() =>
@@ -218,28 +220,6 @@ const PermissionsPage = () => {
             gap={2}
             alignItems={AlignItems.center}
           >
-            {showSuccessToast && (
-              <ToastContainer>
-                <Toast
-                  text={t('disconnectAllSitesSuccess')}
-                  onClose={() => setShowSuccessToast(false)}
-                  autoHideTime={5000}
-                  onAutoHideToast={() => setShowSuccessToast(false)}
-                  dataTestId="disconnect-all-success-toast"
-                />
-              </ToastContainer>
-            )}
-            {showErrorToast && (
-              <ToastContainer>
-                <Toast
-                  text={t('disconnectAllSitesError')}
-                  onClose={() => setShowErrorToast(false)}
-                  autoHideTime={5000}
-                  onAutoHideToast={() => setShowErrorToast(false)}
-                  dataTestId="disconnect-all-error-toast"
-                />
-              </ToastContainer>
-            )}
             <Button
               size={ButtonSize.Lg}
               block


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Migrates the post-disconnect-all toast from the deprecated toast component

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: CEUX-1182

## **Manual testing steps**

1. Connect to a dapp
2. Menu > Dapp connections 
3. Click disconnect all

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only toast migration; disconnect-all behavior and copy are unchanged.
> 
> **Overview**
> **Disconnect-all feedback** on the permissions page now uses the shared **`toast`** helper instead of local state and inline **`Toast` / `ToastContainer`** in the footer.
> 
> After **Disconnect all**, **`handleDisconnectAll`** calls **`toast.success`** or **`toast.error`** with the same i18n strings and stable toast **`id`** values, and the footer no longer renders toast UI. **`t`** was added to the callback dependency array.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2b76a8928efb61a655990ab2b4103dcf384b05a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->