### PR TITLE
fix: various fixes and improvements on batch sell select page

### DIFF
--- a/ui/ducks/batch-sell/selectors.test.ts
+++ b/ui/ducks/batch-sell/selectors.test.ts
@@ -163,6 +163,17 @@ describe('batch-sell selectors', () => {
     jest.clearAllMocks();
   });
 
+  // Non-stablecoin, eligible holding used to satisfy the "network must have
+  // at least one sellable asset" requirement in the tests below.
+  const eligibleHolding = (chainId: CaipChainId, assetSuffix: string) => ({
+    assetId: `${chainId}/erc20:0x${assetSuffix.padStart(40, '0')}`,
+    chainId,
+    symbol: 'TOK',
+    name: 'Test Token',
+    decimals: 18,
+    balance: '1',
+  });
+
   describe('getAvailableBatchSellNetworksSelector', () => {
     beforeEach(() => {
       // Provide at least one stablecoin for every supported chain so the
@@ -200,6 +211,17 @@ describe('batch-sell selectors', () => {
             ],
           },
         },
+      } as never);
+      // Default: every supported chain has an eligible, non-stablecoin
+      // holding, so the "has sellable assets" filter does not strip a
+      // network unless a test explicitly overrides this mock.
+      mockGetBridgeAssetsByAssetId.mockReturnValue({
+        [CAIP_MAINNET]: eligibleHolding(CAIP_MAINNET, '1'),
+        [CAIP_BASE]: eligibleHolding(CAIP_BASE, '2'),
+        [CAIP_BSC]: eligibleHolding(CAIP_BSC, '3'),
+        [CAIP_ARBITRUM]: eligibleHolding(CAIP_ARBITRUM, '4'),
+        [CAIP_POLYGON]: eligibleHolding(CAIP_POLYGON, '5'),
+        [CAIP_LINEA]: eligibleHolding(CAIP_LINEA, '6'),
       } as never);
     });
 
@@ -302,6 +324,35 @@ describe('batch-sell selectors', () => {
             ],
           },
           [CAIP_BASE]: { batchSellDestStablecoins: [] },
+        },
+      } as never);
+
+      const result = getAvailableBatchSellNetworks(buildState());
+
+      expect(result.map((n) => n.chainId)).toStrictEqual([CAIP_MAINNET]);
+    });
+
+    it('excludes a network whose only holdings are ineligible (e.g. all stablecoins)', () => {
+      mockGetAllMultichainNetworkConfigurations.mockReturnValue({
+        [CAIP_MAINNET]: MOCK_MAINNET_NETWORK,
+        [CAIP_BASE]: MOCK_BASE_NETWORK,
+      });
+      mockGetSelectedInternalAccount.mockReturnValue(MOCK_EVM_ACCOUNT as never);
+      mockGetAssetsBySelectedAccountGroup.mockReturnValue({
+        [CHAIN_IDS.MAINNET]: [{ rawBalance: '0x1', fiat: { balance: 500 } }],
+        [CHAIN_IDS.BASE]: [{ rawBalance: '0x1', fiat: { balance: 1000 } }],
+      } as never);
+      // Base's only holding is its own destination stablecoin, so there is
+      // nothing sellable on Base even though it has a positive balance.
+      mockGetBridgeAssetsByAssetId.mockReturnValue({
+        [CAIP_MAINNET]: eligibleHolding(CAIP_MAINNET, '1'),
+        [CAIP_BASE]: {
+          assetId: 'eip155:8453/erc20:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+          chainId: CAIP_BASE,
+          symbol: 'USDC',
+          name: 'USD Coin',
+          decimals: 6,
+          balance: '100',
         },
       } as never);
 
@@ -883,6 +934,10 @@ describe('batch-sell selectors', () => {
             ],
           },
         },
+      } as never);
+      mockGetBridgeAssetsByAssetId.mockReturnValue({
+        [CAIP_MAINNET]: eligibleHolding(CAIP_MAINNET, '1'),
+        [CAIP_BASE]: eligibleHolding(CAIP_BASE, '2'),
       } as never);
 
       const result = getAvailableBatchSellNetworks(buildState());

--- a/ui/ducks/batch-sell/selectors.test.ts
+++ b/ui/ducks/batch-sell/selectors.test.ts
@@ -362,7 +362,8 @@ describe('batch-sell selectors', () => {
       mockGetBridgeAssetsByAssetId.mockReturnValue({
         [CAIP_MAINNET]: eligibleHolding(CAIP_MAINNET, '1'),
         [CAIP_BASE]: {
-          assetId: 'eip155:8453/erc20:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+          assetId:
+            'eip155:8453/erc20:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
           chainId: CAIP_BASE,
           symbol: 'USDC',
           name: 'USD Coin',
@@ -990,7 +991,8 @@ describe('batch-sell selectors', () => {
         // Base's large balance is entirely its own destination stablecoin,
         // so it must not count towards Base's ranking.
         [CAIP_BASE]: {
-          assetId: 'eip155:8453/erc20:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+          assetId:
+            'eip155:8453/erc20:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
           chainId: CAIP_BASE,
           symbol: 'USDC',
           name: 'USD Coin',
@@ -998,7 +1000,7 @@ describe('batch-sell selectors', () => {
           balance: '100',
           tokenFiatAmount: 100,
         },
-        [`${CAIP_BASE  }-eligible`]: eligibleHolding(CAIP_BASE, '2', 10),
+        [`${CAIP_BASE}-eligible`]: eligibleHolding(CAIP_BASE, '2', 10),
         [CAIP_MAINNET]: eligibleHolding(CAIP_MAINNET, '1', 50),
       } as never);
 

--- a/ui/ducks/batch-sell/selectors.test.ts
+++ b/ui/ducks/batch-sell/selectors.test.ts
@@ -164,14 +164,21 @@ describe('batch-sell selectors', () => {
   });
 
   // Non-stablecoin, eligible holding used to satisfy the "network must have
-  // at least one sellable asset" requirement in the tests below.
-  const eligibleHolding = (chainId: CaipChainId, assetSuffix: string) => ({
+  // at least one sellable asset" requirement in the tests below. Accepts an
+  // optional fiat amount since network ranking is based on the fiat value of
+  // eligible holdings only (tokenFiatAmount), not total chain balance.
+  const eligibleHolding = (
+    chainId: CaipChainId,
+    assetSuffix: string,
+    tokenFiatAmount?: number,
+  ) => ({
     assetId: `${chainId}/erc20:0x${assetSuffix.padStart(40, '0')}`,
     chainId,
     symbol: 'TOK',
     name: 'Test Token',
     decimals: 18,
     balance: '1',
+    tokenFiatAmount,
   });
 
   describe('getAvailableBatchSellNetworksSelector', () => {
@@ -225,7 +232,7 @@ describe('batch-sell selectors', () => {
       } as never);
     });
 
-    it('returns supported networks with positive balance, sorted by fiat balance descending', () => {
+    it('returns supported networks with positive balance, sorted by eligible-asset fiat balance descending', () => {
       mockGetAllMultichainNetworkConfigurations.mockReturnValue({
         [CAIP_MAINNET]: MOCK_MAINNET_NETWORK,
         [CAIP_BASE]: MOCK_BASE_NETWORK,
@@ -233,9 +240,15 @@ describe('batch-sell selectors', () => {
       });
       mockGetSelectedInternalAccount.mockReturnValue(MOCK_EVM_ACCOUNT as never);
       mockGetAssetsBySelectedAccountGroup.mockReturnValue({
-        [CHAIN_IDS.MAINNET]: [{ rawBalance: '0x1', fiat: { balance: 500 } }],
-        [CHAIN_IDS.BASE]: [{ rawBalance: '0x1', fiat: { balance: 1000 } }],
-        '0xa': [{ rawBalance: '0x1', fiat: { balance: 300 } }],
+        [CHAIN_IDS.MAINNET]: [{ rawBalance: '0x1' }],
+        [CHAIN_IDS.BASE]: [{ rawBalance: '0x1' }],
+        '0xa': [{ rawBalance: '0x1' }],
+      } as never);
+      // Ranking is based on the fiat value of eligible (sellable) holdings,
+      // not the total chain balance.
+      mockGetBridgeAssetsByAssetId.mockReturnValue({
+        [CAIP_MAINNET]: eligibleHolding(CAIP_MAINNET, '1', 500),
+        [CAIP_BASE]: eligibleHolding(CAIP_BASE, '2', 1000),
       } as never);
 
       const result = getAvailableBatchSellNetworks(buildState());
@@ -247,13 +260,15 @@ describe('batch-sell selectors', () => {
       expect(chainIds).toStrictEqual([CAIP_BASE, CAIP_MAINNET]);
     });
 
-    it('returns empty array when no supported networks have positive balance', () => {
+    it('returns empty array when no supported network has a sellable asset', () => {
       mockGetAllMultichainNetworkConfigurations.mockReturnValue({
         [CAIP_OPTIMISM]: MOCK_OPTIMISM_NETWORK,
       });
       mockGetSelectedInternalAccount.mockReturnValue(MOCK_EVM_ACCOUNT as never);
-      mockGetAssetsBySelectedAccountGroup.mockReturnValue({
-        '0xa': [{ rawBalance: '0x1', fiat: { balance: 300 } }],
+      // The only holding sits on an unsupported chain (Optimism), so no
+      // supported network has an eligible, sellable asset.
+      mockGetBridgeAssetsByAssetId.mockReturnValue({
+        [CAIP_OPTIMISM]: eligibleHolding(CAIP_OPTIMISM, 'a', 300),
       } as never);
 
       const result = getAvailableBatchSellNetworks(buildState());
@@ -909,17 +924,16 @@ describe('batch-sell selectors', () => {
     });
   });
 
-  describe('selectFiatBalanceByChain (asset without fiat)', () => {
-    it('treats missing fiat.balance as 0 when computing chain fiat total', () => {
+  describe('getAvailableBatchSellNetworks (fiat ranking based on eligible assets)', () => {
+    it('treats a missing tokenFiatAmount as 0 when computing chain fiat total', () => {
       mockGetAllMultichainNetworkConfigurations.mockReturnValue({
         [CAIP_MAINNET]: MOCK_MAINNET_NETWORK,
         [CAIP_BASE]: MOCK_BASE_NETWORK,
       });
       mockGetSelectedInternalAccount.mockReturnValue(MOCK_EVM_ACCOUNT as never);
       mockGetAssetsBySelectedAccountGroup.mockReturnValue({
-        // Asset has no fiat property at all
         [CHAIN_IDS.MAINNET]: [{ rawBalance: '0x1' }],
-        [CHAIN_IDS.BASE]: [{ rawBalance: '0x1', fiat: { balance: 100 } }],
+        [CHAIN_IDS.BASE]: [{ rawBalance: '0x1' }],
       } as never);
       mockGetBridgeFeatureFlags.mockReturnValue({
         chains: {
@@ -936,8 +950,9 @@ describe('batch-sell selectors', () => {
         },
       } as never);
       mockGetBridgeAssetsByAssetId.mockReturnValue({
+        // Mainnet's eligible holding has no tokenFiatAmount property at all
         [CAIP_MAINNET]: eligibleHolding(CAIP_MAINNET, '1'),
-        [CAIP_BASE]: eligibleHolding(CAIP_BASE, '2'),
+        [CAIP_BASE]: eligibleHolding(CAIP_BASE, '2', 100),
       } as never);
 
       const result = getAvailableBatchSellNetworks(buildState());
@@ -945,6 +960,56 @@ describe('batch-sell selectors', () => {
       // Base ($100) should appear before Mainnet ($0)
       expect(result[0].chainId).toBe(CAIP_BASE);
       expect(result[1].chainId).toBe(CAIP_MAINNET);
+    });
+
+    it('ignores an ineligible asset with a large balance when ranking chains', () => {
+      mockGetAllMultichainNetworkConfigurations.mockReturnValue({
+        [CAIP_MAINNET]: MOCK_MAINNET_NETWORK,
+        [CAIP_BASE]: MOCK_BASE_NETWORK,
+      });
+      mockGetSelectedInternalAccount.mockReturnValue(MOCK_EVM_ACCOUNT as never);
+      mockGetAssetsBySelectedAccountGroup.mockReturnValue({
+        [CHAIN_IDS.MAINNET]: [{ rawBalance: '0x1' }],
+        [CHAIN_IDS.BASE]: [{ rawBalance: '0x1' }],
+      } as never);
+      mockGetBridgeFeatureFlags.mockReturnValue({
+        chains: {
+          [CAIP_MAINNET]: {
+            batchSellDestStablecoins: [
+              'eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48',
+            ],
+          },
+          [CAIP_BASE]: {
+            batchSellDestStablecoins: [
+              'eip155:8453/erc20:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+            ],
+          },
+        },
+      } as never);
+      mockGetBridgeAssetsByAssetId.mockReturnValue({
+        // Base's large balance is entirely its own destination stablecoin,
+        // so it must not count towards Base's ranking.
+        [CAIP_BASE]: {
+          assetId: 'eip155:8453/erc20:0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+          chainId: CAIP_BASE,
+          symbol: 'USDC',
+          name: 'USD Coin',
+          decimals: 6,
+          balance: '100',
+          tokenFiatAmount: 100,
+        },
+        [`${CAIP_BASE  }-eligible`]: eligibleHolding(CAIP_BASE, '2', 10),
+        [CAIP_MAINNET]: eligibleHolding(CAIP_MAINNET, '1', 50),
+      } as never);
+
+      const result = getAvailableBatchSellNetworks(buildState());
+
+      // Mainnet's eligible $50 outranks Base's eligible $10 (its $100
+      // stablecoin holding is excluded from the ranking).
+      expect(result.map((n) => n.chainId)).toStrictEqual([
+        CAIP_MAINNET,
+        CAIP_BASE,
+      ]);
     });
   });
 });

--- a/ui/ducks/batch-sell/selectors.ts
+++ b/ui/ducks/batch-sell/selectors.ts
@@ -135,11 +135,41 @@ const selectFiatBalanceByChain = createSelector(
   },
 );
 
+/**
+ * Determines whether a held asset can be offered as a batch-sell source
+ * token: it must have a positive balance, not itself be one of the chain's
+ * destination stablecoins, and not be an excluded RWA/tokenized asset.
+ *
+ * @param asset - The held asset to evaluate.
+ * @param stablecoinSet - Lowercased set of the chain's destination stablecoin asset ids.
+ */
+const isEligibleBatchSellAsset = (
+  asset: BridgeToken,
+  stablecoinSet: Set<string>,
+): boolean => {
+  if (
+    !asset.balance ||
+    Number.isNaN(Number(asset.balance)) ||
+    Number(asset.balance) <= 0
+  ) {
+    return false;
+  }
+  if (stablecoinSet.has(asset.assetId.toLowerCase())) {
+    return false;
+  }
+  if (isStockRWAToken(asset) || asset.name?.includes(ONDO_TOKENIZED_TOKEN_NAME)) {
+    return false;
+  }
+  return true;
+};
+
 export const getAvailableBatchSellNetworks = createSelector(
   getNetworksWithPositiveBalanceForSelectedAccount,
   selectFiatBalanceByChain,
   getBridgeFeatureFlags,
-  (networksWithBalance, fiatBalanceByChain, bridgeFeatureFlags) =>
+  (state: BridgeAppState) =>
+    getBridgeAssetsByAssetId(state, getSelectedAccountGroup(state)),
+  (networksWithBalance, fiatBalanceByChain, bridgeFeatureFlags, assetsByAssetId) =>
     Object.entries(networksWithBalance)
       .filter(([chainId]) => {
         if (!BATCH_SELL_SUPPORTED_CHAIN_IDS.has(chainId as CaipChainId)) {
@@ -149,7 +179,19 @@ export const getAvailableBatchSellNetworks = createSelector(
         const stablecoins =
           bridgeFeatureFlags?.chains?.[caipChainId]?.batchSellDestStablecoins ??
           [];
-        return stablecoins.length > 0;
+        if (stablecoins.length === 0) {
+          return false;
+        }
+        // Only surface the network if it has at least one asset that would
+        // actually show up in the token picker for it.
+        const stablecoinSet = new Set(
+          stablecoins.map((id) => id.toLowerCase()),
+        );
+        return Object.values(assetsByAssetId ?? {}).some(
+          (asset) =>
+            asset.chainId === chainId &&
+            isEligibleBatchSellAsset(asset, stablecoinSet),
+        );
       })
       .map(([chainId, network]) => ({
         chainId: chainId as CaipChainId,
@@ -242,28 +284,11 @@ export const getAvailableBatchSellSwapAssetsForNetwork = createSelector(
     const stablecoinSet = new Set(stablecoins.map((id) => id.toLowerCase()));
 
     return Object.values(assetsByAssetId)
-      .filter((asset) => {
-        if (asset.chainId !== selectedChainId) {
-          return false;
-        }
-        if (
-          !asset.balance ||
-          Number.isNaN(Number(asset.balance)) ||
-          Number(asset.balance) <= 0
-        ) {
-          return false;
-        }
-        if (stablecoinSet.has(asset.assetId.toLowerCase())) {
-          return false;
-        }
-        if (
-          isStockRWAToken(asset) ||
-          asset.name?.includes(ONDO_TOKENIZED_TOKEN_NAME)
-        ) {
-          return false;
-        }
-        return true;
-      })
+      .filter(
+        (asset) =>
+          asset.chainId === selectedChainId &&
+          isEligibleBatchSellAsset(asset, stablecoinSet),
+      )
       .map((asset): BatchSellAsset => {
         const { tokenFiatPrice, percentageChange } =
           resolveTokenFiatPriceAndChange(asset, marketData, assetsRates);

--- a/ui/ducks/batch-sell/selectors.ts
+++ b/ui/ducks/batch-sell/selectors.ts
@@ -1,17 +1,10 @@
 import { createSelector } from 'reselect';
 import {
   Hex,
-  hexToBigInt,
-  KnownCaipNamespace,
   parseCaipAssetType,
   type CaipAssetType,
   type CaipChainId,
 } from '@metamask/utils';
-import {
-  MultichainNetworkConfiguration,
-  toEvmCaipChainId,
-} from '@metamask/multichain-network-controller';
-import { isEvmAccountType } from '@metamask/keyring-api';
 import {
   formatChainIdToCaip,
   formatChainIdToHex,
@@ -22,15 +15,11 @@ import {
 } from '@metamask/bridge-controller';
 import { CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP } from '../../../shared/constants/network';
 import { convertCaipToHexChainId } from '../../../shared/lib/network.utils';
-import {
-  getAssetsBySelectedAccountGroup,
-  getAssetsRates,
-} from '../../selectors/assets';
+import { getAssetsRates } from '../../selectors/assets';
 import {
   getAllMultichainNetworkConfigurations,
   getMarketData,
 } from '../../selectors';
-import { getSelectedInternalAccount } from '../../../shared/lib/selectors/accounts';
 import {
   getAssetImageUrl,
   isEvmChainId,
@@ -54,86 +43,6 @@ import {
 } from '../../../shared/constants/batch-sell';
 import { isStockRWAToken } from '../../pages/bridge/hooks/useRWAToken';
 import { BatchSellAsset } from './types';
-
-/**
- * Returns all available multichain network configurations for the currently
- * selected account. EVM accounts support all EVM networks; non-EVM accounts
- * only support the networks listed in their declared CAIP-2 scopes.
- */
-const getNetworksForSelectedAccount = createSelector(
-  getAllMultichainNetworkConfigurations,
-  getSelectedInternalAccount,
-  (
-    allNetworks,
-    selectedAccount,
-  ): Record<CaipChainId, MultichainNetworkConfiguration> => {
-    if (!selectedAccount) {
-      return {};
-    }
-    if (isEvmAccountType(selectedAccount.type)) {
-      // EVM accounts support all EVM (eip155:*) networks
-      return Object.fromEntries(
-        Object.entries(allNetworks).filter(([chainId]) =>
-          chainId.startsWith(`${KnownCaipNamespace.Eip155}:`),
-        ),
-      ) as Record<CaipChainId, MultichainNetworkConfiguration>;
-    }
-    // Non-EVM accounts: filter to only their declared scopes
-    const accountScopes = new Set(selectedAccount.scopes ?? []);
-    return Object.fromEntries(
-      Object.entries(allNetworks).filter(([chainId]) =>
-        accountScopes.has(chainId as CaipChainId),
-      ),
-    ) as Record<CaipChainId, MultichainNetworkConfiguration>;
-  },
-);
-
-const getChainsWithPositiveBalanceForSelectedAccount = createSelector(
-  getAssetsBySelectedAccountGroup,
-  (assetsByChain): Set<CaipChainId> => {
-    return new Set(
-      Object.entries(assetsByChain)
-        .filter(([, assets]) =>
-          assets.some((asset) => hexToBigInt(asset.rawBalance) > 0n),
-        )
-        .map(([chainId]) => {
-          // EVM assets use hex keys (e.g. "0x1"), convert to CAIP (e.g. "eip155:1")
-          if (isEvmChainId(chainId as Hex)) {
-            return toEvmCaipChainId(chainId as Hex);
-          }
-          return chainId as CaipChainId;
-        }),
-    );
-  },
-);
-
-const getNetworksWithPositiveBalanceForSelectedAccount = createSelector(
-  getNetworksForSelectedAccount,
-  getChainsWithPositiveBalanceForSelectedAccount,
-  (networksForAccount, chainsWithBalance) =>
-    Object.fromEntries(
-      Object.entries(networksForAccount).filter(([chainId]) =>
-        chainsWithBalance.has(chainId as CaipChainId),
-      ),
-    ) as Record<CaipChainId, MultichainNetworkConfiguration>,
-);
-
-const selectFiatBalanceByChain = createSelector(
-  getAssetsBySelectedAccountGroup,
-  (assetsByChain): Record<string, number> => {
-    const result: Record<string, number> = {};
-    for (const [hexChainId, assets] of Object.entries(assetsByChain)) {
-      const caipChainId = isEvmChainId(hexChainId as Hex)
-        ? toEvmCaipChainId(hexChainId as Hex)
-        : hexChainId;
-      result[caipChainId] = assets.reduce(
-        (sum, asset) => sum + (Number(asset.fiat?.balance) || 0),
-        0,
-      );
-    }
-    return result;
-  },
-);
 
 /**
  * Determines whether a held asset can be offered as a batch-sell source
@@ -163,39 +72,54 @@ const isEligibleBatchSellAsset = (
   return true;
 };
 
-export const getAvailableBatchSellNetworks = createSelector(
-  getNetworksWithPositiveBalanceForSelectedAccount,
-  selectFiatBalanceByChain,
-  getBridgeFeatureFlags,
+/**
+ * Groups the assets that are actually eligible to be sold via batch-sell
+ * (see {@link isEligibleBatchSellAsset}) by chain. A chain is only included
+ * once it has at least one destination stablecoin configured; without one,
+ * none of its assets can be considered eligible.
+ */
+const selectEligibleBatchSellAssetsByChain = createSelector(
   (state: BridgeAppState) =>
     getBridgeAssetsByAssetId(state, getSelectedAccountGroup(state)),
-  (networksWithBalance, fiatBalanceByChain, bridgeFeatureFlags, assetsByAssetId) =>
-    Object.entries(networksWithBalance)
-      .filter(([chainId]) => {
-        if (!BATCH_SELL_SUPPORTED_CHAIN_IDS.has(chainId as CaipChainId)) {
-          return false;
-        }
-        const caipChainId = formatChainIdToCaip(chainId as CaipChainId);
-        const stablecoins =
-          bridgeFeatureFlags?.chains?.[caipChainId]?.batchSellDestStablecoins ??
-          [];
-        if (stablecoins.length === 0) {
-          return false;
-        }
-        // Only surface the network if it has at least one asset that would
-        // actually show up in the token picker for it.
-        const stablecoinSet = new Set(
-          stablecoins.map((id) => id.toLowerCase()),
-        );
-        return Object.values(assetsByAssetId ?? {}).some(
-          (asset) =>
-            asset.chainId === chainId &&
-            isEligibleBatchSellAsset(asset, stablecoinSet),
-        );
-      })
-      .map(([chainId, network]) => ({
+  getBridgeFeatureFlags,
+  (assetsByAssetId, bridgeFeatureFlags): Record<CaipChainId, BridgeToken[]> => {
+    const result: Record<CaipChainId, BridgeToken[]> = {};
+    for (const asset of Object.values(assetsByAssetId ?? {})) {
+      const caipChainId = formatChainIdToCaip(asset.chainId);
+      const stablecoins =
+        bridgeFeatureFlags?.chains?.[caipChainId]?.batchSellDestStablecoins ??
+        [];
+      if (stablecoins.length === 0) {
+        continue;
+      }
+      const stablecoinSet = new Set(stablecoins.map((id) => id.toLowerCase()));
+      if (!isEligibleBatchSellAsset(asset, stablecoinSet)) {
+        continue;
+      }
+      (result[asset.chainId] ??= []).push(asset);
+    }
+    return result;
+  },
+);
+
+const sumEligibleFiatBalance = (assets: BridgeToken[] | undefined): number =>
+  (assets ?? []).reduce((sum, asset) => sum + (asset.tokenFiatAmount ?? 0), 0);
+
+export const getAvailableBatchSellNetworks = createSelector(
+  getAllMultichainNetworkConfigurations,
+  selectEligibleBatchSellAssetsByChain,
+  (allNetworks, eligibleAssetsByChain) =>
+    Object.keys(eligibleAssetsByChain)
+      .filter(
+        (chainId) =>
+          BATCH_SELL_SUPPORTED_CHAIN_IDS.has(chainId as CaipChainId) &&
+          // Only surface the network if it has at least one asset that would
+          // actually show up in the token picker for it.
+          (eligibleAssetsByChain[chainId as CaipChainId]?.length ?? 0) > 0,
+      )
+      .map((chainId) => ({
         chainId: chainId as CaipChainId,
-        name: network.name,
+        name: allNetworks[chainId as CaipChainId]?.name ?? '',
         imageUrl:
           CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP[
             convertCaipToHexChainId(chainId as CaipChainId)
@@ -203,8 +127,8 @@ export const getAvailableBatchSellNetworks = createSelector(
       }))
       .toSorted(
         (a, b) =>
-          (fiatBalanceByChain[b.chainId] ?? 0) -
-          (fiatBalanceByChain[a.chainId] ?? 0),
+          sumEligibleFiatBalance(eligibleAssetsByChain[b.chainId]) -
+          sumEligibleFiatBalance(eligibleAssetsByChain[a.chainId]),
       ),
 );
 

--- a/ui/ducks/batch-sell/selectors.ts
+++ b/ui/ducks/batch-sell/selectors.ts
@@ -66,7 +66,10 @@ const isEligibleBatchSellAsset = (
   if (stablecoinSet.has(asset.assetId.toLowerCase())) {
     return false;
   }
-  if (isStockRWAToken(asset) || asset.name?.includes(ONDO_TOKENIZED_TOKEN_NAME)) {
+  if (
+    isStockRWAToken(asset) ||
+    asset.name?.includes(ONDO_TOKENIZED_TOKEN_NAME)
+  ) {
     return false;
   }
   return true;

--- a/ui/pages/batch-sell/pages/review/hooks/useBatchSellQuotesFetching.test.ts
+++ b/ui/pages/batch-sell/pages/review/hooks/useBatchSellQuotesFetching.test.ts
@@ -6,10 +6,8 @@ import {
   setSelectedQuote,
   updateQuoteRequestParams,
 } from '../../../../../ducks/bridge/actions';
-import {
-  getFromAccount,
-  getIsStxEnabled,
-} from '../../../../../ducks/bridge/selectors';
+import { getIsStxEnabled } from '../../../../../ducks/bridge/selectors';
+import { getInternalAccountBySelectedAccountGroupAndCaip } from '../../../../../selectors/multichain-accounts/account-tree';
 import {
   getBatchSellQuotes,
   getBatchSellQuotesValidationErrors,
@@ -42,8 +40,11 @@ jest.mock('../../../../../ducks/bridge/actions', () => ({
 }));
 
 jest.mock('../../../../../ducks/bridge/selectors', () => ({
-  getFromAccount: jest.fn(),
   getIsStxEnabled: jest.fn(),
+}));
+
+jest.mock('../../../../../selectors/multichain-accounts/account-tree', () => ({
+  getInternalAccountBySelectedAccountGroupAndCaip: jest.fn(),
 }));
 
 jest.mock('../../../../../ducks/batch-sell/selectors', () => ({
@@ -73,7 +74,9 @@ jest.mock('lodash', () => ({
 const mockDispatch = jest.fn();
 const mockUseDispatch = jest.mocked(useDispatch);
 const mockUseSelector = jest.mocked(useSelector);
-const mockGetFromAccount = jest.mocked(getFromAccount);
+const mockGetInternalAccountBySelectedAccountGroupAndCaip = jest.mocked(
+  getInternalAccountBySelectedAccountGroupAndCaip,
+);
 const mockGetIsStxEnabled = jest.mocked(getIsStxEnabled);
 const mockGetBatchSellQuotes = jest.mocked(getBatchSellQuotes);
 const mockGetBatchSellQuotesValidationErrors = jest.mocked(
@@ -181,7 +184,9 @@ describe('useBatchSellQuotesFetching', () => {
     mockDispatch.mockReset();
     mockUseDispatch.mockReturnValue(mockDispatch as never);
 
-    mockGetFromAccount.mockReturnValue(MOCK_ACCOUNT as never);
+    mockGetInternalAccountBySelectedAccountGroupAndCaip.mockReturnValue(
+      MOCK_ACCOUNT as never,
+    );
     mockGetIsStxEnabled.mockReturnValue(true as never);
     mockGetBatchSellQuotes.mockReturnValue(
       MOCK_CONTROLLER_RESULT_NOT_FETCHED as never,
@@ -309,7 +314,9 @@ describe('useBatchSellQuotesFetching', () => {
     });
 
     it('does not dispatch when selectedAccount has no address', () => {
-      mockGetFromAccount.mockReturnValue(null as never);
+      mockGetInternalAccountBySelectedAccountGroupAndCaip.mockReturnValue(
+        null as never,
+      );
 
       renderDefault({ enabled: true });
 

--- a/ui/pages/batch-sell/pages/review/hooks/useBatchSellQuotesFetching.ts
+++ b/ui/pages/batch-sell/pages/review/hooks/useBatchSellQuotesFetching.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import { debounce } from 'lodash';
 import { CaipAssetType } from '@metamask/utils';
+import { formatChainIdToCaip } from '@metamask/bridge-controller';
 import {
   resetBridgeController,
   setSelectedQuote,
@@ -9,9 +10,9 @@ import {
 } from '../../../../../ducks/bridge/actions';
 import {
   type BridgeAppState,
-  getFromAccount,
   getIsStxEnabled,
 } from '../../../../../ducks/bridge/selectors';
+import { getInternalAccountBySelectedAccountGroupAndCaip } from '../../../../../selectors/multichain-accounts/account-tree';
 import {
   BatchSellQuotesConfig,
   BatchSellQuotesResults,
@@ -38,7 +39,24 @@ export const useBatchSellQuotesFetching = (
 ) => {
   const dispatch = useDispatch();
 
-  const selectedAccount = useSelector(getFromAccount);
+  // Batch sell is same-chain, so every entry (and the received asset) shares
+  // one network. Resolve the wallet address from the account in the selected
+  // account group that matches THAT chain's namespace, rather than the bridge's
+  // global `fromAccount`. The latter is driven by chain ranking / the group's
+  // selected internal account, which can be non-EVM (e.g. Solana) even when the
+  // user is selling EVM assets, producing a wallet address whose namespace
+  // doesn't match `srcChainId` and a rejected quote request.
+  const batchSellCaipChainId = useMemo(
+    () => formatChainIdToCaip(receivedAsset.chainId),
+    [receivedAsset.chainId],
+  );
+  const selectedAccount = useSelector((state: BridgeAppState) =>
+    getInternalAccountBySelectedAccountGroupAndCaip(
+      state,
+      batchSellCaipChainId,
+    ),
+  );
+
   const smartTransactionsEnabled = useSelector(getIsStxEnabled);
 
   const entries = useMemo<SendAssetEntry[]>(

--- a/ui/pages/batch-sell/pages/select/batch-sell-select-page.test.tsx
+++ b/ui/pages/batch-sell/pages/select/batch-sell-select-page.test.tsx
@@ -75,9 +75,11 @@ jest.mock('../../providers/batch-sell-selection-provider', () => ({
     selectedNetworkChainId: CHAIN_ID,
     selectedAssetsId: mockHarness.initialAssetsId,
     assetsOrderByBalance: 'desc' as const,
+    hasUserInteracted: false,
     setSelectedNetworkChainId: jest.fn(),
     setSelectedAssetsId: jest.fn(),
     setAssetsOrderByBalance: jest.fn(),
+    setHasUserInteracted: jest.fn(),
   }),
 }));
 

--- a/ui/pages/batch-sell/pages/select/batch-sell-select-page.tsx
+++ b/ui/pages/batch-sell/pages/select/batch-sell-select-page.tsx
@@ -36,9 +36,11 @@ export const BatchSellSelectPage = () => {
     selectedNetworkChainId,
     selectedAssetsId,
     assetsOrderByBalance,
+    hasUserInteracted,
     setSelectedNetworkChainId,
     setSelectedAssetsId,
     setAssetsOrderByBalance,
+    setHasUserInteracted,
   } = useBatchSellSelection();
 
   const availableBatchSellNetworksList = useSelector(
@@ -55,12 +57,21 @@ export const BatchSellSelectPage = () => {
   }, []);
 
   useLayoutEffect(() => {
-    // Default to the first available network when none is selected yet.
-    if (!selectedNetworkChainId && availableNetworkChainIds[0]) {
-      setSelectedNetworkChainId(availableNetworkChainIds[0]);
+    // The available networks list is sorted by balance descending but resolves
+    // asynchronously, so its top entry can change across renders as fiat data
+    // streams in. Until the user makes an explicit selection, keep the default
+    // pinned to the highest-balance network (the first entry) rather than
+    // locking in whichever network happened to load first.
+    if (hasUserInteracted) {
+      return;
+    }
+    const topNetworkChainId = availableNetworkChainIds[0];
+    if (topNetworkChainId && topNetworkChainId !== selectedNetworkChainId) {
+      setSelectedNetworkChainId(topNetworkChainId);
     }
   }, [
     availableNetworkChainIds,
+    hasUserInteracted,
     selectedNetworkChainId,
     setSelectedNetworkChainId,
   ]);
@@ -85,18 +96,21 @@ export const BatchSellSelectPage = () => {
 
   const onNetworkSelect = useCallback(
     (chainId: CaipChainId) => {
+      setHasUserInteracted(true);
       setSelectedAssetsId([]);
       setSelectedNetworkChainId(chainId);
     },
-    [setSelectedAssetsId, setSelectedNetworkChainId],
+    [setHasUserInteracted, setSelectedAssetsId, setSelectedNetworkChainId],
   );
 
   const onSelectAsset = useCallback(
-    (asset: BatchSellAsset) =>
+    (asset: BatchSellAsset) => {
+      setHasUserInteracted(true);
       setSelectedAssetsId((assets) =>
         assets.includes(asset.assetId) ? assets : [...assets, asset.assetId],
-      ),
-    [setSelectedAssetsId],
+      );
+    },
+    [setHasUserInteracted, setSelectedAssetsId],
   );
 
   const onDeselectAsset = useCallback(

--- a/ui/pages/batch-sell/pages/select/components/asset-list.tsx
+++ b/ui/pages/batch-sell/pages/select/components/asset-list.tsx
@@ -18,7 +18,10 @@ export const AssetList = ({
   onDeselect,
 }: AssetListProps) => {
   return (
-    <Box className="flex-1" data-testid="batch-sell-select-asset-list">
+    <Box
+      className="flex-1 min-h-0 overflow-y-auto"
+      data-testid="batch-sell-select-asset-list"
+    >
       {assets.map((asset) => (
         <AssetListItem
           key={asset.assetId}

--- a/ui/pages/batch-sell/providers/batch-sell-selection-provider.test.tsx
+++ b/ui/pages/batch-sell/providers/batch-sell-selection-provider.test.tsx
@@ -18,9 +18,11 @@ const TestConsumer = () => {
     selectedNetworkChainId,
     selectedAssetsId,
     assetsOrderByBalance,
+    hasUserInteracted,
     setSelectedNetworkChainId,
     setSelectedAssetsId,
     setAssetsOrderByBalance,
+    setHasUserInteracted,
   } = useBatchSellSelection();
 
   return (
@@ -28,6 +30,7 @@ const TestConsumer = () => {
       <span data-testid="chain-id">{selectedNetworkChainId ?? 'null'}</span>
       <span data-testid="assets">{selectedAssetsId.join(',')}</span>
       <span data-testid="order">{assetsOrderByBalance}</span>
+      <span data-testid="interacted">{String(hasUserInteracted)}</span>
       <button onClick={() => setSelectedNetworkChainId(CHAIN_ID)}>
         set chain
       </button>
@@ -44,6 +47,7 @@ const TestConsumer = () => {
       <button onClick={() => setAssetsOrderByBalance('desc')}>
         set order desc
       </button>
+      <button onClick={() => setHasUserInteracted(true)}>interact</button>
     </div>
   );
 };
@@ -73,6 +77,12 @@ describe('BatchSellSelectionProvider', () => {
       renderWithProvider();
 
       expect(screen.getByTestId('order')).toHaveTextContent('desc');
+    });
+
+    it('exposes hasUserInteracted as false', () => {
+      renderWithProvider();
+
+      expect(screen.getByTestId('interacted')).toHaveTextContent('false');
     });
 
     it('renders children', () => {
@@ -156,6 +166,18 @@ describe('BatchSellSelectionProvider', () => {
       });
 
       expect(screen.getByTestId('order')).toHaveTextContent('desc');
+    });
+  });
+
+  describe('setHasUserInteracted', () => {
+    it('marks hasUserInteracted as true', () => {
+      renderWithProvider();
+
+      act(() => {
+        fireEvent.click(screen.getByText('interact'));
+      });
+
+      expect(screen.getByTestId('interacted')).toHaveTextContent('true');
     });
   });
 

--- a/ui/pages/batch-sell/providers/batch-sell-selection-provider.tsx
+++ b/ui/pages/batch-sell/providers/batch-sell-selection-provider.tsx
@@ -5,9 +5,14 @@ type BatchSellSelectionContextValue = {
   selectedNetworkChainId: CaipChainId | null;
   selectedAssetsId: CaipAssetType[];
   assetsOrderByBalance: 'asc' | 'desc';
+  // Tracks whether the user has explicitly interacted with the network/asset
+  // selection. Until then, the default network stays synced to the
+  // highest-balance network as the async network list settles.
+  hasUserInteracted: boolean;
   setSelectedNetworkChainId: (chainId: CaipChainId | null) => void;
   setSelectedAssetsId: React.Dispatch<React.SetStateAction<CaipAssetType[]>>;
   setAssetsOrderByBalance: React.Dispatch<React.SetStateAction<'asc' | 'desc'>>;
+  setHasUserInteracted: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 const BatchSellSelectionContext = createContext<BatchSellSelectionContextValue>(
@@ -15,9 +20,11 @@ const BatchSellSelectionContext = createContext<BatchSellSelectionContextValue>(
     selectedNetworkChainId: null,
     selectedAssetsId: [],
     assetsOrderByBalance: 'desc',
+    hasUserInteracted: false,
     setSelectedNetworkChainId: () => undefined,
     setSelectedAssetsId: () => undefined,
     setAssetsOrderByBalance: () => undefined,
+    setHasUserInteracted: () => undefined,
   },
 );
 
@@ -35,17 +42,25 @@ export const BatchSellSelectionProvider = ({
   const [assetsOrderByBalance, setAssetsOrderByBalance] = useState<
     'asc' | 'desc'
   >('desc');
+  const [hasUserInteracted, setHasUserInteracted] = useState(false);
 
   const contextValue = useMemo(
     () => ({
       selectedNetworkChainId,
       selectedAssetsId,
       assetsOrderByBalance,
+      hasUserInteracted,
       setSelectedNetworkChainId,
       setSelectedAssetsId,
       setAssetsOrderByBalance,
+      setHasUserInteracted,
     }),
-    [selectedNetworkChainId, selectedAssetsId, assetsOrderByBalance],
+    [
+      selectedNetworkChainId,
+      selectedAssetsId,
+      assetsOrderByBalance,
+      hasUserInteracted,
+    ],
   );
 
   return (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Introducing various fixes and improvements on batch sell select page.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: various fixes and improvements on batch sell select page.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4765, https://consensyssoftware.atlassian.net/browse/SWAPS-4793, https://consensyssoftware.atlassian.net/browse/SWAPS-4794, https://consensyssoftware.atlassian.net/browse/SWAPS-4795, https://consensyssoftware.atlassian.net/browse/SWAPS-4796

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes batch-sell network visibility, ordering, default UX, and which wallet address is used for quotes—user-visible flow and swap request correctness, but scoped to batch sell with added tests.
> 
> **Overview**
> **Batch sell select** now drives which networks appear, how they’re ordered, and the default network from **sellable** bridge holdings—not raw per-chain wallet balances.
> 
> `getAvailableBatchSellNetworks` only includes supported chains that have at least one **eligible** source token (positive balance, not a destination stablecoin, not excluded RWA/Ondo tokenized names), and sorts by the sum of those tokens’ `tokenFiatAmount`. Shared eligibility logic lives in `isEligibleBatchSellAsset` and is reused for the per-network token picker.
> 
> On the select page, **`hasUserInteracted`** keeps the default network pinned to the highest-balance entry in the async network list until the user picks a network or asset, avoiding locking onto whichever chain loaded first. The asset list gets **`min-h-0 overflow-y-auto`** so long lists scroll inside the layout.
> 
> **Quote fetching** resolves the signing account with `getInternalAccountBySelectedAccountGroupAndCaip` for the receive asset’s chain instead of the bridge global `fromAccount`, so EVM batch sells don’t use a mismatched non-EVM address when the account group’s selected internal account differs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea302d8cc3ff1ad36f4cdf11fdd4636b3417f149. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->