### PR TITLE
chore: migrate AvatarFavicon to MMDS

### DIFF
--- a/ui/components/multichain/pages/permissions-page/__snapshots__/permissions-page.test.js.snap
+++ b/ui/components/multichain/pages/permissions-page/__snapshots__/permissions-page.test.js.snap
@@ -59,12 +59,12 @@ exports[`All Connections render renders correctly 1`] = `
             style="align-self: center;"
           >
             <div
-              class="mm-box mm-text mm-avatar-base mm-avatar-base--size-md mm-avatar-favicon mm-text--body-sm mm-text--text-transform-uppercase mm-box--display-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-text-default mm-box--background-color-background-alternative mm-box--rounded-full mm-box--border-color-transparent box--border-style-solid box--border-width-1"
+              class="inline-flex shrink-0 items-center justify-center overflow-hidden bg-alternative rounded-full h-8 w-8"
               data-testid="connection-list-item__avatar-favicon"
             >
               <img
-                alt="avatar-favicon logo"
-                class="mm-avatar-favicon__image"
+                alt="Dapp logo"
+                class="size-full object-contain"
                 src="https://metamask.github.io/test-dapp/metamask-fox.svg"
               />
             </div>

--- a/ui/components/multichain/pages/permissions-page/connection-list-item.js
+++ b/ui/components/multichain/pages/permissions-page/connection-list-item.js
@@ -2,6 +2,7 @@ import React, { useMemo } from 'react';
 import PropTypes from 'prop-types';
 import { SubjectType } from '@metamask/permission-controller';
 import { useSelector } from 'react-redux';
+import { AvatarFavicon } from '@metamask/design-system-react';
 import {
   AlignItems,
   BackgroundColor,
@@ -16,7 +17,6 @@ import {
 } from '../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import {
-  AvatarFavicon,
   Box,
   Icon,
   IconName,

--- a/ui/components/multichain/permissions-header/permissions-header.tsx
+++ b/ui/components/multichain/permissions-header/permissions-header.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
+  AvatarFavicon,
+  AvatarFaviconSize,
+} from '@metamask/design-system-react';
+import {
   AlignItems,
   BackgroundColor,
   Display,
@@ -10,8 +14,6 @@ import {
   TextVariant,
 } from '../../../helpers/constants/design-system';
 import {
-  AvatarFavicon,
-  AvatarFaviconSize,
   Box,
   ButtonIcon,
   ButtonIconSize,


### PR DESCRIPTION
Migrates remaining Core UX-owned deprecated AvatarFavicon usages from ui/components/component-library to @metamask/design-system-react.

This updates the permissions header and permissions page connection list item to use the MMDS replacement, and refreshes the affected permissions page snapshot for the new rendered markup.

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

Open the permissions/connections page.
Verify dapp connection rows still show the site favicon correctly.
Open a connected dapp permissions detail/header view.
Verify the dapp favicon still appears correctly in the header.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only import swap with no permission or connection logic changes.
> 
> **Overview**
> Swaps the deprecated **component-library** `AvatarFavicon` for **`@metamask/design-system-react`** on permissions UX: dapp connection rows (`connection-list-item.js`) and the connected-site header (`permissions-header.tsx`). Props and behavior stay the same (`src`, `name`, `size`, test ids).
> 
> The permissions page Jest snapshot is updated for MMDS output (Tailwind-based wrapper classes and `alt="Dapp logo"` on the favicon image instead of the old `mm-avatar-favicon` markup).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0c100bac20b823a4e9065599ac6dce73681d127. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->