### PR TITLE
feat: Prototype connecting multiple Trezor devices

### DIFF
--- a/.yarn/patches/@metamask-account-tree-controller-npm-7.5.5-7e92299d95.patch
+++ b/.yarn/patches/@metamask-account-tree-controller-npm-7.5.5-7e92299d95.patch
@@ -1,0 +1,270 @@
+diff --git a/dist/rules/keyring.cjs b/dist/rules/keyring.cjs
+index c703e6e72fa0daddb8835bc27d6de6e22e24a24b..ec257153d00e4aa836370d3d721eefe6121dbed6 100644
+--- a/dist/rules/keyring.cjs
++++ b/dist/rules/keyring.cjs
+@@ -105,6 +105,71 @@ function getAccountGroupPrefixFromKeyringType(type) {
+     }
+ }
+ exports.getAccountGroupPrefixFromKeyringType = getAccountGroupPrefixFromKeyringType;
++
++/**
++ * Keyring types that support multiple simultaneous hardware devices, each
++ * as its own `KeyringController` keyring instance (see
++ * `@metamask/eth-trezor-keyring`). Every other keyring type still groups by
++ * bare type string, matching the pre-existing single-shared-wallet
++ * behavior.
++ */
++const HARDWARE_MULTI_INSTANCE_KEYRING_TYPES = new Set([
++    v2_1.KeyringType.Trezor,
++    keyring_controller_1.KeyringTypes.trezor,
++    v2_1.KeyringType.OneKey,
++    keyring_controller_1.KeyringTypes.oneKey,
++]);
++/**
++ * Finds the `KeyringController` metadata (`{ id, name }`) for the keyring
++ * instance of the given type that owns `address`. Used to give each
++ * multi-instance hardware keyring (one per paired physical device) its own
++ * wallet section instead of collapsing every device of the same type into a
++ * single shared wallet.
++ *
++ * @param messenger - The rule's restricted messenger.
++ * @param keyringType - The keyring type to search within.
++ * @param address - The account address to look up.
++ * @returns The owning keyring's metadata, or `undefined` if not found.
++ */
++function getOwningKeyringMetadata(messenger, keyringType, address) {
++    const { keyrings } = messenger.call('KeyringController:getState');
++    const normalizedAddress = address.toLowerCase();
++    return keyrings.find((keyringEntry) => keyringEntry.type === keyringType &&
++        keyringEntry.accounts.some((account) => account.toLowerCase() === normalizedAddress))?.metadata;
++}
++/**
++ * Resolves the display name for a multi-instance hardware wallet section:
++ * the device's own name if the keyring's metadata was given one (see the
++ * `metamask-extension` connect-hardware flow, which sets it from the
++ * device's user-set label or model), falling back to `"<Type> N"` using
++ * this keyring's position among same-type keyrings. Disambiguates two
++ * devices that report the same name by falling back to the same
++ * `"<Type> N"` scheme.
++ *
++ * @param messenger - The rule's restricted messenger.
++ * @param keyringType - The keyring type being named.
++ * @param keyringId - The specific keyring instance's id.
++ * @returns The wallet's display name.
++ */
++function getHardwareWalletDisplayName(messenger, keyringType, keyringId) {
++    const { keyrings } = messenger.call('KeyringController:getState');
++    const sameType = keyrings.filter((keyringEntry) => keyringEntry.type === keyringType);
++    const thisEntry = sameType.find((keyringEntry) => keyringEntry.metadata.id === keyringId);
++    const name = thisEntry?.metadata.name;
++    if (name) {
++        const sharesName = sameType.filter((keyringEntry) => keyringEntry.metadata.name === name);
++        if (sharesName.length <= 1) {
++            return name;
++        }
++    }
++    const baseName = getAccountWalletNameFromKeyringType(keyringType);
++    if (sameType.length <= 1) {
++        return baseName;
++    }
++    const index = sameType.findIndex((keyringEntry) => keyringEntry.metadata.id === keyringId);
++    return `${baseName} ${index + 1}`;
++}
++
+ class KeyringRule extends rule_1.BaseRule {
+     constructor() {
+         super(...arguments);
+@@ -114,7 +179,19 @@ class KeyringRule extends rule_1.BaseRule {
+     match(account) {
+         // We assume that `type` is really a `KeyringTypes`.
+         const keyringType = account.metadata.keyring.type;
+-        const walletId = (0, account_api_3.toAccountWalletId)(this.walletType, keyringType);
++        // Multi-instance hardware wallets (one keyring per paired physical
++        // device) get their own wallet section keyed by the owning keyring
++        // instance's id, instead of collapsing every device of the same
++        // type into a single shared wallet.
++        let walletDiscriminator = keyringType;
++        let keyringMetadata;
++        if (HARDWARE_MULTI_INSTANCE_KEYRING_TYPES.has(keyringType)) {
++            keyringMetadata = getOwningKeyringMetadata(this.messenger, keyringType, account.address);
++            if (keyringMetadata) {
++                walletDiscriminator = `${keyringType}:${keyringMetadata.id}`;
++            }
++        }
++        const walletId = (0, account_api_3.toAccountWalletId)(this.walletType, walletDiscriminator);
+         const groupId = (0, account_api_3.toAccountGroupId)(walletId, account.address);
+         return {
+             wallet: {
+@@ -123,6 +200,7 @@ class KeyringRule extends rule_1.BaseRule {
+                 metadata: {
+                     keyring: {
+                         type: keyringType,
++                        ...(keyringMetadata ? { id: keyringMetadata.id } : {}),
+                     },
+                 },
+             },
+@@ -138,7 +216,11 @@ class KeyringRule extends rule_1.BaseRule {
+         };
+     }
+     getDefaultAccountWalletName(wallet) {
+-        return getAccountWalletNameFromKeyringType(wallet.metadata.keyring.type);
++        const { type, id } = wallet.metadata.keyring;
++        if (id && HARDWARE_MULTI_INSTANCE_KEYRING_TYPES.has(type)) {
++            return getHardwareWalletDisplayName(this.messenger, type, id);
++        }
++        return getAccountWalletNameFromKeyringType(type);
+     }
+     getComputedAccountGroupName(group) {
+         return super.getComputedAccountGroupName(group);
+diff --git a/dist/rules/keyring.d.cts b/dist/rules/keyring.d.cts
+index a7d743e60b9d29ef74d3d560908d2ba3c6308b95..a85cc784eb51927576871873cc43bbca623514e7 100644
+--- a/dist/rules/keyring.d.cts
++++ b/dist/rules/keyring.d.cts
+@@ -22,6 +22,12 @@ export declare function getAccountWalletNameFromKeyringType(type: KeyringTypes |
+  */
+ export declare function getAccountGroupPrefixFromKeyringType(type: KeyringTypes | KeyringType): string;
+ export declare class KeyringRule extends BaseRule implements Rule<AccountWalletType.Keyring, AccountGroupType.SingleAccount> {
++    /**
++     * For multi-instance hardware wallet types (Trezor/OneKey), the
++     * returned wallet's `metadata.keyring` also carries the owning
++     * keyring instance's `id`, so each paired physical device resolves
++     * to its own wallet section instead of a single shared one.
++     */
+     readonly walletType = AccountWalletType.Keyring;
+     readonly groupType = AccountGroupType.SingleAccount;
+     match(account: InternalAccount): RuleResult<AccountWalletType.Keyring, AccountGroupType.SingleAccount>;
+diff --git a/dist/rules/keyring.d.mts b/dist/rules/keyring.d.mts
+index 2e56fc5d88f89ecab74b4acb4398e62bf1ce8270..6468bfd80a7880dd9285e165685a81ee92268970 100644
+--- a/dist/rules/keyring.d.mts
++++ b/dist/rules/keyring.d.mts
+@@ -22,6 +22,12 @@ export declare function getAccountWalletNameFromKeyringType(type: KeyringTypes |
+  */
+ export declare function getAccountGroupPrefixFromKeyringType(type: KeyringTypes | KeyringType): string;
+ export declare class KeyringRule extends BaseRule implements Rule<AccountWalletType.Keyring, AccountGroupType.SingleAccount> {
++    /**
++     * For multi-instance hardware wallet types (Trezor/OneKey), the
++     * returned wallet's `metadata.keyring` also carries the owning
++     * keyring instance's `id`, so each paired physical device resolves
++     * to its own wallet section instead of a single shared one.
++     */
+     readonly walletType = AccountWalletType.Keyring;
+     readonly groupType = AccountGroupType.SingleAccount;
+     match(account: InternalAccount): RuleResult<AccountWalletType.Keyring, AccountGroupType.SingleAccount>;
+diff --git a/dist/rules/keyring.mjs b/dist/rules/keyring.mjs
+index 287b0f0b6f0c44009b3dcacd7d24de83fd89ce50..df08ab79ac33ae3f8d5cf16779ddc128104eea79 100644
+--- a/dist/rules/keyring.mjs
++++ b/dist/rules/keyring.mjs
+@@ -100,6 +100,71 @@ export function getAccountGroupPrefixFromKeyringType(type) {
+         }
+     }
+ }
++
++/**
++ * Keyring types that support multiple simultaneous hardware devices, each
++ * as its own `KeyringController` keyring instance (see
++ * `@metamask/eth-trezor-keyring`). Every other keyring type still groups by
++ * bare type string, matching the pre-existing single-shared-wallet
++ * behavior.
++ */
++const HARDWARE_MULTI_INSTANCE_KEYRING_TYPES = new Set([
++    KeyringType.Trezor,
++    KeyringTypes.trezor,
++    KeyringType.OneKey,
++    KeyringTypes.oneKey,
++]);
++/**
++ * Finds the `KeyringController` metadata (`{ id, name }`) for the keyring
++ * instance of the given type that owns `address`. Used to give each
++ * multi-instance hardware keyring (one per paired physical device) its own
++ * wallet section instead of collapsing every device of the same type into a
++ * single shared wallet.
++ *
++ * @param messenger - The rule's restricted messenger.
++ * @param keyringType - The keyring type to search within.
++ * @param address - The account address to look up.
++ * @returns The owning keyring's metadata, or `undefined` if not found.
++ */
++function getOwningKeyringMetadata(messenger, keyringType, address) {
++    const { keyrings } = messenger.call('KeyringController:getState');
++    const normalizedAddress = address.toLowerCase();
++    return keyrings.find((keyringEntry) => keyringEntry.type === keyringType &&
++        keyringEntry.accounts.some((account) => account.toLowerCase() === normalizedAddress))?.metadata;
++}
++/**
++ * Resolves the display name for a multi-instance hardware wallet section:
++ * the device's own name if the keyring's metadata was given one (see the
++ * `metamask-extension` connect-hardware flow, which sets it from the
++ * device's user-set label or model), falling back to `"<Type> N"` using
++ * this keyring's position among same-type keyrings. Disambiguates two
++ * devices that report the same name by falling back to the same
++ * `"<Type> N"` scheme.
++ *
++ * @param messenger - The rule's restricted messenger.
++ * @param keyringType - The keyring type being named.
++ * @param keyringId - The specific keyring instance's id.
++ * @returns The wallet's display name.
++ */
++function getHardwareWalletDisplayName(messenger, keyringType, keyringId) {
++    const { keyrings } = messenger.call('KeyringController:getState');
++    const sameType = keyrings.filter((keyringEntry) => keyringEntry.type === keyringType);
++    const thisEntry = sameType.find((keyringEntry) => keyringEntry.metadata.id === keyringId);
++    const name = thisEntry?.metadata.name;
++    if (name) {
++        const sharesName = sameType.filter((keyringEntry) => keyringEntry.metadata.name === name);
++        if (sharesName.length <= 1) {
++            return name;
++        }
++    }
++    const baseName = getAccountWalletNameFromKeyringType(keyringType);
++    if (sameType.length <= 1) {
++        return baseName;
++    }
++    const index = sameType.findIndex((keyringEntry) => keyringEntry.metadata.id === keyringId);
++    return `${baseName} ${index + 1}`;
++}
++
+ export class KeyringRule extends BaseRule {
+     constructor() {
+         super(...arguments);
+@@ -109,7 +174,19 @@ export class KeyringRule extends BaseRule {
+     match(account) {
+         // We assume that `type` is really a `KeyringTypes`.
+         const keyringType = account.metadata.keyring.type;
+-        const walletId = toAccountWalletId(this.walletType, keyringType);
++        // Multi-instance hardware wallets (one keyring per paired physical
++        // device) get their own wallet section keyed by the owning keyring
++        // instance's id, instead of collapsing every device of the same
++        // type into a single shared wallet.
++        let walletDiscriminator = keyringType;
++        let keyringMetadata;
++        if (HARDWARE_MULTI_INSTANCE_KEYRING_TYPES.has(keyringType)) {
++            keyringMetadata = getOwningKeyringMetadata(this.messenger, keyringType, account.address);
++            if (keyringMetadata) {
++                walletDiscriminator = `${keyringType}:${keyringMetadata.id}`;
++            }
++        }
++        const walletId = toAccountWalletId(this.walletType, walletDiscriminator);
+         const groupId = toAccountGroupId(walletId, account.address);
+         return {
+             wallet: {
+@@ -118,6 +195,7 @@ export class KeyringRule extends BaseRule {
+                 metadata: {
+                     keyring: {
+                         type: keyringType,
++                        ...(keyringMetadata ? { id: keyringMetadata.id } : {}),
+                     },
+                 },
+             },
+@@ -133,7 +211,11 @@ export class KeyringRule extends BaseRule {
+         };
+     }
+     getDefaultAccountWalletName(wallet) {
+-        return getAccountWalletNameFromKeyringType(wallet.metadata.keyring.type);
++        const { type, id } = wallet.metadata.keyring;
++        if (id && HARDWARE_MULTI_INSTANCE_KEYRING_TYPES.has(type)) {
++            return getHardwareWalletDisplayName(this.messenger, type, id);
++        }
++        return getAccountWalletNameFromKeyringType(type);
+     }
+     getComputedAccountGroupName(group) {
+         return super.getComputedAccountGroupName(group);

--- a/.yarn/patches/@metamask-eth-trezor-keyring-npm-10.1.0-70aadca269.patch
+++ b/.yarn/patches/@metamask-eth-trezor-keyring-npm-10.1.0-70aadca269.patch
@@ -1,0 +1,378 @@
+diff --git a/dist/trezor-bridge.d.cts b/dist/trezor-bridge.d.cts
+index a20c794f46a31b3f2a362c07897526c3ef463a61..3b04965c331acd16f43fa5d217f6764869146836 100644
+--- a/dist/trezor-bridge.d.cts
++++ b/dist/trezor-bridge.d.cts
+@@ -1,10 +1,17 @@
+-import type { ConnectSettings, EthereumSignedTx, Manifest, PROTO, Response, Params, EthereumSignMessage, EthereumSignTransaction, EthereumSignTypedDataTypes, EthereumSignTypedHash } from "@trezor/connect-web";
++import type { ConnectSettings, EthereumSignedTx, Manifest, PROTO, Response, Params, EthereumSignMessage, EthereumSignTransaction, EthereumSignTypedDataTypes, EthereumSignTypedHash, Features } from "@trezor/connect-web";
+ export type ExtendedPublicKey = {
+     publicKey: string;
+     chainCode: string;
+ };
+ export interface TrezorBridge {
+     model?: string;
++    /**
++     * Stable per-device identity (Trezor's `features.device_id`), set by
++     * the keyring once known so the bridge can target this specific
++     * physical device on every subsequent call, even while other
++     * devices are connected at the same time.
++     */
++    deviceId?: string;
+     init(settings: {
+         manifest: Manifest;
+     } & Partial<ConnectSettings>): Promise<void>;
+@@ -16,5 +23,11 @@ export interface TrezorBridge {
+     ethereumSignTransaction(params: Params<EthereumSignTransaction>): Response<EthereumSignedTx>;
+     ethereumSignMessage(params: Params<EthereumSignMessage>): Response<PROTO.MessageSignature>;
+     ethereumSignTypedData<T extends EthereumSignTypedDataTypes>(params: Params<EthereumSignTypedHash<T>>): Response<PROTO.EthereumTypedDataSignature>;
++    /**
++     * Optional: not every bridge implementation supports reading device
++     * features. When present, the keyring uses it after unlocking to
++     * learn the device's stable `device_id`.
++     */
++    getFeatures?(): Response<Features>;
+ }
+ //# sourceMappingURL=trezor-bridge.d.cts.map
+\ No newline at end of file
+diff --git a/dist/trezor-bridge.d.mts b/dist/trezor-bridge.d.mts
+index 26082a51a675ff4a1fabdac6bffe4d2335808ae8..534b44029beee78b78d25005e20282cfc08504e0 100644
+--- a/dist/trezor-bridge.d.mts
++++ b/dist/trezor-bridge.d.mts
+@@ -1,10 +1,17 @@
+-import type { ConnectSettings, EthereumSignedTx, Manifest, PROTO, Response, Params, EthereumSignMessage, EthereumSignTransaction, EthereumSignTypedDataTypes, EthereumSignTypedHash } from "@trezor/connect-web";
++import type { ConnectSettings, EthereumSignedTx, Manifest, PROTO, Response, Params, EthereumSignMessage, EthereumSignTransaction, EthereumSignTypedDataTypes, EthereumSignTypedHash, Features } from "@trezor/connect-web";
+ export type ExtendedPublicKey = {
+     publicKey: string;
+     chainCode: string;
+ };
+ export interface TrezorBridge {
+     model?: string;
++    /**
++     * Stable per-device identity (Trezor's `features.device_id`), set by
++     * the keyring once known so the bridge can target this specific
++     * physical device on every subsequent call, even while other
++     * devices are connected at the same time.
++     */
++    deviceId?: string;
+     init(settings: {
+         manifest: Manifest;
+     } & Partial<ConnectSettings>): Promise<void>;
+@@ -16,5 +23,11 @@ export interface TrezorBridge {
+     ethereumSignTransaction(params: Params<EthereumSignTransaction>): Response<EthereumSignedTx>;
+     ethereumSignMessage(params: Params<EthereumSignMessage>): Response<PROTO.MessageSignature>;
+     ethereumSignTypedData<T extends EthereumSignTypedDataTypes>(params: Params<EthereumSignTypedHash<T>>): Response<PROTO.EthereumTypedDataSignature>;
++    /**
++     * Optional: not every bridge implementation supports reading device
++     * features. When present, the keyring uses it after unlocking to
++     * learn the device's stable `device_id`.
++     */
++    getFeatures?(): Response<Features>;
+ }
+ //# sourceMappingURL=trezor-bridge.d.mts.map
+\ No newline at end of file
+diff --git a/dist/trezor-keyring.cjs b/dist/trezor-keyring.cjs
+index 61c9a539579e97ba3cad201c6477260b36f0950c..743879a94eca9e5a0557f7ed48bd0643c3b8c9f6 100644
+--- a/dist/trezor-keyring.cjs
++++ b/dist/trezor-keyring.cjs
+@@ -71,6 +71,7 @@ class TrezorKeyring {
+         this.perPage = 5;
+         this.unlockedAccount = 0;
+         this.paths = {};
++        this.deviceId = undefined;
+         if (!bridge) {
+             throw new Error('Bridge is a required dependency for the keyring');
+         }
+@@ -102,6 +103,7 @@ class TrezorKeyring {
+             paths: this.paths,
+             perPage: this.perPage,
+             unlockedAccount: this.unlockedAccount,
++            deviceId: this.deviceId,
+         });
+     }
+     async deserialize(opts) {
+@@ -110,12 +112,43 @@ class TrezorKeyring {
+         this.accounts = (_b = opts.accounts) !== null && _b !== void 0 ? _b : [];
+         this.page = (_c = opts.page) !== null && _c !== void 0 ? _c : 0;
+         this.perPage = (_d = opts.perPage) !== null && _d !== void 0 ? _d : 5;
++        this.deviceId = opts.deviceId;
++        if (this.deviceId) {
++            this.bridge.deviceId = this.deviceId;
++        }
+         return Promise.resolve();
+     }
+     isUnlocked() {
+         var _a;
+         return Boolean((_a = this.hdk) === null || _a === void 0 ? void 0 : _a.publicKey);
+     }
++    /**
++     * Learns and persists this keyring's physical device's stable
++     * `device_id` the first time it can be read, via `bridge.getFeatures()`.
++     * Once known, it is also pushed onto the bridge so every subsequent
++     * call targets this specific device (`device: { path }`), which is
++     * required to route requests correctly when more than one device is
++     * connected at the same time. Best-effort: bridges that do not
++     * implement `getFeatures`, or a transient read failure, leave
++     * `deviceId` unset rather than failing `unlock()`.
++     */
++    async captureDeviceId() {
++        if (this.deviceId || typeof this.bridge.getFeatures !== 'function') {
++            return;
++        }
++        try {
++            const featuresResponse = await this.bridge.getFeatures();
++            if (featuresResponse.success && featuresResponse.payload.device_id) {
++                this.deviceId = featuresResponse.payload.device_id;
++                this.bridge.deviceId = this.deviceId;
++            }
++        }
++        catch (_error) {
++            // Best-effort: signing still works via the bridge's current
++            // implicit device targeting, it just cannot be pinned to a
++            // specific device yet.
++        }
++    }
+     async unlock() {
+         var _a, _b;
+         if (this.isUnlocked()) {
+@@ -131,6 +164,7 @@ class TrezorKeyring {
+             }
+             this.hdk.publicKey = Buffer.from(response.payload.publicKey, 'hex');
+             this.hdk.chainCode = Buffer.from(response.payload.chainCode, 'hex');
++            await this.captureDeviceId();
+             return 'just unlocked';
+         }
+         catch (error) {
+diff --git a/dist/trezor-keyring.d.cts b/dist/trezor-keyring.d.cts
+index f945654a8bc65cb3dc120a2f0ba846702b542354..489b634837d061cefcd5bd5e4035a601854df5ec 100644
+--- a/dist/trezor-keyring.d.cts
++++ b/dist/trezor-keyring.d.cts
+@@ -26,6 +26,7 @@ export type TrezorControllerOptions = {
+     accounts?: Hex[];
+     page?: number;
+     perPage?: number;
++    deviceId?: string;
+ };
+ export type TrezorControllerState = {
+     hdPath: string;
+@@ -34,6 +35,13 @@ export type TrezorControllerState = {
+     paths: Record<Hex, number>;
+     perPage: number;
+     unlockedAccount: number;
++    /**
++     * The physical device's stable `device_id`, learned via
++     * `bridge.getFeatures()` the first time this keyring unlocks.
++     * Persisted so a reconnected device is recognized as the same
++     * one instead of being treated as a new pairing.
++     */
++    deviceId?: string;
+ };
+ export declare class TrezorKeyring implements Keyring {
+     #private;
+@@ -41,6 +49,12 @@ export declare class TrezorKeyring implements Keyring {
+     readonly type: string;
+     accounts: readonly Hex[];
+     hdk: HDKey;
++    /**
++     * The physical device's stable `device_id`, or `undefined` until the
++     * first successful `unlock()` learns it (requires the bridge to
++     * implement `getFeatures`).
++     */
++    deviceId: string | undefined;
+     hdPath: string;
+     page: number;
+     perPage: number;
+@@ -63,6 +77,7 @@ export declare class TrezorKeyring implements Keyring {
+     deserialize(opts: TrezorControllerOptions): Promise<void>;
+     isUnlocked(): boolean;
+     unlock(): Promise<string>;
++    captureDeviceId(): Promise<void>;
+     setAccountToUnlock(index: number | string): void;
+     addAccounts(numberOfAccounts: number): Promise<Hex[]>;
+     getFirstPage(): Promise<AccountPage>;
+diff --git a/dist/trezor-keyring.d.mts b/dist/trezor-keyring.d.mts
+index 2a7598f864ba9ecfc2ef781f6760c00c0d2dd75d..05083283debbc59046d33984743924c6348dd8ea 100644
+--- a/dist/trezor-keyring.d.mts
++++ b/dist/trezor-keyring.d.mts
+@@ -26,6 +26,7 @@ export type TrezorControllerOptions = {
+     accounts?: Hex[];
+     page?: number;
+     perPage?: number;
++    deviceId?: string;
+ };
+ export type TrezorControllerState = {
+     hdPath: string;
+@@ -34,6 +35,13 @@ export type TrezorControllerState = {
+     paths: Record<Hex, number>;
+     perPage: number;
+     unlockedAccount: number;
++    /**
++     * The physical device's stable `device_id`, learned via
++     * `bridge.getFeatures()` the first time this keyring unlocks.
++     * Persisted so a reconnected device is recognized as the same
++     * one instead of being treated as a new pairing.
++     */
++    deviceId?: string;
+ };
+ export declare class TrezorKeyring implements Keyring {
+     #private;
+@@ -41,6 +49,12 @@ export declare class TrezorKeyring implements Keyring {
+     readonly type: string;
+     accounts: readonly Hex[];
+     hdk: HDKey;
++    /**
++     * The physical device's stable `device_id`, or `undefined` until the
++     * first successful `unlock()` learns it (requires the bridge to
++     * implement `getFeatures`).
++     */
++    deviceId: string | undefined;
+     hdPath: string;
+     page: number;
+     perPage: number;
+@@ -63,6 +77,7 @@ export declare class TrezorKeyring implements Keyring {
+     deserialize(opts: TrezorControllerOptions): Promise<void>;
+     isUnlocked(): boolean;
+     unlock(): Promise<string>;
++    captureDeviceId(): Promise<void>;
+     setAccountToUnlock(index: number | string): void;
+     addAccounts(numberOfAccounts: number): Promise<Hex[]>;
+     getFirstPage(): Promise<AccountPage>;
+diff --git a/dist/trezor-keyring.mjs b/dist/trezor-keyring.mjs
+index 0a13ac5ba65c5d7cb04481441716ce317d32b627..307eda334dc1887a2a70f5ccd5b1dfbe974bb4df 100644
+--- a/dist/trezor-keyring.mjs
++++ b/dist/trezor-keyring.mjs
+@@ -72,6 +72,7 @@ export class TrezorKeyring {
+         this.perPage = 5;
+         this.unlockedAccount = 0;
+         this.paths = {};
++        this.deviceId = undefined;
+         if (!bridge) {
+             throw new Error('Bridge is a required dependency for the keyring');
+         }
+@@ -103,6 +104,7 @@ export class TrezorKeyring {
+             paths: this.paths,
+             perPage: this.perPage,
+             unlockedAccount: this.unlockedAccount,
++            deviceId: this.deviceId,
+         });
+     }
+     async deserialize(opts) {
+@@ -111,12 +113,43 @@ export class TrezorKeyring {
+         this.accounts = (_b = opts.accounts) !== null && _b !== void 0 ? _b : [];
+         this.page = (_c = opts.page) !== null && _c !== void 0 ? _c : 0;
+         this.perPage = (_d = opts.perPage) !== null && _d !== void 0 ? _d : 5;
++        this.deviceId = opts.deviceId;
++        if (this.deviceId) {
++            this.bridge.deviceId = this.deviceId;
++        }
+         return Promise.resolve();
+     }
+     isUnlocked() {
+         var _a;
+         return Boolean((_a = this.hdk) === null || _a === void 0 ? void 0 : _a.publicKey);
+     }
++    /**
++     * Learns and persists this keyring's physical device's stable
++     * `device_id` the first time it can be read, via `bridge.getFeatures()`.
++     * Once known, it is also pushed onto the bridge so every subsequent
++     * call targets this specific device (`device: { path }`), which is
++     * required to route requests correctly when more than one device is
++     * connected at the same time. Best-effort: bridges that do not
++     * implement `getFeatures`, or a transient read failure, leave
++     * `deviceId` unset rather than failing `unlock()`.
++     */
++    async captureDeviceId() {
++        if (this.deviceId || typeof this.bridge.getFeatures !== 'function') {
++            return;
++        }
++        try {
++            const featuresResponse = await this.bridge.getFeatures();
++            if (featuresResponse.success && featuresResponse.payload.device_id) {
++                this.deviceId = featuresResponse.payload.device_id;
++                this.bridge.deviceId = this.deviceId;
++            }
++        }
++        catch (_error) {
++            // Best-effort: signing still works via the bridge's current
++            // implicit device targeting, it just cannot be pinned to a
++            // specific device yet.
++        }
++    }
+     async unlock() {
+         var _a, _b;
+         if (this.isUnlocked()) {
+@@ -132,6 +165,7 @@ export class TrezorKeyring {
+             }
+             this.hdk.publicKey = Buffer.from(response.payload.publicKey, 'hex');
+             this.hdk.chainCode = Buffer.from(response.payload.chainCode, 'hex');
++            await this.captureDeviceId();
+             return 'just unlocked';
+         }
+         catch (error) {
+diff --git a/dist/v2/trezor-keyring.cjs b/dist/v2/trezor-keyring.cjs
+index 22c3809ba0c41abd5226321d10fdafb307d03910..5fcc8beba5a534841e8ff96d38f022327d5ef06d 100644
+--- a/dist/v2/trezor-keyring.cjs
++++ b/dist/v2/trezor-keyring.cjs
+@@ -210,6 +210,13 @@ class TrezorKeyring extends v2_2.EthKeyringWrapper {
+     getModel() {
+         return this.inner.getModel();
+     }
++    /**
++     * @returns The physical device's stable `device_id`, or `undefined`
++     * until the inner keyring has unlocked at least once.
++     */
++    get deviceId() {
++        return this.inner.deviceId;
++    }
+     /**
+      * @returns The current derivation path used by the inner keyring.
+      */
+diff --git a/dist/v2/trezor-keyring.d.cts b/dist/v2/trezor-keyring.d.cts
+index f335863f31dd64b80ef502ee1979b2f8e054b83f..aeaf9c94161ed621de3279f32923aca64d26b7ee 100644
+--- a/dist/v2/trezor-keyring.d.cts
++++ b/dist/v2/trezor-keyring.d.cts
+@@ -65,6 +65,11 @@ export declare class TrezorKeyring extends EthKeyringWrapper<TrezorKeyringAsEthK
+      * device is paired.
+      */
+     getModel(): string | undefined;
++    /**
++     * @returns The physical device's stable `device_id`, or `undefined`
++     * until the inner keyring has unlocked at least once.
++     */
++    get deviceId(): string | undefined;
+     /**
+      * @returns The current derivation path used by the inner keyring.
+      */
+diff --git a/dist/v2/trezor-keyring.d.mts b/dist/v2/trezor-keyring.d.mts
+index c792b861f0eed722e6d5f9a05575d151b6ce2619..243a78dfa8456570902ac3b41ea38f235e830ec9 100644
+--- a/dist/v2/trezor-keyring.d.mts
++++ b/dist/v2/trezor-keyring.d.mts
+@@ -65,6 +65,11 @@ export declare class TrezorKeyring extends EthKeyringWrapper<TrezorKeyringAsEthK
+      * device is paired.
+      */
+     getModel(): string | undefined;
++    /**
++     * @returns The physical device's stable `device_id`, or `undefined`
++     * until the inner keyring has unlocked at least once.
++     */
++    get deviceId(): string | undefined;
+     /**
+      * @returns The current derivation path used by the inner keyring.
+      */
+diff --git a/dist/v2/trezor-keyring.mjs b/dist/v2/trezor-keyring.mjs
+index d461f86c9f22e92d50446d8c379b4857a1b9fec2..d75ac1d1f6aef46494c888643928cd81fc07a5ee 100644
+--- a/dist/v2/trezor-keyring.mjs
++++ b/dist/v2/trezor-keyring.mjs
+@@ -207,6 +207,13 @@ export class TrezorKeyring extends EthKeyringWrapper {
+     getModel() {
+         return this.inner.getModel();
+     }
++    /**
++     * @returns The physical device's stable `device_id`, or `undefined`
++     * until the inner keyring has unlocked at least once.
++     */
++    get deviceId() {
++        return this.inner.deviceId;
++    }
+     /**
+      * @returns The current derivation path used by the inner keyring.
+      */

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -8973,6 +8973,9 @@
   "selectEnableDisplayMediaPrivacyPreference": {
     "message": "Turn on Display NFT Media"
   },
+  "selectHardwareWalletDevice": {
+    "message": "Multiple devices detected. Select which one to connect:"
+  },
   "selectHdPath": {
     "message": "Select HD path"
   },

--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -8973,9 +8973,6 @@
   "selectEnableDisplayMediaPrivacyPreference": {
     "message": "Turn on Display NFT Media"
   },
-  "selectHardwareWalletDevice": {
-    "message": "Multiple devices detected. Select which one to connect:"
-  },
   "selectHdPath": {
     "message": "Select HD path"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -8973,6 +8973,9 @@
   "selectEnableDisplayMediaPrivacyPreference": {
     "message": "Turn on Display NFT Media"
   },
+  "selectHardwareWalletDevice": {
+    "message": "Multiple devices detected. Select which one to connect:"
+  },
   "selectHdPath": {
     "message": "Select HD path"
   },

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -8973,9 +8973,6 @@
   "selectEnableDisplayMediaPrivacyPreference": {
     "message": "Turn on Display NFT Media"
   },
-  "selectHardwareWalletDevice": {
-    "message": "Multiple devices detected. Select which one to connect:"
-  },
   "selectHdPath": {
     "message": "Select HD path"
   },

--- a/app/offscreen/hardware-wallets/trezor.test.ts
+++ b/app/offscreen/hardware-wallets/trezor.test.ts
@@ -3,7 +3,7 @@ import {
   OffscreenCommunicationTarget,
   TrezorAction,
 } from '../../../shared/constants/offscreen-communication';
-import init from './trezor';
+import type initType from './trezor';
 
 const mockOn = jest.fn();
 const mockInit = jest.fn();
@@ -30,14 +30,20 @@ jest.mock('@trezor/connect-web', () => ({
       mockEthereumSignTypedData(...args),
     getFeatures: (...args: unknown[]) => mockGetFeatures(...args),
   },
-  DEVICE: { CONNECT: 'device-connect' },
+  DEVICE: {
+    CONNECT: 'device-connect',
+    CHANGED: 'device-changed',
+    DISCONNECT: 'device-disconnect',
+  },
   DEVICE_EVENT: 'DEVICE_EVENT',
+  DeviceUniquePath: (path: string) => path,
 }));
 
 type MessageListener = (
   msg: {
     target: string;
     action?: TrezorAction;
+    deviceId?: string;
     params?: Record<string, unknown>;
   },
   sender: unknown,
@@ -49,12 +55,37 @@ describe('Trezor Offscreen', () => {
   let mockSendMessage: jest.Mock;
   let mockAddListener: jest.Mock;
 
-  // The init handler chains several promises (dispose -> init -> respond);
-  // a macrotask turn drains all pending microtasks so the chain settles.
+  // The init handler chains several promises; a macrotask turn drains all
+  // pending microtasks so the chain settles.
   const flush = () =>
     new Promise((resolve) => {
       setTimeout(resolve, 0);
     });
+
+  const featuresFixture = (
+    deviceId: string,
+    overrides: Record<string, unknown> = {},
+  ) => ({
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    device_id: deviceId,
+    model: 'T',
+    // eslint-disable-next-line @typescript-eslint/naming-convention
+    minor_version: 2,
+    label: null,
+    ...overrides,
+  });
+
+  const connectDevice = (
+    deviceId: string,
+    path: string,
+    overrides: Record<string, unknown> = {},
+  ) => {
+    const deviceEventCallback = mockOn.mock.calls[0][1];
+    deviceEventCallback({
+      type: 'device-connect',
+      payload: { features: featuresFixture(deviceId, overrides), path },
+    });
+  };
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -80,6 +111,15 @@ describe('Trezor Offscreen', () => {
       configurable: true,
     });
 
+    // `trezor.ts` intentionally keeps module-level state (the device
+    // registry, the shared init promise, the active-keyring count) for the
+    // lifetime of the offscreen document, since that is what lets it
+    // survive multiple keyrings pairing/disposing independently. Reset the
+    // module registry so each test starts from a fresh "offscreen document
+    // just loaded" state instead of leaking state across tests.
+    jest.resetModules();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const init: typeof initType = require('./trezor').default;
     init();
   });
 
@@ -90,6 +130,19 @@ describe('Trezor Offscreen', () => {
         target: OffscreenCommunicationTarget.trezorOffscreen,
         action: TrezorAction.init,
         params,
+      },
+      undefined,
+      sendResponse,
+    );
+    return sendResponse;
+  };
+
+  const sendDispose = () => {
+    const sendResponse = jest.fn();
+    capturedMessageListener(
+      {
+        target: OffscreenCommunicationTarget.trezorOffscreen,
+        action: TrezorAction.dispose,
       },
       undefined,
       sendResponse,
@@ -117,22 +170,18 @@ describe('Trezor Offscreen', () => {
   });
 
   describe('init', () => {
-    it('disposes any stale connection before re-initializing', async () => {
+    it('initializes the SDK with the caller-provided settings', async () => {
       const params = { manifest: { appName: 'MetaMask', email: 'x@y.z' } };
 
       const sendResponse = sendInit(params);
       await flush();
 
-      expect(mockDispose).toHaveBeenCalledTimes(1);
+      expect(mockInit).toHaveBeenCalledTimes(1);
       expect(mockInit).toHaveBeenCalledWith(
         expect.objectContaining({
           ...params,
           env: 'webextension',
         }),
-      );
-      // dispose must happen before init so a stale connection is torn down first.
-      expect(mockDispose.mock.invocationCallOrder[0]).toBeLessThan(
-        mockInit.mock.invocationCallOrder[0],
       );
       expect(sendResponse).toHaveBeenCalledWith();
     });
@@ -153,26 +202,34 @@ describe('Trezor Offscreen', () => {
       expect(initSettings.coreMode).toBe('suite-desktop');
     });
 
-    it('re-opens the iframe on a second connection without hanging', async () => {
+    it('does not re-initialize or dispose the shared SDK for a second keyring', async () => {
+      const firstResponse = sendInit();
       await flush();
+
+      const secondResponse = sendInit();
+      await flush();
+
+      // Two Trezor/OneKey keyrings sharing this offscreen document must not
+      // tear down or duplicate each other's session: the SDK singleton is
+      // initialized exactly once regardless of how many keyrings call
+      // `init`.
+      expect(mockInit).toHaveBeenCalledTimes(1);
+      expect(mockDispose).not.toHaveBeenCalled();
+      expect(firstResponse).toHaveBeenCalledWith();
+      expect(secondResponse).toHaveBeenCalledWith();
+    });
+
+    it('allows a retry after a hard init failure', async () => {
+      mockInit.mockRejectedValueOnce(new Error('boom'));
       sendInit();
       await flush();
 
-      // Simulate the SDK throwing Init_AlreadyInitialized if the previous
-      // iframe were not disposed first.
-      mockInit.mockImplementationOnce(() => {
-        throw Object.assign(new Error('Init_AlreadyInitialized'), {
-          code: 'Init_AlreadyInitialized',
-        });
-      });
-
-      const secondSendResponse = sendInit();
+      mockInit.mockResolvedValueOnce(undefined);
+      const secondResponse = sendInit();
       await flush();
 
-      // The second connection still resolves the bridge (no hang) and the
-      // stale connection was disposed on each init.
-      expect(mockDispose).toHaveBeenCalledTimes(2);
-      expect(secondSendResponse).toHaveBeenCalledWith();
+      expect(mockInit).toHaveBeenCalledTimes(2);
+      expect(secondResponse).toHaveBeenCalledWith();
     });
 
     it('resolves the bridge even when init rejects', async () => {
@@ -195,33 +252,121 @@ describe('Trezor Offscreen', () => {
       sendInit();
       await flush();
 
-      const deviceEventCallback = mockOn.mock.calls[0][1];
-      deviceEventCallback({
-        type: 'device-connect',
-        payload: {
-          features: {
-            model: 'T',
-            // eslint-disable-next-line @typescript-eslint/naming-convention
-            minor_version: 2,
-          },
-        },
-      });
+      connectDevice('device-a', '1', { label: 'My Trezor' });
 
       expect(mockSendMessage).toHaveBeenCalledWith({
         target: OffscreenCommunicationTarget.extension,
         event: OffscreenCommunicationEvents.trezorDeviceConnect,
-        payload: { model: 'T', minorVersion: 2 },
+        payload: {
+          deviceId: 'device-a',
+          path: '1',
+          label: 'My Trezor',
+          model: 'T',
+          minorVersion: 2,
+        },
       });
     });
 
-    it('ignores non-connect device events', async () => {
+    it('ignores connect events for a device with no device_id', async () => {
       sendInit();
       await flush();
 
       const deviceEventCallback = mockOn.mock.calls[0][1];
-      deviceEventCallback({ type: 'device-changed', payload: {} });
+      deviceEventCallback({
+        type: 'device-connect',
+        payload: { features: {}, path: '1' },
+      });
 
       expect(mockSendMessage).not.toHaveBeenCalled();
+    });
+
+    it('tracks a device reported via a CHANGED event the same as CONNECT', async () => {
+      sendInit();
+      await flush();
+
+      const deviceEventCallback = mockOn.mock.calls[0][1];
+      deviceEventCallback({
+        type: 'device-changed',
+        payload: { features: featuresFixture('device-a'), path: '1' },
+      });
+
+      expect(mockSendMessage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          event: OffscreenCommunicationEvents.trezorDeviceConnect,
+        }),
+      );
+    });
+
+    it('ignores unrelated device event types', async () => {
+      sendInit();
+      await flush();
+
+      const deviceEventCallback = mockOn.mock.calls[0][1];
+      deviceEventCallback({ type: 'button', payload: {} });
+
+      expect(mockSendMessage).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('listDevices', () => {
+    it('returns an empty list before any device has connected', () => {
+      const sendResponse = jest.fn();
+      capturedMessageListener(
+        {
+          target: OffscreenCommunicationTarget.trezorOffscreen,
+          action: TrezorAction.listDevices,
+        },
+        undefined,
+        sendResponse,
+      );
+
+      expect(sendResponse).toHaveBeenCalledWith([]);
+    });
+
+    it('lists every currently-connected device', async () => {
+      sendInit();
+      await flush();
+      connectDevice('device-a', '1');
+      connectDevice('device-b', '2');
+
+      const sendResponse = jest.fn();
+      capturedMessageListener(
+        {
+          target: OffscreenCommunicationTarget.trezorOffscreen,
+          action: TrezorAction.listDevices,
+        },
+        undefined,
+        sendResponse,
+      );
+
+      expect(sendResponse).toHaveBeenCalledWith([
+        expect.objectContaining({ deviceId: 'device-a', path: '1' }),
+        expect.objectContaining({ deviceId: 'device-b', path: '2' }),
+      ]);
+    });
+
+    it('removes a device on disconnect', async () => {
+      sendInit();
+      await flush();
+      connectDevice('device-a', '1');
+
+      const deviceEventCallback = mockOn.mock.calls[0][1];
+      deviceEventCallback({
+        type: 'device-disconnect',
+        payload: { path: '1' },
+      });
+
+      const sendResponse = jest.fn();
+      capturedMessageListener(
+        {
+          target: OffscreenCommunicationTarget.trezorOffscreen,
+          action: TrezorAction.listDevices,
+        },
+        undefined,
+        sendResponse,
+      );
+
+      expect(sendResponse).toHaveBeenCalledWith([]);
     });
   });
 
@@ -249,23 +394,108 @@ describe('Trezor Offscreen', () => {
       expect(mockGetPublicKey).toHaveBeenCalledWith(params);
       expect(sendResponse).toHaveBeenCalledWith(sdkResult);
     });
-  });
 
-  describe('dispose', () => {
-    it('disposes the Trezor connection', () => {
+    it('targets a specific device once its deviceId is known', async () => {
+      sendInit();
+      await flush();
+      connectDevice('device-a', '1');
+      connectDevice('device-b', '2');
+
+      mockGetPublicKey.mockResolvedValue({ success: true, payload: {} });
       const sendResponse = jest.fn();
+      const params = { path: "m/44'/60'/0'/0", coin: 'ETH' };
 
       capturedMessageListener(
         {
           target: OffscreenCommunicationTarget.trezorOffscreen,
-          action: TrezorAction.dispose,
+          action: TrezorAction.getPublicKey,
+          deviceId: 'device-b',
+          params,
         },
         undefined,
         sendResponse,
       );
+      await flush();
+
+      expect(mockGetPublicKey).toHaveBeenCalledWith({
+        ...params,
+        device: { path: '2' },
+      });
+    });
+
+    it('omits the device param for an unknown deviceId', async () => {
+      mockGetPublicKey.mockResolvedValue({ success: true, payload: {} });
+      const sendResponse = jest.fn();
+      const params = { path: "m/44'/60'/0'/0", coin: 'ETH' };
+
+      capturedMessageListener(
+        {
+          target: OffscreenCommunicationTarget.trezorOffscreen,
+          action: TrezorAction.getPublicKey,
+          deviceId: 'unknown-device',
+          params,
+        },
+        undefined,
+        sendResponse,
+      );
+      await flush();
+
+      expect(mockGetPublicKey).toHaveBeenCalledWith(params);
+    });
+  });
+
+  describe('dispose', () => {
+    it('disposes the Trezor connection when no keyring is active', () => {
+      const sendResponse = sendDispose();
 
       expect(mockDispose).toHaveBeenCalledTimes(1);
       expect(sendResponse).toHaveBeenCalledWith();
+    });
+
+    it('does not dispose the shared SDK while another device is still active', async () => {
+      sendInit();
+      await flush();
+      sendInit();
+      await flush();
+
+      // Only one of the two keyrings sharing this document disposes (e.g.
+      // its device was forgotten); the other's session must survive.
+      const sendResponse = sendDispose();
+
+      expect(mockDispose).not.toHaveBeenCalled();
+      expect(sendResponse).toHaveBeenCalledWith();
+    });
+
+    it('disposes the shared SDK once every active keyring has disposed', async () => {
+      sendInit();
+      await flush();
+      sendInit();
+      await flush();
+
+      sendDispose();
+      const secondResponse = sendDispose();
+
+      expect(mockDispose).toHaveBeenCalledTimes(1);
+      expect(secondResponse).toHaveBeenCalledWith();
+    });
+
+    it('clears the tracked devices once fully disposed', async () => {
+      sendInit();
+      await flush();
+      connectDevice('device-a', '1');
+
+      sendDispose();
+
+      const sendResponse = jest.fn();
+      capturedMessageListener(
+        {
+          target: OffscreenCommunicationTarget.trezorOffscreen,
+          action: TrezorAction.listDevices,
+        },
+        undefined,
+        sendResponse,
+      );
+      expect(sendResponse).toHaveBeenCalledWith([]);
     });
   });
 

--- a/app/offscreen/hardware-wallets/trezor.test.ts
+++ b/app/offscreen/hardware-wallets/trezor.test.ts
@@ -308,44 +308,56 @@ describe('Trezor Offscreen', () => {
     });
   });
 
-  describe('listDevices', () => {
-    it('returns an empty list before any device has connected', () => {
+  describe('identifyDevice', () => {
+    it('calls getFeatures unpinned and passes the result through', async () => {
+      const sdkResult = {
+        success: true,
+        payload: featuresFixture('device-b', { label: 'My Trezor' }),
+      };
+      mockGetFeatures.mockResolvedValue(sdkResult);
       const sendResponse = jest.fn();
+
       capturedMessageListener(
         {
           target: OffscreenCommunicationTarget.trezorOffscreen,
-          action: TrezorAction.listDevices,
+          action: TrezorAction.identifyDevice,
         },
         undefined,
         sendResponse,
       );
+      await flush();
 
-      expect(sendResponse).toHaveBeenCalledWith([]);
+      expect(mockGetFeatures).toHaveBeenCalledWith();
+      expect(sendResponse).toHaveBeenCalledWith(sdkResult);
     });
 
-    it('lists every currently-connected device', async () => {
+    it('stays unpinned even when the sender bridge has a deviceId', async () => {
+      // A bridge always attaches its own deviceId to outgoing messages; the
+      // identify probe must ignore it, otherwise it could never surface a
+      // *different* (e.g. never-paired) device the user picks in the
+      // browser chooser.
       sendInit();
       await flush();
       connectDevice('device-a', '1');
-      connectDevice('device-b', '2');
 
+      mockGetFeatures.mockResolvedValue({ success: true, payload: {} });
       const sendResponse = jest.fn();
+
       capturedMessageListener(
         {
           target: OffscreenCommunicationTarget.trezorOffscreen,
-          action: TrezorAction.listDevices,
+          action: TrezorAction.identifyDevice,
+          deviceId: 'device-a',
         },
         undefined,
         sendResponse,
       );
+      await flush();
 
-      expect(sendResponse).toHaveBeenCalledWith([
-        expect.objectContaining({ deviceId: 'device-a', path: '1' }),
-        expect.objectContaining({ deviceId: 'device-b', path: '2' }),
-      ]);
+      expect(mockGetFeatures).toHaveBeenCalledWith();
     });
 
-    it('removes a device on disconnect', async () => {
+    it('drops a disconnected device from pinned routing', async () => {
       sendInit();
       await flush();
       connectDevice('device-a', '1');
@@ -356,17 +368,25 @@ describe('Trezor Offscreen', () => {
         payload: { path: '1' },
       });
 
+      mockGetPublicKey.mockResolvedValue({ success: true, payload: {} });
       const sendResponse = jest.fn();
+      const params = { path: "m/44'/60'/0'/0", coin: 'ETH' };
+
       capturedMessageListener(
         {
           target: OffscreenCommunicationTarget.trezorOffscreen,
-          action: TrezorAction.listDevices,
+          action: TrezorAction.getPublicKey,
+          deviceId: 'device-a',
+          params,
         },
         undefined,
         sendResponse,
       );
+      await flush();
 
-      expect(sendResponse).toHaveBeenCalledWith([]);
+      // The registry no longer knows the device, so no stale `device`
+      // param is attached.
+      expect(mockGetPublicKey).toHaveBeenCalledWith(params);
     });
   });
 
@@ -486,16 +506,24 @@ describe('Trezor Offscreen', () => {
 
       sendDispose();
 
+      // The registry was cleared, so a pinned call no longer resolves the
+      // device's path and goes out without a `device` param.
+      mockGetPublicKey.mockResolvedValue({ success: true, payload: {} });
       const sendResponse = jest.fn();
+      const params = { path: "m/44'/60'/0'/0", coin: 'ETH' };
       capturedMessageListener(
         {
           target: OffscreenCommunicationTarget.trezorOffscreen,
-          action: TrezorAction.listDevices,
+          action: TrezorAction.getPublicKey,
+          deviceId: 'device-a',
+          params,
         },
         undefined,
         sendResponse,
       );
-      expect(sendResponse).toHaveBeenCalledWith([]);
+      await flush();
+
+      expect(mockGetPublicKey).toHaveBeenCalledWith(params);
     });
   });
 

--- a/app/offscreen/hardware-wallets/trezor.ts
+++ b/app/offscreen/hardware-wallets/trezor.ts
@@ -1,9 +1,132 @@
-import TrezorConnectSDK, { DEVICE, DEVICE_EVENT } from '@trezor/connect-web';
+import TrezorConnectSDK, {
+  DEVICE,
+  DEVICE_EVENT,
+  DeviceUniquePath,
+  type Features,
+} from '@trezor/connect-web';
 import {
   OffscreenCommunicationEvents,
   OffscreenCommunicationTarget,
   TrezorAction,
+  TrezorDevice,
 } from '../../../shared/constants/offscreen-communication';
+
+/**
+ * Devices currently known to be connected, keyed by their stable
+ * `features.device_id`. A device's transport `path` changes across
+ * reconnects, so every request re-resolves it from this registry (kept
+ * fresh via `DEVICE_EVENT`) instead of caching it anywhere long-lived.
+ */
+const devices = new Map<string, TrezorDevice>();
+
+function upsertDevice(features: Features, path: string) {
+  if (!features.device_id) {
+    return;
+  }
+
+  devices.set(features.device_id, {
+    deviceId: features.device_id,
+    path,
+    label: features.label ?? undefined,
+    model: features.model,
+  });
+}
+
+function removeDeviceByPath(path: string) {
+  for (const [deviceId, device] of devices) {
+    if (device.path === path) {
+      devices.delete(deviceId);
+      break;
+    }
+  }
+}
+
+/**
+ * Resolves a `deviceId` to the `device` common param TrezorConnect uses to
+ * target a specific physical device. Returns `{}` when `deviceId` is
+ * unknown or omitted, letting TrezorConnect fall back to its own device
+ * picker (used the first time a not-yet-paired device is contacted).
+ *
+ * @param deviceId - The physical device's stable `device_id`, if known.
+ */
+function deviceParam(deviceId?: string) {
+  const device = deviceId ? devices.get(deviceId) : undefined;
+  return device ? { device: { path: DeviceUniquePath(device.path) } } : {};
+}
+
+// `@trezor/connect-web`'s SDK is a singleton that lives for the lifetime of
+// the offscreen document, independent of the background keyrings it serves.
+// It is initialized exactly once and shared by every Trezor/OneKey keyring
+// instance (one per paired device), so pairing or using a second device
+// never tears down another device's session. Previously this handler
+// disposed and re-initialized the SDK on every `init` call, which broke
+// multi-device use by killing any other device's connection; now `init` is
+// idempotent and only fails over (via `initPromise = undefined`) after a
+// hard error, so a later call can retry.
+let initPromise: Promise<void> | undefined;
+
+// The KeyringController calls `bridge.init()`/`bridge.dispose()` once per
+// keyring instance (on creation/restore and on removal or wallet lock,
+// respectively) — every Trezor/OneKey keyring for every paired device
+// shares this same offscreen document. Tearing down the SDK on the first
+// `dispose()` would kill every other device's session (e.g. forgetting one
+// Trezor while a second is still in use, or locking the wallet with two
+// devices paired), so the real teardown is deferred until every keyring
+// sharing this document has disposed.
+let activeKeyringCount = 0;
+
+function initTrezorConnect(params: object) {
+  if (!initPromise) {
+    initPromise = Promise.resolve()
+      .then(() => {
+        TrezorConnectSDK.on(DEVICE_EVENT, (event) => {
+          switch (event.type) {
+            case DEVICE.CONNECT:
+            case DEVICE.CHANGED: {
+              const { features, path } = event.payload;
+              if (!features?.device_id) {
+                break;
+              }
+
+              upsertDevice(features, path);
+              chrome.runtime.sendMessage({
+                target: OffscreenCommunicationTarget.extension,
+                event: OffscreenCommunicationEvents.trezorDeviceConnect,
+                payload: {
+                  deviceId: features.device_id,
+                  path,
+                  label: features.label ?? undefined,
+                  model: features.model,
+                  minorVersion: features.minor_version,
+                } satisfies TrezorDevice,
+              });
+              break;
+            }
+
+            case DEVICE.DISCONNECT:
+              removeDeviceByPath(event.payload.path);
+              break;
+
+            default:
+              break;
+          }
+        });
+
+        return TrezorConnectSDK.init({
+          ...params,
+          env: 'webextension',
+        });
+      })
+      .catch((error) => {
+        // Allow a future `init` call to retry after a hard failure instead
+        // of getting stuck on a rejected promise forever.
+        initPromise = undefined;
+        throw error;
+      });
+  }
+
+  return initPromise;
+}
 
 /**
  * This listener is used to listen for messages targeting the Trezor Offscreen
@@ -18,6 +141,7 @@ export default function init() {
       msg: {
         target: string;
         action: TrezorAction;
+        deviceId?: string;
 
         // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -32,44 +156,8 @@ export default function init() {
 
       switch (msg.action) {
         case TrezorAction.init:
-          // `@trezor/connect-web`'s SDK is a singleton that lives for the
-          // lifetime of the offscreen document, independent of the background
-          // keyring it serves. When the keyring is recreated (e.g. the user
-          // cancels the connect flow and starts it again) `init` runs a second
-          // time while the previous core (iframe or Suite Desktop) is still
-          // mounted, and `CoreInIframe.init` throws `Init_AlreadyInitialized`.
-          // That would leave `sendResponse` uncalled and hang MetaMask on
-          // "Looking for your Trezor" state. Disposing first tears down any stale
-          // connection so each request re-opens a fresh one. The core mode is
-          // intentionally left to the SDK's default ('auto') / caller-provided
-          // setting so users can connect through Trezor Suite Desktop or the
-          // remote iframe.
-          Promise.resolve()
-            .then(() => TrezorConnectSDK.dispose())
-            .catch(() => undefined)
-            .then(() => {
-              TrezorConnectSDK.on(DEVICE_EVENT, (event) => {
-                if (event.type !== DEVICE.CONNECT) {
-                  return;
-                }
-
-                if (event.payload.features?.model) {
-                  chrome.runtime.sendMessage({
-                    target: OffscreenCommunicationTarget.extension,
-                    event: OffscreenCommunicationEvents.trezorDeviceConnect,
-                    payload: {
-                      model: event.payload.features.model,
-                      minorVersion: event.payload.features.minor_version,
-                    },
-                  });
-                }
-              });
-
-              return TrezorConnectSDK.init({
-                ...msg.params,
-                env: 'webextension',
-              });
-            })
+          activeKeyringCount += 1;
+          initTrezorConnect(msg.params)
             .then(() => sendResponse())
             // Resolve the bridge even if init fails so it does not hang; the
             // subsequent call surfaces the real error to the UI.
@@ -78,47 +166,69 @@ export default function init() {
           break;
 
         case TrezorAction.dispose:
-          // This removes the Trezor Connect iframe from the DOM
-          // This method is not well documented, but the code it calls can be seen
-          // here: https://github.com/trezor/connect/blob/dec4a56af8a65a6059fb5f63fa3c6690d2c37e00/src/js/iframe/builder.js#L181
-          TrezorConnectSDK.dispose();
+          activeKeyringCount = Math.max(0, activeKeyringCount - 1);
+          if (activeKeyringCount === 0) {
+            // This removes the Trezor Connect iframe from the DOM
+            // This method is not well documented, but the code it calls can be seen
+            // here: https://github.com/trezor/connect/blob/dec4a56af8a65a6059fb5f63fa3c6690d2c37e00/src/js/iframe/builder.js#L181
+            TrezorConnectSDK.dispose();
+            initPromise = undefined;
+            devices.clear();
+          }
 
           sendResponse();
 
           break;
 
+        case TrezorAction.listDevices:
+          sendResponse(Array.from(devices.values()));
+
+          break;
+
         case TrezorAction.getPublicKey:
-          TrezorConnectSDK.getPublicKey(msg.params).then((result) => {
+          TrezorConnectSDK.getPublicKey({
+            ...msg.params,
+            ...deviceParam(msg.deviceId),
+          }).then((result) => {
             sendResponse(result);
           });
 
           break;
 
         case TrezorAction.signTransaction:
-          TrezorConnectSDK.ethereumSignTransaction(msg.params).then(
-            (result) => {
-              sendResponse(result);
-            },
-          );
+          TrezorConnectSDK.ethereumSignTransaction({
+            ...msg.params,
+            ...deviceParam(msg.deviceId),
+          }).then((result) => {
+            sendResponse(result);
+          });
 
           break;
 
         case TrezorAction.signMessage:
-          TrezorConnectSDK.ethereumSignMessage(msg.params).then((result) => {
+          TrezorConnectSDK.ethereumSignMessage({
+            ...msg.params,
+            ...deviceParam(msg.deviceId),
+          }).then((result) => {
             sendResponse(result);
           });
 
           break;
 
         case TrezorAction.signTypedData:
-          TrezorConnectSDK.ethereumSignTypedData(msg.params).then((result) => {
+          TrezorConnectSDK.ethereumSignTypedData({
+            ...msg.params,
+            ...deviceParam(msg.deviceId),
+          }).then((result) => {
             sendResponse(result);
           });
 
           break;
 
         case TrezorAction.getFeatures:
-          TrezorConnectSDK.getFeatures().then((result) => {
+          TrezorConnectSDK.getFeatures({
+            ...deviceParam(msg.deviceId),
+          }).then((result) => {
             sendResponse(result);
           });
 

--- a/app/offscreen/hardware-wallets/trezor.ts
+++ b/app/offscreen/hardware-wallets/trezor.ts
@@ -185,8 +185,16 @@ export default function init() {
 
           break;
 
-        case TrezorAction.listDevices:
-          sendResponse(Array.from(devices.values()));
+        case TrezorAction.identifyDevice:
+          // Deliberately unpinned (no `device` param): TrezorConnect's popup
+          // and the browser's WebUSB chooser let the user pick the physical
+          // device — including one that has never been paired and is
+          // therefore invisible to the registry. The resulting DEVICE.CONNECT
+          // event also teaches the registry the device's current path, so
+          // subsequent pinned calls can target it.
+          TrezorConnectSDK.getFeatures().then((result) => {
+            sendResponse(result);
+          });
 
           break;
 

--- a/app/offscreen/hardware-wallets/trezor.ts
+++ b/app/offscreen/hardware-wallets/trezor.ts
@@ -75,7 +75,12 @@ let initPromise: Promise<void> | undefined;
 // sharing this document has disposed.
 let activeKeyringCount = 0;
 
-function initTrezorConnect(params: object) {
+// `params` is the caller-provided (untyped) init settings forwarded as-is
+// from the bridge; it includes internal-only fields (e.g. `env`) that
+// `InitFullSettings<ConnectSettingsWeb>` does not model.
+// TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31973
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function initTrezorConnect(params: any) {
   if (!initPromise) {
     initPromise = Promise.resolve()
       .then(() => {

--- a/app/scripts/constants/sentry-state.ts
+++ b/app/scripts/constants/sentry-state.ts
@@ -102,7 +102,7 @@ export const SENTRY_BACKGROUND_STATE: SentryBackgroundControllerMasks = {
     termsOfUseLastAgreed: true,
     throttledOrigins: false,
     timeoutMinutes: true,
-    trezorModel: true,
+    trezorModels: true,
     pendingExtensionVersion: true,
     updateModalLastDismissedAt: true,
     lastUpdatedAt: true,

--- a/app/scripts/controllers/app-state-controller-method-action-types.ts
+++ b/app/scripts/controllers/app-state-controller-method-action-types.ts
@@ -338,9 +338,12 @@ export type AppStateControllerSetCurrentExtensionPopupIdAction = {
 };
 
 /**
- * Sets a property indicating the model of the user's Trezor hardware wallet
+ * Records the model of a paired Trezor/OneKey hardware wallet, keyed by
+ * its stable `device_id` so multiple simultaneously-paired devices don't
+ * overwrite each other's recorded model.
  *
- * @param trezorModel - The Trezor model.
+ * @param deviceId - The device's stable `device_id`.
+ * @param model - The Trezor model.
  */
 export type AppStateControllerSetTrezorModelAction = {
   type: `AppStateController:setTrezorModel`;

--- a/app/scripts/controllers/app-state-controller.test.ts
+++ b/app/scripts/controllers/app-state-controller.test.ts
@@ -875,7 +875,7 @@ describe('AppStateController', () => {
               "termsOfUseLastAgreed": 1000,
               "throttledOrigins": {},
               "timeoutMinutes": 0,
-              "trezorModel": null,
+              "trezorModels": {},
               "updateModalLastDismissedAt": null,
             }
           `);
@@ -963,7 +963,7 @@ describe('AppStateController', () => {
               "termsOfUseLastAgreed": 1000,
               "throttledOrigins": {},
               "timeoutMinutes": 0,
-              "trezorModel": null,
+              "trezorModels": {},
               "updateModalLastDismissedAt": null,
             }
           `);
@@ -1035,7 +1035,7 @@ describe('AppStateController', () => {
               "snapsInstallPrivacyWarningShown": false,
               "termsOfUseLastAgreed": 1000,
               "timeoutMinutes": 0,
-              "trezorModel": null,
+              "trezorModels": {},
               "updateModalLastDismissedAt": null,
             }
           `);

--- a/app/scripts/controllers/app-state-controller.ts
+++ b/app/scripts/controllers/app-state-controller.ts
@@ -140,7 +140,12 @@ export type AppStateControllerState = {
   termsOfUseLastAgreed?: number;
   throttledOrigins: ThrottledOrigins;
   timeoutMinutes: number;
-  trezorModel: string | null;
+  /**
+   * Trezor/OneKey device models, keyed by the device's stable `device_id`
+   * (one bridge/keyring per paired device, so a single scalar field would
+   * have one device's model overwrite another's).
+   */
+  trezorModels: Record<string, string>;
   updateModalLastDismissedAt: number | null;
   hasShownMultichainAccountsIntroModal: boolean;
   perpsTabBadgeSeen: boolean;
@@ -309,7 +314,7 @@ const getDefaultAppStateControllerState = (): AppStateControllerState => ({
   shieldPausedToastLastClickedOrClosed: null,
   throttledOrigins: {},
   timeoutMinutes: DEFAULT_AUTO_LOCK_TIME_LIMIT,
-  trezorModel: null,
+  trezorModels: {},
   updateModalLastDismissedAt: null,
   hasShownMultichainAccountsIntroModal: false,
   perpsTabBadgeSeen: false,
@@ -589,7 +594,7 @@ const controllerMetadata: StateMetadata<AppStateControllerState> = {
     includeInDebugSnapshot: true,
     usedInUi: false,
   },
-  trezorModel: {
+  trezorModels: {
     includeInStateLogs: true,
     persist: true,
     includeInDebugSnapshot: true,
@@ -1399,13 +1404,22 @@ export class AppStateController extends BaseController<
   }
 
   /**
-   * Sets a property indicating the model of the user's Trezor hardware wallet
+   * Records the model of a paired Trezor/OneKey hardware wallet, keyed by
+   * its stable `device_id` so multiple simultaneously-paired devices don't
+   * overwrite each other's recorded model.
    *
-   * @param trezorModel - The Trezor model.
+   * @param deviceId - The device's stable `device_id`.
+   * @param model - The Trezor model.
    */
-  setTrezorModel(trezorModel: string | null): void {
+  setTrezorModel(
+    deviceId: string | undefined,
+    model: string | undefined,
+  ): void {
+    if (!deviceId || !model) {
+      return;
+    }
     this.update((state) => {
-      state.trezorModel = trezorModel;
+      state.trezorModels[deviceId] = model;
     });
   }
 

--- a/app/scripts/lib/offscreen-bridge/trezor-mv2-bridge.ts
+++ b/app/scripts/lib/offscreen-bridge/trezor-mv2-bridge.ts
@@ -290,10 +290,20 @@ export class TrezorMv2Bridge implements TrezorBridge {
   }
 
   /**
-   * Lists every Trezor device currently connected to Suite Desktop,
-   * regardless of whether it has been paired to a keyring yet.
+   * Identifies the physical device the user selects in Suite Desktop, via
+   * an *unpinned* `getFeatures` call (`this.deviceId` is deliberately not
+   * applied). This is the pairing entry point: a never-paired device may be
+   * absent from the registry, so identity must be established by contacting
+   * it first — the returned `features.device_id` then decides whether it
+   * maps to an existing keyring or a new one.
    */
-  async listDevices(): Promise<TrezorDevice[]> {
-    return Array.from(devices.values());
+  identifyDevice(): TrezorResponse<Features> {
+    return withTrezorDeviceTimeout(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (SuiteDesktopConnect as any)
+        .getFeatures()
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        .then((r: any) => mapError<Features>(r)),
+    ) as unknown as TrezorResponse<Features>;
   }
 }

--- a/app/scripts/lib/offscreen-bridge/trezor-mv2-bridge.ts
+++ b/app/scripts/lib/offscreen-bridge/trezor-mv2-bridge.ts
@@ -15,7 +15,56 @@ import type {
   Features,
 } from '@trezor/connect-web';
 import { TREZOR_DESKTOP_CONNECTION_MISSING_CODE } from '../../../../shared/constants/hardware-wallets';
+import { TrezorDevice } from '../../../../shared/constants/offscreen-communication';
 import { withTrezorDeviceTimeout } from './with-trezor-device-timeout';
+
+/**
+ * Devices currently known to be connected, keyed by their stable
+ * `features.device_id`. Shared at module scope (mirroring the MV3 offscreen
+ * document's registry) because every `TrezorMv2Bridge` instance in this
+ * background page talks to the same `SuiteDesktopConnect` singleton and
+ * would otherwise see every other bridge's `DEVICE_EVENT`s.
+ */
+const devices = new Map<string, TrezorDevice>();
+
+function upsertDevice(features: Features, path: string) {
+  if (!features.device_id) {
+    return;
+  }
+
+  devices.set(features.device_id, {
+    deviceId: features.device_id,
+    path,
+    label: features.label ?? undefined,
+    model: features.model,
+  });
+}
+
+function removeDeviceByPath(path: string) {
+  for (const [deviceId, device] of devices) {
+    if (device.path === path) {
+      devices.delete(deviceId);
+      break;
+    }
+  }
+}
+
+function deviceParam(deviceId?: string) {
+  const device = deviceId ? devices.get(deviceId) : undefined;
+  return device ? { device: { path: device.path } } : {};
+}
+
+// `SuiteDesktopConnect` is a singleton shared by every Trezor/OneKey keyring
+// instance (one per paired device). It is initialized once and the
+// `DEVICE_EVENT` listener registered once, so pairing or using a second
+// device never disposes or duplicates another device's session.
+let initPromise: Promise<void> | undefined;
+let listenerAdded = false;
+// KeyringController calls `bridge.dispose()` once per keyring instance (on
+// removal or wallet lock); the real teardown is deferred until every
+// keyring sharing this singleton has disposed, for the same reason as the
+// MV3 offscreen document (see `app/offscreen/hardware-wallets/trezor.ts`).
+let activeBridgeCount = 0;
 
 // The resolved value type of TrezorResponse<T> = Promise<SuccessWithDevice<T> | Unsuccessful>.
 // `.then()` callbacks receive this type, not the Promise itself.
@@ -81,60 +130,102 @@ function createSuiteDesktopMissingError(): Error {
  * clear error response.
  */
 export class TrezorMv2Bridge implements TrezorBridge {
-  model: string | undefined;
+  /**
+   * Stable per-device identity (Trezor's `features.device_id`). Unset until
+   * the owning keyring learns it (see `TrezorKeyring#captureDeviceId`), at
+   * which point every subsequent call below is routed to this specific
+   * physical device, even while other devices are connected at the same
+   * time.
+   */
+  deviceId: string | undefined;
 
-  #initiated = false;
-
-  #listenerAdded = false;
+  /**
+   * The model reported by this bridge's own device once `deviceId` is
+   * known. Before pairing (deviceId unset), falls back to the sole
+   * currently-connected device's model as a display hint while the user
+   * is connecting it — `SuiteDesktopConnect` is a shared singleton, so this
+   * cannot be derived per-instance any other way.
+   */
+  get model(): string | undefined {
+    if (this.deviceId) {
+      return devices.get(this.deviceId)?.model;
+    }
+    return devices.size === 1 ? [...devices.values()][0].model : undefined;
+  }
 
   async init(
     settings: { manifest: Manifest } & Partial<ConnectSettings>,
   ): Promise<void> {
-    if (!this.#listenerAdded) {
+    activeBridgeCount += 1;
+
+    if (!listenerAdded) {
       // SuiteDesktopConnect properties resolve to `any` via the & Record<string, any>
       // intersection in its type, so the event listener is untyped here.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       SuiteDesktopConnect.on(DEVICE_EVENT as any, (event: any) => {
-        if (event?.type !== DEVICE.CONNECT) {
-          return;
+        switch (event?.type) {
+          case DEVICE.CONNECT:
+          case DEVICE.CHANGED: {
+            const features = event?.payload?.features;
+            const path = event?.payload?.path;
+            if (features?.device_id && path) {
+              upsertDevice(features, path);
+            }
+            break;
+          }
+          case DEVICE.DISCONNECT:
+            if (event?.payload?.path) {
+              removeDeviceByPath(event.payload.path);
+            }
+            break;
+          default:
+            break;
         }
-        this.model = event?.payload?.features?.model;
       });
-      this.#listenerAdded = true;
+      listenerAdded = true;
     }
 
-    if (this.#initiated) {
-      return;
+    if (!initPromise) {
+      initPromise = (async () => {
+        try {
+          // init() on CoreInSuiteDesktop opens a WebSocket to Suite Desktop.
+          // It throws Desktop_ConnectionMissing if the connection cannot be made.
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          await (SuiteDesktopConnect as any).init(settings);
+        } catch (err: unknown) {
+          // Allow a future `init` call to retry after a hard failure
+          // (e.g. once the user opens Suite Desktop) instead of getting
+          // stuck on a rejected promise forever.
+          initPromise = undefined;
+          if (
+            typeof err === 'object' &&
+            err !== null &&
+            (err as { code?: unknown }).code ===
+              TREZOR_DESKTOP_CONNECTION_MISSING_CODE
+          ) {
+            throw createSuiteDesktopMissingError();
+          }
+          if (err instanceof Error) {
+            throw err;
+          }
+          throw new Error(String(err));
+        }
+      })();
     }
 
-    try {
-      // init() on CoreInSuiteDesktop opens a WebSocket to Suite Desktop.
-      // It throws Desktop_ConnectionMissing if the connection cannot be made.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      await (SuiteDesktopConnect as any).init(settings);
-      this.#initiated = true;
-    } catch (err: unknown) {
-      // #initiated stays false so a retry after the user opens Suite Desktop
-      // will re-attempt the connection.
-      if (
-        typeof err === 'object' &&
-        err !== null &&
-        (err as { code?: unknown }).code ===
-          TREZOR_DESKTOP_CONNECTION_MISSING_CODE
-      ) {
-        throw createSuiteDesktopMissingError();
-      }
-      if (err instanceof Error) {
-        throw err;
-      }
-      throw new Error(String(err));
-    }
+    return initPromise;
   }
 
   async dispose(): Promise<void> {
-    this.#initiated = false;
+    activeBridgeCount = Math.max(0, activeBridgeCount - 1);
+    if (activeBridgeCount > 0) {
+      return;
+    }
+
+    initPromise = undefined;
+    devices.clear();
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    return (SuiteDesktopConnect as any).dispose();
+    await (SuiteDesktopConnect as any).dispose();
   }
 
   getPublicKey(params: {
@@ -144,7 +235,7 @@ export class TrezorMv2Bridge implements TrezorBridge {
     return withTrezorDeviceTimeout(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (SuiteDesktopConnect as any)
-        .getPublicKey(params)
+        .getPublicKey({ ...params, ...deviceParam(this.deviceId) })
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .then((r: any) =>
           mapError<{ publicKey: string; chainCode: string }>(r),
@@ -158,7 +249,7 @@ export class TrezorMv2Bridge implements TrezorBridge {
     return withTrezorDeviceTimeout(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (SuiteDesktopConnect as any)
-        .ethereumSignTransaction(params)
+        .ethereumSignTransaction({ ...params, ...deviceParam(this.deviceId) })
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .then((r: any) => mapError<EthereumSignedTx>(r)),
     ) as unknown as TrezorResponse<EthereumSignedTx>;
@@ -170,7 +261,7 @@ export class TrezorMv2Bridge implements TrezorBridge {
     return withTrezorDeviceTimeout(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (SuiteDesktopConnect as any)
-        .ethereumSignMessage(params)
+        .ethereumSignMessage({ ...params, ...deviceParam(this.deviceId) })
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .then((r: any) => mapError<PROTO.MessageSignature>(r)),
     ) as unknown as TrezorResponse<PROTO.MessageSignature>;
@@ -182,7 +273,7 @@ export class TrezorMv2Bridge implements TrezorBridge {
     return withTrezorDeviceTimeout(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (SuiteDesktopConnect as any)
-        .ethereumSignTypedData(params)
+        .ethereumSignTypedData({ ...params, ...deviceParam(this.deviceId) })
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .then((r: any) => mapError<PROTO.EthereumTypedDataSignature>(r)),
     ) as unknown as TrezorResponse<PROTO.EthereumTypedDataSignature>;
@@ -192,9 +283,17 @@ export class TrezorMv2Bridge implements TrezorBridge {
     return withTrezorDeviceTimeout(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (SuiteDesktopConnect as any)
-        .getFeatures()
+        .getFeatures(deviceParam(this.deviceId))
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         .then((r: any) => mapError<Features>(r)),
     ) as unknown as TrezorResponse<Features>;
+  }
+
+  /**
+   * Lists every Trezor device currently connected to Suite Desktop,
+   * regardless of whether it has been paired to a keyring yet.
+   */
+  async listDevices(): Promise<TrezorDevice[]> {
+    return Array.from(devices.values());
   }
 }

--- a/app/scripts/lib/offscreen-bridge/trezor-offscreen-bridge.ts
+++ b/app/scripts/lib/offscreen-bridge/trezor-offscreen-bridge.ts
@@ -16,6 +16,7 @@ import {
   OffscreenCommunicationEvents,
   OffscreenCommunicationTarget,
   TrezorAction,
+  TrezorDevice,
 } from '../../../../shared/constants/offscreen-communication';
 import { withTrezorDeviceTimeout } from './with-trezor-device-timeout';
 
@@ -34,6 +35,15 @@ export class TrezorOffscreenBridge implements TrezorBridge {
 
   minorVersion: number | undefined;
 
+  /**
+   * Stable per-device identity (Trezor's `features.device_id`). Unset until
+   * the owning keyring learns it (see `TrezorKeyring#captureDeviceId`), at
+   * which point every subsequent call below is routed to this specific
+   * physical device by the offscreen document, even while other devices are
+   * connected at the same time.
+   */
+  deviceId: string | undefined;
+
   init(
     settings: {
       manifest: Manifest;
@@ -41,12 +51,26 @@ export class TrezorOffscreenBridge implements TrezorBridge {
   ) {
     chrome.runtime.onMessage.addListener((msg) => {
       if (
-        msg.target === OffscreenCommunicationTarget.extension &&
-        msg.event === OffscreenCommunicationEvents.trezorDeviceConnect
+        msg.target !== OffscreenCommunicationTarget.extension ||
+        msg.event !== OffscreenCommunicationEvents.trezorDeviceConnect
       ) {
-        this.model = msg.payload.model;
-        this.minorVersion = msg.payload.minorVersion;
+        return;
       }
+
+      const payload = msg.payload as TrezorDevice;
+      // Every bridge instance (one per paired device) registers this same
+      // listener, and `chrome.runtime.onMessage` broadcasts every event to
+      // every listener regardless of which device it concerns. Only update
+      // this bridge's model/version hint from events for its own device
+      // (once known), or from any device while pairing (deviceId not yet
+      // known), so a second device connecting cannot clobber the model
+      // shown for this one.
+      if (this.deviceId && payload.deviceId !== this.deviceId) {
+        return;
+      }
+
+      this.model = payload.model;
+      this.minorVersion = payload.minorVersion;
     });
 
     return new Promise<void>((resolve) => {
@@ -94,9 +118,12 @@ export class TrezorOffscreenBridge implements TrezorBridge {
     params?: unknown;
   }): Promise<ResponseType> {
     const responsePromise = new Promise<ResponseType>((resolve) => {
-      chrome.runtime.sendMessage(message, (response) => {
-        resolve(response as ResponseType);
-      });
+      chrome.runtime.sendMessage(
+        { ...message, deviceId: this.deviceId },
+        (response) => {
+          resolve(response as ResponseType);
+        },
+      );
     });
 
     return withTrezorDeviceTimeout(responsePromise);
@@ -143,5 +170,18 @@ export class TrezorOffscreenBridge implements TrezorBridge {
       target: OffscreenCommunicationTarget.trezorOffscreen,
       action: TrezorAction.getFeatures,
     }) as TrezorResponse<Features>;
+  }
+
+  /**
+   * Lists every Trezor device currently connected, regardless of whether it
+   * has been paired to a keyring yet. Used by the connect-hardware flow to
+   * find newly-attached devices to pair, and to recognize a device that is
+   * already bound to an existing keyring.
+   */
+  listDevices() {
+    return this.#sendDeviceMessage<TrezorDevice[]>({
+      target: OffscreenCommunicationTarget.trezorOffscreen,
+      action: TrezorAction.listDevices,
+    });
   }
 }

--- a/app/scripts/lib/offscreen-bridge/trezor-offscreen-bridge.ts
+++ b/app/scripts/lib/offscreen-bridge/trezor-offscreen-bridge.ts
@@ -173,15 +173,18 @@ export class TrezorOffscreenBridge implements TrezorBridge {
   }
 
   /**
-   * Lists every Trezor device currently connected, regardless of whether it
-   * has been paired to a keyring yet. Used by the connect-hardware flow to
-   * find newly-attached devices to pair, and to recognize a device that is
-   * already bound to an existing keyring.
+   * Identifies the physical device the user picks in TrezorConnect's popup /
+   * the browser's WebUSB chooser, via an *unpinned* `getFeatures` call
+   * (`this.deviceId` is deliberately not applied). This is the pairing entry
+   * point: a never-paired device is invisible to the offscreen registry, so
+   * identity must be established by contacting it first — the returned
+   * `features.device_id` then decides whether it maps to an existing keyring
+   * or a new one.
    */
-  listDevices() {
-    return this.#sendDeviceMessage<TrezorDevice[]>({
+  identifyDevice() {
+    return this.#sendDeviceMessage({
       target: OffscreenCommunicationTarget.trezorOffscreen,
-      action: TrezorAction.listDevices,
-    });
+      action: TrezorAction.identifyDevice,
+    }) as TrezorResponse<Features>;
   }
 }

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2927,7 +2927,7 @@ export default class MetamaskController extends EventEmitter {
       getLedgerAppConfiguration: this.getLedgerAppConfiguration.bind(this),
       getLedgerMode: this.getLedgerMode.bind(this),
       getTrezorFeatures: this.getTrezorFeatures.bind(this),
-      listTrezorDevices: this.listTrezorDevices.bind(this),
+      identifyTrezorDevice: this.identifyTrezorDevice.bind(this),
 
       // qr hardware devices
       completeQrCodeScan:
@@ -5426,9 +5426,9 @@ export default class MetamaskController extends EventEmitter {
    * @param page
    * @param hdPath
    * @param deviceId - For Trezor/OneKey only: the physical device's stable
-   * `device_id` (see `listTrezorDevices`) to pair or reconnect to. Omit to
-   * use (or create, if none exists) the first keyring of the type, matching
-   * every other hardware wallet's single-device behavior.
+   * `device_id` (see `identifyTrezorDevice`) to pair or reconnect to. Omit
+   * to use (or create, if none exists) the first keyring of the type,
+   * matching every other hardware wallet's single-device behavior.
    * @returns [] accounts
    */
   async connectHardware(deviceName, page, hdPath, deviceId) {
@@ -5517,31 +5517,49 @@ export default class MetamaskController extends EventEmitter {
   }
 
   /**
-   * Lists every Trezor device currently connected over USB, regardless of
-   * whether it has already been paired to a keyring. Used by the
-   * connect-hardware UI to let the user choose which physical device to
-   * pair when more than one is plugged in at once; selecting an
-   * already-paired device's id simply reconnects to its existing keyring
-   * (see `connectHardware`).
+   * Identifies which physical Trezor/OneKey device the user intends to
+   * connect, via an unpinned `getFeatures` probe: TrezorConnect's popup and
+   * the browser's own WebUSB chooser let the user pick the device — this is
+   * the only way to reach a never-paired device, which is invisible to any
+   * enumeration until it has been granted WebUSB permission. The returned
+   * stable `device_id` is then fed to `connectHardware`, which routes it to
+   * the device's existing keyring (already paired) or a new one (fresh
+   * pairing).
    *
    * @param {HardwareDeviceNames.trezor | HardwareDeviceNames.oneKey} deviceName -
-   * Which keyring type to use for the query. Both share the same
-   * underlying device registry, but this must match the type the caller
-   * intends to pair so a keyring created here (when none exists yet) can
-   * be reused for that device instead of left behind as an empty orphan
-   * once a different-typed keyring is created for it (see
+   * Which keyring type the caller intends to pair. This must match so a
+   * keyring created here (when none exists yet) can be claimed for the
+   * identified device instead of left behind as an empty orphan (see
    * `#findOrCreateHardwareKeyringForDevice`).
-   * @returns {Promise<Array<{deviceId: string, path: string, label?: string, model?: string}>>}
+   * @returns {Promise<{deviceId: string, label?: string, model?: string} | undefined>}
+   * The identified device, or `undefined` when the bridge does not support
+   * identification (e.g. test stubs) — callers then fall back to the
+   * single-device (first keyring of the type) behavior.
    */
-  async listTrezorDevices(deviceName = HardwareDeviceNames.trezor) {
+  async identifyTrezorDevice(deviceName = HardwareDeviceNames.trezor) {
     return this.#withKeyringForDevice(
       { name: deviceName, create: true, deviceRead: true },
       async (keyring) => {
-        if (typeof keyring.bridge.listDevices !== 'function') {
-          return [];
+        if (typeof keyring.bridge.identifyDevice !== 'function') {
+          return undefined;
         }
 
-        return keyring.bridge.listDevices();
+        const response = await keyring.bridge.identifyDevice();
+        if (!response.success) {
+          throw new Error(
+            response.payload?.error ?? 'Failed to identify Trezor device',
+          );
+        }
+
+        if (!response.payload.device_id) {
+          return undefined;
+        }
+
+        return {
+          deviceId: response.payload.device_id,
+          label: response.payload.label ?? undefined,
+          model: response.payload.model,
+        };
       },
     );
   }
@@ -9193,10 +9211,10 @@ export default class MetamaskController extends EventEmitter {
     // devices, each as its own keyring instance (every other hardware
     // wallet here still has exactly one keyring per type). When the caller
     // knows which device it wants — `options.deviceId`, learned once a
-    // keyring has unlocked at least once, or chosen from
-    // `listTrezorDevices` — resolve or create the keyring instance bound to
-    // that specific device instead of always operating on the first
-    // keyring of the type.
+    // keyring has unlocked at least once, or resolved by an
+    // `identifyTrezorDevice` probe — resolve or create the keyring instance
+    // bound to that specific device instead of always operating on the
+    // first keyring of the type.
     const supportsMultipleDevices =
       options.name === HardwareDeviceNames.trezor ||
       options.name === HardwareDeviceNames.oneKey;
@@ -9244,6 +9262,15 @@ export default class MetamaskController extends EventEmitter {
       }
 
       if (supportsMultipleDevices) {
+        if (options.deviceId && !keyring.deviceId) {
+          // First contact with a just-identified device (see
+          // `identifyTrezorDevice`): the keyring has not unlocked yet, so
+          // it has no persisted identity of its own. Pin the bridge to the
+          // identified device so the initial unlock targets it even while
+          // other devices are plugged in; the keyring then captures and
+          // persists the same id itself on unlock.
+          keyring.bridge.deviceId = options.deviceId;
+        }
         this.appStateController.setTrezorModel(
           keyring.deviceId,
           keyring.getModel(),
@@ -9369,10 +9396,10 @@ export default class MetamaskController extends EventEmitter {
       .map((entry, index) => ({ ...entry, index }));
 
     // Tracks the first keyring of this type that has never unlocked (e.g.
-    // one created solely to list currently-connected devices via
-    // `listTrezorDevices`, before the user picked one). Claiming it below
-    // avoids leaving it behind as a permanent empty orphan once a different
-    // keyring is created for the chosen device.
+    // one created solely to run the `identifyTrezorDevice` probe, before
+    // the user picked a device). Claiming it below avoids leaving it behind
+    // as a permanent empty orphan once a different keyring is created for
+    // the chosen device.
     let unboundEntry;
 
     for (const entry of entries) {

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5524,11 +5524,18 @@ export default class MetamaskController extends EventEmitter {
    * already-paired device's id simply reconnects to its existing keyring
    * (see `connectHardware`).
    *
+   * @param {HardwareDeviceNames.trezor | HardwareDeviceNames.oneKey} deviceName -
+   * Which keyring type to use for the query. Both share the same
+   * underlying device registry, but this must match the type the caller
+   * intends to pair so a keyring created here (when none exists yet) can
+   * be reused for that device instead of left behind as an empty orphan
+   * once a different-typed keyring is created for it (see
+   * `#findOrCreateHardwareKeyringForDevice`).
    * @returns {Promise<Array<{deviceId: string, path: string, label?: string, model?: string}>>}
    */
-  async listTrezorDevices() {
+  async listTrezorDevices(deviceName = HardwareDeviceNames.trezor) {
     return this.#withKeyringForDevice(
-      { name: HardwareDeviceNames.trezor, create: true, deviceRead: true },
+      { name: deviceName, create: true, deviceRead: true },
       async (keyring) => {
         if (typeof keyring.bridge.listDevices !== 'function') {
           return [];
@@ -9202,6 +9209,11 @@ export default class MetamaskController extends EventEmitter {
         deviceId: options.deviceId,
         create: Boolean(options.create),
       });
+      if (!keyringId) {
+        throw new Error(
+          `MetamaskController:#withKeyringForDevice - No ${options.name} keyring found for device: ${options.deviceId}`,
+        );
+      }
       keyringSelector = { id: keyringId };
     } else if (options.create) {
       // `withKeyringV2` has no `createIfMissing` option. The connect-device
@@ -9356,27 +9368,41 @@ export default class MetamaskController extends EventEmitter {
       .filter(({ type }) => type === keyringType)
       .map((entry, index) => ({ ...entry, index }));
 
+    // Tracks the first keyring of this type that has never unlocked (e.g.
+    // one created solely to list currently-connected devices via
+    // `listTrezorDevices`, before the user picked one). Claiming it below
+    // avoids leaving it behind as a permanent empty orphan once a different
+    // keyring is created for the chosen device.
+    let unboundEntry;
+
     for (const entry of entries) {
       // Reading `deviceId` lock-free is safe here: it is set at most once,
       // the first time a keyring unlocks, and never changes afterwards, so
       // there is no mutable state for a concurrent locked operation to race
       // with.
-      const isBoundToDevice = await this.keyringController.withKeyringV2Unsafe(
+      const entryDeviceId = await this.keyringController.withKeyringV2Unsafe(
         { type: v2KeyringType, index: entry.index },
-        async ({ keyring }) => keyring.deviceId === deviceId,
+        async ({ keyring }) => keyring.deviceId,
       );
-      if (isBoundToDevice) {
+      if (entryDeviceId === deviceId) {
         return entry.metadata.id;
       }
+      if (!entryDeviceId && !unboundEntry) {
+        unboundEntry = entry;
+      }
+    }
+
+    if (unboundEntry) {
+      return unboundEntry.metadata.id;
     }
 
     if (!create) {
       return undefined;
     }
 
-    // No existing keyring is bound to this device yet; create a new one so
-    // it gets its own wallet section instead of colliding with another
-    // device's keyring.
+    // No existing keyring is bound to this device (or free to claim) yet;
+    // create a new one so it gets its own wallet section instead of
+    // colliding with another device's keyring.
     return this.keyringController.withController(async (controller) => {
       const metadata = await controller.addNewKeyring(keyringType);
       return metadata.id;

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -2927,6 +2927,7 @@ export default class MetamaskController extends EventEmitter {
       getLedgerAppConfiguration: this.getLedgerAppConfiguration.bind(this),
       getLedgerMode: this.getLedgerMode.bind(this),
       getTrezorFeatures: this.getTrezorFeatures.bind(this),
+      listTrezorDevices: this.listTrezorDevices.bind(this),
 
       // qr hardware devices
       completeQrCodeScan:
@@ -5424,9 +5425,13 @@ export default class MetamaskController extends EventEmitter {
    * @param deviceName
    * @param page
    * @param hdPath
+   * @param deviceId - For Trezor/OneKey only: the physical device's stable
+   * `device_id` (see `listTrezorDevices`) to pair or reconnect to. Omit to
+   * use (or create, if none exists) the first keyring of the type, matching
+   * every other hardware wallet's single-device behavior.
    * @returns [] accounts
    */
-  async connectHardware(deviceName, page, hdPath) {
+  async connectHardware(deviceName, page, hdPath, deviceId) {
     // This is the first-time setup path for a hardware wallet; the keyring
     // may not exist yet, so allow creation here. Every other caller of
     // `#withKeyringForDevice` operates on an already-paired device.
@@ -5435,7 +5440,7 @@ export default class MetamaskController extends EventEmitter {
     // entering a PIN), potentially forever if the device stays locked, so it
     // runs as a `deviceRead` outside the controller lock.
     return this.#withKeyringForDevice(
-      { name: deviceName, hdPath, create: true, deviceRead: true },
+      { name: deviceName, hdPath, deviceId, create: true, deviceRead: true },
       async (keyring) => {
         let accounts = [];
         switch (page) {
@@ -5459,13 +5464,15 @@ export default class MetamaskController extends EventEmitter {
    *
    * @param deviceName
    * @param hdPath
+   * @param deviceId - For Trezor/OneKey only, see `connectHardware`.
    * @returns {Promise<boolean>}
    */
-  async checkHardwareStatus(deviceName, hdPath) {
+  async checkHardwareStatus(deviceName, hdPath, deviceId) {
     return this.#withKeyringForDevice(
       {
         name: deviceName,
         hdPath,
+        deviceId,
         create: deviceName === HardwareDeviceNames.qr,
         deviceRead: true,
       },
@@ -5496,15 +5503,38 @@ export default class MetamaskController extends EventEmitter {
     );
   }
 
-  async getTrezorFeatures() {
+  async getTrezorFeatures(deviceId) {
     return await this.#withKeyringForDevice(
-      { name: HardwareDeviceNames.trezor, deviceRead: true },
+      { name: HardwareDeviceNames.trezor, deviceId, deviceRead: true },
       async (keyring) => {
         if (typeof keyring.bridge.getFeatures !== 'function') {
           throw new Error('Trezor bridge does not support getFeatures');
         }
 
         return await keyring.bridge.getFeatures();
+      },
+    );
+  }
+
+  /**
+   * Lists every Trezor device currently connected over USB, regardless of
+   * whether it has already been paired to a keyring. Used by the
+   * connect-hardware UI to let the user choose which physical device to
+   * pair when more than one is plugged in at once; selecting an
+   * already-paired device's id simply reconnects to its existing keyring
+   * (see `connectHardware`).
+   *
+   * @returns {Promise<Array<{deviceId: string, path: string, label?: string, model?: string}>>}
+   */
+  async listTrezorDevices() {
+    return this.#withKeyringForDevice(
+      { name: HardwareDeviceNames.trezor, create: true, deviceRead: true },
+      async (keyring) => {
+        if (typeof keyring.bridge.listDevices !== 'function') {
+          return [];
+        }
+
+        return keyring.bridge.listDevices();
       },
     );
   }
@@ -5533,23 +5563,29 @@ export default class MetamaskController extends EventEmitter {
    * Clear
    *
    * @param deviceName
+   * @param deviceId - For Trezor/OneKey only: forgets only the keyring
+   * bound to this specific device, leaving any other paired device intact.
+   * Omit to forget the first (or only) keyring of the type.
    * @returns {Promise<boolean>}
    */
-  async forgetDevice(deviceName) {
-    return this.#withKeyringForDevice({ name: deviceName }, async (keyring) => {
-      // V2 wrappers return `KeyringAccount[]` from `getAccounts()`; the
-      // remove-handler downstream expects raw addresses.
-      for (const account of await keyring.getAccounts()) {
-        this.controllerMessenger.call(
-          'LegacyBackgroundApiService:onAccountRemoved',
-          account.address,
-        );
-      }
+  async forgetDevice(deviceName, deviceId) {
+    return this.#withKeyringForDevice(
+      { name: deviceName, deviceId },
+      async (keyring) => {
+        // V2 wrappers return `KeyringAccount[]` from `getAccounts()`; the
+        // remove-handler downstream expects raw addresses.
+        for (const account of await keyring.getAccounts()) {
+          this.controllerMessenger.call(
+            'LegacyBackgroundApiService:onAccountRemoved',
+            account.address,
+          );
+        }
 
-      await keyring.forgetDevice();
+        await keyring.forgetDevice();
 
-      return true;
-    });
+        return true;
+      },
+    );
   }
 
   /**
@@ -5646,6 +5682,7 @@ export default class MetamaskController extends EventEmitter {
    * @param deviceName
    * @param hdPath
    * @param hdPathDescription
+   * @param deviceId - For Trezor/OneKey only, see `connectHardware`.
    * @returns {} keyState
    */
   async unlockHardwareWalletAccount(
@@ -5653,9 +5690,10 @@ export default class MetamaskController extends EventEmitter {
     deviceName,
     hdPath,
     hdPathDescription,
+    deviceId,
   ) {
     const { address: unlockedAccount } = await this.#withKeyringForDevice(
-      { name: deviceName, hdPath },
+      { name: deviceName, hdPath, deviceId },
       async (keyring) => {
         const { entropySource } = keyring;
         // Callers may omit `hdPath` and rely on the keyring's currently
@@ -9144,14 +9182,35 @@ export default class MetamaskController extends EventEmitter {
         );
     }
 
-    // `withKeyringV2` has no `createIfMissing` option. The connect-device
-    // flow and QR reconnect status probe may legitimately create a hardware
-    // keyring; every other caller operates on a keyring that should already
-    // exist, and should let the controller throw `KeyringNotFound` if it
-    // doesn't.
-    // `withController` runs the check-and-create as a mutually exclusive
-    // transaction so a concurrent caller can't slip in between.
-    if (options.create) {
+    // Trezor/OneKey support multiple simultaneously-paired physical
+    // devices, each as its own keyring instance (every other hardware
+    // wallet here still has exactly one keyring per type). When the caller
+    // knows which device it wants — `options.deviceId`, learned once a
+    // keyring has unlocked at least once, or chosen from
+    // `listTrezorDevices` — resolve or create the keyring instance bound to
+    // that specific device instead of always operating on the first
+    // keyring of the type.
+    const supportsMultipleDevices =
+      options.name === HardwareDeviceNames.trezor ||
+      options.name === HardwareDeviceNames.oneKey;
+    let keyringSelector = { type: v2KeyringType };
+
+    if (supportsMultipleDevices && options.deviceId) {
+      const keyringId = await this.#findOrCreateHardwareKeyringForDevice({
+        keyringType,
+        v2KeyringType,
+        deviceId: options.deviceId,
+        create: Boolean(options.create),
+      });
+      keyringSelector = { id: keyringId };
+    } else if (options.create) {
+      // `withKeyringV2` has no `createIfMissing` option. The connect-device
+      // flow and QR reconnect status probe may legitimately create a hardware
+      // keyring; every other caller operates on a keyring that should already
+      // exist, and should let the controller throw `KeyringNotFound` if it
+      // doesn't.
+      // `withController` runs the check-and-create as a mutually exclusive
+      // transaction so a concurrent caller can't slip in between.
       await this.keyringController.withController(async (controller) => {
         if (!controller.keyrings.some(({ type }) => type === keyringType)) {
           await controller.addNewKeyring(keyringType);
@@ -9172,12 +9231,11 @@ export default class MetamaskController extends EventEmitter {
         await this.setLedgerTransportPreference(keyring);
       }
 
-      if (
-        options.name === HardwareDeviceNames.trezor ||
-        options.name === HardwareDeviceNames.oneKey
-      ) {
-        const model = keyring.getModel();
-        this.appStateController.setTrezorModel(model);
+      if (supportsMultipleDevices) {
+        this.appStateController.setTrezorModel(
+          keyring.deviceId,
+          keyring.getModel(),
+        );
       }
 
       if (options.name === HardwareDeviceNames.lattice) {
@@ -9193,7 +9251,7 @@ export default class MetamaskController extends EventEmitter {
 
     if (!options.deviceRead) {
       return this.keyringController.withKeyringV2(
-        { type: v2KeyringType },
+        keyringSelector,
         async ({ keyring }) => {
           await prepareKeyring(keyring);
           return await callback(keyring);
@@ -9217,7 +9275,7 @@ export default class MetamaskController extends EventEmitter {
     // and the caller can simply retry — unlike the previous behavior, where
     // the whole wallet wedged on the held mutex.
     await this.keyringController.withKeyringV2(
-      { type: v2KeyringType },
+      keyringSelector,
       async ({ keyring }) => prepareKeyring(keyring),
     );
 
@@ -9227,7 +9285,7 @@ export default class MetamaskController extends EventEmitter {
     // device call rather than cancelling it; a retry while the device call
     // is still pending may be rejected by the transport SDK.
     const deviceReadOperation = this.keyringController.withKeyringV2Unsafe(
-      { type: v2KeyringType },
+      keyringSelector,
       // The facade structurally prevents `deviceRead` callbacks from
       // reaching mutating keyring methods on the lock-free path.
       async ({ keyring }) =>
@@ -9264,6 +9322,65 @@ export default class MetamaskController extends EventEmitter {
         );
       }
     }
+  }
+
+  /**
+   * Finds the id of the existing Trezor/OneKey keyring instance already
+   * bound to `deviceId`, or creates a new keyring instance for it if none
+   * exists yet. Enables pairing a second physical device without disturbing
+   * any other device's keyring, unlike the single-shared-keyring model used
+   * by every other hardware wallet type.
+   *
+   * @param {object} args
+   * @param {string} args.keyringType - The legacy (v1) keyring type string.
+   * @param {string} args.v2KeyringType - The V2 keyring type enum value.
+   * @param {string} args.deviceId - The physical device's stable `device_id`.
+   * @param {boolean} args.create - Whether to create a new keyring instance
+   * when no existing one is bound to `deviceId` yet.
+   * @returns {Promise<string|undefined>} The matching (or newly created)
+   * keyring instance's id, or `undefined` if none matched and `create` is
+   * `false`.
+   */
+  async #findOrCreateHardwareKeyringForDevice({
+    keyringType,
+    v2KeyringType,
+    deviceId,
+    create,
+  }) {
+    const { keyrings } = this.keyringController.state;
+    // `index` must be positional *within the type-filtered list*: that is
+    // how `withKeyringV2`/`withKeyringV2Unsafe`'s `{ type, index }` selector
+    // resolves entries (see `KeyringController`), so it has to be assigned
+    // after filtering by type, not from the unfiltered `keyrings` array.
+    const entries = keyrings
+      .filter(({ type }) => type === keyringType)
+      .map((entry, index) => ({ ...entry, index }));
+
+    for (const entry of entries) {
+      // Reading `deviceId` lock-free is safe here: it is set at most once,
+      // the first time a keyring unlocks, and never changes afterwards, so
+      // there is no mutable state for a concurrent locked operation to race
+      // with.
+      const isBoundToDevice = await this.keyringController.withKeyringV2Unsafe(
+        { type: v2KeyringType, index: entry.index },
+        async ({ keyring }) => keyring.deviceId === deviceId,
+      );
+      if (isBoundToDevice) {
+        return entry.metadata.id;
+      }
+    }
+
+    if (!create) {
+      return undefined;
+    }
+
+    // No existing keyring is bound to this device yet; create a new one so
+    // it gets its own wallet section instead of colliding with another
+    // device's keyring.
+    return this.keyringController.withController(async (controller) => {
+      const metadata = await controller.addNewKeyring(keyringType);
+      return metadata.id;
+    });
   }
 
   #createEnsureOnboardingCompleteCallback() {

--- a/package.json
+++ b/package.json
@@ -312,7 +312,9 @@
     "@pmmmwh/react-refresh-webpack-plugin@npm:^0.5.11": "patch:@pmmmwh/react-refresh-webpack-plugin@npm%3A0.5.13#~/.yarn/patches/@pmmmwh-react-refresh-webpack-plugin-npm-0.5.13-25d13d4186.patch",
     "@metamask/messenger": "^2.0.0",
     "@metamask/bridge-controller@npm:^77.7.0": "patch:@metamask/bridge-controller@npm%3A77.8.0#~/.yarn/patches/@metamask-bridge-controller-npm-77.5.0-c154d2913a.patch",
-    "@metamask/bridge-controller@npm:^77.8.0": "patch:@metamask/bridge-controller@npm%3A77.8.0#~/.yarn/patches/@metamask-bridge-controller-npm-77.5.0-c154d2913a.patch"
+    "@metamask/bridge-controller@npm:^77.8.0": "patch:@metamask/bridge-controller@npm%3A77.8.0#~/.yarn/patches/@metamask-bridge-controller-npm-77.5.0-c154d2913a.patch",
+    "@metamask/account-tree-controller@npm:^7.5.5": "patch:@metamask/account-tree-controller@npm%3A7.5.5#~/.yarn/patches/@metamask-account-tree-controller-npm-7.5.5-7e92299d95.patch",
+    "@metamask/account-tree-controller@npm:^7.5.3": "patch:@metamask/account-tree-controller@npm%3A7.5.5#~/.yarn/patches/@metamask-account-tree-controller-npm-7.5.5-7e92299d95.patch"
   },
   "dependencies": {
     "@babel/runtime": "patch:@babel/runtime@npm%3A7.29.2#~/.yarn/patches/@babel-runtime-npm-7.29.2-b49cad1c67.patch",
@@ -341,7 +343,7 @@
     "@metamask/7715-permission-types": "^0.7.1",
     "@metamask/abi-utils": "^3.0.0",
     "@metamask/account-api": "^1.0.4",
-    "@metamask/account-tree-controller": "^7.5.3",
+    "@metamask/account-tree-controller": "patch:@metamask/account-tree-controller@npm%3A7.5.5#~/.yarn/patches/@metamask-account-tree-controller-npm-7.5.5-7e92299d95.patch",
     "@metamask/account-watcher": "^4.1.3",
     "@metamask/accounts-controller": "^39.0.3",
     "@metamask/address-book-controller": "^7.1.2",
@@ -385,7 +387,7 @@
     "@metamask/eth-sig-util": "^8.2.0",
     "@metamask/eth-snap-keyring": "^22.3.0",
     "@metamask/eth-token-tracker": "^10.0.2",
-    "@metamask/eth-trezor-keyring": "^10.1.0",
+    "@metamask/eth-trezor-keyring": "patch:@metamask/eth-trezor-keyring@npm%3A10.1.0#~/.yarn/patches/@metamask-eth-trezor-keyring-npm-10.1.0-70aadca269.patch",
     "@metamask/etherscan-link": "^3.0.0",
     "@metamask/gas-fee-controller": "^26.1.0",
     "@metamask/gator-permissions-controller": "^4.2.1",

--- a/shared/constants/offscreen-communication.ts
+++ b/shared/constants/offscreen-communication.ts
@@ -70,7 +70,25 @@ export enum TrezorAction {
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
   getFeatures = 'trezor-get-features',
+  // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
+  // eslint-disable-next-line @typescript-eslint/naming-convention
+  listDevices = 'trezor-list-devices',
 }
+
+/**
+ * A Trezor device currently tracked by the Offscreen Document's device
+ * registry. `deviceId` is the device's stable `features.device_id` reported
+ * by TrezorConnect; `path` is the current transport path, which is only
+ * valid for the lifetime of the connection and is re-resolved from
+ * `deviceId` on every request (it changes across reconnects).
+ */
+export type TrezorDevice = {
+  deviceId: string;
+  path: string;
+  label?: string;
+  model?: string;
+  minorVersion?: number;
+};
 
 /**
  * Defines actions intended to be sent to the Trezor Offscreen iframe.

--- a/shared/constants/offscreen-communication.ts
+++ b/shared/constants/offscreen-communication.ts
@@ -72,7 +72,7 @@ export enum TrezorAction {
   getFeatures = 'trezor-get-features',
   // TODO: Fix in https://github.com/MetaMask/metamask-extension/issues/31860
   // eslint-disable-next-line @typescript-eslint/naming-convention
-  listDevices = 'trezor-list-devices',
+  identifyDevice = 'trezor-identify-device',
 }
 
 /**
@@ -89,6 +89,17 @@ export type TrezorDevice = {
   model?: string;
   minorVersion?: number;
 };
+
+/**
+ * The stable identity of a Trezor device, as resolved by an
+ * `identifyDevice` probe: an *unpinned* `getFeatures` call that lets the
+ * TrezorConnect popup (and the browser's own WebUSB device chooser) select
+ * the physical device — including one that has never been paired and is
+ * therefore invisible to the device registry. Unlike {@link TrezorDevice}
+ * there is no `path`: the probe answers "which device did the user pick",
+ * not "where is it right now".
+ */
+export type TrezorDeviceIdentity = Omit<TrezorDevice, 'path'>;
 
 /**
  * Defines actions intended to be sent to the Trezor Offscreen iframe.

--- a/shared/types/background.ts
+++ b/shared/types/background.ts
@@ -109,7 +109,7 @@ export type ControllerStatePropertiesEnumerated = {
   outdatedBrowserWarningLastShown: AppStateControllerState['outdatedBrowserWarningLastShown'];
   productTour?: AppStateControllerState['productTour'];
   showDownloadMobileAppSlide: AppStateControllerState['showDownloadMobileAppSlide'];
-  trezorModel: AppStateControllerState['trezorModel'];
+  trezorModels: AppStateControllerState['trezorModels'];
   currentPopupId?: AppStateControllerState['currentPopupId'];
   onboardingDate: AppStateControllerState['onboardingDate'];
   lastViewedUserSurvey: AppStateControllerState['lastViewedUserSurvey'];

--- a/test/e2e/fixtures/default-fixture.json
+++ b/test/e2e/fixtures/default-fixture.json
@@ -215,7 +215,7 @@
       "slides": [],
       "termsOfUseLastAgreed": 1770282497124,
       "timeoutMinutes": 0,
-      "trezorModel": null,
+      "trezorModels": {},
       "updateModalLastDismissedAt": null
     },
     "AssetsController": {

--- a/test/e2e/fixtures/onboarding-fixture.json
+++ b/test/e2e/fixtures/onboarding-fixture.json
@@ -90,7 +90,7 @@
       "showShieldEntryModalOnce": null,
       "slides": [],
       "timeoutMinutes": 0,
-      "trezorModel": null,
+      "trezorModels": {},
       "updateModalLastDismissedAt": null
     },
     "AssetsController": {

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-background-state.json
@@ -87,7 +87,7 @@
     "storageWriteErrorType": null,
     "termsOfUseLastAgreed": "number",
     "throttledOrigins": "object",
-    "trezorModel": null,
+    "trezorModels": {},
     "updateModalLastDismissedAt": null
   },
   "ApprovalController": {

--- a/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-after-init-opt-in-ui-state.json
@@ -412,7 +412,7 @@
     "transactionBatches": "object",
     "transactionData": "object",
     "transactions": "object",
-    "trezorModel": null,
+    "trezorModels": {},
     "trialedProducts": "object",
     "txHistory": "object",
     "unapprovedDecryptMsgCount": 0,

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-background-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-background-state.json
@@ -63,7 +63,7 @@
       "showShieldEntryModalOnce": null,
       "slides": "object",
       "termsOfUseLastAgreed": "number",
-      "trezorModel": null,
+      "trezorModels": {},
       "updateModalLastDismissedAt": null
     },
     "AssetsController": "object",

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -79,7 +79,7 @@
       "showShieldEntryModalOnce": null,
       "slides": "object",
       "termsOfUseLastAgreed": "number",
-      "trezorModel": null,
+      "trezorModels": {},
       "updateModalLastDismissedAt": null
     },
     "AssetsController": "object",

--- a/test/e2e/tests/settings/state-logs.json
+++ b/test/e2e/tests/settings/state-logs.json
@@ -1567,7 +1567,7 @@
     "transactionBatches": [],
     "transactionData": {},
     "transactions": [],
-    "trezorModel": "null",
+    "trezorModels": {},
     "trialedProducts": [],
     "txHistory": {},
     "unapprovedDecryptMsgCount": "number",

--- a/test/integration/data/integration-init-state.json
+++ b/test/integration/data/integration-init-state.json
@@ -2123,7 +2123,7 @@
       "origin": "tmashuang.github.io"
     }
   ],
-  "trezorModel": null,
+  "trezorModels": {},
   "txHistory": {},
   "unapprovedDecryptMsgCount": 0,
   "unapprovedDecryptMsgs": {},

--- a/test/integration/data/onboarding-completion-route.json
+++ b/test/integration/data/onboarding-completion-route.json
@@ -460,7 +460,7 @@
   "tracesBeforeMetricsOptIn": [],
   "traits": {},
   "transactions": [],
-  "trezorModel": null,
+  "trezorModels": {},
   "unapprovedDecryptMsgCount": 0,
   "unapprovedDecryptMsgs": {},
   "unapprovedEncryptionPublicKeyMsgCount": 0,

--- a/ui/pages/create-account/connect-hardware/index.test.tsx
+++ b/ui/pages/create-account/connect-hardware/index.test.tsx
@@ -51,6 +51,10 @@ const mockCheckHardwareStatus = jest.fn().mockResolvedValue(false);
 const mockForgetDevice = jest.fn().mockResolvedValue(undefined);
 const mockUnlockHardwareWalletAccountsAction = jest.fn();
 const mockUnlockHardwareWalletAccounts = jest.fn().mockResolvedValue(undefined);
+// Only relevant for Trezor/OneKey: defaults to "no extra devices detected"
+// so existing single-device flows behave exactly as before this mock
+// existed. Tests exercising the multi-device picker override this.
+const mockListTrezorDevices = jest.fn().mockResolvedValue([]);
 
 jest.mock('../../../store/actions', () => ({
   connectHardware: (...args: unknown[]) => {
@@ -68,6 +72,7 @@ jest.mock('../../../store/actions', () => ({
   setHardwareWalletDefaultHdPath: () => ({
     type: 'SET_HARDWARE_WALLET_DEFAULT_HD_PATH',
   }),
+  listTrezorDevices: () => mockListTrezorDevices,
 }));
 
 const mockGetActiveQrCodeScanRequest = jest.fn().mockReturnValue(null);
@@ -810,6 +815,7 @@ describe('ConnectHardwareForm', () => {
             HardwareDeviceNames.trezor,
             null,
             '',
+            undefined,
           );
         });
       });

--- a/ui/pages/create-account/connect-hardware/index.test.tsx
+++ b/ui/pages/create-account/connect-hardware/index.test.tsx
@@ -51,10 +51,11 @@ const mockCheckHardwareStatus = jest.fn().mockResolvedValue(false);
 const mockForgetDevice = jest.fn().mockResolvedValue(undefined);
 const mockUnlockHardwareWalletAccountsAction = jest.fn();
 const mockUnlockHardwareWalletAccounts = jest.fn().mockResolvedValue(undefined);
-// Only relevant for Trezor/OneKey: defaults to "no extra devices detected"
-// so existing single-device flows behave exactly as before this mock
-// existed. Tests exercising the multi-device picker override this.
-const mockListTrezorDevices = jest.fn().mockResolvedValue([]);
+// Only relevant for Trezor/OneKey: resolving `undefined` mirrors a bridge
+// that cannot identify devices, so existing single-device flows behave
+// exactly as before this mock existed. Tests exercising multi-device
+// routing override this with a `{ deviceId }` resolution.
+const mockIdentifyTrezorDevice = jest.fn().mockResolvedValue(undefined);
 
 jest.mock('../../../store/actions', () => ({
   connectHardware: (...args: unknown[]) => {
@@ -72,7 +73,7 @@ jest.mock('../../../store/actions', () => ({
   setHardwareWalletDefaultHdPath: () => ({
     type: 'SET_HARDWARE_WALLET_DEFAULT_HD_PATH',
   }),
-  listTrezorDevices: () => mockListTrezorDevices,
+  identifyTrezorDevice: () => mockIdentifyTrezorDevice,
 }));
 
 const mockGetActiveQrCodeScanRequest = jest.fn().mockReturnValue(null);

--- a/ui/pages/create-account/connect-hardware/index.tsx
+++ b/ui/pages/create-account/connect-hardware/index.tsx
@@ -60,6 +60,7 @@ import {
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import type { MetaMaskReduxDispatch } from '../../../store/store';
 import { useDispatch } from '../../../store/hooks';
+import type { TrezorDevice } from '../../../../shared/constants/offscreen-communication';
 import AccountList from './account-list';
 import SelectHardware from './select-hardware';
 
@@ -155,6 +156,20 @@ const ConnectHardwareForm = () => {
   const [unlocked, setUnlocked] = useState(false);
   const [device, setDevice] = useState<string | null>(null);
   const [isFirefox, setIsFirefox] = useState(false);
+  // Only populated when more than one Trezor/OneKey device is connected at
+  // once and none has been chosen yet — lets the user pick which physical
+  // device to pair instead of leaving it to whichever one TrezorConnect
+  // happens to pick.
+  const [trezorDevicePickerOptions, setTrezorDevicePickerOptions] = useState<
+    TrezorDevice[]
+  >([]);
+  // The deviceId of the Trezor/OneKey device whose accounts are currently
+  // shown, if any (undefined for every other hardware wallet type, or if
+  // no explicit device was chosen). Threaded back into `forgetDevice` so
+  // forgetting only removes this device's keyring.
+  const [connectedDeviceId, setConnectedDeviceId] = useState<
+    string | undefined
+  >(undefined);
   const previousActiveQrCodeScanRequest = useRef<ActiveQrCodeScanRequest>(
     activeQrCodeScanRequest,
   );
@@ -224,6 +239,7 @@ const ConnectHardwareForm = () => {
       hdPath: string,
       loadHid?: boolean,
       shouldShowConnectedAlert = true,
+      deviceId?: string,
     ) => {
       // The actions.ts type declares `page` as string, but the background
       // handler expects a number (0 = first, 1 = next, -1 = previous).
@@ -239,6 +255,7 @@ const ConnectHardwareForm = () => {
             hdPath,
             loadHid ?? false,
             t as (key: string) => string,
+            deviceId,
           ),
         )) as { address: string; index?: number }[];
 
@@ -272,6 +289,7 @@ const ConnectHardwareForm = () => {
           setHardwareAccounts(newAccounts);
           setUnlocked(true);
           setCurrentDevice(deviceName);
+          setConnectedDeviceId(deviceId);
           setError(null);
         }
       } catch (e: unknown) {
@@ -397,7 +415,7 @@ const ConnectHardwareForm = () => {
   ]);
 
   const connectToHardwareWallet = useCallback(
-    (nextDevice: string) => {
+    async (nextDevice: string) => {
       if (latestPendingDevice.current === nextDevice) {
         return;
       }
@@ -418,16 +436,42 @@ const ConnectHardwareForm = () => {
           .build(),
       );
 
+      if (
+        nextDevice === HardwareDeviceNames.trezor ||
+        nextDevice === HardwareDeviceNames.oneKey
+      ) {
+        // Multiple physical Trezor/OneKey devices can be connected at
+        // once; let the user choose which one to pair instead of leaving
+        // it to whichever one TrezorConnect happens to pick.
+        const connectedDevices = await dispatch(actions.listTrezorDevices());
+        if (connectedDevices.length > 1) {
+          setTrezorDevicePickerOptions(connectedDevices);
+          return;
+        }
+      }
+
       getPage(nextDevice, 0, defaultHdPaths[nextDevice], true);
     },
     [
       defaultHdPaths,
+      dispatch,
       getPage,
       hardwareAccounts.length,
       hardwareWalletKeyrings.length,
       setCurrentDevice,
       trackEvent,
     ],
+  );
+
+  const connectToSelectedTrezorDevice = useCallback(
+    (selectedDeviceId: string) => {
+      if (!device) {
+        return;
+      }
+      setTrezorDevicePickerOptions([]);
+      getPage(device, 0, defaultHdPaths[device], true, true, selectedDeviceId);
+    },
+    [defaultHdPaths, device, getPage],
   );
 
   const onPathChange = useCallback(
@@ -463,7 +507,12 @@ const ConnectHardwareForm = () => {
   const onForgetDevice = useCallback(
     async (deviceName: string, hdPath: string) => {
       try {
-        await dispatch(actions.forgetDevice(deviceName as HardwareDeviceNames));
+        await dispatch(
+          actions.forgetDevice(
+            deviceName as HardwareDeviceNames,
+            connectedDeviceId,
+          ),
+        );
 
         trackEvent(
           createEventBuilder(MetaMetricsEventName.HardwareWalletForgotten)
@@ -480,6 +529,7 @@ const ConnectHardwareForm = () => {
         latestHardwareAccounts.current = [];
         setHardwareAccounts([]);
         setCurrentDevice(null);
+        setConnectedDeviceId(undefined);
         setUnlocked(false);
       } catch (e) {
         const errorMessage = toErrorMessage(e);
@@ -499,7 +549,7 @@ const ConnectHardwareForm = () => {
         setError(errorMessage);
       }
     },
-    [dispatch, setCurrentDevice, trackEvent],
+    [connectedDeviceId, dispatch, setCurrentDevice, trackEvent],
   );
 
   const onUnlockAccounts = useCallback(
@@ -532,6 +582,7 @@ const ConnectHardwareForm = () => {
             deviceName as HardwareDeviceNames,
             path || null,
             description,
+            connectedDeviceId,
           ),
         );
 
@@ -601,6 +652,7 @@ const ConnectHardwareForm = () => {
       }
     },
     [
+      connectedDeviceId,
       dispatch,
       hardwareWalletKeyrings,
       hdEntropyIndex,
@@ -694,6 +746,27 @@ const ConnectHardwareForm = () => {
 
   const renderContent = () => {
     if (!hardwareAccounts.length) {
+      if (trezorDevicePickerOptions.length > 0) {
+        // Minimal picker: more than one Trezor/OneKey device is connected
+        // and none has been chosen yet.
+        return (
+          <Box marginHorizontal={5} marginBottom={2}>
+            <Box marginBottom={2}>
+              <Text>{t('selectHardwareWalletDevice')}</Text>
+            </Box>
+            {trezorDevicePickerOptions.map((option) => (
+              <TextButton
+                key={option.deviceId}
+                onClick={() => connectToSelectedTrezorDevice(option.deviceId)}
+                className="hw-connect__device-option"
+              >
+                {option.label || option.model || option.deviceId}
+              </TextButton>
+            ))}
+          </Box>
+        );
+      }
+
       return (
         <SelectHardware
           connectToHardwareWallet={connectToHardwareWallet}

--- a/ui/pages/create-account/connect-hardware/index.tsx
+++ b/ui/pages/create-account/connect-hardware/index.tsx
@@ -60,7 +60,6 @@ import {
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import type { MetaMaskReduxDispatch } from '../../../store/store';
 import { useDispatch } from '../../../store/hooks';
-import type { TrezorDevice } from '../../../../shared/constants/offscreen-communication';
 import AccountList from './account-list';
 import SelectHardware from './select-hardware';
 
@@ -156,13 +155,6 @@ const ConnectHardwareForm = () => {
   const [unlocked, setUnlocked] = useState(false);
   const [device, setDevice] = useState<string | null>(null);
   const [isFirefox, setIsFirefox] = useState(false);
-  // Only populated when more than one Trezor/OneKey device is connected at
-  // once and none has been chosen yet — lets the user pick which physical
-  // device to pair instead of leaving it to whichever one TrezorConnect
-  // happens to pick.
-  const [trezorDevicePickerOptions, setTrezorDevicePickerOptions] = useState<
-    TrezorDevice[]
-  >([]);
   // The deviceId of the Trezor/OneKey device whose accounts are currently
   // shown, if any (undefined for every other hardware wallet type, or if
   // no explicit device was chosen). Threaded back into `forgetDevice` so
@@ -451,38 +443,47 @@ const ConnectHardwareForm = () => {
         nextDevice === HardwareDeviceNames.trezor ||
         nextDevice === HardwareDeviceNames.oneKey
       ) {
-        // Multiple physical Trezor/OneKey devices can be connected at
-        // once; let the user choose which one to pair instead of leaving
-        // it to whichever one TrezorConnect happens to pick.
-        const connectedDevices = await dispatch(
-          actions.listTrezorDevices(
-            nextDevice as
-              | HardwareDeviceNames.trezor
-              | HardwareDeviceNames.oneKey,
-          ),
-        );
-        if (connectedDevices.length > 1) {
-          setTrezorDevicePickerOptions(connectedDevices);
-          return;
-        }
-        if (connectedDevices.length === 1) {
-          // Always pass the single connected device's id explicitly: if a
-          // *different* device of this type is already paired, omitting it
-          // would silently reuse that other device's keyring instead of
-          // pairing (or reconnecting to) the one currently plugged in.
-          getPage(
-            nextDevice,
-            0,
-            defaultHdPaths[nextDevice],
-            true,
-            true,
-            connectedDevices[0].deviceId,
+        // Identify which physical device the user intends to connect
+        // *before* choosing a keyring. The probe opens TrezorConnect's
+        // popup and the browser's own WebUSB chooser — the only way to
+        // reach a never-paired device, since no enumeration can see it
+        // until permission is granted. The resolved stable `device_id`
+        // then routes to that device's existing keyring (already paired)
+        // or a new one (fresh pairing).
+        let identified;
+        try {
+          identified = await dispatch(
+            actions.identifyTrezorDevice(
+              nextDevice as
+                | HardwareDeviceNames.trezor
+                | HardwareDeviceNames.oneKey,
+            ),
           );
+        } catch (e: unknown) {
+          // Never fall through to an unidentified connect: with another
+          // device already paired, it would silently open that device's
+          // wallet — the exact mis-routing this probe exists to prevent.
+          const errorMessage = toErrorMessage(e);
+          if (
+            errorMessage !== 'Window closed' &&
+            errorMessage !== 'Popup closed'
+          ) {
+            setError(errorMessage);
+          }
           return;
         }
-        // No device detected yet (e.g. the bridge hasn't initialized
-        // because no keyring exists yet) — fall through and let the
-        // keyring learn the device's identity lazily on first unlock.
+
+        // `identified` is undefined only when the bridge cannot identify
+        // devices (e.g. test stubs); fall back to single-device behavior.
+        getPage(
+          nextDevice,
+          0,
+          defaultHdPaths[nextDevice],
+          true,
+          true,
+          identified?.deviceId,
+        );
+        return;
       }
 
       getPage(nextDevice, 0, defaultHdPaths[nextDevice], true);
@@ -496,17 +497,6 @@ const ConnectHardwareForm = () => {
       setCurrentDevice,
       trackEvent,
     ],
-  );
-
-  const connectToSelectedTrezorDevice = useCallback(
-    (selectedDeviceId: string) => {
-      if (!device) {
-        return;
-      }
-      setTrezorDevicePickerOptions([]);
-      getPage(device, 0, defaultHdPaths[device], true, true, selectedDeviceId);
-    },
-    [defaultHdPaths, device, getPage],
   );
 
   const onPathChange = useCallback(
@@ -781,27 +771,6 @@ const ConnectHardwareForm = () => {
 
   const renderContent = () => {
     if (!hardwareAccounts.length) {
-      if (trezorDevicePickerOptions.length > 0) {
-        // Minimal picker: more than one Trezor/OneKey device is connected
-        // and none has been chosen yet.
-        return (
-          <Box marginHorizontal={5} marginBottom={2}>
-            <Box marginBottom={2}>
-              <Text>{t('selectHardwareWalletDevice')}</Text>
-            </Box>
-            {trezorDevicePickerOptions.map((option) => (
-              <TextButton
-                key={option.deviceId}
-                onClick={() => connectToSelectedTrezorDevice(option.deviceId)}
-                className="hw-connect__device-option"
-              >
-                {option.label || option.model || option.deviceId}
-              </TextButton>
-            ))}
-          </Box>
-        );
-      }
-
       return (
         <SelectHardware
           connectToHardwareWallet={connectToHardwareWallet}

--- a/ui/pages/create-account/connect-hardware/index.tsx
+++ b/ui/pages/create-account/connect-hardware/index.tsx
@@ -175,6 +175,7 @@ const ConnectHardwareForm = () => {
   );
   const latestHardwareAccounts = useRef(hardwareAccounts);
   const latestDevice = useRef(device);
+  const latestConnectedDeviceId = useRef(connectedDeviceId);
   const latestPendingDevice = useRef<string | null>(null);
   const latestGetPageRequestId = useRef(0);
 
@@ -185,6 +186,10 @@ const ConnectHardwareForm = () => {
   useEffect(() => {
     latestDevice.current = device;
   }, [device]);
+
+  useEffect(() => {
+    latestConnectedDeviceId.current = connectedDeviceId;
+  }, [connectedDeviceId]);
 
   const setCurrentDevice = useCallback((nextDevice: string | null) => {
     latestDevice.current = nextDevice;
@@ -241,6 +246,12 @@ const ConnectHardwareForm = () => {
       shouldShowConnectedAlert = true,
       deviceId?: string,
     ) => {
+      // Callers that operate on the already-connected device (pagination,
+      // HD path changes) omit `deviceId`; fall back to the device already
+      // selected so they keep targeting that physical device instead of
+      // silently reverting to the first keyring of the type.
+      const effectiveDeviceId = deviceId ?? latestConnectedDeviceId.current;
+
       // The actions.ts type declares `page` as string, but the background
       // handler expects a number (0 = first, 1 = next, -1 = previous).
       const requestId = latestGetPageRequestId.current + 1;
@@ -255,7 +266,7 @@ const ConnectHardwareForm = () => {
             hdPath,
             loadHid ?? false,
             t as (key: string) => string,
-            deviceId,
+            effectiveDeviceId,
           ),
         )) as { address: string; index?: number }[];
 
@@ -289,7 +300,7 @@ const ConnectHardwareForm = () => {
           setHardwareAccounts(newAccounts);
           setUnlocked(true);
           setCurrentDevice(deviceName);
-          setConnectedDeviceId(deviceId);
+          setConnectedDeviceId(effectiveDeviceId);
           setError(null);
         }
       } catch (e: unknown) {
@@ -443,11 +454,35 @@ const ConnectHardwareForm = () => {
         // Multiple physical Trezor/OneKey devices can be connected at
         // once; let the user choose which one to pair instead of leaving
         // it to whichever one TrezorConnect happens to pick.
-        const connectedDevices = await dispatch(actions.listTrezorDevices());
+        const connectedDevices = await dispatch(
+          actions.listTrezorDevices(
+            nextDevice as
+              | HardwareDeviceNames.trezor
+              | HardwareDeviceNames.oneKey,
+          ),
+        );
         if (connectedDevices.length > 1) {
           setTrezorDevicePickerOptions(connectedDevices);
           return;
         }
+        if (connectedDevices.length === 1) {
+          // Always pass the single connected device's id explicitly: if a
+          // *different* device of this type is already paired, omitting it
+          // would silently reuse that other device's keyring instead of
+          // pairing (or reconnecting to) the one currently plugged in.
+          getPage(
+            nextDevice,
+            0,
+            defaultHdPaths[nextDevice],
+            true,
+            true,
+            connectedDevices[0].deviceId,
+          );
+          return;
+        }
+        // No device detected yet (e.g. the bridge hasn't initialized
+        // because no keyring exists yet) — fall through and let the
+        // keyring learn the device's identity lazily on first unlock.
       }
 
       getPage(nextDevice, 0, defaultHdPaths[nextDevice], true);

--- a/ui/store/actions.test.js
+++ b/ui/store/actions.test.js
@@ -1849,6 +1849,7 @@ describe('Actions', () => {
         HardwareDeviceNames.trezor,
         null,
         '',
+        undefined,
       ]);
     });
 

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -151,6 +151,7 @@ import {
   LedgerTransportTypes,
   LEDGER_USB_VENDOR_ID,
 } from '../../shared/constants/hardware-wallets';
+import type { TrezorDevice } from '../../shared/constants/offscreen-communication';
 import {
   MetaMetricsEventFragment,
   MetaMetricsEventOptions,
@@ -1500,8 +1501,11 @@ export function importNewAccount(
 export function checkHardwareStatus(
   deviceName: HardwareDeviceNames,
   hdPath: string,
+  // For Trezor/OneKey only: check the specific paired device's keyring
+  // instead of the first (or only) one of the type.
+  deviceId?: string,
 ): ThunkAction<Promise<boolean>, MetaMaskReduxState, unknown, AnyAction> {
-  log.debug(`background.checkHardwareStatus`, deviceName, hdPath);
+  log.debug(`background.checkHardwareStatus`, deviceName, hdPath, deviceId);
   return async (dispatch: MetaMaskReduxDispatch) => {
     dispatch(showLoadingIndication());
 
@@ -1509,7 +1513,7 @@ export function checkHardwareStatus(
     try {
       unlocked = await submitRequestToBackground<boolean>(
         'checkHardwareStatus',
-        [deviceName, hdPath],
+        [deviceName, hdPath, deviceId],
       );
     } catch (error) {
       logErrorWithMessage(error);
@@ -1525,12 +1529,15 @@ export function checkHardwareStatus(
 
 export function forgetDevice(
   deviceName: HardwareDeviceNames,
+  // For Trezor/OneKey only: forget only the keyring bound to this specific
+  // device, leaving any other paired device intact.
+  deviceId?: string,
 ): ThunkAction<void, MetaMaskReduxState, unknown, AnyAction> {
-  log.debug(`background.forgetDevice`, deviceName);
+  log.debug(`background.forgetDevice`, deviceName, deviceId);
   return async (dispatch: MetaMaskReduxDispatch) => {
     dispatch(showLoadingIndication());
     try {
-      await submitRequestToBackground('forgetDevice', [deviceName]);
+      await submitRequestToBackground('forgetDevice', [deviceName, deviceId]);
     } catch (error) {
       logErrorWithMessage(error);
       throw error;
@@ -1542,6 +1549,30 @@ export function forgetDevice(
   };
 }
 
+/**
+ * Lists Trezor devices currently connected over USB, regardless of whether
+ * they have already been paired to a keyring. Used to let the user choose
+ * which physical device to pair when more than one is plugged in.
+ */
+export function listTrezorDevices(): ThunkAction<
+  Promise<TrezorDevice[]>,
+  MetaMaskReduxState,
+  unknown,
+  AnyAction
+> {
+  return async () => {
+    try {
+      return await submitRequestToBackground<TrezorDevice[]>(
+        'listTrezorDevices',
+        [],
+      );
+    } catch (error) {
+      logErrorWithMessage(error);
+      throw error;
+    }
+  };
+}
+
 // TODO: Define an Account Type for the return type of this method and anywhere
 // else dealing with accounts.
 export function connectHardware(
@@ -1550,13 +1581,17 @@ export function connectHardware(
   hdPath: string,
   loadHid: boolean,
   t: (key: string) => string,
+  // For Trezor/OneKey only: pair or reconnect to this specific device (see
+  // `listTrezorDevices`). Omit to use (or create, if none exists yet) the
+  // first keyring of the type.
+  deviceId?: string,
 ): ThunkAction<
   Promise<{ address: string }[]>,
   MetaMaskReduxState,
   unknown,
   AnyAction
 > {
-  log.debug(`background.connectHardware`, deviceName, page, hdPath);
+  log.debug(`background.connectHardware`, deviceName, page, hdPath, deviceId);
   return async (dispatch, getState) => {
     const { ledgerTransportType } = getState().metamask;
 
@@ -1599,7 +1634,7 @@ export function connectHardware(
 
       accounts = await submitRequestToBackground<{ address: string }[]>(
         'connectHardware',
-        [deviceName, page, hdPath],
+        [deviceName, page, hdPath, deviceId],
       );
     } catch (error) {
       logErrorWithMessage(error);
@@ -1635,6 +1670,8 @@ export function unlockHardwareWalletAccounts(
   deviceName: HardwareDeviceNames,
   hdPath: string | null,
   hdPathDescription: string,
+  // For Trezor/OneKey only, see `connectHardware`.
+  deviceId?: string,
 ): ThunkAction<Promise<undefined>, MetaMaskReduxState, unknown, AnyAction> {
   log.debug(
     `background.unlockHardwareWalletAccount`,
@@ -1642,6 +1679,7 @@ export function unlockHardwareWalletAccounts(
     deviceName,
     hdPath,
     hdPathDescription,
+    deviceId,
   );
   return async (dispatch: MetaMaskReduxDispatch) => {
     dispatch(showLoadingIndication());
@@ -1653,6 +1691,7 @@ export function unlockHardwareWalletAccounts(
           deviceName,
           hdPath,
           hdPathDescription,
+          deviceId,
         ]);
       } catch (err) {
         logErrorWithMessage(err);

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -1553,8 +1553,17 @@ export function forgetDevice(
  * Lists Trezor devices currently connected over USB, regardless of whether
  * they have already been paired to a keyring. Used to let the user choose
  * which physical device to pair when more than one is plugged in.
+ *
+ * @param deviceName - Must match the type the caller intends to pair
+ * (Trezor vs OneKey): a keyring created here (when none exists yet) is
+ * reused for whichever device the user picks, but only if it was created
+ * with the right type.
  */
-export function listTrezorDevices(): ThunkAction<
+export function listTrezorDevices(
+  deviceName:
+    | HardwareDeviceNames.trezor
+    | HardwareDeviceNames.oneKey = HardwareDeviceNames.trezor,
+): ThunkAction<
   Promise<TrezorDevice[]>,
   MetaMaskReduxState,
   unknown,
@@ -1564,7 +1573,7 @@ export function listTrezorDevices(): ThunkAction<
     try {
       return await submitRequestToBackground<TrezorDevice[]>(
         'listTrezorDevices',
-        [],
+        [deviceName],
       );
     } catch (error) {
       logErrorWithMessage(error);

--- a/ui/store/actions.ts
+++ b/ui/store/actions.ts
@@ -151,7 +151,7 @@ import {
   LedgerTransportTypes,
   LEDGER_USB_VENDOR_ID,
 } from '../../shared/constants/hardware-wallets';
-import type { TrezorDevice } from '../../shared/constants/offscreen-communication';
+import type { TrezorDeviceIdentity } from '../../shared/constants/offscreen-communication';
 import {
   MetaMetricsEventFragment,
   MetaMetricsEventOptions,
@@ -1550,29 +1550,32 @@ export function forgetDevice(
 }
 
 /**
- * Lists Trezor devices currently connected over USB, regardless of whether
- * they have already been paired to a keyring. Used to let the user choose
- * which physical device to pair when more than one is plugged in.
+ * Identifies which physical Trezor/OneKey device the user intends to
+ * connect: an unpinned probe that opens TrezorConnect's popup (and the
+ * browser's own WebUSB chooser) so the user picks the device — including a
+ * never-paired one, which no enumeration can see until it has been granted
+ * permission. Returns the device's stable identity, or `undefined` when the
+ * bridge does not support identification.
  *
  * @param deviceName - Must match the type the caller intends to pair
  * (Trezor vs OneKey): a keyring created here (when none exists yet) is
  * reused for whichever device the user picks, but only if it was created
  * with the right type.
  */
-export function listTrezorDevices(
+export function identifyTrezorDevice(
   deviceName:
     | HardwareDeviceNames.trezor
     | HardwareDeviceNames.oneKey = HardwareDeviceNames.trezor,
 ): ThunkAction<
-  Promise<TrezorDevice[]>,
+  Promise<TrezorDeviceIdentity | undefined>,
   MetaMaskReduxState,
   unknown,
   AnyAction
 > {
   return async () => {
     try {
-      return await submitRequestToBackground<TrezorDevice[]>(
-        'listTrezorDevices',
+      return await submitRequestToBackground<TrezorDeviceIdentity | undefined>(
+        'identifyTrezorDevice',
         [deviceName],
       );
     } catch (error) {
@@ -1591,8 +1594,8 @@ export function connectHardware(
   loadHid: boolean,
   t: (key: string) => string,
   // For Trezor/OneKey only: pair or reconnect to this specific device (see
-  // `listTrezorDevices`). Omit to use (or create, if none exists yet) the
-  // first keyring of the type.
+  // `identifyTrezorDevice`). Omit to use (or create, if none exists yet)
+  // the first keyring of the type.
   deviceId?: string,
 ): ThunkAction<
   Promise<{ address: string }[]>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -5407,7 +5407,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/account-tree-controller@npm:^7.5.3, @metamask/account-tree-controller@npm:^7.5.5":
+"@metamask/account-tree-controller@npm:7.5.5":
   version: 7.5.5
   resolution: "@metamask/account-tree-controller@npm:7.5.5"
   dependencies:
@@ -5429,6 +5429,31 @@ __metadata:
     "@metamask/providers": ^22.0.0
     webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
   checksum: 10/18913a9cdf65a5ab640d2cb608f6fb46b0f4ebce1537d4ed3e6502392efb15acb45b0648319a861421e6f527a40c7574e9e505fc4cefdc4f9fde0a06df1e428e
+  languageName: node
+  linkType: hard
+
+"@metamask/account-tree-controller@patch:@metamask/account-tree-controller@npm%3A7.5.5#~/.yarn/patches/@metamask-account-tree-controller-npm-7.5.5-7e92299d95.patch":
+  version: 7.5.5
+  resolution: "@metamask/account-tree-controller@patch:@metamask/account-tree-controller@npm%3A7.5.5#~/.yarn/patches/@metamask-account-tree-controller-npm-7.5.5-7e92299d95.patch::version=7.5.5&hash=797eb1"
+  dependencies:
+    "@metamask/accounts-controller": "npm:^39.0.5"
+    "@metamask/base-controller": "npm:^9.1.0"
+    "@metamask/keyring-api": "npm:^23.5.0"
+    "@metamask/keyring-controller": "npm:^27.1.0"
+    "@metamask/messenger": "npm:^2.0.0"
+    "@metamask/multichain-account-service": "npm:^13.0.0"
+    "@metamask/profile-sync-controller": "npm:^28.3.0"
+    "@metamask/snaps-controllers": "npm:^19.0.0"
+    "@metamask/snaps-sdk": "npm:^11.0.0"
+    "@metamask/snaps-utils": "npm:^12.1.2"
+    "@metamask/superstruct": "npm:^3.1.0"
+    "@metamask/utils": "npm:^11.11.0"
+    fast-deep-equal: "npm:^3.1.3"
+    lodash: "npm:^4.17.21"
+  peerDependencies:
+    "@metamask/providers": ^22.0.0
+    webextension-polyfill: ^0.10.0 || ^0.11.0 || ^0.12.0
+  checksum: 10/280c8ef9cd7899cda76ed1fe279a3e0ecfa4926951e0ef491c314ea4996ce8dee5625061b7a7e10e5f9de6082227594632e00819bdc46f34d03136859b2acdbd
   languageName: node
   linkType: hard
 
@@ -6575,7 +6600,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@metamask/eth-trezor-keyring@npm:^10.1.0":
+"@metamask/eth-trezor-keyring@npm:10.1.0":
   version: 10.1.0
   resolution: "@metamask/eth-trezor-keyring@npm:10.1.0"
   dependencies:
@@ -6592,6 +6617,26 @@ __metadata:
     hdkey: "npm:^2.1.0"
     tslib: "npm:^2.6.2"
   checksum: 10/20ac27bbb4d6a19807db8108eb941e2b37225e01d2a8efafad5e64d91736caa95de70a0399ccbd9db9e31a76bbc85903a8332c2ef6e3f4f6229d76e48b7a8dd5
+  languageName: node
+  linkType: hard
+
+"@metamask/eth-trezor-keyring@patch:@metamask/eth-trezor-keyring@npm%3A10.1.0#~/.yarn/patches/@metamask-eth-trezor-keyring-npm-10.1.0-70aadca269.patch":
+  version: 10.1.0
+  resolution: "@metamask/eth-trezor-keyring@patch:@metamask/eth-trezor-keyring@npm%3A10.1.0#~/.yarn/patches/@metamask-eth-trezor-keyring-npm-10.1.0-70aadca269.patch::version=10.1.0&hash=eb1f66"
+  dependencies:
+    "@ethereumjs/tx": "npm:^5.4.0"
+    "@ethereumjs/util": "npm:^9.1.0"
+    "@metamask/eth-sig-util": "npm:^8.2.0"
+    "@metamask/hw-wallet-sdk": "npm:^0.8.0"
+    "@metamask/keyring-api": "npm:^23.1.0"
+    "@metamask/keyring-sdk": "npm:^2.1.1"
+    "@metamask/keyring-utils": "npm:^3.3.1"
+    "@metamask/utils": "npm:^11.11.0"
+    "@trezor/connect-plugin-ethereum": "npm:^9.0.5"
+    "@trezor/connect-web": "npm:^9.6.0"
+    hdkey: "npm:^2.1.0"
+    tslib: "npm:^2.6.2"
+  checksum: 10/47a932739c01001e07c6ecee66c38f26d6f48b37397053fa0726b0b7ba5184a39682aa5423e42c24ac68d2491e7df3350e911c95e2b7edf2b9ac61cacbd40672
   languageName: node
   linkType: hard
 
@@ -32843,7 +32888,7 @@ __metadata:
     "@metamask/7715-permission-types": "npm:^0.7.1"
     "@metamask/abi-utils": "npm:^3.0.0"
     "@metamask/account-api": "npm:^1.0.4"
-    "@metamask/account-tree-controller": "npm:^7.5.3"
+    "@metamask/account-tree-controller": "patch:@metamask/account-tree-controller@npm%3A7.5.5#~/.yarn/patches/@metamask-account-tree-controller-npm-7.5.5-7e92299d95.patch"
     "@metamask/account-watcher": "npm:^4.1.3"
     "@metamask/accounts-controller": "npm:^39.0.3"
     "@metamask/address-book-controller": "npm:^7.1.2"
@@ -32900,7 +32945,7 @@ __metadata:
     "@metamask/eth-sig-util": "npm:^8.2.0"
     "@metamask/eth-snap-keyring": "npm:^22.3.0"
     "@metamask/eth-token-tracker": "npm:^10.0.2"
-    "@metamask/eth-trezor-keyring": "npm:^10.1.0"
+    "@metamask/eth-trezor-keyring": "patch:@metamask/eth-trezor-keyring@npm%3A10.1.0#~/.yarn/patches/@metamask-eth-trezor-keyring-npm-10.1.0-70aadca269.patch"
     "@metamask/etherscan-link": "npm:^3.0.0"
     "@metamask/forwarder": "npm:^1.1.0"
     "@metamask/foundryup": "npm:^1.0.1"


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes hardware keyring selection, Trezor request routing, and persisted app state (`trezorModels`), with large behavioral shifts delivered via vendored package patches—errors could mis-target devices or break signing with multiple devices connected.
> 
> **Overview**
> Adds **multi-device Trezor/OneKey** support so each paired physical device gets its own keyring, bridge routing by stable `device_id`, and a separate account-tree wallet section instead of one shared “Trezor” bucket.
> 
> **Transport & bridges:** The MV3 offscreen Trezor handler and MV2 `SuiteDesktopConnect` bridge now keep a **device registry** (connect/changed/disconnect), expose **`listDevices`**, and pass **`deviceId`** on signing/`getFeatures` calls. Trezor Connect is **initialized once** per offscreen document with **reference-counted `dispose`**, replacing per-keyring dispose/re-init that broke a second device. Patched **`@metamask/eth-trezor-keyring`** persists **`deviceId`** after unlock via `getFeatures` and threads it through the bridge.
> 
> **Controller & UI:** Hardware APIs (`connectHardware`, `forgetDevice`, `unlockHardwareWalletAccount`, etc.) accept optional **`deviceId`**; `#findOrCreateHardwareKeyringForDevice` resolves or creates the matching keyring. Connect-hardware flow calls **`listTrezorDevices`** and shows a **device picker** when more than one unit is plugged in. App state **`trezorModel`** becomes **`trezorModels`** keyed by `device_id`.
> 
> **Patches:** Yarn patches on **`account-tree-controller`** split Trezor/OneKey wallets by keyring instance id and disambiguate display names (`"Trezor N"` / device label).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3112491662b3405b9e1f5cba77733205b7f5cca3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->