### PR TITLE
fix(confirmations): use getAssetImageUrl for gas fee token icon

### DIFF
--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-icon/gas-fee-token-icon.test.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-icon/gas-fee-token-icon.test.tsx
@@ -1,16 +1,24 @@
 import React from 'react';
 
 import { NATIVE_TOKEN_ADDRESS } from '../../../../../../../../shared/constants/transaction';
+import { CHAIN_IDS } from '../../../../../../../../shared/constants/network';
 import configureStore from '../../../../../../../store/store';
 import { getMockConfirmStateForTransaction } from '../../../../../../../../test/data/confirmations/helper';
 import { genUnapprovedContractInteractionConfirmation } from '../../../../../../../../test/data/confirmations/contract-interaction';
 import { renderWithConfirmContextProvider } from '../../../../../../../../test/lib/confirmations/render-helpers';
 import { GAS_FEE_TOKEN_MOCK } from '../../../../../../../../test/data/confirmations/gas';
+import { getAssetImageUrl } from '../../../../../../../../shared/lib/asset-utils';
 import { GasFeeTokenIcon } from './gas-fee-token-icon';
 
 jest.mock(
   '../../../../../hooks/alerts/transactions/useInsufficientBalanceAlerts',
 );
+
+jest.mock('../../../../../../../../shared/lib/asset-utils', () => ({
+  getAssetImageUrl: jest.fn().mockReturnValue('https://example.com/token.png'),
+}));
+
+const mockGetAssetImageUrl = jest.mocked(getAssetImageUrl);
 
 const FROM_MOCK = '0x0dcd5d886577d5081b0c52e242ef29e70be3e7bc';
 
@@ -31,7 +39,26 @@ const store = configureStore(
 );
 
 describe('GasFeeTokenIcon', () => {
-  it('renders token icon', () => {
+  beforeEach(() => {
+    mockGetAssetImageUrl.mockReturnValue('https://example.com/token.png');
+  });
+
+  it('renders token icon with image when getAssetImageUrl returns a URL', () => {
+    const { getByTestId } = renderWithConfirmContextProvider(
+      <GasFeeTokenIcon tokenAddress={GAS_FEE_TOKEN_MOCK.tokenAddress} />,
+      store,
+    );
+
+    expect(mockGetAssetImageUrl).toHaveBeenCalledWith(
+      GAS_FEE_TOKEN_MOCK.tokenAddress,
+      CHAIN_IDS.GOERLI,
+    );
+    expect(getByTestId('token-icon')).toBeInTheDocument();
+  });
+
+  it('renders token icon fallback avatar when getAssetImageUrl returns undefined', () => {
+    mockGetAssetImageUrl.mockReturnValue(undefined);
+
     const { getByTestId } = renderWithConfirmContextProvider(
       <GasFeeTokenIcon tokenAddress={GAS_FEE_TOKEN_MOCK.tokenAddress} />,
       store,

--- a/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-icon/gas-fee-token-icon.tsx
+++ b/ui/pages/confirmations/components/confirm/info/shared/gas-fee-token-icon/gas-fee-token-icon.tsx
@@ -10,12 +10,12 @@ import { useSelector } from 'react-redux';
 import { CHAIN_ID_TOKEN_IMAGE_MAP } from '../../../../../../../../shared/constants/network';
 import { NATIVE_TOKEN_ADDRESS } from '../../../../../../../../shared/constants/transaction';
 import { PreferredAvatar } from '../../../../../../../components/app/preferred-avatar';
-import { selectERC20TokensByChain } from '../../../../../../../selectors';
 import {
   selectNetworkConfigurationByChainId,
   type NetworkConfigurationsByChainIdState,
 } from '../../../../../../../../shared/lib/selectors/networks';
 import { useConfirmContext } from '../../../../../context/confirm';
+import { getAssetImageUrl } from '../../../../../../../../shared/lib/asset-utils';
 
 export enum GasFeeTokenIconSize {
   Sm = 'sm',
@@ -37,15 +37,11 @@ export function GasFeeTokenIcon({
       selectNetworkConfigurationByChainId(state, chainId),
   );
 
-  const erc20TokensByChain = useSelector(selectERC20TokensByChain);
+  const image = getAssetImageUrl(tokenAddress, chainId);
 
   if (!currentConfirmation) {
     return null;
   }
-
-  const variation = chainId;
-  const { iconUrl: image } =
-    erc20TokensByChain?.[variation]?.data?.[tokenAddress] ?? {};
 
   if (tokenAddress !== NATIVE_TOKEN_ADDRESS) {
     const avatarSize =


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Replaces the `selectERC20TokensByChain` Redux selector with the `getAssetImageUrl` utility function in the `GasFeeTokenIcon` component. The previous approach looked up the icon URL from the ERC20 tokens state slice, which has been refactored. The new approach uses the shared `getAssetImageUrl` helper from `asset-utils` to derive the static image URL directly from the token address and chain ID.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open MetaMask and navigate to a transaction confirmation that uses a gas fee token (pay-with-token flow).
2. Verify the token icon is displayed correctly in the gas fee row.
3. Verify the native token icon is displayed when the native token is selected.

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized confirmation UI change with equivalent fallback behavior; no auth or transaction logic touched.
> 
> **Overview**
> **Gas fee token icons** on transaction confirmations no longer read `iconUrl` from the `selectERC20TokensByChain` Redux slice. **`GasFeeTokenIcon`** now resolves the image via shared **`getAssetImageUrl(tokenAddress, chainId)`**, keeping the same behavior: **`AvatarToken`** when a URL exists, **`PreferredAvatar`** when it does not. Native-token rendering is unchanged.
> 
> Tests **mock `getAssetImageUrl`**, assert it is called with the token address and confirmation chain ID, and cover both a returned URL and **`undefined`** fallback paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1fc2747daf6a6ddbcd4cbee9fa0ad79d0f2086cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->