### PR TITLE
feat: enable pure black dark mode by default

### DIFF
--- a/.metamaskrc.dist
+++ b/.metamaskrc.dist
@@ -111,4 +111,4 @@ NEW_HARDWARE_WALLET_ONBOARDING='false'
 
 ; Set to `true` to enable pure-black (OLED) dark mode locally and rebuild (`yarn start`).
 ; To enable for all users, change the corresponding entry in builds.yml to `true`.
-MM_PURE_BLACK_PREVIEW=false
+MM_PURE_BLACK_PREVIEW=true

--- a/builds.yml
+++ b/builds.yml
@@ -374,7 +374,7 @@ env:
   - QR_SYNC_ENABLED: false
   # Pure-black (OLED) dark mode. Set to true in .metamaskrc for local dev,
   # or change this entry to true to enable for all users in a build.
-  - MM_PURE_BLACK_PREVIEW: false
+  - MM_PURE_BLACK_PREVIEW: true
 
   ###
   # Meta variables


### PR DESCRIPTION
## **Description**

Flips `MM_PURE_BLACK_PREVIEW` from `false` to `true` in `builds.yml` and `.metamaskrc.dist` so that the pure black (OLED) dark mode is enabled for all users in the build.

This gives us a week of testing in 13.42.x before the feature ships permanently in 13.43.0.

## **Changelog**

CHANGELOG entry: Enabled pure black (OLED) dark mode for users with dark theme active.

## **Related issues**

Fixes: TMCU-1166

## **Manual testing steps**

1. Run `yarn start` (no `.metamaskrc` change needed — the flag is now `true` by default in the build).
2. Enable dark theme in Settings → Preferences and display → Theme → Dark.
3. Confirm pure black (`#000000`) background is applied throughout the extension.
4. Toggle back to light or system theme and confirm no visual regressions.
5. Check the popup flash (`popup-init.html`), side menu, modals, and popovers for correct elevation surfaces.

## **Screenshots/Recordings**

### **Before**

<!-- Pure black was opt-in via .metamaskrc -->

### **After**

<!-- Pure black enabled for all dark mode users -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.