### PR TITLE
chore: remove unused ESLint ignore directives from test directory

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -21,7 +21,6 @@ const queryClient = new QueryClient({
   defaultOptions: { queries: { retry: false } },
 });
 
-// eslint-disable-next-line
 /* @ts-expect-error: Avoids error from window property not existing */
 window.metamaskFeatureFlags = {};
 

--- a/test/data/mock-data.js
+++ b/test/data/mock-data.js
@@ -1,4 +1,3 @@
-/* eslint-disable @metamask/design-tokens/color-no-hex*/
 const TOKENS_API_MOCK_RESULT = [
   {
     name: 'Ethereum',

--- a/test/e2e/flask/multichain-api/evm/wallet_notify.spec.ts
+++ b/test/e2e/flask/multichain-api/evm/wallet_notify.spec.ts
@@ -34,8 +34,6 @@ describe('Calling `eth_subscribe` on a particular network event', function () {
          * Currently we don't have `data-testid` setup for the desired result, so we click on all available results
          * to make the complete text available and later evaluate if scopes match.
          */
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         // TODO: temporarily leave this line in place, will migrate to POM once the ticket is resolved
         const resultSummaries = await driver.findElements('.result-summary');
         resultSummaries.forEach(async (element) => await element.click());

--- a/test/e2e/helpers/seedless-onboarding/mocks.ts
+++ b/test/e2e/helpers/seedless-onboarding/mocks.ts
@@ -228,7 +228,6 @@ export class OAuthMockttpService {
   ) {
     const userEmail = overrides?.userEmail || `e2e-user-${crypto.randomUUID()}`;
     const jsonRpcRequestBody = await request.body.getJson();
-    // eslint-disable-next-line camelcase
     const { grant_type: grantType } = jsonRpcRequestBody as {
       grant_type: string;
     };
@@ -271,23 +270,11 @@ export class OAuthMockttpService {
     return {
       statusCode: 200,
       json: {
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         access_token: accessToken,
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         id_token: idToken,
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         expires_in: 3600,
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         refresh_token: 'mock-refresh-token',
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         revoke_token: 'mock-revoke-token',
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         metadata_access_token: idToken,
       },
     };
@@ -341,11 +328,7 @@ export class OAuthMockttpService {
     return {
       statusCode: 200,
       json: {
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         refresh_token: 'new-mock-refresh-token',
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         revoke_token: 'new-mock-revoke-token',
       },
     };
@@ -363,23 +346,11 @@ export class OAuthMockttpService {
     return {
       statusCode: 200,
       json: {
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         access_token: accessToken,
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         id_token: idToken,
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         expires_in: 3600,
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         refresh_token: 'mock-refresh-token',
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         revoke_token: 'mock-revoke-token',
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         metadata_access_token: idToken,
       },
     };
@@ -425,8 +396,6 @@ export class OAuthMockttpService {
     return {
       statusCode: 200,
       json: {
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         access_token: 'mocked-oidc-access-token',
       },
     };

--- a/test/e2e/lavamoat-stats.js
+++ b/test/e2e/lavamoat-stats.js
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-/* eslint-disable n/hashbang */
 const path = require('path');
 const { promises: fs, constants: fsConstants } = require('fs');
 const yargs = require('yargs/yargs');

--- a/test/e2e/run-api-specs-multichain.ts
+++ b/test/e2e/run-api-specs-multichain.ts
@@ -27,7 +27,7 @@ import { MultichainAuthorizationConfirmationErrors } from './api-specs/Multichai
 import { ConfirmationsRejectRule } from './api-specs/ConfirmationRejectionRule';
 import { login } from './page-objects/flows/login.flow';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const mockServer = require('@open-rpc/mock-server/build/index').default;
 
 async function main() {

--- a/test/e2e/run-openrpc-api-test-coverage.ts
+++ b/test/e2e/run-openrpc-api-test-coverage.ts
@@ -18,7 +18,7 @@ import { DAPP_URL, ACCOUNT_1 } from './constants';
 import transformOpenRPCDocument from './api-specs/transform';
 import { login } from './page-objects/flows/login.flow';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const mockServer = require('@open-rpc/mock-server/build/index').default;
 
 async function main() {

--- a/test/e2e/snaps/test-snap-installed.spec.ts
+++ b/test/e2e/snaps/test-snap-installed.spec.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 import { MockedEndpoint, Mockttp } from 'mockttp';
 import FixtureBuilderV2 from '../fixtures/fixture-builder-v2';
 import { Driver } from '../webdriver/driver';

--- a/test/e2e/tests/bridge/swap-positive-cases.spec.ts
+++ b/test/e2e/tests/bridge/swap-positive-cases.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import { strict as assert } from 'assert';
 import { Suite } from 'mocha';
 import { Mockttp } from 'mockttp';

--- a/test/e2e/tests/confirmations/transactions/contract-deployment-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/contract-deployment-redesign.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
 import { WINDOW_TITLES } from '../../../constants';
 import { login } from '../../../page-objects/flows/login.flow';
 import ContractDeploymentConfirmation from '../../../page-objects/pages/confirmations/deploy-confirmation';

--- a/test/e2e/tests/confirmations/transactions/contract-interaction-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/contract-interaction-redesign.spec.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 import { Mockttp } from 'mockttp';
 import { NETWORK_CLIENT_ID, WINDOW_TITLES } from '../../../constants';
 import { withFixtures } from '../../../helpers';

--- a/test/e2e/tests/confirmations/transactions/erc1155-revoke-set-approval-for-all-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/erc1155-revoke-set-approval-for-all-redesign.spec.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 import { TransactionEnvelopeType } from '@metamask/transaction-controller';
 import { Mockttp } from '../../../mock-e2e';
 import { setTokenPermissions } from '../../../page-objects/flows/token-dapp-transactions.flow';

--- a/test/e2e/tests/confirmations/transactions/erc1155-set-approval-for-all-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/erc1155-set-approval-for-all-redesign.spec.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 import { TransactionEnvelopeType } from '@metamask/transaction-controller';
 import { Mockttp } from '../../../mock-e2e';
 import { login } from '../../../page-objects/flows/login.flow';

--- a/test/e2e/tests/confirmations/transactions/erc20-approve-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/erc20-approve-redesign.spec.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 import { MockttpServer } from 'mockttp';
 import { WINDOW_TITLES } from '../../../constants';
 import { withFixtures } from '../../../helpers';

--- a/test/e2e/tests/confirmations/transactions/erc721-revoke-set-approval-for-all-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/erc721-revoke-set-approval-for-all-redesign.spec.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 import { TransactionEnvelopeType } from '@metamask/transaction-controller';
 import { Mockttp } from '../../../mock-e2e';
 import { login } from '../../../page-objects/flows/login.flow';

--- a/test/e2e/tests/confirmations/transactions/erc721-set-approval-for-all-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/erc721-set-approval-for-all-redesign.spec.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
+/* eslint-disable @typescript-eslint/no-require-imports */
 import { TransactionEnvelopeType } from '@metamask/transaction-controller';
 import { Mockttp } from '../../../mock-e2e';
 import { Anvil } from '../../../seeder/anvil';

--- a/test/e2e/tests/confirmations/transactions/metrics.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/metrics.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
 import { strict as assert } from 'assert';
 import { MockedEndpoint, MockttpServer } from 'mockttp';
 import { TransactionMetaMetricsEvent } from '../../../../../shared/constants/transaction';

--- a/test/e2e/tests/confirmations/transactions/speed-up-and-cancel-confirmations.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/speed-up-and-cancel-confirmations.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
 import { Hex } from '@metamask/utils';
 import { decimalToPrefixedHex } from '../../../../../shared/lib/conversion.utils';
 import { login } from '../../../page-objects/flows/login.flow';

--- a/test/e2e/tests/confirmations/transactions/transaction-decoding-redesign.spec.ts
+++ b/test/e2e/tests/confirmations/transactions/transaction-decoding-redesign.spec.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
 import { MockttpServer } from 'mockttp';
 import { CHAIN_IDS } from '@metamask/transaction-controller';
 import { DAPP_URL, NETWORK_CLIENT_ID, WINDOW_TITLES } from '../../../constants';

--- a/test/e2e/tests/metrics/wallet-imported.spec.ts
+++ b/test/e2e/tests/metrics/wallet-imported.spec.ts
@@ -64,8 +64,6 @@ describe('Wallet Created Events - Imported Account', function () {
         const appInstallBackground = [
           [
             (req: {
-              // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               properties: {
                 category: string;
                 locale: string;
@@ -88,8 +86,6 @@ describe('Wallet Created Events - Imported Account', function () {
         const appInstallFullscreen = [
           [
             (req: {
-              // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               properties: {
                 category: string;
                 locale: string;

--- a/test/e2e/tests/perps/perps-fixture-config.ts
+++ b/test/e2e/tests/perps/perps-fixture-config.ts
@@ -23,7 +23,6 @@ const PROD_REMOTE_FLAGS = getProductionRemoteFlagDefaults();
 const {
   // Omitted from generic Perps manifest flags because the production payload is
   // large and the withdraw confirmation tests provide a small explicit override.
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   confirmations_pay_post_quote: _confirmationsPayPostQuote,
   ...PERPS_PROD_REMOTE_FLAGS
 } = PROD_REMOTE_FLAGS;

--- a/test/e2e/tests/ppom/ppom-toggle-settings.spec.ts
+++ b/test/e2e/tests/ppom/ppom-toggle-settings.spec.ts
@@ -11,7 +11,7 @@ import SettingsPage from '../../page-objects/pages/settings/settings-page';
 import TestDapp from '../../page-objects/pages/test-dapp';
 
 describe('PPOM Settings', function (this: Suite) {
-  // eslint-disable-next-line mocha/no-skipped-tests, mocha/handle-done-callback
+  // eslint-disable-next-line mocha/no-skipped-tests
   it.skip('should not show the PPOM warning when toggle is off', async function () {
     await withFixtures(
       {
@@ -49,7 +49,7 @@ describe('PPOM Settings', function (this: Suite) {
     );
   });
 
-  // eslint-disable-next-line mocha/no-skipped-tests, mocha/handle-done-callback
+  // eslint-disable-next-line mocha/no-skipped-tests
   it.skip('should show the PPOM warning when the toggle is on', async function () {
     await withFixtures(
       {

--- a/test/e2e/tests/solana/common-solana.ts
+++ b/test/e2e/tests/solana/common-solana.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-loss-of-precision */
 import { ReadableStream as ReadableStreamWeb } from 'stream/web';
 import { Readable } from 'stream';
 import * as fs from 'fs/promises';
@@ -1528,7 +1527,6 @@ export async function mockGetAccountInfoDevnet(mockServer: Mockttp) {
           executable: false,
           lamports: 1124837338893,
           owner: 'TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA',
-          // eslint-disable-next-line @typescript-eslint/no-loss-of-precision
           rentEpoch: 18446744073709551615,
           space: 82,
         },

--- a/test/helpers/file.js
+++ b/test/helpers/file.js
@@ -1,4 +1,3 @@
-/* eslint-disable n/hashbang */
 const path = require('path');
 const { promises: fs, constants: fsConstants } = require('fs');
 

--- a/test/integration/config/setup.js
+++ b/test/integration/config/setup.js
@@ -11,8 +11,6 @@ const path = require('path');
 require('../../helpers/setup-helper');
 
 // Fetch
-// fetch is part of node js in future versions, thus triggering no-shadow
-// eslint-disable-next-line no-shadow
 const { default: fetch, Headers, Request, Response } = require('node-fetch');
 
 const handleRelativePathRequest = async (url, localeRelativePathRequest) => {

--- a/test/integration/confirmations/transactions/increase-approval.test.tsx
+++ b/test/integration/confirmations/transactions/increase-approval.test.tsx
@@ -45,7 +45,6 @@ const getMetaMaskStateWithUnapprovedIncreaseApprovalTransaction = () => {
     },
     pendingApprovalCount: 1,
     knownMethodData: {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       '0xd73dd623': {
         name: 'increaseApproval',
         params: [

--- a/test/release-testing-ai-analyzer/llm_providers/claude-analyzer.ts
+++ b/test/release-testing-ai-analyzer/llm_providers/claude-analyzer.ts
@@ -2,7 +2,6 @@
  * Claude API integration for analyzing PR changes and generating testing scenarios
  */
 
-// eslint-disable-next-line import-x/no-named-as-default
 import Anthropic from '@anthropic-ai/sdk';
 import type {
   PullRequestInfo,

--- a/test/release-testing-ai-analyzer/llm_providers/gemini-analyzer.ts
+++ b/test/release-testing-ai-analyzer/llm_providers/gemini-analyzer.ts
@@ -58,7 +58,6 @@ export class GeminiAnalyzer implements LLMAnalyzer {
         );
       }
       // Use dynamic import for ESM module (devDependency for release-testing tooling)
-      // eslint-disable-next-line import-x/no-extraneous-dependencies
       const { GoogleGenAI } = await import('@google/genai');
       this.client = new GoogleGenAI({ apiKey: this.apiKey }) as GoogleGenAI;
     }

--- a/test/release-testing-ai-analyzer/llm_providers/openai-analyzer.ts
+++ b/test/release-testing-ai-analyzer/llm_providers/openai-analyzer.ts
@@ -2,7 +2,6 @@
  * OpenAI GPT API integration for analyzing PR changes and generating testing scenarios
  */
 
-// eslint-disable-next-line import-x/no-named-as-default
 import OpenAI from 'openai';
 import type {
   PullRequestInfo,

--- a/test/release-testing-ai-analyzer/utils/github-client.ts
+++ b/test/release-testing-ai-analyzer/utils/github-client.ts
@@ -94,7 +94,6 @@ type Octokit = {
       }>;
     };
   };
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   paginate: <TItem>(
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     fn: (params: any) => Promise<{ data: TItem[] }>,

--- a/test/unit-global/check-ab-testing-compliance.test.ts
+++ b/test/unit-global/check-ab-testing-compliance.test.ts
@@ -2,7 +2,6 @@
  * @jest-environment node
  */
 
-/* eslint-disable import-x/no-nodejs-modules */
 import { spawnSync } from 'child_process';
 import {
   appendFileSync,

--- a/types/react.d.ts
+++ b/types/react.d.ts
@@ -1,5 +1,4 @@
 declare namespace React {
-  /* eslint-disable-next-line import-x/no-extraneous-dependencies */
   import * as CSS from 'csstype';
 
   // Add custom CSS properties so that they can be used in `style` props


### PR DESCRIPTION
## **Description**

Unused ESLint ignore directives have been removed from the `test` and `.storybook` directories.

This helps unblock the ESLint v9 upgrade (it complains about unused directives by default).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

The CI lint step should be sufficient to test this change.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only lint hygiene with no production code paths modified; remaining risk is CI lint failing if any removed directive was still needed.
> 
> **Overview**
> Removes **unused `eslint-disable` comments** across `.storybook`, `test/`, and `types/react.d.ts` so lint stays clean ahead of **ESLint v9**, which reports unused disable directives by default.
> 
> Most edits are comment-only: dropped file-level disables (e.g. `@metamask/design-tokens/color-no-hex`, `n/hashbang`, `@typescript-eslint/no-require-imports` / `no-var-requires` pairs) and line-level suppressions that no longer match any rule. In **seedless-onboarding mocks**, per-property `naming-convention` disables on OAuth JSON fields were removed where the file already has a file-level `@typescript-eslint/naming-convention` disable. **wallet-imported** metrics tests lost only the redundant outer `properties` type disables; snake_case field disables tied to issue #31860 remain.
> 
> No runtime or test logic changes except trimming obsolete TODO-linked disables (e.g. multichain `wallet_notify` spec) and narrowing Mocha skip comments in **ppom-toggle-settings**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ba6af90b19bc627888f66f153001ff316fe6a5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->