### PR TITLE
chore: remove unused ESLint directives from remaining `ui`

### DIFF
--- a/ui/__mocks__/actions.js
+++ b/ui/__mocks__/actions.js
@@ -50,7 +50,6 @@ module.exports = {
     return Promise.resolve(TOKEN_DETAILS_MOCK[address]);
   },
 
-  // eslint-disable-next-line no-empty-function
   trackMetaMetricsEvent: () => {
     // Intentionally empty
   },

--- a/ui/__mocks__/perps/perps-controller/index.ts
+++ b/ui/__mocks__/perps/perps-controller/index.ts
@@ -564,9 +564,6 @@ export const PERPS_TRANSACTIONS_HISTORY_CONSTANTS = {
   DefaultFundingHistoryDays: 365,
 } as const;
 
-/* eslint-disable @typescript-eslint/consistent-type-definitions */
-// ESLint override: BaseController requires 'type' for Json compatibility, not 'interface'
-
 /**
  * Market data with prices for UI display
  * Protocol-agnostic interface for market information with formatted values

--- a/ui/contexts/hardware-wallets/HardwareWalletContext.tsx
+++ b/ui/contexts/hardware-wallets/HardwareWalletContext.tsx
@@ -257,7 +257,6 @@ export const HardwareWalletProvider = ({
 
   // Abort controller lifecycle
   useEffect(() => {
-    // eslint-disable-next-line react-compiler/react-compiler
     refs.abortControllerRef.current = new AbortController();
     return () => {
       refs.abortControllerRef.current?.abort();

--- a/ui/contexts/metametrics.tsx
+++ b/ui/contexts/metametrics.tsx
@@ -90,9 +90,7 @@ export type UIEndTraceMethod = (request: EndTraceRequest) => void;
  * Used when passing trace context across process boundaries.
  */
 export type SerializedTraceParentContext = {
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   _name: TraceName;
-  // eslint-disable-next-line @typescript-eslint/naming-convention
   _id?: string;
 };
 
@@ -145,7 +143,6 @@ type MetaMetricsProviderProps = {
   children: ReactNode;
 };
 
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function MetaMetricsProvider({ children }: MetaMetricsProviderProps) {
   const location = useLocation();
   const context = useSegmentContext();

--- a/ui/contexts/rive-wasm/index.tsx
+++ b/ui/contexts/rive-wasm/index.tsx
@@ -78,8 +78,6 @@ const RiveWasmContext = createContext<{
   setIsAnimationCompleted: () => {},
 });
 
-// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export default function RiveWasmProvider({
   children,
 }: {

--- a/ui/contexts/shield/shield-subscription.tsx
+++ b/ui/contexts/shield/shield-subscription.tsx
@@ -162,7 +162,6 @@ export const ShieldSubscriptionProvider = ({
     // eslint-disable-next-line no-empty-function
   >(async () => {});
 
-  // eslint-disable-next-line react-compiler/react-compiler
   evaluateCohortEligibilityRef.current = async (
     entrypointCohort: string,
   ): Promise<void> => {

--- a/ui/ducks/bridge/utils.ts
+++ b/ui/ducks/bridge/utils.ts
@@ -110,8 +110,6 @@ const fetchTokenExchangeRates = async (
     includeMarketData: 'true',
     vsCurrency: currency,
   });
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31893
-  // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
   const url = `https://price.api.cx.metamask.io/v3/spot-prices?${queryParams}`;
   const tokenV3PriceResponse = (await handleFetch(url, {
     method: 'GET',

--- a/ui/helpers/constants/common.ts
+++ b/ui/helpers/constants/common.ts
@@ -10,7 +10,6 @@ export const TRANSACTION_SHIELD_SUPPORT_LINK = ZENDESK_URLS.TRANSACTION_SHIELD;
 export const TRANSACTION_SHIELD_LINK = 'https://metamask.io/transaction-shield';
 
 export const FIND_TRANSACTION_HASH_LINK = ZENDESK_URLS.FIND_TRANSACTION_HASH;
-// eslint-disable-next-line prefer-destructuring
 export const METAMETRICS_SETTINGS_LINK = ZENDESK_URLS.METAMETRICS_SETTINGS;
 // eslint-disable-next-line prefer-destructuring
 export const SUPPORT_LINK = process.env.SUPPORT_LINK;

--- a/ui/helpers/utils/confirm-tx.util.ts
+++ b/ui/helpers/utils/confirm-tx.util.ts
@@ -126,8 +126,6 @@ export function areDappSuggestedAndTxParamGasFeesTheSame(
     gasPrice: dappGasPrice,
     maxFeePerGas: dappMaxFeePerGas,
     maxPriorityFeePerGas: dappMaxPriorityFeePerGas,
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   } = dappSuggestedGasFees || {};
 
   const txParamsDoesNotHaveFeeProperties =
@@ -150,8 +148,6 @@ export function areDappSuggestedAndTxParamGasFeesTheSame(
     txParamsMaxPriorityFeePerGas === dappMaxPriorityFeePerGas;
 
   return Boolean(
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     txParamsGasPriceMatchesDappSuggestedGasPrice ||
     txParamsEIP1559FeesMatchDappSuggestedGasPrice ||
     txParamsEIP1559FeesMatchDappSuggestedEIP1559Fees,

--- a/ui/helpers/utils/notification.util.ts
+++ b/ui/helpers/utils/notification.util.ts
@@ -127,8 +127,6 @@ const defaultFormatOptions = {
 export const getLeadingZeroCount = (num: number | string) => {
   const numToString = new BigNumber(num, 10).toString(10);
   const fractionalPart = numToString.split('.')[1] ?? '';
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   return fractionalPart.match(/^0*/u)?.[0]?.length || 0;
 };
 

--- a/ui/helpers/utils/track-hardware-wallet-recovery-connect-cta-clicked.test.ts
+++ b/ui/helpers/utils/track-hardware-wallet-recovery-connect-cta-clicked.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable @typescript-eslint/naming-convention, camelcase -- Segment analytics payload keys */
+/* eslint-disable @typescript-eslint/naming-convention -- Segment analytics payload keys */
 import {
   Category,
   ErrorCode,

--- a/ui/helpers/utils/window.ts
+++ b/ui/helpers/utils/window.ts
@@ -1,5 +1,3 @@
 export const openWindow = (url: string, target?: string) => {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   window.open(url, target || '_blank', 'noopener');
 };

--- a/ui/hooks/bridge/useQuoteFetchEvents.ts
+++ b/ui/hooks/bridge/useQuoteFetchEvents.ts
@@ -1,4 +1,3 @@
-/* eslint-disable camelcase */
 import { useEffect } from 'react';
 import { useDispatch, useSelector, shallowEqual } from 'react-redux';
 import {

--- a/ui/hooks/bridge/useTokensWithFiltering.ts
+++ b/ui/hooks/bridge/useTokensWithFiltering.ts
@@ -84,10 +84,7 @@ const buildTokenData = (
       type: AssetType.native,
       address: '', // Return empty string to match useMultichainBalances output
       image:
-        image ??
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-        // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-        (token.iconUrl || ('icon' in token ? token.icon : '') || ''),
+        image ?? (token.iconUrl || ('icon' in token ? token.icon : '') || ''),
       // Only unimported native assets are processed here so hardcode balance to 0
       balance: '0',
       string: '0',
@@ -304,7 +301,6 @@ export const useTokensWithFiltering = (
                   MULTICHAIN_TOKEN_IMAGE_MAP[
                     token.chainId as keyof typeof MULTICHAIN_TOKEN_IMAGE_MAP
                   ] ??
-                  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- empty string must fall through (https://github.com/MetaMask/metamask-extension/issues/31880)
                   (nativeAsset?.icon || nativeAsset?.iconUrl || assetImageUrl),
                 accountType: token.accountType,
               };

--- a/ui/hooks/hardware-wallets/useHwSwapQrState.test.ts
+++ b/ui/hooks/hardware-wallets/useHwSwapQrState.test.ts
@@ -37,26 +37,20 @@ jest.mock(
 
 const mockUseSelector = jest.requireMock('react-redux').useSelector;
 const mockUseDispatch = jest.requireMock('react-redux').useDispatch;
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const mockGetHardwareWalletType = jest.requireMock(
   '../../../shared/lib/selectors/keyring',
 ).getHardwareWalletType;
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const mockGetActiveQrCodeScanRequest =
   jest.requireMock('../../selectors').getActiveQrCodeScanRequest;
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const mockIsQrHardwareSignRequest = jest.requireMock(
   '../../pages/hardware-wallets/swap/hardware-wallet-signatures.utils',
 ).isQrHardwareSignRequest;
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const mockCleanupPendingApproval = jest.requireMock(
   '../../pages/hardware-wallets/swap/hardware-wallet-signatures.utils',
 ).cleanupPendingApproval;
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const mockCancelQrCodeScan = jest.requireMock(
   '../../store/actions',
 ).cancelQrCodeScan;
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const mockCompleteQrCodeScan = jest.requireMock(
   '../../store/actions',
 ).completeQrCodeScan;

--- a/ui/hooks/hardware-wallets/useHwSwapQuoteData.test.ts
+++ b/ui/hooks/hardware-wallets/useHwSwapQuoteData.test.ts
@@ -18,19 +18,15 @@ jest.mock('react-redux', () => ({
 }));
 
 const mockUseSelector = jest.requireMock('react-redux').useSelector;
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const mockGetBridgeQuotes = jest.requireMock(
   '../../ducks/bridge/selectors',
 ).getBridgeQuotes;
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const mockGetFromToken = jest.requireMock(
   '../../ducks/bridge/selectors',
 ).getFromToken;
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const mockGetToToken = jest.requireMock(
   '../../ducks/bridge/selectors',
 ).getToToken;
-// eslint-disable-next-line @typescript-eslint/no-require-imports
 const mockGetHardwareWalletType = jest.requireMock(
   '../../../shared/lib/selectors/keyring',
 ).getHardwareWalletType;

--- a/ui/hooks/perps/stream/usePerpsLiveAccount.ts
+++ b/ui/hooks/perps/stream/usePerpsLiveAccount.ts
@@ -30,7 +30,6 @@ export type UsePerpsLiveAccountReturn = {
  * @returns Object containing account state and loading state
  */
 export function usePerpsLiveAccount(
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _options: UsePerpsLiveAccountOptions = {},
 ): UsePerpsLiveAccountReturn {
   const { data: account, isInitialLoading } = usePerpsChannel(

--- a/ui/hooks/perps/stream/usePerpsLiveFills.ts
+++ b/ui/hooks/perps/stream/usePerpsLiveFills.ts
@@ -50,7 +50,6 @@ const selectFills = (manager: PerpsStreamManager) => manager.fills;
  * ```
  */
 export function usePerpsLiveFills(
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _options: UsePerpsLiveFillsOptions = {},
 ): UsePerpsLiveFillsReturn {
   const { data: fills, isInitialLoading } = usePerpsChannel(selectFills, []);

--- a/ui/hooks/perps/stream/usePerpsLiveOrders.ts
+++ b/ui/hooks/perps/stream/usePerpsLiveOrders.ts
@@ -33,7 +33,6 @@ const EMPTY_ORDERS: Order[] = [];
  * @returns Object containing orders array and loading state
  */
 export function usePerpsLiveOrders(
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _options: UsePerpsLiveOrdersOptions = {},
 ): UsePerpsLiveOrdersReturn {
   const { data: orders, isInitialLoading } = usePerpsChannel(

--- a/ui/hooks/perps/stream/usePerpsLivePositions.ts
+++ b/ui/hooks/perps/stream/usePerpsLivePositions.ts
@@ -33,7 +33,6 @@ const EMPTY_POSITIONS: Position[] = [];
  * @returns Object containing positions array and loading state
  */
 export function usePerpsLivePositions(
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   _options: UsePerpsLivePositionsOptions = {},
 ): UsePerpsLivePositionsReturn {
   const { data: positions, isInitialLoading } = usePerpsChannel(

--- a/ui/hooks/rewards/useCandidateSubscriptionId.test.ts
+++ b/ui/hooks/rewards/useCandidateSubscriptionId.test.ts
@@ -908,7 +908,6 @@ describe('useCandidateSubscriptionId', () => {
 
       // Resolve the promise
       await act(async () => {
-        // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
         resolvePromise?.('delayed-sub-id');
       });
     });

--- a/ui/hooks/shield/metrics/useSubscriptionMetrics.ts
+++ b/ui/hooks/shield/metrics/useSubscriptionMetrics.ts
@@ -197,8 +197,6 @@ export const useSubscriptionMetrics = () => {
       const formattedParams = formatExistingSubscriptionEventProps(params);
       trackShieldEvent(MetaMetricsEventName.ShieldMembershipCancelled, {
         ...formattedParams,
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         status: params.cancellationStatus,
         error: params.errorMessage,
         // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
@@ -218,8 +216,6 @@ export const useSubscriptionMetrics = () => {
         formatCaptureShieldPaymentMethodChangeEventProps(params);
       trackShieldEvent(MetaMetricsEventName.ShieldPaymentMethodChange, {
         ...formattedParams,
-        // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-        // eslint-disable-next-line @typescript-eslint/naming-convention
         status: params.changeStatus,
         error: params.errorMessage,
       });

--- a/ui/hooks/shield/metrics/utils.ts
+++ b/ui/hooks/shield/metrics/utils.ts
@@ -142,8 +142,6 @@ export function formatCaptureShieldEligibilityCohortEventsProps(
   };
 
   if ('modalType' in params) {
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-    // eslint-disable-next-line @typescript-eslint/naming-convention
     props.modal_type = params.modalType;
   }
 

--- a/ui/hooks/snaps/useDisplayName.ts
+++ b/ui/hooks/snaps/useDisplayName.ts
@@ -79,8 +79,6 @@ export const useDisplayName = (
       );
     });
 
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   return (
     accountGroupName ||
     accountName ||

--- a/ui/hooks/useCarouselManagement/useCarouselManagement.test.ts
+++ b/ui/hooks/useCarouselManagement/useCarouselManagement.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/naming-convention */
 import { renderHook, act } from '@testing-library/react-hooks';
 import { waitFor } from '@testing-library/react';
 import { useDispatch, useSelector } from 'react-redux';

--- a/ui/hooks/useCurrencyRatePolling.ts
+++ b/ui/hooks/useCurrencyRatePolling.ts
@@ -77,8 +77,6 @@ const useCurrencyRatePolling = () => {
   // usePolling is a custom hook that is invoked synchronously.
   usePolling({
     startPolling: currencyRateStartPolling,
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     stopPollingByPollingToken: currencyRateStopPollingByPollingToken,
     input: nativeCurrencies,
     enabled,

--- a/ui/hooks/useDisplayName.ts
+++ b/ui/hooks/useDisplayName.ts
@@ -68,16 +68,8 @@ export function useDisplayNames(
 
     let name =
       accountGroupName ||
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       nameEntry?.name ||
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       firstPartyContractName ||
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       erc20Token?.name ||
       watchedNftName ||
       ensName ||
@@ -87,8 +79,6 @@ export function useDisplayNames(
 
     const displayState = getDisplayState(trustSignal?.state, hasPetname, name);
 
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-    // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
     const image = erc20Token?.image;
 
     const trustSignalIcon = getTrustSignalIcon(displayState);

--- a/ui/hooks/useMultichainSelector.ts
+++ b/ui/hooks/useMultichainSelector.ts
@@ -15,8 +15,6 @@ export function useMultichainSelector<
     (state: TState) => {
       // We either pass an account or fallback to the currently selected one
       // @ts-expect-error state types don't match
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       return selector(state, account || getSelectedInternalAccount(state));
     },
     [selector, account],

--- a/ui/hooks/useMultichainTransactionDisplay.ts
+++ b/ui/hooks/useMultichainTransactionDisplay.ts
@@ -144,8 +144,6 @@ function parseAsset(
   isNegative: boolean,
   decimals?: number,
 ) {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-  // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
   const threshold = 1 / 10 ** (decimals || 8); // Smallest unit to display given the decimals.
   const displayAmount = formatWithThreshold(
     movement.amount,
@@ -153,8 +151,6 @@ function parseAsset(
     locale,
     {
       minimumFractionDigits: 0,
-      // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
       maximumFractionDigits: decimals || 8,
     },
   );

--- a/ui/hooks/useStaticTokensPolling.ts
+++ b/ui/hooks/useStaticTokensPolling.ts
@@ -27,8 +27,6 @@ export const useStaticTokensPolling = () => {
 
   useMultiPolling({
     startPolling: staticAssetsStartPolling,
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     stopPollingByPollingToken: staticAssetsStopPollingByPollingToken,
     input: [
       {

--- a/ui/hooks/useThrottle.ts
+++ b/ui/hooks/useThrottle.ts
@@ -18,7 +18,6 @@ export function useThrottle<ValueType>(value: ValueType, interval = 500) {
       setThrottledValue(value);
     }, interval);
 
-    // eslint-disable-next-line consistent-return
     return () => window.clearTimeout(id);
   }, [value, interval]);
 

--- a/ui/hooks/useTokenBalances.ts
+++ b/ui/hooks/useTokenBalances.ts
@@ -21,8 +21,6 @@ export const useTokenBalances = ({ chainIds }: { chainIds?: Hex[] } = {}) => {
 
   useMultiPolling({
     startPolling: tokenBalancesStartPolling,
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     stopPollingByPollingToken: tokenBalancesStopPollingByPollingToken,
     input: isAssetsUnifyStateEnabled ? [] : [pollableChains],
   });

--- a/ui/hooks/useTokenDetectionPolling.ts
+++ b/ui/hooks/useTokenDetectionPolling.ts
@@ -19,8 +19,6 @@ const useTokenDetectionPolling = () => {
 
   useMultiPolling({
     startPolling: tokenDetectionStartPolling,
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     stopPollingByPollingToken: tokenDetectionStopPollingByPollingToken,
     input: enabled ? [enabledChainIds] : [],
   });

--- a/ui/hooks/useTokenListPolling.ts
+++ b/ui/hooks/useTokenListPolling.ts
@@ -29,8 +29,6 @@ const useTokenListPolling = () => {
 
   useMultiPolling({
     startPolling: tokenListStartPolling,
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     stopPollingByPollingToken: tokenListStopPollingByPollingToken,
     input: enabled ? enabledChainIds : [],
   });

--- a/ui/hooks/useTokenRatesPolling.ts
+++ b/ui/hooks/useTokenRatesPolling.ts
@@ -20,8 +20,6 @@ const useTokenRatesPolling = () => {
 
   useMultiPolling({
     startPolling: tokenRatesStartPolling,
-    // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-    // eslint-disable-next-line @typescript-eslint/no-misused-promises
     stopPollingByPollingToken: tokenRatesStopPollingByPollingToken,
     input: enabled ? [enabledChainIds] : [],
   });

--- a/ui/providers/perps/CandleStreamChannel.ts
+++ b/ui/providers/perps/CandleStreamChannel.ts
@@ -428,7 +428,7 @@ export class CandleStreamChannel {
       entry.isConnected = false;
     });
 
-    // eslint-disable-next-line no-empty-function, @typescript-eslint/no-empty-function
+    // eslint-disable-next-line no-empty-function
     entry.unsubscribeFromSource = () => {};
   }
 

--- a/ui/providers/perps/PerpsControllerProvider.mock.tsx
+++ b/ui/providers/perps/PerpsControllerProvider.mock.tsx
@@ -56,7 +56,6 @@ export type PerpsControllerProviderProps = {
  * </PerpsControllerProvider>
  * ```
  */
-// eslint-disable-next-line @typescript-eslint/naming-convention
 export function PerpsControllerProvider({
   children,
   controller: providedController,

--- a/ui/providers/perps/PerpsDataChannel.ts
+++ b/ui/providers/perps/PerpsDataChannel.ts
@@ -168,7 +168,7 @@ export class PerpsDataChannel<TData> {
     }
 
     // Subscribe with a no-op callback just to keep connection alive
-    // eslint-disable-next-line no-empty-function, @typescript-eslint/no-empty-function
+    // eslint-disable-next-line no-empty-function
     const unsubscribe = this.subscribe(() => {});
 
     this.prewarmUnsubscribe = () => {

--- a/ui/providers/perps/PerpsStreamManager.ts
+++ b/ui/providers/perps/PerpsStreamManager.ts
@@ -56,7 +56,7 @@ const EMPTY_PRICES: PriceUpdate[] = [];
  * Placeholder noop function for channel initialization.
  * Actual connect functions are set when init() is called.
  */
-// eslint-disable-next-line no-empty-function, @typescript-eslint/no-empty-function
+// eslint-disable-next-line no-empty-function
 const placeholderConnectFn = () => () => {};
 
 /**

--- a/ui/providers/perps/getPerpsController.mock.ts
+++ b/ui/providers/perps/getPerpsController.mock.ts
@@ -1,5 +1,4 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-/* eslint-disable @typescript-eslint/no-unused-vars */
 /**
  * Mock implementation of PerpsController for UI development
  *
@@ -184,7 +183,6 @@ class MockPerpsController {
    * @param options0
    * @param options0.callback
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   subscribeToAccount({
     callback,
   }: {

--- a/ui/selectors/assets.test.ts
+++ b/ui/selectors/assets.test.ts
@@ -66,7 +66,6 @@ jest.mock('@metamask/assets-controller', () => ({
 }));
 
 jest.mock('@metamask/assets-controllers', () => {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
   const actual = jest.requireActual('@metamask/assets-controllers');
   return {
     ...actual,

--- a/ui/selectors/assets.ts
+++ b/ui/selectors/assets.ts
@@ -293,8 +293,6 @@ export const getTokenBalancesEvm = createSelector(
               decimals,
               nativeBalances,
               selectedAccountTokenBalancesAcrossChains,
-              // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             }) || '0';
 
           const tokenFiatAmount = calculateTokenFiatAmount({
@@ -324,8 +322,6 @@ export const getTokenBalancesEvm = createSelector(
             if (token.isNative) {
               title = token.symbol === 'ETH' ? 'Ethereum' : token.symbol;
             } else {
-              // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31880
-              // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
               title = token.name || token.symbol;
             }
 

--- a/ui/selectors/multichain.ts
+++ b/ui/selectors/multichain.ts
@@ -37,8 +37,6 @@ import {
   getNativeCurrency,
 } from '../ducks/metamask/metamask';
 import { getConversionRate } from '../ducks/metamask/base-selectors';
-// TODO: Remove restricted import
-// eslint-disable-next-line import-x/no-restricted-paths
 import { MULTICHAIN_NETWORK_TO_ASSET_TYPES } from '../../shared/constants/multichain/assets';
 import {
   CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP,

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -3745,7 +3745,6 @@ function getOrderedConnectedAccountsForConnectedDapp(state, activeTab) {
   } = state;
 
   const permissionHistoryByAccount =
-    // eslint-disable-next-line camelcase
     permissionHistory[activeTab.origin]?.eth_accounts?.accounts;
   const orderedAccounts = getMetaMaskAccountsOrdered(state);
   const connectedAccounts = getPermittedEVMAccountsForSelectedTab(

--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -2441,7 +2441,6 @@ describe('Actions', () => {
 
     it('calls hideAsset in background with the assetId', async () => {
       const store = mockStore();
-      // eslint-disable-next-line prettier/prettier
       const assetId =
         'eip155:1:erc20:0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48';
       const hideAssetStub = sinon.stub().resolves();

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -1027,8 +1027,6 @@ export function storeKeyringEncryptionKey(
 export function tryUnlockMetamask(
   password: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return (dispatch: MetaMaskReduxDispatch) => {
     dispatch(showLoadingIndication());
     log.debug(`background.syncPasswordAndUnlockWallet`);
@@ -1146,8 +1144,6 @@ export function createNewVaultAndRestore(
   password: string,
   seedPhrase: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return (dispatch: MetaMaskReduxDispatch) => {
     dispatch(showLoadingIndication());
     log.debug(`background.createNewVaultAndRestore`);
@@ -1191,8 +1187,6 @@ export function importMnemonicToVault(
 export function createNewVaultAndGetSeedPhrase(
   password: string,
 ): ThunkAction<Promise<string>, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     try {
       const seedPhrase = await fetchSeedPhraseFromBackground(
@@ -1217,8 +1211,6 @@ export function createNewVaultAndGetSeedPhrase(
 export function unlockAndGetSeedPhrase(
   password: string,
 ): ThunkAction<Promise<string>, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     try {
       const seedPhrase = await fetchSeedPhraseFromBackground(
@@ -1381,8 +1373,6 @@ export function requestRevealSeedWords(
   password: string,
   keyringId?: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     dispatch(showLoadingIndication());
     log.debug(`background.verifyPassword`);
@@ -1425,8 +1415,6 @@ export function getSeedPhraseWithPasskey(
 export function tryReverseResolveAddress(
   address: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async () => {
     try {
       await submitRequestToBackground('tryReverseResolveAddress', [address]);
@@ -1464,8 +1452,6 @@ export function resetAccount(): ThunkAction<
 export function removeAccount(
   address: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     dispatch(showLoadingIndication());
 
@@ -1541,8 +1527,6 @@ export function forgetDevice(
   deviceName: HardwareDeviceNames,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
   log.debug(`background.forgetDevice`, deviceName);
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     dispatch(showLoadingIndication());
     try {
@@ -1700,8 +1684,6 @@ export function showQrScanner(): ThunkAction<
 export function setCurrentCurrency(
   currencyCode: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     dispatch(showLoadingIndication());
     log.debug(`background.setCurrentCurrency`);
@@ -1904,8 +1886,6 @@ export async function restoreUserData(jsonString: Json): Promise<true> {
 export function updateSlides(
   slides,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async () => {
     try {
       await submitRequestToBackground('updateSlides', [slides]);
@@ -2267,8 +2247,6 @@ function updateTransactionParams(txId: string, txParams: TransactionParams) {
 export function disableSnap(
   snapId: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await submitRequestToBackground('disableSnap', [snapId]);
     await forceUpdateMetamaskState(dispatch);
@@ -2278,8 +2256,6 @@ export function disableSnap(
 export function enableSnap(
   snapId: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await submitRequestToBackground('enableSnap', [snapId]);
     await forceUpdateMetamaskState(dispatch);
@@ -2351,8 +2327,6 @@ export function revokeDynamicSnapPermissions(
   snapId: string,
   permissionNames: string[],
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await submitRequestToBackground('revokeDynamicSnapPermissions', [
       snapId,
@@ -2368,8 +2342,6 @@ export function deleteExpiredNotifications(): ThunkAction<
   unknown,
   AnyAction
 > {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch, getState) => {
     const state = getState();
     const notifications = state.metamask.metamaskNotificationsList;
@@ -2409,8 +2381,6 @@ export function disconnectOriginFromSnap(
   origin: string,
   snapId: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await submitRequestToBackground('disconnectOriginFromSnap', [
       origin,
@@ -2511,8 +2481,6 @@ export function markPasswordForgotten(): ThunkAction<
   unknown,
   AnyAction
 > {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     try {
       await submitRequestToBackground('markPasswordForgotten', []);
@@ -2530,8 +2498,6 @@ export function unMarkPasswordForgotten(): ThunkAction<
   unknown,
   AnyAction
 > {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await submitRequestToBackground('unMarkPasswordForgotten', []);
     await forceUpdateMetamaskState(dispatch);
@@ -2593,8 +2559,6 @@ export function lockMetamask(
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
   log.debug(`background.setLocked`);
 
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return (dispatch: MetaMaskReduxDispatch) => {
     dispatch(showLoadingIndication(message));
 
@@ -2756,8 +2720,6 @@ export function setAccountGroupName(
 export function setSelectedInternalAccount(
   accountId: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     dispatch(showLoadingIndication());
     log.debug(`background.setSelectedInternalAccount`);
@@ -2794,8 +2756,6 @@ export function setSelectedInternalAccountWithoutLoading(
 export function setSelectedAccount(
   address: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch, getState) => {
     dispatch(showLoadingIndication());
     log.debug(`background.setSelectedAccount`);
@@ -2971,8 +2931,6 @@ export function addToken(
   },
   dontShowLoadingIndicator?: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     if (!address) {
       throw new Error('MetaMask - Cannot add token without address');
@@ -3009,8 +2967,6 @@ export function addImportedTokens(
   tokensToImport: Token[],
   networkClientId?: NetworkClientId,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     try {
       await submitRequestToBackground('addImportedTokens', [
@@ -3070,8 +3026,6 @@ export function ignoreTokens({
     ? tokensToIgnore
     : [tokensToIgnore];
 
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     if (!dontShowLoadingIndicator) {
       dispatch(showLoadingIndication());
@@ -3308,8 +3262,6 @@ export function addNft(
   networkClientId: NetworkClientId,
   dontShowLoadingIndicator: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     if (!address) {
       throw new Error('MetaMask - Cannot add NFT without address');
@@ -3341,8 +3293,6 @@ export function addNftVerifyOwnership(
   networkClientId: string,
   dontShowLoadingIndicator: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     if (!address) {
       throw new Error('MetaMask - Cannot add NFT without address');
@@ -3387,8 +3337,6 @@ export function removeAndIgnoreNft(
   networkClientId: string,
   shouldShowLoadingIndicator?: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     if (!address) {
       throw new Error('MetaMask - Cannot ignore NFT without address');
@@ -3431,8 +3379,6 @@ export function removeNft(
   networkClientId: NetworkClientId,
   dontShowLoadingIndicator: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     if (!address) {
       throw new Error('MetaMask - Cannot remove NFT without address');
@@ -3546,8 +3492,6 @@ export function clearPendingTokens(): Action {
 export function automaticallySwitchNetwork(
   networkClientIdForThisDomain: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await dispatch(
       setActiveNetworkConfigurationId(networkClientIdForThisDomain),
@@ -3565,8 +3509,6 @@ export function automaticallySwitchNetwork(
 export function setCurrentExtensionPopupId(
   id: number,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await submitRequestToBackground<void>('setCurrentExtensionPopupId', [id]);
     await forceUpdateMetamaskState(dispatch);
@@ -3621,8 +3563,6 @@ export function createCancelTransaction(
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
   log.debug('background.createCancelTransaction');
 
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     const actionId = generateActionId();
     const newState = await submitRequestToBackground<
@@ -3650,8 +3590,6 @@ export function createSpeedUpTransaction(
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
   log.debug('background.createSpeedUpTransaction');
 
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     const actionId = generateActionId();
     const newState = await submitRequestToBackground<
@@ -3717,8 +3655,6 @@ export function updateNetwork(
 export function setActiveNetwork(
   id: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch) => {
     log.debug(`background.setActiveNetwork: ${id}`);
     try {
@@ -3732,8 +3668,6 @@ export function setActiveNetwork(
 export function setActiveNetworkWithError(
   networkConfigurationId: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch) => {
     log.debug(`background.setActiveNetwork: ${networkConfigurationId}`);
     try {
@@ -3791,8 +3725,6 @@ export function rollbackToPreviousProvider(): ThunkAction<
   unknown,
   AnyAction
 > {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     try {
       await submitRequestToBackground('rollbackToPreviousProvider');
@@ -3823,8 +3755,6 @@ export function addToAddressBook(
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
   log.debug(`background.addToAddressBook`);
 
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch, getState) => {
     const chainId = customChainId || getProviderConfig(getState()).chainId;
     let set;
@@ -3854,8 +3784,6 @@ export function removeFromAddressBook(
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
   log.debug(`background.removeFromAddressBook`);
 
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch) => {
     await submitRequestToBackground('removeFromAddressBook', [
       chainId,
@@ -4001,8 +3929,6 @@ type NftDropDownState = {
 export function updateNftDropDownState(
   value: NftDropDownState,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await submitRequestToBackground('updateNftDropDownState', [value]);
     await forceUpdateMetamaskState(dispatch);
@@ -4026,8 +3952,6 @@ type QrCodeData = {
 export function qrCodeDetected(
   qrCodeData: QrCodeData,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await dispatch({
       type: actionConstants.QR_CODE_DETECTED,
@@ -4098,8 +4022,6 @@ export function exportAccount(
   unknown,
   AnyAction
 > {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async function (dispatch) {
     dispatch(showLoadingIndication());
 
@@ -4328,8 +4250,6 @@ export function setShowExtensionInFullSizeView(value: boolean) {
 export function setDismissSmartAccountSuggestionEnabled(
   value: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch, getState) => {
     const prevDismissSmartAccountSuggestionEnabled =
       getDismissSmartAccountSuggestionEnabled(getState());
@@ -4369,8 +4289,6 @@ export function setGasSponsorshipOptOut(value: Record<string, boolean>) {
 export function setSmartTransactionsPreferenceEnabled(
   value: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch, getState) => {
     const smartTransactionsOptInStatus =
       getSmartTransactionsOptInStatusInternal(getState());
@@ -4411,8 +4329,6 @@ export function toggleDefaultView(): ThunkAction<
   unknown,
   AnyAction
 > {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     if (!getIsSidePanelFeatureEnabled()) {
       return;
@@ -4500,8 +4416,6 @@ export function setCompletedOnboarding(): ThunkAction<
   unknown,
   AnyAction
 > {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     dispatch(showLoadingIndication());
 
@@ -4520,8 +4434,6 @@ export function setCompletedOnboardingWithSidepanel(): ThunkAction<
   unknown,
   AnyAction
 > {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     dispatch(showLoadingIndication());
 
@@ -4552,8 +4464,6 @@ export function resetOnboarding(): ThunkAction<
   unknown,
   AnyAction
 > {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (
     dispatch: MetaMaskReduxDispatch,
     getState: () => MetaMaskReduxState,
@@ -4800,8 +4710,6 @@ export function setUseTokenDetection(
 export function setOpenSeaEnabled(
   val: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     dispatch(showLoadingIndication());
     log.debug(`background.setOpenSeaEnabled`);
@@ -4816,8 +4724,6 @@ export function setOpenSeaEnabled(
 export function setUseNftDetection(
   val: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     dispatch(showLoadingIndication());
     log.debug(`background.setUseNftDetection`);
@@ -4832,8 +4738,6 @@ export function setUseNftDetection(
 export function setUse4ByteResolution(
   val: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     dispatch(showLoadingIndication());
     log.debug(`background.setUse4ByteResolution`);
@@ -4867,8 +4771,6 @@ export function setUseCurrencyRateCheck(
 export function detectTokens(
   chainIds?: string[],
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     dispatch(showLoadingIndication());
     log.debug(`background.detectTokens`);
@@ -4882,8 +4784,6 @@ export function detectTokens(
 export function detectNfts(
   chainIds: string[],
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     dispatch(showNftStillFetchingIndication());
     log.debug(`background.detectNfts`);
@@ -4917,8 +4817,6 @@ export function setAdvancedGasFee(val: {
 export function setTheme(
   val: ThemeType,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     dispatch(showLoadingIndication());
     log.debug(`background.setTheme`);
@@ -4946,8 +4844,6 @@ export function setIpfsGateway(
 export function toggleExternalServices(
   val: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     log.debug(`background.toggleExternalServices`);
     try {
@@ -5009,8 +4905,6 @@ export function setUseAddressBarEnsResolution(
 export function updateCurrentLocale(
   key: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     dispatch(showLoadingIndication());
 
@@ -5098,8 +4992,6 @@ export function setPendingTokens(pendingTokens: {
 export function setSwapsLiveness(
   swapsLiveness: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await submitRequestToBackground('setSwapsLiveness', [swapsLiveness]);
     await forceUpdateMetamaskState(dispatch);
@@ -5109,8 +5001,6 @@ export function setSwapsLiveness(
 export function setSwapsFeatureFlags(
   featureFlags: TemporaryFeatureFlagDef,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await submitRequestToBackground('setSwapsFeatureFlags', [featureFlags]);
     await forceUpdateMetamaskState(dispatch);
@@ -5159,8 +5049,6 @@ export function fetchAndSetQuotes(
 export function setSelectedQuoteAggId(
   aggId: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await submitRequestToBackground('setSelectedQuoteAggId', [aggId]);
     await forceUpdateMetamaskState(dispatch);
@@ -5170,8 +5058,6 @@ export function setSelectedQuoteAggId(
 export function setSwapsTokens(
   tokens: Token[],
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await submitRequestToBackground('setSwapsTokens', [tokens]);
     await forceUpdateMetamaskState(dispatch);
@@ -5184,8 +5070,6 @@ export function clearSwapsQuotes(): ThunkAction<
   unknown,
   AnyAction
 > {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await submitRequestToBackground('clearSwapsQuotes');
     await forceUpdateMetamaskState(dispatch);
@@ -5198,8 +5082,6 @@ export function resetBackgroundSwapsState(): ThunkAction<
   unknown,
   AnyAction
 > {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await submitRequestToBackground('resetSwapsState');
     await forceUpdateMetamaskState(dispatch);
@@ -5209,8 +5091,6 @@ export function resetBackgroundSwapsState(): ThunkAction<
 export function setCustomApproveTxData(
   data: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await submitRequestToBackground('setCustomApproveTxData', [data]);
     await forceUpdateMetamaskState(dispatch);
@@ -5220,8 +5100,6 @@ export function setCustomApproveTxData(
 export function setSwapsTxGasPrice(
   gasPrice: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await submitRequestToBackground('setSwapsTxGasPrice', [gasPrice]);
     await forceUpdateMetamaskState(dispatch);
@@ -5231,8 +5109,6 @@ export function setSwapsTxGasPrice(
 export function setSwapsTxGasLimit(
   gasLimit: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await submitRequestToBackground('setSwapsTxGasLimit', [gasLimit, true]);
     await forceUpdateMetamaskState(dispatch);
@@ -5248,8 +5124,6 @@ export function updateCustomSwapsEIP1559GasParams({
   maxFeePerGas: string;
   maxPriorityFeePerGas: string;
 }): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await Promise.all([
       submitRequestToBackground('setSwapsTxGasLimit', [gasLimit]),
@@ -5268,8 +5142,6 @@ export function updateCustomSwapsEIP1559GasParams({
 export function updateSwapsUserFeeLevel(
   swapsCustomUserFeeLevel: PriorityLevels,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await submitRequestToBackground('setSwapsUserFeeLevel', [
       swapsCustomUserFeeLevel,
@@ -5281,8 +5153,6 @@ export function updateSwapsUserFeeLevel(
 export function setSwapsQuotesPollingLimitEnabled(
   quotesPollingLimitEnabled: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await submitRequestToBackground('setSwapsQuotesPollingLimitEnabled', [
       quotesPollingLimitEnabled,
@@ -5297,8 +5167,6 @@ export function safeRefetchQuotes(): ThunkAction<
   unknown,
   AnyAction
 > {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await submitRequestToBackground('safeRefetchQuotes');
     await forceUpdateMetamaskState(dispatch);
@@ -5311,8 +5179,6 @@ export function stopPollingForQuotes(): ThunkAction<
   unknown,
   AnyAction
 > {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await submitRequestToBackground('stopPollingForQuotes');
     await forceUpdateMetamaskState(dispatch);
@@ -5322,8 +5188,6 @@ export function stopPollingForQuotes(): ThunkAction<
 export function setBackgroundSwapRouteState(
   routeState: '' | 'loading' | 'awaiting' | 'smartTransactionStatus',
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await submitRequestToBackground('setBackgroundSwapRouteState', [
       routeState,
@@ -5338,8 +5202,6 @@ export function resetSwapsPostFetchState(): ThunkAction<
   unknown,
   AnyAction
 > {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await submitRequestToBackground('resetPostFetchState');
     await forceUpdateMetamaskState(dispatch);
@@ -5349,8 +5211,6 @@ export function resetSwapsPostFetchState(): ThunkAction<
 export function setSwapsErrorKey(
   errorKey: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await submitRequestToBackground('setSwapsErrorKey', [errorKey]);
     await forceUpdateMetamaskState(dispatch);
@@ -5360,8 +5220,6 @@ export function setSwapsErrorKey(
 export function setInitialGasEstimate(
   initialAggId: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await submitRequestToBackground('setInitialGasEstimate', [initialAggId]);
     await forceUpdateMetamaskState(dispatch);
@@ -5409,8 +5267,6 @@ export function approvePermissionsRequest(
 export function rejectPermissionsRequest(
   requestId: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await submitRequestToBackground('rejectPermissionsRequest', [requestId]);
     await forceUpdateMetamaskState(dispatch);
@@ -5442,8 +5298,6 @@ export function removePermissionsFor(
 export function updateNetworksList(
   chainIds: CaipChainId[],
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async () => {
     await submitRequestToBackground('updateNetworksList', [chainIds]);
   };
@@ -5457,8 +5311,6 @@ export function updateNetworksList(
 export function updateAccountsList(
   pinnedAccountList: [],
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async () => {
     await submitRequestToBackground('updateAccountsList', [pinnedAccountList]);
   };
@@ -5507,8 +5359,6 @@ export function setEnabledAllPopularNetworks(): ThunkAction<
 export function updateHiddenAccountsList(
   hiddenAccountList: [],
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async () => {
     await submitRequestToBackground('updateHiddenAccountsList', [
       hiddenAccountList,
@@ -5541,8 +5391,6 @@ export function resolvePendingApproval(
     walletType?: HardwareWalletType | null;
   },
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch, getState) => {
     const walletType = options?.walletType;
     if (walletType) {
@@ -5667,8 +5515,6 @@ export function rejectPendingApproval(
   id: string,
   error: unknown,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     await submitRequestToBackground('rejectPendingApproval', [id, error]);
     // Before closing the current window, check if any additional confirmations
@@ -5690,8 +5536,6 @@ export function updateThrottledOriginState(
   origin: string,
   throttledOriginState: ThrottledOrigin,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async () => {
     await submitRequestToBackground('updateThrottledOriginState', [
       origin,
@@ -5789,8 +5633,6 @@ export function setLastActiveTime(): ThunkAction<
 export function setDismissSeedBackUpReminder(
   value: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     dispatch(showLoadingIndication());
     await submitRequestToBackground('setDismissSeedBackUpReminder', [value]);
@@ -5801,8 +5643,6 @@ export function setDismissSeedBackUpReminder(
 export function setOverrideContentSecurityPolicyHeader(
   value: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     dispatch(showLoadingIndication());
     await submitRequestToBackground('setOverrideContentSecurityPolicyHeader', [
@@ -5815,8 +5655,6 @@ export function setOverrideContentSecurityPolicyHeader(
 export function setManageInstitutionalWallets(
   value: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     dispatch(showLoadingIndication());
     await submitRequestToBackground('setManageInstitutionalWallets', [value]);
@@ -5830,8 +5668,6 @@ export function getRpcMethodPreferences(): ThunkAction<
   unknown,
   AnyAction
 > {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     dispatch(showLoadingIndication());
     await submitRequestToBackground('getRpcMethodPreferences', []);
@@ -5903,8 +5739,6 @@ export function setOutdatedBrowserWarningLastShown(lastShown: number) {
 export function getContractMethodData(
   data = '',
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch, getState) => {
     const prefixedData = addHexPrefix(data);
     const fourBytePrefix = prefixedData.slice(0, 10);
@@ -5944,8 +5778,6 @@ export function getContractMethodData(
 export function setSeedPhraseBackedUp(
   seedPhraseBackupState: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     log.debug(`background.setSeedPhraseBackedUp`);
     await submitRequestToBackground('setSeedPhraseBackedUp', [
@@ -5958,8 +5790,6 @@ export function setSeedPhraseBackedUp(
 export function setHasSeenOnboardingCompletionPage(
   hasSeenOnboardingCompletionPage: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     try {
       log.debug(`background.setHasSeenOnboardingCompletionPage`);
@@ -6041,8 +5871,6 @@ export function getRequestAccountTabIds(): ThunkAction<
   unknown,
   AnyAction
 > {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     const requestAccountTabIds = await submitRequestToBackground<{
       [origin: string]: string;
@@ -6066,8 +5894,6 @@ export function getOpenMetamaskTabsIds(): ThunkAction<
   unknown,
   AnyAction
 > {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     const openMetaMaskTabIDs = await submitRequestToBackground<{
       [tabId: string]: boolean;
@@ -6125,8 +5951,6 @@ export async function getTrezorFeatures(): Promise<TrezorGetFeaturesResponse> {
 export function captureSingleException(
   error: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch, getState) => {
     const { singleExceptions } = getState().appState;
     if (!(error in singleExceptions)) {
@@ -6570,8 +6394,6 @@ export function fetchSmartTransactionFees(
   unsignedTransaction: Partial<TransactionParams> & { chainId: string },
   approveTxParams: TransactionParams,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     if (approveTxParams) {
       approveTxParams.value = '0x0';
@@ -6687,8 +6509,6 @@ export function updateSmartTransaction(
   uuid: string,
   txMeta: TransactionMeta,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     try {
       await submitRequestToBackground('updateSmartTransaction', [
@@ -6717,8 +6537,6 @@ export function updateSmartTransaction(
 export function setSmartTransactionsRefreshInterval(
   refreshInterval: number,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async () => {
     if (refreshInterval === undefined || refreshInterval === null) {
       return;
@@ -6736,8 +6554,6 @@ export function setSmartTransactionsRefreshInterval(
 export function cancelSmartTransaction(
   uuid: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     try {
       await submitRequestToBackground('cancelSmartTransaction', [uuid]);
@@ -7079,8 +6895,6 @@ export function requestUserApproval({
   type: string;
   requestData: object;
 }): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async (dispatch: MetaMaskReduxDispatch) => {
     try {
       return await submitRequestToBackground('requestUserApproval', [
@@ -7292,8 +7106,6 @@ export function performSignIn(): ThunkAction<
   unknown,
   AnyAction
 > {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async () => {
     try {
       await submitRequestToBackground('performSignIn');
@@ -7323,8 +7135,6 @@ export function requestProfilePairing(): ThunkAction<
   unknown,
   AnyAction
 > {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async () => {
     try {
       await submitRequestToBackground('requestProfilePairing');
@@ -7350,8 +7160,6 @@ export function performSignOut(): ThunkAction<
   unknown,
   AnyAction
 > {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async () => {
     try {
       await submitRequestToBackground('performSignOut');
@@ -7377,8 +7185,6 @@ export function setIsBackupAndSyncFeatureEnabled(
   feature: keyof typeof BACKUPANDSYNC_FEATURES,
   enabled: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async () => {
     try {
       await submitRequestToBackground('setIsBackupAndSyncFeatureEnabled', [
@@ -7486,8 +7292,6 @@ export function createOnChainTriggers(): ThunkAction<
   unknown,
   AnyAction
 > {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async () => {
     try {
       await submitRequestToBackground('createOnChainTriggers');
@@ -7511,8 +7315,6 @@ export function createOnChainTriggers(): ThunkAction<
 export function disableAccounts(
   accounts: string[],
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async () => {
     try {
       await submitRequestToBackground('disableAccounts', [accounts]);
@@ -7536,8 +7338,6 @@ export function disableAccounts(
 export function enableAccounts(
   accounts: string[],
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async () => {
     try {
       await submitRequestToBackground('enableAccounts', [accounts]);
@@ -7560,8 +7360,6 @@ export function enableAccounts(
 export function fetchAndUpdateMetamaskNotifications(
   previewToken?: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async () => {
     try {
       const response = await submitRequestToBackground(
@@ -7588,8 +7386,6 @@ export function fetchAndUpdateMetamaskNotifications(
 export function deleteNotificationsById(
   ids: string[],
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async () => {
     try {
       const response = await submitRequestToBackground(
@@ -7618,8 +7414,6 @@ export function syncAccountTreeWithUserStorage(): ThunkAction<
   unknown,
   AnyAction
 > {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async () => {
     try {
       const response = await submitRequestToBackground(
@@ -7647,8 +7441,6 @@ export function deleteAccountSyncingDataFromUserStorage(): ThunkAction<
   unknown,
   AnyAction
 > {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async () => {
     try {
       await Promise.all([
@@ -7706,8 +7498,6 @@ export function syncContactsWithUserStorage(): ThunkAction<
 export function markMetamaskNotificationsAsRead(
   notifications: NotificationServicesController.Types.MarkAsReadNotificationsParam,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async () => {
     try {
       await submitRequestToBackground('markMetamaskNotificationsAsRead', [
@@ -7733,8 +7523,6 @@ export function markMetamaskNotificationsAsRead(
 export function setFeatureAnnouncementsEnabled(
   state: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async () => {
     try {
       await submitRequestToBackground('setFeatureAnnouncementsEnabled', [
@@ -7760,8 +7548,6 @@ export function setFeatureAnnouncementsEnabled(
 export function checkAccountsPresence(
   accounts: string[],
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async () => {
     try {
       const response = await submitRequestToBackground(
@@ -8034,8 +7820,6 @@ export function setTransactionActive(
   transactionId: string,
   isFocused: boolean,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31879
-  // eslint-disable-next-line @typescript-eslint/no-misused-promises
   return async () => {
     await submitRequestToBackground('setTransactionActive', [
       transactionId,


### PR DESCRIPTION
## **Description**

Unused ESLint ignore directives have been removed from all remaining `ui` directories (i.e. all excluding `ui/components` and `ui/pages`, which are handled in separate PRs).

This helps unblock the ESLint v9 upgrade (it complains about unused directives by default).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

The CI lint step should be sufficient to test this change.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Comment-only lint hygiene with no functional code changes; risk is limited to CI failing if any removed directive was still required.
> 
> **Overview**
> This PR **strips unused `eslint-disable` comments** (and related TODOs tied to those suppressions) across the remaining `ui` tree outside `ui/components` and `ui/pages`, so lint no longer reports dead directives on the path to ESLint v9.
> 
> The bulk of the diff is **`ui/store/actions.ts`**, where many `// eslint-disable-next-line @typescript-eslint/no-misused-promises` lines and their `#31879` TODOs are removed from Redux thunks that return async functions. Smaller cleanups drop **prefer-nullish-coalescing**, **naming-convention**, **react-compiler**, **no-require-imports**, **no-unused-vars**, **no-empty-function** / **no-empty-function** pairings, **camelcase**, **prettier/prettier**, and file-level disables in mocks, contexts, hooks, selectors, helpers, and perps providers—**without changing runtime behavior**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 729bc951f1f95c115998fc43de47ab708e32b8b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->