### PR TITLE
fix: update :root dark background to pure black for pre-JS flash

### DIFF
--- a/ui/css/base-styles.scss
+++ b/ui/css/base-styles.scss
@@ -12,7 +12,8 @@
 
   color-scheme: dark light;
   color: light-dark(var(--brand-colors-grey-grey1000), var(--brand-colors-grey-grey050));
-  background-color: light-dark(var(--brand-colors-grey-grey050), var(--brand-colors-grey-grey1000));
+  // TODO: @metamask/design-system-engineers remove once pure black is shipped targeted(13.43.0)
+  background-color: light-dark(var(--brand-colors-grey-grey050), var(--brand-colors-black));
 }
 
 html,


### PR DESCRIPTION
## **Description**

The `:root` rule uses `light-dark()` which responds to `prefers-color-scheme` — it runs before JavaScript has a chance to apply `data-theme` or `data-pure-black` attributes. This means the initial background flash on dark system theme was showing `--brand-colors-grey-grey1000` (`#24272A`) rather than pure black.

Changing the dark value in `light-dark()` to `--brand-colors-black` (`#000000`) ensures the pre-JS flash matches the pure black background. Once JavaScript loads and sets `data-theme='dark'` + `data-pure-black='true'`, the existing `html[data-theme='dark'][data-pure-black='true']` rule in `base-styles.scss` takes over and maintains the correct background via the semantic token.

These two rules cover the same visual goal at different moments in the page lifecycle:
- `:root` `light-dark()` → before JS, uses brand color directly (no data attributes available)
- `html[data-theme='dark'][data-pure-black='true']` → after JS, uses semantic token

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Enable `MM_PURE_BLACK_PREVIEW=true` and dark theme.
2. Hard-reload the extension popup.
3. Observe the initial background flash — it should be pure black rather than dark grey.
4. Confirm light theme users see no change (white background still appears on reload).

## **Screenshots/Recordings**

### **Before**

<!-- Dark flash shows #24272A (grey-grey1000) -->

### **After**

<!-- Dark flash shows #000000 (pure black) -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CSS token swap for pre-JS dark background only; no auth, data, or logic changes.
> 
> **Overview**
> Fixes the **initial background flash** on dark system theme before JavaScript runs. The `:root` rule relies on `light-dark()` and `prefers-color-scheme`, so it cannot use `data-theme` / `data-pure-black` yet.
> 
> The dark branch of `background-color` is changed from `--brand-colors-grey-grey1000` (`#24272A`) to `--brand-colors-black` (`#000000`). **Light theme is unchanged** (still `--brand-colors-grey-grey050`). After JS applies `html[data-theme='dark'][data-pure-black='true']`, the existing semantic-token rule continues to own the background.
> 
> A **TODO** notes removing this override once pure black ships (target 13.43.0).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e74939f9c812aea95328cc5e415e3df5c555404b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->