### PR TITLE
fix: eliminate liveness orphaned-data and MaxListenersExceededWarning console noise in contentscript

### DIFF
--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -100,6 +100,7 @@ import { onUpdate } from './on-update';
 
 import { COOKIE_ID_MARKETING_WHITELIST_ORIGINS } from './constants/marketing-site-whitelist';
 import {
+  BACKGROUND_LIVENESS_STREAM,
   METAMASK_CAIP_MULTICHAIN_PROVIDER,
   METAMASK_EIP_1193_PROVIDER,
 } from './constants/stream';
@@ -610,7 +611,7 @@ const handleOnConnect = async (port) => {
       data: {
         method: BACKGROUND_LIVENESS_METHOD,
       },
-      name: 'background-liveness',
+      name: BACKGROUND_LIVENESS_STREAM,
     });
   } catch (e) {
     log.error(

--- a/app/scripts/constants/stream.ts
+++ b/app/scripts/constants/stream.ts
@@ -5,6 +5,13 @@ export const PHISHING_WARNING_PAGE = 'metamask-phishing-warning-page';
 
 // stream channels
 export const METAMASK_COOKIE_HANDLER = 'metamask-cookie-handler';
+// liveness streams are sent over every port on connection, by the service
+// worker (`app-init-liveness`, see `service-worker.ts`) and the background
+// (`background-liveness`, see `background.js`). Only the extension UI consumes
+// them (see `ui.js`); all other muxes must ignore them to avoid
+// "ObjectMultiplex - orphaned data" warnings.
+export const APP_INIT_LIVENESS_STREAM = 'app-init-liveness';
+export const BACKGROUND_LIVENESS_STREAM = 'background-liveness';
 export const METAMASK_EIP_1193_PROVIDER = 'metamask-provider';
 export const METAMASK_CAIP_MULTICHAIN_PROVIDER = 'metamask-multichain-provider';
 export const PHISHING_SAFELIST = 'metamask-phishing-safelist';

--- a/app/scripts/streams/cookie-handler-stream.ts
+++ b/app/scripts/streams/cookie-handler-stream.ts
@@ -9,6 +9,8 @@ import { EXTENSION_MESSAGES } from '../../../shared/constants/messages';
 import { COOKIE_ID_MARKETING_WHITELIST_ORIGINS } from '../constants/marketing-site-whitelist';
 import { checkForLastError } from '../../../shared/lib/browser-runtime.utils';
 import {
+  APP_INIT_LIVENESS_STREAM,
+  BACKGROUND_LIVENESS_STREAM,
   METAMASK_COOKIE_HANDLER,
   CONTENT_SCRIPT,
   LEGACY_PUBLIC_CONFIG,
@@ -153,6 +155,8 @@ export const setupCookieHandlerExtStreams = (): void => {
   cookieHandlerMux.ignoreStream(METAMASK_CAIP_MULTICHAIN_PROVIDER);
   cookieHandlerMux.ignoreStream(PHISHING_SAFELIST);
   cookieHandlerMux.ignoreStream(PHISHING_STREAM);
+  cookieHandlerMux.ignoreStream(APP_INIT_LIVENESS_STREAM);
+  cookieHandlerMux.ignoreStream(BACKGROUND_LIVENESS_STREAM);
   pipeline(
     cookieHandlerPageChannel,
     cookieHandlerExtChannel,

--- a/app/scripts/streams/phishing-stream.ts
+++ b/app/scripts/streams/phishing-stream.ts
@@ -8,6 +8,8 @@ import { ExtensionPortStream } from 'extension-port-stream';
 import { checkForLastError } from '../../../shared/lib/browser-runtime.utils';
 import { EXTENSION_MESSAGES } from '../../../shared/constants/messages';
 import {
+  APP_INIT_LIVENESS_STREAM,
+  BACKGROUND_LIVENESS_STREAM,
   CONTENT_SCRIPT,
   LEGACY_PROVIDER,
   LEGACY_PUBLIC_CONFIG,
@@ -165,6 +167,8 @@ export const setupPhishingExtStreams = (): void => {
   phishingExtMux.ignoreStream(METAMASK_EIP_1193_PROVIDER);
   phishingExtMux.ignoreStream(METAMASK_CAIP_MULTICHAIN_PROVIDER);
   phishingExtMux.ignoreStream(PHISHING_STREAM);
+  phishingExtMux.ignoreStream(APP_INIT_LIVENESS_STREAM);
+  phishingExtMux.ignoreStream(BACKGROUND_LIVENESS_STREAM);
 
   // eslint-disable-next-line @typescript-eslint/no-use-before-define
   phishingExtPort.onDisconnect.addListener(onDisconnectDestroyPhishingStreams);

--- a/app/scripts/streams/provider-stream.filter.test.ts
+++ b/app/scripts/streams/provider-stream.filter.test.ts
@@ -66,6 +66,10 @@ jest.mock('extension-port-stream', () => ({
     on(_event: string, _fn: (data: unknown) => void) {
       // empty on purpose
     }
+
+    setMaxListeners(_n: number) {
+      // empty on purpose
+    }
   },
 }));
 

--- a/app/scripts/streams/provider-stream.leak.test.ts
+++ b/app/scripts/streams/provider-stream.leak.test.ts
@@ -1,0 +1,251 @@
+import { jest } from '@jest/globals';
+import ObjectMultiplex from '@metamask/object-multiplex';
+import { Substream } from '@metamask/object-multiplex/dist/Substream';
+import {
+  APP_INIT_LIVENESS_STREAM,
+  BACKGROUND_LIVENESS_STREAM,
+  METAMASK_CAIP_MULTICHAIN_PROVIDER,
+} from '../constants/stream';
+import {
+  initStreams,
+  setupExtensionStreams,
+  onDisconnectDestroyStreams,
+} from './provider-stream';
+
+// Set env before any imports or mocks
+process.env.PHISHING_WARNING_PAGE_URL = 'https://example.com/phishing';
+
+type MessageListener = (msg: unknown, port: unknown) => void;
+
+type FakePort = {
+  name: string;
+  onMessage: {
+    addListener: (fn: MessageListener) => void;
+    removeListener: (fn: MessageListener) => void;
+  };
+  onDisconnect: {
+    addListener: (fn: () => void) => void;
+    removeListener: (fn: () => void) => void;
+  };
+  postMessage: (msg: unknown) => void;
+  disconnect: () => void;
+  messageListeners: MessageListener[];
+};
+
+// Capture every port created by `browser.runtime.connect` so tests can inject
+// incoming messages. Exposed via global to satisfy Jest module factory rules.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(global as any).mockPorts = [] as FakePort[];
+// Capture every ExtensionPortStream instance so tests can check its listeners.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(global as any).mockPortStreams = [];
+
+jest.mock('extension-port-stream', () => {
+  const actual = jest.requireActual(
+    'extension-port-stream',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ) as any;
+  return {
+    ...actual,
+    ExtensionPortStream: class extends actual.ExtensionPortStream {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      constructor(...args: any[]) {
+        super(...args);
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (global as any).mockPortStreams.push(this);
+      }
+    },
+  };
+});
+
+// Mock phishing-stream to avoid URL parsing issue at module load
+jest.mock('./phishing-stream', () => ({
+  connectPhishingChannelToWarningSystem: () => {
+    // empty on purpose
+  },
+}));
+
+// Replace the window transport with a plain object-mode passthrough so the
+// real `readable-stream` pipelines can run against it.
+jest.mock('@metamask/post-message-stream', () => {
+  const { PassThrough } = jest.requireActual(
+    'readable-stream',
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ) as any;
+  return {
+    WindowPostMessageStream: class extends PassThrough {
+      constructor() {
+        super({ objectMode: true });
+      }
+    },
+  };
+});
+
+jest.mock('webextension-polyfill', () => ({
+  /* eslint-disable-next-line @typescript-eslint/naming-convention */
+  __esModule: true,
+  default: {
+    runtime: {
+      connect: ({ name }: { name: string }) => {
+        const messageListeners: MessageListener[] = [];
+        const disconnectListeners: (() => void)[] = [];
+        const port = {
+          name,
+          messageListeners,
+          onMessage: {
+            addListener: (fn: MessageListener) => messageListeners.push(fn),
+            removeListener: (fn: MessageListener) => {
+              const index = messageListeners.indexOf(fn);
+              if (index !== -1) {
+                messageListeners.splice(index, 1);
+              }
+            },
+          },
+          onDisconnect: {
+            addListener: (fn: () => void) => disconnectListeners.push(fn),
+            removeListener: (fn: () => void) => {
+              const index = disconnectListeners.indexOf(fn);
+              if (index !== -1) {
+                disconnectListeners.splice(index, 1);
+              }
+            },
+          },
+          postMessage: () => {
+            // empty on purpose
+          },
+          disconnect: () => {
+            // empty on purpose
+          },
+        };
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (global as any).mockPorts.push(port);
+        return port;
+      },
+      onMessage: {
+        addListener: () => {
+          // empty on purpose
+        },
+      },
+    },
+  },
+}));
+
+const flushStreams = async () => {
+  for (let i = 0; i < 5; i++) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+};
+
+const latestPort = (): FakePort => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const ports = (global as any).mockPorts as FakePort[];
+  return ports[ports.length - 1];
+};
+
+describe('provider-stream reconnect cleanup', () => {
+  // These tests share module state on purpose: `initStreams` builds the
+  // page-side streams once (as in a real content script) and the reconnect
+  // test then cycles only the extension side.
+  let caipChannel: Substream;
+
+  it('does not accumulate listeners on the page CAIP channel across service worker reconnects (issue #43090)', () => {
+    const createStreamSpy = jest.spyOn(
+      ObjectMultiplex.prototype as ObjectMultiplex,
+      'createStream',
+    );
+
+    initStreams();
+
+    // The first substream created for the CAIP channel belongs to the
+    // page-side mux; the extension-side one is created later.
+    const caipCallIndex = createStreamSpy.mock.calls.findIndex(
+      ([name]) => name === METAMASK_CAIP_MULTICHAIN_PROVIDER,
+    );
+    expect(caipCallIndex).toBeGreaterThanOrEqual(0);
+    caipChannel = createStreamSpy.mock.results[caipCallIndex]
+      .value as Substream;
+
+    const baseline = {
+      close: caipChannel.listenerCount('close'),
+      end: caipChannel.listenerCount('end'),
+    };
+    // Sanity check: the initial pipeline wiring adds some listeners.
+    expect(baseline.close).toBeGreaterThan(0);
+
+    // Simulate repeated service worker idles/restarts. Before the fix, every
+    // cycle leaked the previous pipeline's listeners onto the persistent
+    // page-side CAIP channel, eventually exceeding the default max of 10 and
+    // triggering MaxListenersExceededWarning in the console.
+    for (let i = 0; i < 5; i++) {
+      onDisconnectDestroyStreams(undefined);
+      setupExtensionStreams();
+    }
+
+    expect(caipChannel.listenerCount('close')).toBe(baseline.close);
+    expect(caipChannel.listenerCount('end')).toBe(baseline.end);
+    expect(caipChannel.listenerCount('close')).toBeLessThanOrEqual(
+      caipChannel.getMaxListeners(),
+    );
+  });
+
+  it('ignores liveness streams sent over the port without logging orphaned data (issue #43090)', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {
+      // empty on purpose
+    });
+
+    const port = latestPort();
+    const emitPortMessage = (msg: unknown) =>
+      port.messageListeners.slice().forEach((fn) => fn(msg, port));
+
+    // Positive control: data for a stream the mux does not know about must
+    // still warn, proving messages actually flow into the mux in this test.
+    emitPortMessage({
+      name: 'unknown-test-stream',
+      data: { method: 'TEST' },
+    });
+    await flushStreams();
+    expect(
+      warnSpy.mock.calls.some(([message]) =>
+        String(message).includes(
+          'orphaned data for stream "unknown-test-stream"',
+        ),
+      ),
+    ).toBe(true);
+
+    // The liveness pings that the service worker and background send on every
+    // port connection must be ignored instead of logged as orphaned data.
+    emitPortMessage({
+      name: APP_INIT_LIVENESS_STREAM,
+      data: { method: 'APP_INIT_ALIVE' },
+    });
+    emitPortMessage({
+      name: BACKGROUND_LIVENESS_STREAM,
+      data: { method: 'ALIVE' },
+    });
+    await flushStreams();
+
+    expect(
+      warnSpy.mock.calls.some(
+        ([message]) =>
+          String(message).includes(APP_INIT_LIVENESS_STREAM) ||
+          String(message).includes(BACKGROUND_LIVENESS_STREAM),
+      ),
+    ).toBe(false);
+  });
+
+  it('accommodates all pipeline listeners on the shared extension port stream', () => {
+    // The first ExtensionPortStream (from initStreams) is shared by the main
+    // and legacy mux pipelines, which together attach more close/end
+    // listeners than the EventEmitter default of 10. Its limit must be
+    // raised, or every setup logs MaxListenersExceededWarning.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const [firstPortStream] = (global as any).mockPortStreams;
+    expect(firstPortStream.listenerCount('close')).toBeGreaterThan(10);
+    expect(firstPortStream.listenerCount('close')).toBeLessThanOrEqual(
+      firstPortStream.getMaxListeners(),
+    );
+    expect(firstPortStream.listenerCount('end')).toBeLessThanOrEqual(
+      firstPortStream.getMaxListeners(),
+    );
+  });
+});

--- a/app/scripts/streams/provider-stream.ts
+++ b/app/scripts/streams/provider-stream.ts
@@ -6,6 +6,8 @@ import { pipeline, Transform } from 'readable-stream';
 import browser from 'webextension-polyfill';
 import { ExtensionPortStream } from 'extension-port-stream';
 import {
+  APP_INIT_LIVENESS_STREAM,
+  BACKGROUND_LIVENESS_STREAM,
   CONTENT_SCRIPT,
   LEGACY_CONTENT_SCRIPT,
   LEGACY_INPAGE,
@@ -113,6 +115,10 @@ export const setupExtensionStreams = () => {
   METAMASK_EXTENSION_CONNECT_SENT = true;
   extensionPort = browser.runtime.connect({ name: CONTENT_SCRIPT });
   extensionStream = new ExtensionPortStream(extensionPort, { chunkSize: 0 });
+  // This stream is shared by the main and legacy mux pipelines, which
+  // together legitimately attach more than the default limit of 10
+  // close/end listeners, so raise the limit like the muxes below do.
+  extensionStream.setMaxListeners(25);
   extensionStream.on('data', extensionStreamMessageListener);
 
   // create and connect channel muxers
@@ -120,6 +126,8 @@ export const setupExtensionStreams = () => {
   extensionMux = new ObjectMultiplex();
   extensionMux.setMaxListeners(25);
   extensionMux.ignoreStream(LEGACY_PUBLIC_CONFIG); // TODO:LegacyProvider: Delete
+  extensionMux.ignoreStream(APP_INIT_LIVENESS_STREAM);
+  extensionMux.ignoreStream(BACKGROUND_LIVENESS_STREAM);
 
   /**
    * Graceful shutdown handler for the extension mux.
@@ -171,6 +179,10 @@ export const setupExtensionStreams = () => {
 /** Destroys all of the extension streams */
 const destroyExtensionStreams = () => {
   pageChannel.removeAllListeners();
+  // The CAIP channel must be cleaned up like `pageChannel`, or the listeners
+  // added by its pipeline accumulate on every service worker reconnect,
+  // eventually triggering MaxListenersExceededWarning.
+  caipChannel.removeAllListeners();
 
   extensionMux.removeAllListeners();
   extensionMux.destroy();
@@ -261,6 +273,8 @@ const setupLegacyExtensionStreams = () => {
   legacyExtMux.ignoreStream(LEGACY_PROVIDER);
   legacyExtMux.ignoreStream(PHISHING_SAFELIST);
   legacyExtMux.ignoreStream(PHISHING_STREAM);
+  legacyExtMux.ignoreStream(APP_INIT_LIVENESS_STREAM);
+  legacyExtMux.ignoreStream(BACKGROUND_LIVENESS_STREAM);
 };
 
 /**

--- a/app/scripts/ui.js
+++ b/app/scripts/ui.js
@@ -47,6 +47,10 @@ import {
 import { isManifestV3 } from '../../shared/lib/mv3.utils';
 import { checkForLastErrorAndLog } from '../../shared/lib/browser-runtime.utils';
 import { endTrace, trace, TraceName } from '../../shared/lib/trace';
+import {
+  APP_INIT_LIVENESS_STREAM,
+  BACKGROUND_LIVENESS_STREAM,
+} from './constants/stream';
 import ExtensionPlatform from './platforms/extension';
 import { setupMultiplex } from './lib/stream-utils';
 import { getEnvironmentType, getPlatform } from './lib/util';
@@ -332,8 +336,8 @@ function connectSubstreams(connectionStream) {
 
   const controllerSubstream = mx.createStream('controller');
   const providerSubstream = mx.createStream('provider');
-  mx.ignoreStream('background-liveness');
-  mx.ignoreStream('app-init-liveness');
+  mx.ignoreStream(BACKGROUND_LIVENESS_STREAM);
+  mx.ignoreStream(APP_INIT_LIVENESS_STREAM);
 
   return {
     controller: controllerSubstream,

--- a/app/service-worker.ts
+++ b/app/service-worker.ts
@@ -2,6 +2,7 @@
 
 import './scripts/load/bootstrap';
 import { APP_INIT_LIVENESS_METHOD } from '../shared/constants/ui-initialization';
+import { APP_INIT_LIVENESS_STREAM } from './scripts/constants/stream';
 import { ExtensionLazyListener } from './scripts/lib/extension-lazy-listener/extension-lazy-listener';
 
 const { chrome } = globalThis;
@@ -71,7 +72,7 @@ chrome.runtime.onConnect.addListener((port) => {
       data: {
         method: APP_INIT_LIVENESS_METHOD,
       },
-      name: 'app-init-liveness',
+      name: APP_INIT_LIVENESS_STREAM,
     });
   } catch (e) {
     console.error(


### PR DESCRIPTION
## Description

Dapp consoles currently show recurring warnings from the MetaMask content script on every page load and on every service worker restart:

```
ObjectMultiplex - orphaned data for stream "app-init-liveness"
ObjectMultiplex - orphaned data for stream "background-liveness"
MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 close listeners added. ...
MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 end listeners added. ...
```

There are three distinct causes, all fixed here:

### 1. Liveness pings are orphaned in every content script mux

`service-worker.ts` (`app-init-liveness`) and `background.js` (`background-liveness`) post a liveness message over **every** connecting port, including content script ports. Only the extension UI consumes these (`ui.js` already calls `ignoreStream` for both); none of the content script muxes did, so `@metamask/object-multiplex` warned about orphaned data — twice per ping on regular dapp pages, because both `extensionMux` and `legacyExtMux` read from the same port stream.

Fix: the two stream names are now shared constants in `app/scripts/constants/stream.ts` (used by the senders and `ui.js` too), and every extension-side mux (`extensionMux`, `legacyExtMux`, `phishingExtMux`, `cookieHandlerMux`) ignores them.

### 2. Genuine listener leak on the page-side CAIP channel

`destroyExtensionStreams()` calls `pageChannel.removeAllListeners()` but was never updated to clean up its CAIP sibling `caipChannel`. Both are persistent page-side substreams that get a fresh `pipeline()` attached on every service worker reconnect, so `caipChannel` accumulated the dead pipelines' listeners without bound (measured: +8 `close` / +6 `end` listeners per reconnect cycle with the repo's exact dependency versions).

Fix: `caipChannel.removeAllListeners()` alongside the existing `pageChannel` cleanup.

### 3. The shared extension port stream legitimately exceeds the default listener limit

The main mux pipeline, the legacy mux pipeline, and the graceful-shutdown handlers all attach to the same `ExtensionPortStream`, which adds up to 13 `close` / 11 `end` listeners on a fresh, correctly-wired stream. Since the stream is recreated on every reconnect, the warning pair re-fired every time the service worker restarted. The muxes were already bumped to 25 for this reason, but the port stream never was.

Fix: `extensionStream.setMaxListeners(25)`, matching the muxes.

## Tests

New `app/scripts/streams/provider-stream.leak.test.ts` (real `readable-stream`/`object-multiplex`/`extension-port-stream`, only the browser transports mocked):

- asserts the page-side CAIP channel's listener counts stay flat across 5 simulated service worker disconnect/reconnect cycles (fails without fix 2);
- asserts liveness chunks arriving over the port produce no orphaned-data warnings, with a positive control proving unknown streams still warn (fails without fix 1);
- asserts the shared port stream's listener count fits within its limit (fails without fix 3).

`provider-stream.filter.test.ts`'s minimal `ExtensionPortStream` mock gained a `setMaxListeners` no-op.

Verified locally: `yarn jest app/scripts/streams/` (4 suites, 9 tests pass, no console-baseline violations, and the MaxListenersExceededWarning that previously appeared in the Jest output of this suite is gone), `eslint` and `tsc` clean.

## Related issues

Fixes: #43090

## Manual testing steps

1. Build and load the extension, open any dapp page with DevTools console open
2. Note no `ObjectMultiplex - orphaned data` warnings appear on load
3. Let the service worker go idle (or kill it via `chrome://serviceworker-internals`), interact with the page so it reconnects, repeat several times
4. Note no `MaxListenersExceededWarning` appears in the page console

## Pre-merge author checklist

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted content-script stream wiring and cleanup with regression tests; no auth, vault, or payment logic changes.
> 
> **Overview**
> Stops recurring dapp console noise from MetaMask’s content-script multiplexers by treating **app-init** and **background liveness** pings as ignored streams everywhere except the extension UI, using shared constants for those channel names.
> 
> On service worker reconnect, it also **cleans up the page-side CAIP channel** like the EIP-1193 channel (fixing listener accumulation) and raises **`ExtensionPortStream` max listeners** to match the shared main/legacy mux pipelines.
> 
> Adds **`provider-stream.leak.test.ts`** to lock in stable CAIP listener counts across reconnects, no orphaned-data warnings for liveness, and port-stream listener limits; updates the filter-test mock for `setMaxListeners`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c47b066e5188a86673adf2e8945cfaf3dbb1b32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->