### PR TITLE
feat: handle stellar reserve balance swaps error

### DIFF
--- a/shared/lib/multichain/trustline.test.ts
+++ b/shared/lib/multichain/trustline.test.ts
@@ -1,4 +1,9 @@
-import { isAssetRequireActivate, isTrustlineAsset } from './trustline';
+import {
+  getAdditionalReserveForMissingTrustline,
+  isAssetRequireActivate,
+  isTrustlineAsset,
+  STELLAR_BASE_RESERVE_PER_SUBENTRY_XLM,
+} from './trustline';
 
 const CLASSIC_ASSET_ID =
   'stellar:pubnet/asset:USDC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN';
@@ -81,5 +86,41 @@ describe('isAssetRequireActivate', () => {
         assetMetadata: { limit: '0' },
       }),
     ).toBe(false);
+  });
+});
+
+describe('getAdditionalReserveForMissingTrustline', () => {
+  it('returns one base reserve when the destination trustline is inactive', () => {
+    expect(
+      getAdditionalReserveForMissingTrustline({
+        toAssetId: CLASSIC_ASSET_ID,
+        toAssetMetadata: { limit: '0' },
+      }),
+    ).toBe(STELLAR_BASE_RESERVE_PER_SUBENTRY_XLM);
+  });
+
+  it('returns one base reserve when destination trustline metadata is missing', () => {
+    expect(
+      getAdditionalReserveForMissingTrustline({
+        toAssetId: CLASSIC_ASSET_ID,
+      }),
+    ).toBe(STELLAR_BASE_RESERVE_PER_SUBENTRY_XLM);
+  });
+
+  it('returns 0 when the destination trustline is already active', () => {
+    expect(
+      getAdditionalReserveForMissingTrustline({
+        toAssetId: CLASSIC_ASSET_ID,
+        toAssetMetadata: { limit: '1000' },
+      }),
+    ).toBe('0');
+  });
+
+  it('returns 0 when the destination is not a trustline asset', () => {
+    expect(
+      getAdditionalReserveForMissingTrustline({
+        toAssetId: SEP41_ASSET_ID,
+      }),
+    ).toBe('0');
   });
 });

--- a/shared/lib/multichain/trustline.ts
+++ b/shared/lib/multichain/trustline.ts
@@ -6,9 +6,17 @@ import { XlmScope } from '@metamask/keyring-api';
  * Account-scoped metadata for a trustline asset, when provided by the
  * account asset controller.
  */
-type AssetMetadata = {
+export type TrustlineAssetMetadata = {
   limit?: string;
 };
+
+/**
+ * One Stellar base reserve in XLM. Opening a new classic trustline locks this
+ * additional amount on the account until the trustline is removed.
+ *
+ * @see https://developers.stellar.org/docs/learn/fundamentals/lumens#minimum-balance
+ */
+export const STELLAR_BASE_RESERVE_PER_SUBENTRY_XLM = '0.5';
 
 /**
  * CAIP asset namespace used for classic trustline assets on each supported
@@ -48,7 +56,7 @@ export function isTrustlineAsset(assetId: string): boolean {
  */
 export function isAssetRequireActivate(params: {
   assetId?: string;
-  assetMetadata?: AssetMetadata;
+  assetMetadata?: TrustlineAssetMetadata;
 }): boolean {
   const { assetId, assetMetadata } = params;
 
@@ -65,4 +73,28 @@ export function isAssetRequireActivate(params: {
   // default to true because the imported token doesn't have assetMetadata at first,
   // we assume it is inactive
   return true;
+}
+
+/**
+ * Extra native reserve (in XLM) required when swapping into a classic asset
+ * that does not yet have an active trustline on the account.
+ *
+ * Uses {@link isAssetRequireActivate}: missing enrichment is treated as
+ * inactive so the reserve is overestimated until metadata is available.
+ *
+ * @param params - Destination asset identity and cached trustline metadata.
+ * @param params.toAssetId - CAIP asset ID of the swap/bridge destination token.
+ * @param params.toAssetMetadata - Trustline enrichment from StellarAssetsController.
+ * @returns `'0.5'` when a new trustline would be required, otherwise `'0'`.
+ */
+export function getAdditionalReserveForMissingTrustline(params: {
+  toAssetId?: string;
+  toAssetMetadata?: TrustlineAssetMetadata;
+}): string {
+  return isAssetRequireActivate({
+    assetId: params.toAssetId,
+    assetMetadata: params.toAssetMetadata,
+  })
+    ? STELLAR_BASE_RESERVE_PER_SUBENTRY_XLM
+    : '0';
 }

--- a/ui/ducks/bridge/selectors.test.ts
+++ b/ui/ducks/bridge/selectors.test.ts
@@ -1,4 +1,5 @@
 import { zeroAddress } from 'ethereumjs-util';
+import { BigNumber } from 'bignumber.js';
 import {
   ChainId,
   type QuoteMetadata,
@@ -218,14 +219,17 @@ describe('Bridge selectors', () => {
     toAssetAccountInfo,
     nonEvmFeesInNative,
     srcTokenAmount = '75000000',
+    metabridgeFeeAmount = '0',
   }: {
     fromTokenInputValue?: string;
     fromNativeBalance?: string;
     baseReserve?: string | null;
     toToken?: ReturnType<typeof toBridgeToken>;
     toAssetAccountInfo?: { limit: string };
-    nonEvmFeesInNative?: string;
+    /** `undefined` = no quote, `null` = quote whose snap fee computation failed */
+    nonEvmFeesInNative?: string | null;
     srcTokenAmount?: string;
+    metabridgeFeeAmount?: string;
   } = {}) => {
     const xlmAsset = getNativeAssetForChainId(ChainId.STELLAR);
     const ethAsset = getNativeAssetForChainId(ChainId.ETH);
@@ -240,6 +244,13 @@ describe('Bridge selectors', () => {
       accountAssetsForAccount[toToken.assetId] = toAssetAccountInfo;
     }
 
+    // Stellar provider fees are deducted from the input amount: the quote's
+    // srcTokenAmount is the routed amount (input - metabridge fee), so the
+    // sent amount (srcTokenAmount + metabridge fee) equals the input.
+    const quoteSrcTokenAmount = new BigNumber(srcTokenAmount)
+      .minus(metabridgeFeeAmount)
+      .toString();
+
     const stellarQuote =
       nonEvmFeesInNative === undefined
         ? undefined
@@ -249,7 +260,7 @@ describe('Bridge selectors', () => {
               bridgeId: 'rango',
               aggregator: 'rango',
               srcChainId: ChainId.STELLAR,
-              srcTokenAmount,
+              srcTokenAmount: quoteSrcTokenAmount,
               srcAsset: xlmAsset,
               destChainId: ChainId.ETH,
               destTokenAmount: '1000000000000000000',
@@ -257,7 +268,7 @@ describe('Bridge selectors', () => {
               minDestTokenAmount: '990000000000000000',
               feeData: {
                 metabridge: {
-                  amount: '0',
+                  amount: metabridgeFeeAmount,
                   asset: xlmAsset,
                 },
               },
@@ -269,7 +280,7 @@ describe('Bridge selectors', () => {
               xdr: 'AAAA',
             },
             estimatedProcessingTimeInSeconds: 30,
-            nonEvmFeesInNative,
+            nonEvmFeesInNative: nonEvmFeesInNative ?? undefined,
           };
 
     return createBridgeMockStore({
@@ -3119,39 +3130,130 @@ describe('Bridge selectors', () => {
       );
     });
 
-    it('should return isInsufficientNativeReserve=true and isInsufficientGasForQuote=false on Stellar when the quote fee is payable but the reserve would be depleted', () => {
+    it('should subtract a plausible snap fee from the Stellar max allowed', () => {
+      // The snap-computed network fee is real when the simulation succeeds:
+      // max = 10 - 0.0000001 - 2.5 = 7.4999999
       const state = createStellarBridgeState({
-        fromTokenInputValue: '7.5',
+        fromTokenInputValue: '7.6',
         fromNativeBalance: '10',
         baseReserve: '2.5',
         nonEvmFeesInNative: '0.0000001',
-        srcTokenAmount: '75000000',
+        srcTokenAmount: '76000000',
       });
       const result = getValidationErrors(state as never);
       const nativeReserveError = getActiveQuoteInsufficientNativeReserveError(
         state as never,
       );
 
-      expect(nativeReserveError?.maxSwappableNativeBalance).toStrictEqual(
-        '7.4999999',
-      );
+      expect(nativeReserveError).toStrictEqual({
+        minimumNativeBalanceToBeKeptInAccount: '2.5',
+        maxSwappableNativeBalance: '7.4999999',
+      });
       expect(result.isInsufficientNativeReserve).toBe(true);
       expect(result.isInsufficientGasForQuote).toBe(false);
     });
 
-    it('should return isInsufficientGasForQuote=true and isInsufficientNativeReserve=false on Stellar when the quote fee cannot be paid', () => {
+    it('should substitute a conservative fee when the snap misreports the required amount as the fee', () => {
+      // The Stellar snap's computeFee returns the amount required by the
+      // failed simulation as the "fee" when the balance can't cover the
+      // swap. The implausible fee is replaced by the 0.1 XLM bound and must
+      // not trigger the gas alert: max = 10 - 0.1 - 2.5 = 7.4
       const state = createStellarBridgeState({
-        fromTokenInputValue: '7.5',
+        fromTokenInputValue: '8',
         fromNativeBalance: '10',
         baseReserve: '2.5',
-        nonEvmFeesInNative: '2.6',
-        srcTokenAmount: '75000000',
+        nonEvmFeesInNative: '8',
+        srcTokenAmount: '80000000',
       });
       const result = getValidationErrors(state as never);
+      const nativeReserveError = getActiveQuoteInsufficientNativeReserveError(
+        state as never,
+      );
 
-      // balance - fee - sent = 10 - 2.6 - 7.5 = -0.1 <= 0 → gas insufficiency
-      expect(result.isInsufficientNativeReserve).toBe(false);
-      expect(result.isInsufficientGasForQuote).toBe(true);
+      expect(nativeReserveError).toStrictEqual({
+        minimumNativeBalanceToBeKeptInAccount: '2.5',
+        maxSwappableNativeBalance: '7.4',
+      });
+      expect(result.isInsufficientNativeReserve).toBe(true);
+      expect(result.isInsufficientGasForQuote).toBe(false);
+    });
+
+    it('should keep the Stellar reserve warning instead of the gas error when the sent amount consumes the full balance', () => {
+      const state = createStellarBridgeState({
+        fromTokenInputValue: '9.98',
+        fromNativeBalance: '10',
+        baseReserve: '2.5',
+        nonEvmFeesInNative: '0.05',
+        srcTokenAmount: '99800000',
+      });
+      const result = getValidationErrors(state as never);
+      const nativeReserveError = getActiveQuoteInsufficientNativeReserveError(
+        state as never,
+      );
+
+      // balance - fee - sent = 10 - 0.05 - 9.98 <= 0, but the reserve
+      // warning is more actionable than the gas error on Stellar:
+      // max = 10 - 0.05 - 2.5 = 7.45
+      expect(nativeReserveError).toStrictEqual({
+        minimumNativeBalanceToBeKeptInAccount: '2.5',
+        maxSwappableNativeBalance: '7.45',
+      });
+      expect(result.isInsufficientNativeReserve).toBe(true);
+      expect(result.isInsufficientGasForQuote).toBe(false);
+    });
+
+    it('should not subtract the metabridge fee from the Stellar max allowed', () => {
+      // Real-world shape: balance 91.510816, base reserve 5 + 0.5 for the
+      // missing trustline, misreported snap fee replaced by the 0.1 bound.
+      // The metabridge fee is deducted from the sent amount (not charged on
+      // top), so it must not reduce the max:
+      // max = 91.510816 - 0.1 - 5.5 = 85.910816
+      const state = createStellarBridgeState({
+        fromTokenInputValue: '89',
+        fromNativeBalance: '91.510816',
+        baseReserve: '5',
+        toToken: toBridgeToken(STELLAR_CLASSIC_ASSET),
+        nonEvmFeesInNative: '88.22125',
+        srcTokenAmount: '890000000',
+        metabridgeFeeAmount: '7787500',
+      });
+      const result = getValidationErrors(state as never);
+      const nativeReserveError = getActiveQuoteInsufficientNativeReserveError(
+        state as never,
+      );
+
+      expect(nativeReserveError).toStrictEqual({
+        minimumNativeBalanceToBeKeptInAccount: '5.5',
+        maxSwappableNativeBalance: '85.910816',
+      });
+      expect(result.isInsufficientNativeReserve).toBe(true);
+      expect(result.isInsufficientGasForQuote).toBe(false);
+    });
+
+    it('should substitute a conservative fee when the snap fee computation failed', () => {
+      // When the balance cannot cover the swap the snap may fail to compute
+      // a fee at all (nonEvmFeesInNative is undefined); the reserve warning
+      // still applies with max = 91.510816 - 0.1 - 5.5 = 85.910816
+      const state = createStellarBridgeState({
+        fromTokenInputValue: '87',
+        fromNativeBalance: '91.510816',
+        baseReserve: '5',
+        toToken: toBridgeToken(STELLAR_CLASSIC_ASSET),
+        nonEvmFeesInNative: null,
+        srcTokenAmount: '870000000',
+        metabridgeFeeAmount: '7612500',
+      });
+      const result = getValidationErrors(state as never);
+      const nativeReserveError = getActiveQuoteInsufficientNativeReserveError(
+        state as never,
+      );
+
+      expect(nativeReserveError).toStrictEqual({
+        minimumNativeBalanceToBeKeptInAccount: '5.5',
+        maxSwappableNativeBalance: '85.910816',
+      });
+      expect(result.isInsufficientNativeReserve).toBe(true);
+      expect(result.isInsufficientGasForQuote).toBe(false);
     });
 
     it('should return isInsufficientNativeReserve=false on Solana even when trying to use full balance', () => {

--- a/ui/ducks/bridge/selectors.test.ts
+++ b/ui/ducks/bridge/selectors.test.ts
@@ -21,7 +21,10 @@ import {
   MOCK_LEDGER_ACCOUNT,
   MOCK_SOLANA_ACCOUNT,
 } from '../../../test/data/bridge/mock-bridge-store';
-import { MOCK_ACCOUNT_TRON_MAINNET } from '../../../test/data/mock-accounts';
+import {
+  MOCK_ACCOUNT_STELLAR_PUBNET,
+  MOCK_ACCOUNT_TRON_MAINNET,
+} from '../../../test/data/mock-accounts';
 import { CHAIN_IDS, FEATURED_RPCS } from '../../../shared/constants/network';
 import { mockNetworkState } from '../../../test/stub/networks';
 import mockErc20Erc20Quotes from '../../../test/data/bridge/mock-quotes-erc20-erc20.json';
@@ -77,6 +80,21 @@ import {
   resolveMinimumBalanceToKeep,
 } from './selectors';
 import { toBridgeToken } from './utils';
+
+const STELLAR_CLASSIC_ASSET_ISSUER =
+  'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN';
+const STELLAR_CLASSIC_ASSET_ID =
+  `stellar:pubnet/asset:USDC-${STELLAR_CLASSIC_ASSET_ISSUER}` as const;
+
+const STELLAR_CLASSIC_ASSET = {
+  symbol: 'USDC',
+  name: 'USD Coin',
+  address: `USDC-${STELLAR_CLASSIC_ASSET_ISSUER}`,
+  decimals: 7,
+  iconUrl: '',
+  chainId: ChainId.STELLAR,
+  assetId: STELLAR_CLASSIC_ASSET_ID,
+};
 
 describe('Bridge selectors', () => {
   const getErc20QuoteAssetExchangeRates = (usdExchangeRate: string) =>
@@ -191,6 +209,106 @@ describe('Bridge selectors', () => {
         usdExchangeRate,
       },
     }) as never;
+
+  const createStellarBridgeState = ({
+    fromTokenInputValue = '7.5',
+    fromNativeBalance = '10',
+    baseReserve = '2.5',
+    toToken = toBridgeToken(getNativeAssetForChainId(ChainId.ETH)),
+    toAssetAccountInfo,
+    nonEvmFeesInNative,
+    srcTokenAmount = '75000000',
+  }: {
+    fromTokenInputValue?: string;
+    fromNativeBalance?: string;
+    baseReserve?: string | null;
+    toToken?: ReturnType<typeof toBridgeToken>;
+    toAssetAccountInfo?: { limit: string };
+    nonEvmFeesInNative?: string;
+    srcTokenAmount?: string;
+  } = {}) => {
+    const xlmAsset = getNativeAssetForChainId(ChainId.STELLAR);
+    const ethAsset = getNativeAssetForChainId(ChainId.ETH);
+    const accountId = MOCK_ACCOUNT_STELLAR_PUBNET.id;
+    const accountAssetsForAccount: Record<string, { baseReserve: string } | { limit: string }> =
+      {};
+
+    if (baseReserve !== null) {
+      accountAssetsForAccount[xlmAsset.assetId] = { baseReserve };
+    }
+    if (toAssetAccountInfo && toToken?.assetId) {
+      accountAssetsForAccount[toToken.assetId] = toAssetAccountInfo;
+    }
+
+    const stellarQuote =
+      nonEvmFeesInNative === undefined
+        ? undefined
+        : {
+            quote: {
+              requestId: 'stellar-quote',
+              bridgeId: 'rango',
+              aggregator: 'rango',
+              srcChainId: ChainId.STELLAR,
+              srcTokenAmount,
+              srcAsset: xlmAsset,
+              destChainId: ChainId.ETH,
+              destTokenAmount: '1000000000000000000',
+              destAsset: ethAsset,
+              minDestTokenAmount: '990000000000000000',
+              feeData: {
+                metabridge: {
+                  amount: '0',
+                  asset: xlmAsset,
+                },
+              },
+              bridges: ['rango'],
+              protocols: ['rango'],
+              steps: [],
+            },
+            trade: {
+              xdr: 'AAAA',
+            },
+            estimatedProcessingTimeInSeconds: 30,
+            nonEvmFeesInNative,
+          };
+
+    return createBridgeMockStore({
+      bridgeSliceOverrides: {
+        fromTokenInputValue,
+        fromToken: toBridgeToken(xlmAsset),
+        toToken,
+      },
+      bridgeStateOverrides: {
+        quotesLastFetched: Date.now(),
+        quoteRequest: {
+          srcChainId: ChainId.STELLAR,
+          srcTokenAmount,
+        },
+        quotes: stellarQuote
+          ? ([stellarQuote] as unknown as QuoteResponse[])
+          : [],
+      },
+      metamaskStateOverrides: {
+        internalAccounts: {
+          accounts: {
+            [accountId]: MOCK_ACCOUNT_STELLAR_PUBNET,
+          },
+          selectedAccount: accountId,
+        },
+        balances: {
+          [accountId]: {
+            [xlmAsset.assetId]: {
+              amount: fromNativeBalance,
+              unit: 'XLM',
+            },
+          },
+        },
+        accountAssets: {
+          [accountId]: accountAssetsForAccount,
+        },
+      },
+    });
+  };
 
   const createTronBridgeState = ({
     fromTokenInputValue = '1',
@@ -2872,6 +2990,137 @@ describe('Bridge selectors', () => {
       });
       const result = getValidationErrors(state as never);
 
+      expect(result.isInsufficientNativeReserve).toBe(false);
+      expect(result.isInsufficientGasForQuote).toBe(true);
+    });
+
+    it('should return isInsufficientNativeReserve=true on Stellar when amount exceeds balance minus baseReserve', () => {
+      const state = createStellarBridgeState({
+        fromTokenInputValue: '7.6',
+        fromNativeBalance: '10',
+        baseReserve: '2.5',
+        srcTokenAmount: '76000000',
+      });
+      const result = getValidationErrors(state as never);
+
+      // 10 - 7.6 = 2.4 XLM remaining, which is < 2.5 XLM reserve
+      expect(result.isInsufficientNativeReserve).toBe(true);
+    });
+
+    it('should return isInsufficientNativeReserve=false on Stellar when amount fits in spendable balance', () => {
+      const state = createStellarBridgeState({
+        fromTokenInputValue: '7.5',
+        fromNativeBalance: '10',
+        baseReserve: '2.5',
+        srcTokenAmount: '75000000',
+      });
+      const result = getValidationErrors(state as never);
+
+      expect(result.isInsufficientNativeReserve).toBe(false);
+    });
+
+    it('should not apply a Stellar native reserve when baseReserve enrichment is missing', () => {
+      const state = createStellarBridgeState({
+        fromTokenInputValue: '9.9',
+        fromNativeBalance: '10',
+        baseReserve: null,
+        srcTokenAmount: '99000000',
+      });
+      const result = getValidationErrors(state as never);
+
+      expect(result.isInsufficientNativeReserve).toBe(false);
+      expect(
+        getInsufficientNativeReserveError(state as never),
+      ).toBeUndefined();
+    });
+
+    it('should not apply a Stellar native reserve when baseReserve enrichment is zero', () => {
+      const state = createStellarBridgeState({
+        fromTokenInputValue: '9.9',
+        fromNativeBalance: '10',
+        baseReserve: '0',
+        toToken: toBridgeToken(STELLAR_CLASSIC_ASSET),
+        srcTokenAmount: '99000000',
+      });
+
+      expect(
+        getInsufficientNativeReserveError(state as never),
+      ).toBeUndefined();
+      expect(getValidationErrors(state as never).isInsufficientNativeReserve).toBe(
+        false,
+      );
+    });
+
+    it('should add one base-reserve subentry when destination trustline metadata is missing', () => {
+      const state = createStellarBridgeState({
+        fromTokenInputValue: '7.5',
+        fromNativeBalance: '10',
+        baseReserve: '2.5',
+        toToken: toBridgeToken(STELLAR_CLASSIC_ASSET),
+        srcTokenAmount: '75000000',
+      });
+      const nativeReserveError = getInsufficientNativeReserveError(
+        state as never,
+      );
+
+      expect(nativeReserveError).toStrictEqual({
+        minimumNativeBalanceToBeKeptInAccount: '3',
+        maxSwappableNativeBalance: '7',
+      });
+      expect(getValidationErrors(state as never).isInsufficientNativeReserve).toBe(
+        true,
+      );
+    });
+
+    it('should not add a trustline subentry when the destination classic asset already has a trustline', () => {
+      const state = createStellarBridgeState({
+        fromTokenInputValue: '7.5',
+        fromNativeBalance: '10',
+        baseReserve: '2.5',
+        toToken: toBridgeToken(STELLAR_CLASSIC_ASSET),
+        toAssetAccountInfo: { limit: '1000' },
+        srcTokenAmount: '75000000',
+      });
+
+      expect(
+        getInsufficientNativeReserveError(state as never),
+      ).toBeUndefined();
+      expect(getValidationErrors(state as never).isInsufficientNativeReserve).toBe(
+        false,
+      );
+    });
+
+    it('should return isInsufficientNativeReserve=true and isInsufficientGasForQuote=false on Stellar when the quote fee is payable but the reserve would be depleted', () => {
+      const state = createStellarBridgeState({
+        fromTokenInputValue: '7.5',
+        fromNativeBalance: '10',
+        baseReserve: '2.5',
+        nonEvmFeesInNative: '0.0000001',
+        srcTokenAmount: '75000000',
+      });
+      const result = getValidationErrors(state as never);
+      const nativeReserveError = getActiveQuoteInsufficientNativeReserveError(
+        state as never,
+      );
+
+      expect(nativeReserveError?.maxSwappableNativeBalance).toStrictEqual(
+        '7.4999999',
+      );
+      expect(result.isInsufficientNativeReserve).toBe(true);
+      expect(result.isInsufficientGasForQuote).toBe(false);
+    });
+
+    it('should return isInsufficientGasForQuote=true and isInsufficientNativeReserve=false on Stellar when the quote fee cannot be paid', () => {
+      const state = createStellarBridgeState({
+        fromTokenInputValue: '7.5',
+        fromNativeBalance: '10',
+        baseReserve: '2.5',
+        nonEvmFeesInNative: '2.6',
+        srcTokenAmount: '75000000',
+      });
+      const result = getValidationErrors(state as never);
+
+      // balance - fee - sent = 10 - 2.6 - 7.5 = -0.1 <= 0 → gas insufficiency
       expect(result.isInsufficientNativeReserve).toBe(false);
       expect(result.isInsufficientGasForQuote).toBe(true);
     });

--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -943,6 +943,15 @@ export const getInsufficientNativeReserveError = createSelector(
   },
 );
 
+/**
+ * Upper bound for a plausible Stellar network fee, in XLM. Real fees are
+ * ~0.00001 XLM (100 stroops per operation) and stay far below this bound
+ * even under surge pricing. A reported fee above it is the Stellar snap's
+ * computeFee fallback misreporting the amount required by a failed
+ * simulation, so the bound doubles as a conservative fee estimate.
+ */
+const STELLAR_MAX_PLAUSIBLE_NETWORK_FEE_XLM = '0.1';
+
 export const getActiveQuoteInsufficientNativeReserveError = createSelector(
   [
     getInsufficientNativeReserveError,
@@ -970,26 +979,51 @@ export const getActiveQuoteInsufficientNativeReserveError = createSelector(
     if (
       isQuoteAwareNativeReserveChain &&
       minimumNativeReserveBalance !== '0' &&
-      activeQuote?.totalNetworkFee?.amount &&
       activeQuote?.sentAmount?.amount &&
       nativeBalance &&
       validatedSrcAmount &&
-      new BigNumber(activeQuote.totalNetworkFee.amount).gt(0)
+      // Bitcoin needs a real quote fee. Stellar substitutes a conservative
+      // estimate below when the snap-reported fee is missing or implausible.
+      (isStellarNativeReserveChain ||
+        new BigNumber(activeQuote?.totalNetworkFee?.amount ?? '0').gt(0))
     ) {
       const nativeBalanceInNativeUnits = new BigNumber(nativeBalance);
-      const totalNetworkFee = new BigNumber(activeQuote.totalNetworkFee.amount);
+      const reportedNetworkFee = new BigNumber(
+        activeQuote.totalNetworkFee?.amount ?? '0',
+      );
       const sentAmount = new BigNumber(activeQuote.sentAmount.amount);
 
-      if (
-        nativeBalanceInNativeUnits.sub(totalNetworkFee).sub(sentAmount).lte(0)
-      ) {
-        return undefined;
-      }
+      // The Stellar snap's computeFee reports the amount required by the
+      // failed simulation as the "fee" when the balance cannot cover the
+      // swap, and reports nothing when validation throws. Real Stellar fees
+      // are far below the plausibility bound, so replace a missing or
+      // implausible fee with the bound itself: the max stays slightly
+      // conservative, and requoting at that amount simulates successfully
+      // and converges on the real fee.
+      const isReportedFeePlausible =
+        reportedNetworkFee.gt(0) &&
+        reportedNetworkFee.lte(STELLAR_MAX_PLAUSIBLE_NETWORK_FEE_XLM);
+      const totalNetworkFee =
+        isStellarNativeReserveChain && !isReportedFeePlausible
+          ? new BigNumber(STELLAR_MAX_PLAUSIBLE_NETWORK_FEE_XLM)
+          : reportedNetworkFee;
 
+      // Provider fees charged on top of the input amount (zero on Stellar,
+      // where provider fees are deducted from the sent amount instead).
       const quoteSourceOverhead = BigNumber.max(
         sentAmount.sub(validatedSrcAmount),
         0,
       );
+
+      if (
+        !isStellarNativeReserveChain &&
+        nativeBalanceInNativeUnits.sub(totalNetworkFee).sub(sentAmount).lte(0)
+      ) {
+        // Defer to the gas error: the quote fee itself cannot be paid. On
+        // Stellar the reserve warning is more actionable instead (the user
+        // holds the balance, it is just reserved), so fall through there.
+        return undefined;
+      }
 
       const maxSwappableNativeBalance = nativeBalanceInNativeUnits
         .sub(totalNetworkFee)
@@ -1018,10 +1052,10 @@ export const getQuoteRequestInsufficientBal = createSelector(
   (fromTokenBalance, validatedSrcAmount, insufficientNativeReserveError) =>
     Boolean(
       insufficientNativeReserveError ||
-      (validatedSrcAmount &&
-        fromTokenBalance &&
-        !Number.isNaN(Number(fromTokenBalance)) &&
-        new BigNumber(fromTokenBalance).lt(validatedSrcAmount)),
+        (validatedSrcAmount &&
+          fromTokenBalance &&
+          !Number.isNaN(Number(fromTokenBalance)) &&
+          new BigNumber(fromTokenBalance).lt(validatedSrcAmount)),
     ),
 );
 
@@ -1108,13 +1142,20 @@ export const computeQuoteValidationErrors = (
   );
 
   const isInsufficientNativeReserve = Boolean(insufficientNativeReserveError);
+  // On Stellar the reserve warning supersedes the gas error: when the balance
+  // can't cover fee + amount it is because of the reserve, and the snap's
+  // computeFee fallback misreports the required amount as the fee, which
+  // would otherwise trigger a misleading "more XLM needed for gas" alert.
+  const isGasErrorSupersededByReserve = Boolean(
+    srcChainId && isStellarChainId(srcChainId) && isInsufficientNativeReserve,
+  );
   const isNetworkFeeUnavailable = Boolean(
     quote &&
-    srcChainId &&
-    (isBitcoinChainId(srcChainId) || isTronChainId(srcChainId)) &&
-    !isGasless &&
-    (quote.totalNetworkFee?.amount === undefined ||
-      new BigNumber(quote.totalNetworkFee?.amount ?? '0').lte(0)),
+      srcChainId &&
+      (isBitcoinChainId(srcChainId) || isTronChainId(srcChainId)) &&
+      !isGasless &&
+      (quote.totalNetworkFee?.amount === undefined ||
+        new BigNumber(quote.totalNetworkFee?.amount ?? '0').lte(0)),
   );
 
   const parsedPriceImpactNumber = Number(quote?.quote?.priceData?.priceImpact);
@@ -1126,32 +1167,33 @@ export const computeQuoteValidationErrors = (
     // Shown prior to fetching quotes (native reserve error takes precedence)
     isInsufficientGasBalance: Boolean(
       nativeBalance &&
-      !quote &&
-      validatedSrcAmount &&
-      fromToken &&
-      !isGasless &&
-      (isNativeAddress(fromToken.assetId)
-        ? new BigNumber(nativeBalance)
-            .sub(minimumBalanceToKeep)
-            .lte(validatedSrcAmount)
-        : new BigNumber(nativeBalance).lte(0)),
+        !quote &&
+        validatedSrcAmount &&
+        fromToken &&
+        !isGasless &&
+        (isNativeAddress(fromToken.assetId)
+          ? new BigNumber(nativeBalance)
+              .sub(minimumBalanceToKeep)
+              .lte(validatedSrcAmount)
+          : new BigNumber(nativeBalance).lte(0)),
     ),
     isInsufficientNativeReserve,
     isNetworkFeeUnavailable,
     // Shown after fetching quotes
     isInsufficientGasForQuote: Boolean(
       !isNetworkFeeUnavailable &&
-      nativeBalance &&
-      quote &&
-      fromToken &&
-      fromTokenInputValue &&
-      !isGasless &&
-      isNativeBalanceInsufficientForQuote(
-        quote,
-        nativeBalance,
-        fromToken,
-        minimumBalanceToKeep,
-      ),
+        !isGasErrorSupersededByReserve &&
+        nativeBalance &&
+        quote &&
+        fromToken &&
+        fromTokenInputValue &&
+        !isGasless &&
+        isNativeBalanceInsufficientForQuote(
+          quote,
+          nativeBalance,
+          fromToken,
+          minimumBalanceToKeep,
+        ),
     ),
     isInsufficientBalance:
       validatedSrcAmount &&
@@ -1171,8 +1213,8 @@ export const computeQuoteValidationErrors = (
         : false,
     isPriceImpactWarning: Boolean(
       priceImpactNumber &&
-      priceImpactNumber > warning &&
-      priceImpactNumber <= error,
+        priceImpactNumber > warning &&
+        priceImpactNumber <= error,
     ),
     isPriceImpactError: Boolean(priceImpactNumber && priceImpactNumber > error),
   };
@@ -1233,10 +1275,10 @@ const _getBaseValidationErrors = createDeepEqualSelector(
         quoteStreamCompleteData?.hasQuotes === false ||
         Boolean(
           !activeQuote &&
-          isValidQuoteRequest(quoteRequest) &&
-          quotesLastFetchedMs &&
-          !isLoading &&
-          quotesRefreshCount > 0,
+            isValidQuoteRequest(quoteRequest) &&
+            quotesLastFetchedMs &&
+            !isLoading &&
+            quotesRefreshCount > 0,
         ),
     };
   },

--- a/ui/ducks/bridge/selectors.ts
+++ b/ui/ducks/bridge/selectors.ts
@@ -108,6 +108,10 @@ import {
 } from '../../pages/bridge/utils/price-impact';
 import { getCurrentCurrency } from '../metamask/metamask';
 import {
+  getStellarMinimumReserveForSwap,
+  type StellarAssetsSelectorState,
+} from '../../selectors/stellar-assets';
+import {
   exchangeRateFromMarketData,
   tokenPriceInNativeAsset,
   getDefaultToToken,
@@ -147,7 +151,8 @@ export type BridgeAppState = {
     MultichainNetworkControllerState &
     TokenListState &
     RemoteFeatureFlagControllerState &
-    CurrencyRateState & {
+    CurrencyRateState &
+    NonNullable<StellarAssetsSelectorState['metamask']> & {
       useExternalServices: boolean;
     };
   bridge: BridgeState;
@@ -838,8 +843,49 @@ export const getFormattedPriceImpactFiat = createSelector(
     formatPriceImpactFiat(activeQuote, currentCurrency),
 );
 
+const getStellarMinimumReserveForBridge = (state: BridgeAppState): string => {
+  const fromToken = getFromToken(state);
+  const fromAccount = getFromAccount(state);
+
+  if (
+    !fromToken?.chainId ||
+    !isStellarChainId(fromToken.chainId) ||
+    !fromAccount?.id
+  ) {
+    return '0';
+  }
+
+  return getStellarMinimumReserveForSwap(
+    state,
+    fromAccount.id,
+    fromToken.assetId,
+    getToToken(state)?.assetId,
+  );
+};
+
+const getNativeReserveMinimum = createSelector(
+  [getFromToken, getStellarMinimumReserveForBridge],
+  (fromToken, stellarMinimumReserve) => {
+    const isBitcoinNativeReserveChain = Boolean(
+      fromToken?.chainId && isBitcoinChainId(fromToken.chainId),
+    );
+    const isStellarNativeReserveChain = Boolean(
+      fromToken?.chainId && isStellarChainId(fromToken.chainId),
+    );
+
+    return {
+      minimumNativeReserveBalance: isStellarNativeReserveChain
+        ? stellarMinimumReserve
+        : getMinimumReserveBalanceForCaipAssetId(fromToken?.assetId),
+      isBitcoinNativeReserveChain,
+      isStellarNativeReserveChain,
+    };
+  },
+);
+
 // Native reserve balances are used for gas-sponsored networks like Monad,
-// and for BTC as a buffer between quote-time and submit-time fee computation.
+// for BTC as a buffer between quote-time and submit-time fee computation,
+// and for Stellar's dynamic baseReserve (plus a trustline subentry when needed).
 export const getInsufficientNativeReserveError = createSelector(
   [
     getFromToken,
@@ -847,6 +893,7 @@ export const getInsufficientNativeReserveError = createSelector(
     _getValidatedSrcAmount,
     getGasFeesSponsoredNetworkEnabled,
     (state: BridgeAppState) => isHardwareWallet(state as never),
+    getNativeReserveMinimum,
   ],
   (
     fromToken,
@@ -854,6 +901,11 @@ export const getInsufficientNativeReserveError = createSelector(
     validatedSrcAmount,
     gasFeesSponsoredNetworkEnabledMap,
     isHardwareWalletAccount,
+    {
+      minimumNativeReserveBalance,
+      isBitcoinNativeReserveChain,
+      isStellarNativeReserveChain,
+    },
   ) => {
     const isNetworkGasSponsored =
       !fromToken?.chainId || isNonEvmChainId(fromToken.chainId)
@@ -867,15 +919,11 @@ export const getInsufficientNativeReserveError = createSelector(
             ],
           );
 
-    const minimumNativeReserveBalance = getMinimumReserveBalanceForCaipAssetId(
-      fromToken?.assetId,
-    );
-    const isBitcoinNativeReserveChain = Boolean(
-      fromToken?.chainId && isBitcoinChainId(fromToken.chainId),
-    );
     const shouldApplyNativeReserve =
       minimumNativeReserveBalance !== '0' &&
-      (isNetworkGasSponsored || isBitcoinNativeReserveChain);
+      (isNetworkGasSponsored ||
+        isBitcoinNativeReserveChain ||
+        isStellarNativeReserveChain);
 
     const minimumNativeBalanceToBeKeptInAccount = shouldApplyNativeReserve
       ? minimumNativeReserveBalance
@@ -902,6 +950,7 @@ export const getActiveQuoteInsufficientNativeReserveError = createSelector(
     getFromNativeBalance,
     _getValidatedSrcAmount,
     getBridgeQuotes,
+    getNativeReserveMinimum,
   ],
   (
     insufficientNativeReserveError,
@@ -909,13 +958,18 @@ export const getActiveQuoteInsufficientNativeReserveError = createSelector(
     nativeBalance,
     validatedSrcAmount,
     { activeQuote },
+    {
+      minimumNativeReserveBalance,
+      isBitcoinNativeReserveChain,
+      isStellarNativeReserveChain,
+    },
   ) => {
-    const isBitcoinNativeReserveChain = Boolean(
-      fromToken?.chainId && isBitcoinChainId(fromToken.chainId),
-    );
+    const isQuoteAwareNativeReserveChain =
+      isBitcoinNativeReserveChain || isStellarNativeReserveChain;
 
     if (
-      isBitcoinNativeReserveChain &&
+      isQuoteAwareNativeReserveChain &&
+      minimumNativeReserveBalance !== '0' &&
       activeQuote?.totalNetworkFee?.amount &&
       activeQuote?.sentAmount?.amount &&
       nativeBalance &&
@@ -937,18 +991,16 @@ export const getActiveQuoteInsufficientNativeReserveError = createSelector(
         0,
       );
 
-      const minimumNativeBalanceToBeKeptInAccount =
-        getMinimumReserveBalanceForCaipAssetId(fromToken?.assetId);
       const maxSwappableNativeBalance = nativeBalanceInNativeUnits
         .sub(totalNetworkFee)
-        .sub(minimumNativeBalanceToBeKeptInAccount)
+        .sub(minimumNativeReserveBalance)
         .sub(quoteSourceOverhead);
 
       return buildInsufficientNativeReserveError({
         fromToken,
         nativeBalance,
         validatedSrcAmount,
-        minimumNativeBalanceToBeKeptInAccount,
+        minimumNativeBalanceToBeKeptInAccount: minimumNativeReserveBalance,
         maxSwappableNativeBalance,
       });
     }

--- a/ui/selectors/stellar-assets.test.ts
+++ b/ui/selectors/stellar-assets.test.ts
@@ -3,6 +3,7 @@ import type { CaipAssetType } from '@metamask/utils';
 
 import {
   getStellarBaseReserveForAccountAsset,
+  getStellarMinimumReserveForSwap,
   getStellarTrustlineAssetInfoForAccount,
 } from './stellar-assets';
 
@@ -110,6 +111,71 @@ describe('stellar-assets selectors', () => {
           SEP41_ASSET_ID,
         ),
       ).toBeUndefined();
+    });
+  });
+
+  describe('getStellarMinimumReserveForSwap', () => {
+    it('returns the base reserve when the destination trustline exists', () => {
+      expect(
+        getStellarMinimumReserveForSwap(
+          mockState,
+          ACCOUNT_ID,
+          STELLAR_NATIVE_ASSET_ID,
+          TRUSTLINE_USDC,
+        ),
+      ).toBe('2.5');
+    });
+
+    it('adds one base reserve when destination trustline metadata is missing', () => {
+      const missingTrustlineAsset =
+        'stellar:pubnet/asset:EURC-GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN' as CaipAssetType;
+
+      expect(
+        getStellarMinimumReserveForSwap(
+          mockState,
+          ACCOUNT_ID,
+          STELLAR_NATIVE_ASSET_ID,
+          missingTrustlineAsset,
+        ),
+      ).toBe('3');
+    });
+
+    it('returns zero when native reserve enrichment is missing', () => {
+      expect(
+        getStellarMinimumReserveForSwap(
+          {
+            metamask: {
+              accountAssets: {
+                [ACCOUNT_ID]: {},
+              },
+            },
+          },
+          ACCOUNT_ID,
+          STELLAR_NATIVE_ASSET_ID,
+          TRUSTLINE_USDC,
+        ),
+      ).toBe('0');
+    });
+
+    it('returns zero when native reserve enrichment is zero', () => {
+      expect(
+        getStellarMinimumReserveForSwap(
+          {
+            metamask: {
+              accountAssets: {
+                [ACCOUNT_ID]: {
+                  [STELLAR_NATIVE_ASSET_ID]: {
+                    baseReserve: '0',
+                  },
+                },
+              },
+            },
+          },
+          ACCOUNT_ID,
+          STELLAR_NATIVE_ASSET_ID,
+          TRUSTLINE_USDC,
+        ),
+      ).toBe('0');
     });
   });
 });

--- a/ui/selectors/stellar-assets.ts
+++ b/ui/selectors/stellar-assets.ts
@@ -5,21 +5,23 @@ import { BigNumber } from 'bignumber.js';
 import {
   getNativeAssetInfoForAsset,
   getTrustlineAssetInfoForAsset,
-  type StellarAssetsControllerState,
 } from '../../app/scripts/controllers/stellar-assets-controller';
 /* eslint-enable import-x/no-restricted-paths */
 import { isSupportBaseReserve } from '../../shared/lib/multichain/spendable-balance';
+import { getAdditionalReserveForMissingTrustline } from '../../shared/lib/multichain/trustline';
 import { createParameterizedSelector } from '../../shared/lib/selectors/selector-creators';
 
 const ACCOUNT_ASSET_LRU_CACHE_SIZE = 50;
 
-type StellarAssetsSelectorState = {
-  metamask?: Pick<StellarAssetsControllerState, 'accountAssets'>;
+export type StellarAssetsSelectorState = {
+  metamask?: {
+    accountAssets?: Record<string, Record<string, unknown>>;
+  };
 };
 
 function getStellarAccountAssets(
   state: StellarAssetsSelectorState,
-): StellarAssetsControllerState['accountAssets'] {
+): Record<string, Record<string, unknown>> {
   return state.metamask?.accountAssets ?? {};
 }
 
@@ -74,11 +76,71 @@ export const getStellarBaseReserveForAccountAsset = createParameterizedSelector(
 export const getStellarTrustlineAssetInfoForAccount =
   createParameterizedSelector(ACCOUNT_ASSET_LRU_CACHE_SIZE)(
     getStellarAccountAssets,
-    (_state, accountId: string) => accountId,
-    (_state, _accountId: string, assetId: CaipAssetType) => assetId,
+    (_state: StellarAssetsSelectorState, accountId: string) => accountId,
+    (
+      _state: StellarAssetsSelectorState,
+      _accountId: string,
+      assetId: CaipAssetType,
+    ) => assetId,
     (accountAssets, accountId, assetId) =>
       getTrustlineAssetInfoForAsset(
         assetId,
         accountAssets[accountId]?.[assetId],
       ),
   );
+
+/**
+ * Returns the dynamic native reserve required for a Stellar swap.
+ *
+ * The cached native reserve already includes existing account subentries. One
+ * additional base reserve is included when the destination classic asset does
+ * not yet have a trustline. Missing or zero native enrichment is treated as
+ * unavailable so it cannot produce a guessed trustline-only reserve.
+ */
+export const getStellarMinimumReserveForSwap = createParameterizedSelector(
+  ACCOUNT_ASSET_LRU_CACHE_SIZE,
+)(
+  getStellarAccountAssets,
+  (_state: StellarAssetsSelectorState, accountId: string) => accountId,
+  (
+    _state: StellarAssetsSelectorState,
+    _accountId: string,
+    nativeAssetId: CaipAssetType,
+  ) => nativeAssetId,
+  (
+    _state: StellarAssetsSelectorState,
+    _accountId: string,
+    _nativeAssetId: CaipAssetType,
+    toAssetId?: CaipAssetType,
+  ) => toAssetId,
+  (accountAssets, accountId, nativeAssetId, toAssetId) => {
+    const baseReserve = resolveBaseReserve(
+      nativeAssetId,
+      getNativeAssetInfoForAsset(
+        nativeAssetId,
+        accountAssets[accountId]?.[nativeAssetId],
+      ),
+    );
+    const parsedBaseReserve = new BigNumber(baseReserve ?? 0);
+
+    if (!parsedBaseReserve.gt(0)) {
+      return '0';
+    }
+
+    const trustlineInfo = toAssetId
+      ? getTrustlineAssetInfoForAsset(
+          toAssetId,
+          accountAssets[accountId]?.[toAssetId],
+        )
+      : undefined;
+
+    return parsedBaseReserve
+      .plus(
+        getAdditionalReserveForMissingTrustline({
+          toAssetId,
+          toAssetMetadata: trustlineInfo,
+        }),
+      )
+      .toString();
+  },
+);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Stellar accounts must keep a minimum XLM balance locked as a protocol reserve. The swap flow didn't validate this, so users could enter amounts dipping into the reserve and only fail at submit time.
This PR reuses the existing insufficient-native-reserve validation (BTC/Monad) for Stellar, using the dynamic `baseReserve` cached by `StellarAssetsController` instead of a fixed constant. An extra 0.5 XLM is reserved when swapping into a classic asset with no active trustline (the swap creates a new subentry). If reserve data isn't available yet, no reserve is applied so swaps are never blocked on missing data.
Users get the same UX as BTC: warning banner with a "use max" action, disabled Swap CTA. BTC and Monad behavior is unchanged.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Added a warning and disabled swaps when a Stellar swap amount would dip into the account's reserved XLM balance, including the extra reserve needed when swapping to a new trustline asset

## **Related issues**

Fixes:

## **Manual testing steps**

1. Build and run the extension with a Stellar account holding XLM (e.g. 10 XLM with a 2.5 XLM reserve)
2. Open Swap, select XLM on Stellar as the source token
3. Enter an amount that exceeds balance minus reserve (e.g. 8 XLM), verify a warning banner appears showing the reserve to keep and the max swappable amount, and the Swap button is disabled
4. Click the "use max" action in the banner, verify the input is set to the spendable amount and the warning clears
5. Select a Stellar classic asset (e.g. USDC) you do **not** hold a trustline for as the destination token, verify the max swappable amount is reduced by an extra 0.5 XLM
6. Select a classic asset you already hold, verify no extra 0.5 XLM is reserved
7. Enter an amount within the spendable balance, verify no warning and the swap can be submitted

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->
<img width="489" height="869" alt="image" src="https://github.com/user-attachments/assets/45a69071-1e66-4338-8333-21770bce7fed" />

<img width="490" height="839" alt="image" src="https://github.com/user-attachments/assets/071b89d8-200a-4057-934a-5a7fd91a881c" />



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes swap validation and max-amount logic for Stellar only, with conservative fallbacks for missing fees/reserve data; BTC/Monad paths are extended but intended to stay behavior-equivalent.
> 
> **Overview**
> Adds **pre-submit validation** for Stellar swaps so users cannot enter amounts that would spend into the protocol’s locked XLM reserve, reusing the same insufficient-native-reserve UX as Bitcoin/Monad (warning + max spendable).
> 
> **Reserve math** uses cached `baseReserve` from account assets via new `getStellarMinimumReserveForSwap`, plus an extra **0.5 XLM** when swapping into a classic asset without an active trustline (`getAdditionalReserveForMissingTrustline`). Missing or zero `baseReserve` enrichment applies **no** reserve so swaps are not blocked on incomplete data.
> 
> **Quote-aware Stellar handling** caps implausible snap-reported network fees at **0.1 XLM**, treats provider fees as deducted from the sent amount (not on top), and **prefers the reserve warning over the gas error** when both would fire—addressing misreported fees from failed simulations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc9a8df25b0e6b6d47c07edd39c7ac4cc40256be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->