### PR TITLE
chore: updated networks for hardware accounts

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5860,6 +5860,9 @@
   "networkNameTron": {
     "message": "Tron"
   },
+  "networkNotSupportedByThisAccount": {
+    "message": "Not supported by this account."
+  },
   "networkOptions": {
     "message": "Network options"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -5860,6 +5860,9 @@
   "networkNameTron": {
     "message": "Tron"
   },
+  "networkNotSupportedByThisAccount": {
+    "message": "Not supported by this account."
+  },
   "networkOptions": {
     "message": "Network options"
   },

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
@@ -443,13 +443,13 @@ describe('NFTs options', () => {
     );
   });
 
-  it('does not show Non-EVM network rows in the home network filter for EVM-only account groups', async () => {
+  it('disables Non-EVM network rows in the home network filter for EVM-only account groups', async () => {
     const state = createMockState();
     selectLedgerAccount(state);
     state.metamask.useExternalServices = true;
     const store = configureMockStore([thunk])(state);
 
-    const { findByTestId, queryByTestId } = renderWithProvider(
+    const { findByTestId } = renderWithProvider(
       <AssetListControlBar />,
       store,
     );
@@ -457,8 +457,10 @@ describe('NFTs options', () => {
     fireEvent.click(await findByTestId('sort-by-networks'));
 
     expect(
-      queryByTestId(`home-network-filter-network-${SOLANA_CHAIN_ID}`),
-    ).not.toBeInTheDocument();
+      (
+        await findByTestId(`home-network-filter-network-${SOLANA_CHAIN_ID}`)
+      ).querySelector('.multichain-network-list-item--disabled'),
+    ).toBeInTheDocument();
   });
 
   it('shows Non-EVM network rows in the home network filter when the selected account group supports them', async () => {

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
@@ -61,6 +61,8 @@ const backgroundConnectionMock = new Proxy(
 const LEDGER_ACCOUNT_ID = '15e69915-2a1a-4019-93b3-916e11fd432f';
 const LEDGER_ACCOUNT_GROUP_ID =
   'keyring:Ledger Hardware/0xc42edfcc21ed14dda456aa0756c153f7985d8813';
+const DEFAULT_ACCOUNT_GROUP_ID = 'entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0';
+const SOLANA_ACCOUNT_ID = 'solana-account-id';
 const SOLANA_CHAIN_ID = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
 
 const createMockState = () => {
@@ -100,6 +102,29 @@ const createMockState = () => {
 const selectLedgerAccount = (state: ReturnType<typeof createMockState>) => {
   state.metamask.internalAccounts.selectedAccount = LEDGER_ACCOUNT_ID;
   state.metamask.selectedAccountGroup = LEDGER_ACCOUNT_GROUP_ID;
+};
+
+const addSolanaAccountToSelectedGroup = (
+  state: ReturnType<typeof createMockState>,
+) => {
+  state.metamask.internalAccounts.accounts[SOLANA_ACCOUNT_ID] = {
+    address: '7Ec4p8d1VzC9QYQ35gzfSNJbdf2D2qTyhQEt9Dz6F5CQ',
+    id: SOLANA_ACCOUNT_ID,
+    metadata: {
+      importTime: 0,
+      name: 'Solana Account',
+      keyring: {
+        type: 'Snap Keyring',
+      },
+    },
+    options: {},
+    methods: ['solana_signTransaction'],
+    scopes: [SOLANA_CHAIN_ID],
+    type: 'solana:data-account',
+  };
+  state.metamask.accountTree.wallets[
+    'entropy:01JKAF3DSGM3AB87EM9N0K41AJ'
+  ].groups[DEFAULT_ACCOUNT_GROUP_ID].accounts.push(SOLANA_ACCOUNT_ID);
 };
 
 describe('NFTs options', () => {
@@ -376,12 +401,10 @@ describe('NFTs options', () => {
 
     renderWithProvider(<AssetListControlBar />, store);
 
-    await waitFor(() =>
-      expect(enableAllPopularNetworksSpy).toHaveBeenCalled(),
-    );
+    await waitFor(() => expect(enableAllPopularNetworksSpy).toHaveBeenCalled());
   });
 
-  it('does not broaden an unsupported network filter for a non-hardware account', async () => {
+  it('falls back to all popular networks when a non-hardware EVM-only account has an unsupported network filter', async () => {
     const enableAllPopularNetworksSpy = jest.spyOn(
       actions,
       'setEnabledAllPopularNetworks',
@@ -396,12 +419,31 @@ describe('NFTs options', () => {
 
     renderWithProvider(<AssetListControlBar />, store);
 
+    await waitFor(() => expect(enableAllPopularNetworksSpy).toHaveBeenCalled());
+  });
+
+  it('does not broaden an unsupported network filter when the selected account group supports that network', async () => {
+    const enableAllPopularNetworksSpy = jest.spyOn(
+      actions,
+      'setEnabledAllPopularNetworks',
+    );
+    const state = createMockState();
+    addSolanaAccountToSelectedGroup(state);
+    state.metamask.enabledNetworkMap = {
+      solana: {
+        [SOLANA_CHAIN_ID]: true,
+      },
+    };
+    const store = configureMockStore([thunk])(state);
+
+    renderWithProvider(<AssetListControlBar />, store);
+
     await waitFor(() =>
       expect(enableAllPopularNetworksSpy).not.toHaveBeenCalled(),
     );
   });
 
-  it('does not show Non-EVM network rows in the home network filter for hardware wallets', async () => {
+  it('does not show Non-EVM network rows in the home network filter for EVM-only account groups', async () => {
     const state = createMockState();
     selectLedgerAccount(state);
     state.metamask.useExternalServices = true;
@@ -417,6 +459,21 @@ describe('NFTs options', () => {
     expect(
       queryByTestId(`home-network-filter-network-${SOLANA_CHAIN_ID}`),
     ).not.toBeInTheDocument();
+  });
+
+  it('shows Non-EVM network rows in the home network filter when the selected account group supports them', async () => {
+    const state = createMockState();
+    addSolanaAccountToSelectedGroup(state);
+    state.metamask.useExternalServices = true;
+    const store = configureMockStore([thunk])(state);
+
+    const { findByTestId } = renderWithProvider(<AssetListControlBar />, store);
+
+    fireEvent.click(await findByTestId('sort-by-networks'));
+
+    expect(
+      await findByTestId(`home-network-filter-network-${SOLANA_CHAIN_ID}`),
+    ).toBeInTheDocument();
   });
 
   it('opens the network filter modal and can navigate to manage networks', async () => {

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
@@ -58,25 +58,49 @@ const backgroundConnectionMock = new Proxy(
   },
 );
 
-const createMockState = () => ({
-  ...mockState,
-  metamask: {
-    ...mockState.metamask,
-    selectedNetworkClientId: 'selectedNetworkClientId',
-    networkConfigurationsByChainId: {
-      '0x1': {
-        chainId: '0x1',
-        defaultRpcEndpointIndex: 0,
-        rpcEndpoints: [
-          {
-            networkClientId: 'selectedNetworkClientId',
-          },
-        ],
+const LEDGER_ACCOUNT_ID = '15e69915-2a1a-4019-93b3-916e11fd432f';
+const LEDGER_ACCOUNT_GROUP_ID =
+  'keyring:Ledger Hardware/0xc42edfcc21ed14dda456aa0756c153f7985d8813';
+const SOLANA_CHAIN_ID = 'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp';
+
+const createMockState = () => {
+  const state = structuredClone(mockState);
+
+  return {
+    ...state,
+    metamask: {
+      ...state.metamask,
+      internalAccounts: {
+        ...state.metamask.internalAccounts,
+        accounts: {
+          ...state.metamask.internalAccounts.accounts,
+        },
       },
-    } as unknown as Record<string, NetworkConfiguration>,
-    useNftDetection: true,
-  },
-});
+      accountTree: structuredClone(state.metamask.accountTree),
+      multichainNetworkConfigurationsByChainId: {
+        ...state.metamask.multichainNetworkConfigurationsByChainId,
+      },
+      selectedNetworkClientId: 'selectedNetworkClientId',
+      networkConfigurationsByChainId: {
+        '0x1': {
+          chainId: '0x1',
+          defaultRpcEndpointIndex: 0,
+          rpcEndpoints: [
+            {
+              networkClientId: 'selectedNetworkClientId',
+            },
+          ],
+        },
+      } as unknown as Record<string, NetworkConfiguration>,
+      useNftDetection: true,
+    },
+  };
+};
+
+const selectLedgerAccount = (state: ReturnType<typeof createMockState>) => {
+  state.metamask.internalAccounts.selectedAccount = LEDGER_ACCOUNT_ID;
+  state.metamask.selectedAccountGroup = LEDGER_ACCOUNT_GROUP_ID;
+};
 
 describe('NFTs options', () => {
   afterEach(() => {
@@ -333,6 +357,66 @@ describe('NFTs options', () => {
     await waitFor(() =>
       expect(onNetworkSelect).toHaveBeenCalledWith(['eip155:1']),
     );
+  });
+
+  it('falls back to all popular networks when a hardware wallet has an unsupported network filter', async () => {
+    setBackgroundConnection(backgroundConnectionMock as never);
+    const enableAllPopularNetworksSpy = jest.spyOn(
+      actions,
+      'setEnabledAllPopularNetworks',
+    );
+    const state = createMockState();
+    selectLedgerAccount(state);
+    state.metamask.enabledNetworkMap = {
+      solana: {
+        [SOLANA_CHAIN_ID]: true,
+      },
+    };
+    const store = configureMockStore([thunk])(state);
+
+    renderWithProvider(<AssetListControlBar />, store);
+
+    await waitFor(() =>
+      expect(enableAllPopularNetworksSpy).toHaveBeenCalled(),
+    );
+  });
+
+  it('does not broaden an unsupported network filter for a non-hardware account', async () => {
+    const enableAllPopularNetworksSpy = jest.spyOn(
+      actions,
+      'setEnabledAllPopularNetworks',
+    );
+    const state = createMockState();
+    state.metamask.enabledNetworkMap = {
+      solana: {
+        [SOLANA_CHAIN_ID]: true,
+      },
+    };
+    const store = configureMockStore([thunk])(state);
+
+    renderWithProvider(<AssetListControlBar />, store);
+
+    await waitFor(() =>
+      expect(enableAllPopularNetworksSpy).not.toHaveBeenCalled(),
+    );
+  });
+
+  it('does not show Non-EVM network rows in the home network filter for hardware wallets', async () => {
+    const state = createMockState();
+    selectLedgerAccount(state);
+    state.metamask.useExternalServices = true;
+    const store = configureMockStore([thunk])(state);
+
+    const { findByTestId, queryByTestId } = renderWithProvider(
+      <AssetListControlBar />,
+      store,
+    );
+
+    fireEvent.click(await findByTestId('sort-by-networks'));
+
+    expect(
+      queryByTestId(`home-network-filter-network-${SOLANA_CHAIN_ID}`),
+    ).not.toBeInTheDocument();
   });
 
   it('opens the network filter modal and can navigate to manage networks', async () => {

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
@@ -449,10 +449,7 @@ describe('NFTs options', () => {
     state.metamask.useExternalServices = true;
     const store = configureMockStore([thunk])(state);
 
-    const { findByTestId } = renderWithProvider(
-      <AssetListControlBar />,
-      store,
-    );
+    const { findByTestId } = renderWithProvider(<AssetListControlBar />, store);
 
     fireEvent.click(await findByTestId('sort-by-networks'));
 

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.test.tsx
@@ -107,7 +107,9 @@ const selectLedgerAccount = (state: ReturnType<typeof createMockState>) => {
 const addSolanaAccountToSelectedGroup = (
   state: ReturnType<typeof createMockState>,
 ) => {
-  state.metamask.internalAccounts.accounts[SOLANA_ACCOUNT_ID] = {
+  (state.metamask.internalAccounts.accounts as Record<string, unknown>)[
+    SOLANA_ACCOUNT_ID
+  ] = {
     address: '7Ec4p8d1VzC9QYQ35gzfSNJbdf2D2qTyhQEt9Dz6F5CQ',
     id: SOLANA_ACCOUNT_ID,
     metadata: {
@@ -446,7 +448,7 @@ describe('NFTs options', () => {
   it('disables Non-EVM network rows in the home network filter for EVM-only account groups', async () => {
     const state = createMockState();
     selectLedgerAccount(state);
-    state.metamask.useExternalServices = true;
+    Object.assign(state.metamask, { useExternalServices: true });
     const store = configureMockStore([thunk])(state);
 
     const { findByTestId } = renderWithProvider(<AssetListControlBar />, store);
@@ -458,12 +460,19 @@ describe('NFTs options', () => {
         await findByTestId(`home-network-filter-network-${SOLANA_CHAIN_ID}`)
       ).querySelector('.multichain-network-list-item--disabled'),
     ).toBeInTheDocument();
+    expect(
+      (
+        await findByTestId(`home-network-filter-network-${SOLANA_CHAIN_ID}`)
+      ).querySelector(
+        `[data-title="${messages.networkNotSupportedByThisAccount.message}"]`,
+      ),
+    ).toBeInTheDocument();
   });
 
   it('shows Non-EVM network rows in the home network filter when the selected account group supports them', async () => {
     const state = createMockState();
     addSolanaAccountToSelectedGroup(state);
-    state.metamask.useExternalServices = true;
+    Object.assign(state.metamask, { useExternalServices: true });
     const store = configureMockStore([thunk])(state);
 
     const { findByTestId } = renderWithProvider(<AssetListControlBar />, store);

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
@@ -91,6 +91,7 @@ import {
   getInternalAccountsFromGroupById,
   getSelectedAccountGroup,
 } from '../../../../../selectors/multichain-accounts/account-tree';
+import type { MultichainAccountsState } from '../../../../../selectors/multichain-accounts/account-tree.types';
 import { HomeNetworkFilterModal } from './home-network-filter-modal';
 
 type AssetListControlBarProps = {
@@ -127,18 +128,22 @@ const AssetListControlBar = ({
   const selectedInternalAccount = useSelector(getSelectedInternalAccount);
   const isEvmOnlySelectedAccountGroup = useSelector(
     (state: MetaMaskReduxState) => {
-    const selectedAccountGroup = getSelectedAccountGroup(state);
-    const selectedAccountGroupAccounts = getInternalAccountsFromGroupById(
-      state,
-      selectedAccountGroup,
-    );
+      const multichainAccountsState =
+        state as unknown as MultichainAccountsState;
+      const selectedAccountGroup = getSelectedAccountGroup(
+        multichainAccountsState,
+      );
+      const selectedAccountGroupAccounts = getInternalAccountsFromGroupById(
+        multichainAccountsState,
+        selectedAccountGroup,
+      );
 
-    return (
-      selectedAccountGroupAccounts.length > 0 &&
-      selectedAccountGroupAccounts.every((account) =>
-        isEvmAccountType(account.type),
-      )
-    );
+      return (
+        selectedAccountGroupAccounts.length > 0 &&
+        selectedAccountGroupAccounts.every((account) =>
+          isEvmAccountType(account.type),
+        )
+      );
     },
   );
 

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
@@ -12,6 +12,7 @@ import {
   ButtonIconSize as DsButtonIconSize,
   IconName as DsIconName,
 } from '@metamask/design-system-react';
+import { isEvmAccountType } from '@metamask/keyring-api';
 import {
   getAllChainsToPoll,
   getIsLineaMainnet,
@@ -72,6 +73,7 @@ import {
   showModal,
   updateBalancesFoAccounts,
 } from '../../../../../store/actions';
+import type { MetaMaskReduxState } from '../../../../../store/store';
 import Tooltip from '../../../../ui/tooltip';
 import {
   getMultichainIsEvm,
@@ -85,7 +87,10 @@ import {
 import { getIsAssetsUnifyStateEnabled } from '../../../../../selectors/assets-unify-state/feature-flags';
 import { getIsNetworkManagementEnabled } from '../../../../../selectors/multichain/feature-flags';
 import { useNetworkFilterButtonLabel } from '../../hooks/useNetworkFilterButtonLabel';
-import { isHardwareKeyring } from '../../../../../helpers/utils/hardware';
+import {
+  getInternalAccountsFromGroupById,
+  getSelectedAccountGroup,
+} from '../../../../../selectors/multichain-accounts/account-tree';
 import { HomeNetworkFilterModal } from './home-network-filter-modal';
 
 type AssetListControlBarProps = {
@@ -120,8 +125,21 @@ const AssetListControlBar = ({
   const isAssetsUnifyStateEnabled = useSelector(getIsAssetsUnifyStateEnabled);
   const isNetworkManagementEnabled = useSelector(getIsNetworkManagementEnabled);
   const selectedInternalAccount = useSelector(getSelectedInternalAccount);
-  const isHardwareWalletAccount = isHardwareKeyring(
-    selectedInternalAccount?.metadata?.keyring?.type,
+  const isEvmOnlySelectedAccountGroup = useSelector(
+    (state: MetaMaskReduxState) => {
+    const selectedAccountGroup = getSelectedAccountGroup(state);
+    const selectedAccountGroupAccounts = getInternalAccountsFromGroupById(
+      state,
+      selectedAccountGroup,
+    );
+
+    return (
+      selectedAccountGroupAccounts.length > 0 &&
+      selectedAccountGroupAccounts.every((account) =>
+        isEvmAccountType(account.type),
+      )
+    );
+    },
   );
 
   const { collections } = useNftsCollections();
@@ -221,7 +239,7 @@ const AssetListControlBar = ({
 
   useEffect(() => {
     if (
-      isHardwareWalletAccount &&
+      isEvmOnlySelectedAccountGroup &&
       !accountSupportsEnabledNetworks &&
       totalEnabledNetworkCount > 0
     ) {
@@ -230,7 +248,7 @@ const AssetListControlBar = ({
   }, [
     accountSupportsEnabledNetworks,
     dispatch,
-    isHardwareWalletAccount,
+    isEvmOnlySelectedAccountGroup,
     totalEnabledNetworkCount,
   ]);
 

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar.tsx
@@ -85,6 +85,7 @@ import {
 import { getIsAssetsUnifyStateEnabled } from '../../../../../selectors/assets-unify-state/feature-flags';
 import { getIsNetworkManagementEnabled } from '../../../../../selectors/multichain/feature-flags';
 import { useNetworkFilterButtonLabel } from '../../hooks/useNetworkFilterButtonLabel';
+import { isHardwareKeyring } from '../../../../../helpers/utils/hardware';
 import { HomeNetworkFilterModal } from './home-network-filter-modal';
 
 type AssetListControlBarProps = {
@@ -119,6 +120,9 @@ const AssetListControlBar = ({
   const isAssetsUnifyStateEnabled = useSelector(getIsAssetsUnifyStateEnabled);
   const isNetworkManagementEnabled = useSelector(getIsNetworkManagementEnabled);
   const selectedInternalAccount = useSelector(getSelectedInternalAccount);
+  const isHardwareWalletAccount = isHardwareKeyring(
+    selectedInternalAccount?.metadata?.keyring?.type,
+  );
 
   const { collections } = useNftsCollections();
 
@@ -216,10 +220,19 @@ const AssetListControlBar = ({
   ]);
 
   useEffect(() => {
-    if (!accountSupportsEnabledNetworks && totalEnabledNetworkCount > 0) {
+    if (
+      isHardwareWalletAccount &&
+      !accountSupportsEnabledNetworks &&
+      totalEnabledNetworkCount > 0
+    ) {
       dispatch(setEnabledAllPopularNetworks());
     }
-  }, [accountSupportsEnabledNetworks, totalEnabledNetworkCount, dispatch]);
+  }, [
+    accountSupportsEnabledNetworks,
+    dispatch,
+    isHardwareWalletAccount,
+    totalEnabledNetworkCount,
+  ]);
 
   const windowType = getEnvironmentType();
   const isFullScreen =

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
@@ -451,11 +451,7 @@ const HomeNetworkFilterModalContent = ({
       blacklistedChainIds,
       availableNetworks,
     ).sort((a, b) => a.name.localeCompare(b.name));
-  }, [
-    blacklistedChainIds,
-    evmNetworks,
-    useExternalServices,
-  ]);
+  }, [blacklistedChainIds, evmNetworks, useExternalServices]);
 
   const handleSelectAllDefaultNetworks = useCallback(() => {
     dispatch(setEnabledAllPopularNetworks());

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
@@ -162,7 +162,7 @@ const HomeNetworkFilterRow = ({
         chainId={chainId}
         selected={selected}
         disabled={disabled}
-        onClick={onClick}
+        onClick={disabled ? () => undefined : onClick}
         focus={false}
         endAccessory={
           endIconName ? (
@@ -325,6 +325,10 @@ const HomeNetworkFilterModalContent = ({
   const [, evmNetworks] = useSelector(
     getMultichainNetworkConfigurationsByChainId,
   );
+  const rawMultichainNetworkConfigurationsByChainId = useSelector(
+    (state: MetaMaskReduxState) =>
+      state.metamask.multichainNetworkConfigurationsByChainId,
+  );
   const enabledNetworks = useSelector(getAllEnabledNetworksForAllNamespaces);
   const useExternalServices = useSelector(getUseExternalServices);
   const showTestnets = useSelector(getShowTestNetworks);
@@ -362,6 +366,21 @@ const HomeNetworkFilterModalContent = ({
   const { nonTestNetworks: customNetworkMap, testNetworks: testNetworkMap } =
     useNetworkManagerState();
 
+  const allDefaultNetworksForSelectedAccountGroup = useMemo(
+    () =>
+      isEvmOnlySelectedAccountGroup
+        ? {
+            ...rawMultichainNetworkConfigurationsByChainId,
+            ...allDefaultNetworkMap,
+          }
+        : allDefaultNetworkMap,
+    [
+      allDefaultNetworkMap,
+      isEvmOnlySelectedAccountGroup,
+      rawMultichainNetworkConfigurationsByChainId,
+    ],
+  );
+
   const enabledNetworkSet = useMemo(
     () => new Set(enabledNetworks),
     [enabledNetworks],
@@ -376,24 +395,26 @@ const HomeNetworkFilterModalContent = ({
     [enabledNetworkSet, enabledNetworks.length],
   );
 
+  const isNetworkDisabled = useCallback(
+    (network: MultichainNetworkConfiguration) =>
+      !network.isEvm && isEvmOnlySelectedAccountGroup,
+    [isEvmOnlySelectedAccountGroup],
+  );
+
   const defaultNetworks = useMemo(() => {
-    return sortNetworks(allDefaultNetworkMap, orderedNetworksList).filter(
-      (network) => {
-        if (!isNetworkInDefaultNetworkTab(network)) {
-          return false;
-        }
+    return sortNetworks(
+      allDefaultNetworksForSelectedAccountGroup,
+      orderedNetworksList,
+    ).filter((network) => {
+      if (!isNetworkInDefaultNetworkTab(network)) {
+        return false;
+      }
 
-        if (!network.isEvm) {
-          return useExternalServices && !isEvmOnlySelectedAccountGroup;
-        }
-
-        return Boolean(evmAccountGroup);
-      },
-    );
+      return network.isEvm ? Boolean(evmAccountGroup) : useExternalServices;
+    });
   }, [
-    allDefaultNetworkMap,
+    allDefaultNetworksForSelectedAccountGroup,
     evmAccountGroup,
-    isEvmOnlySelectedAccountGroup,
     isNetworkInDefaultNetworkTab,
     orderedNetworksList,
     useExternalServices,
@@ -401,29 +422,15 @@ const HomeNetworkFilterModalContent = ({
 
   const customNetworks = useMemo(() => {
     return sortNetworks(customNetworkMap, orderedNetworksList).filter(
-      (network) =>
-        network.isEvm ||
-        (useExternalServices && !isEvmOnlySelectedAccountGroup),
+      (network) => network.isEvm || useExternalServices,
     );
-  }, [
-    customNetworkMap,
-    isEvmOnlySelectedAccountGroup,
-    orderedNetworksList,
-    useExternalServices,
-  ]);
+  }, [customNetworkMap, orderedNetworksList, useExternalServices]);
 
   const testNetworks = useMemo(() => {
     return sortNetworks(testNetworkMap, orderedNetworksList).filter(
-      (network) =>
-        network.isEvm ||
-        (useExternalServices && !isEvmOnlySelectedAccountGroup),
+      (network) => network.isEvm || useExternalServices,
     );
-  }, [
-    isEvmOnlySelectedAccountGroup,
-    orderedNetworksList,
-    testNetworkMap,
-    useExternalServices,
-  ]);
+  }, [orderedNetworksList, testNetworkMap, useExternalServices]);
 
   // When there are no custom networks and no visible test networks, the default
   // list is the only list, so selecting default networks is equivalent to
@@ -437,8 +444,7 @@ const HomeNetworkFilterModalContent = ({
       ({ chainId }) => !evmNetworks[chainId],
     ).filter(
       ({ chainId }) =>
-        isEvmChainId(chainId as CaipChainId) ||
-        (useExternalServices && !isEvmOnlySelectedAccountGroup),
+        isEvmChainId(chainId as CaipChainId) || useExternalServices,
     );
 
     return getFilteredFeaturedNetworks(
@@ -448,7 +454,6 @@ const HomeNetworkFilterModalContent = ({
   }, [
     blacklistedChainIds,
     evmNetworks,
-    isEvmOnlySelectedAccountGroup,
     useExternalServices,
   ]);
 
@@ -491,6 +496,7 @@ const HomeNetworkFilterModalContent = ({
           iconSrc: getNetworkIcon(network),
           chainId: getSelectableChainId(network),
           selected: isNetworkSelected(network),
+          disabled: isNetworkDisabled(network),
           onClick: () => handleSelectNetwork(network.chainId),
           testId: `home-network-filter-network-${getSelectableChainId(network)}`,
         })),
@@ -507,6 +513,7 @@ const HomeNetworkFilterModalContent = ({
           iconSrc: getNetworkIcon(network),
           chainId: getSelectableChainId(network),
           selected: isNetworkSelected(network),
+          disabled: isNetworkDisabled(network),
           onClick: () => handleSelectNetwork(network.chainId),
           testId: `home-network-filter-custom-${getSelectableChainId(network)}`,
         })),
@@ -523,6 +530,7 @@ const HomeNetworkFilterModalContent = ({
           iconSrc: getNetworkIcon(network),
           chainId: getSelectableChainId(network),
           selected: isNetworkSelected(network),
+          disabled: isNetworkDisabled(network),
           onClick: () => handleSelectNetwork(network.chainId),
           testId: `home-network-filter-test-${getSelectableChainId(network)}`,
         })),
@@ -541,6 +549,9 @@ const HomeNetworkFilterModalContent = ({
               network.chainId as keyof typeof CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP
             ],
           chainId: network.chainId,
+          disabled:
+            !isEvmChainId(network.chainId as CaipChainId) &&
+            isEvmOnlySelectedAccountGroup,
           endIconName: IconName.Add,
           onClick: () => handleAddNetwork(network),
           testId: `home-network-filter-additional-${network.chainId}`,
@@ -556,6 +567,8 @@ const HomeNetworkFilterModalContent = ({
     handleAddNetwork,
     handleSelectNetwork,
     hasOnlyDefaultNetworks,
+    isEvmOnlySelectedAccountGroup,
+    isNetworkDisabled,
     isNetworkSelected,
     showTestnets,
     t,

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
@@ -71,6 +71,7 @@ import { selectAdditionalNetworksBlacklistFeatureFlag } from '../../../../../sel
 import { useNetworkManagerState } from '../../../../multichain/network-manager/hooks/useNetworkManagerState';
 import { useNetworkChangeHandlers } from '../../../../multichain/network-manager/hooks/useNetworkChangeHandlers';
 import { NetworkListItem } from '../../../../multichain/network-list-item';
+import Tooltip from '../../../../ui/tooltip';
 
 type HomeNetworkFilterModalProps = {
   isOpen: boolean;
@@ -83,6 +84,7 @@ type NetworkRowProps = {
   chainId?: string;
   selected?: boolean;
   disabled?: boolean;
+  disabledTooltip?: string;
   endIconName?: IconName;
   onClick: () => void;
   testId: string;
@@ -95,6 +97,7 @@ export type NetworkSelectionItem = {
   chainId?: string;
   selected?: boolean;
   disabled?: boolean;
+  disabledTooltip?: string;
   endIconName?: IconName;
   onClick: () => void;
   testId: string;
@@ -150,10 +153,33 @@ const HomeNetworkFilterRow = ({
   chainId,
   selected = false,
   disabled = false,
+  disabledTooltip,
   endIconName,
   onClick,
   testId,
 }: NetworkRowProps) => {
+  let endAccessory: React.ReactNode;
+
+  if (disabledTooltip) {
+    endAccessory = (
+      <Tooltip
+        position="top"
+        title={disabledTooltip}
+        wrapperClassName="flex items-center justify-center"
+      >
+        <Box className="flex items-center justify-center rounded-lg p-1">
+          <Icon name={IconName.Info} size={IconSize.Sm} />
+        </Box>
+      </Tooltip>
+    );
+  } else if (endIconName) {
+    endAccessory = (
+      <Box className="flex items-center justify-center rounded-lg p-1">
+        <Icon name={endIconName} size={IconSize.Lg} />
+      </Box>
+    );
+  }
+
   return (
     <Box data-testid={testId}>
       <NetworkListItem
@@ -164,13 +190,7 @@ const HomeNetworkFilterRow = ({
         disabled={disabled}
         onClick={disabled ? () => undefined : onClick}
         focus={false}
-        endAccessory={
-          endIconName ? (
-            <Box className="flex items-center justify-center rounded-lg p-1">
-              <Icon name={endIconName} size={IconSize.Lg} />
-            </Box>
-          ) : undefined
-        }
+        endAccessory={endAccessory}
         showEndAccessory={!selected}
       />
     </Box>
@@ -400,6 +420,11 @@ const HomeNetworkFilterModalContent = ({
       !network.isEvm && isEvmOnlySelectedAccountGroup,
     [isEvmOnlySelectedAccountGroup],
   );
+  const getDisabledTooltip = useCallback(
+    (disabled: boolean) =>
+      disabled ? t('networkNotSupportedByThisAccount') : undefined,
+    [t],
+  );
 
   const defaultNetworks = useMemo(() => {
     return sortNetworks(
@@ -487,12 +512,13 @@ const HomeNetworkFilterModalContent = ({
         key: 'default-networks',
         title: hasOnlyDefaultNetworks ? undefined : t('defaultNetworks'),
         items: defaultNetworks.map((network) => ({
+          disabled: isNetworkDisabled(network),
           key: network.chainId,
           name: network.name,
           iconSrc: getNetworkIcon(network),
           chainId: getSelectableChainId(network),
           selected: isNetworkSelected(network),
-          disabled: isNetworkDisabled(network),
+          disabledTooltip: getDisabledTooltip(isNetworkDisabled(network)),
           onClick: () => handleSelectNetwork(network.chainId),
           testId: `home-network-filter-network-${getSelectableChainId(network)}`,
         })),
@@ -504,12 +530,13 @@ const HomeNetworkFilterModalContent = ({
         key: 'custom-networks',
         title: t('customNetworks'),
         items: customNetworks.map((network) => ({
+          disabled: isNetworkDisabled(network),
           key: network.chainId,
           name: network.name,
           iconSrc: getNetworkIcon(network),
           chainId: getSelectableChainId(network),
           selected: isNetworkSelected(network),
-          disabled: isNetworkDisabled(network),
+          disabledTooltip: getDisabledTooltip(isNetworkDisabled(network)),
           onClick: () => handleSelectNetwork(network.chainId),
           testId: `home-network-filter-custom-${getSelectableChainId(network)}`,
         })),
@@ -521,12 +548,13 @@ const HomeNetworkFilterModalContent = ({
         key: 'test-networks',
         title: t('testnets'),
         items: testNetworks.map((network) => ({
+          disabled: isNetworkDisabled(network),
           key: network.chainId,
           name: network.name,
           iconSrc: getNetworkIcon(network),
           chainId: getSelectableChainId(network),
           selected: isNetworkSelected(network),
-          disabled: isNetworkDisabled(network),
+          disabledTooltip: getDisabledTooltip(isNetworkDisabled(network)),
           onClick: () => handleSelectNetwork(network.chainId),
           testId: `home-network-filter-test-${getSelectableChainId(network)}`,
         })),
@@ -537,21 +565,26 @@ const HomeNetworkFilterModalContent = ({
       nextSections.push({
         key: 'additional-networks',
         title: t('additionalNetworks'),
-        items: additionalNetworks.map((network) => ({
-          key: network.chainId,
-          name: network.name,
-          iconSrc:
-            CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP[
-              network.chainId as keyof typeof CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP
-            ],
-          chainId: network.chainId,
-          disabled:
+        items: additionalNetworks.map((network) => {
+          const disabled =
             !isEvmChainId(network.chainId as CaipChainId) &&
-            isEvmOnlySelectedAccountGroup,
-          endIconName: IconName.Add,
-          onClick: () => handleAddNetwork(network),
-          testId: `home-network-filter-additional-${network.chainId}`,
-        })),
+            isEvmOnlySelectedAccountGroup;
+
+          return {
+            key: network.chainId,
+            name: network.name,
+            iconSrc:
+              CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP[
+                network.chainId as keyof typeof CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP
+              ],
+            chainId: network.chainId,
+            disabled,
+            disabledTooltip: getDisabledTooltip(disabled),
+            endIconName: IconName.Add,
+            onClick: () => handleAddNetwork(network),
+            testId: `home-network-filter-additional-${network.chainId}`,
+          };
+        }),
       });
     }
 
@@ -560,6 +593,7 @@ const HomeNetworkFilterModalContent = ({
     additionalNetworks,
     customNetworks,
     defaultNetworks,
+    getDisabledTooltip,
     handleAddNetwork,
     handleSelectNetwork,
     hasOnlyDefaultNetworks,

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
@@ -66,6 +66,7 @@ import {
   getInternalAccountsFromGroupById,
   getSelectedAccountGroup,
 } from '../../../../../selectors/multichain-accounts/account-tree';
+import type { MultichainAccountsState } from '../../../../../selectors/multichain-accounts/account-tree.types';
 import { selectAdditionalNetworksBlacklistFeatureFlag } from '../../../../../selectors/network-blacklist/network-blacklist';
 import { useNetworkManagerState } from '../../../../multichain/network-manager/hooks/useNetworkManagerState';
 import { useNetworkChangeHandlers } from '../../../../multichain/network-manager/hooks/useNetworkChangeHandlers';
@@ -335,18 +336,22 @@ const HomeNetworkFilterModalContent = ({
   );
   const isEvmOnlySelectedAccountGroup = useSelector(
     (state: MetaMaskReduxState) => {
-    const selectedAccountGroup = getSelectedAccountGroup(state);
-    const selectedAccountGroupAccounts = getInternalAccountsFromGroupById(
-      state,
-      selectedAccountGroup,
-    );
+      const multichainAccountsState =
+        state as unknown as MultichainAccountsState;
+      const selectedAccountGroup = getSelectedAccountGroup(
+        multichainAccountsState,
+      );
+      const selectedAccountGroupAccounts = getInternalAccountsFromGroupById(
+        multichainAccountsState,
+        selectedAccountGroup,
+      );
 
-    return (
-      selectedAccountGroupAccounts.length > 0 &&
-      selectedAccountGroupAccounts.every((account) =>
-        isEvmAccountType(account.type),
-      )
-    );
+      return (
+        selectedAccountGroupAccounts.length > 0 &&
+        selectedAccountGroupAccounts.every((account) =>
+          isEvmAccountType(account.type),
+        )
+      );
     },
   );
   const { handleNetworkChange } = useNetworkChangeHandlers();

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback, useMemo } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
-import { EthScope } from '@metamask/keyring-api';
+import { EthScope, isEvmAccountType } from '@metamask/keyring-api';
 import { type AddNetworkFields } from '@metamask/network-controller';
 import { type MultichainNetworkConfiguration } from '@metamask/multichain-network-controller';
 import { type CaipChainId } from '@metamask/utils';
@@ -51,6 +51,7 @@ import {
   addNetwork,
   setEnabledAllPopularNetworks,
 } from '../../../../../store/actions';
+import type { MetaMaskReduxState } from '../../../../../store/store';
 import {
   getAllEnabledNetworksForAllNamespaces,
   getMultichainNetworkConfigurationsByChainId,
@@ -60,13 +61,15 @@ import {
   getShowTestNetworks,
   getUseExternalServices,
 } from '../../../../../selectors';
-import { getSelectedInternalAccount } from '../../../../../../shared/lib/selectors/accounts';
-import { getInternalAccountBySelectedAccountGroupAndCaip } from '../../../../../selectors/multichain-accounts/account-tree';
+import {
+  getInternalAccountBySelectedAccountGroupAndCaip,
+  getInternalAccountsFromGroupById,
+  getSelectedAccountGroup,
+} from '../../../../../selectors/multichain-accounts/account-tree';
 import { selectAdditionalNetworksBlacklistFeatureFlag } from '../../../../../selectors/network-blacklist/network-blacklist';
 import { useNetworkManagerState } from '../../../../multichain/network-manager/hooks/useNetworkManagerState';
 import { useNetworkChangeHandlers } from '../../../../multichain/network-manager/hooks/useNetworkChangeHandlers';
 import { NetworkListItem } from '../../../../multichain/network-list-item';
-import { isHardwareKeyring } from '../../../../../helpers/utils/hardware';
 
 type HomeNetworkFilterModalProps = {
   isOpen: boolean;
@@ -330,7 +333,22 @@ const HomeNetworkFilterModalContent = ({
   const evmAccountGroup = useSelector((state) =>
     getInternalAccountBySelectedAccountGroupAndCaip(state, EthScope.Eoa),
   );
-  const selectedInternalAccount = useSelector(getSelectedInternalAccount);
+  const isEvmOnlySelectedAccountGroup = useSelector(
+    (state: MetaMaskReduxState) => {
+    const selectedAccountGroup = getSelectedAccountGroup(state);
+    const selectedAccountGroupAccounts = getInternalAccountsFromGroupById(
+      state,
+      selectedAccountGroup,
+    );
+
+    return (
+      selectedAccountGroupAccounts.length > 0 &&
+      selectedAccountGroupAccounts.every((account) =>
+        isEvmAccountType(account.type),
+      )
+    );
+    },
+  );
   const { handleNetworkChange } = useNetworkChangeHandlers();
   const {
     nonTestNetworks: allDefaultNetworkMap,
@@ -345,9 +363,6 @@ const HomeNetworkFilterModalContent = ({
   );
 
   const isAllDefaultSelected = enabledNetworks.length > 1;
-  const isHardwareWalletAccount = isHardwareKeyring(
-    selectedInternalAccount?.metadata?.keyring?.type,
-  );
 
   const isNetworkSelected = useCallback(
     (network: MultichainNetworkConfiguration) =>
@@ -364,7 +379,7 @@ const HomeNetworkFilterModalContent = ({
         }
 
         if (!network.isEvm) {
-          return useExternalServices && !isHardwareWalletAccount;
+          return useExternalServices && !isEvmOnlySelectedAccountGroup;
         }
 
         return Boolean(evmAccountGroup);
@@ -373,7 +388,7 @@ const HomeNetworkFilterModalContent = ({
   }, [
     allDefaultNetworkMap,
     evmAccountGroup,
-    isHardwareWalletAccount,
+    isEvmOnlySelectedAccountGroup,
     isNetworkInDefaultNetworkTab,
     orderedNetworksList,
     useExternalServices,
@@ -382,11 +397,12 @@ const HomeNetworkFilterModalContent = ({
   const customNetworks = useMemo(() => {
     return sortNetworks(customNetworkMap, orderedNetworksList).filter(
       (network) =>
-        network.isEvm || (useExternalServices && !isHardwareWalletAccount),
+        network.isEvm ||
+        (useExternalServices && !isEvmOnlySelectedAccountGroup),
     );
   }, [
     customNetworkMap,
-    isHardwareWalletAccount,
+    isEvmOnlySelectedAccountGroup,
     orderedNetworksList,
     useExternalServices,
   ]);
@@ -394,10 +410,11 @@ const HomeNetworkFilterModalContent = ({
   const testNetworks = useMemo(() => {
     return sortNetworks(testNetworkMap, orderedNetworksList).filter(
       (network) =>
-        network.isEvm || (useExternalServices && !isHardwareWalletAccount),
+        network.isEvm ||
+        (useExternalServices && !isEvmOnlySelectedAccountGroup),
     );
   }, [
-    isHardwareWalletAccount,
+    isEvmOnlySelectedAccountGroup,
     orderedNetworksList,
     testNetworkMap,
     useExternalServices,
@@ -416,7 +433,7 @@ const HomeNetworkFilterModalContent = ({
     ).filter(
       ({ chainId }) =>
         isEvmChainId(chainId as CaipChainId) ||
-        (useExternalServices && !isHardwareWalletAccount),
+        (useExternalServices && !isEvmOnlySelectedAccountGroup),
     );
 
     return getFilteredFeaturedNetworks(
@@ -426,7 +443,7 @@ const HomeNetworkFilterModalContent = ({
   }, [
     blacklistedChainIds,
     evmNetworks,
-    isHardwareWalletAccount,
+    isEvmOnlySelectedAccountGroup,
     useExternalServices,
   ]);
 

--- a/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
+++ b/ui/components/app/assets/asset-list/asset-list-control-bar/home-network-filter-modal.tsx
@@ -60,11 +60,13 @@ import {
   getShowTestNetworks,
   getUseExternalServices,
 } from '../../../../../selectors';
+import { getSelectedInternalAccount } from '../../../../../../shared/lib/selectors/accounts';
 import { getInternalAccountBySelectedAccountGroupAndCaip } from '../../../../../selectors/multichain-accounts/account-tree';
 import { selectAdditionalNetworksBlacklistFeatureFlag } from '../../../../../selectors/network-blacklist/network-blacklist';
 import { useNetworkManagerState } from '../../../../multichain/network-manager/hooks/useNetworkManagerState';
 import { useNetworkChangeHandlers } from '../../../../multichain/network-manager/hooks/useNetworkChangeHandlers';
 import { NetworkListItem } from '../../../../multichain/network-list-item';
+import { isHardwareKeyring } from '../../../../../helpers/utils/hardware';
 
 type HomeNetworkFilterModalProps = {
   isOpen: boolean;
@@ -328,6 +330,7 @@ const HomeNetworkFilterModalContent = ({
   const evmAccountGroup = useSelector((state) =>
     getInternalAccountBySelectedAccountGroupAndCaip(state, EthScope.Eoa),
   );
+  const selectedInternalAccount = useSelector(getSelectedInternalAccount);
   const { handleNetworkChange } = useNetworkChangeHandlers();
   const {
     nonTestNetworks: allDefaultNetworkMap,
@@ -342,6 +345,9 @@ const HomeNetworkFilterModalContent = ({
   );
 
   const isAllDefaultSelected = enabledNetworks.length > 1;
+  const isHardwareWalletAccount = isHardwareKeyring(
+    selectedInternalAccount?.metadata?.keyring?.type,
+  );
 
   const isNetworkSelected = useCallback(
     (network: MultichainNetworkConfiguration) =>
@@ -357,16 +363,17 @@ const HomeNetworkFilterModalContent = ({
           return false;
         }
 
-        if (!useExternalServices && !network.isEvm) {
-          return false;
+        if (!network.isEvm) {
+          return useExternalServices && !isHardwareWalletAccount;
         }
 
-        return network.isEvm ? Boolean(evmAccountGroup) : true;
+        return Boolean(evmAccountGroup);
       },
     );
   }, [
     allDefaultNetworkMap,
     evmAccountGroup,
+    isHardwareWalletAccount,
     isNetworkInDefaultNetworkTab,
     orderedNetworksList,
     useExternalServices,
@@ -374,15 +381,27 @@ const HomeNetworkFilterModalContent = ({
 
   const customNetworks = useMemo(() => {
     return sortNetworks(customNetworkMap, orderedNetworksList).filter(
-      (network) => useExternalServices || network.isEvm,
+      (network) =>
+        network.isEvm || (useExternalServices && !isHardwareWalletAccount),
     );
-  }, [customNetworkMap, orderedNetworksList, useExternalServices]);
+  }, [
+    customNetworkMap,
+    isHardwareWalletAccount,
+    orderedNetworksList,
+    useExternalServices,
+  ]);
 
   const testNetworks = useMemo(() => {
     return sortNetworks(testNetworkMap, orderedNetworksList).filter(
-      (network) => useExternalServices || network.isEvm,
+      (network) =>
+        network.isEvm || (useExternalServices && !isHardwareWalletAccount),
     );
-  }, [orderedNetworksList, testNetworkMap, useExternalServices]);
+  }, [
+    isHardwareWalletAccount,
+    orderedNetworksList,
+    testNetworkMap,
+    useExternalServices,
+  ]);
 
   // When there are no custom networks and no visible test networks, the default
   // list is the only list, so selecting default networks is equivalent to
@@ -396,14 +415,20 @@ const HomeNetworkFilterModalContent = ({
       ({ chainId }) => !evmNetworks[chainId],
     ).filter(
       ({ chainId }) =>
-        useExternalServices || isEvmChainId(chainId as CaipChainId),
+        isEvmChainId(chainId as CaipChainId) ||
+        (useExternalServices && !isHardwareWalletAccount),
     );
 
     return getFilteredFeaturedNetworks(
       blacklistedChainIds,
       availableNetworks,
     ).sort((a, b) => a.name.localeCompare(b.name));
-  }, [blacklistedChainIds, evmNetworks, useExternalServices]);
+  }, [
+    blacklistedChainIds,
+    evmNetworks,
+    isHardwareWalletAccount,
+    useExternalServices,
+  ]);
 
   const handleSelectAllDefaultNetworks = useCallback(() => {
     dispatch(setEnabledAllPopularNetworks());


### PR DESCRIPTION
This PR is to update network handling. When user is on a hardware account, they should not be able to select non-evm

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: #44523 

## **Manual testing steps**

1. Check non-evm networks are disabled for hardware accounts

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes home network filter selection and automatic enabled-network reset logic based on account group capabilities, which can affect what assets users see for hardware and EVM-only wallets.
> 
> **Overview**
> **EVM-only account groups** (e.g. Ledger / groups with only EVM accounts) can no longer pick non-EVM networks in the home asset **network filter**. Those rows are **disabled** with an info tooltip using the new string `networkNotSupportedByThisAccount`.
> 
> Auto-reset to **all popular networks** when the enabled filter doesn’t match the account now runs only for **EVM-only** groups, so multichain groups (e.g. with Solana in the same group) keep a Solana-only filter instead of being broadened. The modal still lists default non-EVM networks when external services are on, but marks them non-selectable for EVM-only groups.
> 
> Tests cover Ledger and generic EVM-only fallback, no broadening when the group supports the filtered network, and disabled vs enabled Solana rows in the filter UI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8420b60e8b34f0b065bce1ea64fd8b11466a57b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->