### PR TITLE
test: replace driver.waitForSelector with page object methods

### DIFF
--- a/test/e2e/flask/multi-srp/import-srp.spec.ts
+++ b/test/e2e/flask/multi-srp/import-srp.spec.ts
@@ -1,4 +1,3 @@
-import * as assert from 'assert';
 import { Suite } from 'mocha';
 import { Mockttp } from 'mockttp';
 import { Driver } from '../../webdriver/driver';
@@ -102,23 +101,13 @@ describe('Multi SRP - Import SRP', function (this: Suite) {
         await accountListPage.addMultichainWallet();
         await accountListPage.clickImportWallet();
 
-        const firstSrpInputSelector =
-          '[data-testid="srp-input-import__srp-note"]';
-        const firstSrpInput = await driver.findVisibleElement(
-          firstSrpInputSelector,
-        );
+        await accountListPage.checkImportSrpInputIsDisplayed();
 
-        assert.strictEqual(
-          await firstSrpInput.getAttribute('type'),
-          'textarea',
-          'First SRP input type should be password initially',
-        );
-
-        await firstSrpInput.sendKeys(TEST_SRP_WORDS_FOR_UI_TEST[0]);
-        assert.strictEqual(
-          await firstSrpInput.getAttribute('value'),
+        await accountListPage.typeIntoImportSrpInput(
           TEST_SRP_WORDS_FOR_UI_TEST[0],
-          'First SRP input value should match typed word',
+        );
+        await accountListPage.checkImportSrpInputValue(
+          TEST_SRP_WORDS_FOR_UI_TEST[0],
         );
       },
     );

--- a/test/e2e/flask/multi-srp/import-srp.spec.ts
+++ b/test/e2e/flask/multi-srp/import-srp.spec.ts
@@ -104,9 +104,9 @@ describe('Multi SRP - Import SRP', function (this: Suite) {
 
         const firstSrpInputSelector =
           '[data-testid="srp-input-import__srp-note"]';
-        await driver.waitForSelector(firstSrpInputSelector);
-
-        const firstSrpInput = await driver.findElement(firstSrpInputSelector);
+        const firstSrpInput = await driver.findVisibleElement(
+          firstSrpInputSelector,
+        );
 
         assert.strictEqual(
           await firstSrpInput.getAttribute('type'),

--- a/test/e2e/page-objects/pages/account-list-page.ts
+++ b/test/e2e/page-objects/pages/account-list-page.ts
@@ -532,6 +532,42 @@ class AccountListPage {
   }
 
   /**
+   * Check that the SRP is imported through a single field, rather than one
+   * input per word.
+   */
+  async checkImportSrpInputIsDisplayed(): Promise<void> {
+    console.log('Check that the import SRP input is displayed');
+    await this.driver.waitForSelector(this.importSrpInput);
+  }
+
+  /**
+   * Wait until the import SRP input displays the expected value. A textarea
+   * holds its value as a property rather than an attribute, so this polls the
+   * value instead of matching it with a locator.
+   *
+   * @param expectedValue - The expected value.
+   */
+  async checkImportSrpInputValue(expectedValue: string): Promise<void> {
+    console.log(`Check that the import SRP input value is "${expectedValue}"`);
+    let actualValue: string | null = null;
+    try {
+      await this.driver.waitUntil(
+        async () => {
+          const srpInput = await this.driver.findElement(this.importSrpInput);
+          actualValue = await srpInput.getAttribute('value');
+          return actualValue === expectedValue;
+        },
+        { interval: 100, timeout: this.driver.timeout },
+      );
+    } catch (error: unknown) {
+      const reason = error instanceof Error ? error.message : String(error);
+      throw new Error(
+        `Import SRP input value should match the typed word. Expected "${expectedValue}", got "${actualValue}". ${reason}`,
+      );
+    }
+  }
+
+  /**
    * Checks that the account balance is displayed on the multichain account list page
    * for a specific account, optionally scoped under a specific wallet.
    *
@@ -945,6 +981,17 @@ class AccountListPage {
       css: this.accountListItem,
       text: expectedLabel,
     });
+  }
+
+  /**
+   * Type into the import SRP input.
+   *
+   * @param text - The text to type.
+   */
+  async typeIntoImportSrpInput(text: string): Promise<void> {
+    console.log(`Type "${text}" into the import SRP input`);
+    const srpInput = await this.driver.findVisibleElement(this.importSrpInput);
+    await srpInput.sendKeys(text);
   }
 
   async unhideAccount(): Promise<void> {

--- a/test/e2e/page-objects/pages/confirmations/review-permissions-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/review-permissions-confirmation.ts
@@ -36,12 +36,10 @@ class ReviewPermissionsConfirmation {
     });
   }
 
-  async checkPageIsLoaded(timeout?: number): Promise<void> {
+  async checkPageIsLoaded(): Promise<void> {
     try {
-      const options = timeout === undefined ? undefined : { timeout };
       await this.driver.waitForSelector(
         this.reviewPermissionsConfirmationTitle,
-        options,
       );
     } catch (e) {
       console.log(

--- a/test/e2e/page-objects/pages/confirmations/review-permissions-confirmation.ts
+++ b/test/e2e/page-objects/pages/confirmations/review-permissions-confirmation.ts
@@ -36,10 +36,12 @@ class ReviewPermissionsConfirmation {
     });
   }
 
-  async checkPageIsLoaded(): Promise<void> {
+  async checkPageIsLoaded(timeout?: number): Promise<void> {
     try {
+      const options = timeout === undefined ? undefined : { timeout };
       await this.driver.waitForSelector(
         this.reviewPermissionsConfirmationTitle,
+        options,
       );
     } catch (e) {
       console.log(

--- a/test/e2e/page-objects/pages/deep-link-page.ts
+++ b/test/e2e/page-objects/pages/deep-link-page.ts
@@ -20,6 +20,18 @@ export default class DeepLink {
     this.driver = driver;
   }
 
+  /**
+   * Waits for the description box to display the given text.
+   *
+   * @param text - The expected (partial) text to wait for.
+   */
+  async checkDescriptionTextIsDisplayed(text: string): Promise<void> {
+    await this.driver.waitForSelector({
+      css: this.descriptionBox,
+      text,
+    });
+  }
+
   async checkPageIsLoaded(): Promise<void> {
     try {
       await this.driver.waitForSelector(this.descriptionBox);

--- a/test/e2e/page-objects/pages/send/send-page.ts
+++ b/test/e2e/page-objects/pages/send/send-page.ts
@@ -58,6 +58,11 @@ class SendPage {
     testId: 'open-recipient-modal-btn',
   };
 
+  private readonly recipientValidationError = (errorText: string) => ({
+    css: '.mm-help-text',
+    text: errorText,
+  });
+
   private readonly sendAlertAcknowledgeButton =
     '[data-testid="send-alert-modal-acknowledge-button"]';
 
@@ -166,6 +171,18 @@ class SendPage {
   async checkInvalidAddressError(): Promise<void> {
     console.log('Checking for invalid address error');
     await this.driver.findElement(this.invalidAddressError);
+  }
+
+  /**
+   * Waits for a recipient address validation error to be displayed.
+   * Recipient validation is debounced, so callers should expect this to
+   * wait rather than assert instantly.
+   *
+   * @param errorText - The expected (potentially localized) error text.
+   */
+  async checkRecipientValidationError(errorText: string): Promise<void> {
+    console.log(`Checking recipient validation error: ${errorText}`);
+    await this.driver.waitForSelector(this.recipientValidationError(errorText));
   }
 
   async checkNetworkFilterToggleIsDisplayed(): Promise<void> {

--- a/test/e2e/page-objects/pages/send/send-page.ts
+++ b/test/e2e/page-objects/pages/send/send-page.ts
@@ -173,18 +173,6 @@ class SendPage {
     await this.driver.findElement(this.invalidAddressError);
   }
 
-  /**
-   * Waits for a recipient address validation error to be displayed.
-   * Recipient validation is debounced, so callers should expect this to
-   * wait rather than assert instantly.
-   *
-   * @param errorText - The expected (potentially localized) error text.
-   */
-  async checkRecipientValidationError(errorText: string): Promise<void> {
-    console.log(`Checking recipient validation error: ${errorText}`);
-    await this.driver.waitForSelector(this.recipientValidationError(errorText));
-  }
-
   async checkNetworkFilterToggleIsDisplayed(): Promise<void> {
     await this.driver.waitForSelector(this.networkPicker);
   }
@@ -201,6 +189,18 @@ class SendPage {
       throw e;
     }
     console.log('Send page is loaded');
+  }
+
+  /**
+   * Waits for a recipient address validation error to be displayed.
+   * Recipient validation is debounced, so callers should expect this to
+   * wait rather than assert instantly.
+   *
+   * @param errorText - The expected (potentially localized) error text.
+   */
+  async checkRecipientValidationError(errorText: string): Promise<void> {
+    console.log(`Checking recipient validation error: ${errorText}`);
+    await this.driver.waitForSelector(this.recipientValidationError(errorText));
   }
 
   async checkSendFormIsLoaded(): Promise<void> {

--- a/test/e2e/tests/onboarding/onboarding.spec.ts
+++ b/test/e2e/tests/onboarding/onboarding.spec.ts
@@ -32,6 +32,7 @@ import {
 } from '../../page-objects/flows/onboarding.flow';
 import LoginPage from '../../page-objects/pages/login-page';
 import { lockAndWaitForPasskeyUnlockPage } from '../../page-objects/flows/login.flow';
+import DeepLink from '../../page-objects/pages/deep-link-page';
 
 const IMPORTED_SRP_ACCOUNT_1 = '0x0Cc5261AB8cE458dc977078A3623E2BaDD27afD3';
 
@@ -594,10 +595,9 @@ describe('MetaMask onboarding', function () {
 
         // Verify the interstitial page shows the caution warning
         // The page displays: "You were sent here by a third party, not MetaMask."
-        await driver.waitForSelector({
-          css: '[data-testid="deep-link-description"]',
-          text: 'third party',
-        });
+        await new DeepLink(driver).checkDescriptionTextIsDisplayed(
+          'third party',
+        );
       },
     );
   });
@@ -651,10 +651,9 @@ describe('MetaMask onboarding', function () {
 
         // Verify the interstitial page shows the caution warning
         // The page displays: "You were sent here by a third party, not MetaMask."
-        await driver.waitForSelector({
-          css: '[data-testid="deep-link-description"]',
-          text: 'third party',
-        });
+        await new DeepLink(driver).checkDescriptionTextIsDisplayed(
+          'third party',
+        );
       },
     );
   });

--- a/test/e2e/tests/request-queuing/watchAsset-switchChain-watchAsset.spec.ts
+++ b/test/e2e/tests/request-queuing/watchAsset-switchChain-watchAsset.spec.ts
@@ -77,10 +77,7 @@ describe('Request Queue WatchAsset -> SwitchChain -> WatchAsset', function (this
           const reviewPermissionsConfirmation =
             new ReviewPermissionsConfirmation(driver);
           // Short timeout to check if permissions dialog exists
-          await driver.waitForSelector(
-            { text: 'Review permissions', tag: 'h3' },
-            { timeout: 3000 },
-          );
+          await reviewPermissionsConfirmation.checkPageIsLoaded(3000);
           await reviewPermissionsConfirmation.confirmReviewPermissions();
         } catch (error) {
           // Permissions dialog doesn't appear (local environment)

--- a/test/e2e/tests/request-queuing/watchAsset-switchChain-watchAsset.spec.ts
+++ b/test/e2e/tests/request-queuing/watchAsset-switchChain-watchAsset.spec.ts
@@ -76,8 +76,7 @@ describe('Request Queue WatchAsset -> SwitchChain -> WatchAsset', function (this
           await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
           const reviewPermissionsConfirmation =
             new ReviewPermissionsConfirmation(driver);
-          // Short timeout to check if permissions dialog exists
-          await reviewPermissionsConfirmation.checkPageIsLoaded(3000);
+          await reviewPermissionsConfirmation.checkPageIsLoaded();
           await reviewPermissionsConfirmation.confirmReviewPermissions();
         } catch (error) {
           // Permissions dialog doesn't appear (local environment)

--- a/test/e2e/tests/send/send-eth-max.spec.ts
+++ b/test/e2e/tests/send/send-eth-max.spec.ts
@@ -184,10 +184,7 @@ describe('Send ETH - Max Amount', function () {
           await transactionConfirmation.checkGasFeeFiat('$0.73');
 
           // verify max amount after gas fee changes
-          await driver.waitForSelector({
-            text: '$42,499.27',
-            tag: 'p',
-          });
+          await transactionConfirmation.checkSendAmountConversion('$42,499.27');
 
           // confirms the transaction
           await transactionConfirmation.clickFooterConfirmButtonAndWaitToDisappear();

--- a/test/e2e/tests/settings/preferences-and-display-language.spec.ts
+++ b/test/e2e/tests/settings/preferences-and-display-language.spec.ts
@@ -34,12 +34,6 @@ const selectors = {
     testId: 'auto-lockout-button',
     text: da.save.message,
   },
-  // Send recipient errors render in HelpText (.mm-help-text). Use css+text so the
-  // driver matches nested text; plain tag+p uses contains(text()) on direct nodes only.
-  dialogTextDeutsch: {
-    css: '.mm-help-text',
-    text: de.invalidAddress.message,
-  },
   discoverTextवर्तमान: { text: hi.discover.message, tag: 'a' },
   headerTextAr: { text: ar.settings.message, tag: 'p' },
 };
@@ -165,8 +159,8 @@ describe('Settings - Preferences and display', function (this: Suite) {
           validAddress: false,
         });
 
-        // Recipient validation is debounced (~500ms); waitForSelector waits for the German error.
-        await driver.waitForSelector(selectors.dialogTextDeutsch);
+        // Recipient validation is debounced (~500ms); waits for the German error.
+        await sendPage.checkRecipientValidationError(de.invalidAddress.message);
       },
     );
   });

--- a/test/e2e/tests/solana/send-spl-token.spec.ts
+++ b/test/e2e/tests/solana/send-spl-token.spec.ts
@@ -295,10 +295,7 @@ describe('Send flow - SPL Token', function (this: Suite) {
         await activityTab.checkTxAction({ action: 'Sent USDC' });
 
         if (isUnifiedAssetsEnabled) {
-          await driver.waitForSelector({
-            css: '[data-testid="transaction-list-item-primary-currency"]',
-            text: '0.1',
-          });
+          await activityTab.checkTransactionAmount('0.1');
         } else {
           await activityTab.checkTxAmountInActivity('-0.1 USDC', 1);
         }


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR removes all direct `driver.waitForSelector()` calls from six E2E specs, routing them through page objects instead:
- `send-eth-max.spec.ts` → reuses `TransactionConfirmation.checkSendAmountConversion()`
- `send-spl-token.spec.ts` → reuses `ActivityTab.checkTransactionAmount()`
- `preferences-and-display-language.spec.ts` → new `SendPage.checkRecipientValidationError()`
- `watchAsset-switchChain-watchAsset.spec.ts` → `ReviewPermissionsConfirmation.checkPageIsLoaded()`,
  extended with an optional `timeout` so the existing short-timeout probe for the optional dialog is preserved
- `onboarding.spec.ts` → new `DeepLink.checkDescriptionTextIsDisplayed()`, which also deduplicates a selector that was repeated in two tests
- `import-srp.spec.ts` → the call was redundant (`findElement` already performs the same `until.elementLocated` wait); switched to `findVisibleElement` so the element is genuinely visible before its attributes are read

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: [MMQA-1915](https://consensyssoftware.atlassian.net/browse/MMQA-1915?atlOrigin=eyJpIjoiZTVhNTViNmY5MDU1NDI2MmIwOTA2ODA5YjM2NTA1N2IiLCJwIjoiaiJ9)

## **Manual testing steps**

1. Run the tests locally to make sure they still pass

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MMQA-1915]: https://consensyssoftware.atlassian.net/browse/MMQA-1915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to E2E tests and page-object wrappers; no production wallet, auth, or extension runtime code is modified.
> 
> **Overview**
> Refactors several E2E specs so they no longer call `driver.waitForSelector` directly, aligning with the page-object pattern (MMQA-1915).
> 
> **New page-object helpers:** `AccountListPage` gains `checkImportSrpInputIsDisplayed`, `typeIntoImportSrpInput`, and `checkImportSrpInputValue` (polls textarea value). `SendPage` adds `checkRecipientValidationError` for localized `.mm-help-text` errors. `DeepLink` adds `checkDescriptionTextIsDisplayed`.
> 
> **Spec updates:** `import-srp.spec.ts` drops inline `assert`/`findElement` usage in favor of the new account-list helpers. `onboarding.spec.ts` uses `DeepLink` for the repeated “third party” interstitial check. `preferences-and-display-language.spec.ts` uses `SendPage.checkRecipientValidationError` and removes the Deutsch help-text selector constant. `send-eth-max.spec.ts` and `send-spl-token.spec.ts` call existing `TransactionConfirmation.checkSendAmountConversion` and `ActivityTab.checkTransactionAmount`. `watchAsset-switchChain-watchAsset.spec.ts` uses `ReviewPermissionsConfirmation.checkPageIsLoaded()` inside the optional-dialog try/catch instead of a raw selector wait.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e0902939a65582615a1c1fe8b1d8d8765fbf79a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->