### PR TITLE
feat: updated avatarbase and banner alert to use DS

### DIFF
--- a/ui/components/component-library/picker-network/__snapshots__/picker-network.test.tsx.snap
+++ b/ui/components/component-library/picker-network/__snapshots__/picker-network.test.tsx.snap
@@ -42,7 +42,7 @@ exports[`PickerNetwork should render multiple avatars when avatarGroupProps is p
           </div>
         </div>
         <div
-          class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-overlay-inverse mm-box--background-color-overlay-alternative mm-box--rounded-md mm-box--border-color-background-default box--border-style-solid box--border-width-1"
+          class="inline-flex shrink-0 items-center justify-center overflow-hidden h-4 w-4 border border-background-default bg-overlay-alternative text-overlay-inverse rounded-md"
           style="margin-left: -8px; font-size: 8px;"
         >
           +2
@@ -104,7 +104,7 @@ exports[`PickerNetwork should render multiple avatars with a stacked tag when is
           </div>
         </div>
         <div
-          class="mm-box mm-text mm-avatar-base mm-avatar-base--size-xs mm-text--body-xs mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-overlay-inverse mm-box--background-color-overlay-alternative mm-box--rounded-md mm-box--border-color-background-default box--border-style-solid box--border-width-1"
+          class="inline-flex shrink-0 items-center justify-center overflow-hidden h-4 w-4 border border-background-default bg-overlay-alternative text-overlay-inverse rounded-md"
           style="margin-left: -8px; font-size: 8px;"
         >
           +2

--- a/ui/components/multichain/avatar-group/avatar-group.tsx
+++ b/ui/components/multichain/avatar-group/avatar-group.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import classnames from 'clsx';
 import {
+  AvatarBase,
+  AvatarBaseSize,
   AvatarAccount,
   AvatarAccountSize,
   AvatarAccountVariant,
@@ -8,8 +10,6 @@ import {
 import { Text } from '../../component-library/text';
 import {
   AlignItems,
-  BackgroundColor,
-  BorderColor,
   BorderRadius,
   Display,
   TextColor,
@@ -24,10 +24,6 @@ import {
   AvatarNetwork,
   AvatarNetworkSize,
 } from '../../component-library/avatar-network';
-import {
-  AvatarBase,
-  AvatarBaseSize,
-} from '../../component-library/avatar-base';
 import { AvatarGroupProps, AvatarType } from './avatar-group.types';
 
 export const AvatarGroup = ({
@@ -96,12 +92,9 @@ export const AvatarGroup = ({
         })}
         {showTag && isTagOverlay && (
           <AvatarBase
-            backgroundColor={BackgroundColor.overlayAlternative}
+            className="border border-background-default bg-overlay-alternative text-overlay-inverse rounded-md"
             style={{ marginLeft: marginLeftValue, fontSize: 8 }}
             size={AvatarBaseSize.Xs}
-            borderColor={BorderColor.backgroundDefault}
-            borderRadius={BorderRadius.MD}
-            color={TextColor.overlayInverse}
           >
             {tagValue}
           </AvatarBase>

--- a/ui/pages/home/home-notifications-container.tsx
+++ b/ui/pages/home/home-notifications-container.tsx
@@ -1,6 +1,12 @@
 import React, { memo, useCallback, useEffect, useMemo, useState } from 'react';
 import { useDispatch, useSelector } from 'react-redux';
-import { Text, TextVariant, TextColor } from '@metamask/design-system-react';
+import {
+  BannerAlert,
+  BannerAlertSeverity,
+  Text,
+  TextVariant,
+  TextColor,
+} from '@metamask/design-system-react';
 import {
   activeTabHasPermissions,
   getOriginOfCurrentTab,
@@ -38,10 +44,6 @@ import ZENDESK_URLS from '../../helpers/constants/zendesk-url';
 import HomeNotification from '../../components/app/home-notification';
 import MultipleNotifications from '../../components/app/multiple-notifications';
 import { SeedPhraseBackupNotificationContainer } from '../../components/app/recovery-phrase-reminder';
-import {
-  BannerAlert,
-  BannerAlertSeverity,
-} from '../../components/component-library';
 import { useI18nContext } from '../../hooks/useI18nContext';
 import type { MetaMaskReduxState } from '../../store/store';
 

--- a/ui/pages/keychains/reveal-seed-warning.tsx
+++ b/ui/pages/keychains/reveal-seed-warning.tsx
@@ -1,14 +1,12 @@
 import React from 'react';
 import {
+  BannerAlert,
+  BannerAlertSeverity,
   TextVariant,
   TextColor,
   Text,
   FontWeight,
 } from '@metamask/design-system-react';
-import {
-  BannerAlert,
-  BannerAlertSeverity,
-} from '../../components/component-library';
 
 type RevealSeedWarningProps = {
   message: string;


### PR DESCRIPTION
This PR is to remove the deprecated uage of avatarbase and banner alert

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import and styling-only changes for presentational components; no auth, data, or business-logic changes.
> 
> **Overview**
> Migrates deprecated **component-library** usage to **`@metamask/design-system-react`** for avatar overlays and banners.
> 
> **AvatarGroup** now imports `AvatarBase` from the design system and styles the stacked “+N” tag with Tailwind utility classes (`bg-overlay-alternative`, `border-background-default`, etc.) instead of `BackgroundColor` / `BorderColor` / `TextColor` props. **Home notifications** and **reveal seed warning** pull `BannerAlert` and `BannerAlertSeverity` from the same package. Picker-network Jest snapshots were updated for the new overlay markup/classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7dfbcd814728fea4ea079f5b1810c66b72abc0e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->