### PR TITLE
chore: update swap row labels

### DIFF
--- a/app/_locales/de/messages.json
+++ b/app/_locales/de/messages.json
@@ -1002,12 +1002,10 @@
     "message": "Swap fehlgeschlagen"
   },
   "activity_swap_pending_title": {
-    "message": "$1 gegen $2 swappen",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "Swappen"
   },
   "activity_swap_success_title": {
-    "message": "$1 gegen $2 geswappt",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "Geswappt"
   },
   "activity_unwrap_failed_description": {
     "message": "Unwrapping fehlgeschlagen"

--- a/app/_locales/el/messages.json
+++ b/app/_locales/el/messages.json
@@ -1002,12 +1002,10 @@
     "message": "Η ανταλλαγή απέτυχε"
   },
   "activity_swap_pending_title": {
-    "message": "Ανταλλαγή $1 με $2",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "Ανταλλαγή"
   },
   "activity_swap_success_title": {
-    "message": "Ανταλλάχθηκε $1 με $2",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "Ανταλλάχθηκε"
   },
   "activity_unwrap_failed_description": {
     "message": "Η αποδέσμευση απέτυχε"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -1047,15 +1047,13 @@
     "message": ""
   },
   "activity_swap_pending_title": {
-    "message": "Swapping $1 to $2",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "Swapping"
   },
   "activity_swap_success_description": {
     "message": ""
   },
   "activity_swap_success_title": {
-    "message": "Swapped $1 to $2",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "Swapped"
   },
   "activity_unwrap_failed_description": {
     "message": "Unwrap failed"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -1047,15 +1047,13 @@
     "message": ""
   },
   "activity_swap_pending_title": {
-    "message": "Swapping $1 to $2",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "Swapping"
   },
   "activity_swap_success_description": {
     "message": ""
   },
   "activity_swap_success_title": {
-    "message": "Swapped $1 to $2",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "Swapped"
   },
   "activity_unwrap_failed_description": {
     "message": "Unwrap failed"

--- a/app/_locales/es_419/messages.json
+++ b/app/_locales/es_419/messages.json
@@ -1002,12 +1002,10 @@
     "message": "Error al canjear"
   },
   "activity_swap_pending_title": {
-    "message": "Canjeando $1 por $2",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "Canjeando"
   },
   "activity_swap_success_title": {
-    "message": "Se canjeó $1 por $2",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "Se canjeó"
   },
   "activity_unwrap_failed_description": {
     "message": "Error al desenvolver"

--- a/app/_locales/fr/messages.json
+++ b/app/_locales/fr/messages.json
@@ -1002,12 +1002,10 @@
     "message": "Échec du swap"
   },
   "activity_swap_pending_title": {
-    "message": "Échanger des $1 contre des $2",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "Échange"
   },
   "activity_swap_success_title": {
-    "message": "$1 contre des $2 échangé",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "Échangé"
   },
   "activity_unwrap_failed_description": {
     "message": "Le déballage a échoué"

--- a/app/_locales/hi/messages.json
+++ b/app/_locales/hi/messages.json
@@ -1002,12 +1002,10 @@
     "message": "स्वैप नहीं हो पाया"
   },
   "activity_swap_pending_title": {
-    "message": "$1 को $2 से स्वैप किया जा रहा है",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "स्वैप किया जा रहा है"
   },
   "activity_swap_success_title": {
-    "message": "$1 को $2 से स्वैप किया गया",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "स्वैप किया गया"
   },
   "activity_unwrap_failed_description": {
     "message": "अनरैप नहीं हो पाया"

--- a/app/_locales/id/messages.json
+++ b/app/_locales/id/messages.json
@@ -1002,12 +1002,10 @@
     "message": "Pertukaran gagal"
   },
   "activity_swap_pending_title": {
-    "message": "Menukar $1 menjadi $2",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "Menukar"
   },
   "activity_swap_success_title": {
-    "message": "Menukar $1 menjadi $2",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "Ditukar"
   },
   "activity_unwrap_failed_description": {
     "message": "Pembukaan gagal"

--- a/app/_locales/ja/messages.json
+++ b/app/_locales/ja/messages.json
@@ -1002,12 +1002,10 @@
     "message": "スワップに失敗しました"
   },
   "activity_swap_pending_title": {
-    "message": "$1を$2にスワップしています",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "スワップしています"
   },
   "activity_swap_success_title": {
-    "message": "$1を$2にスワップ",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "スワップしました"
   },
   "activity_unwrap_failed_description": {
     "message": "ラップの解除に失敗しました"

--- a/app/_locales/ko/messages.json
+++ b/app/_locales/ko/messages.json
@@ -1002,12 +1002,10 @@
     "message": "스왑 실패"
   },
   "activity_swap_pending_title": {
-    "message": "$1을(를) $2(으)로 스왑 중",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "스왑 중"
   },
   "activity_swap_success_title": {
-    "message": "$1을(를) $2(으)로 스왑 완료",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "스왑 완료"
   },
   "activity_unwrap_failed_description": {
     "message": "언랩 실패"

--- a/app/_locales/pt/messages.json
+++ b/app/_locales/pt/messages.json
@@ -1002,12 +1002,10 @@
     "message": "Falha na troca"
   },
   "activity_swap_pending_title": {
-    "message": "Trocando $1 por $2",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "Trocando"
   },
   "activity_swap_success_title": {
-    "message": "Trocou $1 por $2",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "Trocou"
   },
   "activity_unwrap_failed_description": {
     "message": "Falha ao desencapsular"

--- a/app/_locales/ru/messages.json
+++ b/app/_locales/ru/messages.json
@@ -1002,12 +1002,10 @@
     "message": "Своп не удался"
   },
   "activity_swap_pending_title": {
-    "message": "Своп $1 на $2",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "Своп"
   },
   "activity_swap_success_title": {
-    "message": "Выполнен своп $1 на $2",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "Своп выполнен"
   },
   "activity_unwrap_failed_description": {
     "message": "Ошибка развертывания"

--- a/app/_locales/tl/messages.json
+++ b/app/_locales/tl/messages.json
@@ -1002,12 +1002,10 @@
     "message": "Nabigo ang pag-swap"
   },
   "activity_swap_pending_title": {
-    "message": "Nagsu-swap ng $1 para sa $2",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "Nagsu-swap"
   },
   "activity_swap_success_title": {
-    "message": "Nai-swap ang $1 para sa $2",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "Nai-swap"
   },
   "activity_unwrap_failed_description": {
     "message": "Nabigo ang pag-unwrap"

--- a/app/_locales/tr/messages.json
+++ b/app/_locales/tr/messages.json
@@ -1002,12 +1002,10 @@
     "message": "Takas başarısız oldu"
   },
   "activity_swap_pending_title": {
-    "message": "$1 ile $2 takas ediliyor",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "Takas ediliyor"
   },
   "activity_swap_success_title": {
-    "message": "$1 ile $2 takas edildi",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "Takas edildi"
   },
   "activity_unwrap_failed_description": {
     "message": "Çözme başarısız oldu"

--- a/app/_locales/vi/messages.json
+++ b/app/_locales/vi/messages.json
@@ -1002,12 +1002,10 @@
     "message": "Hoán đổi không thành công"
   },
   "activity_swap_pending_title": {
-    "message": "Đang hoán đổi $1 sang $2",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "Đang hoán đổi"
   },
   "activity_swap_success_title": {
-    "message": "Đã hoán đổi $1 sang $2",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "Đã hoán đổi"
   },
   "activity_unwrap_failed_description": {
     "message": "Hủy bọc thất bại"

--- a/app/_locales/zh_CN/messages.json
+++ b/app/_locales/zh_CN/messages.json
@@ -1002,12 +1002,10 @@
     "message": "交换失败"
   },
   "activity_swap_pending_title": {
-    "message": "正在将 $1 兑换为 $2",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "正在兑换"
   },
   "activity_swap_success_title": {
-    "message": "已将 $1 兑换为 $2",
-    "description": "$1 is the source token symbol, $2 is the destination token symbol"
+    "message": "已兑换"
   },
   "activity_unwrap_failed_description": {
     "message": "解除封装失败"

--- a/test/e2e/page-objects/flows/bridge.flow.ts
+++ b/test/e2e/page-objects/flows/bridge.flow.ts
@@ -49,8 +49,8 @@ export const verifySubmittedSwapTransaction = async ({
 
   if (quote.unapproved) {
     action = isBridge
-      ? `Bridged ${expectedSrcToken}`
-      : `Swapped ${expectedSrcToken} to ${expectedDestToken}`;
+      ? `Bridged ${expectedDestToken ?? expectedSrcToken}`
+      : 'Swapped';
     await activityTab.checkTxAction({
       action,
       confirmedTx: expectedTransactionsCount,
@@ -62,8 +62,8 @@ export const verifySubmittedSwapTransaction = async ({
     });
   } else {
     action = isBridge
-      ? `Bridged ${expectedSrcToken}`
-      : `Swapped ${expectedSrcToken} to ${expectedDestToken}`;
+      ? `Bridged ${expectedDestToken ?? expectedSrcToken}`
+      : 'Swapped';
     await activityTab.checkTxAction({
       action,
       confirmedTx: expectedTransactionsCount,

--- a/test/e2e/page-objects/flows/bridge.flow.ts
+++ b/test/e2e/page-objects/flows/bridge.flow.ts
@@ -48,9 +48,7 @@ export const verifySubmittedSwapTransaction = async ({
   const expectedDestToken = quote.tokenTo ?? expectedSwapTokens?.tokenTo;
 
   if (quote.unapproved) {
-    action = isBridge
-      ? `Bridged ${expectedDestToken ?? expectedSrcToken}`
-      : 'Swapped';
+    action = isBridge ? `Bridged ${expectedSrcToken}` : 'Swapped';
     await activityTab.checkTxAction({
       action,
       confirmedTx: expectedTransactionsCount,
@@ -61,9 +59,7 @@ export const verifySubmittedSwapTransaction = async ({
       txIndex: 2,
     });
   } else {
-    action = isBridge
-      ? `Bridged ${expectedDestToken ?? expectedSrcToken}`
-      : 'Swapped';
+    action = isBridge ? `Bridged ${expectedSrcToken}` : 'Swapped';
     await activityTab.checkTxAction({
       action,
       confirmedTx: expectedTransactionsCount,

--- a/test/e2e/tests/bridge/swap-gasless.spec.ts
+++ b/test/e2e/tests/bridge/swap-gasless.spec.ts
@@ -39,7 +39,7 @@ describe('Gasless swap tests', function (this: Suite) {
         const activityTab = new ActivityTab(driver);
         await activityTab.checkCompletedBridgeTransactionActivity(1);
         await activityTab.checkTxAction({
-          action: 'Swapped ETH to USDC',
+          action: 'Swapped',
           confirmedTx: 1,
         });
       },
@@ -74,7 +74,7 @@ describe('Gasless swap tests', function (this: Suite) {
         const activityTab = new ActivityTab(driver);
         await activityTab.checkCompletedBridgeTransactionActivity(2);
         await activityTab.checkTxAction({
-          action: 'Swapped USDC to DAI',
+          action: 'Swapped',
           confirmedTx: 0,
           txIndex: 1,
         });
@@ -114,7 +114,7 @@ describe('Gasless swap tests', function (this: Suite) {
         const activityTab = new ActivityTab(driver);
         await activityTab.checkCompletedBridgeTransactionActivity(1);
         await activityTab.checkTxAction({
-          action: 'Swapped ETH to USDC',
+          action: 'Swapped',
           confirmedTx: 1,
         });
       },

--- a/test/e2e/tests/smart-transactions/smart-transactions.spec.ts
+++ b/test/e2e/tests/smart-transactions/smart-transactions.spec.ts
@@ -168,7 +168,7 @@ describe('Smart Transactions', function () {
         await activityTab.checkCompletedTxNumberDisplayedInActivity();
         await activityTab.checkNoFailedTransactions();
         await activityTab.checkConfirmedTxNumberDisplayedInActivity();
-        await activityTab.checkTxAction({ action: 'Swapped ETH to DAI' });
+        await activityTab.checkTxAction({ action: 'Swapped' });
         await activityTab.checkTxAmountInActivity(`+4,625.9799 DAI`, 1);
       },
     );

--- a/test/e2e/tests/solana/swap.spec.ts
+++ b/test/e2e/tests/solana/swap.spec.ts
@@ -711,9 +711,7 @@ describe('Swap on Solana', function () {
         await activityTab.checkCompletedBridgeTransactionActivity(1);
         await activityTab.checkTxAmountInActivity('+0.1669 USDC', 1);
         if (!isUnifiedAssetsEnabled) {
-          await activityTab.checkTransactionActivityByText(
-            'Swapped SOL to USDC',
-          );
+          await activityTab.checkTransactionActivityByText('Swapped');
         }
       },
     );
@@ -794,11 +792,9 @@ describe('Swap on Solana', function () {
         await activityTab.checkTxAmountInActivity('+0.005904 SOL', 1);
         await activityTab.checkWaitForTransactionStatus('confirmed');
         if (isUnifiedAssetsEnabled) {
-          await activityTab.checkTransactionActivityByText('Swapped USDC to');
+          await activityTab.checkTransactionActivityByText('Swapped USDC');
         } else {
-          await activityTab.checkTransactionActivityByText(
-            'Swapped USDC to SOL',
-          );
+          await activityTab.checkTransactionActivityByText('Swapped');
         }
       },
     );

--- a/test/e2e/tests/solana/swap.spec.ts
+++ b/test/e2e/tests/solana/swap.spec.ts
@@ -791,11 +791,7 @@ describe('Swap on Solana', function () {
         const activityTab = new ActivityTab(driver);
         await activityTab.checkTxAmountInActivity('+0.005904 SOL', 1);
         await activityTab.checkWaitForTransactionStatus('confirmed');
-        if (isUnifiedAssetsEnabled) {
-          await activityTab.checkTransactionActivityByText('Swapped USDC');
-        } else {
-          await activityTab.checkTransactionActivityByText('Swapped');
-        }
+        await activityTab.checkTransactionActivityByText('Swapped');
       },
     );
   });

--- a/ui/pages/activity/rows/useActivityRowContent.test.tsx
+++ b/ui/pages/activity/rows/useActivityRowContent.test.tsx
@@ -141,38 +141,4 @@ describe('useActivityRowContent', () => {
     );
     expect(result.current.subtitle).toBe('ETH → USDC');
   });
-
-  it('prefers the destination token in the bridge title and shows the token pair subtitle', () => {
-    const activity = {
-      type: 'bridge',
-      chainId: 'eip155:1',
-      status: 'success',
-      timestamp: 1,
-      hash: '0xabc',
-      data: {
-        from: '0x1111111111111111111111111111111111111111',
-        sourceToken: {
-          direction: 'out',
-          symbol: 'ETH',
-          amount: '1',
-          decimals: 18,
-        },
-        destinationToken: {
-          direction: 'in',
-          symbol: 'USDT',
-          amount: '2',
-          decimals: 6,
-        },
-      },
-    } as ActivityListItem;
-
-    const { result } = renderHookWithProvider(() =>
-      useActivityRowContent(activity),
-    );
-
-    expect(result.current.title.props.children).toBe(
-      'activity_bridge_success_title|USDT',
-    );
-    expect(result.current.subtitle).toBe('ETH → USDT');
-  });
 });

--- a/ui/pages/activity/rows/useActivityRowContent.test.tsx
+++ b/ui/pages/activity/rows/useActivityRowContent.test.tsx
@@ -108,7 +108,7 @@ describe('useActivityRowContent', () => {
     expect(result.current.subtitle).toBe('activity_swap_success_description');
   });
 
-  it('keeps full swap copy when destination is present', () => {
+  it('uses a clean swap title with the token pair as subtitle', () => {
     const activity = {
       type: 'swap',
       chainId: 'eip155:1',
@@ -137,7 +137,42 @@ describe('useActivityRowContent', () => {
     );
 
     expect(result.current.title.props.children).toBe(
-      'activity_swap_success_title|ETH,USDC',
+      'activity_swap_success_title',
     );
+    expect(result.current.subtitle).toBe('ETH → USDC');
+  });
+
+  it('prefers the destination token in the bridge title and shows the token pair subtitle', () => {
+    const activity = {
+      type: 'bridge',
+      chainId: 'eip155:1',
+      status: 'success',
+      timestamp: 1,
+      hash: '0xabc',
+      data: {
+        from: '0x1111111111111111111111111111111111111111',
+        sourceToken: {
+          direction: 'out',
+          symbol: 'ETH',
+          amount: '1',
+          decimals: 18,
+        },
+        destinationToken: {
+          direction: 'in',
+          symbol: 'USDT',
+          amount: '2',
+          decimals: 6,
+        },
+      },
+    } as ActivityListItem;
+
+    const { result } = renderHookWithProvider(() =>
+      useActivityRowContent(activity),
+    );
+
+    expect(result.current.title.props.children).toBe(
+      'activity_bridge_success_title|USDT',
+    );
+    expect(result.current.subtitle).toBe('ETH → USDT');
   });
 });

--- a/ui/pages/activity/rows/useActivityRowContent.tsx
+++ b/ui/pages/activity/rows/useActivityRowContent.tsx
@@ -73,7 +73,7 @@ export function useActivityRowContent(activity: ActivityRowProps['data']) {
           secondaryAmount: formatAsFiat(token),
         };
       }
-      // Source and destination in title; two tokens in avatar
+      // Title is "Swapped"; token pair in subtitle; two tokens in avatar
       case 'swap': {
         const { sourceToken, destinationToken } = activity.data;
         const sourceSymbol = sourceToken?.symbol ?? '';
@@ -83,16 +83,17 @@ export function useActivityRowContent(activity: ActivityRowProps['data']) {
         const titleKey = hasDestination
           ? labelKeys.title.key
           : `activity_swapIncomplete_${activity.status}_title`;
+        const subtitle =
+          sourceSymbol && destinationSymbol
+            ? `${sourceSymbol} → ${destinationSymbol}`
+            : t(labelKeys.description.key);
 
         return {
           avatarTokens: hasDestination
             ? [sourceToken?.assetId, destinationToken?.assetId]
             : [sourceToken?.assetId],
-          title: t(
-            titleKey,
-            hasDestination ? [sourceSymbol, destinationSymbol] : [sourceSymbol],
-          ),
-          subtitle: t(labelKeys.description.key),
+          title: hasDestination ? t(titleKey) : t(titleKey, [sourceSymbol]),
+          subtitle,
           primaryAmount: formatTokenAmount(primaryToken),
           primaryDirection: primaryToken?.direction,
           secondaryAmount: hasDestination
@@ -153,16 +154,24 @@ export function useActivityRowContent(activity: ActivityRowProps['data']) {
           secondaryAmount: formatTokenAmount(sourceToken),
         };
       }
-      // Token in title. API bridge rows may only include the source leg.
+      // Destination token in title; token pair in subtitle when both known.
+      // API bridge rows may only include the source leg.
       case 'bridge': {
         const { sourceToken, destinationToken } = activity.data;
-        const symbol = sourceToken?.symbol ?? destinationToken?.symbol ?? '';
+        const sourceSymbol = sourceToken?.symbol;
+        const destinationSymbol = destinationToken?.symbol;
+        const symbol = destinationSymbol ?? sourceSymbol ?? '';
+        const subtitle =
+          sourceSymbol && destinationSymbol
+            ? `${sourceSymbol} → ${destinationSymbol}`
+            : undefined;
 
         return {
           avatarTokens: destinationToken
             ? [sourceToken?.assetId, destinationToken?.assetId]
             : [sourceToken?.assetId],
           title: t(labelKeys.title.key, [symbol]),
+          subtitle,
           primaryAmount: formatTokenAmount(destinationToken ?? sourceToken),
           primaryDirection: (destinationToken ?? sourceToken)?.direction,
           ...(destinationToken

--- a/ui/pages/activity/rows/useActivityRowContent.tsx
+++ b/ui/pages/activity/rows/useActivityRowContent.tsx
@@ -154,24 +154,16 @@ export function useActivityRowContent(activity: ActivityRowProps['data']) {
           secondaryAmount: formatTokenAmount(sourceToken),
         };
       }
-      // Destination token in title; token pair in subtitle when both known.
-      // API bridge rows may only include the source leg.
+      // Token in title. API bridge rows may only include the source leg.
       case 'bridge': {
         const { sourceToken, destinationToken } = activity.data;
-        const sourceSymbol = sourceToken?.symbol;
-        const destinationSymbol = destinationToken?.symbol;
-        const symbol = destinationSymbol ?? sourceSymbol ?? '';
-        const subtitle =
-          sourceSymbol && destinationSymbol
-            ? `${sourceSymbol} → ${destinationSymbol}`
-            : undefined;
+        const symbol = sourceToken?.symbol ?? destinationToken?.symbol ?? '';
 
         return {
           avatarTokens: destinationToken
             ? [sourceToken?.assetId, destinationToken?.assetId]
             : [sourceToken?.assetId],
           title: t(labelKeys.title.key, [symbol]),
-          subtitle,
           primaryAmount: formatTokenAmount(destinationToken ?? sourceToken),
           primaryDirection: (destinationToken ?? sourceToken)?.direction,
           ...(destinationToken


### PR DESCRIPTION
## **Description**

Updates Activity list swap row labels to match Figma
- Swaps: title is `Swapped` / `Swapping`, subtitle is the token pair (`ETH → USDC`)

## **Changelog**

CHANGELOG entry: Updated Activity swap rows labels

## **Related issues**


## **Manual testing steps**

1. Open Activity with recent swap and bridge transactions
2. Confirm swaps show `Swapped` with a token-pair subtitle (e.g. `ETH → USDC`)

## **Screenshots/Recordings**
### **Before**
<img width="262" height="60" alt="image" src="https://github.com/user-attachments/assets/4c6149c3-94d9-454e-9cdb-9c8100486c30" />


### **After**

<img width="175" height="70" alt="image" src="https://github.com/user-attachments/assets/212026a0-7361-42e4-8dbe-4bf796508062" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and presentation-only changes to activity list labels with tests updated; no transaction or auth logic touched.
> 
> **Overview**
> Activity **swap** rows now use short status titles (**Swapped** / **Swapping**) instead of embedding both token symbols in the title, with the pair shown as a subtitle like `ETH → USDC`.
> 
> `useActivityRowContent` builds that subtitle from source/destination symbols when both exist; incomplete swaps still use the source-only incomplete title keys. Locale strings for `activity_swap_pending_title` and `activity_swap_success_title` drop `$1`/`$2` placeholders across all supported languages. E2E expectations and the hook unit test were updated to assert **Swapped** and the arrow subtitle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d429f97b019c91629768e3d018188a7e3dddefe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->