### PR TITLE
fix(activity): transaction details width cp-13.42.0

### DIFF
--- a/ui/pages/details/dialog-modal.scss
+++ b/ui/pages/details/dialog-modal.scss
@@ -1,5 +1,5 @@
 .dialog-modal {
-  max-width: clamp(var(--width-sm), 85vw, var(--width-max));
+  max-width: var(--width-max);
   opacity: 0;
   transform: scale(var(--page-scale-distance));
 
@@ -11,10 +11,6 @@
       transform var(--page-transition-duration) var(--page-transition-ease-out),
       display var(--page-transition-duration) var(--page-transition-ease-out) allow-discrete;
   }
-}
-
-.app--sidepanel .dialog-modal {
-  max-width: var(--width-max-sidepanel);
 }
 
 @starting-style {


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Align the activity transaction details max-width with the recently updated app max width

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: #44840

## **Manual testing steps**

1. Open Activity and click a transaction.
2. Resize the window through narrow, mid (~600–900px), and wide widths.
3. Confirm details always match the app content width with no Activity showing around the edges.
4. Repeat in sidepanel while resizing the panel.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)