### PR TITLE
chore: remove dead app header props

### DIFF
--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -353,7 +353,6 @@
       "Reselect: Input stability warnings": 3
     },
     "ui/components/multichain/app-header/app-header.test.js": {
-      "React: Act warnings (component updates not wrapped)": 4,
       "Reselect: Input stability warnings": 3
     },
     "ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.test.tsx": {

--- a/test/jest/console-baseline-unit.json
+++ b/test/jest/console-baseline-unit.json
@@ -353,6 +353,7 @@
       "Reselect: Input stability warnings": 3
     },
     "ui/components/multichain/app-header/app-header.test.js": {
+      "React: Act warnings (component updates not wrapped)": 4,
       "Reselect: Input stability warnings": 3
     },
     "ui/components/multichain/asset-picker-amount/asset-picker-modal/asset-picker-modal.test.tsx": {

--- a/ui/components/multichain/app-header/app-header.js
+++ b/ui/components/multichain/app-header/app-header.js
@@ -10,7 +10,6 @@ import {
 } from '../../../../shared/constants/metametrics';
 import {
   CONFIRM_TRANSACTION_ROUTE,
-  SEND_ROUTE,
   CROSS_CHAIN_SWAP_ROUTE,
 } from '../../../helpers/constants/routes';
 
@@ -22,7 +21,6 @@ import {
   JustifyContent,
 } from '../../../helpers/constants/design-system';
 import { Box } from '../../component-library';
-import { getUnapprovedTransactions } from '../../../selectors';
 
 import { toggleNetworkMenu } from '../../../store/actions';
 import { getEnvironmentType } from '../../../../shared/lib/environment-type';
@@ -32,7 +30,6 @@ import {
 } from '../../../../shared/constants/app';
 import { getIsUnlocked } from '../../../ducks/metamask/base-selectors';
 import { getSelectedMultichainNetworkConfiguration } from '../../../selectors/multichain/networks';
-import { getNetworkIcon } from '../../../../shared/lib/network.utils';
 import { MultichainMetaFoxLogo } from './multichain-meta-fox-logo';
 import { AppHeaderContainer } from './app-header-container';
 import { AppHeaderUnlockedContent } from './app-header-unlocked-content';
@@ -47,8 +44,7 @@ export const AppHeader = ({ location }) => {
     getSelectedMultichainNetworkConfiguration,
   );
 
-  const { chainId, isEvm } = multichainNetwork;
-  const networkIconSrc = getNetworkIcon(chainId, isEvm);
+  const { chainId } = multichainNetwork;
 
   const dispatch = useDispatch();
 
@@ -56,8 +52,7 @@ export const AppHeader = ({ location }) => {
   const popupStatus = environmentType === ENVIRONMENT_TYPE_POPUP;
   const isSidepanel = environmentType === ENVIRONMENT_TYPE_SIDEPANEL;
 
-  // Disable the network and account pickers if the user is in
-  // a critical flow
+  // Disable the account picker if the user is in a critical flow
   const isConfirmationPage = Boolean(
     matchPath(
       {
@@ -73,22 +68,8 @@ export const AppHeader = ({ location }) => {
       location?.pathname || '',
     ),
   );
-  const isSendPage = Boolean(
-    matchPath({ path: SEND_ROUTE, end: false }, location?.pathname || ''),
-  );
-
-  const unapprovedTransactions = useSelector(getUnapprovedTransactions);
-
-  const hasUnapprovedTransactions =
-    Object.keys(unapprovedTransactions).length > 0;
 
   const disableAccountPicker = isConfirmationPage || isSwapsPage;
-
-  const disableNetworkPicker =
-    isSwapsPage ||
-    isConfirmationPage ||
-    isSendPage ||
-    hasUnapprovedTransactions;
 
   // Callback for network dropdown
   const networkOpenCallback = useCallback(() => {
@@ -141,18 +122,12 @@ export const AppHeader = ({ location }) => {
           >
             {isUnlocked ? (
               <AppHeaderUnlockedContent
-                popupStatus={popupStatus}
-                currentNetwork={multichainNetwork}
-                networkIconSrc={networkIconSrc}
-                networkOpenCallback={networkOpenCallback}
-                disableNetworkPicker={disableNetworkPicker}
                 disableAccountPicker={disableAccountPicker}
                 menuRef={menuRef}
               />
             ) : (
               <AppHeaderLockedContent
                 currentNetwork={multichainNetwork}
-                networkIconSrc={networkIconSrc}
                 networkOpenCallback={networkOpenCallback}
               />
             )}


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Removes dead props that were being passed to but not used by their children AppHeader components

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only cleanup of unused props and selectors; no intended UX or security behavior change if children already ignored those inputs.
> 
> **Overview**
> **Cleans up `AppHeader`** by dropping props and parent logic that were no longer consumed by `AppHeaderUnlockedContent` and `AppHeaderLockedContent`.
> 
> The unlocked header now only receives `disableAccountPicker` and `menuRef`; removed passes of network picker state (`disableNetworkPicker`, `networkOpenCallback`, `currentNetwork`, `networkIconSrc`, `popupStatus`). The locked header no longer gets a precomputed `networkIconSrc` (it already derives icons locally). Parent-side code for send-route matching, unapproved-transaction gating of the network picker, and `getNetworkIcon` / `getUnapprovedTransactions` imports was deleted accordingly. **Account picker** disabling on confirmation and cross-chain swap routes is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c876cb153b84aff95cc84f7df78c5b096c977f4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->