### PR TITLE
refactor(wpc-1068): migrate `requestSafeReload` & `openUpdateTabAndReload` to `LegacyBackgroundApiService`

### DIFF
--- a/app/scripts/lib/open-update-tab-and-reload.ts
+++ b/app/scripts/lib/open-update-tab-and-reload.ts
@@ -1,5 +1,4 @@
 import browser from 'webextension-polyfill';
-import type MetamaskController from '../metamask-controller';
 
 /**
  * Opens the "Updating" page in a new tab and then triggers a safe extension reload.
@@ -8,11 +7,11 @@ import type MetamaskController from '../metamask-controller';
  *
  * If opening the tab fails, the error is logged, and the reload proceeds anyway.
  *
- * @param requestSafeReload - A function from MetamaskController that initiates a safe reload
- * of the extension without disrupting user state.
+ * @param requestSafeReload - A function that initiates a safe reload of the
+ * extension without disrupting user state.
  */
 export async function openUpdateTabAndReload(
-  requestSafeReload: MetamaskController['requestSafeReload'],
+  requestSafeReload: () => Promise<void>,
 ) {
   try {
     await browser.tabs.create({

--- a/app/scripts/messenger-client-init/legacy-background-api-service-init.ts
+++ b/app/scripts/messenger-client-init/legacy-background-api-service-init.ts
@@ -12,6 +12,7 @@ import { MessengerClientInitFunction } from './types';
  * @param request.infuraProjectId - The Infura project ID.
  * @param request.getRequestAccountTabIds - A function that returns a record of account tab IDs.
  * @param request.getOpenMetamaskTabsIds - A function that returns a record of open MetaMask tab IDs.
+ * @param request.requestSafeReload - A function that triggers a safe reload of the extension.
  * @param request.sendUpdate - A function to send updates to the UI.
  * @param request.seedlessOperationMutex - A mutex to use for seedless operations.
  * @param request.createVaultMutex - A mutex to serialize vault creation/export with locking.
@@ -26,6 +27,7 @@ export const LegacyBackgroundApiServiceInit: MessengerClientInitFunction<
   infuraProjectId,
   getRequestAccountTabIds,
   getOpenMetamaskTabsIds,
+  requestSafeReload,
   sendUpdate,
   seedlessOperationMutex,
   createVaultMutex,
@@ -36,6 +38,7 @@ export const LegacyBackgroundApiServiceInit: MessengerClientInitFunction<
     infuraProjectId,
     getRequestAccountTabIds,
     getOpenMetamaskTabsIds,
+    requestSafeReload,
     sendUpdate,
     seedlessOperationMutex,
     createVaultMutex,

--- a/app/scripts/messenger-client-init/types.ts
+++ b/app/scripts/messenger-client-init/types.ts
@@ -239,6 +239,11 @@ export type MessengerClientInitRequest<
   getOpenMetamaskTabsIds: () => Record<string, number>;
 
   /**
+   * Triggers a safe reload of the extension without disrupting user state.
+   */
+  requestSafeReload: () => Promise<void>;
+
+  /**
    * Sends an update to the UI.
    *
    */

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -385,7 +385,6 @@ import { NotificationServicesControllerInit } from './messenger-client-init/noti
 import { NotificationServicesPushControllerInit } from './messenger-client-init/notifications/notification-services-push-controller-init';
 import { DelegationControllerInit } from './messenger-client-init/delegation/delegation-controller-init';
 import { isRelaySupported } from './lib/transaction/transaction-relay';
-import { openUpdateTabAndReload } from './lib/open-update-tab-and-reload';
 import { AccountTreeControllerInit } from './messenger-client-init/accounts/account-tree-controller-init';
 import { MultichainAccountServiceInit } from './messenger-client-init/multichain/multichain-account-service-init';
 import { SnapAccountServiceInit } from './messenger-client-init/accounts/snap-account-service-init';
@@ -3971,9 +3970,14 @@ export default class MetamaskController extends EventEmitter {
         this.controllerMessenger,
         'LegacyBackgroundApiService:isSendBundleSupported',
       ),
-      openUpdateTabAndReload: () =>
-        openUpdateTabAndReload(this.requestSafeReload.bind(this)),
-      requestSafeReload: this.requestSafeReload.bind(this),
+      openUpdateTabAndReload: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'LegacyBackgroundApiService:openUpdateTabAndReload',
+      ),
+      requestSafeReload: this.controllerMessenger.call.bind(
+        this.controllerMessenger,
+        'LegacyBackgroundApiService:requestSafeReload',
+      ),
       applyTransactionContainersExisting: this.controllerMessenger.call.bind(
         this.controllerMessenger,
         'LegacyBackgroundApiService:applyTransactionContainersExisting',
@@ -9299,6 +9303,7 @@ export default class MetamaskController extends EventEmitter {
       getUIState: this.getState.bind(this),
       infuraProjectId: this.opts.infuraProjectId,
       initLangCode: this.opts.initLangCode,
+      requestSafeReload: this.requestSafeReload.bind(this),
       sendUpdate: this.sendUpdate.bind(this),
       offscreenPromise: this.offscreenPromise,
       preinstalledSnaps: this.opts.preinstalledSnaps,

--- a/app/scripts/services/legacy-background-api-service-method-action-types.ts
+++ b/app/scripts/services/legacy-background-api-service-method-action-types.ts
@@ -85,6 +85,23 @@ export type LegacyBackgroundApiServiceGetOpenMetamaskTabsIdsAction = {
 };
 
 /**
+ * Triggers a safe reload of the extension without disrupting user state.
+ */
+export type LegacyBackgroundApiServiceRequestSafeReloadAction = {
+  type: `LegacyBackgroundApiService:requestSafeReload`;
+  handler: LegacyBackgroundApiService['requestSafeReload'];
+};
+
+/**
+ * Opens the "Updating" page in a new tab and then triggers a safe extension
+ * reload. Used when an update is available.
+ */
+export type LegacyBackgroundApiServiceOpenUpdateTabAndReloadAction = {
+  type: `LegacyBackgroundApiService:openUpdateTabAndReload`;
+  handler: LegacyBackgroundApiService['openUpdateTabAndReload'];
+};
+
+/**
  * Updates the phishing lists if necessary and then checks whether the given
  * website is a known phishing site.
  *
@@ -507,6 +524,8 @@ export type LegacyBackgroundApiServiceMethodActions =
   | LegacyBackgroundApiServiceIsSendBundleSupportedAction
   | LegacyBackgroundApiServiceGetRequestAccountTabIdsAction
   | LegacyBackgroundApiServiceGetOpenMetamaskTabsIdsAction
+  | LegacyBackgroundApiServiceRequestSafeReloadAction
+  | LegacyBackgroundApiServiceOpenUpdateTabAndReloadAction
   | LegacyBackgroundApiServiceGetPhishingResultAction
   | LegacyBackgroundApiServiceMarkPasswordForgottenAction
   | LegacyBackgroundApiServiceUnMarkPasswordForgottenAction

--- a/app/scripts/services/legacy-background-api-service.test.ts
+++ b/app/scripts/services/legacy-background-api-service.test.ts
@@ -39,6 +39,7 @@ import { enforceSimulations } from '../lib/transaction/containers/enforced-simul
 import { isSendBundleSupported } from '../lib/transaction/sentinel-api';
 import { isRelaySupported } from '../lib/transaction/transaction-relay';
 import { decodeTransactionData } from '../lib/transaction/decode/util';
+import { openUpdateTabAndReload } from '../lib/open-update-tab-and-reload';
 import {
   LegacyBackgroundApiService,
   LegacyBackgroundApiServiceMessenger,
@@ -60,6 +61,7 @@ const mockGetIsShieldSubscriptionActive = jest.mocked(
 jest.mock('../lib/transaction/sentinel-api');
 jest.mock('../lib/transaction/transaction-relay');
 jest.mock('../lib/transaction/decode/util');
+jest.mock('../lib/open-update-tab-and-reload');
 jest.mock('../../../shared/lib/sentry');
 
 describe('LegacyBackgroundApiService', () => {
@@ -416,6 +418,51 @@ describe('LegacyBackgroundApiService', () => {
 
           expect(result).toEqual(mockTabIds);
           expect(mockGetOpenMetamaskTabsIds).toHaveBeenCalled();
+        },
+      );
+    });
+  });
+
+  describe('requestSafeReload', () => {
+    it('triggers a safe reload of the extension', async () => {
+      const mockRequestSafeReload = jest.fn().mockResolvedValue(undefined);
+
+      await withService(
+        {
+          options: {
+            requestSafeReload: mockRequestSafeReload,
+          },
+        },
+        async ({ rootMessenger }) => {
+          await rootMessenger.call(
+            'LegacyBackgroundApiService:requestSafeReload',
+          );
+
+          expect(mockRequestSafeReload).toHaveBeenCalled();
+        },
+      );
+    });
+  });
+
+  describe('openUpdateTabAndReload', () => {
+    it('opens the update tab and reloads with the injected requestSafeReload', async () => {
+      const mockRequestSafeReload = jest.fn().mockResolvedValue(undefined);
+      jest.mocked(openUpdateTabAndReload).mockResolvedValue(undefined);
+
+      await withService(
+        {
+          options: {
+            requestSafeReload: mockRequestSafeReload,
+          },
+        },
+        async ({ rootMessenger }) => {
+          await rootMessenger.call(
+            'LegacyBackgroundApiService:openUpdateTabAndReload',
+          );
+
+          expect(openUpdateTabAndReload).toHaveBeenCalledWith(
+            mockRequestSafeReload,
+          );
         },
       );
     });
@@ -3692,6 +3739,7 @@ async function withService<ReturnValue>(
     infuraProjectId: 'test-infura-project-id',
     getRequestAccountTabIds: () => ({}),
     getOpenMetamaskTabsIds: () => ({}),
+    requestSafeReload: jest.fn(),
     sendUpdate: jest.fn(),
     seedlessOperationMutex: new Mutex(),
     createVaultMutex: new Mutex(),

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -558,7 +558,7 @@ export class LegacyBackgroundApiService {
    * reload. Used when an update is available.
    */
   async openUpdateTabAndReload(): Promise<void> {
-    return openUpdateTabAndReload(this.#requestSafeReload);
+    return openUpdateTabAndReload(this.#requestSafeReload);return openUpdateTabAndReload(this.#requestSafeReload.bind(this));
   }
 
   /**

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -558,7 +558,7 @@ export class LegacyBackgroundApiService {
    * reload. Used when an update is available.
    */
   async openUpdateTabAndReload(): Promise<void> {
-    return openUpdateTabAndReload(this.#requestSafeReload.bind(this));
+    return openUpdateTabAndReload(this.#requestSafeReload);return openUpdateTabAndReload(this.#requestSafeReload.bind(this));
   }
 
   /**

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -558,7 +558,7 @@ export class LegacyBackgroundApiService {
    * reload. Used when an update is available.
    */
   async openUpdateTabAndReload(): Promise<void> {
-    return openUpdateTabAndReload(this.#requestSafeReload.bind(this));
+    return openUpdateTabAndReload(this.#requestSafeReload);
   }
 
   /**

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -558,7 +558,7 @@ export class LegacyBackgroundApiService {
    * reload. Used when an update is available.
    */
   async openUpdateTabAndReload(): Promise<void> {
-    return openUpdateTabAndReload(this.#requestSafeReload);return openUpdateTabAndReload(this.#requestSafeReload.bind(this));
+    return openUpdateTabAndReload(this.#requestSafeReload.bind(this));
   }
 
   /**

--- a/app/scripts/services/legacy-background-api-service.ts
+++ b/app/scripts/services/legacy-background-api-service.ts
@@ -159,6 +159,7 @@ import {
 import { OnboardingControllerGetIsSocialLoginFlowAction } from '../controllers/onboarding-method-action-types';
 import { getAccountsBySnapId } from '../lib/snap-keyring';
 import { isSendBundleSupported } from '../lib/transaction/sentinel-api';
+import { openUpdateTabAndReload } from '../lib/open-update-tab-and-reload';
 import { applyTransactionContainers } from '../lib/transaction/containers/util';
 import { isRelaySupported } from '../lib/transaction/transaction-relay';
 import { decodeTransactionData } from '../lib/transaction/decode/util';
@@ -218,11 +219,13 @@ const MESSENGER_EXPOSED_METHODS = [
   'isSendBundleSupported',
   'markPasswordForgotten',
   'onAccountRemoved',
+  'openUpdateTabAndReload',
   'rejectAllPendingApprovals',
   'rejectPendingApproval',
   'rejectPermissionsRequest',
   'removeAccount',
   'removePermissionsFor',
+  'requestSafeReload',
   'resetAccount',
   'setAccountLabel',
   'setCurrentCurrency',
@@ -350,6 +353,7 @@ type LegacyBackgroundApiServiceOptions = {
   createVaultMutex: Mutex;
   getRequestAccountTabIds: () => Record<string, number>;
   getOpenMetamaskTabsIds: () => Record<string, number>;
+  requestSafeReload: () => Promise<void>;
   sendUpdate: () => void;
   offscreenPromise: Promise<void>;
 };
@@ -374,6 +378,8 @@ export class LegacyBackgroundApiService {
 
   readonly #getOpenMetamaskTabsIds: () => Record<string, number>;
 
+  readonly #requestSafeReload: () => Promise<void>;
+
   readonly #sendUpdate: () => void;
 
   readonly #seedlessOperationMutex: Mutex;
@@ -391,6 +397,7 @@ export class LegacyBackgroundApiService {
    * @param options.infuraProjectId - The Infura project ID.
    * @param options.getRequestAccountTabIds - A function that returns a record of account tab IDs.
    * @param options.getOpenMetamaskTabsIds - A function that returns a record of open MetaMask tab IDs.
+   * @param options.requestSafeReload - A function that triggers a safe reload of the extension.
    * @param options.sendUpdate - A function that triggers an update to the UI.
    * @param options.seedlessOperationMutex - A mutex to use for seedless operations.
    * @param options.createVaultMutex - A mutex to serialize vault creation/export with locking.
@@ -401,6 +408,7 @@ export class LegacyBackgroundApiService {
     infuraProjectId,
     getRequestAccountTabIds,
     getOpenMetamaskTabsIds,
+    requestSafeReload,
     sendUpdate,
     seedlessOperationMutex,
     createVaultMutex,
@@ -411,6 +419,7 @@ export class LegacyBackgroundApiService {
     this.#infuraProjectId = infuraProjectId;
     this.#getRequestAccountTabIds = getRequestAccountTabIds;
     this.#getOpenMetamaskTabsIds = getOpenMetamaskTabsIds;
+    this.#requestSafeReload = requestSafeReload;
     this.#sendUpdate = sendUpdate;
     // Temporarily get the mutex from `MetamaskController` until we can
     // migrate the seedless onboarding functionality to this service.
@@ -527,6 +536,21 @@ export class LegacyBackgroundApiService {
    */
   getOpenMetamaskTabsIds(): Record<string, number> {
     return this.#getOpenMetamaskTabsIds();
+  }
+
+  /**
+   * Triggers a safe reload of the extension without disrupting user state.
+   */
+  async requestSafeReload(): Promise<void> {
+    return this.#requestSafeReload();
+  }
+
+  /**
+   * Opens the "Updating" page in a new tab and then triggers a safe extension
+   * reload. Used when an update is available.
+   */
+  async openUpdateTabAndReload(): Promise<void> {
+    return openUpdateTabAndReload(this.#requestSafeReload);
   }
 
   /**


### PR DESCRIPTION
## **Description**

Part of the WPC-418 effort to slim down `MetamaskController.getApi()`.

This migrates `requestSafeReload` and `openUpdateTabAndReload` into `LegacyBackgroundApiService`. They ship together because `openUpdateTabAndReload` depends on `requestSafeReload`.

`requestSafeReload` is not a controller method, it is a callback injected via `opts.requestSafeReload` (and it is not messenger-accessible), so it is passed into the service as an option (like `getOpenMetamaskTabsIds`). `openUpdateTabAndReload` wraps the existing `open-update-tab-and-reload` lib, passing the injected callback through.

The lib's parameter type was decoupled from `MetamaskController` (now `() => Promise<void>`), since the service is its only caller after this change.

No behavior change for the client: the UI thunks still call `submitRequestToBackground('requestSafeReload')` and `submitRequestToBackground('openUpdateTabAndReload')` with the same shape.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/WPC-1068

## **Manual testing steps**

1. Trigger the extension-update flow that calls `openUpdateTabAndReload` (an available update).
2. Confirm the "Updating" tab opens and the extension performs a safe reload, same as before.

## **Screenshots/Recordings**

### **Before**

### **After**

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Refactor-only routing change with injected callbacks and tests; extension reload/update behavior is intended to stay the same.
> 
> **Overview**
> Moves **`requestSafeReload`** and **`openUpdateTabAndReload`** off `MetamaskController.getApi()` into **`LegacyBackgroundApiService`**, continuing the slim-down of the legacy background API.
> 
> `requestSafeReload` is injected into the service (same pattern as tab-ID helpers) because it comes from background startup, not a controller. **`openUpdateTabAndReload`** still uses the shared lib but now passes that injected callback. **`MetamaskController`** exposes both entry points only via messenger calls to the service. The update-tab helper’s type no longer references **`MetamaskController`** (`() => Promise<void>`). UI **`submitRequestToBackground`** usage is unchanged; tests cover the new service wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2fff26f70f71e2e5755ec2e0cdca7a1ecbae4af1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->