### PR TITLE
feat: import alias via node subpath imports

### DIFF
--- a/.depcheckrc.yml
+++ b/.depcheckrc.yml
@@ -117,6 +117,9 @@ ignores:
   - '@metamask/institutional-wallet-snap'
   - '@metamask/gator-permissions-snap'
   - '@metamask/permissions-kernel-snap'
+  # package.json subpath imports
+  - '#ui'
+  - '#shared'
 
 # files depcheck should not parse
 ignorePatterns:

--- a/.eslintrc.base.js
+++ b/.eslintrc.base.js
@@ -146,7 +146,20 @@ module.exports = {
     'import-x/order': [
       'error',
       {
-        groups: ['builtin', 'external', 'parent', 'sibling', 'index'],
+        groups: [
+          'builtin',
+          'external',
+          'internal',
+          'parent',
+          'sibling',
+          'index',
+        ],
+        pathGroups: [
+          {
+            pattern: '#*/**',
+            group: 'internal',
+          },
+        ],
         'newlines-between': 'ignore',
         alphabetize: {
           order: 'ignore',

--- a/package.json
+++ b/package.json
@@ -2,6 +2,20 @@
   "name": "metamask-crx",
   "version": "13.41.0",
   "private": true,
+  "imports": {
+    "#ui/*": [
+      "./ui/*",
+      "./ui/*.ts",
+      "./ui/*.tsx",
+      "./ui/*/index.ts"
+    ],
+    "#shared/*": [
+      "./shared/*",
+      "./shared/*.ts",
+      "./shared/*.tsx",
+      "./shared/*/index.ts"
+    ]
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/MetaMask/metamask-extension.git"


### PR DESCRIPTION
## **Description**

Introduces import aliases to replace deep relative paths like ../../../some-directory/....

Why
- Readability: import origin is obvious at a glance
- Refactor-safe: moving files doesn't break imports
- Enforces architecture: #/shared and #/ui make the dependency direction explicit
- No breaking changes: old relative imports continue to work, adoption is gradual

For this first phase, adding these aliases: #/shared and #/ui

Also updates `import-x/order` so these imports rank as internal 

```jsx
// Any file can now:

import { something } from '#shared/constants/app';
import { Component } from '#ui/components/some-component';

// Instead of

import { something } from '../../../../shared/constants/app';
import { Component } from '../../../ui/components/some-component';
```

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. In a TS/TSX file under `ui/`, add `import { SECOND } from '#shared/constants/time';` and confirm TypeScript/VS Code resolves it.
2. Confirm `import-x/order` expects `#ui`/`#shared` imports after external packages and before `../` / `./` relatives.
3. Run a unit test that imports via `#shared/...` and confirm Jest resolves it.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)