### PR TITLE
fix: remove page transition animation from more menu list items

### DIFF
--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -480,10 +480,8 @@ const CoinButtons = ({
 
     if (selectedAccountGroup) {
       // Navigate to the multichain address list page with receive source
-      transitionForward(() =>
-        navigate(
-          getMultichainAccountAddressListReceivePagePath(selectedAccountGroup),
-        ),
+      navigate(
+        getMultichainAccountAddressListReceivePagePath(selectedAccountGroup),
       );
     } else {
       // Show the traditional receive modal
@@ -506,7 +504,7 @@ const CoinButtons = ({
         .build(),
     );
 
-    transitionForward(() => openBatchSellExperience());
+    openBatchSellExperience();
   }, [trackEvent, trackingLocation, chainId, openBatchSellExperience]);
 
   useOnClickOutside({


### PR DESCRIPTION
## **Description**

Removes the View Transition page animation (`transitionForward`) from the Receive and Batch Sell click handlers in the more menu dropdown. The scale/fade animation was firing when selecting an item from the dropdown, which felt unintended — items in a dropdown are a secondary action and shouldn't trigger the same full-page transition as top-level nav buttons.

The Send and Swap handlers in the main button row are unaffected and still use `transitionForward`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open the wallet home screen.
2. Click the "More" (⋯) button to open the dropdown.
3. Click "Receive" — confirm navigation happens instantly without the scale/fade page transition.
4. Repeat with "Batch Sell" (if enabled).
5. Click "Send" and "Swap" from the main button row and confirm their page transition animation still plays.

## **Screenshots/Recordings**

### **Before**

<!-- Page scale/fade animation fires when selecting items from the more menu dropdown -->

### **After**

<!-- No animation — navigation is instant from the dropdown -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UX change in two click handlers; no auth, data, or routing logic changes beyond skipping the transition wrapper.
> 
> **Overview**
> **Receive** and **Batch Sell** in the wallet overview **More** dropdown now navigate or open their flows **without** wrapping actions in `transitionForward`, so the scale/fade view transition no longer runs on those secondary menu picks.
> 
> **Send** and **Swap** on the main button row are unchanged and still use `transitionForward`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0da55dc942b6c28bf6968f65f4b19a00e4476f61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->