### PR TITLE
fix: apply bg-alternative to more menu dropdown in pure black mode

### DIFF
--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -29,6 +29,7 @@ import {
   TextAlign,
   TextColor,
   TextVariant,
+  usePureBlack,
 } from '@metamask/design-system-react';
 import { useAnalytics } from '../../../hooks/useAnalytics';
 import { useAppSelector } from '../../../store/store';
@@ -123,6 +124,8 @@ const MoreButtonsGroup = ({
   modalIsOpen,
 }: MoreButtonsGroupProps) => {
   const t = useContext(I18nContext);
+  // TODO: @metamask/design-system-engineers remove isPureBlack once pure black is shipped targeted(13.43.0)
+  const isPureBlack = usePureBlack();
   const hasOnlyOneEnabledAction =
     actions.filter(({ enabled }) => enabled).length === 1;
   const onlyEnabledAction = actions.filter(({ enabled }) => enabled)[0];
@@ -164,7 +167,7 @@ const MoreButtonsGroup = ({
         onClick={onClick}
       />
       {modalIsOpen && (
-        <Box className="flex flex-col absolute right-0 top-full z-10 mt-4 min-w-[120px] overflow-hidden rounded-lg border border-border-muted bg-background-default shadow-lg">
+        <Box className={`flex flex-col absolute right-0 top-full z-10 mt-4 min-w-[120px] overflow-hidden rounded-lg border border-border-muted shadow-lg${isPureBlack ? ' bg-background-alternative' : ' bg-background-default'}`}>
           {actions.map((action) => (
             <ButtonBase
               key={action.label}


### PR DESCRIPTION
## **Description**

In pure black mode the page background becomes `--color-background-default` (true black), so surfaces need to use `--color-background-alternative` to appear elevated. The more menu dropdown was hardcoded to `bg-background-default`, making it invisible against the pure black canvas.

Uses `usePureBlack()` to conditionally switch the dropdown container between `bg-background-default` (normal dark / light) and `bg-background-alternative` (pure black), matching the same elevation pattern applied to the popover, side drawer, and modals.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Enable `MM_PURE_BLACK_PREVIEW=true` in `.metamaskrc` and run `yarn start`.
2. Enable dark theme (Settings → Preferences and display → Theme → Dark).
3. Open the wallet home screen and click the "More" (⋯) button.
4. Confirm the dropdown background appears elevated (slightly lighter than the pure black page), not invisible.
5. Toggle to light or normal dark theme and confirm the dropdown background reverts to `bg-background-default`.

## **Screenshots/Recordings**

### **Before**

<!-- Dropdown invisible against pure black background -->

### **After**

<!-- Dropdown uses bg-background-alternative, visually elevated -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Theme-only class change on a wallet overview dropdown; no logic, auth, or data paths affected.
> 
> **Overview**
> Fixes the wallet **More** (⋯) menu dropdown blending into the page when **pure black** dark theme is enabled.
> 
> `MoreButtonsGroup` now uses `usePureBlack()` to pick the dropdown container background: `bg-background-alternative` in pure black (elevated surface) and `bg-background-default` otherwise, consistent with other elevated UI in this theme.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15c4bea3f56c8ed50ccce36f1333adb6805e9b6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->