### PR TITLE
fix: prevent wallet crash on invalid Contentful carousel response

### DIFF
--- a/ui/hooks/useCarouselManagement/fetchCarouselSlidesFromContentful.test.ts
+++ b/ui/hooks/useCarouselManagement/fetchCarouselSlidesFromContentful.test.ts
@@ -130,4 +130,166 @@ describe('fetchCarouselSlidesFromContentful', () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     expect(mockCaptureException).not.toHaveBeenCalled();
   });
+
+  it('skips entries with a non-string headline without crashing and reports to Sentry with the entry id', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        items: [
+          {
+            sys: { id: 'evilbanner1' },
+            fields: {
+              headline: { x: 'not-a-string' },
+              teaser: 'Check out this feature',
+              image: { sys: { id: 'img1' } },
+              linkUrl: 'https://metamask.io',
+              undismissable: false,
+              showInExtension: true,
+            },
+          },
+        ],
+        includes: {
+          Asset: [
+            {
+              sys: { id: 'img1' },
+              fields: { file: { url: '//images.ctfassets.net/x/banner.png' } },
+            },
+          ],
+        },
+      }),
+    } as Response);
+
+    const result = await fetchCarouselSlidesFromContentful();
+
+    expect(result.prioritySlides).toHaveLength(0);
+    expect(result.regularSlides).toHaveLength(0);
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    expect(mockCaptureException).toHaveBeenCalledWith(expect.any(Error), {
+      extra: { skippedEntryIds: ['evilbanner1'] },
+    });
+  });
+
+  const validFields = {
+    headline: 'Valid',
+    teaser: 'Valid description',
+    image: { sys: { id: 'asset-1' } },
+    linkUrl: 'https://example.com',
+    undismissable: false,
+    showInExtension: true,
+  };
+
+  const malformedCases: { description: string; entry: unknown }[] = [
+    {
+      description: 'a non-string teaser',
+      entry: { sys: { id: 'e' }, fields: { ...validFields, teaser: { x: 1 } } },
+    },
+    {
+      description: 'a non-string linkUrl',
+      entry: {
+        sys: { id: 'e' },
+        fields: { ...validFields, linkUrl: { x: 1 } },
+      },
+    },
+    {
+      description: 'a non-string sys.id',
+      entry: { sys: { id: 123 }, fields: { ...validFields } },
+    },
+    { description: 'a missing fields object', entry: { sys: { id: 'e' } } },
+    { description: 'a null entry', entry: null },
+    { description: 'a non-object entry', entry: 'not-an-object' },
+  ];
+
+  malformedCases.forEach(({ description, entry }) => {
+    it(`skips an entry with ${description} without crashing and reports to Sentry`, async () => {
+      fetchSpy.mockResolvedValue({
+        ok: true,
+        json: async () => makeBannerResponse({ items: [entry] }),
+      } as Response);
+
+      const result = await fetchCarouselSlidesFromContentful();
+
+      expect(result.prioritySlides).toHaveLength(0);
+      expect(result.regularSlides).toHaveLength(0);
+      expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('keeps valid entries and skips malformed ones in the same response', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () =>
+        makeBannerResponse({
+          items: [
+            {
+              sys: { id: 'good-banner' },
+              fields: {
+                headline: 'Valid Banner',
+                teaser: 'Valid description',
+                image: { sys: { id: 'asset-1' } },
+                linkUrl: 'https://example.com',
+                undismissable: false,
+                showInExtension: true,
+              },
+            },
+            {
+              sys: { id: 'bad-banner' },
+              fields: {
+                headline: { nested: 'object' },
+                teaser: 'Bad description',
+                image: { sys: { id: 'asset-1' } },
+                linkUrl: 'https://example.com',
+                undismissable: false,
+                showInExtension: true,
+              },
+            },
+          ],
+        }),
+    } as Response);
+
+    const result = await fetchCarouselSlidesFromContentful();
+
+    expect(result.regularSlides).toHaveLength(1);
+    expect(result.regularSlides[0].title).toBe('Valid Banner');
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    expect(mockCaptureException).toHaveBeenCalledWith(expect.any(Error), {
+      extra: { skippedEntryIds: ['bad-banner'] },
+    });
+  });
+
+  it('reports every skipped entry id in a single Sentry event when multiple entries are malformed', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () =>
+        makeBannerResponse({
+          items: [
+            {
+              sys: { id: 'bad-1' },
+              fields: { ...validFields, headline: { x: 1 } },
+            },
+            null,
+          ],
+        }),
+    } as Response);
+
+    const result = await fetchCarouselSlidesFromContentful();
+
+    expect(result.regularSlides).toHaveLength(0);
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+    expect(mockCaptureException).toHaveBeenCalledWith(expect.any(Error), {
+      extra: { skippedEntryIds: ['bad-1', 'unknown'] },
+    });
+  });
+
+  it('reports and returns no slides when items is not an array', async () => {
+    fetchSpy.mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: undefined }),
+    } as Response);
+
+    const result = await fetchCarouselSlidesFromContentful();
+
+    expect(result.prioritySlides).toHaveLength(0);
+    expect(result.regularSlides).toHaveLength(0);
+    expect(mockCaptureException).toHaveBeenCalledWith(expect.any(Error));
+  });
 });

--- a/ui/hooks/useCarouselManagement/fetchCarouselSlidesFromContentful.ts
+++ b/ui/hooks/useCarouselManagement/fetchCarouselSlidesFromContentful.ts
@@ -87,6 +87,53 @@ export class UnknownLocaleError extends Error {
   }
 }
 
+/**
+ * Validates that a raw Contentful entry has the shape we rely on. The response
+ * comes from an external API and cannot be trusted: if fields such as
+ * `headline` come back as a non-string (e.g. an object), rendering the slide
+ * crashes the wallet. Malformed entries are skipped rather than rendered.
+ *
+ * @param entry - A raw item from the Contentful response.
+ * @returns True if the entry can be safely turned into a slide.
+ */
+function isValidContentfulBanner(entry: unknown): entry is ContentfulBanner {
+  if (typeof entry !== 'object' || entry === null) {
+    return false;
+  }
+  const { sys, fields } = entry as Partial<ContentfulBanner>;
+  if (
+    typeof sys?.id !== 'string' ||
+    typeof fields !== 'object' ||
+    fields === null
+  ) {
+    return false;
+  }
+  // These fields are rendered or used for navigation directly, so they must be
+  // strings to avoid runtime crashes. `image` is intentionally not validated
+  // here because `resolveImage` degrades gracefully on a missing/malformed
+  // reference.
+  return (
+    typeof fields.headline === 'string' &&
+    typeof fields.teaser === 'string' &&
+    typeof fields.linkUrl === 'string'
+  );
+}
+
+/**
+ * Safely extracts a Contentful entry id for diagnostics. The entry may itself
+ * be malformed, so this never throws.
+ *
+ * @param entry - A raw item from the Contentful response.
+ * @returns The entry's `sys.id` when it is a string, otherwise `'unknown'`.
+ */
+function getContentfulEntryId(entry: unknown): string {
+  if (typeof entry !== 'object' || entry === null) {
+    return 'unknown';
+  }
+  const { sys } = entry as Partial<ContentfulBanner>;
+  return typeof sys?.id === 'string' ? sys.id : 'unknown';
+}
+
 async function fetchEntries(
   baseUrl: URL,
   locale?: string,
@@ -158,8 +205,25 @@ export async function fetchCarouselSlidesFromContentful(
 
   const prioritySlides: CarouselSlide[] = [];
   const regularSlides: CarouselSlide[] = [];
+  const skippedEntryIds: string[] = [];
 
-  for (const entry of res.items) {
+  // A well-formed response always has an array here; anything else is an
+  // unexpected response shape worth reporting rather than silently ignoring.
+  let items: unknown[] = [];
+  if (Array.isArray(res.items)) {
+    items = res.items;
+  } else {
+    captureException(
+      new Error('Contentful response `items` field was not an array'),
+    );
+  }
+
+  for (const entry of items) {
+    if (!isValidContentfulBanner(entry)) {
+      skippedEntryIds.push(getContentfulEntryId(entry));
+      continue;
+    }
+
     const {
       headline,
       teaser,
@@ -198,6 +262,15 @@ export async function fetchCarouselSlidesFromContentful(
     } else {
       regularSlides.push(slide);
     }
+  }
+
+  // Report once per fetch (with the affected entry ids) rather than once per
+  // entry, so a broken content batch cannot flood Sentry. The message is kept
+  // static so Sentry groups these together; the count/ids live in `extra`.
+  if (skippedEntryIds.length > 0) {
+    captureException(new Error('Skipped malformed Contentful banner entries'), {
+      extra: { skippedEntryIds },
+    });
   }
 
   return { prioritySlides, regularSlides };


### PR DESCRIPTION
## **Description**

The promotional banner carousel on the home screen builds its slides directly from the Contentful API response (`cdn.contentful.com`). The response was cast to a trusted type and used without any runtime validation, so when a field such as `headline` came back as a non-string (e.g. an object), rendering the slide threw *"Objects are not valid as a React child"* and crashed the wallet home screen.

This adds validation at the fetch boundary in `fetchCarouselSlidesFromContentful.ts`: each banner entry whose required string fields (`headline`, `teaser`, `linkUrl`) are not strings is skipped and reported to Sentry instead of being rendered. It also guards against a non-array `items` field. Valid slides in the same response are unaffected.

## **Changelog**

CHANGELOG entry: Fixed a crash on the home screen that could occur when the promotional banner service returned an unexpected API response.

## **Related issues**

Fixes #43953

## **Manual testing steps**

1. Set up a proxy (e.g. Charles/mitmproxy) intercepting the request to `https://cdn.contentful.com/spaces/{SPACE_ID}/environments/master/entries?...&content_type=promotionalBanner&fields.showInExtension=true`
2. Return a response where a banner's `headline` is an object instead of a string (the exact payload is in #43953)
3. Open the wallet home screen
4. **Before** this change: the wallet crashes. **After**: the malformed banner is skipped, the home screen renders normally, and the error is reported to Sentry

Automated coverage is included: `fetchCarouselSlidesFromContentful.test.ts` now feeds the malformed payload from the issue and asserts the entry is skipped without crashing, that valid entries in the same response still render, and that a non-array `items` field is handled.

## **Screenshots/Recordings**

<!-- Before recording is in the linked issue #43953. -->

### **Before**

_Home screen crashes (see recording in #43953)._

### **After**

_Home screen renders normally; the malformed banner is skipped._

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Defensive parsing at the Contentful fetch boundary with graceful degradation and observability; no auth, payments, or core wallet state changes.
> 
> **Overview**
> **Hardens the home-screen promotional carousel** against untrusted Contentful API payloads by validating each banner entry before it becomes a slide.
> 
> `fetchCarouselSlidesFromContentful` now checks that required string fields (`headline`, `teaser`, `linkUrl`) and `sys.id` are actually strings; invalid entries are **skipped** while valid ones in the same response still render. If `items` is not an array, the fetch returns empty slides and reports to Sentry. Skipped entry ids are batched into **one** Sentry event per fetch (via `extra.skippedEntryIds`) to avoid noise.
> 
> Tests cover malformed headlines/teasers/linkUrls, null entries, mixed good/bad batches, and non-array `items`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d98fb2030638fccee83ddcfc3789ee168be0a9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->