### PR TITLE
ci(amo): allow release-team manual dispatch of AMO production (INFRA-3769)

### DIFF
--- a/.github/workflows/upload-extension-to-amo.yml
+++ b/.github/workflows/upload-extension-to-amo.yml
@@ -25,15 +25,21 @@ name: Upload extension to Firefox AMO
 #   aud = sts.amazonaws.com
 #   sub = repo:MetaMask/metamask-extension:environment:{amo-dev|amo-flask|amo-production}
 # dev (amo-dev): ref + job_workflow_ref pinned to main (human E2E).
-# PRD flask + production (amo-flask / amo-production):
+# PRD flask (amo-flask):
 #   ref              = refs/heads/main | refs/heads/release/*
 #   job_workflow_ref = .../upload-extension-to-amo.yml@refs/heads/*
-#   actor            = runway-github[bot]
-#   actor_id         = 73448015
+#   actor            = runway-github[bot] OR @MetaMask/release-team member
+#   actor_id         = 73448015 (Runway) OR human release-team member
+# PRD production (amo-production):
+#   ref              = refs/heads/main ONLY (timing-sensitive; aligned with ~1% CWS rollout)
+#   job_workflow_ref = .../upload-extension-to-amo.yml@refs/heads/*
+#   actor            = runway-github[bot] OR @MetaMask/release-team member
+#   actor_id         = 73448015 (Runway) OR human release-team member
 #
-# GitHub Environment deployment branches on amo-production and amo-flask must allow main + release/*.
+# GitHub Environment deployment branches: amo-production → main only; amo-flask → main + release/*.
 #
-# INFRA-3649 — Runway sender verification (defense-in-depth; primary gate is IAM trust actor_id).
+# INFRA-3649 — sender verification (defense-in-depth; primary gate is IAM trust on amo-production/flask).
+# INFRA-3769 — @MetaMask/release-team members may dispatch production manually (main only).
 #
 # Lambda invoke must use alias qualifier (dev | flask | production); unqualified invoke is denied.
 # AMO JWT secrets are read inside Lambda (assumes amo-submission-secrets-{env}), not by the runner.
@@ -97,9 +103,14 @@ jobs:
               echo "::error::Dev (amo-dev) uploads must run from refs/heads/main (current: ${GITHUB_REF})"
               exit 1
             fi
-          elif [[ "${TARGET}" == "production" || "${TARGET}" == "flask" ]]; then
+          elif [[ "${TARGET}" == "production" ]]; then
+            if [[ "${GITHUB_REF}" != "refs/heads/main" ]]; then
+              echo "::error::Production uploads must run from refs/heads/main only (current: ${GITHUB_REF}). AMO production is timing-sensitive; dispatch from main after the release is cut."
+              exit 1
+            fi
+          elif [[ "${TARGET}" == "flask" ]]; then
             if [[ "${GITHUB_REF}" != "refs/heads/main" && ! "${GITHUB_REF}" =~ ^refs/heads/release/ ]]; then
-              echo "::error::Production and Flask uploads must run from refs/heads/main or refs/heads/release/* (current: ${GITHUB_REF})"
+              echo "::error::Flask uploads must run from refs/heads/main or refs/heads/release/* (current: ${GITHUB_REF})"
               exit 1
             fi
           fi
@@ -200,11 +211,15 @@ jobs:
             echo "| Branch | \`${{ github.ref }}\` |"
           } >> "${GITHUB_STEP_SUMMARY}"
 
-      # Defense-in-depth: fail fast if a non-Runway actor dispatches a production or flask run.
-      # The authoritative gate is IAM trust (actor_id=73448015) on amo-submission-production/flask.
-      - name: Verify Runway sender (production and flask)
+      # Defense-in-depth: reject unauthorized actors before any AWS credential exchange.
+      # Allowed: Runway bot (actor_id=73448015) OR a member of @MetaMask/release-team.
+      # The authoritative IAM gate is the amo-submission-production/flask trust policy.
+      # INFRA-3769: release-team members may manually dispatch production from main.
+      - name: Verify authorized sender (production and flask)
         if: inputs.target == 'production' || inputs.target == 'flask'
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTOR: ${{ github.actor }}
           SENDER_ID: ${{ github.event.sender.id }}
           SENDER_LOGIN: ${{ github.event.sender.login }}
           RUNWAY_ACTOR_ID: '73448015'
@@ -212,12 +227,20 @@ jobs:
         run: |
           set -euo pipefail
           echo "Sender: ${SENDER_LOGIN} (id=${SENDER_ID})"
-          echo "Expected: ${RUNWAY_ACTOR_LOGIN} (id=${RUNWAY_ACTOR_ID})"
-          if [[ "${SENDER_ID}" != "${RUNWAY_ACTOR_ID}" ]]; then
-            echo "::error::Production and Flask uploads must be dispatched by Runway (expected sender_id=${RUNWAY_ACTOR_ID} / ${RUNWAY_ACTOR_LOGIN}, got ${SENDER_ID} / ${SENDER_LOGIN}). IAM trust would also reject this OIDC request."
-            exit 1
+          if [[ "${SENDER_ID}" == "${RUNWAY_ACTOR_ID}" ]]; then
+            echo "Runway sender verified (id=${SENDER_ID})."
+            exit 0
           fi
-          echo "Sender verified: ${SENDER_LOGIN} (id=${SENDER_ID})"
+          # Human actor — check @MetaMask/release-team membership via GitHub API.
+          HTTP_STATUS=$(gh api \
+            "orgs/MetaMask/teams/release-team/memberships/${ACTOR}" \
+            --silent -o /dev/null -w "%{http_code}" 2>/dev/null || echo "000")
+          if [[ "${HTTP_STATUS}" == "200" ]]; then
+            echo "Release-team member verified: ${ACTOR}"
+            exit 0
+          fi
+          echo "::error::Unauthorized actor '${ACTOR}' (sender_id=${SENDER_ID}). Production and Flask uploads must be dispatched by Runway (id=${RUNWAY_ACTOR_ID}) or a member of @MetaMask/release-team. IAM trust would also reject this OIDC request."
+          exit 1
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@acca2b1b2070338fb9fd1ca27ecee81d687e58e5 # v6.1.2

--- a/.github/workflows/upload-extension-to-amo.yml
+++ b/.github/workflows/upload-extension-to-amo.yml
@@ -211,36 +211,31 @@ jobs:
             echo "| Branch | \`${{ github.ref }}\` |"
           } >> "${GITHUB_STEP_SUMMARY}"
 
-      # Defense-in-depth: reject unauthorized actors before any AWS credential exchange.
-      # Allowed: Runway bot (actor_id=73448015) OR a member of @MetaMask/release-team.
-      # The authoritative IAM gate is the amo-submission-production/flask trust policy.
-      # INFRA-3769: release-team members may manually dispatch production from main.
+      # Defense-in-depth: production and flask dispatch must be Runway (automated path) or a human
+      # (manual path — INFRA-3769). Non-Runway bots are rejected before any AWS credential exchange.
+      # Human authorization is delegated to the amo-production/amo-flask GitHub Environment
+      # required-reviewers gate (configured by Platform to @MetaMask/release-team), which must be
+      # approved before this job runs. GITHUB_TOKEN does not carry read:org scope so team membership
+      # cannot be verified at the workflow layer. IAM trust is the authoritative technical control.
       - name: Verify authorized sender (production and flask)
         if: inputs.target == 'production' || inputs.target == 'flask'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          ACTOR: ${{ github.actor }}
           SENDER_ID: ${{ github.event.sender.id }}
           SENDER_LOGIN: ${{ github.event.sender.login }}
+          SENDER_TYPE: ${{ github.event.sender.type }}
           RUNWAY_ACTOR_ID: '73448015'
-          RUNWAY_ACTOR_LOGIN: 'runway-github[bot]'
         run: |
           set -euo pipefail
-          echo "Sender: ${SENDER_LOGIN} (id=${SENDER_ID})"
-          if [[ "${SENDER_ID}" == "${RUNWAY_ACTOR_ID}" ]]; then
-            echo "Runway sender verified (id=${SENDER_ID})."
+          echo "sender.type=${SENDER_TYPE} actor=${{ github.actor }} sender=${SENDER_LOGIN} (id=${SENDER_ID})"
+          if [[ "${SENDER_TYPE}" == "Bot" ]]; then
+            if [[ "${SENDER_ID}" != "${RUNWAY_ACTOR_ID}" ]]; then
+              echo "::error::Non-Runway bot dispatch is not permitted for production/flask (sender_id=${SENDER_ID}). Automated uploads must use Runway (id=${RUNWAY_ACTOR_ID}); human dispatches require amo-production/amo-flask environment approval from @MetaMask/release-team."
+              exit 1
+            fi
+            echo "Runway bot verified (id=${SENDER_ID})."
             exit 0
           fi
-          # Human actor — check @MetaMask/release-team membership via GitHub API.
-          HTTP_STATUS=$(gh api \
-            "orgs/MetaMask/teams/release-team/memberships/${ACTOR}" \
-            --silent -o /dev/null -w "%{http_code}" 2>/dev/null || echo "000")
-          if [[ "${HTTP_STATUS}" == "200" ]]; then
-            echo "Release-team member verified: ${ACTOR}"
-            exit 0
-          fi
-          echo "::error::Unauthorized actor '${ACTOR}' (sender_id=${SENDER_ID}). Production and Flask uploads must be dispatched by Runway (id=${RUNWAY_ACTOR_ID}) or a member of @MetaMask/release-team. IAM trust would also reject this OIDC request."
-          exit 1
+          echo "Human dispatch confirmed. Environment reviewer approval is recorded by GitHub before this job runs."
 
       - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@acca2b1b2070338fb9fd1ca27ecee81d687e58e5 # v6.1.2


### PR DESCRIPTION
## **Description**

[INFRA-3769](https://consensyssoftware.atlassian.net/browse/INFRA-3769) — Allow \`@MetaMask/release-team\` to independently trigger AMO production upload via \`workflow_dispatch\`.

Follow-up to Mark Stacey's review of #44017:
> "To retain control over the timing of when the publishing happens, we usually submit to Firefox around the same time we increase rollout to 1% on Chrome. To retain that control, this will need to be removed from this workflow and triggered via an independent \`workflow_dispatch\` instead, **gated by release team approval**."

**\`upload-extension-to-amo.yml\`:**

1. **Production branch restriction tightened** — \`production\` target now requires \`refs/heads/main\` only (was \`main | release/*\`). AMO production is timing-sensitive; it must be dispatched from \`main\` after the release is cut, aligned with the ~1% CWS rollout milestone. Flask keeps \`main | release/*\` unchanged.

2. **Sender gate updated** — replaces the Runway-only "Verify Runway sender" step with "Verify authorized sender" that mirrors the pattern used in \`adjust-cws-rollout.yml\`:
   - Runway bot (\`actor_id=73448015\`) → verified by \`sender.id\`, existing path unchanged
   - Human actor → passed through; authorization delegated to the \`amo-production\` / \`amo-flask\` **GitHub Environment required-reviewers gate** (see prerequisite below)
   - Any other bot → rejected with a clear error before any AWS credential exchange

   \`GITHUB_TOKEN\` does not carry \`read:org\` scope so team membership cannot be verified at the workflow layer. The environment gate is the authoritative human control; IAM trust is the authoritative technical control.

### ⚠️ Hard prerequisite — must be in place before merge

Platform must configure the \`amo-production\` (and \`amo-flask\`) GitHub Environment in repo Settings → Environments with **\`@MetaMask/release-team\` as required reviewers** and deployment branch restricted to \`refs/heads/main\` before this workflow is used in production.

If the environment does not exist or has no required reviewers, GitHub auto-creates it with zero protection rules — meaning human dispatch would run immediately without any approval gate, which is the scenario we are explicitly trying to prevent.

**Out of scope (follow-up tracked in INFRA-3769):**
- IAM trust policy update (\`va-mmc-extension-submission-infra\`) — PR [consensys-vertical-apps/va-mmc-extension-submission-infra#12](https://github.com/consensys-vertical-apps/va-mmc-extension-submission-infra/pull/12) (merged)
- Runbook update: PR #24 in \`MetaMask/releases\` (INFRA-3676)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

- [INFRA-3769](https://consensyssoftware.atlassian.net/browse/INFRA-3769)
- [INFRA-2565](https://consensyssoftware.atlassian.net/browse/INFRA-2565) (epic)

## **Manual testing steps**

1. From \`main\`, dispatch \`upload-extension-to-amo.yml\` with \`target=production\` as a \`@MetaMask/release-team\` member (after env gate is configured) → expect environment approval prompt, then sender step confirms human dispatch and continues.
2. Dispatch with \`target=production\` as a non-Runway bot → expect immediate failure with \`::error::Non-Runway bot dispatch is not permitted\` before any AWS call.
3. Dispatch with \`target=production\` from a \`release/*\` branch → expect branch validation failure.
4. Dispatch with \`target=flask\` from a \`release/*\` branch → expect success (flask keeps \`main | release/*\`).
5. Runway-dispatched run with \`target=production\` → sender check passes on \`actor_id=73448015\`.

## **Screenshots/Recordings**

### **Before**

<!-- N/A — workflow-only change -->

### **After**

<!-- N/A — workflow-only change -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[INFRA-3769]: https://consensyssoftware.atlassian.net/browse/INFRA-3769?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INFRA-2565]: https://consensyssoftware.atlassian.net/browse/INFRA-2565?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes gates on production AMO uploads (timing-sensitive release path); human authorization depends on GitHub Environment reviewers and follow-up IAM trust updates, not workflow-level team verification.
> 
> **Overview**
> **Tightens AMO production dispatch rules** and **opens a manual path** for release-team–gated runs on `upload-extension-to-amo.yml`.
> 
> **Production** uploads now must be dispatched from **`refs/heads/main` only** (no `release/*`), with clearer errors explaining timing alignment with CWS rollout. **Flask** keeps **`main` or `release/*`**; branch validation is split so each target has its own rules.
> 
> The **Runway-only sender check** is replaced by **Verify authorized sender**: non-Runway **bots** are blocked before OIDC; **Runway** (`sender_id=73448015`) still passes; **human** dispatchers are accepted and documented as relying on **`amo-production` / `amo-flask` environment required reviewers** (no org API team check in-workflow). Header comments document separate flask vs production IAM/ref expectations and **INFRA-3769**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2b754982969ac92c95a79e61bc9b0d805c4601f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->