### PR TITLE
fix: remove deprecated METAMASK_ENVIRONMENT=test in favor of testing

### DIFF
--- a/app/scripts/messenger-client-init/assets/network-enablement-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/assets/network-enablement-controller-init.test.ts
@@ -330,9 +330,9 @@ describe('NetworkEnablementControllerInit', () => {
     });
   });
 
-  it('initialises the controller with the correct networks for test environment', () => {
+  it('initialises the controller with the correct networks for testing environment', () => {
     process.env.METAMASK_DEBUG = '';
-    process.env.METAMASK_ENVIRONMENT = 'test';
+    process.env.METAMASK_ENVIRONMENT = 'testing';
     process.env.IN_TEST = '';
 
     NetworkEnablementControllerInit(getInitRequestMock());

--- a/app/scripts/messenger-client-init/assets/network-enablement-controller-init.ts
+++ b/app/scripts/messenger-client-init/assets/network-enablement-controller-init.ts
@@ -96,7 +96,7 @@ const generateDefaultNetworkEnablementControllerState = (
     };
   } else if (
     process.env.METAMASK_DEBUG ||
-    process.env.METAMASK_ENVIRONMENT === 'test'
+    process.env.METAMASK_ENVIRONMENT === 'testing'
   ) {
     return {
       enabledNetworkMap: {

--- a/app/scripts/messenger-client-init/metametrics-controller-init.test.ts
+++ b/app/scripts/messenger-client-init/metametrics-controller-init.test.ts
@@ -38,7 +38,7 @@ describe('MetaMetricsControllerInit', () => {
       messenger: expect.any(Object),
       state: undefined,
       captureException: expect.any(Function),
-      environment: 'test',
+      environment: 'testing',
       extension: expect.any(Object),
       version: 'MOCK_VERSION',
     });

--- a/app/scripts/messenger-client-init/ramps-environment.test.ts
+++ b/app/scripts/messenger-client-init/ramps-environment.test.ts
@@ -29,8 +29,8 @@ describe('getRampsEnvironment', () => {
     expect(getRampsEnvironment()).toBe(RampsEnvironment.Staging);
   });
 
-  it('returns Staging for METAMASK_ENVIRONMENT=test', () => {
-    process.env.METAMASK_ENVIRONMENT = 'test';
+  it('returns Staging for METAMASK_ENVIRONMENT=testing', () => {
+    process.env.METAMASK_ENVIRONMENT = 'testing';
     expect(getRampsEnvironment()).toBe(RampsEnvironment.Staging);
   });
 

--- a/app/scripts/messenger-client-init/ramps-environment.ts
+++ b/app/scripts/messenger-client-init/ramps-environment.ts
@@ -13,7 +13,7 @@ export function getRampsEnvironment(): RampsEnvironment {
     case 'rc':
       return RampsEnvironment.Production;
     case 'dev':
-    case 'test':
+    case 'testing':
     default:
       return RampsEnvironment.Staging;
   }

--- a/shared/constants/bridge.test.ts
+++ b/shared/constants/bridge.test.ts
@@ -50,7 +50,6 @@ describe('getBridgeApiBaseUrlForMetaMaskEnv', () => {
     'e2e',
     'dev',
     'local',
-    'test',
     ENVIRONMENT.DEVELOPMENT,
     ENVIRONMENT.TESTING,
     ENVIRONMENT.OTHER,

--- a/shared/constants/bridge.ts
+++ b/shared/constants/bridge.ts
@@ -89,7 +89,6 @@ export const getBridgeApiBaseUrlForMetaMaskEnv = (): string => {
     case 'e2e':
     case 'dev':
     case 'local':
-    case 'test':
     case ENVIRONMENT.DEVELOPMENT:
     case ENVIRONMENT.TESTING:
     case ENVIRONMENT.OTHER:

--- a/shared/lib/selectors/index.test.ts
+++ b/shared/lib/selectors/index.test.ts
@@ -307,6 +307,9 @@ describe('Selectors', () => {
     jestIt(
       'returns false if feature flag is enabled, not a HW and is BSC network with a non-default RPC URL',
       () => {
+        // RPC host allowlisting only applies in production-like environments.
+        jest.spyOn(envModule, 'isProduction').mockReturnValue(true);
+
         const state = createSwapsMockStore();
         const newState = {
           ...state,
@@ -351,6 +354,9 @@ describe('Selectors', () => {
     jestIt(
       'returns false if feature flag is enabled, not a HW and is Linea network with a non-default RPC URL',
       () => {
+        // RPC host allowlisting only applies in production-like environments.
+        jest.spyOn(envModule, 'isProduction').mockReturnValue(true);
+
         const state = createSwapsMockStore();
         (
           state.metamask.remoteFeatureFlags.smartTransactionsNetworks as Record<

--- a/test/env.js
+++ b/test/env.js
@@ -1,4 +1,4 @@
-process.env.METAMASK_ENVIRONMENT = 'test';
+process.env.METAMASK_ENVIRONMENT = 'testing';
 process.env.SUPPORT_LINK = 'https://support.metamask.io/?utm_source=extension';
 process.env.IFRAME_EXECUTION_ENVIRONMENT_URL =
   'https://execution.metamask.io/0.36.1-flask.1/index.html';

--- a/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.test.tsx
+++ b/ui/components/app/transaction-activity-empty-state/transaction-activity-empty-state.test.tsx
@@ -65,20 +65,20 @@ const createStateOverrides = (
 const createTestnetState = (): ReturnType<typeof createStateOverrides> =>
   createStateOverrides({
     useExternalServices: true,
-    selectedNetworkClientId: 'goerli',
+    selectedNetworkClientId: 'sepolia',
     networkConfigurationsByChainId: {
       ...mockState.metamask.networkConfigurationsByChainId,
-      '0x5': {
-        // Goerli testnet - not in allowed swaps chains
-        chainId: '0x5',
-        name: 'Goerli',
+      '0xaa36a7': {
+        // Sepolia - not in allowed swaps chains (prod or testing/dev)
+        chainId: '0xaa36a7',
+        name: 'Sepolia',
         nativeCurrency: 'ETH',
         defaultRpcEndpointIndex: 0,
         rpcEndpoints: [
           {
             type: 'infura',
-            url: 'https://goerli.infura.io/v3/test',
-            networkClientId: 'goerli',
+            url: 'https://sepolia.infura.io/v3/test',
+            networkClientId: 'sepolia',
           },
         ],
         blockExplorerUrls: [],

--- a/ui/pages/onboarding-flow/welcome/__snapshots__/welcome.test.tsx.snap
+++ b/ui/pages/onboarding-flow/welcome/__snapshots__/welcome.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`Welcome Page render matches snapshot 1`] = `
     <div
       class="welcome-login"
       data-testid="get-started"
-      style="opacity: 0; transform: translateY(80px) scale(0.8); transition: opacity 0.6s ease-out, transform 0.6s ease-out;"
+      style="opacity: 1; transform: translateY(0) scale(1); transition: none;"
     >
       <div
         class="flex flex-col gap-4 w-full"
@@ -41,6 +41,9 @@ exports[`Welcome Page render matches snapshot 1`] = `
         </button>
       </div>
     </div>
+    <div
+      class=""
+    />
   </div>
 </div>
 `;


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

`METAMASK_ENVIRONMENT='test'` is deprecated. Canonical values live in `shared/constants/build-environment.json`, and the correct testing value is `testing`.

This PR removes remaining uses of the deprecated `'test'` value and updates dependent unit tests that previously relied on `'test'` accidentally behaving like production.

### Changes by domain / team

#### Platform / test infra
- Set `process.env.METAMASK_ENVIRONMENT = 'testing'` in `test/env.js` (unit-test global env).
- Updated MetaMetrics controller init test expectation to receive `environment: 'testing'`.

#### Networks / assets
- `network-enablement-controller-init.ts`: debug/testing default network path now checks `METAMASK_ENVIRONMENT === 'testing'` (was `'test'`).
- Production path unchanged (`production` / non-debug builds still use featured networks).

#### Ramps
- `ramps-environment.ts`: staging mapping uses `'testing'` instead of `'test'`.
- Matching unit test updated.

#### Bridge / Swaps
- Removed legacy `case 'test':` from `getBridgeApiBaseUrlForMetaMaskEnv` (still maps `ENVIRONMENT.TESTING` → bridge dev API).
- Updated bridge unit tests accordingly.
- Activity empty-state swap-disabled test now uses Sepolia (not in prod/dev swaps allowlists). Goerli is allowed under `testing` via `getIsSwapsChain`.

#### Transactions / Smart Transactions
- Smart Transactions RPC-host restriction tests now explicitly mock `isProduction() === true`.
- Needed because `isProduction()` correctly treats `testing` as non-production, so RPC allowlisting is skipped unless mocked.

#### Onboarding / UX
- Updated Welcome page snapshot: animation is intentionally skipped when `METAMASK_ENVIRONMENT === 'testing'`.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4844

## **Manual testing steps**

1. Run unit tests that depend on `test/env.js` (or a focused set covering the changed files below) and confirm they pass.
2. Start a normal development build (`yarn start`) and confirm default enabled networks are unchanged for non-debug, non-testing builds.
3. Optional: run a test build (`yarn start:test` / `yarn build:test`) and confirm `METAMASK_ENVIRONMENT` resolves to `testing`, and network-enablement debug/testing defaults still enable Sepolia as before.
4. Spot-check Ramps and Bridge in a testing/dev build: staging/dev API mapping still works; production builds still use production endpoints.

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)