### PR TITLE
fix(pure-black): set main action button dropdown to bg-alternative

### DIFF
--- a/ui/components/app/wallet-overview/coin-buttons.test.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.test.tsx
@@ -1,0 +1,146 @@
+import React from 'react';
+import { fireEvent, waitFor } from '@testing-library/react';
+import { EthAccountType, EthMethod } from '@metamask/keyring-api';
+import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
+import configureStore from '../../../store/store';
+import mockState from '../../../../test/data/mock-state.json';
+import CoinButtons from './coin-buttons';
+
+jest.mock('@metamask/design-system-react', () => ({
+  ...jest.requireActual('@metamask/design-system-react'),
+  usePureBlack: jest.fn(() => false),
+}));
+
+jest.mock('../../../hooks/useAnalytics', () => {
+  const { createEventBuilder } = jest.requireActual(
+    '../../../../shared/lib/analytics/create-event-builder',
+  );
+  return {
+    useAnalytics: () => ({
+      trackEvent: jest.fn(),
+      createEventBuilder,
+    }),
+  };
+});
+
+jest.mock('../../../hooks/ramps/useRampsNavigation/useRampsNavigation', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    goToBuy: jest.fn(),
+    isRampsEnabled: false,
+  })),
+}));
+
+jest.mock('../../../hooks/bridge/useBridging', () => ({
+  __esModule: true,
+  default: jest.fn(() => ({
+    openBridgeExperience: jest.fn(),
+  })),
+}));
+
+jest.mock('../../../hooks/batch-sell/useBatchSell', () => ({
+  useBatchSell: jest.fn(() => ({
+    openBatchSellExperience: jest.fn(),
+  })),
+}));
+
+jest.mock('../../../hooks/useMultichainSelector', () => ({
+  useMultichainSelector: jest.fn((selector) => {
+    if (selector.name === 'getMultichainNetwork') {
+      // CHAIN_IDS.MAINNET = '0x1'
+      return { isEvmNetwork: true, chainId: '0x1' };
+    }
+    return 'ETH';
+  }),
+}));
+
+jest.mock('../../../selectors/multichain', () => ({
+  getMultichainNativeCurrency: jest.fn(),
+  getMultichainNetwork: jest.fn(),
+}));
+
+jest.mock('../../../selectors/batch-sell/feature-flags', () => ({
+  getIsBatchSellEnabled: jest.fn(() => true),
+}));
+
+jest.mock(
+  '../../../../shared/lib/multichain-accounts/remote-feature-flag',
+  () => ({
+    ...jest.requireActual(
+      '../../../../shared/lib/multichain-accounts/remote-feature-flag',
+    ),
+    isMultichainAccountsFeatureEnabled: () => false,
+  }),
+);
+
+jest.mock('../../../store/actions', () => ({
+  setActiveNetworkWithError: jest.fn(),
+  tokenBalancesStartPolling: jest.fn().mockResolvedValue('pollingToken'),
+  tokenBalancesStopPollingByPollingToken: jest.fn(),
+}));
+
+const mockAccount = {
+  address: '0x0000000000000000000000000000000000000001',
+  id: 'mock-account-id',
+  metadata: { name: 'Test Account', keyring: { type: 'HD Key Tree' } },
+  options: {},
+  methods: Object.values(EthMethod),
+  type: EthAccountType.Eoa,
+};
+
+const renderCoinButtons = (batchSellEnabled = true) => {
+  const state = {
+    ...mockState,
+    metamask: {
+      ...mockState.metamask,
+      featureFlags: {
+        ...((mockState.metamask as Record<string, unknown>).featureFlags ?? {}),
+        batchSellEnabled,
+      },
+    },
+  };
+  const store = configureStore(state);
+
+  return renderWithProvider(
+    <CoinButtons
+      account={mockAccount as Parameters<typeof CoinButtons>[0]['account']}
+      chainId="0x1"
+      trackingLocation="home"
+      isSwapsChain={false}
+      isSigningEnabled
+    />,
+    store,
+    '/',
+  );
+};
+
+describe('CoinButtons – MoreButtonsGroup pure black dropdown', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    const { usePureBlack } = jest.requireMock('@metamask/design-system-react');
+    usePureBlack.mockReturnValue(false);
+  });
+
+  it('uses bg-background-default for the dropdown in normal mode', async () => {
+    const { getByTestId, container } = renderCoinButtons();
+    fireEvent.click(getByTestId('coin-overview-more'));
+
+    await waitFor(() => {
+      const dropdown = container.querySelector('.bg-background-default');
+      expect(dropdown).toBeInTheDocument();
+    });
+  });
+
+  it('uses bg-background-alternative for the dropdown in pure black mode', async () => {
+    const { usePureBlack } = jest.requireMock('@metamask/design-system-react');
+    usePureBlack.mockReturnValue(true);
+
+    const { getByTestId, container } = renderCoinButtons();
+    fireEvent.click(getByTestId('coin-overview-more'));
+
+    await waitFor(() => {
+      const dropdown = container.querySelector('.bg-background-alternative');
+      expect(dropdown).toBeInTheDocument();
+    });
+  });
+});

--- a/ui/components/app/wallet-overview/coin-buttons.test.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.test.tsx
@@ -24,6 +24,7 @@ jest.mock('../../../hooks/useAnalytics', () => {
 });
 
 jest.mock('../../../hooks/ramps/useRampsNavigation/useRampsNavigation', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   __esModule: true,
   default: jest.fn(() => ({
     goToBuy: jest.fn(),
@@ -32,6 +33,7 @@ jest.mock('../../../hooks/ramps/useRampsNavigation/useRampsNavigation', () => ({
 }));
 
 jest.mock('../../../hooks/bridge/useBridging', () => ({
+  // eslint-disable-next-line @typescript-eslint/naming-convention
   __esModule: true,
   default: jest.fn(() => ({
     openBridgeExperience: jest.fn(),

--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -29,6 +29,7 @@ import {
   TextAlign,
   TextColor,
   TextVariant,
+  usePureBlack,
 } from '@metamask/design-system-react';
 import { useAnalytics } from '../../../hooks/useAnalytics';
 import { useAppSelector } from '../../../store/store';
@@ -123,6 +124,8 @@ const MoreButtonsGroup = ({
   modalIsOpen,
 }: MoreButtonsGroupProps) => {
   const t = useContext(I18nContext);
+  // TODO: @metamask/design-system-engineers remove isPureBlack once pure black is shipped targeted(13.43.0)
+  const isPureBlack = usePureBlack();
   const hasOnlyOneEnabledAction =
     actions.filter(({ enabled }) => enabled).length === 1;
   const onlyEnabledAction = actions.filter(({ enabled }) => enabled)[0];
@@ -164,7 +167,7 @@ const MoreButtonsGroup = ({
         onClick={onClick}
       />
       {modalIsOpen && (
-        <Box className="flex flex-col absolute right-0 top-full z-10 mt-4 min-w-[120px] overflow-hidden rounded-lg border border-border-muted bg-background-default shadow-lg">
+        <Box className={`flex flex-col absolute right-0 top-full z-10 mt-4 min-w-[120px] overflow-hidden rounded-lg border border-border-muted shadow-lg${isPureBlack ? ' bg-background-alternative' : ' bg-background-default'}`}>
           {actions.map((action) => (
             <ButtonBase
               key={action.label}

--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -167,7 +167,9 @@ const MoreButtonsGroup = ({
         onClick={onClick}
       />
       {modalIsOpen && (
-        <Box className={`flex flex-col absolute right-0 top-full z-10 mt-4 min-w-[120px] overflow-hidden rounded-lg border border-border-muted shadow-lg${isPureBlack ? ' bg-background-alternative' : ' bg-background-default'}`}>
+        <Box
+          className={`flex flex-col absolute right-0 top-full z-10 mt-4 min-w-[120px] overflow-hidden rounded-lg border border-border-muted shadow-lg${isPureBlack ? ' bg-background-alternative' : ' bg-background-default'}`}
+        >
           {actions.map((action) => (
             <ButtonBase
               key={action.label}


### PR DESCRIPTION
## **Description**

When pure black (OLED) dark mode is active, the Main Action Button dropdown now uses bg-alternative as its background color, providing visual separation from the pure black backdrop.

The `MoreButtonsGroup` component in `coin-buttons.tsx` now conditionally applies `bg-background-alternative` (instead of `bg-background-default`) when `usePureBlack()` returns true.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1188

## **Manual testing steps**

1. Enable pure black mode: add `MM_PURE_BLACK_PREVIEW=true` to `.metamaskrc`, set MetaMask theme to Dark
2. Click the main action button area (Buy/Send/Swap) — specifically the "More" (three-dot) button to open its dropdown
3. Verify the dropdown background is visible (bg-alternative, not pure black)
4. Disable pure black (remove the flag) and confirm no regression in normal dark mode

## **Screenshots/Recordings**

### **Before**

<img width="254" height="231" alt="Screenshot 2026-07-28 at 8 53 37 AM" src="https://github.com/user-attachments/assets/997c2453-aae7-49ed-a13d-b1c59bf4ca7d" /><img width="243" height="218" alt="Screenshot 2026-07-28 at 8 53 19 AM" src="https://github.com/user-attachments/assets/ad2e5545-aad6-42dc-b01a-72fbc68c3219" />

### **After**

<img width="261" height="228" alt="Screenshot 2026-07-28 at 8 45 48 AM" src="https://github.com/user-attachments/assets/b4fa288b-7019-4f9a-b243-b0b166714585" /><img width="283" height="233" alt="Screenshot 2026-07-28 at 8 52 48 AM" src="https://github.com/user-attachments/assets/ae2a9979-3033-41af-8dc3-aacb1a0cdbe8" />

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI class change behind an existing theme hook; no auth, data, or transaction logic affected.
> 
> **Overview**
> In **pure black (OLED) dark mode**, the wallet overview **More** menu dropdown (`MoreButtonsGroup` in `coin-buttons.tsx`) now uses **`bg-background-alternative`** instead of **`bg-background-default`**, so the panel stays visible against the black backdrop. Normal dark mode behavior is unchanged via `usePureBlack()`.
> 
> Adds **`coin-buttons.test.tsx`** coverage that opens the More dropdown and asserts the expected background class for `usePureBlack()` true vs false.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 087daaf3562bb5a6b949262375814e601333d9d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->