### PR TITLE
fix: excempt batch sell routes from ConfirmationRouter

### DIFF
--- a/ui/pages/routes/confirmation-router.test.tsx
+++ b/ui/pages/routes/confirmation-router.test.tsx
@@ -1,0 +1,149 @@
+import React from 'react';
+import { useLocation } from 'react-router-dom';
+import configureStore from '../../store/store';
+import { renderWithProvider } from '../../../test/lib/render-helpers-navigate';
+import mockState from '../../../test/data/mock-state.json';
+import { getEnvironmentType } from '../../../shared/lib/environment-type';
+import {
+  ENVIRONMENT_TYPE_FULLSCREEN,
+  ENVIRONMENT_TYPE_POPUP,
+  ENVIRONMENT_TYPE_SIDEPANEL,
+} from '../../../shared/constants/app';
+import {
+  BATCH_SELL_REVIEW_ROUTE,
+  BATCH_SELL_SELECT_ROUTE,
+  CROSS_CHAIN_SWAP_ROUTE,
+  DEFAULT_ROUTE,
+  PREPARE_SWAP_ROUTE,
+} from '../../helpers/constants/routes';
+import { ConfirmationRouter } from './confirmation-router';
+
+jest.mock('../../../shared/lib/environment-type', () => ({
+  ...jest.requireActual('../../../shared/lib/environment-type'),
+  getEnvironmentType: jest.fn(),
+}));
+
+const SWAP_ROUTE = `${CROSS_CHAIN_SWAP_ROUTE}${PREPARE_SWAP_ROUTE}`;
+const PENDING_APPROVAL_ID = 'testApprovalId';
+
+const PathnameDisplay = () => {
+  const { pathname } = useLocation();
+  return <div data-testid="pathname">{pathname}</div>;
+};
+
+const renderConfirmationRouter = ({
+  pathname,
+  hasQuotes = false,
+  hasPendingApproval = false,
+  environmentType = ENVIRONMENT_TYPE_POPUP,
+}: {
+  pathname: string;
+  hasQuotes?: boolean;
+  hasPendingApproval?: boolean;
+  environmentType?: string;
+}) => {
+  (getEnvironmentType as jest.Mock).mockReturnValue(environmentType);
+
+  const store = configureStore({
+    ...mockState,
+    metamask: {
+      ...mockState.metamask,
+      ...(hasPendingApproval
+        ? {}
+        : { pendingApprovals: {}, pendingApprovalCount: 0, approvalFlows: [] }),
+      // Batch sell fetches quotes through the bridge controller, so they land in
+      // the same state that drives the swap redirect. A single entry is enough.
+      quotes: hasQuotes ? [{}] : [],
+    },
+  });
+
+  return renderWithProvider(
+    <>
+      <ConfirmationRouter />
+      <PathnameDisplay />
+    </>,
+    store,
+    pathname,
+  );
+};
+
+describe('ConfirmationRouter', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('with bridge quotes in state', () => {
+    it('redirects to the swap page from a non-exempted route in the popup', () => {
+      const { getByTestId } = renderConfirmationRouter({
+        pathname: DEFAULT_ROUTE,
+        hasQuotes: true,
+      });
+
+      expect(getByTestId('pathname')).toHaveTextContent(SWAP_ROUTE);
+    });
+
+    it('stays on the batch sell review page', () => {
+      const { getByTestId } = renderConfirmationRouter({
+        pathname: BATCH_SELL_REVIEW_ROUTE,
+        hasQuotes: true,
+      });
+
+      expect(getByTestId('pathname')).toHaveTextContent(
+        BATCH_SELL_REVIEW_ROUTE,
+      );
+    });
+
+    it('stays on the batch sell select page', () => {
+      const { getByTestId } = renderConfirmationRouter({
+        pathname: BATCH_SELL_SELECT_ROUTE,
+        hasQuotes: true,
+      });
+
+      expect(getByTestId('pathname')).toHaveTextContent(
+        BATCH_SELL_SELECT_ROUTE,
+      );
+    });
+
+    it('does not redirect from a non-exempted route in fullscreen', () => {
+      const { getByTestId } = renderConfirmationRouter({
+        pathname: DEFAULT_ROUTE,
+        hasQuotes: true,
+        environmentType: ENVIRONMENT_TYPE_FULLSCREEN,
+      });
+
+      expect(getByTestId('pathname')).toHaveTextContent(DEFAULT_ROUTE);
+    });
+
+    it('does not redirect from a non-exempted route in the side panel', () => {
+      const { getByTestId } = renderConfirmationRouter({
+        pathname: DEFAULT_ROUTE,
+        hasQuotes: true,
+        environmentType: ENVIRONMENT_TYPE_SIDEPANEL,
+      });
+
+      expect(getByTestId('pathname')).toHaveTextContent(DEFAULT_ROUTE);
+    });
+  });
+
+  describe('with a pending approval', () => {
+    it('navigates to the confirmation from a non-exempted route', () => {
+      const { getByTestId } = renderConfirmationRouter({
+        pathname: DEFAULT_ROUTE,
+        hasPendingApproval: true,
+      });
+
+      expect(getByTestId('pathname')).toHaveTextContent(PENDING_APPROVAL_ID);
+    });
+
+    it('leaves batch sell in place, so the confirmation is shown once the user exits', () => {
+      const { getByTestId } = renderConfirmationRouter({
+        pathname: BATCH_SELL_REVIEW_ROUTE,
+        hasPendingApproval: true,
+      });
+
+      expect(getByTestId('pathname')).toHaveTextContent(
+        BATCH_SELL_REVIEW_ROUTE,
+      );
+    });
+  });
+});

--- a/ui/pages/routes/confirmation-router.test.tsx
+++ b/ui/pages/routes/confirmation-router.test.tsx
@@ -12,6 +12,7 @@ import {
 import {
   BATCH_SELL_REVIEW_ROUTE,
   BATCH_SELL_SELECT_ROUTE,
+  CONFIRM_TRANSACTION_ROUTE,
   CROSS_CHAIN_SWAP_ROUTE,
   DEFAULT_ROUTE,
   PREPARE_SWAP_ROUTE,
@@ -79,7 +80,9 @@ describe('ConfirmationRouter', () => {
         hasQuotes: true,
       });
 
-      expect(getByTestId('pathname')).toHaveTextContent(SWAP_ROUTE);
+      // `toHaveTextContent` does a substring match, and every route here
+      // contains a `/`, so we compare `textContent` directly for an exact match.
+      expect(getByTestId('pathname').textContent).toBe(SWAP_ROUTE);
     });
 
     it('stays on the batch sell review page', () => {
@@ -88,7 +91,7 @@ describe('ConfirmationRouter', () => {
         hasQuotes: true,
       });
 
-      expect(getByTestId('pathname')).toHaveTextContent(
+      expect(getByTestId('pathname').textContent).toBe(
         BATCH_SELL_REVIEW_ROUTE,
       );
     });
@@ -99,7 +102,7 @@ describe('ConfirmationRouter', () => {
         hasQuotes: true,
       });
 
-      expect(getByTestId('pathname')).toHaveTextContent(
+      expect(getByTestId('pathname').textContent).toBe(
         BATCH_SELL_SELECT_ROUTE,
       );
     });
@@ -111,7 +114,7 @@ describe('ConfirmationRouter', () => {
         environmentType: ENVIRONMENT_TYPE_FULLSCREEN,
       });
 
-      expect(getByTestId('pathname')).toHaveTextContent(DEFAULT_ROUTE);
+      expect(getByTestId('pathname').textContent).toBe(DEFAULT_ROUTE);
     });
 
     it('does not redirect from a non-exempted route in the side panel', () => {
@@ -121,7 +124,7 @@ describe('ConfirmationRouter', () => {
         environmentType: ENVIRONMENT_TYPE_SIDEPANEL,
       });
 
-      expect(getByTestId('pathname')).toHaveTextContent(DEFAULT_ROUTE);
+      expect(getByTestId('pathname').textContent).toBe(DEFAULT_ROUTE);
     });
   });
 
@@ -132,7 +135,9 @@ describe('ConfirmationRouter', () => {
         hasPendingApproval: true,
       });
 
-      expect(getByTestId('pathname')).toHaveTextContent(PENDING_APPROVAL_ID);
+      expect(getByTestId('pathname').textContent).toBe(
+        `${CONFIRM_TRANSACTION_ROUTE}/${PENDING_APPROVAL_ID}`,
+      );
     });
 
     it('leaves batch sell in place, so the confirmation is shown once the user exits', () => {
@@ -141,7 +146,7 @@ describe('ConfirmationRouter', () => {
         hasPendingApproval: true,
       });
 
-      expect(getByTestId('pathname')).toHaveTextContent(
+      expect(getByTestId('pathname').textContent).toBe(
         BATCH_SELL_REVIEW_ROUTE,
       );
     });

--- a/ui/pages/routes/confirmation-router.test.tsx
+++ b/ui/pages/routes/confirmation-router.test.tsx
@@ -91,9 +91,7 @@ describe('ConfirmationRouter', () => {
         hasQuotes: true,
       });
 
-      expect(getByTestId('pathname').textContent).toBe(
-        BATCH_SELL_REVIEW_ROUTE,
-      );
+      expect(getByTestId('pathname').textContent).toBe(BATCH_SELL_REVIEW_ROUTE);
     });
 
     it('stays on the batch sell select page', () => {
@@ -102,9 +100,7 @@ describe('ConfirmationRouter', () => {
         hasQuotes: true,
       });
 
-      expect(getByTestId('pathname').textContent).toBe(
-        BATCH_SELL_SELECT_ROUTE,
-      );
+      expect(getByTestId('pathname').textContent).toBe(BATCH_SELL_SELECT_ROUTE);
     });
 
     it('does not redirect from a non-exempted route in fullscreen', () => {
@@ -146,9 +142,7 @@ describe('ConfirmationRouter', () => {
         hasPendingApproval: true,
       });
 
-      expect(getByTestId('pathname').textContent).toBe(
-        BATCH_SELL_REVIEW_ROUTE,
-      );
+      expect(getByTestId('pathname').textContent).toBe(BATCH_SELL_REVIEW_ROUTE);
     });
   });
 });

--- a/ui/pages/routes/confirmation-router.tsx
+++ b/ui/pages/routes/confirmation-router.tsx
@@ -14,6 +14,7 @@ import {
   CONFIRM_ADD_SUGGESTED_NFT_ROUTE,
   SHIELD_PLAN_ROUTE,
   TRANSACTION_SHIELD_ROUTE,
+  BATCH_SELL_ROOT_ROUTE,
 } from '../../helpers/constants/routes';
 import { getConfirmationRoute } from '../confirmations/hooks/useConfirmationNavigation';
 import { getEnvironmentType } from '../../../shared/lib/environment-type';
@@ -46,6 +47,7 @@ const EXEMPTED_ROUTES = [
   // shield approval transaction back to shield plan and transaction shield settings page on cancel/confirm, need to be exempted otherwise it will redirect to home page
   SHIELD_PLAN_ROUTE,
   TRANSACTION_SHIELD_ROUTE,
+  BATCH_SELL_ROOT_ROUTE,
 ];
 
 const SNAP_APPROVAL_TYPES = [


### PR DESCRIPTION
## **Description**

The Batch Sell flow fetches its quotes through the `BridgeController`, which is the same controller that backs the unified Swap/Bridge experience. Those quotes land in `state.metamask.quotes` — precisely the state that `selectHasBridgeQuotes` reads.

`ConfirmationRouter` is mounted globally on every route and redirects to the Swap page whenever bridge quotes are present, the UI is running as the browser action popup, and the current route is not in `EXEMPTED_ROUTES`. `/batch-sell` was not on that list, so users sitting on the Batch Sell select or review screens were pushed to the Swap page the moment their quotes arrived. The report was intermittent because the redirect is popup-only: it never triggers in a full-size tab or the side panel.

This adds `BATCH_SELL_ROOT_ROUTE` to `EXEMPTED_ROUTES`. The check is a `pathname.startsWith` match, so this covers the select page, the review page, and any Batch Sell subroute added later. No Batch Sell code needed to change.

One intentional behavior consequence: the exemption returns early before both branches of `checkStatusAndNavigate`, so while the user is inside Batch Sell, `ConfirmationRouter` also stops auto-navigating to pending confirmations. Those surface once the user leaves the flow. This matches how the Swap route (`CROSS_CHAIN_SWAP_ROUTE`) already behaves and is covered by a test so the intent is explicit.

This PR also adds the first test coverage for `ConfirmationRouter`, which previously had none.

## **Changelog**

CHANGELOG entry: Fixed a bug that unexpectedly redirected users from the Batch Sell screens to the Swap screen

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4845

## **Manual testing steps**

Setup:

1. Enable the Batch Sell remote feature flag locally by adding it to `.manifest-overrides.json`:
   `{ "_flags": { "remoteFeatureFlags": { "batchSell": { "enabled": true } } } }`
   and setting `MANIFEST_OVERRIDES=.manifest-overrides.json` in `.metamaskrc`.
2. Run the extension and unlock a wallet that holds at least two tokens with a non-zero balance on a supported network (Ethereum Mainnet, BSC, Base, Linea, Arbitrum, or Polygon). Batch Sell is hidden for hardware wallet accounts, so use a regular account.
3. Open the wallet by clicking the MetaMask toolbar icon so the UI runs as the popup. This is essential — the bug does not reproduce in a full-size tab or the side panel. Also confirm "Open MetaMask in full-size view" is off in Settings > Advanced.

Verify the fix:

4. From the home screen, tap the Sell button to open Batch Sell.
5. Select two or more tokens and continue to the review screen.
6. Wait for the quotes to finish loading and stay on the screen through at least one quote refresh.
7. Verify you remain on the Batch Sell review screen the whole time and are never moved to the Swap screen.
8. Adjust a send percentage and change the received asset, letting quotes refetch each time. Verify you still stay on the review screen.
9. Tap back to the select screen, then continue to review again. Verify no redirect occurs.
10. Complete a batch sell submission and verify you land on the Activity tab as before.

Confirm the original behavior (optional, to see what was broken):

11. Repeat steps 4 to 6 on `main`. As soon as the quotes load, the popup navigates away to the Swap page.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small routing exemption plus tests; behavior is localized to popup navigation when bridge quotes or approvals are present.
> 
> **Overview**
> Fixes an unwanted **popup-only** redirect that sent users from Batch Sell to Swap when bridge quotes appeared in shared Redux state (Batch Sell uses the same bridge quote pipeline as Swap).
> 
> **`BATCH_SELL_ROOT_ROUTE`** is added to **`EXEMPTED_ROUTES`** in `confirmation-router.tsx`, so paths under `/batch-sell` skip the global router logic—including the swap redirect and, while in that flow, auto-navigation to pending confirmations (same pattern as the swap route).
> 
> Adds the first **`ConfirmationRouter`** unit tests: quote-driven swap redirect in popup vs fullscreen/side panel, batch sell select/review staying put with quotes, and pending-approval navigation behavior on batch sell vs default routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6bc127752561559845451dd3fc2f15406696d05e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->