### PR TITLE
fix: eliminate dark-mode background flash for pure black mode

### DIFF
--- a/app/html/ui/popup-init.html
+++ b/app/html/ui/popup-init.html
@@ -34,7 +34,7 @@
       }
       @media screen and (prefers-color-scheme: dark) {
         html {
-          background: #121314;
+          background: #000000;
         }
       }
     </style>

--- a/ui/css/base-styles.scss
+++ b/ui/css/base-styles.scss
@@ -12,7 +12,8 @@
 
   color-scheme: dark light;
   color: light-dark(var(--brand-colors-grey-grey1000), var(--brand-colors-grey-grey050));
-  background-color: light-dark(var(--brand-colors-grey-grey050), var(--brand-colors-grey-grey1000));
+  // TODO: @metamask/design-system-engineers remove once pure black is shipped targeted(13.43.0)
+  background-color: light-dark(var(--brand-colors-grey-grey050), var(--brand-colors-black));
 }
 
 html,


### PR DESCRIPTION
## **Description**

Fixes the background flash sequence system-dark users see when opening the extension in pure black mode. There are three moments where a background color is visible before the full UI renders, and they all need to agree:

1. **\`popup-init.html\`** — a static redirect page with no JavaScript. Uses \`prefers-color-scheme: dark\` to set an initial background while it redirects to \`popup.html\`. Changed from \`#121314\` to \`#000000\`.

2. **\`:root\` in \`base-styles.scss\`** — the \`light-dark()\` fallback that fires immediately on \`popup.html\` parse, before JavaScript has applied \`data-theme\` or \`data-pure-black\` attributes. Because no data attributes exist at this point, a CSS selector cannot be used — brand color tokens are the only option. Changed from \`--brand-colors-grey-grey1000\` to \`--brand-colors-black\`.

3. **\`html[data-theme='dark'][data-pure-black='true']\`** (already in \`base-styles.scss\`) — applies after JavaScript sets theme attributes. Unchanged; this continues to own the post-JS state via the semantic token.

Without both changes, fixing only \`popup-init.html\` would swap one mismatch for another: \`#000000\` init flash → \`grey-grey1000\` root frame → \`#000000\` themed.

> **Note:** Both changes affect all system-dark users, not just pure black users, since neither \`prefers-color-scheme\` nor \`:root\` can read MetaMask theme settings. They should not be merged until the \`MM_PURE_BLACK_PREVIEW\` feature flag ships in 13.43.0.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: TMCU-1158

## **Manual testing steps**

1. Enable \`MM_PURE_BLACK_PREVIEW=true\` in \`.metamaskrc\` and run \`yarn start\`.
2. Enable dark theme in Settings → Preferences and display → Theme → Dark.
3. Click the extension icon — the flash from \`popup-init.html\`, the \`:root\` frame on \`popup.html\`, and the final themed background should all be pure black with no visible transition.
4. Toggle to light theme and verify the white background still appears at each stage.

## **Screenshots/Recordings**

### **Before**

Flash sequence: #121314 (popup-init) → #24272A (root) → #000000 (themed) 

https://github.com/user-attachments/assets/27c3b95a-c36d-4e31-8b2a-e60ebe1bf6db

### **After**

Flash sequence: #000000 → #000000 → #000000 — seamless

https://github.com/user-attachments/assets/0e5d7183-b1bc-42f1-b161-623b99d9b7ef

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.