### PR TITLE
fix: updated checkbox and permissions page width cp-13.42.0

### DIFF
--- a/ui/components/multichain/edit-networks-modal/edit-networks-modal.js
+++ b/ui/components/multichain/edit-networks-modal/edit-networks-modal.js
@@ -129,7 +129,6 @@ export const EditNetworksModal = ({
               }}
               startAccessory={
                 <Checkbox
-                  className="pointer-events-none"
                   isSelected={selectedChainIds.includes(network.caipChainId)}
                   onChange={() => handleNetworkClick(network.caipChainId)}
                   onClick={(event) => event.stopPropagation()}
@@ -150,7 +149,6 @@ export const EditNetworksModal = ({
               }}
               startAccessory={
                 <Checkbox
-                  className="pointer-events-none"
                   isSelected={selectedChainIds.includes(network.caipChainId)}
                   onChange={() => handleNetworkClick(network.caipChainId)}
                   onClick={(event) => event.stopPropagation()}

--- a/ui/components/multichain/edit-networks-modal/edit-networks-modal.js
+++ b/ui/components/multichain/edit-networks-modal/edit-networks-modal.js
@@ -34,6 +34,10 @@ import {
   MetaMetricsEventName,
 } from '../../../../shared/constants/metametrics';
 
+const checkboxContainerProps = {
+  style: { pointerEvents: 'none' },
+};
+
 export const EditNetworksModal = ({
   nonTestNetworks,
   testNetworks,
@@ -114,6 +118,7 @@ export const EditNetworksModal = ({
               label={t('selectAll')}
               isSelected={checked || isIndeterminate}
               onChange={() => (allAreSelected() ? deselectAll() : selectAll())}
+              checkboxContainerProps={checkboxContainerProps}
               checkedIconProps={
                 isIndeterminate ? { name: IconName.MinusBold } : undefined
               }
@@ -130,6 +135,7 @@ export const EditNetworksModal = ({
               startAccessory={
                 <Checkbox
                   isSelected={selectedChainIds.includes(network.caipChainId)}
+                  checkboxContainerProps={checkboxContainerProps}
                   onChange={() => handleNetworkClick(network.caipChainId)}
                   onClick={(event) => event.stopPropagation()}
                 />
@@ -150,6 +156,7 @@ export const EditNetworksModal = ({
               startAccessory={
                 <Checkbox
                   isSelected={selectedChainIds.includes(network.caipChainId)}
+                  checkboxContainerProps={checkboxContainerProps}
                   onChange={() => handleNetworkClick(network.caipChainId)}
                   onClick={(event) => event.stopPropagation()}
                 />

--- a/ui/components/multichain/edit-networks-modal/edit-networks-modal.js
+++ b/ui/components/multichain/edit-networks-modal/edit-networks-modal.js
@@ -129,10 +129,10 @@ export const EditNetworksModal = ({
               }}
               startAccessory={
                 <Checkbox
+                  className="pointer-events-none"
                   isSelected={selectedChainIds.includes(network.caipChainId)}
                   onChange={() => handleNetworkClick(network.caipChainId)}
                   onClick={(event) => event.stopPropagation()}
-                  checkboxContainerProps={{ className: 'pointer-events-none' }}
                 />
               }
             />
@@ -150,10 +150,10 @@ export const EditNetworksModal = ({
               }}
               startAccessory={
                 <Checkbox
+                  className="pointer-events-none"
                   isSelected={selectedChainIds.includes(network.caipChainId)}
                   onChange={() => handleNetworkClick(network.caipChainId)}
                   onClick={(event) => event.stopPropagation()}
-                  checkboxContainerProps={{ className: 'pointer-events-none' }}
                 />
               }
               showEndAccessory={false}

--- a/ui/pages/permissions-connect/index.scss
+++ b/ui/pages/permissions-connect/index.scss
@@ -38,6 +38,12 @@
     width: $width-screen-lg-min;
   }
 
+  .app--sidepanel & {
+    width: 100%;
+    max-width: var(--width-max);
+    margin: 0 auto;
+  }
+
   &__top-bar {
     display: grid;
     grid-template-columns: 1fr 1fr;


### PR DESCRIPTION
- Restores visible checkboxes in the Edit networks modal by moving the pointer-events-none workaround to the outer MMDS Checkbox, preserving the internal checkbox styling.
- Updates the connection page sidepanel layout so it uses the full available width up to the shared max width instead of applying desktop percentage widths.

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open MetaMask in the sidepanel.
2. Connect to a dapp, such as Uniswap.
3. On the connection page, verify the layout is centered and constrained correctly, with no oversized or awkwardly stretched content.
4. Click Edit networks.
5. Verify the individual network checkboxes are visible.
6. Select and deselect networks.
7. Verify the row click behavior still toggles selection.
8. Click Update and confirm the modal closes correctly.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**
<img width="932" height="1314" alt="Screenshot 2026-07-26 at 5 22 40 PM" src="https://github.com/user-attachments/assets/99d4eac5-e1c3-403f-adbe-9d4765e99140" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI/CSS fixes in the edit-networks modal and permissions-connect sidepanel layout with no auth, data, or permission logic changes.
> 
> **Overview**
> Fixes **Edit networks** checkboxes that were not rendering visibly after the design-system `Checkbox` change, and tightens **permissions connect** layout in the **sidepanel**.
> 
> In `edit-networks-modal`, the row-level `pointer-events-none` class on `checkboxContainerProps` is replaced with a shared `checkboxContainerProps` object using `style: { pointerEvents: 'none' }`, applied to **Select all** and every network row checkbox so clicks still go through the list row while the checkbox visuals show correctly.
> 
> In `permissions-connect/index.scss`, when the app runs under `.app--sidepanel`, `.permissions-connect` now uses full width with `max-width: var(--width-max)` and centered margins instead of the responsive `vw` widths used on larger popup layouts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93189eb3d9524025cc92a6cfcf349636a2b7d7a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->