### PR TITLE
chore: fix ESLint ignore config

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -33,7 +33,7 @@ module.exports = defineConfig([
     ignores: readFileSync('.prettierignore', 'utf8')
       .trim()
       .split('\n')
-      .map((path) => (path.startsWith('/') ? `.${path}` : path)),
+      .map((path) => (path.startsWith('/') ? path.slice(1) : `**/${path}`)),
   },
   {
     languageOptions: {


### PR DESCRIPTION
## **Description**

The ESLint ignore configuration was misconfigured to only ignore top- level `node_modules` and `__snapshots__` directories. This mistake was made due to a difference in how ESLint interprets ignore paths that was missed in the v9 update (see here for details: https://eslint.org/docs/v9.x/use/configure/ignore#ignoring-directories)

This change has no impact other than making the lint job marginally faster, but it prevents some errors on another draft branch I am working on.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

N/A

## **Manual testing steps**

N/A

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only change to ESLint ignore globs; no product code, auth, or data paths affected.
> 
> **Overview**
> Fixes how **`.eslintrc.js`** maps **`.prettierignore`** entries into ESLint flat-config **`ignores`**, so ignored paths match ESLint v9 directory semantics instead of only top-level folders.
> 
> **Root-anchored patterns** (leading `/`) now drop the slash instead of being prefixed with `.`, and **other patterns** are wrapped as `**/${path}` so matches apply anywhere in the tree (e.g. nested `node_modules` and `__snapshots__`). Lint should skip the same files Prettier ignores and run slightly faster; no application runtime behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6957d570894091c31664d4e32a3bae5ae3b74c4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->