### PR TITLE
test: skip ERC20 max balance WS update test (ASSETS-3385)

### DIFF
--- a/test/e2e/tests/send/send-erc20-max-balance-validation.spec.ts
+++ b/test/e2e/tests/send/send-erc20-max-balance-validation.spec.ts
@@ -102,7 +102,11 @@ function mockV5Balances(mockServer: Mockttp, tstBalance: { value: string }) {
 }
 
 describe('Send ERC20 - Max Balance Validation', function () {
-  it('reflects a WebSocket balance update in the Tokens list and Send "Max"', async function () {
+  // ASSETS-3385: AssetsController discards a WebSocket balance update when a
+  // stale accounts-API snapshot commits after it, so the Tokens list / Send
+  // "Max" never reflect the WS post-balance. Skip until that race is fixed.
+  // eslint-disable-next-line mocha/no-skipped-tests -- ASSETS-3385: blocked on AssetsController WS vs accounts-API race
+  it.skip('reflects a WebSocket balance update in the Tokens list and Send "Max"', async function () {
     const account = DEFAULT_FIXTURE_ACCOUNT_LOWERCASE;
     const tstBalanceHolder = { value: '10' };
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->
Skip the Send ERC20 max-balance WebSocket E2E until ASSETS-3385 is fixed — AssetsController can drop a WS balance update when a stale accounts-API snapshot commits afterward.

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change; no application or controller logic is modified.
> 
> **Overview**
> Marks the **Send ERC20 - Max Balance Validation** E2E as skipped (`it.skip`) so CI no longer fails on a known product bug tracked as **ASSETS-3385**.
> 
> Inline comments document that **AssetsController** can discard a WebSocket balance update when a stale accounts-API snapshot commits afterward, so the Tokens list and Send **Max** do not show the WS post-balance. An `eslint-disable-next-line` for `mocha/no-skipped-tests` records the intentional skip until that race is fixed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76d03fad2bb1dfd7cefb0952a35b8d511bb955bf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->