### PR TITLE
chore: remove unused ESLint directives from `ui/pages`

### DIFF
--- a/ui/pages/asset/components/token-buttons.tsx
+++ b/ui/pages/asset/components/token-buttons.tsx
@@ -150,8 +150,6 @@ const TokenButtons = ({
         label={t('buy')}
         data-testid="token-overview-buy"
         onClick={handleBuyAndSellOnClick}
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         disabled={token.isERC721}
       />
 

--- a/ui/pages/batch-sell/hooks/useBatchSellInfoModal.test.tsx
+++ b/ui/pages/batch-sell/hooks/useBatchSellInfoModal.test.tsx
@@ -95,7 +95,6 @@ describe('useBatchSellModal', () => {
 
   describe('consumer component integration', () => {
     it('wires openModal and closeModal to UI actions correctly', () => {
-      // eslint-disable-next-line @typescript-eslint/naming-convention
       const TestConsumer = () => {
         const { openModal, closeModal } = useBatchSellInfoModal();
         return (

--- a/ui/pages/batch-sell/pages/review/components/review-and-confirm-modal.tsx
+++ b/ui/pages/batch-sell/pages/review/components/review-and-confirm-modal.tsx
@@ -34,7 +34,6 @@ import { AvatarGroup } from '../../../../../components/multichain/avatar-group';
 import { AvatarType } from '../../../../../components/multichain/avatar-group/avatar-group.types';
 // eslint-disable-next-line import-x/no-restricted-paths
 import { Tooltip } from '../../../../bridge/layout';
-// eslint-disable-next-line import-x/no-restricted-paths
 import {
   bpsToPercentage,
   formatCurrencyAmount,

--- a/ui/pages/bridge/awaiting-signatures/awaiting-signatures.tsx
+++ b/ui/pages/bridge/awaiting-signatures/awaiting-signatures.tsx
@@ -34,8 +34,6 @@ import {
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useNavigateOnQrScanComplete } from '../hooks/useNavigateOnQrScanComplete';
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function AwaitingSignatures() {
   const t = useI18nContext();
   const { activeQuote } = useSelector(getBridgeQuotes, shallowEqual);

--- a/ui/pages/bridge/index.tsx
+++ b/ui/pages/bridge/index.tsx
@@ -119,8 +119,6 @@ const CrossChainSwap = () => {
           iconName={IconName.ArrowLeft}
           size={ButtonIconSize.Md}
           ariaLabel={t('back')}
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-          // eslint-disable-next-line @typescript-eslint/no-misused-promises
           onClick={handleBack}
         />
       }

--- a/ui/pages/bridge/prepare/bridge-input-group.tsx
+++ b/ui/pages/bridge/prepare/bridge-input-group.tsx
@@ -112,8 +112,6 @@ export const BridgeInputGroup = ({
   const balanceAmount = useSelector(getFromTokenBalance);
 
   const isAmountReadOnly =
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     amountFieldProps?.readOnly || amountFieldProps?.disabled;
   const shouldShowAmountSkeleton = Boolean(
     showAmountSkeleton && isAmountReadOnly,

--- a/ui/pages/bridge/prepare/components/bridge-alert-banner-list.test.tsx
+++ b/ui/pages/bridge/prepare/components/bridge-alert-banner-list.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import React from 'react';
 import type { Provider } from '@metamask/network-controller';
 import {

--- a/ui/pages/bridge/prepare/prepare-bridge-page.tsx
+++ b/ui/pages/bridge/prepare/prepare-bridge-page.tsx
@@ -393,8 +393,6 @@ const PrepareBridgePage = ({
           amountFieldProps={{
             testId: 'from-amount',
             autoFocus: true,
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             value: fromAmount || undefined,
           }}
           containerProps={{

--- a/ui/pages/bridge/utils/quote.ts
+++ b/ui/pages/bridge/utils/quote.ts
@@ -2,7 +2,6 @@ import { BigNumber } from 'bignumber.js';
 import { type QuoteResponse } from '@metamask/bridge-controller';
 import { formatCurrency } from '../../../helpers/utils/confirm-tx.util';
 import { DEFAULT_PRECISION } from '../../../hooks/useCurrencyDisplay';
-// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0021): route-isolation backlog
 import { formatAmount } from '../../../../shared/lib/format-amount';
 import type { BridgeToken } from '../../../ducks/bridge/types';
 

--- a/ui/pages/confirm-add-suggested-nft/confirm-add-suggested-nft.stories.js
+++ b/ui/pages/confirm-add-suggested-nft/confirm-add-suggested-nft.stories.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React from 'react';
 import { Provider } from 'react-redux';
 import { ApprovalType } from '@metamask/controller-utils';

--- a/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.stories.js
+++ b/ui/pages/confirm-add-suggested-token/confirm-add-suggested-token.stories.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React from 'react';
 import { Provider } from 'react-redux';
 import { pendingTokenApprovals as mockPendingTokenApprovals } from '../../../.storybook/initial-states/approval-screens/add-suggested-token';

--- a/ui/pages/confirmations/components/activity/block-explorer-link/block-explorer-link.tsx
+++ b/ui/pages/confirmations/components/activity/block-explorer-link/block-explorer-link.tsx
@@ -31,7 +31,6 @@ function getBlockExplorerTxUrl(
   return undefined;
 }
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function BlockExplorerLink({
   chainId,
   hash,

--- a/ui/pages/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-account-row/transaction-details-account-row.tsx
@@ -43,7 +43,6 @@ function selectFirstAccountGroupName(state: unknown): string | undefined {
     : undefined;
 }
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function TransactionDetailsAccountRow() {
   const t = useI18nContext();
   const { transactionMeta } = useTransactionDetails();

--- a/ui/pages/confirmations/components/activity/transaction-details-bridge-fee-row/transaction-details-bridge-fee-row.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-bridge-fee-row/transaction-details-bridge-fee-row.tsx
@@ -8,7 +8,6 @@ import { TransactionDetailsRow } from '../transaction-details-row';
 import { useTransactionDetails } from '../transaction-details-context';
 import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function TransactionDetailsBridgeFeeRow() {
   const t = useI18nContext();
   const { transactionMeta } = useTransactionDetails();

--- a/ui/pages/confirmations/components/activity/transaction-details-context/transaction-details-context.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-context/transaction-details-context.tsx
@@ -24,7 +24,6 @@ type TransactionDetailsProviderProps = {
   transactionMeta: TransactionMeta;
 };
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function TransactionDetailsProvider({
   children,
   transactionMeta,

--- a/ui/pages/confirmations/components/activity/transaction-details-date-row/transaction-details-date-row.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-date-row/transaction-details-date-row.tsx
@@ -11,7 +11,6 @@ import { TransactionDetailsRow } from '../transaction-details-row';
 import { useTransactionDetails } from '../transaction-details-context';
 import { formatTransactionDateTime } from '../utils';
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function TransactionDetailsDateRow() {
   const t = useI18nContext();
   const { transactionMeta } = useTransactionDetails();

--- a/ui/pages/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-hero/transaction-details-hero.tsx
@@ -8,7 +8,6 @@ import {
 import { useFiatFormatter } from '../../../../../hooks/useFiatFormatter';
 import { useTransactionDetails } from '../transaction-details-context';
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function TransactionDetailsHero() {
   const { transactionMeta } = useTransactionDetails();
   const fiatFormatter = useFiatFormatter({ overrideCurrency: 'usd' });

--- a/ui/pages/confirmations/components/activity/transaction-details-modal/transaction-details-modal.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-modal/transaction-details-modal.tsx
@@ -25,7 +25,6 @@ export type TransactionDetailsModalProps = {
   onClose: () => void;
 };
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function TransactionDetailsModal({
   transactionMeta,
   onClose,

--- a/ui/pages/confirmations/components/activity/transaction-details-network-fee-row/transaction-details-network-fee-row.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-network-fee-row/transaction-details-network-fee-row.tsx
@@ -6,7 +6,6 @@ import { useFiatFormatter } from '../../../../../hooks/useFiatFormatter';
 import { TransactionDetailsRow } from '../transaction-details-row';
 import { useTransactionDetails } from '../transaction-details-context';
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function TransactionDetailsNetworkFeeRow() {
   const t = useI18nContext();
   const { transactionMeta } = useTransactionDetails();

--- a/ui/pages/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-paid-with-row/transaction-details-paid-with-row.tsx
@@ -15,7 +15,6 @@ import { useTokenWithBalance } from '../../../hooks/tokens/useTokenWithBalance';
 import { TokenIcon } from '../../token-icon';
 import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function TransactionDetailsPaidWithRow() {
   const t = useI18nContext();
   const { transactionMeta } = useTransactionDetails();

--- a/ui/pages/confirmations/components/activity/transaction-details-row/transaction-details-row.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-row/transaction-details-row.tsx
@@ -14,7 +14,6 @@ export type TransactionDetailsRowProps = {
   'data-testid'?: string;
 };
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function TransactionDetailsRow({
   children,
   label,

--- a/ui/pages/confirmations/components/activity/transaction-details-status-row/transaction-details-status-row.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-status-row/transaction-details-status-row.tsx
@@ -25,7 +25,6 @@ function getStatusTextColor(status: TransactionStatus): TextColor {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function TransactionDetailsStatusRow() {
   const t = useI18nContext();
   const { transactionMeta } = useTransactionDetails();

--- a/ui/pages/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details-total-row/transaction-details-total-row.tsx
@@ -8,7 +8,6 @@ import { TransactionDetailsRow } from '../transaction-details-row';
 import { useTransactionDetails } from '../transaction-details-context';
 import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function TransactionDetailsTotalRow() {
   const t = useI18nContext();
   const { transactionMeta } = useTransactionDetails();

--- a/ui/pages/confirmations/components/activity/transaction-details/transaction-details.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-details/transaction-details.tsx
@@ -18,7 +18,6 @@ import { TransactionDetailsSummary } from '../transaction-details-summary';
 import { useTransactionDetails } from '../transaction-details-context';
 import { hasTransactionType } from '../../../../../../shared/lib/transactions.utils';
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function TransactionDetails() {
   const { transactionMeta } = useTransactionDetails();
   const hasPaymentDetails = Boolean(transactionMeta.metamaskPay);

--- a/ui/pages/confirmations/components/activity/transaction-status-icon/transaction-status-icon.tsx
+++ b/ui/pages/confirmations/components/activity/transaction-status-icon/transaction-status-icon.tsx
@@ -35,7 +35,6 @@ function getStatusIconColor(status: TransactionStatus): IconColor {
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function TransactionStatusIcon({ status }: TransactionStatusIconProps) {
   return (
     <Icon

--- a/ui/pages/confirmations/components/confirm/footer/origin-throttle-modal.tsx
+++ b/ui/pages/confirmations/components/confirm/footer/origin-throttle-modal.tsx
@@ -151,8 +151,6 @@ const OriginBlockedContent = ({
   );
 };
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function OriginThrottleModal({
   isOpen,
   onConfirmationCancel,

--- a/ui/pages/confirmations/components/confirm/header/wallet-initiated-header.tsx
+++ b/ui/pages/confirmations/components/confirm/header/wallet-initiated-header.tsx
@@ -115,8 +115,6 @@ export const WalletInitiatedHeader = () => {
         iconName={IconName.ArrowLeft}
         ariaLabel={t('back')}
         size={ButtonIconSize.Md}
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         onClick={handleBackButtonClick}
         data-testid="wallet-initiated-header-back-button"
         color={IconColor.iconDefault}

--- a/ui/pages/confirmations/components/confirm/info/approve/edit-spending-cap-modal/edit-spending-cap-modal.tsx
+++ b/ui/pages/confirmations/components/confirm/info/approve/edit-spending-cap-modal/edit-spending-cap-modal.tsx
@@ -232,8 +232,6 @@ export const EditSpendingCapModal = ({
               >
                 {t('editSpendingCapAccountBalance', [
                   accountBalance,
-                  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-                  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
                   tokenSymbol || '',
                 ])}
               </Text>
@@ -241,16 +239,12 @@ export const EditSpendingCapModal = ({
           )}
         </ModalBody>
         <ModalFooter
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-          // eslint-disable-next-line @typescript-eslint/no-misused-promises
           onSubmit={handleSubmit}
           onCancel={handleCancel}
           submitButtonProps={{
             children: t('save'),
             loading: pending || isModalSaving,
             disabled:
-              // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               showDecimalError ||
               showSpecialCharacterError ||
               customSpendingCapInputValue === '',

--- a/ui/pages/confirmations/components/confirm/info/batch/batch-simulation-details/batch-simulation-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/batch/batch-simulation-details/batch-simulation-details.tsx
@@ -20,8 +20,6 @@ import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
 import { updateAtomicBatchData } from '../../../../../../../store/controller-actions/transaction-controller';
 import { useIsUpgradeTransaction } from '../../hooks/useIsUpgradeTransaction';
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function BatchSimulationDetails() {
   const t = useI18nContext();
   const { isUpgradeOnly } = useIsUpgradeTransaction();
@@ -100,8 +98,6 @@ export function BatchSimulationDetails() {
             <EditSpendingCapModal
               data={nestedTransactionToEdit?.data}
               isOpenEditSpendingCapModal={true}
-              // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-              // eslint-disable-next-line @typescript-eslint/no-misused-promises
               onSubmit={handleEditSubmit}
               setIsOpenEditSpendingCapModal={setIsEditApproveModalOpen}
               to={nestedTransactionToEdit?.to}

--- a/ui/pages/confirmations/components/confirm/info/batch/nested-transaction-data/nested-transaction-data.tsx
+++ b/ui/pages/confirmations/components/confirm/info/batch/nested-transaction-data/nested-transaction-data.tsx
@@ -18,8 +18,6 @@ import { useI18nContext } from '../../../../../../../hooks/useI18nContext';
 import { useDappSwapContext } from '../../../../../context/dapp-swap';
 import { useNestedTransactionLabels } from '../../hooks/useNestedTransactionLabels';
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function NestedTransactionData() {
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const { chainId, nestedTransactions } = currentConfirmation ?? {};

--- a/ui/pages/confirmations/components/confirm/info/batch/transaction-account-details/transaction-account-details.tsx
+++ b/ui/pages/confirmations/components/confirm/info/batch/transaction-account-details/transaction-account-details.tsx
@@ -18,8 +18,6 @@ import {
 } from '../../hooks/useIsUpgradeTransaction';
 import { RecipientRow } from '../../shared/transaction-details/transaction-details';
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function TransactionAccountDetails() {
   const t = useI18nContext();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();

--- a/ui/pages/confirmations/components/confirm/info/hooks/useTransactionGasFeeEstimate.ts
+++ b/ui/pages/confirmations/components/confirm/info/hooks/useTransactionGasFeeEstimate.ts
@@ -26,18 +26,10 @@ export function useTransactionGasFeeEstimate(
     ?.estimatedBaseFee;
 
   // override with values from `dappSuggestedGasFees` if they exist
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   gasLimit = gasLimit || HEX_ZERO;
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   gasPrice = gasPrice || HEX_ZERO;
   const maxPriorityFeePerGas =
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     transactionMeta.txParams?.maxPriorityFeePerGas || HEX_ZERO;
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const maxFeePerGas = transactionMeta.txParams?.maxFeePerGas || HEX_ZERO;
 
   let gasEstimate: Hex;

--- a/ui/pages/confirmations/components/confirm/info/info.tsx
+++ b/ui/pages/confirmations/components/confirm/info/info.tsx
@@ -31,8 +31,6 @@ import TypedSignV1Info from './typed-sign-v1/typed-sign-v1';
 import TypedSignInfo from './typed-sign/typed-sign';
 import TypedSignPermissionInfo from './typed-sign/typed-sign-permission';
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const DefaultHeadingSkeleton = () => (
   <>
     <Skeleton
@@ -54,7 +52,6 @@ const DefaultHeadingSkeleton = () => (
   </>
 );
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const SendHeadingSkeleton = () => (
   <div
     data-testid="confirmation__send_info_skeleton"
@@ -76,7 +73,6 @@ const SendHeadingSkeleton = () => (
   </div>
 );
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 const SectionSkeletons = () => (
   <>
     <Skeleton

--- a/ui/pages/confirmations/components/confirm/info/shared/batched-approval-function/batched-approval-function.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/batched-approval-function/batched-approval-function.tsx
@@ -93,8 +93,6 @@ const getBatchedApprovalDisplayValue = async (
   return undefined;
 };
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function BatchedApprovalFunction({
   method,
   nestedTransactionIndex,

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-icon/gas-fee-token-icon.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-icon/gas-fee-token-icon.tsx
@@ -22,8 +22,6 @@ export enum GasFeeTokenIconSize {
   Md = 'md',
 }
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function GasFeeTokenIcon({
   size = GasFeeTokenIconSize.Md,
   tokenAddress,

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-list-item/gas-fee-token-list-item.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-list-item/gas-fee-token-list-item.tsx
@@ -40,8 +40,6 @@ export type GasFeeTokenListItemProps = {
   warning?: string;
 };
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function GasFeeTokenListItem({
   isSelected,
   onClick,

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-modal/gas-fee-token-modal.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-modal/gas-fee-token-modal.tsx
@@ -37,8 +37,6 @@ import Tooltip from '../../../../../../../components/ui/tooltip';
 import { useIsGaslessSupported } from '../../../../../hooks/gas/useIsGaslessSupported';
 import { useIsInsufficientBalance } from '../../../../../hooks/useIsInsufficientBalance';
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function GasFeeTokenModal({ onClose }: { onClose?: () => void }) {
   const t = useI18nContext();
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
@@ -155,8 +153,6 @@ export function GasFeeTokenModal({ onClose }: { onClose?: () => void }) {
                 selectedGasFeeToken?.toLowerCase() ===
                 tokenAddress.toLowerCase()
               }
-              // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-              // eslint-disable-next-line @typescript-eslint/no-misused-promises
               onClick={handleTokenClick}
             />
           ))}

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-toast/gas-fee-token-toast.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-toast/gas-fee-token-toast.tsx
@@ -19,8 +19,6 @@ import {
 const TOAST_ID = 'gas-fee-token-toast';
 const TOAST_DURATION = 5 * SECOND;
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function GasFeeTokenToast() {
   const t = useI18nContext();
   const chainId = useTransactionMetadataRequestOptional()?.chainId;

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-sponsorship-modal/gas-sponsorship-modal.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-sponsorship-modal/gas-sponsorship-modal.tsx
@@ -29,8 +29,6 @@ import { CHAIN_ID_TOKEN_IMAGE_MAP } from '../../../../../../../../shared/constan
 import { useNativeCurrencySymbol } from '../../hooks/useNativeCurrencySymbol';
 import { useFeeCalculations } from '../../hooks/useFeeCalculations';
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function GasSponsorshipModal({ onClose }: { onClose: () => void }) {
   const t = useI18nContext();
   const { currentConfirmation: transactionMeta } =

--- a/ui/pages/confirmations/components/confirm/info/shared/nft-send-heading/nft-send-heading.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/nft-send-heading/nft-send-heading.tsx
@@ -63,8 +63,6 @@ const NFTSendHeading = () => {
   const imageOriginal = (nft as Nft | undefined)?.imageOriginal;
   const image = getNftImage((nft as Nft | undefined)?.image);
   const nftImageAlt = nft ? getNftImageAlt(nft) : '';
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const nftSrcUrl = imageOriginal ?? (image || imageFromTokenURI || '');
   const isIpfsURL = nftSrcUrl?.startsWith('ipfs:');
   const currentChain = networkConfigurations[chainId];
@@ -75,12 +73,8 @@ const NFTSendHeading = () => {
   const TokenImage = (
     <Box style={{ width: '48px' }}>
       <NftItem
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         src={nftItemSrc}
         alt={nftImageAlt}
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         name={assetName || nameFromTokenURI}
         networkName={currentChain.name ?? ''}
         networkSrc={

--- a/ui/pages/confirmations/components/confirm/info/shared/selected-gas-fee-token/selected-gas-fee-token.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/selected-gas-fee-token/selected-gas-fee-token.tsx
@@ -18,8 +18,6 @@ import { useIsGaslessSupported } from '../../../../../hooks/gas/useIsGaslessSupp
 import { useIsInsufficientBalance } from '../../../../../hooks/useIsInsufficientBalance';
 import { useNativeCurrencySymbol } from '../../hooks/useNativeCurrencySymbol';
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function SelectedGasFeeToken() {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();

--- a/ui/pages/confirmations/components/confirm/info/shared/transaction-data/transaction-data.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/transaction-data/transaction-data.tsx
@@ -150,8 +150,6 @@ export function Container({
         <ConfirmInfoRow
           label={t('advancedDetailsDataDesc')}
           copyEnabled={Boolean(transactionData)}
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-          // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
           copyText={transactionData || undefined}
         >
           <Box>{isLoading && <Preloader size={20} />}</Box>

--- a/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/decoded-simulation/decoded-simulation.tsx
+++ b/ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/decoded-simulation/decoded-simulation.tsx
@@ -196,8 +196,6 @@ const DecodedSimulation = () => {
         )
       }
       isLoading={decodingLoading}
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       isCollapsed={decodingLoading || !stateChangeFragment.length}
     />
   );

--- a/ui/pages/confirmations/components/confirm/ledger-info/ledger-info.tsx
+++ b/ui/pages/confirmations/components/confirm/ledger-info/ledger-info.tsx
@@ -76,8 +76,6 @@ const LedgerInfo = () => {
           variant={ButtonVariant.Link}
           textAlign={TextAlign.Left}
           fontWeight={FontWeight.Normal}
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-          // eslint-disable-next-line @typescript-eslint/no-misused-promises
           onClick={async () => {
             if (environmentTypeIsFullScreen) {
               window.location.reload();
@@ -95,8 +93,6 @@ const LedgerInfo = () => {
             variant={ButtonVariant.Link}
             textAlign={TextAlign.Left}
             fontWeight={FontWeight.Normal}
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-            // eslint-disable-next-line @typescript-eslint/no-misused-promises
             onClick={async () => {
               if (environmentTypeIsFullScreen) {
                 let connectedDevices: HIDDevice[] = [];

--- a/ui/pages/confirmations/components/confirm/nav/nav.tsx
+++ b/ui/pages/confirmations/components/confirm/nav/nav.tsx
@@ -108,8 +108,6 @@ export const Nav = ({ confirmationId }: NavProps) => {
         className="confirm_nav__reject_all"
         data-testid="confirm-nav__reject-all"
         fontWeight={FontWeight.Normal}
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         onClick={onRejectAll}
         paddingLeft={3}
         paddingRight={3}

--- a/ui/pages/confirmations/components/confirm/row/dataTree.tsx
+++ b/ui/pages/confirmations/components/confirm/row/dataTree.tsx
@@ -141,15 +141,11 @@ export const DataTree = ({
 };
 
 function isDateField(label: string, primaryType?: PrimaryType) {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   return (FIELD_DATE_PRIMARY_TYPES[label] || [])?.includes(primaryType || '');
 }
 
 function isTokenUnitsField(label: string, primaryType?: PrimaryType) {
   return (FIELD_TOKEN_UTILS_PRIMARY_TYPES[label] || [])?.includes(
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     primaryType || '',
   );
 }

--- a/ui/pages/confirmations/components/confirm/smart-account-tab/account-network/account-network.tsx
+++ b/ui/pages/confirmations/components/confirm/smart-account-tab/account-network/account-network.tsx
@@ -112,8 +112,6 @@ export const AccountNetwork = ({
           <Preloader size={12} />
         </Box>
       ) : (
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         <ButtonLink onClick={onSwitch} data-testid={`switch_account-${name}`}>
           {addressSupportSmartAccount ? t('switchBack') : t('switch')}
         </ButtonLink>

--- a/ui/pages/confirmations/components/confirm/title/title.tsx
+++ b/ui/pages/confirmations/components/confirm/title/title.tsx
@@ -253,8 +253,6 @@ const getDescription = (
   }
 };
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function TitleSkeleton() {
   return (
     <Box

--- a/ui/pages/confirmations/components/pay-token-amount/pay-token-amount.tsx
+++ b/ui/pages/confirmations/components/pay-token-amount/pay-token-amount.tsx
@@ -25,7 +25,6 @@ export type PayTokenAmountProps = {
   disabled?: boolean;
 };
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function PayTokenAmount({ amountHuman, disabled }: PayTokenAmountProps) {
   const locale = useSelector(getCurrentLocale) ?? 'en';
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
@@ -94,7 +93,6 @@ export function PayTokenAmount({ amountHuman, disabled }: PayTokenAmountProps) {
   );
 }
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function PayTokenAmountSkeleton() {
   return (
     <Box data-testid="pay-token-amount-skeleton">

--- a/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
+++ b/ui/pages/confirmations/components/rows/bridge-fee-row/bridge-fee-row.tsx
@@ -42,7 +42,6 @@ export type BridgeFeeRowProps = {
   tooltipDescription?: string;
 };
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function BridgeFeeRow({
   variant = ConfirmInfoRowSize.Default,
   tooltipDescription,

--- a/ui/pages/confirmations/components/rows/bridge-time-row/bridge-time-row.tsx
+++ b/ui/pages/confirmations/components/rows/bridge-time-row/bridge-time-row.tsx
@@ -31,7 +31,6 @@ export type BridgeTimeRowProps = {
   rowVariant?: ConfirmInfoRowSize;
 };
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function BridgeTimeRow({
   rowVariant = ConfirmInfoRowSize.Default,
 }: BridgeTimeRowProps) {

--- a/ui/pages/confirmations/components/rows/enforced-simulations-row/enforced-simulations-row.test.tsx
+++ b/ui/pages/confirmations/components/rows/enforced-simulations-row/enforced-simulations-row.test.tsx
@@ -187,7 +187,6 @@ describe('EnforcedSimulationsRow', () => {
       'enforced-simulations-toggle-input',
     ) as HTMLInputElement;
 
-    // eslint-disable-next-line @typescript-eslint/require-await
     await act(async () => {
       input?.click();
     });

--- a/ui/pages/confirmations/components/rows/receive-row/receive-row.tsx
+++ b/ui/pages/confirmations/components/rows/receive-row/receive-row.tsx
@@ -36,7 +36,6 @@ export type ReceiveRowProps = {
  * @param options0.inputAmountUsd
  * @param options0.variant
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function ReceiveRow({
   inputAmountUsd,
   variant = ConfirmInfoRowSize.Default,

--- a/ui/pages/confirmations/components/rows/total-row/total-row.tsx
+++ b/ui/pages/confirmations/components/rows/total-row/total-row.tsx
@@ -22,7 +22,6 @@ export type TotalRowProps = {
   variant?: ConfirmInfoRowSize;
 };
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function TotalRow({
   variant = ConfirmInfoRowSize.Default,
 }: TotalRowProps) {

--- a/ui/pages/confirmations/components/set-approval-for-all-warning/set-approval-for-all-warning.stories.js
+++ b/ui/pages/confirmations/components/set-approval-for-all-warning/set-approval-for-all-warning.stories.js
@@ -1,4 +1,3 @@
-/* eslint-disable react/prop-types */
 import React from 'react';
 import SetApproveForAllWarning from '.';
 

--- a/ui/pages/confirmations/components/simulation-details/useSimulationMetrics.ts
+++ b/ui/pages/confirmations/components/simulation-details/useSimulationMetrics.ts
@@ -172,8 +172,6 @@ function useIncompleteAssetEvent(
       const displayName = displayNamesByAddress[assetAddress];
 
       const isIncomplete =
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
         (change.asset.address && !change.fiatAmount) ||
         getPetnameType(change, displayName) === PetnameType.Unknown;
 

--- a/ui/pages/confirmations/components/smart-contract-with-logo/smart-contract-with-logo.tsx
+++ b/ui/pages/confirmations/components/smart-contract-with-logo/smart-contract-with-logo.tsx
@@ -9,8 +9,6 @@ import {
 import { Box, Text } from '../../../../components/component-library';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 function SmartContractWithLogo() {
   const t = useI18nContext();
   return (

--- a/ui/pages/confirmations/components/token-icon/token-icon.tsx
+++ b/ui/pages/confirmations/components/token-icon/token-icon.tsx
@@ -44,7 +44,6 @@ const NETWORK_BADGE_STYLE_MAP: Record<TokenIconSize, React.CSSProperties> = {
   md: {},
 };
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function TokenIcon({
   chainId,
   tokenAddress,

--- a/ui/pages/confirmations/components/transactions/nested-transaction-tag/nested-transaction-tag.tsx
+++ b/ui/pages/confirmations/components/transactions/nested-transaction-tag/nested-transaction-tag.tsx
@@ -62,8 +62,6 @@ const NestedTransactionTagContent = ({
  * when switching between confirmations with different numbers of nested transactions.
  * See: https://github.com/MetaMask/metamask-extension/issues/29191
  */
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function NestedTransactionTag() {
   const { currentConfirmation } = useConfirmContext<TransactionMeta>();
   const { nestedTransactions } = currentConfirmation ?? {};

--- a/ui/pages/confirmations/confirm/stories/utils.tsx
+++ b/ui/pages/confirmations/confirm/stories/utils.tsx
@@ -17,8 +17,6 @@ export const ARG_TYPES_SIGNATURE = {
   },
 };
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function ConfirmStoryTemplate(
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -41,8 +39,6 @@ export function ConfirmStoryTemplate(
   );
 }
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function SignatureStoryTemplate(
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/ui/pages/confirmations/confirmation/util.ts
+++ b/ui/pages/confirmations/confirmation/util.ts
@@ -22,8 +22,6 @@ export function processError(
   input: undefined | string | ResultComponent | ResultComponent[],
   fallback: string,
 ): TemplateRendererComponent | (string | TemplateRendererComponent)[] {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const currentInput = convertResultComponents(input) || fallback;
 
   if (typeof currentInput !== 'string') {
@@ -49,8 +47,6 @@ export function processString(
   input: undefined | string | ResultComponent | ResultComponent[],
   fallback: string,
 ): TemplateRendererComponent | (string | TemplateRendererComponent)[] {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const currentInput = convertResultComponents(input) || fallback;
 
   if (typeof currentInput !== 'string') {

--- a/ui/pages/confirmations/hooks/alerts/transactions/AccountTypeMessage.tsx
+++ b/ui/pages/confirmations/hooks/alerts/transactions/AccountTypeMessage.tsx
@@ -9,8 +9,6 @@ import {
 import ZENDESK_URLS from '../../../../../helpers/constants/zendesk-url';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function AccountTypeMessage() {
   const t = useI18nContext();
 

--- a/ui/pages/confirmations/hooks/alerts/useBlockaidAlerts.ts
+++ b/ui/pages/confirmations/hooks/alerts/useBlockaidAlerts.ts
@@ -25,7 +25,7 @@ import { useConfirmContext } from '../../context/confirm';
 import useCurrentSignatureSecurityAlertResponse from '../useCurrentSignatureSecurityAlertResponse';
 import { normalizeProviderAlert } from './utils';
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+// eslint-disable-next-line @typescript-eslint/no-require-imports
 const zlib = require('zlib');
 
 export const ALERT_RESULT_TYPES = [
@@ -66,8 +66,6 @@ const useBlockaidAlerts = (): Alert[] => {
   );
 
   const securityAlertResponse =
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     signatureSecurityAlertResponse || transactionSecurityAlertResponse;
 
   const isTransactionTypeSupported =

--- a/ui/pages/confirmations/hooks/alerts/utils.ts
+++ b/ui/pages/confirmations/hooks/alerts/utils.ts
@@ -74,8 +74,6 @@ export function normalizeProviderAlert(
   reportUrl?: string,
 ): Alert {
   return {
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     key: securityAlertResponse.securityAlertId || '',
     reason: t(
       REASON_TO_TITLE_TKEY[

--- a/ui/pages/confirmations/hooks/send/useNameValidation.test.ts
+++ b/ui/pages/confirmations/hooks/send/useNameValidation.test.ts
@@ -1,7 +1,6 @@
 import mockState from '../../../../../test/data/mock-state.json';
 import { renderHookWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import { lookupDomainName } from '../../../../ducks/domains';
-// eslint-disable-next-line import-x/no-namespace
 import * as SendValidationUtils from '../../utils/sendValidations';
 import { useNameValidation } from './useNameValidation';
 

--- a/ui/pages/confirmations/hooks/tokens/useTokenFiatRates.ts
+++ b/ui/pages/confirmations/hooks/tokens/useTokenFiatRates.ts
@@ -13,7 +13,6 @@ export type TokenFiatRateRequest = {
   currency?: string;
 };
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function useTokenFiatRates(
   requests: TokenFiatRateRequest[],
 ): (number | undefined)[] {
@@ -58,7 +57,6 @@ export function useTokenFiatRates(
   return useDeepMemo(() => result, [result]);
 }
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function useTokenFiatRate(
   tokenAddress: Hex,
   chainId: Hex,

--- a/ui/pages/confirmations/hooks/useCurrentConfirmation.ts
+++ b/ui/pages/confirmations/hooks/useCurrentConfirmation.ts
@@ -46,7 +46,6 @@ const useCurrentConfirmation = (providedConfirmationId?: string) => {
 
   // TODO: Migrate to selectUnapprovedSignatureRequestById once all consumers
   // of currentConfirmation are updated from msgParams to messageParams.
-  // eslint-disable-next-line @typescript-eslint/no-deprecated
   const signatureMessage = useSelector((state) =>
     selectUnapprovedMessage(state, confirmationIdForSelectors),
   );

--- a/ui/pages/confirmations/hooks/useIsEnforcedSimulationsEligible.test.ts
+++ b/ui/pages/confirmations/hooks/useIsEnforcedSimulationsEligible.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/naming-convention, camelcase */
+/* eslint-disable @typescript-eslint/naming-convention */
 import { TransactionMeta } from '@metamask/transaction-controller';
 import { renderHookWithConfirmContextProvider } from '../../../../test/lib/confirmations/render-helpers';
 import { getMockConfirmStateForTransaction } from '../../../../test/data/confirmations/helper';

--- a/ui/pages/confirmations/utils/transaction-pay.ts
+++ b/ui/pages/confirmations/utils/transaction-pay.ts
@@ -115,7 +115,6 @@ export function getAvailableTokens({
           t.chainId === chainId && t.address === getNativeTokenAddress(chainId),
       );
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const noNativeBalance =
         !nativeToken || new BigNumber(nativeToken.balance ?? 0).isZero();
 

--- a/ui/pages/create-account/connect-hardware/index.tsx
+++ b/ui/pages/create-account/connect-hardware/index.tsx
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/naming-convention */
-/* eslint-disable react-compiler/react-compiler */
 import React, {
   useCallback,
   useContext,

--- a/ui/pages/create-snap-account/create-snap-account.stories.tsx
+++ b/ui/pages/create-snap-account/create-snap-account.stories.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import CreateSnapAccount from './create-snap-account';
 
-// eslint-disable-next-line import-x/no-anonymous-default-export
 export default {
   title: 'Components/UI/CreateSnapAccount',
 };

--- a/ui/pages/hardware-wallets/swap/hardware-wallet-signatures.tsx
+++ b/ui/pages/hardware-wallets/swap/hardware-wallet-signatures.tsx
@@ -81,8 +81,6 @@ export default function HardwareWalletSignatures() {
             size={ButtonIconSize.Md}
             ariaLabel={t('back')}
             iconName={IconName.ArrowLeft}
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-            // eslint-disable-next-line @typescript-eslint/no-misused-promises
             onClick={handleCancel}
             data-testid="hardware-wallet-signatures__back-button"
           />

--- a/ui/pages/hardware-wallets/swap/hardware-wallet-signatures.utils.test.ts
+++ b/ui/pages/hardware-wallets/swap/hardware-wallet-signatures.utils.test.ts
@@ -29,7 +29,6 @@ jest.mock('../../../store/actions', () => ({
   rejectPendingApproval: jest.fn(() => 'REJECT_ACTION'),
 }));
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const mockRejectPendingApproval = jest.requireMock(
   '../../../store/actions',
 ).rejectPendingApproval;

--- a/ui/pages/keychains/reveal-seed.test.tsx
+++ b/ui/pages/keychains/reveal-seed.test.tsx
@@ -598,7 +598,6 @@ describe('Reveal Seed Page', () => {
           category: MetaMetricsEventCategory.Keys,
           // eslint-disable-next-line @typescript-eslint/naming-convention
           key_type: MetaMetricsEventKeyType.Srp,
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           screen: 'QUIZ_INTRODUCTION_SCREEN',
           // eslint-disable-next-line @typescript-eslint/naming-convention
           hd_entropy_index: 0,

--- a/ui/pages/multichain-accounts/multichain-accounts-connect-page/multichain-accounts-connect-page.stories.tsx
+++ b/ui/pages/multichain-accounts/multichain-accounts-connect-page/multichain-accounts-connect-page.stories.tsx
@@ -132,7 +132,6 @@ const store = configureStore({
       mockState.metamask.networkConfigurationsByChainId,
     permissionHistory: {
       'https://test.dapp': {
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         eth_accounts: {
           accounts: {
             '0x123': 1709225290848,

--- a/ui/pages/notification-details/notification-details.tsx
+++ b/ui/pages/notification-details/notification-details.tsx
@@ -62,8 +62,6 @@ function useEffectOnNotificationView(notificationData?: INotification) {
   }, []);
 }
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function NotificationDetails() {
   const navigate = useNavigate();
   const { notification } = useNotificationByPath();

--- a/ui/pages/notifications-settings/notifications-settings-allow-notifications.tsx
+++ b/ui/pages/notifications-settings/notifications-settings-allow-notifications.tsx
@@ -33,8 +33,6 @@ import {
   NotificationsSettingsType,
 } from '../../components/multichain';
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function NotificationsSettingsAllowNotifications({
   loading,
   setLoading,
@@ -66,8 +64,6 @@ export function NotificationsSettingsAllowNotifications({
     useEnableNotifications();
   const { disableNotifications, error: errorDisableNotifications } =
     useDisableNotifications();
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const error = errorEnableNotifications || errorDisableNotifications;
 
   useEffect(() => {
@@ -169,8 +165,6 @@ export function NotificationsSettingsAllowNotifications({
     >
       <NotificationsSettingsBox
         value={toggleValue}
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         onToggle={toggleNotifications}
         disabled={disabled}
         loading={loading}

--- a/ui/pages/notifications-settings/notifications-settings-per-account.tsx
+++ b/ui/pages/notifications-settings/notifications-settings-per-account.tsx
@@ -58,8 +58,6 @@ export const NotificationsSettingsPerAccount = ({
     <>
       <NotificationsSettingsBox
         value={isEnabled ?? false}
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-        // eslint-disable-next-line @typescript-eslint/no-misused-promises
         onToggle={handleToggleAccountNotifications}
         key={address}
         disabled={disabledSwitch}

--- a/ui/pages/notifications-settings/notifications-settings.tsx
+++ b/ui/pages/notifications-settings/notifications-settings.tsx
@@ -16,8 +16,6 @@ import { NotificationsSettingsAllowNotifications } from './notifications-setting
 import { NotificationsSettingsTypes } from './notifications-settings-types';
 import { useNotificationAccountGroups } from './notifications-settings-helpers';
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function NotificationsSettingsContent() {
   const isMetamaskNotificationsEnabled = useSelector(
     selectIsMetamaskNotificationsEnabled,

--- a/ui/pages/notifications/NewFeatureTag.tsx
+++ b/ui/pages/notifications/NewFeatureTag.tsx
@@ -11,8 +11,6 @@ import {
 } from '../../helpers/constants/design-system';
 import { useI18nContext } from '../../hooks/useI18nContext';
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function NewFeatureTag() {
   const t = useI18nContext();
 

--- a/ui/pages/notifications/notification-components/feature-announcement/feature-announcement.tsx
+++ b/ui/pages/notifications/notification-components/feature-announcement/feature-announcement.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import { NotificationServicesController } from '@metamask/notification-services-controller';
-// eslint-disable-next-line import-x/no-named-as-default
 import DOMPurify from 'dompurify';
 import { isOfTypeNodeGuard } from '../node-guard';
 import {

--- a/ui/pages/notifications/notification-components/swap-completed/swap-completed.tsx
+++ b/ui/pages/notifications/notification-components/swap-completed/swap-completed.tsx
@@ -215,8 +215,6 @@ export const components: NotificationComponent<SwapCompletedNotification> = {
               color: TextColor.infoDefault,
               backgroundColor: BackgroundColor.infoMuted,
             }}
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-            // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             label={t('notificationItemRate') || ''}
             detail={`1 ${notification.payload.data.token_out.symbol} ≈ ${(
               1 / parseFloat(notification.payload.data.rate)

--- a/ui/pages/notifications/notifications-list-item.tsx
+++ b/ui/pages/notifications/notifications-list-item.tsx
@@ -25,8 +25,6 @@ import {
   hasNotificationComponents,
 } from './notification-components';
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function NotificationsListItem({
   notification,
 }: {

--- a/ui/pages/notifications/notifications-list-placeholder.tsx
+++ b/ui/pages/notifications/notifications-list-placeholder.tsx
@@ -21,8 +21,6 @@ type NotificationsPlaceholderProps = {
   text: string;
 };
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function NotificationsPlaceholder({
   title,
   text,

--- a/ui/pages/notifications/notifications.tsx
+++ b/ui/pages/notifications/notifications.tsx
@@ -163,8 +163,6 @@ export const filterNotifications = (
   return notifications;
 };
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function Notifications() {
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();

--- a/ui/pages/onboarding-flow/account-exist/account-exist.tsx
+++ b/ui/pages/onboarding-flow/account-exist/account-exist.tsx
@@ -10,8 +10,6 @@ import { TraceName, TraceOperation } from '../../../../shared/lib/trace';
 import { AccountStatusLayout } from '../account-status-layout';
 import { useAccountStatusContext } from '../hooks/useAccountStatusContext';
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function AccountExist() {
   const navigate = useNavigate();
   const {

--- a/ui/pages/onboarding-flow/account-not-found/account-not-found.tsx
+++ b/ui/pages/onboarding-flow/account-not-found/account-not-found.tsx
@@ -10,8 +10,6 @@ import { TraceName, TraceOperation } from '../../../../shared/lib/trace';
 import { AccountStatusLayout } from '../account-status-layout';
 import { useAccountStatusContext } from '../hooks/useAccountStatusContext';
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function AccountNotFound() {
   const navigate = useNavigate();
   const {

--- a/ui/pages/onboarding-flow/create-password/create-password.test.tsx
+++ b/ui/pages/onboarding-flow/create-password/create-password.test.tsx
@@ -40,7 +40,6 @@ jest.mock('../../../hooks/useIsFirefox', () => ({
   useIsFirefox: jest.fn().mockReturnValue(false),
 }));
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const { useIsFirefox } = jest.requireMock('../../../hooks/useIsFirefox');
 
 jest.mock('../../../../shared/lib/passkey', () => ({

--- a/ui/pages/onboarding-flow/create-password/create-password.tsx
+++ b/ui/pages/onboarding-flow/create-password/create-password.tsx
@@ -52,8 +52,6 @@ type CreatePasswordProps = {
   secretRecoveryPhrase: string;
 };
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function CreatePassword({
   createNewAccount,
   importWithRecoveryPhrase,

--- a/ui/pages/onboarding-flow/creation-successful/creation-successful.tsx
+++ b/ui/pages/onboarding-flow/creation-successful/creation-successful.tsx
@@ -39,8 +39,6 @@ import { useOnboardingSearchParams } from '../hooks/useOnboardingSearchParams';
 import { useOnboardingCompletion } from '../hooks/useOnboardingCompletion';
 import WalletReadyAnimation from './wallet-ready-animation';
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function CreationSuccessful() {
   const navigate = useNavigate();
   const t = useI18nContext();

--- a/ui/pages/onboarding-flow/creation-successful/wallet-ready-animation.tsx
+++ b/ui/pages/onboarding-flow/creation-successful/wallet-ready-animation.tsx
@@ -14,8 +14,6 @@ import {
   useRiveWasmFile,
 } from '../../../contexts/rive-wasm';
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function WalletReadyAnimation() {
   const theme = useTheme();
   const context = useRiveWasmContext();

--- a/ui/pages/onboarding-flow/download-app/download-app.tsx
+++ b/ui/pages/onboarding-flow/download-app/download-app.tsx
@@ -19,8 +19,6 @@ import {
 } from '../../../helpers/constants/routes';
 import { getCurrentKeyring } from '../../../../shared/lib/selectors/keyring';
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function OnboardingDownloadApp() {
   const t = useI18nContext();
   const navigate = useNavigate();

--- a/ui/pages/onboarding-flow/import-srp/import-srp.tsx
+++ b/ui/pages/onboarding-flow/import-srp/import-srp.tsx
@@ -38,8 +38,6 @@ const hasUpperCase = (draftSrp: string) => {
   return draftSrp !== draftSrp.toLowerCase();
 };
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function ImportSRP({
   submitSecretRecoveryPhrase,
 }: ImportSRPProps) {

--- a/ui/pages/onboarding-flow/metametrics/metametrics.tsx
+++ b/ui/pages/onboarding-flow/metametrics/metametrics.tsx
@@ -114,8 +114,6 @@ function MetametricsCheckboxOption({
   );
 }
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function OnboardingMetametrics() {
   const t = useI18nContext();
   const dispatch = useDispatch();

--- a/ui/pages/onboarding-flow/onboarding-app-header/onboarding-app-header.tsx
+++ b/ui/pages/onboarding-flow/onboarding-app-header/onboarding-app-header.tsx
@@ -41,8 +41,6 @@ type OnboardingAppHeaderProps = {
   location: RouterLocation;
 };
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function OnboardingAppHeader({
   isWelcomePage = false,
   location,

--- a/ui/pages/onboarding-flow/onboarding-flow-switch/onboarding-flow-switch.test.tsx
+++ b/ui/pages/onboarding-flow/onboarding-flow-switch/onboarding-flow-switch.test.tsx
@@ -27,9 +27,7 @@ jest.mock('../../../hooks/useIsFirefox', () => ({
   useIsFirefox: jest.fn().mockReturnValue(false),
 }));
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const buildTypes = jest.requireMock('../../../../shared/lib/build-types');
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const { useIsFirefox } = jest.requireMock('../../../hooks/useIsFirefox');
 
 type LocationCaptureProps = {

--- a/ui/pages/onboarding-flow/onboarding-flow-switch/onboarding-flow-switch.tsx
+++ b/ui/pages/onboarding-flow/onboarding-flow-switch/onboarding-flow-switch.tsx
@@ -33,10 +33,7 @@ import {
   isMain,
 } from '../../../../shared/lib/build-types';
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function OnboardingFlowSwitch() {
-  /* eslint-disable prefer-const */
   const isFirefox = useIsFirefox();
   const completedOnboarding = useSelector(getCompletedOnboarding);
   const isInitialized = useSelector(getIsInitialized);

--- a/ui/pages/onboarding-flow/onboarding-flow.tsx
+++ b/ui/pages/onboarding-flow/onboarding-flow.tsx
@@ -115,7 +115,6 @@ const ExperimentalArea = mmLazy(
 const toRelativePath = (path: string) =>
   toRelativeRoutePath(path, ONBOARDING_ROUTE);
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function OnboardingFlow() {
   const [secretRecoveryPhrase, setSecretRecoveryPhrase] = useState('');
   const [isLoading, setIsLoading] = useState(false);

--- a/ui/pages/onboarding-flow/privacy-settings/privacy-settings.tsx
+++ b/ui/pages/onboarding-flow/privacy-settings/privacy-settings.tsx
@@ -77,8 +77,6 @@ import { Setting } from './setting';
 
 const ANIMATION_TIME = 500;
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function PrivacySettings() {
   const t = useI18nContext();
   const dispatch = useDispatch();

--- a/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.tsx
@@ -75,8 +75,6 @@ const generateQuizWords = (
   return quizWords;
 };
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function ConfirmRecoveryPhrase({ secretRecoveryPhrase = '' }) {
   const dispatch = useDispatch();
 

--- a/ui/pages/onboarding-flow/recovery-phrase/confirm-srp-modal.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/confirm-srp-modal.tsx
@@ -27,8 +27,6 @@ type ConfirmSrpModalProps = {
   isError: boolean;
 };
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function ConfirmSrpModal({
   onContinue,
   onClose,

--- a/ui/pages/onboarding-flow/recovery-phrase/recovery-phrase-chips.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/recovery-phrase-chips.tsx
@@ -52,8 +52,6 @@ export const fakeSeedPhraseWords = [
   'treat',
 ];
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function RecoveryPhraseChips({
   secretRecoveryPhrase,
   phraseRevealed = true,

--- a/ui/pages/onboarding-flow/recovery-phrase/reveal-recovery-phrase.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/reveal-recovery-phrase.tsx
@@ -84,8 +84,6 @@ function getSrpExportEventProperties(
   };
 }
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function RevealRecoveryPhrase({
   setSecretRecoveryPhrase,
 }: {

--- a/ui/pages/onboarding-flow/recovery-phrase/review-recovery-phrase.test.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/review-recovery-phrase.test.tsx
@@ -43,7 +43,6 @@ jest.mock('../../../hooks/useIsFirefox', () => ({
   useIsFirefox: jest.fn().mockReturnValue(false),
 }));
 
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const { useIsFirefox } = jest.requireMock('../../../hooks/useIsFirefox');
 
 const mockState = {

--- a/ui/pages/onboarding-flow/recovery-phrase/review-recovery-phrase.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/review-recovery-phrase.tsx
@@ -49,8 +49,6 @@ type RecoveryPhraseProps = {
   secretRecoveryPhrase: string;
 };
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function RecoveryPhrase({
   secretRecoveryPhrase,
 }: RecoveryPhraseProps) {

--- a/ui/pages/onboarding-flow/welcome/fox-appear-animation.tsx
+++ b/ui/pages/onboarding-flow/welcome/fox-appear-animation.tsx
@@ -17,8 +17,6 @@ type FoxAppearAnimationProps = {
   skipTransition?: boolean;
 };
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function FoxAppearAnimation({
   isLoader = false,
   skipTransition = false,

--- a/ui/pages/onboarding-flow/welcome/login-error-modal.tsx
+++ b/ui/pages/onboarding-flow/welcome/login-error-modal.tsx
@@ -54,9 +54,6 @@ type LoginErrorModalProps = {
  * @param props.onClose - The function to call when the modal is closed
  * @param props.loginError - The type of login error that occurred
  */
-
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function LoginErrorModal({
   onClose,
   loginError,

--- a/ui/pages/onboarding-flow/welcome/login-options.tsx
+++ b/ui/pages/onboarding-flow/welcome/login-options.tsx
@@ -65,8 +65,6 @@ export const SocialButton = React.forwardRef(
   },
 );
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function LoginOptions({
   loginOption,
   handleLogin,

--- a/ui/pages/onboarding-flow/welcome/metamask-wordmark-animation.tsx
+++ b/ui/pages/onboarding-flow/welcome/metamask-wordmark-animation.tsx
@@ -30,8 +30,6 @@ const INPUT_NAMES = {
   START: 'Start',
 } as const;
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function MetamaskWordMarkAnimation({
   setIsAnimationComplete,
   isAnimationComplete = false,

--- a/ui/pages/onboarding-flow/welcome/welcome-login.tsx
+++ b/ui/pages/onboarding-flow/welcome/welcome-login.tsx
@@ -17,8 +17,6 @@ import { ONBOARDING_WELCOME_ROUTE } from '../../../helpers/constants/routes';
 import LoginOptions from './login-options';
 import { LOGIN_OPTION, LOGIN_TYPE, LoginOptionType, LoginType } from './types';
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function WelcomeLogin({
   onLogin,
   isAnimationComplete,

--- a/ui/pages/onboarding-flow/welcome/welcome.tsx
+++ b/ui/pages/onboarding-flow/welcome/welcome.tsx
@@ -99,8 +99,6 @@ const FoxAppearAnimation = lazy(
     }>,
 );
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function OnboardingWelcome() {
   const dispatch = useDispatch();
   const navigate = useNavigate();

--- a/ui/pages/permissions-connect/permissions-connect.tsx
+++ b/ui/pages/permissions-connect/permissions-connect.tsx
@@ -191,7 +191,6 @@ function getNonEvmRequestedCaipChainIds(
   return getRequestedCaipChainIds(permissions, false);
 }
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 function PermissionsConnect() {
   const dispatch = useDispatch();
   const navigate = useNavigate();

--- a/ui/pages/perps/perps-order-entry-page.test.tsx
+++ b/ui/pages/perps/perps-order-entry-page.test.tsx
@@ -2130,7 +2130,6 @@ describe('PerpsOrderEntryPage', () => {
     it('shows fallback order failure toast for non-Error throws', async () => {
       mockSubmitRequestToBackground.mockImplementation((method: string) => {
         if (method === 'perpsPlaceOrder') {
-          // eslint-disable-next-line prefer-promise-reject-errors
           return Promise.reject('string error');
         }
         return Promise.resolve({ success: true });

--- a/ui/pages/remove-snap-account/remove-snap-account.stories.tsx
+++ b/ui/pages/remove-snap-account/remove-snap-account.stories.tsx
@@ -6,7 +6,6 @@ import RemoveSnapAccount from './remove-snap-account';
 
 const store = configureStore(testData);
 
-// eslint-disable-next-line import-x/no-anonymous-default-export
 export default {
   title: 'Components/UI/RemoveSnapAccount', // title should follow the folder structure location of the component. Don't use spaces.
   decorators: [(story) => <Provider store={store}>{story()}</Provider>],

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable jsdoc/check-tag-names */
 /* eslint-disable import-x/no-useless-path-segments */
 /* eslint-disable import-x/extensions */
 import classnames from 'clsx';
@@ -608,7 +607,6 @@ export const routeConfig = [
   },
 ];
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function Routes() {
   const dispatch = useDispatch();
   const location = useLocation();

--- a/ui/pages/settings/debug-tab/debug-content/backup-and-sync.tsx
+++ b/ui/pages/settings/debug-tab/debug-content/backup-and-sync.tsx
@@ -47,8 +47,6 @@ const DeleteSyncedData = ({
         </div>
 
         <div className="settings-page__content-item-col">
-          {/* TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879 */}
-          {/* eslint-disable-next-line @typescript-eslint/no-misused-promises */}
           <Button variant={ButtonVariant.Primary} onClick={onDelete}>
             Reset
           </Button>

--- a/ui/pages/settings/debug-tab/debug-content/debug-content.tsx
+++ b/ui/pages/settings/debug-tab/debug-content/debug-content.tsx
@@ -142,8 +142,6 @@ const DebugContent = () => {
         <div className="settings-page__content-item-col">
           <Button
             variant={ButtonVariant.Primary}
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-            // eslint-disable-next-line @typescript-eslint/no-misused-promises
             onClick={handleResetOnboardingClick}
           >
             Reset

--- a/ui/pages/settings/debug-tab/debug-content/sentry-test.tsx
+++ b/ui/pages/settings/debug-tab/debug-content/sentry-test.tsx
@@ -30,8 +30,6 @@ function sleep(ms: number) {
 
 const SentryTest = () => {
   const currentLocale: string =
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     useSelector(getCurrentLocale) || FALLBACK_LOCALE;
 
   return (
@@ -239,8 +237,6 @@ function TestButton({
       hasError = true;
       throw error;
     } finally {
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       if (expectError || !hasError) {
         setIsComplete(true);
       }
@@ -261,8 +257,6 @@ function TestButton({
       <div className="settings-page__content-item-col">
         <Button
           variant={ButtonVariant.Primary}
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-          // eslint-disable-next-line @typescript-eslint/no-misused-promises
           onClick={handleClick}
           size={ButtonSize.Lg}
           data-testid={testId}

--- a/ui/pages/settings/privacy-tab/data-collection-item.tsx
+++ b/ui/pages/settings/privacy-tab/data-collection-item.tsx
@@ -72,10 +72,8 @@ export const DataCollectionToggleItem = () => {
       createEventBuilder(MetaMetricsEventName.AnalyticsPreferenceSelected)
         .addCategory(MetaMetricsEventCategory.Settings)
         .addProperties({
-          /* eslint-disable @typescript-eslint/naming-convention */
           [MetaMetricsUserTrait.IsMetricsOptedIn]: true,
           [MetaMetricsUserTrait.HasMarketingConsent]: Boolean(newValue),
-          /* eslint-enable @typescript-eslint/naming-convention */
           location: 'Settings',
         })
         .build(),

--- a/ui/pages/settings/privacy-tab/metametrics-item.tsx
+++ b/ui/pages/settings/privacy-tab/metametrics-item.tsx
@@ -80,10 +80,8 @@ export const MetametricsToggleItem = () => {
         createEventBuilder(MetaMetricsEventName.AnalyticsPreferenceSelected)
           .addCategory(MetaMetricsEventCategory.Settings)
           .addProperties({
-            /* eslint-disable @typescript-eslint/naming-convention */
             [MetaMetricsUserTrait.IsMetricsOptedIn]: false,
             [MetaMetricsUserTrait.HasMarketingConsent]: false,
-            /* eslint-enable @typescript-eslint/naming-convention */
             location: 'Settings',
           })
           .build(),

--- a/ui/pages/settings/settings.tsx
+++ b/ui/pages/settings/settings.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable import-x/extensions */
 import React, {
   Fragment,
   Suspense,
@@ -50,12 +49,8 @@ import {
 } from '../../selectors';
 import { getSnapName } from '../../helpers/utils/util';
 import { getHasSubscribedToShield } from '../../selectors/subscription/subscription';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
 import { getIsMetaMaskShieldFeatureEnabled } from '../../../shared/lib/environment';
 import ShieldEntryModal from '../../components/app/shield-entry-modal';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
 import { SHIELD_QUERY_PARAMS } from '../../../shared/lib/deep-links/routes/shield';
 import { toRelativeRoutePath } from '../routes/utils';
 import {

--- a/ui/pages/settings/sync-accounts/components/enter-verification-code.tsx
+++ b/ui/pages/settings/sync-accounts/components/enter-verification-code.tsx
@@ -224,7 +224,6 @@ const EnterVerificationCode = ({ onRestart }: EnterVerificationCodeProps) => {
           <Input
             // The list is a fixed-length set of positional inputs, so the
             // index is a stable identity here.
-            // eslint-disable-next-line react/no-array-index-key
             key={`verification-code-${index}`}
             ref={(ref) => {
               inputRefs.current[index] = ref;

--- a/ui/pages/shield/transaction-shield/components/cancel-membership-modal.tsx
+++ b/ui/pages/shield/transaction-shield/components/cancel-membership-modal.tsx
@@ -18,8 +18,6 @@ import {
   getIsSubscriptionCancelNotAllowed,
 } from '../../../../../shared/lib/shield';
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function CancelMembershipModal({
   onConfirm,
   onClose,

--- a/ui/pages/swaps/swaps.util.ts
+++ b/ui/pages/swaps/swaps.util.ts
@@ -420,8 +420,6 @@ export function getRenderableNetworkFeesForQuote({
   const gasTotalInWeiHex = sumHexes(
     tradeGasFeeTotalHex,
     approveGasFeeTotalHex,
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     multiLayerL1FeeTotal || '0x0',
   );
 
@@ -461,8 +459,6 @@ export function getRenderableNetworkFeesForQuote({
   }
 
   const chainCurrencySymbolToUse =
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     nativeCurrencySymbol || SWAPS_CHAINID_DEFAULT_TOKEN_MAP[chainId].symbol;
 
   return {

--- a/ui/pages/unlock-page/formatted-counter.tsx
+++ b/ui/pages/unlock-page/formatted-counter.tsx
@@ -13,8 +13,6 @@ const formatTimeToUnlock = (timeInSeconds: number) => {
     .padStart(2, '0')}.`;
 };
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function FormattedCounter({
   startFrom,
   onCountdownEnd,

--- a/ui/pages/unlock-page/passkey/unlock-passkey-section.tsx
+++ b/ui/pages/unlock-page/passkey/unlock-passkey-section.tsx
@@ -164,7 +164,6 @@ export const UnlockPasskeySection = ({
                 status: 'cancelled',
                 // eslint-disable-next-line @typescript-eslint/naming-convention
                 duration_ms: durationMs,
-                // eslint-disable-next-line @typescript-eslint/naming-convention
                 reason: errorCode,
               })
               .build(),

--- a/ui/pages/unlock-page/reset-password-modal.tsx
+++ b/ui/pages/unlock-page/reset-password-modal.tsx
@@ -45,8 +45,6 @@ import { SUPPORT_LINK } from '../../helpers/constants/common';
 import { useBoolean } from '../../hooks/useBoolean';
 import { isPopupOrSidePanelEnvironment } from '../../../shared/lib/environment-type';
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function ResetPasswordModal({
   onClose,
 }: {

--- a/ui/pages/unlock-page/unlock-page.component.tsx
+++ b/ui/pages/unlock-page/unlock-page.component.tsx
@@ -355,8 +355,6 @@ class UnlockPageBase extends Component<UnlockPageProps, UnlockPageState> {
             // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
             // eslint-disable-next-line @typescript-eslint/naming-convention
             account_type: accountTypeForMetrics,
-            // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-            // eslint-disable-next-line @typescript-eslint/naming-convention
             biometrics: false,
             // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
             // eslint-disable-next-line @typescript-eslint/naming-convention


### PR DESCRIPTION
## **Description**

Unused ESLint ignore directives have been removed from the `ui/pages` directory.

This helps unblock the ESLint v9 upgrade (it complains about unused directives by default).

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

The CI lint step should be sufficient to test this change.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only cleanup with no logic changes; risk is limited to CI failing if any removed directive was still required by the linter.
> 
> **Overview**
> This PR **strips unused `eslint-disable` comments** across `ui/pages` so ESLint v9 can flag stale suppressions during the upgrade. **No runtime or UI behavior changes**—only comment/directive cleanup.
> 
> Removals are mostly **obsolete suppressions** tied to MetaMask issues **#31860** (`@typescript-eslint/naming-convention`), **#31879** (`no-misused-promises` on async handlers), and **#31880** (`prefer-nullish-coalescing`), plus **file-level** disables in stories/tests (e.g. `react/prop-types`, blanket `naming-convention`). A few **narrow comment edits** remain where rules still apply (e.g. restricted imports, explicit `any` in tests).
> 
> Touches bridge/swap, confirmations, onboarding, notifications, settings debug, and related tests—**lint hygiene only**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d572defc26842fd0f1caf69e9d7bec5ecb79e37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->