### PR TITLE
refactor: replace deprecated Callout with BannerAlert in confirmation page

### DIFF
--- a/ui/pages/confirmations/confirmation/confirmation.js
+++ b/ui/pages/confirmations/confirmation/confirmation.js
@@ -44,8 +44,7 @@ import {
   getIsHardwareWalletErrorModalVisible,
 } from '../../../selectors';
 import { getNetworkConfigurationsByChainId } from '../../../../shared/lib/selectors/networks';
-import Callout from '../../../components/ui/callout';
-import { Box } from '../../../components/component-library';
+import { Box, BannerAlert } from '../../../components/component-library';
 import Loading from '../../../components/ui/loading-screen';
 import SnapAuthorshipHeader from '../../../components/app/snaps/snap-authorship-header';
 import { SnapUIRenderer } from '../../../components/app/snaps/snap-ui-renderer';
@@ -608,16 +607,14 @@ export default function ConfirmationPage({
                 Object.values(alertState[pendingConfirmation.id])
                   .filter((alert) => alert.dismissed === false)
                   .map((alert, idx, filtered) => (
-                    <Callout
+                    <BannerAlert
                       key={alert.id}
                       severity={alert.severity}
-                      dismiss={() => dismissAlert(alert.id)}
-                      isFirst={idx === 0}
-                      isLast={idx === filtered.length - 1}
-                      isMultiple={filtered.length > 1}
+                      onClose={() => dismissAlert(alert.id)}
+                      marginBottom={idx === filtered.length - 1 ? 0 : 2}
                     >
                       <MetaMaskTemplateRenderer sections={alert.content} />
-                    </Callout>
+                    </BannerAlert>
                   ))
               }
               style={
@@ -641,13 +638,13 @@ export default function ConfirmationPage({
               cancelText={templatedValues.cancelText}
               loading={loading}
               submitAlerts={submitAlerts.map((alert, idx) => (
-                <Callout
+                <BannerAlert
                   key={alert.id}
                   severity={alert.severity}
-                  isFirst={idx === 0}
+                  marginBottom={idx === submitAlerts.length - 1 ? 0 : 2}
                 >
                   <MetaMaskTemplateRenderer sections={alert.content} />
-                </Callout>
+                </BannerAlert>
               ))}
             />
           )}

--- a/ui/pages/confirmations/confirmation/templates/__snapshots__/switch-ethereum-chain.test.js.snap
+++ b/ui/pages/confirmations/confirmation/templates/__snapshots__/switch-ethereum-chain.test.js.snap
@@ -204,29 +204,22 @@ exports[`switch-ethereum-chain confirmation should show alert if there are pendi
       class="confirmation-footer"
     >
       <div
-        class="callout callout--warning callout--dismissible callout--first callout--last"
+        class="mm-box mm-banner-base mm-banner-alert mm-banner-alert--severity-warning mm-box--margin-bottom-0 mm-box--padding-3 mm-box--padding-left-2 mm-box--display-flex mm-box--gap-2 mm-box--background-color-warning-muted mm-box--rounded-sm"
       >
-        <svg
-          class="info-icon info-icon--warning"
-          fill="none"
-          height="16"
-          viewBox="0 0 16 16"
-          width="16"
-          xmlns="http://www.w3.org/2000/svg"
-        >
-          <path
-            d="M15.75 8C15.75 3.75 12.25 0.25 8 0.25C3.71875 0.25 0.25 3.75 0.25 8C0.25 12.2812 3.71875 15.75 8 15.75C12.25 15.75 15.75 12.2812 15.75 8ZM8 9.5625C8.78125 9.5625 9.4375 10.2188 9.4375 11C9.4375 11.8125 8.78125 12.4375 8 12.4375C7.1875 12.4375 6.5625 11.8125 6.5625 11C6.5625 10.2188 7.1875 9.5625 8 9.5625ZM6.625 4.40625C6.59375 4.1875 6.78125 4 7 4H8.96875C9.1875 4 9.375 4.1875 9.34375 4.40625L9.125 8.65625C9.09375 8.875 8.9375 9 8.75 9H7.21875C7.03125 9 6.875 8.875 6.84375 8.65625L6.625 4.40625Z"
-          />
-        </svg>
-        <p
-          class="mm-box mm-text callout__content mm-text--body-md mm-box--color-text-default"
+        <span
+          class="mm-box mm-icon mm-icon--size-lg mm-box--display-inline-block mm-box--color-warning-default"
+          style="mask-image: url('./images/icons/danger.svg');"
+        />
+        <div
+          class="mm-box mm-box--min-width-0"
         >
           <span>
             Switching networks will cancel all pending confirmations
           </span>
-        </p>
+        </div>
         <button
-          class="mm-box mm-button-icon mm-button-icon--size-sm callout__close-button mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
+          aria-label="Close"
+          class="mm-box mm-button-icon mm-button-icon--size-sm mm-banner-base__close-button mm-box--margin-left-auto mm-box--display-inline-flex mm-box--justify-content-center mm-box--align-items-center mm-box--color-icon-default mm-box--background-color-transparent mm-box--rounded-lg"
         >
           <span
             class="mm-box mm-icon mm-icon--size-md mm-box--display-inline-block mm-box--color-inherit"

--- a/ui/pages/confirmations/confirmation/templates/create-snap-account.test.js
+++ b/ui/pages/confirmations/confirmation/templates/create-snap-account.test.js
@@ -73,7 +73,6 @@ describe('create-snap-account confirmation', () => {
       expect(
         getByText(messages.createSnapAccountTitle.message),
       ).toBeInTheDocument();
-      expect(container.querySelector('.callout')).toBeDefined();
       expect(container).toMatchSnapshot();
     });
   });

--- a/ui/pages/confirmations/confirmation/templates/remove-snap-account.test.js
+++ b/ui/pages/confirmations/confirmation/templates/remove-snap-account.test.js
@@ -75,7 +75,6 @@ describe('remove-snap-account confirmation', () => {
     );
     await waitFor(() => {
       expect(getByText(messages.removeAccount.message)).toBeInTheDocument();
-      expect(container.querySelector('.callout')).toBeDefined();
       expect(container).toMatchSnapshot();
     });
   });

--- a/ui/pages/confirmations/confirmation/templates/snap-account-redirect.test.js
+++ b/ui/pages/confirmations/confirmation/templates/snap-account-redirect.test.js
@@ -79,7 +79,6 @@ describe('snap-account-redirect confirmation', () => {
         getByText(`Follow the instructions from ${mockSnapName}`),
       ).toBeInTheDocument();
       expect(getByText('Test Snap Account Message')).toBeInTheDocument();
-      expect(container.querySelector('.callout')).toBeDefined();
       expect(container).toMatchSnapshot();
     });
   });

--- a/ui/pages/confirmations/confirmation/templates/switch-ethereum-chain.test.js
+++ b/ui/pages/confirmations/confirmation/templates/switch-ethereum-chain.test.js
@@ -62,7 +62,7 @@ describe('switch-ethereum-chain confirmation', () => {
     const store = configureMockStore(middleware)(testStore);
     const { container } = renderWithProvider(<Confirmation />, store);
     await waitFor(() => {
-      expect(container.querySelector('.callout')).toBeFalsy();
+      expect(container.querySelector('.mm-banner-alert')).toBeFalsy();
       expect(container).toMatchSnapshot();
     });
   });


### PR DESCRIPTION
## **Description**

The `Callout` component (`ui/components/ui/callout`) is deprecated in favor of the `BannerAlert` component from the component-library. This PR replaces the two remaining `Callout` usages in the confirmation page (`confirmation.js`) — the dismissible footer alerts and the submit alerts — with `BannerAlert`.

Prop migration:
- `dismiss` → `onClose` (note: `BannerAlert` dismisses immediately; the old `Callout`'s 500ms fade-out animation is not preserved, which is the standard `BannerAlert` behavior)
- `isFirst` / `isLast` / `isMultiple` (used only for spacing between stacked alerts) → `marginBottom` on all but the last alert
- `severity` is passed through unchanged — the existing values already match `BannerAlertSeverity`

The affected snapshot and a few test selectors that referenced the old `.callout` class were updated accordingly. `Callout` now has no remaining usages; removing the deprecated component itself is left as a follow-up so this PR stays a focused, single-component migration.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes #20470

## **Manual testing steps**

1. Pull this branch and run `yarn storybook`
2. Compare `Components/UI/Callout (deprecated)` (old) with `Components/ComponentLibrary/BannerAlert (deprecated)` (new)
3. In the app, trigger a confirmation that renders footer alerts (e.g. add/switch Ethereum chain with a network-detail mismatch, or switch chain with a pending transaction) and verify the alert renders as a `BannerAlert` with the correct severity styling and a working dismiss button

## **Screenshots/Recordings**

<!-- Storybook before/after of the migrated component -->

### **Before**

_Callout (deprecated)_

<img width="1056" height="112" alt="callout-BEFORE" src="https://github.com/user-attachments/assets/dfd907b6-6da5-4c00-b51e-141bec4d3034" />

### **After**

_BannerAlert_

<img width="1056" height="96" alt="banneralert-AFTER" src="https://github.com/user-attachments/assets/1bd0cc75-13a0-4bc0-92ab-292f40f72d33" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only component swap on the confirmation page with no auth, network, or transaction logic changes; behavior should match aside from BannerAlert styling.
> 
> **Overview**
> Replaces the last **Callout** usages on the templated confirmation page with **BannerAlert** from the component library, completing the deprecation path for that UI in this flow.
> 
> Footer template alerts and submit-time error alerts now use `BannerAlert` with `onClose` for dismissible warnings, `severity` unchanged, and `marginBottom` between stacked alerts instead of Callout’s `isFirst` / `isLast` / `isMultiple` spacing props. Snapshots and tests drop `.callout` checks and assert `.mm-banner-alert` where relevant (e.g. switch-chain with no pending txs).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 096dc48404af021dc1e7660a7bf0c8e45f8c5967. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->