### PR TITLE
feat: migrate swap asset picker search to DSR TextFieldSearch

### DIFF
--- a/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
+++ b/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
@@ -951,25 +951,29 @@ exports[`BridgeInputGroup should search for tokens 1`] = `
               </p>
             </button>
             <div
-              class="inline-flex items-center border bg-default transition-colors h-12 pl-4 pr-0 border-default rounded-full app-text-field-search mx-4"
+              class="mx-4"
             >
-              <svg
-                class="inline-block w-5 h-5 text-icon-alternative"
-                fill="currentColor"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
+              <div
+                class="inline-flex items-center border bg-default transition-colors h-12 pl-4 pr-0 border-default rounded-full app-text-field-search"
               >
-                <path
-                  d="m19.6 21-6.3-6.3q-.75.6-1.725.95C10.6 16 10.233 16 9.5 16q-2.725 0-4.612-1.888C3 12.224 3 11.317 3 9.5q0-2.725 1.888-4.612C6.776 3 7.683 3 9.5 3q2.725 0 4.613 1.888C16 6.776 16 7.683 16 9.5a6.1 6.1 0 0 1-1.3 3.8l6.3 6.3zM9.5 14q1.875 0 3.188-1.312C14 11.375 14 10.75 14 9.5s-.437-2.312-1.312-3.187S10.75 5 9.5 5s-2.312.438-3.187 1.313S5 8.25 5 9.5s.438 2.313 1.313 3.188S8.25 14 9.5 14"
+                <svg
+                  class="inline-block w-5 h-5 text-icon-alternative"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="m19.6 21-6.3-6.3q-.75.6-1.725.95C10.6 16 10.233 16 9.5 16q-2.725 0-4.612-1.888C3 12.224 3 11.317 3 9.5q0-2.725 1.888-4.612C6.776 3 7.683 3 9.5 3q2.725 0 4.613 1.888C16 6.776 16 7.683 16 9.5a6.1 6.1 0 0 1-1.3 3.8l6.3 6.3zM9.5 14q1.875 0 3.188-1.312C14 11.375 14 10.75 14 9.5s-.437-2.312-1.312-3.187S10.75 5 9.5 5s-2.312.438-3.187 1.313S5 8.25 5 9.5s.438 2.313 1.313 3.188S8.25 14 9.5 14"
+                  />
+                </svg>
+                <input
+                  class="w-full rounded text-default outline-none transition-colors border-transparent placeholder:text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular m-0 h-full min-w-0 flex-1 border-0 bg-transparent p-0 pl-2 pr-4 truncate"
+                  data-testid="bridge-asset-picker-search-input"
+                  placeholder="Enter token name or paste address"
+                  type="search"
+                  value=""
                 />
-              </svg>
-              <input
-                class="w-full rounded text-default outline-none transition-colors border-transparent placeholder:text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular m-0 h-full min-w-0 flex-1 border-0 bg-transparent p-0 pl-2 pr-4 truncate"
-                data-testid="bridge-asset-picker-search-input"
-                placeholder="Enter token name or paste address"
-                type="search"
-                value=""
-              />
+              </div>
             </div>
           </div>
           <div
@@ -1338,41 +1342,45 @@ exports[`BridgeInputGroup should search for tokens 5`] = `
               </p>
             </button>
             <div
-              class="inline-flex items-center border bg-default transition-colors h-12 pl-4 pr-4 border-default rounded-full app-text-field-search mx-4"
+              class="mx-4"
             >
-              <svg
-                class="inline-block w-5 h-5 text-icon-alternative"
-                fill="currentColor"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="m19.6 21-6.3-6.3q-.75.6-1.725.95C10.6 16 10.233 16 9.5 16q-2.725 0-4.612-1.888C3 12.224 3 11.317 3 9.5q0-2.725 1.888-4.612C6.776 3 7.683 3 9.5 3q2.725 0 4.613 1.888C16 6.776 16 7.683 16 9.5a6.1 6.1 0 0 1-1.3 3.8l6.3 6.3zM9.5 14q1.875 0 3.188-1.312C14 11.375 14 10.75 14 9.5s-.437-2.312-1.312-3.187S10.75 5 9.5 5s-2.312.438-3.187 1.313S5 8.25 5 9.5s.438 2.313 1.313 3.188S8.25 14 9.5 14"
-                />
-              </svg>
-              <input
-                class="w-full rounded text-default outline-none transition-colors border-transparent placeholder:text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular m-0 h-full min-w-0 flex-1 border-0 bg-transparent p-0 pl-2 pr-2 truncate"
-                data-testid="bridge-asset-picker-search-input"
-                placeholder="Enter token name or paste address"
-                type="search"
-                value="USD"
-              />
-              <button
-                aria-label="Clear"
-                class="inline-flex items-center justify-center p-0 h-8 w-8 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
-                data-testid="text-field-search-clear-button"
+              <div
+                class="inline-flex items-center border bg-default transition-colors h-12 pl-4 pr-4 border-default rounded-full app-text-field-search"
               >
                 <svg
-                  class="inline-block w-6 h-6 text-inherit"
+                  class="inline-block w-5 h-5 text-icon-alternative"
                   fill="currentColor"
                   viewBox="0 0 24 24"
                   xmlns="http://www.w3.org/2000/svg"
                 >
                   <path
-                    d="m8.4 17 3.6-3.6 3.6 3.6 1.4-1.4-3.6-3.6L17 8.4 15.6 7 12 10.6 8.4 7 7 8.4l3.6 3.6L7 15.6zm3.6 5q-2.075 0-3.9-.787c-1.825-.788-2.275-1.238-3.175-2.138S3.313 17.117 2.788 15.9 2 13.383 2 12s.262-2.683.787-3.9 1.238-2.275 2.138-3.175S6.883 3.312 8.1 2.787 10.617 2 12 2s2.683.262 3.9.787 2.275 1.238 3.175 2.138 1.613 1.958 2.138 3.175S22 10.617 22 12s-.262 2.683-.787 3.9-1.238 2.275-2.138 3.175-1.958 1.613-3.175 2.138S13.383 22 12 22m0-2q3.35 0 5.675-2.325C20 15.35 20 14.233 20 12q0-3.35-2.325-5.675C15.35 4 14.233 4 12 4Q8.65 4 6.325 6.325C4 8.65 4 9.767 4 12q0 3.35 2.325 5.675C8.65 20 9.767 20 12 20"
+                    d="m19.6 21-6.3-6.3q-.75.6-1.725.95C10.6 16 10.233 16 9.5 16q-2.725 0-4.612-1.888C3 12.224 3 11.317 3 9.5q0-2.725 1.888-4.612C6.776 3 7.683 3 9.5 3q2.725 0 4.613 1.888C16 6.776 16 7.683 16 9.5a6.1 6.1 0 0 1-1.3 3.8l6.3 6.3zM9.5 14q1.875 0 3.188-1.312C14 11.375 14 10.75 14 9.5s-.437-2.312-1.312-3.187S10.75 5 9.5 5s-2.312.438-3.187 1.313S5 8.25 5 9.5s.438 2.313 1.313 3.188S8.25 14 9.5 14"
                   />
                 </svg>
-              </button>
+                <input
+                  class="w-full rounded text-default outline-none transition-colors border-transparent placeholder:text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular m-0 h-full min-w-0 flex-1 border-0 bg-transparent p-0 pl-2 pr-2 truncate"
+                  data-testid="bridge-asset-picker-search-input"
+                  placeholder="Enter token name or paste address"
+                  type="search"
+                  value="USD"
+                />
+                <button
+                  aria-label="Clear"
+                  class="inline-flex items-center justify-center p-0 h-8 w-8 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+                  data-testid="text-field-search-clear-button"
+                >
+                  <svg
+                    class="inline-block w-6 h-6 text-inherit"
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="m8.4 17 3.6-3.6 3.6 3.6 1.4-1.4-3.6-3.6L17 8.4 15.6 7 12 10.6 8.4 7 7 8.4l3.6 3.6L7 15.6zm3.6 5q-2.075 0-3.9-.787c-1.825-.788-2.275-1.238-3.175-2.138S3.313 17.117 2.788 15.9 2 13.383 2 12s.262-2.683.787-3.9 1.238-2.275 2.138-3.175S6.883 3.312 8.1 2.787 10.617 2 12 2s2.683.262 3.9.787 2.275 1.238 3.175 2.138 1.613 1.958 2.138 3.175S22 10.617 22 12s-.262 2.683-.787 3.9-1.238 2.275-2.138 3.175-1.958 1.613-3.175 2.138S13.383 22 12 22m0-2q3.35 0 5.675-2.325C20 15.35 20 14.233 20 12q0-3.35-2.325-5.675C15.35 4 14.233 4 12 4Q8.65 4 6.325 6.325C4 8.65 4 9.767 4 12q0 3.35 2.325 5.675C8.65 20 9.767 20 12 20"
+                    />
+                  </svg>
+                </button>
+              </div>
             </div>
           </div>
           <div

--- a/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
+++ b/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
@@ -951,8 +951,7 @@ exports[`BridgeInputGroup should search for tokens 1`] = `
               </p>
             </button>
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--focused mm-text-field--truncate mm-box--margin-inline-4 mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted mm-box--border-width-1 box--border-style-solid"
-              style="min-height: 48px; padding-right: 8px; outline: none;"
+              class="inline-flex items-center border bg-default transition-colors h-12 pl-4 pr-0 border-default rounded-full app-text-field-search mx-4"
             >
               <svg
                 class="inline-block w-5 h-5 text-icon-alternative"
@@ -965,12 +964,10 @@ exports[`BridgeInputGroup should search for tokens 1`] = `
                 />
               </svg>
               <input
-                autocomplete="off"
-                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none mm-box--border-color-border-muted box--border-width-1"
+                class="w-full rounded text-default outline-none transition-colors border-transparent placeholder:text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular m-0 h-full min-w-0 flex-1 border-0 bg-transparent p-0 pl-2 pr-4 truncate"
                 data-testid="bridge-asset-picker-search-input"
-                focused="true"
                 placeholder="Enter token name or paste address"
-                type="text"
+                type="search"
                 value=""
               />
             </div>
@@ -1341,8 +1338,7 @@ exports[`BridgeInputGroup should search for tokens 5`] = `
               </p>
             </button>
             <div
-              class="mm-box mm-text-field mm-text-field--size-md mm-text-field--focused mm-text-field--truncate mm-box--margin-inline-4 mm-box--padding-right-0 mm-box--padding-left-4 mm-box--display-inline-flex mm-box--align-items-center mm-box--background-color-background-default mm-box--rounded-xl mm-box--border-color-border-muted mm-box--border-width-1 box--border-style-solid"
-              style="min-height: 48px; padding-right: 8px; outline: none;"
+              class="inline-flex items-center border bg-default transition-colors h-12 pl-4 pr-4 border-default rounded-full app-text-field-search mx-4"
             >
               <svg
                 class="inline-block w-5 h-5 text-icon-alternative"
@@ -1355,14 +1351,28 @@ exports[`BridgeInputGroup should search for tokens 5`] = `
                 />
               </svg>
               <input
-                autocomplete="off"
-                class="mm-box mm-text mm-input mm-input--disable-state-styles mm-text-field__input mm-text--body-md mm-box--margin-0 mm-box--padding-0 mm-box--padding-right-2 mm-box--padding-left-2 mm-box--color-text-default mm-box--background-color-transparent mm-box--border-style-none mm-box--border-color-border-muted box--border-width-1"
+                class="w-full rounded text-default outline-none transition-colors border-transparent placeholder:text-alternative text-s-body-md leading-s-body-md tracking-s-body-md md:text-l-body-md md:leading-l-body-md md:tracking-l-body-md font-regular m-0 h-full min-w-0 flex-1 border-0 bg-transparent p-0 pl-2 pr-2 truncate"
                 data-testid="bridge-asset-picker-search-input"
-                focused="true"
                 placeholder="Enter token name or paste address"
-                type="text"
+                type="search"
                 value="USD"
               />
+              <button
+                aria-label="Clear"
+                class="inline-flex items-center justify-center p-0 h-8 w-8 rounded-lg bg-transparent hover:bg-hover active:bg-pressed text-icon-default"
+                data-testid="text-field-search-clear-button"
+              >
+                <svg
+                  class="inline-block w-6 h-6 text-inherit"
+                  fill="currentColor"
+                  viewBox="0 0 24 24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="m8.4 17 3.6-3.6 3.6 3.6 1.4-1.4-3.6-3.6L17 8.4 15.6 7 12 10.6 8.4 7 7 8.4l3.6 3.6L7 15.6zm3.6 5q-2.075 0-3.9-.787c-1.825-.788-2.275-1.238-3.175-2.138S3.313 17.117 2.788 15.9 2 13.383 2 12s.262-2.683.787-3.9 1.238-2.275 2.138-3.175S6.883 3.312 8.1 2.787 10.617 2 12 2s2.683.262 3.9.787 2.275 1.238 3.175 2.138 1.613 1.958 2.138 3.175S22 10.617 22 12s-.262 2.683-.787 3.9-1.238 2.275-2.138 3.175-1.958 1.613-3.175 2.138S13.383 22 12 22m0-2q3.35 0 5.675-2.325C20 15.35 20 14.233 20 12q0-3.35-2.325-5.675C15.35 4 14.233 4 12 4Q8.65 4 6.325 6.325C4 8.65 4 9.767 4 12q0 3.35 2.325 5.675C8.65 20 9.767 20 12 20"
+                  />
+                </svg>
+              </button>
             </div>
           </div>
           <div

--- a/ui/pages/bridge/prepare/components/bridge-asset-picker/bridge-asset-picker-content.tsx
+++ b/ui/pages/bridge/prepare/components/bridge-asset-picker/bridge-asset-picker-content.tsx
@@ -9,6 +9,7 @@ import React, {
 } from 'react';
 import { useSelector } from 'react-redux';
 import {
+  Box,
   ButtonBase,
   ButtonBaseSize,
   FontWeight,
@@ -206,20 +207,22 @@ export const BridgeAssetPickerContent = forwardRef<
             onClose={() => setIsNetworkPickerOpen(false)}
             testId="bridge-network-picker-popover"
           />
-          <TextFieldSearch
-            autoFocus
-            className="app-text-field-search mx-4"
-            clearButtonOnClick={() => setSearchQuery('')}
-            inputProps={
-              {
-                'data-testid': 'bridge-asset-picker-search-input',
-              } as React.ComponentPropsWithoutRef<'input'>
-            }
-            onChange={(event) => setSearchQuery(event.target.value)}
-            placeholder={t('enterTokenNameOrAddress')}
-            size={TextFieldSize.Lg}
-            value={searchQuery}
-          />
+          <Box className="mx-4">
+            <TextFieldSearch
+              autoFocus
+              className="app-text-field-search"
+              clearButtonOnClick={() => setSearchQuery('')}
+              inputProps={
+                {
+                  'data-testid': 'bridge-asset-picker-search-input',
+                } as React.ComponentPropsWithoutRef<'input'>
+              }
+              onChange={(event) => setSearchQuery(event.target.value)}
+              placeholder={t('enterTokenNameOrAddress')}
+              size={TextFieldSize.Lg}
+              value={searchQuery}
+            />
+          </Box>
         </div>
 
         {isNetworkManagementEnabled || !isNetworkPickerOpen ? (

--- a/ui/pages/bridge/prepare/components/bridge-asset-picker/bridge-asset-picker-content.tsx
+++ b/ui/pages/bridge/prepare/components/bridge-asset-picker/bridge-asset-picker-content.tsx
@@ -12,24 +12,18 @@ import {
   ButtonBase,
   ButtonBaseSize,
   FontWeight,
-  Icon,
-  IconColor,
   IconName,
   IconSize,
   Text,
   TextColor,
+  TextFieldSearch,
+  TextFieldSize,
   TextVariant as DsTextVariant,
 } from '@metamask/design-system-react';
 import { type CaipChainId } from '@metamask/utils';
 import { getIsNetworkManagementEnabled } from '../../../../../selectors/multichain/feature-flags';
 import { NETWORK_TO_SHORT_NETWORK_NAME_MAP } from '../../../../../../shared/constants/bridge';
-import { TextField } from '../../../../../components/component-library';
 import { useI18nContext } from '../../../../../hooks/useI18nContext';
-import {
-  BorderColor,
-  BorderRadius,
-  TextVariant,
-} from '../../../../../helpers/constants/design-system';
 import { getAccountGroupsByAddress } from '../../../../../selectors/multichain-accounts/account-tree';
 import { type BridgeAppState } from '../../../../../ducks/bridge/selectors';
 import { type BridgeToken } from '../../../../../ducks/bridge/types';
@@ -212,37 +206,19 @@ export const BridgeAssetPickerContent = forwardRef<
             onClose={() => setIsNetworkPickerOpen(false)}
             testId="bridge-network-picker-popover"
           />
-          <TextField
+          <TextFieldSearch
             autoFocus
-            testId={'bridge-asset-picker-search-input'}
-            placeholder={t('enterTokenNameOrAddress')}
-            value={searchQuery}
-            onChange={(e) => {
-              setSearchQuery(e.target.value);
-            }}
-            borderRadius={BorderRadius.XL}
-            borderWidth={1}
-            borderColor={BorderColor.borderMuted}
-            inputProps={{
-              disableStateStyles: true,
-              textVariant: TextVariant.bodyMd,
-              paddingRight: 2,
-              borderColor: BorderColor.borderMuted,
-            }}
-            style={{
-              minHeight: 48,
-              paddingRight: 8,
-              outline: 'none',
-              borderColor: BorderColor.borderMuted,
-            }}
-            marginInline={4}
-            startAccessory={
-              <Icon
-                color={IconColor.IconAlternative}
-                name={IconName.Search}
-                size={IconSize.Md}
-              />
+            className="app-text-field-search mx-4"
+            clearButtonOnClick={() => setSearchQuery('')}
+            inputProps={
+              {
+                'data-testid': 'bridge-asset-picker-search-input',
+              } as React.ComponentPropsWithoutRef<'input'>
             }
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder={t('enterTokenNameOrAddress')}
+            size={TextFieldSize.Lg}
+            value={searchQuery}
           />
         </div>
 


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Replace deprecated component-library `TextField` in BridgeAssetPickerContent with design-system `TextFieldSearch`.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: updates the Swap/Bridge asset picker to use TextFieldSearch component

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to swaps and pick either To or From asset picker
2. Test that search field styles are updated and search still functions as expected

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<img width="639" height="181" alt="image" src="https://github.com/user-attachments/assets/8cb22e9b-6c10-4705-b674-5b0f7e7d8219" />


### **After**

<img width="528" height="170" alt="image" src="https://github.com/user-attachments/assets/6c26b13f-5db8-4d23-b1af-2c4c8d2ca2bb" />


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only component swap on bridge token search with no changes to bridge logic or data flow; snapshot updates cover the new DOM.
> 
> **Overview**
> The bridge asset picker token search is swapped from the deprecated component-library **`TextField`** to design-system **`TextFieldSearch`**, with **`app-text-field-search`** styling and horizontal margin via a DSR **`Box`**.
> 
> Search behavior is unchanged (`searchQuery` still drives the asset list), but the field now uses a pill-shaped search UI (`type="search"`) and a built-in **clear** control that resets the query via **`clearButtonOnClick`**. The existing **`bridge-asset-picker-search-input`** test id is preserved through **`inputProps`**.
> 
> Jest snapshots for **`BridgeInputGroup`** were updated to match the new markup (including the clear button when the input has a value).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d6d82607b60217b07811c982f972495097d7c4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->