### PR TITLE
refactor: add useEventListener

### DIFF
--- a/ui/components/multichain/account-list-item-menu/account-list-item-menu.js
+++ b/ui/components/multichain/account-list-item-menu/account-list-item-menu.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 
 import { IconName, Text, TextVariant } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+import { useEventListener } from '../../../hooks/useEventListener';
 import {
   getPinnedAccountsList,
   getHiddenAccountsList,
@@ -79,13 +80,7 @@ export const AccountListItemMenu = ({
     [onClose],
   );
 
-  useEffect(() => {
-    document.addEventListener('mousedown', handleClickOutside);
-
-    return () => {
-      document.removeEventListener('mousedown', handleClickOutside);
-    };
-  }, [handleClickOutside]);
+  useEventListener('mousedown', handleClickOutside);
 
   const handlePinning = (address) => {
     const updatedPinnedAccountList = [...pinnedAccountList, address];

--- a/ui/components/multichain/global-menu-drawer/global-menu-drawer.tsx
+++ b/ui/components/multichain/global-menu-drawer/global-menu-drawer.tsx
@@ -10,6 +10,7 @@ import {
   IconName,
 } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../hooks/useI18nContext';
+import { useEventListener } from '../../../hooks/useEventListener';
 import { getEnvironmentType } from '../../../../shared/lib/environment-type';
 import {
   ENVIRONMENT_TYPE_FULLSCREEN,
@@ -262,18 +263,14 @@ export const GlobalMenuDrawer = ({
   }, [isOpen, isFullscreen]);
 
   // Escape key closes drawer (Dialog would unmount on close and block leave transition in popup)
-  useEffect(() => {
+  useEventListener('keydown', (e: KeyboardEvent) => {
     if (!isOpen) {
       return;
     }
-    const handleKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        onClose();
-      }
-    };
-    document.addEventListener('keydown', handleKeyDown);
-    return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen, onClose]);
+    if (e.key === 'Escape') {
+      onClose();
+    }
+  });
 
   const titleId = 'global-menu-drawer-title';
   // Popup: no portal, fixed overlay. Fullscreen/sidepanel: portal into .app and overlay root layout.

--- a/ui/components/ui/unit-input/unit-input.component.js
+++ b/ui/components/ui/unit-input/unit-input.component.js
@@ -9,6 +9,7 @@ import React, {
 import { Tooltip } from 'react-tippy';
 import PropTypes from 'prop-types';
 import classnames from 'clsx';
+import { useEventListener } from '../../../hooks/useEventListener';
 
 const INPUT_HORIZONTAL_PADDING = 4;
 
@@ -77,15 +78,12 @@ const UnitInput = forwardRef(function UnitInput(
     }
   }, []);
 
-  useEffect(() => {
-    if (isFocusOnInput) {
-      document.addEventListener('keypress', handleFocus);
-      return () => {
-        document.removeEventListener('keypress', handleFocus);
-      };
+  useEventListener('keypress', () => {
+    if (!isFocusOnInput) {
+      return;
     }
-    return undefined;
-  }, [handleFocus, isFocusOnInput]);
+    handleFocus();
+  });
 
   const handleInputFocus = useCallback(({ target: { value: inputValue } }) => {
     if (inputValue === '0') {

--- a/ui/hooks/bridge/usePrefillFromBridgeState.ts
+++ b/ui/hooks/bridge/usePrefillFromBridgeState.ts
@@ -12,6 +12,7 @@ import {
   setToToken,
 } from '../../ducks/bridge/actions';
 import { getBridgeQuotes, getFromChains } from '../../ducks/bridge/selectors';
+import { useEventListener } from '../useEventListener';
 import { useBridgeNavigation } from './useBridgeNavigation';
 
 /**
@@ -75,15 +76,8 @@ export const usePrefillFromBridgeState = () => {
     } else if (shouldRestoreInputsFromQuote) {
       dispatch(restoreQuoteRequestFromState(activeQuote));
     }
-
-    // Reset controller and inputs before unloading the page
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    window.addEventListener('beforeunload', resetControllerAndCache);
-    return () => {
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-      // eslint-disable-next-line @typescript-eslint/no-misused-promises
-      window.removeEventListener('beforeunload', resetControllerAndCache);
-    };
   }, []);
+
+  // Reset controller and inputs before unloading the page
+  useEventListener('beforeunload', resetControllerAndCache);
 };

--- a/ui/hooks/useEventListener.test.ts
+++ b/ui/hooks/useEventListener.test.ts
@@ -1,0 +1,30 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useEventListener } from './useEventListener';
+
+describe('useEventListener', () => {
+  it('listens on window by default', () => {
+    const handler = jest.fn();
+
+    renderHook(() => useEventListener('click', handler));
+
+    act(() => {
+      window.dispatchEvent(new Event('click'));
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes the listener on unmount', () => {
+    const handler = jest.fn();
+
+    const { unmount } = renderHook(() => useEventListener('click', handler));
+
+    unmount();
+
+    act(() => {
+      window.dispatchEvent(new Event('click'));
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+});

--- a/ui/hooks/useEventListener.ts
+++ b/ui/hooks/useEventListener.ts
@@ -1,0 +1,43 @@
+import { useEffect, useRef, type RefObject } from 'react';
+
+type EventTargetOrRef = EventTarget | RefObject<EventTarget | null>;
+
+function resolveTarget(
+  target: EventTargetOrRef | undefined,
+): EventTarget | null {
+  if (target === undefined) {
+    return window;
+  }
+
+  if (!('addEventListener' in target)) {
+    return target.current;
+  }
+
+  return target;
+}
+
+export function useEventListener<EventType extends Event = Event>(
+  eventName: string,
+  handler: (event: EventType) => void,
+  element?: EventTargetOrRef,
+): void {
+  const savedHandler = useRef(handler);
+  savedHandler.current = handler;
+
+  useEffect(() => {
+    const target = resolveTarget(element);
+
+    if (!target?.addEventListener) {
+      return undefined;
+    }
+
+    const listener = (event: Event) => {
+      savedHandler.current(event as EventType);
+    };
+
+    target.addEventListener(eventName, listener);
+    return () => {
+      target.removeEventListener(eventName, listener);
+    };
+  }, [eventName, element]);
+}

--- a/ui/hooks/useTheme.ts
+++ b/ui/hooks/useTheme.ts
@@ -1,7 +1,8 @@
-import { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import { useSelector } from 'react-redux';
 import { getTheme } from '../selectors';
 import { ThemeType } from '../../shared/constants/preferences';
+import { useEventListener } from './useEventListener';
 
 /**
  * List of valid themes.
@@ -73,23 +74,17 @@ export function useTheme(): ThemeType.light | ThemeType.dark {
     resolveTheme(settingTheme, systemTheme),
   );
 
+  const mediaQuery = useRef(
+    window.matchMedia('(prefers-color-scheme: dark)'),
+  ).current;
+
   // Handler for system theme changes
   const handleSystemThemeChange = useCallback((event: MediaQueryListEvent) => {
     const newSystemTheme = event.matches ? ThemeType.dark : ThemeType.light;
     setSystemTheme(newSystemTheme);
   }, []);
 
-  // Listen for system theme changes
-  useEffect(() => {
-    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
-
-    // Add listener for system theme changes
-    mediaQuery.addEventListener('change', handleSystemThemeChange);
-
-    return () => {
-      mediaQuery.removeEventListener('change', handleSystemThemeChange);
-    };
-  }, [handleSystemThemeChange]);
+  useEventListener('change', handleSystemThemeChange, mediaQuery);
 
   // Update theme when setting or system theme changes
   useEffect(() => {

--- a/ui/hooks/useWindowFocus.ts
+++ b/ui/hooks/useWindowFocus.ts
@@ -1,20 +1,11 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
+import { useEventListener } from './useEventListener';
 
 export const useWindowFocus = () => {
   const [isFocused, setIsFocused] = useState(document.hasFocus());
 
-  useEffect(() => {
-    const onFocus = () => setIsFocused(true);
-    const onBlur = () => setIsFocused(false);
-
-    window.addEventListener('focus', onFocus);
-    window.addEventListener('blur', onBlur);
-
-    return () => {
-      window.removeEventListener('focus', onFocus);
-      window.removeEventListener('blur', onBlur);
-    };
-  }, []);
+  useEventListener('focus', () => setIsFocused(true));
+  useEventListener('blur', () => setIsFocused(false));
 
   return isFocused;
 };

--- a/ui/pages/activity/activity-list.tsx
+++ b/ui/pages/activity/activity-list.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useMemo, useState } from 'react';
 import { useDeferredValue } from '../../hooks/useDeferredValue';
 import { PendingTransactionCancelSpeedUpProvider } from '../../components/app/pending-transaction-action-buttons/pending-transaction-cancel-speed-up-provider';
 import AssetListControlBar from '../../components/app/assets/asset-list/asset-list-control-bar/asset-list-control-bar';
@@ -9,6 +9,7 @@ import { useScrollContainer } from '../../contexts/scroll-container';
 import { useFormatters } from '../../hooks/useFormatters';
 import { useI18nContext } from '../../hooks/useI18nContext';
 import { useItemInView } from '../../hooks/useItemInView';
+import { useEventListener } from '../../hooks/useEventListener';
 import {
   MetaMetricsEventCategory,
   MetaMetricsEventName,
@@ -84,14 +85,9 @@ export function ActivityList({ filter }: { filter?: ActivityListFilter } = {}) {
     onVisible: fetchNextVisiblePage,
   });
 
-  useEffect(() => {
-    const onPopState = () => {
-      setSelectedItem(null);
-    };
-
-    window.addEventListener('popstate', onPopState);
-    return () => window.removeEventListener('popstate', onPopState);
-  }, []);
+  useEventListener('popstate', () => {
+    setSelectedItem(null);
+  });
 
   const handleClick = (item: ActivityListItem) => {
     if (!item.hash) {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Add a reusable`useEventListener` hook and migrate existing `addEventListener`/`removeEventListener` usages

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Open the extension popup and full screen views
2. Open/close menus, modals, and popovers (Escape, outside click)
3. Confirm theme still follows OS preference when set to System

## **Screenshots/Recordings**

### **Before**
```
useEffect(() => {
      document.addEventListener('keydown', handleEscKey);
      document.addEventListener('mousedown', handleClickOutside);

      return () => {
        document.removeEventListener('keydown', handleEscKey);
        document.removeEventListener('mousedown', handleClickOutside);
      };
    }, []);
```
### **After**
```
useEventListener('keydown', handleEscKey);
useEventListener('mousedown', handleClickOutside);
```

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)