### PR TITLE
release(runway): cherry-pick fix(ci): Remove "What's in this RC ...and more changes" section to match Extension RC Slack message to Mobile layout cp-13.41.0

### DIFF
--- a/.github/scripts/slack-rc-notification.mts
+++ b/.github/scripts/slack-rc-notification.mts
@@ -4,9 +4,10 @@
  * Posts a Block Kit message when a release-candidate Main workflow completes, aligned with
  * metamask-mobile/scripts/slack-rc-notification.mjs (bot token + chat.postMessage).
  *
- * Build URLs include main Chrome/Firefox Webpack artifacts plus the deprecated Browserify fallback.
- * Slack also links to run-specific PR comment anchors for cherry-picks and full RC notes
- * (same pattern as Mobile after MetaMask/metamask-mobile#32969).
+ * Mobile parity: downloads + cherry-picks link + View full RC notes. No inline CHANGELOG.md dump.
+ *
+ * Build URLs include main Chrome/Firefox Webpack artifacts.
+ * Slack links to run-specific PR comment anchors for cherry-picks and full RC notes.
  *
  * Local / manual testing
  * ----------------------
@@ -21,23 +22,15 @@
  *   SEMVER=… BUILD_RUN_ID=… SLACK_BOT_TOKEN='xoxb-…' SLACK_CHANNEL='#my-test' HOST_URL=… \
  *   node ./.github/scripts/slack-rc-notification.mts
  *
- * Requires `@metamask/auto-changelog`.
- *
  * @see metamask-mobile/scripts/slack-rc-notification.mjs
  */
 
-import { readFileSync } from 'fs';
-import path from 'path';
-import { fileURLToPath, pathToFileURL } from 'url';
-import { parseChangelog } from '@metamask/auto-changelog';
+import { pathToFileURL } from 'url';
 import packageJson from '../../package.json' with { type: 'json' };
 import {
   getBuildLinks,
   type BuildLinks,
 } from '../../development/metamaskbot-build-announce/build-links.ts';
-
-const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const REPO_ROOT = path.join(__dirname, '..', '..');
 
 const REPO_URL = process.env.GITHUB_REPOSITORY
   ? `https://github.com/${process.env.GITHUB_REPOSITORY}`
@@ -49,37 +42,8 @@ type SlackPayload = {
 };
 
 type MainBrowserLinks = {
-  browserify: BuildLinks['browserify']['main'];
   webpack: BuildLinks['webpack']['main'];
 };
-
-function escapeSlackMrkdwn(text: string | undefined | null): string {
-  if (text === undefined || text === null) {
-    return '';
-  }
-  return String(text)
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;');
-}
-
-/**
- * Changelog lines use GitHub-style `(#12345)` PR refs. Some lines use markdown
- * `[#123](https://github.com/org/repo/pull/123)`. After escaping the line for Slack,
- * turn those into mrkdwn links. Parentheses stay plain text around the link: `(<url|#123>)`.
- */
-function linkifyChangelogPrRefs(text: string, repoBaseUrl: string): string {
-  let out = text.replace(/\(#(\d+)\)/g, (_match, prNumber: string) => {
-    return `(<${repoBaseUrl}/pull/${prNumber}|#${prNumber}>)`;
-  });
-  out = out.replace(
-    /\[#(\d+)\]\((https:\/\/github\.com\/[^/]+\/[^/]+\/pull\/\d+)\)/g,
-    (_match, prNumber: string, url: string) => {
-      return `(<${url}|#${prNumber}>)`;
-    },
-  );
-  return out;
-}
 
 function getExtensionMainBuildLinks(
   hostUrl: string,
@@ -90,114 +54,8 @@ function getExtensionMainBuildLinks(
     version: packageVersion,
   });
   return {
-    browserify: buildLinks.browserify.main,
     webpack: buildLinks.webpack.main,
   };
-}
-
-/**
- * `@metamask/auto-changelog` `getReleaseChanges` returns each line as a plain string
- * (not `{ description, prNumbers }`). See `Changelog.getReleaseChanges` → `string[]`.
- */
-function extractChangelogEntries(
-  version: string,
-): Record<string, string[]> | null {
-  const changelogPath = path.join(REPO_ROOT, 'CHANGELOG.md');
-
-  let changelogContent: string;
-  try {
-    changelogContent = readFileSync(changelogPath, 'utf8');
-  } catch (error) {
-    const err = error as Error;
-    console.error(`Failed to read CHANGELOG.md: ${err.message}`);
-    return null;
-  }
-
-  try {
-    const changelog = parseChangelog({
-      changelogContent,
-      repoUrl: REPO_URL,
-    });
-
-    return changelog.getReleaseChanges(version) ?? null;
-  } catch (error) {
-    const err = error as Error;
-    console.error(`Failed to parse CHANGELOG.md: ${err.message}`);
-    return null;
-  }
-}
-
-function changelogLineToText(entry: unknown): string {
-  if (typeof entry === 'string') {
-    return entry;
-  }
-  if (entry && typeof entry === 'object' && 'description' in entry) {
-    const d = (entry as { description: unknown }).description;
-    if (typeof d === 'string') {
-      return d;
-    }
-  }
-  return '';
-}
-
-function formatChangesForSlack(
-  changes: Record<string, string[]>,
-  maxEntries = 15,
-): string {
-  const formattedEntries: string[] = [];
-
-  /** Keep a Changelog — https://keepachangelog.com/en/1.0.0/ */
-  const categoryOrder = [
-    'Added',
-    'Changed',
-    'Deprecated',
-    'Removed',
-    'Fixed',
-    'Security',
-    'Uncategorized',
-  ];
-
-  const knownCategories = new Set(categoryOrder);
-  const extraCategories = Object.keys(changes)
-    .filter((k) => !knownCategories.has(k))
-    .sort((a, b) => a.localeCompare(b));
-
-  const categoriesToIterate = [...categoryOrder, ...extraCategories];
-
-  outer: for (const category of categoriesToIterate) {
-    const entries = changes[category] ?? [];
-    for (const entry of entries) {
-      if (formattedEntries.length >= maxEntries) {
-        break outer;
-      }
-
-      const line = changelogLineToText(entry).trim();
-      if (line === '') {
-        continue;
-      }
-
-      const description = linkifyChangelogPrRefs(
-        escapeSlackMrkdwn(line),
-        REPO_URL,
-      );
-      formattedEntries.push(`• ${description}`);
-    }
-  }
-
-  const allEntriesCount = categoriesToIterate.reduce((sum, category) => {
-    const entries = changes[category];
-    if (!Array.isArray(entries)) {
-      return sum;
-    }
-    return sum + entries.filter(Boolean).length;
-  }, 0);
-  const remaining = allEntriesCount - formattedEntries.length;
-
-  if (remaining > 0) {
-    formattedEntries.push(`\n_...and ${remaining} more changes_`);
-  }
-
-  return formattedEntries.join('\n');
 }
 
 function isValidUrl(url: string | undefined): boolean {
@@ -226,25 +84,13 @@ function buildSlackMessage(options: {
   packageVersion: string;
   runId: string;
   links: MainBrowserLinks;
-  changelogText: string;
-  hasChangelog: boolean;
   actionsRunUrl: string | undefined;
   prNumber?: string;
 }): SlackPayload {
-  const {
-    semver,
-    packageVersion,
-    runId,
-    links,
-    changelogText,
-    hasChangelog,
-    actionsRunUrl,
-    prNumber,
-  } = options;
+  const { semver, packageVersion, runId, links, actionsRunUrl, prNumber } =
+    options;
 
   const buildIdLabel = `run ${runId}`;
-
-  const b = links.browserify;
   const w = links.webpack;
 
   const blocks: Record<string, unknown>[] = [
@@ -293,52 +139,7 @@ function buildSlackMessage(options: {
         },
       ],
     },
-    {
-      type: 'section',
-      text: {
-        type: 'mrkdwn',
-        text: '*📦 Deprecated main build zips (Browserify)*',
-      },
-    },
-    {
-      type: 'section',
-      fields: [
-        {
-          type: 'mrkdwn',
-          text: isValidUrl(b.chrome)
-            ? `*Chrome (MV3):*\n<${b.chrome}|Download zip>`
-            : '*Chrome (MV3):*\n_Not available_',
-        },
-        {
-          type: 'mrkdwn',
-          text: isValidUrl(b.firefox)
-            ? `*Firefox (MV2):*\n<${b.firefox}|Download zip>`
-            : '*Firefox (MV2):*\n_Not available_',
-        },
-      ],
-    },
   ];
-
-  if (hasChangelog && changelogText) {
-    blocks.push(
-      { type: 'divider' },
-      {
-        type: 'section',
-        text: {
-          type: 'mrkdwn',
-          text: `*📋 What's in this RC:*\n${changelogText}`,
-        },
-      },
-    );
-  } else {
-    blocks.push({
-      type: 'section',
-      text: {
-        type: 'mrkdwn',
-        text: '_No changelog entries found for this version in CHANGELOG.md (section may not exist yet)._',
-      },
-    });
-  }
 
   // Match Mobile: link Slack to the run-specific PR comment anchors.
   // GitHub prefixes user-provided anchor IDs with `user-content-`.
@@ -354,6 +155,14 @@ function buildSlackMessage(options: {
         },
       },
     );
+  } else {
+    blocks.push({
+      type: 'section',
+      text: {
+        type: 'mrkdwn',
+        text: `_Cherry-picks available in the release PR._`,
+      },
+    });
   }
 
   const footerBits = [
@@ -486,7 +295,6 @@ export async function main(): Promise<void> {
   const links: MainBrowserLinks = hostUrlOk
     ? getExtensionMainBuildLinks(trimmedHostUrl, packageVersion)
     : {
-        browserify: { chrome: '', firefox: '' },
         webpack: { chrome: '', firefox: '' },
       };
 
@@ -509,23 +317,8 @@ export async function main(): Promise<void> {
   } else {
     console.log(`📍 Target channel: ${expectedChannelName}`);
   }
-
-  console.log('\n📖 Reading CHANGELOG.md...');
-  const changes = extractChangelogEntries(semver);
-
-  let changelogText = '';
-  let hasChangelog = false;
-
-  if (changes) {
-    const totalChanges = Object.values(changes).flat().filter(Boolean).length;
-    console.log(`   Found ${totalChanges} changelog entries for v${semver}`);
-
-    if (totalChanges > 0) {
-      hasChangelog = true;
-      changelogText = formatChangesForSlack(changes);
-    }
-  } else {
-    console.log('   ⚠️ Could not read changelog for this version');
+  if (prNumber) {
+    console.log(`📍 Release PR: #${prNumber}`);
   }
 
   const [owner, repo] = (
@@ -541,8 +334,6 @@ export async function main(): Promise<void> {
     packageVersion,
     runId,
     links,
-    changelogText,
-    hasChangelog,
     actionsRunUrl,
     prNumber,
   });


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Cherry-pick of #44740 onto `release/13.41.0`.
Removes the inline CHANGELOG / “What's in this RC” bullet dump from Extension RC Slack notifications so the message matches Mobile: builds → Cherry-picks → View Build Pipeline | View full RC notes.
<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only Slack notification script changes with no runtime extension, auth, or data-handling impact.
> 
> **Overview**
> **Extension RC Slack notifications** no longer inline-parse `CHANGELOG.md` or show a “What’s in this RC” bullet list (including the “…and N more changes” truncation). The Block Kit message now follows **Mobile parity**: Webpack Chrome/Firefox download links → cherry-picks link (or fallback copy) → footer with **View Build Pipeline** and **View full RC notes** on the release PR.
> 
> The script also **drops deprecated Browserify main-build zip links** and removes `@metamask/auto-changelog` plus related changelog formatting helpers; cherry-picks are linked immediately after the download section instead of after changelog content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c392396af7b7588211a326411566028e22ce7002. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->