### PR TITLE
fix: mascot being rendered twice in onboarding unlock page

### DIFF
--- a/ui/components/ui/mascot/mascot.component.js
+++ b/ui/components/ui/mascot/mascot.component.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import MetaMaskLogo from '@metamask/logo';
 import { debounce } from 'lodash';
 import { getFoxMeshJson } from '../../../../shared/lib/build-types';
@@ -26,25 +26,13 @@ function Mascot({
 }) {
   const mascotContainerRef = useRef(null);
   const directionTargetMapRef = useRef(null);
-  const logoRef = useRef(null);
   const animationEventEmitterRef = useRef(animationEventEmitter);
   animationEventEmitterRef.current = animationEventEmitter;
   const prevFollowMouseRef = useRef(followMouse);
+  // Capture the sizing/follow props at first render so we don't make them reactive dependencies of the mount effect.
+  const initialLogoOptionsRef = useRef({ followMouse, width, height });
 
-  if (!logoRef.current) {
-    logoRef.current = MetaMaskLogo({
-      followMouse,
-      pxNotRatio: true,
-      width,
-      height,
-      meshJson: getFoxMeshJson(),
-      verticalFieldOfView: Math.PI / 37.5,
-      near: 100,
-      far: 340,
-    });
-  }
-
-  const logo = logoRef.current;
+  const [logo, setLogo] = useState(null);
 
   useEffect(() => {
     const mascotContainer = mascotContainerRef.current;
@@ -52,36 +40,57 @@ function Mascot({
       return undefined;
     }
 
-    mascotContainer.appendChild(logo.container);
+    const {
+      followMouse: initialFollowMouse,
+      width: initialWidth,
+      height: initialHeight,
+    } = initialLogoOptionsRef.current;
+    const logoViewer = MetaMaskLogo({
+      followMouse: initialFollowMouse,
+      pxNotRatio: true,
+      width: initialWidth,
+      height: initialHeight,
+      meshJson: getFoxMeshJson(),
+      verticalFieldOfView: Math.PI / 37.5,
+      near: 100,
+      far: 340,
+    });
+    setLogo(logoViewer);
+
+    mascotContainer.appendChild(logoViewer.container);
     directionTargetMapRef.current = directionTargetGenerator(
       mascotContainer.getBoundingClientRect(),
     );
 
-    const refollowMouse = debounce(logo.setFollowMouse.bind(logo, true), 1000);
-    const unfollowMouse = logo.setFollowMouse.bind(logo, false);
+    const refollowMouse = debounce(
+      logoViewer.setFollowMouse.bind(logoViewer, true),
+      1000,
+    );
+    const unfollowMouse = logoViewer.setFollowMouse.bind(logoViewer, false);
 
     const lookAt = (target) => {
       unfollowMouse();
-      logo.lookAtAndRender(target);
+      logoViewer.lookAtAndRender(target);
       refollowMouse();
     };
 
     const emitter = animationEventEmitterRef.current;
-    const setFollowMouseHandler = logo.setFollowMouse.bind(logo);
+    const setFollowMouseHandler = logoViewer.setFollowMouse.bind(logoViewer);
 
     emitter.on('point', lookAt);
     emitter.on('setFollowMouse', setFollowMouseHandler);
 
     return () => {
       emitter.removeAllListeners();
-      logo.container.remove();
-      logo.stopAnimation();
+      logoViewer.container.remove();
+      logoViewer.stopAnimation();
+      setLogo(null);
     };
-  }, [logo]);
+  }, []);
 
   useEffect(() => {
     const directionTargetMap = directionTargetMapRef.current;
-    if (!directionTargetMap) {
+    if (!logo || !directionTargetMap) {
       return;
     }
 
@@ -93,6 +102,10 @@ function Mascot({
   }, [lookAtDirection, lookAtTarget, logo]);
 
   useEffect(() => {
+    if (!logo) {
+      return;
+    }
+
     if (prevFollowMouseRef.current === followMouse) {
       return;
     }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Fixes a duplicate MetaMask fox appearing on the unlock page in development builds **Strict Mode**. One fox renders correctly inside the mascot container, while a second orphaned fox is appended directly under `<body>`. 

The fix moves `MetaMaskLogo` construction out of the render phase and into a mount-only effect so every logo instance is paired with cleanup.


<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed extra mascot showing in unlock page while on strict mode.

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run app locally (development/strict mode)
2. Login with existing social account
3. User will redirect to onboarding unlock page
4. While in onboarding unlock page, scroll the page down (an extra mascot will show at the bottom)

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

https://github.com/user-attachments/assets/050fbbf9-5963-465f-be91-752fead47e58


<!-- [screenshots/recordings] -->

### **After**

https://github.com/user-attachments/assets/4bcd200e-9572-46ec-9891-d02afceb6eb5


<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI lifecycle change in the mascot component with no auth or data impact; behavior should match production aside from fixing the duplicate render in Strict Mode.
> 
> **Overview**
> Fixes a **second MetaMask fox** appearing on the onboarding unlock page in development **Strict Mode**, where one instance stayed in the mascot container and another was orphaned under `<body>`.
> 
> **`Mascot` no longer creates `MetaMaskLogo` during render.** Logo construction, DOM append, and animation wiring run in a **mount-only** `useEffect` with cleanup that removes the container, stops animation, and clears state. Initial `width` / `height` / `followMouse` are snapshotted in a ref so the mount effect stays dependency-free. Look-at and follow-mouse effects wait until `logo` exists before calling the viewer API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb09984332a48dad64c1167224876a469cd57aa3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->