### PR TITLE
fix: add missing events to bottom nav bar experiment config cp-13.42.0

### DIFF
--- a/shared/lib/ab-testing/configs/bottom-nav-bar.ts
+++ b/shared/lib/ab-testing/configs/bottom-nav-bar.ts
@@ -33,6 +33,8 @@ export const BOTTOM_NAV_AB_TEST_ANALYTICS_MAPPING: ABTestAnalyticsMapping = {
   validVariants: [ABTestVariant.Control, ABTestVariant.Treatment],
   eventNames: [
     MetaMetricsEventName.TokenScreenViewed,
+    MetaMetricsEventName.DeFiScreenViewed,
+    MetaMetricsEventName.NftScreenViewed,
     MetaMetricsEventName.PerpsScreenViewed,
     MetaMetricsEventName.ActivityScreenViewed,
     'Unified SwapBridge Page Viewed',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds two missing events to the Bottom Nav Bar experiment config so that they are enriched with relevant ab test properties. They need to be added because the subtab is preserved on navigation away, so when the user clicks back to Home, it won't always be the Token Screen Viewed metric emitted.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Click Defi subtab from home screen
2. Navigate to a bottom nav tab, e.g. Activity
3. Navigate to Home
4. See that the `DeFi Screen Viewed` metric that is fired contains `active_ab_tests` property
5. Repeat for NFT subtab

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Analytics allowlist-only change with no runtime behavior beyond experiment property enrichment on two additional screen-view events.
> 
> **Overview**
> Extends the **Bottom Nav Bar** A/B test analytics allowlist so **DeFi** and **NFT** tab screen views are enriched with the same `active_ab_tests` properties as the other bottom-nav destinations.
> 
> `BOTTOM_NAV_AB_TEST_ANALYTICS_MAPPING` now includes `MetaMetricsEventName.DeFiScreenViewed` and `MetaMetricsEventName.NftScreenViewed` alongside the existing token, perps, activity, and swap/bridge events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 779b67a03aff63a9df2cd022d75f966d641fbe90. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->