### PR TITLE
test: replace driver.waitForSelector from snaps spec files  with page object methods

### DIFF
--- a/test/e2e/flask/snaps/preinstalled-example.spec.ts
+++ b/test/e2e/flask/snaps/preinstalled-example.spec.ts
@@ -118,10 +118,10 @@ describe('Preinstalled example Snap', function () {
         await testSnaps.scrollAndClickButton('showPreinstalledDialogButton');
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
-        await driver.waitForSelector({
-          css: '.snap-ui-renderer__text',
-          text: 'This is a custom dialog. It has a custom footer and can be resolved to any value.',
-        });
+        await testSnaps.checkMessageResultSpan(
+          'snapUiRendererText',
+          'This is a custom dialog. It has a custom footer and can be resolved to any value.',
+        );
       },
     );
   });

--- a/test/e2e/page-objects/pages/dialog/snap-install.ts
+++ b/test/e2e/page-objects/pages/dialog/snap-install.ts
@@ -9,6 +9,11 @@ class SnapInstall {
 
   private readonly approveButton = '[data-testid="confirmation-submit-button"]';
 
+  private readonly closeButton = {
+    tag: 'button',
+    text: 'Close',
+  };
+
   private readonly confirmationDialogBoldUrl = {
     text: 'snaps.metamask.io',
     tag: 'b',
@@ -110,6 +115,11 @@ class SnapInstall {
   async clickCheckboxPermission() {
     console.log('Clicking permission checkbox');
     await this.driver.clickElement(this.permissionConnect);
+  }
+
+  async clickCloseButton() {
+    console.log('Clicking Close button and wait for dialog to close');
+    await this.driver.clickElementAndWaitForWindowToClose(this.closeButton);
   }
 
   async clickConfirmationDialogLinkText(): Promise<void> {

--- a/test/e2e/page-objects/pages/snap-list-page.ts
+++ b/test/e2e/page-objects/pages/snap-list-page.ts
@@ -95,6 +95,16 @@ class SnapListPage {
     });
   }
 
+  /**
+   * Checks that a snap with the given name is displayed in the snap list.
+   *
+   * @param snapName - The name of the snap expected to be displayed.
+   */
+  async checkSnapNameIsDisplayed(snapName: string): Promise<void> {
+    console.log(`Checking snap name is displayed: ${snapName}`);
+    await this.driver.waitForSelector({ text: snapName, tag: 'p' });
+  }
+
   async checkUpdateLinkIsNotDisplayed(): Promise<void> {
     await this.driver.assertElementNotPresent(this.updateSnapButton, {
       // make sure the Snap page has loaded

--- a/test/e2e/page-objects/pages/test-snaps.ts
+++ b/test/e2e/page-objects/pages/test-snaps.ts
@@ -175,7 +175,7 @@ export const spanLocator = {
   wasmResultSpan: '#wasmResult',
   unencryptedStateResultSpan: '#unencryptedStateResult',
   getStateUnencryptedResultSpan: '#getStateUnencryptedResult',
-  backgroundEventResultSpan: '#schedulebackgroundEventResult',
+  backgroundEventResultSpan: '#scheduleBackgroundEventResult',
   getBackgroundEventResultSpan: '#getBackgroundEventsResult',
 } satisfies Record<string, string>;
 
@@ -413,6 +413,21 @@ export class TestSnaps {
       text: name,
       css: `${locator} option`,
     });
+  }
+
+  /**
+   * Wait until the given result span contains text, and return that text.
+   *
+   * @param spanSelectorId - The name of the result span locator to wait for.
+   * @returns The text of the result span.
+   */
+  async waitForNonEmptyResult(
+    spanSelectorId: keyof typeof spanLocator,
+  ): Promise<string> {
+    console.log(`Waiting for a result in ${spanSelectorId}`);
+    const element = await this.driver.findElement(spanLocator[spanSelectorId]);
+    await this.driver.waitForNonEmptyElement(element);
+    return await element.getText();
   }
 
   async waitForWebSocketUpdate(state: {

--- a/test/e2e/page-objects/pages/test-snaps.ts
+++ b/test/e2e/page-objects/pages/test-snaps.ts
@@ -162,6 +162,7 @@ export const spanLocator = {
   sendManageStateResultSpan: '#sendManageStateResult',
   snapUIRenderer: '.snap-ui-renderer__content',
   snapUiRendererPanel: '.snap-ui-renderer__panel',
+  snapUiRendererText: '.snap-ui-renderer__text',
   sendUnencryptedManageStateResultSpan: '#sendUnencryptedManageStateResult',
   signMessageMultichainResultSpan: '#signMessageMultichainResult',
   signTypedDataMultichainResultSpan: '#signTypedDataMultichainResult',

--- a/test/e2e/snaps/test-snap-background-events.spec.ts
+++ b/test/e2e/snaps/test-snap-background-events.spec.ts
@@ -1,6 +1,7 @@
 import { mockBackgroundEventsSnap } from '../mock-response-data/snaps/snap-binary-mocks';
 import { openTestSnapClickButtonAndInstall } from '../page-objects/flows/install-test-snap.flow';
 import { login } from '../page-objects/flows/login.flow';
+import SnapInstall from '../page-objects/pages/dialog/snap-install';
 import { TestSnaps } from '../page-objects/pages/test-snaps';
 import { Driver } from '../webdriver/driver';
 import { DAPP_PATH, WINDOW_TITLES } from '../constants';
@@ -24,6 +25,7 @@ describe('Test Snap Background Events', function () {
         await login(driver);
 
         const testSnaps = new TestSnaps(driver);
+        const snapInstall = new SnapInstall(driver);
 
         // Navigate to test snaps page, connect to background events Snap, complete installation and validate
         await openTestSnapClickButtonAndInstall(
@@ -42,17 +44,9 @@ describe('Test Snap Background Events', function () {
 
         await testSnaps.clickButton('scheduleBackgroundEventWithDateButton');
 
-        const scheduleResult = await driver.findElement(
-          '#scheduleBackgroundEventResult',
-        );
-        await driver.waitForNonEmptyElement(scheduleResult);
+        await testSnaps.waitForNonEmptyResult('backgroundEventResultSpan');
 
         await testSnaps.clickButton('getBackgroundEventResultButton');
-
-        const eventsResult = await driver.findElement(
-          '#getBackgroundEventsResult',
-        );
-        await driver.waitForNonEmptyElement(eventsResult);
 
         await testSnaps.checkMessageResultSpanIncludes(
           'getBackgroundEventResultSpan',
@@ -67,11 +61,8 @@ describe('Test Snap Background Events', function () {
           'This dialog was triggered by a background event',
         );
 
-        // try to click on the Ok button and pass test if window closes
-        await driver.clickElementAndWaitForWindowToClose({
-          text: 'Close',
-          tag: 'button',
-        });
+        // try to click on the Close button and pass test if window closes
+        await snapInstall.clickCloseButton();
       },
     );
   });
@@ -89,9 +80,10 @@ describe('Test Snap Background Events', function () {
         testSpecificMock: mockBackgroundEventsSnap,
       },
       async ({ driver }: { driver: Driver }) => {
-        await login(driver, { validateBalance: false });
+        await login(driver);
 
         const testSnaps = new TestSnaps(driver);
+        const snapInstall = new SnapInstall(driver);
 
         // Navigate to test snaps page, connect to background events Snap, complete installation and validate
         await openTestSnapClickButtonAndInstall(
@@ -116,17 +108,9 @@ describe('Test Snap Background Events', function () {
           'scheduleBackgroundEventWithDurationButton',
         );
 
-        const scheduleResult = await driver.findElement(
-          '#scheduleBackgroundEventResult',
-        );
-        await driver.waitForNonEmptyElement(scheduleResult);
+        await testSnaps.waitForNonEmptyResult('backgroundEventResultSpan');
 
         await testSnaps.clickButton('getBackgroundEventResultButton');
-
-        const eventsResult = await driver.findElement(
-          '#getBackgroundEventsResult',
-        );
-        await driver.waitForNonEmptyElement(eventsResult);
 
         await testSnaps.checkMessageResultSpanIncludes(
           'getBackgroundEventResultSpan',
@@ -141,11 +125,8 @@ describe('Test Snap Background Events', function () {
           'This dialog was triggered by a background event',
         );
 
-        // try to click on the Ok button and pass test if window closes
-        await driver.clickElementAndWaitForWindowToClose({
-          text: 'Close',
-          tag: 'button',
-        });
+        // try to click on the Close button and pass test if window closes
+        await snapInstall.clickCloseButton();
       },
     );
   });
@@ -163,7 +144,7 @@ describe('Test Snap Background Events', function () {
         testSpecificMock: mockBackgroundEventsSnap,
       },
       async ({ driver }: { driver: Driver }) => {
-        await login(driver, { validateBalance: false });
+        await login(driver);
 
         const testSnaps = new TestSnaps(driver);
 
@@ -182,24 +163,18 @@ describe('Test Snap Background Events', function () {
 
         await testSnaps.clickButton('scheduleBackgroundEventWithDateButton');
 
-        const scheduleResult = await driver.findElement(
-          '#scheduleBackgroundEventResult',
+        const scheduleResult = await testSnaps.waitForNonEmptyResult(
+          'backgroundEventResultSpan',
         );
-        await driver.waitForNonEmptyElement(scheduleResult);
 
         await testSnaps.clickButton('getBackgroundEventResultButton');
-
-        const eventsResult = await driver.findElement(
-          '#getBackgroundEventsResult',
-        );
-        await driver.waitForNonEmptyElement(eventsResult);
 
         await testSnaps.checkMessageResultSpanIncludes(
           'getBackgroundEventResultSpan',
           'fireDialog',
         );
 
-        const eventIdText = JSON.parse(await scheduleResult.getText());
+        const eventIdText = JSON.parse(scheduleResult);
         await testSnaps.fillMessage('cancelBackgroundEventInput', eventIdText);
 
         await testSnaps.clickButton('cancelBackgroundEventButton');

--- a/test/e2e/snaps/test-snap-background-events.spec.ts
+++ b/test/e2e/snaps/test-snap-background-events.spec.ts
@@ -62,10 +62,10 @@ describe('Test Snap Background Events', function () {
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         // look for the dialog popup to verify background event fired
-        await driver.waitForSelector({
-          css: '.snap-ui-renderer__content',
-          text: 'This dialog was triggered by a background event',
-        });
+        await testSnaps.checkMessageResultSpan(
+          'snapUIRenderer',
+          'This dialog was triggered by a background event',
+        );
 
         // try to click on the Ok button and pass test if window closes
         await driver.clickElementAndWaitForWindowToClose({
@@ -136,10 +136,10 @@ describe('Test Snap Background Events', function () {
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
 
         // look for the dialog popup to verify background event fired
-        await driver.waitForSelector({
-          css: '.snap-ui-renderer__content',
-          text: 'This dialog was triggered by a background event',
-        });
+        await testSnaps.checkMessageResultSpan(
+          'snapUIRenderer',
+          'This dialog was triggered by a background event',
+        );
 
         // try to click on the Ok button and pass test if window closes
         await driver.clickElementAndWaitForWindowToClose({

--- a/test/e2e/snaps/test-snap-get-locale.spec.ts
+++ b/test/e2e/snaps/test-snap-get-locale.spec.ts
@@ -2,6 +2,7 @@ import { Driver } from '../webdriver/driver';
 import { TestSnaps } from '../page-objects/pages/test-snaps';
 import HomePage from '../page-objects/pages/home/homepage';
 import PreferencesAndDisplaySettings from '../page-objects/pages/settings/preferences-and-display-settings';
+import SnapListPage from '../page-objects/pages/snap-list-page';
 import FixtureBuilderV2 from '../fixtures/fixture-builder-v2';
 import { login } from '../page-objects/flows/login.flow';
 import { closeSettings } from '../page-objects/flows/settings.flow';
@@ -59,9 +60,9 @@ describe('Test Snap Get Locale', function () {
         await closeSettings(driver);
 
         await homePage.headerNavbar.openSnapListPage();
-        await driver.waitForSelector({
-          text: 'Oversættelses Eksempel Snap',
-        });
+        await new SnapListPage(driver).checkSnapNameIsDisplayed(
+          'Oversættelses Eksempel Snap',
+        );
 
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestSnaps);
         await testSnaps.clickButton('sendGetLocaleHelloButton');

--- a/test/e2e/snaps/test-snap-uilinks.spec.ts
+++ b/test/e2e/snaps/test-snap-uilinks.spec.ts
@@ -1,6 +1,7 @@
 import { Driver } from '../webdriver/driver';
 import { TestSnaps, spanLocator } from '../page-objects/pages/test-snaps';
 import SnapInstall from '../page-objects/pages/dialog/snap-install';
+import MockedPage from '../page-objects/pages/mocked-page';
 import FixtureBuilderV2 from '../fixtures/fixture-builder-v2';
 import { login } from '../page-objects/flows/login.flow';
 import { openTestSnapClickButtonAndInstall } from '../page-objects/flows/install-test-snap.flow';
@@ -33,11 +34,6 @@ async function mockSnapBinaryAndWebsite(
 ) {
   return [await mockDialogSnap(mockServer), await mockSnapsWebsite(mockServer)];
 }
-
-const EMPTY_PAGE_BODY_SELECTOR = {
-  testId: 'empty-page-body',
-  text: 'Empty page by MetaMask',
-};
 
 describe('Test Snap UI Links', function () {
   it('test link in confirmation snap_dialog type', async function () {
@@ -75,7 +71,9 @@ describe('Test Snap UI Links', function () {
         await snapInstall.clickVisitSiteLink();
 
         await driver.switchToWindowWithTitle(WINDOW_TITLES.TestE2EPage);
-        await driver.waitForSelector(EMPTY_PAGE_BODY_SELECTOR);
+        await new MockedPage(driver).checkDisplayedMessage(
+          'Empty page by MetaMask',
+        );
 
         await driver.switchToWindowWithTitle(WINDOW_TITLES.Dialog);
         await snapInstall.waitForDialogApproveButton();


### PR DESCRIPTION

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Follow-up to the previous [PR](https://github.com/MetaMask/metamask-extension/pull/44898), covering the four remaining Snap E2E specs that called `driver.waitForSelector` directly. 

Each call was replaced with a page object method. Three of the four needed no new page object code at all, just the existing method:

- **`test-snap-background-events.spec.ts`** (2 occurrences) — now uses `testSnaps.checkMessageResultSpan('snapUIRenderer', )`. This is the same assertion `test-snap-cronjob.spec.ts` already makes against the same snap dialog, and the method body is identical to the inline call being removed.
- **`test-snap-uilinks.spec.ts`** — now uses `MockedPage.checkDisplayedMessage()`, matching how `portfolio-site.spec.ts` already asserts on the same "Empty page by MetaMask" mock page. The local `EMPTY_PAGE_BODY_SELECTOR` constant is no longer needed.
- **`preinstalled-example.spec.ts`** — now uses `testSnaps.checkMessageResultSpan('snapUiRendererText', ...)`, adding a
  `snapUiRendererText` entry to `spanLocator` alongside the existing `snap-ui-renderer__content` and `__panel` selectors.
- **`test-snap-get-locale.spec.ts`** — now uses `SnapListPage.checkSnapNameIsDisplayed()`, new method.
  `SnapListPage` had no assertion-only way to check a snap name in the list (`openSnapByName` waits for it but then clicks through to the detail page), so this reuses that method's established locator.



## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes: [MMQA-1915](https://consensyssoftware.atlassian.net/browse/MMQA-1915?atlOrigin=eyJpIjoiYTRkOTc5NWIwZjdhNDYzYmIyZDc4ZmMzYjg5ODFmYmIiLCJwIjoiaiJ9)

## **Manual testing steps**

1. Run the tests locally to make sure they still pass

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


[MMQA-1915]: https://consensyssoftware.atlassian.net/browse/MMQA-1915?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only refactors with no production code changes; risk is limited to E2E stability if locators drift.
> 
> **Overview**
> Continues the Snap E2E cleanup by routing remaining inline `driver.waitForSelector` calls through page objects in four specs.
> 
> **Preinstalled dialog** uses `TestSnaps.checkMessageResultSpan` with a new `snapUiRendererText` locator. **Background-events** specs assert dialog copy via `checkMessageResultSpan('snapUIRenderer', …)`, wait on schedule results with `waitForNonEmptyResult`, and dismiss dialogs through `SnapInstall.clickCloseButton`. **Get-locale** checks the translated snap name on the list via new `SnapListPage.checkSnapNameIsDisplayed`. **UI links** asserts the mocked empty page with `MockedPage.checkDisplayedMessage` and drops the local selector constant.
> 
> `TestSnaps` also fixes the `backgroundEventResultSpan` DOM id casing and adds `waitForNonEmptyResult` for reusable “wait until span has text” flows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61d51d5836178f239127cbff86c663199fd94d23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->