### PR TITLE
feat: keep the balance left aligned for lower viewport cp-13.42.0

### DIFF
--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -77,10 +77,10 @@ export type CoinOverviewProps = {
 
 const BalanceOverviewSkeleton = () => (
   <Box
-    className="flex w-full max-w-[400px] items-center gap-[10px] self-center px-2 pb-4 pt-6 [.wallet-overview-fullscreen_&]:px-4"
+    className="wallet-overview__balance-skeleton flex w-full max-w-[400px] items-center gap-[10px] px-2 pb-4 pt-6 [.wallet-overview-fullscreen_&]:px-4"
     data-testid="coin-overview-balance-skeleton"
   >
-    <Box className="flex w-full max-w-[368px] flex-col items-start justify-center gap-[2px] [.wallet-overview-fullscreen_&]:items-center">
+    <Box className="wallet-overview__balance-skeleton-lines flex w-full max-w-[368px] flex-col items-start justify-center gap-[2px]">
       <Skeleton className="h-[50px] w-full rounded-lg" />
       <Skeleton className="h-6 w-[180px] rounded-lg" />
     </Box>

--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -375,9 +375,7 @@ export const CoinOverview = ({
       title={t('balanceOutdated')}
       disabled={!balanceIsCached}
     >
-      <div
-        className={`${classPrefix}-overview__balance [.wallet-overview-fullscreen_&]:items-center`}
-      >
+      <div className={`${classPrefix}-overview__balance`}>
         <div className={`${classPrefix}-overview__primary-container`}>
           {balanceSection}
           {balanceIsCached && !shouldShowBalanceEmptyState && (

--- a/ui/components/app/wallet-overview/index.scss
+++ b/ui/components/app/wallet-overview/index.scss
@@ -14,6 +14,12 @@
     align-items: center;
   }
 
+  &-sidepanel {
+    @media (max-width: 490px) {
+      align-items: start;
+    }
+  }
+
   &__balance {
     flex: 1;
     display: flex;
@@ -24,6 +30,12 @@
 
     .wallet-overview-fullscreen > & {
       align-items: center;
+    }
+
+    .wallet-overview-sidepanel > & {
+      @media (max-width: 490px) {
+        align-items: start;
+      }
     }
   }
 
@@ -77,6 +89,16 @@
     min-width: 0;
     position: relative;
     align-items: start;
+
+    .wallet-overview-fullscreen & {
+      align-items: center;
+    }
+
+    .wallet-overview-sidepanel & {
+      @media (max-width: 490px) {
+        align-items: start;
+      }
+    }
   }
 
   &__primary-container {

--- a/ui/components/app/wallet-overview/index.scss
+++ b/ui/components/app/wallet-overview/index.scss
@@ -2,10 +2,10 @@
 
 $wallet-overview-sidepanel-max-width: 490px;
 
-@mixin sidepanel-left-align-before-max-width {
+@mixin sidepanel-start-before-max-width($property) {
   .wallet-overview-sidepanel & {
     @media (max-width: $wallet-overview-sidepanel-max-width) {
-      align-items: start;
+      #{$property}: start;
     }
   }
 }
@@ -36,7 +36,7 @@ $wallet-overview-sidepanel-max-width: 490px;
       align-items: center;
     }
 
-    @include sidepanel-left-align-before-max-width;
+    @include sidepanel-start-before-max-width(align-items);
   }
 
   &__buttons {
@@ -56,6 +56,24 @@ $wallet-overview-sidepanel-max-width: 490px;
     flex-direction: row;
     gap: 8px;
     flex-wrap: wrap;
+  }
+
+  &__balance-skeleton {
+    align-self: start;
+
+    .wallet-overview-fullscreen & {
+      align-self: center;
+    }
+
+    @include sidepanel-start-before-max-width(align-self);
+  }
+
+  &__balance-skeleton-lines {
+    .wallet-overview-fullscreen & {
+      align-items: center;
+    }
+
+    @include sidepanel-start-before-max-width(align-items);
   }
 }
 
@@ -94,7 +112,7 @@ $wallet-overview-sidepanel-max-width: 490px;
       align-items: center;
     }
 
-    @include sidepanel-left-align-before-max-width;
+    @include sidepanel-start-before-max-width(align-items);
   }
 
   &__primary-container {

--- a/ui/components/app/wallet-overview/index.scss
+++ b/ui/components/app/wallet-overview/index.scss
@@ -1,5 +1,15 @@
 @use "design-system";
 
+$wallet-overview-sidepanel-max-width: 490px;
+
+@mixin sidepanel-left-align-before-max-width {
+  .wallet-overview-sidepanel & {
+    @media (max-width: $wallet-overview-sidepanel-max-width) {
+      align-items: start;
+    }
+  }
+}
+
 .wallet-overview {
   display: flex;
   justify-content: space-between;
@@ -14,12 +24,6 @@
     align-items: center;
   }
 
-  &-sidepanel {
-    @media (max-width: 490px) {
-      align-items: start;
-    }
-  }
-
   &__balance {
     flex: 1;
     display: flex;
@@ -32,11 +36,7 @@
       align-items: center;
     }
 
-    .wallet-overview-sidepanel > & {
-      @media (max-width: 490px) {
-        align-items: start;
-      }
-    }
+    @include sidepanel-left-align-before-max-width;
   }
 
   &__buttons {
@@ -44,7 +44,7 @@
     flex-direction: row;
     height: 100%;
     width: 100%;
-    max-width: calc(490px - 32px); // 490px (sidepanel max-width) - 32px (side padding)
+    max-width: calc(#{$wallet-overview-sidepanel-max-width} - 32px);
 
     .wallet-overview-fullscreen > & {
       align-self: center;
@@ -94,11 +94,7 @@
       align-items: center;
     }
 
-    .wallet-overview-sidepanel & {
-      @media (max-width: 490px) {
-        align-items: start;
-      }
-    }
+    @include sidepanel-left-align-before-max-width;
   }
 
   &__primary-container {

--- a/ui/components/app/wallet-overview/wallet-overview.js
+++ b/ui/components/app/wallet-overview/wallet-overview.js
@@ -19,6 +19,8 @@ const WalletOverview = ({ balance, buttons, className }) => {
           'wallet-overview-fullscreen':
             environmentType === ENVIRONMENT_TYPE_FULLSCREEN ||
             environmentType === ENVIRONMENT_TYPE_SIDEPANEL,
+          'wallet-overview-sidepanel':
+            environmentType === ENVIRONMENT_TYPE_SIDEPANEL,
         },
         className,
       )}


### PR DESCRIPTION
This PR is to make sure that the balance is left aligned for smaller viewports


## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/91524f4d-55e2-44ca-8f00-71a89b3c2f98


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only layout changes in wallet overview with no auth, data, or business-logic impact.
> 
> **Overview**
> **Wallet overview balance alignment** is updated so the sidepanel keeps the balance **left-aligned** when the viewport is at or below **490px**, while fullscreen/sidepanel layouts still **center** the balance on wider widths.
> 
> Adds a **`wallet-overview-sidepanel`** class on the sidepanel environment and a shared SCSS mixin that applies `start` alignment under that breakpoint for the balance block, coin overview balance, and loading skeleton. Inline Tailwind alignment on the balance wrapper and skeleton is removed in favor of these styles, and the sidepanel max-width is centralized as a SCSS variable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2e6500031af10366e5643707aad82e766a04c84. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->