### PR TITLE
chore: remove defi v2 fetching from getApi

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2637,7 +2637,6 @@ export default class MetamaskController extends EventEmitter {
       notificationServicesController,
       notificationServicesPushController,
       deFiPositionsController,
-      deFiPositionsControllerV2,
       multichainAssetsRatesController,
       staticAssetsController,
     } = this;
@@ -3763,10 +3762,6 @@ export default class MetamaskController extends EventEmitter {
       ),
       deFiStopPolling: deFiPositionsController.stopPollingByPollingToken.bind(
         deFiPositionsController,
-      ),
-
-      fetchDeFiPositions: deFiPositionsControllerV2.fetchDeFiPositions.bind(
-        deFiPositionsControllerV2,
       ),
 
       // GasFeeController


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

Removed new and yet unused defi position fetching from metamask-controller getApi as discussed here: https://github.com/MetaMask/metamask-extension/pull/44772#discussion_r3639962763

This is done after verifying in this follow up PR that the method works: https://github.com/MetaMask/metamask-extension/pull/44392

A route with a messenger will be used instead.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow API cleanup with no auth, data, or user-facing behavior change; v2 fetching was unused from `getApi`.
> 
> **Overview**
> Removes **DeFi Positions v2** from the background **`getApi`** surface: `deFiPositionsControllerV2` is no longer destructured there, and **`fetchDeFiPositions`** is no longer exposed to the UI/extension API.
> 
> **v1 DeFi polling** (`deFiStartPolling` / `deFiStopPolling` via `deFiPositionsController`) is unchanged. The v2 controller can still be wired elsewhere; this only drops unused API plumbing ahead of a separate integration path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79ee4de9c3f8c5388cfb38e188075a2aa2432d48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->