### PR TITLE
refactor(ui): migrate home notification checkbox to MMDS Checkbox

### DIFF
--- a/ui/components/app/home-notification/home-notification.component.js
+++ b/ui/components/app/home-notification/home-notification.component.js
@@ -1,8 +1,8 @@
 import React, { useState } from 'react';
 import classnames from 'clsx';
 import PropTypes from 'prop-types';
+import { Checkbox } from '@metamask/design-system-react';
 import { Button, ButtonVariant, Icon, IconName } from '../../component-library';
-import Checkbox from '../../ui/check-box';
 import Tooltip from '../../ui/tooltip';
 import { IconColor } from '../../../helpers/constants/design-system';
 
@@ -34,9 +34,9 @@ const HomeNotification = ({
   const checkboxElement = checkboxText && (
     <Checkbox
       id="homeNotification_checkbox"
-      checked={checkboxState}
+      isSelected={checkboxState}
       className="home-notification__checkbox"
-      onClick={() => setCheckBoxState((checked) => !checked)}
+      onChange={() => setCheckBoxState((checked) => !checked)}
     />
   );
 


### PR DESCRIPTION
## What this does

Migrates the checkbox in the home notification component from the deprecated `CheckBox` in `ui/components/ui/check-box` to the `Checkbox` from `@metamask/design-system-react`, as tracked in #43340.

The prop mapping follows the way the MMDS `Checkbox` is already used in `edit-networks-modal`:

- `checked` becomes `isSelected`
- the toggle handler moves from `onClick` to `onChange`

No behavior change is intended. The checkbox still toggles local state and that state is still passed to `onIgnore` when the ignore button is pressed.

## Scope

One file, one component. `Tooltip` in this file stays as it is because there is no MMDS replacement for it yet, so per the tracker rules it is left untouched.

## Visual evidence

Captured from the `HomeNotification` Storybook story `WithIgnoreCheckbox`, same viewport and args for both.


Story used: `Components/App/HomeNotification` story `WithIgnoreCheckbox`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-component UI swap with equivalent state and ignore-handler wiring; no auth, data, or business-logic changes.
> 
> **Overview**
> **Home notification** swaps the deprecated `ui/check-box` control for **`Checkbox` from `@metamask/design-system-react`**, aligning with the broader MMDS migration (#43340).
> 
> Props are remapped to the MMDS API: **`checked` → `isSelected`** and **`onClick` → `onChange`**. Local toggle state and the value passed into **`onIgnore`** when the ignore button is used are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe90404aac637f7833ab0218d48fbb4c93bfbb95. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->