### PR TITLE
fix: restored old behavior to show Paid by MetaMask label in sponsored transactions from activity page cp-13.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Fixed
+
+- Fixed sponsored network fee transfer to show the `Paid by MetaMask` label in activity page (#44314)
+
 ## [13.40.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-
-- Fixed sponsored network fee transfer to show the `Paid by MetaMask` label in activity page (#44314)
-
 ## [13.40.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## Fixed
+### Fixed
 
 - Fixed sponsored network fee transfer to show the `Paid by MetaMask` label in activity page (#44314)
 

--- a/shared/lib/activity/adapters/helpers.test.ts
+++ b/shared/lib/activity/adapters/helpers.test.ts
@@ -58,6 +58,22 @@ describe('getLocalTransactionFees', () => {
     ]);
   });
 
+  it('returns the calculated network fee for hardware wallet transactions even when gas-sponsored', () => {
+    expect(
+      getLocalTransactionFees(
+        buildTransactionGroup({
+          isGasFeeSponsored: true,
+        }),
+        { isHardwareWalletAccount: true },
+      ),
+    ).toStrictEqual([
+      expect.objectContaining({
+        amount: '6',
+        type: 'base',
+      }),
+    ]);
+  });
+
   it('does not return a sponsored marker for failed sponsored transactions without a receipt', () => {
     expect(
       getLocalTransactionFees(

--- a/shared/lib/activity/adapters/helpers.test.ts
+++ b/shared/lib/activity/adapters/helpers.test.ts
@@ -1,0 +1,72 @@
+import {
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import type { TransactionGroup } from '../../multichain/types';
+import { CHAIN_IDS } from '../../../constants/network';
+import { GAS_FEE_SPONSORED } from '../fees';
+import { getLocalTransactionFees } from './helpers';
+
+function buildTransactionGroup(
+  overrides: Partial<TransactionGroup['primaryTransaction']> = {},
+): TransactionGroup {
+  const transaction = {
+    chainId: CHAIN_IDS.MAINNET,
+    status: TransactionStatus.confirmed,
+    type: TransactionType.swap,
+    txParams: {
+      gasPrice: '0x2',
+    },
+    txReceipt: {
+      gasUsed: '0x3',
+      effectiveGasPrice: '0x2',
+    },
+    ...overrides,
+  } as TransactionGroup['primaryTransaction'];
+
+  return {
+    hasCancelled: false,
+    hasRetried: false,
+    initialTransaction: transaction,
+    nonce: '0x1',
+    primaryTransaction: transaction,
+    transactions: [transaction],
+  };
+}
+
+describe('getLocalTransactionFees', () => {
+  it('returns the calculated network fee for non-sponsored transactions', () => {
+    expect(getLocalTransactionFees(buildTransactionGroup())).toStrictEqual([
+      expect.objectContaining({
+        amount: '6',
+        type: 'base',
+      }),
+    ]);
+  });
+
+  it('returns a sponsored network fee marker for gas-sponsored transactions', () => {
+    expect(
+      getLocalTransactionFees(
+        buildTransactionGroup({
+          isGasFeeSponsored: true,
+        }),
+      ),
+    ).toStrictEqual([
+      {
+        type: GAS_FEE_SPONSORED,
+      },
+    ]);
+  });
+
+  it('does not return a sponsored marker for failed sponsored transactions without a receipt', () => {
+    expect(
+      getLocalTransactionFees(
+        buildTransactionGroup({
+          isGasFeeSponsored: true,
+          status: TransactionStatus.failed,
+          txReceipt: undefined,
+        }),
+      ),
+    ).toBeUndefined();
+  });
+});

--- a/shared/lib/activity/adapters/helpers.ts
+++ b/shared/lib/activity/adapters/helpers.ts
@@ -165,6 +165,11 @@ export function getFees(
 export function getLocalTransactionFees(
   transactionGroup: Pick<TransactionGroup, 'primaryTransaction'> &
     Partial<Pick<TransactionGroup, 'initialTransaction'>>,
+  {
+    isHardwareWalletAccount = false,
+  }: {
+    isHardwareWalletAccount?: boolean;
+  } = {},
 ): ActivityFee[] | undefined {
   const { initialTransaction, primaryTransaction } = transactionGroup;
   const transaction =
@@ -172,7 +177,12 @@ export function getLocalTransactionFees(
       ? primaryTransaction
       : initialTransaction;
 
-  if (isTransactionGasFeeSponsored({ transaction })) {
+  if (
+    isTransactionGasFeeSponsored({
+      transaction,
+      isHardwareWalletAccount,
+    })
+  ) {
     return [buildSponsoredNetworkFee()];
   }
 

--- a/shared/lib/activity/adapters/helpers.ts
+++ b/shared/lib/activity/adapters/helpers.ts
@@ -21,6 +21,8 @@ import { STATIC_MAINNET_TOKEN_LIST } from '../../../constants/tokens';
 import { toAssetId } from '../../asset-utils';
 import { isEqualCaseInsensitive as equalsIgnoreCase } from '../../string-utils';
 import type { TransactionGroup } from '../../multichain/types';
+import { isTransactionGasFeeSponsored } from '../../transaction-gas-fee.utils';
+import { GAS_FEE_SPONSORED } from '../fees';
 import type { ActivityFee, Status, TokenAmount } from '../types';
 
 export type ValueTransfer = NonNullable<
@@ -133,6 +135,12 @@ function buildBaseNetworkFee(
   };
 }
 
+function buildSponsoredNetworkFee(): ActivityFee {
+  return {
+    type: GAS_FEE_SPONSORED,
+  };
+}
+
 function getNetworkFee(
   transaction: V1TransactionByHashResponse,
   chainId: string,
@@ -155,9 +163,19 @@ export function getFees(
 }
 
 export function getLocalTransactionFees(
-  transactionGroup: Pick<TransactionGroup, 'primaryTransaction'>,
+  transactionGroup: Pick<TransactionGroup, 'primaryTransaction'> &
+    Partial<Pick<TransactionGroup, 'initialTransaction'>>,
 ): ActivityFee[] | undefined {
-  const { primaryTransaction } = transactionGroup;
+  const { initialTransaction, primaryTransaction } = transactionGroup;
+  const transaction =
+    primaryTransaction.isGasFeeSponsored || !initialTransaction
+      ? primaryTransaction
+      : initialTransaction;
+
+  if (isTransactionGasFeeSponsored({ transaction })) {
+    return [buildSponsoredNetworkFee()];
+  }
+
   const amount = toNetworkFeeAmount(
     primaryTransaction.txReceipt?.gasUsed,
     primaryTransaction.txReceipt?.effectiveGasPrice ??

--- a/shared/lib/activity/fees.test.ts
+++ b/shared/lib/activity/fees.test.ts
@@ -1,0 +1,113 @@
+import type { ActivityListItem } from './types';
+import { GAS_FEE_SPONSORED, mergeActivityItemSponsoredFees } from './fees';
+
+function buildSwapItem(data: Record<string, unknown>): ActivityListItem {
+  return {
+    type: 'swap',
+    chainId: 'eip155:1',
+    hash: '0xabc',
+    status: 'success',
+    timestamp: 1,
+    data,
+  } as ActivityListItem;
+}
+
+describe('mergeActivityItemSponsoredFees', () => {
+  it('preserves a local sponsored fee marker while keeping target token data', () => {
+    const sourceItem = buildSwapItem({
+      fees: [{ type: GAS_FEE_SPONSORED }],
+      sourceToken: {
+        amount: '1000000000000000000',
+        direction: 'out',
+        symbol: 'MON',
+      },
+    });
+
+    const targetItem = buildSwapItem({
+      destinationToken: {
+        amount: '3000000',
+        decimals: 6,
+        direction: 'in',
+        symbol: 'USDC',
+      },
+      fees: [
+        {
+          amount: '6',
+          symbol: 'MON',
+          type: 'base',
+        },
+        {
+          amount: '2',
+          symbol: 'MON',
+          type: 'priority',
+        },
+      ],
+      sourceToken: {
+        amount: '1000000000000000000',
+        decimals: 18,
+        direction: 'out',
+        symbol: 'MON',
+      },
+    });
+
+    expect(
+      mergeActivityItemSponsoredFees(sourceItem, targetItem),
+    ).toStrictEqual({
+      ...targetItem,
+      data: {
+        ...(targetItem.data as Record<string, unknown>),
+        fees: [
+          { type: GAS_FEE_SPONSORED },
+          {
+            amount: '2',
+            symbol: 'MON',
+            type: 'priority',
+          },
+        ],
+      },
+    });
+  });
+
+  it('returns the target item if the source item has no sponsored fee', () => {
+    const sourceItem = buildSwapItem({
+      fees: [
+        {
+          amount: '6',
+          symbol: 'MON',
+          type: 'base',
+        },
+      ],
+    });
+    const targetItem = buildSwapItem({
+      fees: [
+        {
+          amount: '2',
+          symbol: 'MON',
+          type: 'priority',
+        },
+      ],
+    });
+
+    expect(mergeActivityItemSponsoredFees(sourceItem, targetItem)).toBe(
+      targetItem,
+    );
+  });
+
+  it('returns the target item if the target item cannot carry fees', () => {
+    const sourceItem = buildSwapItem({
+      fees: [{ type: GAS_FEE_SPONSORED }],
+    });
+    const targetItem = {
+      type: 'buy',
+      chainId: 'eip155:1',
+      hash: '0xabc',
+      status: 'success',
+      timestamp: 1,
+      data: {},
+    } as ActivityListItem;
+
+    expect(mergeActivityItemSponsoredFees(sourceItem, targetItem)).toBe(
+      targetItem,
+    );
+  });
+});

--- a/shared/lib/activity/fees.ts
+++ b/shared/lib/activity/fees.ts
@@ -1,0 +1,61 @@
+import type { ActivityListItem } from './types';
+
+/**
+ * Activity fee marker for a network fee paid by MetaMask instead of the user.
+ *
+ * ActivityItem fees normally represent token amounts. Sponsored gas has no
+ * user-paid token amount, so this marker preserves the sponsorship state while
+ * allowing Activity Details to render the network-fee row.
+ */
+export const GAS_FEE_SPONSORED = 'gas-fee-sponsored';
+
+/**
+ * Retrieves sponsored fees from an ActivityListItem.
+ *
+ * Filters the fees array in the activity item's data to return only fees
+ * that are marked as sponsored (where type is GAS_FEE_SPONSORED).
+ *
+ * @param item - The ActivityListItem to extract sponsored fees from.
+ * @returns An array of sponsored fees if present, otherwise undefined.
+ */
+function getSponsoredFees(item: ActivityListItem) {
+  return 'fees' in item.data
+    ? item.data.fees?.filter((fee) => fee.type === GAS_FEE_SPONSORED)
+    : undefined;
+}
+
+/**
+ * Copies a sponsored network fee from a local ActivityItem to an API-enriched one.
+ *
+ * When we have both a local item and an API item for the same transaction, we prefer
+ * the API item because it has better token metadata. However, the API doesn't know
+ * about our local `isGasFeeSponsored` flag. This function transfers the sponsored
+ * fee marker from the local item to the API item while removing any base network fee.
+ *
+ * @param sourceItem - The local ActivityItem that contains the sponsored fee marker.
+ * @param targetItem - The API-enriched ActivityItem to update.
+ * @returns The API item with the sponsored fee marker added.
+ */
+export function mergeActivityItemSponsoredFees(
+  sourceItem: ActivityListItem,
+  targetItem: ActivityListItem,
+): ActivityListItem {
+  const sponsoredFees = getSponsoredFees(sourceItem);
+
+  if (!sponsoredFees?.length || !('fees' in targetItem.data)) {
+    return targetItem;
+  }
+
+  const nonBaseTargetFees =
+    targetItem.data.fees?.filter(
+      (fee) => fee.type !== 'base' && fee.type !== GAS_FEE_SPONSORED,
+    ) ?? [];
+
+  return {
+    ...targetItem,
+    data: {
+      ...targetItem.data,
+      fees: [...sponsoredFees, ...nonBaseTargetFees],
+    },
+  } as ActivityListItem;
+}

--- a/shared/lib/transaction-gas-fee.utils.test.ts
+++ b/shared/lib/transaction-gas-fee.utils.test.ts
@@ -1,0 +1,97 @@
+import {
+  type TransactionMeta,
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/transaction-controller';
+import { isTransactionGasFeeSponsored } from './transaction-gas-fee.utils';
+
+const BASE_TRANSACTION = {
+  id: 'test-tx',
+  chainId: '0x1',
+  status: TransactionStatus.confirmed,
+  time: Date.now(),
+  txParams: {
+    from: '0x1',
+  },
+  txReceipt: {
+    gasUsed: '0x5208',
+  },
+  isGasFeeSponsored: true,
+} as unknown as TransactionMeta;
+
+function buildTransaction(
+  overrides: Partial<TransactionMeta> = {},
+): TransactionMeta {
+  return {
+    ...BASE_TRANSACTION,
+    ...overrides,
+  } as TransactionMeta;
+}
+
+describe('isTransactionGasFeeSponsored', () => {
+  it('returns true for a confirmed transaction with the sponsored flag', () => {
+    expect(
+      isTransactionGasFeeSponsored({
+        transaction: buildTransaction(),
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when the transaction is not flagged as sponsored', () => {
+    expect(
+      isTransactionGasFeeSponsored({
+        transaction: buildTransaction({ isGasFeeSponsored: false }),
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false for hardware wallet accounts', () => {
+    expect(
+      isTransactionGasFeeSponsored({
+        transaction: buildTransaction(),
+        isHardwareWalletAccount: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false for rejected transactions', () => {
+    expect(
+      isTransactionGasFeeSponsored({
+        transaction: buildTransaction({
+          status: TransactionStatus.rejected,
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  it('returns false for failed transactions without gas usage', () => {
+    expect(
+      isTransactionGasFeeSponsored({
+        transaction: buildTransaction({
+          status: TransactionStatus.failed,
+          txReceipt: undefined,
+        }),
+      }),
+    ).toBe(false);
+  });
+
+  it('returns true for failed transactions with gas usage', () => {
+    expect(
+      isTransactionGasFeeSponsored({
+        transaction: buildTransaction({
+          status: TransactionStatus.failed,
+        }),
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false for revoke delegation transactions', () => {
+    expect(
+      isTransactionGasFeeSponsored({
+        transaction: buildTransaction({
+          type: TransactionType.revokeDelegation,
+        }),
+      }),
+    ).toBe(false);
+  });
+});

--- a/shared/lib/transaction-gas-fee.utils.ts
+++ b/shared/lib/transaction-gas-fee.utils.ts
@@ -1,0 +1,37 @@
+import {
+  type TransactionMeta,
+  TransactionStatus,
+  TransactionType,
+} from '@metamask/transaction-controller';
+
+/**
+ * Determines whether a transaction should be displayed as gas-fee sponsored.
+ *
+ * This mirrors the legacy transaction breakdown behavior: a transaction must
+ * be flagged as sponsored, but the label is suppressed for unsupported account
+ * types, revoke delegation transactions, rejected transactions, and failed
+ * transactions that never produced gas usage.
+ *
+ * @param options - The sponsorship evaluation options.
+ * @param options.transaction - The transaction metadata to evaluate.
+ * @param options.isHardwareWalletAccount - Whether the signing account cannot
+ * use gas sponsorship.
+ * @returns Whether the UI should render the network fee as paid by MetaMask.
+ */
+export function isTransactionGasFeeSponsored({
+  transaction,
+  isHardwareWalletAccount = false,
+}: {
+  transaction: TransactionMeta;
+  isHardwareWalletAccount?: boolean;
+}) {
+  const { isGasFeeSponsored, status, type } = transaction;
+
+  return (
+    isGasFeeSponsored &&
+    type !== TransactionType.revokeDelegation &&
+    !isHardwareWalletAccount &&
+    status !== TransactionStatus.rejected &&
+    !(status === TransactionStatus.failed && !transaction.txReceipt?.gasUsed)
+  );
+}

--- a/ui/components/app/transaction-breakdown/transaction-breakdown-utils.test.ts
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown-utils.test.ts
@@ -106,6 +106,22 @@ describe('getTransactionBreakdownData', () => {
     expect(result.isGasFeeSponsored).toBeFalsy();
   });
 
+  it('returns isGasFeeSponsored false for hardware wallet accounts', () => {
+    const result = getTransactionBreakdownData({
+      state: MOCK_STATE,
+      transaction: {
+        ...BASE_TX,
+        status: TransactionStatus.confirmed,
+        isGasFeeSponsored: true,
+        txReceipt: { gasUsed: '0x5208' } as TransactionMeta['txReceipt'],
+      } as TransactionMeta,
+      isTokenApprove: false,
+      isHardwareWalletAccount: true,
+    });
+
+    expect(result.isGasFeeSponsored).toBe(false);
+  });
+
   it('returns isGasFeeSponsored false for revokeDelegation even when sponsored flag is true', () => {
     const result = getTransactionBreakdownData({
       state: MOCK_STATE,

--- a/ui/components/app/transaction-breakdown/transaction-breakdown-utils.ts
+++ b/ui/components/app/transaction-breakdown/transaction-breakdown-utils.ts
@@ -17,6 +17,7 @@ import {
 } from '../../../../shared/lib/transactions-controller-utils';
 import { MetaMaskReduxState } from '../../../store/store';
 import { calcHexGasTotal } from '../../../../shared/lib/transaction-breakdown-utils';
+import { isTransactionGasFeeSponsored } from '../../../../shared/lib/transaction-gas-fee.utils';
 
 export const getTransactionBreakdownData = ({
   state,
@@ -42,7 +43,6 @@ export const getTransactionBreakdownData = ({
     destinationTokenSymbol,
     status,
     type,
-    isGasFeeSponsored,
   } = transaction;
 
   const sourceTokenAmount =
@@ -110,13 +110,6 @@ export const getTransactionBreakdownData = ({
     l1HexGasTotal ?? 0,
   );
 
-  const isGasActuallySponsored =
-    isGasFeeSponsored &&
-    type !== TransactionType.revokeDelegation &&
-    !isHardwareWalletAccount &&
-    status !== TransactionStatus.rejected &&
-    !(status === TransactionStatus.failed && !transaction.txReceipt?.gasUsed);
-
   return {
     nativeCurrency: getNativeCurrency(state),
     showFiat: getShouldShowFiat(state),
@@ -130,7 +123,10 @@ export const getTransactionBreakdownData = ({
     priorityFee,
     baseFee: baseFeePerGas,
     isEIP1559Transaction: isEIP1559Transaction(transaction),
-    isGasFeeSponsored: isGasActuallySponsored,
+    isGasFeeSponsored: isTransactionGasFeeSponsored({
+      transaction,
+      isHardwareWalletAccount,
+    }),
     l1HexGasTotal,
     sourceAmountFormatted,
     destinationAmountFormatted,

--- a/ui/pages/details/components/amounts-section.test.tsx
+++ b/ui/pages/details/components/amounts-section.test.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import { render, screen, within } from '@testing-library/react';
+import type { ActivityListItem } from '../../../../shared/lib/activity/types';
+import { GAS_FEE_SPONSORED } from '../../../../shared/lib/activity/fees';
+import { FeesRows } from './amounts-section';
+
+jest.mock('../../../hooks/useI18nContext', () => ({
+  useI18nContext: () => (key: string) =>
+    ({
+      networkFee: 'Network fee',
+      paidByMetaMask: 'Paid by MetaMask',
+      priorityFee: 'Priority fee',
+    })[key] ?? key,
+}));
+
+jest.mock('../../../components/app/transaction/token-fiat-value', () => ({
+  TokenFiatValue: ({ token }: { token: { amount?: string } }) => (
+    <span data-testid="token-fiat-value">{token.amount}</span>
+  ),
+}));
+
+jest.mock('../../../components/app/transaction/token-label', () => ({
+  TokenLabel: ({ symbol }: { symbol?: string }) => (
+    <span data-testid="token-label">{symbol}</span>
+  ),
+}));
+
+describe('FeesRows', () => {
+  it('renders sponsored network fees as Paid by MetaMask', () => {
+    render(
+      <FeesRows
+        item={
+          {
+            data: {
+              fees: [{ type: GAS_FEE_SPONSORED }],
+            },
+          } as ActivityListItem
+        }
+      />,
+    );
+
+    const row = screen.getByTestId('transaction-base-fee');
+
+    expect(
+      within(row).getByTestId('transaction-breakdown-row-title'),
+    ).toHaveTextContent('Network fee');
+    expect(
+      within(row).getByTestId('transaction-breakdown-row-value'),
+    ).toHaveTextContent('Paid by MetaMask');
+  });
+
+  it('renders base network fees as token amounts', () => {
+    render(
+      <FeesRows
+        item={
+          {
+            data: {
+              fees: [
+                {
+                  amount: '6',
+                  symbol: 'ETH',
+                  type: 'base',
+                },
+              ],
+            },
+          } as ActivityListItem
+        }
+      />,
+    );
+
+    const row = screen.getByTestId('transaction-base-fee');
+
+    expect(
+      within(row).getByTestId('transaction-breakdown-row-title'),
+    ).toHaveTextContent('Network fee');
+    expect(within(row).getByTestId('token-fiat-value')).toHaveTextContent('6');
+    expect(within(row).getByTestId('token-label')).toHaveTextContent('ETH');
+  });
+});

--- a/ui/pages/details/components/amounts-section.tsx
+++ b/ui/pages/details/components/amounts-section.tsx
@@ -6,8 +6,10 @@ import type {
   FiatAmount,
   TokenAmount,
 } from '../../../../shared/lib/activity/types';
+import { GAS_FEE_SPONSORED } from '../../../../shared/lib/activity/fees';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useFormatters } from '../../../hooks/useFormatters';
+import { SuccessPill } from '../../../components/component-library';
 import { TokenFiatValue } from '../../../components/app/transaction/token-fiat-value';
 import { TokenLabel } from '../../../components/app/transaction/token-label';
 // eslint-disable-next-line import-x/no-restricted-paths
@@ -32,7 +34,9 @@ export function FeesRows({ item }: { item: ActivityListItem }) {
   const t = useI18nContext();
   const visibleFees =
     'fees' in item.data
-      ? (item.data.fees?.filter((fee) => fee.amount) ?? [])
+      ? (item.data.fees?.filter(
+          (fee) => fee.amount || fee.type === GAS_FEE_SPONSORED,
+        ) ?? [])
       : [];
 
   if (!visibleFees.length) {
@@ -44,27 +48,32 @@ export function FeesRows({ item }: { item: ActivityListItem }) {
       {visibleFees.map((fee, index) => {
         const { assetId, symbol, type } = fee;
         let label = type;
+        let value = (
+          <div className="flex items-center justify-end gap-2">
+            <TokenFiatValue token={feeToToken(fee)} />
+            <TokenLabel assetId={assetId as CaipAssetType} symbol={symbol} />
+          </div>
+        );
 
         if (type === 'base') {
           label = t('networkFee');
         } else if (type === 'priority') {
           label = t('priorityFee');
+        } else if (type === GAS_FEE_SPONSORED) {
+          label = t('networkFee');
+          value = <SuccessPill label={t('paidByMetaMask')} />;
         }
 
         return (
           <Row
             key={`${type}-${assetId ?? symbol ?? index}`}
             label={label}
-            testId={type === 'base' ? 'transaction-base-fee' : undefined}
-            value={
-              <div className="flex items-center justify-end gap-2">
-                <TokenFiatValue token={feeToToken(fee)} />
-                <TokenLabel
-                  assetId={assetId as CaipAssetType}
-                  symbol={symbol}
-                />
-              </div>
+            testId={
+              type === 'base' || type === GAS_FEE_SPONSORED
+                ? 'transaction-base-fee'
+                : undefined
             }
+            value={value}
           />
         );
       })}

--- a/ui/pages/details/transaction-details.tsx
+++ b/ui/pages/details/transaction-details.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo } from 'react';
 import { useSelector } from 'react-redux';
 import { mapApiTransaction } from '@metamask/client-utils';
+import { mergeActivityItemSponsoredFees } from '../../../shared/lib/activity/fees';
 import {
   selectEvmAddress,
   selectLocalActivityItemsByIdentifier,
@@ -57,7 +58,10 @@ export function TransactionDetails({ chainId, txIdentifier, onBack }: Props) {
         apiActivityItem &&
         (hasMatchingActivityType || isLocalUncategorized)
       ) {
-        return apiActivityItem;
+        return mergeActivityItemSponsoredFees(
+          localActivityItem,
+          apiActivityItem,
+        );
       }
 
       return localActivityItem;

--- a/ui/selectors/activity.ts
+++ b/ui/selectors/activity.ts
@@ -29,6 +29,7 @@ import { CHAIN_ID_TO_CURRENCY_SYMBOL_MAP } from '../../shared/constants/network'
 import { NATIVE_TOKEN_ADDRESS } from '../../shared/constants/transaction';
 import type { MetaMaskReduxState } from '../store/store';
 import { getSelectedInternalAccount } from '../../shared/lib/selectors/accounts';
+import { isHardwareWallet } from '../../shared/lib/selectors/keyring';
 import { getNetworkConfigurationsByChainId } from '../../shared/lib/selectors/networks';
 import { getTokensControllerAllTokens } from '../../shared/lib/selectors/assets-migration';
 import { toAssetId } from '../../shared/lib/asset-utils';
@@ -69,6 +70,9 @@ const selectTransactionPayData = (state: MetaMaskReduxState) =>
   (state.metamask as unknown as TransactionPayControllerState)
     .transactionData ??
   (EMPTY_OBJECT as TransactionPayControllerState['transactionData']);
+
+const selectIsHardwareWallet = (state: MetaMaskReduxState) =>
+  isHardwareWallet(state as never);
 
 function isFromSelectedAccount(tx: TransactionMeta, selectedAddress: string) {
   // Ported from selectedAddressTxListSelector
@@ -406,6 +410,7 @@ export const selectLocalActivityItems = createSelector(
   getNetworkConfigurationsByChainId,
   getSelectedInternalAccount,
   getTokensControllerAllTokens,
+  selectIsHardwareWallet,
   (
     transactionGroups,
     bridgeHistory,
@@ -413,6 +418,7 @@ export const selectLocalActivityItems = createSelector(
     networkConfigurationsByChainId,
     selectedAccount,
     allTokens,
+    isHardwareWalletAccount,
   ) => {
     const selectedAddress = selectedAccount?.address?.toLowerCase();
 
@@ -512,7 +518,9 @@ export const selectLocalActivityItems = createSelector(
           transactionGroup,
         );
         const activityStatus = getBridgeActivityStatus(bridgeHistoryItem);
-        const fees = getLocalTransactionFees(transactionGroup);
+        const fees = getLocalTransactionFees(transactionGroup, {
+          isHardwareWalletAccount,
+        });
 
         const prepared = {
           ...transactionGroup,


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Fixes Monad swap activity details showing a network fee amount instead of `Paid by MetaMask` for gas-sponsored swaps.
This PR reuses the existing gas sponsorship display logic and applies it to the new Activity Details fee rows. 
When a local transaction is marked as gas-sponsored, Activity Details now renders the network fee as `Paid by MetaMask` instead of showing a calculated fee.
Also adds unit tests for the sponsorship logic and fee row rendering.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed sponsored network fee transfer to show the `Paid by MetaMask` label in activity page

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/WPN-1713 | [[Bug]: Monad Swap activity is not showing Paid By Metamask](https://github.com/MetaMask/metamask-extension/issues/44753)

## **Manual testing steps**

1. Perform a MON to USDC swap on Monad.
2. Open the Activity tab.
3. Click the completed swap transaction.
4. Verify the transaction details show:
    - Network fee
    - Paid by MetaMask
5. Open the same swap from the token details activity list
6. Verify the token details transaction view also shows
    - Network fee
    - Paid by MetaMask
10. As a regression check, open a normal non-sponsored transaction
11. Verify normal transactions still show the calculated network fee amount instead of `Paid by MetaMask`
12. As another regression check, verify rejected transactions do not show `Paid by MetaMask`

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->
<img width="831" height="813" alt="625474154-06befb51-1ed3-48be-8a88-a91cbd295c6a" src="https://github.com/user-attachments/assets/da34bba1-ba3c-47c1-98f0-432494f4a094" />

### **After**

<!-- [screenshots/recordings] -->
<img width="1009" height="1283" alt="Screenshot From 2026-07-23 15-51-51" src="https://github.com/user-attachments/assets/9b921be1-41c5-4906-94a7-1376c9f8b0a5" />

## **Pre-merge author checklist**

- [X] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [X] I've completed the PR template to the best of my ability
- [X] I’ve included tests if applicable
- [X] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [X] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [X] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [X] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only activity fee labeling with shared sponsorship helper; covered by unit tests and no payment or signing logic changes.
> 
> **Overview**
> Gas-sponsored swaps (e.g. Monad) were showing a calculated **network fee** in Activity Details instead of **Paid by MetaMask**. This change wires the same sponsorship rules used on the legacy transaction breakdown into the activity fee pipeline.
> 
> Local activity items now attach a `gas-fee-sponsored` fee marker when `isGasFeeSponsored` applies (with hardware wallets, failed-without-receipt, revoke delegation, and rejected txs excluded). When API-enriched activity replaces the local row, `mergeActivityItemSponsoredFees` keeps that marker and drops the API’s base network fee. **FeesRows** renders the sponsored type as **Paid by MetaMask** via `SuccessPill`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1800b9bd766e833a840590726b9d1f1becf3a0e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->