### PR TITLE
chore: remove unused ESLint ignore directives from `app`

### DIFF
--- a/app/offscreen/hardware-wallets/lattice.ts
+++ b/app/offscreen/hardware-wallets/lattice.ts
@@ -87,7 +87,6 @@ export default function init() {
       );
     });
 
-    // eslint-disable-next-line consistent-return
     return true;
   });
 }

--- a/app/offscreen/hardware-wallets/trezor.ts
+++ b/app/offscreen/hardware-wallets/trezor.ts
@@ -135,7 +135,6 @@ export default function init() {
 
       // This keeps sendResponse function valid after return
       // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/runtime/onMessage
-      // eslint-disable-next-line consistent-return
       return true;
     },
   );

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -97,8 +97,6 @@ import { setupMultiplex } from './lib/stream-utils';
 import rawFirstTimeState from './first-time-state';
 import { onUpdate } from './on-update';
 
-/* eslint-enable import-x/first */
-
 import { COOKIE_ID_MARKETING_WHITELIST_ORIGINS } from './constants/marketing-site-whitelist';
 import {
   METAMASK_CAIP_MULTICHAIN_PROVIDER,
@@ -834,7 +832,7 @@ async function initialize(backup) {
   if (process.env.IN_TEST && window.navigator?.webdriver) {
     const { getSocketBackgroundToMocha } =
       // Load conditionally so this test-only code can be dead-code-eliminated from production builds.
-      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, n/global-require
+      // eslint-disable-next-line n/global-require
       require('../../test/e2e/background-socket/socket-background-to-mocha');
     getSocketBackgroundToMocha();
   }
@@ -1011,7 +1009,7 @@ export async function loadStateFromPersistence(backup) {
     const withState = JSON.parse(process.env.WITH_STATE);
 
     // Load conditionally so this test-only code can be dead-code-eliminated from production builds.
-    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, n/global-require
+    // eslint-disable-next-line n/global-require
     const { generateWalletState } = require('./fixtures/generate-wallet-state');
     const fixtureBuilder = await generateWalletState(withState, false);
 
@@ -1068,7 +1066,7 @@ export async function loadStateFromPersistence(backup) {
   const migrator = new Migrator({
     migrations,
     defaultVersion: process.env.WITH_STATE
-      ? // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, n/global-require
+      ? // eslint-disable-next-line n/global-require
         require('../../test/e2e/fixtures/default-fixture.json').meta.version
       : null,
   });

--- a/app/scripts/controllers/analytics/platform-adapter.test.ts
+++ b/app/scripts/controllers/analytics/platform-adapter.test.ts
@@ -40,7 +40,6 @@ const DEFAULT_ENRICHMENT_CONTEXT: PlatformAdapterEnrichmentContext = {
 const DEFAULT_APP_CONTEXT = {
   app: { name: 'MetaMask Extension', version: '1.0.0' },
   userAgent: '',
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   marketingCampaignCookieId: null,
 };
 
@@ -114,7 +113,6 @@ describe('createPlatformAdapter', () => {
       expect(segment.track).toHaveBeenCalledWith(
         expect.objectContaining({
           context: expect.objectContaining({
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             marketingCampaignCookieId: null,
           }),
         }),
@@ -132,7 +130,6 @@ describe('createPlatformAdapter', () => {
       expect(segment.track).toHaveBeenCalledWith(
         expect.objectContaining({
           context: expect.objectContaining({
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             marketingCampaignCookieId: 'campaign-cookie-id',
           }),
         }),
@@ -186,7 +183,6 @@ describe('createPlatformAdapter', () => {
           context: {
             app: { name: 'MetaMask Extension', version: '1.0.0' },
             userAgent: '',
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             marketingCampaignCookieId: null,
           },
           messageId: 'msg-1',
@@ -344,7 +340,6 @@ describe('createPlatformAdapter', () => {
           context: {
             app: { name: 'MetaMask Extension', version: '1.0.0' },
             userAgent: '',
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             marketingCampaignCookieId: null,
           },
           messageId: 'id-1',
@@ -401,7 +396,6 @@ describe('createPlatformAdapter', () => {
           context: {
             app: { name: 'MetaMask Extension', version: '1.0.0' },
             userAgent: '',
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             marketingCampaignCookieId: null,
           },
           messageId: 'page-1',

--- a/app/scripts/controllers/analytics/platform-adapter.ts
+++ b/app/scripts/controllers/analytics/platform-adapter.ts
@@ -147,12 +147,8 @@ export function enrichEventProperties(
     'chain_id_caip' in enrichedProperties &&
     typeof enrichedProperties.chain_id_caip === 'string'
   ) {
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     enrichedProperties.chain_id = null;
   } else if (typeof enrichedProperties.chain_id !== 'string') {
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     enrichedProperties.chain_id = ctx.getDefaultChainId();
   }
 
@@ -162,11 +158,7 @@ export function enrichEventProperties(
 
   if (isAnonymousEvent) {
     const anonymousProperties = { ...enrichedProperties };
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     delete anonymousProperties.profile_id;
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     delete anonymousProperties.canonical_profile_id;
     delete anonymousProperties[ANONYMOUS_EVENT_PROPERTY];
     return anonymousProperties;
@@ -191,10 +183,7 @@ export function enrichWithABTestAnalytics(
 ): AnalyticsEventProperties {
   let enrichedProperties = properties;
 
-  if (
-    // eslint-disable-next-line @typescript-eslint/naming-convention
-    properties.active_ab_tests !== undefined
-  ) {
+  if (properties.active_ab_tests !== undefined) {
     try {
       enrichedProperties =
         enrichWithABTests(
@@ -397,8 +386,6 @@ export function createPlatformAdapter(
       const pageChainProperties = enrichmentContext.getPageChainProperties();
       Object.assign(enrichedProperties, pageChainProperties);
       if (!('chain_id_caip' in pageChainProperties)) {
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         delete enrichedProperties.chain_id_caip;
       }
       const enrichedContext = enrichEventContext(context, enrichmentContext);

--- a/app/scripts/controllers/app-state-controller.test.ts
+++ b/app/scripts/controllers/app-state-controller.test.ts
@@ -1324,8 +1324,6 @@ async function withController<ReturnValue>(
 
   rootMessenger.registerActionHandler(
     'ApprovalController:addRequest',
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     addRequestMock || jest.fn().mockResolvedValue(undefined),
   );
 

--- a/app/scripts/controllers/decrypt-message.ts
+++ b/app/scripts/controllers/decrypt-message.ts
@@ -427,8 +427,6 @@ export class DecryptMessageController extends BaseController<
 
   private _requestApproval(messageParams: AbstractMessageParamsMetamask) {
     const id = messageParams.metamaskId as string;
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const origin = messageParams.origin || ORIGIN_METAMASK;
     try {
       this.messenger.call(

--- a/app/scripts/controllers/encryption-public-key.ts
+++ b/app/scripts/controllers/encryption-public-key.ts
@@ -416,8 +416,6 @@ export class EncryptionPublicKeyController extends BaseController<
 
   private _requestApproval(msgParams: AbstractMessageParamsMetamask) {
     const id = msgParams.metamaskId as string;
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const origin = msgParams.origin || ORIGIN_METAMASK;
 
     this.messenger

--- a/app/scripts/controllers/metametrics-controller.test.ts
+++ b/app/scripts/controllers/metametrics-controller.test.ts
@@ -365,7 +365,6 @@ describe('MetaMetricsController', function () {
     it('should throw an error if the param is missing successEvent', async function () {
       await withController(async ({ controller }) => {
         await expect(() => {
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-expect-error because we are testing the error case
           controller.createEventFragment({ category: 'test' });
         }).toThrow(/Must specify success event\./u);
@@ -1034,7 +1033,6 @@ describe('MetaMetricsController', function () {
     it('should throw if event not provided', async function () {
       await withController(({ controller }) => {
         expect(() => {
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
           // @ts-expect-error because we are testing the error case
           trackLegacyMetaMetricsPayload({ category: 'test' });
         }).toThrow(/Must specify event\./u);
@@ -3397,7 +3395,6 @@ async function withController<ReturnValue>(
       const pageChainProperties = enrichmentContext.getPageChainProperties();
       Object.assign(enrichedProperties, pageChainProperties);
       if (!('chain_id_caip' in pageChainProperties)) {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         delete enrichedProperties.chain_id_caip;
       }
       const enrichedContext = enrichEventContext(context, enrichmentContext);

--- a/app/scripts/controllers/metametrics-controller.ts
+++ b/app/scripts/controllers/metametrics-controller.ts
@@ -460,7 +460,6 @@ export class MetaMetricsController extends BaseController<
     // a timeout can be specified that will cause an abandoned event to be
     // tracked if the event isn't progressed within that amount of time.
     if (isManifestV3) {
-      /* eslint-disable no-undef */
       this.#extension.alarms.getAll().then((alarms) => {
         const hasAlarm = checkAlarmExists(
           alarms,
@@ -496,8 +495,6 @@ export class MetaMetricsController extends BaseController<
    */
   #getCurrentChainId(networkClientId?: NetworkClientId): Hex {
     const selectedNetworkClientId =
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       networkClientId ||
       this.messenger.call('NetworkController:getState').selectedNetworkClientId;
     const {
@@ -766,8 +763,6 @@ export class MetaMetricsController extends BaseController<
     // this.extension not currently defined in tests
     if (this.#extension && this.#extension.runtime) {
       this.#extension.runtime.setUninstallURL(
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31893
-        // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
         `${EXTENSION_UNINSTALL_URL}?${queryString}`,
       );
     }
@@ -991,8 +986,6 @@ export class MetaMetricsController extends BaseController<
         Object.values(metamaskState.addressBook).map(size),
       ),
       [MetaMetricsUserTrait.InstallDateExt]:
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         traits[MetaMetricsUserTrait.InstallDateExt] || '',
       ...(storageKindTrait
         ? { [MetaMetricsUserTrait.StorageKind]: storageKindTrait }

--- a/app/scripts/controllers/qr-sync/mwp-dapp-client-factory.ts
+++ b/app/scripts/controllers/qr-sync/mwp-dapp-client-factory.ts
@@ -50,7 +50,7 @@ export async function createProductionMwpStack(
  */
 export async function createE2eMwpStack(): Promise<DappClient> {
   // Load conditionally so this test-only code can be dead-code-eliminated from production builds.
-  /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, n/global-require */
+  /* eslint-disable @typescript-eslint/no-require-imports */
   const {
     E2eMwpMockClient,
   } = require('../../../../test/e2e/helpers/qr-sync/e2e-mwp-mock-client');
@@ -60,7 +60,7 @@ export async function createE2eMwpStack(): Promise<DappClient> {
   const {
     registerQrSyncE2eBridge,
   } = require('../../../../test/e2e/helpers/qr-sync/qr-sync-e2e-bridge');
-  /* eslint-enable @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, n/global-require */
+  /* eslint-enable @typescript-eslint/no-require-imports */
 
   const client = new E2eMwpMockClient();
   const simulator = new MobileWalletSimulator(client);

--- a/app/scripts/controllers/rewards/rewards-controller.test.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.test.ts
@@ -293,7 +293,6 @@ async function withController<ReturnValue>(
   // Setup default mocks
   const mockMessengerCall = jest.fn();
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   jest.spyOn(controllerMessenger, 'call').mockImplementation(mockMessengerCall);
 
   const controller = new RewardsController({

--- a/app/scripts/controllers/rewards/rewards-controller.types.ts
+++ b/app/scripts/controllers/rewards/rewards-controller.types.ts
@@ -46,17 +46,14 @@ export type LoginResponseDto = {
   subscription: SubscriptionDto;
 };
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type VipFeatureDto = {
   enabled: boolean;
 };
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type SubscriptionFeaturesDto = {
   vip: VipFeatureDto;
 };
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type SubscriptionDto = {
   id: string;
   referralCode: string;
@@ -77,24 +74,20 @@ export type SubscriptionDto = {
 // Backend wire format for GET /vip/fees — mirrors va-mmcx-rewards
 // src/main/vip/dto/vip-fees.dto.ts (PR #546). Fee bips are returned as
 // strings; the controller parses them as needed.
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type HyperliquidVipFeesDto = {
   builderCode: string;
   builderFeeBips: string;
 };
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type SwapsVipFeesDto = {
   feeBips: string;
 };
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type VipFeesGroupDto = {
   hyperliquid: HyperliquidVipFeesDto;
   swaps: SwapsVipFeesDto;
 };
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type VipFeesResponseDto = {
   vipTier: number;
   fees: VipFeesGroupDto | null;
@@ -104,7 +97,6 @@ export type VipFeesResponseDto = {
 // Per-subscription cache for VIP perps builder fee.
 // We store the raw bips string from the backend rather than a derived
 // discount so the cache stays valid if the perps base fee constant changes.
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type VipPerpsFeesState = {
   hyperliquidBuilderFeeBips: string;
   lastFetched: number;
@@ -344,7 +336,6 @@ export type PointsEventDto = BasePointsEventDto &
       }
   );
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type SeasonTierDto = {
   id: string;
   name: string;
@@ -636,14 +627,12 @@ export type RewardClaimData =
   | AlphaFoxInviteRewardData
   | null;
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type PointsBoostRewardData = {
   seasonPointsBonusId: string;
   activeUntil: string; // reward expiration date
   activeFrom: string; // claim date
 };
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type AlphaFoxInviteRewardData = {
   telegramHandle: string;
 };
@@ -665,7 +654,6 @@ export type ThemeImage = {
   darkModeUrl: string;
 };
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type RewardsAccountState = {
   account: CaipAccountId;
   hasOptedIn?: boolean;
@@ -807,7 +795,6 @@ export type PointsEstimateHistoryEntry = {
   responseBonusBips: number;
 };
 
-// eslint-disable-next-line @typescript-eslint/consistent-type-definitions
 export type RewardsControllerState = {
   rewardsActiveAccount: RewardsAccountState | null;
   rewardsAccounts: { [account: CaipAccountId]: RewardsAccountState };

--- a/app/scripts/controllers/rewards/rewards-data-service-types.ts
+++ b/app/scripts/controllers/rewards/rewards-data-service-types.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-definitions */
 import { Messenger } from '@metamask/messenger';
 import { PreferencesControllerGetStateAction } from '../preferences-controller';
 import { RewardsDataServiceMethodActions } from './rewards-data-service-method-action-types';

--- a/app/scripts/controllers/rewards/rewards-data-service.ts
+++ b/app/scripts/controllers/rewards/rewards-data-service.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/consistent-type-definitions */
 // TODO: find similar functionality in extession
 // import { getSubscriptionToken } from '../utils/multi-subscription-token-vault';
 import log from 'loglevel';

--- a/app/scripts/development/wdyr.ts
+++ b/app/scripts/development/wdyr.ts
@@ -3,7 +3,7 @@
 import React from 'react';
 
 if (process.env.ENABLE_WHY_DID_YOU_RENDER) {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   const whyDidYouRender = require('@welldone-software/why-did-you-render');
   whyDidYouRender(React, {
     trackAllPureComponents: true,

--- a/app/scripts/lib/SnapsNameProvider.test.ts
+++ b/app/scripts/lib/SnapsNameProvider.test.ts
@@ -60,16 +60,12 @@ function createMockMessenger({
   >;
 } = {}): SnapsNameProviderMessenger {
   const getAllSnapsMock =
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     getAllSnaps ||
     jest
       .fn()
       .mockReturnValue([SNAP_MOCK, SNAP_MOCK_2, SNAP_MOCK_3, SNAP_MOCK_4]);
 
   const getSnapMock =
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     getSnap ||
     jest
       .fn()
@@ -80,13 +76,9 @@ function createMockMessenger({
       );
 
   const handleSnapRequestMock =
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     handleSnapRequest || jest.fn().mockResolvedValue(Promise.resolve());
 
   const getPermissionControllerStateMock =
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     getPermissionControllerState ||
     jest.fn().mockReturnValue({
       subjects: {

--- a/app/scripts/lib/SnapsNameProvider.ts
+++ b/app/scripts/lib/SnapsNameProvider.ts
@@ -65,8 +65,6 @@ export class SnapsNameProvider implements NameProvider {
 
         return {
           ...acc,
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           [snap.id]: snapName || snap.id,
         };
       },

--- a/app/scripts/lib/createOriginThrottlingMiddleware.ts
+++ b/app/scripts/lib/createOriginThrottlingMiddleware.ts
@@ -92,8 +92,6 @@ export default function createOriginThrottlingMiddleware({
         }
 
         // User rejected the request
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         const throttledOriginState = getThrottledOriginState(origin) || {
           rejections: 0,
           lastRejection: 0,

--- a/app/scripts/lib/dapp-swap/dapp-swap-middleware.test.ts
+++ b/app/scripts/lib/dapp-swap/dapp-swap-middleware.test.ts
@@ -20,7 +20,6 @@ const getNetworkConfigurationByNetworkClientId = jest.fn();
 
 const createMiddleware = (
   args: {
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     dappSwapMetricsFlag?: {
       enabled: boolean;
       bridge_quote_fees: number;
@@ -32,7 +31,6 @@ const createMiddleware = (
     fetchQuotes,
     setDappSwapComparisonData,
     getNetworkConfigurationByNetworkClientId,
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     dappSwapMetricsFlag: {
       enabled: true,
       bridge_quote_fees: 250,
@@ -68,7 +66,6 @@ describe('DappSwapMiddleware', () => {
   it('does not fetch quotes if dapp swap is not enabled', async () => {
     fetchQuotes.mockReturnValueOnce(mockBridgeQuotes);
     const { middlewareFunction } = createMiddleware({
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       dappSwapMetricsFlag: {
         enabled: false,
         bridge_quote_fees: 250,
@@ -238,7 +235,6 @@ describe('DappSwapMiddleware', () => {
   it('does not fetch quotes if origin is not in the list of allowed origins', async () => {
     fetchQuotes.mockReturnValueOnce(mockBridgeQuotes);
     const { middlewareFunction } = createMiddleware({
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       dappSwapMetricsFlag: {
         enabled: true,
         bridge_quote_fees: 250,

--- a/app/scripts/lib/dapp-swap/dapp-swap-util.ts
+++ b/app/scripts/lib/dapp-swap/dapp-swap-util.ts
@@ -90,7 +90,6 @@ export function getQuotesForConfirmation({
   try {
     const {
       enabled: dappSwapEnabled,
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       bridge_quote_fees: bridgeQuoteFees,
       origins,
     } = dappSwapMetricsFlag;

--- a/app/scripts/lib/metaRPCClientFactory.ts
+++ b/app/scripts/lib/metaRPCClientFactory.ts
@@ -11,8 +11,6 @@ import {
 } from '@metamask/utils';
 import { JsonRpcError } from '@metamask/rpc-errors';
 import getNextId from '../../../shared/lib/random-id';
-// It *is* used: in TypeDoc comment, you silly goose.
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type MetamaskController from '../metamask-controller';
 
 const JSON_RPC_VERSION = '2.0' as const;

--- a/app/scripts/lib/rpc-method-middleware/createUnsupportedMethodMiddleware.ts
+++ b/app/scripts/lib/rpc-method-middleware/createUnsupportedMethodMiddleware.ts
@@ -12,8 +12,6 @@ import { UNSUPPORTED_RPC_METHODS } from '../../../../shared/constants/network';
 export function createUnsupportedMethodMiddleware(
   methods: Set<string> = UNSUPPORTED_RPC_METHODS,
 ): JsonRpcMiddleware<JsonRpcParams, null> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async function unsupportedMethodMiddleware(req, _res, next, end) {
     if (methods.has(req.method)) {
       return end(rpcErrors.methodNotSupported());

--- a/app/scripts/lib/segment/custom-segment-tracking.test.ts
+++ b/app/scripts/lib/segment/custom-segment-tracking.test.ts
@@ -172,7 +172,6 @@ describe('trackSegmentEventWhileOptedOut', () => {
           version: '1.0.0',
         },
         userAgent: '',
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         marketingCampaignCookieId: null,
       },
     });

--- a/app/scripts/lib/sentry-make-transport.test.ts
+++ b/app/scripts/lib/sentry-make-transport.test.ts
@@ -10,7 +10,6 @@ const originalMakeFetchTransport = Sentry.makeFetchTransport.bind(Sentry);
 // observable after a microtask drain with no timers involved.
 async function flushMicrotasks(depth = 5): Promise<void> {
   for (let i = 0; i < depth; i += 1) {
-    // eslint-disable-next-line no-await-in-loop
     await new Promise<void>((resolve) => queueMicrotask(resolve));
   }
 }

--- a/app/scripts/lib/sentry-session-lifecycle.test.ts
+++ b/app/scripts/lib/sentry-session-lifecycle.test.ts
@@ -10,7 +10,6 @@ type FetchCallArgs = [RequestInfo | URL, RequestInit | undefined];
 // this suite owns the first `Sentry.init` in the worker.
 async function flushMicrotasks(depth = 5): Promise<void> {
   for (let i = 0; i < depth; i += 1) {
-    // eslint-disable-next-line no-await-in-loop
     await new Promise<void>((resolve) => queueMicrotask(resolve));
   }
 }

--- a/app/scripts/lib/smart-transaction/smart-transactions.ts
+++ b/app/scripts/lib/smart-transaction/smart-transactions.ts
@@ -267,8 +267,6 @@ class SmartTransactionHook {
     return new Promise((resolve) => {
       this.#controllerMessenger.subscribe(
         'SmartTransactionsController:smartTransaction',
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         async (smartTransaction: SmartTransaction) => {
           if (smartTransaction.uuid === uuid) {
             const { status, statusMetadata } = smartTransaction;
@@ -394,8 +392,6 @@ class SmartTransactionHook {
 
     const transactionsWithChainId = unsignedTransactions.map((tx) => ({
       ...tx,
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       chainId: tx.chainId || this.#chainId,
     }));
 

--- a/app/scripts/lib/transaction/metrics-builders/batch.ts
+++ b/app/scripts/lib/transaction/metrics-builders/batch.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import {
   TransactionStatus,
   TransactionType,

--- a/app/scripts/lib/transaction/metrics-builders/gas.test.ts
+++ b/app/scripts/lib/transaction/metrics-builders/gas.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import { getGasMetricsProperties } from './gas';
 import { createBuilderRequest } from './test-utils';
 

--- a/app/scripts/lib/transaction/metrics-builders/gasless.test.ts
+++ b/app/scripts/lib/transaction/metrics-builders/gasless.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import { getGaslessMetricsProperties } from './gasless';
 import { createBuilderRequest } from './test-utils';
 

--- a/app/scripts/lib/transaction/metrics-builders/gasless.ts
+++ b/app/scripts/lib/transaction/metrics-builders/gasless.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import { NATIVE_TOKEN_ADDRESS } from '../../../../../shared/constants/transaction';
 import { getMaximumGasTotalInHexWei } from '../../../../../shared/lib/gas.utils';
 import { Numeric } from '../../../../../shared/lib/Numeric';

--- a/app/scripts/lib/transaction/metrics-builders/hash.test.ts
+++ b/app/scripts/lib/transaction/metrics-builders/hash.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { getHashMetricsProperties } from './hash';
 import { createBuilderRequest } from './test-utils';

--- a/app/scripts/lib/transaction/metrics-builders/hash.ts
+++ b/app/scripts/lib/transaction/metrics-builders/hash.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import { TransactionStatus } from '@metamask/transaction-controller';
 import type { MetricsProperties, TransactionMetricsBuilder } from './types';
 

--- a/app/scripts/lib/transaction/metrics-builders/metamask-pay.ts
+++ b/app/scripts/lib/transaction/metrics-builders/metamask-pay.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import {
   TransactionMeta,
   TransactionType,

--- a/app/scripts/lib/transaction/metrics-builders/rpc.test.ts
+++ b/app/scripts/lib/transaction/metrics-builders/rpc.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import {
   TransactionStatus,
   type TransactionMeta,

--- a/app/scripts/lib/transaction/metrics-builders/swap-bridge.test.ts
+++ b/app/scripts/lib/transaction/metrics-builders/swap-bridge.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import { getSwapBridgeMetricsProperties } from './swap-bridge';
 import { createBuilderRequest } from './test-utils';
 

--- a/app/scripts/lib/transaction/metrics-builders/transaction-details.test.ts
+++ b/app/scripts/lib/transaction/metrics-builders/transaction-details.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import { TransactionMetaMetricsEvent } from '../../../../../shared/constants/transaction';
 import { getTransactionDetailsMetricsProperties } from './transaction-details';
 import { createBuilderRequest } from './test-utils';

--- a/app/scripts/lib/transaction/swap-post-transaction-metric-handler.ts
+++ b/app/scripts/lib/transaction/swap-post-transaction-metric-handler.ts
@@ -46,9 +46,7 @@ export async function handleSwapPostTransactionMetricHandler(
       );
 
       const quoteVsExecutionRatio = tokensReceived
-        ? // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31893
-          // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-          `${new BigNumber(tokensReceived, 10)
+        ? `${new BigNumber(tokensReceived, 10)
             .div(transactionMeta.swapMetaData.token_to_amount, 10)
             .times(100)
             .toFixed(2)}%`
@@ -57,9 +55,7 @@ export async function handleSwapPostTransactionMetricHandler(
       const estimatedVsUsedGasRatio =
         transactionMeta.txReceipt?.gasUsed &&
         transactionMeta.swapMetaData.estimated_gas
-          ? // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31893
-            // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-            `${new BigNumber(transactionMeta.txReceipt.gasUsed, 16)
+          ? `${new BigNumber(transactionMeta.txReceipt.gasUsed, 16)
               .div(transactionMeta.swapMetaData.estimated_gas, 10)
               .times(100)
               .toFixed(2)}%`

--- a/app/scripts/lib/util.ts
+++ b/app/scripts/lib/util.ts
@@ -478,23 +478,11 @@ export function formatTxMetaForRpcResult(
     from,
     hash,
     nonce: nonce ? `${nonce}` : '0x0',
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     input: data || '0x',
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     value: value || '0x0',
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     accessList: accessList || null,
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     blockHash: txReceipt?.blockHash || null,
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     blockNumber: txReceipt?.blockNumber || null,
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     transactionIndex: txReceipt?.transactionIndex || null,
     type:
       maxFeePerGas && maxPriorityFeePerGas

--- a/app/scripts/lockdown-run.js
+++ b/app/scripts/lockdown-run.js
@@ -1,6 +1,6 @@
 // Freezes all intrinsics
 try {
-  // eslint-disable-next-line no-undef,import-x/unambiguous
+  // eslint-disable-next-line no-undef
   lockdown({
     consoleTaming: 'unsafe',
     errorTaming: 'unsafe',

--- a/app/scripts/messenger-client-init/notifications/notification-services-push-controller-init.ts
+++ b/app/scripts/messenger-client-init/notifications/notification-services-push-controller-init.ts
@@ -102,8 +102,6 @@ export const NotificationServicesPushControllerInit: MessengerClientInitFunction
         subscribeToPushNotifications: createSubscribeToPushNotifications({
           messenger: controllerMessenger,
           onReceivedHandler: onPushNotificationReceived,
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-          // eslint-disable-next-line @typescript-eslint/no-misused-promises
           onClickHandler: onPushNotificationClicked,
         }),
       },

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5010,11 +5010,8 @@ export default class MetamaskController extends EventEmitter {
           createEventBuilder(MetaMetricsEventName.ImportSecretRecoveryPhrase)
             .addProperties({
               status: 'completed',
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               hd_entropy_index: newHdEntropyIndex,
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               number_of_solana_accounts_discovered: discoveredAccounts?.Solana,
-              // eslint-disable-next-line @typescript-eslint/naming-convention
               number_of_bitcoin_accounts_discovered:
                 discoveredAccounts?.Bitcoin,
             })

--- a/app/scripts/migrations/174.test.ts
+++ b/app/scripts/migrations/174.test.ts
@@ -451,11 +451,9 @@ describe(`migration #${newVersion}`, () => {
       });
 
       const {
-        // eslint-disable-next-line no-unused-vars
         data: { BridgeStatusController: _, ...otherOldStates },
       } = oldState;
       const {
-        // eslint-disable-next-line no-unused-vars
         data: {
           BridgeStatusController: bridgeStatusControllerState,
           ...otherStates

--- a/app/scripts/offscreen.js
+++ b/app/scripts/offscreen.js
@@ -56,7 +56,7 @@ export async function createOffscreen() {
         if (process.env.IN_TEST && msg.webdriverPresent) {
           const { getSocketBackgroundToMocha } =
             // Load conditionally so this test-only code can be dead-code-eliminated from production builds.
-            // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, n/global-require
+            // eslint-disable-next-line n/global-require
             require('../../test/e2e/background-socket/socket-background-to-mocha');
           getSocketBackgroundToMocha();
         }

--- a/app/scripts/services/data-deletion-service.test.ts
+++ b/app/scripts/services/data-deletion-service.test.ts
@@ -326,7 +326,6 @@ describe('DataDeletionService', () => {
         const fetchOperation = () =>
           dataDeletionService.createDataDeletionRegulationTask(mockAnalyticsId);
         // Initial calls to exhaust maximum allowed failures
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         for (const _ of Array(attemptsToTriggerBreak).keys()) {
           await expect(() =>
             fetchWithFakeTimers({
@@ -368,7 +367,6 @@ describe('DataDeletionService', () => {
           dataDeletionService.createDataDeletionRegulationTask(mockAnalyticsId);
 
         // Initial calls to exhaust maximum allowed failures
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         for (const _ of Array(attemptsToTriggerBreak).keys()) {
           await expect(() =>
             fetchWithFakeTimers({
@@ -403,7 +401,6 @@ describe('DataDeletionService', () => {
         const fetchOperation = () =>
           dataDeletionService.createDataDeletionRegulationTask(mockAnalyticsId);
         // Initial calls to exhaust maximum allowed failures
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         for (const _ of Array(attemptsToTriggerBreak).keys()) {
           await expect(() =>
             fetchWithFakeTimers({
@@ -459,7 +456,6 @@ describe('DataDeletionService', () => {
         const fetchOperation = () =>
           dataDeletionService.createDataDeletionRegulationTask(mockAnalyticsId);
         // Initial calls to exhaust maximum allowed failures
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         for (const _ of Array(attemptsToTriggerBreak).keys()) {
           await expect(() =>
             fetchWithFakeTimers({
@@ -529,7 +525,6 @@ describe('DataDeletionService', () => {
         const fetchOperation = () =>
           dataDeletionService.createDataDeletionRegulationTask(mockAnalyticsId);
         // Initial calls to exhaust maximum allowed failures
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         for (const _ of Array(attemptsToTriggerBreak).keys()) {
           await expect(() => {
             return fetchWithFakeTimers({
@@ -864,7 +859,6 @@ describe('DataDeletionService', () => {
         const fetchOperation = () =>
           dataDeletionService.fetchDeletionRegulationStatus(mockTaskId);
         // Initial calls to exhaust maximum allowed failures
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         for (const _ of Array(attemptsToTriggerBreak).keys()) {
           await expect(() =>
             fetchWithFakeTimers({
@@ -906,7 +900,6 @@ describe('DataDeletionService', () => {
           dataDeletionService.fetchDeletionRegulationStatus(mockTaskId);
 
         // Initial calls to exhaust maximum allowed failures
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         for (const _ of Array(attemptsToTriggerBreak).keys()) {
           await expect(() =>
             fetchWithFakeTimers({
@@ -941,7 +934,6 @@ describe('DataDeletionService', () => {
         const fetchOperation = () =>
           dataDeletionService.fetchDeletionRegulationStatus(mockTaskId);
         // Initial calls to exhaust maximum allowed failures
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         for (const _ of Array(attemptsToTriggerBreak).keys()) {
           await expect(() =>
             fetchWithFakeTimers({
@@ -998,7 +990,6 @@ describe('DataDeletionService', () => {
         const fetchOperation = () =>
           dataDeletionService.fetchDeletionRegulationStatus(mockTaskId);
         // Initial calls to exhaust maximum allowed failures
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         for (const _ of Array(attemptsToTriggerBreak).keys()) {
           await expect(() =>
             fetchWithFakeTimers({
@@ -1071,7 +1062,6 @@ describe('DataDeletionService', () => {
         const fetchOperation = () =>
           dataDeletionService.fetchDeletionRegulationStatus(mockTaskId);
         // Initial calls to exhaust maximum allowed failures
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         for (const _ of Array(attemptsToTriggerBreak).keys()) {
           await expect(() => {
             return fetchWithFakeTimers({
@@ -1141,7 +1131,6 @@ async function fetchWithFakeTimers({
 
   // Advance timer enough to exceed max possible retry delay for initial call and all
   // subsequent retries, until request has resolved.
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   for (const _ of Array(retries + 1).keys()) {
     if (resolved) {
       break;
@@ -1150,7 +1139,6 @@ async function fetchWithFakeTimers({
     // waiting period, and to prevent unnecessarily long waiting.
     const intervalLength = defaultMaxRetryDelay / 10;
     const numberOfIntervals = defaultMaxRetryDelay / intervalLength;
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     for (const _interval of new Array(numberOfIntervals).keys()) {
       if (resolved) {
         break;

--- a/app/scripts/services/oauth/oauth-service.ts
+++ b/app/scripts/services/oauth/oauth-service.ts
@@ -440,7 +440,7 @@ export class OAuthService {
     if (process.env.IN_TEST) {
       const { MOCK_AUTH_CONNECTION_ID, MOCK_GROUPED_AUTH_CONNECTION_ID } =
         // Load conditionally so this test-only code can be dead-code-eliminated from production builds.
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, n/global-require
+        // eslint-disable-next-line @typescript-eslint/no-require-imports, n/global-require
         require('../../../../test/e2e/constants');
       authConnectionId = MOCK_AUTH_CONNECTION_ID;
       groupedAuthConnectionId = MOCK_GROUPED_AUTH_CONNECTION_ID;

--- a/app/scripts/services/oauth/telegram-login-handler.ts
+++ b/app/scripts/services/oauth/telegram-login-handler.ts
@@ -101,11 +101,7 @@ export class TelegramLoginHandler extends BaseLoginHandler {
     const initiateUrl = new URL(
       `${this.#getProfileSyncAuthApiUrl()}${this.OAUTH_SERVER_INITIATE_PATH}`,
     );
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     initiateUrl.searchParams.set('code_challenge', challenge);
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     initiateUrl.searchParams.set('app_redirect_uri', appRedirectUri);
     initiateUrl.searchParams.set('state', this.#state);
 
@@ -194,8 +190,6 @@ export class TelegramLoginHandler extends BaseLoginHandler {
       }
     }
 
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     mintData.profile_pairing_token = hydraIdToken;
 
     return mintData;

--- a/app/scripts/services/oauth/web-authenticator-factory.ts
+++ b/app/scripts/services/oauth/web-authenticator-factory.ts
@@ -66,7 +66,7 @@ export function webAuthenticatorFactory(): WebAuthenticator {
   if (process.env.IN_TEST) {
     const { mockWebAuthenticator } =
       // Load conditionally so this test-only code can be dead-code-eliminated from production builds.
-      // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, n/global-require
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
       require('../../../../test/e2e/helpers/seedless-onboarding/mock-web-authenticator');
     return mockWebAuthenticator();
   }

--- a/app/scripts/streams/cookie-handler-stream.ts
+++ b/app/scripts/streams/cookie-handler-stream.ts
@@ -1,7 +1,6 @@
 import browser from 'webextension-polyfill';
 import { WindowPostMessageStream } from '@metamask/post-message-stream';
 import ObjectMultiplex from '@metamask/object-multiplex';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error @types/readable-stream does not export pipeline
 import { pipeline } from 'readable-stream';
 import { Substream } from '@metamask/object-multiplex/dist/Substream';
@@ -205,8 +204,6 @@ const onDisconnectDestroyCookieStreams = () => {
    * once the port and connections are ready. Delay time is arbitrary.
    */
   if (err) {
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31893
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     console.warn(`${err} Resetting the cookie streams.`);
     setTimeout(setupCookieHandlerExtStreams, 1000);
   }

--- a/app/scripts/streams/phishing-stream.ts
+++ b/app/scripts/streams/phishing-stream.ts
@@ -1,7 +1,6 @@
 import { WindowPostMessageStream } from '@metamask/post-message-stream';
 import ObjectMultiplex from '@metamask/object-multiplex';
 import { Substream } from '@metamask/object-multiplex/dist/Substream';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error @types/readable-stream does not export pipeline
 import { pipeline } from 'readable-stream';
 import browser from 'webextension-polyfill';
@@ -192,8 +191,6 @@ const onDisconnectDestroyPhishingStreams = (): void => {
    * once the port and connections are ready. Delay time is arbitrary.
    */
   if (err) {
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31893
-    // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     console.warn(`${err} Resetting the phishing streams.`);
     setTimeout(setupPhishingExtStreams, 1000);
   }
@@ -233,8 +230,6 @@ export function redirectToPhishingWarning(): void {
   const baseUrl = process.env.PHISHING_WARNING_PAGE_URL;
 
   const querystring = new URLSearchParams({ hostname, href });
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31893
-  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
   window.location.href = `${baseUrl}#${querystring}`;
   // eslint-disable-next-line no-constant-condition
   while (1) {

--- a/app/scripts/streams/provider-stream.ts
+++ b/app/scripts/streams/provider-stream.ts
@@ -1,7 +1,6 @@
 import ObjectMultiplex from '@metamask/object-multiplex';
 import { Substream } from '@metamask/object-multiplex/dist/Substream';
 import { WindowPostMessageStream } from '@metamask/post-message-stream';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error @types/readable-stream does not export pipeline or Transform
 import { pipeline, Transform } from 'readable-stream';
 import browser from 'webextension-polyfill';
@@ -166,8 +165,6 @@ export const setupExtensionStreams = () => {
   // connect "phishing" channel to warning system
   connectPhishingChannelToWarningSystem(extensionMux);
 
-  // eslint-disable-next-line no-use-before-define
-  // eslint-disable-next-line @typescript-eslint/no-use-before-define
   extensionPort.onDisconnect.addListener(onDisconnectDestroyStreams);
 };
 

--- a/app/scripts/wallet-init/instance-options/transaction-controller.ts
+++ b/app/scripts/wallet-init/instance-options/transaction-controller.ts
@@ -111,8 +111,6 @@ export function setupTransactionControllerListeners({
 }: SetupTransactionControllerListenersRequest) {
   messenger.subscribe(
     'TransactionController:postTransactionBalanceUpdated',
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     (...args) =>
       handlePostTransactionBalanceUpdate(
         getTransactionMetricsRequest(),
@@ -122,34 +120,22 @@ export function setupTransactionControllerListeners({
 
   messenger.subscribe(
     'TransactionController:unapprovedTransactionAdded',
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     (transactionMeta) =>
       handleTransactionAdded(getTransactionMetricsRequest(), {
         transactionMeta,
       }),
   );
 
-  messenger.subscribe(
-    'TransactionController:transactionApproved',
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    (...args) =>
-      handleTransactionApproved(getTransactionMetricsRequest(), ...args),
+  messenger.subscribe('TransactionController:transactionApproved', (...args) =>
+    handleTransactionApproved(getTransactionMetricsRequest(), ...args),
   );
 
-  messenger.subscribe(
-    'TransactionController:transactionDropped',
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    (...args) =>
-      handleTransactionDropped(getTransactionMetricsRequest(), ...args),
+  messenger.subscribe('TransactionController:transactionDropped', (...args) =>
+    handleTransactionDropped(getTransactionMetricsRequest(), ...args),
   );
 
   messenger.subscribe(
     'TransactionController:transactionConfirmed',
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     (transactionMeta) =>
       handleTransactionConfirmed(
         getTransactionMetricsRequest(),
@@ -157,28 +143,16 @@ export function setupTransactionControllerListeners({
       ),
   );
 
-  messenger.subscribe(
-    'TransactionController:transactionFailed',
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    (...args) =>
-      handleTransactionFailed(getTransactionMetricsRequest(), ...args),
+  messenger.subscribe('TransactionController:transactionFailed', (...args) =>
+    handleTransactionFailed(getTransactionMetricsRequest(), ...args),
   );
 
-  messenger.subscribe(
-    'TransactionController:transactionRejected',
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    (...args) =>
-      handleTransactionRejected(getTransactionMetricsRequest(), ...args),
+  messenger.subscribe('TransactionController:transactionRejected', (...args) =>
+    handleTransactionRejected(getTransactionMetricsRequest(), ...args),
   );
 
-  messenger.subscribe(
-    'TransactionController:transactionSubmitted',
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
-    (...args) =>
-      handleTransactionSubmitted(getTransactionMetricsRequest(), ...args),
+  messenger.subscribe('TransactionController:transactionSubmitted', (...args) =>
+    handleTransactionSubmitted(getTransactionMetricsRequest(), ...args),
   );
 }
 

--- a/app/scripts/wallet-init/keyrings.ts
+++ b/app/scripts/wallet-init/keyrings.ts
@@ -122,15 +122,15 @@ export function getKeyringBuilders(
   const overrides = process.env.IN_TEST
     ? {
         // Load conditionally so this test-only code can be dead-code-eliminated from production builds.
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, n/global-require
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
         trezorBridge: require('../../../test/stub/keyring-bridge')
           .FakeTrezorBridge,
         // Load conditionally so this test-only code can be dead-code-eliminated from production builds.
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, n/global-require
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
         ledgerBridge: require('../../../test/stub/keyring-bridge')
           .FakeLedgerBridge,
         // Load conditionally so this test-only code can be dead-code-eliminated from production builds.
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, n/global-require
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
         qrBridge: require('../../../test/stub/keyring-bridge').FakeQrBridge,
       }
     : {};

--- a/app/service-worker.ts
+++ b/app/service-worker.ts
@@ -54,7 +54,6 @@ async function runImportScripts() {
 }
 
 // Ref: https://stackoverflow.com/questions/66406672/chrome-extension-mv3-modularize-service-worker-js-file
-// eslint-disable-next-line no-undef
 self.addEventListener('install', runImportScripts);
 
 // listen for connection events from other contexts, and respond to liveness
@@ -93,7 +92,6 @@ chrome.runtime.onConnect.addListener((port) => {
  * is 'activated'.
  */
 // @ts-expect-error - typescript doesn't know about this
-// eslint-disable-next-line no-undef
 if (self.serviceWorker.state === 'activated') {
   runImportScripts();
 }


### PR DESCRIPTION
## **Description**

Unused ESLint ignore directives have been removed from the `app` directory.

This helps unblock the ESLint v9 upgrade (it complains about unused directives by default).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

The CI lint step should be sufficient to test this change.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only lint cleanup with no production behavior changes; CI lint is the main verification.
> 
> **Overview**
> Removes **unused `eslint-disable` comments** across the `app` tree so lint no longer reports stale suppressions (required for the ESLint v9 upgrade).
> 
> Most removals are for rules that no longer fire on those lines—e.g. **`consistent-return`** on `return true` in extension `onMessage` handlers, **`@typescript-eslint/naming-convention`** on analytics snake_case fields and Segment test fixtures, **`prefer-nullish-coalescing`** where `||` is intentional, and **`no-misused-promises`** on messenger subscribers. File-level **`@typescript-eslint/naming-convention`** disables were dropped from transaction metrics builders and rewards types after config/overrides made them unnecessary.
> 
> A few **`require()`** blocks keep narrower disables (e.g. **`n/global-require`** only) where dynamic test imports remain. **No runtime or behavioral changes**—only comment cleanup and minor formatting (e.g. collapsed `messenger.subscribe` callbacks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f46317a1d44e221cb95732edd0dddb0e04047d62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->