### PR TITLE
chore: remove unused ESLint ignore directives from `development`

### DIFF
--- a/development/lib/variables.js
+++ b/development/lib/variables.js
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/check-tag-names */
 const assert = require('assert');
 
 const DeclaredOnly = Symbol(

--- a/development/metamaskbot-build-announce/index.test.ts
+++ b/development/metamaskbot-build-announce/index.test.ts
@@ -32,7 +32,6 @@ function setEnv(overrides: Record<string, string | undefined> = {}): void {
 async function flushPromises(): Promise<void> {
   // Several passes to let chained promises resolve
   for (let i = 0; i < 5; i++) {
-    // eslint-disable-next-line no-await-in-loop
     await new Promise<void>((resolve) => setImmediate(resolve));
   }
 }

--- a/development/ts-migration-dashboard/app/components/App.tsx
+++ b/development/ts-migration-dashboard/app/components/App.tsx
@@ -30,8 +30,6 @@ const overallTotal = {
   numModules: allModules.length,
 };
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function App() {
   const [boxRectsByModuleId, setBoxRectsById] = useState<Record<
     string,

--- a/development/ts-migration-dashboard/app/components/Box.tsx
+++ b/development/ts-migration-dashboard/app/components/Box.tsx
@@ -4,8 +4,6 @@ import { Tooltip as ReactTippy } from 'react-tippy';
 import type { ModulePartitionChild } from '../../common/build-module-partitions';
 import type { BoxRect } from './types';
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function Box({
   module,
   register,

--- a/development/ts-migration-dashboard/app/components/Connections.tsx
+++ b/development/ts-migration-dashboard/app/components/Connections.tsx
@@ -96,8 +96,6 @@ function LineStart({
   );
 }
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function Connections({ activeBox }: { activeBox: BoxModel }) {
   return (
     <svg className="module-connections">

--- a/development/ts-migration-dashboard/common/partitions-file.ts
+++ b/development/ts-migration-dashboard/common/partitions-file.ts
@@ -9,7 +9,7 @@ export const PARTITIONS_FILE = join(
 );
 
 export function readPartitionsFile() {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   return require('../build/intermediate/partitions.json') as ModulePartition[];
 }
 

--- a/development/ts-migration-dashboard/scripts/build-app.ts
+++ b/development/ts-migration-dashboard/scripts/build-app.ts
@@ -6,7 +6,6 @@ import chokidar from 'chokidar';
 import browserify from 'browserify';
 import pify from 'pify';
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error @types/readable-stream does not export finished or pipeline
 import { finished, pipeline } from 'readable-stream';
 import gulp from 'gulp';

--- a/development/webpack/test/dev-server.test.ts
+++ b/development/webpack/test/dev-server.test.ts
@@ -284,7 +284,6 @@ function withFakeWebSocket(
     if (descriptor) {
       Object.defineProperty(globalThis, 'WebSocket', descriptor);
     } else {
-      // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
       delete (globalThis as Record<string, unknown>).WebSocket;
     }
   }

--- a/development/webpack/test/loaders.reactCompilerLoader.test.ts
+++ b/development/webpack/test/loaders.reactCompilerLoader.test.ts
@@ -36,7 +36,6 @@ describe('getReactCompilerLoader', () => {
 
       const opts = (
         loader as {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           options: { __verbose?: boolean };
         }
       ).options;
@@ -52,7 +51,6 @@ describe('getReactCompilerLoader', () => {
 
       const opts = (
         loader as {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           options: { __verbose?: boolean };
         }
       ).options;
@@ -109,7 +107,6 @@ describe('getReactCompilerLoader', () => {
 
       const opts = (
         loader as {
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           options: { __verbose?: boolean };
         }
       ).options;

--- a/development/webpack/utils/config.ts
+++ b/development/webpack/utils/config.ts
@@ -71,8 +71,6 @@ export function getBuildName(
   args: Pick<Args, 'manifestVersion' | 'lavamoat' | 'snow'>,
 ) {
   const buildName =
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     build.buildNameOverride ||
     `MetaMask ${type.slice(0, 1).toUpperCase()}${type.slice(1)}`;
   if (isDev) {

--- a/development/webpack/utils/loaders/reactCompilerLoader.ts
+++ b/development/webpack/utils/loaders/reactCompilerLoader.ts
@@ -116,7 +116,6 @@ export function getReactCompilerLoader(
         loader: getWrapperPath(),
         options: {
           ...defineReactCompilerLoaderOption(reactCompilerOptions),
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           __verbose: verbose,
         },
       }

--- a/development/webpack/utils/loaders/reactCompilerLoaderWrapper.ts
+++ b/development/webpack/utils/loaders/reactCompilerLoaderWrapper.ts
@@ -38,7 +38,6 @@ const REACT_COMPILER_STATUS_KEY = '__reactCompilerStatus__';
 type ReactCompilerStatus = 'compiled' | 'skipped' | 'error' | 'unsupported';
 
 type LoaderOptions = {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   __verbose?: boolean;
   logger?: unknown;
   [key: string]: unknown;

--- a/development/webpack/utils/plugins/ManifestPlugin/index.ts
+++ b/development/webpack/utils/plugins/ManifestPlugin/index.ts
@@ -619,8 +619,6 @@ export class ManifestPlugin<Z extends boolean> {
       if (resources && resources.length > 0) {
         if (manifest.manifest_version === 3) {
           manifest.web_accessible_resources =
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             manifest.web_accessible_resources || [];
           const war = manifest.web_accessible_resources.find((resource) =>
             resource.matches.includes('<all_urls>'),
@@ -637,8 +635,6 @@ export class ManifestPlugin<Z extends boolean> {
           }
         } else {
           manifest.web_accessible_resources = [
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             ...(manifest.web_accessible_resources || []),
             ...resources,
           ];


### PR DESCRIPTION
## **Description**

Unused ESLint ignore directives have been removed from the `development` directory.

This helps unblock the ESLint v9 upgrade (it complains about unused directives by default).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

The CI lint step should be sufficient to test this change.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only lint cleanup in development tooling; no production extension logic changed.
> 
> **Overview**
> Removes **unused ESLint disable comments** (and a few paired TODOs) under `development/` so lint stays clean ahead of **ESLint v9**, which reports unused directives by default.
> 
> Touches build tooling and internal dashboards/tests only—for example `variables.js` file-level JSDoc suppressions, `metamaskbot-build-announce` test loop awaits, TS migration dashboard React default exports, webpack dev-server and React Compiler loader tests, `getBuildName` / `ManifestPlugin` `prefer-nullish-coalescing` overrides, and `__verbose` naming-convention suppressions. In `partitions-file.ts`, the `require` line keeps a single `no-require-imports` disable after dropping redundant `no-var-requires`.
> 
> **No runtime or build behavior changes**—comment-only cleanup validated by existing CI lint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b92d401fd1b7faeb9a757ae825c62e7ff52c4753. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->