### PR TITLE
ci: update cla.yml with more Cursor names

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -27,6 +27,6 @@ jobs:
           url-to-cladocument: 'https://metamask.io/cla'
           # This branch can't have protections, commits are made directly to the specified branch.
           branch: 'cla-signatures'
-          allowlist: 'dependabot[bot],metamaskbot,metamaskbotv2[bot],crowdin-bot,runway-github[bot],cursoragent,Copilot,metamask-aep[bot],metamask-ci[bot]'
+          allowlist: 'dependabot[bot],metamaskbot,metamaskbotv2[bot],crowdin-bot,runway-github[bot],cursorbot,cursoragent,cursor[bot],Copilot,metamask-aep[bot],metamask-ci[bot]'
           allow-organization-members: true
           blockchain-storage-flag: false


### PR DESCRIPTION
## **Description**

Update cla.yml with more Cursor names.

## **Changelog**

CHANGELOG entry: null

<!--## **Related issues**
## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single CI configuration change with no runtime, auth, or data-handling impact.
> 
> **Overview**
> Updates the **CLA Signature Bot** workflow allowlist so additional Cursor-related GitHub actors are exempt from CLA checks.
> 
> The `allowlist` in `.github/workflows/cla.yml` now includes **`cursorbot`** and **`cursor[bot]`** alongside the existing **`cursoragent`** entry, so automated Cursor PRs are treated like other trusted bots (e.g. Dependabot, Copilot).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aabb4faedc8bb8dcb4ca709e755a24f883b37712. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->