### PR TITLE
chore: use same toaster-bottom-offset var for legacy toasts

### DIFF
--- a/ui/components/multichain/toast/index.scss
+++ b/ui/components/multichain/toast/index.scss
@@ -2,7 +2,7 @@
 
 .toasts-container {
   position: fixed;
-  bottom: 16px;
+  bottom: var(--toaster-bottom-offset, 16px);
   left: 0;
   right: 0;
   margin-left: auto;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Use the same offset for the bottom of legacy toasts so that they sit above footer bars when present (e.g. cta footer, dapp connection bar, bottom nav bar, etc). Same styles as the newer toasts which the old ones are currently being migrated to.

### On bottom-nav routes

| Toast | Component | File | Route(s) | After |
|---|---|---|---|---|
| Permitted network ("has access to X") — screenshot | `PermittedNetworkToast` | `ui/components/app/toast-master/toast-master.js` | Home | 80 / 148px |
| Survey | `SurveyToast` | `ui/components/ui/survey-toast/survey-toast.tsx` | Home | 80 / 148px |
| Privacy policy | `PrivacyPolicyToast` | `ui/components/app/toast-master/toast-master.js` | Home | 80 / 148px |
| Infura → MetaMask default switch | `InfuraSwitchToast` | `ui/components/app/toast-master/toast-master.js` | Home | 80 / 148px |
| Shield payment paused | `ShieldPausedToast` | `ui/components/app/toast-master/toast-master.js` | Home | 80 / 148px |
| Shield coverage ending | `ShieldEndingToast` | `ui/components/app/toast-master/toast-master.js` | Home | 80 / 148px |
| Side-panel migration | `SidePanelMigrationToast` | `ui/components/app/toast-master/toast-master.js` | Home (side panel) | 80 / 148px |
| Perps withdraw | `PerpsWithdrawToast` | `ui/components/app/perps/perps-withdraw-toast.tsx` | Home, Perps | 80 / 148px |
| Storage write error | `StorageErrorToast` | `ui/components/app/toast-master/toast-master.js` | Home, Perps, Settings, any screen | 80px where nav/footer present |
| Bridge "block explorer link copied" | inline `Toast` | `ui/pages/bridge/prepare/prepare-bridge-page.tsx` | Swaps | 80px |
| Perps order/position toasts | `PerpsToastProvider` | `ui/components/app/perps/perps-toast/perps-toast-provider.tsx` | Perps screens + modals | now driven by variable; its `bottom-20` was already dead code |

### Not on bottom-nav routes (also affected — now clear a footer instead of overlapping it)

| Toast | Component | File | Route |
|---|---|---|---|
| SRP revealed / success | inline `Toast` | `ui/pages/keychains/reveal-seed.tsx` | Reveal SRP |
| Contact deleted / updated | inline `Toast` | `ui/pages/contacts/contacts-list-page.tsx` | Contacts |
| Download state logs error | inline `Toast` | `ui/pages/settings/privacy-tab/download-state-logs-item.tsx` | Settings |
| Cancel/speed-up error | `CancelSpeedupErrorToast` | `ui/pages/confirmations/components/cancel-speedup-toast/cancel-speedup-error-toast.tsx` | Cancel/Speed-up (portal) |
| Asset activation error | `AssetActivationErrorToast` | `ui/pages/asset/components/asset-activation-error-toast.tsx` | Asset |
| Rewards error | `RewardsErrorToast` | `ui/components/app/rewards/RewardsErrorToast.tsx` | Rewards |

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Raise legacy toasts over footers when applicable

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="1151" height="308" alt="image" src="https://github.com/user-attachments/assets/232272ef-0193-4d2a-ad79-6636e284f238" />

### **After**

<img width="476" height="758" alt="image 6" src="https://github.com/user-attachments/assets/8a5d4064-f446-4aed-9bee-1ca460fa9084" />

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single SCSS property change with no logic or data impact; behavior only affects toast layout when UI chrome is present.
> 
> **Overview**
> Legacy multichain toast positioning now uses **`--toaster-bottom-offset`** (default **16px**) instead of a hardcoded **`bottom: 16px`**, matching the react-hot-toast stack in the same stylesheet.
> 
> When footers, the dapp connection bar, or bottom nav are present, the existing **`:root:has(...)`** rules raise that variable to **80px** or **148px**, so legacy toasts sit above those chrome layers instead of overlapping them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76879c49c23421e3902af3b67456698121430595. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->