### PR TITLE
fix(pure-black): remove border-l and bg-alternative from drawer in popup/compact sidepanel

### DIFF
--- a/ui/components/multichain/global-menu-drawer/global-menu-drawer.test.tsx
+++ b/ui/components/multichain/global-menu-drawer/global-menu-drawer.test.tsx
@@ -104,7 +104,9 @@ describe('GlobalMenuDrawer', () => {
     );
 
     await waitFor(() => {
-      expect(container.querySelector('.border-l.border-muted')).not.toBeInTheDocument();
+      expect(
+        container.querySelector('.border-l.border-muted'),
+      ).not.toBeInTheDocument();
     });
   });
 

--- a/ui/components/multichain/global-menu-drawer/global-menu-drawer.test.tsx
+++ b/ui/components/multichain/global-menu-drawer/global-menu-drawer.test.tsx
@@ -8,6 +8,7 @@ import {
   NETWORKS_ROUTE,
   PERMISSIONS,
 } from '../../../helpers/constants/routes';
+import { ENVIRONMENT_TYPE_POPUP } from '../../../../shared/constants/app';
 import { isGatorPermissionsRevocationFeatureEnabled } from '../../../../shared/lib/environment';
 import { GlobalMenuDrawer } from './global-menu-drawer';
 import { GlobalMenuDrawerWithList } from './global-menu-drawer-with-list';
@@ -86,9 +87,13 @@ describe('GlobalMenuDrawer', () => {
     expect(getByTestId('global-menu-drawer')).toBeInTheDocument();
   });
 
-  it('applies border in pure black mode', async () => {
+  // Fullscreen drawer uses a portal that requires layout measurement — tested via manual QA.
+  // The border-l is applied only when isPureBlack && isLargeDrawer (fullscreen or wide sidepanel).
+
+  it('does not apply border-l in pure black mode on popup', async () => {
     const { usePureBlack } = jest.requireMock('@metamask/design-system-react');
     usePureBlack.mockReturnValue(true);
+    getEnvironmentType.mockReturnValue(ENVIRONMENT_TYPE_POPUP);
 
     const { container } = renderWithProvider(
       <GlobalMenuDrawer isOpen onClose={() => undefined}>
@@ -99,8 +104,7 @@ describe('GlobalMenuDrawer', () => {
     );
 
     await waitFor(() => {
-      const panel = container.querySelector('.border-l.border-muted');
-      expect(panel).toBeInTheDocument();
+      expect(container.querySelector('.border-l.border-muted')).not.toBeInTheDocument();
     });
   });
 

--- a/ui/components/multichain/global-menu-drawer/global-menu-drawer.tsx
+++ b/ui/components/multichain/global-menu-drawer/global-menu-drawer.tsx
@@ -63,6 +63,8 @@ export const GlobalMenuDrawer = ({
   const [contentTopOffset, setContentTopOffset] = useState(0);
   const [isCompactSidepanelDrawer, setIsCompactSidepanelDrawer] =
     useState(false);
+  // TODO: @metamask/design-system-engineers remove once pure black is shipped targeted(13.43.0)
+  const isLargeDrawer = isFullscreen || (isSidepanel && !isCompactSidepanelDrawer);
   const [drawerPhase, setDrawerPhase] = useState<DrawerPhase | null>(() =>
     isOpen && !usePortal ? 'open' : null,
   );
@@ -362,9 +364,9 @@ export const GlobalMenuDrawer = ({
           style={{ maxWidth: isCompactSidepanelDrawer ? undefined : width }}
         >
           <Box
-            className={`h-full min-h-0 flex flex-col overflow-hidden shadow-[var(--shadow-size-lg)_var(--color-shadow-default)]${isPureBlack ? ' border-l border-muted' : ''}`}
+            className={`h-full min-h-0 flex flex-col overflow-hidden shadow-[var(--shadow-size-lg)_var(--color-shadow-default)]${isPureBlack && isLargeDrawer ? ' border-l border-muted' : ''}`}
             backgroundColor={
-              isPureBlack
+              isPureBlack && isLargeDrawer
                 ? BoxBackgroundColor.BackgroundAlternative
                 : BoxBackgroundColor.BackgroundDefault
             }

--- a/ui/components/multichain/global-menu-drawer/global-menu-drawer.tsx
+++ b/ui/components/multichain/global-menu-drawer/global-menu-drawer.tsx
@@ -64,7 +64,8 @@ export const GlobalMenuDrawer = ({
   const [isCompactSidepanelDrawer, setIsCompactSidepanelDrawer] =
     useState(false);
   // TODO: @metamask/design-system-engineers remove once pure black is shipped targeted(13.43.0)
-  const isLargeDrawer = isFullscreen || (isSidepanel && !isCompactSidepanelDrawer);
+  const isLargeDrawer =
+    isFullscreen || (isSidepanel && !isCompactSidepanelDrawer);
   const [drawerPhase, setDrawerPhase] = useState<DrawerPhase | null>(() =>
     isOpen && !usePortal ? 'open' : null,
   );


### PR DESCRIPTION
## **Description**

In pure black (OLED) dark mode, the global menu drawer showed a `border-l border-muted` and `bg-background-alternative` background on all screen sizes. On popup and compact sidepanel these caused two issues:

- **TMCU-1171** (double border): The left border combined with the page edge created a visible double border on the left of the drawer
- **TMCU-1172** (sidebar not pure black): `bg-background-alternative` is slightly off-black, but in popup/compact mode the drawer should blend with the pure black surface using `bg-background-default`

**Fix:** Gate both on `isLargeDrawer` — true only for fullscreen or wide sidepanel. Popup and compact sidepanel now get `bg-background-default` with no border, matching the surrounding pure black background.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1171, https://consensyssoftware.atlassian.net/browse/TMCU-1172

## **Manual testing steps**

1. Add `MM_PURE_BLACK_PREVIEW=true` to `.metamaskrc`, set MetaMask theme to Dark
2. Open the extension in **popup** mode and open the hamburger menu drawer
3. Verify no double border on the left edge and the drawer background is pure black (`bg-background-default`)
4. Open in **fullscreen** — verify the `border-l` separator and `bg-background-alternative` are still present
5. Remove the flag and confirm no regression in normal dark mode

## **Screenshots/Recordings**

### **Before**

Popup drawer shows border-l double border and bg-alternative (off-black) in both expanded and popup view

https://github.com/user-attachments/assets/d0a6c633-c65b-4494-b9f5-7c667f3b3ad9

### **After**

Popup drawer has no border-l and bg-default (pure black) in popup view

https://github.com/user-attachments/assets/e7e5497a-1762-4435-a059-a33abb23f6c4

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped UI/theming change in the global menu drawer with a targeted unit test; no auth, data, or security impact.
> 
> **Overview**
> In **pure black (OLED) dark mode**, the global menu drawer no longer applies the left **`border-l border-muted`** separator or **`bg-background-alternative`** on **popup** and **compact sidepanel**. Those styles are now limited to **large** drawers—fullscreen or a wide sidepanel—via a new **`isLargeDrawer`** flag.
> 
> Popup/compact layouts use **`bg-background-default`** so the drawer matches the surrounding pure black surface and avoids the double left-edge border (TMCU-1171 / TMCU-1172). Tests were updated to assert no border on popup in pure black; fullscreen portal styling is called out for manual QA.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae3c84734524afa21d7ff0f014ecf441cb67974e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->