### PR TITLE
chore: skip linting Jest snapshots

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -495,7 +495,6 @@ module.exports = {
      */
     {
       files: [
-        '**/__snapshots__/*.snap',
         'app/scripts/controllers/app-state-controller.test.ts',
         'app/scripts/controllers/alert-controller.test.ts',
         'app/scripts/metamask-controller.actions.test.js',
@@ -533,13 +532,6 @@ module.exports = {
 
         // Static hex values are only discouraged in application code, using them in tests is OK.
         '@metamask/design-tokens/color-no-hex': 'off',
-
-        // *.snap files weren't parsed by previous versions of this eslint
-        // config section, but something got fixed somewhere, and now this rule
-        // causes failures. We need to turn it off instead of fix them because
-        // we aren't even remotely close to being in alignment. If it bothers
-        // you open a PR to fix it yourself.
-        'jest/no-large-snapshots': 'off',
         'jest/no-restricted-matchers': 'off',
 
         /**

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,6 +1,7 @@
 *.scss
 .nyc_output/**/*
 node_modules/**/*
+__snapshots__/**/*
 # Exclude lottie json files
 /app/images/animations/**/*.json
 /app/vendor/**


### PR DESCRIPTION
## **Description**

Jest snapshots are automatically generated, and the one rule that applies to them is disabled in our configuration
(`jest/no-large-snapshots`). Given that, there's no point in linting them with ESLint. They are now ignored.

This should make the `lint` command marginally faster, and it helps unblock the ESLint v9 upgrade (there were some snapshot-related errors that this lets me bypass).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

The CI lint step should be sufficient to test this change.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only ignore and config cleanup with no runtime or application behavior changes.
> 
> **Overview**
> Stops ESLint from processing Jest snapshot files by adding **`__snapshots__/**/*`** to **`.prettierignore`**, which ESLint already mirrors via **`ignorePatterns`**.
> 
> The Jest ESLint override no longer lists snapshot globs or disables **`jest/no-large-snapshots`**, since snapshots are excluded entirely. This should slightly speed up **`lint`** and avoid snapshot-related failures during the ESLint v9 upgrade.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54c783663b337296b794b91bab50b05ba41c8ea3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->