### PR TITLE
test: refactor account-list page object to remove references to other page objects

### DIFF
--- a/test/e2e/flask/multi-srp/add-accounts.spec.ts
+++ b/test/e2e/flask/multi-srp/add-accounts.spec.ts
@@ -3,7 +3,10 @@ import { Driver } from '../../webdriver/driver';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { withFixtures } from '../../helpers';
 import { login } from '../../page-objects/flows/login.flow';
-import { importAdditionalSecretRecoveryPhrase } from '../../page-objects/flows/multi-srp.flow';
+import {
+  importAdditionalSecretRecoveryPhrase,
+  verifyAccountBelongsToSrp,
+} from '../../page-objects/flows/multi-srp.flow';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import AccountListPage from '../../page-objects/pages/account-list-page';
 import HomePage from '../../page-objects/pages/home/homepage';
@@ -25,7 +28,10 @@ const addAccountToSrp = async (driver: Driver, srpIndex: number) => {
   });
 
   await accountListPage.closeMultichainAccountsPage();
-  await accountListPage.checkAccountBelongsToSrp('Account 2', srpIndex + 1);
+  await verifyAccountBelongsToSrp(driver, {
+    accountName: 'Account 2',
+    srpIndex: srpIndex + 1,
+  });
 };
 
 describe('Multi SRP - Add accounts', function (this: Suite) {

--- a/test/e2e/flask/multi-srp/import-srp.spec.ts
+++ b/test/e2e/flask/multi-srp/import-srp.spec.ts
@@ -9,6 +9,7 @@ import { login } from '../../page-objects/flows/login.flow';
 import {
   importAdditionalSecretRecoveryPhrase,
   SECOND_TEST_E2E_SRP,
+  verifyAccountBelongsToSrp,
 } from '../../page-objects/flows/multi-srp.flow';
 import HeaderNavbar from '../../page-objects/pages/header-navbar';
 import AccountListPage from '../../page-objects/pages/account-list-page';
@@ -43,8 +44,10 @@ describe('Multi SRP - Import SRP', function (this: Suite) {
       async ({ driver }) => {
         await login(driver);
         await importAdditionalSecretRecoveryPhrase(driver);
-        const accountListPage = new AccountListPage(driver);
-        await accountListPage.checkAccountBelongsToSrp('Account 1', 2);
+        await verifyAccountBelongsToSrp(driver, {
+          accountName: 'Account 1',
+          srpIndex: 2,
+        });
       },
     );
   });

--- a/test/e2e/page-objects/flows/multi-srp.flow.ts
+++ b/test/e2e/page-objects/flows/multi-srp.flow.ts
@@ -56,3 +56,27 @@ export async function verifySrp(
   await privacySettings.fillPasswordToRevealSrp(WALLET_PASSWORD);
   await privacySettings.checkSrpTextIsDisplayed(srp);
 }
+
+/**
+ * Verifies that an account belongs to a given Secret Recovery Phrase by
+ * navigating to the SRP list in Security & Privacy settings.
+ *
+ * @param driver - The webdriver instance.
+ * @param options - Options for the verification.
+ * @param options.accountName - The name of the account expected under the SRP.
+ * @param options.srpIndex - The 1-based index of the Secret Recovery Phrase.
+ */
+export async function verifyAccountBelongsToSrp(
+  driver: Driver,
+  { accountName, srpIndex }: { accountName: string; srpIndex: number },
+): Promise<void> {
+  await new HeaderNavbar(driver).openSettingsPage();
+  const settingsPage = new SettingsPage(driver);
+  await settingsPage.checkPageIsLoaded();
+  await settingsPage.goToSecurityAndPasswordSettings();
+
+  const privacySettings = new PrivacySettings(driver);
+  await privacySettings.checkSecurityAndPasswordPageIsLoaded();
+  await privacySettings.openSrpList();
+  await privacySettings.checkAccountBelongsToSrp({ accountName, srpIndex });
+}

--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -2,9 +2,6 @@ import { Driver } from '../../webdriver/driver';
 import { largeDelayMs } from '../../helpers';
 import { quoteXPathText } from '../../../helpers/quoteXPathText';
 import { ACCOUNT_TYPE } from '../../constants';
-import PrivacySettings from './settings/privacy-settings';
-import HeaderNavbar from './header-navbar';
-import SettingsPage from './settings/settings-page';
 
 class AccountListPage {
   private readonly driver: Driver;
@@ -966,39 +963,6 @@ class AccountListPage {
     await this.openAccountDetailsModal(accountLabel);
     await this.driver.delay(500);
     await this.driver.clickElement(this.exportSrpButton);
-  }
-
-  async checkAccountBelongsToSrp(
-    accountName: string,
-    srpIndex: number,
-  ): Promise<void> {
-    console.log(`Check that current account is an imported account`);
-    await new HeaderNavbar(this.driver).openSettingsPage();
-    const settingsPage = new SettingsPage(this.driver);
-    await settingsPage.checkPageIsLoaded();
-    await settingsPage.goToSecurityAndPasswordSettings();
-
-    const privacySettings = new PrivacySettings(this.driver);
-    await privacySettings.checkSecurityAndPasswordPageIsLoaded();
-    await privacySettings.openSrpList();
-
-    if (srpIndex === 0) {
-      throw new Error('SRP index must be > 0');
-    }
-
-    const selectedSrp = await this.driver.waitForSelector({
-      css: '.select-srp__container',
-      text: `Secret Recovery Phrase ${srpIndex}`,
-    });
-    const showAccountsButton = await this.driver.waitForSelector(
-      `[data-testid="srp-list-show-accounts-${srpIndex - 1}"]`,
-    );
-    await showAccountsButton.click();
-
-    await this.driver.findNestedElement(selectedSrp, {
-      text: accountName,
-      tag: 'p',
-    });
   }
 
   async checkAccountNameIsDisplayed(accountName: string): Promise<void> {

--- a/test/e2e/page-objects/pages/settings/privacy-settings.ts
+++ b/test/e2e/page-objects/pages/settings/privacy-settings.ts
@@ -73,6 +73,16 @@ class PrivacySettings {
 
   private readonly selectSrpContainer = '[data-testid="select-srp-container"]';
 
+  private readonly selectSrpContainerItem = '.select-srp__container';
+
+  private readonly selectSrpContainerItemByIndex = (srpIndex: number) => ({
+    css: this.selectSrpContainerItem,
+    text: `Secret Recovery Phrase ${srpIndex.toString()}`,
+  });
+
+  private readonly srpShowAccountsButtonByIndex = (srpIndex: number) =>
+    `[data-testid="srp-list-show-accounts-${srpIndex - 1}"]`;
+
   private readonly privacyTabButton =
     '[data-testid="settings-tab-item-privacy"]';
 
@@ -341,12 +351,56 @@ class PrivacySettings {
   async openRevealSrpQuiz(srpIndex: number = 1): Promise<void> {
     await this.openSrpList();
     await this.driver.waitForSelector(this.selectSrpContainer);
-    await this.driver.clickElement({
-      css: '.select-srp__container',
-      text: `Secret Recovery Phrase ${srpIndex.toString()}`,
-    });
+    await this.driver.clickElement(
+      this.selectSrpContainerItemByIndex(srpIndex),
+    );
 
     await this.driver.waitForSelector(this.revealSrpQuizModalTitle);
+  }
+
+  /**
+   * Check that an account belongs to a given SRP in the SRP list.
+   *
+   * @param options - Options for the verification.
+   * @param options.accountName - The name of the account expected under the SRP.
+   * @param options.srpIndex - The 1-based index of the Secret Recovery Phrase.
+   */
+  async checkAccountBelongsToSrp({
+    accountName,
+    srpIndex,
+  }: {
+    accountName: string;
+    srpIndex: number;
+  }): Promise<void> {
+    console.log(
+      `Check that account ${accountName} belongs to Secret Recovery Phrase ${srpIndex}`,
+    );
+    if (srpIndex < 1) {
+      throw new Error('SRP index must be > 0');
+    }
+
+    await this.driver.waitForSelector(
+      this.selectSrpContainerItemByIndex(srpIndex),
+    );
+    await this.driver.clickElement(this.srpShowAccountsButtonByIndex(srpIndex));
+
+    await this.driver.waitUntil(
+      async () => {
+        try {
+          const selectedSrp = await this.driver.findElement(
+            this.selectSrpContainerItemByIndex(srpIndex),
+          );
+          await this.driver.findNestedElement(selectedSrp, {
+            text: accountName,
+            tag: 'p',
+          });
+          return true;
+        } catch {
+          return false;
+        }
+      },
+      { interval: 500, timeout: this.driver.timeout },
+    );
   }
 
   /**


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix anti-patterns in the account-list page where we are referencing other page objects.
We shouldn't reference a page object inside another page object. If we need to use multiple page objects to complete some steps, we just be using a flow file

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-2073

## **Manual testing steps**

1. ci continues to pass

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only page-object refactor with no production or wallet logic changes; behavior should match prior E2E assertions with minor stability improvements.
> 
> **Overview**
> **Refactors multi-SRP E2E page-object boundaries** so account-list no longer drives Settings/Security navigation to assert which SRP owns an account.
> 
> `AccountListPage.checkAccountBelongsToSrp` is removed along with its imports of `HeaderNavbar`, `SettingsPage`, and `PrivacySettings`. That check moves to **`verifyAccountBelongsToSrp`** in `multi-srp.flow.ts`, which opens Settings → Security & Privacy, opens the SRP list, and delegates to **`PrivacySettings.checkAccountBelongsToSrp`**. Multi-SRP specs (`add-accounts`, `import-srp`) call the flow helper instead of the account-list page.
> 
> On **Privacy settings**, SRP list interactions gain shared locators (`selectSrpContainerItemByIndex`, `srpShowAccountsButtonByIndex`); `openRevealSrpQuiz` uses them. The new `checkAccountBelongsToSrp` validates `srpIndex >= 1`, expands the SRP’s accounts, and waits with `waitUntil` until the account name appears under that phrase—slightly more resilient than the old nested find.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83da0bc296f72750a863a8fee93470013d708a6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->