### PR TITLE
fix: non-evm bridge activity

### DIFF
--- a/shared/lib/asset-utils.ts
+++ b/shared/lib/asset-utils.ts
@@ -334,6 +334,10 @@ export const isTronSpecialAsset = (
 export function getChainIdFromAssetId(
   assetId: CaipAssetType,
 ): CaipChainId | undefined {
+  if (!assetId) {
+    return undefined;
+  }
+
   return CaipAssetTypeStruct.is(assetId)
     ? parseCaipAssetType(assetId).chainId
     : undefined;

--- a/test/e2e/tests/btc/btc-swap.spec.ts
+++ b/test/e2e/tests/btc/btc-swap.spec.ts
@@ -245,12 +245,10 @@ describe('BTC Account - Swap (Bridge)', function (this: Suite) {
         await bridgePage.submitQuote();
 
         // Navigate to activity list and verify the pending row.
-        // After @metamask/client-utils mapper migration (#44366), keyring txs are
-        // no longer reclassified via bridgeHistory — BTC bridges show as send.
         await homePage.goToActivityList();
         const activityTab = new ActivityTab(driver);
         await activityTab.checkTxAction({
-          action: 'Sending BTC',
+          action: 'Bridging BTC',
           confirmedTx: 0,
         });
       },
@@ -302,7 +300,7 @@ describe('BTC Account - Swap (Bridge)', function (this: Suite) {
         await homePage.goToActivityList();
         const activityTab = new ActivityTab(driver);
         await activityTab.checkTxAction({
-          action: 'Sending BTC',
+          action: 'Bridging BTC',
           confirmedTx: 0,
         });
       },

--- a/ui/pages/activity/rows/useActivityRowContent.tsx
+++ b/ui/pages/activity/rows/useActivityRowContent.tsx
@@ -1,6 +1,6 @@
 import React, { type ReactNode } from 'react';
 import cn from 'clsx';
-import type { CaipAssetType } from '@metamask/utils';
+import type { CaipAssetType, CaipChainId } from '@metamask/utils';
 import { KnownCaipNamespace, parseCaipChainId } from '@metamask/utils';
 import { NETWORK_TO_NAME_MAP } from '../../../../shared/constants/network';
 import { MULTICHAIN_NETWORK_TO_NICKNAME } from '../../../../shared/constants/multichain/networks';
@@ -29,7 +29,7 @@ type ActivityContent = {
   avatarTokens: ActivityListItemAvatarTokens;
 };
 
-function getChainDisplay(caipChainId: string) {
+function getChainDisplay(caipChainId: CaipChainId) {
   const { namespace } = parseCaipChainId(caipChainId);
   const chainId =
     namespace === KnownCaipNamespace.Eip155

--- a/ui/pages/activity/rows/useActivityRowContent.tsx
+++ b/ui/pages/activity/rows/useActivityRowContent.tsx
@@ -1,8 +1,10 @@
 import React, { type ReactNode } from 'react';
 import cn from 'clsx';
+import type { CaipAssetType } from '@metamask/utils';
 import { KnownCaipNamespace, parseCaipChainId } from '@metamask/utils';
 import { NETWORK_TO_NAME_MAP } from '../../../../shared/constants/network';
 import { MULTICHAIN_NETWORK_TO_NICKNAME } from '../../../../shared/constants/multichain/networks';
+import { getChainIdFromAssetId } from '../../../../shared/lib/asset-utils';
 import { getLabelKeys } from '../../../../shared/lib/activity/label-keys';
 import { convertCaipToHexChainId } from '../../../../shared/lib/network.utils';
 import { ActivityAvatar } from '../../../components/app/activity-list-item-avatar';
@@ -27,18 +29,18 @@ type ActivityContent = {
   avatarTokens: ActivityListItemAvatarTokens;
 };
 
-function getChainDisplay(activity: ActivityRowProps['data']) {
-  const { namespace } = parseCaipChainId(activity.chainId);
+function getChainDisplay(caipChainId: string) {
+  const { namespace } = parseCaipChainId(caipChainId);
   const chainId =
     namespace === KnownCaipNamespace.Eip155
-      ? convertCaipToHexChainId(activity.chainId)
-      : activity.chainId;
+      ? convertCaipToHexChainId(caipChainId)
+      : caipChainId;
   const networkName =
     NETWORK_TO_NAME_MAP[chainId as keyof typeof NETWORK_TO_NAME_MAP] ??
     MULTICHAIN_NETWORK_TO_NICKNAME[
-      activity.chainId as keyof typeof MULTICHAIN_NETWORK_TO_NICKNAME
+      caipChainId as keyof typeof MULTICHAIN_NETWORK_TO_NICKNAME
     ] ??
-    activity.chainId;
+    caipChainId;
 
   return { chainId, networkName };
 }
@@ -47,7 +49,7 @@ export function useActivityRowContent(activity: ActivityRowProps['data']) {
   const t = useI18nContext();
   const formatTokenAmount = useFormatTokenAmount();
   const { formatCurrencyWithMinThreshold } = useFormatters();
-  const { chainId } = getChainDisplay(activity);
+  const { chainId } = getChainDisplay(activity.chainId);
   const formatAsFiat = useFormatFiatAmount(chainId);
   const labelKeys = getLabelKeys({
     type: activity.type,
@@ -158,12 +160,23 @@ export function useActivityRowContent(activity: ActivityRowProps['data']) {
       case 'bridge': {
         const { sourceToken, destinationToken } = activity.data;
         const symbol = sourceToken?.symbol ?? destinationToken?.symbol ?? '';
+        const sourceChainId = getChainIdFromAssetId(
+          sourceToken?.assetId as CaipAssetType,
+        );
+        const destinationChainId = getChainIdFromAssetId(
+          destinationToken?.assetId as CaipAssetType,
+        );
+        const subtitle =
+          sourceChainId && destinationChainId
+            ? `${getChainDisplay(sourceChainId).networkName} → ${getChainDisplay(destinationChainId).networkName}`
+            : undefined;
 
         return {
           avatarTokens: destinationToken
             ? [sourceToken?.assetId, destinationToken?.assetId]
             : [sourceToken?.assetId],
           title: t(labelKeys.title.key, [symbol]),
+          subtitle,
           primaryAmount: formatTokenAmount(destinationToken ?? sourceToken),
           primaryDirection: (destinationToken ?? sourceToken)?.direction,
           ...(destinationToken

--- a/ui/selectors/activity.test.ts
+++ b/ui/selectors/activity.test.ts
@@ -1,4 +1,5 @@
 import { StatusTypes } from '@metamask/bridge-controller';
+import type { BridgeHistoryItem } from '@metamask/bridge-status-controller';
 import type { Transaction } from '@metamask/keyring-api';
 import { TransactionStatus, TransactionType } from '@metamask/keyring-api';
 import type { MultichainTransactionsControllerState } from '@metamask/multichain-transactions-controller';
@@ -160,7 +161,7 @@ describe('selectNonEvmActivityItems', () => {
     };
     (
       state.metamask as MetaMaskReduxState['metamask'] & {
-        txHistory: Record<string, unknown>;
+        txHistory: Record<string, BridgeHistoryItem>;
       }
     ).txHistory = {
       [solanaTxId]: {
@@ -187,7 +188,7 @@ describe('selectNonEvmActivityItems', () => {
           srcChain: { txHash: solanaTxId },
           destChain: { amount: '38467' },
         },
-      },
+      } as unknown as BridgeHistoryItem,
     };
 
     const [activity] = selectNonEvmActivityItems(state);

--- a/ui/selectors/activity.test.ts
+++ b/ui/selectors/activity.test.ts
@@ -1,4 +1,6 @@
+import { StatusTypes } from '@metamask/bridge-controller';
 import type { Transaction } from '@metamask/keyring-api';
+import { TransactionStatus, TransactionType } from '@metamask/keyring-api';
 import type { MultichainTransactionsControllerState } from '@metamask/multichain-transactions-controller';
 import { MultichainNetworks } from '../../shared/constants/multichain/networks';
 import type { MetaMaskReduxState } from '../store/store';
@@ -7,6 +9,7 @@ import mockState from '../../test/data/mock-state.json';
 import { MOCK_ACCOUNT_SOLANA_MAINNET } from '../../test/data/mock-accounts';
 import type { MultichainAccountsState } from './multichain-accounts/account-tree.types';
 import {
+  selectNonEvmActivityItems,
   selectNonEvmTransactionsForActivity,
   selectEvmAddress,
 } from './activity';
@@ -93,6 +96,144 @@ describe('selectNonEvmTransactionsForActivity', () => {
     ) as unknown as MetaMaskReduxState & MultichainAccountsState;
 
     expect(selectNonEvmTransactionsForActivity(state)).toEqual([benignTx]);
+  });
+});
+
+describe('selectNonEvmActivityItems', () => {
+  const solanaAddress = '8FnX3xo2yYw3EUE6w3nQA4GfXGS9wpK6oj3veJpbFzLo';
+  const solanaTxId =
+    '3r2jec1giywQcMg1rLx48QPF2JDkr7i916j2eTcBEGoHmf7jhYugBRRkWTe5gBKJ4yMHHqZSLA6DSMv7uDGv7ra9';
+
+  const solanaSendTransaction = {
+    id: solanaTxId,
+    chain: MultichainNetworks.SOLANA,
+    account: MOCK_ACCOUNT_SOLANA_MAINNET.id,
+    status: TransactionStatus.Confirmed,
+    timestamp: 1784777693,
+    type: TransactionType.Send,
+    from: [
+      {
+        address: solanaAddress,
+        asset: {
+          fungible: true,
+          type: `${MultichainNetworks.SOLANA}/token:EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v`,
+          unit: 'USDC',
+          amount: '0.038467',
+        },
+      },
+    ],
+    to: [{ address: 'to-address', asset: null }],
+    fees: [],
+    events: [],
+  } as unknown as Transaction;
+
+  it('reclassifies cross-chain non-EVM sends matched in bridge history as bridges', () => {
+    const state = structuredClone(
+      typedMockState,
+    ) as unknown as MetaMaskReduxState & MultichainAccountsState;
+
+    state.metamask.internalAccounts.selectedAccount =
+      MOCK_ACCOUNT_SOLANA_MAINNET.id;
+    state.metamask.internalAccounts.accounts = {
+      ...state.metamask.internalAccounts.accounts,
+      [MOCK_ACCOUNT_SOLANA_MAINNET.id]: {
+        ...MOCK_ACCOUNT_SOLANA_MAINNET,
+        address: solanaAddress,
+      },
+    };
+    state.metamask.accountTree.wallets[
+      'entropy:01JKAF3DSGM3AB87EM9N0K41AJ'
+    ].groups['entropy:01JKAF3DSGM3AB87EM9N0K41AJ/0'].accounts.push(
+      MOCK_ACCOUNT_SOLANA_MAINNET.id,
+    );
+    state.metamask.nonEvmTransactions = {
+      [MOCK_ACCOUNT_SOLANA_MAINNET.id]: {
+        [MultichainNetworks.SOLANA]: {
+          transactions: [solanaSendTransaction],
+          next: null,
+          lastUpdated: 0,
+        },
+      },
+    };
+    state.metamask.enabledNetworkMap = {
+      solana: { [MultichainNetworks.SOLANA]: true },
+    };
+    (
+      state.metamask as MetaMaskReduxState['metamask'] & {
+        txHistory: Record<string, unknown>;
+      }
+    ).txHistory = {
+      [solanaTxId]: {
+        account: solanaAddress,
+        quote: {
+          srcChainId: MultichainNetworks.SOLANA,
+          destChainId: 8453,
+          srcTokenAmount: '4912640',
+          destTokenAmount: '38467',
+          srcAsset: {
+            assetId: `${MultichainNetworks.SOLANA}/slip44:501`,
+            decimals: 9,
+            symbol: 'SOL',
+          },
+          destAsset: {
+            assetId:
+              'eip155:8453/token:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+            decimals: 6,
+            symbol: 'USDC',
+          },
+        },
+        status: {
+          status: StatusTypes.COMPLETE,
+          srcChain: { txHash: solanaTxId },
+          destChain: { amount: '38467' },
+        },
+      },
+    };
+
+    const [activity] = selectNonEvmActivityItems(state);
+
+    expect(activity.type).toBe('bridge');
+    expect(activity.data).toMatchObject({
+      sourceToken: {
+        symbol: 'SOL',
+        direction: 'out',
+        assetId: `${MultichainNetworks.SOLANA}/slip44:501`,
+      },
+      destinationToken: {
+        symbol: 'USDC',
+        direction: 'in',
+        assetId: 'eip155:8453/token:0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+      },
+    });
+  });
+
+  it('keeps unmatched non-EVM sends classified as sends', () => {
+    const accountId = mockState.metamask.internalAccounts.selectedAccount;
+
+    const state = buildState({
+      [accountId]: {
+        [MultichainNetworks.SOLANA]: {
+          transactions: [
+            {
+              ...solanaSendTransaction,
+              account: accountId,
+            },
+          ],
+          next: null,
+          lastUpdated: 0,
+        },
+      },
+    }) as unknown as MetaMaskReduxState & MultichainAccountsState;
+
+    const [activity] = selectNonEvmActivityItems(state);
+
+    expect(activity.type).toBe('send');
+    expect(activity.data).toMatchObject({
+      token: {
+        symbol: 'USDC',
+        direction: 'out',
+      },
+    });
   });
 });
 

--- a/ui/selectors/activity.ts
+++ b/ui/selectors/activity.ts
@@ -259,7 +259,7 @@ export const selectNonEvmActivityItems = createSelector(
           data: {
             from: subjectAddress,
             ...tokens,
-            ...(fees !== undefined ? { fees } : {}),
+            ...(fees === undefined ? {} : { fees }),
           },
         };
       }

--- a/ui/selectors/activity.ts
+++ b/ui/selectors/activity.ts
@@ -261,7 +261,7 @@ export const selectNonEvmActivityItems = createSelector(
             ...tokens,
             ...(fees === undefined ? {} : { fees }),
           },
-        };
+        } as ActivityListItem;
       }
 
       return activity;

--- a/ui/selectors/activity.ts
+++ b/ui/selectors/activity.ts
@@ -35,6 +35,7 @@ import { toAssetId } from '../../shared/lib/asset-utils';
 import { getLocalTransactionFees } from '../../shared/lib/activity/adapters/helpers';
 import { isProtectedByEnforcedSimulations } from '../pages/confirmations/utils/confirm';
 import { ActivityListItem, Status } from '../../shared/lib/activity/types';
+import { selectBridgeHistoryItemForTxHash } from '../ducks/bridge-status/selectors';
 import { getInternalAccountsObject } from './accounts';
 import { getInternalAccountBySelectedAccountGroupAndCaip } from './multichain-accounts/account-tree';
 import type { MultichainAccountsState } from './multichain-accounts/account-tree.types';
@@ -59,7 +60,7 @@ import {
 import { EMPTY_ARRAY, EMPTY_OBJECT } from './shared';
 
 // @deprecated - Migrate to selectBridgeHistoryItem
-const selectBridgeHistory = (state: MetaMaskReduxState) =>
+const selectBridgeHistoryDeprecated = (state: MetaMaskReduxState) =>
   (state.metamask.txHistory ?? EMPTY_OBJECT) as Record<
     string,
     BridgeHistoryItem
@@ -220,20 +221,51 @@ export const selectNonEvmTransactionsForActivity = createSelector(
   },
 );
 
+const selectBridgeHistory = createSelector(
+  [(state: MetaMaskReduxState) => state],
+  (state) => (txHash?: string) =>
+    txHash ? selectBridgeHistoryItemForTxHash(state, txHash) : undefined,
+);
+
 export const selectNonEvmActivityItems = createSelector(
   [
     selectNonEvmTransactionsForActivity,
     getAssetsMetadata,
     getInternalAccountsObject,
+    selectBridgeHistory,
   ],
-  (transactions, assetsMetadata, internalAccountsById) =>
-    transactions.map((transaction) =>
-      mapKeyringTransaction({
+  (transactions, assetsMetadata, internalAccountsById, getBridgeHistory) =>
+    transactions.map((transaction) => {
+      const subjectAddress =
+        internalAccountsById?.[transaction.account]?.address;
+      const activity = mapKeyringTransaction({
         // Unified assets caused Snap token movements with empty or placeholder units.
         transaction: patchKeyringTransaction(transaction, assetsMetadata),
-        subjectAddress: internalAccountsById?.[transaction.account]?.address,
-      }),
-    ),
+        subjectAddress,
+      });
+
+      const bridgeHistoryEntry = getBridgeHistory(transaction.id);
+      const { quote } = bridgeHistoryEntry ?? {};
+
+      if (quote && isCrossChain(quote.srcChainId, quote.destChainId)) {
+        const tokens = getSwapTokens(bridgeHistoryEntry);
+        const status = getBridgeActivityStatus(bridgeHistoryEntry);
+        const fees = 'fees' in activity.data ? activity.data.fees : undefined;
+
+        return {
+          ...activity,
+          type: 'bridge',
+          ...(status ? { status } : {}),
+          data: {
+            from: subjectAddress,
+            ...tokens,
+            ...(fees !== undefined ? { fees } : {}),
+          },
+        };
+      }
+
+      return activity;
+    }),
 );
 
 export const selectNonEvmActivityItemsById = createSelector(
@@ -401,7 +433,7 @@ function getBridgeActivityStatus(
 
 export const selectLocalActivityItems = createSelector(
   selectLocalTransactions,
-  selectBridgeHistory,
+  selectBridgeHistoryDeprecated,
   selectTransactionPayData,
   getNetworkConfigurationsByChainId,
   getSelectedInternalAccount,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Fix labels of non-EVM source bridge transactions

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fix: non EVM activity labels

## **Related issues**

Fixes: #44752 

## **Manual testing steps**

1. Bridge a non EVM token to EVM
2. Check activity history

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="341" height="68" alt="image" src="https://github.com/user-attachments/assets/60f88e8b-00ca-4991-a18d-c315998cd293" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes activity classification and display for non-EVM transactions using bridge history lookups; incorrect matching could mislabel sends as bridges, but scope is limited to activity UI/selectors.
> 
> **Overview**
> **Non-EVM keyring transactions that match cross-chain bridge history are shown as bridges again**, with source/destination tokens from the quote instead of a plain send.
> 
> `selectNonEvmActivityItems` now resolves bridge history per transaction id via `selectBridgeHistoryItemForTxHash` and, when `isCrossChain` applies, overrides the mapped activity to `type: 'bridge'` with swap tokens and bridge status. Unmatched sends stay sends (covered by new selector tests).
> 
> **Bridge rows in the activity list** can show a **source chain → destination chain** subtitle by deriving chain ids from token `assetId`s; `getChainIdFromAssetId` returns `undefined` for missing ids. BTC bridge e2e expectations were updated from “Sending BTC” to “Bridging BTC”.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ca022a5ecc6a61b103119dd9b3ef809c04b9ca8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->