### PR TITLE
test: add LavaMoat runtime E2E coverage

### DIFF
--- a/app/offscreen/offscreen.ts
+++ b/app/offscreen/offscreen.ts
@@ -11,6 +11,8 @@ import initTrezor from './hardware-wallets/trezor';
 import initLattice from './hardware-wallets/lattice';
 import initConnectivityDetection from './connectivity';
 
+// This E2E-only probe runs in browser CI, outside Istanbul coverage.
+/* istanbul ignore next */
 if (process.env.IN_TEST && process.env.JEST_WORKER_ID === 'undefined') {
   const { hasConsoleAccess } =
     // Load conditionally so this test-only package is excluded from production builds and policies.

--- a/app/offscreen/offscreen.ts
+++ b/app/offscreen/offscreen.ts
@@ -11,6 +11,17 @@ import initTrezor from './hardware-wallets/trezor';
 import initLattice from './hardware-wallets/lattice';
 import initConnectivityDetection from './connectivity';
 
+if (process.env.IN_TEST) {
+  const { hasConsoleAccess } =
+    // Load conditionally so this test-only package is excluded from production builds and policies.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, n/global-require
+    require('@metamask/lavamoat-policy-probe');
+
+  document.documentElement.dataset.lavaMoatPolicyProbeConsoleAccess = String(
+    hasConsoleAccess(),
+  );
+}
+
 /**
  * Initialize a post message stream with the parent window that is initialized
  * in the metamask-controller (background/serivce worker) process. This will be

--- a/app/offscreen/offscreen.ts
+++ b/app/offscreen/offscreen.ts
@@ -11,15 +11,14 @@ import initTrezor from './hardware-wallets/trezor';
 import initLattice from './hardware-wallets/lattice';
 import initConnectivityDetection from './connectivity';
 
-if (process.env.IN_TEST) {
+if (process.env.IN_TEST && process.env.JEST_WORKER_ID === 'undefined') {
   const { hasConsoleAccess } =
     // Load conditionally so this test-only package is excluded from production builds and policies.
     // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, n/global-require
     require('@metamask/lavamoat-policy-probe');
 
-  document.documentElement.dataset.lavaMoatPolicyProbeConsoleAccess = String(
-    hasConsoleAccess(),
-  );
+  document.documentElement.dataset.lavaMoatPolicyProbeConsoleAccess =
+    String(hasConsoleAccess());
 }
 
 /**

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -140,6 +140,29 @@ const maxSeenFailedNonces = 99;
 
 const inTest = process.env.IN_TEST;
 
+if (process.env.IN_TEST) {
+  const { hasConsoleAccess } =
+    // Load conditionally so this test-only package is excluded from production builds and policies.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, n/global-require
+    require('@metamask/lavamoat-policy-probe');
+
+  const hasLavaMoatPolicyProbeConsoleAccess = hasConsoleAccess();
+
+  if (isManifestV3) {
+    browser.storage.session
+      .set({
+        hasLavaMoatPolicyProbeConsoleAccess,
+      })
+      .catch((error) => {
+        console.error('Failed to store the LavaMoat policy probe result', error);
+      });
+  } else {
+    document.documentElement.dataset.lavaMoatPolicyProbeConsoleAccess = String(
+      hasLavaMoatPolicyProbeConsoleAccess,
+    );
+  }
+}
+
 const VAULT_AT_STARTUP_TEST_WINDOW_MS = 60_000;
 
 /**

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -140,6 +140,8 @@ const maxSeenFailedNonces = 99;
 
 const inTest = process.env.IN_TEST;
 
+// This E2E-only probe runs in browser CI, outside Istanbul coverage.
+/* istanbul ignore next */
 if (process.env.IN_TEST && process.env.JEST_WORKER_ID === 'undefined') {
   const { hasConsoleAccess } =
     // Load conditionally so this test-only package is excluded from production builds and policies.

--- a/app/scripts/background.js
+++ b/app/scripts/background.js
@@ -140,7 +140,7 @@ const maxSeenFailedNonces = 99;
 
 const inTest = process.env.IN_TEST;
 
-if (process.env.IN_TEST) {
+if (process.env.IN_TEST && process.env.JEST_WORKER_ID === 'undefined') {
   const { hasConsoleAccess } =
     // Load conditionally so this test-only package is excluded from production builds and policies.
     // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, n/global-require
@@ -154,7 +154,10 @@ if (process.env.IN_TEST) {
         hasLavaMoatPolicyProbeConsoleAccess,
       })
       .catch((error) => {
-        console.error('Failed to store the LavaMoat policy probe result', error);
+        console.error(
+          'Failed to store the LavaMoat policy probe result',
+          error,
+        );
       });
   } else {
     document.documentElement.dataset.lavaMoatPolicyProbeConsoleAccess = String(

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "metamask-crx",
   "version": "13.41.0",
   "private": true,
+  "workspaces": [
+    "test/fakes/lavamoat-policy-probe"
+  ],
   "imports": {
     "#ui/*": [
       "./ui/*",
@@ -592,7 +595,7 @@
     "@metamask/forwarder": "^1.1.0",
     "@metamask/foundryup": "^1.0.1",
     "@metamask/java-tron-up": "^1.0.0",
-    "@metamask/lavamoat-policy-probe": "file:test/fakes/lavamoat-policy-probe",
+    "@metamask/lavamoat-policy-probe": "workspace:*",
     "@metamask/messenger-cli": "^0.1.0",
     "@metamask/phishing-warning": "^5.1.0",
     "@metamask/preferences-controller": "^23.0.0",

--- a/package.json
+++ b/package.json
@@ -592,6 +592,7 @@
     "@metamask/forwarder": "^1.1.0",
     "@metamask/foundryup": "^1.0.1",
     "@metamask/java-tron-up": "^1.0.0",
+    "@metamask/lavamoat-policy-probe": "file:test/fakes/lavamoat-policy-probe",
     "@metamask/messenger-cli": "^0.1.0",
     "@metamask/phishing-warning": "^5.1.0",
     "@metamask/preferences-controller": "^23.0.0",

--- a/test/e2e/tests/account/lavamoat.spec.ts
+++ b/test/e2e/tests/account/lavamoat.spec.ts
@@ -1,0 +1,81 @@
+import { strict as assert } from 'assert';
+import { withFixtures } from '../../helpers';
+import { PAGES, Driver } from '../../webdriver/driver';
+import { executeScriptInExtensionServiceWorker } from '../../webdriver/extension-service-worker';
+import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
+import { isManifestV3 } from '../../../../shared/lib/mv3.utils';
+
+const policyProbeScript = `
+const storageKey = 'hasLavaMoatPolicyProbeConsoleAccess';
+const deadline = Date.now() + 10_000;
+
+while (Date.now() < deadline) {
+  const result = await chrome.storage.session.get(storageKey);
+  if (typeof result[storageKey] === 'boolean') {
+    return result[storageKey];
+  }
+  await new Promise((resolve) => setTimeout(resolve, 50));
+}
+
+throw new Error('The LavaMoat policy probe result is unavailable');
+`;
+
+const domPolicyProbeScript = `
+return document.documentElement.dataset.lavaMoatPolicyProbeConsoleAccess;
+`;
+
+describe('LavaMoat policy', function (this: Mocha.Suite) {
+  it('denies unapproved globals in the UI dependency graph', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilderV2().build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        await driver.navigate(PAGES.HOME);
+
+        assert.strictEqual(
+          await driver.executeScript(domPolicyProbeScript),
+          'false',
+          'Expected LavaMoat to deny console access to the UI policy probe package',
+        );
+      },
+    );
+  });
+
+  it('denies unapproved globals in the background dependency graph', async function () {
+    await withFixtures(
+      {
+        fixtures: new FixtureBuilderV2().build(),
+        title: this.test?.fullTitle(),
+      },
+      async ({ driver }: { driver: Driver }) => {
+        if (isManifestV3) {
+          await driver.navigate(PAGES.OFFSCREEN);
+          assert.strictEqual(
+            await driver.executeScript(domPolicyProbeScript),
+            'false',
+            'Expected LavaMoat to deny console access to the offscreen policy probe package',
+          );
+
+          await driver.navigate(PAGES.HOME);
+          assert.strictEqual(
+            await executeScriptInExtensionServiceWorker(
+              driver,
+              policyProbeScript,
+            ),
+            false,
+            'Expected LavaMoat to deny console access to the service worker policy probe package',
+          );
+        } else {
+          await driver.navigate(PAGES.BACKGROUND);
+          assert.strictEqual(
+            await driver.executeScript(domPolicyProbeScript),
+            'false',
+            'Expected LavaMoat to deny console access to the background policy probe package',
+          );
+        }
+      },
+    );
+  });
+});

--- a/test/e2e/tests/account/lockdown.spec.ts
+++ b/test/e2e/tests/account/lockdown.spec.ts
@@ -1,8 +1,14 @@
 import { strict as assert } from 'assert';
+import { Browser } from 'selenium-webdriver';
 import { withFixtures } from '../../helpers';
 import { PAGES, Driver } from '../../webdriver/driver';
+import { executeScriptInExtensionServiceWorker } from '../../webdriver/extension-service-worker';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { isManifestV3 } from '../../../../shared/lib/mv3.utils';
+
+const isFirefox = process.env.SELENIUM_BROWSER === Browser.FIREFOX;
+
+const lockdownTarget = isFirefox ? 'window' : 'globalThis';
 
 // Detect scuttling by prodding globals until found
 // This for loop is likely running only once, unless the first global it finds is in the exceptions list. The test is immune to changes to scuttling exceptions.
@@ -27,15 +33,15 @@ function assertScuttling() {
 }
 
 // This is enough of a proof that lockdown is in effect and the shared prototypes are also hardened.
-function assertLockdown() {
+function assertLockdown(target: typeof globalThis) {
   if (
     !(
       (
-        Object.isFrozen(window.Object) &&
-        Object.isFrozen(window.Object.prototype) &&
-        Object.isFrozen(window.Function) &&
-        Object.isFrozen(window.Function.prototype) &&
-        Function.prototype.constructor !== window.Function
+        Object.isFrozen(target.Object) &&
+        Object.isFrozen(target.Object.prototype) &&
+        Object.isFrozen(target.Function) &&
+        Object.isFrozen(target.Function.prototype) &&
+        target.Function.prototype.constructor !== target.Function
       ) // this is proof that repairIntrinsics part of lockdown worked
     )
   ) {
@@ -45,7 +51,7 @@ function assertLockdown() {
 
 const testCode = `
 ${assertLockdown.toString()};
-assertLockdown();
+assertLockdown(${lockdownTarget});
 ${assertScuttling.toString()};
 assertScuttling();
 return true;
@@ -81,15 +87,24 @@ describe('lockdown', function (this: Mocha.Suite) {
       },
       async ({ driver }: { driver: Driver }) => {
         if (isManifestV3) {
-          // TODO: add logic for testing the Service-Worker on MV3
           await driver.navigate(PAGES.OFFSCREEN);
+          assert(
+            await driver.executeScript(testCode),
+            'Expected script execution to be complete. driver.executeScript might have failed silently.',
+          );
+
+          await driver.navigate(PAGES.HOME);
+          assert(
+            await executeScriptInExtensionServiceWorker(driver, testCode),
+            'Expected script execution to be complete. executeScriptInExtensionServiceWorker might have failed silently.',
+          );
         } else {
           await driver.navigate(PAGES.BACKGROUND);
+          assert(
+            await driver.executeScript(testCode),
+            'Expected script execution to be complete. driver.executeScript might have failed silently.',
+          );
         }
-        assert(
-          await driver.executeScript(testCode),
-          'Expected script execution to be complete. driver.executeScript might have failed silently.',
-        );
       },
     );
   });

--- a/test/e2e/webdriver/extension-service-worker.ts
+++ b/test/e2e/webdriver/extension-service-worker.ts
@@ -1,0 +1,170 @@
+import type { Driver } from './driver';
+
+type CdpCommandResponse<Result> = {
+  error?: {
+    code?: number;
+    message?: string;
+  };
+  result?: Result;
+};
+
+type CdpConnection = {
+  sessionId: string | null;
+  send: <Result>(
+    method: string,
+    params?: Record<string, unknown>,
+  ) => Promise<CdpCommandResponse<Result>>;
+};
+
+type ServiceWorkerTarget = {
+  targetId: string;
+  type: string;
+  url: string;
+};
+
+type GetTargetsResult = {
+  targetInfos?: ServiceWorkerTarget[];
+};
+
+type AttachToTargetResult = {
+  sessionId?: string;
+};
+
+type RuntimeEvaluationResult = {
+  exceptionDetails?: {
+    exception?: {
+      description?: string;
+    };
+    text?: string;
+  };
+  result?: {
+    value?: unknown;
+  };
+};
+
+async function sendCdpCommand<Result>(
+  connection: CdpConnection,
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<Result | undefined> {
+  const { error, result } = await connection.send<Result>(method, params);
+
+  if (error) {
+    const code = error.code === undefined ? '' : ` (${error.code})`;
+    throw new Error(
+      `CDP command ${method} failed${code}: ${error.message ?? 'Unknown error'}`,
+    );
+  }
+
+  return result;
+}
+
+/**
+ * Executes a script in the extension's MV3 service worker.
+ *
+ * @param driver - The active E2E driver.
+ * @param script - The service worker script body to execute.
+ * @param timeout - Maximum time to wait for the service worker target.
+ * @returns The script's serialized return value.
+ */
+export async function executeScriptInExtensionServiceWorker(
+  driver: Driver,
+  script: string,
+  timeout: number = driver.timeout,
+): Promise<unknown> {
+  const cdpConnection = (await driver.driver.createCDPConnection(
+    'browser',
+  )) as CdpConnection;
+  let target: ServiceWorkerTarget | undefined;
+
+  try {
+    await driver.waitUntil(
+      async () => {
+        const result = await sendCdpCommand<GetTargetsResult>(
+          cdpConnection,
+          'Target.getTargets',
+        );
+        target = result?.targetInfos?.find(
+          ({ type, url }) =>
+            type === 'service_worker' && url.startsWith(driver.extensionUrl),
+        );
+        return target !== undefined;
+      },
+      { interval: 250, timeout },
+    );
+  } catch (error) {
+    const result = await sendCdpCommand<GetTargetsResult>(
+      cdpConnection,
+      'Target.getTargets',
+    );
+    const errorMessage =
+      error instanceof Error && error.message ? `${error.message} ` : '';
+
+    throw new Error(
+      `Failed to resolve the extension service worker target for ${
+        driver.extensionUrl
+      }. ${errorMessage}Known targets: ${JSON.stringify(
+        result?.targetInfos ?? [],
+        null,
+        2,
+      )}`,
+    );
+  }
+
+  if (!target) {
+    throw new Error(
+      `Failed to resolve the extension service worker target for ${driver.extensionUrl}`,
+    );
+  }
+
+  const attachResult = await sendCdpCommand<AttachToTargetResult>(
+    cdpConnection,
+    'Target.attachToTarget',
+    {
+      targetId: target.targetId,
+      flatten: true,
+    },
+  );
+  const sessionId = attachResult?.sessionId;
+
+  if (!sessionId) {
+    throw new Error(
+      `Failed to attach to extension service worker target ${target.targetId}`,
+    );
+  }
+
+  cdpConnection.sessionId = sessionId;
+
+  try {
+    await sendCdpCommand(cdpConnection, 'Runtime.enable');
+    const evaluationResult = await sendCdpCommand<RuntimeEvaluationResult>(
+      cdpConnection,
+      'Runtime.evaluate',
+      {
+        expression: `(async () => {\n${script}\n})()`,
+        awaitPromise: true,
+        returnByValue: true,
+      },
+    );
+
+    if (evaluationResult?.exceptionDetails) {
+      throw new Error(
+        evaluationResult.exceptionDetails.exception?.description ??
+          evaluationResult.exceptionDetails.text ??
+          'Runtime evaluation failed in the extension service worker',
+      );
+    }
+
+    return evaluationResult?.result?.value;
+  } finally {
+    cdpConnection.sessionId = null;
+
+    try {
+      await sendCdpCommand(cdpConnection, 'Target.detachFromTarget', {
+        sessionId,
+      });
+    } catch {
+      // The worker may terminate before the best-effort cleanup completes.
+    }
+  }
+}

--- a/test/e2e/webdriver/extension-service-worker.ts
+++ b/test/e2e/webdriver/extension-service-worker.ts
@@ -41,7 +41,9 @@ export async function executeScriptInExtensionServiceWorker(
     const { error, result } = await cdpConnection.send<Result>(method, params);
 
     if (error) {
-      throw new Error(`CDP ${method} failed: ${error.message ?? 'Unknown error'}`);
+      throw new Error(
+        `CDP ${method} failed: ${error.message ?? 'Unknown error'}`,
+      );
     }
 
     return result as Result;

--- a/test/e2e/webdriver/extension-service-worker.ts
+++ b/test/e2e/webdriver/extension-service-worker.ts
@@ -1,19 +1,14 @@
 import type { Driver } from './driver';
 
-type CdpCommandResponse<Result> = {
-  error?: {
-    code?: number;
-    message?: string;
-  };
-  result?: Result;
-};
-
 type CdpConnection = {
   sessionId: string | null;
-  send: <Result>(
+  send<Result>(
     method: string,
     params?: Record<string, unknown>,
-  ) => Promise<CdpCommandResponse<Result>>;
+  ): Promise<{
+    error?: { message?: string };
+    result?: Result;
+  }>;
 };
 
 type ServiceWorkerTarget = {
@@ -22,51 +17,14 @@ type ServiceWorkerTarget = {
   url: string;
 };
 
-type GetTargetsResult = {
-  targetInfos?: ServiceWorkerTarget[];
-};
-
-type AttachToTargetResult = {
-  sessionId?: string;
-};
-
 type RuntimeEvaluationResult = {
   exceptionDetails?: {
-    exception?: {
-      description?: string;
-    };
+    exception?: { description?: string };
     text?: string;
   };
-  result?: {
-    value?: unknown;
-  };
+  result?: { value?: unknown };
 };
 
-async function sendCdpCommand<Result>(
-  connection: CdpConnection,
-  method: string,
-  params?: Record<string, unknown>,
-): Promise<Result | undefined> {
-  const { error, result } = await connection.send<Result>(method, params);
-
-  if (error) {
-    const code = error.code === undefined ? '' : ` (${error.code})`;
-    throw new Error(
-      `CDP command ${method} failed${code}: ${error.message ?? 'Unknown error'}`,
-    );
-  }
-
-  return result;
-}
-
-/**
- * Executes a script in the extension's MV3 service worker.
- *
- * @param driver - The active E2E driver.
- * @param script - The service worker script body to execute.
- * @param timeout - Maximum time to wait for the service worker target.
- * @returns The script's serialized return value.
- */
 export async function executeScriptInExtensionServiceWorker(
   driver: Driver,
   script: string,
@@ -75,70 +33,48 @@ export async function executeScriptInExtensionServiceWorker(
   const cdpConnection = (await driver.driver.createCDPConnection(
     'browser',
   )) as CdpConnection;
-  let target: ServiceWorkerTarget | undefined;
 
-  try {
-    await driver.waitUntil(
-      async () => {
-        const result = await sendCdpCommand<GetTargetsResult>(
-          cdpConnection,
-          'Target.getTargets',
-        );
-        target = result?.targetInfos?.find(
-          ({ type, url }) =>
-            type === 'service_worker' && url.startsWith(driver.extensionUrl),
-        );
-        return target !== undefined;
-      },
-      { interval: 250, timeout },
-    );
-  } catch (error) {
-    const result = await sendCdpCommand<GetTargetsResult>(
-      cdpConnection,
-      'Target.getTargets',
-    );
-    const errorMessage =
-      error instanceof Error && error.message ? `${error.message} ` : '';
+  async function send<Result>(
+    method: string,
+    params?: Record<string, unknown>,
+  ): Promise<Result> {
+    const { error, result } = await cdpConnection.send<Result>(method, params);
 
-    throw new Error(
-      `Failed to resolve the extension service worker target for ${
-        driver.extensionUrl
-      }. ${errorMessage}Known targets: ${JSON.stringify(
-        result?.targetInfos ?? [],
-        null,
-        2,
-      )}`,
-    );
+    if (error) {
+      throw new Error(`CDP ${method} failed: ${error.message ?? 'Unknown error'}`);
+    }
+
+    return result as Result;
   }
 
-  if (!target) {
-    throw new Error(
-      `Failed to resolve the extension service worker target for ${driver.extensionUrl}`,
-    );
-  }
+  const target = (await driver.driver.wait(
+    async () => {
+      const { targetInfos } = await send<{
+        targetInfos: ServiceWorkerTarget[];
+      }>('Target.getTargets');
 
-  const attachResult = await sendCdpCommand<AttachToTargetResult>(
-    cdpConnection,
+      return targetInfos.find(
+        ({ type, url }) =>
+          type === 'service_worker' && url.startsWith(driver.extensionUrl),
+      );
+    },
+    timeout,
+    `Failed to resolve the extension service worker target for ${driver.extensionUrl}`,
+    250,
+  )) as ServiceWorkerTarget;
+
+  const { sessionId } = await send<{ sessionId: string }>(
     'Target.attachToTarget',
     {
       targetId: target.targetId,
       flatten: true,
     },
   );
-  const sessionId = attachResult?.sessionId;
-
-  if (!sessionId) {
-    throw new Error(
-      `Failed to attach to extension service worker target ${target.targetId}`,
-    );
-  }
 
   cdpConnection.sessionId = sessionId;
 
   try {
-    await sendCdpCommand(cdpConnection, 'Runtime.enable');
-    const evaluationResult = await sendCdpCommand<RuntimeEvaluationResult>(
-      cdpConnection,
+    const evaluationResult = await send<RuntimeEvaluationResult>(
       'Runtime.evaluate',
       {
         expression: `(async () => {\n${script}\n})()`,
@@ -147,7 +83,7 @@ export async function executeScriptInExtensionServiceWorker(
       },
     );
 
-    if (evaluationResult?.exceptionDetails) {
+    if (evaluationResult.exceptionDetails) {
       throw new Error(
         evaluationResult.exceptionDetails.exception?.description ??
           evaluationResult.exceptionDetails.text ??
@@ -155,16 +91,11 @@ export async function executeScriptInExtensionServiceWorker(
       );
     }
 
-    return evaluationResult?.result?.value;
+    return evaluationResult.result?.value;
   } finally {
     cdpConnection.sessionId = null;
 
-    try {
-      await sendCdpCommand(cdpConnection, 'Target.detachFromTarget', {
-        sessionId,
-      });
-    } catch {
-      // The worker may terminate before the best-effort cleanup completes.
-    }
+    // The worker may terminate before the best-effort cleanup completes.
+    await send('Target.detachFromTarget', { sessionId }).catch(() => undefined);
   }
 }

--- a/test/fakes/lavamoat-policy-probe/index.ts
+++ b/test/fakes/lavamoat-policy-probe/index.ts
@@ -1,0 +1,3 @@
+export function hasConsoleAccess() {
+  return typeof console !== 'undefined' && typeof console.log === 'function';
+}

--- a/test/fakes/lavamoat-policy-probe/package.json
+++ b/test/fakes/lavamoat-policy-probe/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "@metamask/lavamoat-policy-probe",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "main": "./index.ts"
+}

--- a/ui/index.js
+++ b/ui/index.js
@@ -69,15 +69,14 @@ export {
   CriticalErrorTranslationKey,
 } from './helpers/utils/display-critical-error';
 
-if (process.env.IN_TEST) {
+if (process.env.IN_TEST && process.env.JEST_WORKER_ID === 'undefined') {
   const { hasConsoleAccess } =
     // Load conditionally so this test-only package is excluded from production builds and policies.
     // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, n/global-require
     require('@metamask/lavamoat-policy-probe');
 
-  document.documentElement.dataset.lavaMoatPolicyProbeConsoleAccess = String(
-    hasConsoleAccess(),
-  );
+  document.documentElement.dataset.lavaMoatPolicyProbeConsoleAccess =
+    String(hasConsoleAccess());
 }
 
 log.setLevel(global.METAMASK_DEBUG ? 'debug' : 'warn', false);

--- a/ui/index.js
+++ b/ui/index.js
@@ -69,6 +69,17 @@ export {
   CriticalErrorTranslationKey,
 } from './helpers/utils/display-critical-error';
 
+if (process.env.IN_TEST) {
+  const { hasConsoleAccess } =
+    // Load conditionally so this test-only package is excluded from production builds and policies.
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires, n/global-require
+    require('@metamask/lavamoat-policy-probe');
+
+  document.documentElement.dataset.lavaMoatPolicyProbeConsoleAccess = String(
+    hasConsoleAccess(),
+  );
+}
+
 log.setLevel(global.METAMASK_DEBUG ? 'debug' : 'warn', false);
 
 /**

--- a/ui/index.js
+++ b/ui/index.js
@@ -69,6 +69,8 @@ export {
   CriticalErrorTranslationKey,
 } from './helpers/utils/display-critical-error';
 
+// This E2E-only probe runs in browser CI, outside Istanbul coverage.
+/* istanbul ignore next */
 if (process.env.IN_TEST && process.env.JEST_WORKER_ID === 'undefined') {
   const { hasConsoleAccess } =
     // Load conditionally so this test-only package is excluded from production builds and policies.

--- a/yarn.lock
+++ b/yarn.lock
@@ -6966,6 +6966,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@metamask/lavamoat-policy-probe@file:test/fakes/lavamoat-policy-probe::locator=metamask-crx%40workspace%3A.":
+  version: 0.0.0
+  resolution: "@metamask/lavamoat-policy-probe@file:test/fakes/lavamoat-policy-probe#test/fakes/lavamoat-policy-probe::hash=c3d450&locator=metamask-crx%40workspace%3A."
+  checksum: 10/3fd8069c0ae84bd2a8acaf2960bd4da50bae52f3f90d7d07ed6b65958c5baff479afd432282aa18ceaa7d1f499d02d46db63d8a2d0c0fa78bf98ecdc00b8474a
+  languageName: node
+  linkType: hard
+
 "@metamask/local-node-utils@npm:^1.0.0":
   version: 1.0.0
   resolution: "@metamask/local-node-utils@npm:1.0.0"
@@ -32835,6 +32842,7 @@ __metadata:
     "@metamask/keyring-sdk": "npm:^2.2.0"
     "@metamask/keyring-snap-client": "npm:^9.0.2"
     "@metamask/keyring-utils": "npm:^3.3.1"
+    "@metamask/lavamoat-policy-probe": "file:test/fakes/lavamoat-policy-probe"
     "@metamask/logging-controller": "npm:^8.0.0"
     "@metamask/logo": "npm:^4.0.0"
     "@metamask/message-manager": "npm:^14.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6966,12 +6966,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/lavamoat-policy-probe@file:test/fakes/lavamoat-policy-probe::locator=metamask-crx%40workspace%3A.":
-  version: 0.0.0
-  resolution: "@metamask/lavamoat-policy-probe@file:test/fakes/lavamoat-policy-probe#test/fakes/lavamoat-policy-probe::hash=c3d450&locator=metamask-crx%40workspace%3A."
-  checksum: 10/3fd8069c0ae84bd2a8acaf2960bd4da50bae52f3f90d7d07ed6b65958c5baff479afd432282aa18ceaa7d1f499d02d46db63d8a2d0c0fa78bf98ecdc00b8474a
-  languageName: node
-  linkType: hard
+"@metamask/lavamoat-policy-probe@workspace:*, @metamask/lavamoat-policy-probe@workspace:test/fakes/lavamoat-policy-probe":
+  version: 0.0.0-use.local
+  resolution: "@metamask/lavamoat-policy-probe@workspace:test/fakes/lavamoat-policy-probe"
+  languageName: unknown
+  linkType: soft
 
 "@metamask/local-node-utils@npm:^1.0.0":
   version: 1.0.0
@@ -32842,7 +32841,7 @@ __metadata:
     "@metamask/keyring-sdk": "npm:^2.2.0"
     "@metamask/keyring-snap-client": "npm:^9.0.2"
     "@metamask/keyring-utils": "npm:^3.3.1"
-    "@metamask/lavamoat-policy-probe": "file:test/fakes/lavamoat-policy-probe"
+    "@metamask/lavamoat-policy-probe": "workspace:*"
     "@metamask/logging-controller": "npm:^8.0.0"
     "@metamask/logo": "npm:^4.0.0"
     "@metamask/message-manager": "npm:^14.0.0"


### PR DESCRIPTION
## **Description**

This PR is stacked on #44173, which simplifies the MV3 LavaMoat service-worker build. It ports the useful coverage concepts from `feat/service-worker-lavamoat-e2e` without carrying over its bootstrap, HTML, manifest, Webpack plugin, dev-server, workflow, or policy refactors.

The existing lockdown test covered the UI and page-based background contexts, but did not execute assertions in the actual MV3 service worker. This change adds an isolated CDP helper that attaches directly to the extension service worker, then uses it to verify lockdown and scuttling there.

It also adds a tiny test-only package that probes access to an unapproved global. The E2E suite verifies that LavaMoat's default-deny policy blocks that package in the UI, MV2 background page, MV3 offscreen document, and MV3 service worker. Page contexts report through a test-only DOM marker; the service worker reports through `storage.session` because its LavaMoat compartment is intentionally isolated from the CDP host global.

### Validation

- `yarn lint:changed`
- `yarn lint:json`
- `yarn lint:tsc`
- `yarn test:unit:webpack` (506 passing)
- `yarn build:test`
- `yarn build:test:mv2`
- `yarn test:e2e:single test/e2e/tests/account/lavamoat.spec.ts --browser=chrome` (2 passing)
- `yarn test:e2e:single test/e2e/tests/account/lockdown.spec.ts --browser=chrome` (2 passing)

The Firefox E2E command could not start locally because this environment does not have a Firefox binary. The LavaMoat-enabled MV2 build completed successfully.

## **Changelog**

CHANGELOG entry: null

<!--
## **Related issues**

No related issue.
-->

## **Manual testing steps**

1. Load the LavaMoat-enabled Chrome MV3 test build from `dist/chrome` as an unpacked extension.
2. Open MetaMask and verify that the wallet UI initializes and the home page renders normally.
3. From `chrome://extensions`, inspect the MetaMask service worker and offscreen document and verify that both initialize without startup errors.
4. Load the LavaMoat-enabled Firefox MV2 test build from `dist/firefox` and verify that the UI and background page initialize normally.

<!--
## **Screenshots/Recordings**

Not applicable; this PR only adds runtime test coverage.
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.
