### PR TITLE
ci: Harden absolute benchmark gate against within-noise breaches

### DIFF
--- a/development/metamaskbot-build-announce/compare-benchmarks.test.ts
+++ b/development/metamaskbot-build-announce/compare-benchmarks.test.ts
@@ -666,10 +666,11 @@ describe('buildMetricLines', () => {
   });
 
   it('reports the absolute ceiling, not the relative improvement, on an absolute-only fail', () => {
-    // #42867 onboardingImportWallet total.p75: fails the absolute ceiling
-    // (11291 > 11050ms) while the relative delta is a stale-baseline improvement
-    // (-72.1%). The line must attribute the failure to the ceiling, never paint
-    // the improvement as the reason.
+    // Observed on a live benchmark run (onboardingImportWallet total.p75):
+    // the metric fails the absolute ceiling (11291 > 11050ms) while the
+    // relative delta is a stale-baseline improvement (-72.1%). The line must
+    // attribute the failure to the ceiling, never paint the improvement as
+    // the reason.
     const lines = buildMetricLines(
       makeComparison({
         relativeMetrics: [

--- a/development/metamaskbot-build-announce/compare-benchmarks.test.ts
+++ b/development/metamaskbot-build-announce/compare-benchmarks.test.ts
@@ -665,6 +665,44 @@ describe('buildMetricLines', () => {
     expect(lines[0].hasIssue).toBe(true);
   });
 
+  it('reports the absolute ceiling, not the relative improvement, on an absolute-only fail', () => {
+    // #42867 onboardingImportWallet total.p75: fails the absolute ceiling
+    // (11291 > 11050ms) while the relative delta is a stale-baseline improvement
+    // (-72.1%). The line must attribute the failure to the ceiling, never paint
+    // the improvement as the reason.
+    const lines = buildMetricLines(
+      makeComparison({
+        relativeMetrics: [
+          {
+            metric: 'total',
+            percentile: 'p75',
+            current: 11291,
+            baseline: 40000,
+            delta: -28709,
+            deltaPercent: -0.721,
+            severity: COMPARISON_SEVERITY.Pass.value,
+            indication: COMPARISON_SEVERITY.Pass.icon,
+          },
+        ],
+        absoluteViolations: [
+          {
+            metricId: 'total',
+            percentile: 'p75',
+            value: 11291,
+            threshold: 11050,
+            severity: THRESHOLD_SEVERITY.Fail,
+          },
+        ],
+      }),
+    );
+
+    const { details } = lines[0];
+    expect(details).toContain('absolute ceiling exceeded');
+    expect(details).toContain('11291ms');
+    expect(details).toContain('11050ms');
+    expect(details).not.toContain('-72.1%');
+  });
+
   it('overrides icon with 🟡 when absolute Warn violation matches the metric', () => {
     const lines = buildMetricLines(
       makeComparison({

--- a/development/metamaskbot-build-announce/compare-benchmarks.ts
+++ b/development/metamaskbot-build-announce/compare-benchmarks.ts
@@ -33,6 +33,7 @@ import { fetchHistoricalPerformanceDataFromMain } from './historical-comparison'
 import type { HistoricalBaselineReference } from './historical-comparison';
 import {
   applyGatingPolicy,
+  applyNoiseTolerance,
   compareBenchmarkEntries,
   formatDeltaPercent,
   scaleThresholdsForBrowser,
@@ -125,7 +126,10 @@ export function runComparison(
         thresholdConfig,
         baselineMetrics,
       );
-      const comparison = applyGatingPolicy(rawComparison, GATED_METRICS);
+      const comparison = applyNoiseTolerance(
+        applyGatingPolicy(rawComparison, GATED_METRICS),
+        results,
+      );
 
       if (parsed) {
         comparison.source = `${parsed.browser}-${parsed.buildType}`;
@@ -247,8 +251,23 @@ export function buildMetricLines(
         }
 
         if (isIssue) {
-          const delta = formatDeltaPercent(rel.deltaPercent);
-          details.push(`${pKey}: ${formatValue(rel.current)} (${delta})`);
+          if (absoluteSeverity) {
+            // Absolute-gate driven: report the ceiling and measured value, not
+            // the relative delta (which may be a stale/incomparable baseline —
+            // even an improvement). Never present a relative improvement as the
+            // reason for the red/yellow.
+            const violation = comparison.absoluteViolations.find(
+              (v) => v.metricId === metric && v.percentile === pKey,
+            );
+            details.push(
+              violation
+                ? `${pKey}: ${formatValue(violation.value)} (absolute ceiling exceeded, limit ${formatValue(violation.threshold)})`
+                : `${pKey}: ${formatValue(rel.current)} (absolute ceiling exceeded)`,
+            );
+          } else {
+            const delta = formatDeltaPercent(rel.deltaPercent);
+            details.push(`${pKey}: ${formatValue(rel.current)} (${delta})`);
+          }
           hasIssue = true;
           displayIcon = updateDisplayIcon(icon, displayIcon);
         }

--- a/development/metamaskbot-build-announce/comparison-utils.test.ts
+++ b/development/metamaskbot-build-announce/comparison-utils.test.ts
@@ -600,8 +600,9 @@ describe('THRESHOLD_REGISTRY', () => {
         p95: { total: 11689 },
       }) as unknown as BenchmarkResults;
 
-    // #42867 onboardingImportWallet, chrome-webpack: p75 11291 vs limit 11050,
-    // breach 241ms < stdDev 303ms — a coin-flip on which samples landed.
+    // Observed on a live benchmark run (onboardingImportWallet,
+    // chrome-webpack): p75 11291 vs limit 11050, breach 241ms < stdDev 303ms
+    // — a coin-flip on which samples landed.
     it('downgrades a Fail to Warn when the breach is within one stdDev', () => {
       const result = applyNoiseTolerance(
         makeComparison(THRESHOLD_SEVERITY.Fail, 11291, 11050),

--- a/development/metamaskbot-build-announce/comparison-utils.test.ts
+++ b/development/metamaskbot-build-announce/comparison-utils.test.ts
@@ -12,6 +12,7 @@ import { THRESHOLD_REGISTRY } from '../../test/e2e/benchmarks/utils/thresholds';
 
 import {
   applyGatingPolicy,
+  applyNoiseTolerance,
   compareMetric,
   compareBenchmarkEntries,
   formatDeltaPercent,
@@ -573,5 +574,75 @@ describe('THRESHOLD_REGISTRY', () => {
     expect(
       THRESHOLD_REGISTRY['firefox-webpack-startupPowerUserHome'],
     ).toBeUndefined();
+  });
+
+  describe('applyNoiseTolerance', () => {
+    const makeComparison = (
+      severity: ThresholdViolation['severity'],
+      value: number,
+      threshold: number,
+    ): BenchmarkEntryComparison => ({
+      benchmarkName: 'onboardingImportWallet',
+      relativeMetrics: [],
+      absoluteViolations: [
+        { metricId: 'total', percentile: 'p75', value, threshold, severity },
+      ],
+      hasRegression: false,
+      hasWarning: severity === THRESHOLD_SEVERITY.Warn,
+      absoluteFailed: severity === THRESHOLD_SEVERITY.Fail,
+    });
+
+    const makeResults = (stdDev?: number): BenchmarkResults =>
+      ({
+        mean: { total: 11000 },
+        stdDev: stdDev === undefined ? {} : { total: stdDev },
+        p75: { total: 11291 },
+        p95: { total: 11689 },
+      }) as unknown as BenchmarkResults;
+
+    // #42867 onboardingImportWallet, chrome-webpack: p75 11291 vs limit 11050,
+    // breach 241ms < stdDev 303ms — a coin-flip on which samples landed.
+    it('downgrades a Fail to Warn when the breach is within one stdDev', () => {
+      const result = applyNoiseTolerance(
+        makeComparison(THRESHOLD_SEVERITY.Fail, 11291, 11050),
+        makeResults(303),
+      );
+      expect(result.absoluteViolations[0].severity).toBe(
+        THRESHOLD_SEVERITY.Warn,
+      );
+      expect(result.absoluteFailed).toBe(false);
+      expect(result.hasWarning).toBe(true);
+    });
+
+    it('keeps a Fail when the breach exceeds one stdDev', () => {
+      const result = applyNoiseTolerance(
+        makeComparison(THRESHOLD_SEVERITY.Fail, 12000, 11050),
+        makeResults(303),
+      );
+      expect(result.absoluteViolations[0].severity).toBe(
+        THRESHOLD_SEVERITY.Fail,
+      );
+      expect(result.absoluteFailed).toBe(true);
+    });
+
+    it('leaves the violation unchanged when stdDev is unavailable', () => {
+      const result = applyNoiseTolerance(
+        makeComparison(THRESHOLD_SEVERITY.Fail, 11291, 11050),
+        makeResults(undefined),
+      );
+      expect(result.absoluteViolations[0].severity).toBe(
+        THRESHOLD_SEVERITY.Fail,
+      );
+    });
+
+    it('does not touch Warn-severity violations', () => {
+      const result = applyNoiseTolerance(
+        makeComparison(THRESHOLD_SEVERITY.Warn, 11291, 11050),
+        makeResults(1),
+      );
+      expect(result.absoluteViolations[0].severity).toBe(
+        THRESHOLD_SEVERITY.Warn,
+      );
+    });
   });
 });

--- a/development/metamaskbot-build-announce/comparison-utils.ts
+++ b/development/metamaskbot-build-announce/comparison-utils.ts
@@ -313,3 +313,63 @@ export function applyGatingPolicy(
       ) || downgraded.some((v) => v.severity === THRESHOLD_SEVERITY.Warn),
   };
 }
+
+/**
+ * Number of standard deviations of the metric's own run-to-run noise within
+ * which an absolute-gate breach is treated as data quality, not a regression.
+ *
+ * The absolute gate compares a percentile (e.g. p75) against a fixed ceiling.
+ * When the breach margin (`value - threshold`) is smaller than the metric's
+ * stdDev, which side of the ceiling a run lands on is noise, not signal — a
+ * `Fail` there is a coin-flip on which samples landed.
+ */
+export const WITHIN_NOISE_STDDEV_MULTIPLIER = 1;
+
+/**
+ * Downgrades absolute-gate `Fail` violations to `Warn` when the breach margin
+ * is within {@link WITHIN_NOISE_STDDEV_MULTIPLIER} stdDev of the metric's own
+ * noise. Uses the metric's stdDev from the benchmark results; violations for
+ * metrics without a usable stdDev are unchanged. Mirrors the missing-percentile
+ * skip guard rather than hard-failing on noise. `Warn` violations and
+ * `relativeMetrics` are never modified.
+ *
+ * Returns a new comparison object — does not mutate the input.
+ *
+ * @param comparison - Comparison entry to soften.
+ * @param results - Benchmark results carrying per-metric stdDev.
+ */
+export function applyNoiseTolerance(
+  comparison: BenchmarkEntryComparison,
+  results: BenchmarkResults,
+): BenchmarkEntryComparison {
+  const downgraded = comparison.absoluteViolations.map((v) => {
+    if (v.severity !== THRESHOLD_SEVERITY.Fail) {
+      return v;
+    }
+    const stdDev = results.stdDev?.[v.metricId];
+    if (stdDev === undefined || stdDev <= 0) {
+      return v;
+    }
+    const breach = v.value - v.threshold;
+    if (breach > 0 && breach < stdDev * WITHIN_NOISE_STDDEV_MULTIPLIER) {
+      console.log(
+        `Downgrading "${comparison.benchmarkName}.${v.metricId}" (${v.percentile}) to warn: ` +
+          `breach ${breach.toFixed(0)}ms is within one stdDev (${stdDev.toFixed(0)}ms) — within noise.`,
+      );
+      return { ...v, severity: THRESHOLD_SEVERITY.Warn };
+    }
+    return v;
+  });
+
+  return {
+    ...comparison,
+    absoluteViolations: downgraded,
+    absoluteFailed: downgraded.some(
+      (v) => v.severity === THRESHOLD_SEVERITY.Fail,
+    ),
+    hasWarning:
+      comparison.relativeMetrics.some(
+        (m) => m.severity === COMPARISON_SEVERITY.Warn.value,
+      ) || downgraded.some((v) => v.severity === THRESHOLD_SEVERITY.Warn),
+  };
+}


### PR DESCRIPTION
## **Description**

The absolute benchmark gate hard-fails a metric when it breaches its ceiling by a margin smaller than the metric's own run-to-run noise, so pass/fail becomes a coin-flip on which samples landed — and the PR comment then paints the relative *improvement* red. This hardens the gate and reporter, on top of the existing CV-based skip/widening:

- **Noise-aware gate** — `applyNoiseTolerance` downgrades an absolute-gate `Fail` to `Warn` when `value − threshold < stdDev` (the breach is within the metric's own noise). Threshold is the named constant `WITHIN_NOISE_STDDEV_MULTIPLIER`.
- **Honest reporting** — a line that fails only the absolute gate now shows `absolute ceiling exceeded, limit <X>ms` with the measured value, never a stale/incomparable relative delta; a relative improvement is never colored as the failure.
- The **high-CV skip** criterion is already satisfied on `main`: `validateResultThresholds` skips metrics with CV > `CV_THRESHOLDS.POOR` (50%) and adaptively widens thresholds for 25–50% CV.

## **Related issues**

- Fixes: MetaMask/MetaMask-planning#7480
- Part of: MetaMask/MetaMask-planning#6944 (Performance Quality Gates)

## **Manual testing steps**

1. Run the benchmark-comparison unit tests (below).
2. Against the #42867 `onboardingImportWallet` (chrome-webpack) case — `total.p75` 11291ms vs absolute limit 11050ms, breach 241ms, stdDev 303ms — the gate now **warns** instead of hard-failing, and the PR-comment line reads `absolute ceiling exceeded, limit 11050ms`, not `-72.1%`.

## **Changelog**

CHANGELOG entry: null

<!-- CI/tooling change, non-user-facing; please apply the `no-changelog` label. -->

## 🧪 Validation Run

**Durable evidence — falsifying-regression check.**
- `development/metamaskbot-build-announce/comparison-utils.test.ts` — `applyNoiseTolerance`: a within-one-stdDev breach downgrades to Warn (the exact #42867 numbers — value 11291, limit 11050, breach 241 < stdDev 303); a breach beyond one stdDev stays Fail; a missing stdDev leaves the violation unchanged; Warn-severity violations are untouched.
- `development/metamaskbot-build-announce/compare-benchmarks.test.ts` — `buildMetricLines`: an absolute-only fail with a relative improvement reports `absolute ceiling exceeded, limit 11050ms` with `11291ms`, and never `-72.1%`.
- Both suites pass locally (comparison-utils 38, compare-benchmarks 31); Unit tests CI runs on this head once pushed.

## **Screenshots/Recordings**

N/A — CI/tooling change, no UI surface. Evidence is the unit tests above.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only benchmark announce logic with targeted unit tests; no product runtime, auth, or data-path changes.
> 
> **Overview**
> CI benchmark comparison now treats **tiny absolute-ceiling breaches** as run noise instead of hard failures, and PR comment lines no longer blame stale relative deltas when the absolute gate is what failed.
> 
> **Noise-aware gating:** `applyNoiseTolerance` runs after gating and downgrades absolute `Fail` to `Warn` when `value − threshold` is positive but smaller than one standard deviation of that metric (`WITHIN_NOISE_STDDEV_MULTIPLIER = 1`). Missing or non-positive `stdDev` leaves failures unchanged; existing `Warn` violations are untouched.
> 
> **Reporting:** When an issue is driven by an absolute violation, `buildMetricLines` shows measured value plus `absolute ceiling exceeded, limit <X>ms` instead of a relative percent—so a large baseline improvement cannot appear as the reason for a red/yellow line.
> 
> Unit tests cover the live `onboardingImportWallet` numbers and the absolute-only messaging case.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3466631d30f4827266dd5210bee59aaf74a3917f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->