### PR TITLE
[DO NOT MERGE] bisect: main + v10 scuttle-exception additions only

### DIFF
--- a/development/webpack/utils/plugins/LavamoatPlugin/index.ts
+++ b/development/webpack/utils/plugins/LavamoatPlugin/index.ts
@@ -65,6 +65,8 @@ const getScuttleGlobalThisExceptions = (args: Args) => [
   'Date',
   // Selenium atoms construct regexes while locating elements.
   'RegExp',
+  'WebAssembly',
+  'Request',
   // globals sentry needs to function
   '__SENTRY__',
   'appState',
@@ -75,6 +77,9 @@ const getScuttleGlobalThisExceptions = (args: Args) => [
   'logEncryptedVault',
   // needed by Sentry and react-router-dom v6 HashRouter
   'history',
+  // v10 Sentry web-vitals (whenIdleOrHidden) feature-detects this;
+  // under scuttling the detection itself throws unless excepted.
+  'requestIdleCallback',
   // globals used by react-dom
   'getSelection',
   // globals opera needs to function


### PR DESCRIPTION
Bisect arm B for the `import-custom-token-with-custom-network` stall on #42867 (webpack-only, CI-only; spec is new on main as of #43821).

This branch is plain main plus exactly one change: the v10 branch's three scuttling-exception additions (`WebAssembly`, `Request`, `requestIdleCallback`) in `LavamoatPlugin/index.ts`. The spec's webpack shard here answers whether that build-layer change alone triggers the stall, with zero Sentry-SDK involvement.

- Fails → trigger found: the exception additions change runtime behavior (likely `Request` flipping feature detection in fetch middleware); fundamental fix = scope or drop the exceptions.
- Passes → the exceptions are exonerated; the bisect continues inside the SDK swap + policy regen (arm A, the tracing-stripped probe on #44581, is the other axis).

Will be closed after one CI cycle; results recorded on #42867.