### PR TITLE
chore: Revert "chore(6926): migrate ReactDOM.render to createRoot (#43872)"

### DIFF
--- a/development/ts-migration-dashboard/app/index.tsx
+++ b/development/ts-migration-dashboard/app/index.tsx
@@ -1,12 +1,7 @@
 import * as React from 'react';
-import { createRoot } from 'react-dom/client';
+import ReactDOM from 'react-dom';
 import App from './components/App';
 
 const appElement = document.querySelector('#app');
 
-if (!appElement) {
-  throw new Error('TS migration dashboard mount node "#app" not found');
-}
-
-const root = createRoot(appElement);
-root.render(<App />);
+ReactDOM.render(<App />, appElement);

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -55,7 +55,6 @@
       "ObjectMultiplex: Malformed chunk warnings": 1,
       "error: AssertionError: The Snaps platform requires": 1,
       "error: Error: invalid address (argument=\"address\", value=\"0x\",": 2,
-      "error: This browser doesn't support cancelAnimationFrame.": 1,
       "error: {": 1,
       "warn: Error during SnapController initialization. AssertionError:": 2
     },
@@ -236,9 +235,6 @@
     "ui/components/app/multi-rpc-edit-modal/network-list-item/network-list-item.test.tsx": {
       "React: Act warnings (component updates not wrapped)": 1
     },
-    "ui/components/app/musd/hooks/useMerklRewards.test.ts": {
-      "React: State updates on unmounted components": 1
-    },
     "ui/components/app/name/name-details/name-details.test.tsx": {
       "React: Act warnings (component updates not wrapped)": 12
     },
@@ -258,7 +254,6 @@
       "MetaMask: Background connection not initialized": 4
     },
     "ui/components/app/rewards/RewardsVipBadge.test.tsx": {
-      "React: State updates on unmounted components": 1,
       "error: Error: test": 1
     },
     "ui/components/app/selected-account/selected-account-component.test.js": {
@@ -402,7 +397,6 @@
       "error: Unexpected key \"internalAccounts\" found in": 1
     },
     "ui/components/multichain/networks-form/networks-form.test.js": {
-      "React: State updates on unmounted components": 1,
       "Reselect: Input stability warnings": 1
     },
     "ui/components/multichain/notifications-settings-box/notifications-settings-box.test.tsx": {
@@ -465,10 +459,6 @@
     "ui/hooks/bridge/useSubmitBridgeTransaction.test.tsx": {
       "Reselect: Identity function warnings": 1
     },
-    "ui/hooks/bridge/useTokenSearchResults.test.ts": {
-      "React: Act warnings (component updates not wrapped)": 2,
-      "Reselect: Input stability warnings": 1
-    },
     "ui/hooks/gator-permissions/useGatorPermissionTokenInfo.test.tsx": {
       "React: Act warnings (component updates not wrapped)": 10
     },
@@ -515,7 +505,6 @@
       "React: Act warnings (component updates not wrapped)": 2
     },
     "ui/hooks/rewards/useVipTier.test.ts": {
-      "React: State updates on unmounted components": 1,
       "error: Error: fail": 1
     },
     "ui/hooks/subscription/useSubscriptionPricing.test.ts": {
@@ -528,8 +517,7 @@
       "React: Act warnings (component updates not wrapped)": 3
     },
     "ui/hooks/useDecodedTransactionData.test.ts": {
-      "React: Act usage warnings (incorrect await)": 10,
-      "React: Act warnings (component updates not wrapped)": 10,
+      "React: Act warnings (component updates not wrapped)": 7,
       "error: Unexpected keys \"data\", \"to\", \"chainId\"": 1
     },
     "ui/hooks/useDisplayName.test.ts": {
@@ -566,15 +554,12 @@
     "ui/hooks/useTransactionDisplayData.test.js": {
       "MetaMask: XChain Swaps warnings": 4
     },
-    "ui/hooks/useTrustSignals.test.ts": {
-      "Test errors: Uncaught Errors": 4
-    },
     "ui/pages/asset/components/asset-page.test.tsx": {
       "React: DOM nesting violations": 2,
       "Reselect: Identity function warnings": 1
     },
     "ui/pages/bridge/index.test.tsx": {
-      "React: Act warnings (component updates not wrapped)": 5,
+      "React: Act warnings (component updates not wrapped)": 4,
       "Reselect: Identity function warnings": 1,
       "Reselect: Input stability warnings": 1
     },
@@ -633,8 +618,7 @@
       "React: Act warnings (component updates not wrapped)": 2
     },
     "ui/pages/confirmations/components/confirm/info/hooks/useDecodedTransactionData.test.ts": {
-      "React: Act usage warnings (incorrect await)": 9,
-      "React: Act warnings (component updates not wrapped)": 9
+      "React: Act warnings (component updates not wrapped)": 7
     },
     "ui/pages/confirmations/components/confirm/info/hooks/useFeeCalculations.test.ts": {
       "MetaMask: Background connection not initialized": 32
@@ -663,8 +647,7 @@
       "Reselect: Identity function warnings": 1
     },
     "ui/pages/confirmations/components/confirm/info/shared/batched-approval-function/batched-approval-function.test.tsx": {
-      "React: Act usage warnings (incorrect await)": 4,
-      "React: Act warnings (component updates not wrapped)": 4
+      "React: Act warnings (component updates not wrapped)": 2
     },
     "ui/pages/confirmations/components/confirm/info/shared/edit-gas-fees-row/edit-gas-fees-row.test.tsx": {
       "MetaMask: Background connection not initialized": 88
@@ -706,8 +689,7 @@
       "React: Act warnings (component updates not wrapped)": 1
     },
     "ui/pages/confirmations/components/confirm/info/shared/transaction-data/transaction-data.test.tsx": {
-      "React: Act usage warnings (incorrect await)": 10,
-      "React: Act warnings (component updates not wrapped)": 9,
+      "React: Act warnings (component updates not wrapped)": 1,
       "React: Missing key props in lists": 1
     },
     "ui/pages/confirmations/components/confirm/info/shared/transaction-details/transaction-details.test.tsx": {

--- a/ui/index.js
+++ b/ui/index.js
@@ -1,7 +1,9 @@
 import copyToClipboard from 'copy-to-clipboard';
 import log from 'loglevel';
-import React, { StrictMode } from 'react';
-import { createRoot } from 'react-dom/client';
+import React from 'react';
+// TODO: https://github.com/MetaMask/MetaMask-planning/issues/6925
+// eslint-disable-next-line react/no-deprecated
+import { render } from 'react-dom';
 import browser from 'webextension-polyfill';
 import { isInternalAccountInPermittedAccountIds } from '@metamask/chain-agnostic-permission';
 
@@ -68,30 +70,6 @@ export {
 } from './helpers/utils/display-critical-error';
 
 log.setLevel(global.METAMASK_DEBUG ? 'debug' : 'warn', false);
-
-const reactRoots = new WeakMap();
-
-function renderUi(element, container) {
-  let root = reactRoots.get(container);
-  if (!root) {
-    root = createRoot(container);
-    reactRoots.set(container, root);
-  }
-  root.render(element);
-}
-
-function wrapWithStrictModeIfDevelopment(element) {
-  const isDevelopment =
-    process.env.NODE_ENV === 'development' ||
-    process.env.METAMASK_DEBUG ||
-    global.METAMASK_DEBUG;
-
-  if (isDevelopment) {
-    return <StrictMode>{element}</StrictMode>;
-  }
-
-  return element;
-}
 
 /**
  * @type {PromiseWithResolvers<ReturnType<typeof configureStore>>}
@@ -273,12 +251,7 @@ async function startApp(metamaskState, opts) {
   // `submitRequestToBackground` with it.
   const uiMessenger = createUIMessenger();
   trace({ name: TraceName.FirstRender, parentContext: traceContext }, () =>
-    renderUi(
-      wrapWithStrictModeIfDevelopment(
-        <Root store={store} uiMessenger={uiMessenger} />,
-      ),
-      opts.container,
-    ),
+    render(<Root store={store} uiMessenger={uiMessenger} />, opts.container),
   );
 
   return store;

--- a/ui/pages/settings/debug-tab/debug-content/debug-content.tsx
+++ b/ui/pages/settings/debug-tab/debug-content/debug-content.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../../../helpers/constants/design-system';
 import { ONBOARDING_REVIEW_SRP_ROUTE } from '../../../../helpers/constants/routes';
 
+import { useI18nContext } from '../../../../hooks/useI18nContext';
 import {
   perpsToggleTestnet,
   resetOnboarding,
@@ -37,29 +38,15 @@ import SentryTest from './sentry-test';
 import { BackupAndSyncDevSettings } from './backup-and-sync';
 import MigrateToSplitStateTest from './migrate-to-split-state-test';
 
-const PAGE_CRASH_ERROR_MESSAGE =
-  'Unable to find value of key "debug" for locale "en"';
-
-type PageCrashTriggerProps = {
-  shouldCrash: boolean;
-};
-
-const PageCrashTrigger = ({ shouldCrash }: PageCrashTriggerProps) => {
-  if (shouldCrash) {
-    throw new Error(PAGE_CRASH_ERROR_MESSAGE);
-  }
-
-  return null;
-};
-
 const DebugContent = () => {
+  const t = useI18nContext();
   const dispatch = useDispatch();
   const navigate = useNavigate();
 
-  const [shouldCrashPage, setShouldCrashPage] = useState(false);
-  const triggerPageCrash = useCallback(() => {
-    setShouldCrashPage(true);
-  }, []);
+  // This translation call is only required for the "Generate Page Crash" test button.
+  // The crash mechanism works by setting 'debug' to undefined in the locale,
+  // which causes this t() call to throw an error that triggers the error boundary.
+  t('debug');
 
   const [hasResetAnnouncements, setHasResetAnnouncements] = useState(false);
   const [hasResetOnboarding, setHasResetOnboarding] = useState(false);
@@ -226,7 +213,6 @@ const DebugContent = () => {
 
   return (
     <div className="settings-page__body">
-      <PageCrashTrigger shouldCrash={shouldCrashPage} />
       <Text className="settings-page__security-tab-sub-header__bold">
         States
       </Text>
@@ -264,7 +250,7 @@ const DebugContent = () => {
       </div>
 
       <BackupAndSyncDevSettings />
-      <SentryTest triggerPageCrash={triggerPageCrash} />
+      <SentryTest />
       <hr />
       <MigrateToSplitStateTest />
       <hr />

--- a/ui/pages/settings/debug-tab/debug-content/sentry-test.tsx
+++ b/ui/pages/settings/debug-tab/debug-content/sentry-test.tsx
@@ -1,4 +1,6 @@
 import React, { useState, useCallback, ReactElement } from 'react';
+import { flushSync } from 'react-dom';
+import { useDispatch, useSelector } from 'react-redux';
 import {
   Box,
   Button,
@@ -18,15 +20,20 @@ import {
 } from '../../../../helpers/constants/design-system';
 import { trace, TraceName } from '../../../../../shared/lib/trace';
 
+import { setCurrentLocale } from '../../../../store/actions';
+import { FALLBACK_LOCALE, fetchLocale } from '../../../../../shared/lib/i18n';
+import { getCurrentLocale } from '../../../../ducks/locale/locale';
+
 function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
-type SentryTestProps = {
-  triggerPageCrash: () => void;
-};
+const SentryTest = () => {
+  const currentLocale: string =
+    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
+    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
+    useSelector(getCurrentLocale) || FALLBACK_LOCALE;
 
-const SentryTest = ({ triggerPageCrash }: SentryTestProps) => {
   return (
     <>
       <Text className="settings-page__security-tab-sub-header__bold">
@@ -38,7 +45,7 @@ const SentryTest = ({ triggerPageCrash }: SentryTestProps) => {
         <CaptureUIError />
         <CaptureBackgroundError />
         <GenerateTrace />
-        <GeneratePageCrash triggerPageCrash={triggerPageCrash} />
+        <GeneratePageCrash currentLocale={currentLocale} />
       </div>
     </>
   );
@@ -175,14 +182,20 @@ function GenerateTrace() {
 
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 // eslint-disable-next-line @typescript-eslint/naming-convention
-function GeneratePageCrash({
-  triggerPageCrash,
-}: {
-  triggerPageCrash: () => void;
-}) {
-  const handleClick = useCallback(async () => {
-    triggerPageCrash();
-  }, [triggerPageCrash]);
+function GeneratePageCrash({ currentLocale }: { currentLocale: string }) {
+  const dispatch = useDispatch();
+  const handleClick = async () => {
+    const localeMessages = await fetchLocale(currentLocale);
+    flushSync(() => {
+      dispatch(
+        setCurrentLocale(currentLocale, {
+          ...localeMessages,
+          // @ts-expect-error - remove a language string in this page to trigger a page crash
+          debug: undefined,
+        }),
+      );
+    });
+  };
 
   return (
     <TestButton
@@ -224,9 +237,7 @@ function TestButton({
       await onClick();
     } catch (error) {
       hasError = true;
-      if (!expectError) {
-        throw error;
-      }
+      throw error;
     } finally {
       // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
       // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
@@ -234,7 +245,7 @@ function TestButton({
         setIsComplete(true);
       }
     }
-  }, [onClick, expectError]);
+  }, [onClick]);
 
   return (
     <Box


### PR DESCRIPTION
This reverts commit 9efc6d62eda0b07512497ea9daaa5888c4c7f76d.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the primary UI bootstrap path (deprecated API, no StrictMode) and alters dev-only Sentry crash testing; behavior may differ from the createRoot migration until issue #6925 is addressed.
> 
> **Overview**
> Reverts the **React 18 `createRoot`** rollout and restores **`ReactDOM.render`** for the extension UI (`ui/index.js`) and the TS migration dashboard. That drops the **`WeakMap` root cache**, **dev-only `StrictMode` wrapping**, and the **`#app` mount guard** on the dashboard.
> 
> The debug **“Generate Page Crash”** flow is reworked: **`PageCrashTrigger`** and the `triggerPageCrash` prop are removed in favor of **`GeneratePageCrash`** dispatching locale messages with `debug: undefined` inside **`flushSync`**, while **`DebugContent`** calls **`t('debug')`** so a missing string trips the error boundary. **`TestButton`** always rethrows caught errors instead of swallowing them when `expectError` is false.
> 
> **`test/jest/console-baseline-unit.json`** is updated to match changed Jest console noise (fewer StrictMode/double-render warnings, removed entries for some tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e98b5cbc8df030b26bd2d417cd71e84394164ec1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->