### PR TITLE
feat: render high rate alert modal in batch sell review page

### DIFF
--- a/ui/pages/batch-sell/hooks/useBatchSellHighRateAlertModal.test.ts
+++ b/ui/pages/batch-sell/hooks/useBatchSellHighRateAlertModal.test.ts
@@ -1,0 +1,206 @@
+import type { CaipAssetType, CaipChainId } from '@metamask/utils';
+import { renderHook, act } from '@testing-library/react-hooks';
+import * as useBridgingModule from '../../../hooks/bridge/useBridging';
+import { buildBatchSellAsset } from '../../../../test/data/batch-sell';
+import { MetaMetricsSwapsEventSource } from '../../../../shared/constants/metametrics';
+import { useBatchSellHighRateAlertModal } from './useBatchSellHighRateAlertModal';
+
+const CHAIN_ID = 'eip155:1' as CaipChainId;
+const NATIVE_ASSET_ID = 'eip155:1/slip44:60' as CaipAssetType;
+const ERC20_TOKEN_ADDRESS =
+  '0xdAC17F958D2ee523a2206206994597C13D831ec' as `0x${string}`;
+const ERC20_ASSET_ID = `eip155:1/erc20:${ERC20_TOKEN_ADDRESS}` as CaipAssetType;
+const DEST_ASSET_ID =
+  'eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48' as CaipAssetType;
+
+const makeAsset = (overrides: Record<string, unknown> = {}) =>
+  buildBatchSellAsset({
+    assetId: NATIVE_ASSET_ID,
+    name: 'Ether',
+    symbol: 'ETH',
+    chainId: CHAIN_ID,
+    ...overrides,
+  });
+
+// Both objects are prefixed with `mock` so they can be referenced from
+// inside `jest.mock(..)` factories (which only permit out-of-scope
+// variables whose names start with `mock`).
+const mockHarness = {
+  selectedNetworkChainId: CHAIN_ID as CaipChainId | null,
+  destStablecoins: [DEST_ASSET_ID] as CaipAssetType[],
+};
+
+const mockFns = {
+  openModal: jest.fn(),
+  closeModal: jest.fn(),
+  openBridgeExperience: jest.fn(),
+};
+
+jest.mock('../../../hooks/useI18nContext', () => ({
+  useI18nContext: () => (key: string) => key,
+}));
+
+jest.mock('./useBatchSellInfoModal', () => ({
+  useBatchSellInfoModal: () => ({
+    openModal: mockFns.openModal,
+    closeModal: mockFns.closeModal,
+  }),
+}));
+
+jest.mock('../providers/batch-sell-selection-provider', () => ({
+  useBatchSellSelection: () => ({
+    selectedNetworkChainId: mockHarness.selectedNetworkChainId,
+  }),
+}));
+
+jest.mock('../../../ducks/batch-sell/selectors', () => ({
+  getBatchSellDestStablecoinsForNetwork: () => mockHarness.destStablecoins,
+}));
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: (selector: (state: unknown) => unknown) => selector({}),
+}));
+
+// `useBridging` has a default export, so we auto-mock the module and
+// re-bind it inside `beforeEach` via `jest.spyOn`.
+jest.mock('../../../hooks/bridge/useBridging');
+
+/**
+ * Opens the modal via the hook and immediately invokes the CTA callback
+ * that was registered with `openModal`, returning nothing because every
+ * assertion is made against the `mockFns` jest functions.
+ *
+ * @param sourceAsset - The asset passed as the first argument to `openHighAlertModal`.
+ * @param destAssetId - The asset id passed as the second argument to `openHighAlertModal`.
+ */
+function openAndClickCta(
+  sourceAsset: Parameters<
+    ReturnType<typeof useBatchSellHighRateAlertModal>['openHighAlertModal']
+  >[0],
+  destAssetId: CaipAssetType,
+) {
+  const { result } = renderHook(() => useBatchSellHighRateAlertModal());
+
+  act(() => {
+    result.current.openHighAlertModal(sourceAsset, destAssetId);
+  });
+
+  act(() => {
+    mockFns.openModal.mock.calls[0][0].ctaProps.onClick();
+  });
+}
+
+describe('useBatchSellHighRateAlertModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockHarness.selectedNetworkChainId = CHAIN_ID;
+    mockHarness.destStablecoins = [DEST_ASSET_ID];
+    jest
+      .spyOn(useBridgingModule, 'default')
+      .mockReturnValue({ openBridgeExperience: mockFns.openBridgeExperience });
+  });
+
+  it('returns openHighAlertModal and closeHighAlertModal', () => {
+    const { result } = renderHook(() => useBatchSellHighRateAlertModal());
+
+    expect(typeof result.current.openHighAlertModal).toBe('function');
+    expect(result.current.closeHighAlertModal).toBe(mockFns.closeModal);
+  });
+
+  describe('openHighAlertModal', () => {
+    it('opens the modal with the high rate alert copy', () => {
+      const { result } = renderHook(() => useBatchSellHighRateAlertModal());
+
+      act(() => {
+        result.current.openHighAlertModal(makeAsset(), DEST_ASSET_ID);
+      });
+
+      expect(mockFns.openModal).toHaveBeenCalledTimes(1);
+      expect(mockFns.openModal).toHaveBeenCalledWith(
+        expect.objectContaining({
+          titleProps: { children: 'batchSellHighRateAlert' },
+          descriptionProps: {
+            children: 'batchSellHightRateAlertModalDescription',
+          },
+          ctaProps: expect.objectContaining({
+            text: 'yesSwap',
+            onClick: expect.any(Function),
+          }),
+        }),
+      );
+    });
+
+    it('does not navigate to the bridge experience until the CTA is clicked', () => {
+      const { result } = renderHook(() => useBatchSellHighRateAlertModal());
+
+      act(() => {
+        result.current.openHighAlertModal(makeAsset(), DEST_ASSET_ID);
+      });
+
+      expect(mockFns.openBridgeExperience).not.toHaveBeenCalled();
+    });
+
+    it('closes the modal before navigating to the bridge experience when the CTA is clicked', () => {
+      openAndClickCta(makeAsset(), DEST_ASSET_ID);
+
+      expect(mockFns.closeModal).toHaveBeenCalledTimes(1);
+      expect(mockFns.openBridgeExperience).toHaveBeenCalledTimes(1);
+      expect(mockFns.closeModal.mock.invocationCallOrder[0]).toBeLessThan(
+        mockFns.openBridgeExperience.mock.invocationCallOrder[0],
+      );
+    });
+
+    it('passes the swaps main-view metametrics source and the given destAssetId', () => {
+      openAndClickCta(makeAsset(), DEST_ASSET_ID);
+
+      expect(mockFns.openBridgeExperience).toHaveBeenCalledWith(
+        MetaMetricsSwapsEventSource.MainView,
+        expect.anything(),
+        DEST_ASSET_ID,
+      );
+    });
+
+    it('derives the canonical zero address as the source token for a native asset', () => {
+      openAndClickCta(makeAsset(), DEST_ASSET_ID);
+
+      expect(mockFns.openBridgeExperience).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          symbol: 'ETH',
+          address: '0x0000000000000000000000000000000000000000',
+          name: 'Ether',
+          chainId: CHAIN_ID,
+        }),
+        expect.anything(),
+      );
+    });
+
+    it('derives the contract address as the source token for an ERC-20 asset', () => {
+      const erc20 = makeAsset({
+        assetId: ERC20_ASSET_ID,
+        symbol: 'USDT',
+        name: 'Tether USD',
+      });
+
+      openAndClickCta(erc20, DEST_ASSET_ID);
+
+      expect(mockFns.openBridgeExperience).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({
+          symbol: 'USDT',
+          address: ERC20_TOKEN_ADDRESS,
+          name: 'Tether USD',
+          chainId: CHAIN_ID,
+        }),
+        expect.anything(),
+      );
+    });
+
+    it('passes undefined as the source token when no source asset is given', () => {
+      openAndClickCta(undefined, DEST_ASSET_ID);
+
+      expect(mockFns.openBridgeExperience.mock.calls[0][1]).toBeUndefined();
+    });
+  });
+});

--- a/ui/pages/batch-sell/hooks/useBatchSellHighRateAlertModal.ts
+++ b/ui/pages/batch-sell/hooks/useBatchSellHighRateAlertModal.ts
@@ -64,7 +64,7 @@ export const useBatchSellHighRateAlertModal = () => {
         },
       });
     },
-    [],
+    [openModal, t, navigateToBridgePageAndPreselect],
   );
 
   return {

--- a/ui/pages/batch-sell/hooks/useBatchSellHighRateAlertModal.ts
+++ b/ui/pages/batch-sell/hooks/useBatchSellHighRateAlertModal.ts
@@ -1,0 +1,74 @@
+import { useCallback } from 'react';
+import { useSelector } from 'react-redux';
+import { formatAddressToCaipReference } from '@metamask/bridge-controller';
+import { CaipAssetType } from '@metamask/utils';
+import type { BridgeAppState } from '../../../ducks/bridge/selectors';
+import { getBatchSellDestStablecoinsForNetwork } from '../../../ducks/batch-sell/selectors';
+import { useBatchSellSelection } from '../providers/batch-sell-selection-provider';
+import { transitionForward } from '../../../components/ui/transition';
+import useBridging from '../../../hooks/bridge/useBridging';
+import { MetaMetricsSwapsEventSource } from '../../../../shared/constants/metametrics';
+import { useI18nContext } from '../../../hooks/useI18nContext';
+import { BatchSellAsset } from '../../../ducks/batch-sell/types';
+import { useBatchSellInfoModal } from './useBatchSellInfoModal';
+
+export const useBatchSellHighRateAlertModal = () => {
+  const t = useI18nContext();
+  const { openModal, closeModal: closeHighAlertModal } =
+    useBatchSellInfoModal();
+  const { openBridgeExperience } = useBridging();
+  const { selectedNetworkChainId } = useBatchSellSelection();
+  const batchSellDestStablecoins = useSelector((state: BridgeAppState) =>
+    getBatchSellDestStablecoinsForNetwork(
+      state,
+      selectedNetworkChainId ?? undefined,
+    ),
+  );
+
+  const navigateToBridgePageAndPreselect = useCallback(
+    (sourceAsset: BatchSellAsset | undefined, destAssetId: CaipAssetType) =>
+      () => {
+        closeHighAlertModal();
+        const sourceToken = sourceAsset
+          ? {
+              symbol: sourceAsset.symbol,
+              address: formatAddressToCaipReference(sourceAsset.assetId),
+              name: sourceAsset.name,
+              chainId: sourceAsset.chainId,
+            }
+          : undefined;
+
+        transitionForward(() =>
+          openBridgeExperience(
+            MetaMetricsSwapsEventSource.MainView,
+            sourceToken,
+            destAssetId,
+          ),
+        );
+      },
+    [batchSellDestStablecoins, closeHighAlertModal, openBridgeExperience],
+  );
+
+  const openHighAlertModal = useCallback(
+    (sourceAsset: BatchSellAsset | undefined, destAssetId: CaipAssetType) => {
+      openModal({
+        titleProps: {
+          children: t('batchSellHighRateAlert'),
+        },
+        descriptionProps: {
+          children: t('batchSellHightRateAlertModalDescription'),
+        },
+        ctaProps: {
+          text: t('yesSwap'),
+          onClick: navigateToBridgePageAndPreselect(sourceAsset, destAssetId),
+        },
+      });
+    },
+    [],
+  );
+
+  return {
+    openHighAlertModal,
+    closeHighAlertModal,
+  };
+};

--- a/ui/pages/batch-sell/pages/review/batch-sell-review-page.test.tsx
+++ b/ui/pages/batch-sell/pages/review/batch-sell-review-page.test.tsx
@@ -11,6 +11,11 @@ import { useBatchSellQuotesFetching } from './hooks/useBatchSellQuotesFetching';
 import { useBatchSellAggregateValidation } from './hooks/useBatchSellAggregateValidation';
 import { BatchSellReviewPage } from './batch-sell-review-page';
 
+// Referenced from inside the `useBatchSellHighRateAlertModal` jest.mock(..)
+// factory below, so its name must start with `mock` (see other `mock`-
+// prefixed variables further down for the same reason).
+const mockOpenHighAlertModal = jest.fn();
+
 // ── Hooks ──────────────────────────────────────────────────────────────────
 jest.mock('./hooks/useBatchSellQuotesConfig');
 jest.mock('./hooks/useBatchSellQuotesFetching');
@@ -18,6 +23,12 @@ jest.mock('./hooks/useBatchSellTradesFetching', () => ({
   useBatchSellTradesFetching: jest.fn(),
 }));
 jest.mock('./hooks/useBatchSellAggregateValidation');
+jest.mock('../../hooks/useBatchSellHighRateAlertModal', () => ({
+  useBatchSellHighRateAlertModal: () => ({
+    openHighAlertModal: mockOpenHighAlertModal,
+    closeHighAlertModal: jest.fn(),
+  }),
+}));
 
 // ── Utilities ──────────────────────────────────────────────────────────────
 jest.mock('./utils/hasAtLeastOneQuoteAvailable', () => ({
@@ -168,8 +179,12 @@ const mockUseSelector = jest.mocked(useSelector);
 
 // ── Default return values ──────────────────────────────────────────────────
 const defaultQuotesConfig = {
+  // Two enabled assets by default so `onReviewClick` takes the
+  // "open the review-and-confirm modal" branch; tests for the
+  // single-enabled-asset ("high alert modal") branch override this.
   sendAssetsConfig: {
     [BATCH_SELL_ASSET_IDS.DAI]: buildSendAssetConfigEntry(true),
+    [BATCH_SELL_ASSET_IDS.USDT]: buildSendAssetConfigEntry(true),
   },
   selectedReceiveAsset: buildReceivedAsset({
     assetId: BATCH_SELL_ASSET_IDS.USDC,
@@ -423,6 +438,90 @@ describe('BatchSellReviewPage', () => {
             .getAttribute('data-fees-loading'),
         ).toBe('true');
       });
+    });
+  });
+
+  describe('onReviewClick', () => {
+    it('opens the review-and-confirm modal (not the high alert modal) when more than one asset is enabled to sell', () => {
+      renderPage();
+
+      fireEvent.click(screen.getByTestId('footer-review'));
+
+      expect(mockOpenHighAlertModal).not.toHaveBeenCalled();
+      expect(screen.getByTestId('review-confirm-modal')).toBeInTheDocument();
+    });
+
+    it('opens the review-and-confirm modal when no assets are enabled to sell', () => {
+      renderPage({
+        quotesConfig: {
+          sendAssetsConfig: {
+            [BATCH_SELL_ASSET_IDS.DAI]: buildSendAssetConfigEntry(false),
+          },
+        },
+      });
+
+      fireEvent.click(screen.getByTestId('footer-review'));
+
+      expect(mockOpenHighAlertModal).not.toHaveBeenCalled();
+      expect(screen.getByTestId('review-confirm-modal')).toBeInTheDocument();
+    });
+
+    it('opens the high alert modal instead of the review-and-confirm modal when exactly one asset is enabled to sell', () => {
+      const singleAssetConfig = {
+        [BATCH_SELL_ASSET_IDS.DAI]: buildSendAssetConfigEntry(true),
+      };
+      renderPage({ quotesConfig: { sendAssetsConfig: singleAssetConfig } });
+
+      fireEvent.click(screen.getByTestId('footer-review'));
+
+      expect(mockOpenHighAlertModal).toHaveBeenCalledTimes(1);
+      expect(mockOpenHighAlertModal).toHaveBeenCalledWith(
+        singleAssetConfig[BATCH_SELL_ASSET_IDS.DAI].asset,
+        defaultQuotesConfig.selectedReceiveAsset.assetId,
+      );
+      expect(
+        screen.queryByTestId('review-confirm-modal'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('ignores disabled assets when counting how many assets are enabled to sell', () => {
+      const oneEnabledOneDisabledConfig = {
+        [BATCH_SELL_ASSET_IDS.DAI]: buildSendAssetConfigEntry(true),
+        [BATCH_SELL_ASSET_IDS.USDT]: buildSendAssetConfigEntry(false),
+      };
+      renderPage({
+        quotesConfig: { sendAssetsConfig: oneEnabledOneDisabledConfig },
+      });
+
+      fireEvent.click(screen.getByTestId('footer-review'));
+
+      expect(mockOpenHighAlertModal).toHaveBeenCalledWith(
+        oneEnabledOneDisabledConfig[BATCH_SELL_ASSET_IDS.DAI].asset,
+        defaultQuotesConfig.selectedReceiveAsset.assetId,
+      );
+    });
+
+    it('passes the currently selected receive asset id to the high alert modal', () => {
+      const singleAssetConfig = {
+        [BATCH_SELL_ASSET_IDS.DAI]: buildSendAssetConfigEntry(true),
+      };
+      const selectedReceiveAsset = buildReceivedAsset({
+        assetId: BATCH_SELL_ASSET_IDS.ETH_NATIVE,
+        symbol: 'ETH',
+      });
+      renderPage({
+        quotesConfig: {
+          sendAssetsConfig: singleAssetConfig,
+          selectedReceiveAsset,
+        },
+      });
+
+      fireEvent.click(screen.getByTestId('footer-review'));
+
+      expect(mockOpenHighAlertModal).toHaveBeenCalledWith(
+        expect.anything(),
+        selectedReceiveAsset.assetId,
+      );
     });
   });
 

--- a/ui/pages/batch-sell/pages/review/batch-sell-review-page.tsx
+++ b/ui/pages/batch-sell/pages/review/batch-sell-review-page.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Navigate } from 'react-router-dom';
 import { useSelector } from 'react-redux';
 import { Box, BoxFlexDirection } from '@metamask/design-system-react';
@@ -8,6 +8,7 @@ import {
 } from '../../../../constants/batch-sell';
 import { BATCH_SELL_SELECT_ROUTE } from '../../../../helpers/constants/routes';
 import { getBatchSellTrades } from '../../../../ducks/batch-sell/selectors';
+import { useBatchSellHighRateAlertModal } from '../../hooks/useBatchSellHighRateAlertModal';
 import { useBatchSellQuotesConfig } from './hooks/useBatchSellQuotesConfig';
 import { Header } from './components/header';
 import { QuotesList } from './components/quotes-list';
@@ -29,6 +30,8 @@ export const BatchSellReviewPage = () => {
     useState(false);
   const [totalReceivedModalIsOpen, setTotalReceivedAssetModalIsOpen] =
     useState(false);
+
+  const { openHighAlertModal } = useBatchSellHighRateAlertModal();
 
   const {
     sendAssetsConfig,
@@ -87,6 +90,22 @@ export const BatchSellReviewPage = () => {
     [sendAssetsConfig],
   );
 
+  const onReviewClick = useCallback(() => {
+    const selectedAssetsToSell = Object.values(sendAssetsConfig).filter(
+      (config) => config.enabled,
+    );
+
+    if (selectedAssetsToSell.length === 1) {
+      openHighAlertModal(
+        selectedAssetsToSell[0].asset,
+        selectedReceiveAsset.assetId,
+      );
+      return;
+    }
+
+    setReviewAndConfirmModalIsOpen(true);
+  }, [sendAssetsConfig, openHighAlertModal, selectedReceiveAsset.assetId]);
+
   useEffect(() => {
     setReviewAndConfirmModalIsOpen(false);
   }, [areQuotesRefreshExpired]);
@@ -129,7 +148,7 @@ export const BatchSellReviewPage = () => {
       />
       <Footer
         quotesAreLoading={quotesAreLoading}
-        onReviewClick={() => setReviewAndConfirmModalIsOpen(true)}
+        onReviewClick={onReviewClick}
         reviewIsDisabled={
           quotesAreLoading || !data || validation.isNoQuotesAvailable
         }

--- a/ui/pages/batch-sell/pages/select/batch-sell-select-page.test.tsx
+++ b/ui/pages/batch-sell/pages/select/batch-sell-select-page.test.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react';
 import type { CaipAssetType, CaipChainId } from '@metamask/utils';
-import * as useBridgingModule from '../../../../hooks/bridge/useBridging';
 import { buildBatchSellAsset } from '../../../../../test/data/batch-sell';
 import { BatchSellSelectPage } from './batch-sell-select-page';
 
 const CHAIN_ID = 'eip155:1' as CaipChainId;
 const NATIVE_ASSET_ID = 'eip155:1/slip44:60' as CaipAssetType;
-const ERC20_TOKEN_ADDRESS =
-  '0xdAC17F958D2ee523a2206206994597C13D831ec7' as `0x${string}`;
-const ERC20_ASSET_ID = `eip155:1/erc20:${ERC20_TOKEN_ADDRESS}` as CaipAssetType;
+const ERC20_ASSET_ID =
+  'eip155:1/erc20:0xdAC17F958D2ee523a2206206994597C13D831ec7' as CaipAssetType;
 const STABLECOIN_ASSET_ID =
   'eip155:1/erc20:0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48' as CaipAssetType;
+const OTHER_STABLECOIN_ASSET_ID =
+  'eip155:1/erc20:0x6B175474E89094C44Da98b954EedeAC495271d0F' as CaipAssetType;
 
 const makeAsset = (overrides: Record<string, unknown> = {}) =>
   buildBatchSellAsset({
@@ -35,38 +35,28 @@ const mockHarness = {
 };
 
 const mockFns = {
-  openBridgeExperience: jest.fn(),
   navigateToBatchSellConfirmPage: jest.fn(),
-  openModal: jest.fn(),
-  closeModal: jest.fn(),
+  openHighAlertModal: jest.fn(),
 };
 
-// Router & i18n: minimal stubs so hooks resolve.
+// Router: minimal stub so hooks resolve.
 jest.mock('react-router-dom', () => ({
   ...jest.requireActual('react-router-dom'),
   useLocation: () => ({ state: null, pathname: '/batch-sell/select' }),
   useNavigate: () => jest.fn(),
 }));
 
-jest.mock('../../../../hooks/useI18nContext', () => ({
-  useI18nContext: () => (key: string) => key,
-}));
-
 // Hooks under integration: forwarded to `mockFns` so tests can assert on them.
-// `useBridging` has a default export, so we auto-mock the module and re-bind
-// it inside `beforeEach` via `jest.spyOn` (see below).
-jest.mock('../../../../hooks/bridge/useBridging');
-
 jest.mock('../../../../hooks/batch-sell/useBatchSellNavigation', () => ({
   useBatchSellNavigation: () => ({
     navigateToBatchSellConfirmPage: mockFns.navigateToBatchSellConfirmPage,
   }),
 }));
 
-jest.mock('../../hooks/useBatchSellInfoModal', () => ({
-  useBatchSellInfoModal: () => ({
-    openModal: mockFns.openModal,
-    closeModal: mockFns.closeModal,
+jest.mock('../../hooks/useBatchSellHighRateAlertModal', () => ({
+  useBatchSellHighRateAlertModal: () => ({
+    openHighAlertModal: mockFns.openHighAlertModal,
+    closeHighAlertModal: jest.fn(),
   }),
 }));
 
@@ -100,7 +90,7 @@ jest.mock('react-redux', () => ({
 // Sub-components: rendered as nulls because their real implementations pull
 // in more redux/selector wiring than this test needs. The Footer is replaced
 // with a button that always fires onSubmit, regardless of selection count,
-// because every test exercises the < MIN_SELECTED_ALLOWED_TOKENS branch.
+// so each test only needs to control `mockHarness.initialAssetsId`.
 jest.mock('./components/header', () => ({ Header: () => null }));
 jest.mock('./components/network-toolbar', () => ({
   NetworkToolbar: () => null,
@@ -121,99 +111,85 @@ jest.mock('./components/footer', () => ({
 }));
 
 /**
- * Renders the page, clicks the (mocked) Footer submit button, then invokes
- * the CTA callback that the page registers with `openModal`. Returns nothing
- * because every assertion is made against the `mockFns` jest functions.
+ * Renders the page and clicks the (mocked) Footer submit button, triggering
+ * `onSubmit`. Returns nothing because every assertion is made against the
+ * `mockFns` jest functions.
  */
-function renderAndTriggerBridgeNavigation() {
+function renderAndSubmit() {
   const { getByTestId } = render(<BatchSellSelectPage />);
   fireEvent.click(getByTestId('footer-submit'));
-  mockFns.openModal.mock.calls[0]?.[0]?.ctaProps?.onClick?.();
 }
 
-describe('BatchSellSelectPage – navigateToBridgePageAndPreselect', () => {
+describe('BatchSellSelectPage – onSubmit', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockHarness.initialAssetsId = [];
     mockHarness.assetList = [makeAsset()];
     mockHarness.destStablecoins = [STABLECOIN_ASSET_ID];
-    jest
-      .spyOn(useBridgingModule, 'default')
-      .mockReturnValue({ openBridgeExperience: mockFns.openBridgeExperience });
   });
 
-  it('passes the first batchSellDestStablecoin as destTokenAssetId when the list is non-empty', () => {
-    renderAndTriggerBridgeNavigation();
+  describe('when fewer than MIN_SELECTED_ALLOWED_TOKENS assets are selected', () => {
+    it('opens the high alert modal instead of navigating to the confirm page', () => {
+      renderAndSubmit();
 
-    expect(mockFns.openBridgeExperience).toHaveBeenCalledTimes(1);
-    expect(mockFns.openBridgeExperience.mock.calls[0][2]).toBe(
-      STABLECOIN_ASSET_ID,
-    );
-  });
-
-  it('passes undefined as destTokenAssetId when batchSellDestStablecoins is empty', () => {
-    mockHarness.destStablecoins = [];
-
-    renderAndTriggerBridgeNavigation();
-
-    expect(mockFns.openBridgeExperience).toHaveBeenCalledTimes(1);
-    expect(mockFns.openBridgeExperience.mock.calls[0][2]).toBeUndefined();
-  });
-
-  it('calls closeModal before navigating to the bridge page', () => {
-    renderAndTriggerBridgeNavigation();
-
-    expect(mockFns.closeModal).toHaveBeenCalledTimes(1);
-    expect(mockFns.openBridgeExperience).toHaveBeenCalledTimes(1);
-    expect(mockFns.closeModal.mock.invocationCallOrder[0]).toBeLessThan(
-      mockFns.openBridgeExperience.mock.invocationCallOrder[0],
-    );
-  });
-
-  it('passes the source token derived from the selected native asset', () => {
-    mockHarness.initialAssetsId = [NATIVE_ASSET_ID];
-
-    renderAndTriggerBridgeNavigation();
-
-    expect(mockFns.openBridgeExperience).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        symbol: 'ETH',
-        // Native EVM assets resolve to the canonical zero address.
-        address: '0x0000000000000000000000000000000000000000',
-        name: 'Ether',
-        chainId: CHAIN_ID,
-      }),
-      expect.anything(),
-    );
-  });
-
-  it('passes the contract address as source token address for an ERC-20 asset', () => {
-    const erc20 = makeAsset({
-      assetId: ERC20_ASSET_ID,
-      symbol: 'USDT',
-      name: 'Tether USD',
+      expect(mockFns.openHighAlertModal).toHaveBeenCalledTimes(1);
+      expect(mockFns.navigateToBatchSellConfirmPage).not.toHaveBeenCalled();
     });
-    mockHarness.assetList = [erc20];
-    mockHarness.initialAssetsId = [ERC20_ASSET_ID];
 
-    renderAndTriggerBridgeNavigation();
+    it('passes the asset matching the first selected asset id as the source asset', () => {
+      mockHarness.initialAssetsId = [NATIVE_ASSET_ID];
 
-    expect(mockFns.openBridgeExperience).toHaveBeenCalledWith(
-      expect.any(String),
-      expect.objectContaining({
-        symbol: 'USDT',
-        address: ERC20_TOKEN_ADDRESS,
-        name: 'Tether USD',
-        chainId: CHAIN_ID,
-      }),
-      expect.anything(),
-    );
+      renderAndSubmit();
+
+      expect(mockFns.openHighAlertModal).toHaveBeenCalledWith(
+        mockHarness.assetList[0],
+        STABLECOIN_ASSET_ID,
+      );
+    });
+
+    it('passes undefined as the source asset when no asset is selected', () => {
+      renderAndSubmit();
+
+      expect(mockFns.openHighAlertModal).toHaveBeenCalledWith(
+        undefined,
+        STABLECOIN_ASSET_ID,
+      );
+    });
+
+    it('passes the first batchSellDestStablecoin as the destination asset id', () => {
+      mockHarness.destStablecoins = [
+        STABLECOIN_ASSET_ID,
+        OTHER_STABLECOIN_ASSET_ID,
+      ];
+
+      renderAndSubmit();
+
+      expect(mockFns.openHighAlertModal).toHaveBeenCalledWith(
+        undefined,
+        STABLECOIN_ASSET_ID,
+      );
+    });
+
+    it('passes undefined as the destination asset id when batchSellDestStablecoins is empty', () => {
+      mockHarness.destStablecoins = [];
+
+      renderAndSubmit();
+
+      expect(mockFns.openHighAlertModal).toHaveBeenCalledWith(
+        undefined,
+        undefined,
+      );
+    });
   });
 
-  it('passes undefined as source token when no asset is selected', () => {
-    renderAndTriggerBridgeNavigation();
+  describe('when at least MIN_SELECTED_ALLOWED_TOKENS assets are selected', () => {
+    it('navigates to the confirm page instead of opening the high alert modal', () => {
+      mockHarness.initialAssetsId = [NATIVE_ASSET_ID, ERC20_ASSET_ID];
 
-    expect(mockFns.openBridgeExperience.mock.calls[0][1]).toBeUndefined();
+      renderAndSubmit();
+
+      expect(mockFns.navigateToBatchSellConfirmPage).toHaveBeenCalledTimes(1);
+      expect(mockFns.openHighAlertModal).not.toHaveBeenCalled();
+    });
   });
 });

--- a/ui/pages/batch-sell/pages/select/batch-sell-select-page.tsx
+++ b/ui/pages/batch-sell/pages/select/batch-sell-select-page.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useEffect, useLayoutEffect, useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { CaipChainId } from '@metamask/utils';
 import { Box, BoxFlexDirection } from '@metamask/design-system-react';
-import { formatAddressToCaipReference } from '@metamask/bridge-controller';
 import {
   getAvailableBatchSellSwapAssetsForNetwork,
   getAvailableBatchSellNetworks,
@@ -11,15 +10,12 @@ import {
 import type { BridgeAppState } from '../../../../ducks/bridge/selectors';
 import { BatchSellAsset } from '../../../../ducks/batch-sell/types';
 import { useSortBatchSellAssetsByBalance } from '../../../../hooks/batch-sell/useSortBatchSellAssetsByBalance';
-import { useI18nContext } from '../../../../hooks/useI18nContext';
-import { useBatchSellInfoModal } from '../../hooks/useBatchSellInfoModal';
 import { useBatchSellNavigation } from '../../../../hooks/batch-sell/useBatchSellNavigation';
 import { useBatchSellSelection } from '../../providers/batch-sell-selection-provider';
 import { MIN_SELECTED_ALLOWED_TOKENS } from '../../../../constants/batch-sell';
 import { transitionForward } from '../../../../components/ui/transition';
-import useBridging from '../../../../hooks/bridge/useBridging';
-import { MetaMetricsSwapsEventSource } from '../../../../../shared/constants/metametrics';
 import { endTrace, TraceName } from '../../../../../shared/lib/trace';
+import { useBatchSellHighRateAlertModal } from '../../hooks/useBatchSellHighRateAlertModal';
 import { SortingToolbar } from './components/sorting-toolbar';
 import { NetworkToolbar } from './components/network-toolbar';
 import { Header } from './components/header';
@@ -28,9 +24,7 @@ import { AssetList } from './components/asset-list';
 import { BatchSellEmptySelectTokens } from './components/batch-sell-empty-select-tokens';
 
 export const BatchSellSelectPage = () => {
-  const t = useI18nContext();
-  const { openBridgeExperience } = useBridging();
-  const { openModal, closeModal } = useBatchSellInfoModal();
+  const { openHighAlertModal } = useBatchSellHighRateAlertModal();
   const { navigateToBatchSellConfirmPage } = useBatchSellNavigation();
   const {
     selectedNetworkChainId,
@@ -122,61 +116,24 @@ export const BatchSellSelectPage = () => {
     [setSelectedAssetsId],
   );
 
-  const navigateToBridgePageAndPreselect = useCallback(() => {
-    closeModal();
-    const selectedAsset = availableBatchSellAssetsForNetworkList.find(
-      (asset) => asset.assetId === selectedAssetsId[0],
-    );
-    const sourceToken = selectedAsset
-      ? {
-          symbol: selectedAsset.symbol,
-          address: formatAddressToCaipReference(selectedAsset.assetId),
-          name: selectedAsset.name,
-          chainId: selectedAsset.chainId,
-        }
-      : undefined;
-
-    const destTokenAssetId = batchSellDestStablecoins[0];
-
-    transitionForward(() =>
-      openBridgeExperience(
-        MetaMetricsSwapsEventSource.MainView,
-        sourceToken,
-        destTokenAssetId,
-      ),
-    );
-  }, [
-    availableBatchSellAssetsForNetworkList,
-    batchSellDestStablecoins,
-    closeModal,
-    openBridgeExperience,
-    selectedAssetsId,
-  ]);
-
   const onSubmit = useCallback(() => {
     if (selectedAssetsId.length < MIN_SELECTED_ALLOWED_TOKENS) {
-      openModal({
-        titleProps: {
-          children: t('batchSellHighRateAlert'),
-        },
-        descriptionProps: {
-          children: t('batchSellHightRateAlertModalDescription'),
-        },
-        ctaProps: {
-          text: t('yesSwap'),
-          onClick: navigateToBridgePageAndPreselect,
-        },
-      });
+      const selectedAsset = availableBatchSellAssetsForNetworkList.find(
+        (asset) => asset.assetId === selectedAssetsId[0],
+      );
+      const destTokenAssetId = batchSellDestStablecoins[0];
+
+      openHighAlertModal(selectedAsset, destTokenAssetId);
       return;
     }
 
     transitionForward(navigateToBatchSellConfirmPage);
   }, [
     selectedAssetsId,
-    openModal,
     navigateToBatchSellConfirmPage,
-    navigateToBridgePageAndPreselect,
-    t,
+    availableBatchSellAssetsForNetworkList,
+    batchSellDestStablecoins,
+    openHighAlertModal,
   ]);
 
   if (!selectedNetworkChainId) {


### PR DESCRIPTION
## **Description**

Extracts the "high rate alert" modal logic that previously lived inline in
`batch-sell-select-page.tsx` into a new shared hook,
`useBatchSellHighRateAlertModal` (`ui/pages/batch-sell/hooks/useBatchSellHighRateAlertModal.ts`),
and reuses it on the review page as well.

**Reason for the change:** the high-rate alert warning was only ever shown at
asset-selection time (when the user tried to continue with fewer than
`MIN_SELECTED_ALLOWED_TOKENS` assets). If a user removed assets *after*
quotes had already been fetched and ended up on the review page with only
one asset still enabled to sell, they could hit "Review" and go straight to
the review-and-confirm modal without ever seeing that warning.

**Solution:**
- Added `useBatchSellHighRateAlertModal`, which wraps `useBatchSellInfoModal`,
  `useBridging`, the alert copy (`batchSellHighRateAlert` /
  `batchSellHightRateAlertModalDescription` / `yesSwap`), and the
  `formatAddressToCaipReference` + `transitionForward` navigation logic that
  used to live directly inside `batch-sell-select-page.tsx`.
- `batch-sell-select-page.tsx`'s `onSubmit` now calls
  `openHighAlertModal(selectedAsset, destTokenAssetId)` from the shared hook
  instead of assembling the modal props inline.
- `batch-sell-review-page.tsx`'s `onReviewClick` now counts how many
  `sendAssetsConfig` entries are `enabled`; if exactly one, it opens the same
  high-rate alert modal (via the shared hook) instead of opening the
  review-and-confirm modal. Otherwise (0 or 2+ enabled), it opens the
  review-and-confirm modal as before.
- Added `useBatchSellHighRateAlertModal.test.ts` and updated
  `batch-sell-select-page.test.tsx` and `batch-sell-review-page.test.tsx` to
  cover the new/changed behavior.

## **Changelog**

CHANGELOG entry: Added a high-rate alert warning when reviewing a batch sell with only one asset still selected to sell.

<!-- Alternatively, if this is considered internal/non-user-facing enough (e.g. still behind a flag, or the review-page case is rare/edge-case), use:
CHANGELOG entry: null
-->

## **Related issues**

Fixes: <!-- add ticket/issue number --> https://consensyssoftware.atlassian.net/browse/SWAPS-4766, https://github.com/MetaMask/metamask-extension/issues/43681

## **Manual testing steps**

1. Go to the batch sell select page and pick a network with 2+ eligible assets.
2. Select only **one** asset (below the minimum allowed), then submit.
3. Verify the high-rate alert modal appears with the same copy as before ("batchSellHighRateAlert" title, "Yes, swap" CTA).
4. Click "Yes, swap" and verify it closes the modal and navigates to the swap/bridge experience with the selected asset pre-filled as the source token and the network's destination stablecoin pre-filled as the destination.
5. Go back, select **two or more** assets, and continue to the review page as usual.
6. On the review page, delete/disable assets until exactly **one** remains enabled.
7. Click "Review" and verify the high-rate alert modal now appears here too (this is the new behavior), instead of the review-and-confirm modal.
8. Click "Yes, swap" from the review page and verify it navigates to swap/bridge with that single asset preselected, using the currently selected receive asset as the destination.
9. With **two or more** assets still enabled on the review page, click "Review" and verify the normal review-and-confirm modal opens as before (no high-rate alert modal).

## **Screenshots/Recordings**

### **Before**
### **After**


https://github.com/user-attachments/assets/7a754dba-0447-4b05-a1e7-17a91d36086a





## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when users are steered to swap/bridge vs batch review on a trading path; behavior is covered by new tests but affects fund-movement UX.
> 
> **Overview**
> Pulls the batch-sell **high-rate alert** (warning + “Yes, swap” → bridge with preselected tokens) out of the select page into **`useBatchSellHighRateAlertModal`**, and wires both flows through it.
> 
> On **review**, **Review** no longer always opens review-and-confirm: if **exactly one** asset is **enabled** in `sendAssetsConfig`, it opens the same alert (source asset + selected receive asset id); with zero or two+ enabled, behavior is unchanged. The select page still shows the alert when continuing with fewer than `MIN_SELECTED_ALLOWED_TOKENS` selected, but delegates to the hook instead of inline modal/bridge code.
> 
> Adds hook unit tests and extends select/review page tests for the new branching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 208f86f6a4bd0f47825da0c8d208fcc17fd07b3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->