### PR TITLE
chore: introduce bulk error suppression

### DIFF
--- a/.eslintrc.base.js
+++ b/.eslintrc.base.js
@@ -192,5 +192,9 @@ module.exports = {
     'promise/catch-or-return': 'off',
     'promise/no-return-wrap': 'off',
     'promise/param-names': 'off',
+
+    // TODO: Update to `@metamask/eslint-config@15`, which includes these changes
+    'promise/no-nesting': 'error',
+    'promise/no-callback-in-promise': 'error',
   },
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -40,6 +40,9 @@ module.exports = defineConfig([
       // eslint's parser, esprima, is not compatible with ESM, so use the babel parser instead
       parser: babelParser,
     },
+    linterOptions: {
+      reportUnusedDisableDirectives: 'error',
+    },
   },
 
   /**
@@ -402,7 +405,7 @@ module.exports = defineConfig([
       'react/default-props-match-prop-types': 'error',
       'react/jsx-no-duplicate-props': 'error',
       'react-hooks/exhaustive-deps': [
-        'warn',
+        'error',
         {
           additionalHooks: 'useAsync(Callback|Result|ResultOrThrow)',
         },
@@ -446,12 +449,12 @@ module.exports = defineConfig([
     rules: {
       'react-compiler/react-compiler': 'error',
       'react/no-unused-prop-types': 'error',
-      'react/no-unused-state': 'warn',
+      'react/no-unused-state': 'error',
       'react/jsx-boolean-value': 'off',
       'react/jsx-curly-brace-presence': 'off',
-      'react/no-deprecated': 'warn',
-      'react/default-props-match-prop-types': 'warn',
-      'react/jsx-no-duplicate-props': 'warn',
+      'react/no-deprecated': 'error',
+      'react/default-props-match-prop-types': 'error',
+      'react/jsx-no-duplicate-props': 'error',
       'react/display-name': 'off',
       'react/no-unescaped-entities': 'error',
       'react/prop-types': 'off',
@@ -459,7 +462,7 @@ module.exports = defineConfig([
       'react/jsx-key': 'error',
       'react-hooks/rules-of-hooks': 'error',
       'react-hooks/exhaustive-deps': [
-        'warn',
+        'error',
         {
           additionalHooks: 'useAsync(Callback|Result|ResultOrThrow)',
         },
@@ -605,6 +608,9 @@ module.exports = defineConfig([
 
       // TODO: Re-enable after ESLint v9 update
       'jest/unbound-method': 'off',
+
+      // TODO: Update to `@metamask/eslint-config-jest@15`, which includes these changes
+      'jest/no-disabled-tests': 'error',
     },
   },
   /**

--- a/.prettierignore
+++ b/.prettierignore
@@ -14,6 +14,7 @@ __snapshots__/**/*
 /development/ts-migration-dashboard/filesToConvert.json
 /development/ts-migration-dashboard/build/**
 /dist/**/*
+/eslint-suppressions.json
 /lavamoat/**/policy.json
 /lavamoat/**/policy-override.json
 /storybook-build/**/*

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -1,0 +1,515 @@
+{
+  "app/scripts/controllers/qr-sync/qr-sync-controller.ts": {
+    "promise/no-nesting": {
+      "count": 1
+    }
+  },
+  "app/scripts/lib/metaRPCClientFactory.test.js": {
+    "promise/no-callback-in-promise": {
+      "count": 3
+    }
+  },
+  "app/scripts/metamask-controller.test.js": {
+    "jest/no-disabled-tests": {
+      "count": 1
+    }
+  },
+  "development/webpack/utils/loaders/swcLoader.ts": {
+    "promise/no-callback-in-promise": {
+      "count": 1
+    }
+  },
+  "ui/components/app/balance-empty-state/balance-empty-state.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 2
+    }
+  },
+  "ui/components/app/currency-input/currency-input.js": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/components/app/modals/multichain-accounts/intro-modal/multichain-account-intro-modal.container.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/components/app/perps/hooks/useClickOutside.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/components/app/shield-entry-modal/shield-illustration-animation.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/components/app/snaps/snap-ui-address-input/snap-ui-address-input.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/components/app/snaps/snap-ui-asset-selector/useSnapAssetDisplay.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/components/app/snaps/snap-ui-input/snap-ui-input.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/components/app/snaps/snap-ui-selector/snap-ui-selector.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/components/app/srp-quiz-modal/SRPQuiz/SRPQuiz.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/components/app/terms-of-use-popup/terms-of-use-popup.js": {
+    "react-hooks/exhaustive-deps": {
+      "count": 2
+    }
+  },
+  "ui/components/app/wallet-overview/aggregated-percentage-overview-cross-chains.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/components/app/wallet-overview/coin-buttons.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 4
+    }
+  },
+  "ui/components/component-library/modal-content/deprecated/modal-content.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/components/component-library/modal-content/modal-content.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/components/multichain-accounts/multichain-account-menu/multichain-account-menu.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/components/multichain-accounts/permissions/multichain-edit-networks-page/multichain-edit-networks-page.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 2
+    }
+  },
+  "ui/components/multichain/asset-picker-amount/asset-picker-modal/hooks/useAssetMetadata.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/components/multichain/dropdown-editor/dropdown-editor.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/components/multichain/edit-networks-modal/edit-networks-modal.js": {
+    "react-hooks/exhaustive-deps": {
+      "count": 2
+    }
+  },
+  "ui/components/multichain/network-list-menu/add-block-explorer-modal/add-block-explorer-modal.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/components/multichain/network-list-menu/add-rpc-url-modal/add-rpc-url-modal.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/components/multichain/network-list-menu/popular-network-list/popular-network-list.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/components/multichain/networks-form/networks-form-state.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/components/multichain/networks-form/networks-form.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 4
+    }
+  },
+  "ui/components/multichain/toast/toast.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/components/ui/form-combo-field/form-combo-field.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 3
+    }
+  },
+  "ui/components/ui/jazzicon/jazzicon.component.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 2
+    }
+  },
+  "ui/components/ui/survey-toast/survey-toast.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/contexts/hardware-wallets/HardwareWalletContext.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/hooks/accounts/useAccountsOperationsLoadingStates.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/hooks/bridge/useBridgeNavigation.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 6
+    }
+  },
+  "ui/hooks/bridge/useInitialBridgeTokens.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/hooks/bridge/useLatestBalance.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/hooks/bridge/usePrefillFromBridgeState.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/hooks/bridge/usePrefillFromSearchQuery.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 5
+    }
+  },
+  "ui/hooks/bridge/useQuoteFetchEvents.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/hooks/bridge/useRewards.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 2
+    }
+  },
+  "ui/hooks/bridge/useTokenSearchResults.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 3
+    }
+  },
+  "ui/hooks/bridge/useTxAlerts.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/hooks/gator-permissions/useGatorPermissionTokenInfo.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/hooks/metamask-notifications/useSwitchNotifications.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 3
+    }
+  },
+  "ui/hooks/swap/useSwapDefaultToToken.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/hooks/useAsync.test.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/hooks/useAsync.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 4
+    }
+  },
+  "ui/hooks/useCarouselManagement/useCarouselManagement.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/hooks/useMultiPolling.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/hooks/usePolling.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/hooks/useScrollRequired.js": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/hooks/useTokenFiatAmount.js": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/activity/useActivityScreenViewed.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/activity/useTransactionsQuery.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/batch-sell/hooks/useBatchSellHighRateAlertModal.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/bridge/awaiting-signatures/awaiting-signatures.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/bridge/hooks/useExternalAccountResolution.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/bridge/prepare/components/bridge-alert-modal.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/bridge/prepare/components/bridge-asset-picker/bridge-asset-picker-content.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/bridge/prepare/prepare-bridge-page.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 2
+    }
+  },
+  "ui/pages/confirmations/components/confirm/dapp-swap-comparison-banner/dapp-swap-comparison-banner.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/confirmations/components/confirm/footer/shield-footer-coverage-indicator/shield-icon-animation.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 4
+    }
+  },
+  "ui/pages/confirmations/components/confirm/info/approve/hooks/use-is-nft.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/confirmations/components/confirm/info/hooks/useDecodedTransactionData.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/confirmations/components/confirm/info/hooks/useMaxValueRefresher.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/confirmations/components/confirm/info/shared/batched-approval-function/batched-approval-function.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/confirmations/components/confirm/info/typed-sign/typed-sign-v4-simulation/decoded-simulation/decoded-simulation.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/confirmations/components/confirm/scroll-to-bottom/scroll-to-bottom.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 2
+    }
+  },
+  "ui/pages/confirmations/components/send/amount/amount.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/confirmations/components/send/hex-data/hex-data.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/confirmations/components/simulation-details/useSimulationMetrics.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 2
+    }
+  },
+  "ui/pages/confirmations/hooks/alerts/transactions/useContractCode.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/confirmations/hooks/alerts/transactions/useGasFeeLowAlerts.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/confirmations/hooks/alerts/transactions/useGasTooLowAlerts.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/confirmations/hooks/alerts/transactions/useNoGasPriceAlerts.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/confirmations/hooks/alerts/transactions/useNonContractAddressAlerts.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/confirmations/hooks/alerts/useNetworkAndOriginSwitchingAlerts.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/confirmations/hooks/send/useContactRecipients.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/confirmations/hooks/send/useMaxAmount.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/confirmations/hooks/send/useSendNfts.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/confirmations/hooks/send/useSendQueryParams.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/confirmations/hooks/send/useSnapAmountOnInput.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/confirmations/hooks/transactions/dapp-swap-comparison/useDappSwapUSDValues.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 2
+    }
+  },
+  "ui/pages/confirmations/hooks/useAddEthereumChain.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/confirmations/hooks/useCancelSpeedupInitialGas.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/confirmations/hooks/useDecodedSignatureMetrics.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/confirmations/hooks/useLedgerConnection.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/confirmations/hooks/useSetConfirmationAlerts.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 2
+    }
+  },
+  "ui/pages/create-account/connect-hardware/account-list.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/create-account/connect-hardware/index.tsx": {
+    "promise/no-nesting": {
+      "count": 1
+    },
+    "react-hooks/exhaustive-deps": {
+      "count": 3
+    }
+  },
+  "ui/pages/create-account/connect-hardware/select-hardware.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/details/components/convert-again-button.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/details/templates/helpers.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/hardware-wallets/swap/hooks/useSendBundleSubmission.ts": {
+    "react-hooks/exhaustive-deps": {
+      "count": 2
+    }
+  },
+  "ui/pages/multichain-accounts/multichain-accounts-connect-page/multichain-accounts-connect-page.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/notification-details/notification-details.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/notifications-settings/notifications-settings-allow-notifications.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 2
+    }
+  },
+  "ui/pages/settings/debug-tab/debug-content/sentry-test.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  },
+  "ui/pages/shield/transaction-shield/shield-banner-animation.tsx": {
+    "react-hooks/exhaustive-deps": {
+      "count": 3
+    }
+  },
+  "ui/pages/swaps/awaiting-signatures/awaiting-signatures.js": {
+    "react-hooks/exhaustive-deps": {
+      "count": 1
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "lint:changelog:rc": "auto-changelog validate --prettier --rc",
     "lint:debug": "DEBUG=eslint:cli-engine yarn lint",
     "lint:eslint": "NODE_OPTIONS='--max-old-space-size=6144' eslint . -c  ./.eslintrc.js --ext js,ts,tsx,snap --cache --cache-location node_modules/.cache/eslint/.eslint-cache",
-    "lint:eslint:fix": "yarn lint:eslint --fix --cache --cache-location node_modules/.cache/eslint/.eslint-cache",
+    "lint:eslint:fix": "yarn lint:eslint --fix --prune-suppressions",
     "lint:lockfile:dedupe": "yarn dedupe --check",
     "lint:lockfile:dedupe:fix": "yarn dedupe",
     "lint:lockfile": "lockfile-lint --path yarn.lock --allowed-hosts npm yarn github.com codeload.github.com --empty-hostname true --allowed-schemes \"https:\" \"git+https:\" \"npm:\" \"patch:\" \"workspace:\"",

--- a/test/e2e/tests/metrics/empty-buy-banner-displayed.spec.ts
+++ b/test/e2e/tests/metrics/empty-buy-banner-displayed.spec.ts
@@ -64,11 +64,7 @@ describe('Empty Buy Banner Displayed event', function () {
           ? 'sidepanel'
           : 'fullscreen';
         const {
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           profile_id: _profileId,
-          // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
-          // eslint-disable-next-line @typescript-eslint/naming-convention
           canonical_profile_id: _canonicalProfileId,
           ...eventProperties
         } = events[0].properties;


### PR DESCRIPTION
## **Description**

All remaining lint warnings have been upgraded to errors and suppressed using ESLint's bulk error suppression. We should never have warnings again going forward.

The error suppression file can be updated using `yarn lint:eslint:fix`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

`yarn lint` should no longer produce warnings. Check the CI logs for the lint step as well.

You could also try introducing a new lint warning and running `yarn lint:eslint:fix` to test that the suppressed error file can be updated.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint and CI tooling only; no production runtime behavior changes. New errors only affect new or unsuppressed lint issues.
> 
> **Overview**
> Tightens ESLint so **warnings are no longer allowed**: several React, React Hooks, Jest, and Promise rules move from `warn` to `error`, and unused `eslint-disable` comments are reported as errors via `reportUnusedDisableDirectives`.
> 
> Existing violations are recorded in a new **`eslint-suppressions.json`** (bulk per-file/per-rule counts) so CI can pass without fixing everything at once. **`yarn lint:eslint:fix`** now runs with **`--prune-suppressions`** to keep that file in sync when issues are fixed. The suppressions file is excluded from Prettier.
> 
> Base config also enables **`promise/no-nesting`** and **`promise/no-callback-in-promise`**, and Jest config enables **`jest/no-disabled-tests`**. A metrics e2e spec drops redundant disable comments for destructured `profile_id` fields while leaving others for `chain_id` / `environment_type`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 620e86e151b57990809313c640c816f6ec0fa6b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->