### PR TITLE
release(runway): cherry-pick fix(ci): align Extension RC Slack notes with Mobile Runway changelog cp-13.41.0

### DIFF
--- a/.github/scripts/slack-rc-notification.mts
+++ b/.github/scripts/slack-rc-notification.mts
@@ -5,6 +5,8 @@
  * metamask-mobile/scripts/slack-rc-notification.mjs (bot token + chat.postMessage).
  *
  * Build URLs include main Chrome/Firefox Webpack artifacts plus the deprecated Browserify fallback.
+ * Slack also links to run-specific PR comment anchors for cherry-picks and full RC notes
+ * (same pattern as Mobile after MetaMask/metamask-mobile#32969).
  *
  * Local / manual testing
  * ----------------------
@@ -338,14 +340,17 @@ function buildSlackMessage(options: {
     });
   }
 
+  // Match Mobile: link Slack to the run-specific PR comment anchors.
+  // GitHub prefixes user-provided anchor IDs with `user-content-`.
   if (prNumber) {
+    const cherryPicksLink = `<${REPO_URL}/pull/${prNumber}#user-content-cherry-picks-${runId}|View cherry-picks>`;
     blocks.push(
       { type: 'divider' },
       {
         type: 'section',
         text: {
           type: 'mrkdwn',
-          text: `*:cherries: What's in this RC:* <${REPO_URL}/pull/${prNumber}#user-content-whats-in-this-rc-${runId}|View details>`,
+          text: `*🍒 Cherry-picks:* ${cherryPicksLink}`,
         },
       },
     );
@@ -353,21 +358,25 @@ function buildSlackMessage(options: {
 
   const footerBits = [
     actionsRunUrl ? `<${actionsRunUrl}|View Build Pipeline>` : null,
-    `<${REPO_URL}/blob/release/${semver}/CHANGELOG.md|View full release notes>`,
+    prNumber
+      ? `<${REPO_URL}/pull/${prNumber}#user-content-whats-in-this-rc-${runId}|View full RC notes>`
+      : null,
   ].filter(Boolean);
 
-  blocks.push(
-    { type: 'divider' },
-    {
-      type: 'context',
-      elements: [
-        {
-          type: 'mrkdwn',
-          text: footerBits.join(' | '),
-        },
-      ],
-    },
-  );
+  if (footerBits.length > 0) {
+    blocks.push(
+      { type: 'divider' },
+      {
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: footerBits.join(' | '),
+          },
+        ],
+      },
+    );
+  }
 
   return {
     blocks,
@@ -391,6 +400,8 @@ async function postToSlack(
         channel: channelName,
         blocks: payload.blocks,
         text: payload.text,
+        unfurl_links: false,
+        unfurl_media: false,
       }),
     });
 

--- a/development/metamaskbot-build-announce/cherry-picks-section.test.ts
+++ b/development/metamaskbot-build-announce/cherry-picks-section.test.ts
@@ -4,6 +4,8 @@ import {
   buildWhatsInRcFailureSection,
   buildWhatsInRcSection,
   extractWhatsInRc,
+  getChangelogAnchorId,
+  getCherryPicksAnchorId,
   getWhatsInRcAnchorId,
 } from './cherry-picks-section';
 
@@ -48,11 +50,11 @@ describe('cherry-picks-section', () => {
       mockGit(
         {
           'merge-base HEAD origin/main': 'merge-base-sha\n',
-          'describe --tags --abbrev=0 --match v[0-9]*.[0-9]*.[0-9]* --exclude *-* merge-base-sha^':
-            'v13.35.1\n',
-          'log --format=%h %s merge-base-sha..HEAD':
+          'tag --sort=-version:refname --list v*.*.* --merged merge-base-sha':
+            'v13.35.1\nv13.35.0\n',
+          'log --ancestry-path --format=%h %s merge-base-sha..HEAD':
             'abc1234 fix: cherry-pick (#123)\n',
-          'log --format=%h %s v13.35.1..merge-base-sha':
+          'log --format=%h %s v13.35.1..merge-base-sha --first-parent':
             'def5678 feat: changelog entry (#456)\n',
         },
         (args) => gitCalls.push(args),
@@ -65,37 +67,141 @@ describe('cherry-picks-section', () => {
         ],
         mergeBase: 'merge-base-sha',
         previousTag: 'v13.35.1',
+        changelogFromReleaseBranch: false,
       });
       expect(gitCalls[1]).toStrictEqual([
-        'describe',
-        '--tags',
-        '--abbrev=0',
-        '--match',
-        'v[0-9]*.[0-9]*.[0-9]*',
-        '--exclude',
-        '*-*',
-        'merge-base-sha^',
+        'tag',
+        '--sort=-version:refname',
+        '--list',
+        'v*.*.*',
+        '--merged',
+        'merge-base-sha',
       ]);
     });
 
-    it('throws when the previous release tag cannot be found', () => {
+    it('falls back to the release branch when main-line changelog is empty', () => {
       mockGit({
         'merge-base HEAD origin/main': 'merge-base-sha\n',
-        'describe --tags --abbrev=0 --match v[0-9]*.[0-9]*.[0-9]* --exclude *-* merge-base-sha^':
-          new Error('no matching tag'),
+        'tag --sort=-version:refname --list v*.*.* --merged merge-base-sha':
+          'v13.39.2\n',
+        'log --ancestry-path --format=%h %s merge-base-sha..HEAD':
+          'abc1234 release(runway): cherry-pick fix (#123)\n',
+        'log --format=%h %s v13.39.2..merge-base-sha --first-parent': '',
+        'log --format=%h %s v13.39.2..HEAD':
+          'abc1234 release(runway): cherry-pick fix (#123)\ndef5678 feat: feature on release (#456)\n',
       });
 
-      expect(() => extractWhatsInRc()).toThrow(
-        'Unable to find previous release tag before merge base merge-base-sha',
-      );
+      expect(extractWhatsInRc()).toStrictEqual({
+        cherryPicks: [
+          {
+            hash: 'abc1234',
+            subject: 'release(runway): cherry-pick fix (#123)',
+          },
+        ],
+        changelog: [
+          {
+            hash: 'abc1234',
+            subject: 'release(runway): cherry-pick fix (#123)',
+          },
+          { hash: 'def5678', subject: 'feat: feature on release (#456)' },
+        ],
+        mergeBase: 'merge-base-sha',
+        previousTag: 'v13.39.2',
+        changelogFromReleaseBranch: true,
+      });
+    });
+
+    it('falls back to the release branch when main-line changelog is only release commits', () => {
+      mockGit({
+        'merge-base HEAD origin/main': 'merge-base-sha\n',
+        'tag --sort=-version:refname --list v*.*.* --merged merge-base-sha':
+          'v13.39.2\n',
+        'log --ancestry-path --format=%h %s merge-base-sha..HEAD':
+          'abc1234 release(runway): cherry-pick fix (#123)\n',
+        'log --format=%h %s v13.39.2..merge-base-sha --first-parent':
+          'aaa1111 release: bump version\n',
+        'log --format=%h %s v13.39.2..HEAD':
+          'abc1234 release(runway): cherry-pick fix (#123)\ndef5678 feat: feature on release (#456)\n',
+      });
+
+      expect(extractWhatsInRc()).toMatchObject({
+        changelogFromReleaseBranch: true,
+        changelog: [
+          {
+            hash: 'abc1234',
+            subject: 'release(runway): cherry-pick fix (#123)',
+          },
+          { hash: 'def5678', subject: 'feat: feature on release (#456)' },
+        ],
+      });
+    });
+
+    it('falls back when main-line changelog is only scoped release commits', () => {
+      mockGit({
+        'merge-base HEAD origin/main': 'merge-base-sha\n',
+        'tag --sort=-version:refname --list v*.*.* --merged merge-base-sha':
+          'v13.39.2\n',
+        'log --ancestry-path --format=%h %s merge-base-sha..HEAD':
+          'abc1234 release(runway): cherry-pick fix (#123)\n',
+        'log --format=%h %s v13.39.2..merge-base-sha --first-parent':
+          'aaa1111 release(runway): cut release\nbbb2222 release(cp): bump dep\n',
+        'log --format=%h %s v13.39.2..HEAD':
+          'abc1234 release(runway): cherry-pick fix (#123)\ndef5678 feat: feature on release (#456)\n',
+      });
+
+      expect(extractWhatsInRc()).toMatchObject({
+        changelogFromReleaseBranch: true,
+        previousTag: 'v13.39.2',
+        changelog: [
+          {
+            hash: 'abc1234',
+            subject: 'release(runway): cherry-pick fix (#123)',
+          },
+          { hash: 'def5678', subject: 'feat: feature on release (#456)' },
+        ],
+      });
+    });
+
+    it('skips merge commits when collecting changelog entries', () => {
+      mockGit({
+        'merge-base HEAD origin/main': 'merge-base-sha\n',
+        'tag --sort=-version:refname --list v*.*.* --merged merge-base-sha':
+          'v13.39.2\n',
+        'log --ancestry-path --format=%h %s merge-base-sha..HEAD': '',
+        'log --format=%h %s v13.39.2..merge-base-sha --first-parent':
+          'aaa1111 Merge pull request #1 from MetaMask/release/13.39.2\nbbb2222 feat: real change (#2)\n',
+      });
+
+      expect(extractWhatsInRc().changelog).toStrictEqual([
+        { hash: 'bbb2222', subject: 'feat: real change (#2)' },
+      ]);
+    });
+
+    it('returns a null previous tag when none are merged into the merge base', () => {
+      mockGit({
+        'merge-base HEAD origin/main': 'merge-base-sha\n',
+        'tag --sort=-version:refname --list v*.*.* --merged merge-base-sha': '',
+        'log --ancestry-path --format=%h %s merge-base-sha..HEAD':
+          'abc1234 fix: cherry-pick (#123)\n',
+      });
+
+      expect(extractWhatsInRc()).toStrictEqual({
+        cherryPicks: [{ hash: 'abc1234', subject: 'fix: cherry-pick (#123)' }],
+        changelog: [],
+        mergeBase: 'merge-base-sha',
+        previousTag: null,
+        changelogFromReleaseBranch: false,
+      });
     });
 
     it('throws when a git log command fails', () => {
       mockGit({
         'merge-base HEAD origin/main': 'merge-base-sha\n',
-        'describe --tags --abbrev=0 --match v[0-9]*.[0-9]*.[0-9]* --exclude *-* merge-base-sha^':
+        'tag --sort=-version:refname --list v*.*.* --merged merge-base-sha':
           'v13.35.1\n',
-        'log --format=%h %s merge-base-sha..HEAD': new Error('git log failed'),
+        'log --ancestry-path --format=%h %s merge-base-sha..HEAD': new Error(
+          'git log failed',
+        ),
       });
 
       expect(() => extractWhatsInRc()).toThrow('git log failed');
@@ -103,7 +209,7 @@ describe('cherry-picks-section', () => {
   });
 
   describe('buildWhatsInRcSection', () => {
-    it('builds a stable run-specific anchor id', () => {
+    it('builds stable run-specific anchor ids', () => {
       expect(getWhatsInRcAnchorId()).toBe('whats-in-this-rc');
       expect(getWhatsInRcAnchorId('28063612297')).toBe(
         'whats-in-this-rc-28063612297',
@@ -111,6 +217,10 @@ describe('cherry-picks-section', () => {
       expect(getWhatsInRcAnchorId('Run 123 / RC')).toBe(
         'whats-in-this-rc-run-123-rc',
       );
+      expect(getCherryPicksAnchorId('28063612297')).toBe(
+        'cherry-picks-28063612297',
+      );
+      expect(getChangelogAnchorId('28063612297')).toBe('changelog-28063612297');
     });
 
     it('renders the stable section anchor when no commits are found', () => {
@@ -119,25 +229,67 @@ describe('cherry-picks-section', () => {
         changelog: [],
         mergeBase: 'merge-base-sha',
         previousTag: 'v13.35.1',
+        changelogFromReleaseBranch: false,
       });
 
       expect(section).toContain('<a id="whats-in-this-rc"></a>');
+      expect(section).toContain('<a id="cherry-picks"></a>');
       expect(section).toContain('No cherry-picks or changelog commits found.');
-      expect(section).not.toContain('<a id="cherry-picks"></a>');
     });
 
-    it('renders a run-specific section anchor when a suffix is provided', () => {
+    it('still emits the cherry-picks anchor when only changelog commits exist', () => {
       const section = buildWhatsInRcSection(
         {
           cherryPicks: [],
-          changelog: [],
+          changelog: [
+            { hash: 'def5678', subject: 'feat: changelog entry (#456)' },
+          ],
           mergeBase: 'merge-base-sha',
           previousTag: 'v13.35.1',
+          changelogFromReleaseBranch: false,
+        },
+        '28063612297',
+      );
+
+      expect(section).toContain('<a id="cherry-picks-28063612297"></a>');
+      expect(section).toContain('<a id="changelog-28063612297"></a>');
+      expect(section).not.toContain('Cherry-picks (');
+    });
+
+    it('renders run-specific section anchors when a suffix is provided', () => {
+      const section = buildWhatsInRcSection(
+        {
+          cherryPicks: [
+            { hash: 'abc1234', subject: 'fix: cherry-pick (#123)' },
+          ],
+          changelog: [
+            { hash: 'def5678', subject: 'feat: changelog entry (#456)' },
+          ],
+          mergeBase: 'merge-base-sha',
+          previousTag: 'v13.35.1',
+          changelogFromReleaseBranch: false,
         },
         '28063612297',
       );
 
       expect(section).toContain('<a id="whats-in-this-rc-28063612297"></a>');
+      expect(section).toContain('<a id="cherry-picks-28063612297"></a>');
+      expect(section).toContain('<a id="changelog-28063612297"></a>');
+      expect(section).toContain('Changelog (1 commits from main at RC cut)');
+    });
+
+    it('labels changelog as release-branch fallback when applicable', () => {
+      const section = buildWhatsInRcSection({
+        cherryPicks: [],
+        changelog: [
+          { hash: 'def5678', subject: 'feat: changelog entry (#456)' },
+        ],
+        mergeBase: 'merge-base-sha',
+        previousTag: 'v13.39.2',
+        changelogFromReleaseBranch: true,
+      });
+
+      expect(section).toContain('Changelog (1 commits since v13.39.2)');
     });
 
     it('escapes table-breaking characters and links PR references', () => {
@@ -151,6 +303,7 @@ describe('cherry-picks-section', () => {
         changelog: [],
         mergeBase: 'merge-base-sha',
         previousTag: 'v13.35.1',
+        changelogFromReleaseBranch: false,
       });
 
       expect(section).toContain('<a id="cherry-picks"></a>');
@@ -167,6 +320,7 @@ describe('cherry-picks-section', () => {
       );
 
       expect(section).toContain('<a id="whats-in-this-rc"></a>');
+      expect(section).toContain('<a id="cherry-picks"></a>');
       expect(section).toContain('git failed for &lt;tag&gt; &amp; branch');
     });
   });

--- a/development/metamaskbot-build-announce/cherry-picks-section.ts
+++ b/development/metamaskbot-build-announce/cherry-picks-section.ts
@@ -1,6 +1,13 @@
 /**
  * Extracts cherry-picks and changelog commits from git history
  * and generates the "What's in this RC" markdown section for PR comments.
+ *
+ * Two sections are generated:
+ * 1. Cherry-picks: Commits on the release branch after forking from main
+ * (ancestry-path from merge-base to HEAD)
+ * 2. Changelog: Commits since the previous release tag. For Runway releases,
+ * falls back to the release branch when main-line changelog is empty or
+ * only `release:` commits.
  */
 
 import { execFileSync } from 'child_process';
@@ -9,9 +16,13 @@ const REPO_URL = process.env.GITHUB_REPOSITORY
   ? `https://github.com/${process.env.GITHUB_REPOSITORY}`
   : 'https://github.com/MetaMask/metamask-extension';
 
-const RELEASE_TAG_PATTERN = 'v[0-9]*.[0-9]*.[0-9]*';
+const RELEASE_TAG_LIST_PATTERN = 'v*.*.*';
 
-const PRERELEASE_TAG_PATTERN = '*-*';
+const SKIP_MERGE_COMMIT_SUBJECT =
+  /^Merge (branch|pull request|remote-tracking)/u;
+
+/** Conventional-commit `release` type, with or without scope (`release:`, `release(runway):`). */
+const RELEASE_COMMIT_SUBJECT = /^release(\(.*\))?:/u;
 
 // GitHub-hosted Ubuntu runners install Git here; avoid resolving it via PATH.
 const GIT_EXECUTABLE = '/usr/bin/git';
@@ -26,22 +37,36 @@ export type WhatsInRcResult = {
   changelog: CommitInfo[];
   mergeBase: string;
   previousTag: string | null;
+  changelogFromReleaseBranch: boolean;
 };
 
-export function getWhatsInRcAnchorId(anchorSuffix?: string): string {
+function sanitizeAnchorSuffix(anchorSuffix?: string): string {
   if (!anchorSuffix) {
-    return 'whats-in-this-rc';
+    return '';
   }
 
-  const sanitizedSuffix = anchorSuffix
+  return anchorSuffix
     .toLowerCase()
     .replace(/[^a-z0-9_-]/gu, '-')
     .replace(/-+/gu, '-')
     .replace(/^-|-$/gu, '');
+}
 
+export function getWhatsInRcAnchorId(anchorSuffix?: string): string {
+  const sanitizedSuffix = sanitizeAnchorSuffix(anchorSuffix);
   return sanitizedSuffix
     ? `whats-in-this-rc-${sanitizedSuffix}`
     : 'whats-in-this-rc';
+}
+
+export function getCherryPicksAnchorId(anchorSuffix?: string): string {
+  const sanitizedSuffix = sanitizeAnchorSuffix(anchorSuffix);
+  return sanitizedSuffix ? `cherry-picks-${sanitizedSuffix}` : 'cherry-picks';
+}
+
+export function getChangelogAnchorId(anchorSuffix?: string): string {
+  const sanitizedSuffix = sanitizeAnchorSuffix(anchorSuffix);
+  return sanitizedSuffix ? `changelog-${sanitizedSuffix}` : 'changelog';
 }
 
 function git(...args: string[]): string {
@@ -52,58 +77,119 @@ function getErrorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
 }
 
-function parseGitLog(logOutput: string): CommitInfo[] {
+function parseGitLog(
+  logOutput: string,
+  { skipMergeCommits = false }: { skipMergeCommits?: boolean } = {},
+): CommitInfo[] {
   if (!logOutput) {
     return [];
   }
-  return logOutput.split('\n').map((line) => {
-    const [hash, ...subjectParts] = line.split(' ');
-    return { hash, subject: subjectParts.join(' ') };
-  });
+  return logOutput
+    .split('\n')
+    .map((line) => {
+      const [hash, ...subjectParts] = line.split(' ');
+      return { hash, subject: subjectParts.join(' ') };
+    })
+    .filter((commit) => {
+      if (!skipMergeCommits) {
+        return true;
+      }
+      return !SKIP_MERGE_COMMIT_SUBJECT.test(commit.subject.trim());
+    });
 }
 
-function getPreviousReleaseTag(mergeBase: string): string {
+/**
+ * Get the most recent release tag merged into a given commit.
+ * Uses --merged to find the highest version tag that is an ancestor of the commit.
+ * @param mergeBase
+ */
+function getPreviousReleaseTag(mergeBase: string): string | null {
   try {
-    return git(
-      'describe',
-      '--tags',
-      '--abbrev=0',
-      '--match',
-      RELEASE_TAG_PATTERN,
-      '--exclude',
-      PRERELEASE_TAG_PATTERN,
-      `${mergeBase}^`,
+    const out = git(
+      'tag',
+      '--sort=-version:refname',
+      '--list',
+      RELEASE_TAG_LIST_PATTERN,
+      '--merged',
+      mergeBase,
     );
+    const tags = out
+      .split('\n')
+      .map((tag) => tag.trim())
+      .filter(Boolean)
+      // Exclude prerelease tags such as v13.40.0-flask.0
+      .filter((tag) => !tag.includes('-'));
+    return tags[0] || null;
   } catch (error) {
     throw new Error(
-      `Unable to find previous release tag before merge base ${mergeBase}: ${getErrorMessage(error)}`,
+      `Unable to find previous release tag for merge base ${mergeBase}: ${getErrorMessage(error)}`,
     );
   }
 }
 
 function getCherryPicks(mergeBase: string): CommitInfo[] {
-  const log = git('log', '--format=%h %s', `${mergeBase}..HEAD`);
+  const log = git(
+    'log',
+    '--ancestry-path',
+    '--format=%h %s',
+    `${mergeBase}..HEAD`,
+  );
   return parseGitLog(log);
 }
 
-function getChangelogCommits(
-  mergeBase: string,
-  previousTag: string | null,
+/**
+ * Get commits between two refs.
+ *
+ * @param fromRef
+ * @param toRef
+ * @param firstParent - If true, use --first-parent for main-line history.
+ */
+function getCommitsBetween(
+  fromRef: string,
+  toRef: string,
+  firstParent = true,
 ): CommitInfo[] {
-  if (!previousTag) {
-    return [];
+  const args = ['log', '--format=%h %s', `${fromRef}..${toRef}`];
+  if (firstParent) {
+    args.push('--first-parent');
   }
-  const log = git('log', '--format=%h %s', `${previousTag}..${mergeBase}`);
-  return parseGitLog(log);
+  const log = git(...args);
+  return parseGitLog(log, { skipMergeCommits: true });
 }
 
 export function extractWhatsInRc(): WhatsInRcResult {
   const mergeBase = git('merge-base', 'HEAD', 'origin/main');
   const previousTag = getPreviousReleaseTag(mergeBase);
   const cherryPicks = getCherryPicks(mergeBase);
-  const changelog = getChangelogCommits(mergeBase, previousTag);
 
-  return { cherryPicks, changelog, mergeBase, previousTag };
+  let changelog: CommitInfo[] = [];
+  let changelogFromReleaseBranch = false;
+
+  if (previousTag) {
+    // First try: commits on main from previous release to merge-base
+    changelog = getCommitsBetween(previousTag, mergeBase, true);
+
+    // Runway releases often have an empty main-line range (or only release
+    // bumps) because features land via cherry-picks on the release branch.
+    const isOnlyReleaseCommits =
+      changelog.length > 0 &&
+      changelog.every((commit) =>
+        RELEASE_COMMIT_SUBJECT.test(commit.subject.trim()),
+      );
+
+    if (changelog.length === 0 || isOnlyReleaseCommits) {
+      changelog = getCommitsBetween(previousTag, 'HEAD', false);
+      changelogFromReleaseBranch = true;
+    }
+  }
+
+  return {
+    cherryPicks,
+    changelog,
+    mergeBase,
+    previousTag,
+    changelogFromReleaseBranch,
+  };
 }
 
 function escapeHtml(text: string): string {
@@ -150,8 +236,10 @@ export function buildWhatsInRcSection(
   result: WhatsInRcResult,
   anchorSuffix?: string,
 ): string {
-  const { cherryPicks, changelog } = result;
+  const { cherryPicks, changelog, previousTag, changelogFromReleaseBranch } =
+    result;
   const anchorId = getWhatsInRcAnchorId(anchorSuffix);
+  const cherryPicksAnchorId = getCherryPicksAnchorId(anchorSuffix);
 
   let section = `<a id="${anchorId}"></a>
 ### :cherries: What's in this RC
@@ -159,22 +247,30 @@ export function buildWhatsInRcSection(
 `;
 
   if (cherryPicks.length === 0 && changelog.length === 0) {
-    return `${section}<p><i>No cherry-picks or changelog commits found.</i></p>\n\n`;
+    // Still emit the cherry-picks anchor so Slack deep links have a target.
+    return `${section}<a id="${cherryPicksAnchorId}"></a>
+<p><i>No cherry-picks or changelog commits found.</i></p>\n\n`;
   }
 
   if (cherryPicks.length > 0) {
     section += buildCommitsTable(
       cherryPicks,
       `Cherry-picks (${cherryPicks.length} commits)`,
-      'cherry-picks',
+      cherryPicksAnchorId,
     );
+  } else {
+    // Slack always links to #cherry-picks-{runId}; keep a target when empty.
+    section += `<a id="${cherryPicksAnchorId}"></a>\n`;
   }
 
   if (changelog.length > 0) {
+    const changelogLabel = changelogFromReleaseBranch
+      ? `Changelog (${changelog.length} commits since ${previousTag})`
+      : `Changelog (${changelog.length} commits from main at RC cut)`;
     section += buildCommitsTable(
       changelog,
-      `Changelog (${changelog.length} commits from main at RC cut)`,
-      'changelog',
+      changelogLabel,
+      getChangelogAnchorId(anchorSuffix),
     );
   }
 
@@ -187,9 +283,11 @@ export function buildWhatsInRcFailureSection(
 ): string {
   const errorMsg = error ? `: ${escapeHtml(error)}` : '';
   const anchorId = getWhatsInRcAnchorId(anchorSuffix);
+  const cherryPicksAnchorId = getCherryPicksAnchorId(anchorSuffix);
   return `<a id="${anchorId}"></a>
 ### :cherries: What's in this RC
 
+<a id="${cherryPicksAnchorId}"></a>
 <p><i>Unable to extract cherry-picks and changelog${errorMsg}</i></p>
 
 `;
@@ -204,6 +302,13 @@ if (process.argv[1]?.endsWith('cherry-picks-section.ts')) {
     console.log(`Previous tag: ${result.previousTag ?? 'none'}`);
     console.log(`Cherry-picks: ${result.cherryPicks.length}`);
     console.log(`Changelog commits: ${result.changelog.length}`);
+    console.log(
+      `Changelog source: ${
+        result.changelogFromReleaseBranch
+          ? 'release branch fallback'
+          : 'main at RC cut'
+      }`,
+    );
     console.log('\n--- Cherry-picks ---');
     result.cherryPicks.forEach((c) => console.log(`${c.hash} ${c.subject}`));
     console.log('\n--- Changelog ---');

--- a/development/metamaskbot-build-announce/index.test.ts
+++ b/development/metamaskbot-build-announce/index.test.ts
@@ -56,6 +56,7 @@ function configureMocks(): void {
     changelog: [{ hash: 'def5678', subject: 'feat: new feature (#456)' }],
     mergeBase: 'base123',
     previousTag: 'v13.32.0',
+    changelogFromReleaseBranch: false,
   });
   cherryPicks.buildWhatsInRcSection.mockReturnValue('<p>whats-in-this-rc</p>');
   cherryPicks.buildWhatsInRcFailureSection.mockReturnValue(


### PR DESCRIPTION
…(#44597)

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once. -->
Ports Mobile’s Runway RC fix so Extension “What’s in this RC” / Slack notes show the real changelog and cherry-picks (not a handful of merge commits).

Tag lookup via git tag --merged
Cherry-picks via --ancestry-path
Fallback to the release branch when main-line changelog is empty / only release:
Slack links match Mobile: Cherry-picks + View full RC notes


<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs` `CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

Fixes:


<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

<!-- [screenshots/recordings] -->

<!-- [screenshots/recordings] -->

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding
Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only release automation and notification scripts with broad test coverage; no runtime extension or user-facing product behavior.
> 
> **Overview**
> Ports Mobile’s Runway RC fix so Extension **“What’s in this RC”** PR comments and Slack deep links show meaningful cherry-picks and changelog instead of sparse merge noise.
> 
> **Git extraction** in `cherry-picks-section.ts` now resolves the prior release via `git tag --merged` (nullable, no hard fail), lists cherry-picks with `--ancestry-path`, and builds changelog from main `--first-parent` while skipping merge commits. When that range is empty or only `release:` / scoped release commits, it **falls back** to commits since the tag on the release branch (`HEAD`) and labels that in the markdown. Run-specific **`cherry-picks`** and **`changelog`** anchors are always emitted so Slack links resolve.
> 
> **Slack RC notifications** match Mobile: a dedicated **View cherry-picks** link to `#user-content-cherry-picks-{runId}`, **View full RC notes** on the PR anchor (replacing the release-branch `CHANGELOG.md` blob link), optional footer when links exist, and `unfurl_links` / `unfurl_media` disabled on post.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4e6700d8cb846c92a2dec1bc3cda72555cb90692. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
