### PR TITLE
chore: popover for failed transaction status

### DIFF
--- a/ui/components/app/transaction/transaction-status.tsx
+++ b/ui/components/app/transaction/transaction-status.tsx
@@ -67,7 +67,7 @@ export function TransactionStatus({
         type="button"
         className="border-0 bg-transparent p-0"
         // @ts-expect-error We need to update React types
-        interestfor={id}
+        interestfor={id} // eslint-disable-line react/no-unknown-property
       >
         {label}
       </button>

--- a/ui/components/app/transaction/transaction-status.tsx
+++ b/ui/components/app/transaction/transaction-status.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useId } from 'react';
+import { useLocalTransactionMeta } from '#ui/hooks/activity/useLocalTransactionMeta';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 
 const statusConfig: Record<
@@ -30,17 +31,55 @@ const statusConfig: Record<
   },
 };
 
-export function TransactionStatus({ status }: { status: string }) {
+export function TransactionStatus({
+  status,
+  hash,
+}: {
+  status: string;
+  hash?: string;
+}) {
   const t = useI18nContext();
+  const id = useId();
   const config = statusConfig[status];
+  const localError = useLocalTransactionMeta(hash)?.error;
+  const error =
+    status === 'failed'
+      ? localError?.rpc?.message || localError?.message
+      : undefined;
 
   if (!config) {
     return null;
   }
 
-  return (
+  const label = (
     <span className={config.className} data-testid={config.testId}>
       {t(config.messageKey)}
     </span>
+  );
+
+  if (!error) {
+    return label;
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        className="border-0 bg-transparent p-0"
+        // @ts-expect-error We need to update React types
+        interestfor={id}
+      >
+        {label}
+      </button>
+      <div
+        id={id}
+        data-testid="transaction-status-error-tooltip"
+        className="m-0 max-w-[250px] rounded-lg border border-border-muted bg-background-default p-4 text-start text-text-default shadow-md [position-area:bottom]"
+        // @ts-expect-error We need to update React types
+        popover="hint"
+      >
+        {error}
+      </div>
+    </>
   );
 }

--- a/ui/components/app/transaction/transaction-status.tsx
+++ b/ui/components/app/transaction/transaction-status.tsx
@@ -1,5 +1,5 @@
 import React, { useId } from 'react';
-import { useLocalTransactionMeta } from '#ui/hooks/activity/useLocalTransactionMeta';
+import { useLocalTransactionMeta } from '../../../hooks/activity/useLocalTransactionMeta';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 
 const statusConfig: Record<

--- a/ui/pages/activity/activity-list.tsx
+++ b/ui/pages/activity/activity-list.tsx
@@ -200,7 +200,7 @@ export function ActivityList({
 
       <dialog
         ref={dialogRef}
-        className="dialog-modal w-full h-dvh max-h-dvh mx-auto p-0 border-0 bg-background-default"
+        className="dialog-modal w-full h-dvh max-h-dvh mx-auto p-0 border-0 bg-background-default text-default"
         onClose={handleClose}
       >
         <TransactionDetails

--- a/ui/pages/details/components/sections.tsx
+++ b/ui/pages/details/components/sections.tsx
@@ -1,15 +1,15 @@
 import React from 'react';
-import { TransactionStatus } from '#ui/components/app/transaction/transaction-status';
 import type {
   ActivityListItem,
   TokenAmount,
 } from '../../../../shared/lib/activity/types';
-import { useI18nContext } from '../../../hooks/useI18nContext';
-import { useFormatters } from '../../../hooks/useFormatters';
-import { NetworkName } from '../../../components/app/transaction/network-name';
-import { AccountName } from '../../../components/app/transaction/account-name';
-import { TransactionId } from '../../../components/app/transaction/transaction-id';
 import { isValidTransactionHash } from '../../../../shared/lib/transactions.utils';
+import { AccountName } from '../../../components/app/transaction/account-name';
+import { NetworkName } from '../../../components/app/transaction/network-name';
+import { TransactionId } from '../../../components/app/transaction/transaction-id';
+import { TransactionStatus } from '../../../components/app/transaction/transaction-status';
+import { useFormatters } from '../../../hooks/useFormatters';
+import { useI18nContext } from '../../../hooks/useI18nContext';
 import { Row, Section } from './shared';
 import { TokenRow } from './token-row';
 

--- a/ui/pages/details/components/sections.tsx
+++ b/ui/pages/details/components/sections.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { TransactionStatus } from '#ui/components/app/transaction/transaction-status';
 import type {
   ActivityListItem,
   TokenAmount,
@@ -6,7 +7,6 @@ import type {
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useFormatters } from '../../../hooks/useFormatters';
 import { NetworkName } from '../../../components/app/transaction/network-name';
-import { TransactionStatus } from '../../../components/app/transaction/transaction-status';
 import { AccountName } from '../../../components/app/transaction/account-name';
 import { TransactionId } from '../../../components/app/transaction/transaction-id';
 import { isValidTransactionHash } from '../../../../shared/lib/transactions.utils';
@@ -61,7 +61,7 @@ export function MetadataSection({
     <Section>
       <Row
         label={t('status')}
-        value={<TransactionStatus status={item.status} />}
+        value={<TransactionStatus status={item.status} hash={item.hash} />}
       />
 
       <Row label={t('date')} value={formatDateTime(item.timestamp)} />

--- a/ui/pages/details/templates/bridge-details/bridge-details.tsx
+++ b/ui/pages/details/templates/bridge-details/bridge-details.tsx
@@ -129,7 +129,7 @@ export function BridgeDetails({
         <Section>
           <Row
             label={t('status')}
-            value={<TransactionStatus status={status} />}
+            value={<TransactionStatus status={status} hash={item.hash} />}
           />
           <Row label={t('date')} value={formatDateTime(item.timestamp)} />
           {showFromToAccountRows ? (

--- a/ui/pages/details/templates/perps-deposit-details.tsx
+++ b/ui/pages/details/templates/perps-deposit-details.tsx
@@ -67,7 +67,7 @@ export function PerpsDepositDetails({ item }: Readonly<Props>) {
         <Section>
           <Row
             label={t('status')}
-            value={<TransactionStatus status={item.status} />}
+            value={<TransactionStatus status={item.status} hash={item.hash} />}
           />
 
           <Row label={t('date')} value={formatDateTime(item.timestamp)} />

--- a/ui/pages/details/templates/perps-details.tsx
+++ b/ui/pages/details/templates/perps-details.tsx
@@ -83,7 +83,7 @@ export function PerpsDetails({
         <Section>
           <Row
             label={t('status')}
-            value={<TransactionStatus status={item.status} />}
+            value={<TransactionStatus status={item.status} hash={item.hash} />}
           />
           <Row label={t('date')} value={formatDateTime(item.timestamp)} />
           <Row


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Popover for failed transaction status

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Fail a transaction
2. Activity > transaciton details
3. Hover over failed status

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<img width="272" height="127" alt="image" src="https://github.com/user-attachments/assets/5bedc125-1e0c-4fcc-a81e-630a63edd4b8" />

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only change using the Popover API and existing local tx meta; no auth or transaction submission logic touched.
> 
> **Overview**
> Failed transaction status on activity detail screens can now surface the underlying error message from local transaction metadata.
> 
> **`TransactionStatus`** accepts an optional `hash`, loads errors via `useLocalTransactionMeta`, and when status is `failed` and a message exists (RPC or generic), the status label becomes a control that opens a **hint popover** with the error text. Call sites in metadata and detail templates pass `item.hash` (or bridge `item.hash`). The activity details dialog also sets **`text-default`** for consistent typography.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0c802a4a9ad1562c382a0706884aad8e0a62232. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->