### PR TITLE
fix(pure-black): set perps balance dropdown to bg-alternative

### DIFF
--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx
@@ -9,6 +9,12 @@ import {
   invokePerpsBalanceAction,
 } from './perps-balance-dropdown';
 
+const mockUsePureBlack = jest.fn().mockReturnValue(false);
+jest.mock('@metamask/design-system-react', () => ({
+  ...jest.requireActual('@metamask/design-system-react'),
+  usePureBlack: () => mockUsePureBlack(),
+}));
+
 // Mobile test convention: mock the Compliance barrel so the gate hook never runs
 // (and never reaches the now-strict AccessRestrictedProvider context throw). The
 // gate is a passthrough here; real gating behavior is covered in
@@ -317,5 +323,39 @@ describe('PerpsBalanceDropdown', () => {
     expect(screen.getByTestId('perps-balance-dropdown-pnl-value')).toHaveClass(
       'text-success-default',
     );
+  });
+
+  describe('pure black mode', () => {
+    beforeEach(() => {
+      mockUsePureBlack.mockReturnValue(false);
+    });
+
+    it('uses bg-background-default for the dropdown panel in normal dark mode', () => {
+      renderWithProvider(<PerpsBalanceDropdown />, mockStore);
+
+      fireEvent.click(screen.getByTestId('perps-balance-dropdown-balance'));
+
+      expect(screen.getByTestId('perps-balance-dropdown-panel')).toHaveClass(
+        'bg-background-default',
+      );
+      expect(
+        screen.getByTestId('perps-balance-dropdown-panel'),
+      ).not.toHaveClass('bg-background-alternative');
+    });
+
+    it('uses bg-background-alternative for the dropdown panel in pure black mode', () => {
+      mockUsePureBlack.mockReturnValue(true);
+
+      renderWithProvider(<PerpsBalanceDropdown />, mockStore);
+
+      fireEvent.click(screen.getByTestId('perps-balance-dropdown-balance'));
+
+      expect(screen.getByTestId('perps-balance-dropdown-panel')).toHaveClass(
+        'bg-background-alternative',
+      );
+      expect(
+        screen.getByTestId('perps-balance-dropdown-panel'),
+      ).not.toHaveClass('bg-background-default');
+    });
   });
 });

--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
@@ -213,7 +213,9 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
           <Box
             className={twMerge(
               'absolute right-0 top-full z-10 mt-1 min-w-[120px] overflow-hidden rounded-lg border border-border-muted shadow-lg',
-              isPureBlack ? 'bg-background-alternative' : 'bg-background-default',
+              isPureBlack
+                ? 'bg-background-alternative'
+                : 'bg-background-default',
             )}
             flexDirection={BoxFlexDirection.Column}
             data-testid="perps-balance-dropdown-panel"

--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import {
   twMerge,
+  usePureBlack,
   TextVariant,
   TextColor,
   IconColor,
@@ -86,6 +87,9 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
   const { privacyMode } = useSelector(getPreferences);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isGeoBlockModalOpen, setIsGeoBlockModalOpen] = useState(false);
+
+  // TODO: @metamask/design-system-engineers remove isPureBlack once pure black is shipped targeted(13.43.0)
+  const isPureBlack = usePureBlack();
 
   const totalBalance = account?.totalBalance ?? '0';
   const unrealizedPnl = account?.unrealizedPnl ?? '0';
@@ -207,7 +211,10 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
         {/* Floating dropdown menu anchored to the balance row */}
         {isDropdownOpen && (
           <Box
-            className="absolute right-0 top-full z-10 mt-1 min-w-[120px] overflow-hidden rounded-lg border border-border-muted bg-background-default shadow-lg"
+            className={twMerge(
+              'absolute right-0 top-full z-10 mt-1 min-w-[120px] overflow-hidden rounded-lg border border-border-muted shadow-lg',
+              isPureBlack ? 'bg-background-alternative' : 'bg-background-default',
+            )}
             flexDirection={BoxFlexDirection.Column}
             data-testid="perps-balance-dropdown-panel"
           >


### PR DESCRIPTION
## **Description**

When pure black (OLED) dark mode is active, the Perps Balance Dropdown now uses bg-alternative as its background color with a visible border.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1184

## **Manual testing steps**

1. Enable pure black mode: add `MM_PURE_BLACK_PREVIEW=true` to `.metamaskrc`, set MetaMask theme to Dark
2. Navigate to Perps tab, click on the balance/account dropdown and verify the background is distinguishable from the page background
3. Verify the fix is applied correctly
4. Disable pure black (remove the flag) and confirm no regression in normal dark mode

## **Screenshots/Recordings**

### **Before**

<img width="402" height="352" alt="Screenshot 2026-07-24 at 3 27 59 PM" src="https://github.com/user-attachments/assets/1a1fbdfb-2799-4fe6-a8a0-cf12e21ca33a" />

### **After**

<img width="188" height="226" alt="Screenshot 2026-07-24 at 3 27 30 PM" src="https://github.com/user-attachments/assets/21bc1e14-cabe-4132-b045-3d6ceef3583f" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped Perps UI theming with no auth, data, or business-logic changes; behavior in non–pure-black mode is unchanged and covered by new tests.
> 
> **Overview**
> Fixes **pure black (OLED) dark mode** on the Perps tab so the balance **Add funds / Withdraw** dropdown panel is visible against the page.
> 
> The floating panel no longer always uses `bg-background-default`. It now reads **`usePureBlack()`** and applies **`bg-background-alternative`** when pure black is active, keeping **`bg-background-default`** in normal dark mode (existing border styling is unchanged).
> 
> Tests mock `usePureBlack` and assert the panel class for both modes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c6abc3d770db37714fd20fc2c0b4b1b06305d423. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->