### PR TITLE
fix(activity): apply text color token to native dialog for dark theme cp-13.42.0

### DIFF
--- a/ui/pages/activity/activity-list.tsx
+++ b/ui/pages/activity/activity-list.tsx
@@ -200,7 +200,7 @@ export function ActivityList({
 
       <dialog
         ref={dialogRef}
-        className="dialog-modal w-full h-dvh max-h-dvh mx-auto p-0 border-0 bg-background-default text-text-default"
+        className="dialog-modal w-full h-dvh max-h-dvh mx-auto p-0 border-0 bg-background-default text-default"
         onClose={handleClose}
       >
         <TransactionDetails

--- a/ui/pages/activity/activity-list.tsx
+++ b/ui/pages/activity/activity-list.tsx
@@ -200,7 +200,7 @@ export function ActivityList({
 
       <dialog
         ref={dialogRef}
-        className="dialog-modal w-full h-dvh max-h-dvh mx-auto p-0 border-0 bg-background-default"
+        className="dialog-modal w-full h-dvh max-h-dvh mx-auto p-0 border-0 bg-background-default text-text-default"
         onClose={handleClose}
       >
         <TransactionDetails

--- a/ui/pages/details/components/shared.tsx
+++ b/ui/pages/details/components/shared.tsx
@@ -93,13 +93,12 @@ export function Row({
         {label}
       </Text>
 
-      <Text
+      <div
         className="min-w-0 break-words text-end @compact:text-s-body-sm"
         data-testid="transaction-breakdown-row-value"
-        asChild
       >
-        <div>{value}</div>
-      </Text>
+        {value}
+      </div>
     </div>
   );
 }

--- a/ui/pages/details/components/shared.tsx
+++ b/ui/pages/details/components/shared.tsx
@@ -93,12 +93,13 @@ export function Row({
         {label}
       </Text>
 
-      <div
+      <Text
         className="min-w-0 break-words text-end @compact:text-s-body-sm"
         data-testid="transaction-breakdown-row-value"
+        asChild
       >
-        {value}
-      </div>
+        <div>{value}</div>
+      </Text>
     </div>
   );
 }


### PR DESCRIPTION
## **Description**

Fixes the dark theme regression in transaction details introduced by #44599 (native \`<dialog>\` refactor).

The browser UA stylesheet sets \`color: canvastext\` directly on \`<dialog>\` elements, which overrides the inherited \`color: var(--color-text-default)\` from \`html[data-theme]\`. Because \`canvastext\` resolves based on the browser's native color-scheme rather than MetaMask's \`data-theme\` attribute, text inside the dialog renders with the wrong color in dark mode. Adding \`text-default\` here sets the MMDS color token as an author style directly on the dialog element, taking precedence over the UA rule and restoring correct text color for all descendants.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes #44836

## **Manual testing steps**

> **Note:** The bug only reproduces when your OS/system theme differs from the MetaMask theme. Set your OS to **light** mode and MetaMask to **dark** mode to trigger it.

1. Set OS appearance to Light mode
2. In MetaMask, go to Settings → General → Theme → Dark
3. Go to Activity
4. Click any transaction
5. Verify all text in the transaction details dialog is visible (white/light on dark background, not invisible black)

## **Screenshots/Recordings**

### **Before**

<img width="1506" height="869" alt="Screenshot 2026-07-24 at 1 34 22 PM" src="https://github.com/user-attachments/assets/825237cc-e95b-4915-abf1-d94aa1cebdf6" />


<img width="451" height="624" alt="Image" src="https://github.com/user-attachments/assets/fa5e2a3a-4153-40e9-a821-fc7e9e9417b3" />

### **After**

<img width="1507" height="871" alt="Screenshot 2026-07-24 at 1 31 51 PM" src="https://github.com/user-attachments/assets/34383cb5-1e6f-46d8-a15a-a05411510fba" />

<img width="455" height="651" alt="Image" src="https://github.com/user-attachments/assets/289b0c93-f702-4645-a2a0-680f4406b593" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.