### PR TITLE
bump: websocket-driver to fix audit

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -44702,13 +44702,13 @@ __metadata:
   linkType: hard
 
 "websocket-driver@npm:>=0.5.1, websocket-driver@npm:^0.7.4":
-  version: 0.7.4
-  resolution: "websocket-driver@npm:0.7.4"
+  version: 0.7.5
+  resolution: "websocket-driver@npm:0.7.5"
   dependencies:
     http-parser-js: "npm:>=0.5.1"
     safe-buffer: "npm:>=5.1.0"
     websocket-extensions: "npm:>=0.1.1"
-  checksum: 10/17197d265d5812b96c728e70fd6fe7d067471e121669768fe0c7100c939d997ddfc807d371a728556e24fc7238aa9d58e630ea4ff5fd4cfbb40f3d0a240ef32d
+  checksum: 10/0671fef8c79ba1b1b2fa6b7d95cb034d059410e7c4cfd7ef42063a254e12ca2917806c3a5026206b33abf25a5d44a651c547b8f74d9ec94c9fe4df6fa1bc63f7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

Bump `websocket-driver` from `0.7.4` to `0.7.5`

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:  #44500

<!--## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level transitive dependency bump with no application code changes; typical low-risk security/audit maintenance.
> 
> **Overview**
> Updates the lockfile so **`websocket-driver`** resolves to **0.7.5** instead of **0.7.4**, addressing a dependency audit finding (fixes #44500).
> 
> This is a **lockfile-only** change: version, resolution, and checksum for `websocket-driver` are updated; dependency declarations (`http-parser-js`, `safe-buffer`, `websocket-extensions`) are unchanged. The package is pulled in transitively (e.g. **`webpack-dev-server` → `sockjs` → `websocket-driver`**), not as a direct app dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c04bb63e819aa2dc2f19d03b15b0c28333b48480. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->