### PR TITLE
test: cover Wallet Creation Attempted Segment event

### DIFF
--- a/test/e2e/tests/metrics/wallet-creation-attempted.spec.ts
+++ b/test/e2e/tests/metrics/wallet-creation-attempted.spec.ts
@@ -1,0 +1,165 @@
+import { strict as assert } from 'assert';
+import { Browser } from 'selenium-webdriver';
+import { Mockttp } from 'mockttp';
+import { getEventPayloads, withFixtures } from '../../helpers';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
+import {
+  goToOnboardingWelcomeLoginPage,
+  handleSidepanelPostOnboarding,
+  onboardingMetricsFlow,
+  skipPasskeySetup,
+} from '../../page-objects/flows/onboarding.flow';
+import OnboardingCompletePage from '../../page-objects/pages/onboarding/onboarding-complete-page';
+import OnboardingPasswordPage from '../../page-objects/pages/onboarding/onboarding-password-page';
+import SecureWalletPage from '../../page-objects/pages/onboarding/secure-wallet-page';
+import TestDapp from '../../page-objects/pages/test-dapp';
+import HomePage from '../../page-objects/pages/home/homepage';
+import {
+  MOCK_ANALYTICS_ID,
+  WALLET_PASSWORD,
+  WINDOW_TITLES,
+} from '../../constants';
+import { Driver } from '../../webdriver/driver';
+import { mockSegment } from './mocks/segment';
+
+/**
+ * Historically this Segment event was named "Wallet Password Created".
+ * Do not use the constants from the metrics constants files, because if these
+ * change we want a strong indicator to our data team that the shape of data
+ * will change.
+ */
+const WALLET_CREATION_ATTEMPTED_EVENT = 'Wallet Creation Attempted';
+
+async function navigateToCreatePasswordPage(driver: Driver) {
+  const startOnboardingPage = await goToOnboardingWelcomeLoginPage({
+    driver,
+    optedIn: true,
+  });
+  await startOnboardingPage.clickCreateWalletButton();
+  await startOnboardingPage.checkTermsOfUsageAndPrivacyLinksAreVisible();
+  await startOnboardingPage.clickCreateWithSrpButton();
+
+  const onboardingPasswordPage = new OnboardingPasswordPage(driver);
+  await onboardingPasswordPage.checkPageIsLoaded();
+  return onboardingPasswordPage;
+}
+
+async function completeOnboardingFromPasswordPage(
+  driver: Driver,
+  onboardingPasswordPage: OnboardingPasswordPage,
+) {
+  await onboardingPasswordPage.createWalletPassword(WALLET_PASSWORD);
+  await skipPasskeySetup(driver);
+
+  const secureWalletPage = new SecureWalletPage(driver);
+  await secureWalletPage.checkPageIsLoaded();
+  await secureWalletPage.revealAndConfirmSRP();
+
+  if (process.env.SELENIUM_BROWSER !== Browser.FIREFOX) {
+    await onboardingMetricsFlow(driver, { optedIn: true });
+  }
+
+  const onboardingCompletePage = new OnboardingCompletePage(driver);
+  await onboardingCompletePage.checkPageIsLoaded();
+  await onboardingCompletePage.checkWalletReadyMessageIsDisplayed();
+  await onboardingCompletePage.completeOnboarding();
+  await handleSidepanelPostOnboarding(driver);
+
+  const homePage = new HomePage(driver);
+  await homePage.checkPageIsLoaded();
+  await homePage.waitForLoadingOverlayToDisappear();
+}
+
+function getWalletCreationAttemptedEvents(
+  events: { type?: string; event?: string }[],
+) {
+  return events.filter(
+    (event) =>
+      event.type === 'track' && event.event === WALLET_CREATION_ATTEMPTED_EVENT,
+  );
+}
+
+describe('Wallet Creation Attempted event', function () {
+  it('is sent when the password is created after a dapp send attempt', async function () {
+    await withFixtures(
+      {
+        dappOptions: { numberOfTestDapps: 1 },
+        fixtures: new FixtureBuilderV2({ onboarding: true })
+          .withMetaMetricsController({
+            analyticsId: MOCK_ANALYTICS_ID,
+          })
+          .build(),
+        title: this.test?.fullTitle(),
+        testSpecificMock: async (server: Mockttp) => {
+          return await mockSegment(server, [WALLET_CREATION_ATTEMPTED_EVENT]);
+        },
+      },
+      async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+        const onboardingPasswordPage =
+          await navigateToCreatePasswordPage(driver);
+
+        // Attempt a dapp send before the password exists.
+        const testDapp = new TestDapp(driver);
+        await testDapp.openTestDappPage();
+        await testDapp.checkPageIsLoaded();
+
+        const sendButton = await driver.findElement('#sendButton');
+        assert.equal(
+          await sendButton.isEnabled(),
+          false,
+          'Expected send button to stay disabled before password creation',
+        );
+
+        // Create the password after the dapp send attempt, then assert the event.
+        await driver.switchToWindowWithTitle(
+          WINDOW_TITLES.ExtensionInFullScreenView,
+        );
+        await onboardingPasswordPage.checkPageIsLoaded();
+        await completeOnboardingFromPasswordPage(
+          driver,
+          onboardingPasswordPage,
+        );
+
+        const events = await getEventPayloads(driver, mockedEndpoints);
+        const trackEvents = getWalletCreationAttemptedEvents(events);
+
+        assert.equal(trackEvents.length, 1);
+        assert.deepStrictEqual(trackEvents[0].properties, {
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          account_type: 'metamask',
+          category: 'Onboarding',
+          locale: 'en',
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          chain_id: '0x1',
+          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+          // eslint-disable-next-line @typescript-eslint/naming-convention
+          environment_type: 'fullscreen',
+        });
+      },
+    );
+  });
+
+  it('is not sent when the user reaches create password but does not create one', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilderV2({ onboarding: true })
+          .withMetaMetricsController({
+            analyticsId: MOCK_ANALYTICS_ID,
+          })
+          .build(),
+        title: this.test?.fullTitle(),
+        testSpecificMock: async (server: Mockttp) => {
+          return await mockSegment(server, [WALLET_CREATION_ATTEMPTED_EVENT]);
+        },
+      },
+      async ({ driver, mockedEndpoint: mockedEndpoints }) => {
+        await navigateToCreatePasswordPage(driver);
+
+        const events = await getEventPayloads(driver, mockedEndpoints, false);
+        assert.equal(getWalletCreationAttemptedEvents(events).length, 0);
+      },
+    );
+  });
+});

--- a/test/e2e/tests/metrics/wallet-creation-attempted.spec.ts
+++ b/test/e2e/tests/metrics/wallet-creation-attempted.spec.ts
@@ -22,12 +22,6 @@ import {
 import { Driver } from '../../webdriver/driver';
 import { mockSegment } from './mocks/segment';
 
-/**
- * Historically this Segment event was named "Wallet Password Created".
- * Do not use the constants from the metrics constants files, because if these
- * change we want a strong indicator to our data team that the shape of data
- * will change.
- */
 const WALLET_CREATION_ATTEMPTED_EVENT = 'Wallet Creation Attempted';
 
 async function navigateToCreatePasswordPage(driver: Driver) {
@@ -70,9 +64,13 @@ async function completeOnboardingFromPasswordPage(
   await homePage.waitForLoadingOverlayToDisappear();
 }
 
-function getWalletCreationAttemptedEvents(
-  events: { type?: string; event?: string }[],
-) {
+type SegmentTrackEvent = {
+  type?: string;
+  event?: string;
+  properties?: Record<string, unknown>;
+};
+
+function getWalletCreationAttemptedEvents(events: SegmentTrackEvent[]) {
   return events.filter(
     (event) =>
       event.type === 'track' && event.event === WALLET_CREATION_ATTEMPTED_EVENT,

--- a/ui/pages/onboarding-flow/create-password/create-password.test.tsx
+++ b/ui/pages/onboarding-flow/create-password/create-password.test.tsx
@@ -14,7 +14,10 @@ import {
   ONBOARDING_SETUP_PASSKEY_ROUTE,
   ONBOARDING_WELCOME_ROUTE,
 } from '../../../helpers/constants/routes';
-import { MetaMetricsEventName } from '../../../../shared/constants/metametrics';
+import {
+  MetaMetricsEventCategory,
+  MetaMetricsEventName,
+} from '../../../../shared/constants/metametrics';
 import { FirstTimeFlowType } from '../../../../shared/constants/onboarding';
 import { getIsPasskeyFeatureEnabled } from '../../../../shared/lib/environment';
 import * as Actions from '../../../store/actions';
@@ -506,6 +509,54 @@ describe('Onboarding Create Password', () => {
           {
             replace: true,
           },
+        );
+      });
+    });
+
+    it('tracks Wallet Creation Attempted when creating a new wallet password', async () => {
+      // Historically this Segment event was named "Wallet Password Created".
+      const mockStore = configureMockStore([thunk])({
+        ...mockState,
+        metamask: {
+          ...mockState.metamask,
+          firstTimeFlowType: FirstTimeFlowType.create,
+        },
+      });
+      const { queryByTestId } = renderWithProvider(
+        <CreatePassword
+          createNewAccount={mockCreateNewAccount}
+          importWithRecoveryPhrase={mockImportWithRecoveryPhrase}
+          secretRecoveryPhrase="SRP"
+        />,
+        mockStore,
+      );
+
+      const password = '12345678';
+      fireEvent.change(
+        queryByTestId('create-password-new-input') as HTMLElement,
+        {
+          target: { value: password },
+        },
+      );
+      fireEvent.change(
+        queryByTestId('create-password-confirm-input') as HTMLElement,
+        {
+          target: { value: password },
+        },
+      );
+      fireEvent.click(queryByTestId('create-password-terms') as HTMLElement);
+      fireEvent.click(queryByTestId('create-password-submit') as HTMLElement);
+
+      await waitFor(() => {
+        expect(mockTrackEvent).toHaveBeenCalledWith(
+          expect.objectContaining({
+            name: MetaMetricsEventName.WalletCreationAttempted,
+            properties: expect.objectContaining({
+              category: MetaMetricsEventCategory.Onboarding,
+              // eslint-disable-next-line @typescript-eslint/naming-convention
+              account_type: 'metamask',
+            }),
+          }),
         );
       });
     });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Added e2e and unit coverage for Wallet Creation Attempted when successfully created and fires after a dapp send attempt when the password is created, and is not sent if password creation is skipped.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:
https://consensyssoftware.atlassian.net/browse/MMQA-2058

## **Manual testing steps**

CI should pass
yarn test:unit ui/pages/onboarding-flow/create-password/create-password.test.tsx
yarn test:e2e:single test/e2e/tests/metrics/wallet-creation-attempted.spec.ts --browser=chrome

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production or analytics instrumentation modifications.
> 
> **Overview**
> Adds **test coverage** for the onboarding **Wallet Creation Attempted** Segment track event (the create-password flow already emits it via `MetaMetricsEventName.WalletCreationAttempted`).
> 
> A new e2e spec mocks Segment and asserts the event fires **once** with expected properties after onboarding completes when the user opened a test dapp (send disabled) before setting a password, and asserts **no** event when the user only reaches create-password without submitting. The create-password unit suite gains a case that verifies `trackEvent` is called with onboarding category and `account_type: 'metamask'` on successful new-wallet password creation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91460471b70ba91573f856dd1b1b3776186ea881. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->