### PR TITLE
ci: turn on the Triage and Retry System by default (no retry-ci label needed)

### DIFF
--- a/.github/rules/retry-config.jsonc
+++ b/.github/rules/retry-config.jsonc
@@ -71,12 +71,14 @@
     "502 Bad Gateway", // load-balancer/proxy failure between runner and upstream
     "503 Service Unavailable", // upstream service temporarily down
     "504 Gateway Time-out", // upstream timed out behind a proxy/LB
-    "API rate limit exceeded", // GitHub REST API rate limit
     "Anvil exited: Error: Address already in use", // port collision starting Foundry local chain
+    "API rate limit exceeded", // GitHub REST API rate limit
     "Authentication failed for", // transient git auth failure cloning repos
     "Back off \\d+(\\.\\d+)? seconds before retry", // npm registry throttle (e.g. "Back off 16.402 seconds before retry")
     "binaries\\.sonarsource\\.com.*\\n.*Action failed: Unexpected HTTP response", // SonarScanner CDN flake (4xx/5xx downloading scanner-cli zip)
     "Command failed after \\d+ attempts", // Prepare dependencies: yarn install retries exhausted
+    "Could not assume role with OIDC: Token expired", // AWS OIDC credential expired during a long-running job; a rerun gets a fresh token
+    "Could not find the pullrequest with key", // SonarCloud PR analysis race: PR exists in GitHub but is not yet visible to SonarCloud
     "Could not resolve host", // DNS resolution failure
     "EAI_AGAIN", // Node.js DNS lookup timed out
     "ECONNREFUSED", // TCP connection refused (service not listening)
@@ -88,12 +90,13 @@
     "Exceeded timeout of \\d+ ms for a test", // Jest test timeout (flaky slow test)
     "expected flush after ref listing", // git protocol error during fetch/clone (usually GitHub 500)
     "Fail to request.*sonarcloud\\.io", // SonarCloud API unreachable during scan
-    "fatal: unable to access", // git clone/fetch network failure
     "Failed to FinalizeArtifact", // GitHub artifact upload failure (403/transient API error)
     "Failed to resolve action download info", // GitHub Actions HTTP timeout downloading action tarball
+    "fatal: unable to access", // git clone/fetch network failure
     "git.* failed with exit code 128", // git op failed (auth, network, corrupt pack)
     "gzip: stdin: not in gzip format", // download returned non-gzip content (e.g. error page from CDN instead of tarball)
     "heap out of memory", // V8 heap exhaustion (generic form)
+    "Internal Server Error occurred while resolving", // GitHub Actions failed to resolve an action dependency
     "JavaScript heap out of memory", // Node.js OOM crash
     "net::ERR_", // Chromium network errors in E2E (ERR_CONNECTION_REFUSED, etc.)
     "No space left on device", // runner disk full
@@ -101,10 +104,13 @@
     "OOMKilled", // Linux OOM killer terminated the process
     "re-run this check after the baseline refresh completes", // yarn-audit-diff: ambient CVEs triggered a baseline refresh
     "read ECONNRESET", // TCP read failure (more specific than ECONNRESET alone)
+    "Recv failure: Connection reset by peer", // curl TLS connection reset while downloading workflow metadata
     "resource temporarily unavailable", // file descriptor / process limit exhaustion
     "socket hang up", // HTTP connection dropped mid-request
+    "sonarcloud\\.io.*failed with HTTP \\d+", // SonarScanner CLI hitting api/scanner.sonarcloud.io with 4xx/5xx (JRE metadata or JRE binary download)
     "tar: Error is not recoverable", // fatal tar extraction failure (corrupted or non-archive input)
     "The requested URL returned error: 429", // GitHub raw content / API rate limit (curl error)
+    "Unhandled error: HttpError: <!DOCTYPE html>", // GitHub API returned an HTML error page instead of JSON
     "Upload progress stalled", // GitHub artifact upload timeout (actions/upload-artifact)
     "vkCreateInstance failed with VK_ERROR_INCOMPATIBLE_DRIVER", // GPU driver issue on runner for headless Chrome
     "VulkanError.cpp", // GPU driver crash in headless Chrome
@@ -120,8 +126,11 @@
   "deterministicErrorPatterns": [
     "\\.github/workflows/.*\\.yml:\\d+:\\d+:", // actionlint: any workflow lint error (expression, shellcheck, syntax, etc.)
     "\\*\\*\\w+\\*\\*: \\d+ unused messages", // verify-locale-strings: locale files have unused message keys (e.g. "**de**: 43 unused messages")
+    "✖ \\d+ problems? \\(", // ESLint summary: "✖ N problems (X errors, Y warnings)"
+    "✖ failing tests:", // Node.js test runner (node --test) summary of failures
     "BASELINE VIOLATIONS DETECTED", // lint-baseline.mts: new violations added to already-baselined files
-    "Can't walk dependency graph", // ts-migration-dashboard build (Browserify/module-deps): unresolvable import/require chain
+    "Can't find stylesheet to import", // Sass compilation error: missing or invalid stylesheet import
+    "Can't walk dependency graph", // Browserify build: broken import/require chain
     "Cannot find module", // Node.js require/import of missing package or path
     "Code style issues found", // oxlint --check or ESLint formatting rule failure
     "compiled with \\d+ errors?", // Webpack build errors
@@ -132,26 +141,33 @@
     "Error occurred when checking code style", // oxfmt parse error checking formatting
     "Failed to build the preview", // Storybook: Webpack compilation error building story preview
     "Format issues found in above \\d+ files", // Prettier or oxfmt --check: files need reformatting
+    "I18nProvider: Support for defaultProps", // Unit console baseline check: React defaultProps warning count changed
     "Invalid code fence parameters", // build: malformed code fence in source (BEGIN:, END:)
     "Invalid package.json", // malformed package.json (parse error during yarn install)
     "LavaMoat - required.*package not in allowlist", // LavaMoat policy: dependency not in allowlist (node builtin or regular package)
+    "Lint errors encountered for transformed file", // Browserify build: ESLint errors in post-transform output
     "Module not found", // Webpack: import of nonexistent module
     "NEW FILES \\(not in baseline\\)", // lint-baseline.mts: new files with violations not yet baselined
     "No build-name entries found in main.yml", // filter-files-changed: main.yml missing expected build-name fields
     "no platform directories.*found in dist", // build verification: platform folders missing from output
     "Not a valid commit name", // git can't resolve a commit SHA (shallow clone, force-pushed, or pruned ref)
     "packageManager.*current global version", // Corepack not enabled: workflow uses wrong Yarn version (needs corepack enable)
+    "Post comment failed with status '(Forbidden|Unauthorized)'", // Publish prerelease: GitHub comment denied because issue is locked or token lacks permission
+    "Protected branch update failed for refs/heads/", // Storybook deploy: target branch requires a PR and rejects force pushes
     "ReferenceError:", // JS runtime error: undefined variable or function
+    "runInChildProcess for task .* encountered an error", // Browserify build: a build sub-task crashed
     "shellcheck reported issue", // actionlint/shellcheck: shell script issues in workflow YAML
     "snapshots? failed", // Jest snapshot assertion mismatch
+    "Syntax Error", // JS/TS parser error emitted with spaced wording rather than SyntaxError
     "SyntaxError:", // JS/TS parse error (bad syntax, duplicate declaration, unexpected token)
     "test at .*\\.test\\.[tj]sx?:\\d+:\\d+\\n.*✖", // node:test runner: failure location followed by ✖ marker (2-line match ensures only failures are caught)
     "Test Files.*failed", // Vitest summary line: one or more test files failed
     "Test Suites:.*failed", // Jest summary line: one or more test suites failed
+    "Token exchange failed: 403 Forbidden", // Publish prerelease: deterministic policy/permission denial from token exchange service
     "Unable to resolve action", // GitHub Actions can't resolve a composite/reusable action (deleted tag or missing ref)
+    "Update baseline: yarn test:integration:update-baseline", // Integration console baseline detected new warnings
+    "useSelector\\(\\(state\\) =>", // Integration console baseline: React-Redux selector identity warning surfaced with concrete source line in log
     "Working tree dirty", // git working tree has uncommitted changes after a build/generate step
-    "yarn audit FAILED", // yarn audit found a production vulnerability
-    "✖ failing tests:", // Node.js test runner (node --test) summary of failures
-    "✖ \\d+ problems? \\(" // ESLint summary: "✖ N problems (X errors, Y warnings)"
+    "yarn audit FAILED" // yarn audit found a production vulnerability
   ]
 }

--- a/.github/scripts/classify-failures.mts
+++ b/.github/scripts/classify-failures.mts
@@ -1,10 +1,6 @@
 /**
  * classify-failures.mts
  *
- * REVIEWER FOCUS: The classification logic and retry decision tree are the
- * most important things to verify. See retry-config.jsonc for the pattern
- * definitions that drive classification.
- *
  * Analyzes failed jobs in a GitHub Actions workflow run and classifies each
  * failure (jobRetryable) based on job name patterns and transient error
  * detection. Derives an overall is-retryable decision from individual results.
@@ -41,7 +37,9 @@
  * Outputs (to $GITHUB_OUTPUT):
  *   is-retryable=true|false    — whether all failures are retryable
  *   has-retry-label=true|false — whether the originating PR has retry-ci
- *   will-retry=true|false      — is-retryable AND has-retry-label AND under attempt limit
+ *   will-retry=true|false      — is-retryable AND has PR AND under active retry limit
+ *   consume-retry-label=true|false — whether this retry should remove retry-ci
+ *   retry-mode=automatic|label|none — source of the retry budget used
  *   pr-number=<N>|""           — originating PR number (empty for push)
  *
  * Also writes a markdown report to $GITHUB_STEP_SUMMARY and optionally:
@@ -57,6 +55,12 @@ import { parseArgs } from 'node:util';
 import { ghApi } from './shared/gh-api.mts';
 import { getGitHubToken } from './shared/github-token.mts';
 import { stripJsonComments } from './shared/json-tools.mts';
+import {
+  DEFAULT_RETRY_MAX_ATTEMPT,
+  getRetryBudget,
+  RETRY_CI_LABEL_MAX_ATTEMPT,
+  type RetryBudgetDecision,
+} from './shared/retry-budget.mts';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -142,10 +146,9 @@ if (!MAIN_RUN_ID) {
   process.exit(1);
 }
 
-// Maximum number of workflow run attempts before retries are disabled.
-// Attempts are 1-indexed: after attempt MAX_ATTEMPTS, no further retries.
-// This must stay in sync with the guard in ci-status-gate.yml.
-const MAX_ATTEMPTS = 4;
+// Retry limits are 1-indexed and shared with ci-status-gate.yml's merge queue
+// deferral rules: default retries can create attempt 2, and retry-ci can create
+// attempts 3 and 4.
 
 const [owner, repo] = REPO.split('/');
 const repoApi = `/repos/${owner}/${repo}`;
@@ -520,6 +523,15 @@ function classifyJob(job: Job): JobClassification {
 
 const WORKFLOW_CONCLUSION = process.env.WORKFLOW_CONCLUSION ?? '';
 
+function writeNoRetryOutput(): void {
+  if (GITHUB_OUTPUT) {
+    appendFileSync(
+      GITHUB_OUTPUT,
+      'is-retryable=false\nhas-retry-label=false\nwill-retry=false\nconsume-retry-label=false\nretry-mode=none\npr-number=\n',
+    );
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Cancelled-run early exit
 // ---------------------------------------------------------------------------
@@ -552,12 +564,7 @@ if (WORKFLOW_CONCLUSION === 'cancelled' && Number(ATTEMPT) > 1) {
     }
   }
 
-  if (GITHUB_OUTPUT) {
-    appendFileSync(
-      GITHUB_OUTPUT,
-      'is-retryable=false\nhas-retry-label=false\nwill-retry=false\npr-number=\n',
-    );
-  }
+  writeNoRetryOutput();
 
   const Sentry = initSentry();
   if (Sentry) {
@@ -638,12 +645,7 @@ if (WORKFLOW_EVENT === 'merge_group') {
           }
         }
 
-        if (GITHUB_OUTPUT) {
-          appendFileSync(
-            GITHUB_OUTPUT,
-            'is-retryable=false\nhas-retry-label=false\nwill-retry=false\npr-number=\n',
-          );
-        }
+        writeNoRetryOutput();
         process.exit(0);
       }
     } catch (err) {
@@ -690,12 +692,7 @@ if (failedJobs.length === 0) {
     }
   }
 
-  if (GITHUB_OUTPUT) {
-    appendFileSync(
-      GITHUB_OUTPUT,
-      'is-retryable=false\nhas-retry-label=false\nwill-retry=false\npr-number=\n',
-    );
-  }
+  writeNoRetryOutput();
   process.exit(0);
 }
 
@@ -821,21 +818,26 @@ function checkRetryLabel(prNum: string): boolean {
 
 const prNumber = resolvePrNumber();
 const targetBranch = resolveTargetBranch();
-const hasRetryLabel = checkRetryLabel(prNumber);
-const atMaxAttempts = Number(ATTEMPT) >= MAX_ATTEMPTS;
-const willRetry = isRetryable && hasRetryLabel && !atMaxAttempts;
 const hasPR = Boolean(prNumber);
+const hasRetryLabel = checkRetryLabel(prNumber);
+const retryBudget = getRetryBudget({
+  attempt: ATTEMPT,
+  hasPr: hasPR,
+  hasRetryLabel,
+  isRetryable,
+});
+const atMaxAttempts = retryBudget.atRetryLimit;
+const willRetry = retryBudget.willRetry;
 
-// The retry decision depends on three independent facts:
+// The retry decision depends on the classification result, whether the run
+// has an originating PR, and the active retry budget:
 //
 //   isRetryable    — did classification determine all failures are retryable?
 //   hasPR          — is there an originating PR? (false for push events)
-//   hasRetryLabel  — does that PR have the `retry-ci` label?
+//   retryBudget    — default retries through attempt 2, retry-ci through attempt 4
 //
-// A retry only happens when ALL THREE are true (will-retry). The other
-// combinations produce different reports and Sentry attributes so we can
-// distinguish "retryable but nobody asked for a retry" from "someone asked
-// but the failures aren't retryable."
+// Attempt 1 retries automatically. Attempts 2 and 3 require retry-ci and
+// consume the label after the rerun is triggered.
 //
 // Note: hasRetryLabel implies hasPR (can't have a label without a PR),
 // so the retryable=*,hasPR=false,hasLabel=true combination never occurs.
@@ -847,19 +849,34 @@ function resolveDecision(
   retryable: boolean,
   hasPr: boolean,
   hasLabel: boolean,
-  maxAttempts: boolean,
+  budget: RetryBudgetDecision,
   pr: string,
 ): { key: string; label: string } {
   if (retryable) {
-    if (hasPr && hasLabel && !maxAttempts)
+    if (hasPr && budget.willRetry && budget.retryMode === 'automatic')
       return {
         key: 'will-retry',
-        label: '♻️ Will retry (retry-ci label present)',
+        label: `♻️ Will retry automatically (default retry budget: attempt ${budget.attemptNumber} of ${DEFAULT_RETRY_MAX_ATTEMPT})`,
       };
-    if (hasPr && hasLabel && maxAttempts)
+    if (hasPr && budget.willRetry && budget.retryMode === 'label')
+      return {
+        key: 'will-retry',
+        label: `♻️ Will retry (retry-ci label present; attempt ${budget.attemptNumber} of ${RETRY_CI_LABEL_MAX_ATTEMPT})`,
+      };
+    if (hasPr && budget.atRetryLimit && budget.retryLimitSource === 'retry-ci')
       return {
         key: 'max-attempts-reached',
-        label: `🛑 Retryable with retry-ci label, but attempt ${ATTEMPT} reached the limit of ${MAX_ATTEMPTS}`,
+        label: `🛑 Retryable, but attempt ${budget.attemptNumber} reached the retry-ci limit of ${budget.retryLimit}`,
+      };
+    if (hasPr && budget.atRetryLimit)
+      return {
+        key: 'retryable-no-label',
+        label: `⏸️ Retryable, but the default retry budget ended at attempt ${budget.retryLimit}`,
+      };
+    if (hasPr && budget.usedRetryCiBudget)
+      return {
+        key: 'retryable-retry-ci-consumed',
+        label: `⏸️ Retryable, but retry-ci was consumed by an earlier retry; add it again to retry attempt ${budget.attemptNumber + 1}`,
       };
     if (hasPr)
       return {
@@ -890,18 +907,18 @@ const { key: decision, label: decisionLabel } = resolveDecision(
   isRetryable,
   hasPR,
   hasRetryLabel,
-  atMaxAttempts,
+  retryBudget,
   prNumber,
 );
 
-if (atMaxAttempts && hasRetryLabel && isRetryable) {
+if (atMaxAttempts && hasPR && isRetryable) {
   console.log(
-    `PR #${prNumber}: retry-ci label present but attempt ${ATTEMPT} >= ${MAX_ATTEMPTS} — will not retry`,
+    `PR #${prNumber}: attempt ${retryBudget.attemptNumber} reached the ${retryBudget.retryLimitSource} retry limit (${retryBudget.retryLimit}) — will not retry`,
   );
 } else {
   console.log(
     prNumber
-      ? `PR #${prNumber}: retry-ci label ${hasRetryLabel ? 'present' : 'absent'} → will-retry=${willRetry}`
+      ? `PR #${prNumber}: retry-ci label ${hasRetryLabel ? 'present' : 'absent'}, retry-mode=${retryBudget.retryMode} → will-retry=${willRetry}`
       : `No originating PR for event '${WORKFLOW_EVENT}' → will-retry=false`,
   );
 }
@@ -909,11 +926,11 @@ if (atMaxAttempts && hasRetryLabel && isRetryable) {
 // ---------------------------------------------------------------------------
 // Post deferred failure commit status (merge queue only)
 //
-// ci-status-gate.yml defers the "All jobs pass" commit status when it
-// sees retry-ci on attempts below the limit (< MAX_ATTEMPTS), giving
-// triage time to retry. If we decide NOT to retry (non-retryable
-// failures, or max attempts reached), we must post the failure status
-// here to unblock the merge queue for ejection.
+// ci-status-gate.yml defers the "All jobs pass" commit status for merge queue
+// failures while a retry budget is still available, giving triage time to
+// retry. If we decide NOT to retry (non-retryable failures, or retry limit
+// reached), we must post the failure status here to unblock the merge queue
+// for ejection.
 //
 // The merge queue requires two checks (ruleset or classic branch protection):
 //   Rule 1 — Merge queue > ALLGREEN (monitors check suites directly)
@@ -922,18 +939,19 @@ if (atMaxAttempts && hasRetryLabel && isRetryable) {
 // can't eject the PR.
 // ---------------------------------------------------------------------------
 
-// The gate defers when: merge_group + failure + retry-ci + attempt < MAX_ATTEMPTS.
-// We can't re-check hasRetryLabel here because the API call might fail (rate
-// limit, transient outage), and if it does, the deferred status would never
-// post — leaving the queue stuck. Instead, post on any merge_group where we
-// won't retry. If the gate didn't actually defer (no label), this posts a
-// redundant failure status — harmless, since ci-status-gate already posted one.
+// The gate defers when a merge_group failure is under either the default or
+// retry-ci retry budget. We can't rely on re-checking labels here because the
+// API call might fail (rate limit, transient outage), and if it does, the
+// deferred status would never post — leaving the queue stuck. Instead, post on
+// any merge_group where we won't retry. If the gate didn't actually defer, this
+// posts a redundant failure status — harmless, since ci-status-gate already
+// posted one.
 if (WORKFLOW_EVENT === 'merge_group' && !willRetry) {
   const headSha = getRunHeadSha();
   const description = atMaxAttempts
-    ? `Retry limit reached (attempt ${ATTEMPT} of ${MAX_ATTEMPTS})`
+    ? `Retry limit reached (attempt ${retryBudget.attemptNumber} of ${retryBudget.retryLimit})`
     : isRetryable
-      ? 'Retryable failures, but no retry-ci label'
+      ? 'Retryable failures, but no retry budget available'
       : 'Non-retryable failures detected';
   try {
     ghApi(`${repoApi}/statuses/${headSha}`, {
@@ -961,6 +979,9 @@ if (GITHUB_OUTPUT) {
       `is-retryable=${isRetryable}`,
       `has-retry-label=${hasRetryLabel}`,
       `will-retry=${willRetry}`,
+      `consume-retry-label=${retryBudget.consumeRetryLabel}`,
+      `retry-mode=${retryBudget.retryMode}`,
+      `retry-limit=${retryBudget.retryLimit}`,
       `pr-number=${prNumber}`,
     ].join('\n') + '\n',
   );
@@ -979,6 +1000,7 @@ const reportLines = [
   `**Run:** [${MAIN_RUN_ID}](${mainRunUrl})${ATTEMPT ? ` (attempt ${ATTEMPT})` : ''}`,
   `**Classification:** ${isRetryable ? '✅ All failures retryable' : '❌ Non-retryable failures detected'}`,
   `**Retry:** ${decisionLabel}`,
+  `**Retry mode:** ${retryBudget.retryMode} (limit ${retryBudget.retryLimit}, ${retryBudget.retryLimitSource})`,
   `**Failed jobs:** ${failedJobs.length}`,
   ``,
   `| Job | Category | Job Retryable | Reason |`,
@@ -998,10 +1020,10 @@ if (unmatchedJobs.length > 0) {
   );
 }
 
-if (atMaxAttempts && isRetryable && hasRetryLabel) {
+if (atMaxAttempts && isRetryable && hasPR) {
   reportLines.push(
     ``,
-    `> 🛑 **Retry limit reached** — attempt ${ATTEMPT} of ${MAX_ATTEMPTS}. The failures look retryable, but no more automatic retries will be attempted.`,
+    `> 🛑 **Retry limit reached** — attempt ${retryBudget.attemptNumber} of ${retryBudget.retryLimit}. The failures look retryable, but no more automatic retries will be attempted for this run.`,
   );
 }
 
@@ -1102,6 +1124,10 @@ if (Sentry) {
     'ci.prNumber': prNumber || 'none',
     'ci.retry.date': new Date().toISOString().slice(0, 10),
     'ci.retry.decision': decision,
+    'ci.retry.mode': retryBudget.retryMode,
+    'ci.retry.limit': String(retryBudget.retryLimit),
+    'ci.retry.limitSource': retryBudget.retryLimitSource,
+    'ci.retry.consumeRetryLabel': String(retryBudget.consumeRetryLabel),
     'ci.retry.runId': MAIN_RUN_ID,
     'ci.retry.attempt': ATTEMPT || 'unknown',
     'ci.retry.event': WORKFLOW_EVENT || '',
@@ -1126,6 +1152,7 @@ if (Sentry) {
       'ci.retry.runId': MAIN_RUN_ID,
       'ci.retry.date': new Date().toISOString().slice(0, 10),
       'ci.retry.decision': decision,
+      'ci.retry.mode': retryBudget.retryMode,
       'ci.retry.attempt': ATTEMPT || 'unknown',
       'ci.retry.event': WORKFLOW_EVENT || '',
       'ci.retry.parentTriageLink': parentTriageLink,

--- a/.github/scripts/shared/merge-queue-entry.mts
+++ b/.github/scripts/shared/merge-queue-entry.mts
@@ -1,0 +1,100 @@
+/**
+ * Verifies that a failed merge-group run still represents the PR's active
+ * merge-queue entry. A workflow_run can start after GitHub has rebuilt or
+ * removed that entry, and rerunning such a workflow would waste CI on a
+ * commit the queue will never merge.
+ *
+ * This module deliberately separates a confirmed stale entry from an
+ * unverified one. A successful API response that reports no entry or a
+ * different commit is stale. An API error is retried, then reported as
+ * unverified if GitHub cannot be reached reliably.
+ */
+export type MergeQueueEntryState = 'current' | 'stale' | 'unverified';
+
+export interface MergeQueueEntryVerification {
+  /** Whether retrying the failed merge-group workflow is safe. */
+  state: MergeQueueEntryState;
+  /** The active queue-entry SHA when GitHub returned one. */
+  headSha?: string;
+}
+
+export interface VerifyMergeQueueEntryOptions {
+  /** SHA from the failed workflow_run event. */
+  expectedHeadSha: string;
+  /** Fetches the active merge queue entry's head SHA, or null if none exists. */
+  getHeadSha: () => Promise<string | null>;
+  /** Limits transient API retries so triage cannot hold the queue indefinitely. */
+  maxAttempts?: number;
+  /** Injectable delay for unit tests and bounded production backoff. */
+  sleep?: (milliseconds: number) => Promise<void>;
+}
+
+export interface VerifyMergeQueueRetryOptions
+  extends VerifyMergeQueueEntryOptions {
+  /** Confirms the failed run's temporary merge-queue ref still exists. */
+  refExists: () => Promise<boolean>;
+}
+
+const DEFAULT_MAX_ATTEMPTS = 3;
+
+function defaultSleep(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+export async function verifyMergeQueueEntry({
+  expectedHeadSha,
+  getHeadSha,
+  maxAttempts = DEFAULT_MAX_ATTEMPTS,
+  sleep = defaultSleep,
+}: VerifyMergeQueueEntryOptions): Promise<MergeQueueEntryVerification> {
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      const headSha = await getHeadSha();
+      if (headSha === expectedHeadSha) {
+        // The PR is still queued on the same synthetic merge-group commit.
+        return { state: 'current', headSha };
+      }
+
+      // A null result or a different SHA is a successful, authoritative API
+      // response. Retrying would not make this obsolete workflow current.
+      return { state: 'stale', ...(headSha ? { headSha } : {}) };
+    } catch {
+      if (attempt === maxAttempts) {
+        // Keep the fail-closed distinction: callers must not retry when they
+        // cannot establish whether this workflow still belongs to the queue.
+        return { state: 'unverified' };
+      }
+
+      // Back off briefly for transient GitHub API failures without extending
+      // the merge queue's pending state for an unbounded period.
+      await sleep(attempt * 1000);
+    }
+  }
+
+  return { state: 'unverified' };
+}
+
+export async function verifyMergeQueueRetry({
+  refExists,
+  ...entryOptions
+}: VerifyMergeQueueRetryOptions): Promise<MergeQueueEntryVerification> {
+  const entryVerification = await verifyMergeQueueEntry(entryOptions);
+  if (entryVerification.state !== 'current') {
+    // The ref has no bearing once the entry itself is confirmed stale or the
+    // API could not establish that it is current.
+    return entryVerification;
+  }
+
+  // GitHub can delete the temporary gh-readonly-queue ref between the GraphQL
+  // lookup and the rerun request. Check it last, immediately before callers
+  // authorize the retry, to close that race.
+  try {
+    return (await refExists())
+      ? entryVerification
+      : { state: 'stale', headSha: entryVerification.headSha };
+  } catch {
+    // A ref API error does not prove the ref disappeared. Fail closed without
+    // misreporting a still-current queue entry as stale.
+    return { state: 'unverified', headSha: entryVerification.headSha };
+  }
+}

--- a/.github/scripts/shared/merge-queue-entry.test.mts
+++ b/.github/scripts/shared/merge-queue-entry.test.mts
@@ -1,0 +1,132 @@
+import {
+  verifyMergeQueueEntry,
+  verifyMergeQueueRetry,
+} from './merge-queue-entry.mts';
+
+describe('verifyMergeQueueEntry', () => {
+  it('returns current when the queue entry matches the failed run SHA', async () => {
+    const result = await verifyMergeQueueEntry({
+      expectedHeadSha: 'current-sha',
+      getHeadSha: async () => 'current-sha',
+      sleep: async () => undefined,
+    });
+
+    expect(result).toStrictEqual({
+      state: 'current',
+      headSha: 'current-sha',
+    });
+  });
+
+  it('returns stale when the queue entry is missing', async () => {
+    const result = await verifyMergeQueueEntry({
+      expectedHeadSha: 'current-sha',
+      getHeadSha: async () => null,
+      sleep: async () => undefined,
+    });
+
+    expect(result).toStrictEqual({ state: 'stale' });
+  });
+
+  it('returns stale when the queue entry points to another SHA', async () => {
+    const result = await verifyMergeQueueEntry({
+      expectedHeadSha: 'current-sha',
+      getHeadSha: async () => 'replacement-sha',
+      sleep: async () => undefined,
+    });
+
+    expect(result).toStrictEqual({
+      state: 'stale',
+      headSha: 'replacement-sha',
+    });
+  });
+
+  it('retries an API failure before returning the current entry', async () => {
+    let calls = 0;
+    const delays: number[] = [];
+    const result = await verifyMergeQueueEntry({
+      expectedHeadSha: 'current-sha',
+      getHeadSha: async () => {
+        calls += 1;
+        if (calls < 3) {
+          throw new Error('GitHub API unavailable');
+        }
+        return 'current-sha';
+      },
+      sleep: async (milliseconds) => {
+        delays.push(milliseconds);
+      },
+    });
+
+    expect(result).toStrictEqual({
+      state: 'current',
+      headSha: 'current-sha',
+    });
+    expect(delays).toStrictEqual([1000, 2000]);
+  });
+
+  it('returns unverified after exhausting API retries', async () => {
+    let calls = 0;
+    const result = await verifyMergeQueueEntry({
+      expectedHeadSha: 'current-sha',
+      getHeadSha: async () => {
+        calls += 1;
+        throw new Error('GitHub API unavailable');
+      },
+      sleep: async () => undefined,
+    });
+
+    expect(result).toStrictEqual({ state: 'unverified' });
+    expect(calls).toBe(3);
+  });
+});
+
+describe('verifyMergeQueueRetry', () => {
+  it('returns stale when the queue ref disappears after entry verification', async () => {
+    const result = await verifyMergeQueueRetry({
+      expectedHeadSha: 'current-sha',
+      getHeadSha: async () => 'current-sha',
+      refExists: async () => false,
+      sleep: async () => undefined,
+    });
+
+    expect(result).toStrictEqual({
+      state: 'stale',
+      headSha: 'current-sha',
+    });
+  });
+
+  it('returns unverified when the queue ref cannot be checked', async () => {
+    const result = await verifyMergeQueueRetry({
+      expectedHeadSha: 'current-sha',
+      getHeadSha: async () => 'current-sha',
+      refExists: async () => {
+        throw new Error('GitHub API unavailable');
+      },
+      sleep: async () => undefined,
+    });
+
+    expect(result).toStrictEqual({
+      state: 'unverified',
+      headSha: 'current-sha',
+    });
+  });
+
+  it('does not check the queue ref when the entry is stale', async () => {
+    let refChecks = 0;
+    const result = await verifyMergeQueueRetry({
+      expectedHeadSha: 'current-sha',
+      getHeadSha: async () => 'replacement-sha',
+      refExists: async () => {
+        refChecks += 1;
+        return true;
+      },
+      sleep: async () => undefined,
+    });
+
+    expect(result).toStrictEqual({
+      state: 'stale',
+      headSha: 'replacement-sha',
+    });
+    expect(refChecks).toBe(0);
+  });
+});

--- a/.github/scripts/shared/retry-budget.mts
+++ b/.github/scripts/shared/retry-budget.mts
@@ -1,0 +1,102 @@
+/**
+ * The pure retry-budget policy shared by failure classification and its tests.
+ * Workflow YAML mirrors the numeric limits where it must run without a
+ * checkout, but this module is the source of truth for triage decisions.
+ *
+ * Attempts are one-indexed GitHub Actions run attempts. A retry is allowed
+ * only before the selected limit: attempt 1 can create attempt 2; a retry-ci
+ * label can additionally authorize attempts 2 -> 3 and 3 -> 4.
+ */
+export const DEFAULT_RETRY_MAX_ATTEMPT = 2;
+export const RETRY_CI_LABEL_MAX_ATTEMPT = 4;
+
+export type RetryMode = 'automatic' | 'label' | 'none';
+export type RetryLimitSource = 'default' | 'retry-ci';
+
+export interface RetryBudgetInput {
+  /** GitHub Actions run_attempt from the failed Main workflow. */
+  attempt: number | string;
+  /** Whether this run can be associated with an originating PR. */
+  hasPr: boolean;
+  /** Whether the originating PR currently has the retry-ci label. */
+  hasRetryLabel: boolean;
+  /** Whether all non-optional failed jobs were classified as retryable. */
+  isRetryable: boolean;
+}
+
+export interface RetryBudgetDecision {
+  /** Sanitized one-indexed attempt number used for all policy comparisons. */
+  attemptNumber: number;
+  /** True only for retryable PR failures that have exhausted their budget. */
+  atRetryLimit: boolean;
+  /** True only when this retry spends the retry-ci label authorization. */
+  consumeRetryLabel: boolean;
+  /** Last permitted attempt for the selected retry budget. */
+  retryLimit: number;
+  /** Explains whether the default or retry-ci limit was selected. */
+  retryLimitSource: RetryLimitSource;
+  /** True when this run could only have been reached with retry-ci funding. */
+  usedRetryCiBudget: boolean;
+  /** Distinguishes automatic, label-funded, and terminal decisions. */
+  retryMode: RetryMode;
+  /** Whether triage should call gh run rerun --failed. */
+  willRetry: boolean;
+}
+
+export function parseAttempt(attempt: number | string): number {
+  const attemptNumber =
+    typeof attempt === 'number' ? attempt : Number.parseInt(attempt, 10);
+
+  if (!Number.isFinite(attemptNumber) || attemptNumber < 1) {
+    // Fail safe to attempt 1: malformed workflow input must not accidentally
+    // skip the automatic retry or authorize an unbounded retry.
+    return 1;
+  }
+
+  return Math.floor(attemptNumber);
+}
+
+export function getRetryBudget({
+  attempt,
+  hasPr,
+  hasRetryLabel,
+  isRetryable,
+}: RetryBudgetInput): RetryBudgetDecision {
+  const attemptNumber = parseAttempt(attempt);
+  // Attempts above the default ceiling can only be created by a prior
+  // retry-ci-funded rerun. The label is removed after that rerun succeeds,
+  // so preserve the selected ceiling for later reporting and terminal status.
+  const usedRetryCiBudget = attemptNumber > DEFAULT_RETRY_MAX_ATTEMPT;
+  const retryLimit = hasRetryLabel || usedRetryCiBudget
+    ? RETRY_CI_LABEL_MAX_ATTEMPT
+    : DEFAULT_RETRY_MAX_ATTEMPT;
+  const retryLimitSource: RetryLimitSource = hasRetryLabel || usedRetryCiBudget
+    ? 'retry-ci'
+    : 'default';
+  // Pushes and other runs without an originating PR are observation-only.
+  // A retry also requires a retryable classification and a current label for
+  // retries beyond the automatic attempt 1 -> 2 transition.
+  const willRetry =
+    isRetryable &&
+    hasPr &&
+    attemptNumber < retryLimit &&
+    (attemptNumber < DEFAULT_RETRY_MAX_ATTEMPT || hasRetryLabel);
+  const retryMode: RetryMode = !willRetry
+    ? 'none'
+    : attemptNumber < DEFAULT_RETRY_MAX_ATTEMPT
+      ? 'automatic'
+      : 'label';
+
+  return {
+    attemptNumber,
+    // Do not call a non-retryable failure "at limit"; that distinction drives
+    // the human-readable classifier report and terminal status description.
+    atRetryLimit: isRetryable && hasPr && attemptNumber >= retryLimit,
+    consumeRetryLabel: retryMode === 'label',
+    retryLimit,
+    retryLimitSource,
+    retryMode,
+    usedRetryCiBudget,
+    willRetry,
+  };
+}

--- a/.github/scripts/shared/retry-budget.test.mts
+++ b/.github/scripts/shared/retry-budget.test.mts
@@ -1,0 +1,153 @@
+import { getRetryBudget, parseAttempt } from './retry-budget.mts';
+
+describe('parseAttempt', () => {
+  it('uses attempt 1 when the value is missing or invalid', () => {
+    expect(parseAttempt('')).toBe(1);
+    expect(parseAttempt('abc')).toBe(1);
+    expect(parseAttempt(0)).toBe(1);
+  });
+
+  it('normalizes valid attempts to whole numbers', () => {
+    expect(parseAttempt('2')).toBe(2);
+    expect(parseAttempt(3.9)).toBe(3);
+  });
+});
+
+describe('getRetryBudget', () => {
+  it('retries retryable PR failures on attempt 1 without a label', () => {
+    expect(
+      getRetryBudget({
+        attempt: 1,
+        hasPr: true,
+        hasRetryLabel: false,
+        isRetryable: true,
+      }),
+    ).toStrictEqual({
+      attemptNumber: 1,
+      atRetryLimit: false,
+      consumeRetryLabel: false,
+      retryLimit: 2,
+      retryLimitSource: 'default',
+      retryMode: 'automatic',
+      usedRetryCiBudget: false,
+      willRetry: true,
+    });
+  });
+
+  it('does not consume retry-ci when attempt 1 is inside the default budget', () => {
+    const decision = getRetryBudget({
+      attempt: 1,
+      hasPr: true,
+      hasRetryLabel: true,
+      isRetryable: true,
+    });
+
+    expect(decision.retryMode).toBe('automatic');
+    expect(decision.consumeRetryLabel).toBe(false);
+    expect(decision.willRetry).toBe(true);
+  });
+
+  it('stops at attempt 2 without retry-ci', () => {
+    const decision = getRetryBudget({
+      attempt: 2,
+      hasPr: true,
+      hasRetryLabel: false,
+      isRetryable: true,
+    });
+
+    expect(decision.atRetryLimit).toBe(true);
+    expect(decision.retryLimit).toBe(2);
+    expect(decision.retryMode).toBe('none');
+    expect(decision.willRetry).toBe(false);
+  });
+
+  it('uses retry-ci to retry attempts 2 and 3', () => {
+    for (const attempt of [2, 3]) {
+      const decision = getRetryBudget({
+        attempt,
+        hasPr: true,
+        hasRetryLabel: true,
+        isRetryable: true,
+      });
+
+      expect(decision.consumeRetryLabel).toBe(true);
+      expect(decision.retryLimit).toBe(4);
+      expect(decision.retryLimitSource).toBe('retry-ci');
+      expect(decision.retryMode).toBe('label');
+      expect(decision.willRetry).toBe(true);
+    }
+  });
+
+  it('stops at attempt 4 even with retry-ci', () => {
+    const decision = getRetryBudget({
+      attempt: 4,
+      hasPr: true,
+      hasRetryLabel: true,
+      isRetryable: true,
+    });
+
+    expect(decision.atRetryLimit).toBe(true);
+    expect(decision.retryLimit).toBe(4);
+    expect(decision.retryMode).toBe('none');
+    expect(decision.usedRetryCiBudget).toBe(true);
+    expect(decision.willRetry).toBe(false);
+  });
+
+  it('preserves the retry-ci ceiling after the label-funded retry consumes the label', () => {
+    const decision = getRetryBudget({
+      attempt: 3,
+      hasPr: true,
+      hasRetryLabel: false,
+      isRetryable: true,
+    });
+
+    expect(decision.atRetryLimit).toBe(false);
+    expect(decision.retryLimit).toBe(4);
+    expect(decision.retryLimitSource).toBe('retry-ci');
+    expect(decision.retryMode).toBe('none');
+    expect(decision.usedRetryCiBudget).toBe(true);
+    expect(decision.willRetry).toBe(false);
+  });
+
+  it('reports the retry-ci ceiling at attempt 4 after the label was consumed', () => {
+    const decision = getRetryBudget({
+      attempt: 4,
+      hasPr: true,
+      hasRetryLabel: false,
+      isRetryable: true,
+    });
+
+    expect(decision.atRetryLimit).toBe(true);
+    expect(decision.retryLimit).toBe(4);
+    expect(decision.retryLimitSource).toBe('retry-ci');
+    expect(decision.retryMode).toBe('none');
+    expect(decision.usedRetryCiBudget).toBe(true);
+    expect(decision.willRetry).toBe(false);
+  });
+
+  it('does not retry non-retryable failures', () => {
+    const decision = getRetryBudget({
+      attempt: 1,
+      hasPr: true,
+      hasRetryLabel: true,
+      isRetryable: false,
+    });
+
+    expect(decision.atRetryLimit).toBe(false);
+    expect(decision.retryMode).toBe('none');
+    expect(decision.willRetry).toBe(false);
+  });
+
+  it('does not retry runs without an originating PR', () => {
+    const decision = getRetryBudget({
+      attempt: 1,
+      hasPr: false,
+      hasRetryLabel: false,
+      isRetryable: true,
+    });
+
+    expect(decision.atRetryLimit).toBe(false);
+    expect(decision.retryMode).toBe('none');
+    expect(decision.willRetry).toBe(false);
+  });
+});

--- a/.github/scripts/verify-merge-queue-entry.mts
+++ b/.github/scripts/verify-merge-queue-entry.mts
@@ -1,0 +1,150 @@
+/**
+ * GitHub Actions CLI for the merge-group retry guard.
+ *
+ * workflow_run is privileged and resolves this script from the default branch.
+ * Before triage reruns failed jobs, this script proves the failed merge-group
+ * commit is still queued, then writes `state=current` to GITHUB_OUTPUT. For a
+ * stale or unverified entry, it publishes the terminal required status itself
+ * so the merge queue can eject rather than remaining pending.
+ */
+
+import { appendFileSync } from 'node:fs';
+import { execFileSync } from 'node:child_process';
+
+import { verifyMergeQueueRetry } from './shared/merge-queue-entry.mts';
+
+const REPO = process.env.REPO ?? '';
+const PR_NUMBER = process.env.PR_NUMBER ?? '';
+const HEAD_SHA = process.env.HEAD_SHA ?? '';
+const HEAD_BRANCH = process.env.HEAD_BRANCH ?? '';
+const GITHUB_OUTPUT = process.env.GITHUB_OUTPUT ?? '';
+
+// These values describe the original failed workflow run, not the triage
+// workflow. They are provided by triage-and-retry-system.yml.
+if (!REPO || !PR_NUMBER || !HEAD_SHA || !HEAD_BRANCH) {
+  throw new Error('REPO, PR_NUMBER, HEAD_SHA, and HEAD_BRANCH must be set');
+}
+
+const [owner, repository] = REPO.split('/');
+if (!owner || !repository) {
+  throw new Error(`Invalid repository: ${REPO}`);
+}
+
+// The entry's head commit is more precise than checking merely whether the PR
+// has some queue entry: GitHub may have rebuilt the entry on a newer SHA while
+// this old workflow_run was waiting for triage.
+const query = `query($owner: String!, $repository: String!, $prNumber: Int!) {
+  repository(owner: $owner, name: $repository) {
+    pullRequest(number: $prNumber) {
+      mergeQueueEntry {
+        headCommit {
+          oid
+        }
+      }
+    }
+  }
+}`;
+
+const verification = await verifyMergeQueueRetry({
+  expectedHeadSha: HEAD_SHA,
+  getHeadSha: async () => {
+    // GraphQL/CLI failures throw and are retried by verifyMergeQueueEntry.
+    // A valid response with no entry intentionally returns null instead, which
+    // is a confirmed stale result rather than an API failure.
+    const response = JSON.parse(
+      execFileSync(
+        'gh',
+        [
+          'api',
+          'graphql',
+          '-f',
+          `query=${query}`,
+          '-F',
+          `owner=${owner}`,
+          '-F',
+          `repository=${repository}`,
+          '-F',
+          `prNumber=${PR_NUMBER}`,
+        ],
+        { encoding: 'utf8' },
+      ),
+    ) as {
+      data?: {
+        repository?: {
+          pullRequest?: {
+            mergeQueueEntry?: { headCommit?: { oid?: string } };
+          };
+        };
+      };
+      errors?: Array<{ message: string }>;
+    };
+
+    if (response.errors?.length) {
+      // GitHub may return GraphQL errors in a successful CLI response; convert
+      // them to a thrown error so the bounded retry policy still applies.
+      throw new Error(response.errors.map(({ message }) => message).join('; '));
+    }
+
+    return (
+      response.data?.repository?.pullRequest?.mergeQueueEntry?.headCommit?.oid ??
+      null
+    );
+  },
+  refExists: async () => {
+    try {
+      // Verify the exact temporary ref from the failed run. A current queue
+      // entry alone is insufficient if GitHub has already deleted this ref.
+      execFileSync(
+        'gh',
+        ['api', `repos/${REPO}/git/ref/heads/${HEAD_BRANCH}`],
+        { stdio: ['ignore', 'ignore', 'pipe'] },
+      );
+      return true;
+    } catch (error) {
+      const stderr = String(
+        (error as { stderr?: unknown }).stderr ?? '',
+      );
+      if (stderr.includes('HTTP 404')) {
+        return false;
+      }
+
+      // Non-404 API failures are unverified, not proof that GitHub removed
+      // the ref. verifyMergeQueueRetry converts this to its fail-closed state.
+      throw error;
+    }
+  },
+});
+
+console.log(`Merge queue entry verification: ${verification.state}`);
+if (GITHUB_OUTPUT) {
+  // The workflow only invokes `gh run rerun --failed` when this is current.
+  appendFileSync(GITHUB_OUTPUT, `state=${verification.state}\n`);
+}
+
+if (verification.state !== 'current') {
+  // ci-status-gate deferred All jobs pass while retry was possible. Once this
+  // guard rejects retrying, publish a final failure so ALLGREEN can eject the
+  // entry instead of leaving the required status pending.
+  const description =
+    verification.state === 'stale'
+      ? 'Merge queue entry was replaced — skipping retry'
+      : 'Could not verify merge queue entry — skipping retry';
+  console.warn(description);
+  // This status belongs on the failed merge-group SHA, not the triage SHA.
+  execFileSync(
+    'gh',
+    [
+      'api',
+      `repos/${REPO}/statuses/${HEAD_SHA}`,
+      '--method',
+      'POST',
+      '-f',
+      'state=failure',
+      '-f',
+      'context=All jobs pass',
+      '-f',
+      `description=${description}`,
+    ],
+    { stdio: 'inherit' },
+  );
+}

--- a/.github/workflows/ci-status-gate.yml
+++ b/.github/workflows/ci-status-gate.yml
@@ -6,8 +6,8 @@
 #
 # Responsibilities:
 #   1. Check that all jobs passed (from caller's needs-json)
-#   2. Retry gate: defer commit status when retry-ci label is present
-#      on merge_group failures, giving triage time to retry
+#   2. Retry gate: defer commit status while a merge_group retry budget
+#      is available, giving triage time to retry
 #   3. Post "All jobs pass" commit status (success or failure)
 #   4. Emit Sentry events (resolved-at-attempt, merge queue outcome)
 #   5. Fail the job if any checks failed
@@ -114,20 +114,23 @@ jobs:
       #
       # Timeline of a merge_group retry:
       #   1. main.yml attempt 1 fails → suite completes with failure
-      #   2. This step sees retry-ci label → skips commit status
+      #   2. This step sees default retry budget → skips commit status
       #   3. Rule 1 wants to eject, but "All jobs pass" is pending → blocked
       #   4. Triage fires (workflow_run completed) → calls gh run rerun
       #   5. main.yml attempt 2 starts → suite resets to in_progress
       #   6. If attempt 2 passes → commit status posted as success → merge
       #      If attempt 2 fails without retry-ci → commit status posted as failure → eject
+      #      If attempt 2 fails with retry-ci → skips commit status again
       #
-      # The retry-ci label is removed by triage after each retry, so
-      # the user must re-add it to authorize additional retries.
-      # A hard limit of 4 attempts applies (run_attempt < 4 below).
+      # The default budget allows attempt 2. retry-ci extends the budget
+      # through attempt 4. The retry-ci label is removed by triage after
+      # each label-funded retry, so the user must re-add it to authorize
+      # another extra retry.
       # On attempt 4+, the commit status is always posted immediately.
-      # Keep this in sync with MAX_ATTEMPTS in classify-failures.mts.
+      # retry-budget.mts is the source of truth for these limits. This mirrors
+      # them because the gate deliberately runs without a checkout.
       # ────────────────────────────────────────────────────────────────
-      - name: Check retry-ci label (merge queue only)
+      - name: Check retry budget (merge queue only)
         id: retry-gate
         if: >-
           ${{
@@ -138,6 +141,22 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          ATTEMPT=${{ github.run_attempt }}
+          DEFAULT_RETRY_MAX_ATTEMPT=2
+          RETRY_CI_LABEL_MAX_ATTEMPT=4
+
+          if (( ATTEMPT < DEFAULT_RETRY_MAX_ATTEMPT )); then
+            echo "Attempt $ATTEMPT is within the default retry budget — deferring commit status for triage retry"
+            echo "skip-status=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if (( ATTEMPT >= RETRY_CI_LABEL_MAX_ATTEMPT )); then
+            echo "Attempt $ATTEMPT reached the retry-ci limit — posting commit status"
+            echo "skip-status=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
           if [[ "$BRANCH" =~ gh-readonly-queue/[^/]+/pr-([0-9]+)- ]]; then
             PR="${BASH_REMATCH[1]}"
             if ! RAW_LABELS=$(gh pr view "$PR" --repo "${{ github.repository }}" --json labels --jq '.labels[].name' 2>&1); then

--- a/.github/workflows/triage-and-retry-system.yml
+++ b/.github/workflows/triage-and-retry-system.yml
@@ -13,10 +13,12 @@
 #   1. Emits a lightweight "cancelled" event to Sentry and exits
 #      (no full classification needed)
 #
-# Retry is label-gated for all events that have an originating PR:
+# Retry has two budgets for events that have an originating PR:
 #
 #   - pull_request / merge_group:
-#     Retry only when the `retry-ci` label is present on the PR.
+#     Retry retryable failures once by default (attempt 1 → attempt 2).
+#     If the `retry-ci` label is present, retryable failures can retry up
+#     to attempt 4. Label-funded retries consume/remove the label.
 #     For merge_group, the PR number is extracted from the branch name
 #     (gh-readonly-queue/{base}/pr-{N}-{sha}).
 #
@@ -24,9 +26,9 @@
 #     Observation only — no retry (no originating PR to label).
 #
 # Reruns call `gh run rerun --failed`, which triggers a new main.yml
-# completion → workflow_run fires again. A maximum of 4 attempts are
-# allowed (configurable via MAX_ATTEMPTS in classify-failures.mts and
-# the matching guard in ci-status-gate.yml).
+# completion → workflow_run fires again. The default budget allows attempt 2;
+# retry-ci extends the budget through attempt 4. Keep these limits in sync with
+# classify-failures.mts and ci-status-gate.yml.
 #
 # Merge queue interaction:
 #   The merge queue requires two checks (configured via a repository
@@ -41,19 +43,17 @@
 #     Monitors the commit status posted by ci-status-gate.yml.
 #
 #   Both must agree before the queue merges or ejects. ci-status-gate
-#   exploits this: on early merge_group failures, it skips posting
-#   the commit status when retry-ci is present, keeping Rule 2
-#   pending. This blocks Rule 1 from ejecting, giving triage time
-#   to retry.
+#   exploits this: on early merge_group failures, it skips posting the
+#   commit status while a retry budget is still available, keeping Rule 2
+#   pending. This blocks Rule 1 from ejecting, giving triage time to retry.
 #
 #   When triage calls `gh run rerun --failed`, it resets main.yml's check
 #   suite to in_progress and triggers a new attempt. On the final
-#   attempt (no retry-ci label), ci-status-gate posts the commit
+#   attempt (no retry budget available), ci-status-gate posts the commit
 #   status, unblocking the queue to merge or eject.
 #
-#   Edge case: if retry-ci is present but triage classifies the
-#   failure as non-retryable, ci-status-gate has already deferred
-#   (skipped) the commit status. This workflow must post the failure
+#   Edge case: if ci-status-gate deferred but triage classifies the
+#   failure as non-retryable, this workflow must post the failure
 #   status itself to unblock the queue for ejection. Without this,
 #   "All jobs pass" stays pending forever and auto-merge re-queues
 #   the PR in an infinite loop.
@@ -73,8 +73,8 @@ jobs:
     # Pseudocode:
     #   if run.conclusion not in ['failure','cancelled'] → skip
     #   if run.repo != run.head_repo          → skip (cross-repo — no permissions)
-    #   if run.event == 'merge_group'         → run  (label-gated retry via PR)
-    #   if run.event == 'pull_request'        → run  (label-gated retry via PR)
+    #   if run.event == 'merge_group'         → run  (retry budget via PR)
+    #   if run.event == 'pull_request'        → run  (retry budget via PR)
     #   if run.event == 'push'
     #     and run.branch in ['main','stable'] → run  (observation only — no retry)
     #   else                                  → skip (release/*, workflow_dispatch, etc.)
@@ -146,30 +146,55 @@ jobs:
         id: classify
         run: node .github/scripts/classify-failures.mts
 
-      # -- Label-gated retry: requires `retry-ci` label on the originating PR --
-      # The classify step already checked for the label and outputs will-retry,
-      # has-retry-label, and pr-number. This step just acts on those outputs.
+      - name: Verify current merge queue entry
+        id: verify-queue-entry
+        # The verifier posts a terminal failure status for stale or
+        # unverified entries; the retry step runs only for current entries.
+        if: >-
+          ${{
+            steps.classify.outputs.will-retry == 'true'
+            && env.WORKFLOW_EVENT == 'merge_group'
+          }}
+        env:
+          PR_NUMBER: ${{ steps.classify.outputs.pr-number }}
+        run: node .github/scripts/verify-merge-queue-entry.mts
+
+      # -- Retry retryable failures when a retry budget is available --
+      # The classify step decides whether this is an automatic retry or a
+      # retry-ci-funded retry, then outputs whether retry-ci should be consumed.
       #
       # Order matters: rerun BEFORE removing the label. If the rerun API
       # call fails, the label stays on the PR — signaling that the retry
       # was attempted but didn't go through.
-      - name: Retry (if retry-ci label)
+      - name: Retry (if retry budget available)
         id: retry
-        if: ${{ steps.classify.outputs.will-retry == 'true' }}
+        if: >-
+          ${{
+            steps.classify.outputs.will-retry == 'true'
+            && (
+              env.WORKFLOW_EVENT != 'merge_group'
+              || steps.verify-queue-entry.outputs.state == 'current'
+            )
+          }}
         run: |
           PR="${{ steps.classify.outputs.pr-number }}"
+          CONSUME_RETRY_LABEL="${{ steps.classify.outputs.consume-retry-label }}"
 
           echo "Rerunning failed jobs..."
           gh run rerun "$MAIN_RUN_ID" --failed --repo "$REPO"
           echo "Rerun triggered."
 
-          echo "Removing retry-ci label from PR #$PR..."
-          gh pr edit "$PR" --repo "$REPO" --remove-label "retry-ci" \
-            || echo "::warning::Failed to remove retry-ci label from PR #$PR — label stays"
+          if [[ "$CONSUME_RETRY_LABEL" == "true" ]]; then
+            echo "Removing retry-ci label from PR #$PR..."
+            gh pr edit "$PR" --repo "$REPO" --remove-label "retry-ci" \
+              || echo "::warning::Failed to remove retry-ci label from PR #$PR — label stays"
+          else
+            echo "Retry did not consume retry-ci label."
+          fi
 
       # -- Rescue: post deferred failure status when triage job fails --
       #
-      # If ci-status-gate deferred the commit status (merge_group + retry-ci)
+      # If ci-status-gate deferred the commit status (merge_group + retry budget)
       # and anything in this job failed or timed out, "All jobs pass" is
       # stuck pending. Post it as failure so the merge queue can eject
       # instead of stalling.

--- a/.github/workflows/triage-and-retry-system.yml
+++ b/.github/workflows/triage-and-retry-system.yml
@@ -171,14 +171,29 @@ jobs:
         if: >-
           ${{
             steps.classify.outputs.will-retry == 'true'
-            && (
-              env.WORKFLOW_EVENT != 'merge_group'
-              || steps.verify-queue-entry.outputs.state == 'current'
-            )
+            && (env.WORKFLOW_EVENT != 'merge_group'
+              || steps.verify-queue-entry.outputs.state == 'current')
           }}
         run: |
           PR="${{ steps.classify.outputs.pr-number }}"
           CONSUME_RETRY_LABEL="${{ steps.classify.outputs.consume-retry-label }}"
+
+          # A pushed commit can supersede this failed PR run before triage
+          # starts. Rerunning the old run would reuse its concurrency group and
+          # can cancel the current commit's CI, so only retry an exact head.
+          if [[ "$WORKFLOW_EVENT" == 'pull_request' ]]; then
+            if ! CURRENT_HEAD=$(gh api "repos/$REPO/pulls/$PR" --jq '.head.sha' 2>/dev/null); then
+              echo "::warning::Could not verify PR #$PR head — skipping retry"
+              exit 0
+            fi
+
+            if [[ "$CURRENT_HEAD" != "$HEAD_SHA" ]]; then
+              echo "PR #$PR advanced from $HEAD_SHA to $CURRENT_HEAD — skipping stale retry"
+              exit 0
+            fi
+
+            echo "PR #$PR head still matches failed run $HEAD_SHA"
+          fi
 
           echo "Rerunning failed jobs..."
           gh run rerun "$MAIN_RUN_ID" --failed --repo "$REPO"


### PR DESCRIPTION
## **Description**

In March, I started the Triage and Retry System, and it's been fully operational since April.  But it's kind of been in stealth mode, where someone has to apply the `retry-ci` label for it to work.

While it's been in stealth mode, I've been monitoring the decisions it would make with a custom Sentry dashboard https://metamask.sentry.io/dashboard/521041/?project=4510302346608640, and adjusting .github/rules/retry-config.jsonc so it makes better decisions about when to retry.

Now it has almost 4 months of data, and I'm confident it will make intelligent decisions.

### **The new rules** (applies for both pull requests and Merge Queue runs)
- If CI fails, decide whether it's a transient error or a deterministic error (.github/rules/retry-config.jsonc)
- If it's a transient error
  - Retry once automatically, from attempt 1 to attempt 2
  - Adding a `retry-ci` label allows attempt 3 (which will remove the label), and adding it again allows attempt 4
- If it's a deterministic error
  - Do not retry

It also handles the edge cases of retry failure, cancellation, manual dequeue, and replaced merge-group entries without rerunning stale CI or leaving merge-queue status pending.

### **Testing**

- Added unit coverage for the retry-budget decision matrix.
- Ran a fork-based end-to-end validation campaign through 24 scenarios for PR and merge-queue retries, including automatic retries, label-funded retries, terminal cases, cancellation, manual dequeue, retry API failure handling, replaced merge groups, and successful queue resolution.
- Verified merge-queue behavior with GitHub workflow, queue, and commit-status APIs.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Closes: MetaMask/MetaMask-planning#7454

<!--## **Manual testing steps**
## **Screenshots/Recordings**
## **Pre-merge author checklist**
## **Pre-merge reviewer checklist**-->




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default CI retry behavior and merge-queue status deferral for all PRs; incorrect classification or budget sync could retry real failures or leave the queue stuck, though policy is centralized and heavily tested.
> 
> **Overview**
> **Turns on the Triage and Retry System by default** for PR and merge-queue runs: retryable (transient) failures on **attempt 1** rerun automatically to attempt 2 without the `retry-ci` label. The label still funds extra retries (attempts 2→3 and 3→4) and is **removed only on label-funded** reruns, via a shared **`retry-budget`** policy used by `classify-failures.mts` and mirrored in **`ci-status-gate.yml`** deferral logic.
> 
> **Merge queue and stale-run safety:** before rerunning failed merge-group jobs, triage verifies the queue entry and temporary ref are still current; stale or unverified entries get a terminal **All jobs pass** failure instead of a wasted rerun. For **`pull_request`**, retries are skipped if the PR head SHA has moved past the failed run.
> 
> **Classification tuning:** `retry-config.jsonc` adds transient patterns (OIDC expiry, Sonar/GitHub flakes, etc.) and deterministic patterns (ESLint/node-test summaries, Sass, baselines, publish/Storybook denials) so auto-retries target infra flakes, not real breakages.
> 
> New unit tests cover the retry-budget matrix and merge-queue verification helpers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ca1e60035b9a6bb08ebb2d17744a71ceb0afff8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->