### PR TITLE
fix: prevent duplicate events during tab switch

### DIFF
--- a/ui/components/ui/tabs/tabs.test.tsx
+++ b/ui/components/ui/tabs/tabs.test.tsx
@@ -39,6 +39,26 @@ describe('Tabs', () => {
     expect(getByText('Tab 2 Content')).toBeInTheDocument();
   });
 
+  it('keeps clicked tab content visible while activeTab prop is still stale', () => {
+    const onTabClick = jest.fn();
+    const { getByText, queryByText } = render(
+      <Tabs activeTab="tab1" onTabClick={onTabClick}>
+        <Tab tabKey="tab1" name="Tab 1">
+          Tab 1 Content
+        </Tab>
+        <Tab tabKey="tab2" name="Tab 2">
+          Tab 2 Content
+        </Tab>
+      </Tabs>,
+    );
+
+    fireEvent.click(getByText('Tab 2'));
+
+    expect(onTabClick).toHaveBeenCalledWith('tab2');
+    expect(queryByText('Tab 1 Content')).not.toBeInTheDocument();
+    expect(getByText('Tab 2 Content')).toBeInTheDocument();
+  });
+
   it('renders with activeTab', () => {
     const { getByText, queryByText } = renderTabs({
       activeTab: 'tab2',

--- a/ui/components/ui/tabs/tabs.tsx
+++ b/ui/components/ui/tabs/tabs.tsx
@@ -86,10 +86,10 @@ export const Tabs = <TKey extends string = string>({
 
   useEffect(() => {
     const childIndex = findChildByKey(activeTab);
-    if (childIndex >= 0 && activeTabIndex !== childIndex) {
+    if (childIndex >= 0) {
       setActiveTabIndex(childIndex);
     }
-  }, [activeTab, findChildByKey, activeTabIndex]);
+  }, [activeTab, findChildByKey]);
 
   const clampedIndex =
     getValidChildren.length > 0
@@ -113,8 +113,8 @@ export const Tabs = <TKey extends string = string>({
       const direction = tabIndex > clampedIndex ? 'forward' : 'backward';
 
       const applyUpdate = () => {
-        setActiveTabIndex(tabIndex);
         onTabClick?.(tabKey);
+        setActiveTabIndex(tabIndex);
       };
 
       if (animated) {

--- a/ui/hooks/useTabState.test.ts
+++ b/ui/hooks/useTabState.test.ts
@@ -4,7 +4,10 @@ import { useTabState } from './useTabState';
 const mockSetSearchParams = jest.fn();
 
 jest.mock('react-router-dom', () => ({
-  useSearchParams: () => [new URLSearchParams('tab=tokens'), mockSetSearchParams],
+  useSearchParams: () => [
+    new URLSearchParams('tab=tokens'),
+    mockSetSearchParams,
+  ],
 }));
 
 describe('useTabState', () => {

--- a/ui/hooks/useTabState.test.ts
+++ b/ui/hooks/useTabState.test.ts
@@ -1,0 +1,26 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useTabState } from './useTabState';
+
+const mockSetSearchParams = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+  useSearchParams: () => [new URLSearchParams('tab=tokens'), mockSetSearchParams],
+}));
+
+describe('useTabState', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('clears navigation state when changing tabs', () => {
+    const { result } = renderHook(() => useTabState());
+
+    act(() => {
+      result.current[1]('defi');
+    });
+
+    expect(mockSetSearchParams).toHaveBeenCalledWith(expect.any(Function), {
+      state: null,
+    });
+  });
+});

--- a/ui/hooks/useTabState.ts
+++ b/ui/hooks/useTabState.ts
@@ -8,10 +8,14 @@ export function useTabState<TTab extends string = AccountOverviewTab>() {
 
   const setTab = useCallback(
     (value: TTab) =>
-      setSearchParams((prev) => {
-        prev.set('tab', value);
-        return prev;
-      }),
+      setSearchParams(
+        (prev) => {
+          prev.set('tab', value);
+          return prev;
+        },
+        // Clear stale location state when changing tabs via search params.
+        { state: null },
+      ),
     [setSearchParams],
   );
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Account overview subtabs use `Tabs` with two sources of truth for the active tab: internal `activeTabIndex` (what renders immediately on click) and the `activeTab` prop from the URL (`?tab=`).

When a user clicked a subtab (e.g. Tokens → DeFi):

1. `Tabs` updated `activeTabIndex` immediately, mounting DeFi content
2. `onTabClick` queued a URL update via `setSearchParams`
3. Before the URL caught up, a sync `useEffect` saw `activeTab` still pointing at the old tab and reset `activeTabIndex` back

This caused caused duplicate events to be emitted.

**Solution:**

1. **`tabs.tsx`** — Call `onTabClick` before `setActiveTabIndex` so URL/state updates are queued first. Only sync `activeTabIndex` from the `activeTab` prop when `activeTab` changes (remove `activeTabIndex` from the effect deps) so the effect does not fight an in-progress click.
2. **`useTabState.ts`** — Pass `{ state: null }` to `setSearchParams` when changing subtabs, so stale `location.state` from prior navigation (e.g. bottom-nav arrival) is not carried across subtab switches.

## **Changelog**

CHANGELOG entry: Fixed a bug where home subtab content was emitting duplicate events

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run `node development/mock-segment.js`
2. Open the extension home page on the Tokens subtab.
3. Click between the tabs
4. Verify that only one ...ScreenOpened or ...ScreenViewed event is emitted per tab load

Before, when clicking between tabs we'd see three events instead of one - one for the tab being clicked into, then the previous tab, and then the new tab again.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.