### PR TITLE
chore: rename SettingsHeader to PageHeaderWithSearch

### DIFF
--- a/test/e2e/page-objects/pages/dialog/add-edit-network.ts
+++ b/test/e2e/page-objects/pages/dialog/add-edit-network.ts
@@ -23,7 +23,7 @@ class AddEditNetworkModal {
     tag: 'button',
   };
 
-  private readonly backButton = '[data-testid="settings-header-back-button"]';
+  private readonly backButton = '[data-testid="page-header-back-button"]';
 
   private readonly chainIdInputField = {
     testId: 'network-form-chain-id',

--- a/test/e2e/page-objects/pages/dialog/select-network.ts
+++ b/test/e2e/page-objects/pages/dialog/select-network.ts
@@ -33,8 +33,7 @@ class SelectNetwork {
 
   private readonly rpcUrlItem = '.select-rpc-url__item';
 
-  private readonly searchButton =
-    '[data-testid="page-header-search-button"]';
+  private readonly searchButton = '[data-testid="page-header-search-button"]';
 
   private readonly searchInput = '[data-testid="page-header-search-input"]';
 

--- a/test/e2e/page-objects/pages/dialog/select-network.ts
+++ b/test/e2e/page-objects/pages/dialog/select-network.ts
@@ -8,7 +8,7 @@ class SelectNetwork {
 
   private readonly addNetworkButton = '[data-testid="test-add-button"]';
 
-  private readonly closeButton = '[data-testid="settings-header-back-button"]';
+  private readonly closeButton = '[data-testid="page-header-back-button"]';
 
   private readonly confirmDeleteNetworkButton =
     '[data-testid="confirm-delete-network-modal-delete-button"]';
@@ -34,9 +34,9 @@ class SelectNetwork {
   private readonly rpcUrlItem = '.select-rpc-url__item';
 
   private readonly searchButton =
-    '[data-testid="settings-header-search-button"]';
+    '[data-testid="page-header-search-button"]';
 
-  private readonly searchInput = '[data-testid="settings-header-search-input"]';
+  private readonly searchInput = '[data-testid="page-header-search-input"]';
 
   private readonly selectNetworkMessage = {
     text: 'Manage networks',

--- a/test/e2e/page-objects/pages/settings/notifications-settings-page.ts
+++ b/test/e2e/page-objects/pages/settings/notifications-settings-page.ts
@@ -49,7 +49,7 @@ class NotificationsSettingsPage {
   ) => `[data-testid="${section}-in-app-notifications-toggle-input"]`;
 
   private readonly headerBackButton =
-    '[data-testid="settings-header-back-button"]';
+    '[data-testid="page-header-back-button"]';
 
   private readonly notificationsPerAccountSection =
     '[data-testid="notifications-settings-per-account"]';

--- a/test/e2e/page-objects/pages/settings/notifications-settings-page.ts
+++ b/test/e2e/page-objects/pages/settings/notifications-settings-page.ts
@@ -48,8 +48,7 @@ class NotificationsSettingsPage {
     section: Exclude<NotificationPreferenceSection, 'walletActivity'>,
   ) => `[data-testid="${section}-in-app-notifications-toggle-input"]`;
 
-  private readonly headerBackButton =
-    '[data-testid="page-header-back-button"]';
+  private readonly headerBackButton = '[data-testid="page-header-back-button"]';
 
   private readonly notificationsPerAccountSection =
     '[data-testid="notifications-settings-per-account"]';

--- a/test/e2e/page-objects/pages/settings/settings-page.ts
+++ b/test/e2e/page-objects/pages/settings/settings-page.ts
@@ -41,8 +41,7 @@ class SettingsPage {
   private readonly searchSettingsInput =
     '[data-testid="page-header-search-input"]';
 
-  private readonly searchButton =
-    '[data-testid="page-header-search-button"]';
+  private readonly searchButton = '[data-testid="page-header-search-button"]';
 
   private readonly settingsPageFullscreenRoot =
     '[data-testid="settings-tab-bar-grouped"]';

--- a/test/e2e/page-objects/pages/settings/settings-page.ts
+++ b/test/e2e/page-objects/pages/settings/settings-page.ts
@@ -12,7 +12,7 @@ class SettingsPage {
     '[data-testid="settings-tab-item-assets"]';
 
   private readonly backButton = {
-    testId: 'settings-header-back-button',
+    testId: 'page-header-back-button',
   };
 
   private readonly developerToolsSettingsButton =
@@ -39,10 +39,10 @@ class SettingsPage {
     '[data-testid="settings-search-result-item"]';
 
   private readonly searchSettingsInput =
-    '[data-testid="settings-header-search-input"]';
+    '[data-testid="page-header-search-input"]';
 
   private readonly searchButton =
-    '[data-testid="settings-header-search-button"]';
+    '[data-testid="page-header-search-button"]';
 
   private readonly settingsPageFullscreenRoot =
     '[data-testid="settings-tab-bar-grouped"]';

--- a/test/e2e/page-objects/pages/settings/shield/shield-claim-page.ts
+++ b/test/e2e/page-objects/pages/settings/shield/shield-claim-page.ts
@@ -15,7 +15,7 @@ export default class ShieldClaimPage {
     text: accountName,
   });
 
-  private readonly backButton = '[data-testid="settings-header-back-button"]';
+  private readonly backButton = '[data-testid="page-header-back-button"]';
 
   private readonly claimErrorToast = '[data-testid="claim-submit-toast-error"]';
 

--- a/ui/components/app/page-header-with-search/page-header-with-search.test.tsx
+++ b/ui/components/app/page-header-with-search/page-header-with-search.test.tsx
@@ -22,13 +22,9 @@ describe('PageHeaderWithSearch', () => {
     jest.clearAllMocks();
   });
 
-  it('renders the title and search button when forceSearchButton is set in a popup', () => {
+  it('renders the title and search button by default', () => {
     renderWithProvider(
-      <PageHeaderWithSearch
-        title={messages.settings.message}
-        isPopupOrSidepanel
-        forceSearchButton
-      />,
+      <PageHeaderWithSearch title={messages.settings.message} />,
       createMockStore(),
     );
 
@@ -36,11 +32,11 @@ describe('PageHeaderWithSearch', () => {
     expect(screen.getByTestId('page-header-search-button')).toBeVisible();
   });
 
-  it('renders the close button instead of the search button in a popup when forceSearchButton is not set', () => {
+  it('renders the close button instead of the search button when endAction is close', () => {
     renderWithProvider(
       <PageHeaderWithSearch
         title={messages.settings.message}
-        isPopupOrSidepanel
+        endAction="close"
       />,
       createMockStore(),
     );
@@ -55,7 +51,7 @@ describe('PageHeaderWithSearch', () => {
     renderWithProvider(
       <PageHeaderWithSearch
         title={messages.settings.message}
-        isPopupOrSidepanel
+        endAction="close"
       />,
       createMockStore(),
     );
@@ -65,20 +61,19 @@ describe('PageHeaderWithSearch', () => {
     expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE);
   });
 
-  it('calls onClose when back button is clicked', () => {
-    const onClose = jest.fn();
+  it('calls onBack when back button is clicked', () => {
+    const onBack = jest.fn();
     renderWithProvider(
       <PageHeaderWithSearch
         title={messages.settings.message}
-        isPopupOrSidepanel
-        onClose={onClose}
+        onBack={onBack}
       />,
       createMockStore(),
     );
 
     fireEvent.click(screen.getByTestId('page-header-back-button'));
 
-    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(onBack).toHaveBeenCalledTimes(1);
   });
 
   it('calls onOpenSearch when search button is clicked', () => {
@@ -86,8 +81,6 @@ describe('PageHeaderWithSearch', () => {
     renderWithProvider(
       <PageHeaderWithSearch
         title={messages.settings.message}
-        isPopupOrSidepanel
-        forceSearchButton
         onOpenSearch={onOpenSearch}
       />,
       createMockStore(),

--- a/ui/components/app/page-header-with-search/page-header-with-search.test.tsx
+++ b/ui/components/app/page-header-with-search/page-header-with-search.test.tsx
@@ -6,7 +6,7 @@ import mockState from '../../../../test/data/mock-state.json';
 import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
-import { SettingsHeader } from './settings-header';
+import { PageHeaderWithSearch } from './page-header-with-search';
 
 const mockNavigate = jest.fn();
 
@@ -17,52 +17,50 @@ jest.mock('react-router-dom', () => ({
 
 const createMockStore = () => configureMockStore([thunk])(mockState);
 
-describe('SettingsHeader', () => {
+describe('PageHeaderWithSearch', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  it('renders title and search button at settings root', () => {
+  it('renders the title and search button when forceSearchButton is set in a popup', () => {
     renderWithProvider(
-      <SettingsHeader
+      <PageHeaderWithSearch
         title={messages.settings.message}
         isPopupOrSidepanel
-        isOnSettingsRoot
-        searchValue=""
+        forceSearchButton
       />,
       createMockStore(),
     );
 
     expect(screen.getByText(messages.settings.message)).toBeInTheDocument();
-    expect(screen.getByTestId('settings-header-search-button')).toBeVisible();
+    expect(screen.getByTestId('page-header-search-button')).toBeVisible();
   });
 
-  it('renders close button in end accessory for popup subpages', () => {
+  it('renders the close button instead of the search button in a popup when forceSearchButton is not set', () => {
     renderWithProvider(
-      <SettingsHeader
+      <PageHeaderWithSearch
         title={messages.settings.message}
         isPopupOrSidepanel
-        isOnSettingsRoot={false}
       />,
       createMockStore(),
     );
 
+    expect(screen.getByTestId('page-header-close-button')).toBeVisible();
     expect(
-      screen.queryByTestId('settings-header-search-button'),
+      screen.queryByTestId('page-header-search-button'),
     ).not.toBeInTheDocument();
   });
 
-  it('navigates to default route when close button is clicked on popup subpage', () => {
+  it('navigates to the default route when the close button is clicked', () => {
     renderWithProvider(
-      <SettingsHeader
+      <PageHeaderWithSearch
         title={messages.settings.message}
         isPopupOrSidepanel
-        isOnSettingsRoot={false}
       />,
       createMockStore(),
     );
 
-    fireEvent.click(screen.getByTestId('settings-header-close-button'));
+    fireEvent.click(screen.getByTestId('page-header-close-button'));
 
     expect(mockNavigate).toHaveBeenCalledWith(DEFAULT_ROUTE);
   });
@@ -70,16 +68,15 @@ describe('SettingsHeader', () => {
   it('calls onClose when back button is clicked', () => {
     const onClose = jest.fn();
     renderWithProvider(
-      <SettingsHeader
+      <PageHeaderWithSearch
         title={messages.settings.message}
         isPopupOrSidepanel
-        isOnSettingsRoot={false}
         onClose={onClose}
       />,
       createMockStore(),
     );
 
-    fireEvent.click(screen.getByTestId('settings-header-back-button'));
+    fireEvent.click(screen.getByTestId('page-header-back-button'));
 
     expect(onClose).toHaveBeenCalledTimes(1);
   });
@@ -87,23 +84,23 @@ describe('SettingsHeader', () => {
   it('calls onOpenSearch when search button is clicked', () => {
     const onOpenSearch = jest.fn();
     renderWithProvider(
-      <SettingsHeader
+      <PageHeaderWithSearch
         title={messages.settings.message}
         isPopupOrSidepanel
-        isOnSettingsRoot
+        forceSearchButton
         onOpenSearch={onOpenSearch}
       />,
       createMockStore(),
     );
 
-    fireEvent.click(screen.getByTestId('settings-header-search-button'));
+    fireEvent.click(screen.getByTestId('page-header-search-button'));
 
     expect(onOpenSearch).toHaveBeenCalledTimes(1);
   });
 
   it('renders search input when isSearchOpen is true', () => {
     renderWithProvider(
-      <SettingsHeader
+      <PageHeaderWithSearch
         title={messages.settings.message}
         isSearchOpen
         searchValue=""
@@ -113,7 +110,7 @@ describe('SettingsHeader', () => {
       createMockStore(),
     );
 
-    expect(screen.getByTestId('settings-header-search-input')).toBeVisible();
+    expect(screen.getByTestId('page-header-search-input')).toBeVisible();
     expect(
       screen.queryByText(messages.settings.message),
     ).not.toBeInTheDocument();
@@ -123,7 +120,7 @@ describe('SettingsHeader', () => {
     const onCloseSearch = jest.fn();
     const onSearchClear = jest.fn();
     renderWithProvider(
-      <SettingsHeader
+      <PageHeaderWithSearch
         title={messages.settings.message}
         isSearchOpen
         searchValue="test"

--- a/ui/components/app/page-header-with-search/page-header-with-search.tsx
+++ b/ui/components/app/page-header-with-search/page-header-with-search.tsx
@@ -67,7 +67,7 @@ export const PageHeaderWithSearch = ({
           autoFocus: true,
           inputProps: {
             'data-testid': 'page-header-search-input',
-          } as React.ComponentPropsWithoutRef<'input'>,
+          },
         }}
       />
     );

--- a/ui/components/app/page-header-with-search/page-header-with-search.tsx
+++ b/ui/components/app/page-header-with-search/page-header-with-search.tsx
@@ -10,10 +10,7 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { Header } from '../../multichain/pages/page';
-import {
-  HeaderSearch,
-  HeaderSearchVariant,
-} from '../../component-library';
+import { HeaderSearch, HeaderSearchVariant } from '../../component-library';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 
 type PageHeaderWithSearchProps = {
@@ -68,7 +65,7 @@ export const PageHeaderWithSearch = ({
           autoFocus: true,
           inputProps: {
             'data-testid': 'page-header-search-input',
-          }  as React.ComponentPropsWithoutRef<'input'>,
+          } as React.ComponentPropsWithoutRef<'input'>,
         }}
       />
     );

--- a/ui/components/app/page-header-with-search/page-header-with-search.tsx
+++ b/ui/components/app/page-header-with-search/page-header-with-search.tsx
@@ -15,9 +15,13 @@ import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 
 type PageHeaderWithSearchProps = {
   title: string;
-  isPopupOrSidepanel?: boolean;
-  forceSearchButton?: boolean;
-  onClose?: () => void;
+  /**
+   * Which button to render on the right side of the header when search is
+   * closed: the search toggle (`'search'`) or a close button that navigates
+   * back to the wallet home (`'close'`). Defaults to `'search'`.
+   */
+  endAction?: 'search' | 'close';
+  onBack?: () => void;
   isSearchOpen?: boolean;
   onOpenSearch?: () => void;
   onCloseSearch?: () => void;
@@ -30,9 +34,8 @@ type PageHeaderWithSearchProps = {
 
 export const PageHeaderWithSearch = ({
   title,
-  isPopupOrSidepanel = false,
-  forceSearchButton = false,
-  onClose,
+  endAction = 'search',
+  onBack,
   isSearchOpen = false,
   onOpenSearch,
   onCloseSearch,
@@ -44,7 +47,6 @@ export const PageHeaderWithSearch = ({
 }: PageHeaderWithSearchProps) => {
   const t = useI18nContext();
   const navigate = useNavigate();
-  const showSearchButton = !isPopupOrSidepanel || forceSearchButton;
 
   if (isSearchOpen) {
     return (
@@ -77,7 +79,7 @@ export const PageHeaderWithSearch = ({
       alignItems={BoxAlignItems.Center}
       gap={1}
     >
-      {showSearchButton ? (
+      {endAction === 'search' ? (
         <ButtonIcon
           iconName={IconName.Search}
           ariaLabel={t('search')}
@@ -106,7 +108,7 @@ export const PageHeaderWithSearch = ({
         iconName={IconName.ArrowLeft}
         ariaLabel={t('back')}
         size={ButtonIconSize.Md}
-        onClick={onClose}
+        onClick={onBack}
         data-testid="page-header-back-button"
       />
     </Box>

--- a/ui/components/app/page-header-with-search/page-header-with-search.tsx
+++ b/ui/components/app/page-header-with-search/page-header-with-search.tsx
@@ -9,17 +9,17 @@ import {
 } from '@metamask/design-system-react';
 import { useNavigate } from 'react-router-dom';
 import { useI18nContext } from '../../../hooks/useI18nContext';
-import { Header } from '../../../components/multichain/pages/page';
+import { Header } from '../../multichain/pages/page';
 import {
   HeaderSearch,
   HeaderSearchVariant,
-} from '../../../components/component-library';
+} from '../../component-library';
 import { DEFAULT_ROUTE } from '../../../helpers/constants/routes';
 
-type SettingsHeaderProps = {
+type PageHeaderWithSearchProps = {
   title: string;
   isPopupOrSidepanel?: boolean;
-  isOnSettingsRoot?: boolean;
+  forceSearchButton?: boolean;
   onClose?: () => void;
   isSearchOpen?: boolean;
   onOpenSearch?: () => void;
@@ -31,10 +31,10 @@ type SettingsHeaderProps = {
   showSearchBorder?: boolean;
 };
 
-export const SettingsHeader = ({
+export const PageHeaderWithSearch = ({
   title,
   isPopupOrSidepanel = false,
-  isOnSettingsRoot = false,
+  forceSearchButton = false,
   onClose,
   isSearchOpen = false,
   onOpenSearch,
@@ -44,10 +44,10 @@ export const SettingsHeader = ({
   onSearchChange,
   onSearchClear,
   showSearchBorder = true,
-}: SettingsHeaderProps) => {
+}: PageHeaderWithSearchProps) => {
   const t = useI18nContext();
   const navigate = useNavigate();
-  const showSearchButton = !isPopupOrSidepanel || isOnSettingsRoot;
+  const showSearchButton = !isPopupOrSidepanel || forceSearchButton;
 
   if (isSearchOpen) {
     return (
@@ -63,14 +63,12 @@ export const SettingsHeader = ({
         textFieldSearchProps={{
           value: searchValue,
           placeholder: searchPlaceholder ?? t('search'),
-          className: 'rounded-full border border-border-muted',
           onChangeText: onSearchChange,
           onClickClearButton: onSearchClear,
-          showClearButton: false,
           autoFocus: true,
           inputProps: {
-            'data-testid': 'settings-header-search-input',
-          },
+            'data-testid': 'page-header-search-input',
+          }  as React.ComponentPropsWithoutRef<'input'>,
         }}
       />
     );
@@ -88,7 +86,7 @@ export const SettingsHeader = ({
           ariaLabel={t('search')}
           size={ButtonIconSize.Md}
           onClick={onOpenSearch}
-          data-testid="settings-header-search-button"
+          data-testid="page-header-search-button"
         />
       ) : (
         <ButtonIcon
@@ -96,7 +94,7 @@ export const SettingsHeader = ({
           ariaLabel={t('close')}
           size={ButtonIconSize.Md}
           onClick={() => navigate(DEFAULT_ROUTE)}
-          data-testid="settings-header-close-button"
+          data-testid="page-header-close-button"
         />
       )}
     </Box>
@@ -112,7 +110,7 @@ export const SettingsHeader = ({
         ariaLabel={t('back')}
         size={ButtonIconSize.Md}
         onClick={onClose}
-        data-testid="settings-header-back-button"
+        data-testid="page-header-back-button"
       />
     </Box>
   );

--- a/ui/pages/networks/networks-page.test.tsx
+++ b/ui/pages/networks/networks-page.test.tsx
@@ -271,9 +271,9 @@ describe('NetworksPage', () => {
     expect(testnetToggle).toBeChecked();
     expect(testnetToggle).toBeDisabled();
 
-    await userEvent.click(screen.getByTestId('settings-header-search-button'));
+    await userEvent.click(screen.getByTestId('page-header-search-button'));
     await userEvent.type(
-      screen.getByTestId('settings-header-search-input'),
+      screen.getByTestId('page-header-search-input'),
       'ugtfvh',
     );
 

--- a/ui/pages/networks/networks-page.tsx
+++ b/ui/pages/networks/networks-page.tsx
@@ -43,7 +43,6 @@ import {
 } from '../../selectors/multichain/networks';
 import { getIsChainlistEnabled } from '../../selectors/multichain/feature-flags';
 import { getEditedNetwork } from '../../selectors/selectors';
-// eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0021): route-isolation backlog
 import { PageHeaderWithSearch } from '../../components/app/page-header-with-search/page-header-with-search';
 import { useGlobalMenuRouteTransition } from '../routes/global-menu-route-transition';
 import { useAnalytics } from '../../hooks/useAnalytics';

--- a/ui/pages/networks/networks-page.tsx
+++ b/ui/pages/networks/networks-page.tsx
@@ -415,7 +415,7 @@ export const NetworksPage = () => {
         <>
           <PageHeaderWithSearch
             title={t('manageNetworksMenuHeading')}
-            onClose={handleRootBack}
+            onBack={handleRootBack}
             isSearchOpen={isSearchOpen}
             onOpenSearch={() => setIsSearchOpen(true)}
             onCloseSearch={() => setIsSearchOpen(false)}

--- a/ui/pages/networks/networks-page.tsx
+++ b/ui/pages/networks/networks-page.tsx
@@ -44,7 +44,7 @@ import {
 import { getIsChainlistEnabled } from '../../selectors/multichain/feature-flags';
 import { getEditedNetwork } from '../../selectors/selectors';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0021): route-isolation backlog
-import { SettingsHeader } from '../settings/shared/settings-header';
+import { PageHeaderWithSearch } from '../../components/app/page-header-with-search/page-header-with-search';
 import { useGlobalMenuRouteTransition } from '../routes/global-menu-route-transition';
 import { useAnalytics } from '../../hooks/useAnalytics';
 import { AddRpcUrlPageForm } from './add-rpc-url-page-form';
@@ -413,7 +413,7 @@ export const NetworksPage = () => {
     <Box className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-background-default">
       {view === '' ? (
         <>
-          <SettingsHeader
+          <PageHeaderWithSearch
             title={t('manageNetworksMenuHeading')}
             onClose={handleRootBack}
             isSearchOpen={isSearchOpen}

--- a/ui/pages/settings/settings.test.tsx
+++ b/ui/pages/settings/settings.test.tsx
@@ -161,9 +161,7 @@ describe('Settings', () => {
     it('navigates to home with the global menu drawer open when back is clicked at settings root', async () => {
       renderSettings(mockStore);
 
-      const backButton = await screen.findByTestId(
-        'page-header-back-button',
-      );
+      const backButton = await screen.findByTestId('page-header-back-button');
 
       fireEvent.click(backButton);
 
@@ -178,9 +176,7 @@ describe('Settings', () => {
       mockPathname = `${SETTINGS_ROUTE}?drawerOpen=true`;
       renderSettings(mockStore);
 
-      const backButton = await screen.findByTestId(
-        'page-header-back-button',
-      );
+      const backButton = await screen.findByTestId('page-header-back-button');
 
       fireEvent.click(backButton);
 
@@ -195,9 +191,7 @@ describe('Settings', () => {
       mockPathname = CURRENCY_ROUTE;
       renderSettings(mockStore);
 
-      const backButton = await screen.findByTestId(
-        'page-header-back-button',
-      );
+      const backButton = await screen.findByTestId('page-header-back-button');
 
       fireEvent.click(backButton);
 
@@ -212,9 +206,7 @@ describe('Settings', () => {
       mockPathname = NOTIFICATIONS_SETTINGS_WALLET_ACTIVITY_ROUTE;
       renderSettings(mockStore);
 
-      const backButton = await screen.findByTestId(
-        'page-header-back-button',
-      );
+      const backButton = await screen.findByTestId('page-header-back-button');
 
       fireEvent.click(backButton);
 

--- a/ui/pages/settings/settings.test.tsx
+++ b/ui/pages/settings/settings.test.tsx
@@ -162,7 +162,7 @@ describe('Settings', () => {
       renderSettings(mockStore);
 
       const backButton = await screen.findByTestId(
-        'settings-header-back-button',
+        'page-header-back-button',
       );
 
       fireEvent.click(backButton);
@@ -179,7 +179,7 @@ describe('Settings', () => {
       renderSettings(mockStore);
 
       const backButton = await screen.findByTestId(
-        'settings-header-back-button',
+        'page-header-back-button',
       );
 
       fireEvent.click(backButton);
@@ -196,7 +196,7 @@ describe('Settings', () => {
       renderSettings(mockStore);
 
       const backButton = await screen.findByTestId(
-        'settings-header-back-button',
+        'page-header-back-button',
       );
 
       fireEvent.click(backButton);
@@ -213,7 +213,7 @@ describe('Settings', () => {
       renderSettings(mockStore);
 
       const backButton = await screen.findByTestId(
-        'settings-header-back-button',
+        'page-header-back-button',
       );
 
       fireEvent.click(backButton);

--- a/ui/pages/settings/settings.tsx
+++ b/ui/pages/settings/settings.tsx
@@ -51,6 +51,7 @@ import { getSnapName } from '../../helpers/utils/util';
 import { getHasSubscribedToShield } from '../../selectors/subscription/subscription';
 import { getIsMetaMaskShieldFeatureEnabled } from '../../../shared/lib/environment';
 import ShieldEntryModal from '../../components/app/shield-entry-modal';
+import { PageHeaderWithSearch } from '../../components/app/page-header-with-search/page-header-with-search';
 import { SHIELD_QUERY_PARAMS } from '../../../shared/lib/deep-links/routes/shield';
 import { toRelativeRoutePath } from '../routes/utils';
 import {
@@ -65,7 +66,7 @@ import {
   SETTINGS_RENDERABLE_ROUTES,
   getSettingsRouteMeta,
 } from './settings-registry';
-import { SettingsHeader, SettingsRoot, SettingsSearchResults } from './shared';
+import { SettingsRoot, SettingsSearchResults } from './shared';
 import { useSettingsSearch, MIN_SEARCH_LENGTH } from './useSettingsSearch';
 import { useSettingsI18n } from './useSettingsI18n';
 
@@ -465,10 +466,10 @@ const SettingsLayout = ({ children }: { children: React.ReactNode }) => {
           onClose={() => setShowShieldEntryModal(false)}
         />
       )}
-      <SettingsHeader
+      <PageHeaderWithSearch
         title={headerTitle}
         isPopupOrSidepanel={usesCompactSettingsLayout}
-        isOnSettingsRoot={isOnSettingsRoot}
+        forceSearchButton={isOnSettingsRoot}
         onClose={handleClose}
         isSearchOpen={isSearchOpen}
         onOpenSearch={() => setIsSearchOpen(true)}

--- a/ui/pages/settings/settings.tsx
+++ b/ui/pages/settings/settings.tsx
@@ -468,9 +468,10 @@ const SettingsLayout = ({ children }: { children: React.ReactNode }) => {
       )}
       <PageHeaderWithSearch
         title={headerTitle}
-        isPopupOrSidepanel={usesCompactSettingsLayout}
-        forceSearchButton={isOnSettingsRoot}
-        onClose={handleClose}
+        endAction={
+          usesCompactSettingsLayout && !isOnSettingsRoot ? 'close' : 'search'
+        }
+        onBack={handleClose}
         isSearchOpen={isSearchOpen}
         onOpenSearch={() => setIsSearchOpen(true)}
         onCloseSearch={handleCloseSearch}

--- a/ui/pages/settings/shared/index.ts
+++ b/ui/pages/settings/shared/index.ts
@@ -7,6 +7,5 @@ export { Divider } from './divider';
 export { PrivacyPolicyLink } from './privacy-policy-link';
 export { SettingsTab } from './settings-tab';
 export { SettingsSelectItem } from './settings-select-item';
-export { SettingsHeader } from './settings-header';
 export { SettingsRoot } from './settings-root';
 export { SettingsSearchResults } from './settings-search-results';


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

SettingsHeader is used in both Settings pages and NetworkManager so this PR moves it to a shared directory and makes the naming and props more generic rather than Settings-centric.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Test that Settings search and Manage Networks search still function as expected
2. They should show the search icon at the end, and when search is active, the close icon
3. On Settings sub-pages, the close icon should navigate home

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor limited to header component location, naming, props, and test selectors; navigation/search behavior is preserved via equivalent wiring in Settings and Networks.
> 
> **Overview**
> **Renames and generalizes** the settings-only header into a shared `PageHeaderWithSearch` under `ui/components/app/page-header-with-search`, so Settings and Manage Networks can use the same component without settings-specific naming.
> 
> **API changes:** `isPopupOrSidepanel` / `isOnSettingsRoot` are replaced by `endAction` (`'search'` | `'close'`), and `onClose` becomes `onBack`. Settings sets `endAction` to `'close'` on compact layout sub-pages and `'search'` otherwise. **Test IDs** are unified from `settings-header-*` to `page-header-*` across unit tests, networks tests, and e2e page objects.
> 
> The old `SettingsHeader` export is removed from `settings/shared`; consumers import the new component directly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b7dea486b236174b6f8066c96bf1c3483e161d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->