### PR TITLE
chore(ui): migrate home notifications BannerAlert to MMDS

### DIFF
--- a/ui/pages/home/home-notifications-container.tsx
+++ b/ui/pages/home/home-notifications-container.tsx
@@ -1,6 +1,12 @@
 import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Text, TextVariant, TextColor } from '@metamask/design-system-react';
+import {
+  Text,
+  TextVariant,
+  TextColor,
+  BannerAlert,
+  BannerAlertSeverity,
+} from '@metamask/design-system-react';
 import {
   activeTabHasPermissions,
   getOriginOfCurrentTab,
@@ -38,10 +44,6 @@ import ZENDESK_URLS from '../../helpers/constants/zendesk-url';
 import HomeNotification from '../../components/app/home-notification';
 import MultipleNotifications from '../../components/app/multiple-notifications';
 import { SeedPhraseBackupNotificationContainer } from '../../components/app/recovery-phrase-reminder';
-import {
-  BannerAlert,
-  BannerAlertSeverity,
-} from '../../components/component-library';
 import { useI18nContext } from '../../hooks/useI18nContext';
 import type { MetaMaskReduxState } from '../../store/store';
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Migrates the home notifications success banners from the deprecated `BannerAlert` / `BannerAlertSeverity` exports in `../../components/component-library` to `@metamask/design-system-react`.

1. **Reason:** Part of the ongoing UI migration away from the deprecated component-library toward MetaMask Design System (MMDS), tracked in #43340.
2. **Solution:** Import-only update in `ui/pages/home/home-notifications-container.tsx`. JSX usage (`severity`, `onClose`, children) is unchanged, so behavior and visuals should remain the same.

Part of #43340

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of #43340

## **Manual testing steps**

1. Build and load the extension from this branch (`yarn start`, then Load unpacked / reload).
2. Unlock the wallet and open **Settings → Networks** (Manage networks).
3. Add a custom network you do not already have (e.g. Arbitrum Sepolia or Base Sepolia).
4. Confirm the green success banner appears (e.g. “was successfully added!”).
5. Optionally edit that network and confirm the green “successfully edited” banner still appears.
6. Dismiss the banner with the X and confirm it closes normally.

## **Screenshots/Recordings**

### **Before**

<img width="960" height="824" alt="before-new-network" src="https://github.com/user-attachments/assets/0c27430d-0da5-43ff-9f40-e5ae5cdb7d21" />


### **After**

<img width="960" height="829" alt="after-new-network" src="https://github.com/user-attachments/assets/eb9859b0-0ead-445c-9790-7910f20b3fbd" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.