### PR TITLE
feat: added skeleton for token list after stale open

### DIFF
--- a/ui/components/app/assets/hooks/useTokenDisplayInfo.tsx
+++ b/ui/components/app/assets/hooks/useTokenDisplayInfo.tsx
@@ -6,6 +6,7 @@ import {
   getAllTokens,
   getEnabledNetworksByNamespace,
   getShowFiatInTestnets,
+  getUseCurrencyRateCheck,
   selectERC20TokensByChain,
 } from '../../../../selectors';
 import { Token, TokenDisplayInfo, TokenWithFiatAmount } from '../types';
@@ -58,6 +59,7 @@ export const useTokenDisplayInfo = ({
 
   const isMainnet = !isTestnetSelected;
   const showFiatInTestnets = useSelector(getShowFiatInTestnets);
+  const useCurrencyRateCheck = useSelector(getUseCurrencyRateCheck);
 
   // isTestnet value is tied to the value of state.metamask.selectedNetworkClientId;
   // In some cases; the user has "all popular networks" selected or a specific popular network selected, while being on a dapp that is connected to a testnet,
@@ -68,6 +70,9 @@ export const useTokenDisplayInfo = ({
 
   const shouldShowFiat =
     showFiat && (isMainnet || (isTestnetSelected && showFiatInTestnets));
+  const shouldAttemptFiat =
+    useCurrencyRateCheck &&
+    (isMainnet || (isTestnetSelected && showFiatInTestnets));
   // Format for fiat balance with currency style
   const secondary =
     shouldShowFiat &&
@@ -78,6 +83,10 @@ export const useTokenDisplayInfo = ({
           fixCurrencyToUSD ? 'USD' : currentCurrency,
         )
       : undefined;
+  const isFiatLoading =
+    shouldAttemptFiat &&
+    (token.tokenFiatAmount === null || token.tokenFiatAmount === undefined) &&
+    token.balance !== undefined;
 
   const isEvmMainnet =
     token.chainId && isEvm ? isChainIdMainnet(token.chainId) : false;
@@ -117,6 +126,7 @@ export const useTokenDisplayInfo = ({
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore
       secondary,
+      isFiatLoading,
       isStakeable,
       tokenChainImage: tokenChainImage as string,
     };
@@ -132,6 +142,7 @@ export const useTokenDisplayInfo = ({
     title: token.title,
     tokenImage: token.image,
     secondary: showFiat ? nonEvmSecondary : null,
+    isFiatLoading,
     isStakeable: false,
     tokenChainImage: token.image as string,
   };

--- a/ui/components/app/assets/hooks/useTokenDisplayInfo.tsx
+++ b/ui/components/app/assets/hooks/useTokenDisplayInfo.tsx
@@ -7,6 +7,7 @@ import {
   getEnabledNetworksByNamespace,
   getShowFiatInTestnets,
   getUseCurrencyRateCheck,
+  selectAnyEnabledNetworksAreAvailable,
   selectERC20TokensByChain,
 } from '../../../../selectors';
 import { Token, TokenDisplayInfo, TokenWithFiatAmount } from '../types';
@@ -60,6 +61,9 @@ export const useTokenDisplayInfo = ({
   const isMainnet = !isTestnetSelected;
   const showFiatInTestnets = useSelector(getShowFiatInTestnets);
   const useCurrencyRateCheck = useSelector(getUseCurrencyRateCheck);
+  const anyEnabledNetworksAreAvailable = useSelector(
+    selectAnyEnabledNetworksAreAvailable,
+  );
 
   // isTestnet value is tied to the value of state.metamask.selectedNetworkClientId;
   // In some cases; the user has "all popular networks" selected or a specific popular network selected, while being on a dapp that is connected to a testnet,
@@ -86,7 +90,7 @@ export const useTokenDisplayInfo = ({
   const isFiatLoading =
     shouldAttemptFiat &&
     (token.tokenFiatAmount === null || token.tokenFiatAmount === undefined) &&
-    token.balance !== undefined;
+    !anyEnabledNetworksAreAvailable;
 
   const isEvmMainnet =
     token.chainId && isEvm ? isChainIdMainnet(token.chainId) : false;

--- a/ui/components/app/assets/token-cell/cells/token-cell-percent-change.test.tsx
+++ b/ui/components/app/assets/token-cell/cells/token-cell-percent-change.test.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import mockState from '../../../../../../test/data/mock-state.json';
+import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
+import type { TokenFiatDisplayInfo } from '../../types';
+import { TokenCellPercentChange } from './token-cell-percent-change';
+
+describe('TokenCellPercentChange', () => {
+  const store = configureMockStore([thunk])(mockState);
+
+  const token = {
+    address: '0xAnotherToken',
+    symbol: 'TEST',
+    image: '',
+    decimals: 18,
+    chainId: '0x1',
+    title: 'TEST',
+    tokenImage: '',
+    tokenChainImage: '',
+    secondary: null,
+    balance: '5',
+    isFiatLoading: true,
+  } as TokenFiatDisplayInfo;
+
+  it('shows a skeleton while fiat value is loading', () => {
+    const { getByTestId } = renderWithProvider(
+      <TokenCellPercentChange token={token} />,
+      store,
+    );
+
+    expect(
+      getByTestId('multichain-token-list-item-percentage-skeleton'),
+    ).toBeInTheDocument();
+  });
+});

--- a/ui/components/app/assets/token-cell/cells/token-cell-percent-change.tsx
+++ b/ui/components/app/assets/token-cell/cells/token-cell-percent-change.tsx
@@ -29,7 +29,7 @@ export const TokenCellPercentChange = React.memo(
     if (token.isFiatLoading) {
       return (
         <Skeleton
-          className="h-4 w-8"
+          className="h-3.5 w-8"
           data-testid="multichain-token-list-item-percentage-skeleton"
         />
       );

--- a/ui/components/app/assets/token-cell/cells/token-cell-percent-change.tsx
+++ b/ui/components/app/assets/token-cell/cells/token-cell-percent-change.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useSelector } from 'react-redux';
 import { getNativeTokenAddress } from '@metamask/assets-controllers';
 import { CaipAssetType, Hex } from '@metamask/utils';
+import { Skeleton } from '@metamask/design-system-react';
 import { getMarketData } from '../../../../../selectors';
 import { TokenFiatDisplayInfo } from '../../types';
 import { PercentageChange } from '../../../../multichain/token-list-item/price/percentage-change';
@@ -25,6 +26,15 @@ export const TokenCellPercentChange = React.memo(
         ? getNativeTokenAddress(token.chainId as Hex)
         : token.address;
 
+    if (token.isFiatLoading) {
+      return (
+        <Skeleton
+          className="h-4 w-8"
+          data-testid="multichain-token-list-item-percentage-skeleton"
+        />
+      );
+    }
+
     let tokenPercentageChange;
 
     // Compare null and undefined
@@ -45,6 +55,7 @@ export const TokenCellPercentChange = React.memo(
   },
   (prevProps, nextProps) =>
     prevProps.token.address === nextProps.token.address &&
+    prevProps.token.isFiatLoading === nextProps.token.isFiatLoading &&
     prevProps.price === nextProps.price &&
     prevProps.comparePrice === nextProps.comparePrice,
 );

--- a/ui/components/app/assets/token-cell/cells/token-cell-secondary-display.test.tsx
+++ b/ui/components/app/assets/token-cell/cells/token-cell-secondary-display.test.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import configureMockStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import mockState from '../../../../../../test/data/mock-state.json';
+import { renderWithProvider } from '../../../../../../test/lib/render-helpers-navigate';
+import type { TokenFiatDisplayInfo } from '../../types';
+import { TokenCellSecondaryDisplay } from './token-cell-secondary-display';
+
+jest.mock('../../../../../hooks/useIsOriginalNativeTokenSymbol', () => ({
+  useIsOriginalNativeTokenSymbol: jest.fn(() => true),
+}));
+
+describe('TokenCellSecondaryDisplay', () => {
+  const store = configureMockStore([thunk])(mockState);
+
+  const token = {
+    address: '0xAnotherToken',
+    symbol: 'TEST',
+    image: '',
+    decimals: 18,
+    chainId: '0x1',
+    title: 'TEST',
+    tokenImage: '',
+    tokenChainImage: '',
+    secondary: null,
+    balance: '5',
+    isFiatLoading: true,
+  } as TokenFiatDisplayInfo;
+
+  it('shows a skeleton while fiat value is loading', () => {
+    const { getByTestId } = renderWithProvider(
+      <TokenCellSecondaryDisplay
+        token={token}
+        handleScamWarningModal={jest.fn()}
+        privacyMode={false}
+      />,
+      store,
+    );
+
+    expect(
+      getByTestId('multichain-token-list-item-secondary-value-skeleton'),
+    ).toBeInTheDocument();
+  });
+});

--- a/ui/components/app/assets/token-cell/cells/token-cell-secondary-display.tsx
+++ b/ui/components/app/assets/token-cell/cells/token-cell-secondary-display.tsx
@@ -92,7 +92,7 @@ export const TokenCellSecondaryDisplay = React.memo(
             isZeroAmount(secondaryDisplayText) &&
             secondaryDisplayText !== '—')
         }
-        className="mb-1"
+        className="h-3.5"
         data-testid="multichain-token-list-item-secondary-value-skeleton"
       >
         <SensitiveText

--- a/ui/components/app/assets/token-cell/cells/token-cell-secondary-display.tsx
+++ b/ui/components/app/assets/token-cell/cells/token-cell-secondary-display.tsx
@@ -87,11 +87,13 @@ export const TokenCellSecondaryDisplay = React.memo(
     return (
       <Skeleton
         hideChildren={
-          !anyEnabledNetworksAreAvailable &&
-          isZeroAmount(secondaryDisplayText) &&
-          secondaryDisplayText !== '—'
+          token.isFiatLoading ||
+          (!anyEnabledNetworksAreAvailable &&
+            isZeroAmount(secondaryDisplayText) &&
+            secondaryDisplayText !== '—')
         }
         className="mb-1"
+        data-testid="multichain-token-list-item-secondary-value-skeleton"
       >
         <SensitiveText
           fontWeight={token.secondary ? FontWeight.Medium : FontWeight.Normal}
@@ -113,5 +115,6 @@ export const TokenCellSecondaryDisplay = React.memo(
   },
   (prevProps, nextProps) =>
     prevProps.token.secondary === nextProps.token.secondary &&
+    prevProps.token.isFiatLoading === nextProps.token.isFiatLoading &&
     prevProps.privacyMode === nextProps.privacyMode,
 );

--- a/ui/components/app/assets/token-cell/token-cell.test.tsx
+++ b/ui/components/app/assets/token-cell/token-cell.test.tsx
@@ -14,6 +14,7 @@ import {
   getUseSafeChainsListValidation,
   getEnabledNetworksByNamespace,
   getAllTokens,
+  selectAnyEnabledNetworksAreAvailable,
   selectERC20TokensByChain,
 } from '../../../../selectors';
 import { getPreferences } from '../../../../../shared/lib/selectors/preferences';
@@ -188,6 +189,7 @@ describe('Token Cell', () => {
     ticker: 'ETH',
     rpcPrefs: { blockExplorerUrl: 'https://etherscan.io' },
   });
+  let mockAnyEnabledNetworksAreAvailable = true;
   const useSelectorMock = useSelector;
   (useSelectorMock as jest.Mock).mockImplementation((selector) => {
     if (selector === getPreferences) {
@@ -220,6 +222,9 @@ describe('Token Cell', () => {
     if (selector === getUseSafeChainsListValidation) {
       return true;
     }
+    if (selector === selectAnyEnabledNetworksAreAvailable) {
+      return mockAnyEnabledNetworksAreAvailable;
+    }
     if (selector === getEnabledNetworksByNamespace) {
       return {
         '0x1': true,
@@ -248,6 +253,10 @@ describe('Token Cell', () => {
     return undefined;
   });
   (useTokenFiatAmount as jest.Mock).mockReturnValue('5.00');
+
+  beforeEach(() => {
+    mockAnyEnabledNetworksAreAvailable = true;
+  });
 
   it('should match snapshot', () => {
     const { container } = renderWithProvider(
@@ -297,6 +306,8 @@ describe('Token Cell', () => {
   });
 
   it('shows a skeleton for native token percentage while fiat is loading', () => {
+    mockAnyEnabledNetworksAreAvailable = false;
+
     const nativeTokenWithoutFiatAmount = {
       ...propToken,
       isNative: true,

--- a/ui/components/app/assets/token-cell/token-cell.test.tsx
+++ b/ui/components/app/assets/token-cell/token-cell.test.tsx
@@ -296,6 +296,28 @@ describe('Token Cell', () => {
     expect(amountElement.textContent).toBe('5.00M TEST');
   });
 
+  it('shows a skeleton for native token percentage while fiat is loading', () => {
+    const nativeTokenWithoutFiatAmount = {
+      ...propToken,
+      isNative: true,
+      tokenFiatAmount: undefined,
+    };
+
+    const { getByTestId } = renderWithProvider(
+      <TokenCell
+        {...({
+          ...props,
+          token: nativeTokenWithoutFiatAmount,
+        } as TokenCellProps)}
+      />,
+      mockStore,
+    );
+
+    expect(
+      getByTestId('multichain-token-list-item-percentage-skeleton'),
+    ).toBeInTheDocument();
+  });
+
   describe('musd.convert', () => {
     it('does not show the mUSD convert CTA when musd.convert is not passed', () => {
       mockShouldShowTokenListItemCta.mockReturnValue(true);

--- a/ui/components/app/assets/types.ts
+++ b/ui/components/app/assets/types.ts
@@ -6,6 +6,7 @@ import type { Asset, TokenListToken } from '@metamask/assets-controllers';
 export type TokenDisplayValues = {
   secondary: number | null;
   string?: string;
+  isFiatLoading?: boolean;
 };
 
 export type TokenBalanceValues = {


### PR DESCRIPTION
This PR is to add skeleton for token list

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: added skeleton for token loading

## **Related issues**

Fixes: [issue](https://consensyssoftware.atlassian.net/browse/CEUX-1202?atlOrigin=eyJpIjoiNzc2Mzg2ZmVkNmYzNDJkMDlhYTMwMGJiZDEzNGZmMzMiLCJwIjoiaiJ9
)
## **Manual testing steps**

1. Open MetaMask with an account that has token/native asset balances.
2. Lock MetaMask.
3. Run metamask with `yarn start` and unlock
4. Observe the homepage token list while fiat data loads.
5. Verify token rows do not flash — under the token name.
6. Verify token rows do not flash - for the lower-left price-change value.
7. Verify skeletons appear in those fields while fiat/value data is loading.
8. Wait for fiat data to finish loading.
9. Verify the token rows display the expected fiat values and price-change values.
10. Repeat with a cold extension open and confirm the same behavior.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**




https://github.com/user-attachments/assets/d3dc0ee6-a7c1-4435-8794-5f58a3a85be6


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only loading states in the token list with no auth, transaction, or data-persistence changes; risk is limited to display timing and memo/render edge cases.
> 
> **Overview**
> Adds **loading skeletons** on the homepage token list so fiat value and 24h percent-change fields don’t flash empty placeholders while rates load after unlock or a cold open (CEUX-1202).
> 
> `useTokenDisplayInfo` now exposes **`isFiatLoading`**: true when currency-rate check is on, fiat should be shown, `tokenFiatAmount` is still missing, and **`selectAnyEnabledNetworksAreAvailable`** is false. That flag is threaded through **`TokenDisplayValues`** / **`TokenFiatDisplayInfo`**.
> 
> **`TokenCellSecondaryDisplay`** drives its existing `Skeleton` via `token.isFiatLoading` (with a dedicated test id) instead of only inferring load state from zero secondary text. **`TokenCellPercentChange`** renders a small design-system skeleton when fiat is loading, before market data is applied.
> 
> Unit tests cover secondary display, percent change, and **`TokenCell`** integration for the native-token percentage skeleton.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5c055fd875069a0f13e8817b9dc6789c4d89dd16. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->