### PR TITLE
fix(perps): prevent tutorial modal from reopening on remount after back navigation

### DIFF
--- a/test/e2e/tests/settings/state-logs.json
+++ b/test/e2e/tests/settings/state-logs.json
@@ -1621,7 +1621,8 @@
   "perpsTutorial": {
     "tutorialModalOpen": "boolean",
     "activeStep": "string",
-    "tutorialCompleted": "boolean"
+    "tutorialCompleted": "boolean",
+    "autoOpenAttempted": "boolean"
   },
   "platform": {
     "arch": "string",

--- a/ui/components/app/perps/perps-view.test.tsx
+++ b/ui/components/app/perps/perps-view.test.tsx
@@ -689,6 +689,64 @@ describe('PerpsView', () => {
     expect(screen.queryByTestId('perps-watchlist-BTC')).not.toBeInTheDocument();
   });
 
+  describe('tutorial modal auto-open', () => {
+    const buildFirstTimeUserStore = () =>
+      configureStore({
+        metamask: {
+          ...mockState.metamask,
+          isTestnet: false,
+          isFirstTimeUser: { testnet: false, mainnet: true },
+          watchlistMarkets: {
+            testnet: [],
+            mainnet: ['BTC', 'ETH'],
+          },
+        },
+      });
+
+    it('auto-opens the tutorial for a first-time user once loading resolves', () => {
+      const store = buildFirstTimeUserStore();
+
+      renderWithProvider(<PerpsView />, store);
+
+      expect(store.getState().perpsTutorial.tutorialModalOpen).toBe(true);
+      expect(store.getState().perpsTutorial.autoOpenAttempted).toBe(true);
+    });
+
+    it('does not re-open the tutorial when the tab remounts after its data has already loaded once (e.g. navigating back from Market Details)', () => {
+      const store = buildFirstTimeUserStore();
+
+      // First mount: simulate the user navigating away (e.g. tapping into
+      // Market Details) before the perps data finishes loading, so the
+      // auto-open decision never gets to run.
+      jest.mocked(streamHooks.usePerpsLivePositions).mockReturnValue({
+        positions: [],
+        isInitialLoading: true,
+      });
+
+      const { unmount } = renderWithProvider(<PerpsView />, store);
+
+      expect(store.getState().perpsTutorial.tutorialModalOpen).toBe(false);
+      // The one-time attempt is claimed immediately on mount, regardless of
+      // the still-pending load.
+      expect(store.getState().perpsTutorial.autoOpenAttempted).toBe(true);
+
+      unmount();
+
+      // Second mount: simulate returning to the Perps tab (e.g. clicking
+      // "back" on Market Details) once the data has finished loading.
+      jest.mocked(streamHooks.usePerpsLivePositions).mockReturnValue({
+        positions: [],
+        isInitialLoading: false,
+      });
+
+      renderWithProvider(<PerpsView />, store);
+
+      // The tutorial must NOT pop open on this remount — the one-time
+      // attempt was already spent by the first mount.
+      expect(store.getState().perpsTutorial.tutorialModalOpen).toBe(false);
+    });
+  });
+
   describe('analytics tracking', () => {
     it('fires Perp Screen Viewed with wallet_home_perps_tab screen_type once loading completes', () => {
       renderWithProvider(<PerpsView />, mockStore);

--- a/ui/components/app/perps/perps-view.tsx
+++ b/ui/components/app/perps/perps-view.tsx
@@ -6,7 +6,13 @@ import {
   TextColor,
 } from '@metamask/design-system-react';
 import type { Order, Position } from '@metamask/perps-controller';
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { useDispatch, useSelector } from 'react-redux';
 import {
   usePerpsLivePositions,
@@ -23,6 +29,8 @@ import {
   selectPerpsIsTestnet,
 } from '../../../selectors/perps-controller';
 import {
+  markTutorialAutoOpenAttempted,
+  selectTutorialAutoOpenAttempted,
   selectTutorialCompleted,
   setTutorialModalOpen,
 } from '../../../ducks/perps';
@@ -74,6 +82,7 @@ export const PerpsView = () => {
   const isFirstTimeUser = useSelector(selectPerpsIsFirstTimeUser);
   const isTestnet = useSelector(selectPerpsIsTestnet);
   const tutorialCompleted = useSelector(selectTutorialCompleted);
+  const autoOpenAttempted = useSelector(selectTutorialAutoOpenAttempted);
   const { isEligible } = usePerpsEligibility();
   const { gate } = useSelectedAccountComplianceGate();
   const { trigger: triggerDeposit } = usePerpsDepositConfirmation();
@@ -328,15 +337,49 @@ export const PerpsView = () => {
   // state propagates doesn't reopen the modal on the next effect run.
   // Explicitly skips when isFirstTimeUser is undefined so that unhydrated
   // controller state is never treated as "first-time user = true".
+  //
+  // `PerpsView` unmounts/remounts on every route change (e.g. navigating to
+  // Market Details and back), and isLoading/isFirstTimeUser can resolve
+  // *after* the user has already navigated away. Without a cross-mount
+  // guard, the effect below would re-evaluate on that later remount and
+  // pop the tutorial open right after the user hits "back" — see #43491.
+  // `canAttemptAutoOpen` is captured once per mount (via useRef, not
+  // useState) from the Redux flag as it existed when this component was
+  // created, so a fast remount whose predecessor already claimed the
+  // one-time attempt is permanently excluded, while the *current* mount
+  // keeps evaluating correctly across its own isLoading/isFirstTimeUser
+  // updates.
+  const canAttemptAutoOpenTutorial = useRef(!autoOpenAttempted).current;
+
   useEffect(() => {
-    if (isLoading || tutorialCompleted || isFirstTimeUser === undefined) {
+    if (canAttemptAutoOpenTutorial) {
+      dispatch(markTutorialAutoOpenAttempted());
+    }
+    // Only ever claim the one-time attempt once, on mount.
+    // eslint-disable-next-line react-compiler/react-compiler, react-hooks/exhaustive-deps
+  }, []);
+
+  useEffect(() => {
+    if (
+      !canAttemptAutoOpenTutorial ||
+      isLoading ||
+      tutorialCompleted ||
+      isFirstTimeUser === undefined
+    ) {
       return;
     }
     const networkKey = isTestnet ? 'testnet' : 'mainnet';
     if (isFirstTimeUser[networkKey]) {
       dispatch(setTutorialModalOpen(true));
     }
-  }, [dispatch, isFirstTimeUser, isLoading, isTestnet, tutorialCompleted]);
+  }, [
+    canAttemptAutoOpenTutorial,
+    dispatch,
+    isFirstTimeUser,
+    isLoading,
+    isTestnet,
+    tutorialCompleted,
+  ]);
 
   // Show loading state while initial stream data is being fetched.
   // Transaction history loads in parallel; Recent Activity skeleton is included here

--- a/ui/ducks/perps/index.ts
+++ b/ui/ducks/perps/index.ts
@@ -12,6 +12,7 @@ export {
   setTutorialModalOpen,
   setTutorialActiveStep,
   markTutorialCompleted,
+  markTutorialAutoOpenAttempted,
   resetTutorialState,
   PerpsTutorialStep,
   TUTORIAL_STEPS_ORDER,
@@ -22,4 +23,5 @@ export {
   selectTutorialModalOpen,
   selectTutorialActiveStep,
   selectTutorialCompleted,
+  selectTutorialAutoOpenAttempted,
 } from './selectors';

--- a/ui/ducks/perps/selectors.ts
+++ b/ui/ducks/perps/selectors.ts
@@ -8,3 +8,6 @@ export const selectTutorialActiveStep = (state: MetaMaskReduxState) =>
 
 export const selectTutorialCompleted = (state: MetaMaskReduxState) =>
   state.perpsTutorial.tutorialCompleted;
+
+export const selectTutorialAutoOpenAttempted = (state: MetaMaskReduxState) =>
+  state.perpsTutorial.autoOpenAttempted;

--- a/ui/ducks/perps/tutorial.ts
+++ b/ui/ducks/perps/tutorial.ts
@@ -31,12 +31,14 @@ export type PerpsTutorialState = {
   tutorialModalOpen: boolean;
   activeStep: PerpsTutorialStep;
   tutorialCompleted: boolean;
+  autoOpenAttempted: boolean;
 };
 
 export const initialState: PerpsTutorialState = {
   tutorialModalOpen: false,
   activeStep: PerpsTutorialStep.WhatArePerps,
   tutorialCompleted: false,
+  autoOpenAttempted: false,
 };
 
 const perpsTutorialSlice = createSlice({
@@ -63,6 +65,16 @@ const perpsTutorialSlice = createSlice({
       state.tutorialModalOpen = false;
     },
 
+    // Marks that the Perps home tab has already made its one-time attempt to
+    // auto-open the tutorial for a first-time user. This is claimed
+    // immediately on mount (before isFirstTimeUser/isLoading resolve) so that
+    // remounting the Perps tab — e.g. after navigating back from Market
+    // Details — never gets a second chance to auto-open the modal. See
+    // PerpsView's auto-open effect.
+    markTutorialAutoOpenAttempted: (state) => {
+      state.autoOpenAttempted = true;
+    },
+
     resetTutorialState: () => {
       return { ...initialState };
     },
@@ -73,6 +85,7 @@ export const {
   setTutorialModalOpen,
   setTutorialActiveStep,
   markTutorialCompleted,
+  markTutorialAutoOpenAttempted,
   resetTutorialState,
 } = perpsTutorialSlice.actions;
 


### PR DESCRIPTION
## **Description**

**Context:** When a first-time user enters the Perps tab, `PerpsView` auto-opens the onboarding tutorial modal once loading/eligibility data resolves. This modal is only meant to appear on the user's original entry into the Perps tab (e.g. tapping the Perps banner), not as a side effect of unrelated navigation.

**Problem:** `PerpsView`'s auto-open-tutorial `useEffect` dispatches `setTutorialModalOpen(true)` for first-time users, gated only by `isLoading` / `tutorialCompleted` / `isFirstTimeUser`, with no guard against re-firing on every **remount**. `PerpsView` fully unmounts when the user navigates to a different top-level route (e.g. Market Details) and remounts when they return. If a first-time user navigates away before the effect's async conditions resolve, the effect misses its chance on the original mount — but by the time the user clicks "back," those conditions have resolved, so the *remount* fires it instead, popping the tutorial open right after back-navigation instead of on the original Perps-tab entry. This is the bug reported in #43491.

**Solution:** Added a new `autoOpenAttempted` flag to the `perpsTutorial` Redux slice. `PerpsView` claims this flag unconditionally on mount via a `useRef` snapshot, so only the very first mount in a popup session can ever attempt the auto-open, regardless of how loading timing shakes out. The tutorial-opening effect is now gated behind this flag, so remounts (e.g. after back-navigation) can no longer re-trigger the modal. The flag lives in the ephemeral UI Redux store, so it resets naturally each time the extension popup is reopened fresh — a user who genuinely never saw the tutorial still gets a chance next session.

**Note on verification:** I was unable to view the issue's linked Loom video, so the exact "Perps banner" entry point described in the report was inferred from code and timing analysis rather than a visual confirmation of the original repro. The manual testing steps below are written to validate the inferred root cause (remount-after-navigation firing the modal); it would be good for a reviewer with access to the Loom video to double check the repro matches before merging.

## **Changelog**

CHANGELOG entry: Fixed a bug where the Perps tutorial modal could incorrectly reappear when navigating back from the Market Details page

## **Related issues**

Fixes: #43491

## **Manual testing steps**

1. Onboard/reset as a first-time Perps user (tutorial not yet completed).
2. Enter the Perps tab (e.g. via the Perps banner).
3. Quickly tap into a market's Market Details page **before** the Perps tab finishes loading its data.
4. Tap "back" to return to the Perps tab.
5. Verify the tutorial modal does **NOT** appear as a result of that back-navigation.
6. Close and reopen the extension popup fresh (new session), enter the Perps tab again, and let it fully load.
7. Verify the tutorial modal **DOES** appear on this normal, fresh first entry into the Perps tab.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)