### PR TITLE
fix: include Mantle operator fee in Activity Details network fee

### DIFF
--- a/shared/lib/activity/adapters/helpers.test.ts
+++ b/shared/lib/activity/adapters/helpers.test.ts
@@ -1,0 +1,93 @@
+import { getLocalTransactionFees } from './helpers';
+
+describe('getLocalTransactionFees', () => {
+  it('builds a base network fee from the receipt (gasUsed * effectiveGasPrice)', () => {
+    const group = {
+      primaryTransaction: {
+        chainId: '0x1',
+        txReceipt: { gasUsed: '0x5208', effectiveGasPrice: '0x3b9aca00' },
+        txParams: {},
+      },
+    } as unknown as Parameters<typeof getLocalTransactionFees>[0];
+
+    expect(getLocalTransactionFees(group)).toStrictEqual([
+      {
+        type: 'base',
+        amount: '21000000000000',
+        decimals: 18,
+        symbol: 'ETH',
+        assetId: 'eip155:1/slip44:60',
+      },
+    ]);
+  });
+
+  it('returns undefined when there is no gas data', () => {
+    const group = {
+      primaryTransaction: { chainId: '0x1', txReceipt: {}, txParams: {} },
+    } as unknown as Parameters<typeof getLocalTransactionFees>[0];
+
+    expect(getLocalTransactionFees(group)).toBeUndefined();
+  });
+
+  it('adds layer1GasFee (L1 + operator) onto the L2 network fee', () => {
+    const group = {
+      primaryTransaction: {
+        chainId: '0x1388',
+        layer1GasFee: '0x5f5e100', // 100_000_000
+        txReceipt: { gasUsed: '0x5208', effectiveGasPrice: '0x3b9aca00' },
+        txParams: {},
+      },
+    } as unknown as Parameters<typeof getLocalTransactionFees>[0];
+
+    // 21_000_000_000_000 + 100_000_000
+    // Mantle is outside the bridge native-asset registry, so symbol/assetId are omitted.
+    expect(getLocalTransactionFees(group)).toStrictEqual([
+      {
+        type: 'base',
+        amount: '21000100000000',
+        decimals: 18,
+      },
+    ]);
+  });
+
+  it('falls back to receipt l1Fee when layer1GasFee is absent', () => {
+    const group = {
+      primaryTransaction: {
+        chainId: '0xa',
+        txReceipt: {
+          gasUsed: '0x5208',
+          effectiveGasPrice: '0x3b9aca00',
+          l1Fee: '0x5f5e100',
+        },
+        txParams: {},
+      },
+    } as unknown as Parameters<typeof getLocalTransactionFees>[0];
+
+    expect(getLocalTransactionFees(group)).toStrictEqual([
+      {
+        type: 'base',
+        amount: '21000100000000',
+        decimals: 18,
+        symbol: 'ETH',
+        assetId: 'eip155:10/slip44:60',
+      },
+    ]);
+  });
+
+  it('prefers layer1GasFee over receipt l1Fee to avoid double-counting', () => {
+    const group = {
+      primaryTransaction: {
+        chainId: '0x1388',
+        layer1GasFee: '0x5f5e100',
+        txReceipt: {
+          gasUsed: '0x5208',
+          effectiveGasPrice: '0x3b9aca00',
+          l1Fee: '0xffffffff',
+        },
+        txParams: {},
+      },
+    } as unknown as Parameters<typeof getLocalTransactionFees>[0];
+
+    expect(getLocalTransactionFees(group)?.[0]?.amount).toBe('21000100000000');
+  });
+});

--- a/shared/lib/activity/adapters/helpers.ts
+++ b/shared/lib/activity/adapters/helpers.ts
@@ -116,6 +116,33 @@ function toNetworkFeeAmount(
   }
 }
 
+/**
+ * Adds L1 / operator fee (hex wei) onto an L2 network fee (decimal wei string).
+ * Prefers `layer1GasFee` (L1 data fee + operator fee from TransactionController)
+ * over raw receipt `l1Fee` so Mantle operator fee is included when available.
+ *
+ * @param networkFeeAmount - L2 network fee amount in decimal wei.
+ * @param layer1GasFee - Optional hex wei L1 + operator fee from TransactionMeta.
+ * @param receiptL1Fee - Optional hex wei L1 fee from the transaction receipt.
+ * @returns Combined fee amount in decimal wei, or the original L2 amount on failure.
+ */
+function addLayer1FeeToNetworkFeeAmount(
+  networkFeeAmount: string,
+  layer1GasFee: string | undefined,
+  receiptL1Fee: string | undefined,
+): string {
+  const layer1OrL1Fee = layer1GasFee ?? receiptL1Fee;
+  if (!layer1OrL1Fee) {
+    return networkFeeAmount;
+  }
+
+  try {
+    return String(BigInt(networkFeeAmount) + BigInt(layer1OrL1Fee));
+  } catch {
+    return networkFeeAmount;
+  }
+}
+
 function buildBaseNetworkFee(
   amount: string,
   chainId: string | number,
@@ -154,19 +181,36 @@ export function getFees(
   return networkFee ? [networkFee] : undefined;
 }
 
+/**
+ * Builds the base network fee (in the chain's native token) for a local
+ * transaction from its receipt (`gasUsed × effectiveGasPrice`), plus any
+ * L1 / operator fee from `layer1GasFee` or receipt `l1Fee`. Falls back to
+ * `txParams.gasPrice` while pending.
+ *
+ * @param transactionGroup - Transaction group with the primary transaction.
+ * @returns Activity fee list with a single base network fee, or undefined.
+ */
 export function getLocalTransactionFees(
   transactionGroup: Pick<TransactionGroup, 'primaryTransaction'>,
 ): ActivityFee[] | undefined {
   const { primaryTransaction } = transactionGroup;
-  const amount = toNetworkFeeAmount(
+  const l2Amount = toNetworkFeeAmount(
     primaryTransaction.txReceipt?.gasUsed,
     primaryTransaction.txReceipt?.effectiveGasPrice ??
       primaryTransaction.txParams?.gasPrice,
   );
 
-  return amount
-    ? [buildBaseNetworkFee(amount, primaryTransaction.chainId)]
-    : undefined;
+  if (!l2Amount) {
+    return undefined;
+  }
+
+  const amount = addLayer1FeeToNetworkFeeAmount(
+    l2Amount,
+    primaryTransaction.layer1GasFee,
+    primaryTransaction.txReceipt?.l1Fee,
+  );
+
+  return [buildBaseNetworkFee(amount, primaryTransaction.chainId)];
 }
 
 const resolveAssetId = (

--- a/ui/selectors/activity.ts
+++ b/ui/selectors/activity.ts
@@ -502,6 +502,8 @@ export const selectLocalActivityItems = createSelector(
           : undefined;
       })();
 
+      const fees = getLocalTransactionFees(transactionGroup);
+
       if (
         type === TransactionType.swap ||
         type === TransactionType.swapAndSend ||
@@ -512,7 +514,6 @@ export const selectLocalActivityItems = createSelector(
           transactionGroup,
         );
         const activityStatus = getBridgeActivityStatus(bridgeHistoryItem);
-        const fees = getLocalTransactionFees(transactionGroup);
 
         const prepared = {
           ...transactionGroup,
@@ -528,6 +529,7 @@ export const selectLocalActivityItems = createSelector(
 
       const prepared = {
         ...transactionGroup,
+        fees,
         nativeAssetSymbol,
         contractTokenMetadata,
         ...(sourceToken ? { sourceToken } : {}),


### PR DESCRIPTION
## **Description**

After WPN-1001, confirmation estimates include Mantle’s L1 + operator fee via `transactionMeta.layer1GasFee`, but Activity Details still showed L2 only (`gasUsed × effectiveGasPrice`), so the fee after confirm looked lower than before confirm.

Activity Details now adds `layer1GasFee` (preferred; includes Mantle operator fee) or receipt `l1Fee` onto the network fee, and applies this for all local activity types.

## **Changelog**

CHANGELOG entry: Fixed Mantle transaction Activity Details to include the operator fee in the network fee

## **Related issues**

Fixes: WPN-1001 follow-up (Activity Details operator fee)

## **Manual testing steps**

1. On Mantle, confirm a transaction and note the confirmation fee.
2. Open the transaction in Activity Details.
3. Verify Network fee matches the confirmation fee (includes operator fee).
4. On Optimism or Base, confirm a transaction and verify Network fee is still correct with no L1 double-count.
5. On Ethereum, verify Network fee is unchanged when `layer1GasFee` / `l1Fee` are absent.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only fee calculation change with guarded BigInt math and tests; no auth, signing, or transaction submission logic touched.
> 
> **Overview**
> **Activity Details** now shows the full network fee for local transactions by adding L1 / operator costs on top of the L2 `gasUsed × effectiveGasPrice` amount.
> 
> `getLocalTransactionFees` uses a new `addLayer1FeeToNetworkFeeAmount` helper that prefers **`layer1GasFee`** from transaction meta (Mantle operator + L1 data) and otherwise falls back to receipt **`l1Fee`**, avoiding double-count when both are present. The activity selector computes these fees once for **all** local activity types, not only swap/bridge flows.
> 
> Unit tests cover base L2 fee, missing gas data, Mantle `layer1GasFee`, Optimism-style `l1Fee` fallback, and preference over receipt `l1Fee`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff34d8a9a81aac7ef0a3433d00fa6d7bd9226eb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->