### PR TITLE
test(e2e): extend Tron fixtures for assets E2E coverage

### DIFF
--- a/test/e2e/tests/tron/fixtures/environments.ts
+++ b/test/e2e/tests/tron/fixtures/environments.ts
@@ -4,6 +4,23 @@ import { GAS_FREE, HTX, SEED, TRX, USDD, USDT } from './tokens';
 
 export const TRON_PORTFOLIO_TRX_BALANCE_IN_SUN = 6_072_392;
 
+/** Mirrors `LOW_VALUE_ASSET_FIAT_THRESHOLD` in token-list.tsx ($1 USD). */
+export const LOW_VALUE_FIAT_THRESHOLD_USD = 1;
+
+/** Non-native portfolio tokens intentionally priced below $1 fiat. */
+export const TRON_PORTFOLIO_LOW_VALUE_ASSET_NAMES = [
+  'GasFreeTransferSolution',
+  'SEED',
+  'USDD',
+] as const;
+
+/** Portfolio tokens that remain visible in the main list when low-value is collapsed. */
+export const TRON_PORTFOLIO_MAIN_LIST_ASSET_NAMES = [
+  'Tron',
+  'HTX DAO',
+  'Tether',
+] as const;
+
 export const EMPTY_TRON_ACCOUNT: TronFixtureAccount = {
   address: TRON_ACCOUNT_ADDRESS,
   assets: [{ ...TRX, balance: 0, priceUsd: TRX_TO_USD_RATE }],
@@ -17,25 +34,15 @@ export const TRON_PORTFOLIO_ACCOUNT: TronFixtureAccount = {
       balance: TRON_PORTFOLIO_TRX_BALANCE_IN_SUN,
       priceUsd: TRX_TO_USD_RATE,
     },
+    // Below $1 fiat → collapsed low-value section.
     { ...GAS_FREE, balance: '33333333', priceUsd: 0.000_000_001 },
     { ...HTX, balance: '3156454956836360132407885', priceUsd: 0.00000168 },
+    // Below $1 fiat → collapsed low-value section.
     { ...SEED, balance: '89851311', priceUsd: 0.000_000_001 },
+    // Below $1 fiat → collapsed low-value section.
     { ...USDD, balance: '289757448699320931', priceUsd: 0.999959 },
     { ...USDT, balance: '2804595', priceUsd: 0.999176 },
   ],
-};
-
-export const TRON_STAKED_PORTFOLIO_ACCOUNT: TronFixtureAccount = {
-  ...TRON_PORTFOLIO_ACCOUNT,
-  assets: TRON_PORTFOLIO_ACCOUNT.assets?.map((asset) =>
-    asset.type === 'native'
-      ? {
-          ...asset,
-          balance: TRON_PORTFOLIO_TRX_BALANCE_IN_SUN + 20_000_000,
-        }
-      : asset,
-  ),
-  stakedTrxBalance: '20000000',
 };
 
 export const TRON_LOW_TRX_WITH_USDT_ACCOUNT: TronFixtureAccount = {

--- a/test/e2e/tests/tron/fixtures/with-tron-fixtures.ts
+++ b/test/e2e/tests/tron/fixtures/with-tron-fixtures.ts
@@ -10,13 +10,22 @@ import {
 } from '../../../seeder/tron/assets';
 import { TronNode } from '../../../seeder/tron/node';
 import { TronSeeder } from '../../../seeder/tron/tron-seeder';
+import { mockTokensV2SupportedNetworks } from '../../btc/mocks/tokens-api';
 import {
   TRON_ACCOUNT_ADDRESS,
   TRON_CHAIN_ID,
   TRON_RECIPIENT_ADDRESS,
+  SUN_PER_TRX,
+  mockAccountsApiV2WithTron,
   mockExchangeRates,
   mockFiatExchangeRates,
   mockTronFeatureFlags,
+  mockTronGetBlock,
+  mockTronGetBlockByNum,
+  mockTronGetNowBlock,
+  mockTronGetReward,
+  mockTronGetTransactions,
+  mockTronGetTrc20Transactions,
 } from '../mocks/common-tron';
 import { proxyTronBlockchainCalls } from '../mocks/local-tron-node-mocks';
 
@@ -63,7 +72,6 @@ export type TronTrc20FixtureAsset = {
 export type TronFixtureAccount = {
   address: string;
   assets?: TronFixtureAsset[];
-  stakedTrxBalance?: string;
   transactions?: {
     raw?: unknown[];
     trc20?: unknown[];
@@ -99,8 +107,6 @@ export function buildTronNodeOptions(
     string,
     Partial<Record<TronTrc20Symbol, string>>
   > = {};
-  const stakedTrxBalances: Record<string, string> = {};
-
   for (const account of accounts) {
     for (const asset of account.assets ?? []) {
       if (asset.type === 'native') {
@@ -117,17 +123,12 @@ export function buildTronNodeOptions(
         };
       }
     }
-
-    if (account.stakedTrxBalance) {
-      stakedTrxBalances[account.address] = account.stakedTrxBalance;
-    }
   }
 
   return {
     ...(Object.keys(initialBalances).length ? { initialBalances } : {}),
     ...(Object.keys(trc10Balances).length ? { trc10Balances } : {}),
     ...(Object.keys(trc20Balances).length ? { trc20Balances } : {}),
-    ...(Object.keys(stakedTrxBalances).length ? { stakedTrxBalances } : {}),
   };
 }
 
@@ -238,11 +239,26 @@ async function mockTronFixtureApis(
   ].filter((v, i, arr) => arr.indexOf(v) === i);
 
   return [
+    await mockTokensV2SupportedNetworks(mockServer),
+    await mockAccountsApiV2WithTron(mockServer),
+    await mockTronFixtureAccountsApiV5(mockServer, accounts, tronNode),
     await mockTronFeatureFlags(mockServer),
     await mockExchangeRates(mockServer),
     await mockFiatExchangeRates(mockServer),
     await mockTronFixtureSpotPrices(mockServer, accounts, tronNode),
     await mockTronFixtureAssets(mockServer, accounts, tronNode),
+    await mockTronGetReward(mockServer),
+    await mockTronGetBlock(mockServer),
+    await mockTronGetNowBlock(mockServer),
+    await mockTronGetBlockByNum(mockServer),
+    await mockTronGetTransactions(mockServer),
+    await mockTronGetTrc20Transactions(mockServer),
+    // NOTE: no static `broadcasttransaction` mock here. mockttp serves the
+    // first matching *unused* rule, so a static broadcast mock would swallow
+    // each test's single broadcast with a fake txid that the local node never
+    // sees — the tx then polls as pending forever. `proxyTronBlockchainCalls`
+    // below proxies broadcasts to the local Tron node and replays them as
+    // confirmed history.
     ...fixtureHistoryEndpoints,
     ...(await proxyTronBlockchainCalls(mockServer, tronNode, allAddresses)),
     await mockWildcardTronAccountApis(mockServer, tronNode, accountByAddress),
@@ -316,25 +332,95 @@ async function mockWildcardTronAccountApis(
     });
 }
 
+function formatFixtureBalanceForAccountsApi(asset: TronFixtureAsset): string {
+  if (asset.type === 'native') {
+    return String(asset.balance / SUN_PER_TRX);
+  }
+
+  return String(Number(asset.balance) / 10 ** asset.decimals);
+}
+
+function buildFixtureTokenMetadata(
+  accounts: TronFixtureAccount[],
+  tronNode: TronNode,
+) {
+  const nativeTrx = {
+    assetId: `${TRON_CHAIN_ID}/slip44:195`,
+    decimals: 6,
+    name: 'Tron',
+    symbol: 'TRX',
+  };
+
+  const fixtureAssets = getUniqueAssets(accounts).map((asset) => ({
+    assetId: getAssetId(asset, tronNode),
+    decimals: asset.decimals,
+    name: asset.name,
+    symbol: asset.symbol,
+  }));
+
+  const assetsById = new Map(
+    [nativeTrx, ...fixtureAssets].map((asset) => [asset.assetId, asset]),
+  );
+
+  return [...assetsById.values()];
+}
+
+async function mockTronFixtureAccountsApiV5(
+  mockServer: Mockttp,
+  accounts: TronFixtureAccount[],
+  tronNode: TronNode,
+): Promise<MockedEndpoint> {
+  const balances = accounts.flatMap((account) => {
+    const assetBalances = (account.assets ?? []).map((asset) => ({
+      accountId: `${TRON_CHAIN_ID}:${account.address}`,
+      assetId: getAssetId(asset, tronNode),
+      balance: formatFixtureBalanceForAccountsApi(asset),
+    }));
+
+    return assetBalances;
+  });
+
+  return mockServer
+    .forGet(
+      /https:\/\/accounts\.api\.cx\.metamask\.io\/v5\/multiaccount\/balances/u,
+    )
+    .always()
+    .thenCallback(() => ({
+      statusCode: 200,
+      json: {
+        count: balances.length,
+        unprocessedNetworks: [],
+        balances,
+      },
+    }));
+}
+
 async function mockTronFixtureAssets(
   mockServer: Mockttp,
   accounts: TronFixtureAccount[],
   tronNode: TronNode,
 ): Promise<MockedEndpoint> {
+  const knownAssets = buildFixtureTokenMetadata(accounts, tronNode);
+
   return mockServer
     .forGet('https://tokens.api.cx.metamask.io/v3/assets')
     .always()
-    .thenCallback(() => ({
-      statusCode: 200,
-      json: getUniqueAssets(accounts)
-        .filter((asset) => asset.type !== 'native')
-        .map((asset) => ({
-          assetId: getAssetId(asset, tronNode),
-          decimals: asset.decimals,
-          name: asset.name,
-          symbol: asset.symbol,
-        })),
-    }));
+    .thenCallback((request) => {
+      const assetIdsParam =
+        new URL(request.url).searchParams.get('assetIds') ?? '';
+
+      const json =
+        assetIdsParam.length > 0
+          ? knownAssets.filter((asset) => assetIdsParam.includes(asset.assetId))
+          : knownAssets.filter(
+              (asset) => !asset.assetId.endsWith('/slip44:195'),
+            );
+
+      return {
+        statusCode: 200,
+        json,
+      };
+    });
 }
 
 async function mockTronFixtureSpotPrices(


### PR DESCRIPTION
## **Description**

Extends Tron E2E fixtures with assets-focused mocks and environment wiring, and removes staking-only fixture state from the shared helper. Stacks on #44777.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Part of the local-blockchain E2E initiative (WPN-536).
Stacks on #44777.

## **Manual testing steps**

1. `yarn build:test`
2. Verify the branch builds and existing Tron E2E tests still pass.

## **Screenshots/Recordings**

N/A — test infrastructure only, no user-facing UI change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)