### PR TITLE
feat: initialize DeFiPositionsControllerV2

### DIFF
--- a/app/scripts/messenger-client-init/controller-list.ts
+++ b/app/scripts/messenger-client-init/controller-list.ts
@@ -19,6 +19,7 @@ import {
   AssetsContractController,
   CurrencyRateController,
   DeFiPositionsController,
+  DeFiPositionsControllerV2,
   MultichainAssetsController,
   MultichainAssetsRatesController,
   MultichainBalancesController,
@@ -159,6 +160,7 @@ export type MessengerClient =
   | DecryptMessageManager
   | DelegationController
   | DeFiPositionsController
+  | DeFiPositionsControllerV2
   | EncryptionPublicKeyController
   | EncryptionPublicKeyManager
   | EnsController
@@ -275,6 +277,7 @@ export type MessengerClientFlatState = AccountOrderController['state'] &
   CronjobController['state'] &
   CurrencyRateController['state'] &
   DeFiPositionsController['state'] &
+  DeFiPositionsControllerV2['state'] &
   DelegationController['state'] &
   EnsController['state'] &
   GasFeeController['state'] &

--- a/app/scripts/messenger-client-init/defi-positions/defi-positions-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/defi-positions/defi-positions-controller-init.test.ts
@@ -10,19 +10,44 @@ import {
   getDeFiPositionsControllerMessenger,
 } from '../messengers/defi-positions/defi-positions-controller-messenger';
 import { getRootMessenger } from '../../lib/messenger';
+import { FeatureFlagNames } from '../../../../shared/lib/feature-flags';
+import { DEFI_CONTROLLER_V2_FLAG } from '../../../../shared/lib/defi-controller-v2/remote-feature-flag';
 import { DeFiPositionsControllerInit } from './defi-positions-controller-init';
 
 jest.mock('@metamask/assets-controllers');
 
-function buildInitRequestMock(): jest.Mocked<
+jest.mock('../../controllers/analytics', () => ({
+  createEventBuilder: jest.fn(() => ({
+    addProperties: jest.fn().mockReturnThis(),
+    addSensitiveProperties: jest.fn().mockReturnThis(),
+    build: jest.fn().mockReturnValue({}),
+  })),
+  trackEvent: jest.fn(),
+}));
+
+function buildInitRequestMock(
+  options: {
+    useExternalServices?: boolean;
+    completedOnboarding?: boolean;
+    assetsDefiPositionsEnabled?: boolean;
+    defiControllerV2Enabled?: boolean;
+  } = {},
+): jest.Mocked<
   MessengerClientInitRequest<
     DeFiPositionsControllerMessenger,
     DeFiPositionsControllerInitMessenger
   >
 > {
+  const {
+    useExternalServices = true,
+    completedOnboarding = true,
+    assetsDefiPositionsEnabled = true,
+    defiControllerV2Enabled = false,
+  } = options;
+
   const baseControllerMessenger = getRootMessenger();
 
-  return {
+  const requestMock = {
     ...buildControllerInitRequestMock(),
     controllerMessenger: getDeFiPositionsControllerMessenger(
       baseControllerMessenger,
@@ -31,6 +56,32 @@ function buildInitRequestMock(): jest.Mocked<
       baseControllerMessenger,
     ),
   };
+
+  requestMock.initMessenger.call = jest.fn().mockImplementation((action) => {
+    if (action === 'RemoteFeatureFlagController:getState') {
+      return {
+        remoteFeatureFlags: {
+          [FeatureFlagNames.AssetsDefiPositionsEnabled]:
+            assetsDefiPositionsEnabled,
+          [DEFI_CONTROLLER_V2_FLAG]: { enabled: defiControllerV2Enabled },
+        },
+      };
+    }
+    throw new Error(`Unexpected action: ${action}`);
+  });
+
+  // @ts-expect-error: Partial mock.
+  requestMock.getMessengerClient.mockImplementation((name: string) => {
+    if (name === 'PreferencesController') {
+      return { state: { useExternalServices } };
+    }
+    if (name === 'OnboardingController') {
+      return { state: { completedOnboarding } };
+    }
+    throw new Error(`Unexpected messenger client: ${name}`);
+  });
+
+  return requestMock;
 }
 
 describe('DefiPositionsControllerInit', () => {
@@ -52,5 +103,60 @@ describe('DefiPositionsControllerInit', () => {
     DeFiPositionsControllerInit(requestMock);
 
     expect(defiPositionsControllerClassMock).toHaveBeenCalled();
+  });
+
+  describe('isEnabled', () => {
+    it('returns true when legacy conditions are met and V2 is disabled', () => {
+      const requestMock = buildInitRequestMock();
+      DeFiPositionsControllerInit(requestMock);
+
+      const { isEnabled } = defiPositionsControllerClassMock.mock.calls[0][0];
+      expect(isEnabled).toBeDefined();
+      expect(isEnabled?.()).toBe(true);
+    });
+
+    it('returns false when V2 feature flag is enabled', () => {
+      const requestMock = buildInitRequestMock({
+        defiControllerV2Enabled: true,
+      });
+      DeFiPositionsControllerInit(requestMock);
+
+      const { isEnabled } = defiPositionsControllerClassMock.mock.calls[0][0];
+      expect(isEnabled).toBeDefined();
+      expect(isEnabled?.()).toBe(false);
+    });
+
+    it('returns false when onboarding is incomplete', () => {
+      const requestMock = buildInitRequestMock({
+        completedOnboarding: false,
+      });
+      DeFiPositionsControllerInit(requestMock);
+
+      const { isEnabled } = defiPositionsControllerClassMock.mock.calls[0][0];
+      expect(isEnabled).toBeDefined();
+      expect(isEnabled?.()).toBe(false);
+    });
+
+    it('returns false when external services are disabled', () => {
+      const requestMock = buildInitRequestMock({
+        useExternalServices: false,
+      });
+      DeFiPositionsControllerInit(requestMock);
+
+      const { isEnabled } = defiPositionsControllerClassMock.mock.calls[0][0];
+      expect(isEnabled).toBeDefined();
+      expect(isEnabled?.()).toBe(false);
+    });
+
+    it('returns false when assets DeFi positions flag is disabled', () => {
+      const requestMock = buildInitRequestMock({
+        assetsDefiPositionsEnabled: false,
+      });
+      DeFiPositionsControllerInit(requestMock);
+
+      const { isEnabled } = defiPositionsControllerClassMock.mock.calls[0][0];
+      expect(isEnabled).toBeDefined();
+      expect(isEnabled?.()).toBe(false);
+    });
   });
 });

--- a/app/scripts/messenger-client-init/defi-positions/defi-positions-controller-init.ts
+++ b/app/scripts/messenger-client-init/defi-positions/defi-positions-controller-init.ts
@@ -9,6 +9,11 @@ import {
   FeatureFlagNames,
 } from '../../../../shared/lib/feature-flags';
 import {
+  DEFI_CONTROLLER_V2_FLAG,
+  isDefiControllerV2Enabled,
+  type DefiControllerV2FeatureFlag,
+} from '../../../../shared/lib/defi-controller-v2/remote-feature-flag';
+import {
   MetaMetricsEventOptions,
   MetaMetricsEventPayload,
 } from '../../../../shared/constants/metametrics';
@@ -34,16 +39,27 @@ export const DeFiPositionsControllerInit: MessengerClientInitFunction<
         state: { completedOnboarding },
       } = getOnboardingController();
 
+      const { remoteFeatureFlags } = initMessenger.call(
+        'RemoteFeatureFlagController:getState',
+      );
       const assetsDefiPositionsEnabled = Boolean(
-        initMessenger.call('RemoteFeatureFlagController:getState')
-          ?.remoteFeatureFlags?.[FeatureFlagNames.AssetsDefiPositionsEnabled] ??
+        remoteFeatureFlags?.[FeatureFlagNames.AssetsDefiPositionsEnabled] ??
         DEFAULT_FEATURE_FLAG_VALUES[
           FeatureFlagNames.AssetsDefiPositionsEnabled
         ],
       );
+      const defiControllerV2Enabled = isDefiControllerV2Enabled(
+        remoteFeatureFlags?.[DEFI_CONTROLLER_V2_FLAG] as
+          | DefiControllerV2FeatureFlag
+          | undefined,
+      );
 
+      // Legacy controller runs only when V2 is disabled.
       return (
-        completedOnboarding && useExternalServices && assetsDefiPositionsEnabled
+        completedOnboarding &&
+        useExternalServices &&
+        assetsDefiPositionsEnabled &&
+        !defiControllerV2Enabled
       );
     },
     trackEvent: (

--- a/app/scripts/messenger-client-init/defi-positions/defi-positions-controller-v2-init.test.ts
+++ b/app/scripts/messenger-client-init/defi-positions/defi-positions-controller-v2-init.test.ts
@@ -23,7 +23,7 @@ function buildInitRequestMock(
   options: {
     useExternalServices?: boolean;
     completedOnboarding?: boolean;
-    currentCurrency?: string;
+    selectedCurrency?: string;
     defiControllerV2Enabled?: boolean;
   } = {},
 ): jest.Mocked<
@@ -35,7 +35,7 @@ function buildInitRequestMock(
   const {
     useExternalServices = true,
     completedOnboarding = true,
-    currentCurrency = 'usd',
+    selectedCurrency = 'usd',
     defiControllerV2Enabled = true,
   } = options;
 
@@ -52,6 +52,12 @@ function buildInitRequestMock(
   };
 
   requestMock.initMessenger.call = jest.fn().mockImplementation((action) => {
+    if (action === 'PreferencesController:getState') {
+      return { useExternalServices };
+    }
+    if (action === 'OnboardingController:getState') {
+      return { completedOnboarding };
+    }
     if (action === 'RemoteFeatureFlagController:getState') {
       return {
         remoteFeatureFlags: {
@@ -59,21 +65,10 @@ function buildInitRequestMock(
         },
       };
     }
-    if (action === 'CurrencyRateController:getState') {
-      return { currentCurrency };
+    if (action === 'AssetsController:getState') {
+      return { selectedCurrency };
     }
     throw new Error(`Unexpected action: ${action}`);
-  });
-
-  // @ts-expect-error: Partial mock.
-  requestMock.getMessengerClient.mockImplementation((name: string) => {
-    if (name === 'PreferencesController') {
-      return { state: { useExternalServices } };
-    }
-    if (name === 'OnboardingController') {
-      return { state: { completedOnboarding } };
-    }
-    throw new Error(`Unexpected messenger client: ${name}`);
   });
 
   return requestMock;
@@ -159,8 +154,8 @@ describe('DeFiPositionsControllerV2Init', () => {
   });
 
   describe('getVsCurrency', () => {
-    it('returns the current currency from CurrencyRateController', () => {
-      const requestMock = buildInitRequestMock({ currentCurrency: 'eur' });
+    it('returns the selected currency from AssetsController', () => {
+      const requestMock = buildInitRequestMock({ selectedCurrency: 'eur' });
       DeFiPositionsControllerV2Init(requestMock);
 
       const { getVsCurrency } =

--- a/app/scripts/messenger-client-init/defi-positions/defi-positions-controller-v2-init.test.ts
+++ b/app/scripts/messenger-client-init/defi-positions/defi-positions-controller-v2-init.test.ts
@@ -1,0 +1,172 @@
+import {
+  DeFiPositionsControllerV2,
+  DeFiPositionsControllerV2Messenger,
+} from '@metamask/assets-controllers';
+import { buildControllerInitRequestMock } from '../test/utils';
+import { MessengerClientInitRequest } from '../types';
+import {
+  DeFiPositionsControllerV2InitMessenger,
+  getDeFiPositionsControllerV2InitMessenger,
+  getDeFiPositionsControllerV2Messenger,
+} from '../messengers/defi-positions/defi-positions-controller-v2-messenger';
+import { getRootMessenger } from '../../lib/messenger';
+import { DEFI_CONTROLLER_V2_FLAG } from '../../../../shared/lib/defi-controller-v2/remote-feature-flag';
+import { DeFiPositionsControllerV2Init } from './defi-positions-controller-v2-init';
+
+jest.mock('@metamask/assets-controllers');
+
+jest.mock('@metamask/core-backend', () => ({
+  createApiPlatformClient: jest.fn().mockReturnValue({ mockApiClient: true }),
+}));
+
+function buildInitRequestMock(
+  options: {
+    useExternalServices?: boolean;
+    completedOnboarding?: boolean;
+    currentCurrency?: string;
+    defiControllerV2Enabled?: boolean;
+  } = {},
+): jest.Mocked<
+  MessengerClientInitRequest<
+    DeFiPositionsControllerV2Messenger,
+    DeFiPositionsControllerV2InitMessenger
+  >
+> {
+  const {
+    useExternalServices = true,
+    completedOnboarding = true,
+    currentCurrency = 'usd',
+    defiControllerV2Enabled = true,
+  } = options;
+
+  const baseControllerMessenger = getRootMessenger();
+
+  const requestMock = {
+    ...buildControllerInitRequestMock(),
+    controllerMessenger: getDeFiPositionsControllerV2Messenger(
+      baseControllerMessenger,
+    ),
+    initMessenger: getDeFiPositionsControllerV2InitMessenger(
+      baseControllerMessenger,
+    ),
+  };
+
+  requestMock.initMessenger.call = jest.fn().mockImplementation((action) => {
+    if (action === 'RemoteFeatureFlagController:getState') {
+      return {
+        remoteFeatureFlags: {
+          [DEFI_CONTROLLER_V2_FLAG]: { enabled: defiControllerV2Enabled },
+        },
+      };
+    }
+    if (action === 'CurrencyRateController:getState') {
+      return { currentCurrency };
+    }
+    throw new Error(`Unexpected action: ${action}`);
+  });
+
+  // @ts-expect-error: Partial mock.
+  requestMock.getMessengerClient.mockImplementation((name: string) => {
+    if (name === 'PreferencesController') {
+      return { state: { useExternalServices } };
+    }
+    if (name === 'OnboardingController') {
+      return { state: { completedOnboarding } };
+    }
+    throw new Error(`Unexpected messenger client: ${name}`);
+  });
+
+  return requestMock;
+}
+
+describe('DeFiPositionsControllerV2Init', () => {
+  const defiPositionsControllerV2ClassMock = jest.mocked(
+    DeFiPositionsControllerV2,
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns controller instance', () => {
+    const requestMock = buildInitRequestMock();
+    expect(
+      DeFiPositionsControllerV2Init(requestMock).messengerClient,
+    ).toBeInstanceOf(DeFiPositionsControllerV2);
+  });
+
+  it('returns null persistedStateKey', () => {
+    const requestMock = buildInitRequestMock();
+    expect(DeFiPositionsControllerV2Init(requestMock).persistedStateKey).toBe(
+      null,
+    );
+  });
+
+  it('initializes with messenger, apiClient, isEnabled, and getVsCurrency', () => {
+    const requestMock = buildInitRequestMock();
+    DeFiPositionsControllerV2Init(requestMock);
+
+    expect(defiPositionsControllerV2ClassMock).toHaveBeenCalledWith({
+      messenger: requestMock.controllerMessenger,
+      apiClient: { mockApiClient: true },
+      isEnabled: expect.any(Function),
+      getVsCurrency: expect.any(Function),
+    });
+  });
+
+  describe('isEnabled', () => {
+    it('returns true when onboarding is complete, external services are on, and V2 flag is enabled', () => {
+      const requestMock = buildInitRequestMock();
+      DeFiPositionsControllerV2Init(requestMock);
+
+      const { isEnabled } = defiPositionsControllerV2ClassMock.mock.calls[0][0];
+      expect(isEnabled).toBeDefined();
+      expect(isEnabled?.()).toBe(true);
+    });
+
+    it('returns false when onboarding is incomplete', () => {
+      const requestMock = buildInitRequestMock({
+        completedOnboarding: false,
+      });
+      DeFiPositionsControllerV2Init(requestMock);
+
+      const { isEnabled } = defiPositionsControllerV2ClassMock.mock.calls[0][0];
+      expect(isEnabled).toBeDefined();
+      expect(isEnabled?.()).toBe(false);
+    });
+
+    it('returns false when external services are disabled', () => {
+      const requestMock = buildInitRequestMock({
+        useExternalServices: false,
+      });
+      DeFiPositionsControllerV2Init(requestMock);
+
+      const { isEnabled } = defiPositionsControllerV2ClassMock.mock.calls[0][0];
+      expect(isEnabled).toBeDefined();
+      expect(isEnabled?.()).toBe(false);
+    });
+
+    it('returns false when V2 feature flag is disabled', () => {
+      const requestMock = buildInitRequestMock({
+        defiControllerV2Enabled: false,
+      });
+      DeFiPositionsControllerV2Init(requestMock);
+
+      const { isEnabled } = defiPositionsControllerV2ClassMock.mock.calls[0][0];
+      expect(isEnabled).toBeDefined();
+      expect(isEnabled?.()).toBe(false);
+    });
+  });
+
+  describe('getVsCurrency', () => {
+    it('returns the current currency from CurrencyRateController', () => {
+      const requestMock = buildInitRequestMock({ currentCurrency: 'eur' });
+      DeFiPositionsControllerV2Init(requestMock);
+
+      const { getVsCurrency } =
+        defiPositionsControllerV2ClassMock.mock.calls[0][0];
+      expect(getVsCurrency).toBeDefined();
+      expect(getVsCurrency?.()).toBe('eur');
+    });
+  });
+});

--- a/app/scripts/messenger-client-init/defi-positions/defi-positions-controller-v2-init.test.ts
+++ b/app/scripts/messenger-client-init/defi-positions/defi-positions-controller-v2-init.test.ts
@@ -97,9 +97,9 @@ describe('DeFiPositionsControllerV2Init', () => {
 
   it('returns null persistedStateKey', () => {
     const requestMock = buildInitRequestMock();
-    expect(DeFiPositionsControllerV2Init(requestMock).persistedStateKey).toBe(
-      null,
-    );
+    expect(
+      DeFiPositionsControllerV2Init(requestMock).persistedStateKey,
+    ).toBeNull();
   });
 
   it('initializes with messenger, apiClient, isEnabled, and getVsCurrency', () => {

--- a/app/scripts/messenger-client-init/defi-positions/defi-positions-controller-v2-init.ts
+++ b/app/scripts/messenger-client-init/defi-positions/defi-positions-controller-v2-init.ts
@@ -56,23 +56,17 @@ export const DeFiPositionsControllerV2Init: MessengerClientInitFunction<
   DeFiPositionsControllerV2,
   DeFiPositionsControllerV2Messenger,
   DeFiPositionsControllerV2InitMessenger
-> = ({ initMessenger, controllerMessenger, getMessengerClient }) => {
-  const getPreferencesController = () =>
-    getMessengerClient('PreferencesController');
-  const getOnboardingController = () =>
-    getMessengerClient('OnboardingController');
-
+> = ({ initMessenger, controllerMessenger }) => {
   const messengerClient = new DeFiPositionsControllerV2({
     messenger: controllerMessenger,
     apiClient: getApiClient(initMessenger),
     isEnabled: () => {
-      const {
-        state: { useExternalServices },
-      } = getPreferencesController();
-      const {
-        state: { completedOnboarding },
-      } = getOnboardingController();
-
+      const { useExternalServices } = initMessenger.call(
+        'PreferencesController:getState',
+      );
+      const { completedOnboarding } = initMessenger.call(
+        'OnboardingController:getState',
+      );
       const { remoteFeatureFlags } = initMessenger.call(
         'RemoteFeatureFlagController:getState',
       );
@@ -87,7 +81,7 @@ export const DeFiPositionsControllerV2Init: MessengerClientInitFunction<
       );
     },
     getVsCurrency: () =>
-      initMessenger.call('CurrencyRateController:getState').currentCurrency,
+      initMessenger.call('AssetsController:getState').selectedCurrency,
   });
 
   return {

--- a/app/scripts/messenger-client-init/defi-positions/defi-positions-controller-v2-init.ts
+++ b/app/scripts/messenger-client-init/defi-positions/defi-positions-controller-v2-init.ts
@@ -1,0 +1,97 @@
+import {
+  DeFiPositionsControllerV2,
+  DeFiPositionsControllerV2Messenger,
+} from '@metamask/assets-controllers';
+import { createApiPlatformClient } from '@metamask/core-backend';
+import type { ApiPlatformClient } from '@metamask/core-backend';
+import { MessengerClientInitFunction } from '../types';
+import { DeFiPositionsControllerV2InitMessenger } from '../messengers/defi-positions';
+import {
+  DEFI_CONTROLLER_V2_FLAG,
+  isDefiControllerV2Enabled,
+  type DefiControllerV2FeatureFlag,
+} from '../../../../shared/lib/defi-controller-v2/remote-feature-flag';
+
+/**
+ * Cached API client instance shared across init calls (matches AssetsController).
+ */
+let apiClient: ApiPlatformClient | null = null;
+
+/**
+ * Safely retrieves the bearer token for API authentication.
+ *
+ * @param initMessenger - The initialization messenger.
+ * @returns The bearer token or undefined if retrieval fails.
+ */
+async function safeGetBearerToken(
+  initMessenger: DeFiPositionsControllerV2InitMessenger,
+): Promise<string | undefined> {
+  try {
+    return await initMessenger.call('AuthenticationController:getBearerToken');
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Gets or creates the API platform client used to fetch DeFi positions.
+ *
+ * @param initMessenger - The initialization messenger.
+ * @returns The API platform client.
+ */
+function getApiClient(
+  initMessenger: DeFiPositionsControllerV2InitMessenger,
+): ApiPlatformClient {
+  if (!apiClient) {
+    apiClient = createApiPlatformClient({
+      clientProduct: 'metamask-extension',
+      clientVersion: process.env.METAMASK_VERSION,
+      getBearerToken: () => safeGetBearerToken(initMessenger),
+    });
+  }
+  return apiClient;
+}
+
+export const DeFiPositionsControllerV2Init: MessengerClientInitFunction<
+  DeFiPositionsControllerV2,
+  DeFiPositionsControllerV2Messenger,
+  DeFiPositionsControllerV2InitMessenger
+> = ({ initMessenger, controllerMessenger, getMessengerClient }) => {
+  const getPreferencesController = () =>
+    getMessengerClient('PreferencesController');
+  const getOnboardingController = () =>
+    getMessengerClient('OnboardingController');
+
+  const messengerClient = new DeFiPositionsControllerV2({
+    messenger: controllerMessenger,
+    apiClient: getApiClient(initMessenger),
+    isEnabled: () => {
+      const {
+        state: { useExternalServices },
+      } = getPreferencesController();
+      const {
+        state: { completedOnboarding },
+      } = getOnboardingController();
+
+      const { remoteFeatureFlags } = initMessenger.call(
+        'RemoteFeatureFlagController:getState',
+      );
+      const defiControllerV2Enabled = isDefiControllerV2Enabled(
+        remoteFeatureFlags?.[DEFI_CONTROLLER_V2_FLAG] as
+          | DefiControllerV2FeatureFlag
+          | undefined,
+      );
+
+      return (
+        completedOnboarding && useExternalServices && defiControllerV2Enabled
+      );
+    },
+    getVsCurrency: () =>
+      initMessenger.call('CurrencyRateController:getState').currentCurrency,
+  });
+
+  return {
+    messengerClient,
+    persistedStateKey: null,
+  };
+};

--- a/app/scripts/messenger-client-init/messengers/defi-positions/defi-positions-controller-v2-messenger.test.ts
+++ b/app/scripts/messenger-client-init/messengers/defi-positions/defi-positions-controller-v2-messenger.test.ts
@@ -46,8 +46,10 @@ describe('getDeFiPositionsControllerV2InitMessenger', () => {
     expect(delegateSpy).toHaveBeenCalledWith(
       expect.objectContaining({
         actions: [
+          'PreferencesController:getState',
+          'OnboardingController:getState',
           'RemoteFeatureFlagController:getState',
-          'CurrencyRateController:getState',
+          'AssetsController:getState',
           'AuthenticationController:getBearerToken',
         ],
       }),

--- a/app/scripts/messenger-client-init/messengers/defi-positions/defi-positions-controller-v2-messenger.test.ts
+++ b/app/scripts/messenger-client-init/messengers/defi-positions/defi-positions-controller-v2-messenger.test.ts
@@ -1,0 +1,56 @@
+import { Messenger } from '@metamask/messenger';
+import { getRootMessenger } from '../../../lib/messenger';
+import {
+  getDeFiPositionsControllerV2InitMessenger,
+  getDeFiPositionsControllerV2Messenger,
+} from './defi-positions-controller-v2-messenger';
+
+describe('getDeFiPositionsControllerV2Messenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = getRootMessenger<never, never>();
+    const defiPositionsControllerV2Messenger =
+      getDeFiPositionsControllerV2Messenger(messenger);
+
+    expect(defiPositionsControllerV2Messenger).toBeInstanceOf(Messenger);
+  });
+
+  it('delegates required actions for DeFiPositionsControllerV2', () => {
+    const messenger = getRootMessenger<never, never>();
+    const delegateSpy = jest.spyOn(messenger, 'delegate');
+
+    getDeFiPositionsControllerV2Messenger(messenger);
+
+    expect(delegateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actions: ['AccountTreeController:getAccountsFromSelectedAccountGroup'],
+      }),
+    );
+  });
+});
+
+describe('getDeFiPositionsControllerV2InitMessenger', () => {
+  it('returns a restricted messenger', () => {
+    const messenger = getRootMessenger<never, never>();
+    const defiPositionsControllerV2InitMessenger =
+      getDeFiPositionsControllerV2InitMessenger(messenger);
+
+    expect(defiPositionsControllerV2InitMessenger).toBeInstanceOf(Messenger);
+  });
+
+  it('delegates required initialization actions', () => {
+    const messenger = getRootMessenger<never, never>();
+    const delegateSpy = jest.spyOn(messenger, 'delegate');
+
+    getDeFiPositionsControllerV2InitMessenger(messenger);
+
+    expect(delegateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actions: [
+          'RemoteFeatureFlagController:getState',
+          'CurrencyRateController:getState',
+          'AuthenticationController:getBearerToken',
+        ],
+      }),
+    );
+  });
+});

--- a/app/scripts/messenger-client-init/messengers/defi-positions/defi-positions-controller-v2-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/defi-positions/defi-positions-controller-v2-messenger.ts
@@ -3,12 +3,12 @@ import {
   type MessengerActions,
   type MessengerEvents,
 } from '@metamask/messenger';
-import {
-  DeFiPositionsControllerV2Messenger,
-  CurrencyRateControllerGetStateAction,
-} from '@metamask/assets-controllers';
+import { DeFiPositionsControllerV2Messenger } from '@metamask/assets-controllers';
+import type { AssetsControllerGetStateAction } from '@metamask/assets-controller';
 import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
 import { AuthenticationControllerGetBearerTokenAction } from '@metamask/profile-sync-controller/auth';
+import { PreferencesControllerGetStateAction } from '../../../controllers/preferences-controller';
+import { OnboardingControllerGetStateAction } from '../../../controllers/onboarding';
 import { RootMessenger } from '../../../lib/messenger';
 
 /**
@@ -38,8 +38,10 @@ export function getDeFiPositionsControllerV2Messenger(
 }
 
 type AllowedInitializationActions =
+  | PreferencesControllerGetStateAction
+  | OnboardingControllerGetStateAction
   | RemoteFeatureFlagControllerGetStateAction
-  | CurrencyRateControllerGetStateAction
+  | AssetsControllerGetStateAction
   | AuthenticationControllerGetBearerTokenAction;
 
 export type DeFiPositionsControllerV2InitMessenger = ReturnType<
@@ -61,8 +63,10 @@ export function getDeFiPositionsControllerV2InitMessenger(
   messenger.delegate({
     messenger: controllerInitMessenger,
     actions: [
+      'PreferencesController:getState',
+      'OnboardingController:getState',
       'RemoteFeatureFlagController:getState',
-      'CurrencyRateController:getState',
+      'AssetsController:getState',
       'AuthenticationController:getBearerToken',
     ],
   });

--- a/app/scripts/messenger-client-init/messengers/defi-positions/defi-positions-controller-v2-messenger.ts
+++ b/app/scripts/messenger-client-init/messengers/defi-positions/defi-positions-controller-v2-messenger.ts
@@ -1,0 +1,70 @@
+import {
+  Messenger,
+  type MessengerActions,
+  type MessengerEvents,
+} from '@metamask/messenger';
+import {
+  DeFiPositionsControllerV2Messenger,
+  CurrencyRateControllerGetStateAction,
+} from '@metamask/assets-controllers';
+import { RemoteFeatureFlagControllerGetStateAction } from '@metamask/remote-feature-flag-controller';
+import { AuthenticationControllerGetBearerTokenAction } from '@metamask/profile-sync-controller/auth';
+import { RootMessenger } from '../../../lib/messenger';
+
+/**
+ * Get a restricted messenger for the DeFi Positions V2 controller. This is
+ * scoped to the actions and events that the controller is allowed to handle.
+ *
+ * @param messenger - The controller messenger to restrict.
+ * @returns The restricted controller messenger.
+ */
+export function getDeFiPositionsControllerV2Messenger(
+  messenger: RootMessenger<
+    MessengerActions<DeFiPositionsControllerV2Messenger>,
+    MessengerEvents<DeFiPositionsControllerV2Messenger>
+  >,
+): DeFiPositionsControllerV2Messenger {
+  const controllerMessenger: DeFiPositionsControllerV2Messenger = new Messenger(
+    {
+      namespace: 'DeFiPositionsControllerV2',
+      parent: messenger,
+    },
+  );
+  messenger.delegate({
+    messenger: controllerMessenger,
+    actions: ['AccountTreeController:getAccountsFromSelectedAccountGroup'],
+  });
+  return controllerMessenger;
+}
+
+type AllowedInitializationActions =
+  | RemoteFeatureFlagControllerGetStateAction
+  | CurrencyRateControllerGetStateAction
+  | AuthenticationControllerGetBearerTokenAction;
+
+export type DeFiPositionsControllerV2InitMessenger = ReturnType<
+  typeof getDeFiPositionsControllerV2InitMessenger
+>;
+
+export function getDeFiPositionsControllerV2InitMessenger(
+  messenger: RootMessenger<AllowedInitializationActions, never>,
+) {
+  const controllerInitMessenger = new Messenger<
+    'DeFiPositionsControllerV2Init',
+    AllowedInitializationActions,
+    never,
+    typeof messenger
+  >({
+    namespace: 'DeFiPositionsControllerV2Init',
+    parent: messenger,
+  });
+  messenger.delegate({
+    messenger: controllerInitMessenger,
+    actions: [
+      'RemoteFeatureFlagController:getState',
+      'CurrencyRateController:getState',
+      'AuthenticationController:getBearerToken',
+    ],
+  });
+  return controllerInitMessenger;
+}

--- a/app/scripts/messenger-client-init/messengers/defi-positions/index.ts
+++ b/app/scripts/messenger-client-init/messengers/defi-positions/index.ts
@@ -4,3 +4,10 @@ export {
 } from './defi-positions-controller-messenger';
 
 export type { DeFiPositionsControllerInitMessenger } from './defi-positions-controller-messenger';
+
+export {
+  getDeFiPositionsControllerV2Messenger,
+  getDeFiPositionsControllerV2InitMessenger,
+} from './defi-positions-controller-v2-messenger';
+
+export type { DeFiPositionsControllerV2InitMessenger } from './defi-positions-controller-v2-messenger';

--- a/app/scripts/messenger-client-init/messengers/index.ts
+++ b/app/scripts/messenger-client-init/messengers/index.ts
@@ -66,6 +66,10 @@ import {
 } from './notifications';
 import { getDeFiPositionsControllerMessenger } from './defi-positions';
 import { getDeFiPositionsControllerInitMessenger } from './defi-positions/defi-positions-controller-messenger';
+import {
+  getDeFiPositionsControllerV2Messenger,
+  getDeFiPositionsControllerV2InitMessenger,
+} from './defi-positions/defi-positions-controller-v2-messenger';
 import { getDelegationControllerMessenger } from './delegation/delegation-controller-messenger';
 import {
   getAccountTreeControllerMessenger,
@@ -441,6 +445,10 @@ export const MESSENGER_FACTORIES = {
   DeFiPositionsController: {
     getMessenger: getDeFiPositionsControllerMessenger,
     getInitMessenger: getDeFiPositionsControllerInitMessenger,
+  },
+  DeFiPositionsControllerV2: {
+    getMessenger: getDeFiPositionsControllerV2Messenger,
+    getInitMessenger: getDeFiPositionsControllerV2InitMessenger,
   },
   DelegationController: {
     getMessenger: getDelegationControllerMessenger,

--- a/app/scripts/messenger-client-init/utils.ts
+++ b/app/scripts/messenger-client-init/utils.ts
@@ -49,6 +49,7 @@ export type MessengerClientsToInitialize =
   | 'ClientController'
   | 'CronjobController'
   | 'DeFiPositionsController'
+  | 'DeFiPositionsControllerV2'
   | 'ExecutionService'
   | 'MultichainAssetsController'
   | 'MultichainAssetsRatesController'

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -375,6 +375,7 @@ import { AuthenticationControllerInit } from './messenger-client-init/identity/a
 import { UserStorageControllerInit } from './messenger-client-init/identity/user-storage-controller-init';
 import { AuthenticatedUserStorageServiceInit } from './messenger-client-init/authenticated-user-storage-service-init';
 import { DeFiPositionsControllerInit } from './messenger-client-init/defi-positions/defi-positions-controller-init';
+import { DeFiPositionsControllerV2Init } from './messenger-client-init/defi-positions/defi-positions-controller-v2-init';
 import { NotificationServicesControllerInit } from './messenger-client-init/notifications/notification-services-controller-init';
 import { NotificationServicesPushControllerInit } from './messenger-client-init/notifications/notification-services-push-controller-init';
 import { DelegationControllerInit } from './messenger-client-init/delegation/delegation-controller-init';
@@ -727,6 +728,7 @@ export default class MetamaskController extends EventEmitter {
       NotificationServicesPushController:
         NotificationServicesPushControllerInit,
       DeFiPositionsController: DeFiPositionsControllerInit,
+      DeFiPositionsControllerV2: DeFiPositionsControllerV2Init,
       DelegationController: DelegationControllerInit,
       OAuthService: OAuthServiceInit,
       SeedlessOnboardingController: SeedlessOnboardingControllerInit,
@@ -875,6 +877,8 @@ export default class MetamaskController extends EventEmitter {
       messengerClientsByName.NotificationServicesPushController;
     this.deFiPositionsController =
       messengerClientsByName.DeFiPositionsController;
+    this.deFiPositionsControllerV2 =
+      messengerClientsByName.DeFiPositionsControllerV2;
     this.accountTreeController = messengerClientsByName.AccountTreeController;
     this.oauthService = messengerClientsByName.OAuthService;
     this.subscriptionService = messengerClientsByName.SubscriptionService;
@@ -1471,6 +1475,7 @@ export default class MetamaskController extends EventEmitter {
         this.notificationServicesPushController,
       RemoteFeatureFlagController: this.remoteFeatureFlagController,
       DeFiPositionsController: this.deFiPositionsController,
+      DeFiPositionsControllerV2: this.deFiPositionsControllerV2,
       ProfileMetricsController: this.profileMetricsController,
       ConfigRegistryController: this.configRegistryController,
       TransactionController: this.txController,
@@ -1538,6 +1543,7 @@ export default class MetamaskController extends EventEmitter {
           this.notificationServicesPushController,
         RemoteFeatureFlagController: this.remoteFeatureFlagController,
         DeFiPositionsController: this.deFiPositionsController,
+        DeFiPositionsControllerV2: this.deFiPositionsControllerV2,
         PhishingController: this.phishingController,
         ShieldController: this.shieldController,
         ClaimsController: this.claimsController,
@@ -2626,6 +2632,7 @@ export default class MetamaskController extends EventEmitter {
       notificationServicesController,
       notificationServicesPushController,
       deFiPositionsController,
+      deFiPositionsControllerV2,
       multichainAssetsRatesController,
       staticAssetsController,
     } = this;
@@ -3750,6 +3757,10 @@ export default class MetamaskController extends EventEmitter {
       ),
       deFiStopPolling: deFiPositionsController.stopPollingByPollingToken.bind(
         deFiPositionsController,
+      ),
+
+      fetchDeFiPositions: deFiPositionsControllerV2.fetchDeFiPositions.bind(
+        deFiPositionsControllerV2,
       ),
 
       // GasFeeController

--- a/lavamoat/webpack/mv2/beta/policy.json
+++ b/lavamoat/webpack/mv2/beta/policy.json
@@ -872,6 +872,7 @@
         "@metamask/base-controller": true,
         "@metamask/contract-metadata": true,
         "@metamask/controller-utils": true,
+        "@metamask/core-backend": true,
         "@metamask/controller-utils>@metamask/eth-query": true,
         "@metamask/keyring-api": true,
         "@metamask/keyring-snap-client": true,

--- a/lavamoat/webpack/mv2/experimental/policy.json
+++ b/lavamoat/webpack/mv2/experimental/policy.json
@@ -872,6 +872,7 @@
         "@metamask/base-controller": true,
         "@metamask/contract-metadata": true,
         "@metamask/controller-utils": true,
+        "@metamask/core-backend": true,
         "@metamask/controller-utils>@metamask/eth-query": true,
         "@metamask/keyring-api": true,
         "@metamask/keyring-snap-client": true,

--- a/lavamoat/webpack/mv2/flask/policy.json
+++ b/lavamoat/webpack/mv2/flask/policy.json
@@ -872,6 +872,7 @@
         "@metamask/base-controller": true,
         "@metamask/contract-metadata": true,
         "@metamask/controller-utils": true,
+        "@metamask/core-backend": true,
         "@metamask/controller-utils>@metamask/eth-query": true,
         "@metamask/keyring-api": true,
         "@metamask/keyring-snap-client": true,

--- a/lavamoat/webpack/mv2/main/policy.json
+++ b/lavamoat/webpack/mv2/main/policy.json
@@ -872,6 +872,7 @@
         "@metamask/base-controller": true,
         "@metamask/contract-metadata": true,
         "@metamask/controller-utils": true,
+        "@metamask/core-backend": true,
         "@metamask/controller-utils>@metamask/eth-query": true,
         "@metamask/keyring-api": true,
         "@metamask/keyring-snap-client": true,

--- a/lavamoat/webpack/mv3/beta/policy.json
+++ b/lavamoat/webpack/mv3/beta/policy.json
@@ -958,6 +958,7 @@
         "@metamask/base-controller": true,
         "@metamask/contract-metadata": true,
         "@metamask/controller-utils": true,
+        "@metamask/core-backend": true,
         "@metamask/controller-utils>@metamask/eth-query": true,
         "@metamask/keyring-api": true,
         "@metamask/keyring-snap-client": true,

--- a/lavamoat/webpack/mv3/experimental/policy.json
+++ b/lavamoat/webpack/mv3/experimental/policy.json
@@ -958,6 +958,7 @@
         "@metamask/base-controller": true,
         "@metamask/contract-metadata": true,
         "@metamask/controller-utils": true,
+        "@metamask/core-backend": true,
         "@metamask/controller-utils>@metamask/eth-query": true,
         "@metamask/keyring-api": true,
         "@metamask/keyring-snap-client": true,

--- a/lavamoat/webpack/mv3/flask/policy.json
+++ b/lavamoat/webpack/mv3/flask/policy.json
@@ -958,6 +958,7 @@
         "@metamask/base-controller": true,
         "@metamask/contract-metadata": true,
         "@metamask/controller-utils": true,
+        "@metamask/core-backend": true,
         "@metamask/controller-utils>@metamask/eth-query": true,
         "@metamask/keyring-api": true,
         "@metamask/keyring-snap-client": true,

--- a/lavamoat/webpack/mv3/main/policy.json
+++ b/lavamoat/webpack/mv3/main/policy.json
@@ -958,6 +958,7 @@
         "@metamask/base-controller": true,
         "@metamask/contract-metadata": true,
         "@metamask/controller-utils": true,
+        "@metamask/core-backend": true,
         "@metamask/controller-utils>@metamask/eth-query": true,
         "@metamask/keyring-api": true,
         "@metamask/keyring-snap-client": true,

--- a/shared/types/background.ts
+++ b/shared/types/background.ts
@@ -12,6 +12,7 @@ import type {
   MultichainAssetsRatesControllerState,
   MultichainAssetsControllerState,
   DeFiPositionsControllerState,
+  DeFiPositionsControllerV2State,
   AccountTrackerControllerState,
 } from '@metamask/assets-controllers';
 import type { MultichainTransactionsControllerState } from '@metamask/multichain-transactions-controller';
@@ -175,6 +176,7 @@ export type ControllerStatePropertiesEnumerated = {
   unapprovedDecryptMsgCount: DecryptMessageControllerState['unapprovedDecryptMsgCount'];
   allDeFiPositions: DeFiPositionsControllerState['allDeFiPositions'];
   allDeFiPositionsCount: DeFiPositionsControllerState['allDeFiPositionsCount'];
+  allDeFiPositionsV2: DeFiPositionsControllerV2State['allDeFiPositionsV2'];
   unapprovedEncryptionPublicKeyMsgs: EncryptionPublicKeyControllerState['unapprovedEncryptionPublicKeyMsgs'];
   unapprovedEncryptionPublicKeyMsgCount: EncryptionPublicKeyControllerState['unapprovedEncryptionPublicKeyMsgCount'];
   ensResolutionsByAddress: EnsControllerState['ensResolutionsByAddress'];
@@ -353,6 +355,7 @@ type ControllerStateTypesMerged = AccountsControllerState &
   CurrencyRateState &
   DecryptMessageControllerState &
   DeFiPositionsControllerState &
+  DeFiPositionsControllerV2State &
   EncryptionPublicKeyControllerState &
   EnsControllerState & {
     // This is necessary due to the nested unions and intersections in the `GasFeeState` type definition

--- a/test/e2e/fixtures/default-fixture.json
+++ b/test/e2e/fixtures/default-fixture.json
@@ -381,6 +381,9 @@
       },
       "currentCurrency": "usd"
     },
+    "DeFiPositionsControllerV2": {
+      "allDeFiPositionsV2": {}
+    },
     "EnsController": {
       "ensEntries": {
         "0x1": {

--- a/test/e2e/fixtures/onboarding-fixture.json
+++ b/test/e2e/fixtures/onboarding-fixture.json
@@ -131,6 +131,9 @@
       },
       "currentCurrency": "usd"
     },
+    "DeFiPositionsControllerV2": {
+      "allDeFiPositionsV2": {}
+    },
     "EnsController": {
       "ensEntries": {
         "0x1": {

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -146,6 +146,7 @@
     "currentCurrency": "usd"
   },
   "DeFiPositionsController": "object",
+  "DeFiPositionsControllerV2": "object",
   "DecryptMessageController": {
     "unapprovedDecryptMsgCount": 0,
     "unapprovedDecryptMsgs": "object"

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -87,6 +87,7 @@
     },
     "allDeFiPositions": "object",
     "allDeFiPositionsCount": "object",
+    "allDeFiPositionsV2": "object",
     "allDetectedTokens": {},
     "allIgnoredAssets": "object",
     "allIgnoredTokens": {},

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-background-state.json
@@ -93,6 +93,9 @@
       },
       "currentCurrency": "usd"
     },
+    "DeFiPositionsControllerV2": {
+      "allDeFiPositionsV2": "object"
+    },
     "EnsController": {
       "ensEntries": "object",
       "ensResolutionsByAddress": "object"

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-background-state.json
@@ -93,9 +93,7 @@
       },
       "currentCurrency": "usd"
     },
-    "DeFiPositionsControllerV2": {
-      "allDeFiPositionsV2": "object"
-    },
+    "DeFiPositionsControllerV2": "object",
     "EnsController": {
       "ensEntries": "object",
       "ensResolutionsByAddress": "object"

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -100,6 +100,9 @@
       },
       "currentCurrency": "usd"
     },
+    "DeFiPositionsControllerV2": {
+      "allDeFiPositionsV2": "object"
+    },
     "EnsController": {
       "ensEntries": "object",
       "ensResolutionsByAddress": "object"

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -100,9 +100,7 @@
       },
       "currentCurrency": "usd"
     },
-    "DeFiPositionsControllerV2": {
-      "allDeFiPositionsV2": "object"
-    },
+    "DeFiPositionsControllerV2": "object",
     "EnsController": {
       "ensEntries": "object",
       "ensResolutionsByAddress": "object"

--- a/test/e2e/tests/settings/state-logs.json
+++ b/test/e2e/tests/settings/state-logs.json
@@ -278,6 +278,7 @@
       "0x5cfe73b6021e818b776b421b1c4db2474086a7e1": "null"
     },
     "allDeFiPositionsCount": {},
+    "allDeFiPositionsV2": {},
     "allDetectedTokens": {},
     "allIgnoredAssets": {},
     "allIgnoredTokens": {},


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Add new DeFiPositionsControllerV2 initialisation logic and plug it to the feature flag.

This PR does not address the UI changes needed after the flag is enabled, just the controller initialisation. The flag will stay off until those are addressed, but even if it were to be turned on, it would not crash the app.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3601

## **Manual testing steps**

No changes introduced yet, just a new controller being initialised and disabled behind a feature flag.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces authenticated external API access and dual-controller gating; impact is limited while the flag stays off, but mis-flagging could switch which DeFi positions backend runs.
> 
> **Overview**
> Adds **DeFiPositionsControllerV2** to the extension background: messenger wiring, init that builds a cached `@metamask/core-backend` API client (bearer token via `AuthenticationController`), `getVsCurrency` from `AssetsController`, and **`isEnabled`** when onboarding is complete, external services are on, and the `defiControllerV2` remote flag is on. V2 uses **`persistedStateKey: null`**; state is exposed as **`allDeFiPositionsV2`** on background/UI types and stores.
> 
> The **legacy** `DeFiPositionsController` **`isEnabled`** now also requires the V2 flag to be **off**, so only one implementation is active when the flag flips. The background API gains **`fetchDeFiPositions`** bound to V2 (legacy polling APIs unchanged).
> 
> Includes unit tests for V2 init/messengers and expanded legacy init tests; e2e fixtures/metrics snapshots and LavaMoat policies allow **`@metamask/core-backend`** for assets-controllers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e56973b52d457e888541279db5d63c61584a6125. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->