### PR TITLE
test: pom lint rule supporting groups (selectors, constructor, actions)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -12,6 +12,7 @@ const reactHooksPlugin = require('eslint-plugin-react-hooks');
 const reactCompilerPlugin = require('eslint-plugin-react-compiler');
 const storybookPlugin = require('eslint-plugin-storybook');
 const tailwindCssPlugin = require('eslint-plugin-tailwindcss');
+const pageObjectMemberOrderRule = require('./development/eslint-rules/page-object-member-order');
 
 const {
   architecturalZones,
@@ -845,12 +846,13 @@ module.exports = defineConfig([
   /**
    * E2E page objects
    *
-   * Page objects should declare selectors (fields) alphabetically at the
-   * top, followed by the constructor, then methods in alphabetical order.
-   *
-   * The files listed in `excludedFiles` don't yet comply. They are
-   * temporarily exempt and should be removed from this list as each one is
-   * reordered. Do NOT add new files here — new page objects must comply.
+   * Page objects should declare selectors first (both constant fields and
+   * arrow-function locator builders), followed by the constructor, then the
+   * action methods that drive the `driver`. Everything is alphabetical within
+   * its group.
+   * The files listed in `ignores` don't yet comply. They are temporarily
+   * exempt and should be removed from this list as each one is reordered. Do
+   * NOT add new files here. New page objects must comply.
    *
    * TODO: Reorder the excluded files and delete them from this list.
    */
@@ -985,16 +987,15 @@ module.exports = defineConfig([
       'test/e2e/page-objects/pages/vault-decryptor-page.ts',
       'test/e2e/page-objects/pages/wallet-details-page.ts',
     ],
-    rules: {
-      '@typescript-eslint/member-ordering': [
-        'error',
-        {
-          classes: {
-            memberTypes: ['field', 'constructor', 'method'],
-            order: 'alphabetically',
-          },
+    plugins: {
+      'page-object': {
+        rules: {
+          'member-order': pageObjectMemberOrderRule,
         },
-      ],
+      },
+    },
+    rules: {
+      'page-object/member-order': 'error',
     },
   },
   /**

--- a/development/eslint-rules/page-object-member-order.js
+++ b/development/eslint-rules/page-object-member-order.js
@@ -1,0 +1,134 @@
+'use strict';
+
+/**
+ * Custom ESLint rule: enforce E2E page-object member order.
+ *
+ * Required order inside a page-object class:
+ *   1. Selectors      — every class *property* (`PropertyDefinition`), whether
+ *                       its value is a string, an object, or an arrow function
+ *                       that builds a dynamic locator.
+ *   2. Constructor
+ *   3. Action methods — every class *method* (`MethodDefinition`) that drives
+ *                       the `driver`.
+ *
+ * Members are additionally required to be alphabetical within each group, to
+ * match the existing `order: 'alphabetically'` convention.
+ */
+
+const GROUP = { SELECTOR: 0, CONSTRUCTOR: 1, ACTION: 2 };
+
+const GROUP_LABEL = {
+  [GROUP.SELECTOR]: 'selector',
+  [GROUP.CONSTRUCTOR]: 'constructor',
+  [GROUP.ACTION]: 'action method',
+};
+
+/**
+ * @param {import('estree').MethodDefinition | import('estree').PropertyDefinition} member
+ * @returns {string | null}
+ */
+function getMemberName(member) {
+  const { key } = member;
+  if (!key) {
+    return null;
+  }
+  switch (key.type) {
+    case 'Identifier':
+      return key.name;
+    case 'PrivateIdentifier':
+      return `#${key.name}`;
+    case 'Literal':
+      return String(key.value);
+    default:
+      return null;
+  }
+}
+
+/**
+ * @param {import('estree').Node} member
+ * @returns {number | null} one of GROUP.*, or null for members we ignore
+ */
+function classify(member) {
+  if (member.type === 'MethodDefinition') {
+    return member.kind === 'constructor' ? GROUP.CONSTRUCTOR : GROUP.ACTION;
+  }
+  // PropertyDefinition covers strings, objects, AND arrow-function selectors.
+  if (member.type === 'PropertyDefinition') {
+    return GROUP.SELECTOR;
+  }
+  // StaticBlock, TSIndexSignature, etc. are ignored.
+  return null;
+}
+
+module.exports = {
+  meta: {
+    type: 'suggestion',
+    docs: {
+      description:
+        'enforce selector-first member order in E2E page objects (selectors, then constructor, then action methods)',
+    },
+    schema: [],
+    messages: {
+      groupOrder:
+        'A {{ current }} ("{{ name }}") must be declared before {{ before }}.',
+      alphabetical:
+        '{{ group }} "{{ name }}" should be declared before "{{ other }}" (alphabetical order).',
+    },
+  },
+
+  create(context) {
+    /**
+     * @param {import('estree').ClassBody} classBody
+     */
+    function check(classBody) {
+      const members = classBody.body
+        .map((node) => ({
+          node,
+          group: classify(node),
+          name: getMemberName(node),
+        }))
+        .filter((member) => member.group !== null && member.name !== null);
+
+      // 1. Group ordering: selectors < constructor < actions.
+      let highestGroupSeen = GROUP.SELECTOR;
+      for (const member of members) {
+        if (member.group < highestGroupSeen) {
+          context.report({
+            node: member.node,
+            messageId: 'groupOrder',
+            data: {
+              current: GROUP_LABEL[member.group],
+              name: member.name,
+              before: `all ${GROUP_LABEL[highestGroupSeen]}s`,
+            },
+          });
+        } else {
+          highestGroupSeen = member.group;
+        }
+      }
+
+      // 2. Alphabetical ordering within each group.
+      let previous = null;
+      for (const member of members) {
+        if (
+          previous &&
+          previous.group === member.group &&
+          member.name.localeCompare(previous.name) < 0
+        ) {
+          context.report({
+            node: member.node,
+            messageId: 'alphabetical',
+            data: {
+              group: GROUP_LABEL[member.group],
+              name: member.name,
+              other: previous.name,
+            },
+          });
+        }
+        previous = member;
+      }
+    }
+
+    return { ClassBody: check };
+  },
+};

--- a/development/eslint-rules/page-object-member-order.test.js
+++ b/development/eslint-rules/page-object-member-order.test.js
@@ -57,6 +57,21 @@ class Page {
   private readonly bButton = '[data-testid="b"]';
 }`,
     },
+    {
+      name: 'handles private-identifier and string-literal keys and ignores members without a resolvable name (static blocks, computed keys)',
+      code: `
+class Page {
+  static {}
+
+  readonly #secret = '[data-testid="s"]';
+
+  private readonly 'data-role' = '[data-testid="r"]';
+
+  [computed.key]() {}
+
+  async doThing(): Promise<void> {}
+}`,
+    },
   ],
   invalid: [
     {

--- a/development/eslint-rules/page-object-member-order.test.js
+++ b/development/eslint-rules/page-object-member-order.test.js
@@ -1,0 +1,123 @@
+'use strict';
+
+const { RuleTester } = require('eslint');
+const { parser: tsParser } = require('typescript-eslint');
+const rule = require('./page-object-member-order');
+
+const ruleTester = new RuleTester({
+  languageOptions: {
+    parser: tsParser,
+    ecmaVersion: 2022,
+    sourceType: 'module',
+  },
+});
+
+ruleTester.run('page-object-member-order', rule, {
+  valid: [
+    {
+      name: 'selectors (constant and arrow-function), constructor, then alphabetical actions',
+      code: `
+class Page {
+  private readonly aButton = '[data-testid="a"]';
+
+  private readonly bLabel = { xpath: '//b' };
+
+  private readonly rowValue = (i: number) => ({ css: \`row:\${i}\` });
+
+  private readonly statusLabel = (s: string) => ({ testId: s });
+
+  constructor(driver: Driver) {
+    this.driver = driver;
+  }
+
+  async clickThing(): Promise<void> {}
+
+  async waitForThing(): Promise<void> {}
+}`,
+    },
+    {
+      name: 'arrow-function selector may appear among constant selectors',
+      code: `
+class Page {
+  private readonly aButton = '[data-testid="a"]';
+
+  private readonly bRow = (i: number) => ({ css: \`row:\${i}\` });
+
+  private readonly cButton = '[data-testid="c"]';
+
+  async clickThing(): Promise<void> {}
+}`,
+    },
+    {
+      name: 'class with only selectors',
+      code: `
+class Page {
+  private readonly aButton = '[data-testid="a"]';
+
+  private readonly bButton = '[data-testid="b"]';
+}`,
+    },
+  ],
+  invalid: [
+    {
+      name: 'action method declared before a selector',
+      code: `
+class Page {
+  private readonly aButton = '[data-testid="a"]';
+
+  async clickThing(): Promise<void> {}
+
+  private readonly bButton = '[data-testid="b"]';
+}`,
+      errors: [{ messageId: 'groupOrder' }],
+    },
+    {
+      name: 'arrow-function selector declared after an action method is still a misplaced selector',
+      code: `
+class Page {
+  private readonly aButton = '[data-testid="a"]';
+
+  async clickThing(): Promise<void> {}
+
+  private readonly rowValue = (i: number) => ({ css: \`row:\${i}\` });
+}`,
+      errors: [{ messageId: 'groupOrder' }],
+    },
+    {
+      name: 'selector declared after the constructor',
+      code: `
+class Page {
+  private readonly aButton = '[data-testid="a"]';
+
+  constructor(driver: Driver) {
+    this.driver = driver;
+  }
+
+  private readonly bButton = '[data-testid="b"]';
+}`,
+      errors: [{ messageId: 'groupOrder' }],
+    },
+    {
+      name: 'selectors out of alphabetical order',
+      code: `
+class Page {
+  private readonly zebra = '[data-testid="z"]';
+
+  private readonly apple = '[data-testid="a"]';
+}`,
+      errors: [{ messageId: 'alphabetical' }],
+    },
+    {
+      name: 'action methods out of alphabetical order',
+      code: `
+class Page {
+  private readonly aButton = '[data-testid="a"]';
+
+  async waitForThing(): Promise<void> {}
+
+  async clickThing(): Promise<void> {}
+}`,
+      errors: [{ messageId: 'alphabetical' }],
+    },
+  ],
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,6 +7,7 @@ module.exports = {
     '<rootDir>/shared/**/*.(js|ts|tsx)',
     '<rootDir>/ui/**/*.(js|ts|tsx)',
     '<rootDir>/development/build/transforms/**/*.js',
+    '<rootDir>/development/eslint-rules/**/*.js',
     '<rootDir>/development/metamaskbot-build-announce/**/*.(js|ts|mts)',
     '<rootDir>/test/unit-global/**/*.test.(js|ts|tsx)',
   ],

--- a/test/e2e/page-objects/pages/settings/sync-accounts-settings-page.ts
+++ b/test/e2e/page-objects/pages/settings/sync-accounts-settings-page.ts
@@ -34,6 +34,9 @@ class SyncAccountsSettingsPage {
 
   private readonly qrExpiredMessage = { text: 'QR code expired' };
 
+  private readonly qrSyncWalletRowId = (walletId: string) =>
+    `[data-testid="qr-sync-wallet-row-${walletId}"]`;
+
   private readonly sessionExpiredErrorMessage = {
     text: 'This sync session expired. Start again to generate a new QR code.',
   };
@@ -43,23 +46,18 @@ class SyncAccountsSettingsPage {
 
   private readonly success = '[data-testid="qr-sync-success"]';
 
-  private readonly syncButton = '[data-testid="qr-sync-sync-button"]';
-
-  private readonly qrSyncWalletRowId = (walletId: string) =>
-    `[data-testid="qr-sync-wallet-row-${walletId}"]`;
-
   private readonly successWithSyncedCountsLocator = (
     walletCount: number,
     accountCount: number,
   ): string =>
     `[data-testid="qr-sync-success"][data-synced-wallet-count="${walletCount}"][data-synced-account-count="${accountCount}"]`;
 
-  // eslint-disable-next-line @typescript-eslint/member-ordering
+  private readonly syncButton = '[data-testid="qr-sync-sync-button"]';
+
   constructor(driver: Driver) {
     this.driver = driver;
   }
 
-  // eslint-disable-next-line @typescript-eslint/member-ordering
   async assertSuccessSyncedCounts(
     walletCount: number,
     accountCount: number,

--- a/test/e2e/page-objects/pages/test-dapp-bitcoin.ts
+++ b/test/e2e/page-objects/pages/test-dapp-bitcoin.ts
@@ -84,20 +84,20 @@ export class TestDappBitcoin {
     testId: dataTestIds.testPage.sendTransaction.sendTransaction,
   };
 
-  private readonly signMessageButtonSelector = {
-    testId: dataTestIds.testPage.signMessage.signMessage,
-  };
-
-  private readonly signPsbtButtonSelector = {
-    testId: dataTestIds.testPage.signTransaction.signTransaction,
-  };
-
   private readonly signedMessageSelector = {
     testId: dataTestIds.testPage.signMessage.signedMessage,
   };
 
   private readonly signedPsbtSelector = {
     testId: dataTestIds.testPage.signTransaction.signedPsbt,
+  };
+
+  private readonly signMessageButtonSelector = {
+    testId: dataTestIds.testPage.signMessage.signMessage,
+  };
+
+  private readonly signPsbtButtonSelector = {
+    testId: dataTestIds.testPage.signTransaction.signTransaction,
   };
 
   private readonly standardButtonSelector = {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Our E2E page-object ordering rule used@typescript-eslint/member-ordering with ['field', 'constructor', 'method']. But that plugin classifies an arrow-function class property as a method, not a field. So in our page objects, dynamic selectors (function selectors) got flagged if placed in the beginning (selectors place), so they had to be mixed with action methods in the bottom, if we wanted to make lint pass, making it impossible to enforce the "all selectors first (constant or function), then actions."

Solution:
Added a small local ESLint rule, page-object/member-order, that classifies members by type instead: 
- first selectors: every PropertyDefinition is a selector (string, object, or arrow function)
- then the constructor
- then every MethodDefinition (actions)

and each group is ordered alphabetically.
 
## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MMQA-1962

## **Manual testing steps**

1. Open a compliant page object/remove from the allow list one of them and run `yarn eslint test/e2e/page-objects/pages/home/nfts-tab.ts -c ./.eslintrc.js`
2. Move an action method above a selector, re-run → error: "A selector must be declared before all action methods."
3. Put two selectors out of alphabetical order, re-run → error: "...should be declared before... (alphabetical order)."
4. Confirm an arrow-function selector placed among the constant selectors is accepted (not flagged as a method)

## **Screenshots/Recordings**

<img width="1004" height="669" alt="image" src="https://github.com/user-attachments/assets/f9a9fea7-45a5-4e5a-8ed3-abf06aec2e0b" />


### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lint and test-infra only; two page objects are reorder-only with no behavior changes.
> 
> **Overview**
> Replaces **`@typescript-eslint/member-ordering`** on E2E page objects with a local **`page-object/member-order`** rule so **arrow-function locators count as selectors** (all `PropertyDefinition` members), not methods—enforcing **selectors → constructor → driver actions**, each group **alphabetical**.
> 
> Adds **`development/eslint-rules/page-object-member-order.js`** with RuleTester coverage and includes that path in Jest **`collectCoverageFrom`**. Docs in **`.eslintrc.js`** are updated; the long **`ignores`** list for non-compliant files stays.
> 
> **`sync-accounts-settings-page.ts`** and **`test-dapp-bitcoin.ts`** are reordered to match the new rule and drop **`member-ordering`** disables.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e377945911a762ff1e6f39c34ea7a1b597d19941. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->