### PR TITLE
fix(pure-black): use bg-section for Perps balance dropdown menu

### DIFF
--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.test.tsx
@@ -1,19 +1,20 @@
 import React from 'react';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
+import { ThemeType } from '../../../../../shared/constants/preferences';
 import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
 import configureStore from '../../../../store/store';
 import mockState from '../../../../../test/data/mock-state.json';
+import * as useThemeHook from '../../../../hooks/useTheme';
 import { mockAccountState, mockPositions } from '../mocks';
 import {
   PerpsBalanceDropdown,
   invokePerpsBalanceAction,
 } from './perps-balance-dropdown';
 
-const mockUsePureBlack = jest.fn().mockReturnValue(false);
-jest.mock('@metamask/design-system-react', () => ({
-  ...jest.requireActual('@metamask/design-system-react'),
-  usePureBlack: () => mockUsePureBlack(),
-}));
+jest.mock('../../../../hooks/useTheme');
+const mockUseTheme = useThemeHook.useTheme as jest.MockedFunction<
+  typeof useThemeHook.useTheme
+>;
 
 // Mobile test convention: mock the Compliance barrel so the gate hook never runs
 // (and never reaches the now-strict AccessRestrictedProvider context throw). The
@@ -95,6 +96,10 @@ describe('invokePerpsBalanceAction', () => {
 });
 
 describe('PerpsBalanceDropdown', () => {
+  beforeEach(() => {
+    mockUseTheme.mockReturnValue(ThemeType.light);
+  });
+
   it('renders the balance dropdown component', () => {
     renderWithProvider(<PerpsBalanceDropdown />, mockStore);
 
@@ -325,37 +330,39 @@ describe('PerpsBalanceDropdown', () => {
     );
   });
 
-  describe('pure black mode', () => {
+  describe('elevated menu background', () => {
     beforeEach(() => {
-      mockUsePureBlack.mockReturnValue(false);
+      mockUseTheme.mockReturnValue(ThemeType.light);
     });
 
-    it('uses bg-background-default for the dropdown panel in normal dark mode', () => {
-      renderWithProvider(<PerpsBalanceDropdown />, mockStore);
-
-      fireEvent.click(screen.getByTestId('perps-balance-dropdown-balance'));
-
-      expect(screen.getByTestId('perps-balance-dropdown-panel')).toHaveClass(
-        'bg-background-default',
-      );
-      expect(
-        screen.getByTestId('perps-balance-dropdown-panel'),
-      ).not.toHaveClass('bg-background-alternative');
-    });
-
-    it('uses bg-background-alternative for the dropdown panel in pure black mode', () => {
-      mockUsePureBlack.mockReturnValue(true);
+    it('uses bg-default for the dropdown panel in light mode', () => {
+      mockUseTheme.mockReturnValue(ThemeType.light);
 
       renderWithProvider(<PerpsBalanceDropdown />, mockStore);
 
       fireEvent.click(screen.getByTestId('perps-balance-dropdown-balance'));
 
       expect(screen.getByTestId('perps-balance-dropdown-panel')).toHaveClass(
-        'bg-background-alternative',
+        'bg-default',
       );
       expect(
         screen.getByTestId('perps-balance-dropdown-panel'),
-      ).not.toHaveClass('bg-background-default');
+      ).not.toHaveClass('bg-section');
+    });
+
+    it('uses bg-section for the dropdown panel in dark mode (including pure black)', () => {
+      mockUseTheme.mockReturnValue(ThemeType.dark);
+
+      renderWithProvider(<PerpsBalanceDropdown />, mockStore);
+
+      fireEvent.click(screen.getByTestId('perps-balance-dropdown-balance'));
+
+      expect(screen.getByTestId('perps-balance-dropdown-panel')).toHaveClass(
+        'bg-section',
+      );
+      expect(
+        screen.getByTestId('perps-balance-dropdown-panel'),
+      ).not.toHaveClass('bg-default');
     });
   });
 });

--- a/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
+++ b/ui/components/app/perps/perps-balance-dropdown/perps-balance-dropdown.tsx
@@ -2,7 +2,6 @@ import React, { useCallback, useRef, useState } from 'react';
 import { useSelector } from 'react-redux';
 import {
   twMerge,
-  usePureBlack,
   TextVariant,
   TextColor,
   IconColor,
@@ -19,6 +18,7 @@ import {
   ButtonBase,
 } from '@metamask/design-system-react';
 import type { Position } from '@metamask/perps-controller';
+import { ThemeType } from '../../../../../shared/constants/preferences';
 import {
   formatPerpsFiat,
   PRICE_RANGES_MINIMAL_VIEW,
@@ -26,6 +26,7 @@ import {
 import { getPreferences } from '../../../../../shared/lib/selectors/preferences';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { useFormatters } from '../../../../hooks/useFormatters';
+import { useTheme } from '../../../../hooks/useTheme';
 import { usePerpsEligibility } from '../../../../hooks/perps';
 import { usePerpsLiveAccount } from '../../../../hooks/perps/stream';
 import { useSelectedAccountComplianceGate } from '../../compliance';
@@ -88,8 +89,9 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isGeoBlockModalOpen, setIsGeoBlockModalOpen] = useState(false);
 
-  // TODO: @metamask/design-system-engineers remove isPureBlack once pure black is shipped targeted(13.43.0)
-  const isPureBlack = usePureBlack();
+  // Elevated menus: bg-section in dark (incl. pure black), bg-default + shadow in light.
+  const theme = useTheme();
+  const isDarkTheme = theme === ThemeType.dark;
 
   const totalBalance = account?.totalBalance ?? '0';
   const unrealizedPnl = account?.unrealizedPnl ?? '0';
@@ -213,9 +215,7 @@ export const PerpsBalanceDropdown: React.FC<PerpsBalanceDropdownProps> = ({
           <Box
             className={twMerge(
               'absolute right-0 top-full z-10 mt-1 min-w-[120px] overflow-hidden rounded-lg border border-border-muted shadow-lg',
-              isPureBlack
-                ? 'bg-background-alternative'
-                : 'bg-background-default',
+              isDarkTheme ? 'bg-section' : 'bg-default',
             )}
             flexDirection={BoxFlexDirection.Column}
             data-testid="perps-balance-dropdown-panel"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

Updates the Perps Balance Dropdown floating menu background to match the latest elevated-surface guidance for menu-type components:

- **Dark / pure black:** `bg-section` (`#18181b` in pure black)
- **Light:** `bg-default` with existing shadow

### Context

[TMCU-1184](https://consensyssoftware.atlassian.net/browse/TMCU-1184) originally asked for `bg-alternative` in pure black. That was shipped in #44875.

Design guidance for elevated surfaces (one degree above the background) has since updated: use **`section` for dark mode** and **`default` with shadow for light mode** (same elevation pattern as toast). In pure black, `bg-alternative` resolves to `#0d0d0f`, which is nearly indistinguishable from the `#000` page background, while `bg-section` resolves to `#18181b` and provides clear elevation.

This PR replaces the `usePureBlack` / `bg-background-alternative` conditional with a theme-based `useTheme` check (`bg-section` vs `bg-default`).

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1184

## **Manual testing steps**

1. Add `MM_PURE_BLACK_PREVIEW=true` to `.metamaskrc`, set MetaMask theme to **Dark**
2. Open the **Perps** tab and click the Total balance row to open the Add funds / Withdraw menu
3. Confirm the dropdown panel uses an elevated surface (`bg-section`) that is clearly distinct from the pure black page
4. Switch theme to **Light** and reopen the dropdown
5. Confirm the panel uses `bg-default` with a visible shadow and no regression

## **Screenshots/Recordings**

Token-accurate demo using MetaMask design tokens (pure black + light).

### **Before**

Previous pure-black fix (`bg-alternative` → `#0d0d0f` on `#000`):

[Before: Perps balance dropdown using bg-alternative in pure black](https://cursor.com/agents/bc-8afa356e-d3e5-409b-bffc-0ca6f5721b04/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbefore-pure-black-bg-alternative.png)

Original UAT report (menu blending into pure black page):

[Original UAT before screenshot showing menu blending into background](https://cursor.com/agents/bc-8afa356e-d3e5-409b-bffc-0ca6f5721b04/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fbefore-broken-blends.png)

### **After**

Updated requirement (`bg-section` → `#18181b` on `#000`):

[After: Perps balance dropdown using bg-section in pure black](https://cursor.com/agents/bc-8afa356e-d3e5-409b-bffc-0ca6f5721b04/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fafter-pure-black-bg-section.png)

Light mode (`bg-default` + shadow):

[After: Perps balance dropdown using bg-default in light mode](https://cursor.com/agents/bc-8afa356e-d3e5-409b-bffc-0ca6f5721b04/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fafter-light-bg-default.png)

Side-by-side comparison:

[Before/after/light comparison demo](https://cursor.com/agents/bc-8afa356e-d3e5-409b-bffc-0ca6f5721b04/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fdemo-comparison.png)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8afa356e-d3e5-409b-bffc-0ca6f5721b04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8afa356e-d3e5-409b-bffc-0ca6f5721b04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[TMCU-1184]: https://consensyssoftware.atlassian.net/browse/TMCU-1184?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ