### PR TITLE
chore: add fitness function to prevent new SCSS file additions

### DIFF
--- a/development/fitness-functions/common/constants.test.ts
+++ b/development/fitness-functions/common/constants.test.ts
@@ -1,4 +1,4 @@
-import { E2E_TESTS_REGEX, JS_REGEX } from './constants';
+import { E2E_TESTS_REGEX, JS_REGEX, SCSS_REGEX } from './constants';
 
 describe('Regular Expressions used in Fitness Functions', (): void => {
   describe(`E2E_TESTS_REGEX "${E2E_TESTS_REGEX}"`, (): void => {
@@ -99,6 +99,46 @@ describe('Regular Expressions used in Fitness Functions', (): void => {
       PATHS_IT_SHOULD_NOT_MATCH.forEach((path: string): void => {
         it(`should not match "${path}"`, (): void => {
           const result = JS_REGEX.test(path);
+          expect(result).toStrictEqual(false);
+        });
+      });
+    });
+  });
+
+  describe(`SCSS_REGEX "${SCSS_REGEX}"`, (): void => {
+    const PATHS_IT_SHOULD_MATCH = [
+      'app/much/longer/path/file.scss',
+      'shared/file.scss',
+      'ui/much/longer/path/file.scss',
+    ];
+
+    const PATHS_IT_SHOULD_NOT_MATCH = [
+      // any without SCSS extension
+      'file',
+      'file.extension',
+      'path/file.extension',
+      'much/longer/path/file.extension',
+      'file.css',
+      'path/file.css',
+      'much/longer/path/file.css',
+      // any SCSS files outside the app, shared, and ui directories
+      'test/longer/path/file.scss',
+      'random/longer/path/file.scss',
+    ];
+
+    describe('included paths', (): void => {
+      PATHS_IT_SHOULD_MATCH.forEach((path: string): void => {
+        it(`should match "${path}"`, (): void => {
+          const result = SCSS_REGEX.test(path);
+          expect(result).toStrictEqual(true);
+        });
+      });
+    });
+
+    describe('excluded paths', (): void => {
+      PATHS_IT_SHOULD_NOT_MATCH.forEach((path: string): void => {
+        it(`should not match "${path}"`, (): void => {
+          const result = SCSS_REGEX.test(path);
           expect(result).toStrictEqual(false);
         });
       });

--- a/development/fitness-functions/common/constants.ts
+++ b/development/fitness-functions/common/constants.ts
@@ -8,6 +8,9 @@ const E2E_TESTS_REGEX =
 // include JS and JSX files only in the app, shared, and ui directories
 const JS_REGEX = /^(app|shared|ui)\/.*\.(js|jsx)$/u;
 
+// include SCSS files only in the app, shared, and ui directories
+const SCSS_REGEX = /^(app|shared|ui)\/.*\.scss$/u;
+
 // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
 // eslint-disable-next-line @typescript-eslint/naming-convention
 enum AUTOMATION_TYPE {
@@ -20,4 +23,4 @@ enum AUTOMATION_TYPE {
   PRE_PUSH_HOOK = 'pre-push-hook',
 }
 
-export { E2E_TESTS_REGEX, JS_REGEX, AUTOMATION_TYPE };
+export { E2E_TESTS_REGEX, JS_REGEX, SCSS_REGEX, AUTOMATION_TYPE };

--- a/development/fitness-functions/rules/index.ts
+++ b/development/fitness-functions/rules/index.ts
@@ -1,6 +1,7 @@
 import { preventSinonAssertSyntax } from './sinon-assert-syntax';
 import { preventJavaScriptFileAdditions } from './javascript-additions';
 import { preventDeprecatedImports } from './prevent-deprecated-imports';
+import { preventScssFileAdditions } from './scss-additions';
 
 const RULES: IRule[] = [
   {
@@ -20,6 +21,12 @@ const RULES: IRule[] = [
     fn: preventDeprecatedImports,
     errorMessage:
       'The diff includes imports from deprecated paths. Please use @metamask/design-system-react instead. See: https://github.com/MetaMask/metamask-extension/blob/main/docs/design-system.md',
+  },
+  {
+    name: "Don't add new SCSS files",
+    fn: preventScssFileAdditions,
+    errorMessage:
+      'The diff includes a newly created SCSS file. Please use Tailwind CSS utility classes instead. New SCSS files are not allowed as we migrate to Tailwind CSS to align with the design system and prevent CSS file size growth.',
   },
 ];
 

--- a/development/fitness-functions/rules/index.ts
+++ b/development/fitness-functions/rules/index.ts
@@ -26,7 +26,7 @@ const RULES: IRule[] = [
     name: "Don't add new SCSS files",
     fn: preventScssFileAdditions,
     errorMessage:
-      'The diff includes a newly created SCSS file. Please use Tailwind CSS utility classes instead. New SCSS files are not allowed as we migrate to Tailwind CSS to align with the design system and prevent CSS file size growth.',
+      'The diff includes a newly created SCSS file. Please use Tailwind CSS utility classes instead.',
   },
 ];
 

--- a/development/fitness-functions/rules/scss-additions.test.ts
+++ b/development/fitness-functions/rules/scss-additions.test.ts
@@ -16,8 +16,15 @@ describe('preventScssFileAdditions()', (): void => {
   it('should pass when modifying an existing SCSS file', (): void => {
     const testDiff = [
       generateModifyFilesDiff('new-file.ts', 'foo', 'bar'),
-      generateModifyFilesDiff('ui/components/app/button/button.scss', 'color: red', undefined),
-      generateCreateFileDiff('ui/components/app/button/button.tsx', 'export default Button;'),
+      generateModifyFilesDiff(
+        'ui/components/app/button/button.scss',
+        'color: red',
+        undefined,
+      ),
+      generateCreateFileDiff(
+        'ui/components/app/button/button.tsx',
+        'export default Button;',
+      ),
     ].join('');
 
     const hasRulePassed = preventScssFileAdditions(testDiff);
@@ -28,8 +35,15 @@ describe('preventScssFileAdditions()', (): void => {
   it('should pass when creating a new TS file', (): void => {
     const testDiff = [
       generateModifyFilesDiff('new-file.ts', 'foo', 'bar'),
-      generateModifyFilesDiff('ui/components/app/button/button.scss', undefined, 'color: red'),
-      generateCreateFileDiff('ui/components/app/button/button.tsx', 'export default Button;'),
+      generateModifyFilesDiff(
+        'ui/components/app/button/button.scss',
+        undefined,
+        'color: red',
+      ),
+      generateCreateFileDiff(
+        'ui/components/app/button/button.tsx',
+        'export default Button;',
+      ),
     ].join('');
 
     const hasRulePassed = preventScssFileAdditions(testDiff);
@@ -40,8 +54,15 @@ describe('preventScssFileAdditions()', (): void => {
   it('should not pass when creating a new SCSS file in the ui directory', (): void => {
     const testDiff = [
       generateModifyFilesDiff('new-file.ts', 'foo', 'bar'),
-      generateModifyFilesDiff('ui/components/app/button/button.scss', undefined, 'color: red'),
-      generateCreateFileDiff('ui/components/app/button/button.scss', '.button { color: red; }'),
+      generateModifyFilesDiff(
+        'ui/components/app/button/button.scss',
+        undefined,
+        'color: red',
+      ),
+      generateCreateFileDiff(
+        'ui/components/app/button/button.scss',
+        '.button { color: red; }',
+      ),
     ].join('');
 
     const hasRulePassed = preventScssFileAdditions(testDiff);
@@ -53,7 +74,10 @@ describe('preventScssFileAdditions()', (): void => {
     const testDiff = [
       generateModifyFilesDiff('new-file.ts', 'foo', 'bar'),
       generateModifyFilesDiff('old-file.scss', undefined, 'color: blue'),
-      generateCreateFileDiff('app/styles/new-component.scss', '.component { display: flex; }'),
+      generateCreateFileDiff(
+        'app/styles/new-component.scss',
+        '.component { display: flex; }',
+      ),
     ].join('');
 
     const hasRulePassed = preventScssFileAdditions(testDiff);
@@ -65,7 +89,10 @@ describe('preventScssFileAdditions()', (): void => {
     const testDiff = [
       generateModifyFilesDiff('new-file.ts', 'foo', 'bar'),
       generateModifyFilesDiff('old-file.scss', undefined, 'color: blue'),
-      generateCreateFileDiff('shared/styles/tokens.scss', '$color-primary: blue;'),
+      generateCreateFileDiff(
+        'shared/styles/tokens.scss',
+        '$color-primary: blue;',
+      ),
     ].join('');
 
     const hasRulePassed = preventScssFileAdditions(testDiff);

--- a/development/fitness-functions/rules/scss-additions.test.ts
+++ b/development/fitness-functions/rules/scss-additions.test.ts
@@ -15,7 +15,9 @@ describe('preventScssFileAdditions()', (): void => {
 
   it('should pass when modifying an existing SCSS file', (): void => {
     const testDiff = [
+      generateModifyFilesDiff('new-file.ts', 'foo', 'bar'),
       generateModifyFilesDiff('ui/components/app/button/button.scss', 'color: red', undefined),
+      generateCreateFileDiff('ui/components/app/button/button.tsx', 'export default Button;'),
     ].join('');
 
     const hasRulePassed = preventScssFileAdditions(testDiff);
@@ -25,6 +27,8 @@ describe('preventScssFileAdditions()', (): void => {
 
   it('should pass when creating a new TS file', (): void => {
     const testDiff = [
+      generateModifyFilesDiff('new-file.ts', 'foo', 'bar'),
+      generateModifyFilesDiff('ui/components/app/button/button.scss', undefined, 'color: red'),
       generateCreateFileDiff('ui/components/app/button/button.tsx', 'export default Button;'),
     ].join('');
 
@@ -35,6 +39,8 @@ describe('preventScssFileAdditions()', (): void => {
 
   it('should not pass when creating a new SCSS file in the ui directory', (): void => {
     const testDiff = [
+      generateModifyFilesDiff('new-file.ts', 'foo', 'bar'),
+      generateModifyFilesDiff('ui/components/app/button/button.scss', undefined, 'color: red'),
       generateCreateFileDiff('ui/components/app/button/button.scss', '.button { color: red; }'),
     ].join('');
 
@@ -45,6 +51,8 @@ describe('preventScssFileAdditions()', (): void => {
 
   it('should not pass when creating a new SCSS file in the app directory', (): void => {
     const testDiff = [
+      generateModifyFilesDiff('new-file.ts', 'foo', 'bar'),
+      generateModifyFilesDiff('old-file.scss', undefined, 'color: blue'),
       generateCreateFileDiff('app/styles/new-component.scss', '.component { display: flex; }'),
     ].join('');
 
@@ -55,6 +63,8 @@ describe('preventScssFileAdditions()', (): void => {
 
   it('should not pass when creating a new SCSS file in the shared directory', (): void => {
     const testDiff = [
+      generateModifyFilesDiff('new-file.ts', 'foo', 'bar'),
+      generateModifyFilesDiff('old-file.scss', undefined, 'color: blue'),
       generateCreateFileDiff('shared/styles/tokens.scss', '$color-primary: blue;'),
     ].join('');
 

--- a/development/fitness-functions/rules/scss-additions.test.ts
+++ b/development/fitness-functions/rules/scss-additions.test.ts
@@ -1,0 +1,65 @@
+import {
+  generateModifyFilesDiff,
+  generateCreateFileDiff,
+} from '../common/test-data';
+import { preventScssFileAdditions } from './scss-additions';
+
+describe('preventScssFileAdditions()', (): void => {
+  it('should pass when receiving an empty diff', (): void => {
+    const testDiff = '';
+
+    const hasRulePassed = preventScssFileAdditions(testDiff);
+
+    expect(hasRulePassed).toBe(true);
+  });
+
+  it('should pass when modifying an existing SCSS file', (): void => {
+    const testDiff = [
+      generateModifyFilesDiff('ui/components/app/button/button.scss', 'color: red', undefined),
+    ].join('');
+
+    const hasRulePassed = preventScssFileAdditions(testDiff);
+
+    expect(hasRulePassed).toBe(true);
+  });
+
+  it('should pass when creating a new TS file', (): void => {
+    const testDiff = [
+      generateCreateFileDiff('ui/components/app/button/button.tsx', 'export default Button;'),
+    ].join('');
+
+    const hasRulePassed = preventScssFileAdditions(testDiff);
+
+    expect(hasRulePassed).toBe(true);
+  });
+
+  it('should not pass when creating a new SCSS file in the ui directory', (): void => {
+    const testDiff = [
+      generateCreateFileDiff('ui/components/app/button/button.scss', '.button { color: red; }'),
+    ].join('');
+
+    const hasRulePassed = preventScssFileAdditions(testDiff);
+
+    expect(hasRulePassed).toBe(false);
+  });
+
+  it('should not pass when creating a new SCSS file in the app directory', (): void => {
+    const testDiff = [
+      generateCreateFileDiff('app/styles/new-component.scss', '.component { display: flex; }'),
+    ].join('');
+
+    const hasRulePassed = preventScssFileAdditions(testDiff);
+
+    expect(hasRulePassed).toBe(false);
+  });
+
+  it('should not pass when creating a new SCSS file in the shared directory', (): void => {
+    const testDiff = [
+      generateCreateFileDiff('shared/styles/tokens.scss', '$color-primary: blue;'),
+    ].join('');
+
+    const hasRulePassed = preventScssFileAdditions(testDiff);
+
+    expect(hasRulePassed).toBe(false);
+  });
+});

--- a/development/fitness-functions/rules/scss-additions.ts
+++ b/development/fitness-functions/rules/scss-additions.ts
@@ -1,0 +1,15 @@
+import { SCSS_REGEX } from '../common/constants';
+import {
+  filterDiffFileCreations,
+  restrictedFilePresent,
+} from '../common/shared';
+
+function preventScssFileAdditions(diff: string): boolean {
+  const diffAdditions = filterDiffFileCreations(diff);
+  if (restrictedFilePresent(diffAdditions, SCSS_REGEX)) {
+    return false;
+  }
+  return true;
+}
+
+export { preventScssFileAdditions };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

This PR adds a new fitness function rule that prevents new SCSS files from being created in the `app/`, `shared/`, and `ui/` directories.

**Why:** We are migrating to Tailwind CSS to align with the MetaMask design system and prevent our CSS bundle from growing further. New styles should use Tailwind utility classes instead of SCSS.

**What this does:**
- Blocks creation of new `.scss` files in `app/`, `shared/`, and `ui/` directories during CI and pre-commit/pre-push hooks
- Existing SCSS files can still be modified (the rule uses `filterDiffFileCreations`, which only flags new file additions)
- Follows the same pattern as the existing `preventJavaScriptFileAdditions` rule

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Attempt to create a new `.scss` file in `ui/`, `app/`, or `shared/` and commit it — the pre-commit hook should block it with a message directing to Tailwind CSS
2. Modify an existing `.scss` file and commit — this should pass without issue
3. Run `yarn jest development/fitness-functions --no-coverage` — all tests should pass

## **Screenshots/Recordings**

### **Before**

N/A — new fitness function rule

### **After**

N/A — enforced at commit/CI time

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only fitness-function and test changes; no production runtime or auth/data paths affected.
> 
> **Overview**
> Adds a **fitness function** that fails CI and git hooks when a diff **creates** a new `.scss` file under `app/`, `shared/`, or `ui/`, steering styling toward **Tailwind** instead of new SCSS.
> 
> The change introduces `SCSS_REGEX`, a `preventScssFileAdditions` rule (same shape as `preventJavaScriptFileAdditions`: only new files via `filterDiffFileCreations`, edits to existing SCSS still allowed), wires it into the shared `RULES` list with a Tailwind-oriented error message, and adds unit tests for the regex and rule behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18e24640a58e97a396ae9093ef27c611560707f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->