### PR TITLE
fix: Allow QR singing in side panel on brave

### DIFF
--- a/ui/helpers/utils/webcam-utils.js
+++ b/ui/helpers/utils/webcam-utils.js
@@ -65,7 +65,9 @@ class WebcamUtils {
     // so redirect those to fullscreen whenever the grant isn't already in
     // place. Once granted, the origin-scoped permission is reused in place —
     // this is what lets the user sign entirely within the side panel.
-    const environmentReady = !(isRestrictedEnvironment && !hasWebcamPermissions);
+    const environmentReady = !(
+      isRestrictedEnvironment && !hasWebcamPermissions
+    );
 
     return {
       permissions: hasWebcamPermissions,

--- a/ui/helpers/utils/webcam-utils.js
+++ b/ui/helpers/utils/webcam-utils.js
@@ -3,11 +3,9 @@
 import {
   ENVIRONMENT_TYPE_POPUP,
   ENVIRONMENT_TYPE_SIDEPANEL,
-  PLATFORM_BRAVE,
-  PLATFORM_FIREFOX,
 } from '../../../shared/constants/app';
 import { getEnvironmentType } from '../../../shared/lib/environment-type';
-import { getBrowserName } from '../../../shared/lib/browser-runtime.utils';
+import { CameraPermissionState } from '../../contexts/hardware-wallets/constants';
 import {
   openCameraVideoStream,
   queryCameraPermissionWithStatus,
@@ -42,41 +40,37 @@ class WebcamUtils {
 
   static async checkStatus() {
     const environmentType = getEnvironmentType();
-    const isPopup = environmentType === ENVIRONMENT_TYPE_POPUP;
-    const isSidepanel = environmentType === ENVIRONMENT_TYPE_SIDEPANEL;
-    const browserName = getBrowserName();
-    const isFirefoxOrBrave =
-      browserName === PLATFORM_FIREFOX || browserName === PLATFORM_BRAVE;
+    const isRestrictedEnvironment =
+      environmentType === ENVIRONMENT_TYPE_POPUP ||
+      environmentType === ENVIRONMENT_TYPE_SIDEPANEL;
 
     const devices = await window.navigator.mediaDevices.enumerateDevices();
-    const webcams = devices.filter((device) => device.kind === 'videoinput');
-    const hasWebcam = webcams.length > 0;
-    // A non-empty-string label implies that the webcam has been granted permission, as
-    // otherwise the label is kept blank to prevent fingerprinting
-    const hasWebcamPermissions = webcams.some(
-      (webcam) => webcam.label && webcam.label.length > 0,
-    );
+    const hasWebcam = devices.some((device) => device.kind === 'videoinput');
 
-    if (hasWebcam) {
-      let environmentReady = true;
-      // Popup and sidepanel modes have limited camera permission capabilities.
-      // When permissions aren't granted, redirect to fullscreen mode where
-      // the browser can properly prompt for camera access.
-      const isRestrictedEnvironment = isPopup || isSidepanel;
-      if (
-        (isFirefoxOrBrave && isRestrictedEnvironment) ||
-        (isRestrictedEnvironment && !hasWebcamPermissions)
-      ) {
-        environmentReady = false;
-      }
-      return {
-        permissions: hasWebcamPermissions,
-        environmentReady,
-      };
+    if (!hasWebcam) {
+      const error = new Error('No webcam found');
+      error.type = 'NO_WEBCAM_FOUND';
+      throw error;
     }
-    const error = new Error('No webcam found');
-    error.type = 'NO_WEBCAM_FOUND';
-    throw error;
+
+    // Detect permission via the Permissions API rather than device labels.
+    // Device labels stay blank until `getUserMedia` has succeeded in the
+    // current document (per the media-capture spec, and reinforced by Brave's
+    // anti-fingerprinting "farbling"), so they can't tell us whether the
+    // extension origin already holds a persisted grant.
+    const { state } = await queryCameraPermissionWithStatus();
+    const hasWebcamPermissions = state === CameraPermissionState.Granted;
+
+    // No Chromium context (popup or side panel) can surface a camera prompt,
+    // so redirect those to fullscreen whenever the grant isn't already in
+    // place. Once granted, the origin-scoped permission is reused in place —
+    // this is what lets the user sign entirely within the side panel.
+    const environmentReady = !(isRestrictedEnvironment && !hasWebcamPermissions);
+
+    return {
+      permissions: hasWebcamPermissions,
+      environmentReady,
+    };
   }
 }
 

--- a/ui/helpers/utils/webcam-utils.test.ts
+++ b/ui/helpers/utils/webcam-utils.test.ts
@@ -103,44 +103,48 @@ describe('WebcamUtils', () => {
         });
       });
 
-      describe.each([
+      const restrictedEnvironments = [
         ['popup', ENVIRONMENT_TYPE_POPUP],
         ['sidepanel', ENVIRONMENT_TYPE_SIDEPANEL],
-      ])('in %s mode', (_name, environmentType) => {
-        beforeEach(() => {
-          mockGetEnvironmentType.mockReturnValue(environmentType);
-        });
+      ] as const;
 
-        it('returns environmentReady true when permission is granted', async () => {
-          mockQueryPermission.mockResolvedValue({ state: 'granted' });
-
-          const result = await WebcamUtils.checkStatus();
-
-          expect(result).toStrictEqual({
-            permissions: true,
-            environmentReady: true,
+      restrictedEnvironments.forEach(([name, environmentType]) => {
+        describe(`in ${name} mode`, () => {
+          beforeEach(() => {
+            mockGetEnvironmentType.mockReturnValue(environmentType);
           });
-        });
 
-        it('returns environmentReady false when permission is not yet granted (prompt)', async () => {
-          mockQueryPermission.mockResolvedValue({ state: 'prompt' });
+          it('returns environmentReady true when permission is granted', async () => {
+            mockQueryPermission.mockResolvedValue({ state: 'granted' });
 
-          const result = await WebcamUtils.checkStatus();
+            const result = await WebcamUtils.checkStatus();
 
-          expect(result).toStrictEqual({
-            permissions: false,
-            environmentReady: false,
+            expect(result).toStrictEqual({
+              permissions: true,
+              environmentReady: true,
+            });
           });
-        });
 
-        it('returns environmentReady false when permission is denied', async () => {
-          mockQueryPermission.mockResolvedValue({ state: 'denied' });
+          it('returns environmentReady false when permission is not yet granted (prompt)', async () => {
+            mockQueryPermission.mockResolvedValue({ state: 'prompt' });
 
-          const result = await WebcamUtils.checkStatus();
+            const result = await WebcamUtils.checkStatus();
 
-          expect(result).toStrictEqual({
-            permissions: false,
-            environmentReady: false,
+            expect(result).toStrictEqual({
+              permissions: false,
+              environmentReady: false,
+            });
+          });
+
+          it('returns environmentReady false when permission is denied', async () => {
+            mockQueryPermission.mockResolvedValue({ state: 'denied' });
+
+            const result = await WebcamUtils.checkStatus();
+
+            expect(result).toStrictEqual({
+              permissions: false,
+              environmentReady: false,
+            });
           });
         });
       });

--- a/ui/helpers/utils/webcam-utils.test.ts
+++ b/ui/helpers/utils/webcam-utils.test.ts
@@ -3,29 +3,20 @@ import {
   ENVIRONMENT_TYPE_POPUP,
   ENVIRONMENT_TYPE_SIDEPANEL,
   ENVIRONMENT_TYPE_FULLSCREEN,
-  PLATFORM_CHROME,
-  PLATFORM_FIREFOX,
 } from '../../../shared/constants/app';
-import { getBrowserName } from '../../../shared/lib/browser-runtime.utils';
 import WebcamUtils from './webcam-utils';
 
 jest.mock('../../../shared/lib/environment-type', () => ({
   getEnvironmentType: jest.fn(),
 }));
 
-jest.mock('../../../shared/lib/browser-runtime.utils', () => ({
-  getBrowserName: jest.fn(),
-}));
-
 const mockGetEnvironmentType = getEnvironmentType as jest.MockedFunction<
   typeof getEnvironmentType
->;
-const mockGetBrowserName = getBrowserName as jest.MockedFunction<
-  typeof getBrowserName
 >;
 
 describe('WebcamUtils', () => {
   const mockEnumerateDevices = jest.fn();
+  const mockQueryPermission = jest.fn();
   let originalNavigator: Navigator;
 
   beforeEach(() => {
@@ -34,19 +25,23 @@ describe('WebcamUtils', () => {
     // Store original navigator
     originalNavigator = window.navigator;
 
-    // Mock navigator.mediaDevices
+    // Mock navigator.mediaDevices and navigator.permissions
     Object.defineProperty(window, 'navigator', {
       value: {
         ...originalNavigator,
         mediaDevices: {
           enumerateDevices: mockEnumerateDevices,
         },
+        permissions: {
+          query: mockQueryPermission,
+        },
       },
       writable: true,
       configurable: true,
     });
 
-    mockGetBrowserName.mockReturnValue(PLATFORM_CHROME);
+    // Default: camera permission has been granted.
+    mockQueryPermission.mockResolvedValue({ state: 'granted' });
   });
 
   afterEach(() => {
@@ -59,6 +54,9 @@ describe('WebcamUtils', () => {
   });
 
   describe('checkStatus', () => {
+    // Labels are intentionally blank: detection no longer relies on them.
+    const webcam = { kind: 'videoinput', label: '' };
+
     describe('when no webcam is found', () => {
       it('throws NO_WEBCAM_FOUND error', async () => {
         mockEnumerateDevices.mockResolvedValue([]);
@@ -72,14 +70,9 @@ describe('WebcamUtils', () => {
     });
 
     describe('when webcam is found', () => {
-      const webcamWithPermission = {
-        kind: 'videoinput',
-        label: 'FaceTime HD Camera',
-      };
-      const webcamWithoutPermission = {
-        kind: 'videoinput',
-        label: '',
-      };
+      beforeEach(() => {
+        mockEnumerateDevices.mockResolvedValue([webcam]);
+      });
 
       describe('in fullscreen mode', () => {
         beforeEach(() => {
@@ -87,7 +80,7 @@ describe('WebcamUtils', () => {
         });
 
         it('returns environmentReady true with permissions', async () => {
-          mockEnumerateDevices.mockResolvedValue([webcamWithPermission]);
+          mockQueryPermission.mockResolvedValue({ state: 'granted' });
 
           const result = await WebcamUtils.checkStatus();
 
@@ -97,11 +90,12 @@ describe('WebcamUtils', () => {
           });
         });
 
-        it('returns environmentReady true without permissions', async () => {
-          mockEnumerateDevices.mockResolvedValue([webcamWithoutPermission]);
+        it('returns environmentReady true even without permissions', async () => {
+          mockQueryPermission.mockResolvedValue({ state: 'prompt' });
 
           const result = await WebcamUtils.checkStatus();
 
+          // Fullscreen can prompt in place, so it never needs a redirect.
           expect(result).toStrictEqual({
             permissions: false,
             environmentReady: true,
@@ -109,13 +103,16 @@ describe('WebcamUtils', () => {
         });
       });
 
-      describe('in popup mode', () => {
+      describe.each([
+        ['popup', ENVIRONMENT_TYPE_POPUP],
+        ['sidepanel', ENVIRONMENT_TYPE_SIDEPANEL],
+      ])('in %s mode', (_name, environmentType) => {
         beforeEach(() => {
-          mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_POPUP);
+          mockGetEnvironmentType.mockReturnValue(environmentType);
         });
 
-        it('returns environmentReady true when permissions are granted', async () => {
-          mockEnumerateDevices.mockResolvedValue([webcamWithPermission]);
+        it('returns environmentReady true when permission is granted', async () => {
+          mockQueryPermission.mockResolvedValue({ state: 'granted' });
 
           const result = await WebcamUtils.checkStatus();
 
@@ -125,8 +122,8 @@ describe('WebcamUtils', () => {
           });
         });
 
-        it('returns environmentReady false when permissions are not granted', async () => {
-          mockEnumerateDevices.mockResolvedValue([webcamWithoutPermission]);
+        it('returns environmentReady false when permission is not yet granted (prompt)', async () => {
+          mockQueryPermission.mockResolvedValue({ state: 'prompt' });
 
           const result = await WebcamUtils.checkStatus();
 
@@ -136,54 +133,13 @@ describe('WebcamUtils', () => {
           });
         });
 
-        it('returns environmentReady false in Firefox even with permissions', async () => {
-          mockGetBrowserName.mockReturnValue(PLATFORM_FIREFOX);
-          mockEnumerateDevices.mockResolvedValue([webcamWithPermission]);
-
-          const result = await WebcamUtils.checkStatus();
-
-          expect(result).toStrictEqual({
-            permissions: true,
-            environmentReady: false,
-          });
-        });
-      });
-
-      describe('in sidepanel mode', () => {
-        beforeEach(() => {
-          mockGetEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_SIDEPANEL);
-        });
-
-        it('returns environmentReady true when permissions are granted', async () => {
-          mockEnumerateDevices.mockResolvedValue([webcamWithPermission]);
-
-          const result = await WebcamUtils.checkStatus();
-
-          expect(result).toStrictEqual({
-            permissions: true,
-            environmentReady: true,
-          });
-        });
-
-        it('returns environmentReady false when permissions are not granted', async () => {
-          mockEnumerateDevices.mockResolvedValue([webcamWithoutPermission]);
+        it('returns environmentReady false when permission is denied', async () => {
+          mockQueryPermission.mockResolvedValue({ state: 'denied' });
 
           const result = await WebcamUtils.checkStatus();
 
           expect(result).toStrictEqual({
             permissions: false,
-            environmentReady: false,
-          });
-        });
-
-        it('returns environmentReady false in Firefox even with permissions', async () => {
-          mockGetBrowserName.mockReturnValue(PLATFORM_FIREFOX);
-          mockEnumerateDevices.mockResolvedValue([webcamWithPermission]);
-
-          const result = await WebcamUtils.checkStatus();
-
-          expect(result).toStrictEqual({
-            permissions: true,
             environmentReady: false,
           });
         });
@@ -192,31 +148,11 @@ describe('WebcamUtils', () => {
   });
 
   describe('queryCameraPermission', () => {
-    beforeEach(() => {
-      Object.defineProperty(window, 'navigator', {
-        value: {
-          ...originalNavigator,
-          mediaDevices: {
-            enumerateDevices: mockEnumerateDevices,
-          },
-          permissions: {
-            query: jest.fn(),
-          },
-        },
-        writable: true,
-        configurable: true,
-      });
-    });
-
     it('returns state and permissionStatus when supported', async () => {
       const permissionStatus = {
         state: 'denied',
       } as PermissionStatus;
-      (
-        window.navigator.permissions.query as jest.MockedFunction<
-          typeof window.navigator.permissions.query
-        >
-      ).mockResolvedValue(permissionStatus);
+      mockQueryPermission.mockResolvedValue(permissionStatus);
 
       await expect(WebcamUtils.queryCameraPermission()).resolves.toStrictEqual({
         state: 'denied',
@@ -225,11 +161,7 @@ describe('WebcamUtils', () => {
     });
 
     it('falls back to prompt when query throws', async () => {
-      (
-        window.navigator.permissions.query as jest.MockedFunction<
-          typeof window.navigator.permissions.query
-        >
-      ).mockRejectedValue(new Error('unsupported'));
+      mockQueryPermission.mockRejectedValue(new Error('unsupported'));
 
       await expect(WebcamUtils.queryCameraPermission()).resolves.toStrictEqual({
         state: 'prompt',


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

### Problem
- when signing a qr transaction in sidepanel or popup, the user is taken to fullscreen mode when its time to scan the qr code from the hw wallet (using the webcam).

- The problem is when the user clicks get signature in popup/sidepanel mode, they are brought to a full screen that prompts them to re scan the same qr code they just scanned.

- When the user gets to this step, they should be prompted to open the camera (or the camera should automatically open if they have granted permissions), to scan the code from the hw wallet. This could be contributing to our low conversion rate for qr. 

- This issue does not seem to effecting chrome but it is still effecting brave browser. 

### Solution

  QR hardware wallet signing worked in the side panel on Chrome but always bounced to fullscreen on Brave,
  even when camera permission was already granted.

  Root cause was in WebcamUtils.checkStatus(): it detected camera permission by reading enumerateDevices()
  labels and had a hard-coded "always redirect Firefox/Brave to fullscreen" branch. Device labels stay
  blank until getUserMedia succeeds (and Brave farbles them anyway), so the heuristic could never confirm
  a granted permission on Brave.

  Switched detection to the Permissions API (navigator.permissions.query({ name: 'camera' })) and dropped
  the Brave/Firefox special-case. Now every Chromium browser is treated the same: permission granted →
  sign in place in the side panel; not granted → open fullscreen to prompt (no Chromium context can show a
  camera prompt in the panel/popup, so the fullscreen grant step stays).

  Tests updated to drive off permission state instead of labels. Existing checkStatus callers are
  unaffected (return shape preserved).

  Note: this lets Brave attempt the in-panel flow — worth a quick manual check that Brave keeps the panel
  open and the stream goes live post-grant (there's a known Brave side-panel bug, #32132). If it
  misbehaves, easy to add a Brave-scoped fallback gated on the real failure.

 ### Firefox impact

  Removing the hard-coded `isFirefoxOrBrave` branch also changes Firefox behavior, since it was lumped
  into the same override. Firefox has no side panel here (not in `app/manifest/v3/firefox.json`), so the
  only affected surface is the **popup** — which previously redirected to fullscreen on *every* QR sign
  attempt, regardless of granted permission. That matches
  [metamask-extension#43364](https://github.com/MetaMask/metamask-extension/issues/43364) exactly, so this
  likely fixes it as a side effect: granted → stay in popup, not granted → fullscreen, same as every
  other browser now.

  **Worth a manual check:** Firefox's `permissions.query('camera')` support only shipped in Firefox
  118/119 ([intent-to-ship](https://groups.google.com/a/mozilla.org/g/dev-platform/c/auH04v5gGk8)), and
  Firefox's one-time/per-session permission model means `granted` may not persist across restarts the way
  it does in Chrome/Brave. Neither is a regression, but both are worth verifying alongside the Brave
  testing.


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: Allow QR signing in side panel on Brave Browser

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/MUL-1876
Fixes: https://consensyssoftware.atlassian.net/browse/MUL-2053

## **Manual testing steps**

1. Download and configure brave browser (if you do not have it installed already)
2. setup the extension on brave (its the exact same as chrome)
3. configure a keystone wallet
4. when prompted to give camera permissions, set to always allow
5. go to perform a send form the side panel window
6. you should be able to scan and complete the signing all in side panel without opening full screen mode.

#### Test case without permissions
1. Download and configure brave browser (if you do not have it installed already)
2. setup the extension on brave (its the exact same as chrome)
3. configure a keystone wallet
4. when prompted to give camera permissions, allow it but only allow for a temporary amount of time
    - Alternatively, you can set the camera permissions to be Ask in the browser settings by viewing the extensions permissions (right click on the extension Icon)
 
<img width="370" height="370" alt="Screenshot 2026-07-28 at 11 40 19 AM" src="https://github.com/user-attachments/assets/22dcec48-4b91-4533-9186-3227b3c05d33" />

6. go to perform a send form the side panel window
7. Configure the send, clicking the last confirm step should prompt the user to allow camera permissions in full screen
8. the user should be brought to full screen mode and prompted to grant permissions
9. if the user grants camera access, then we should be able to complete the send
10. if camera access it denied, you should continuously be warned that camera permissions are needed and prompted to grant them.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**


https://github.com/user-attachments/assets/cfb0272e-7236-47c0-b5ca-c30b0123d529

Firefox before:


https://github.com/user-attachments/assets/e756b9f7-c461-4fc3-bc07-ea78c75eb47d



### **After**

With Camera Permissions

https://github.com/user-attachments/assets/8aad4af2-d9f4-4f86-8f70-6cbbac8128a3

Without Camera Permissions (Needs fullscreen)


https://github.com/user-attachments/assets/75187d2a-9afe-494a-ac31-e39354147bc5


Firefox after (now works in popup)

https://github.com/user-attachments/assets/52bc3d78-11e8-45c4-8329-727078aea294



<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized change to webcam readiness logic with the same return shape; tests cover restricted vs fullscreen environments.
> 
> **Overview**
> Fixes **Brave side panel QR signing** always bouncing to fullscreen even when camera access was already granted.
> 
> **`WebcamUtils.checkStatus()`** no longer infers permission from `enumerateDevices()` labels or applies a **Firefox/Brave** “always redirect” rule. It now calls **`queryCameraPermissionWithStatus()`** and treats **`granted`** as permission present. **Popup and side panel** still set `environmentReady` to false when permission is not granted (Chromium can’t prompt there); **fullscreen** stays ready so it can prompt in place.
> 
> Tests mock **`navigator.permissions.query`** and assert behavior by permission state (`granted` / `prompt` / `denied`) instead of device labels; Firefox-specific cases are removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 965582170a88bd49c8af1ab273a873404ba45dc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->