### PR TITLE
fix(pure-black): settings sidebar uses bg-alternative in pure black mode

### DIFF
--- a/ui/pages/settings/settings.test.tsx
+++ b/ui/pages/settings/settings.test.tsx
@@ -225,41 +225,87 @@ describe('Settings', () => {
     beforeEach(() => {
       jest.clearAllMocks();
       setBackgroundConnection(backgroundConnectionMock as never);
-      mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_FULLSCREEN);
     });
 
-    it('applies bg-background-default and border-r border-muted to sidebar in pure black mode', async () => {
-      const { usePureBlack } = jest.requireMock(
-        '@metamask/design-system-react',
-      );
-      usePureBlack.mockReturnValue(true);
-      mockPathname = CURRENCY_ROUTE;
+    describe('fullscreen', () => {
+      beforeEach(() => {
+        mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_FULLSCREEN);
+      });
 
-      const { container } = renderSettings(mockStore);
-
-      await waitFor(() => {
-        const sidebar = container.querySelector(
-          '.border-r.border-muted',
+      it('applies bg-background-default and border-r border-muted to sidebar in pure black mode', async () => {
+        const { usePureBlack } = jest.requireMock(
+          '@metamask/design-system-react',
         );
-        expect(sidebar).toBeInTheDocument();
+        usePureBlack.mockReturnValue(true);
+        mockPathname = CURRENCY_ROUTE;
+
+        const { container } = renderSettings(mockStore);
+
+        await waitFor(() => {
+          expect(
+            container.querySelector('.border-r.border-muted'),
+          ).toBeInTheDocument();
+        });
+      });
+
+      it('applies bg-background-muted to sidebar when pure black is off', async () => {
+        const { usePureBlack } = jest.requireMock(
+          '@metamask/design-system-react',
+        );
+        usePureBlack.mockReturnValue(false);
+        mockPathname = CURRENCY_ROUTE;
+
+        const { container } = renderSettings(mockStore);
+
+        await waitFor(() => {
+          expect(
+            container.querySelector('.bg-background-muted'),
+          ).toBeInTheDocument();
+          expect(
+            container.querySelector('.border-r.border-muted'),
+          ).not.toBeInTheDocument();
+        });
       });
     });
 
-    it('applies bg-background-muted to sidebar when pure black is off', async () => {
-      const { usePureBlack } = jest.requireMock(
-        '@metamask/design-system-react',
-      );
-      usePureBlack.mockReturnValue(false);
-      mockPathname = CURRENCY_ROUTE;
+    describe('popup', () => {
+      beforeEach(() => {
+        mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_POPUP);
+      });
 
-      const { container } = renderSettings(mockStore);
+      it('applies bg-background-alternative to sidebar in pure black mode', async () => {
+        const { usePureBlack } = jest.requireMock(
+          '@metamask/design-system-react',
+        );
+        usePureBlack.mockReturnValue(true);
+        mockPathname = CURRENCY_ROUTE;
 
-      await waitFor(() => {
-        const sidebar = container.querySelector('.bg-background-muted');
-        expect(sidebar).toBeInTheDocument();
-        expect(
-          container.querySelector('.border-r.border-muted'),
-        ).not.toBeInTheDocument();
+        const { container } = renderSettings(mockStore);
+
+        await waitFor(() => {
+          expect(
+            container.querySelector('.bg-background-alternative'),
+          ).toBeInTheDocument();
+        });
+      });
+
+      it('applies bg-background-default to sidebar when pure black is off', async () => {
+        const { usePureBlack } = jest.requireMock(
+          '@metamask/design-system-react',
+        );
+        usePureBlack.mockReturnValue(false);
+        mockPathname = CURRENCY_ROUTE;
+
+        const { container } = renderSettings(mockStore);
+
+        await waitFor(() => {
+          expect(
+            container.querySelector('.bg-background-default'),
+          ).toBeInTheDocument();
+          expect(
+            container.querySelector('.bg-background-alternative'),
+          ).not.toBeInTheDocument();
+        });
       });
     });
   });

--- a/ui/pages/settings/settings.test.tsx
+++ b/ui/pages/settings/settings.test.tsx
@@ -21,6 +21,11 @@ import {
 } from '../../../shared/constants/app';
 import Settings from './settings';
 
+jest.mock('@metamask/design-system-react', () => ({
+  ...jest.requireActual('@metamask/design-system-react'),
+  usePureBlack: jest.fn(() => false),
+}));
+
 const mockNavigate = jest.fn();
 const mockGetEnvironmentType = jest.fn(() => ENVIRONMENT_TYPE_POPUP);
 
@@ -212,6 +217,49 @@ describe('Settings', () => {
 
       await waitFor(() => {
         expect(mockNavigate).toHaveBeenCalledWith(NOTIFICATIONS_SETTINGS_ROUTE);
+      });
+    });
+  });
+
+  describe('pure black theme', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+      setBackgroundConnection(backgroundConnectionMock as never);
+      mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_FULLSCREEN);
+    });
+
+    it('applies bg-background-default and border-r border-muted to sidebar in pure black mode', async () => {
+      const { usePureBlack } = jest.requireMock(
+        '@metamask/design-system-react',
+      );
+      usePureBlack.mockReturnValue(true);
+      mockPathname = CURRENCY_ROUTE;
+
+      const { container } = renderSettings(mockStore);
+
+      await waitFor(() => {
+        const sidebar = container.querySelector(
+          '.border-r.border-muted',
+        );
+        expect(sidebar).toBeInTheDocument();
+      });
+    });
+
+    it('applies bg-background-muted to sidebar when pure black is off', async () => {
+      const { usePureBlack } = jest.requireMock(
+        '@metamask/design-system-react',
+      );
+      usePureBlack.mockReturnValue(false);
+      mockPathname = CURRENCY_ROUTE;
+
+      const { container } = renderSettings(mockStore);
+
+      await waitFor(() => {
+        const sidebar = container.querySelector('.bg-background-muted');
+        expect(sidebar).toBeInTheDocument();
+        expect(
+          container.querySelector('.border-r.border-muted'),
+        ).not.toBeInTheDocument();
       });
     });
   });

--- a/ui/pages/settings/settings.test.tsx
+++ b/ui/pages/settings/settings.test.tsx
@@ -225,87 +225,41 @@ describe('Settings', () => {
     beforeEach(() => {
       jest.clearAllMocks();
       setBackgroundConnection(backgroundConnectionMock as never);
+      mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_FULLSCREEN);
     });
 
-    describe('fullscreen', () => {
-      beforeEach(() => {
-        mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_FULLSCREEN);
-      });
+    it('applies bg-background-alternative to sidebar in pure black mode', async () => {
+      const { usePureBlack } = jest.requireMock(
+        '@metamask/design-system-react',
+      );
+      usePureBlack.mockReturnValue(true);
+      mockPathname = CURRENCY_ROUTE;
 
-      it('applies bg-background-default and border-r border-muted to sidebar in pure black mode', async () => {
-        const { usePureBlack } = jest.requireMock(
-          '@metamask/design-system-react',
-        );
-        usePureBlack.mockReturnValue(true);
-        mockPathname = CURRENCY_ROUTE;
+      const { container } = renderSettings(mockStore);
 
-        const { container } = renderSettings(mockStore);
-
-        await waitFor(() => {
-          expect(
-            container.querySelector('.border-r.border-muted'),
-          ).toBeInTheDocument();
-        });
-      });
-
-      it('applies bg-background-muted to sidebar when pure black is off', async () => {
-        const { usePureBlack } = jest.requireMock(
-          '@metamask/design-system-react',
-        );
-        usePureBlack.mockReturnValue(false);
-        mockPathname = CURRENCY_ROUTE;
-
-        const { container } = renderSettings(mockStore);
-
-        await waitFor(() => {
-          expect(
-            container.querySelector('.bg-background-muted'),
-          ).toBeInTheDocument();
-          expect(
-            container.querySelector('.border-r.border-muted'),
-          ).not.toBeInTheDocument();
-        });
+      await waitFor(() => {
+        expect(
+          container.querySelector('.bg-background-alternative'),
+        ).toBeInTheDocument();
       });
     });
 
-    describe('popup', () => {
-      beforeEach(() => {
-        mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_POPUP);
-      });
+    it('applies bg-background-muted to sidebar when pure black is off', async () => {
+      const { usePureBlack } = jest.requireMock(
+        '@metamask/design-system-react',
+      );
+      usePureBlack.mockReturnValue(false);
+      mockPathname = CURRENCY_ROUTE;
 
-      it('applies bg-background-alternative to sidebar in pure black mode', async () => {
-        const { usePureBlack } = jest.requireMock(
-          '@metamask/design-system-react',
-        );
-        usePureBlack.mockReturnValue(true);
-        mockPathname = CURRENCY_ROUTE;
+      const { container } = renderSettings(mockStore);
 
-        const { container } = renderSettings(mockStore);
-
-        await waitFor(() => {
-          expect(
-            container.querySelector('.bg-background-alternative'),
-          ).toBeInTheDocument();
-        });
-      });
-
-      it('applies bg-background-default to sidebar when pure black is off', async () => {
-        const { usePureBlack } = jest.requireMock(
-          '@metamask/design-system-react',
-        );
-        usePureBlack.mockReturnValue(false);
-        mockPathname = CURRENCY_ROUTE;
-
-        const { container } = renderSettings(mockStore);
-
-        await waitFor(() => {
-          expect(
-            container.querySelector('.bg-background-default'),
-          ).toBeInTheDocument();
-          expect(
-            container.querySelector('.bg-background-alternative'),
-          ).not.toBeInTheDocument();
-        });
+      await waitFor(() => {
+        expect(
+          container.querySelector('.bg-background-muted'),
+        ).toBeInTheDocument();
+        expect(
+          container.querySelector('.bg-background-alternative'),
+        ).not.toBeInTheDocument();
       });
     });
   });

--- a/ui/pages/settings/settings.tsx
+++ b/ui/pages/settings/settings.tsx
@@ -340,7 +340,6 @@ const SettingsLayout = ({ children }: { children: React.ReactNode }) => {
             {
               flex: isOnSettingsRoot || !usesCompactSettingsLayout,
               hidden: !isOnSettingsRoot && usesCompactSettingsLayout,
-              'max-w-full': isOnSettingsRoot && usesCompactSettingsLayout,
             },
           )}
         >

--- a/ui/pages/settings/settings.tsx
+++ b/ui/pages/settings/settings.tsx
@@ -335,22 +335,12 @@ const SettingsLayout = ({ children }: { children: React.ReactNode }) => {
         <Box
           className={classnames(
             'w-full h-full max-w-[262px]',
-            // Popup/compact: mirrors the GlobalMenuDrawer pattern (bg-alternative in pure black).
-            // Fullscreen: bg-muted normally, bg-default in pure black to avoid muted-overlay artifact.
-            // TODO: @metamask/design-system-engineers remove isPureBlack conditions once pure black is shipped targeted(13.43.0)
-            usesCompactSettingsLayout
-              ? isPureBlack
-                ? 'bg-background-alternative'
-                : 'bg-background-default'
-              : isPureBlack
-                ? 'bg-background-default'
-                : 'bg-background-muted',
+            // TODO: @metamask/design-system-engineers remove isPureBlack once pure black is shipped targeted(13.43.0)
+            isPureBlack ? 'bg-background-alternative' : 'bg-background-muted',
             {
               flex: isOnSettingsRoot || !usesCompactSettingsLayout,
               hidden: !isOnSettingsRoot && usesCompactSettingsLayout,
               'max-w-full': isOnSettingsRoot && usesCompactSettingsLayout,
-              'border-r border-muted':
-                isPureBlack && !usesCompactSettingsLayout,
             },
           )}
         >

--- a/ui/pages/settings/settings.tsx
+++ b/ui/pages/settings/settings.tsx
@@ -335,15 +335,20 @@ const SettingsLayout = ({ children }: { children: React.ReactNode }) => {
         <Box
           className={classnames(
             'w-full h-full max-w-[262px]',
-            isPureBlack ? 'bg-background-default' : 'bg-background-muted',
+            // Popup/compact: mirrors the GlobalMenuDrawer pattern (bg-alternative in pure black).
+            // Fullscreen: bg-muted normally, bg-default in pure black to avoid muted-overlay artifact.
+            // TODO: @metamask/design-system-engineers remove isPureBlack conditions once pure black is shipped targeted(13.43.0)
+            usesCompactSettingsLayout
+              ? isPureBlack
+                ? 'bg-background-alternative'
+                : 'bg-background-default'
+              : isPureBlack
+                ? 'bg-background-default'
+                : 'bg-background-muted',
             {
               flex: isOnSettingsRoot || !usesCompactSettingsLayout,
               hidden: !isOnSettingsRoot && usesCompactSettingsLayout,
-              'max-w-full bg-background-default':
-                isOnSettingsRoot && usesCompactSettingsLayout,
-              // Single right border provides visual separation from the content
-              // panel in pure black mode, replacing the muted-background edge
-              // that would otherwise create a double-border effect.
+              'max-w-full': isOnSettingsRoot && usesCompactSettingsLayout,
               'border-r border-muted':
                 isPureBlack && !usesCompactSettingsLayout,
             },

--- a/ui/pages/settings/settings.tsx
+++ b/ui/pages/settings/settings.tsx
@@ -27,6 +27,7 @@ import {
   Text,
   TextColor,
   TextVariant,
+  usePureBlack,
 } from '@metamask/design-system-react';
 import classnames from 'clsx';
 import { useSelector } from 'react-redux';
@@ -129,6 +130,9 @@ const SettingsLayout = ({ children }: { children: React.ReactNode }) => {
   const normalizedPathname = normalizeSettingsPath(location.pathname);
   const meta = getSettingsRouteMeta(normalizedPathname);
   const environmentType = getEnvironmentType();
+
+  // TODO: @metamask/design-system-engineers remove isPureBlack once pure black is shipped targeted(13.43.0)
+  const isPureBlack = usePureBlack();
 
   const isSidepanel = environmentType === ENVIRONMENT_TYPE_SIDEPANEL;
   const isCompactSidepanel = useIsSidepanelCompactSettingsLayout(isSidepanel);
@@ -330,12 +334,18 @@ const SettingsLayout = ({ children }: { children: React.ReactNode }) => {
       >
         <Box
           className={classnames(
-            'w-full h-full max-w-[262px] bg-background-muted',
+            'w-full h-full max-w-[262px]',
+            isPureBlack ? 'bg-background-default' : 'bg-background-muted',
             {
               flex: isOnSettingsRoot || !usesCompactSettingsLayout,
               hidden: !isOnSettingsRoot && usesCompactSettingsLayout,
               'max-w-full bg-background-default':
                 isOnSettingsRoot && usesCompactSettingsLayout,
+              // Single right border provides visual separation from the content
+              // panel in pure black mode, replacing the muted-background edge
+              // that would otherwise create a double-border effect.
+              'border-r border-muted':
+                isPureBlack && !usesCompactSettingsLayout,
             },
           )}
         >


### PR DESCRIPTION
## **Description**

In pure black (OLED) dark mode, the settings navigation panel was using `bg-background-muted` which is visually heavier than the side menu drawer. The fix changes it to `bg-background-alternative` to match the `GlobalMenuDrawer` pattern used throughout the app.

**Dead code removed:** The `'max-w-full bg-background-default': isOnSettingsRoot && usesCompactSettingsLayout` classname condition in the `else` branch was unreachable — that condition is the definition of `showRootLandingPage`, which takes the `else if` branch above instead.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1182

## **Manual testing steps**

1. Add `MM_PURE_BLACK_PREVIEW=true` to `.metamaskrc`, set MetaMask theme to Dark
2. Open Settings and navigate to any sub-page (e.g. General → Currency)
3. Verify the left navigation panel uses `bg-background-alternative`, matching the side menu drawer
4. Remove the flag and confirm `bg-background-muted` is restored with no regression

## **Screenshots/Recordings**

### **Before**

Settings nav panel shows bg-background-muted (too heavy)

https://github.com/user-attachments/assets/b8e7899c-e9a9-4b0d-86bd-a85c04d987c8

### **After**

Settings nav panel shows bg-background-alternative, matching the side menu drawer

https://github.com/user-attachments/assets/7ed00eff-f429-4260-b5d8-42a6bddc8ffa


Testing across expanded, side panel, popup in both light and dark mode

https://github.com/user-attachments/assets/0e40ef34-0a0d-4c0d-a176-624975ec05b0

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.