### PR TITLE
chore: remove unused ESLint directives from `shared`

### DIFF
--- a/shared/constants/metametrics.ts
+++ b/shared/constants/metametrics.ts
@@ -777,8 +777,6 @@ export enum MetaMetricsUserTrait {
   /**
    * Whether the device is mobile or desktop.
    */
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   DeviceType = 'device_type',
   /**
    * The operating system (normalized).

--- a/shared/constants/multichain/assets.ts
+++ b/shared/constants/multichain/assets.ts
@@ -26,8 +26,6 @@ export enum MultichainNativeAssets {
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
   SOLANA_TESTNET = `${MultichainNetworks.SOLANA_TESTNET}/slip44:501`,
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   TRON = `${MultichainNetworks.TRON}/slip44:195`,
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
@@ -35,8 +33,6 @@ export enum MultichainNativeAssets {
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
   TRON_SHASTA = `${MultichainNetworks.TRON_SHASTA}/slip44:195`,
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   STELLAR = `${MultichainNetworks.STELLAR}/slip44:148`,
 }
 

--- a/shared/constants/multichain/networks.ts
+++ b/shared/constants/multichain/networks.ts
@@ -63,8 +63,6 @@ export enum MultichainNetworks {
   // eslint-disable-next-line @typescript-eslint/naming-convention
   SOLANA_TESTNET = SolScope.Testnet,
 
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   TRON = TrxScope.Mainnet,
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/shared/lib/Numeric.ts
+++ b/shared/lib/Numeric.ts
@@ -340,8 +340,6 @@ export class Numeric {
     denomination?: EtherDenomination,
   ) {
     if (value instanceof Numeric) {
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       if (base || denomination) {
         throw new Error(
           `Numeric.from was called with a value (${value.toString()}) that is already a Numeric but a base and/or denomination was provided. Only supply base or denomination when creating a new Numeric`,

--- a/shared/lib/bridge-utils/security-alerts-api.util.ts
+++ b/shared/lib/bridge-utils/security-alerts-api.util.ts
@@ -56,11 +56,7 @@ function getSecurityApiScanTokenRequestBody(
  */
 function getFirstTokenAlert(features: TokenFeature[]): TokenFeature | null {
   return (
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     features.find((feature) => feature.type === TokenFeatureType.MALICIOUS) ||
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     features.find((feature) => feature.type === TokenFeatureType.WARNING) ||
     null
   );

--- a/shared/lib/caip-stream.ts
+++ b/shared/lib/caip-stream.ts
@@ -1,5 +1,4 @@
 import { isObject } from '@metamask/utils';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error pipeline() isn't defined as part of @types/readable-stream
 import { pipeline, Duplex } from 'readable-stream';
 

--- a/shared/lib/dapp-swap-comparison/dapp-swap-command-utils.ts
+++ b/shared/lib/dapp-swap-comparison/dapp-swap-command-utils.ts
@@ -128,7 +128,6 @@ const SWAP_EXACT_IN_STRUCT = `(address currencyIn,${
   PATH_KEY_STRUCT
 }[] path,uint128 amountIn,uint128 amountOutMinimum)`;
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 export const V4_BASE_ACTIONS_ABI_DEFINITION: Partial<
   Record<V4Actions, { name: string; type: string }[]>
 > = {

--- a/shared/lib/deep-links/constants.ts
+++ b/shared/lib/deep-links/constants.ts
@@ -1,5 +1,4 @@
 // no destructuring as process.env detection stops working
-// eslint-disable-next-line prefer-destructuring
 export const DEEP_LINK_HOST = process.env.DEEP_LINK_HOST ?? 'link.metamask.io';
 export const DEEP_LINK_MAX_LENGTH = 2048;
 export const SIG_PARAM = 'sig';

--- a/shared/lib/deep-links/routes/index.ts
+++ b/shared/lib/deep-links/routes/index.ts
@@ -44,7 +44,7 @@ export function addRoute(route: Route) {
 }
 
 if (process.env.ENABLE_SETTINGS_PAGE_DEV_OPTIONS || process.env.IN_TEST) {
-  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, n/global-require
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
   addRoute(require('./test-route').test);
 }
 

--- a/shared/lib/feature-flags/version-gating.test.ts
+++ b/shared/lib/feature-flags/version-gating.test.ts
@@ -70,7 +70,6 @@ describe('version-gating', () => {
 
     it('returns false when semver.gte throws a non-Error exception', () => {
       semverGteMock.mockImplementation(() => {
-        // eslint-disable-next-line no-throw-literal
         throw 'Some string error';
       });
 

--- a/shared/lib/hash.utils.ts
+++ b/shared/lib/hash.utils.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-undef */
 export async function sha256(str: string): Promise<string> {
   const buf = await crypto.subtle.digest(
     'SHA-256',

--- a/shared/lib/i18n.ts
+++ b/shared/lib/i18n.ts
@@ -184,8 +184,6 @@ function missingKeyError(
     onError?.(error);
     log.error(error);
 
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     if (process.env.IN_TEST || process.env.ENABLE_SETTINGS_PAGE_DEV_OPTIONS) {
       throw error;
     }

--- a/shared/lib/manifestFlags.ts
+++ b/shared/lib/manifestFlags.ts
@@ -167,8 +167,6 @@ export function getManifestFlags(): ManifestFlags {
   }
 
   return (
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     (browser.runtime.getManifest() as WebExtensionManifestWithFlags)._flags ||
     {}
   );

--- a/shared/lib/perps-feature-flags.test.ts
+++ b/shared/lib/perps-feature-flags.test.ts
@@ -167,7 +167,6 @@ describe('perps-feature-flags', () => {
 
         it('returns false when semver throws a non-Error exception', () => {
           semverGteMock.mockImplementation(() => {
-            // eslint-disable-next-line no-throw-literal
             throw 'Some string error';
           });
 

--- a/shared/lib/selectors/feature-flags.ts
+++ b/shared/lib/selectors/feature-flags.ts
@@ -60,8 +60,6 @@ export function getFeatureFlagsByChainId(
   state: ProviderConfigState & FeatureFlagsMetaMaskState,
   chainId?: string,
 ) {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const effectiveChainId = chainId || getCurrentChainId(state);
   const networkName = getNetworkNameByChainId(effectiveChainId);
   const featureFlags = state.metamask.swapsState?.swapsFeatureFlags;

--- a/shared/lib/selectors/smart-transactions.ts
+++ b/shared/lib/selectors/smart-transactions.ts
@@ -152,8 +152,6 @@ export const getChainSupportsSmartTransactions = (
   state: NetworkState,
   chainId?: string,
 ): boolean => {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const effectiveChainId = chainId || getCurrentChainId(state);
   return getAllowedSmartTransactionsChainIds().includes(effectiveChainId);
 };
@@ -175,8 +173,6 @@ const getIsAllowedRpcUrlForSmartTransactions = (
   state: NetworkState & RemoteFeatureFlagsState,
   chainId?: string,
 ) => {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const effectiveChainId = chainId || getCurrentChainId(state);
   // Allow in non-production or if chain ID is on skip list.
   if (
@@ -210,7 +206,6 @@ export const getSmartTransactionsEnabled = (
   state: SmartTransactionsState,
   chainId?: string,
 ): boolean => {
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const effectiveChainId = (chainId || getCurrentChainId(state)) as Hex;
   // @ts-expect-error Smart transaction selector types does not match controller state
   const supportedAccount = accountSupportsSmartTx(state);

--- a/shared/lib/shield/metrics.ts
+++ b/shared/lib/shield/metrics.ts
@@ -26,7 +26,6 @@ import {
   ExistingSubscriptionEventParams,
   ShieldSubscriptionMetricsPropsFromUI,
 } from '../../types';
-// eslint-disable-next-line import-x/no-restricted-paths
 import {
   getDefaultSubscriptionPaymentOptions,
   getIsTrialedSubscription,

--- a/shared/lib/transaction-breakdown-utils.ts
+++ b/shared/lib/transaction-breakdown-utils.ts
@@ -20,14 +20,10 @@ export const calcHexGasTotal = (txMeta: TransactionMeta) => {
   // use the effectiveGasPrice from the receipt, which will ultimately represent to true cost
   // of the transaction. Either of these are used the same way with gasLimit to calculate total
   // cost. effectiveGasPrice will be available on the txReciept for all EIP1559 networks
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const usedGasPrice = gasPrice || effectiveGasPrice;
   const hexGasTotal =
     (gasLimit &&
       usedGasPrice &&
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       getHexGasTotal({ gasLimit, gasPrice: usedGasPrice })) ||
     '0x0';
 

--- a/shared/lib/transaction.utils.ts
+++ b/shared/lib/transaction.utils.ts
@@ -131,8 +131,6 @@ export function txParamsAreDappSuggested(
     transactionMeta?.txParams || {};
   return Boolean(
     (gasPrice &&
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       gasPrice === transactionMeta?.dappSuggestedGasFees?.gasPrice) ||
     (maxPriorityFeePerGas &&
       maxFeePerGas &&
@@ -310,8 +308,6 @@ export async function determineTransactionAssetType(
   ].find((methodName) => methodName === inferrableType);
 
   if (
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     isTokenMethod ||
     // We can also check any contract interaction type to see if the to address
     // is a token contract. If it isn't, then the method will throw and we can
@@ -484,8 +480,6 @@ export const parseTypedDataMessage = (dataToParse: DataMessageParam) => {
       : JSON.parse(quoteLargeJsonIntegers(String(dataToParse)));
 
   if (result.message?.value) {
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     result.message.value = String(result.message.value);
   }
 

--- a/shared/lib/transactions-controller-utils.test.ts
+++ b/shared/lib/transactions-controller-utils.test.ts
@@ -42,9 +42,7 @@ describe('transaction controller utils', () => {
       // BigNumber#div in the past when the value that was passed into it was not a BigNumber.
       [123456, 36, '1.23456e-31'],
       [3000123456789678, 6, '3000123456.789678'],
-      // eslint-disable-next-line no-loss-of-precision
       [3000123456789123456789123456789, 3, '3.0001234567891233e+27'], // expected precision lost
-      // eslint-disable-next-line no-loss-of-precision
       [3000123456789123456789123456789, 6, '3.0001234567891233e+24'], // expected precision lost
       // string values
       ['0', 5, '0'],

--- a/shared/lib/translate.ts
+++ b/shared/lib/translate.ts
@@ -31,8 +31,6 @@ export function getCurrentLocale(): string {
 
 export function t(key: string, ...substitutions: string[]): string | null {
   return (
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     getMessage(currentLocale, translations, key, substitutions) ||
     getMessage(FALLBACK_LOCALE, enTranslations, key, substitutions)
   );


### PR DESCRIPTION
## **Description**

Unused ESLint ignore directives have been removed from the `shared` directory.

This helps unblock the ESLint v9 upgrade (it complains about unused directives by default).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

The CI lint step should be sufficient to test this change.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only lint hygiene; CI lint is the main verification gate.
> 
> **Overview**
> Removes **unused `eslint-disable` comments** across the `shared` tree so ESLint v9 can run without reporting stale suppressions. No application logic, types, or runtime behavior change—only comment cleanup.
> 
> Touches constants (multichain networks/assets, metametrics enum members), utilities (`Numeric`, i18n, transactions, smart-transaction selectors, bridge security alerts, deep links, hash utils), tests (version-gating, perps flags, transactions-controller), and a few narrow rule trims (e.g. `no-var-requires` → `no-require-imports` on the dev test route).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b85ad2bea20ee1ec5e388ef7e6c687ff2712b75. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->