### PR TITLE
test: cover Empty Buy Banner Displayed event

### DIFF
--- a/test/e2e/tests/metrics/empty-buy-banner-displayed.spec.ts
+++ b/test/e2e/tests/metrics/empty-buy-banner-displayed.spec.ts
@@ -1,0 +1,85 @@
+import { strict as assert } from 'assert';
+import { Mockttp } from 'mockttp';
+import {
+  getEventPayloads,
+  isSidePanelEnabled,
+  withFixtures,
+} from '../../helpers';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
+import { completeCreateNewWalletOnboardingFlow } from '../../page-objects/flows/onboarding.flow';
+import HomePage from '../../page-objects/pages/home/homepage';
+import { MOCK_ANALYTICS_ID } from '../../constants';
+
+/**
+ * Mocks the segment API for the Empty Buy Banner Displayed event.
+ * Do not use the constants from the metrics constants files, because if these
+ * change we want a strong indicator to our data team that the shape of data
+ * will change.
+ *
+ * @param mockServer - The mock server instance.
+ * @returns The mocked endpoints
+ */
+async function mockSegment(mockServer: Mockttp) {
+  return [
+    await mockServer
+      .forPost('https://api.segment.io/v1/batch')
+      .withJsonBodyIncluding({
+        batch: [{ type: 'track', event: 'Empty Buy Banner Displayed' }],
+      })
+      .thenCallback(() => {
+        return {
+          statusCode: 200,
+        };
+      }),
+  ];
+}
+
+describe('Empty Buy Banner Displayed event', function () {
+  it('is sent when the balance empty state is shown after onboarding', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilderV2({ onboarding: true })
+          .withMetaMetricsController({
+            analyticsId: MOCK_ANALYTICS_ID,
+            completedMetaMetricsOnboarding: true,
+            optedIn: true,
+          })
+          .build(),
+        title: this.test?.fullTitle(),
+        testSpecificMock: mockSegment,
+      },
+      async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+        await completeCreateNewWalletOnboardingFlow({
+          driver,
+          completedMetaMetricsOnboarding: true,
+          optedIn: true,
+        });
+
+        const homePage = new HomePage(driver);
+        await homePage.checkPageIsLoaded();
+        await homePage.checkBalanceEmptyStateIsDisplayed();
+
+        const events = await getEventPayloads(driver, mockedEndpoints);
+        assert.equal(events.length, 1);
+        assert.equal(events[0].event, 'Empty Buy Banner Displayed');
+
+        const expectedEnvironmentType = (await isSidePanelEnabled())
+          ? 'sidepanel'
+          : 'fullscreen';
+
+        assert.deepStrictEqual(events[0].properties, {
+          category: 'Navigation',
+          locale: 'en',
+          referrer: 'metamask',
+          location: 'balance_empty_state',
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          chain_id: '0x1',
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          environment_type: expectedEnvironmentType,
+        });
+      },
+    );
+  });
+});

--- a/test/e2e/tests/metrics/empty-buy-banner-displayed.spec.ts
+++ b/test/e2e/tests/metrics/empty-buy-banner-displayed.spec.ts
@@ -12,9 +12,6 @@ import { MOCK_ANALYTICS_ID } from '../../constants';
 
 /**
  * Mocks the segment API for the Empty Buy Banner Displayed event.
- * Do not use the constants from the metrics constants files, because if these
- * change we want a strong indicator to our data team that the shape of data
- * will change.
  *
  * @param mockServer - The mock server instance.
  * @returns The mocked endpoints
@@ -66,8 +63,17 @@ describe('Empty Buy Banner Displayed event', function () {
         const expectedEnvironmentType = (await isSidePanelEnabled())
           ? 'sidepanel'
           : 'fullscreen';
+        const {
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          profile_id: _profileId,
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          canonical_profile_id: _canonicalProfileId,
+          ...eventProperties
+        } = events[0].properties;
 
-        assert.deepStrictEqual(events[0].properties, {
+        assert.deepStrictEqual(eventProperties, {
           category: 'Navigation',
           locale: 'en',
           referrer: 'metamask',

--- a/ui/components/app/balance-empty-state/balance-empty-state.test.tsx
+++ b/ui/components/app/balance-empty-state/balance-empty-state.test.tsx
@@ -2,16 +2,36 @@ import React from 'react';
 import { fireEvent, screen } from '@testing-library/react';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import mockState from '../../../../test/data/mock-state.json';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../shared/constants/metametrics';
+import { ORIGIN_METAMASK } from '../../../../shared/constants/app';
 import configureStore from '../../../store/store';
 import {
   BalanceEmptyState,
   BalanceEmptyStateProps,
 } from './balance-empty-state';
 
+const mockTrackEvent = jest.fn();
+
+jest.mock('../../../hooks/useAnalytics', () => {
+  const { createEventBuilder } = jest.requireActual(
+    '../../../../shared/lib/analytics/create-event-builder',
+  );
+  return {
+    useAnalytics: () => ({
+      trackEvent: mockTrackEvent,
+      createEventBuilder,
+    }),
+  };
+});
+
 const store = configureStore({
   metamask: {
     ...mockState.metamask,
   },
+  localeMessages: mockState.localeMessages,
 });
 
 const renderComponent = (props: Partial<BalanceEmptyStateProps> = {}) => {
@@ -26,6 +46,23 @@ describe('BalanceEmptyState', () => {
   it('should render the component', () => {
     renderComponent();
     expect(screen.getByRole('button')).toBeInTheDocument();
+  });
+
+  it('tracks Empty Buy Banner Displayed when the component mounts', () => {
+    renderComponent();
+
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      name: MetaMetricsEventName.EmptyBuyBannerDisplayed,
+      properties: {
+        category: MetaMetricsEventCategory.Navigation,
+        locale: 'en',
+        network: 'Goerli',
+        referrer: ORIGIN_METAMASK,
+        location: 'balance_empty_state',
+      },
+      sensitiveProperties: {},
+    });
   });
 
   it('should open the funding method modal when button is clicked', () => {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds unit and E2E coverage that asserts the Empty Buy Banner Displayed Segment event when the balance empty state is shown.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null 

## **Related issues**

Fixes:
https://consensyssoftware.atlassian.net/browse/MMQA-2051

## **Manual testing steps**

CI should pass
Execute the code locally using below commands:-
yarn start:test
Unit test --> yarn test:unit ui/components/app/balance-empty-state/balance-empty-state.test.tsx
e2e test --> yarn test:e2e:single test/e2e/tests/metrics/empty-buy-banner-displayed.spec.ts --browser=chrome


## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to unit and E2E tests; no production or analytics implementation is modified in this diff.
> 
> **Overview**
> Adds **test-only** coverage for the **Empty Buy Banner Displayed** Segment/MetaMetrics event when the home **balance empty state** appears.
> 
> **Unit:** `balance-empty-state.test.tsx` mocks `useAnalytics` and asserts a single `trackEvent` on mount with `MetaMetricsEventName.EmptyBuyBannerDisplayed`, Navigation category, `location: balance_empty_state`, locale, network, and `referrer: metamask`. The test store now includes `localeMessages`.
> 
> **E2E:** New `empty-buy-banner-displayed.spec.ts` runs wallet onboarding with metrics opted in, waits for the balance empty state on home, intercepts Segment `batch` posts, and checks one **Empty Buy Banner Displayed** event with expected properties (`chain_id`, `environment_type` for sidepanel vs fullscreen, etc.).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 418db510403348200215447e99f64e8cd7e4c679. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->