### PR TITLE
fix: use pure black background on loading screen in pure black theme

### DIFF
--- a/ui/css/base-styles.scss
+++ b/ui/css/base-styles.scss
@@ -42,6 +42,11 @@ html[data-theme='dark'] {
   --bar-border-color: var(--color-border-muted);
 }
 
+// TODO: @metamask/design-system-engineers remove once pure black is shipped targeted(13.43.0)
+html[data-theme='dark'][data-pure-black='true'] {
+  background-color: var(--color-background-default);
+}
+
 #app-content,
 #critical-error-content {
   overflow-x: hidden;

--- a/ui/css/loading.scss
+++ b/ui/css/loading.scss
@@ -38,6 +38,14 @@
 }
 
 @media (prefers-color-scheme: dark) {
+  :root {
+    // Pure black: use #000000 directly since design system tokens are not
+    // available before `[data-theme]` is set on <html> by React. This ensures
+    // the loading screen background matches pure black mode on OLED displays.
+    // TODO: @metamask/design-system-engineers remove once pure black is shipped targeted(13.43.0)
+    background-color: #000000;
+  }
+
   .loading-timeout-message {
     // the design system uses dark grey300 for `--color-text-alternative` in
     // dark mode, but the design system only switches to dark mode once the


### PR DESCRIPTION
## **Description**

Two related fixes for the pure black (OLED) loading screen background:

**1. Pre-hydration (loading splash — CSS only)** — `ui/css/loading.scss`

Before React mounts, `[data-theme]` and `[data-pure-black]` aren't set on `<html>` yet, so design system tokens aren't available. Added a `@media (prefers-color-scheme: dark)` rule (following the existing pattern in this file) that sets `:root { background-color: #000000 }` directly, matching the pure black OLED background from the first paint.

**2. Post-hydration** — `ui/css/base-styles.scss`

Added the CSS selector rule for when React has finished mounting and `data-pure-black='true'` is set on `<html>`, using the `var(--color-background-default)` token (which resolves to `#000000` in pure black mode):

```scss
html[data-theme='dark'][data-pure-black='true'] {
  background-color: var(--color-background-default);
}
```

Both changes include the standard TODO comment for removal when pure black ships at 13.43.0.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1161

## **Manual testing steps**

1. Enable pure black mode via `.metamaskrc` (`MM_PURE_BLACK_PREVIEW=true`) and set theme to dark
2. Open or reload the MetaMask extension
3. Confirm the loading splash screen (fox logo + spinner) has a pure black `#000000` background
4. Confirm the main app background is also pure black once React loads
5. Disable pure black — confirm the loading screen reverts to dark gray

## **Screenshots/Recordings**

### **Before**

Loading screen shows dark gray (`grey1000` / `#141618`) background — not pure black.

### **After**

Loading screen shows `#000000` pure black background from first paint.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only CSS with no auth, data, or business-logic changes; pre-hydration dark rule may need QA when pure black is off but system theme is dark.
> 
> **Overview**
> Aligns the extension **loading splash** and post-hydration shell with **pure black (OLED) dark mode** so the background is `#000000` instead of default dark gray.
> 
> **Pre-React:** `loading.scss` adds a `@media (prefers-color-scheme: dark)` rule on `:root` with hard-coded `#000000`, since design tokens are not applied until `[data-theme]` exists. **After React mounts:** `base-styles.scss` sets `html[data-theme='dark'][data-pure-black='true']` to `var(--color-background-default)`. Both spots use the standard TODO to drop when pure black ships in 13.43.0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66f66d35273f67e092aa7d680e493a7c628554ff. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->