### PR TITLE
fix(pure-black): add border to account rename modal

### DIFF
--- a/ui/components/multichain-accounts/multichain-account-edit-modal/multichain-account-edit-modal.test.tsx
+++ b/ui/components/multichain-accounts/multichain-account-edit-modal/multichain-account-edit-modal.test.tsx
@@ -16,6 +16,11 @@ jest.mock('../../../store/actions', () => ({
   }),
 }));
 
+jest.mock('@metamask/design-system-react', () => ({
+  ...jest.requireActual('@metamask/design-system-react'),
+  usePureBlack: jest.fn().mockReturnValue(false),
+}));
+
 describe('MultichainAccountEditModal', () => {
   const mockProps: MultichainAccountEditModalProps = {
     isOpen: true,
@@ -306,6 +311,31 @@ describe('MultichainAccountEditModal', () => {
         'New Account Name',
       );
       expect(mockProps.onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('pure black mode', () => {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { usePureBlack } = require('@metamask/design-system-react');
+
+    it('applies border-muted class to ModalContent dialog when pure black is active', () => {
+      (usePureBlack as jest.Mock).mockReturnValue(true);
+      const store = configureStore(mockDefaultState);
+      renderWithProvider(<MultichainAccountEditModal {...mockProps} />, store);
+
+      // The modal dialog Box rendered by ModalContent receives the border class
+      const dialog = screen.getByRole('dialog');
+      expect(dialog.parentElement).toHaveClass('border');
+      expect(dialog.parentElement).toHaveClass('border-muted');
+    });
+
+    it('does not apply border class to ModalContent dialog when pure black is inactive', () => {
+      (usePureBlack as jest.Mock).mockReturnValue(false);
+      const store = configureStore(mockDefaultState);
+      renderWithProvider(<MultichainAccountEditModal {...mockProps} />, store);
+
+      const dialog = screen.getByRole('dialog');
+      expect(dialog.parentElement).not.toHaveClass('border-muted');
     });
   });
 });

--- a/ui/components/multichain-accounts/multichain-account-edit-modal/multichain-account-edit-modal.tsx
+++ b/ui/components/multichain-accounts/multichain-account-edit-modal/multichain-account-edit-modal.tsx
@@ -11,6 +11,7 @@ import {
   ModalFooter,
   ModalHeader,
   ModalOverlay,
+  usePureBlack,
 } from '@metamask/design-system-react';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { setAccountGroupName } from '../../../store/actions';
@@ -29,6 +30,8 @@ export const MultichainAccountEditModal = ({
 }: MultichainAccountEditModalProps) => {
   const t = useI18nContext();
   const dispatch = useDispatch();
+  // TODO: @metamask/design-system-engineers remove isPureBlack once pure black is shipped targeted(13.43.0)
+  const isPureBlack = usePureBlack();
   const accountGroup = useSelector((state) =>
     getMultichainAccountGroupById(state, accountGroupId),
   );
@@ -63,7 +66,11 @@ export const MultichainAccountEditModal = ({
   return (
     <Modal isOpen={isOpen} onClose={onClose}>
       <ModalOverlay />
-      <ModalContent>
+      <ModalContent
+        modalDialogProps={{
+          className: isPureBlack ? 'border border-muted' : undefined,
+        }}
+      >
         <ModalHeader
           data-testid="account-edit-modal-header"
           onClose={onClose}


### PR DESCRIPTION
## **Description**

When pure black (OLED) dark mode is active, the account rename modal now displays with a visible border-muted border, providing visual separation from the pure black background.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1173, https://consensyssoftware.atlassian.net/browse/TMCU-1178

## **Manual testing steps**

1. Enable pure black mode: add `MM_PURE_BLACK_PREVIEW=true` to `.metamaskrc`, set MetaMask theme to Dark
2. Navigate to Accounts > click three-dot menu on an account > select Rename, verify the modal has a visible border
3. Verify the fix is applied correctly
4. Disable pure black (remove the flag) and confirm no regression in normal dark mode

## **Screenshots/Recordings**

### **Before**

<!-- Visual verification required by reviewer - component lacks correct pure black styling -->

### **After**

<!-- Visual verification required by reviewer -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic modal styling gated on a design-system flag; no changes to rename logic or account data.
> 
> **Overview**
> When **pure black (OLED) dark mode** is on, the multichain **account rename** modal now gets a **muted border** on the dialog so it stands out from the background.
> 
> `MultichainAccountEditModal` reads `usePureBlack()` and passes `border border-muted` through `ModalContent`’s `modalDialogProps` only when that flag is true; normal dark mode is unchanged.
> 
> Tests mock `usePureBlack` and assert the dialog wrapper has (or lacks) those classes. A TODO notes removing this hook after pure black ships (~13.43.0).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4ca7de627409898394f5faad8352ef82f18ff9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->