### PR TITLE
feat: setup for new defi flag

### DIFF
--- a/.github/scripts/known-feature-flag-constants.mts
+++ b/.github/scripts/known-feature-flag-constants.mts
@@ -57,6 +57,11 @@ const FILE_SOURCES: Array<{
     file: 'shared/lib/transaction/pay-prefill.ts',
     exportName: 'PAY_EXTENDED_FEATURE_FLAG',
   },
+  {
+    key: 'DEFI_CONTROLLER_V2_FLAG',
+    file: 'shared/lib/defi-controller-v2/remote-feature-flag.ts',
+    exportName: 'DEFI_CONTROLLER_V2_FLAG',
+  },
 ];
 
 /**

--- a/shared/lib/defi-controller-v2/remote-feature-flag.test.ts
+++ b/shared/lib/defi-controller-v2/remote-feature-flag.test.ts
@@ -1,0 +1,29 @@
+import {
+  isDefiControllerV2Enabled,
+  type DefiControllerV2FeatureFlag,
+} from './remote-feature-flag';
+
+describe('isDefiControllerV2Enabled', () => {
+  it('returns false when featureFlag is undefined', () => {
+    expect(isDefiControllerV2Enabled(undefined)).toBe(false);
+  });
+
+  it('returns false when featureFlag is null', () => {
+    expect(isDefiControllerV2Enabled(null)).toBe(false);
+  });
+
+  it('returns false when enabled is false', () => {
+    const featureFlag: DefiControllerV2FeatureFlag = { enabled: false };
+    expect(isDefiControllerV2Enabled(featureFlag)).toBe(false);
+  });
+
+  it('returns false when enabled is absent', () => {
+    const featureFlag: DefiControllerV2FeatureFlag = {};
+    expect(isDefiControllerV2Enabled(featureFlag)).toBe(false);
+  });
+
+  it('returns true when enabled is true', () => {
+    const featureFlag: DefiControllerV2FeatureFlag = { enabled: true };
+    expect(isDefiControllerV2Enabled(featureFlag)).toBe(true);
+  });
+});

--- a/shared/lib/defi-controller-v2/remote-feature-flag.ts
+++ b/shared/lib/defi-controller-v2/remote-feature-flag.ts
@@ -1,0 +1,68 @@
+/**
+ * Client-config / RemoteFeatureFlagController key (camelCase). LaunchDarkly
+ * may use a kebab-case key that is converted before it reaches the extension.
+ */
+export const DEFI_CONTROLLER_V2_FLAG = 'defiControllerV2';
+
+/**
+ * Shape of the `defiControllerV2` remote feature flag after it has been
+ * resolved by `RemoteFeatureFlagController`. The controller processes the raw
+ * version-scoped / threshold format and stores only the matching value
+ * (e.g. `{ enabled: true }`).
+ *
+ * Raw remote config template (version gating + threshold rollout). Version
+ * keys are minimum SemVer floors; the highest key `<=` the client version is
+ * selected, then threshold arrays are bucketed. With `thresholdVersion: 2`,
+ * the selected entry's `value` is stored directly (not wrapped as
+ * `{ name, value }`). `scope.value` is cumulative in `[0, 1]` (e.g. `0.1` =
+ * 10% of users).
+ *
+ * @example
+ * ```json
+ * {
+ *   "versions": {
+ *     "13.41.0": {
+ *       "enabled": false
+ *     },
+ *     "13.42.0": [
+ *       {
+ *         "scope": {
+ *           "type": "threshold",
+ *           "value": 0.1
+ *         },
+ *         "thresholdName": "feature is ON for 10% of users",
+ *         "thresholdVersion": 2,
+ *         "value": {
+ *           "enabled": true
+ *         }
+ *       },
+ *       {
+ *         "scope": {
+ *           "type": "threshold",
+ *           "value": 1
+ *         },
+ *         "thresholdName": "feature is OFF for remaining users",
+ *         "thresholdVersion": 2,
+ *         "value": {
+ *           "enabled": false
+ *         }
+ *       }
+ *     ]
+ *   }
+ * }
+ * ```
+ */
+export type DefiControllerV2FeatureFlag = {
+  enabled?: boolean;
+};
+
+/**
+ * Shared helper to check whether the defiControllerV2 feature is enabled.
+ * Keeps background and UI gating logic in sync.
+ *
+ * @param featureFlag - The defiControllerV2 feature flag.
+ * @returns boolean - True if the feature is enabled, false otherwise.
+ */
+export const isDefiControllerV2Enabled = (
+  featureFlag: DefiControllerV2FeatureFlag | undefined | null,
+): boolean => Boolean(featureFlag?.enabled);

--- a/test/e2e/feature-flags/feature-flag-registry.ts
+++ b/test/e2e/feature-flags/feature-flag-registry.ts
@@ -222,6 +222,20 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
+  defiControllerV2: {
+    name: 'defiControllerV2',
+    type: FeatureFlagType.Remote,
+    inProd: false,
+    productionDefault: {
+      versions: {
+        '13.41.0': {
+          enabled: false,
+        },
+      },
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
   assetsEnableNotificationsByDefault: {
     name: 'assetsEnableNotificationsByDefault',
     type: FeatureFlagType.Remote,

--- a/ui/selectors/defi-controller-v2/feature-flags.test.ts
+++ b/ui/selectors/defi-controller-v2/feature-flags.test.ts
@@ -1,0 +1,79 @@
+import { DEFI_CONTROLLER_V2_FLAG } from '../../../shared/lib/defi-controller-v2/remote-feature-flag';
+import {
+  getDefiControllerV2RemoteFeatureFlag,
+  getIsDefiControllerV2Enabled,
+} from './feature-flags';
+
+const buildState = (
+  remoteFeatureFlags: Record<string, unknown> = {},
+): { metamask: { remoteFeatureFlags: Record<string, unknown> } } => ({
+  metamask: {
+    remoteFeatureFlags,
+  },
+});
+
+describe('DeFi Controller V2 Feature Flags', () => {
+  describe('getDefiControllerV2RemoteFeatureFlag', () => {
+    it('returns the feature flag when it exists and is valid', () => {
+      expect(
+        getDefiControllerV2RemoteFeatureFlag(
+          buildState({
+            [DEFI_CONTROLLER_V2_FLAG]: { enabled: true },
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          }) as any,
+        ),
+      ).toEqual({
+        enabled: true,
+      });
+    });
+
+    it('returns undefined when feature flag does not exist', () => {
+      expect(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        getDefiControllerV2RemoteFeatureFlag(buildState() as any),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined when feature flag has invalid structure', () => {
+      expect(
+        getDefiControllerV2RemoteFeatureFlag(
+          buildState({
+            [DEFI_CONTROLLER_V2_FLAG]: { invalid: 'structure' },
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          }) as any,
+        ),
+      ).toBeUndefined();
+    });
+  });
+
+  describe('getIsDefiControllerV2Enabled', () => {
+    it('returns true when enabled is true', () => {
+      expect(
+        getIsDefiControllerV2Enabled(
+          buildState({
+            [DEFI_CONTROLLER_V2_FLAG]: { enabled: true },
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          }) as any,
+        ),
+      ).toBe(true);
+    });
+
+    it('returns false when enabled is false', () => {
+      expect(
+        getIsDefiControllerV2Enabled(
+          buildState({
+            [DEFI_CONTROLLER_V2_FLAG]: { enabled: false },
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          }) as any,
+        ),
+      ).toBe(false);
+    });
+
+    it('returns false when feature flag is absent', () => {
+      expect(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        getIsDefiControllerV2Enabled(buildState() as any),
+      ).toBe(false);
+    });
+  });
+});

--- a/ui/selectors/defi-controller-v2/feature-flags.ts
+++ b/ui/selectors/defi-controller-v2/feature-flags.ts
@@ -1,0 +1,61 @@
+import {
+  Infer,
+  object,
+  boolean,
+  optional,
+  assert,
+} from '@metamask/superstruct';
+import {
+  getRemoteFeatureFlags,
+  type RemoteFeatureFlagsState,
+} from '../../../shared/lib/selectors/remote-feature-flags';
+import {
+  DEFI_CONTROLLER_V2_FLAG,
+  isDefiControllerV2Enabled,
+} from '../../../shared/lib/defi-controller-v2/remote-feature-flag';
+
+/**
+ * Feature flag structure for the defiControllerV2 remote flag.
+ */
+const DefiControllerV2FeatureFlag = object({
+  enabled: optional(boolean()),
+});
+
+/**
+ * Feature flag type for the defiControllerV2 remote flag.
+ */
+export type DefiControllerV2FeatureFlagType = Infer<
+  typeof DefiControllerV2FeatureFlag
+>;
+
+/**
+ * Selector to get the defiControllerV2 remote feature flag.
+ *
+ * @param state - The MetaMask state object
+ * @returns The feature flag for defiControllerV2, or undefined if not set.
+ */
+export const getDefiControllerV2RemoteFeatureFlag = (
+  state: RemoteFeatureFlagsState,
+): DefiControllerV2FeatureFlagType | undefined => {
+  try {
+    const defiControllerV2FeatureFlag =
+      getRemoteFeatureFlags(state)[DEFI_CONTROLLER_V2_FLAG];
+
+    assert(defiControllerV2FeatureFlag, DefiControllerV2FeatureFlag);
+
+    return defiControllerV2FeatureFlag;
+  } catch (error) {
+    return undefined;
+  }
+};
+
+/**
+ * Selector to check if the defiControllerV2 feature is enabled.
+ *
+ * @param state - The MetaMask state object
+ * @returns True if the feature is enabled, false otherwise.
+ */
+export const getIsDefiControllerV2Enabled = (
+  state: RemoteFeatureFlagsState,
+): boolean =>
+  isDefiControllerV2Enabled(getDefiControllerV2RemoteFeatureFlag(state));


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

This PR just adds the new feature flag for DeFi to the registry. It does not start using it yet, that will come in subsequent PRs.

The flag supports minimum version and progressive rollout.

Splitting the PR for code reviewing to be easier and nicely split by codeowners.

Follow up PR (that will also be split) here: https://github.com/MetaMask/metamask-extension/pull/44392/changes

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3599

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive flag plumbing and tests only; defaults keep the feature off and nothing in the diff wires it into runtime DeFi flows yet.
> 
> **Overview**
> Introduces **remote feature-flag infrastructure** for **DeFi Controller V2** (`defiControllerV2`) ahead of follow-up PRs that will actually gate behavior.
> 
> Adds `shared/lib/defi-controller-v2/remote-feature-flag.ts` with the flag key `DEFI_CONTROLLER_V2_FLAG`, a resolved `{ enabled?: boolean }` type, and `isDefiControllerV2Enabled` so background and UI can share the same check. UI Redux selectors in `ui/selectors/defi-controller-v2/feature-flags.ts` read and validate the flag from `remoteFeatureFlags`.
> 
> Registers the flag in the **E2E feature-flag registry** with `inProd: false` and a version-scoped default (`13.41.0` → `enabled: false`), and adds `DEFI_CONTROLLER_V2_FLAG` to **known-feature-flag-constants** for CI registry checks. Unit tests cover the helper and selectors.
> 
> **No product code consumes the flag in this PR**—it only prepares rollout (including documented version + threshold rollout shape).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af59d855a48526dfb5cede9ddb2d59401affda05. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->