### PR TITLE
chore: swap position of network picker and search bar on swaps asset picker

### DIFF
--- a/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
+++ b/ui/pages/bridge/prepare/__snapshots__/bridge-input-group.test.tsx.snap
@@ -928,28 +928,6 @@ exports[`BridgeInputGroup should search for tokens 1`] = `
           <div
             class="flex flex-col gap-4"
           >
-            <button
-              class="inline-flex items-center justify-center gap-x-1 font-medium overflow-hidden relative h-8 transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] mx-4 w-max rounded-lg border border-muted bg-default px-2 hover:bg-hover active:bg-pressed text-default"
-              data-testid="multichain-asset-picker__network"
-              role="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="inline-block w-5 h-5 shrink-0 text-inherit"
-                fill="currentColor"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 18v-2h4v2zm-4-5v-2h12v2zM3 8V6h18v2z"
-                />
-              </svg>
-              <p
-                class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-medium font-default truncate"
-              >
-                All networks
-              </p>
-            </button>
             <div
               class="mx-4"
             >
@@ -975,6 +953,28 @@ exports[`BridgeInputGroup should search for tokens 1`] = `
                 />
               </div>
             </div>
+            <button
+              class="inline-flex items-center justify-center gap-x-1 font-medium overflow-hidden relative h-8 transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] mx-4 w-max rounded-lg border border-muted bg-default px-2 hover:bg-hover active:bg-pressed text-default"
+              data-testid="multichain-asset-picker__network"
+              role="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="inline-block w-5 h-5 shrink-0 text-inherit"
+                fill="currentColor"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 18v-2h4v2zm-4-5v-2h12v2zM3 8V6h18v2z"
+                />
+              </svg>
+              <p
+                class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-medium font-default truncate"
+              >
+                All networks
+              </p>
+            </button>
           </div>
           <div
             class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"
@@ -1319,28 +1319,6 @@ exports[`BridgeInputGroup should search for tokens 5`] = `
           <div
             class="flex flex-col gap-4"
           >
-            <button
-              class="inline-flex items-center justify-center gap-x-1 font-medium overflow-hidden relative h-8 transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] mx-4 w-max rounded-lg border border-muted bg-default px-2 hover:bg-hover active:bg-pressed text-default"
-              data-testid="multichain-asset-picker__network"
-              role="button"
-            >
-              <svg
-                aria-hidden="true"
-                class="inline-block w-5 h-5 shrink-0 text-inherit"
-                fill="currentColor"
-                viewBox="0 0 24 24"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M10 18v-2h4v2zm-4-5v-2h12v2zM3 8V6h18v2z"
-                />
-              </svg>
-              <p
-                class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-medium font-default truncate"
-              >
-                All networks
-              </p>
-            </button>
             <div
               class="mx-4"
             >
@@ -1382,6 +1360,28 @@ exports[`BridgeInputGroup should search for tokens 5`] = `
                 </button>
               </div>
             </div>
+            <button
+              class="inline-flex items-center justify-center gap-x-1 font-medium overflow-hidden relative h-8 transition-all duration-100 ease-linear active:scale-[0.97] active:ease-[cubic-bezier(0.3,0.8,0.3,1)] mx-4 w-max rounded-lg border border-muted bg-default px-2 hover:bg-hover active:bg-pressed text-default"
+              data-testid="multichain-asset-picker__network"
+              role="button"
+            >
+              <svg
+                aria-hidden="true"
+                class="inline-block w-5 h-5 shrink-0 text-inherit"
+                fill="currentColor"
+                viewBox="0 0 24 24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M10 18v-2h4v2zm-4-5v-2h12v2zM3 8V6h18v2z"
+                />
+              </svg>
+              <p
+                class="text-default text-s-body-sm leading-s-body-sm tracking-s-body-sm md:text-l-body-sm md:leading-l-body-sm md:tracking-l-body-sm font-medium font-default truncate"
+              >
+                All networks
+              </p>
+            </button>
           </div>
           <div
             class="mm-box mm-container mm-container--max-width-undefined mm-box--display-flex mm-box--flex-direction-column mm-box--width-full"

--- a/ui/pages/bridge/prepare/components/bridge-asset-picker/bridge-asset-picker-content.tsx
+++ b/ui/pages/bridge/prepare/components/bridge-asset-picker/bridge-asset-picker-content.tsx
@@ -162,6 +162,22 @@ export const BridgeAssetPickerContent = forwardRef<
     return (
       <>
         <div className="flex flex-col gap-4">
+          <Box className="mx-4">
+            <TextFieldSearch
+              autoFocus
+              className="app-text-field-search"
+              clearButtonOnClick={() => setSearchQuery('')}
+              inputProps={
+                {
+                  'data-testid': 'bridge-asset-picker-search-input',
+                } as React.ComponentPropsWithoutRef<'input'>
+              }
+              onChange={(event) => setSearchQuery(event.target.value)}
+              placeholder={t('enterTokenNameOrAddress')}
+              size={TextFieldSize.Lg}
+              value={searchQuery}
+            />
+          </Box>
           <ButtonBase
             ref={networkPickerButtonRef}
             onClick={() =>
@@ -207,22 +223,6 @@ export const BridgeAssetPickerContent = forwardRef<
             onClose={() => setIsNetworkPickerOpen(false)}
             testId="bridge-network-picker-popover"
           />
-          <Box className="mx-4">
-            <TextFieldSearch
-              autoFocus
-              className="app-text-field-search"
-              clearButtonOnClick={() => setSearchQuery('')}
-              inputProps={
-                {
-                  'data-testid': 'bridge-asset-picker-search-input',
-                } as React.ComponentPropsWithoutRef<'input'>
-              }
-              onChange={(event) => setSearchQuery(event.target.value)}
-              placeholder={t('enterTokenNameOrAddress')}
-              size={TextFieldSize.Lg}
-              value={searchQuery}
-            />
-          </Box>
         </div>
 
         {isNetworkManagementEnabled || !isNetworkPickerOpen ? (


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Moves the network picker below the search bar to bring parity of the layout with other pages in the app.

<img width="531" height="416" alt="image" src="https://github.com/user-attachments/assets/fa4a0245-95d1-4589-97c7-38e3fad6e1eb" />


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: moves swaps token picker network filter to below the search bar

## **Related issues**

Fixes:

## **Manual testing steps**

1. Open Swaps
2. Click into to or from asset and view the asset picker layout

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only reorder with snapshot updates; no swap, bridge, or filtering logic changes.
> 
> **Overview**
> **Reorders the bridge/swap token picker header** so the **search field appears above** the **network filter** button, matching layout on other asset-picker screens.
> 
> The change is limited to JSX order in `bridge-asset-picker-content.tsx`; behavior and test IDs are unchanged. Jest snapshots for `bridge-input-group` were updated for the new DOM order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d52568880755dafdaa06eb40ff011e4d2c33723. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->