### PR TITLE
fix(pure-black): remove borders from Auto close TP/SL inputs

### DIFF
--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.test.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.test.tsx
@@ -75,6 +75,27 @@ describe('AutoCloseSection', () => {
       expect(screen.getByTestId('sl-price-input')).toBeInTheDocument();
     });
 
+    it('removes borders from TP/SL price and percent inputs', () => {
+      renderWithProvider(
+        <AutoCloseSection {...defaultProps} enabled={true} />,
+        mockStore,
+      );
+
+      const inputTestIds = [
+        'tp-price-input',
+        'tp-percent-input',
+        'sl-price-input',
+        'sl-percent-input',
+      ];
+
+      for (const testId of inputTestIds) {
+        const textField = screen.getByTestId(testId).closest('.mm-text-field');
+        expect(textField).toHaveClass('border-0');
+        expect(textField).toHaveClass('mm-box--border-style-none');
+        expect(textField).toHaveClass('mm-box--border-width-0');
+      }
+    });
+
     it('shows percent inputs when enabled', () => {
       renderWithProvider(
         <AutoCloseSection {...defaultProps} enabled={true} />,

--- a/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
+++ b/ui/components/app/perps/order-entry/components/auto-close-section/auto-close-section.tsx
@@ -23,6 +23,7 @@ import {
 
 import {
   BorderRadius,
+  BorderStyle,
   BackgroundColor,
 } from '../../../../../../helpers/constants/design-system';
 import { useI18nContext } from '../../../../../../hooks/useI18nContext';
@@ -502,8 +503,9 @@ export const AutoCloseSection = ({
                   placeholder="0.00"
                   borderRadius={BorderRadius.MD}
                   borderWidth={0}
+                  borderStyle={BorderStyle.none}
                   backgroundColor={BackgroundColor.backgroundMuted}
-                  className="w-full"
+                  className="w-full border-0"
                   data-testid="tp-price-input"
                   inputProps={{
                     inputMode: 'decimal',
@@ -530,8 +532,9 @@ export const AutoCloseSection = ({
                   placeholder="0"
                   borderRadius={BorderRadius.MD}
                   borderWidth={0}
+                  borderStyle={BorderStyle.none}
                   backgroundColor={BackgroundColor.backgroundMuted}
-                  className="w-full"
+                  className="w-full border-0"
                   data-testid="tp-percent-input"
                   inputProps={{
                     inputMode: 'decimal',
@@ -634,8 +637,9 @@ export const AutoCloseSection = ({
                   placeholder="0.00"
                   borderRadius={BorderRadius.MD}
                   borderWidth={0}
+                  borderStyle={BorderStyle.none}
                   backgroundColor={BackgroundColor.backgroundMuted}
-                  className="w-full"
+                  className="w-full border-0"
                   data-testid="sl-price-input"
                   inputProps={{
                     inputMode: 'decimal',
@@ -662,8 +666,9 @@ export const AutoCloseSection = ({
                   placeholder="0"
                   borderRadius={BorderRadius.MD}
                   borderWidth={0}
+                  borderStyle={BorderStyle.none}
                   backgroundColor={BackgroundColor.backgroundMuted}
-                  className="w-full"
+                  className="w-full border-0"
                   data-testid="sl-percent-input"
                   inputProps={{
                     inputMode: 'decimal',

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.test.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.test.tsx
@@ -222,6 +222,24 @@ describe('UpdateTPSLModalContent', () => {
       expect(percentInputs).toHaveLength(2);
     });
 
+    it('removes borders from TP/SL price and percent inputs on the sheet', () => {
+      renderTpslModalContent();
+
+      const inputTestIds = [
+        'perps-update-tpsl-tp-price-input',
+        'perps-update-tpsl-tp-percent-input',
+        'perps-update-tpsl-sl-price-input',
+        'perps-update-tpsl-sl-percent-input',
+      ];
+
+      for (const testId of inputTestIds) {
+        const textField = screen.getByTestId(testId).closest('.mm-text-field');
+        expect(textField).toHaveClass('border-0');
+        expect(textField).toHaveClass('mm-box--border-style-none');
+        expect(textField).toHaveClass('mm-box--border-width-0');
+      }
+    });
+
     it('keeps the TP percent value selected after focus switches to the raw value', async () => {
       renderTpslModalContent();
 

--- a/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
+++ b/ui/components/app/perps/update-tpsl/update-tpsl-modal-content.tsx
@@ -37,6 +37,7 @@ import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { TextField, TextFieldSize } from '../../../component-library';
 import {
   BorderRadius,
+  BorderStyle,
   BackgroundColor,
 } from '../../../../helpers/constants/design-system';
 import {
@@ -721,8 +722,9 @@ export const UpdateTPSLModalContent = ({
               placeholder="0.00"
               borderRadius={BorderRadius.MD}
               borderWidth={0}
+              borderStyle={BorderStyle.none}
               backgroundColor={BackgroundColor.backgroundMuted}
-              className="w-full"
+              className="w-full border-0"
               disabled={isSaving}
               autoFocus
               testId="perps-update-tpsl-tp-price-input"
@@ -751,8 +753,9 @@ export const UpdateTPSLModalContent = ({
               placeholder="0"
               borderRadius={BorderRadius.MD}
               borderWidth={0}
+              borderStyle={BorderStyle.none}
               backgroundColor={BackgroundColor.backgroundMuted}
-              className="w-full"
+              className="w-full border-0"
               disabled={isSaving}
               testId="perps-update-tpsl-tp-percent-input"
               inputRef={tpPercentInputRef}
@@ -863,8 +866,9 @@ export const UpdateTPSLModalContent = ({
               placeholder="0.00"
               borderRadius={BorderRadius.MD}
               borderWidth={0}
+              borderStyle={BorderStyle.none}
               backgroundColor={BackgroundColor.backgroundMuted}
-              className="w-full"
+              className="w-full border-0"
               disabled={isSaving}
               testId="perps-update-tpsl-sl-price-input"
               inputProps={{ onKeyDown: handleInputEnterKey }}
@@ -892,8 +896,9 @@ export const UpdateTPSLModalContent = ({
               placeholder="0"
               borderRadius={BorderRadius.MD}
               borderWidth={0}
+              borderStyle={BorderStyle.none}
               backgroundColor={BackgroundColor.backgroundMuted}
-              className="w-full"
+              className="w-full border-0"
               disabled={isSaving}
               testId="perps-update-tpsl-sl-percent-input"
               inputRef={slPercentInputRef}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Removes visible borders from the Take Profit / Stop Loss `TextField` inputs on the Perps **Auto close** sheet (and the matching order-entry auto-close section) so they sit cleanly on the Pure Black modal/sheet background.

Context from Slack (Andrew Cohen): “Border on inputs needs to be removed or changed when laid on top of this sheet.” Ticket: [TMCU-1169](https://consensyssoftware.atlassian.net/browse/TMCU-1169) (epic [TMCU-1130](https://consensyssoftware.atlassian.net/browse/TMCU-1130)).

`borderWidth={0}` alone was not enough to fully suppress the TextField border (SCSS still sets `border-color`, and Tailwind preflight keeps `border-style: solid`). This change also sets `borderStyle={BorderStyle.none}` and adds the Tailwind `border-0` class, matching the existing Perps limit-price input pattern.

## **Changelog**

CHANGELOG entry: Removed borders from Perps Auto close take profit and stop loss inputs in Pure Black theme

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1169

## **Manual testing steps**

1. Run the extension with Pure Black / dark theme enabled.
2. Open Perps and open a position’s **Auto close** (Update TP/SL) modal.
3. Confirm the Take Profit and Stop Loss `$` and `%` inputs have no border on the sheet background.
4. Optionally open order entry Auto close and confirm the same inputs have no border.

## **Screenshots/Recordings**

### **Before**

[Before: Auto close TP/SL inputs with borders on Pure Black sheet](https://cursor.com/agents/bc-e52b73bc-139f-46b2-a25a-2a587d026185/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftmcu-1169-before-auto-close-inputs.png)

### **After**

[After: Auto close TP/SL inputs with borders removed on Pure Black sheet](https://cursor.com/agents/bc-e52b73bc-139f-46b2-a25a-2a587d026185/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftmcu-1169-after-auto-close-inputs.png)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e52b73bc-139f-46b2-a25a-2a587d026185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e52b73bc-139f-46b2-a25a-2a587d026185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[TMCU-1169]: https://consensyssoftware.atlassian.net/browse/TMCU-1169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TMCU-1130]: https://consensyssoftware.atlassian.net/browse/TMCU-1130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ