### PR TITLE
fix: allow Firefox WebDriver system access for about:debugging

### DIFF
--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -145,6 +145,13 @@ class FirefoxDriver {
       path.join(process.cwd(), 'test-artifacts', 'downloads'),
     );
 
+    // Firefox 153 restricts WebDriver navigation to privileged pages (most
+    // `about:` pages, `chrome://`, `resource://`) unless the browser is
+    // launched with system access allowed. `getInternalId` reads the extension
+    // UUID from `about:debugging#addons`, so without this the session cannot
+    // start. See https://bugzilla.mozilla.org/show_bug.cgi?id=1579790
+    options.addArguments('--remote-allow-system-access');
+
     if (isHeadless('SELENIUM')) {
       // TODO: Remove notice and consider non-experimental when results are consistent
       console.warn(


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

E2E test started failing on Firefox with error:

`UnsupportedOperationError: Navigation to "about:debugging#addons" is not allowed in this context`

This is due to recent Firefox [change](https://bugzilla.mozilla.org/show_bug.cgi?id=1579790) which "restricted navigation to privileged pages (certain` about:*` pages, `chrome://,` and `resource://` URLs) when operating in content scope."

We pass the `--remote-allow-system-access` argument when launching Firefox in t`est/e2e/webdriver/firefox.js.` 

Firefox 153 blocks WebDriver navigation to privileged URLs unless the browser is started with system access allowed, and our session setup needs it: `getInternalId() `navigates to `about:debugging#addons` to scrape the extension's internal UUID, which is required to build the `moz-extension://<uuid>` URL every test uses. The flag restores that navigation. 
## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Run any test in Firefox to make sure it passes

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only WebDriver launch flag; no production extension or user-facing behavior changes.
> 
> **Overview**
> Fixes Firefox e2e session startup failures on **Firefox 153+** by passing **`--remote-allow-system-access`** when building Firefox WebDriver options in `test/e2e/webdriver/firefox.js`.
> 
> Mozilla now blocks WebDriver navigation to privileged URLs (including **`about:debugging#addons`**) unless the browser is launched with system access. Session setup still calls **`getInternalId()`**, which navigates there to read the extension UUID for **`moz-extension://`** URLs, so without the flag tests error with navigation not allowed in this context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcb7fa779c00905cfa13454f0cac510497b60950. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->