### PR TITLE
refactor(ui): use Arrow2UpRight for Send action icons

### DIFF
--- a/ui/components/app/wallet-overview/coin-buttons.tsx
+++ b/ui/components/app/wallet-overview/coin-buttons.tsx
@@ -560,7 +560,7 @@ const CoinButtons = ({
         data-testid={`${classPrefix}-overview-send`}
         Icon={
           <Icon
-            name={IconName.Send}
+            name={IconName.Arrow2UpRight}
             color={IconColor.IconAlternative}
             size={IconSize.Md}
           />

--- a/ui/components/ui/icon-button/icon-button.stories.tsx
+++ b/ui/components/ui/icon-button/icon-button.stories.tsx
@@ -17,7 +17,7 @@ const meta: Meta<typeof IconButton> = {
   },
   args: {
     onClick: () => {},
-    Icon: <Icon name={IconName.Send} />,
+    Icon: <Icon name={IconName.Arrow2UpRight} />,
     disabled: false,
     label: 'Send',
     className: '',

--- a/ui/pages/asset/components/token-buttons.tsx
+++ b/ui/pages/asset/components/token-buttons.tsx
@@ -159,7 +159,7 @@ const TokenButtons = ({
           onClick={handleSendOnClick}
           Icon={
             <Icon
-              name={IconName.Send}
+              name={IconName.Arrow2UpRight}
               color={IconColor.iconAlternative}
               size={IconSize.Md}
             />

--- a/ui/pages/design-system/design-system.stories.tsx
+++ b/ui/pages/design-system/design-system.stories.tsx
@@ -126,7 +126,7 @@ const WalletHome = () => {
             Receive
           </ButtonBase>
           <ButtonBase className="h-auto flex-1 flex-col justify-center rounded-lg bg-muted py-4 hover:bg-muted-hover active:bg-muted-pressed">
-            <Icon name={IconName.Send} className="mb-2" />
+            <Icon name={IconName.Arrow2UpRight} className="mb-2" />
             Send
           </ButtonBase>
         </Box>


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Send action buttons were still using `IconName.Send`, while other send-related UI (activity/transaction icons, notification badges) already uses the MMDS `arrow-2-up-right` icon. This aligns the labeled Send buttons and matching stories on that icon for visual consistency.

**What changed:**
- Home/wallet overview Send button (`coin-buttons.tsx`) now uses `IconName.Arrow2UpRight`
- Token asset page Send button (`token-buttons.tsx`) now uses `IconName.Arrow2UpRight`
- Related Storybook examples updated (`icon-button.stories.tsx`, `design-system.stories.tsx`)

## **Changelog**

CHANGELOG entry: Updated the Send button icon to use the MetaMask Design System arrow-2-up-right icon

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/DSYS-973?atlOrigin=eyJpIjoiZGJjMjFkNDAxYTU2NDk1NGE3M2MwZjg5OTk4MDY5ODkiLCJwIjoiamlyYS1zbGFjay1pbnQifQ

## **Manual testing steps**

1. Run `yarn start` and load the extension.
2. On the wallet home overview, confirm the Send action button shows the arrow-2-up-right icon (not the previous Send glyph).
3. Open a token asset detail page and confirm the Send button uses the same arrow-2-up-right icon.
4. Optionally run `yarn storybook` and check:
   - `Components/UI/IconButton`
   - `Design System/Example Screen`
   and confirm the Send examples use arrow-2-up-right.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**
<img width="396" height="597" alt="Screenshot 2026-07-27 at 2 42 20 PM" src="https://github.com/user-attachments/assets/91bb8879-b6e9-42db-9d7e-acf2b303dfaf" />
<img width="402" height="600" alt="Screenshot 2026-07-27 at 2 42 25 PM" src="https://github.com/user-attachments/assets/c9eb4441-6d34-43be-9e14-0cc93f1d34f3" />
<img width="581" height="376" alt="Screenshot 2026-07-27 at 2 44 07 PM" src="https://github.com/user-attachments/assets/8990ff85-6c66-4e02-b6f2-aa0f8131a282" />
<img width="106" height="212" alt="Screenshot 2026-07-27 at 2 44 19 PM" src="https://github.com/user-attachments/assets/2dd4cea6-3c9d-4bdb-9200-84a435f438b2" />

### **After**

<img width="400" height="597" alt="Screenshot 2026-07-27 at 2 40 46 PM" src="https://github.com/user-attachments/assets/f0fd8671-aee8-4838-a02c-01507e84ea4e" />
<img width="400" height="599" alt="Screenshot 2026-07-27 at 2 40 41 PM" src="https://github.com/user-attachments/assets/1b0c05eb-af26-4938-8353-811aa42b2e38" />
<img width="574" height="327" alt="Screenshot 2026-07-27 at 2 44 47 PM" src="https://github.com/user-attachments/assets/42ec5dcf-503d-4e04-9739-2844ca83124e" />
<img width="91" height="198" alt="Screenshot 2026-07-27 at 2 44 39 PM" src="https://github.com/user-attachments/assets/cf87d3f0-e21d-45b1-b9e2-9c7c43a74447" />


## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic icon-only changes with no logic, routing, or data handling impact.
> 
> **Overview**
> **Send** action icons are switched from `IconName.Send` to `IconName.Arrow2UpRight` so labeled Send buttons match other send-related UI that already uses the MetaMask Design System **arrow-2-up-right** glyph.
> 
> Wallet home overview (`coin-buttons.tsx`) and token asset overview (`token-buttons.tsx`) Send buttons are updated; Storybook defaults in `icon-button.stories.tsx` and the design-system example screen Send action follow the same icon. Behavior, labels, and click handlers are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e82311a55a67652afbad6d32c63d6d47335a6eb0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->