### PR TITLE
chore: bump `@metamask/tron-wallet-snap` to `^1.33.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -461,7 +461,7 @@
     "@metamask/subscription-controller": "^6.2.0",
     "@metamask/transaction-controller": "^69.1.0",
     "@metamask/transaction-pay-controller": "^24.0.3",
-    "@metamask/tron-wallet-snap": "^1.33.0",
+    "@metamask/tron-wallet-snap": "^1.33.1",
     "@metamask/user-operation-controller": "^41.2.5",
     "@metamask/utils": "^11.11.0",
     "@metamask/wallet": "^7.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8410,10 +8410,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/tron-wallet-snap@npm:^1.33.0":
-  version: 1.33.0
-  resolution: "@metamask/tron-wallet-snap@npm:1.33.0"
-  checksum: 10/1a7a68460bdefc7a65709ffea310ba55c2e974c2fddacaa20d800cad892596a4f0d61257ec31c633a2468f0969b312a6c3fb9a1574620d03998d37491c9b0ad0
+"@metamask/tron-wallet-snap@npm:^1.33.1":
+  version: 1.33.1
+  resolution: "@metamask/tron-wallet-snap@npm:1.33.1"
+  checksum: 10/cd1d5acb6ad4b7753aca0fd78bb2abec2dc1977d6e93fd6512e9536cf6af46ded04e83092b63a13ba6aac91e96b192a38aba959b96d42c025b13d3d7bfab5c79
   languageName: node
   linkType: hard
 
@@ -32914,7 +32914,7 @@ __metadata:
     "@metamask/test-snaps": "npm:^3.5.2"
     "@metamask/transaction-controller": "npm:^69.1.0"
     "@metamask/transaction-pay-controller": "npm:^24.0.3"
-    "@metamask/tron-wallet-snap": "npm:^1.33.0"
+    "@metamask/tron-wallet-snap": "npm:^1.33.1"
     "@metamask/user-operation-controller": "npm:^41.2.5"
     "@metamask/utils": "npm:^11.11.0"
     "@metamask/wallet": "npm:^7.0.1"


### PR DESCRIPTION
## **Description**

Brings version 1.33.1 of `@metamask/tron-wallet-snap` into the extension. This release persists the Snap’s chain-parameter cache across Snap restarts, allowing still-valid cached values to be reused after the Snap is recreated.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: n/a

## **Manual testing steps**

Not applicable. This PR updates the bundled Snap package version; the functional change was tested in the upstream Snap release.

## **Screenshots/Recordings**

<!-- Not applicable: this dependency version bump has no extension UI changes. -->

<!--
### **Before**

[screenshots/recordings]

### **After**

[screenshots/recordings]
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.