### PR TITLE
fix(pure-black): correct tooltip background and arrow colors in dark and pure black themes

### DIFF
--- a/ui/components/ui/tooltip/index.scss
+++ b/ui/components/ui/tooltip/index.scss
@@ -2,7 +2,7 @@
 
 .tippy-popper {
   .tippy-tooltip.tippy-tooltip--mm-custom-theme {
-    background: var(--color-background-section);
+    background: var(--color-background-default);
     color: var(--color-text-default);
     box-shadow: var(--shadow-size-md) var(--color-shadow-default);
     padding: 10px 14px;
@@ -47,27 +47,26 @@
 }
 
 // TODO: @metamask/design-system-engineers remove once pure black is shipped targeted(13.43.0)
-html[data-theme='dark'][data-pure-black='true'] {
+html[data-theme='dark'] {
   .tippy-popper {
     .tippy-tooltip.tippy-tooltip--mm-custom-theme {
-      background: var(--color-background-alternative);
-      border: 1px solid var(--color-border-muted);
+      background: var(--color-background-section);
     }
 
     &[x-placement^='top'] .tippy-tooltip.tippy-tooltip--mm-custom-theme [x-arrow] {
-      border-top-color: var(--color-background-alternative);
+      border-top-color: var(--color-background-section);
     }
 
     &[x-placement^='right'] .tippy-tooltip.tippy-tooltip--mm-custom-theme [x-arrow] {
-      border-right-color: var(--color-background-alternative);
+      border-right-color: var(--color-background-section);
     }
 
     &[x-placement^='left'] .tippy-tooltip.tippy-tooltip--mm-custom-theme [x-arrow] {
-      border-left-color: var(--color-background-alternative);
+      border-left-color: var(--color-background-section);
     }
 
     &[x-placement^='bottom'] .tippy-tooltip.tippy-tooltip--mm-custom-theme [x-arrow] {
-      border-bottom-color: var(--color-background-alternative);
+      border-bottom-color: var(--color-background-section);
     }
   }
 }

--- a/ui/components/ui/tooltip/index.scss
+++ b/ui/components/ui/tooltip/index.scss
@@ -45,3 +45,29 @@
     border-bottom-color: var(--color-background-default);
   }
 }
+
+// TODO: @metamask/design-system-engineers remove once pure black is shipped targeted(13.43.0)
+html[data-theme='dark'][data-pure-black='true'] {
+  .tippy-popper {
+    .tippy-tooltip.tippy-tooltip--mm-custom-theme {
+      background: var(--color-background-alternative);
+      border: 1px solid var(--color-border-muted);
+    }
+
+    &[x-placement^='top'] .tippy-tooltip.tippy-tooltip--mm-custom-theme [x-arrow] {
+      border-top-color: var(--color-background-alternative);
+    }
+
+    &[x-placement^='right'] .tippy-tooltip.tippy-tooltip--mm-custom-theme [x-arrow] {
+      border-right-color: var(--color-background-alternative);
+    }
+
+    &[x-placement^='left'] .tippy-tooltip.tippy-tooltip--mm-custom-theme [x-arrow] {
+      border-left-color: var(--color-background-alternative);
+    }
+
+    &[x-placement^='bottom'] .tippy-tooltip.tippy-tooltip--mm-custom-theme [x-arrow] {
+      border-bottom-color: var(--color-background-alternative);
+    }
+  }
+}


### PR DESCRIPTION
## **Description**

Fixes two tooltip issues in dark mode:

1. **Invisible arrow (pre-existing bug):** The CSS triangle arrow was colored with `background-default` while the tooltip body used `background-section`. In dark mode, `background-default` resolves to `#131416` — nearly identical to the page background — causing the arrow to be invisible (it blended into the background rather than appearing as a visual extension of the tooltip).

2. **Wrong tooltip background in pure black:** The base tooltip used `background-section` universally, which caused light mode tooltips to render with a muted grey tint instead of white. A targeted `[data-theme='dark']` override now applies `background-section` only in dark contexts. Because `--color-background-section` resolves to `#1c1d1f` in dark and `#18181b` in pure black, a single selector covers both modes without needing a separate `[data-pure-black='true']` block.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1179, https://consensyssoftware.atlassian.net/browse/TMCU-1186, https://consensyssoftware.atlassian.net/browse/TMCU-1189, https://consensyssoftware.atlassian.net/browse/TMCU-1190

## **Manual testing steps**

1. Enable pure black mode: add `MM_PURE_BLACK_PREVIEW=true` to `.metamaskrc`, set MetaMask theme to Dark
2. Hover over any info icon, gas fee, or confirmation tooltip to trigger a tooltip display
3. Verify the tooltip arrow is visible and matches the tooltip body color
4. Disable pure black (remove the flag) and confirm no regression in normal dark mode or light mode

## **Screenshots/Recordings**

### *Before*

<img width="204" height="211" alt="Screenshot 2026-07-27 at 7 33 55 PM" src="https://github.com/user-attachments/assets/0de93772-bec2-4fa5-9e4c-1f796b4d38aa" /><img width="220" height="227" alt="Screenshot 2026-07-27 at 7 34 14 PM" src="https://github.com/user-attachments/assets/1c083ffc-e1dd-4626-9086-d5b0837ada9d" />


### *After*

<img width="193" height="192" alt="Screenshot 2026-07-27 at 7 34 32 PM" src="https://github.com/user-attachments/assets/efb4f6a0-0fe2-45fa-98dc-a6a97faf6732" /><img width="226" height="221" alt="Screenshot 2026-07-27 at 7 34 48 PM" src="https://github.com/user-attachments/assets/23196883-565d-4308-b4b1-561054578558" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.