### PR TITLE
refactor: migrate multichain review permissions toast

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -137,9 +137,6 @@
   "accountOptions": {
     "message": "Kontooptionen"
   },
-  "accountPermissionToast": {
-    "message": "Kontogenehmigungen aktualisiert"
-  },
   "accountSelectionRequired": {
     "message": "Sie müssen ein Konto auswählen!"
   },

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -137,9 +137,6 @@
   "accountOptions": {
     "message": "Επιλογές λογαριασμού"
   },
-  "accountPermissionToast": {
-    "message": "Ενημέρωση αδειών λογαριασμού"
-  },
   "accountSelectionRequired": {
     "message": "Πρέπει να επιλέξετε έναν λογαριασμό!"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -137,9 +137,6 @@
   "accountOptions": {
     "message": "Account options"
   },
-  "accountPermissionToast": {
-    "message": "Account permissions updated"
-  },
   "accountSelectionRequired": {
     "message": "You need to select an account!"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -137,9 +137,6 @@
   "accountOptions": {
     "message": "Account options"
   },
-  "accountPermissionToast": {
-    "message": "Account permissions updated"
-  },
   "accountSelectionRequired": {
     "message": "You need to select an account!"
   },

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -137,9 +137,6 @@
   "accountOptions": {
     "message": "Opciones de la cuenta"
   },
-  "accountPermissionToast": {
-    "message": "Se actualizaron los permisos de la cuenta"
-  },
   "accountSelectionRequired": {
     "message": "¡Debe seleccionar una cuenta!"
   },

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -137,9 +137,6 @@
   "accountOptions": {
     "message": "Options du compte"
   },
-  "accountPermissionToast": {
-    "message": "Les autorisations accordées au compte ont été mises à jour"
-  },
   "accountSelectionRequired": {
     "message": "Vous devez sélectionner un compte !"
   },

--- a/app/_locales/ga/messages.json
+++ b/app/_locales/ga/messages.json
@@ -112,9 +112,6 @@
   "accountOptions": {
     "message": "Roghanna cuntais"
   },
-  "accountPermissionToast": {
-    "message": "Ceadanna cuntais nuashonraithe"
-  },
   "accountSelectionRequired": {
     "message": "Ní mór duit cuntas a roghnú!"
   },

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -137,9 +137,6 @@
   "accountOptions": {
     "message": "अकाउंट विकल्प"
   },
-  "accountPermissionToast": {
-    "message": "अकाउंट अनुमतियां अपडेट की गईं"
-  },
   "accountSelectionRequired": {
     "message": "आपको एक अकाउंट चुनना होगा!"
   },

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -137,9 +137,6 @@
   "accountOptions": {
     "message": "Opsi akun"
   },
-  "accountPermissionToast": {
-    "message": "Izin akun diperbarui"
-  },
   "accountSelectionRequired": {
     "message": "Anda harus memilih satu akun!"
   },

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -137,9 +137,6 @@
   "accountOptions": {
     "message": "アカウントのオプション"
   },
-  "accountPermissionToast": {
-    "message": "アカウントのアクセス許可が更新されました"
-  },
   "accountSelectionRequired": {
     "message": "アカウントを選択する必要があります！"
   },

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -137,9 +137,6 @@
   "accountOptions": {
     "message": "계정 옵션"
   },
-  "accountPermissionToast": {
-    "message": "계정 권한이 업데이트됨"
-  },
   "accountSelectionRequired": {
     "message": "계정을 선택해야 합니다!"
   },

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -137,9 +137,6 @@
   "accountOptions": {
     "message": "Opções da conta"
   },
-  "accountPermissionToast": {
-    "message": "Permissões de conta atualizadas"
-  },
   "accountSelectionRequired": {
     "message": "Você precisa selecionar uma conta!"
   },

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -137,9 +137,6 @@
   "accountOptions": {
     "message": "Параметры счета"
   },
-  "accountPermissionToast": {
-    "message": "Разрешения счета обновлены"
-  },
   "accountSelectionRequired": {
     "message": "Вам необходимо выбрать счет!"
   },

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -137,9 +137,6 @@
   "accountOptions": {
     "message": "Mga Opsyon sa Account"
   },
-  "accountPermissionToast": {
-    "message": "In-update ang mga pahintulot ng account"
-  },
   "accountSelectionRequired": {
     "message": "Kailangan mong pumili ng account!"
   },

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -137,9 +137,6 @@
   "accountOptions": {
     "message": "Hesap Seçenekleri"
   },
-  "accountPermissionToast": {
-    "message": "Hesap izinleri güncellendi"
-  },
   "accountSelectionRequired": {
     "message": "Bir hesap seçmeniz gerekiyor!"
   },

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -137,9 +137,6 @@
   "accountOptions": {
     "message": "Tùy chọn tài khoản"
   },
-  "accountPermissionToast": {
-    "message": "Đã cập nhật quyền đối với tài khoản"
-  },
   "accountSelectionRequired": {
     "message": "Bạn cần chọn một tài khoản!"
   },

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -137,9 +137,6 @@
   "accountOptions": {
     "message": "账户选项"
   },
-  "accountPermissionToast": {
-    "message": "账户许可已更新"
-  },
   "accountSelectionRequired": {
     "message": "您需要选择一个账户！"
   },

--- a/ui/components/multichain-accounts/permissions/permission-review-page/multichain-review-permissions-page.tsx
+++ b/ui/components/multichain-accounts/permissions/permission-review-page/multichain-review-permissions-page.tsx
@@ -34,7 +34,7 @@ import {
   setPermittedAccounts,
   setPermittedChains,
 } from '../../../../store/actions';
-import { ToastContainer, Toast } from '../../../multichain/toast/toast';
+import { toast, ToastContent } from '../../../ui/toast/toast';
 import { NoConnectionContent } from '../../../multichain/pages/connections/components/no-connection';
 import { Content, Footer, Page } from '../../../multichain/pages/page';
 import { SubjectsType } from '../../../multichain/pages/connections/components/connections.types';
@@ -72,8 +72,6 @@ export const MultichainReviewPermissions = () => {
 
   const originParam = searchParams.get('origin');
   const securedOrigin = decodeURIComponent(originParam ?? '');
-  const [showAccountToast, setShowAccountToast] = useState(false);
-  const [showNetworkToast, setShowNetworkToast] = useState(false);
   const [showDisconnectAllModal, setShowDisconnectAllModal] = useState(false);
   const [showDisconnectPermissionsModal, setShowDisconnectPermissionsModal] =
     useState(false);
@@ -85,13 +83,6 @@ export const MultichainReviewPermissions = () => {
   const showPermittedNetworkToastOpen = useSelector(
     getShowPermittedNetworkToastOpen,
   );
-
-  useEffect(() => {
-    if (showPermittedNetworkToastOpen) {
-      setShowNetworkToast(showPermittedNetworkToastOpen);
-      dispatch(hidePermittedNetworkToast());
-    }
-  }, [showPermittedNetworkToastOpen, dispatch]);
 
   const requestAccountsAndChainPermissions = async () => {
     const requestId = await dispatch(
@@ -109,6 +100,26 @@ export const MultichainReviewPermissions = () => {
   );
   const connectedSubjectsMetadata = subjectMetadata[activeTabOrigin];
   const subjects = useSelector(getPermissionSubjects);
+
+  const showNetworkPermissionToast = useCallback(() => {
+    toast.success(<ToastContent title={t('networkPermissionToast')} />, {
+      id: 'network-permission-toast',
+      icon: (
+        <AvatarFavicon
+          name={connectedSubjectsMetadata?.name}
+          size={AvatarFaviconSize.Sm}
+          src={connectedSubjectsMetadata?.iconUrl}
+        />
+      ),
+    });
+  }, [connectedSubjectsMetadata?.iconUrl, connectedSubjectsMetadata?.name, t]);
+
+  useEffect(() => {
+    if (showPermittedNetworkToastOpen) {
+      showNetworkPermissionToast();
+      dispatch(hidePermittedNetworkToast());
+    }
+  }, [showPermittedNetworkToastOpen, dispatch, showNetworkPermissionToast]);
 
   const disconnectAllPermissions = () => {
     const subject = (subjects as SubjectsType)[activeTabOrigin];
@@ -178,7 +189,7 @@ export const MultichainReviewPermissions = () => {
 
     dispatch(setPermittedChains(activeTabOrigin, chainIds));
 
-    setShowNetworkToast(true);
+    showNetworkPermissionToast();
   };
 
   const existingPermissions = useSelector((state) =>
@@ -413,36 +424,6 @@ export const MultichainReviewPermissions = () => {
                 gap={2}
                 alignItems={BoxAlignItems.Center}
               >
-                {showAccountToast ? (
-                  <ToastContainer>
-                    <Toast
-                      text={t('accountPermissionToast')}
-                      onClose={() => setShowAccountToast(false)}
-                      startAdornment={
-                        <AvatarFavicon
-                          name={connectedSubjectsMetadata?.name}
-                          size={AvatarFaviconSize.Sm}
-                          src={connectedSubjectsMetadata?.iconUrl}
-                        />
-                      }
-                    />
-                  </ToastContainer>
-                ) : null}
-                {showNetworkToast ? (
-                  <ToastContainer>
-                    <Toast
-                      text={t('networkPermissionToast')}
-                      onClose={() => setShowNetworkToast(false)}
-                      startAdornment={
-                        <AvatarFavicon
-                          name={connectedSubjectsMetadata?.name}
-                          size={AvatarFaviconSize.Sm}
-                          src={connectedSubjectsMetadata?.iconUrl}
-                        />
-                      }
-                    />
-                  </ToastContainer>
-                ) : null}
                 <Button
                   size={ButtonSize.Lg}
                   isFullWidth


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Migrates the multichain review permissions page toast 

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: CEUX-1183

## **Manual testing steps**

1. Connect to a dapp
2. Menu > Dapp pemissions
3. Edit the allowed chains

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only toast plumbing on the dapp permissions review page; the main product change is losing the account-permissions confirmation toast.
> 
> **Overview**
> **Migrates network-permission feedback** on the multichain review permissions page from inline `ToastContainer` / multichain `Toast` components to the shared `ui/toast` API (`toast.success` + `ToastContent`), including the dapp favicon and a stable toast id when chains are updated or when Redux signals the permitted-network toast should show.
> 
> **Removes the account-permissions success toast** from the page footer (and drops the `accountPermissionToast` string from all locale files), so only the network update path still surfaces a confirmation via the global toaster.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb428dd6064b1ef597b4b8f46f876c82471491bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->