### PR TITLE
fix(pure-black): use background-default on Back up SRP onboarding page

### DIFF
--- a/ui/pages/onboarding-flow/onboarding-flow.test.tsx
+++ b/ui/pages/onboarding-flow/onboarding-flow.test.tsx
@@ -192,6 +192,11 @@ jest.mock('../../hooks/useSidePanelEnabled', () => ({
   useSidePanelEnabled: jest.fn(() => false),
 }));
 
+jest.mock('@metamask/design-system-react', () => ({
+  ...jest.requireActual('@metamask/design-system-react'),
+  usePureBlack: jest.fn(() => false),
+}));
+
 function createDeferred<ResolvedValue = void>() {
   let resolvePromise: (
     value: ResolvedValue | PromiseLike<ResolvedValue>,
@@ -653,5 +658,48 @@ describe('Onboarding Flow', () => {
 
     // Restore build type
     process.env.METAMASK_BUILD_TYPE = 'main';
+  });
+
+  describe('pure black theme', () => {
+    afterEach(() => {
+      const { usePureBlack } = jest.requireMock(
+        '@metamask/design-system-react',
+      );
+      usePureBlack.mockReturnValue(false);
+    });
+
+    it('applies background-default to the container in pure black mode on Back up SRP page', () => {
+      const { usePureBlack } = jest.requireMock(
+        '@metamask/design-system-react',
+      );
+      usePureBlack.mockReturnValue(true);
+
+      const { getByTestId } = renderWithProvider(
+        <OnboardingFlowWithRouteContext />,
+        store,
+        ONBOARDING_REVEAL_SRP_ROUTE,
+      );
+
+      expect(getByTestId('onboarding-flow-container')).toHaveStyle({
+        backgroundColor: 'var(--color-background-default)',
+      });
+    });
+
+    it('applies background-muted to the container when pure black is off', () => {
+      const { usePureBlack } = jest.requireMock(
+        '@metamask/design-system-react',
+      );
+      usePureBlack.mockReturnValue(false);
+
+      const { getByTestId } = renderWithProvider(
+        <OnboardingFlowWithRouteContext />,
+        store,
+        ONBOARDING_REVEAL_SRP_ROUTE,
+      );
+
+      expect(getByTestId('onboarding-flow-container')).toHaveStyle({
+        backgroundColor: 'var(--color-background-muted)',
+      });
+    });
   });
 });

--- a/ui/pages/onboarding-flow/onboarding-flow.test.tsx
+++ b/ui/pages/onboarding-flow/onboarding-flow.test.tsx
@@ -192,11 +192,6 @@ jest.mock('../../hooks/useSidePanelEnabled', () => ({
   useSidePanelEnabled: jest.fn(() => false),
 }));
 
-jest.mock('@metamask/design-system-react', () => ({
-  ...jest.requireActual('@metamask/design-system-react'),
-  usePureBlack: jest.fn(() => false),
-}));
-
 function createDeferred<ResolvedValue = void>() {
   let resolvePromise: (
     value: ResolvedValue | PromiseLike<ResolvedValue>,
@@ -658,48 +653,5 @@ describe('Onboarding Flow', () => {
 
     // Restore build type
     process.env.METAMASK_BUILD_TYPE = 'main';
-  });
-
-  describe('pure black theme', () => {
-    afterEach(() => {
-      const { usePureBlack } = jest.requireMock(
-        '@metamask/design-system-react',
-      );
-      usePureBlack.mockReturnValue(false);
-    });
-
-    it('applies background-default to the container in pure black mode on Back up SRP page', () => {
-      const { usePureBlack } = jest.requireMock(
-        '@metamask/design-system-react',
-      );
-      usePureBlack.mockReturnValue(true);
-
-      const { getByTestId } = renderWithProvider(
-        <OnboardingFlowWithRouteContext />,
-        store,
-        ONBOARDING_REVEAL_SRP_ROUTE,
-      );
-
-      expect(getByTestId('onboarding-flow-container')).toHaveStyle({
-        backgroundColor: 'var(--color-background-default)',
-      });
-    });
-
-    it('applies background-muted to the container when pure black is off', () => {
-      const { usePureBlack } = jest.requireMock(
-        '@metamask/design-system-react',
-      );
-      usePureBlack.mockReturnValue(false);
-
-      const { getByTestId } = renderWithProvider(
-        <OnboardingFlowWithRouteContext />,
-        store,
-        ONBOARDING_REVEAL_SRP_ROUTE,
-      );
-
-      expect(getByTestId('onboarding-flow-container')).toHaveStyle({
-        backgroundColor: 'var(--color-background-muted)',
-      });
-    });
   });
 });

--- a/ui/pages/onboarding-flow/onboarding-flow.tsx
+++ b/ui/pages/onboarding-flow/onboarding-flow.tsx
@@ -16,7 +16,6 @@ import {
   BoxFlexDirection,
   BoxAlignItems,
   BoxJustifyContent,
-  usePureBlack,
 } from '@metamask/design-system-react';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0021): route-isolation backlog
 import Unlock from '../unlock-page';
@@ -383,9 +382,6 @@ export default function OnboardingFlow() {
     pathname === ONBOARDING_UNLOCK_ROUTE ||
     (isFlask() && pathname === ONBOARDING_EXPERIMENTAL_AREA);
 
-  // TODO: @metamask/design-system-engineers remove isPureBlack once pure black is shipped targeted(13.43.0)
-  const isPureBlack = usePureBlack();
-
   const backgroundColorForWelcomePage = useMemo(() => {
     if (isWelcomePage) {
       return theme === ThemeType.light
@@ -398,16 +394,6 @@ export default function OnboardingFlow() {
   const isTransparentContainer =
     [ONBOARDING_WELCOME_ROUTE, ONBOARDING_UNLOCK_ROUTE].includes(pathname) ||
     isPopup;
-
-  // In pure black (OLED) mode the muted card looks gray against #000; use
-  // background-default so pages like Back up SRP match the pure black schema.
-  // TODO: @metamask/design-system-engineers remove isPureBlack once pure black is shipped targeted(13.43.0)
-  let containerBackgroundColor = 'var(--color-background-muted)';
-  if (isTransparentContainer) {
-    containerBackgroundColor = 'transparent';
-  } else if (isPureBlack) {
-    containerBackgroundColor = 'var(--color-background-default)';
-  }
 
   return (
     <Box
@@ -446,9 +432,10 @@ export default function OnboardingFlow() {
         }
         marginBottom={pathname === ONBOARDING_EXPERIMENTAL_AREA ? 6 : 0}
         style={{
-          backgroundColor: containerBackgroundColor,
+          backgroundColor: isTransparentContainer
+            ? 'transparent'
+            : 'var(--color-background-default)',
         }}
-        data-testid="onboarding-flow-container"
       >
         <ErrorBoundary>
           <Suspense fallback={null}>

--- a/ui/pages/onboarding-flow/onboarding-flow.tsx
+++ b/ui/pages/onboarding-flow/onboarding-flow.tsx
@@ -16,6 +16,7 @@ import {
   BoxFlexDirection,
   BoxAlignItems,
   BoxJustifyContent,
+  usePureBlack,
 } from '@metamask/design-system-react';
 // eslint-disable-next-line import-x/no-restricted-paths -- TODO(ADR-0021): route-isolation backlog
 import Unlock from '../unlock-page';
@@ -382,6 +383,9 @@ export default function OnboardingFlow() {
     pathname === ONBOARDING_UNLOCK_ROUTE ||
     (isFlask() && pathname === ONBOARDING_EXPERIMENTAL_AREA);
 
+  // TODO: @metamask/design-system-engineers remove isPureBlack once pure black is shipped targeted(13.43.0)
+  const isPureBlack = usePureBlack();
+
   const backgroundColorForWelcomePage = useMemo(() => {
     if (isWelcomePage) {
       return theme === ThemeType.light
@@ -390,6 +394,20 @@ export default function OnboardingFlow() {
     }
     return 'var(--color-background-default)';
   }, [isWelcomePage, theme]);
+
+  const isTransparentContainer =
+    [ONBOARDING_WELCOME_ROUTE, ONBOARDING_UNLOCK_ROUTE].includes(pathname) ||
+    isPopup;
+
+  // In pure black (OLED) mode the muted card looks gray against #000; use
+  // background-default so pages like Back up SRP match the pure black schema.
+  // TODO: @metamask/design-system-engineers remove isPureBlack once pure black is shipped targeted(13.43.0)
+  let containerBackgroundColor = 'var(--color-background-muted)';
+  if (isTransparentContainer) {
+    containerBackgroundColor = 'transparent';
+  } else if (isPureBlack) {
+    containerBackgroundColor = 'var(--color-background-default)';
+  }
 
   return (
     <Box
@@ -428,13 +446,9 @@ export default function OnboardingFlow() {
         }
         marginBottom={pathname === ONBOARDING_EXPERIMENTAL_AREA ? 6 : 0}
         style={{
-          backgroundColor:
-            [ONBOARDING_WELCOME_ROUTE, ONBOARDING_UNLOCK_ROUTE].includes(
-              pathname,
-            ) || isPopup
-              ? 'transparent'
-              : 'var(--color-background-muted)',
+          backgroundColor: containerBackgroundColor,
         }}
+        data-testid="onboarding-flow-container"
       >
         <ErrorBoundary>
           <Suspense fallback={null}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

In pure black (OLED) dark mode, the onboarding flow content container used `background-muted`, so Secret Recovery Phrase backup pages rendered as a gray card on `#000` instead of a pure black surface.

This simplifies the container to always use `var(--color-background-default)` for non-transparent onboarding pages (welcome/unlock/popup remain transparent). No `usePureBlack` branching is needed.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1187

## **Manual testing steps**

1. Add `MM_PURE_BLACK_PREVIEW=true` to `.metamaskrc` and set the MetaMask theme to Dark.
2. Create a new wallet and proceed to the Save / Back up Secret Recovery Phrase onboarding step.
3. Confirm the page/container background is pure black (`#000` / `background-default`), not a muted gray card.
4. Also spot-check create-password and other onboarding steps still look correct.

## **Screenshots/Recordings**

### **Before**

Muted onboarding container (`background-muted`) on pure black:

[Before: muted gray SRP backup container](https://cursor.com/agents/bc-68a4b60e-9373-4ab9-a494-a4ff0a860d28/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpure-black-srp%2Fbefore-backup-srp-muted.png)

### **After**

Onboarding container uses `background-default` (pure black):

[After: pure black SRP backup container](https://cursor.com/agents/bc-68a4b60e-9373-4ab9-a494-a4ff0a860d28/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpure-black-srp%2Fafter-backup-srp-pure-black.png)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68a4b60e-9373-4ab9-a494-a4ff0a860d28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68a4b60e-9373-4ab9-a494-a4ff0a860d28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

