### PR TITLE
chore: removed deprecated checkbox with DS

### DIFF
--- a/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-network.tsx
+++ b/ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal-network.tsx
@@ -7,7 +7,9 @@ import {
 } from '@metamask/network-controller';
 import type { CaipChainId } from '@metamask/utils';
 import {
+  Checkbox,
   FontWeight,
+  IconName,
   Text as DsText,
   TextColor as DsTextColor,
   TextVariant as DsTextVariant,
@@ -30,10 +32,8 @@ import {
   Modal,
   Box,
   ButtonLink,
-  Checkbox,
   Text,
   AvatarNetworkSize,
-  IconName,
 } from '../../../component-library';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { NetworkListItem } from '../../network-list-item';
@@ -217,15 +217,13 @@ export const AssetPickerModalNetwork = ({
         {isMultiselectEnabled && (
           <Box display={Display.Flex} padding={4}>
             <Checkbox
-              isIndeterminate={Object.values(checkedChainIds).every((v) => v)}
-              iconProps={{
+              id="asset-picker-network-select-all"
+              isSelected
+              checkedIconProps={{
                 name: Object.values(checkedChainIds).some((v) => !v)
                   ? IconName.MinusBold
                   : IconName.Add,
-                color: IconColor.primaryInverse,
-                backgroundColor: BackgroundColor.primaryDefault,
               }}
-              isChecked
               onChange={() => {
                 handleToggleAllNetworks();
               }}
@@ -301,8 +299,10 @@ export const AssetPickerModalNetwork = ({
                     startAccessory={
                       isMultiselectEnabled ? (
                         <Checkbox
-                          isChecked={checkedChainIds[chainId]}
-                          name={chainId}
+                          id={`asset-picker-network-checkbox-${chainId}`}
+                          isSelected={checkedChainIds[chainId]}
+                          onChange={() => handleToggleNetwork(chainId)}
+                          onClick={(event) => event.stopPropagation()}
                         />
                       ) : undefined
                     }

--- a/ui/components/multichain/edit-networks-modal/edit-networks-modal.js
+++ b/ui/components/multichain/edit-networks-modal/edit-networks-modal.js
@@ -1,9 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
-import {
-  Checkbox,
-  IconName,
-} from '@metamask/design-system-react';
+import { Checkbox, IconName } from '@metamask/design-system-react';
 import { useAnalytics } from '../../../hooks/useAnalytics';
 import {
   AlignItems,
@@ -135,6 +132,7 @@ export const EditNetworksModal = ({
                   isSelected={selectedChainIds.includes(network.caipChainId)}
                   onChange={() => handleNetworkClick(network.caipChainId)}
                   onClick={(event) => event.stopPropagation()}
+                  checkboxContainerProps={{ className: 'pointer-events-none' }}
                 />
               }
             />
@@ -155,6 +153,7 @@ export const EditNetworksModal = ({
                   isSelected={selectedChainIds.includes(network.caipChainId)}
                   onChange={() => handleNetworkClick(network.caipChainId)}
                   onClick={(event) => event.stopPropagation()}
+                  checkboxContainerProps={{ className: 'pointer-events-none' }}
                 />
               }
               showEndAccessory={false}

--- a/ui/components/multichain/edit-networks-modal/edit-networks-modal.js
+++ b/ui/components/multichain/edit-networks-modal/edit-networks-modal.js
@@ -1,5 +1,9 @@
 import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
+import {
+  Checkbox,
+  IconName,
+} from '@metamask/design-system-react';
 import { useAnalytics } from '../../../hooks/useAnalytics';
 import {
   AlignItems,
@@ -17,7 +21,6 @@ import {
   ModalOverlay,
   ModalContent,
   ModalHeader,
-  Checkbox,
   Text,
   Box,
   ModalFooter,
@@ -25,7 +28,6 @@ import {
   ButtonPrimarySize,
   ModalBody,
   Icon,
-  IconName,
   IconSize,
 } from '../../component-library';
 import { NetworkListItem } from '../network-list-item';
@@ -113,10 +115,11 @@ export const EditNetworksModal = ({
           <Box padding={4}>
             <Checkbox
               label={t('selectAll')}
-              isChecked={checked}
-              gap={4}
-              onClick={() => (allAreSelected() ? deselectAll() : selectAll())}
-              isIndeterminate={isIndeterminate}
+              isSelected={checked || isIndeterminate}
+              onChange={() => (allAreSelected() ? deselectAll() : selectAll())}
+              checkedIconProps={
+                isIndeterminate ? { name: IconName.MinusBold } : undefined
+              }
             />
           </Box>
           {nonTestNetworks.map((network) => (
@@ -129,7 +132,9 @@ export const EditNetworksModal = ({
               }}
               startAccessory={
                 <Checkbox
-                  isChecked={selectedChainIds.includes(network.caipChainId)}
+                  isSelected={selectedChainIds.includes(network.caipChainId)}
+                  onChange={() => handleNetworkClick(network.caipChainId)}
+                  onClick={(event) => event.stopPropagation()}
                 />
               }
             />
@@ -147,7 +152,9 @@ export const EditNetworksModal = ({
               }}
               startAccessory={
                 <Checkbox
-                  isChecked={selectedChainIds.includes(network.caipChainId)}
+                  isSelected={selectedChainIds.includes(network.caipChainId)}
+                  onChange={() => handleNetworkClick(network.caipChainId)}
+                  onClick={(event) => event.stopPropagation()}
                 />
               }
               showEndAccessory={false}

--- a/ui/components/multichain/network-list-item/network-list-item.stories.js
+++ b/ui/components/multichain/network-list-item/network-list-item.stories.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Checkbox } from '../../component-library';
+import { Checkbox } from '@metamask/design-system-react';
 import { NetworkListItem } from '.';
 
 export default {


### PR DESCRIPTION
PR to migrate deprecated checkbox component

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only checkbox component swap with equivalent selection behavior; no auth, data, or backend changes.
> 
> **Overview**
> Migrates network multiselect UI from the deprecated **component-library** `Checkbox` to **`@metamask/design-system-react`**, in the asset picker network modal, edit networks modal, and the network list item story.
> 
> **Asset picker network modal:** “Select all” and per-network checkboxes now use `isSelected`, `onChange`, and `checkedIconProps` (minus icon when partially selected) instead of `isChecked` / `isIndeterminate` / `iconProps`. Row checkboxes wire `onChange` to toggle and stop propagation on click.
> 
> **Edit networks modal:** Same API swap for select-all (indeterminate via `checkedIconProps`) and list checkboxes, with `onChange` handlers and `checkboxContainerProps` so row clicks still drive selection without double-firing from the checkbox.
> 
> **Stories:** `NetworkListItem` story imports `Checkbox` from the design system instead of component-library.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad559ad59122a8c7825e46fb3f47f13e0dd3ad40. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->