### PR TITLE
fix: match asset page routes in analytics

### DIFF
--- a/ui/helpers/constants/routes.test.ts
+++ b/ui/helpers/constants/routes.test.ts
@@ -1,9 +1,17 @@
+import { matchPath } from 'react-router-dom';
 import {
+  ASSET_DETAILS_ROUTE,
+  ASSET_ROUTE,
   ROUTES,
   getPaths,
   PATH_NAME_MAP,
   DEVELOPER_OPTIONS_ROUTE,
 } from './routes';
+
+const findMatchingAnalyticsPath = (pathname: string) =>
+  getPaths().find((path) =>
+    matchPath({ path, end: true, caseSensitive: false }, pathname),
+  );
 
 describe('Routes Constants', () => {
   describe('ROUTES Array', () => {
@@ -112,6 +120,25 @@ describe('Routes Constants', () => {
           expect(getPaths()).not.toContain(route.path);
         }
       });
+    });
+  });
+
+  describe('asset analytics routes', () => {
+    it('matches native asset pages without an asset address', () => {
+      const matchingPath = findMatchingAnalyticsPath('/asset/0xe708/');
+
+      expect(matchingPath).toBe(ASSET_DETAILS_ROUTE);
+      expect(PATH_NAME_MAP.get(ASSET_DETAILS_ROUTE)).toBe('Asset Page');
+    });
+
+    it('matches NFT image pages before the generic asset route', () => {
+      const nftImageRoute = `${ASSET_ROUTE}/image/:asset/:id` as const;
+      const matchingPath = findMatchingAnalyticsPath(
+        '/asset/image/0x1234/5678',
+      );
+
+      expect(matchingPath).toBe(nftImageRoute);
+      expect(PATH_NAME_MAP.get(nftImageRoute)).toBe('Nft Image Page');
     });
   });
 });

--- a/ui/helpers/constants/routes.ts
+++ b/ui/helpers/constants/routes.ts
@@ -13,6 +13,8 @@ export const PREVIOUS_ROUTE = -1;
 export const UNLOCK_ROUTE = '/unlock';
 export const LOCK_ROUTE = '/lock';
 export const ASSET_ROUTE = '/asset';
+export const ASSET_DETAILS_ROUTE =
+  `${ASSET_ROUTE}/:chainId/:asset?/:id?` as const;
 export const SETTINGS_ROUTE = '/settings';
 export const LEGACY_SETTINGS_V2_ROUTE = '/settings-v2';
 export const ASSETS_ROUTE = '/settings/assets';
@@ -270,13 +272,13 @@ export const ROUTES = [
     trackInAnalytics: true,
   },
   {
-    path: `${ASSET_ROUTE}/:asset/:id`,
-    label: 'Asset Page',
+    path: `${ASSET_ROUTE}/image/:asset/:id`,
+    label: 'Nft Image Page',
     trackInAnalytics: true,
   },
   {
-    path: `${ASSET_ROUTE}/image/:asset/:id`,
-    label: 'Nft Image Page',
+    path: ASSET_DETAILS_ROUTE,
+    label: 'Asset Page',
     trackInAnalytics: true,
   },
   { path: SETTINGS_ROUTE, label: 'Settings Page', trackInAnalytics: true },

--- a/ui/pages/routes/routes.component.tsx
+++ b/ui/pages/routes/routes.component.tsx
@@ -17,6 +17,7 @@ import { ImportNftsModal } from '../../components/multichain';
 import Alerts from '../../components/app/alerts';
 
 import {
+  ASSET_DETAILS_ROUTE,
   ASSET_ROUTE,
   CONFIRM_ADD_SUGGESTED_TOKEN_ROUTE,
   CONFIRM_ADD_SUGGESTED_NFT_ROUTE,
@@ -416,7 +417,7 @@ export const routeConfig = [
         element: <NftFullImage />,
       },
       {
-        path: `${ASSET_ROUTE}/:chainId/:asset?/:id?`,
+        path: ASSET_DETAILS_ROUTE,
         element: <Asset />,
       },
       {


### PR DESCRIPTION
## **Description**

Native EVM assets navigate to paths such as `/asset/0xe708/` because they do not include a contract address. The application router accepts this route, but the MetaMetrics route registry required both `:asset` and `:id`, causing valid asset pages to be reported to Sentry as unmatched routes.

This change:

- defines a shared asset-details route pattern used by both the application router and MetaMetrics
- supports native assets, fungible tokens, CAIP-19 assets, and NFTs through the router's existing optional parameters
- keeps the more-specific NFT image route ahead of the generic asset route so it retains its analytics label
- adds regression coverage for native asset and NFT image route matching

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

Fixes:
-->

## **Manual testing steps**

1. Start the extension and unlock the wallet.
2. From the home page, click the native Ethereum asset.
3. Confirm the asset page opens at a path such as `/asset/0x1/`.
4. With Sentry reporting configured, confirm navigation does not report `Segment page tracking found unmatched route`.
5. Open an NFT image detail page and confirm it continues to load normally.

<!--
## **Screenshots/Recordings**

Not applicable; this change has no visual impact.
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
