### PR TITLE
Detect bare special-use names in isSpecialUseDomain

### DIFF
--- a/app/scripts/lib/util.test.js
+++ b/app/scripts/lib/util.test.js
@@ -1057,6 +1057,23 @@ describe('app utils', () => {
       });
     });
 
+    describe('bare special-use names used as a hostname', () => {
+      it('should return true for a bare special-use name', () => {
+        expect(isSpecialUseDomain('localhost')).toBe(true);
+        expect(isSpecialUseDomain('test')).toBe(true);
+        expect(isSpecialUseDomain('invalid')).toBe(true);
+        expect(isSpecialUseDomain('example')).toBe(true);
+        expect(isSpecialUseDomain('local')).toBe(true);
+      });
+
+      it('should not treat a public domain that merely contains a special-use name as special-use', () => {
+        expect(isSpecialUseDomain('latest')).toBe(false);
+        expect(isSpecialUseDomain('notlocal')).toBe(false);
+        expect(isSpecialUseDomain('test.com')).toBe(false);
+        expect(isSpecialUseDomain('contest.com')).toBe(false);
+      });
+    });
+
     describe('RFC 6761 reserved example domains', () => {
       it('should return true for example.com', () => {
         expect(isSpecialUseDomain('example.com')).toBe(true);

--- a/app/scripts/lib/util.ts
+++ b/app/scripts/lib/util.ts
@@ -592,8 +592,15 @@ const RESERVED_EXAMPLE_DOMAINS = ['example.com', 'example.net', 'example.org'];
 export function isSpecialUseDomain(hostname: string): boolean {
   const lowerHostname = hostname.toLowerCase();
 
-  // Check special-use TLDs
-  if (SPECIAL_USE_TLDS.some((tld) => lowerHostname.endsWith(tld))) {
+  // Check special-use TLDs. Match both the bare name used as a hostname
+  // (e.g. "localhost") and any subdomain of it (e.g. "rpc.localhost"). Without
+  // the bare-name check, a hostname like "localhost" (from "http://localhost:8545")
+  // slips through because it does not end with the ".localhost" TLD form.
+  if (
+    SPECIAL_USE_TLDS.some(
+      (tld) => lowerHostname === tld.slice(1) || lowerHostname.endsWith(tld),
+    )
+  ) {
     return true;
   }
 


### PR DESCRIPTION
## What / Why

`isSpecialUseDomain` is documented as an RFC 6761 check and is used to keep private/special-use RPC hosts out of analytics (`initializeRpcProviderDomains`, `extractRpcDomain`). It matched the special-use TLDs only in their dotted form:

```js
SPECIAL_USE_TLDS.some((tld) => lowerHostname.endsWith(tld)) // tld = '.localhost' etc.
```

So a **bare** special-use name used as a hostname was missed, because `'localhost'.endsWith('.localhost')` is `false`. Most notably:

```js
isSpecialUseDomain('localhost'); // false  <- hostname of http://localhost:8545
isSpecialUseDomain('test');      // false
isSpecialUseDomain('invalid');   // false
isSpecialUseDomain('local');     // false
```

RFC 6761 lists those bare names as special-use, so this is both a correctness gap and a small privacy gap for a function whose whole job is deciding what is safe to report.

## Change

Match the bare name as well as any subdomain of it:

```js
SPECIAL_USE_TLDS.some(
  (tld) => lowerHostname === tld.slice(1) || lowerHostname.endsWith(tld),
);
```

Public domains that merely contain a special-use name are still excluded (`latest`, `test.com`, `contest.com`, `notlocal`).

## Tests

Added cases to the existing `isSpecialUseDomain` suite for bare special-use names and for the look-alike public domains that must stay excluded. The prior suite only covered subdomain forms, which is why this slipped through.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, targeted change to hostname classification with new unit tests; affects analytics filtering only, not RPC connectivity.
> 
> **Overview**
> **`isSpecialUseDomain`** now treats **bare** RFC 6761 special-use names (e.g. `localhost`, `test`, `invalid`, `example`, `local`) as special-use, not only hostnames that end with dotted TLD forms like `.localhost`.
> 
> The TLD check adds an exact match against the bare label (`tld.slice(1)`) alongside the existing `endsWith(tld)` subdomain rule, so common dev RPC hosts such as `http://localhost:8545` are classified correctly for analytics filtering in **`initializeRpcProviderDomains`** / related RPC domain handling.
> 
> Tests cover bare special-use names and confirm look-alike public hostnames (`latest`, `test.com`, etc.) still return false.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ed04133dc43bb6b226b1418167259db09c7a564. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->