### PR TITLE
fix(ci): enable isolated benchmark re-runs

### DIFF
--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -17,7 +17,9 @@ jobs:
   benchmarks:
     if: ${{ github.event_name != 'merge_group' }} # Skip this job for the Merge Queue
     name: ${{ matrix.browser }}-${{ matrix.buildType }}-${{ matrix.pageType }}
-    continue-on-error: true
+    # No continue-on-error: each leg gates its own metrics (gate step below), so a
+    # metric breach fails just that leg and only that leg is re-run to re-measure.
+    # The `quality-gate` job separately evaluates all legs together.
     strategy:
       fail-fast: false
       matrix:
@@ -68,6 +70,7 @@ jobs:
           run-id: ${{ inputs.builds-from-run }}
 
       - name: Run the benchmark
+        id: run-benchmark
         run: >-
           ${{ matrix.pageType == 'startupPowerUserHome' && format('yarn test:e2e:benchmark --preset startupPowerUserHome --browserLoads 15 --pageLoads 7 --out test-artifacts/benchmarks/benchmark-{0}-{1}-startupPowerUserHome.json --retries 2', matrix.browser, matrix.buildType) || format('yarn test:e2e:benchmark --preset {2} --out test-artifacts/benchmarks/benchmark-{0}-{1}-{2}.json --retries 2', matrix.browser, matrix.buildType, matrix.pageType) }}
         shell: bash
@@ -112,10 +115,29 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
+      # compare-benchmarks.ts evaluates each result file independently, so
+      # pointing --current at this leg's single-file dir gates exactly this leg.
+      # A breach fails the leg, so it can be re-run in isolation. Honors the
+      # skip-benchmark-gate label; runs only when the benchmark produced a result.
+      - name: Gate this benchmark leg
+        if: ${{ github.event_name == 'pull_request' && steps.run-benchmark.outcome == 'success' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if gh api "repos/$REPO/issues/$PR_NUMBER/labels" --jq '.[].name' | grep -qx 'skip-benchmark-gate'; then
+            echo "skip-benchmark-gate label present — skipping per-leg gate"
+            exit 0
+          fi
+          yarn tsx development/metamaskbot-build-announce/compare-benchmarks.ts --current test-artifacts/benchmarks/
+        shell: bash
+
   benchmarks-page-load:
     if: ${{ github.event_name != 'merge_group' }} # Skip this job for the Merge Queue
     name: chrome-webpack-pageLoadBenchmark
-    continue-on-error: true
+    # Not continue-on-error: this job gates its own metrics below so a breach
+    # fails it and it can be re-run in isolation (see the matrix `benchmarks` job).
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: ${{ github.ref_name == 'main' && 'default-branch' || null }}
@@ -148,6 +170,7 @@ jobs:
         run: yarn playwright install chromium
 
       - name: Run dapp page load benchmarks
+        id: run-page-load
         run: yarn test:e2e:benchmark --preset=pageLoadBenchmark
 
       - name: Send benchmark results to Sentry (main/release only)
@@ -189,6 +212,23 @@ jobs:
           path: test-artifacts/benchmarks/${{ env.DAPP_BENCHMARK_JSON }}
           retention-days: 7
           if-no-files-found: ignore
+
+      # Gate this job against its own page-load result file so a breach fails it
+      # and it can be re-run in isolation. Same rationale/label handling as the
+      # matrix `benchmarks` job's per-leg gate.
+      - name: Gate this benchmark leg
+        if: ${{ github.event_name == 'pull_request' && steps.run-page-load.outcome == 'success' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if gh api "repos/$REPO/issues/$PR_NUMBER/labels" --jq '.[].name' | grep -qx 'skip-benchmark-gate'; then
+            echo "skip-benchmark-gate label present — skipping per-leg gate"
+            exit 0
+          fi
+          yarn tsx development/metamaskbot-build-announce/compare-benchmarks.ts --current test-artifacts/benchmarks/
+        shell: bash
 
   # Evaluates benchmark results against constant thresholds (THRESHOLD_REGISTRY).
   # Rollout across 4 phases:

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -17,9 +17,7 @@ jobs:
   benchmarks:
     if: ${{ github.event_name != 'merge_group' }} # Skip this job for the Merge Queue
     name: ${{ matrix.browser }}-${{ matrix.buildType }}-${{ matrix.pageType }}
-    # `quality-gate` is the only check that blocks the PR, so this leg is
-    # continue-on-error. It still gates its own metrics below, which turns just
-    # this leg red on a breach and lets only this leg be re-run to re-measure.
+    # We decide whether to block the PR in the `quality-gate` step
     continue-on-error: true
     strategy:
       fail-fast: false
@@ -116,10 +114,6 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
-      # compare-benchmarks.ts evaluates each result file independently, so
-      # pointing --current at this leg's single-file dir gates exactly this leg.
-      # A breach fails the leg, so it can be re-run in isolation. Runs only when
-      # the benchmark produced a result.
       - name: Gate this benchmark leg
         if: ${{ steps.run-benchmark.outcome == 'success' }}
         run: yarn tsx development/metamaskbot-build-announce/compare-benchmarks.ts --current test-artifacts/benchmarks/
@@ -128,9 +122,7 @@ jobs:
   benchmarks-page-load:
     if: ${{ github.event_name != 'merge_group' }} # Skip this job for the Merge Queue
     name: chrome-webpack-pageLoadBenchmark
-    # continue-on-error for the same reason as the matrix `benchmarks` job: it
-    # gates its own metrics below so a breach turns it red and it can be re-run in
-    # isolation, while `quality-gate` remains the only check that blocks the PR.
+    # We decide whether to block the PR in the `quality-gate` step
     continue-on-error: true
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -207,9 +199,6 @@ jobs:
           retention-days: 7
           if-no-files-found: ignore
 
-      # Gate this job against its own page-load result file so a breach fails it
-      # and it can be re-run in isolation. Same rationale as the matrix
-      # `benchmarks` job's per-leg gate.
       - name: Gate this benchmark leg
         if: ${{ steps.run-page-load.outcome == 'success' }}
         run: yarn tsx development/metamaskbot-build-announce/compare-benchmarks.ts --current test-artifacts/benchmarks/

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -17,9 +17,10 @@ jobs:
   benchmarks:
     if: ${{ github.event_name != 'merge_group' }} # Skip this job for the Merge Queue
     name: ${{ matrix.browser }}-${{ matrix.buildType }}-${{ matrix.pageType }}
-    # No continue-on-error: each leg gates its own metrics (gate step below), so a
-    # metric breach fails just that leg and only that leg is re-run to re-measure.
-    # The `quality-gate` job separately evaluates all legs together.
+    # `quality-gate` is the only check that blocks the PR, so this leg is
+    # continue-on-error. It still gates its own metrics below, which turns just
+    # this leg red on a breach and lets only this leg be re-run to re-measure.
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix:
@@ -117,27 +118,20 @@ jobs:
 
       # compare-benchmarks.ts evaluates each result file independently, so
       # pointing --current at this leg's single-file dir gates exactly this leg.
-      # A breach fails the leg, so it can be re-run in isolation. Honors the
-      # skip-benchmark-gate label; runs only when the benchmark produced a result.
+      # A breach fails the leg, so it can be re-run in isolation. Runs only when
+      # the benchmark produced a result.
       - name: Gate this benchmark leg
-        if: ${{ github.event_name == 'pull_request' && steps.run-benchmark.outcome == 'success' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          if gh api "repos/$REPO/issues/$PR_NUMBER/labels" --jq '.[].name' | grep -qx 'skip-benchmark-gate'; then
-            echo "skip-benchmark-gate label present — skipping per-leg gate"
-            exit 0
-          fi
-          yarn tsx development/metamaskbot-build-announce/compare-benchmarks.ts --current test-artifacts/benchmarks/
+        if: ${{ steps.run-benchmark.outcome == 'success' }}
+        run: yarn tsx development/metamaskbot-build-announce/compare-benchmarks.ts --current test-artifacts/benchmarks/
         shell: bash
 
   benchmarks-page-load:
     if: ${{ github.event_name != 'merge_group' }} # Skip this job for the Merge Queue
     name: chrome-webpack-pageLoadBenchmark
-    # Not continue-on-error: this job gates its own metrics below so a breach
-    # fails it and it can be re-run in isolation (see the matrix `benchmarks` job).
+    # continue-on-error for the same reason as the matrix `benchmarks` job: it
+    # gates its own metrics below so a breach turns it red and it can be re-run in
+    # isolation, while `quality-gate` remains the only check that blocks the PR.
+    continue-on-error: true
     runs-on: ubuntu-latest
     timeout-minutes: 30
     environment: ${{ github.ref_name == 'main' && 'default-branch' || null }}
@@ -214,20 +208,11 @@ jobs:
           if-no-files-found: ignore
 
       # Gate this job against its own page-load result file so a breach fails it
-      # and it can be re-run in isolation. Same rationale/label handling as the
-      # matrix `benchmarks` job's per-leg gate.
+      # and it can be re-run in isolation. Same rationale as the matrix
+      # `benchmarks` job's per-leg gate.
       - name: Gate this benchmark leg
-        if: ${{ github.event_name == 'pull_request' && steps.run-page-load.outcome == 'success' }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-        run: |
-          if gh api "repos/$REPO/issues/$PR_NUMBER/labels" --jq '.[].name' | grep -qx 'skip-benchmark-gate'; then
-            echo "skip-benchmark-gate label present — skipping per-leg gate"
-            exit 0
-          fi
-          yarn tsx development/metamaskbot-build-announce/compare-benchmarks.ts --current test-artifacts/benchmarks/
+        if: ${{ steps.run-page-load.outcome == 'success' }}
+        run: yarn tsx development/metamaskbot-build-announce/compare-benchmarks.ts --current test-artifacts/benchmarks/
         shell: bash
 
   # Evaluates benchmark results against constant thresholds (THRESHOLD_REGISTRY).


### PR DESCRIPTION
## **Changelog**

CHANGELOG entry: null

## **Description**

Makes a flaky benchmark re-runnable in isolation, so a within-noise gate failure no longer forces re-running the entire CI workflow.

**Problem.** The `quality-gate` job is a fan-in (`needs: [benchmarks, benchmarks-page-load]`) that only *reads* the uploaded `benchmark-*.json` artifacts, and the benchmark legs are `continue-on-error: true` — so they never go red even when a run is noisy. When the gate fails on a borderline metric, GitHub's **Re-run failed jobs** re-runs only the gate, which re-downloads the same within-run-immutable artifacts and deterministically re-fails. The actual measurement lives in the (green) benchmark job and never re-executes, so the only way to get fresh numbers is **Re-run all jobs**.

**Fix.** Move the threshold check *into* each benchmark leg:

- `compare-benchmarks.ts` already evaluates each result file independently (`loadCurrentBenchmarks` iterates files; `runComparison` checks each against `THRESHOLD_REGISTRY` using that file's own samples), so pointing `--current` at a leg's single-file directory gates exactly that leg.
- A gated-metric breach now fails **that leg**, so **Re-run failed jobs** re-runs it and re-measures — no full-workflow re-run.
- The per-leg gate honors the `skip-benchmark-gate` label, matching the aggregate gate.

**Unchanged.** The aggregate `quality-gate` job stays as the authoritative, required cross-cutting check; this only adds a per-leg signal that makes the underlying measurement re-runnable.

This is orthogonal to the within-noise hardening of the gate — that reduces false failures, this fixes the re-run ergonomics when a failure does occur.

### Relationship to the rest of the re-run work

This is the *precondition* for #45352, not a duplicate of it. #45352 stops a re-run from clearing a gate that already failed, by pinning the decision per commit. This PR makes a re-run produce fresh numbers at all. Without it, "re-run" and "re-read the same artifact" are the same operation.

## **Related issues**

- #45351 — benchmark gating coverage is non-deterministic per commit, addressed by #45352
- #45450 — a gated benchmark that never ran scores as a pass

## **Manual testing steps**

GitHub Actions behavior can't be exercised locally, so validation is in CI on this PR:

1. Workflow parses and all four jobs still schedule (`benchmarks`, `benchmarks-page-load`, `quality-gate`, `store-benchmark-stats`).
2. A passing run: per-leg "Gate this benchmark leg" step is green; aggregate `quality-gate` still green.
3. Induce a single-leg breach with a temporary threshold tweak: only that leg goes red, and **Re-run failed jobs** re-runs just that leg and re-measures without re-running the full matrix.
4. The `skip-benchmark-gate` label suppresses both the per-leg gate and the aggregate gate.

🧪 **Validation Run:** [posted as a comment](https://github.com/MetaMask/metamask-extension/pull/44724#issuecomment-5145551389) so it has a linkable anchor.

## **Screenshots/Recordings**

CI workflow-only change with no user-visible surface; nothing to capture.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change that adds per-leg gating steps without altering application code or required-check semantics beyond making individual benchmark legs fail visibly.
> 
> **Overview**
> Adds a **Gate this benchmark leg** step to each benchmark matrix job and the page-load benchmark job so threshold checks run right after that leg’s JSON is produced, using `compare-benchmarks.ts` against that leg’s `test-artifacts/benchmarks/` directory.
> 
> Benchmark run steps get stable ids (`run-benchmark`, `run-page-load`) so the gate only runs when the measurement step succeeded. Comments clarify that jobs still use `continue-on-error: true` and the aggregate **`quality-gate`** job remains the authoritative required check.
> 
> When a leg breaches thresholds it can fail independently, so **Re-run failed jobs** can re-execute that leg and get fresh numbers instead of re-running only `quality-gate` against the same uploaded artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e3555438c5d8d5b1fe9ae6439f0da3e560059fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
