### PR TITLE
test: fix flaky test Add account added account should persist after wallet lock

### DIFF
--- a/test/e2e/tests/multichain-accounts/add-account.spec.ts
+++ b/test/e2e/tests/multichain-accounts/add-account.spec.ts
@@ -276,6 +276,13 @@ describe('Add account', function () {
 
         await headerNavbar.checkAccountLabel(CUSTOM_ACCOUNT_NAME);
 
+        // Wait for the runtime-created non-EVM (Solana/Bitcoin) accounts to finish
+        // loading before locking. Otherwise account creation is still in-flight in
+        // the background when the wallet locks, which slows the service-worker restart
+        // and makes the post-lock navigate time out waiting for `.controller-loaded`.
+        const homePage = new HomePage(driver);
+        await homePage.waitForNonEvmAccountsLoaded();
+
         // Lock and unlock wallet
         await lockAndWaitForLoginPage(driver);
         await login(driver, { validateBalance: false });


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

The test is failing in CI with error `TimeoutError: Waiting for element to be located By(css selector, .controller-loaded) Wait timed out after 10203ms`

The test locked the wallet right after switching accounts, while that creation was still in-flight, which slowed
the service-worker restart on unlock and made the post-lock `login()` time out waiting for `.controller-loaded`.

CI [logs](https://github.com/MetaMask/metamask-extension/actions/runs/29865740894/job/88755009110)

This change waits for the non-EVM accounts to finish loading (`waitForNonEvmAccountsLoaded()`) before locking, so the background is settled and the service worker restarts cleanly on unlock. 


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<img width="780" height="493" alt="test-failure-screenshot-1" src="https://github.com/user-attachments/assets/a863c3e7-568e-404c-978b-01df4136a8ba" />


### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 4a0f371148e3434da79253337934bbfcb9a7848a. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->