### PR TITLE
fix(perps): show wallet-confirmed deposits immediately in Perps Activity

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -7057,6 +7057,10 @@
   "perpsDateYesterday": {
     "message": "Yesterday"
   },
+  "perpsDepositEmptyTitle": {
+    "message": "Deposit",
+    "description": "Title shown for a wallet-tracked deposit transaction on the Activity page when the deposited amount is zero or unknown"
+  },
   "perpsDepositErrorBridgeFailed": {
     "message": "Bridge failed"
   },
@@ -7086,6 +7090,10 @@
   },
   "perpsDepositToastSuccessTitle": {
     "message": "Your Perps account was funded"
+  },
+  "perpsDepositedVerb": {
+    "message": "Deposited",
+    "description": "Verb shown in the title of a wallet-tracked deposit transaction on the Activity page, followed by the amount and asset (e.g. 'Deposited 5.00 USDC')"
   },
   "perpsDeposits": {
     "message": "Deposits"
@@ -7798,6 +7806,14 @@
   "perpsWithdrawTooltip": {
     "message": "MetaMask will swap to your desired token for you. No MetaMask fee applies when you swap to mUSD.",
     "description": "Tooltip shown on the Transaction fee row of the Perps Withdraw confirmation"
+  },
+  "perpsWithdrawalEmptyTitle": {
+    "message": "Withdrawal",
+    "description": "Title shown for a wallet-tracked withdrawal transaction on the Activity page when the withdrawn amount is zero or unknown"
+  },
+  "perpsWithdrewVerb": {
+    "message": "Withdrew",
+    "description": "Verb shown in the title of a wallet-tracked withdrawal transaction on the Activity page, followed by the amount and asset (e.g. 'Withdrew 5.00 USDC')"
   },
   "perpsYouReceive": {
     "message": "You receive"

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -7481,11 +7481,17 @@
   "perpsStatusCompleted": {
     "message": "Completed"
   },
+  "perpsStatusFailed": {
+    "message": "Failed"
+  },
   "perpsStatusFilled": {
     "message": "Filled"
   },
   "perpsStatusOpen": {
     "message": "Open"
+  },
+  "perpsStatusPending": {
+    "message": "Pending"
   },
   "perpsStatusQueued": {
     "message": "Queued"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -7057,6 +7057,10 @@
   "perpsDateYesterday": {
     "message": "Yesterday"
   },
+  "perpsDepositEmptyTitle": {
+    "message": "Deposit",
+    "description": "Title shown for a wallet-tracked deposit transaction on the Activity page when the deposited amount is zero or unknown"
+  },
   "perpsDepositErrorBridgeFailed": {
     "message": "Bridge failed"
   },
@@ -7086,6 +7090,10 @@
   },
   "perpsDepositToastSuccessTitle": {
     "message": "Your Perps account was funded"
+  },
+  "perpsDepositedVerb": {
+    "message": "Deposited",
+    "description": "Verb shown in the title of a wallet-tracked deposit transaction on the Activity page, followed by the amount and asset (e.g. 'Deposited 5.00 USDC')"
   },
   "perpsDeposits": {
     "message": "Deposits"
@@ -7798,6 +7806,14 @@
   "perpsWithdrawTooltip": {
     "message": "MetaMask will swap to your desired token for you. No MetaMask fee applies when you swap to mUSD.",
     "description": "Tooltip shown on the Transaction fee row of the Perps Withdraw confirmation"
+  },
+  "perpsWithdrawalEmptyTitle": {
+    "message": "Withdrawal",
+    "description": "Title shown for a wallet-tracked withdrawal transaction on the Activity page when the withdrawn amount is zero or unknown"
+  },
+  "perpsWithdrewVerb": {
+    "message": "Withdrew",
+    "description": "Verb shown in the title of a wallet-tracked withdrawal transaction on the Activity page, followed by the amount and asset (e.g. 'Withdrew 5.00 USDC')"
   },
   "perpsYouReceive": {
     "message": "You receive"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -7481,11 +7481,17 @@
   "perpsStatusCompleted": {
     "message": "Completed"
   },
+  "perpsStatusFailed": {
+    "message": "Failed"
+  },
   "perpsStatusFilled": {
     "message": "Filled"
   },
   "perpsStatusOpen": {
     "message": "Open"
+  },
+  "perpsStatusPending": {
+    "message": "Pending"
   },
   "perpsStatusQueued": {
     "message": "Queued"

--- a/ui/components/app/perps/transaction-card/transaction-card.test.tsx
+++ b/ui/components/app/perps/transaction-card/transaction-card.test.tsx
@@ -320,9 +320,7 @@ describe('TransactionCard', () => {
       );
 
       expect(
-        screen.getByText(
-          `${messages.perpsDepositedVerb.message} 5.00 USDC`,
-        ),
+        screen.getByText(`${messages.perpsDepositedVerb.message} 5.00 USDC`),
       ).toBeInTheDocument();
     });
 

--- a/ui/components/app/perps/transaction-card/transaction-card.test.tsx
+++ b/ui/components/app/perps/transaction-card/transaction-card.test.tsx
@@ -323,6 +323,87 @@ describe('TransactionCard', () => {
         screen.getByText(messages.perpsStatusCompleted.message),
       ).toBeInTheDocument();
     });
+
+    it('shows "Pending" status for a pending wallet-tracked deposit', () => {
+      const transaction = createMockTransaction({
+        type: 'deposit',
+        category: 'deposit',
+        symbol: 'USDC',
+        title: 'Deposited 100.00 USDC',
+        fill: undefined,
+        depositWithdrawal: {
+          amount: '+$100.00',
+          amountNumber: 100,
+          isPositive: true,
+          asset: 'USDC',
+          txHash: '0x1234567890abcdef',
+          status: 'pending',
+          type: 'deposit',
+        },
+      });
+      renderWithProvider(
+        <TransactionCard transaction={transaction} />,
+        mockStore,
+      );
+
+      expect(
+        screen.getByText(messages.perpsStatusPending.message),
+      ).toBeInTheDocument();
+    });
+
+    it('shows "Failed" status for a failed wallet-tracked deposit', () => {
+      const transaction = createMockTransaction({
+        type: 'deposit',
+        category: 'deposit',
+        symbol: 'USDC',
+        title: 'Deposited 100.00 USDC',
+        fill: undefined,
+        depositWithdrawal: {
+          amount: '+$100.00',
+          amountNumber: 100,
+          isPositive: true,
+          asset: 'USDC',
+          txHash: '0x1234567890abcdef',
+          status: 'failed',
+          type: 'deposit',
+        },
+      });
+      renderWithProvider(
+        <TransactionCard transaction={transaction} />,
+        mockStore,
+      );
+
+      expect(
+        screen.getByText(messages.perpsStatusFailed.message),
+      ).toBeInTheDocument();
+    });
+
+    it('shows "Pending" status for a pending wallet-tracked withdrawal', () => {
+      const transaction = createMockTransaction({
+        type: 'withdrawal',
+        category: 'withdrawal',
+        symbol: 'USDC',
+        title: 'Withdrew 50.00 USDC',
+        fill: undefined,
+        depositWithdrawal: {
+          amount: '-$50.00',
+          amountNumber: 50,
+          isPositive: false,
+          asset: 'USDC',
+          txHash: '0xabcdef1234567890',
+          status: 'pending',
+          type: 'withdrawal',
+        },
+      });
+      renderWithProvider(
+        <TransactionCard transaction={transaction} />,
+        mockStore,
+      );
+
+      expect(
+        screen.getByText(messages.perpsStatusPending.message),
+      ).toBeInTheDocument();
+    });
   });
 
   describe('Order transactions', () => {

--- a/ui/components/app/perps/transaction-card/transaction-card.test.tsx
+++ b/ui/components/app/perps/transaction-card/transaction-card.test.tsx
@@ -297,6 +297,116 @@ describe('TransactionCard', () => {
       expect(amountElement).toHaveClass('text-error-default');
     });
 
+    it('shows the translated verb, amount, and asset in the title for a deposit', () => {
+      const transaction = createMockTransaction({
+        type: 'deposit',
+        category: 'deposit',
+        symbol: 'USDC',
+        title: 'Deposited 5.00 USDC',
+        fill: undefined,
+        depositWithdrawal: {
+          amount: '+$5.00',
+          amountNumber: 5,
+          isPositive: true,
+          asset: 'USDC',
+          txHash: '0x1234567890abcdef',
+          status: 'completed',
+          type: 'deposit',
+        },
+      });
+      renderWithProvider(
+        <TransactionCard transaction={transaction} />,
+        mockStore,
+      );
+
+      expect(
+        screen.getByText(
+          `${messages.perpsDepositedVerb.message} 5.00 USDC`,
+        ),
+      ).toBeInTheDocument();
+    });
+
+    it('shows the translated verb, amount, and asset in the title for a withdrawal', () => {
+      const transaction = createMockTransaction({
+        type: 'withdrawal',
+        category: 'withdrawal',
+        symbol: 'USDC',
+        title: 'Withdrew 5.00 USDC',
+        fill: undefined,
+        depositWithdrawal: {
+          amount: '-$5.00',
+          amountNumber: -5,
+          isPositive: false,
+          asset: 'USDC',
+          txHash: '0xabcdef1234567890',
+          status: 'completed',
+          type: 'withdrawal',
+        },
+      });
+      renderWithProvider(
+        <TransactionCard transaction={transaction} />,
+        mockStore,
+      );
+
+      expect(
+        screen.getByText(`${messages.perpsWithdrewVerb.message} 5.00 USDC`),
+      ).toBeInTheDocument();
+    });
+
+    it('shows the translated empty-state title for a zero-amount deposit', () => {
+      const transaction = createMockTransaction({
+        type: 'deposit',
+        category: 'deposit',
+        symbol: 'USDC',
+        title: 'Deposit',
+        fill: undefined,
+        depositWithdrawal: {
+          amount: '+$0.00',
+          amountNumber: 0,
+          isPositive: true,
+          asset: 'USDC',
+          txHash: '0x1234567890abcdef',
+          status: 'pending',
+          type: 'deposit',
+        },
+      });
+      renderWithProvider(
+        <TransactionCard transaction={transaction} />,
+        mockStore,
+      );
+
+      expect(
+        screen.getByText(messages.perpsDepositEmptyTitle.message),
+      ).toBeInTheDocument();
+    });
+
+    it('shows the translated empty-state title for a zero-amount withdrawal', () => {
+      const transaction = createMockTransaction({
+        type: 'withdrawal',
+        category: 'withdrawal',
+        symbol: 'USDC',
+        title: 'Withdrawal',
+        fill: undefined,
+        depositWithdrawal: {
+          amount: '-$0.00',
+          amountNumber: 0,
+          isPositive: false,
+          asset: 'USDC',
+          txHash: '0xabcdef1234567890',
+          status: 'pending',
+          type: 'withdrawal',
+        },
+      });
+      renderWithProvider(
+        <TransactionCard transaction={transaction} />,
+        mockStore,
+      );
+
+      expect(
+        screen.getByText(messages.perpsWithdrawalEmptyTitle.message),
+      ).toBeInTheDocument();
+    });
+
     it('shows "Completed" status for deposits', () => {
       const transaction = createMockTransaction({
         type: 'deposit',

--- a/ui/components/app/perps/transaction-card/transaction-card.tsx
+++ b/ui/components/app/perps/transaction-card/transaction-card.tsx
@@ -121,6 +121,29 @@ export const TransactionCard = ({
 
   const amountDisplay = getAmountDisplay();
 
+  // Construct title display based on transaction type. Deposit/withdrawal
+  // titles are rendered directly (unlike the subtitle, there's no other
+  // override downstream), so the verb and empty-state text must be
+  // translated here rather than left as the transform's deterministic
+  // English string.
+  const getTitleDisplay = (): string => {
+    if (
+      (transaction.type === 'deposit' || transaction.type === 'withdrawal') &&
+      transaction.depositWithdrawal
+    ) {
+      const isDeposit = transaction.type === 'deposit';
+      const magnitude = Math.abs(transaction.depositWithdrawal.amountNumber);
+      if (magnitude === 0) {
+        return t(
+          isDeposit ? 'perpsDepositEmptyTitle' : 'perpsWithdrawalEmptyTitle',
+        );
+      }
+      const verb = t(isDeposit ? 'perpsDepositedVerb' : 'perpsWithdrewVerb');
+      return `${verb} ${magnitude.toFixed(2)} ${transaction.depositWithdrawal.asset}`;
+    }
+    return transaction.title;
+  };
+
   // Construct subtitle display based on transaction type
   const getSubtitleDisplay = (): string => {
     if (transaction.type === 'trade' && transaction.fill) {
@@ -176,7 +199,7 @@ export const TransactionCard = ({
             fontWeight={FontWeight.Medium}
             className="text-s-body-md @compact:text-s-body-sm"
           >
-            {transaction.title}
+            {getTitleDisplay()}
           </Text>
           {!(isClickable && hasInteractiveBadge) && (
             <PerpsFillTag transaction={transaction} screenName={screenName} />

--- a/ui/components/app/perps/transaction-card/transaction-card.tsx
+++ b/ui/components/app/perps/transaction-card/transaction-card.tsx
@@ -35,6 +35,16 @@ const ORDER_STATUS_TO_I18N_KEY: Record<string, string> = {
   triggered: 'perpsStatusTriggered',
 };
 
+// `bridging` is treated the same as `pending` for display purposes — the
+// wallet doesn't currently emit a distinct in-progress-bridge state, but the
+// depositWithdrawal.status type supports it for other request-based sources.
+const DEPOSIT_WITHDRAWAL_STATUS_TO_I18N_KEY: Record<string, string> = {
+  completed: 'perpsStatusCompleted',
+  pending: 'perpsStatusPending',
+  bridging: 'perpsStatusPending',
+  failed: 'perpsStatusFailed',
+};
+
 /**
  * TransactionCard component displays individual transaction information
  * Two rows: logo + title/subtitle on left, amount + time on right
@@ -127,9 +137,14 @@ export const TransactionCard = ({
     if (transaction.type === 'funding') {
       return displayName;
     }
-    // For deposits/withdrawals, show status
+    // For deposits/withdrawals, show the transaction's real status (e.g. a
+    // wallet-tracked deposit/withdrawal may still be pending or have failed)
+    // instead of always displaying "Completed".
     if (transaction.type === 'deposit' || transaction.type === 'withdrawal') {
-      return t('perpsStatusCompleted');
+      const status = transaction.depositWithdrawal?.status ?? 'completed';
+      const i18nKey =
+        DEPOSIT_WITHDRAWAL_STATUS_TO_I18N_KEY[status] ?? 'perpsStatusCompleted';
+      return t(i18nKey);
     }
     return transaction.subtitle;
   };

--- a/ui/components/app/perps/utils/transactionTransforms.test.ts
+++ b/ui/components/app/perps/utils/transactionTransforms.test.ts
@@ -27,7 +27,8 @@ import {
   transformWithdrawalRequestsToTransactions,
   transformDepositRequestsToTransactions,
   transformWalletPerpsDepositsToTransactions,
-  dedupeWalletDepositsByTxHash,
+  transformWalletPerpsWithdrawalsToTransactions,
+  dedupeWalletTransactionsByTxHash,
   type WithdrawalRequest,
   type DepositRequest,
 } from './transactionTransforms';
@@ -53,6 +54,33 @@ const createMockWalletDepositTx = (
     status: TransactionStatus.confirmed,
     type: TransactionType.perpsDeposit,
     hash: '0xabc123',
+    txParams: {
+      from: '0x1234567890123456789012345678901234567890',
+      to: ARBITRUM_USDC.address,
+      data,
+    },
+    ...overrides,
+  } as TransactionMeta;
+};
+
+// Helper to create a mock wallet-tracked Perps withdrawal TransactionMeta,
+// matching the shape `transformWalletPerpsWithdrawalsToTransactions` expects.
+const createMockWalletWithdrawalTx = (
+  overrides: Partial<TransactionMeta> = {},
+): TransactionMeta => {
+  const amountRaw = '50000000'; // 50 USDC at 6 decimals
+  const data = erc20Interface.encodeFunctionData('transfer', [
+    '0x2Df1c51E09aECF9cacB7bc98cB1742757f163dF7',
+    amountRaw,
+  ]) as `0x${string}`;
+
+  return {
+    id: 'wallet-withdraw-tx-1',
+    chainId: '0xa4b1',
+    time: Date.now(),
+    status: TransactionStatus.confirmed,
+    type: TransactionType.perpsWithdraw,
+    hash: '0xdef456',
     txParams: {
       from: '0x1234567890123456789012345678901234567890',
       to: ARBITRUM_USDC.address,
@@ -449,6 +477,7 @@ describe('Transaction Transform Utilities', () => {
       expect(result[0].type).toBe('deposit');
       expect(result[0].category).toBe('deposit');
       expect(result[0].title).toBe('Deposited 1000.00 USDC');
+      expect(result[0].subtitle).toBe('Completed');
       expect(result[0].depositWithdrawal?.isPositive).toBe(true);
       expect(result[0].depositWithdrawal?.amount).toBe('+$1000.00');
     });
@@ -501,6 +530,7 @@ describe('Transaction Transform Utilities', () => {
       expect(result).toHaveLength(1);
       expect(result[0].type).toBe('withdrawal');
       expect(result[0].title).toBe('Withdrew 250.00 USDC');
+      expect(result[0].subtitle).toBe('Completed');
       expect(result[0].depositWithdrawal?.amount).toBe('-$250.00');
       expect(result[0].depositWithdrawal?.amountNumber).toBe(-250);
       expect(result[0].depositWithdrawal?.isPositive).toBe(false);
@@ -588,7 +618,7 @@ describe('Transaction Transform Utilities', () => {
   });
 
   describe('transformWalletPerpsDepositsToTransactions', () => {
-    it('transforms a confirmed wallet perpsDeposit transaction into a deposit', () => {
+    it('transforms a confirmed wallet perpsDeposit transaction into a completed deposit', () => {
       const tx = createMockWalletDepositTx();
 
       const result = transformWalletPerpsDepositsToTransactions([tx]);
@@ -597,6 +627,7 @@ describe('Transaction Transform Utilities', () => {
       expect(result[0].type).toBe('deposit');
       expect(result[0].title).toBe('Deposited 100.00 USDC');
       expect(result[0].subtitle).toBe('Completed');
+      expect(result[0].depositWithdrawal?.status).toBe('completed');
       expect(result[0].depositWithdrawal?.amount).toBe('+$100.00');
       expect(result[0].depositWithdrawal?.amountNumber).toBe(100);
       expect(result[0].depositWithdrawal?.isPositive).toBe(true);
@@ -613,22 +644,74 @@ describe('Transaction Transform Utilities', () => {
       expect(result).toHaveLength(1);
     });
 
-    it('excludes non-confirmed wallet deposit transactions', () => {
-      const pendingTx = createMockWalletDepositTx({
+    it('includes a submitted deposit with a pending status', () => {
+      const tx = createMockWalletDepositTx({
         id: 'wallet-tx-pending',
         status: TransactionStatus.submitted,
       });
-      const failedTx = createMockWalletDepositTx({
+
+      const result = transformWalletPerpsDepositsToTransactions([tx]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].subtitle).toBe('Pending');
+      expect(result[0].depositWithdrawal?.status).toBe('pending');
+    });
+
+    it('includes an unapproved deposit with a pending status', () => {
+      const tx = createMockWalletDepositTx({
+        id: 'wallet-tx-unapproved',
+        status: TransactionStatus.unapproved,
+      });
+
+      const result = transformWalletPerpsDepositsToTransactions([tx]);
+
+      expect(result[0].depositWithdrawal?.status).toBe('pending');
+    });
+
+    it('includes a failed deposit with a failed status', () => {
+      const tx = createMockWalletDepositTx({
         id: 'wallet-tx-failed',
         status: TransactionStatus.failed,
       });
 
-      const result = transformWalletPerpsDepositsToTransactions([
-        pendingTx,
-        failedTx,
-      ]);
+      const result = transformWalletPerpsDepositsToTransactions([tx]);
 
-      expect(result).toHaveLength(0);
+      expect(result).toHaveLength(1);
+      expect(result[0].subtitle).toBe('Failed');
+      expect(result[0].depositWithdrawal?.status).toBe('failed');
+    });
+
+    it('includes a dropped deposit with a failed status', () => {
+      const tx = createMockWalletDepositTx({
+        id: 'wallet-tx-dropped',
+        status: TransactionStatus.dropped,
+      });
+
+      const result = transformWalletPerpsDepositsToTransactions([tx]);
+
+      expect(result[0].depositWithdrawal?.status).toBe('failed');
+    });
+
+    it('includes a rejected deposit with a failed status', () => {
+      const tx = createMockWalletDepositTx({
+        id: 'wallet-tx-rejected',
+        status: TransactionStatus.rejected,
+      });
+
+      const result = transformWalletPerpsDepositsToTransactions([tx]);
+
+      expect(result[0].depositWithdrawal?.status).toBe('failed');
+    });
+
+    it('includes a cancelled deposit with a failed status', () => {
+      const tx = createMockWalletDepositTx({
+        id: 'wallet-tx-cancelled',
+        status: TransactionStatus.cancelled,
+      });
+
+      const result = transformWalletPerpsDepositsToTransactions([tx]);
+
+      expect(result[0].depositWithdrawal?.status).toBe('failed');
     });
 
     it('uses a generic title when the transfer amount cannot be decoded', () => {
@@ -646,7 +729,65 @@ describe('Transaction Transform Utilities', () => {
     });
   });
 
-  describe('dedupeWalletDepositsByTxHash', () => {
+  describe('transformWalletPerpsWithdrawalsToTransactions', () => {
+    it('transforms a confirmed wallet perpsWithdraw transaction into a completed withdrawal', () => {
+      const tx = createMockWalletWithdrawalTx();
+
+      const result = transformWalletPerpsWithdrawalsToTransactions([tx]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('withdrawal');
+      expect(result[0].title).toBe('Withdrew 50.00 USDC');
+      expect(result[0].subtitle).toBe('Completed');
+      expect(result[0].depositWithdrawal?.status).toBe('completed');
+      expect(result[0].depositWithdrawal?.amount).toBe('-$50.00');
+      expect(result[0].depositWithdrawal?.amountNumber).toBe(-50);
+      expect(result[0].depositWithdrawal?.isPositive).toBe(false);
+      expect(result[0].depositWithdrawal?.txHash).toBe('0xdef456');
+    });
+
+    it('includes a submitted withdrawal with a pending status', () => {
+      const tx = createMockWalletWithdrawalTx({
+        id: 'wallet-withdraw-tx-pending',
+        status: TransactionStatus.submitted,
+      });
+
+      const result = transformWalletPerpsWithdrawalsToTransactions([tx]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].subtitle).toBe('Pending');
+      expect(result[0].depositWithdrawal?.status).toBe('pending');
+    });
+
+    it('includes a failed withdrawal with a failed status', () => {
+      const tx = createMockWalletWithdrawalTx({
+        id: 'wallet-withdraw-tx-failed',
+        status: TransactionStatus.failed,
+      });
+
+      const result = transformWalletPerpsWithdrawalsToTransactions([tx]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].subtitle).toBe('Failed');
+      expect(result[0].depositWithdrawal?.status).toBe('failed');
+    });
+
+    it('uses a generic title when the transfer amount cannot be decoded', () => {
+      const tx = createMockWalletWithdrawalTx({
+        txParams: {
+          from: '0x1234567890123456789012345678901234567890',
+          to: ARBITRUM_USDC.address,
+          data: '0x',
+        },
+      });
+
+      const result = transformWalletPerpsWithdrawalsToTransactions([tx]);
+
+      expect(result[0].title).toBe('Withdrawal');
+    });
+  });
+
+  describe('dedupeWalletTransactionsByTxHash', () => {
     const walletDeposit: PerpsTransaction = {
       id: 'wallet-deposit-1',
       type: 'deposit',
@@ -666,8 +807,27 @@ describe('Transaction Transform Utilities', () => {
       },
     };
 
+    const walletWithdrawal: PerpsTransaction = {
+      id: 'wallet-withdrawal-1',
+      type: 'withdrawal',
+      category: 'withdrawal',
+      title: 'Withdrew 50.00 USDC',
+      subtitle: 'Completed',
+      timestamp: Date.now(),
+      symbol: 'USDC',
+      depositWithdrawal: {
+        amount: '-$50.00',
+        amountNumber: -50,
+        isPositive: false,
+        asset: 'USDC',
+        txHash: '0xDEF456',
+        status: 'completed',
+        type: 'withdrawal',
+      },
+    };
+
     it('keeps wallet deposits with no matching existing deposit', () => {
-      const result = dedupeWalletDepositsByTxHash([walletDeposit], []);
+      const result = dedupeWalletTransactionsByTxHash([walletDeposit], []);
 
       expect(result).toEqual([walletDeposit]);
     });
@@ -682,7 +842,7 @@ describe('Transaction Transform Utilities', () => {
         } as PerpsTransaction['depositWithdrawal'],
       };
 
-      const result = dedupeWalletDepositsByTxHash(
+      const result = dedupeWalletTransactionsByTxHash(
         [walletDeposit],
         [existingDeposit],
       );
@@ -697,12 +857,72 @@ describe('Transaction Transform Utilities', () => {
         type: 'trade',
       };
 
-      const result = dedupeWalletDepositsByTxHash(
+      const result = dedupeWalletTransactionsByTxHash(
         [walletDeposit],
         [existingTrade],
       );
 
       expect(result).toEqual([walletDeposit]);
+    });
+
+    it('keeps wallet withdrawals with no matching existing withdrawal', () => {
+      const result = dedupeWalletTransactionsByTxHash([walletWithdrawal], []);
+
+      expect(result).toEqual([walletWithdrawal]);
+    });
+
+    it('drops wallet withdrawals already represented by an existing withdrawal with the same txHash (case-insensitive)', () => {
+      const existingWithdrawal: PerpsTransaction = {
+        ...walletWithdrawal,
+        id: 'history-withdrawal-1',
+        depositWithdrawal: {
+          ...walletWithdrawal.depositWithdrawal,
+          txHash: '0xdef456',
+        } as PerpsTransaction['depositWithdrawal'],
+      };
+
+      const result = dedupeWalletTransactionsByTxHash(
+        [walletWithdrawal],
+        [existingWithdrawal],
+      );
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('does not dedupe a wallet withdrawal against a deposit sharing the same txHash', () => {
+      const existingDepositSameHash: PerpsTransaction = {
+        ...walletDeposit,
+        id: 'history-deposit-same-hash',
+        depositWithdrawal: {
+          ...walletDeposit.depositWithdrawal,
+          txHash: walletWithdrawal.depositWithdrawal?.txHash ?? '',
+        } as PerpsTransaction['depositWithdrawal'],
+      };
+
+      const result = dedupeWalletTransactionsByTxHash(
+        [walletWithdrawal],
+        [existingDepositSameHash],
+      );
+
+      expect(result).toEqual([walletWithdrawal]);
+    });
+
+    it('dedupes deposits and withdrawals independently when both are present', () => {
+      const existingDeposit: PerpsTransaction = {
+        ...walletDeposit,
+        id: 'history-deposit-1',
+        depositWithdrawal: {
+          ...walletDeposit.depositWithdrawal,
+          txHash: '0xabc123',
+        } as PerpsTransaction['depositWithdrawal'],
+      };
+
+      const result = dedupeWalletTransactionsByTxHash(
+        [walletDeposit, walletWithdrawal],
+        [existingDeposit],
+      );
+
+      expect(result).toEqual([walletWithdrawal]);
     });
   });
 });

--- a/ui/components/app/perps/utils/transactionTransforms.test.ts
+++ b/ui/components/app/perps/utils/transactionTransforms.test.ts
@@ -4,11 +4,20 @@ import type {
   OrderFill,
   UserHistoryItem,
 } from '@metamask/perps-controller';
+import { Interface } from '@ethersproject/abi';
+import { abiERC20 } from '@metamask/metamask-eth-abis';
+import {
+  TransactionStatus,
+  TransactionType,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
 import {
   FillType,
   PerpsOrderTransactionStatus,
   PerpsOrderTransactionStatusType,
+  type PerpsTransaction,
 } from '../types/transactionHistory';
+import { ARBITRUM_USDC } from '../../../../pages/confirmations/constants/perps';
 import {
   aggregateFillsByTimestamp,
   transformFillsToTransactions,
@@ -17,9 +26,41 @@ import {
   transformUserHistoryToTransactions,
   transformWithdrawalRequestsToTransactions,
   transformDepositRequestsToTransactions,
+  transformWalletPerpsDepositsToTransactions,
+  dedupeWalletDepositsByTxHash,
   type WithdrawalRequest,
   type DepositRequest,
 } from './transactionTransforms';
+
+const erc20Interface = new Interface(abiERC20);
+
+// Helper to create a mock wallet-tracked Perps deposit TransactionMeta with a
+// standard ERC20 `transfer(address,uint256)` payload, matching the shape
+// `transformWalletPerpsDepositsToTransactions` expects.
+const createMockWalletDepositTx = (
+  overrides: Partial<TransactionMeta> = {},
+): TransactionMeta => {
+  const amountRaw = '100000000'; // 100 USDC at 6 decimals
+  const data = erc20Interface.encodeFunctionData('transfer', [
+    '0x2Df1c51E09aECF9cacB7bc98cB1742757f163dF7',
+    amountRaw,
+  ]) as `0x${string}`;
+
+  return {
+    id: 'wallet-tx-1',
+    chainId: '0xa4b1',
+    time: Date.now(),
+    status: TransactionStatus.confirmed,
+    type: TransactionType.perpsDeposit,
+    hash: '0xabc123',
+    txParams: {
+      from: '0x1234567890123456789012345678901234567890',
+      to: ARBITRUM_USDC.address,
+      data,
+    },
+    ...overrides,
+  } as TransactionMeta;
+};
 
 // Helper to create mock OrderFill
 const createMockFill = (overrides: Partial<OrderFill> = {}): OrderFill => ({
@@ -543,6 +584,125 @@ describe('Transaction Transform Utilities', () => {
       const result = transformDepositRequestsToTransactions(requests);
 
       expect(result).toHaveLength(1);
+    });
+  });
+
+  describe('transformWalletPerpsDepositsToTransactions', () => {
+    it('transforms a confirmed wallet perpsDeposit transaction into a deposit', () => {
+      const tx = createMockWalletDepositTx();
+
+      const result = transformWalletPerpsDepositsToTransactions([tx]);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].type).toBe('deposit');
+      expect(result[0].title).toBe('Deposited 100.00 USDC');
+      expect(result[0].subtitle).toBe('Completed');
+      expect(result[0].depositWithdrawal?.amount).toBe('+$100.00');
+      expect(result[0].depositWithdrawal?.amountNumber).toBe(100);
+      expect(result[0].depositWithdrawal?.isPositive).toBe(true);
+      expect(result[0].depositWithdrawal?.txHash).toBe('0xabc123');
+    });
+
+    it('includes confirmed perpsDepositAndOrder transactions', () => {
+      const tx = createMockWalletDepositTx({
+        type: TransactionType.perpsDepositAndOrder,
+      });
+
+      const result = transformWalletPerpsDepositsToTransactions([tx]);
+
+      expect(result).toHaveLength(1);
+    });
+
+    it('excludes non-confirmed wallet deposit transactions', () => {
+      const pendingTx = createMockWalletDepositTx({
+        id: 'wallet-tx-pending',
+        status: TransactionStatus.submitted,
+      });
+      const failedTx = createMockWalletDepositTx({
+        id: 'wallet-tx-failed',
+        status: TransactionStatus.failed,
+      });
+
+      const result = transformWalletPerpsDepositsToTransactions([
+        pendingTx,
+        failedTx,
+      ]);
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('uses a generic title when the transfer amount cannot be decoded', () => {
+      const tx = createMockWalletDepositTx({
+        txParams: {
+          from: '0x1234567890123456789012345678901234567890',
+          to: ARBITRUM_USDC.address,
+          data: '0x',
+        },
+      });
+
+      const result = transformWalletPerpsDepositsToTransactions([tx]);
+
+      expect(result[0].title).toBe('Deposit');
+    });
+  });
+
+  describe('dedupeWalletDepositsByTxHash', () => {
+    const walletDeposit: PerpsTransaction = {
+      id: 'wallet-deposit-1',
+      type: 'deposit',
+      category: 'deposit',
+      title: 'Deposited 100.00 USDC',
+      subtitle: 'Completed',
+      timestamp: Date.now(),
+      symbol: 'USDC',
+      depositWithdrawal: {
+        amount: '+$100.00',
+        amountNumber: 100,
+        isPositive: true,
+        asset: 'USDC',
+        txHash: '0xABC123',
+        status: 'completed',
+        type: 'deposit',
+      },
+    };
+
+    it('keeps wallet deposits with no matching existing deposit', () => {
+      const result = dedupeWalletDepositsByTxHash([walletDeposit], []);
+
+      expect(result).toEqual([walletDeposit]);
+    });
+
+    it('drops wallet deposits already represented by an existing deposit with the same txHash (case-insensitive)', () => {
+      const existingDeposit: PerpsTransaction = {
+        ...walletDeposit,
+        id: 'history-deposit-1',
+        depositWithdrawal: {
+          ...walletDeposit.depositWithdrawal,
+          txHash: '0xabc123',
+        } as PerpsTransaction['depositWithdrawal'],
+      };
+
+      const result = dedupeWalletDepositsByTxHash(
+        [walletDeposit],
+        [existingDeposit],
+      );
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('does not dedupe against existing non-deposit transactions', () => {
+      const existingTrade: PerpsTransaction = {
+        ...walletDeposit,
+        id: 'trade-1',
+        type: 'trade',
+      };
+
+      const result = dedupeWalletDepositsByTxHash(
+        [walletDeposit],
+        [existingTrade],
+      );
+
+      expect(result).toEqual([walletDeposit]);
     });
   });
 });

--- a/ui/components/app/perps/utils/transactionTransforms.ts
+++ b/ui/components/app/perps/utils/transactionTransforms.ts
@@ -511,6 +511,54 @@ export function transformFundingToTransactions(
 }
 
 /**
+ * Maps a wallet TransactionController status to the Perps deposit/withdrawal
+ * status this transform surfaces. Every status resolves to a bucket so
+ * wallet-tracked deposits/withdrawals are visible on the Activity page from
+ * the moment they're submitted, not just once confirmed — the row's
+ * subtitle reflects the real state (Pending/Failed/Completed) via
+ * `getDepositWithdrawalStatusText` instead of always showing "Completed".
+ */
+const WALLET_TX_STATUS_TO_PERPS_STATUS: Record<
+  WalletTransactionStatus,
+  'completed' | 'failed' | 'pending'
+> = {
+  [WalletTransactionStatus.confirmed]: 'completed',
+  [WalletTransactionStatus.failed]: 'failed',
+  [WalletTransactionStatus.rejected]: 'failed',
+  [WalletTransactionStatus.dropped]: 'failed',
+  [WalletTransactionStatus.cancelled]: 'failed',
+  [WalletTransactionStatus.signed]: 'pending',
+  [WalletTransactionStatus.submitted]: 'pending',
+  [WalletTransactionStatus.approved]: 'pending',
+  [WalletTransactionStatus.unapproved]: 'pending',
+};
+
+/**
+ * Plain-English status text for deposit/withdrawal rows, keyed by
+ * `depositWithdrawal.status`. Mirrors the `PerpsOrderTransactionStatus`
+ * convention used for order rows: transforms set deterministic English text
+ * here, and the Activity page's `TransactionCard` maps that text to a
+ * translated string for display.
+ *
+ * @param status - The deposit/withdrawal status to derive display text for.
+ * @returns Plain-English status text ('Completed', 'Failed', or 'Pending').
+ */
+function getDepositWithdrawalStatusText(
+  status: 'completed' | 'failed' | 'pending' | 'bridging',
+): string {
+  switch (status) {
+    case 'completed':
+      return 'Completed';
+    case 'failed':
+      return 'Failed';
+    case 'pending':
+    case 'bridging':
+    default:
+      return 'Pending';
+  }
+}
+
+/**
  * Transform UserHistoryItem objects to PerpsTransaction format.
  * Only shows completed deposits/withdrawals (txHash not displayed in UI).
  *
@@ -531,15 +579,12 @@ export function transformUserHistoryToTransactions(
       const amountBN = new BigNumber(amount);
       const displayAmount = `${isDeposit ? '+' : '-'}$${amountBN.toFixed(2)}`;
 
-      // For completed transactions, status is always positive (green)
-      const statusText = 'Completed';
-
       return {
         id: `${type}-${id}`,
         type: isDeposit ? 'deposit' : 'withdrawal',
         category: isDeposit ? 'deposit' : 'withdrawal',
         title: `${isDeposit ? 'Deposited' : 'Withdrew'} ${amount} ${asset}`,
-        subtitle: statusText,
+        subtitle: getDepositWithdrawalStatusText(status),
         timestamp,
         symbol: asset,
         depositWithdrawal: {
@@ -556,20 +601,6 @@ export function transformUserHistoryToTransactions(
 }
 
 /**
- * Maps a wallet TransactionController status to the subset of Perps
- * deposit statuses this transform surfaces. Only `confirmed` resolves to a
- * status, since the Activity page's deposit/withdrawal row always renders
- * a "Completed" subtitle regardless of `depositWithdrawal.status` — showing
- * a pending or failed wallet transaction here would render a misleading
- * "Completed" label.
- */
-const WALLET_STATUS_TO_DEPOSIT_STATUS: Partial<
-  Record<WalletTransactionStatus, 'completed'>
-> = {
-  [WalletTransactionStatus.confirmed]: 'completed',
-};
-
-/**
  * Transform wallet-tracked Perps deposit transactions (`perpsDeposit` /
  * `perpsDepositAndOrder`) into `PerpsTransaction` rows.
  *
@@ -583,6 +614,10 @@ const WALLET_STATUS_TO_DEPOSIT_STATUS: Partial<
  * deposits and de-duplicates by `txHash`, so once the ledger catches up the
  * two representations of the same deposit collapse into one.
  *
+ * Deposits are included regardless of wallet status (pending/failed/
+ * confirmed) so a still-confirming or failed deposit is visible with an
+ * accurate status instead of only appearing once confirmed.
+ *
  * @param transactions - Array of TransactionMeta with type `perpsDeposit` or
  * `perpsDepositAndOrder`, already scoped to the active account.
  * @returns Array of PerpsTransaction objects with type 'deposit'.
@@ -590,75 +625,134 @@ const WALLET_STATUS_TO_DEPOSIT_STATUS: Partial<
 export function transformWalletPerpsDepositsToTransactions(
   transactions: TransactionMeta[],
 ): PerpsTransaction[] {
-  return transactions
-    .filter((tx) => WALLET_STATUS_TO_DEPOSIT_STATUS[tx.status] === 'completed')
-    .map((tx) => {
-      const tokenTransfer = getTokenTransferData(tx);
-      const decoded = tokenTransfer
-        ? parseStandardTokenTransactionData(tokenTransfer.data)
-        : undefined;
-      const rawAmount = decoded?.args?._value?.toString?.();
-      const amountBN =
-        rawAmount === undefined
-          ? new BigNumber(0)
-          : calcTokenAmount(rawAmount, ARBITRUM_USDC.decimals);
+  return transactions.map((tx) => {
+    const tokenTransfer = getTokenTransferData(tx);
+    const decoded = tokenTransfer
+      ? parseStandardTokenTransactionData(tokenTransfer.data)
+      : undefined;
+    const rawAmount = decoded?.args?._value?.toString?.();
+    const amountBN =
+      rawAmount === undefined
+        ? new BigNumber(0)
+        : calcTokenAmount(rawAmount, ARBITRUM_USDC.decimals);
 
-      const displayAmount = `+$${amountBN.toFixed(2)}`;
-      const title = amountBN.isZero()
-        ? 'Deposit'
-        : `Deposited ${amountBN.toFixed(2)} ${ARBITRUM_USDC.symbol}`;
+    const displayAmount = `+$${amountBN.toFixed(2)}`;
+    const status = WALLET_TX_STATUS_TO_PERPS_STATUS[tx.status] ?? 'pending';
+    const title = amountBN.isZero()
+      ? 'Deposit'
+      : `Deposited ${amountBN.toFixed(2)} ${ARBITRUM_USDC.symbol}`;
 
-      return {
-        id: `wallet-deposit-${tx.id}`,
+    return {
+      id: `wallet-deposit-${tx.id}`,
+      type: 'deposit' as const,
+      category: 'deposit' as const,
+      title,
+      subtitle: getDepositWithdrawalStatusText(status),
+      timestamp: tx.time ?? 0,
+      symbol: ARBITRUM_USDC.symbol,
+      depositWithdrawal: {
+        amount: displayAmount,
+        amountNumber: amountBN.toNumber(),
+        isPositive: true,
+        asset: ARBITRUM_USDC.symbol,
+        txHash: tx.hash ?? '',
+        status,
         type: 'deposit' as const,
-        category: 'deposit' as const,
-        title,
-        subtitle: 'Completed',
-        timestamp: tx.time ?? 0,
-        symbol: ARBITRUM_USDC.symbol,
-        depositWithdrawal: {
-          amount: displayAmount,
-          amountNumber: amountBN.toNumber(),
-          isPositive: true,
-          asset: ARBITRUM_USDC.symbol,
-          txHash: tx.hash ?? '',
-          status: 'completed' as const,
-          type: 'deposit' as const,
-        },
-      };
-    });
+      },
+    };
+  });
 }
 
 /**
- * Filters out wallet-sourced deposit transactions whose `txHash` already
- * appears among `existingDeposits` (typically the user-history deposits
- * already present in the merged transaction list).
+ * Transform wallet-tracked Perps withdrawal transactions (`perpsWithdraw`)
+ * into `PerpsTransaction` rows.
  *
- * Used by `usePerpsTransactionHistory` to avoid showing the same deposit
- * twice once HyperLiquid's user-history ledger catches up with a deposit
- * that was initially only visible via the wallet's own transaction record.
+ * Mirrors `transformWalletPerpsDepositsToTransactions`: HyperLiquid's
+ * user-history ledger can lag behind the wallet's own on-chain withdrawal
+ * transaction confirming, so this fallback keeps a just-submitted
+ * withdrawal visible on the Activity page immediately, with its real
+ * pending/failed/completed status. `usePerpsTransactionHistory` merges this
+ * list with the user-history withdrawals and de-duplicates by `txHash`.
  *
- * @param walletDeposits - Deposit transactions sourced from the wallet's
- * TransactionController (see `transformWalletPerpsDepositsToTransactions`).
- * @param existingDeposits - Deposit transactions already present in the
- * merged list (e.g. from user history) to de-duplicate against.
- * @returns The subset of `walletDeposits` not already represented.
+ * @param transactions - Array of TransactionMeta with type `perpsWithdraw`,
+ * already scoped to the active account.
+ * @returns Array of PerpsTransaction objects with type 'withdrawal'.
  */
-export function dedupeWalletDepositsByTxHash(
-  walletDeposits: PerpsTransaction[],
-  existingDeposits: PerpsTransaction[],
+export function transformWalletPerpsWithdrawalsToTransactions(
+  transactions: TransactionMeta[],
+): PerpsTransaction[] {
+  return transactions.map((tx) => {
+    const tokenTransfer = getTokenTransferData(tx);
+    const decoded = tokenTransfer
+      ? parseStandardTokenTransactionData(tokenTransfer.data)
+      : undefined;
+    const rawAmount = decoded?.args?._value?.toString?.();
+    const amountBN =
+      rawAmount === undefined
+        ? new BigNumber(0)
+        : calcTokenAmount(rawAmount, ARBITRUM_USDC.decimals);
+
+    const displayAmount = `-$${amountBN.toFixed(2)}`;
+    const status = WALLET_TX_STATUS_TO_PERPS_STATUS[tx.status] ?? 'pending';
+    const title = amountBN.isZero()
+      ? 'Withdrawal'
+      : `Withdrew ${amountBN.toFixed(2)} ${ARBITRUM_USDC.symbol}`;
+
+    return {
+      id: `wallet-withdrawal-${tx.id}`,
+      type: 'withdrawal' as const,
+      category: 'withdrawal' as const,
+      title,
+      subtitle: getDepositWithdrawalStatusText(status),
+      timestamp: tx.time ?? 0,
+      symbol: ARBITRUM_USDC.symbol,
+      depositWithdrawal: {
+        amount: displayAmount,
+        amountNumber: -amountBN.toNumber(),
+        isPositive: false,
+        asset: ARBITRUM_USDC.symbol,
+        txHash: tx.hash ?? '',
+        status,
+        type: 'withdrawal' as const,
+      },
+    };
+  });
+}
+
+/**
+ * Filters out wallet-sourced deposit/withdrawal transactions whose `txHash`
+ * already appears among an existing transaction of the same type
+ * (typically the user-history deposits/withdrawals already present in the
+ * merged transaction list).
+ *
+ * Used by `usePerpsTransactionHistory` to avoid showing the same deposit or
+ * withdrawal twice once HyperLiquid's user-history ledger catches up with a
+ * transaction that was initially only visible via the wallet's own
+ * transaction record.
+ *
+ * @param walletTransactions - Deposit or withdrawal transactions sourced
+ * from the wallet's TransactionController (see
+ * `transformWalletPerpsDepositsToTransactions` /
+ * `transformWalletPerpsWithdrawalsToTransactions`).
+ * @param existingTransactions - Transactions already present in the merged
+ * list (e.g. from user history) to de-duplicate against.
+ * @returns The subset of `walletTransactions` not already represented.
+ */
+export function dedupeWalletTransactionsByTxHash(
+  walletTransactions: PerpsTransaction[],
+  existingTransactions: PerpsTransaction[],
 ): PerpsTransaction[] {
   const existingTxHashes = new Set<string>();
-  for (const tx of existingDeposits) {
+  for (const tx of existingTransactions) {
     const txHash = tx.depositWithdrawal?.txHash?.toLowerCase();
-    if (tx.type === 'deposit' && txHash) {
-      existingTxHashes.add(txHash);
+    if ((tx.type === 'deposit' || tx.type === 'withdrawal') && txHash) {
+      existingTxHashes.add(`${tx.type}:${txHash}`);
     }
   }
 
-  return walletDeposits.filter((tx) => {
+  return walletTransactions.filter((tx) => {
     const txHash = tx.depositWithdrawal?.txHash?.toLowerCase();
-    return !txHash || !existingTxHashes.has(txHash);
+    return !txHash || !existingTxHashes.has(`${tx.type}:${txHash}`);
   });
 }
 
@@ -711,15 +805,18 @@ export function transformWithdrawalRequestsToTransactions(
 
       // Completion status is separate from amount polarity.
       // Withdrawals are outflows, so they are always negative for styling.
-      const statusText = 'Completed';
       const isPositive = false;
+
+      const title = amountBN.isZero()
+        ? 'Withdrawal'
+        : `Withdrew ${amount} ${asset}`;
 
       return {
         id: `withdrawal-${id}`,
         type: 'withdrawal' as const,
         category: 'withdrawal' as const,
-        title: `Withdrew ${amount} ${asset}`,
-        subtitle: statusText,
+        title,
+        subtitle: getDepositWithdrawalStatusText(status),
         timestamp,
         symbol: asset,
         depositWithdrawal: {
@@ -754,8 +851,6 @@ export function transformDepositRequestsToTransactions(
       const amountBN = new BigNumber(amount);
       const displayAmount = `+$${amountBN.toFixed(2)}`;
 
-      // For completed deposits, status is always positive (green)
-      const statusText = 'Completed';
       const isPositive = true;
 
       // Create title based on whether we have the actual amount
@@ -769,7 +864,7 @@ export function transformDepositRequestsToTransactions(
         type: 'deposit' as const,
         category: 'deposit' as const,
         title,
-        subtitle: statusText,
+        subtitle: getDepositWithdrawalStatusText(status),
         timestamp,
         symbol: asset,
         depositWithdrawal: {

--- a/ui/components/app/perps/utils/transactionTransforms.ts
+++ b/ui/components/app/perps/utils/transactionTransforms.ts
@@ -591,9 +591,7 @@ export function transformWalletPerpsDepositsToTransactions(
   transactions: TransactionMeta[],
 ): PerpsTransaction[] {
   return transactions
-    .filter(
-      (tx) => WALLET_STATUS_TO_DEPOSIT_STATUS[tx.status] === 'completed',
-    )
+    .filter((tx) => WALLET_STATUS_TO_DEPOSIT_STATUS[tx.status] === 'completed')
     .map((tx) => {
       const tokenTransfer = getTokenTransferData(tx);
       const decoded = tokenTransfer

--- a/ui/components/app/perps/utils/transactionTransforms.ts
+++ b/ui/components/app/perps/utils/transactionTransforms.ts
@@ -601,6 +601,65 @@ export function transformUserHistoryToTransactions(
 }
 
 /**
+ * Shared logic behind `transformWalletPerpsDepositsToTransactions` and
+ * `transformWalletPerpsWithdrawalsToTransactions`: decodes the USDC amount
+ * from the wallet transaction's ERC20-transfer calldata and maps its wallet
+ * status to a Perps deposit/withdrawal row, differing only in sign, title
+ * wording, and the deposit/withdrawal type.
+ *
+ * @param transactions - Array of TransactionMeta already scoped to the
+ * active account and the relevant deposit/withdrawal tx type(s).
+ * @param direction - Whether these are deposit or withdrawal transactions.
+ * @returns Array of PerpsTransaction objects with the given direction's type.
+ */
+function transformWalletPerpsTransactions(
+  transactions: TransactionMeta[],
+  direction: 'deposit' | 'withdrawal',
+): PerpsTransaction[] {
+  const isDeposit = direction === 'deposit';
+  const sign = isDeposit ? '+' : '-';
+  const verb = isDeposit ? 'Deposited' : 'Withdrew';
+  const emptyTitle = isDeposit ? 'Deposit' : 'Withdrawal';
+
+  return transactions.map((tx) => {
+    const tokenTransfer = getTokenTransferData(tx);
+    const decoded = tokenTransfer
+      ? parseStandardTokenTransactionData(tokenTransfer.data)
+      : undefined;
+    const rawAmount = decoded?.args?._value?.toString?.();
+    const amountBN =
+      rawAmount === undefined
+        ? new BigNumber(0)
+        : calcTokenAmount(rawAmount, ARBITRUM_USDC.decimals);
+
+    const displayAmount = `${sign}$${amountBN.toFixed(2)}`;
+    const status = WALLET_TX_STATUS_TO_PERPS_STATUS[tx.status] ?? 'pending';
+    const title = amountBN.isZero()
+      ? emptyTitle
+      : `${verb} ${amountBN.toFixed(2)} ${ARBITRUM_USDC.symbol}`;
+
+    return {
+      id: `wallet-${direction}-${tx.id}`,
+      type: direction,
+      category: direction,
+      title,
+      subtitle: getDepositWithdrawalStatusText(status),
+      timestamp: tx.time ?? 0,
+      symbol: ARBITRUM_USDC.symbol,
+      depositWithdrawal: {
+        amount: displayAmount,
+        amountNumber: isDeposit ? amountBN.toNumber() : -amountBN.toNumber(),
+        isPositive: isDeposit,
+        asset: ARBITRUM_USDC.symbol,
+        txHash: tx.hash ?? '',
+        status,
+        type: direction,
+      },
+    };
+  });
+}
+
+/**
  * Transform wallet-tracked Perps deposit transactions (`perpsDeposit` /
  * `perpsDepositAndOrder`) into `PerpsTransaction` rows.
  *
@@ -625,42 +684,7 @@ export function transformUserHistoryToTransactions(
 export function transformWalletPerpsDepositsToTransactions(
   transactions: TransactionMeta[],
 ): PerpsTransaction[] {
-  return transactions.map((tx) => {
-    const tokenTransfer = getTokenTransferData(tx);
-    const decoded = tokenTransfer
-      ? parseStandardTokenTransactionData(tokenTransfer.data)
-      : undefined;
-    const rawAmount = decoded?.args?._value?.toString?.();
-    const amountBN =
-      rawAmount === undefined
-        ? new BigNumber(0)
-        : calcTokenAmount(rawAmount, ARBITRUM_USDC.decimals);
-
-    const displayAmount = `+$${amountBN.toFixed(2)}`;
-    const status = WALLET_TX_STATUS_TO_PERPS_STATUS[tx.status] ?? 'pending';
-    const title = amountBN.isZero()
-      ? 'Deposit'
-      : `Deposited ${amountBN.toFixed(2)} ${ARBITRUM_USDC.symbol}`;
-
-    return {
-      id: `wallet-deposit-${tx.id}`,
-      type: 'deposit' as const,
-      category: 'deposit' as const,
-      title,
-      subtitle: getDepositWithdrawalStatusText(status),
-      timestamp: tx.time ?? 0,
-      symbol: ARBITRUM_USDC.symbol,
-      depositWithdrawal: {
-        amount: displayAmount,
-        amountNumber: amountBN.toNumber(),
-        isPositive: true,
-        asset: ARBITRUM_USDC.symbol,
-        txHash: tx.hash ?? '',
-        status,
-        type: 'deposit' as const,
-      },
-    };
-  });
+  return transformWalletPerpsTransactions(transactions, 'deposit');
 }
 
 /**
@@ -681,42 +705,7 @@ export function transformWalletPerpsDepositsToTransactions(
 export function transformWalletPerpsWithdrawalsToTransactions(
   transactions: TransactionMeta[],
 ): PerpsTransaction[] {
-  return transactions.map((tx) => {
-    const tokenTransfer = getTokenTransferData(tx);
-    const decoded = tokenTransfer
-      ? parseStandardTokenTransactionData(tokenTransfer.data)
-      : undefined;
-    const rawAmount = decoded?.args?._value?.toString?.();
-    const amountBN =
-      rawAmount === undefined
-        ? new BigNumber(0)
-        : calcTokenAmount(rawAmount, ARBITRUM_USDC.decimals);
-
-    const displayAmount = `-$${amountBN.toFixed(2)}`;
-    const status = WALLET_TX_STATUS_TO_PERPS_STATUS[tx.status] ?? 'pending';
-    const title = amountBN.isZero()
-      ? 'Withdrawal'
-      : `Withdrew ${amountBN.toFixed(2)} ${ARBITRUM_USDC.symbol}`;
-
-    return {
-      id: `wallet-withdrawal-${tx.id}`,
-      type: 'withdrawal' as const,
-      category: 'withdrawal' as const,
-      title,
-      subtitle: getDepositWithdrawalStatusText(status),
-      timestamp: tx.time ?? 0,
-      symbol: ARBITRUM_USDC.symbol,
-      depositWithdrawal: {
-        amount: displayAmount,
-        amountNumber: -amountBN.toNumber(),
-        isPositive: false,
-        asset: ARBITRUM_USDC.symbol,
-        txHash: tx.hash ?? '',
-        status,
-        type: 'withdrawal' as const,
-      },
-    };
-  });
+  return transformWalletPerpsTransactions(transactions, 'withdrawal');
 }
 
 /**

--- a/ui/components/app/perps/utils/transactionTransforms.ts
+++ b/ui/components/app/perps/utils/transactionTransforms.ts
@@ -15,12 +15,20 @@ import type {
   UserHistoryItem,
 } from '@metamask/perps-controller';
 import {
+  TransactionStatus as WalletTransactionStatus,
+  type TransactionMeta,
+} from '@metamask/transaction-controller';
+import {
   FillType,
   PerpsOrderTransactionStatus,
   PerpsOrderTransactionStatusType,
   type PerpsTransaction,
 } from '../types/transactionHistory';
 import { formatPositionSize } from '../../../../../shared/lib/perps-formatters';
+import { parseStandardTokenTransactionData } from '../../../../../shared/lib/transaction.utils';
+import { calcTokenAmount } from '../../../../../shared/lib/transactions-controller-utils';
+import { ARBITRUM_USDC } from '../../../../pages/confirmations/constants/perps';
+import { getTokenTransferData } from '../../../../pages/confirmations/utils/transaction-pay';
 import { getDisplaySymbol } from '../utils';
 import { formatOrderLabel } from './orderUtils';
 
@@ -545,6 +553,115 @@ export function transformUserHistoryToTransactions(
         },
       };
     });
+}
+
+/**
+ * Maps a wallet TransactionController status to the subset of Perps
+ * deposit statuses this transform surfaces. Only `confirmed` resolves to a
+ * status, since the Activity page's deposit/withdrawal row always renders
+ * a "Completed" subtitle regardless of `depositWithdrawal.status` — showing
+ * a pending or failed wallet transaction here would render a misleading
+ * "Completed" label.
+ */
+const WALLET_STATUS_TO_DEPOSIT_STATUS: Partial<
+  Record<WalletTransactionStatus, 'completed'>
+> = {
+  [WalletTransactionStatus.confirmed]: 'completed',
+};
+
+/**
+ * Transform wallet-tracked Perps deposit transactions (`perpsDeposit` /
+ * `perpsDepositAndOrder`) into `PerpsTransaction` rows.
+ *
+ * HyperLiquid's user-history ledger (the primary source `transformUserHistoryToTransactions`
+ * draws from) only reflects a deposit once the bridged funds have actually
+ * landed on HyperLiquid, which can lag behind the wallet's own on-chain
+ * deposit transaction confirming. Without this fallback, a just-completed
+ * deposit can be invisible under the Activity page's Deposits filter for a
+ * while even though the user's Perps balance already reflects it.
+ * `usePerpsTransactionHistory` merges this list with the user-history
+ * deposits and de-duplicates by `txHash`, so once the ledger catches up the
+ * two representations of the same deposit collapse into one.
+ *
+ * @param transactions - Array of TransactionMeta with type `perpsDeposit` or
+ * `perpsDepositAndOrder`, already scoped to the active account.
+ * @returns Array of PerpsTransaction objects with type 'deposit'.
+ */
+export function transformWalletPerpsDepositsToTransactions(
+  transactions: TransactionMeta[],
+): PerpsTransaction[] {
+  return transactions
+    .filter(
+      (tx) => WALLET_STATUS_TO_DEPOSIT_STATUS[tx.status] === 'completed',
+    )
+    .map((tx) => {
+      const tokenTransfer = getTokenTransferData(tx);
+      const decoded = tokenTransfer
+        ? parseStandardTokenTransactionData(tokenTransfer.data)
+        : undefined;
+      const rawAmount = decoded?.args?._value?.toString?.();
+      const amountBN =
+        rawAmount === undefined
+          ? new BigNumber(0)
+          : calcTokenAmount(rawAmount, ARBITRUM_USDC.decimals);
+
+      const displayAmount = `+$${amountBN.toFixed(2)}`;
+      const title = amountBN.isZero()
+        ? 'Deposit'
+        : `Deposited ${amountBN.toFixed(2)} ${ARBITRUM_USDC.symbol}`;
+
+      return {
+        id: `wallet-deposit-${tx.id}`,
+        type: 'deposit' as const,
+        category: 'deposit' as const,
+        title,
+        subtitle: 'Completed',
+        timestamp: tx.time ?? 0,
+        symbol: ARBITRUM_USDC.symbol,
+        depositWithdrawal: {
+          amount: displayAmount,
+          amountNumber: amountBN.toNumber(),
+          isPositive: true,
+          asset: ARBITRUM_USDC.symbol,
+          txHash: tx.hash ?? '',
+          status: 'completed' as const,
+          type: 'deposit' as const,
+        },
+      };
+    });
+}
+
+/**
+ * Filters out wallet-sourced deposit transactions whose `txHash` already
+ * appears among `existingDeposits` (typically the user-history deposits
+ * already present in the merged transaction list).
+ *
+ * Used by `usePerpsTransactionHistory` to avoid showing the same deposit
+ * twice once HyperLiquid's user-history ledger catches up with a deposit
+ * that was initially only visible via the wallet's own transaction record.
+ *
+ * @param walletDeposits - Deposit transactions sourced from the wallet's
+ * TransactionController (see `transformWalletPerpsDepositsToTransactions`).
+ * @param existingDeposits - Deposit transactions already present in the
+ * merged list (e.g. from user history) to de-duplicate against.
+ * @returns The subset of `walletDeposits` not already represented.
+ */
+export function dedupeWalletDepositsByTxHash(
+  walletDeposits: PerpsTransaction[],
+  existingDeposits: PerpsTransaction[],
+): PerpsTransaction[] {
+  const existingTxHashes = new Set<string>();
+  for (const tx of existingDeposits) {
+    const txHash = tx.depositWithdrawal?.txHash?.toLowerCase();
+    if (tx.type === 'deposit' && txHash) {
+      existingTxHashes.add(txHash);
+    }
+  }
+
+  return walletDeposits.filter((tx) => {
+    const txHash = tx.depositWithdrawal?.txHash?.toLowerCase();
+    return !txHash || !existingTxHashes.has(txHash);
+  });
 }
 
 /**

--- a/ui/hooks/perps/usePerpsTransactionHistory.test.ts
+++ b/ui/hooks/perps/usePerpsTransactionHistory.test.ts
@@ -84,11 +84,22 @@ jest.mock('./useWalletPerpsDepositTransactions', () => ({
     mockUseWalletPerpsDepositTransactions(),
 }));
 
+const mockUseWalletPerpsWithdrawalTransactions = jest.fn().mockReturnValue([]);
+
+// Mock useWalletPerpsWithdrawalTransactions — same rationale as the deposit
+// hook mock above. Individual tests can override the return value to
+// exercise the wallet-withdrawal merge/dedup behavior.
+jest.mock('./useWalletPerpsWithdrawalTransactions', () => ({
+  useWalletPerpsWithdrawalTransactions: () =>
+    mockUseWalletPerpsWithdrawalTransactions(),
+}));
+
 describe('usePerpsTransactionHistory', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     resetCoalesceCacheForTests();
     mockUseWalletPerpsDepositTransactions.mockReturnValue([]);
+    mockUseWalletPerpsWithdrawalTransactions.mockReturnValue([]);
     // Default: return appropriate data per method
     mockSubmitRequestToBackground.mockImplementation((method: string) => {
       if (method === 'perpsGetOrderFills') {
@@ -372,6 +383,145 @@ describe('usePerpsTransactionHistory', () => {
       });
 
       expect(result.current.transactions[0].id).toBe('wallet-deposit-tx-1');
+    });
+  });
+
+  describe('wallet-sourced withdrawals', () => {
+    it('includes a wallet withdrawal not yet reflected in user history', async () => {
+      mockUseWalletPerpsWithdrawalTransactions.mockReturnValue([
+        {
+          id: 'wallet-withdrawal-tx-1',
+          type: 'withdrawal',
+          category: 'withdrawal',
+          title: 'Withdrew 50.00 USDC',
+          subtitle: 'Pending',
+          timestamp: Date.now(),
+          symbol: 'USDC',
+          depositWithdrawal: {
+            amount: '-$50.00',
+            amountNumber: -50,
+            isPositive: false,
+            asset: 'USDC',
+            txHash: '0xdef',
+            status: 'pending',
+            type: 'withdrawal',
+          },
+        },
+      ]);
+
+      const { result } = renderHook(() =>
+        usePerpsTransactionHistory({ skipInitialFetch: true }),
+      );
+
+      await act(async () => {
+        await result.current.refetch();
+      });
+
+      expect(
+        result.current.transactions.some(
+          (tx) => tx.id === 'wallet-withdrawal-tx-1',
+        ),
+      ).toBe(true);
+    });
+
+    it('sorts a wallet withdrawal into the merged, timestamp-descending list', async () => {
+      const newestTimestamp = Date.now() + 10_000;
+      mockUseWalletPerpsWithdrawalTransactions.mockReturnValue([
+        {
+          id: 'wallet-withdrawal-tx-1',
+          type: 'withdrawal',
+          category: 'withdrawal',
+          title: 'Withdrew 50.00 USDC',
+          subtitle: 'Completed',
+          timestamp: newestTimestamp,
+          symbol: 'USDC',
+          depositWithdrawal: {
+            amount: '-$50.00',
+            amountNumber: -50,
+            isPositive: false,
+            asset: 'USDC',
+            txHash: '0xdef',
+            status: 'completed',
+            type: 'withdrawal',
+          },
+        },
+      ]);
+
+      const { result } = renderHook(() =>
+        usePerpsTransactionHistory({ skipInitialFetch: true }),
+      );
+
+      await act(async () => {
+        await result.current.refetch();
+      });
+
+      expect(result.current.transactions[0].id).toBe(
+        'wallet-withdrawal-tx-1',
+      );
+    });
+
+    it('merges wallet deposits and withdrawals together without cross-deduping', async () => {
+      mockUseWalletPerpsDepositTransactions.mockReturnValue([
+        {
+          id: 'wallet-deposit-tx-3',
+          type: 'deposit',
+          category: 'deposit',
+          title: 'Deposited 100.00 USDC',
+          subtitle: 'Completed',
+          timestamp: Date.now(),
+          symbol: 'USDC',
+          depositWithdrawal: {
+            amount: '+$100.00',
+            amountNumber: 100,
+            isPositive: true,
+            asset: 'USDC',
+            txHash: '0xaaa',
+            status: 'completed',
+            type: 'deposit',
+          },
+        },
+      ]);
+      mockUseWalletPerpsWithdrawalTransactions.mockReturnValue([
+        {
+          id: 'wallet-withdrawal-tx-3',
+          type: 'withdrawal',
+          category: 'withdrawal',
+          title: 'Withdrew 50.00 USDC',
+          subtitle: 'Completed',
+          timestamp: Date.now(),
+          symbol: 'USDC',
+          depositWithdrawal: {
+            amount: '-$50.00',
+            amountNumber: -50,
+            isPositive: false,
+            asset: 'USDC',
+            // Same txHash as the deposit above — must not be deduped since
+            // dedupe is scoped per transaction type.
+            txHash: '0xaaa',
+            status: 'completed',
+            type: 'withdrawal',
+          },
+        },
+      ]);
+
+      const { result } = renderHook(() =>
+        usePerpsTransactionHistory({ skipInitialFetch: true }),
+      );
+
+      await act(async () => {
+        await result.current.refetch();
+      });
+
+      expect(
+        result.current.transactions.some(
+          (tx) => tx.id === 'wallet-deposit-tx-3',
+        ),
+      ).toBe(true);
+      expect(
+        result.current.transactions.some(
+          (tx) => tx.id === 'wallet-withdrawal-tx-3',
+        ),
+      ).toBe(true);
     });
   });
 });

--- a/ui/hooks/perps/usePerpsTransactionHistory.test.ts
+++ b/ui/hooks/perps/usePerpsTransactionHistory.test.ts
@@ -74,10 +74,21 @@ jest.mock('./stream/usePerpsLiveFills', () => ({
   }),
 }));
 
+const mockUseWalletPerpsDepositTransactions = jest.fn().mockReturnValue([]);
+
+// Mock useWalletPerpsDepositTransactions — depends on redux state, which
+// these tests don't provide a Provider for. Individual tests can override
+// the return value to exercise the wallet-deposit merge/dedup behavior.
+jest.mock('./useWalletPerpsDepositTransactions', () => ({
+  useWalletPerpsDepositTransactions: () =>
+    mockUseWalletPerpsDepositTransactions(),
+}));
+
 describe('usePerpsTransactionHistory', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     resetCoalesceCacheForTests();
+    mockUseWalletPerpsDepositTransactions.mockReturnValue([]);
     // Default: return appropriate data per method
     mockSubmitRequestToBackground.mockImplementation((method: string) => {
       if (method === 'perpsGetOrderFills') {
@@ -289,5 +300,78 @@ describe('usePerpsTransactionHistory', () => {
     const ids = result.current.transactions.map((tx) => tx.id);
     const uniqueIds = [...new Set(ids)];
     expect(ids.length).toBe(uniqueIds.length);
+  });
+
+  describe('wallet-sourced deposits', () => {
+    it('includes a wallet deposit not yet reflected in user history', async () => {
+      mockUseWalletPerpsDepositTransactions.mockReturnValue([
+        {
+          id: 'wallet-deposit-tx-1',
+          type: 'deposit',
+          category: 'deposit',
+          title: 'Deposited 100.00 USDC',
+          subtitle: 'Completed',
+          timestamp: Date.now(),
+          symbol: 'USDC',
+          depositWithdrawal: {
+            amount: '+$100.00',
+            amountNumber: 100,
+            isPositive: true,
+            asset: 'USDC',
+            txHash: '0xabc',
+            status: 'completed',
+            type: 'deposit',
+          },
+        },
+      ]);
+
+      const { result } = renderHook(() =>
+        usePerpsTransactionHistory({ skipInitialFetch: true }),
+      );
+
+      await act(async () => {
+        await result.current.refetch();
+      });
+
+      expect(
+        result.current.transactions.some(
+          (tx) => tx.id === 'wallet-deposit-tx-1',
+        ),
+      ).toBe(true);
+    });
+
+    it('sorts a wallet deposit into the merged, timestamp-descending list', async () => {
+      const newestTimestamp = Date.now() + 10_000;
+      mockUseWalletPerpsDepositTransactions.mockReturnValue([
+        {
+          id: 'wallet-deposit-tx-1',
+          type: 'deposit',
+          category: 'deposit',
+          title: 'Deposited 100.00 USDC',
+          subtitle: 'Completed',
+          timestamp: newestTimestamp,
+          symbol: 'USDC',
+          depositWithdrawal: {
+            amount: '+$100.00',
+            amountNumber: 100,
+            isPositive: true,
+            asset: 'USDC',
+            txHash: '0xabc',
+            status: 'completed',
+            type: 'deposit',
+          },
+        },
+      ]);
+
+      const { result } = renderHook(() =>
+        usePerpsTransactionHistory({ skipInitialFetch: true }),
+      );
+
+      await act(async () => {
+        await result.current.refetch();
+      });
+
+      expect(result.current.transactions[0].id).toBe('wallet-deposit-tx-1');
+    });
   });
 });

--- a/ui/hooks/perps/usePerpsTransactionHistory.test.ts
+++ b/ui/hooks/perps/usePerpsTransactionHistory.test.ts
@@ -455,9 +455,7 @@ describe('usePerpsTransactionHistory', () => {
         await result.current.refetch();
       });
 
-      expect(result.current.transactions[0].id).toBe(
-        'wallet-withdrawal-tx-1',
-      );
+      expect(result.current.transactions[0].id).toBe('wallet-withdrawal-tx-1');
     });
 
     it('merges wallet deposits and withdrawals together without cross-deduping', async () => {

--- a/ui/hooks/perps/usePerpsTransactionHistory.ts
+++ b/ui/hooks/perps/usePerpsTransactionHistory.ts
@@ -6,7 +6,7 @@ import {
   transformOrdersToTransactions,
   transformFundingToTransactions,
   transformUserHistoryToTransactions,
-  dedupeWalletDepositsByTxHash,
+  dedupeWalletTransactionsByTxHash,
 } from '../../components/app/perps/utils/transactionTransforms';
 import type {
   Order,
@@ -22,6 +22,7 @@ import {
 } from './coalesceBackgroundRequest';
 import { usePerpsCacheKey } from './usePerpsCacheKey';
 import { useWalletPerpsDepositTransactions } from './useWalletPerpsDepositTransactions';
+import { useWalletPerpsWithdrawalTransactions } from './useWalletPerpsWithdrawalTransactions';
 
 /**
  * Parameters for the usePerpsTransactionHistory hook
@@ -143,11 +144,13 @@ export function usePerpsTransactionHistory({
   // This ensures new trades appear immediately without waiting for REST refetch
   const { fills: liveFills } = usePerpsLiveFills({ throttleMs: 0 });
 
-  // Wallet-tracked deposits (perpsDeposit / perpsDepositAndOrder), used as a
-  // fallback so a just-completed deposit is visible immediately even before
-  // HyperLiquid's user-history ledger reflects it. De-duplicated against
-  // userHistoryTransactions by txHash below.
+  // Wallet-tracked deposits/withdrawals (perpsDeposit / perpsDepositAndOrder /
+  // perpsWithdraw), used as a fallback so a just-completed deposit or
+  // withdrawal is visible immediately even before HyperLiquid's user-history
+  // ledger reflects it. De-duplicated against userHistoryTransactions by
+  // txHash below.
   const walletDepositTransactions = useWalletPerpsDepositTransactions();
+  const walletWithdrawalTransactions = useWalletPerpsWithdrawalTransactions();
 
   // Store userHistory in ref to avoid recreating fetchAllTransactions callback
   const userHistoryRef = useRef(userHistory);
@@ -333,12 +336,14 @@ export function usePerpsTransactionHistory({
     // Note: transformFillsToTransactions now aggregates split stop loss/TP fills
     const liveTransactions = transformFillsToTransactions(liveFills);
 
-    // If no REST transactions yet, return live fills plus wallet deposits
-    // (deduped against nothing, since there's no user-history yet)
+    // If no REST transactions yet, return live fills plus wallet
+    // deposits/withdrawals (deduped against nothing, since there's no
+    // user-history yet)
     if (transactions.length === 0) {
       const allTransactions = [
         ...liveTransactions,
-        ...dedupeWalletDepositsByTxHash(walletDepositTransactions, []),
+        ...dedupeWalletTransactionsByTxHash(walletDepositTransactions, []),
+        ...dedupeWalletTransactionsByTxHash(walletWithdrawalTransactions, []),
       ];
       return allTransactions.sort((a, b) => b.timestamp - a.timestamp);
     }
@@ -373,19 +378,28 @@ export function usePerpsTransactionHistory({
     }
 
     // Combine deduplicated trades with non-trade transactions and any
-    // wallet-sourced deposits not yet reflected in user history
+    // wallet-sourced deposits/withdrawals not yet reflected in user history
     const allTransactions = [
       ...Array.from(tradeMap.values()),
       ...nonTradeTransactions,
-      ...dedupeWalletDepositsByTxHash(
+      ...dedupeWalletTransactionsByTxHash(
         walletDepositTransactions,
+        nonTradeTransactions,
+      ),
+      ...dedupeWalletTransactionsByTxHash(
+        walletWithdrawalTransactions,
         nonTradeTransactions,
       ),
     ];
 
     // Sort by timestamp descending
     return allTransactions.sort((a, b) => b.timestamp - a.timestamp);
-  }, [liveFills, transactions, walletDepositTransactions]);
+  }, [
+    liveFills,
+    transactions,
+    walletDepositTransactions,
+    walletWithdrawalTransactions,
+  ]);
 
   return {
     transactions: mergedTransactions,

--- a/ui/hooks/perps/usePerpsTransactionHistory.ts
+++ b/ui/hooks/perps/usePerpsTransactionHistory.ts
@@ -6,6 +6,7 @@ import {
   transformOrdersToTransactions,
   transformFundingToTransactions,
   transformUserHistoryToTransactions,
+  dedupeWalletDepositsByTxHash,
 } from '../../components/app/perps/utils/transactionTransforms';
 import type {
   Order,
@@ -20,6 +21,7 @@ import {
   invalidateCoalescedRequest,
 } from './coalesceBackgroundRequest';
 import { usePerpsCacheKey } from './usePerpsCacheKey';
+import { useWalletPerpsDepositTransactions } from './useWalletPerpsDepositTransactions';
 
 /**
  * Parameters for the usePerpsTransactionHistory hook
@@ -140,6 +142,12 @@ export function usePerpsTransactionHistory({
   // Subscribe to live WebSocket fills for instant trade updates
   // This ensures new trades appear immediately without waiting for REST refetch
   const { fills: liveFills } = usePerpsLiveFills({ throttleMs: 0 });
+
+  // Wallet-tracked deposits (perpsDeposit / perpsDepositAndOrder), used as a
+  // fallback so a just-completed deposit is visible immediately even before
+  // HyperLiquid's user-history ledger reflects it. De-duplicated against
+  // userHistoryTransactions by txHash below.
+  const walletDepositTransactions = useWalletPerpsDepositTransactions();
 
   // Store userHistory in ref to avoid recreating fetchAllTransactions callback
   const userHistoryRef = useRef(userHistory);
@@ -325,9 +333,14 @@ export function usePerpsTransactionHistory({
     // Note: transformFillsToTransactions now aggregates split stop loss/TP fills
     const liveTransactions = transformFillsToTransactions(liveFills);
 
-    // If no REST transactions yet, return only live fills
+    // If no REST transactions yet, return live fills plus wallet deposits
+    // (deduped against nothing, since there's no user-history yet)
     if (transactions.length === 0) {
-      return liveTransactions;
+      const allTransactions = [
+        ...liveTransactions,
+        ...dedupeWalletDepositsByTxHash(walletDepositTransactions, []),
+      ];
+      return allTransactions.sort((a, b) => b.timestamp - a.timestamp);
     }
 
     // Separate trade transactions from non-trade transactions (orders, funding, deposits)
@@ -359,15 +372,20 @@ export function usePerpsTransactionHistory({
       tradeMap.set(dedupKey, tx);
     }
 
-    // Combine deduplicated trades with non-trade transactions
+    // Combine deduplicated trades with non-trade transactions and any
+    // wallet-sourced deposits not yet reflected in user history
     const allTransactions = [
       ...Array.from(tradeMap.values()),
       ...nonTradeTransactions,
+      ...dedupeWalletDepositsByTxHash(
+        walletDepositTransactions,
+        nonTradeTransactions,
+      ),
     ];
 
     // Sort by timestamp descending
     return allTransactions.sort((a, b) => b.timestamp - a.timestamp);
-  }, [liveFills, transactions]);
+  }, [liveFills, transactions, walletDepositTransactions]);
 
   return {
     transactions: mergedTransactions,

--- a/ui/hooks/perps/useWalletPerpsDepositTransactions.test.ts
+++ b/ui/hooks/perps/useWalletPerpsDepositTransactions.test.ts
@@ -1,0 +1,129 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { TransactionStatus, TransactionType } from '@metamask/transaction-controller';
+import type { TransactionMeta } from '@metamask/transaction-controller';
+import { getSelectedInternalAccount } from '../../../shared/lib/selectors/accounts';
+import { useWalletPerpsDepositTransactions } from './useWalletPerpsDepositTransactions';
+
+const mockUseSelector = jest.fn();
+jest.mock('react-redux', () => ({
+  useSelector: (selector: unknown) => mockUseSelector(selector),
+}));
+
+const SELECTED_ADDRESS = '0x1234567890123456789012345678901234567890';
+
+const createMockTx = (
+  overrides: Partial<TransactionMeta> = {},
+): TransactionMeta =>
+  ({
+    id: 'tx-1',
+    chainId: '0xa4b1',
+    time: Date.now(),
+    status: TransactionStatus.confirmed,
+    type: TransactionType.perpsDeposit,
+    hash: '0xabc',
+    txParams: {
+      from: SELECTED_ADDRESS,
+      to: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+      data: '0x',
+    },
+    ...overrides,
+  }) as TransactionMeta;
+
+function setSelectors({
+  transactions = [],
+  address = SELECTED_ADDRESS,
+}: {
+  transactions?: TransactionMeta[];
+  address?: string | undefined;
+} = {}) {
+  mockUseSelector.mockImplementation((selector: unknown) => {
+    if (selector === getSelectedInternalAccount) {
+      return address ? { address } : undefined;
+    }
+    // useWalletPerpsDepositTransactions calls useSelector with an inline
+    // arrow that internally invokes selectTransactions(state) — simulate
+    // that by invoking the passed selector against a fake state.
+    return (selector as (state: unknown) => unknown)({
+      metamask: { transactions },
+    });
+  });
+}
+
+describe('useWalletPerpsDepositTransactions', () => {
+  beforeEach(() => {
+    mockUseSelector.mockReset();
+  });
+
+  it('returns an empty array when no account is selected', () => {
+    setSelectors({ transactions: [createMockTx()], address: '' });
+
+    const { result } = renderHook(() => useWalletPerpsDepositTransactions());
+
+    expect(result.current).toEqual([]);
+  });
+
+  it('returns a PerpsTransaction for a confirmed perpsDeposit from the selected account', () => {
+    setSelectors({ transactions: [createMockTx()] });
+
+    const { result } = renderHook(() => useWalletPerpsDepositTransactions());
+
+    expect(result.current).toHaveLength(1);
+    expect(result.current[0].type).toBe('deposit');
+  });
+
+  it('includes perpsDepositAndOrder transactions', () => {
+    setSelectors({
+      transactions: [createMockTx({ type: TransactionType.perpsDepositAndOrder })],
+    });
+
+    const { result } = renderHook(() => useWalletPerpsDepositTransactions());
+
+    expect(result.current).toHaveLength(1);
+  });
+
+  it('excludes transactions from other accounts', () => {
+    setSelectors({
+      transactions: [
+        createMockTx({
+          txParams: {
+            from: '0x9999999999999999999999999999999999999999',
+            to: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+            data: '0x',
+          },
+        }),
+      ],
+    });
+
+    const { result } = renderHook(() => useWalletPerpsDepositTransactions());
+
+    expect(result.current).toHaveLength(0);
+  });
+
+  it('matches the selected account case-insensitively', () => {
+    setSelectors({
+      transactions: [
+        createMockTx({
+          txParams: {
+            from: SELECTED_ADDRESS.toUpperCase(),
+            to: '0xaf88d065e77c8cC2239327C5EDb3A432268e5831',
+            data: '0x',
+          },
+        }),
+      ],
+    });
+
+    const { result } = renderHook(() => useWalletPerpsDepositTransactions());
+
+    expect(result.current).toHaveLength(1);
+  });
+
+  it('excludes unrelated transaction types (e.g. simple sends)', () => {
+    setSelectors({
+      transactions: [createMockTx({ type: TransactionType.simpleSend })],
+    });
+
+    const { result } = renderHook(() => useWalletPerpsDepositTransactions());
+
+    expect(result.current).toHaveLength(0);
+  });
+});

--- a/ui/hooks/perps/useWalletPerpsDepositTransactions.test.ts
+++ b/ui/hooks/perps/useWalletPerpsDepositTransactions.test.ts
@@ -1,5 +1,8 @@
 import { renderHook } from '@testing-library/react-hooks';
-import { TransactionStatus, TransactionType } from '@metamask/transaction-controller';
+import {
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/transaction-controller';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import { getSelectedInternalAccount } from '../../../shared/lib/selectors/accounts';
 import { useWalletPerpsDepositTransactions } from './useWalletPerpsDepositTransactions';
@@ -73,7 +76,9 @@ describe('useWalletPerpsDepositTransactions', () => {
 
   it('includes perpsDepositAndOrder transactions', () => {
     setSelectors({
-      transactions: [createMockTx({ type: TransactionType.perpsDepositAndOrder })],
+      transactions: [
+        createMockTx({ type: TransactionType.perpsDepositAndOrder }),
+      ],
     });
 
     const { result } = renderHook(() => useWalletPerpsDepositTransactions());

--- a/ui/hooks/perps/useWalletPerpsDepositTransactions.test.ts
+++ b/ui/hooks/perps/useWalletPerpsDepositTransactions.test.ts
@@ -88,9 +88,7 @@ describe('useWalletPerpsDepositTransactions', () => {
 
   it('includes a submitted perpsDeposit transaction with a pending status', () => {
     setSelectors({
-      transactions: [
-        createMockTx({ status: TransactionStatus.submitted }),
-      ],
+      transactions: [createMockTx({ status: TransactionStatus.submitted })],
     });
 
     const { result } = renderHook(() => useWalletPerpsDepositTransactions());

--- a/ui/hooks/perps/useWalletPerpsDepositTransactions.ts
+++ b/ui/hooks/perps/useWalletPerpsDepositTransactions.ts
@@ -1,0 +1,47 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { TransactionType } from '@metamask/transaction-controller';
+import { getSelectedInternalAccount } from '../../../shared/lib/selectors/accounts';
+import { isEqualCaseInsensitive } from '../../../shared/lib/string-utils';
+import { hasTransactionType } from '../../../shared/lib/transactions.utils';
+import {
+  selectTransactions,
+  type TransactionState,
+} from '../../selectors/transactionController';
+import { transformWalletPerpsDepositsToTransactions } from '../../components/app/perps/utils/transactionTransforms';
+import type { PerpsTransaction } from '../../components/app/perps/types';
+
+const PERPS_DEPOSIT_TRANSACTION_TYPES = [
+  TransactionType.perpsDeposit,
+  TransactionType.perpsDepositAndOrder,
+];
+
+/**
+ * Surfaces the active account's Perps deposit transactions tracked locally
+ * by the TransactionController, transformed into `PerpsTransaction` rows.
+ *
+ * See `transformWalletPerpsDepositsToTransactions` for why this fallback is
+ * needed: HyperLiquid's user-history ledger can lag behind the wallet's own
+ * on-chain deposit confirmation.
+ */
+export function useWalletPerpsDepositTransactions(): PerpsTransaction[] {
+  const transactions = useSelector((state: TransactionState) =>
+    selectTransactions(state),
+  );
+  const selectedAccount = useSelector(getSelectedInternalAccount);
+  const selectedAddress = selectedAccount?.address;
+
+  return useMemo(() => {
+    if (!selectedAddress) {
+      return [];
+    }
+
+    const depositTransactions = transactions.filter(
+      (tx) =>
+        hasTransactionType(tx, PERPS_DEPOSIT_TRANSACTION_TYPES) &&
+        isEqualCaseInsensitive(tx.txParams?.from ?? '', selectedAddress),
+    );
+
+    return transformWalletPerpsDepositsToTransactions(depositTransactions);
+  }, [transactions, selectedAddress]);
+}

--- a/ui/hooks/perps/useWalletPerpsWithdrawalTransactions.test.ts
+++ b/ui/hooks/perps/useWalletPerpsWithdrawalTransactions.test.ts
@@ -5,7 +5,7 @@ import {
 } from '@metamask/transaction-controller';
 import type { TransactionMeta } from '@metamask/transaction-controller';
 import { getSelectedInternalAccount } from '../../../shared/lib/selectors/accounts';
-import { useWalletPerpsDepositTransactions } from './useWalletPerpsDepositTransactions';
+import { useWalletPerpsWithdrawalTransactions } from './useWalletPerpsWithdrawalTransactions';
 
 const mockUseSelector = jest.fn();
 jest.mock('react-redux', () => ({
@@ -22,7 +22,7 @@ const createMockTx = (
     chainId: '0xa4b1',
     time: Date.now(),
     status: TransactionStatus.confirmed,
-    type: TransactionType.perpsDeposit,
+    type: TransactionType.perpsWithdraw,
     hash: '0xabc',
     txParams: {
       from: SELECTED_ADDRESS,
@@ -43,7 +43,7 @@ function setSelectors({
     if (selector === getSelectedInternalAccount) {
       return address ? { address } : undefined;
     }
-    // useWalletPerpsDepositTransactions calls useSelector with an inline
+    // useWalletPerpsWithdrawalTransactions calls useSelector with an inline
     // arrow that internally invokes selectTransactions(state) — simulate
     // that by invoking the passed selector against a fake state.
     return (selector as (state: unknown) => unknown)({
@@ -52,7 +52,7 @@ function setSelectors({
   });
 }
 
-describe('useWalletPerpsDepositTransactions', () => {
+describe('useWalletPerpsWithdrawalTransactions', () => {
   beforeEach(() => {
     mockUseSelector.mockReset();
   });
@@ -60,40 +60,34 @@ describe('useWalletPerpsDepositTransactions', () => {
   it('returns an empty array when no account is selected', () => {
     setSelectors({ transactions: [createMockTx()], address: '' });
 
-    const { result } = renderHook(() => useWalletPerpsDepositTransactions());
+    const { result } = renderHook(() =>
+      useWalletPerpsWithdrawalTransactions(),
+    );
 
     expect(result.current).toEqual([]);
   });
 
-  it('returns a PerpsTransaction for a confirmed perpsDeposit from the selected account', () => {
+  it('returns a PerpsTransaction for a confirmed perpsWithdraw from the selected account', () => {
     setSelectors({ transactions: [createMockTx()] });
 
-    const { result } = renderHook(() => useWalletPerpsDepositTransactions());
+    const { result } = renderHook(() =>
+      useWalletPerpsWithdrawalTransactions(),
+    );
 
     expect(result.current).toHaveLength(1);
-    expect(result.current[0].type).toBe('deposit');
+    expect(result.current[0].type).toBe('withdrawal');
   });
 
-  it('includes perpsDepositAndOrder transactions', () => {
-    setSelectors({
-      transactions: [
-        createMockTx({ type: TransactionType.perpsDepositAndOrder }),
-      ],
-    });
-
-    const { result } = renderHook(() => useWalletPerpsDepositTransactions());
-
-    expect(result.current).toHaveLength(1);
-  });
-
-  it('includes a submitted perpsDeposit transaction with a pending status', () => {
+  it('includes a submitted perpsWithdraw transaction with a pending status', () => {
     setSelectors({
       transactions: [
         createMockTx({ status: TransactionStatus.submitted }),
       ],
     });
 
-    const { result } = renderHook(() => useWalletPerpsDepositTransactions());
+    const { result } = renderHook(() =>
+      useWalletPerpsWithdrawalTransactions(),
+    );
 
     expect(result.current).toHaveLength(1);
     expect(result.current[0].depositWithdrawal?.status).toBe('pending');
@@ -112,7 +106,9 @@ describe('useWalletPerpsDepositTransactions', () => {
       ],
     });
 
-    const { result } = renderHook(() => useWalletPerpsDepositTransactions());
+    const { result } = renderHook(() =>
+      useWalletPerpsWithdrawalTransactions(),
+    );
 
     expect(result.current).toHaveLength(0);
   });
@@ -130,7 +126,9 @@ describe('useWalletPerpsDepositTransactions', () => {
       ],
     });
 
-    const { result } = renderHook(() => useWalletPerpsDepositTransactions());
+    const { result } = renderHook(() =>
+      useWalletPerpsWithdrawalTransactions(),
+    );
 
     expect(result.current).toHaveLength(1);
   });
@@ -140,7 +138,21 @@ describe('useWalletPerpsDepositTransactions', () => {
       transactions: [createMockTx({ type: TransactionType.simpleSend })],
     });
 
-    const { result } = renderHook(() => useWalletPerpsDepositTransactions());
+    const { result } = renderHook(() =>
+      useWalletPerpsWithdrawalTransactions(),
+    );
+
+    expect(result.current).toHaveLength(0);
+  });
+
+  it('excludes wallet deposit transactions', () => {
+    setSelectors({
+      transactions: [createMockTx({ type: TransactionType.perpsDeposit })],
+    });
+
+    const { result } = renderHook(() =>
+      useWalletPerpsWithdrawalTransactions(),
+    );
 
     expect(result.current).toHaveLength(0);
   });

--- a/ui/hooks/perps/useWalletPerpsWithdrawalTransactions.test.ts
+++ b/ui/hooks/perps/useWalletPerpsWithdrawalTransactions.test.ts
@@ -60,9 +60,7 @@ describe('useWalletPerpsWithdrawalTransactions', () => {
   it('returns an empty array when no account is selected', () => {
     setSelectors({ transactions: [createMockTx()], address: '' });
 
-    const { result } = renderHook(() =>
-      useWalletPerpsWithdrawalTransactions(),
-    );
+    const { result } = renderHook(() => useWalletPerpsWithdrawalTransactions());
 
     expect(result.current).toEqual([]);
   });
@@ -70,9 +68,7 @@ describe('useWalletPerpsWithdrawalTransactions', () => {
   it('returns a PerpsTransaction for a confirmed perpsWithdraw from the selected account', () => {
     setSelectors({ transactions: [createMockTx()] });
 
-    const { result } = renderHook(() =>
-      useWalletPerpsWithdrawalTransactions(),
-    );
+    const { result } = renderHook(() => useWalletPerpsWithdrawalTransactions());
 
     expect(result.current).toHaveLength(1);
     expect(result.current[0].type).toBe('withdrawal');
@@ -80,14 +76,10 @@ describe('useWalletPerpsWithdrawalTransactions', () => {
 
   it('includes a submitted perpsWithdraw transaction with a pending status', () => {
     setSelectors({
-      transactions: [
-        createMockTx({ status: TransactionStatus.submitted }),
-      ],
+      transactions: [createMockTx({ status: TransactionStatus.submitted })],
     });
 
-    const { result } = renderHook(() =>
-      useWalletPerpsWithdrawalTransactions(),
-    );
+    const { result } = renderHook(() => useWalletPerpsWithdrawalTransactions());
 
     expect(result.current).toHaveLength(1);
     expect(result.current[0].depositWithdrawal?.status).toBe('pending');
@@ -106,9 +98,7 @@ describe('useWalletPerpsWithdrawalTransactions', () => {
       ],
     });
 
-    const { result } = renderHook(() =>
-      useWalletPerpsWithdrawalTransactions(),
-    );
+    const { result } = renderHook(() => useWalletPerpsWithdrawalTransactions());
 
     expect(result.current).toHaveLength(0);
   });
@@ -126,9 +116,7 @@ describe('useWalletPerpsWithdrawalTransactions', () => {
       ],
     });
 
-    const { result } = renderHook(() =>
-      useWalletPerpsWithdrawalTransactions(),
-    );
+    const { result } = renderHook(() => useWalletPerpsWithdrawalTransactions());
 
     expect(result.current).toHaveLength(1);
   });
@@ -138,9 +126,7 @@ describe('useWalletPerpsWithdrawalTransactions', () => {
       transactions: [createMockTx({ type: TransactionType.simpleSend })],
     });
 
-    const { result } = renderHook(() =>
-      useWalletPerpsWithdrawalTransactions(),
-    );
+    const { result } = renderHook(() => useWalletPerpsWithdrawalTransactions());
 
     expect(result.current).toHaveLength(0);
   });
@@ -150,9 +136,7 @@ describe('useWalletPerpsWithdrawalTransactions', () => {
       transactions: [createMockTx({ type: TransactionType.perpsDeposit })],
     });
 
-    const { result } = renderHook(() =>
-      useWalletPerpsWithdrawalTransactions(),
-    );
+    const { result } = renderHook(() => useWalletPerpsWithdrawalTransactions());
 
     expect(result.current).toHaveLength(0);
   });

--- a/ui/hooks/perps/useWalletPerpsWithdrawalTransactions.ts
+++ b/ui/hooks/perps/useWalletPerpsWithdrawalTransactions.ts
@@ -1,0 +1,47 @@
+import { useMemo } from 'react';
+import { useSelector } from 'react-redux';
+import { TransactionType } from '@metamask/transaction-controller';
+import { getSelectedInternalAccount } from '../../../shared/lib/selectors/accounts';
+import { isEqualCaseInsensitive } from '../../../shared/lib/string-utils';
+import { hasTransactionType } from '../../../shared/lib/transactions.utils';
+import {
+  selectTransactions,
+  type TransactionState,
+} from '../../selectors/transactionController';
+import { transformWalletPerpsWithdrawalsToTransactions } from '../../components/app/perps/utils/transactionTransforms';
+import type { PerpsTransaction } from '../../components/app/perps/types';
+
+const PERPS_WITHDRAWAL_TRANSACTION_TYPES = [TransactionType.perpsWithdraw];
+
+/**
+ * Surfaces the active account's Perps withdrawal transactions tracked
+ * locally by the TransactionController, transformed into `PerpsTransaction`
+ * rows.
+ *
+ * See `transformWalletPerpsWithdrawalsToTransactions` for why this fallback
+ * is needed: HyperLiquid's user-history ledger can lag behind the wallet's
+ * own on-chain withdrawal confirmation.
+ */
+export function useWalletPerpsWithdrawalTransactions(): PerpsTransaction[] {
+  const transactions = useSelector((state: TransactionState) =>
+    selectTransactions(state),
+  );
+  const selectedAccount = useSelector(getSelectedInternalAccount);
+  const selectedAddress = selectedAccount?.address;
+
+  return useMemo(() => {
+    if (!selectedAddress) {
+      return [];
+    }
+
+    const withdrawalTransactions = transactions.filter(
+      (tx) =>
+        hasTransactionType(tx, PERPS_WITHDRAWAL_TRANSACTION_TYPES) &&
+        isEqualCaseInsensitive(tx.txParams?.from ?? '', selectedAddress),
+    );
+
+    return transformWalletPerpsWithdrawalsToTransactions(
+      withdrawalTransactions,
+    );
+  }, [transactions, selectedAddress]);
+}

--- a/ui/pages/perps/perps-activity-page.test.tsx
+++ b/ui/pages/perps/perps-activity-page.test.tsx
@@ -27,14 +27,18 @@ jest.mock('../../selectors/perps/feature-flags', () => ({
   getIsPerpsExperienceAvailable: jest.fn(),
 }));
 
-// Mock usePerpsTransactionHistory hook to avoid controller dependency
+// Mock usePerpsTransactionHistory hook to avoid controller dependency. Tests
+// that need to simulate the initial-fetch-in-progress-with-wallet-data
+// scenario override this via mockUsePerpsTransactionHistory.mockReturnValue.
+const mockUsePerpsTransactionHistory = jest.fn().mockReturnValue({
+  transactions: mockTransactions,
+  isLoading: false,
+  error: null,
+  refetch: jest.fn(),
+});
+
 jest.mock('../../hooks/perps/usePerpsTransactionHistory', () => ({
-  usePerpsTransactionHistory: () => ({
-    transactions: mockTransactions,
-    isLoading: false,
-    error: null,
-    refetch: jest.fn(),
-  }),
+  usePerpsTransactionHistory: () => mockUsePerpsTransactionHistory(),
 }));
 
 const mockGetIsPerpsExperienceAvailable =
@@ -53,6 +57,12 @@ describe('PerpsActivityPage', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockGetIsPerpsExperienceAvailable.mockReturnValue(true);
+    mockUsePerpsTransactionHistory.mockReturnValue({
+      transactions: mockTransactions,
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
   });
 
   it('renders with correct data-testid', () => {
@@ -181,6 +191,63 @@ describe('PerpsActivityPage', () => {
     expect(
       screen.getByTestId('perps-activity-filter-button'),
     ).toHaveTextContent('Deposits');
+  });
+
+  describe('initial fetch with wallet-tracked transactions already available', () => {
+    // Simulates usePerpsTransactionHistory's mergedTransactions behavior:
+    // wallet-tracked deposits/withdrawals are merged in and returned
+    // immediately, even while the REST fetch (isLoading) is still in flight.
+    const walletDepositTransaction = mockTransactions.find(
+      (tx) => tx.id === 'tx-005',
+    );
+
+    it('shows the skeleton (not a blank list) when a wallet transaction is present for a non-matching filter while loading', () => {
+      mockUsePerpsTransactionHistory.mockReturnValue({
+        transactions: [walletDepositTransaction],
+        isLoading: true,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      renderWithProvider(<PerpsActivityPage />, createMockStore());
+
+      // Default filter is 'trade'; the only available transaction is a
+      // deposit, so groupedTransactions is empty for this filter and the
+      // skeleton must render instead of leaving the content area blank.
+      expect(
+        screen.getByTestId('perps-activity-page-skeleton'),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('transaction-card-tx-005'),
+      ).not.toBeInTheDocument();
+    });
+
+    it('renders the already-known wallet transaction immediately while still loading, for a matching filter', () => {
+      mockUsePerpsTransactionHistory.mockReturnValue({
+        transactions: [walletDepositTransaction],
+        isLoading: true,
+        error: null,
+        refetch: jest.fn(),
+      });
+
+      renderWithProvider(<PerpsActivityPage />, createMockStore());
+
+      // Switch to the Deposits filter, which matches the wallet transaction.
+      fireEvent.click(screen.getByTestId('perps-activity-filter-button'));
+      fireEvent.click(
+        screen.getByTestId('perps-activity-filter-option-deposit'),
+      );
+
+      // The wallet-tracked deposit renders immediately, without waiting for
+      // isLoading to become false, and no skeleton is shown since there is
+      // already something to display.
+      expect(
+        screen.getByTestId('transaction-card-tx-005'),
+      ).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('perps-activity-page-skeleton'),
+      ).not.toBeInTheDocument();
+    });
   });
 
   describe('order transaction navigation', () => {

--- a/ui/pages/perps/perps-activity-page.test.tsx
+++ b/ui/pages/perps/perps-activity-page.test.tsx
@@ -241,9 +241,7 @@ describe('PerpsActivityPage', () => {
       // The wallet-tracked deposit renders immediately, without waiting for
       // isLoading to become false, and no skeleton is shown since there is
       // already something to display.
-      expect(
-        screen.getByTestId('transaction-card-tx-005'),
-      ).toBeInTheDocument();
+      expect(screen.getByTestId('transaction-card-tx-005')).toBeInTheDocument();
       expect(
         screen.queryByTestId('perps-activity-page-skeleton'),
       ).not.toBeInTheDocument();

--- a/ui/pages/perps/perps-activity-page.tsx
+++ b/ui/pages/perps/perps-activity-page.tsx
@@ -153,7 +153,12 @@ const PerpsActivityPage = () => {
         {/* Transaction List */}
         <Box flexDirection={BoxFlexDirection.Column}>
           {/* Loading State */}
-          {isLoading && transactions.length === 0 && (
+          {/* Gated on groupedTransactions (not the raw transactions array) so
+              that wallet-tracked deposits/withdrawals which are already
+              available (and thus render immediately, see mergedTransactions
+              in usePerpsTransactionHistory) don't wrongly suppress the
+              skeleton when they don't match the currently selected filter. */}
+          {isLoading && groupedTransactions.length === 0 && (
             <PerpsActivityPageSkeleton />
           )}
 
@@ -193,8 +198,11 @@ const PerpsActivityPage = () => {
           )}
 
           {/* Transaction Groups */}
-          {!isLoading &&
-            !error &&
+          {/* Not gated on isLoading: wallet-tracked deposits/withdrawals (and,
+              once the REST fetch resolves, the full merged list) must render
+              immediately rather than waiting for isLoading to flip to false,
+              otherwise the list would go blank until the fetch completes. */}
+          {!error &&
             groupedTransactions.map((group) => (
               <Box
                 key={group.date}


### PR DESCRIPTION
## **Description**

**Context / Problem:** `usePerpsTransactionHistory` relied solely on HyperLiquid's `userHistory` REST ledger for deposits/withdrawals. That ledger only reflects a deposit/withdrawal once HyperLiquid itself has processed it, which lags behind the wallet's own on-chain confirmation of the `perpsDeposit`/`perpsDepositAndOrder`/`perpsWithdraw` transaction. As a result, a just-completed Perps deposit was invisible under the Activity page's Deposits filter for a while, even though the user's Perps balance already reflected it, and wallet-tracked withdrawals weren't surfaced at all until HyperLiquid's ledger caught up. Mobile already handles both cases by merging wallet-tracked deposits/withdrawals into the same list, with their real wallet status reflected in the row; Extension was missing both.

**Solution:**
- Added `transformWalletPerpsDepositsToTransactions` in `transactionTransforms.ts`, which converts wallet `perpsDeposit`/`perpsDepositAndOrder` transactions into `PerpsTransaction` rows, decoding the USDC amount via the existing ERC20-transfer decoding utilities (`getTokenTransferData`/`parseStandardTokenTransactionData`).
- Added a new `useWalletPerpsDepositTransactions` hook that selects the active account's wallet-tracked Perps deposit transactions from `TransactionController` state.
- **Status mapping:** wallet-tracked deposits are no longer filtered to `confirmed` only — every wallet transaction status now maps to a `completed`/`failed`/`pending` Perps status (mirroring mobile's status mapping), and the Activity row's subtitle reflects that real status ("Completed"/"Failed"/"Pending") instead of always showing "Completed".
- **Withdrawal merging:** added `transformWalletPerpsWithdrawalsToTransactions` and a new `useWalletPerpsWithdrawalTransactions` hook, so wallet-tracked Perps withdrawals (`perpsWithdraw`) are merged into the Activity list the same way deposits are, with the same pending/failed/completed status mapping.
- Generalized the txHash dedupe helper (`dedupeWalletDepositsByTxHash` → `dedupeWalletTransactionsByTxHash`) so it dedupes wallet-sourced deposits and withdrawals against HyperLiquid `userHistory` records independently, scoped by transaction type, avoiding duplicate rows once the ledger catches up.
- `usePerpsTransactionHistory` now merges both wallet-sourced deposits and withdrawals into `mergedTransactions`.
- Added `perpsStatusPending` and `perpsStatusFailed` locale strings, following the existing `perpsStatusCompleted`/`perpsStatusFilled`/etc. naming convention.

## **Changelog**

CHANGELOG entry: Fixed a bug where a completed Perps deposit could be missing from the Perps Activity Deposits filter, and Perps withdrawals now appear immediately with an accurate status

## **Related issues**

Fixes: #43950

## **Manual testing steps**

1. Make a Perps deposit from the Extension.
2. Immediately open the Perps Activity page and filter by "Deposits".
3. Confirm the deposit appears right away, without needing to wait or manually refresh, and shows "Pending" while the on-chain transaction is still confirming.
4. Once the on-chain transaction confirms (before HyperLiquid's ledger reflects it), confirm the row now shows "Completed".
5. Wait for HyperLiquid's ledger to catch up (i.e. until the deposit would normally have appeared before this fix).
6. Confirm the deposit still appears exactly once in the filtered list (no duplicate row once HyperLiquid's `userHistory` ledger reflects it too).
7. Repeat steps 1-6 for a Perps withdrawal, confirming it appears immediately in the Activity list with the correct status and does not duplicate once HyperLiquid's ledger reflects it.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)
