### PR TITLE
ci(slsa): publish attestation bundles and pin run-build actions (INFRA-3786)

### DIFF
--- a/.github/scripts/release-create-gh-release.sh
+++ b/.github/scripts/release-create-gh-release.sh
@@ -167,9 +167,23 @@ for artifact in build-dist-webpack/builds/metamask-chrome-*.zip \
     done < <(compgen -G "${artifact}")
 done
 
+# Sigstore bundles produced by the Collect attestation bundles workflow step.
+# Published alongside the zips so downstream submission jobs can verify build
+# provenance without a GitHub token (INFRA-3786).
+attestation_bundles=()
+for artifact in "${webpack_artifacts[@]}"; do
+    bundle="$(basename "${artifact}").sigstore.json"
+    if [[ ! -f "${bundle}" ]]; then
+        echo "::error::Attestation bundle not found: ${bundle} — Collect attestation bundles workflow step may have failed"
+        exit 1
+    fi
+    attestation_bundles+=("${bundle}")
+done
+
 release_body="$(awk -v version="[${VERSION}]" -f .github/scripts/show-changelog.awk CHANGELOG.md)"
 gh release create "${tag}" \
     "${webpack_artifacts[@]}" \
+    "${attestation_bundles[@]}" \
     SHA256SUMS \
     --title "Version ${VERSION}" \
     --notes "${release_body}" \

--- a/.github/workflows/publish-release-from-release-head.yml
+++ b/.github/workflows/publish-release-from-release-head.yml
@@ -242,24 +242,73 @@ jobs:
 
       # SLSA build provenance attestation (INFRA-2665).
       - name: Attest webpack chrome artifact
+        id: attest-chrome
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
         with:
           subject-path: build-dist-webpack/builds/metamask-chrome-*.zip
 
       - name: Attest webpack firefox artifact
+        id: attest-firefox
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
         with:
           subject-path: build-dist-mv2-webpack/builds/metamask-firefox-*.zip
 
       - name: Attest webpack flask chrome artifact
+        id: attest-flask-chrome
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
         with:
           subject-path: build-flask-webpack/builds/metamask-chrome-*.zip
 
       - name: Attest webpack flask firefox artifact
+        id: attest-flask-firefox
         uses: actions/attest-build-provenance@0f67c3f4856b2e3261c31976d6725780e5e4c373 # v4
         with:
           subject-path: build-flask-mv2-webpack/builds/metamask-firefox-*.zip
+
+      # Publish each Sigstore bundle as a release asset so the AMO submission
+      # Lambda can verify provenance without a GitHub token (INFRA-3786). Each
+      # attest step writes its bundle to a path that the next step overwrites,
+      # so the copy has to happen once per step rather than in a single pass.
+      - name: Collect attestation bundles
+        env:
+          CHROME_BUNDLE: ${{ steps.attest-chrome.outputs.bundle-path }}
+          FIREFOX_BUNDLE: ${{ steps.attest-firefox.outputs.bundle-path }}
+          FLASK_CHROME_BUNDLE: ${{ steps.attest-flask-chrome.outputs.bundle-path }}
+          FLASK_FIREFOX_BUNDLE: ${{ steps.attest-flask-firefox.outputs.bundle-path }}
+        run: |
+          set -euo pipefail
+
+          # Names the bundle after the release asset it covers, so the AMO
+          # Lambda can resolve it from the zip name alone.
+          collect_bundle() {
+            local bundle_path="${1}"
+            local zip_glob="${2}"
+
+            if [[ -z "${bundle_path}" || ! -f "${bundle_path}" ]]; then
+              echo "::error::Attestation bundle missing for ${zip_glob}"
+              exit 1
+            fi
+
+            local zips=()
+            while IFS= read -r zip; do
+              zips+=("${zip}")
+            done < <(compgen -G "${zip_glob}" || true)
+
+            if [[ "${#zips[@]}" -ne 1 ]]; then
+              echo "::error::Expected exactly 1 artifact for ${zip_glob}, found ${#zips[@]}"
+              exit 1
+            fi
+
+            local dest
+            dest="${GITHUB_WORKSPACE}/$(basename "${zips[0]}").sigstore.json"
+            cp "${bundle_path}" "${dest}"
+            echo "Collected $(basename "${dest}")"
+          }
+
+          collect_bundle "${CHROME_BUNDLE}" 'build-dist-webpack/builds/metamask-chrome-*.zip'
+          collect_bundle "${FIREFOX_BUNDLE}" 'build-dist-mv2-webpack/builds/metamask-firefox-*.zip'
+          collect_bundle "${FLASK_CHROME_BUNDLE}" 'build-flask-webpack/builds/metamask-chrome-*.zip'
+          collect_bundle "${FLASK_FIREFOX_BUNDLE}" 'build-flask-mv2-webpack/builds/metamask-firefox-*.zip'
 
       - name: Generate SHA256SUMS
         run: |
@@ -305,6 +354,7 @@ jobs:
             echo "| Sentry (Flask webpack) | ✅ Published |"
             echo "| Sentry (Flask MV2 webpack) | ✅ Published |"
             echo "| Attestation (4 webpack artifacts) | ✅ Attested |"
+            echo "| Attestation bundles (release assets) | ✅ Published |"
             echo "| SHA256SUMS | ✅ Generated |"
             echo "| GitHub Release | ✅ Created |"
             echo "| Firefox Bundle | ✅ Pushed |"

--- a/.github/workflows/publish-release-from-release-head.yml
+++ b/.github/workflows/publish-release-from-release-head.yml
@@ -266,9 +266,11 @@ jobs:
           subject-path: build-flask-mv2-webpack/builds/metamask-firefox-*.zip
 
       # Publish each Sigstore bundle as a release asset so the AMO submission
-      # Lambda can verify provenance without a GitHub token (INFRA-3786). Each
-      # attest step writes its bundle to a path that the next step overwrites,
-      # so the copy has to happen once per step rather than in a single pass.
+      # Lambda can verify provenance without a GitHub token (INFRA-3786).
+      # actions/attest (pinned via attest-build-provenance) writes each bundle
+      # under a unique RUNNER_TEMP/<mkdtemp>/attestation.json, so the four
+      # bundle-path outputs point at four distinct files and can be collected
+      # in one pass after the last attest step.
       - name: Collect attestation bundles
         env:
           CHROME_BUNDLE: ${{ steps.attest-chrome.outputs.bundle-path }}

--- a/.github/workflows/run-build.yml
+++ b/.github/workflows/run-build.yml
@@ -78,7 +78,7 @@ jobs:
       VAPID_KEY: ${{ secrets.VAPID_KEY }}
     steps:
       - name: Checkout and setup environment
-        uses: MetaMask/action-checkout-and-setup@v3
+        uses: MetaMask/action-checkout-and-setup@0543b5929698c71e3ccc6ed24eac87825669b5de # v3.5.0
         with:
           is-high-risk-environment: ${{ github.ref_name == 'main' || github.ref_name == 'stable' || startsWith(github.ref_name, 'release/') }}
           skip-allow-scripts: true
@@ -99,7 +99,7 @@ jobs:
 
       - name: Upload bundle analyzer report to S3
         if: ${{ inputs.bundle-analyzer && vars.AWS_REGION && vars.AWS_IAM_ROLE && vars.AWS_S3_BUCKET }}
-        uses: MetaMask/github-tools/.github/actions/upload-s3@v1
+        uses: MetaMask/github-tools/.github/actions/upload-s3@bd5fd59aef9f5f31c77ffc63c2bbd53127e4f7b9 # v1.16.0
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: ${{ vars.AWS_IAM_ROLE }}
@@ -111,7 +111,7 @@ jobs:
         run: rm -f dist/report.html
 
       - name: Upload artifact '${{ inputs.build-name }}'
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: ${{ inputs.build-name }}
           path: |
@@ -120,7 +120,7 @@ jobs:
 
       - name: Upload 'builds' to S3
         if: ${{ vars.AWS_REGION && vars.AWS_IAM_ROLE && vars.AWS_S3_BUCKET }}
-        uses: MetaMask/github-tools/.github/actions/upload-s3@v1
+        uses: MetaMask/github-tools/.github/actions/upload-s3@bd5fd59aef9f5f31c77ffc63c2bbd53127e4f7b9 # v1.16.0
         with:
           aws-region: ${{ vars.AWS_REGION }}
           role-to-assume: ${{ vars.AWS_IAM_ROLE }}


### PR DESCRIPTION
## **Description**

Two independent pieces of [INFRA-3786](https://consensyssoftware.atlassian.net/browse/INFRA-3786), continuing from INFRA-2665 (publish-side attestation) and INFRA-3661 (CWS upload-side verify).

**1. Publish Sigstore bundles as release assets.** The release already attests all four webpack zips, but the bundles were never published anywhere the AMO submission Lambda could reach. The Lambda resolves an attestation from a release asset named `<zip>.sigstore.json`, so today enabling AMO verification would fail with `attestation_not_found`. Each `attest-build-provenance` step now exposes its `bundle-path` output, a new step copies it to `<zip>.sigstore.json`, and the release script attaches them.

Using the action's `bundle-path` output rather than `gh attestation download` keeps the step token-free and avoids any attestation-propagation race. `actions/attest` (pinned via `attest-build-provenance`) writes each bundle under a unique `RUNNER_TEMP/<mkdtemp>/attestation.json`, so the four `bundle-path` outputs point at four distinct files and are collected in one pass after the last attest step.

**2. Pin the mutable action references in `run-build.yml`.** This workflow is shared by PR CI (`main.yml`), the release pipeline, and nightly builds, so a compromised tag reaches every build. The publish workflow already pins its SLSA action to a digest; this brings `run-build.yml` to the same standard:

| Action | Was | Now |
| --- | --- | --- |
| `MetaMask/action-checkout-and-setup` | `@v3` | `0543b59` (v3.5.0) |
| `MetaMask/github-tools/.github/actions/upload-s3` | `@v1` | `bd5fd59` (v1.16.0) |
| `actions/upload-artifact` | `@v6` | `b7c566a` (v6.0.0) |

Each digest is the commit the tag currently points at; all three tags are lightweight, so these are commit SHAs rather than tag objects.

**Known follow-up:** `.github/dependabot.yml` only watches npm, so these pins will go stale with nothing proposing bumps. Adding the `github-actions` ecosystem was deliberately left out of this PR and needs a follow-up.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: [INFRA-3786](https://consensyssoftware.atlassian.net/browse/INFRA-3786)
Epic: [INFRA-2565](https://consensyssoftware.atlassian.net/browse/INFRA-2565)

Consumer side: consensys-vertical-apps/va-mmc-extension-submission#23 (Lambda verification) and consensys-vertical-apps/va-mmc-extension-submission-infra#13 (UAT toggle).

## **Manual testing steps**

1. Cut a release from a `release/*` branch so `publish-release-from-release-head.yml` runs.
2. In the run summary, confirm the **Collect attestation bundles** step logs four `Collected ...sigstore.json` lines.
3. Open the resulting GitHub Release and confirm four `<zip>.sigstore.json` assets sit alongside the four zips and `SHA256SUMS`.
4. Download one zip and its bundle, then run `gh attestation verify <zip> --repo MetaMask/metamask-extension --signer-workflow MetaMask/metamask-extension/.github/workflows/publish-release-from-release-head.yml` and confirm it passes.
5. Confirm the CWS upload workflow still succeeds, i.e. the added assets do not disturb its `gh release download --pattern` calls.
6. On any PR, confirm the build jobs still complete with the digest-pinned actions.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

[INFRA-3786]: https://consensyssoftware.atlassian.net/browse/INFRA-3786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[INFRA-3786]: https://consensyssoftware.atlassian.net/browse/INFRA-3786?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
