### PR TITLE
fix(pure-black): use bg-default for perps markets skeleton rows

### DIFF
--- a/ui/pages/perps/market-list/components/market-row-skeleton/market-row-skeleton.test.tsx
+++ b/ui/pages/perps/market-list/components/market-row-skeleton/market-row-skeleton.test.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { MarketRowSkeleton } from './market-row-skeleton';
+
+describe('MarketRowSkeleton', () => {
+  it('renders the market row skeleton', () => {
+    render(<MarketRowSkeleton />);
+
+    expect(screen.getByTestId('market-row-skeleton')).toBeInTheDocument();
+  });
+
+  it('uses bg-default to match MarketRow in pure black theme', () => {
+    render(<MarketRowSkeleton />);
+
+    expect(screen.getByTestId('market-row-skeleton')).toHaveClass('bg-default');
+  });
+});

--- a/ui/pages/perps/market-list/components/market-row-skeleton/market-row-skeleton.tsx
+++ b/ui/pages/perps/market-list/components/market-row-skeleton/market-row-skeleton.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import {
   Box,
-  BoxBackgroundColor,
   BoxFlexDirection,
   BoxAlignItems,
   Skeleton,
@@ -14,8 +13,7 @@ import {
 export const MarketRowSkeleton = () => {
   return (
     <Box
-      className="px-4 py-3"
-      backgroundColor={BoxBackgroundColor.BackgroundMuted}
+      className="bg-default px-4 py-3"
       flexDirection={BoxFlexDirection.Row}
       alignItems={BoxAlignItems.Center}
       gap={3}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## **Description**

In Pure Black (OLED) dark mode, the Perps Markets list skeleton used `BoxBackgroundColor.BackgroundMuted`, which renders as grey bands against `#000000`. Loaded market rows already use `bg-default`.

This change updates `MarketRowSkeleton` to use `bg-default` so the loading state matches the loaded rows and the pure black page background.

## **Changelog**

CHANGELOG entry: Fixed Perps Markets skeleton background color in Pure Black theme

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/TMCU-1174

## **Manual testing steps**

1. Add `MM_PURE_BLACK_PREVIEW=true` to `.metamaskrc` and set MetaMask theme to Dark.
2. Open Perps → Markets while market data is loading (or throttle the network to keep skeletons visible).
3. Confirm skeleton rows use the same pure black page background as loaded market rows (no grey band behind each row).
4. Disable Pure Black / use standard Dark and confirm skeletons still look correct.

## **Screenshots/Recordings**

Demo using Pure Black design tokens (`--color-background-default: #000000`, `--color-background-muted: #e2e2ff1b`).

### **Before**

`MarketRowSkeleton` with `BackgroundMuted` — grey bands on OLED black:

[Before: markets skeleton with BackgroundMuted grey bands](https://cursor.com/agents/bc-91141056-1b75-4e9a-932f-085c397c7350/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmarkets-skeleton-before.png)

### **After**

`MarketRowSkeleton` with `bg-default` — matches page background:

[After: markets skeleton with bg-default](https://cursor.com/agents/bc-91141056-1b75-4e9a-932f-085c397c7350/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmarkets-skeleton-after.png)

Side-by-side:

[Before and after comparison](https://cursor.com/agents/bc-91141056-1b75-4e9a-932f-085c397c7350/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Fmarkets-skeleton-before-after.png)

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91141056-1b75-4e9a-932f-085c397c7350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91141056-1b75-4e9a-932f-085c397c7350"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

