### PR TITLE
fix(perps): guard against stale cached position/order data on popup mount

### DIFF
--- a/ui/pages/perps/perps-layout.tsx
+++ b/ui/pages/perps/perps-layout.tsx
@@ -85,6 +85,7 @@ export default function PerpsLayout() {
       orders: userEntry?.orders,
       account: userEntry?.accountState,
       address: userEntry?.address,
+      timestamp: userEntry?.timestamp,
     };
   }, shallowEqual);
 

--- a/ui/providers/perps/PerpsStreamManager.test.ts
+++ b/ui/providers/perps/PerpsStreamManager.test.ts
@@ -1438,5 +1438,72 @@ describe('PerpsStreamManager', () => {
       expect(manager.markets.hasCachedData()).toBe(true);
       expect(manager.positions.hasCachedData()).toBe(false);
     });
+
+    // Regression test for #44616: a phantom position (closed on another
+    // device/session) kept rendering forever because a long-stale
+    // `cachedUserDataByProvider` snapshot was hydrated unconditionally on
+    // every popup mount, which also suppressed the WS-grace REST fallback
+    // that would otherwise have corrected it.
+    it('refuses to hydrate user-scoped channels when the snapshot is older than the max cache age', () => {
+      const now = Date.now();
+      const positions = [makePosition('BTC')];
+
+      manager.hydrateFromControllerCache(
+        {
+          positions,
+          orders: [{ orderId: '1' } as never],
+          account: { totalBalance: '100' } as never,
+          address: ADDR,
+          timestamp: now - 5 * 60 * 1000 - 1,
+        },
+        ADDR,
+      );
+
+      expect(manager.positions.hasCachedData()).toBe(false);
+      expect(manager.orders.hasCachedData()).toBe(false);
+      expect(manager.account.hasCachedData()).toBe(false);
+    });
+
+    it('hydrates user-scoped channels when the snapshot is within the max cache age', () => {
+      const now = Date.now();
+      const positions = [makePosition('BTC')];
+
+      manager.hydrateFromControllerCache(
+        {
+          positions,
+          address: ADDR,
+          timestamp: now - 5 * 60 * 1000 + 1,
+        },
+        ADDR,
+      );
+
+      expect(manager.positions.hasCachedData()).toBe(true);
+      expect(manager.positions.getCachedData()).toEqual(positions);
+    });
+
+    it('hydrates user-scoped channels when no timestamp is provided (legacy snapshot)', () => {
+      const positions = [makePosition('BTC')];
+
+      manager.hydrateFromControllerCache({ positions, address: ADDR }, ADDR);
+
+      expect(manager.positions.hasCachedData()).toBe(true);
+    });
+
+    it('still hydrates markets when the user-scoped snapshot is stale', () => {
+      const markets = [{ symbol: 'BTC' } as never];
+
+      manager.hydrateFromControllerCache(
+        {
+          markets,
+          positions: [makePosition('BTC')],
+          address: ADDR,
+          timestamp: Date.now() - 24 * 60 * 60 * 1000,
+        },
+        ADDR,
+      );
+
+      expect(manager.markets.hasCachedData()).toBe(true);
+      expect(manager.positions.hasCachedData()).toBe(false);
+    });
   });
 });

--- a/ui/providers/perps/PerpsStreamManager.ts
+++ b/ui/providers/perps/PerpsStreamManager.ts
@@ -83,6 +83,18 @@ const OPTIMISTIC_OVERRIDE_TTL_MS = 30000;
 // Prevents immediate overwrite from stale WebSocket data
 const WEBSOCKET_BLOCK_MS = 3000;
 
+// Maximum age of a controller-persisted user-data snapshot (positions/orders/
+// account) that we trust for the cold-mount "skip loading skeleton"
+// optimization. The controller only refreshes `cachedUserDataByProvider` via
+// REST preload while its WebSocket is disconnected (see
+// `#performUserDataPreload`), so this snapshot can go stale for long periods
+// if the WebSocket reports "connected" without ever delivering a live
+// correction (e.g. a position closed on another device while this session's
+// stream stalled silently). Beyond this age we treat the snapshot as absent
+// so the channel falls through to its normal REST-fallback + WebSocket
+// reconciliation path instead of rendering a phantom position indefinitely.
+const MAX_USER_DATA_CACHE_AGE_MS = 5 * 60 * 1000;
+
 class PerpsStreamManager {
   // Data channels
   positions: PerpsDataChannel<Position[]>;
@@ -715,6 +727,15 @@ class PerpsStreamManager {
    * initialised for, so an account switch while the popup is closed does
    * not paint the old account's data under the new account's identity.
    *
+   * They are also skipped when `snapshot.timestamp` is older than
+   * `MAX_USER_DATA_CACHE_AGE_MS`: the controller only refreshes this cache
+   * via REST while its WebSocket is disconnected, so a long-stale snapshot
+   * (e.g. a position closed elsewhere while this session's stream stalled
+   * without reporting disconnected) would otherwise render a phantom
+   * position/order indefinitely, since seeding the channel here also
+   * suppresses the WS-grace REST fallback below. Skipping falls through to
+   * that normal REST-fallback + WebSocket reconciliation path instead.
+   *
    * Empty arrays intentionally no-op: pushing an empty array would flip
    * `hasCachedData()` to true (since the pushed reference differs from
    * `initialValue`) and suppress the WS-grace REST fallback in each
@@ -726,6 +747,7 @@ class PerpsStreamManager {
    * @param snapshot.orders - Cached orders for `snapshot.address`.
    * @param snapshot.account - Cached `AccountState` for `snapshot.address`.
    * @param snapshot.address - Address that owns the user-scoped entries. User channels are skipped unless this matches the currently selected address. Pass `null` to hydrate nothing user-scoped.
+   * @param snapshot.timestamp - When the user-scoped entries were last refreshed by the controller. User channels are skipped when this is older than `MAX_USER_DATA_CACHE_AGE_MS`. Omit only for legacy/test snapshots — real controller entries always carry a timestamp.
    * @param selectedAddress - Address the caller considers active; must equal `snapshot.address` for user channels to hydrate.
    */
   hydrateFromControllerCache(
@@ -735,6 +757,7 @@ class PerpsStreamManager {
       orders?: Order[] | null;
       account?: AccountState | null;
       address?: string | null;
+      timestamp?: number | null;
     },
     selectedAddress?: string | null,
   ): void {
@@ -747,6 +770,13 @@ class PerpsStreamManager {
       !selectedAddress ||
       !snapshotAddress ||
       snapshotAddress.toLowerCase() !== selectedAddress.toLowerCase()
+    ) {
+      return;
+    }
+
+    if (
+      typeof snapshot.timestamp === 'number' &&
+      Date.now() - snapshot.timestamp > MAX_USER_DATA_CACHE_AGE_MS
     ) {
       return;
     }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

**Context:** Perp positions are rendered from `PerpsStreamManager` data channels (positions/orders/account), which on popup mount can be seeded ("hydrated") from a Redux-persisted `cachedUserDataByProvider` snapshot to avoid a loading skeleton flash.

**Problem:** `hydrateFromControllerCache` had no staleness check on that snapshot. The underlying `@metamask/perps-controller` only refreshes this cache via REST while its WebSocket is disconnected, so if the WebSocket silently stalls while still reporting "connected" (e.g. a position is closed on another device/session while this session's stream never delivers the update), the cached snapshot can go stale indefinitely. Worse, seeding a channel from this stale snapshot also suppresses the normal 3-second WS-grace REST fallback that would otherwise self-correct — so a phantom position/order can render forever and can't be closed or edited (Sev1, regression in RC-13.41.0).

**Solution:** Added a `MAX_USER_DATA_CACHE_AGE_MS` (5 minute) staleness guard in `hydrateFromControllerCache`. Snapshots older than that threshold are now treated as absent, so the affected channel falls through to the normal REST-fallback + WebSocket reconciliation path instead of rendering stale data indefinitely. Wired the previously-unused `timestamp` field through from `perps-layout.tsx`'s Redux selector so the check has data to work with.

**Known caveats / judgment calls for reviewers:**
- The 5-minute threshold is a judgment call on my part, not a spec from product/eng — please sanity-check whether this is the right value (too short risks reintroducing loading-skeleton flicker on legitimate slow connections; too long risks leaving phantom data visible for longer).
- This PR only bounds the blast radius on the Extension side. The deeper architectural gap — no cache invalidation on position close/TPSL, and REST preload being skipped whenever the WebSocket merely reports "connected" without verifying liveness — lives in the external `@metamask/perps-controller` package (separate repo) and is not fixed by this change.

## **Changelog**

CHANGELOG entry: Fixed a bug that could leave a closed Perps position stuck and unclosable in the UI

## **Related issues**

Fixes: #44616

## **Manual testing steps**

This is a timing/cache-staleness bug that depends on the WebSocket silently stalling while reporting "connected" for over 5 minutes, which isn't practically reproducible through the UI alone without live perps test infrastructure or the ability to hold a session open for 5+ minutes while forcing a stale WS state. Realistic manual verification would require QA-side tooling to simulate the controller's cache/WebSocket state directly (e.g. mocking `cachedUserDataByProvider` with an old `timestamp` and a WebSocket that reports connected but delivers no updates), which is beyond what can be described as generic manual UI steps here. I did not invent steps that wouldn't genuinely exercise the fix.

For sanity-checking the change didn't regress the normal (non-stale) hydration path:
1. Open a perp position on a supported network.
2. Close the extension popup and reopen it within a few seconds.
3. Verify the position still renders immediately (from cache) without a loading-skeleton flash, and that it can still be closed/edited normally.

The automated test suite (`ui/providers/perps/PerpsStreamManager.test.ts` and `ui/pages/perps/perps-layout.test.tsx`, 94 tests) covers the staleness-guard logic itself, including both the "cache too old -> falls through to REST/WS reconciliation" and "cache fresh -> still hydrates normally" cases.

## **Screenshots/Recordings**

<!--
No UI-visible changes — this is a data-hydration timing fix with no visual/UI impact.

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
