### PR TITLE
fix(deep-links): require interstitial for CAIP-19 asset links

### DIFF
--- a/app/scripts/lib/deep-links/deep-link.router.test.ts
+++ b/app/scripts/lib/deep-links/deep-link.router.test.ts
@@ -325,26 +325,24 @@ describe('DeepLinkRouter', () => {
       });
     });
 
-    describe('skipInterstitial routes', () => {
-      it('should redirect unsigned asset links directly without interstitial', async () => {
-        const tabId = 1;
-        const url =
-          'https://link.metamask.io/asset?assetId=eip155%3A1%2Ferc20%3A0x6b175474e89094c44da98b954eedeac495271d0f';
-        parseMock.mockResolvedValue({
-          signature: 'missing',
-          destination: {
-            path: 'asset/eip155:1/eip155%3A1%2Ferc20%3A0x6b175474e89094c44da98b954eedeac495271d0f',
-            query: new URLSearchParams(),
-          },
-          route: { pathname: '/asset' },
-        } as ParsedDeepLink);
-        await onBeforeRequest?.({
-          tabId,
-          url,
-        } as browser.WebRequest.OnBeforeRequestDetailsType);
-        expect(browser.tabs.update).toHaveBeenCalledWith(tabId, {
-          url: 'chrome-extension://extension-id/home.html#asset/eip155:1/eip155%3A1%2Ferc20%3A0x6b175474e89094c44da98b954eedeac495271d0f',
-        });
+    it('should show the interstitial for unsigned asset links', async () => {
+      const tabId = 1;
+      const url =
+        'https://link.metamask.io/asset?assetId=eip155%3A1%2Ferc20%3A0x6b175474e89094c44da98b954eedeac495271d0f';
+      parseMock.mockResolvedValue({
+        signature: 'missing',
+        destination: {
+          path: 'asset/eip155:1/eip155%3A1%2Ferc20%3A0x6b175474e89094c44da98b954eedeac495271d0f',
+          query: new URLSearchParams(),
+        },
+        route: { pathname: '/asset' },
+      } as ParsedDeepLink);
+      await onBeforeRequest?.({
+        tabId,
+        url,
+      } as browser.WebRequest.OnBeforeRequestDetailsType);
+      expect(browser.tabs.update).toHaveBeenCalledWith(tabId, {
+        url: 'chrome-extension://extension-id/home.html#link?u=%2Fasset%3FassetId%3Deip155%253A1%252Ferc20%253A0x6b175474e89094c44da98b954eedeac495271d0f',
       });
     });
 

--- a/shared/lib/deep-links/routes/interstitial-bypass.test.ts
+++ b/shared/lib/deep-links/routes/interstitial-bypass.test.ts
@@ -8,7 +8,6 @@ describe('deep link interstitial bypass routes', () => {
   it('includes the Extension routes matching mobile whitelisted actions', () => {
     expect([...DEEP_LINK_INTERSTITIAL_BYPASS_ROUTE_PATHS].sort()).toStrictEqual(
       [
-        '/asset',
         '/buy',
         '/batch-sell',
         '/card-onboarding',
@@ -39,7 +38,7 @@ describe('deep link interstitial bypass routes', () => {
     ).toBe(false);
     expect(
       isDeepLinkRouteAllowedToBypassInterstitial(routes.get('/asset')),
-    ).toBe(true);
+    ).toBe(false);
     expect(
       isDeepLinkRouteAllowedToBypassInterstitial(routes.get('/notifications')),
     ).toBe(false);

--- a/shared/lib/deep-links/routes/interstitial-bypass.ts
+++ b/shared/lib/deep-links/routes/interstitial-bypass.ts
@@ -1,7 +1,6 @@
 import type { Route } from './route';
 
 const deepLinkInterstitialBypassRoutePathList = [
-  '/asset',
   '/buy',
   '/sell',
   '/batch-sell',

--- a/shared/lib/deep-links/utils.test.ts
+++ b/shared/lib/deep-links/utils.test.ts
@@ -276,7 +276,7 @@ describe('Deep link utils', () => {
         });
       });
 
-      it('returns navigate route for unsigned whitelisted asset link', async () => {
+      it('returns interstitial route for unsigned asset link', async () => {
         const createdAt = 1000000;
         jest.setSystemTime(createdAt + 60 * 1000);
         const assetLink =
@@ -297,10 +297,9 @@ describe('Deep link utils', () => {
         });
 
         expect(result).toStrictEqual({
-          type: DeferredDeepLinkRouteType.Navigate,
-          route:
-            '/asset/eip155:1/eip155%3A1%2Ferc20%3A0x6b175474e89094c44da98b954eedeac495271d0f',
-          signature: MISSING,
+          type: DeferredDeepLinkRouteType.Interstitial,
+          urlPathAndQuery:
+            '/asset?assetId=eip155%3A1%2Ferc20%3A0x6b175474e89094c44da98b954eedeac495271d0f',
         });
       });
     });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

CAIP-19 asset deep links were included in the extension's interstitial bypass route list, so unsigned `/asset` links navigated directly to the token page. That bypassed the phishing interstitial and could show malicious token metadata from scam links.

This change removes `/asset` from the bypass list so unsigned asset deep links follow the same interstitial flow as other non-whitelisted routes, unless the user has opted in to skip the interstitial or the link originates from a trusted MetaMask domain.

## **Changelog**

CHANGELOG entry: Fixed a bug where CAIP-19 asset deep links could bypass the phishing interstitial page.

## **Related issues**

Fixes: https://github.com/MetaMask/metamask-extension/issues/44589
Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3689

## **Manual testing steps**

1. Open MetaMask extension and go to **Settings → Privacy**.
2. Ensure **Skip interstitial** is **off**.
3. Paste this URL in the browser address bar:
   `https://link.metamask.io/asset?assetId=eip155:1/erc20:0xb047c8032b99841713b8e3872f06cf32beb27b82`
4. Verify the deep-link interstitial page is shown instead of the token page.
5. Click **Continue** and confirm the asset page loads afterward.
6. Enable **Skip interstitial**, open a signed asset deep link, and confirm it can still bypass the interstitial when expected.

## **Screenshots/Recordings**

N/A — behavior fix verified via unit tests; manual steps above for QA.

### **Before**

Asset deep links opened the token page directly, skipping the phishing interstitial.

### **After**

Unsigned asset deep links show the phishing interstitial when skip-interstitial is disabled.

## **Changed files**

| File | Change | Verification |
| --- | --- | --- |
| `shared/lib/deep-links/routes/interstitial-bypass.ts` | Removed `/asset` from bypass route list | `yarn test:unit shared/lib/deep-links/routes/interstitial-bypass.test.ts --coverage=false` |
| `shared/lib/deep-links/routes/interstitial-bypass.test.ts` | Updated bypass route expectations | same as above |
| `app/scripts/lib/deep-links/deep-link.router.test.ts` | Expect interstitial for unsigned asset links | `yarn test:unit app/scripts/lib/deep-links/deep-link.router.test.ts --coverage=false` |
| `shared/lib/deep-links/utils.test.ts` | Expect deferred asset links to use interstitial route | `yarn test:unit shared/lib/deep-links/utils.test.ts --coverage=false` |

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-633d546b-2806-46ff-90ee-c6e491bb73da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-633d546b-2806-46ff-90ee-c6e491bb73da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

