### PR TITLE
fix(ci): post RC Slack when Builds ready, not only green main

### DIFF
--- a/.github/scripts/slack-rc-notification.mts
+++ b/.github/scripts/slack-rc-notification.mts
@@ -1,8 +1,8 @@
 /**
  * Slack RC Build Notification (Extension)
  *
- * Posts a Block Kit message when a release-candidate Main workflow completes, aligned with
- * metamask-mobile/scripts/slack-rc-notification.mjs (bot token + chat.postMessage).
+ * Posts when Publish prerelease succeeds (Builds ready); Main may still be red.
+ * Aligned with metamask-mobile/scripts/slack-rc-notification.mjs.
  *
  * Mobile parity: downloads + cherry-picks link + View full RC notes. No inline CHANGELOG.md dump.
  *

--- a/.github/workflows/rc-slack-notify.yml
+++ b/.github/workflows/rc-slack-notify.yml
@@ -1,13 +1,10 @@
-# Posts a Slack Block Kit message after a successful Main workflow run on release/X.Y.Z,
-# when there is a release PR into stable for the release branch.
+# Slack RC notify after Main on release/X.Y.Z when Publish prerelease succeeded
+# (Builds ready), even if other Main jobs failed. Needs a release PR → stable.
 # See .github/scripts/slack-rc-notification.mts
 #
-# Test without waiting for Main:
-#   Actions → RC Slack notify → Run workflow → fill head_sha, semver, github_run_id, test_channel
-#   (requires SLACK_BOT_TOKEN secret and vars.AWS_CLOUDFRONT_URL for real download URLs)
-#
-# Optional repo variable (Settings → Variables): SLACK_RC_CHANNEL — if set, automated workflow_run
-# posts there instead of #release-extension-* (use only for staging; clear when done).
+# Manual test: Actions → RC Slack notify → Run workflow
+# Optional vars.SLACK_RC_CHANNEL overrides #release-extension-* (staging only).
+# workflow_run uses YAML from the default branch only.
 
 name: RC Slack notify
 
@@ -37,28 +34,30 @@ on:
 permissions:
   contents: read
   pull-requests: read
+  actions: read
 
 jobs:
   notify:
     runs-on: ubuntu-latest
-    # workflow_dispatch: manual test to a channel. workflow_run: successful push to semver release branch in this repo.
+    # Dispatch: manual. workflow_run: Main success|failure; gate requires Publish prerelease.
     if: >-
       ${{
         github.event_name == 'workflow_dispatch' ||
         (github.event_name == 'workflow_run' &&
-          github.event.workflow_run.conclusion == 'success' &&
+          contains(fromJson('["success","failure"]'), github.event.workflow_run.conclusion) &&
           github.event.workflow_run.event == 'push' &&
           github.event.workflow_run.head_repository.full_name == github.repository &&
           startsWith(github.event.workflow_run.head_branch, 'release/'))
       }}
     steps:
-      - name: Find release PR (workflow_run only)
+      - name: Find release PR and confirm Builds ready (workflow_run only)
         id: gate
         if: github.event_name == 'workflow_run'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           BRANCH: ${{ github.event.workflow_run.head_branch }}
+          WORKFLOW_RUN_ID: ${{ github.event.workflow_run.id }}
         run: |
           set -euo pipefail
           echo "skip=true" >> "$GITHUB_OUTPUT"
@@ -71,13 +70,27 @@ jobs:
             echo "No PR with base stable for head $BRANCH — skipping Slack."
             exit 0
           fi
+          # Same signal as PR "Builds ready"
+          PUBLISH_CONCLUSION="$(
+            gh run view "$WORKFLOW_RUN_ID" --repo "$GH_REPO" --json jobs --jq '
+              [
+                .jobs[]
+                | select(.name == "Publish prerelease" or (.name | startswith("Publish prerelease /")))
+              ]
+              | .[0].conclusion // empty
+            '
+          )"
+          if [[ "$PUBLISH_CONCLUSION" != "success" ]]; then
+            echo "Publish prerelease conclusion=${PUBLISH_CONCLUSION:-missing} on run ${WORKFLOW_RUN_ID} — skipping Slack (no Builds ready)."
+            exit 0
+          fi
           PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
           {
             echo "skip=false"
             echo "semver=${BRANCH#release/}"
             echo "pr_number=${PR_NUMBER}"
           } >> "$GITHUB_OUTPUT"
-          echo "Proceeding: found release PR #${PR_NUMBER}."
+          echo "Proceeding: found release PR #${PR_NUMBER}; Publish prerelease succeeded."
 
       - name: Set notification variables
         id: notif

--- a/.github/workflows/rc-slack-notify.yml
+++ b/.github/workflows/rc-slack-notify.yml
@@ -70,18 +70,18 @@ jobs:
             echo "No PR with base stable for head $BRANCH — skipping Slack."
             exit 0
           fi
-          # Same signal as PR "Builds ready"
+          # Same signal as PR "Builds ready" (inner job — not "… / Generate AI test plan")
           PUBLISH_CONCLUSION="$(
             gh run view "$WORKFLOW_RUN_ID" --repo "$GH_REPO" --json jobs --jq '
               [
                 .jobs[]
-                | select(.name == "Publish prerelease" or (.name | startswith("Publish prerelease /")))
+                | select(.name == "Publish prerelease / Publish prerelease")
               ]
               | .[0].conclusion // empty
             '
           )"
           if [[ "$PUBLISH_CONCLUSION" != "success" ]]; then
-            echo "Publish prerelease conclusion=${PUBLISH_CONCLUSION:-missing} on run ${WORKFLOW_RUN_ID} — skipping Slack (no Builds ready)."
+            echo "Publish prerelease / Publish prerelease conclusion=${PUBLISH_CONCLUSION:-missing} on run ${WORKFLOW_RUN_ID} — skipping Slack (no Builds ready)."
             exit 0
           fi
           PR_NUMBER=$(echo "$PR_JSON" | jq -r '.number')
@@ -90,7 +90,7 @@ jobs:
             echo "semver=${BRANCH#release/}"
             echo "pr_number=${PR_NUMBER}"
           } >> "$GITHUB_OUTPUT"
-          echo "Proceeding: found release PR #${PR_NUMBER}; Publish prerelease succeeded."
+          echo "Proceeding: found release PR #${PR_NUMBER}; Publish prerelease / Publish prerelease succeeded."
 
       - name: Set notification variables
         id: notif


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
RC Slack was gated on full main `success`, so “Builds ready” on the PR could exist while Slack never posted (e.g. 13.42.0). Slack now posts when `Publish prerelease` succeeds on a release main run, even if other jobs failed.
## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: [Slack thread](https://consensys.slack.com/archives/C0BJLRDCADT/p1784847360954639?thread_ts=1784847158.875339&cid=C0BJLRDCADT)

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI notification gating only; no runtime, auth, or release artifact logic changes beyond when Slack is sent.
> 
> **Overview**
> **RC Slack notifications** now fire when release **Main** finishes with **Builds ready** (`Publish prerelease / Publish prerelease` succeeded), instead of requiring the entire **Main** workflow to be green.
> 
> The `workflow_run` trigger still runs on completed **Main** for `release/*`, but the job `if` accepts **success** or **failure** conclusions. A new gate step uses `gh run view` (with **`actions: read`**) to require the inner **Publish prerelease** job succeeded and an open **release → stable** PR before posting. Comments in `rc-slack-notify.yml` and `slack-rc-notification.mts` describe this behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35b5992e3b996c5bb5a5abcca4319745fbd833ce. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->