### PR TITLE
ci: run fitness functions in merge queue

### DIFF
--- a/.github/workflows/repository-health-checks.yml
+++ b/.github/workflows/repository-health-checks.yml
@@ -201,9 +201,10 @@ jobs:
           fi
 
       - name: Run fitness functions
-        if: ${{ !cancelled() && github.event_name == 'pull_request'}}
+        if: ${{ !cancelled() }}
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: yarn fitness-functions ci
+          FITNESS_FUNCTION_AUTOMATION_TYPE: ${{  github.event_name == 'pull_request' && 'pr' || 'ci' }}
+        run: yarn fitness-functions "${FITNESS_FUNCTION_AUTOMATION_TYPE}"

--- a/.github/workflows/repository-health-checks.yml
+++ b/.github/workflows/repository-health-checks.yml
@@ -201,7 +201,7 @@ jobs:
           fi
 
       - name: Run fitness functions
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && contains(fromJSON('["merge_group", "pull_request"]'), github.event_name)}}
         env:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/repository-health-checks.yml
+++ b/.github/workflows/repository-health-checks.yml
@@ -206,5 +206,5 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          FITNESS_FUNCTION_AUTOMATION_TYPE: ${{  github.event_name == 'pull_request' && 'pr' || 'ci' }}
+          FITNESS_FUNCTION_AUTOMATION_TYPE: ${{ github.event_name == 'pull_request' && 'pr' || 'ci' }}
         run: yarn fitness-functions "${FITNESS_FUNCTION_AUTOMATION_TYPE}"

--- a/development/fitness-functions/common/constants.ts
+++ b/development/fitness-functions/common/constants.ts
@@ -12,6 +12,7 @@ const JS_REGEX = /^(app|shared|ui)\/.*\.(js|jsx)$/u;
 // eslint-disable-next-line @typescript-eslint/naming-convention
 enum AUTOMATION_TYPE {
   CI = 'ci',
+  PR = 'pr',
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
   PRE_COMMIT_HOOK = 'pre-commit-hook',

--- a/development/fitness-functions/common/get-diff.ts
+++ b/development/fitness-functions/common/get-diff.ts
@@ -58,6 +58,7 @@ function runGitCommand(args: string[]): string {
  * @returns The diff for the HEAD commit
  */
 async function getCommitDiff(): Promise<string> {
+  runGitCommand(['fetch', '--deepen=1']);
   return runGitCommand(['diff', 'HEAD^', 'HEAD']);
 }
 

--- a/development/fitness-functions/common/get-diff.ts
+++ b/development/fitness-functions/common/get-diff.ts
@@ -28,7 +28,7 @@ async function getDiffByAutomationType(
   }
 
   if (automationType === AUTOMATION_TYPE.CI) {
-    // For non-PR triggers (e.g. `merge_queue` or `push ` to protected branch)
+    // For non-PR triggers (e.g. `merge_queue` or `push` to protected branch)
     // we can assume we're dealing with a single squashed commit.
     return await getCommitDiff();
   } else if (automationType === AUTOMATION_TYPE.PR) {

--- a/development/fitness-functions/common/get-diff.ts
+++ b/development/fitness-functions/common/get-diff.ts
@@ -19,25 +19,7 @@ async function getDiffByAutomationType(
     process.exit(1);
   }
 
-  let diff;
-  if (automationType === AUTOMATION_TYPE.CI) {
-    const optionalArguments = process.argv.slice(3);
-    if (optionalArguments.length > 1) {
-      console.error('Invalid number of arguments.');
-      process.exit(1);
-    }
-
-    diff = await getCIDiff(optionalArguments[0]);
-  } else if (automationType === AUTOMATION_TYPE.PRE_COMMIT_HOOK) {
-    diff = getPreCommitHookDiff();
-  } else if (automationType === AUTOMATION_TYPE.PRE_PUSH_HOOK) {
-    diff = getPrePushHookDiff();
-  }
-
-  return diff;
-}
-
-async function getCIDiff(path?: string): Promise<string> {
+  const [path] = process.argv.slice(3);
   if (path) {
     return fs.readFileSync(path, {
       encoding: 'utf8',
@@ -45,16 +27,37 @@ async function getCIDiff(path?: string): Promise<string> {
     });
   }
 
-  // No file argument — fetch diff directly (requires CI environment variables).
-  // Lazy dynamic import to avoid pulling @actions/github into local dev hooks
-  // (and because @actions/github is now ESM-only).
-  const { getPrDiff } =
-    await import('../../../.github/scripts/shared/get-pr-diff.mts');
-  return getPrDiff({ baseBranch: process.env.BASE_REF || 'main' });
+  if (automationType === AUTOMATION_TYPE.CI) {
+    // For non-PR triggers (e.g. `merge_queue` or `push ` to protected branch)
+    // we can assume we're dealing with a single squashed commit.
+    return await getCommitDiff();
+  } else if (automationType === AUTOMATION_TYPE.PR) {
+    // Fetch diff directly (requires CI environment variables).
+    // Lazy dynamic import to avoid pulling @actions/github into local dev hooks
+    // (and because @actions/github is now ESM-only).
+    const { getPrDiff } =
+      await import('../../../.github/scripts/shared/get-pr-diff.mts');
+    return await getPrDiff({ baseBranch: process.env.BASE_REF || 'main' });
+  } else if (automationType === AUTOMATION_TYPE.PRE_COMMIT_HOOK) {
+    return await getPreCommitHookDiff();
+  } else if (automationType === AUTOMATION_TYPE.PRE_PUSH_HOOK) {
+    return await getPrePushHookDiff();
+  } else {
+    throw new Error(`Unknown automation type: ${automationType}`);
+  }
 }
 
 function runGitCommand(args: string[]): string {
   return execFileSync('git', args, GIT_EXEC_FILE_OPTIONS).trim();
+}
+
+/**
+ * Get the diff for the HEAD commit.
+ *
+ * @returns The diff for the HEAD commit
+ */
+async function getCommitDiff(): Promise<string> {
+  return runGitCommand(['diff', 'HEAD^']);
 }
 
 function getPreCommitHookDiff(): string {

--- a/development/fitness-functions/common/get-diff.ts
+++ b/development/fitness-functions/common/get-diff.ts
@@ -42,9 +42,10 @@ async function getDiffByAutomationType(
     return await getPreCommitHookDiff();
   } else if (automationType === AUTOMATION_TYPE.PRE_PUSH_HOOK) {
     return await getPrePushHookDiff();
-  } else {
-    throw new Error(`Unknown automation type: ${automationType}`);
   }
+
+  // Check that all types were handled
+  automationType satisfies never;
 }
 
 function runGitCommand(args: string[]): string {

--- a/development/fitness-functions/common/get-diff.ts
+++ b/development/fitness-functions/common/get-diff.ts
@@ -57,7 +57,7 @@ function runGitCommand(args: string[]): string {
  * @returns The diff for the HEAD commit
  */
 async function getCommitDiff(): Promise<string> {
-  return runGitCommand(['diff', 'HEAD^']);
+  return runGitCommand(['diff', 'HEAD^', 'HEAD']);
 }
 
 function getPreCommitHookDiff(): string {

--- a/development/fitness-functions/common/get-diff.ts
+++ b/development/fitness-functions/common/get-diff.ts
@@ -30,18 +30,18 @@ async function getDiffByAutomationType(
   if (automationType === AUTOMATION_TYPE.CI) {
     // For non-PR triggers (e.g. `merge_queue` or `push` to protected branch)
     // we can assume we're dealing with a single squashed commit.
-    return await getCommitDiff();
+    return getCommitDiff();
   } else if (automationType === AUTOMATION_TYPE.PR) {
     // Fetch diff directly (requires CI environment variables).
     // Lazy dynamic import to avoid pulling @actions/github into local dev hooks
     // (and because @actions/github is now ESM-only).
     const { getPrDiff } =
       await import('../../../.github/scripts/shared/get-pr-diff.mts');
-    return await getPrDiff({ baseBranch: process.env.BASE_REF || 'main' });
+    return getPrDiff({ baseBranch: process.env.BASE_REF || 'main' });
   } else if (automationType === AUTOMATION_TYPE.PRE_COMMIT_HOOK) {
-    return await getPreCommitHookDiff();
+    return getPreCommitHookDiff();
   } else if (automationType === AUTOMATION_TYPE.PRE_PUSH_HOOK) {
-    return await getPrePushHookDiff();
+    return getPrePushHookDiff();
   }
 
   // Check that all types were handled


### PR DESCRIPTION
## **Description**

The fitness functions CI step was only run on PRs, so failures caused by a branch update would not be caught by the merge queue. This has resulted in `main` breaking, impacting unrelated PRs and confusing contributors.

The workflow has been updated to run fitness functions for all types of triggers, ensuring that we catch errors in the merge queue and ensuring we can see the current status on the `main` branch properly.

The fitness function script had to be updated to support getting a diff in CI outside of a PR context.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: N/A

## **Manual testing steps**

The existing 'automation types' should work identically as they did before, except `ci` has been renamed to `pr` (it's called in the same context `ci` was called before). Also they all have support for the optional `path` parameter now (for a file diff). Though this will have no impact, as a path is never passed in for these types (or for any type frankly, that's currently an unused feature).

There is a new automation type introduced here though: `ci`, which just diffs the HEAD commit. You can test it by running `yarn fitness-functions ci`. It should flag any issues in the HEAD commit.

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow and fitness-function diff selection changes; no runtime app or security logic.
> 
> **Overview**
> Fitness functions now run on **merge queue** events as well as pull requests, so policy checks still run after a branch is updated and before changes land on `main`.
> 
> The health-check workflow picks the automation mode from the trigger: **`pr`** keeps the existing PR/base-branch diff fetch; **`ci`** diffs only `HEAD^..HEAD` (with a shallow fetch) for merge-queue and other non-PR CI runs.
> 
> `get-diff` is refactored so an optional diff **file path** applies to every automation type, and a new **`PR`** enum value replaces the old PR-specific **`ci`** behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34566ad0e11631c302234ed231398d616a917aee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->