### PR TITLE
bump: brace-expansion to 5.0.8

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -20495,11 +20495,11 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^5.0.5":
-  version: 5.0.7
-  resolution: "brace-expansion@npm:5.0.7"
+  version: 5.0.8
+  resolution: "brace-expansion@npm:5.0.8"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10/98c12de33fa53ab07b2b5179f6740045508c61c4319638faf47a0d72615db80058f66c0d1cb74dc8ed591bbf507c068027e80cfb86a2f467bfd330574e13ed7b
+  checksum: 10/75d2d2ebc8f5f65156d16706216d23e48f499a1164e4b045e0ca4045d3ce6b16ced11ea2e4c76e3670b6c38454123213f43d23127df8fc6840980aea9a35e061
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## **Description**

This fixes the production vulnerability by bumping brace-expansion to 5.0.8.

It **DOES NOT FIX** the development vulnerabilities of `brace-expansion@1.1.16` and `brace-expansion@2.1.2`

```
brace-expansion
├─ minimatch@10.2.5
│  └─ brace-expansion@5.0.8 (via ^5.0.8)        ✅ patched
│
├─ minimatch@3.1.5
│  └─ brace-expansion@1.1.16 (via ^1.1.7)       ⚠ vulnerable
│
├─ minimatch@5.1.9
│  └─ brace-expansion@2.1.2 (via ^2.0.1)        ⚠ vulnerable
│
├─ minimatch@7.4.9
│  └─ brace-expansion@2.1.2 (via ^2.0.2)        ⚠ vulnerable
│
└─ minimatch@9.0.9
   └─ brace-expansion@2.1.2 (via ^2.0.2)        ⚠ vulnerable
```

Updating these old minimatch packages is held back by

```
minimatch@3.1.5
├─ @eslint/config-array@0.21.2
├─ @eslint/eslintrc@3.3.5
├─ eslint@9.39.2 / 9.39.4
├─ eslint-plugin-react@7.37.5
├─ filelist@1.0.1
├─ fork-ts-checker-webpack-plugin@8.0.0
├─ glob@7.2.0 / 7.2.3
├─ jake@10.8.5
├─ multimatch@5.0.0
├─ node-dir@0.1.17
├─ serve-handler@6.1.5
└─ test-exclude@6.0.0

minimatch@5.1.9
└─ mocha@10.2.0

minimatch@7.4.9
└─ depcheck@1.4.7

minimatch@9.0.9
├─ @sentry/node@10.38.0
├─ @typescript-eslint/typescript-estree@7.18.0
└─ glob@10.5.0
```

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Closes: #44884 

<!--## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Lockfile-only patch dependency update with no application code changes; residual risk is limited to unfixed older brace-expansion instances still present in dev tooling.
> 
> **Overview**
> Updates the root **`yarn.lock`** so transitive **`brace-expansion@^5.0.5`** resolves to **5.0.8** (from 5.0.7), addressing a reported production vulnerability on the **`minimatch@10`** dependency line.
> 
> **Older `brace-expansion` copies** (1.x and 2.x) pulled in via legacy **`minimatch`** versions are **unchanged**; the PR author notes those dev-time paths remain vulnerable until upstream packages (e.g. ESLint, Mocha, Sentry) move to newer **`minimatch`** releases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dcf0707a2102ea3d187b3011f8dc7fd0d256abc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->