### PR TITLE
feat: show verified badge on swaps token button

### DIFF
--- a/ui/hooks/bridge/useSelectedTokenSecurityData.test.ts
+++ b/ui/hooks/bridge/useSelectedTokenSecurityData.test.ts
@@ -150,10 +150,7 @@ describe('useSelectedTokenSecurityData', () => {
         BridgeAssetSecurityDataType.VERIFIED,
         [feature],
       ),
-      createTokenAsset(
-        OTHER_ASSET_ID,
-        BridgeAssetSecurityDataType.MALICIOUS,
-      ),
+      createTokenAsset(OTHER_ASSET_ID, BridgeAssetSecurityDataType.MALICIOUS),
     ]);
 
     const { result } = renderSecurityHook();
@@ -179,10 +176,7 @@ describe('useSelectedTokenSecurityData', () => {
         }),
       )
       .mockResolvedValueOnce([
-        createTokenAsset(
-          OTHER_ASSET_ID,
-          BridgeAssetSecurityDataType.VERIFIED,
-        ),
+        createTokenAsset(OTHER_ASSET_ID, BridgeAssetSecurityDataType.VERIFIED),
       ]);
 
     let fromToken = createBridgeToken(SOURCE_ASSET_ID);
@@ -208,10 +202,7 @@ describe('useSelectedTokenSecurityData', () => {
     });
     await act(async () => {
       resolveFirstRequest([
-        createTokenAsset(
-          SOURCE_ASSET_ID,
-          BridgeAssetSecurityDataType.VERIFIED,
-        ),
+        createTokenAsset(SOURCE_ASSET_ID, BridgeAssetSecurityDataType.VERIFIED),
       ]);
     });
 
@@ -226,11 +217,19 @@ describe('useSelectedTokenSecurityData', () => {
     expect(result.current).toEqual({});
   });
 
-  it.each([
-    ['empty responses', () => Promise.resolve([])],
-    ['failed responses', () => Promise.reject(new Error('Request failed'))],
-  ])('treats %s as unknown security data', async (_description, getResponse) => {
-    mockFetchCachedTokenAssets.mockReturnValue(getResponse());
+  it('treats empty responses as unknown security data', async () => {
+    mockFetchCachedTokenAssets.mockResolvedValue([]);
+
+    const { result } = renderSecurityHook();
+
+    await waitFor(() => {
+      expect(mockFetchCachedTokenAssets).toHaveBeenCalledTimes(1);
+      expect(result.current).toEqual({});
+    });
+  });
+
+  it('treats failed responses as unknown security data', async () => {
+    mockFetchCachedTokenAssets.mockRejectedValue(new Error('Request failed'));
 
     const { result } = renderSecurityHook();
 

--- a/ui/hooks/bridge/useSelectedTokenSecurityData.test.ts
+++ b/ui/hooks/bridge/useSelectedTokenSecurityData.test.ts
@@ -1,0 +1,242 @@
+import { act, waitFor } from '@testing-library/react';
+import type {
+  TokenAsset,
+  TokenSecurityFeature,
+} from '@metamask/assets-controllers';
+import type { CaipAssetType } from '@metamask/utils';
+import { renderHookWithProvider } from '../../../test/lib/render-helpers-navigate';
+import { createBridgeMockStore } from '../../../test/data/bridge/mock-bridge-store';
+import { toBridgeToken } from '../../ducks/bridge/utils';
+import { BridgeAssetSecurityDataType } from '../../pages/bridge/utils/tokens';
+import { useSelectedTokenSecurityData } from './useSelectedTokenSecurityData';
+
+const mockFetchCachedTokenAssets = jest.fn();
+
+jest.mock('../../pages/bridge/utils/token-security', () => ({
+  ...jest.requireActual('../../pages/bridge/utils/token-security'),
+  fetchCachedTokenAssets: (...args: unknown[]) =>
+    mockFetchCachedTokenAssets(...args),
+}));
+
+const SOURCE_ASSET_ID =
+  'eip155:1/erc20:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as CaipAssetType;
+const DESTINATION_ASSET_ID =
+  'eip155:1/erc20:0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as CaipAssetType;
+const OTHER_ASSET_ID =
+  'eip155:1/erc20:0xcccccccccccccccccccccccccccccccccccccccc' as CaipAssetType;
+
+function createBridgeToken(assetId: CaipAssetType) {
+  return toBridgeToken({
+    assetId,
+    name: 'Token',
+    symbol: 'TKN',
+    decimals: 18,
+  });
+}
+
+function createTokenAsset(
+  assetId: CaipAssetType,
+  resultType?: string,
+  features: TokenSecurityFeature[] = [],
+): TokenAsset {
+  return {
+    assetId,
+    name: 'Token',
+    symbol: 'TKN',
+    decimals: 18,
+    ...(resultType
+      ? {
+          securityData: {
+            resultType,
+            maliciousScore: '0',
+            fees: {
+              transfer: 0,
+              transferFeeMaxAmount: null,
+              buy: 0,
+              sell: null,
+            },
+            features,
+            financialStats: {
+              supply: 0,
+              topHolders: [],
+              holdersCount: 0,
+              tradeVolume24h: null,
+              lockedLiquidityPct: null,
+              markets: [],
+            },
+            metadata: {
+              externalLinks: {
+                homepage: null,
+                twitterPage: null,
+                telegramChannelId: null,
+              },
+            },
+            created: '',
+          },
+        }
+      : {}),
+  };
+}
+
+function renderSecurityHook({
+  fromToken = createBridgeToken(SOURCE_ASSET_ID),
+  toToken = createBridgeToken(DESTINATION_ASSET_ID),
+  useExternalServices = true,
+} = {}) {
+  return renderHookWithProvider(
+    () => useSelectedTokenSecurityData(fromToken, toToken),
+    createBridgeMockStore({
+      metamaskStateOverrides: { useExternalServices },
+    }),
+  );
+}
+
+describe('useSelectedTokenSecurityData', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockFetchCachedTokenAssets.mockResolvedValue([]);
+  });
+
+  it('fetches source and destination security data in one request', async () => {
+    renderSecurityHook();
+
+    await waitFor(() => {
+      expect(mockFetchCachedTokenAssets).toHaveBeenCalledWith([
+        SOURCE_ASSET_ID,
+        DESTINATION_ASSET_ID,
+      ]);
+    });
+    expect(mockFetchCachedTokenAssets).toHaveBeenCalledTimes(1);
+  });
+
+  it('deduplicates identical selected asset IDs', async () => {
+    renderSecurityHook({
+      toToken: createBridgeToken(SOURCE_ASSET_ID),
+    });
+
+    await waitFor(() => {
+      expect(mockFetchCachedTokenAssets).toHaveBeenCalledWith([
+        SOURCE_ASSET_ID,
+      ]);
+    });
+  });
+
+  it('skips tokens with existing security metadata', async () => {
+    const enrichedToken = {
+      ...createBridgeToken(SOURCE_ASSET_ID),
+      isVerified: false,
+    };
+    renderSecurityHook({
+      fromToken: enrichedToken,
+      toToken: createBridgeToken(DESTINATION_ASSET_ID),
+    });
+
+    await waitFor(() => {
+      expect(mockFetchCachedTokenAssets).toHaveBeenCalledWith([
+        DESTINATION_ASSET_ID,
+      ]);
+    });
+  });
+
+  it('matches EVM asset IDs case-insensitively and adapts security data', async () => {
+    const feature = {
+      featureId: 'verified-list',
+      type: BridgeAssetSecurityDataType.VERIFIED,
+      description: 'Verified by trusted sources',
+    };
+    mockFetchCachedTokenAssets.mockResolvedValue([
+      createTokenAsset(
+        'eip155:1/erc20:0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA' as CaipAssetType,
+        BridgeAssetSecurityDataType.VERIFIED,
+        [feature],
+      ),
+      createTokenAsset(
+        OTHER_ASSET_ID,
+        BridgeAssetSecurityDataType.MALICIOUS,
+      ),
+    ]);
+
+    const { result } = renderSecurityHook();
+
+    await waitFor(() => {
+      expect(result.current[SOURCE_ASSET_ID]).toEqual({
+        isVerified: true,
+        securityData: {
+          type: BridgeAssetSecurityDataType.VERIFIED,
+          metadata: { features: [feature] },
+        },
+      });
+    });
+    expect(result.current[OTHER_ASSET_ID]).toBeUndefined();
+  });
+
+  it('ignores stale responses when selected asset IDs change', async () => {
+    let resolveFirstRequest: (tokens: TokenAsset[]) => void = () => undefined;
+    mockFetchCachedTokenAssets
+      .mockReturnValueOnce(
+        new Promise<TokenAsset[]>((resolve) => {
+          resolveFirstRequest = resolve;
+        }),
+      )
+      .mockResolvedValueOnce([
+        createTokenAsset(
+          OTHER_ASSET_ID,
+          BridgeAssetSecurityDataType.VERIFIED,
+        ),
+      ]);
+
+    let fromToken = createBridgeToken(SOURCE_ASSET_ID);
+    const toToken = {
+      ...createBridgeToken(DESTINATION_ASSET_ID),
+      isVerified: false,
+    };
+    const { result, rerender } = renderHookWithProvider(
+      () => useSelectedTokenSecurityData(fromToken, toToken),
+      createBridgeMockStore({
+        metamaskStateOverrides: { useExternalServices: true },
+      }),
+    );
+
+    await waitFor(() => {
+      expect(mockFetchCachedTokenAssets).toHaveBeenCalledTimes(1);
+    });
+    fromToken = createBridgeToken(OTHER_ASSET_ID);
+    rerender();
+
+    await waitFor(() => {
+      expect(result.current[OTHER_ASSET_ID]?.isVerified).toBe(true);
+    });
+    await act(async () => {
+      resolveFirstRequest([
+        createTokenAsset(
+          SOURCE_ASSET_ID,
+          BridgeAssetSecurityDataType.VERIFIED,
+        ),
+      ]);
+    });
+
+    expect(result.current[SOURCE_ASSET_ID]).toBeUndefined();
+    expect(result.current[OTHER_ASSET_ID]?.isVerified).toBe(true);
+  });
+
+  it('does not fetch when external services are disabled', () => {
+    const { result } = renderSecurityHook({ useExternalServices: false });
+
+    expect(mockFetchCachedTokenAssets).not.toHaveBeenCalled();
+    expect(result.current).toEqual({});
+  });
+
+  it.each([
+    ['empty responses', () => Promise.resolve([])],
+    ['failed responses', () => Promise.reject(new Error('Request failed'))],
+  ])('treats %s as unknown security data', async (_description, getResponse) => {
+    mockFetchCachedTokenAssets.mockReturnValue(getResponse());
+
+    const { result } = renderSecurityHook();
+
+    await waitFor(() => {
+      expect(mockFetchCachedTokenAssets).toHaveBeenCalledTimes(1);
+      expect(result.current).toEqual({});
+    });
+  });
+});

--- a/ui/hooks/bridge/useSelectedTokenSecurityData.ts
+++ b/ui/hooks/bridge/useSelectedTokenSecurityData.ts
@@ -39,12 +39,11 @@ export function toBridgeTokenSecurityData(
   }
 
   const features = Array.isArray(token.securityData?.features)
-    ? token.securityData.features
-        .flatMap(({ featureId, type, description }) =>
-          isBridgeAssetSecurityDataType(type)
-            ? [{ featureId, type, description }]
-            : [],
-        )
+    ? token.securityData.features.flatMap(({ featureId, type, description }) =>
+        isBridgeAssetSecurityDataType(type)
+          ? [{ featureId, type, description }]
+          : [],
+      )
     : [];
 
   return {
@@ -61,9 +60,8 @@ export function useSelectedTokenSecurityData(
   toToken: BridgeToken,
 ): SelectedTokenSecurityDataByAssetId {
   const useExternalServices = useSelector(getUseExternalServices);
-  const [securityDataByAssetId, setSecurityDataByAssetId] = useState<
-    SelectedTokenSecurityDataByAssetId
-  >(EMPTY_SECURITY_DATA);
+  const [securityDataByAssetId, setSecurityDataByAssetId] =
+    useState<SelectedTokenSecurityDataByAssetId>(EMPTY_SECURITY_DATA);
 
   const assetIds = useMemo(() => {
     const tokens = [fromToken, toToken];
@@ -99,16 +97,15 @@ export function useSelectedTokenSecurityData(
         const requestedAssetKeys = new Set(
           assetIds.map(getTokenSecurityAssetKey),
         );
-        const nextSecurityData = tokens.reduce<
-          SelectedTokenSecurityDataByAssetId
-        >((result, token) => {
-          const assetKey = getTokenSecurityAssetKey(token.assetId);
-          const securityData = toBridgeTokenSecurityData(token);
-          if (requestedAssetKeys.has(assetKey) && securityData) {
-            result[assetKey] = securityData;
-          }
-          return result;
-        }, {});
+        const nextSecurityData =
+          tokens.reduce<SelectedTokenSecurityDataByAssetId>((result, token) => {
+            const assetKey = getTokenSecurityAssetKey(token.assetId);
+            const securityData = toBridgeTokenSecurityData(token);
+            if (requestedAssetKeys.has(assetKey) && securityData) {
+              result[assetKey] = securityData;
+            }
+            return result;
+          }, {});
 
         setSecurityDataByAssetId(nextSecurityData);
       })

--- a/ui/hooks/bridge/useSelectedTokenSecurityData.ts
+++ b/ui/hooks/bridge/useSelectedTokenSecurityData.ts
@@ -1,0 +1,127 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useSelector } from 'react-redux';
+import type { TokenAsset } from '@metamask/assets-controllers';
+import type { CaipAssetType } from '@metamask/utils';
+import type { BridgeToken } from '../../ducks/bridge/types';
+import { getUseExternalServices } from '../../selectors';
+import { BridgeAssetSecurityDataType } from '../../pages/bridge/utils/tokens';
+import {
+  fetchCachedTokenAssets,
+  getTokenSecurityAssetKey,
+} from '../../pages/bridge/utils/token-security';
+
+export type SelectedTokenSecurityData = Pick<
+  BridgeToken,
+  'isVerified' | 'securityData'
+>;
+
+type SelectedTokenSecurityDataByAssetId = Partial<
+  Record<CaipAssetType, SelectedTokenSecurityData>
+>;
+
+const EMPTY_SECURITY_DATA: SelectedTokenSecurityDataByAssetId = {};
+const SECURITY_DATA_TYPES = new Set<string>(
+  Object.values(BridgeAssetSecurityDataType),
+);
+
+function isBridgeAssetSecurityDataType(
+  value: string,
+): value is BridgeAssetSecurityDataType {
+  return SECURITY_DATA_TYPES.has(value);
+}
+
+export function toBridgeTokenSecurityData(
+  token: TokenAsset,
+): SelectedTokenSecurityData | undefined {
+  const resultType = token.securityData?.resultType;
+  if (!resultType || !isBridgeAssetSecurityDataType(resultType)) {
+    return undefined;
+  }
+
+  const features = Array.isArray(token.securityData?.features)
+    ? token.securityData.features
+        .flatMap(({ featureId, type, description }) =>
+          isBridgeAssetSecurityDataType(type)
+            ? [{ featureId, type, description }]
+            : [],
+        )
+    : [];
+
+  return {
+    isVerified: resultType === BridgeAssetSecurityDataType.VERIFIED,
+    securityData: {
+      type: resultType,
+      metadata: { features },
+    },
+  };
+}
+
+export function useSelectedTokenSecurityData(
+  fromToken: BridgeToken,
+  toToken: BridgeToken,
+): SelectedTokenSecurityDataByAssetId {
+  const useExternalServices = useSelector(getUseExternalServices);
+  const [securityDataByAssetId, setSecurityDataByAssetId] = useState<
+    SelectedTokenSecurityDataByAssetId
+  >(EMPTY_SECURITY_DATA);
+
+  const assetIds = useMemo(() => {
+    const tokens = [fromToken, toToken];
+    const assetIdsByKey = new Map<CaipAssetType, CaipAssetType>();
+
+    tokens.forEach((token) => {
+      const hasSecurityData =
+        token.isVerified !== undefined || token.securityData !== undefined;
+      if (!hasSecurityData) {
+        assetIdsByKey.set(
+          getTokenSecurityAssetKey(token.assetId),
+          token.assetId,
+        );
+      }
+    });
+
+    return [...assetIdsByKey.values()];
+  }, [fromToken, toToken]);
+
+  useEffect(() => {
+    setSecurityDataByAssetId(EMPTY_SECURITY_DATA);
+    if (!useExternalServices || assetIds.length === 0) {
+      return undefined;
+    }
+
+    let isCurrentRequest = true;
+    fetchCachedTokenAssets(assetIds)
+      .then((tokens) => {
+        if (!isCurrentRequest) {
+          return;
+        }
+
+        const requestedAssetKeys = new Set(
+          assetIds.map(getTokenSecurityAssetKey),
+        );
+        const nextSecurityData = tokens.reduce<
+          SelectedTokenSecurityDataByAssetId
+        >((result, token) => {
+          const assetKey = getTokenSecurityAssetKey(token.assetId);
+          const securityData = toBridgeTokenSecurityData(token);
+          if (requestedAssetKeys.has(assetKey) && securityData) {
+            result[assetKey] = securityData;
+          }
+          return result;
+        }, {});
+
+        setSecurityDataByAssetId(nextSecurityData);
+      })
+      .catch(() => {
+        if (isCurrentRequest) {
+          setSecurityDataByAssetId(EMPTY_SECURITY_DATA);
+        }
+      });
+
+    return () => {
+      isCurrentRequest = false;
+    };
+  }, [assetIds, useExternalServices]);
+
+  return useExternalServices ? securityDataByAssetId : EMPTY_SECURITY_DATA;
+}

--- a/ui/pages/bridge/prepare/bridge-input-group.test.tsx
+++ b/ui/pages/bridge/prepare/bridge-input-group.test.tsx
@@ -258,6 +258,25 @@ describe('BridgeInputGroup', () => {
     });
   });
 
+  it('passes fetched security metadata to the selected asset button', () => {
+    const { getByTestId } = renderBridgeInputGroup(
+      {},
+      { tokenSecurityData: { isVerified: true } },
+    );
+
+    expect(
+      getByTestId('bridge-selected-asset-verified-badge'),
+    ).toBeInTheDocument();
+  });
+
+  it('leaves the selected asset button unchanged without fetched metadata', () => {
+    const { queryByTestId } = renderBridgeInputGroup();
+
+    expect(
+      queryByTestId('bridge-selected-asset-verified-badge'),
+    ).not.toBeInTheDocument();
+  });
+
   it('should search for tokens', async () => {
     setupFetchMock();
     const { getByTestId } = renderBridgeInputGroup();

--- a/ui/pages/bridge/prepare/bridge-input-group.tsx
+++ b/ui/pages/bridge/prepare/bridge-input-group.tsx
@@ -67,6 +67,7 @@ export const BridgeInputGroup = ({
   showAmountSkeleton = false,
   isAssetPickerOpen,
   setIsAssetPickerOpen,
+  tokenSecurityData,
 }: {
   isAssetPickerOpen: boolean;
   setIsAssetPickerOpen: (isOpen: boolean) => void;
@@ -83,6 +84,7 @@ export const BridgeInputGroup = ({
   networks: BridgeNetwork[];
   containerProps?: React.ComponentProps<typeof Column>;
   showAmountSkeleton?: boolean;
+  tokenSecurityData?: Pick<BridgeToken, 'isVerified' | 'securityData'>;
 } & Pick<
   React.ComponentProps<typeof BridgeAssetPicker>,
   | 'header'
@@ -103,6 +105,17 @@ export const BridgeInputGroup = ({
   const locale = useSelector(getIntlLocale);
 
   const selectedChainId = token?.chainId;
+  const selectedButtonAsset = useMemo(
+    () =>
+      tokenSecurityData
+        ? {
+            ...token,
+            isVerified: token.isVerified ?? tokenSecurityData.isVerified,
+            securityData: token.securityData ?? tokenSecurityData.securityData,
+          }
+        : token,
+    [token, tokenSecurityData],
+  );
 
   // useCopyToClipboard analysis: Copies a public address
   const [, handleCopy] = useCopyToClipboard({ clearDelayMs: null });
@@ -292,7 +305,7 @@ export const BridgeInputGroup = ({
               navigate(SWAP_ASSETS_PATH);
             }
           }}
-          asset={token}
+          asset={selectedButtonAsset}
           data-testid={buttonProps.testId}
         />
       </Row>

--- a/ui/pages/bridge/prepare/components/bridge-asset-picker/selected-asset-button.test.tsx
+++ b/ui/pages/bridge/prepare/components/bridge-asset-picker/selected-asset-button.test.tsx
@@ -52,6 +52,38 @@ describe('SelectedAssetButton', () => {
     expect(badgeWrapper).toBeInTheDocument();
   });
 
+  it('renders the verified badge for a verified asset', () => {
+    const { getByTestId } = renderButton({
+      ...toBridgeToken(getNativeAssetForChainId('0x1')),
+      isVerified: true,
+    });
+
+    expect(
+      getByTestId('bridge-selected-asset-verified-badge'),
+    ).toBeInTheDocument();
+  });
+
+  it('does not render the verified badge for an unverified asset', () => {
+    const { queryByTestId } = renderButton({
+      ...toBridgeToken(getNativeAssetForChainId('0x1')),
+      isVerified: false,
+    });
+
+    expect(
+      queryByTestId('bridge-selected-asset-verified-badge'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('does not render the verified badge when verification is absent', () => {
+    const { queryByTestId } = renderButton(
+      toBridgeToken(getNativeAssetForChainId('0x1')),
+    );
+
+    expect(
+      queryByTestId('bridge-selected-asset-verified-badge'),
+    ).not.toBeInTheDocument();
+  });
+
   it('applies the bridge-selected-asset-button class', () => {
     const { container } = renderButton(
       toBridgeToken(getNativeAssetForChainId('0x1')),

--- a/ui/pages/bridge/prepare/components/bridge-asset-picker/selected-asset-button.tsx
+++ b/ui/pages/bridge/prepare/components/bridge-asset-picker/selected-asset-button.tsx
@@ -5,6 +5,10 @@ import {
   AvatarNetworkSize,
   AvatarToken,
   BadgeWrapper,
+  Icon,
+  IconColor,
+  IconName as DesignSystemIconName,
+  IconSize,
 } from '@metamask/design-system-react';
 import {
   SelectButtonProps,
@@ -27,6 +31,7 @@ import {
   BRIDGE_CHAIN_ID_TO_NETWORK_IMAGE_MAP,
   NETWORK_TO_SHORT_NETWORK_NAME_MAP,
 } from '../../../../../../shared/constants/bridge';
+import { useAssetSecurityData } from '../../../hooks/useAssetSecurityData';
 
 export const SelectedAssetButton = ({
   asset,
@@ -35,6 +40,7 @@ export const SelectedAssetButton = ({
   asset: BridgeToken;
 } & SelectButtonProps<'div'>) => {
   const caipChainId = formatChainIdToCaip(asset.chainId);
+  const { assetIsVerified } = useAssetSecurityData(asset);
 
   return (
     <SelectButton
@@ -70,6 +76,14 @@ export const SelectedAssetButton = ({
             <AvatarToken src={asset.iconUrl ?? undefined} name={asset.symbol} />
           </BadgeWrapper>
           <Label className="cursor-pointer">{asset.symbol}</Label>
+          {assetIsVerified && (
+            <Icon
+              data-testid="bridge-selected-asset-verified-badge"
+              name={DesignSystemIconName.VerifiedFilled}
+              size={IconSize.Sm}
+              color={IconColor.InfoDefault}
+            />
+          )}
         </div>
       }
       {...props}

--- a/ui/pages/bridge/prepare/prepare-bridge-page.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.tsx
@@ -73,6 +73,7 @@ import { getMultichainProviderConfig } from '../../../selectors/multichain';
 import { Toast, ToastContainer } from '../../../components/multichain';
 import type { BridgeToken } from '../../../ducks/bridge/types';
 import { useLatestBalance } from '../../../hooks/bridge/useLatestBalance';
+import { useSelectedTokenSecurityData } from '../../../hooks/bridge/useSelectedTokenSecurityData';
 import { MarketClosedModal } from '../../../components/app/assets/market-closed-modal';
 import { isArcTokenUSDC } from '../../../components/app/assets/enablement/arc';
 import { useGasIncluded7702 } from '../hooks/useGasIncluded7702';
@@ -85,6 +86,7 @@ import { useDestinationAccount } from '../hooks/useDestinationAccount';
 import { useBridgeAlerts } from '../hooks/useBridgeAlerts';
 import { useSecurityAlerts } from '../hooks/useSecurityAlerts';
 import { useEnsureNetworkEnabled } from '../hooks/useEnsureNetworkEnabled';
+import { getTokenSecurityAssetKey } from '../utils/token-security';
 import { BridgeInputGroup } from './bridge-input-group';
 import { PrepareBridgePageFooter } from './prepare-bridge-page-footer';
 import { DestinationAccountPickerModal } from './components/destination-account-picker-modal';
@@ -109,6 +111,10 @@ const PrepareBridgePage = ({
 
   const fromToken = useSelector(getFromToken);
   const toToken = useSelector(getToToken);
+  const selectedTokenSecurityData = useSelectedTokenSecurityData(
+    fromToken,
+    toToken,
+  );
 
   const fromChains = useSelector(getFromChains);
   const toChains = useSelector(getToChains);
@@ -352,6 +358,11 @@ const PrepareBridgePage = ({
           }
           header={t('swapSelectToken')}
           token={fromToken}
+          tokenSecurityData={
+            selectedTokenSecurityData[
+              getTokenSecurityAssetKey(fromToken.assetId)
+            ]
+          }
           accountAddress={selectedAccount?.address}
           onAmountChange={(e) => {
             dispatch(setFromTokenInputValue(e));
@@ -514,6 +525,11 @@ const PrepareBridgePage = ({
               selectedDestinationAccount?.address ?? selectedAccount.address
             }
             token={toToken}
+            tokenSecurityData={
+              selectedTokenSecurityData[
+                getTokenSecurityAssetKey(toToken.assetId)
+              ]
+            }
             // If the fromChain is a bridge-only chain, disable it in the toChain picker
             disabledChainId={
               fromChain?.chainId &&

--- a/ui/pages/bridge/utils/token-security.test.ts
+++ b/ui/pages/bridge/utils/token-security.test.ts
@@ -58,7 +58,7 @@ describe('fetchCachedTokenAssets', () => {
       [FIRST_ASSET_ID, SECOND_ASSET_ID],
       { includeTokenSecurityData: true },
     );
-    expect(getCacheKey).toHaveBeenCalledWith('token-security', {
+    expect(getCacheKey).toHaveBeenCalledWith('fetchTokenAssets', {
       assetIds: [FIRST_ASSET_ID, SECOND_ASSET_ID],
       includeTokenSecurityData: true,
     });
@@ -103,7 +103,7 @@ describe('fetchCachedTokenAssets', () => {
 
     expect(updateCache).toHaveBeenCalledWith(
       tokens,
-      expect.stringContaining('token-security:'),
+      expect.stringContaining('fetchTokenAssets:'),
     );
   });
 

--- a/ui/pages/bridge/utils/token-security.test.ts
+++ b/ui/pages/bridge/utils/token-security.test.ts
@@ -39,9 +39,7 @@ describe('fetchCachedTokenAssets', () => {
     jest.resetAllMocks();
     jest
       .mocked(getCacheKey)
-      .mockImplementation(
-        (url, body) => `${url}:${JSON.stringify(body)}`,
-      );
+      .mockImplementation((url, body) => `${url}:${JSON.stringify(body)}`);
     jest.mocked(retrieveCachedResponse).mockResolvedValue(null);
   });
 
@@ -107,11 +105,15 @@ describe('fetchCachedTokenAssets', () => {
     );
   });
 
-  it.each([
-    ['empty', () => Promise.resolve([])],
-    ['failed', () => Promise.reject(new Error('Request failed'))],
-  ])('does not cache an %s response', async (_description, getResponse) => {
-    mockFetchTokenAssets.mockReturnValue(getResponse());
+  it('does not cache an empty response', async () => {
+    mockFetchTokenAssets.mockResolvedValue([]);
+
+    await expect(fetchCachedTokenAssets([FIRST_ASSET_ID])).resolves.toEqual([]);
+    expect(updateCache).not.toHaveBeenCalled();
+  });
+
+  it('does not cache a failed response', async () => {
+    mockFetchTokenAssets.mockRejectedValue(new Error('Request failed'));
 
     await expect(fetchCachedTokenAssets([FIRST_ASSET_ID])).resolves.toEqual([]);
     expect(updateCache).not.toHaveBeenCalled();

--- a/ui/pages/bridge/utils/token-security.test.ts
+++ b/ui/pages/bridge/utils/token-security.test.ts
@@ -1,0 +1,128 @@
+import type { TokenAsset } from '@metamask/assets-controllers';
+import type { CaipAssetType } from '@metamask/utils';
+import {
+  fetchCachedTokenAssets,
+  getTokenSecurityAssetKey,
+} from './token-security';
+import { getCacheKey, retrieveCachedResponse, updateCache } from './cache';
+
+const mockFetchTokenAssets = jest.fn();
+
+jest.mock('@metamask/assets-controllers', () => ({
+  fetchTokenAssets: (...args: unknown[]) => mockFetchTokenAssets(...args),
+}));
+
+jest.mock('./cache', () => ({
+  getCacheKey: jest.fn(
+    (url: string, body: object) => `${url}:${JSON.stringify(body)}`,
+  ),
+  retrieveCachedResponse: jest.fn(),
+  updateCache: jest.fn(),
+}));
+
+const FIRST_ASSET_ID =
+  'eip155:1/erc20:0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as CaipAssetType;
+const SECOND_ASSET_ID =
+  'eip155:1/erc20:0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' as CaipAssetType;
+
+function createToken(assetId: CaipAssetType): TokenAsset {
+  return {
+    assetId,
+    name: 'Token',
+    symbol: 'TKN',
+    decimals: 18,
+  };
+}
+
+describe('fetchCachedTokenAssets', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    jest
+      .mocked(getCacheKey)
+      .mockImplementation(
+        (url, body) => `${url}:${JSON.stringify(body)}`,
+      );
+    jest.mocked(retrieveCachedResponse).mockResolvedValue(null);
+  });
+
+  it('normalizes, deduplicates, and sorts asset IDs', async () => {
+    mockFetchTokenAssets.mockResolvedValue([createToken(FIRST_ASSET_ID)]);
+
+    await fetchCachedTokenAssets([
+      'eip155:1/erc20:0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB' as CaipAssetType,
+      FIRST_ASSET_ID,
+      SECOND_ASSET_ID,
+    ]);
+
+    expect(mockFetchTokenAssets).toHaveBeenCalledWith(
+      [FIRST_ASSET_ID, SECOND_ASSET_ID],
+      { includeTokenSecurityData: true },
+    );
+    expect(getCacheKey).toHaveBeenCalledWith('token-security', {
+      assetIds: [FIRST_ASSET_ID, SECOND_ASSET_ID],
+      includeTokenSecurityData: true,
+    });
+  });
+
+  it('returns a persistent cache hit without fetching', async () => {
+    const cachedTokens = [createToken(FIRST_ASSET_ID)];
+    jest.mocked(retrieveCachedResponse).mockResolvedValue(cachedTokens);
+
+    await expect(fetchCachedTokenAssets([FIRST_ASSET_ID])).resolves.toEqual(
+      cachedTokens,
+    );
+    expect(mockFetchTokenAssets).not.toHaveBeenCalled();
+    expect(updateCache).not.toHaveBeenCalled();
+  });
+
+  it('deduplicates simultaneous requests for the same cache key', async () => {
+    let resolveFetch: (tokens: TokenAsset[]) => void = () => undefined;
+    mockFetchTokenAssets.mockReturnValue(
+      new Promise<TokenAsset[]>((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+
+    const firstRequest = fetchCachedTokenAssets([FIRST_ASSET_ID]);
+    const secondRequest = fetchCachedTokenAssets([FIRST_ASSET_ID]);
+    await Promise.resolve();
+    resolveFetch([createToken(FIRST_ASSET_ID)]);
+
+    await expect(Promise.all([firstRequest, secondRequest])).resolves.toEqual([
+      [createToken(FIRST_ASSET_ID)],
+      [createToken(FIRST_ASSET_ID)],
+    ]);
+    expect(mockFetchTokenAssets).toHaveBeenCalledTimes(1);
+  });
+
+  it('writes successful responses to the persistent cache', async () => {
+    const tokens = [createToken(FIRST_ASSET_ID)];
+    mockFetchTokenAssets.mockResolvedValue(tokens);
+
+    await fetchCachedTokenAssets([FIRST_ASSET_ID]);
+
+    expect(updateCache).toHaveBeenCalledWith(
+      tokens,
+      expect.stringContaining('token-security:'),
+    );
+  });
+
+  it.each([
+    ['empty', () => Promise.resolve([])],
+    ['failed', () => Promise.reject(new Error('Request failed'))],
+  ])('does not cache an %s response', async (_description, getResponse) => {
+    mockFetchTokenAssets.mockReturnValue(getResponse());
+
+    await expect(fetchCachedTokenAssets([FIRST_ASSET_ID])).resolves.toEqual([]);
+    expect(updateCache).not.toHaveBeenCalled();
+  });
+});
+
+describe('getTokenSecurityAssetKey', () => {
+  it('preserves case-sensitive non-EVM asset IDs', () => {
+    const assetId =
+      'solana:5eykt4UsFv8P8NJdTREpY1vzqKqZKvdp/token:AbCd' as CaipAssetType;
+
+    expect(getTokenSecurityAssetKey(assetId)).toBe(assetId);
+  });
+});

--- a/ui/pages/bridge/utils/token-security.ts
+++ b/ui/pages/bridge/utils/token-security.ts
@@ -9,7 +9,7 @@ import {
 } from '@metamask/utils';
 import { getCacheKey, retrieveCachedResponse, updateCache } from './cache';
 
-const TOKEN_SECURITY_CACHE_KEY = 'fetchTokenAssets';
+const TOKEN_SECURITY_CACHE_KEY_PREFIX = 'fetchTokenAssets';
 const inFlightRequests = new Map<string, Promise<TokenAsset[]>>();
 
 export function getTokenSecurityAssetKey(
@@ -62,7 +62,7 @@ export async function fetchCachedTokenAssets(
     return [];
   }
 
-  const cacheKey = getCacheKey(TOKEN_SECURITY_CACHE_KEY, {
+  const cacheKey = getCacheKey(TOKEN_SECURITY_CACHE_KEY_PREFIX, {
     assetIds: uniqueAssetIds.map(getTokenSecurityAssetKey),
     includeTokenSecurityData: true,
   });

--- a/ui/pages/bridge/utils/token-security.ts
+++ b/ui/pages/bridge/utils/token-security.ts
@@ -38,9 +38,7 @@ function isTokenAsset(value: unknown): value is TokenAsset {
   );
 }
 
-function getUniqueSortedAssetIds(
-  assetIds: CaipAssetType[],
-): CaipAssetType[] {
+function getUniqueSortedAssetIds(assetIds: CaipAssetType[]): CaipAssetType[] {
   const uniqueAssetIds = new Map<CaipAssetType, CaipAssetType>();
   assetIds.forEach((assetId) => {
     const assetKey = getTokenSecurityAssetKey(assetId);
@@ -73,10 +71,7 @@ export async function fetchCachedTokenAssets(
 
   const request = (async () => {
     const cachedResponse = await retrieveCachedResponse(cacheKey);
-    if (
-      Array.isArray(cachedResponse) &&
-      cachedResponse.every(isTokenAsset)
-    ) {
+    if (Array.isArray(cachedResponse) && cachedResponse.every(isTokenAsset)) {
       return cachedResponse;
     }
 

--- a/ui/pages/bridge/utils/token-security.ts
+++ b/ui/pages/bridge/utils/token-security.ts
@@ -1,0 +1,100 @@
+import {
+  fetchTokenAssets,
+  type TokenAsset,
+} from '@metamask/assets-controllers';
+import {
+  KnownCaipNamespace,
+  parseCaipAssetType,
+  type CaipAssetType,
+} from '@metamask/utils';
+import { getCacheKey, retrieveCachedResponse, updateCache } from './cache';
+
+const TOKEN_SECURITY_CACHE_URL = 'token-security';
+const inFlightRequests = new Map<string, Promise<TokenAsset[]>>();
+
+export function getTokenSecurityAssetKey(
+  assetId: CaipAssetType,
+): CaipAssetType {
+  const { chain } = parseCaipAssetType(assetId);
+  return chain.namespace === KnownCaipNamespace.Eip155
+    ? (assetId.toLowerCase() as CaipAssetType)
+    : assetId;
+}
+
+function isTokenAsset(value: unknown): value is TokenAsset {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+
+  return (
+    'assetId' in value &&
+    typeof value.assetId === 'string' &&
+    'name' in value &&
+    typeof value.name === 'string' &&
+    'symbol' in value &&
+    typeof value.symbol === 'string' &&
+    'decimals' in value &&
+    typeof value.decimals === 'number'
+  );
+}
+
+function getUniqueSortedAssetIds(
+  assetIds: CaipAssetType[],
+): CaipAssetType[] {
+  const uniqueAssetIds = new Map<CaipAssetType, CaipAssetType>();
+  assetIds.forEach((assetId) => {
+    const assetKey = getTokenSecurityAssetKey(assetId);
+    uniqueAssetIds.set(assetKey, assetKey);
+  });
+
+  return [...uniqueAssetIds.values()].sort((first, second) =>
+    getTokenSecurityAssetKey(first).localeCompare(
+      getTokenSecurityAssetKey(second),
+    ),
+  );
+}
+
+export async function fetchCachedTokenAssets(
+  assetIds: CaipAssetType[],
+): Promise<TokenAsset[]> {
+  const uniqueAssetIds = getUniqueSortedAssetIds(assetIds);
+  if (uniqueAssetIds.length === 0) {
+    return [];
+  }
+
+  const cacheKey = getCacheKey(TOKEN_SECURITY_CACHE_URL, {
+    assetIds: uniqueAssetIds.map(getTokenSecurityAssetKey),
+    includeTokenSecurityData: true,
+  });
+  const inFlightRequest = inFlightRequests.get(cacheKey);
+  if (inFlightRequest) {
+    return await inFlightRequest;
+  }
+
+  const request = (async () => {
+    const cachedResponse = await retrieveCachedResponse(cacheKey);
+    if (
+      Array.isArray(cachedResponse) &&
+      cachedResponse.every(isTokenAsset)
+    ) {
+      return cachedResponse;
+    }
+
+    try {
+      const tokens = await fetchTokenAssets(uniqueAssetIds, {
+        includeTokenSecurityData: true,
+      });
+      if (tokens.length > 0) {
+        await updateCache(tokens, cacheKey);
+      }
+      return tokens;
+    } catch {
+      return [];
+    }
+  })().finally(() => {
+    inFlightRequests.delete(cacheKey);
+  });
+
+  inFlightRequests.set(cacheKey, request);
+  return await request;
+}

--- a/ui/pages/bridge/utils/token-security.ts
+++ b/ui/pages/bridge/utils/token-security.ts
@@ -67,7 +67,7 @@ export async function fetchCachedTokenAssets(
     includeTokenSecurityData: true,
   });
   const inFlightRequest = inFlightRequests.get(cacheKey);
-  if (inFlightRequest) {
+  if (inFlightRequest !== undefined) {
     return await inFlightRequest;
   }
 

--- a/ui/pages/bridge/utils/token-security.ts
+++ b/ui/pages/bridge/utils/token-security.ts
@@ -9,7 +9,7 @@ import {
 } from '@metamask/utils';
 import { getCacheKey, retrieveCachedResponse, updateCache } from './cache';
 
-const TOKEN_SECURITY_CACHE_URL = 'token-security';
+const TOKEN_SECURITY_CACHE_KEY = 'fetchTokenAssets';
 const inFlightRequests = new Map<string, Promise<TokenAsset[]>>();
 
 export function getTokenSecurityAssetKey(
@@ -62,7 +62,7 @@ export async function fetchCachedTokenAssets(
     return [];
   }
 
-  const cacheKey = getCacheKey(TOKEN_SECURITY_CACHE_URL, {
+  const cacheKey = getCacheKey(TOKEN_SECURITY_CACHE_KEY, {
     assetIds: uniqueAssetIds.map(getTokenSecurityAssetKey),
     includeTokenSecurityData: true,
   });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Adds a verified badge to the selected token buttons in Unified Swaps.

Default source and destination tokens do not always include security metadata. This change fetches security data for the selected assets, adapts it to the existing Bridge token shape, and applies it locally to the buttons without changing Redux state or quote inputs. Requests reuse the 15-minute Bridge cache, deduplicate in-flight work, and preserve case-sensitive non-EVM asset IDs.

Focused unit tests for the cache utility, security-data hook, input group, and selected asset button passed. `yarn lint:changed:fix` completed with two existing warnings in `prepare-bridge-page.tsx`.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added verified badges to selected Swaps tokens

## **Related issues**

Fixes: [SWAPS-4802](https://consensyssoftware.atlassian.net/browse/SWAPS-4802)

## **Manual testing steps**

1. Build and run the extension, then unlock the wallet.
2. Open Unified Swaps and wait for the initial source and destination tokens to load.
3. Verify a selected token marked as verified displays the verified badge beside its symbol.
4. Select an unverified token and verify the badge is not displayed.
5. Reopen Unified Swaps and verify the selected-token badges still load correctly from cached security data.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

Not captured.

### **After**

<!-- [screenshots/recordings] -->


https://github.com/user-attachments/assets/d76c7ce4-a89c-4781-9a8f-9cdbfed45a2e


Caching of API call

https://github.com/user-attachments/assets/af3b5634-98ce-44a8-add2-f89faa2c0bd1



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[SWAPS-4802]: https://consensyssoftware.atlassian.net/browse/SWAPS-4802?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only enrichment with cached external reads; failures degrade to no badge and do not alter swap/quote state.
> 
> **Overview**
> Unified Swaps **selected token buttons** can now show a **verified badge** when security metadata says the asset is verified, even when the default Redux `BridgeToken` objects lack that data.
> 
> A new **`fetchCachedTokenAssets`** helper loads token security via `fetchTokenAssets` with `includeTokenSecurityData`, reusing the existing Bridge **15-minute cache**, **in-flight deduplication**, EVM **case-normalized** asset keys, and no fetch when external services are off. **`useSelectedTokenSecurityData`** batches from/to tokens that still need metadata, maps API results into the bridge token shape, and ignores stale responses when selection changes—**without updating Redux or quote inputs**.
> 
> **`prepare-bridge-page`** passes the fetched overlay into each **`BridgeInputGroup`** as `tokenSecurityData`, which merges into the asset shown on **`SelectedAssetButton`**; the button uses existing **`useAssetSecurityData`** to render the verified icon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcbd9c4ebfa1501143ae738a90bf8e580bb087f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->