### PR TITLE
fix: gas sponsorship being shown for hw accounts when the user has selected a nonevm network

### DIFF
--- a/ui/hooks/useIsHardwareWalletAccount.test.ts
+++ b/ui/hooks/useIsHardwareWalletAccount.test.ts
@@ -1,0 +1,124 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { KeyringTypes } from '@metamask/keyring-controller';
+import type { InternalAccount } from '@metamask/keyring-internal-api';
+import { useSelector } from 'react-redux';
+import { getInternalAccountByAddress } from '../selectors/accounts';
+import { getInternalAccountBySelectedAccountGroupAndCaip } from '../selectors/multichain-accounts/account-tree';
+import { isHardwareWallet } from '../../shared/lib/selectors/keyring';
+import { useIsHardwareWalletAccount } from './useIsHardwareWalletAccount';
+
+jest.mock('react-redux', () => ({
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../selectors/accounts', () => ({
+  ...jest.requireActual('../selectors/accounts'),
+  getInternalAccountByAddress: jest.fn(),
+}));
+
+jest.mock('../selectors/multichain-accounts/account-tree', () => ({
+  ...jest.requireActual('../selectors/multichain-accounts/account-tree'),
+  getInternalAccountBySelectedAccountGroupAndCaip: jest.fn(),
+}));
+
+jest.mock('../../shared/lib/selectors/keyring', () => ({
+  ...jest.requireActual('../../shared/lib/selectors/keyring'),
+  isHardwareWallet: jest.fn(),
+}));
+
+const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+
+const LEDGER_ADDRESS = '0x1234567890123456789012345678901234567890';
+
+const ledgerAccount = {
+  address: LEDGER_ADDRESS,
+  metadata: {
+    keyring: { type: KeyringTypes.ledger },
+  },
+} as InternalAccount;
+
+const hdAccount = {
+  address: LEDGER_ADDRESS,
+  metadata: {
+    keyring: { type: KeyringTypes.hd },
+  },
+} as InternalAccount;
+
+const renderWithMock = ({
+  address,
+  accountByAddress,
+  evmAccountFromSelectedGroup = null,
+  isHardwareWalletSelected = false,
+}: {
+  address?: string;
+  accountByAddress?: InternalAccount;
+  evmAccountFromSelectedGroup?: InternalAccount | null;
+  isHardwareWalletSelected?: boolean;
+}) => {
+  // Inline selectors in the hook are anonymous; resolve by call order.
+  let callIndex = 0;
+  mockUseSelector.mockImplementation((selector) => {
+    if (selector === isHardwareWallet) {
+      return isHardwareWalletSelected;
+    }
+    callIndex += 1;
+    if (callIndex === 1) {
+      return accountByAddress;
+    }
+    if (callIndex === 2) {
+      return evmAccountFromSelectedGroup;
+    }
+    return undefined;
+  });
+
+  (getInternalAccountByAddress as unknown as jest.Mock).mockReturnValue(
+    accountByAddress,
+  );
+  (
+    getInternalAccountBySelectedAccountGroupAndCaip as unknown as jest.Mock
+  ).mockReturnValue(evmAccountFromSelectedGroup);
+
+  return renderHook(() => useIsHardwareWalletAccount(address));
+};
+
+describe('useIsHardwareWalletAccount', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns true when address resolves to a hardware wallet', () => {
+    const { result } = renderWithMock({
+      address: LEDGER_ADDRESS,
+      accountByAddress: ledgerAccount,
+      isHardwareWalletSelected: false,
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('returns false when address resolves to a non-hardware wallet', () => {
+    const { result } = renderWithMock({
+      address: LEDGER_ADDRESS,
+      accountByAddress: hdAccount,
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it('returns true from selected group EVM account when address is omitted', () => {
+    const { result } = renderWithMock({
+      evmAccountFromSelectedGroup: ledgerAccount,
+      isHardwareWalletSelected: false,
+    });
+
+    expect(result.current).toBe(true);
+  });
+
+  it('falls back to selected-account detection when address and group EVM are missing', () => {
+    const { result } = renderWithMock({
+      isHardwareWalletSelected: true,
+    });
+
+    expect(result.current).toBe(true);
+  });
+});

--- a/ui/hooks/useIsHardwareWalletAccount.ts
+++ b/ui/hooks/useIsHardwareWalletAccount.ts
@@ -1,0 +1,41 @@
+import { EthScope } from '@metamask/keyring-api';
+import { useSelector } from 'react-redux';
+import { isHardwareAccount } from '../components/app/rewards/utils/isHardwareAccount';
+import { getInternalAccountByAddress } from '../selectors/accounts';
+import { getInternalAccountBySelectedAccountGroupAndCaip } from '../selectors/multichain-accounts/account-tree';
+import { isHardwareWallet } from '../../shared/lib/selectors/keyring';
+
+/**
+ * Whether the relevant account is a hardware wallet.
+ *
+ * Prefer an explicit `address` when available (e.g. confirmation `txParams.from`).
+ * Otherwise check the selected account group's EVM account, then the globally
+ * selected account.
+ *
+ * Selecting a Non-EVM network silently switches `selectedAccount` to a Snap
+ * account while the selected group (and EVM send `from`) can still be a
+ * hardware wallet — so `isHardwareWallet` alone is not enough.
+ *
+ * @param address - Optional account address to check.
+ */
+export function useIsHardwareWalletAccount(address?: string): boolean {
+  const accountByAddress = useSelector((state) =>
+    address ? getInternalAccountByAddress(state, address) : undefined,
+  );
+
+  const evmAccountFromSelectedGroup = useSelector((state) =>
+    getInternalAccountBySelectedAccountGroupAndCaip(state, EthScope.Eoa),
+  );
+
+  const isHardwareWalletSelected = useSelector(isHardwareWallet);
+
+  if (accountByAddress) {
+    return isHardwareAccount(accountByAddress);
+  }
+
+  if (evmAccountFromSelectedGroup) {
+    return isHardwareAccount(evmAccountFromSelectedGroup);
+  }
+
+  return isHardwareWalletSelected;
+}

--- a/ui/hooks/useIsNetworkGasSponsored.test.ts
+++ b/ui/hooks/useIsNetworkGasSponsored.test.ts
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { useSelector } from 'react-redux';
 import { getGasFeesSponsoredNetworkEnabled } from '../selectors';
-import { isHardwareWallet } from '../../shared/lib/selectors/keyring';
+import { useIsHardwareWalletAccount } from './useIsHardwareWalletAccount';
 import { useIsNetworkGasSponsored } from './useIsNetworkGasSponsored';
 
 jest.mock('react-redux', () => ({
@@ -11,29 +11,26 @@ jest.mock('react-redux', () => ({
 jest.mock('../selectors', () => ({
   getGasFeesSponsoredNetworkEnabled: jest.fn(),
 }));
-jest.mock('../../shared/lib/selectors/keyring', () => ({
-  ...jest.requireActual('../../shared/lib/selectors/keyring'),
-  isHardwareWallet: jest.fn(),
-}));
+
+jest.mock('./useIsHardwareWalletAccount');
 
 const mockUseSelector = useSelector as jest.MockedFunction<typeof useSelector>;
+const mockUseIsHardwareWalletAccount = jest.mocked(useIsHardwareWalletAccount);
 
 const renderWithMock = ({
   chainId,
-  mockIsHardwareWallet = false,
+  mockIsHardwareWalletAccount = false,
   mockGasFeesSponsoredNetworkEnabled = {
     '0x1': true,
     '0x2': false,
   },
 }: {
   chainId: string | undefined;
-  mockIsHardwareWallet?: boolean;
+  mockIsHardwareWalletAccount?: boolean;
   mockGasFeesSponsoredNetworkEnabled?: { [key: string]: boolean };
 }) => {
+  mockUseIsHardwareWalletAccount.mockReturnValue(mockIsHardwareWalletAccount);
   mockUseSelector.mockImplementation((selector) => {
-    if (selector === isHardwareWallet) {
-      return mockIsHardwareWallet;
-    }
     if (selector === getGasFeesSponsoredNetworkEnabled) {
       return mockGasFeesSponsoredNetworkEnabled;
     }
@@ -80,7 +77,7 @@ describe('useIsNetworkGasSponsored', () => {
   it('returns false when network is enabled using hex chainId BUT is hardware wallet', () => {
     const { result } = renderWithMock({
       chainId: '0x1',
-      mockIsHardwareWallet: true,
+      mockIsHardwareWalletAccount: true,
     });
     expect(result.current).toEqual({ isNetworkGasSponsored: false });
   });
@@ -88,7 +85,7 @@ describe('useIsNetworkGasSponsored', () => {
   it('returns false when network is enabled using CAIP chainId BUT is hardware wallet', () => {
     const { result } = renderWithMock({
       chainId: 'eip155:1',
-      mockIsHardwareWallet: true,
+      mockIsHardwareWalletAccount: true,
     });
     expect(result.current).toEqual({ isNetworkGasSponsored: false });
   });

--- a/ui/hooks/useIsNetworkGasSponsored.ts
+++ b/ui/hooks/useIsNetworkGasSponsored.ts
@@ -2,8 +2,8 @@ import { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { CaipChainId } from '@metamask/utils';
 import { getGasFeesSponsoredNetworkEnabled } from '../selectors';
-import { isHardwareWallet } from '../../shared/lib/selectors/keyring';
 import { convertCaipToHexChainId } from '../../shared/lib/network.utils';
+import { useIsHardwareWalletAccount } from './useIsHardwareWalletAccount';
 
 export const useIsNetworkGasSponsored = (
   networkChainId: string | undefined,
@@ -13,7 +13,8 @@ export const useIsNetworkGasSponsored = (
   const gasFeesSponsoredNetworkEnabledMap = useSelector(
     getGasFeesSponsoredNetworkEnabled,
   );
-  const isHardwareWalletAccount = useSelector(isHardwareWallet);
+  const isHardwareWalletAccount = useIsHardwareWalletAccount();
+
   // Check if a network has gas sponsorship enabled
   return useMemo(() => {
     if (!networkChainId || isHardwareWalletAccount) {

--- a/ui/pages/confirmations/hooks/gas/useGaslessSupportedSmartTransactions.test.ts
+++ b/ui/pages/confirmations/hooks/gas/useGaslessSupportedSmartTransactions.test.ts
@@ -5,7 +5,7 @@ import { genUnapprovedContractInteractionConfirmation } from '../../../../../tes
 import { getMockConfirmStateForTransaction } from '../../../../../test/data/confirmations/helper';
 import { renderHookWithConfirmContextProvider } from '../../../../../test/lib/confirmations/render-helpers';
 import { isSendBundleSupported } from '../../../../store/actions';
-import { isHardwareWallet } from '../../../../../shared/lib/selectors/keyring';
+import { useIsHardwareWalletAccount } from '../../../../hooks/useIsHardwareWalletAccount';
 import { useGaslessSupportedSmartTransactions } from './useGaslessSupportedSmartTransactions';
 
 jest.mock('../../../../../shared/lib/selectors');
@@ -17,10 +17,7 @@ jest.mock('../../../../store/actions', () => ({
 jest.mock('../../../../selectors', () => ({
   ...jest.requireActual('../../../../selectors'),
 }));
-jest.mock('../../../../../shared/lib/selectors/keyring', () => ({
-  ...jest.requireActual('../../../../../shared/lib/selectors/keyring'),
-  isHardwareWallet: jest.fn(),
-}));
+jest.mock('../../../../hooks/useIsHardwareWalletAccount');
 
 const CHAIN_ID_MOCK = '0x5';
 
@@ -44,13 +41,15 @@ async function runHook() {
 describe('useGaslessSupportedSmartTransactions', () => {
   const getIsSmartTransactionMock = jest.mocked(getIsSmartTransaction);
   const isSendBundleSupportedMock = jest.mocked(isSendBundleSupported);
-  const isHardwareWalletMock = jest.mocked(isHardwareWallet);
+  const useIsHardwareWalletAccountMock = jest.mocked(
+    useIsHardwareWalletAccount,
+  );
 
   beforeEach(() => {
     jest.resetAllMocks();
     getIsSmartTransactionMock.mockReturnValue(false);
     isSendBundleSupportedMock.mockResolvedValue(false);
-    isHardwareWalletMock.mockReturnValue(false);
+    useIsHardwareWalletAccountMock.mockReturnValue(false);
   });
 
   it('returns isSupported = true when smart transactions enabled and sendBundle supported', async () => {
@@ -154,7 +153,7 @@ describe('useGaslessSupportedSmartTransactions', () => {
   });
 
   it('returns isSupported false for hardware wallets even when smart transactions and sendBundle are supported', async () => {
-    isHardwareWalletMock.mockReturnValue(true);
+    useIsHardwareWalletAccountMock.mockReturnValue(true);
     getIsSmartTransactionMock.mockReturnValue(true);
     isSendBundleSupportedMock.mockResolvedValue(true);
 

--- a/ui/pages/confirmations/hooks/gas/useGaslessSupportedSmartTransactions.ts
+++ b/ui/pages/confirmations/hooks/gas/useGaslessSupportedSmartTransactions.ts
@@ -6,8 +6,8 @@ import {
   SmartTransactionsState,
 } from '../../../../../shared/lib/selectors';
 import { useAsyncResult } from '../../../../hooks/useAsync';
+import { useIsHardwareWalletAccount } from '../../../../hooks/useIsHardwareWalletAccount';
 import { isSendBundleSupported } from '../../../../store/actions';
-import { isHardwareWallet } from '../../../../../shared/lib/selectors/keyring';
 import { useConfirmContext } from '../../context/confirm';
 
 export function useGaslessSupportedSmartTransactions(): {
@@ -19,7 +19,9 @@ export function useGaslessSupportedSmartTransactions(): {
     useConfirmContext<TransactionMeta>();
 
   const { chainId } = transactionMeta ?? {};
-  const isHardwareWalletAccount = useSelector(isHardwareWallet);
+  const isHardwareWalletAccount = useIsHardwareWalletAccount(
+    transactionMeta?.txParams?.from,
+  );
   const isSmartTransaction = useSelector((state: SmartTransactionsState) =>
     getIsSmartTransaction(state, chainId),
   );

--- a/ui/pages/confirmations/hooks/gas/useIsGaslessSupported.test.ts
+++ b/ui/pages/confirmations/hooks/gas/useIsGaslessSupported.test.ts
@@ -5,7 +5,7 @@ import { getMockConfirmStateForTransaction } from '../../../../../test/data/conf
 import { renderHookWithConfirmContextProvider } from '../../../../../test/lib/confirmations/render-helpers';
 import { EIP_7702_REVOKE_ADDRESS } from '../../../../../shared/lib/eip7702-utils';
 import { isRelaySupported } from '../../../../store/actions';
-import { isHardwareWallet } from '../../../../../shared/lib/selectors/keyring';
+import { useIsHardwareWalletAccount } from '../../../../hooks/useIsHardwareWalletAccount';
 import { useIsGaslessSupported } from './useIsGaslessSupported';
 import { useGaslessSupportedSmartTransactions } from './useGaslessSupportedSmartTransactions';
 
@@ -22,10 +22,7 @@ jest.mock('../../../../selectors', () => ({
 }));
 
 jest.mock('./useGaslessSupportedSmartTransactions');
-jest.mock('../../../../../shared/lib/selectors/keyring', () => ({
-  ...jest.requireActual('../../../../../shared/lib/selectors/keyring'),
-  isHardwareWallet: jest.fn(),
-}));
+jest.mock('../../../../hooks/useIsHardwareWalletAccount');
 
 async function runHook({
   authorizationList,
@@ -46,7 +43,9 @@ async function runHook({
 
 describe('useIsGaslessSupported', () => {
   const isRelaySupportedMock = jest.mocked(isRelaySupported);
-  const isHardwareWalletMock = jest.mocked(isHardwareWallet);
+  const useIsHardwareWalletAccountMock = jest.mocked(
+    useIsHardwareWalletAccount,
+  );
   const useGaslessSupportedSmartTransactionsMock = jest.mocked(
     useGaslessSupportedSmartTransactions,
   );
@@ -55,7 +54,7 @@ describe('useIsGaslessSupported', () => {
     jest.resetAllMocks();
 
     isRelaySupportedMock.mockResolvedValue(false);
-    isHardwareWalletMock.mockReturnValue(false);
+    useIsHardwareWalletAccountMock.mockReturnValue(false);
     useGaslessSupportedSmartTransactionsMock.mockReturnValue({
       isSmartTransaction: false,
       isSupported: false,
@@ -168,7 +167,7 @@ describe('useIsGaslessSupported', () => {
   });
 
   it('returns isSupported false for hardware wallets even when smart transactions are supported', async () => {
-    isHardwareWalletMock.mockReturnValue(true);
+    useIsHardwareWalletAccountMock.mockReturnValue(true);
     useGaslessSupportedSmartTransactionsMock.mockReturnValue({
       isSmartTransaction: true,
       isSupported: true,
@@ -185,12 +184,27 @@ describe('useIsGaslessSupported', () => {
   });
 
   it('returns isSupported false for hardware wallets even when relay is supported', async () => {
-    isHardwareWalletMock.mockReturnValue(true);
+    useIsHardwareWalletAccountMock.mockReturnValue(true);
     isRelaySupportedMock.mockResolvedValue(true);
 
     const result = await runHook();
 
     expect(isRelaySupportedMock).not.toHaveBeenCalled();
+
+    expect(result).toStrictEqual({
+      isSupported: false,
+      isSmartTransaction: false,
+      pending: false,
+    });
+  });
+
+  it('returns isSupported false when confirmation from is hardware wallet after Non-EVM network selection', async () => {
+    // Selected account may be a non-HW Snap account after switching to Solana,
+    // but the confirmation still signs with a Ledger/Trezor from address.
+    useIsHardwareWalletAccountMock.mockReturnValue(true);
+    isRelaySupportedMock.mockResolvedValue(true);
+
+    const result = await runHook();
 
     expect(result).toStrictEqual({
       isSupported: false,

--- a/ui/pages/confirmations/hooks/gas/useIsGaslessSupported.ts
+++ b/ui/pages/confirmations/hooks/gas/useIsGaslessSupported.ts
@@ -1,8 +1,7 @@
 import { TransactionMeta } from '@metamask/transaction-controller';
-import { useSelector } from 'react-redux';
 import { EIP_7702_REVOKE_ADDRESS } from '../../../../../shared/lib/eip7702-utils';
 import { useAsyncResult } from '../../../../hooks/useAsync';
-import { isHardwareWallet } from '../../../../../shared/lib/selectors/keyring';
+import { useIsHardwareWalletAccount } from '../../../../hooks/useIsHardwareWalletAccount';
 import { useConfirmContext } from '../../context/confirm';
 import { isRelaySupported } from '../../../../store/actions';
 import { useGaslessSupportedSmartTransactions } from './useGaslessSupportedSmartTransactions';
@@ -16,6 +15,9 @@ import { useGaslessSupportedSmartTransactions } from './useGaslessSupportedSmart
  *
  * Hardware wallets are excluded from gasless support because they cannot sign
  * EIP-7702 authorization lists. They fall back to the standard "user pay gas" flow.
+ * Detection uses the confirmation's `txParams.from` account (not the globally
+ * selected account) so Non-EVM network selection cannot mis-classify a Ledger/
+ * Trezor send as gasless-eligible.
  *
  * Account downgrade (revoke delegation) transactions are excluded because gasless
  * requires an upgraded account, which conflicts with the downgrade intent.
@@ -30,7 +32,9 @@ export function useIsGaslessSupported() {
     useConfirmContext<TransactionMeta>();
 
   const { chainId } = transactionMeta ?? {};
-  const isHardwareWalletAccount = useSelector(isHardwareWallet);
+  const isHardwareWalletAccount = useIsHardwareWalletAccount(
+    transactionMeta?.txParams?.from,
+  );
 
   const isDowngradeTransaction =
     transactionMeta?.txParams?.authorizationList?.[0]?.address ===


### PR DESCRIPTION
## **Description**

When a hardware-wallet account group is selected and the user switches to a Non-EVM network, MetaMask silently changes `selectedAccount` to a Snap account. Gas sponsorship / gasless eligibility still used `isHardwareWallet`, which only checks that globally selected account, so the HW account was mis-classified as eligible and “Gas sponsored” UI could incorrectly appear.

This PR adds `useIsHardwareWalletAccount`, which prefers an explicit address (e.g. confirmation `txParams.from`), then the selected group’s EVM account, then the global selection. Gas sponsorship and gasless hooks (`useIsNetworkGasSponsored`, `useIsGaslessSupported`, `useGaslessSupportedSmartTransactions`) now use that helper so HW accounts stay excluded even when a Non-EVM network is selected.

## **Changelog**

CHANGELOG entry: Fixed gas sponsorship incorrectly appearing for hardware wallet accounts when a Non-EVM network is selected

## **Related issues**

Fixes: [MUL-2011](https://consensyssoftware.atlassian.net/browse/MUL-2011?atlOrigin=eyJpIjoiZjE0NDgwZjVlYWM4NDE2NWJmZmFhMGFiYjNjY2QzNzMiLCJwIjoiaiJ9)

## **Manual testing steps**

1. Import/connect a Ledger, Trezor, or QR hardware wallet account and select that account group.
2. Switch the selected network to a Non-EVM network (e.g. Solana).
3. Navigate to a gas-sponsored EVM network flow (e.g. send / confirmation on Monad or another sponsored chain available in your build).
4. Verify the “Gas sponsored” / gasless UI is **not** shown for the hardware wallet account.
5. Switch back to an HD/imported EOA on the same sponsored network and verify gas sponsorship still appears when expected.
6. With HW selected on an EVM network (no Non-EVM switch), confirm sponsorship remains hidden as before.

## **Screenshots/Recordings**
### **Before**

https://github.com/user-attachments/assets/36df87eb-942f-41a3-8104-e094aa322795


### **After**

https://github.com/user-attachments/assets/e796243a-e042-411c-b3a6-f821ef92e5ac

<!--
## **Screenshots/Recordings**



-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[MUL-2011]: https://consensyssoftware.atlassian.net/browse/MUL-2011?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes eligibility logic for gas sponsorship and gasless confirmations across multiple hooks; behavior is narrower (more HW exclusions) but affects user-visible transaction flows.
> 
> **Overview**
> Fixes **gas sponsored** and **gasless** UI incorrectly treating Ledger/Trezor sends as eligible when the user picks a Non-EVM network while a hardware account group is still selected—`selectedAccount` can become a Snap account even though the EVM `from` address is still hardware.
> 
> Introduces **`useIsHardwareWalletAccount`**, which resolves hardware status in order: optional address (e.g. confirmation `txParams.from`), the selected account group’s EVM EOA, then the legacy `isHardwareWallet` global selection.
> 
> **`useIsNetworkGasSponsored`**, **`useIsGaslessSupported`**, and **`useGaslessSupportedSmartTransactions`** now use this hook instead of `isHardwareWallet` alone; confirmation paths pass **`transactionMeta?.txParams?.from`** so eligibility follows the signing account. Unit tests cover the new hook and the Non-EVM / HW `from` scenario.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60d0ff76f3abff0950619e0412d13b7c18f16eaf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->