### PR TITLE
fix: show error instead of false success when network update fails

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -5780,6 +5780,9 @@
   "networkURLDefinition": {
     "message": "The URL used to access this network."
   },
+  "networkUpdateFailed": {
+    "message": "Failed to update network."
+  },
   "networkUrlErrorWarning": {
     "message": "Attackers sometimes mimic sites by making small changes to the site address. Make sure you're interacting with the intended site before you continue. Punycode version: $1",
     "description": "$1 replaced by RPC URL for network"
@@ -8715,6 +8718,9 @@
   },
   "rpcUrl": {
     "message": "RPC URL"
+  },
+  "rpcUrlAlreadyInUse": {
+    "message": "This RPC URL is already in use by another network."
   },
   "safeTransferFrom": {
     "message": "Safe transfer from"

--- a/ui/components/multichain/network-list-menu/select-rpc-url-modal/select-rpc-url-modal.test.tsx
+++ b/ui/components/multichain/network-list-menu/select-rpc-url-modal/select-rpc-url-modal.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, screen } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import configureMockStore from 'redux-mock-store';
 import { NetworkConfiguration } from '@metamask/network-controller';
 import { toEvmCaipChainId } from '@metamask/multichain-network-controller';
@@ -15,7 +15,7 @@ import { stripProtocol } from '../rpc-list-item';
 import { createMockInternalAccount } from '../../../../../test/jest/mocks';
 import { SelectRpcUrlModal } from './select-rpc-url-modal';
 
-const mockDispatch = jest.fn();
+const mockDispatch = jest.fn().mockReturnValue({});
 jest.mock('react-redux', () => ({
   ...jest.requireActual('react-redux'),
   useDispatch: () => mockDispatch,
@@ -116,7 +116,7 @@ describe('SelectRpcUrlModal Component', () => {
     expect(selectedItem).toHaveClass('select-rpc-url__item--selected');
   });
 
-  it('should dispatch the correct actions when an RPC endpoint is clicked', () => {
+  it('should dispatch the correct actions when an RPC endpoint is clicked', async () => {
     const { getByText } = renderWithProvider(
       <SelectRpcUrlModal
         networkConfiguration={networkConfiguration}
@@ -134,10 +134,12 @@ describe('SelectRpcUrlModal Component', () => {
       defaultRpcEndpointIndex: 1,
     };
 
-    expect(mockDispatch).toHaveBeenCalledWith(updateNetwork(network));
-    expect(mockDispatch).toHaveBeenCalledWith(setActiveNetwork('flashbots'));
-    expect(mockDispatch).toHaveBeenCalledWith(setEditedNetwork());
-    expect(mockDispatch).toHaveBeenCalledWith(toggleNetworkMenu());
+    await waitFor(() => {
+      expect(mockDispatch).toHaveBeenCalledWith(updateNetwork(network));
+      expect(mockDispatch).toHaveBeenCalledWith(setActiveNetwork('flashbots'));
+      expect(mockDispatch).toHaveBeenCalledWith(setEditedNetwork());
+      expect(mockDispatch).toHaveBeenCalledWith(toggleNetworkMenu());
+    });
   });
 
   it('should render the selected indicator correctly for the default RPC', () => {
@@ -174,7 +176,7 @@ describe('SelectRpcUrlModal Component', () => {
     );
   });
 
-  it('should handle click on RPC URL and call onNetworkChange', () => {
+  it('should handle click on RPC URL and call onNetworkChange', async () => {
     const updatedNetwork = {
       ...networkConfiguration,
       defaultRpcEndpointIndex: 1,
@@ -192,11 +194,13 @@ describe('SelectRpcUrlModal Component', () => {
       screen.getByText(stripProtocol(networkConfiguration.rpcEndpoints[1].url)),
     );
 
-    expect(mockDispatch).toHaveBeenCalledWith(updateNetwork(updatedNetwork));
-    expect(mockDispatch).toHaveBeenCalledWith(setEditedNetwork());
-    expect(mockOnNetworkChange).toHaveBeenCalledWith(
-      toEvmCaipChainId(updatedNetwork.chainId),
-      'flashbots',
-    );
+    await waitFor(() => {
+      expect(mockDispatch).toHaveBeenCalledWith(updateNetwork(updatedNetwork));
+      expect(mockDispatch).toHaveBeenCalledWith(setEditedNetwork());
+      expect(mockOnNetworkChange).toHaveBeenCalledWith(
+        toEvmCaipChainId(updatedNetwork.chainId),
+        'flashbots',
+      );
+    });
   });
 });

--- a/ui/components/multichain/network-list-menu/select-rpc-url-modal/select-rpc-url-modal.tsx
+++ b/ui/components/multichain/network-list-menu/select-rpc-url-modal/select-rpc-url-modal.tsx
@@ -20,7 +20,9 @@ import {
   TextVariant,
 } from '../../../../helpers/constants/design-system';
 import { CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP } from '../../../../../shared/constants/network';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { setEditedNetwork, updateNetwork } from '../../../../store/actions';
+import { toast } from '../../../ui/toast/toast';
 import RpcListItem from '../rpc-list-item';
 import { getMultichainNetworkConfigurationsByChainId } from '../../../../selectors';
 
@@ -32,6 +34,7 @@ export const SelectRpcUrlModal = ({
   onNetworkChange: (chainId: CaipChainId, networkClientId: string) => void;
 }) => {
   const dispatch = useDispatch();
+  const t = useI18nContext();
   const location = useLocation();
   const chainId = location.state?.chainId;
 
@@ -82,12 +85,16 @@ export const SelectRpcUrlModal = ({
           paddingRight={4}
           display={Display.Flex}
           key={rpcEndpoint.url}
-          onClick={() => {
+          onClick={async () => {
             const network = {
               ...networkConfigurationToUse,
               defaultRpcEndpointIndex: index,
             };
-            dispatch(updateNetwork(network));
+            const result = await dispatch(updateNetwork(network));
+            if (!result) {
+              toast.error(t('networkUpdateFailed'));
+              return;
+            }
             dispatch(setEditedNetwork());
             onNetworkChange(
               toEvmCaipChainId(network.chainId),

--- a/ui/components/multichain/networks-form/networks-form.tsx
+++ b/ui/components/multichain/networks-form/networks-form.tsx
@@ -46,6 +46,7 @@ import {
   toggleNetworkMenu,
   updateNetwork,
 } from '../../../store/actions';
+import { toast } from '../../ui/toast/toast';
 import {
   Box,
   ButtonLink,
@@ -271,6 +272,23 @@ export const NetworksForm = ({
       rpcUrls?.rpcEndpoints?.[rpcUrls?.defaultRpcEndpointIndex ?? -1]?.url;
 
     if (rpcUrl) {
+      const chainIdHex = chainId ? toHex(chainId) : undefined;
+      const conflictingNetwork = Object.values(networkConfigurations).find(
+        (config) =>
+          config.chainId !== chainIdHex &&
+          config.rpcEndpoints.some((ep) => ep.url === rpcUrl),
+      );
+      if (conflictingNetwork) {
+        setErrors((state) => ({
+          ...state,
+          rpcUrl: {
+            key: 'rpcUrlInUseByAnotherNetwork',
+            msg: t('rpcUrlAlreadyInUse'),
+          },
+        }));
+        return;
+      }
+
       jsonRpcRequest(templateInfuraRpc(rpcUrl), 'eth_chainId')
         .then((response) => {
           setFetchedChainId(response as string);
@@ -313,7 +331,11 @@ export const NetworksForm = ({
                 ? rpcUrls?.defaultRpcEndpointIndex
                 : undefined,
           };
-          await dispatch(updateNetwork(networkPayload, options));
+          const result = await dispatch(updateNetwork(networkPayload, options));
+          if (!result) {
+            toast.error(t('networkUpdateFailed'));
+            return;
+          }
           if (
             toggleNetworkMenuAfterSubmit &&
             Object.keys(tokenNetworkFilter).length === 1


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
When adding a custom RPC URL to a network, if the controller rejects the update (e.g. the same RPC URL is already configured on another network), the UI shows "was successfully edited!" even though nothing changed. This happens because:

1. In select-rpc-url-modal.tsx, updateNetwork was not awaited and setEditedNetwork() fired unconditionally
2. In networks-form.tsx, the updateNetwork return value was not checked before showing the success toast

This PR fixes both paths:

- select-rpc-url-modal.tsx — Await updateNetwork. If it returns undefined (failure), show an error toast via react-hot-toast instead of the success toast.
- networks-form.tsx — Check updateNetwork result before showing success. Add inline validation that checks if the RPC URL is already in use by another network, preventing the form from being saved (same pattern as the existing chain ID validation).

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Fixed a bug where editing a network showed a success message even when the update failed silently.

## **Related issues**

Fixes:  #44892

## **Manual testing steps**

1. Go to Settings > Networks > Ethereum > Edit
2. Add a custom RPC URL (e.g. http://127.0.0.1:8545) and save — works fine
3. Go to Settings > Networks > Arbitrum > Edit
4. Add the same RPC URL (http://127.0.0.1:8545)
5. Observe: inline error "This RPC URL is already in use by another network." appears, Save is disabled
6. For the RPC dropdown: if the state already has duplicate URLs across chains, switching RPC shows an error toast "Failed to update network." instead of a false success

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only validation and error handling around network editing; no auth or payment paths, with behavior limited to clearer failure feedback and duplicate-RPC prevention.
> 
> **Overview**
> Fixes **false success** when a network update is rejected by the controller (e.g. duplicate RPC URL on another chain).
> 
> **RPC selection modal** now **awaits** `updateNetwork` and only continues with `setEditedNetwork`, active network, and menu toggles when the thunk succeeds; on failure it shows an error toast (`networkUpdateFailed`) and stops.
> 
> **Network edit form** checks the `updateNetwork` result before running the success path (token filter, enabled networks, success messaging). It also **validates RPC URLs** against other networks’ endpoints before `eth_chainId` fetch, surfacing `rpcUrlAlreadyInUse` inline like existing chain ID errors.
> 
> Tests mock dispatch to return a resolved promise and use `waitFor` for the async click handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cb5ca8a1ac1dbbf1f524a17a1c1ee6f2b6bad18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->