### PR TITLE
feat: add Security & Trust header signals to TDP

### DIFF
--- a/app/_locales/en/messages.json
+++ b/app/_locales/en/messages.json
@@ -8935,6 +8935,300 @@
   "securitySrpLabel": {
     "message": "SECRET RECOVERY PHRASES"
   },
+  "securityTrustBuySellTax": {
+    "message": "Buy/Sell Tax"
+  },
+  "securityTrustBuyTax": {
+    "message": "Buy tax"
+  },
+  "securityTrustContinueAnyway": {
+    "message": "Continue anyway"
+  },
+  "securityTrustCreated": {
+    "message": "Created"
+  },
+  "securityTrustDataUnavailable": {
+    "message": "Security data unavailable"
+  },
+  "securityTrustEtherscan": {
+    "message": "Etherscan"
+  },
+  "securityTrustEvaluationDisclaimer": {
+    "message": "This security review is for evaluation only and does not constitute an endorsement or recommendation to trade."
+  },
+  "securityTrustFeatureAirdropPattern": {
+    "message": "Suspicious airdrop"
+  },
+  "securityTrustFeatureCanBlacklist": {
+    "message": "Can blacklist"
+  },
+  "securityTrustFeatureCanWhitelist": {
+    "message": "Can whitelist"
+  },
+  "securityTrustFeatureConcentratedSupplyDistribution": {
+    "message": "Concentrated supply"
+  },
+  "securityTrustFeatureConfidentialTransfersEnabled": {
+    "message": "Confidential transfers"
+  },
+  "securityTrustFeatureDynamicAnalysis": {
+    "message": "Suspicious behavior"
+  },
+  "securityTrustFeatureExternalFunctions": {
+    "message": "External calls"
+  },
+  "securityTrustFeatureFakeTradeMakerCount": {
+    "message": "Inflated trader count"
+  },
+  "securityTrustFeatureFakeVolume": {
+    "message": "Fake volume"
+  },
+  "securityTrustFeatureHasTradingCooldown": {
+    "message": "Trading cooldown"
+  },
+  "securityTrustFeatureHeavilySniped": {
+    "message": "Heavy bot activity"
+  },
+  "securityTrustFeatureHiddenOwner": {
+    "message": "Hidden owner"
+  },
+  "securityTrustFeatureHiddenSupplyByKeyHolder": {
+    "message": "Undisclosed supply"
+  },
+  "securityTrustFeatureHighBuyFee": {
+    "message": "High buy fee"
+  },
+  "securityTrustFeatureHighReputationToken": {
+    "message": "Established reputation"
+  },
+  "securityTrustFeatureHighSellFee": {
+    "message": "High sell fee"
+  },
+  "securityTrustFeatureHighTradeVolume": {
+    "message": "High trading volume"
+  },
+  "securityTrustFeatureHighTransferFee": {
+    "message": "High transfer fee"
+  },
+  "securityTrustFeatureHoneypot": {
+    "message": "Honeypot risk"
+  },
+  "securityTrustFeatureImpersonator": {
+    "message": "Impersonator"
+  },
+  "securityTrustFeatureImpersonatorHighConfidence": {
+    "message": "Likely impersonator"
+  },
+  "securityTrustFeatureImpersonatorLowConfidence": {
+    "message": "Unconfirmed impersonator"
+  },
+  "securityTrustFeatureImpersonatorMediumConfidence": {
+    "message": "Possible impersonator"
+  },
+  "securityTrustFeatureImpersonatorSensitiveAsset": {
+    "message": "Impersonates a sensitive asset"
+  },
+  "securityTrustFeatureInappropriateContent": {
+    "message": "Inappropriate content"
+  },
+  "securityTrustFeatureInorganicVolume": {
+    "message": "Artificial volume"
+  },
+  "securityTrustFeatureInsufficientLockedLiquidity": {
+    "message": "Low locked liquidity"
+  },
+  "securityTrustFeatureIsMintable": {
+    "message": "Mintable"
+  },
+  "securityTrustFeatureKnownMalicious": {
+    "message": "Known malicious"
+  },
+  "securityTrustFeatureListedOnCentralizedExchange": {
+    "message": "Listed on exchange"
+  },
+  "securityTrustFeatureLowReputationCreator": {
+    "message": "Creator has low reputation"
+  },
+  "securityTrustFeatureMetadata": {
+    "message": "Suspicious metadata"
+  },
+  "securityTrustFeatureModifiableTaxes": {
+    "message": "Modifiable taxes"
+  },
+  "securityTrustFeatureNonTranserable": {
+    "message": "Non-transferable"
+  },
+  "securityTrustFeatureOwnerCanChangeBalance": {
+    "message": "Owner can change balance"
+  },
+  "securityTrustFeaturePostDump": {
+    "message": "Possible price manipulation"
+  },
+  "securityTrustFeatureProxyContract": {
+    "message": "Proxy contract"
+  },
+  "securityTrustFeatureRugpull": {
+    "message": "Rugpull risk"
+  },
+  "securityTrustFeatureSanctionedCreator": {
+    "message": "Sanctioned creator"
+  },
+  "securityTrustFeatureSimilarMaliciousContract": {
+    "message": "Resembles malicious contract"
+  },
+  "securityTrustFeatureSnipeAtMint": {
+    "message": "Bot activity at launch"
+  },
+  "securityTrustFeatureSpamText": {
+    "message": "Spam text"
+  },
+  "securityTrustFeatureStaticCodeSignature": {
+    "message": "Suspicious code"
+  },
+  "securityTrustFeatureTokenBackdoor": {
+    "message": "Token backdoor"
+  },
+  "securityTrustFeatureTransferFromReverts": {
+    "message": "Transfer reversals enabled"
+  },
+  "securityTrustFeatureTransferHookEnabled": {
+    "message": "Transfer hook enabled"
+  },
+  "securityTrustFeatureTransferPauseable": {
+    "message": "Transfers pauseable"
+  },
+  "securityTrustFeatureUnsellableToken": {
+    "message": "Unsellable token"
+  },
+  "securityTrustFeatureUnstableTokenPrice": {
+    "message": "Unstable price"
+  },
+  "securityTrustFeatureVerifiedContract": {
+    "message": "Published contract"
+  },
+  "securityTrustFeatureWashTrading": {
+    "message": "Wash trading"
+  },
+  "securityTrustMalicious": {
+    "message": "Malicious"
+  },
+  "securityTrustMaliciousLabel": {
+    "message": "Malicious"
+  },
+  "securityTrustMaliciousTokenBannerDescription": {
+    "message": "$1 is flagged as malicious. It's likely to steal funds from anyone who interacts with it."
+  },
+  "securityTrustMaliciousTokenBannerDescriptionNoSymbol": {
+    "message": "This token is flagged as malicious. It's likely to steal funds from anyone who interacts with it."
+  },
+  "securityTrustMaliciousTokenSheetDescription": {
+    "message": "Serious risk signals detected on $1. We recommend not trading this token."
+  },
+  "securityTrustMaliciousTokenSheetDescriptionNoSymbol": {
+    "message": "Serious risk signals detected on this token. We recommend not trading this token."
+  },
+  "securityTrustMaliciousTokenTitle": {
+    "message": "Malicious token"
+  },
+  "securityTrustMore": {
+    "message": "more"
+  },
+  "securityTrustNa": {
+    "message": "N/A"
+  },
+  "securityTrustNetwork": {
+    "message": "Network"
+  },
+  "securityTrustNoHiddenFeesDetected": {
+    "message": "No hidden fees detected"
+  },
+  "securityTrustNoIssues": {
+    "message": "No issues"
+  },
+  "securityTrustOfficialLinks": {
+    "message": "Official Links"
+  },
+  "securityTrustOther": {
+    "message": "Other"
+  },
+  "securityTrustRisky": {
+    "message": "Risky"
+  },
+  "securityTrustRiskyTokenDescription": {
+    "message": "$1 is flagged as suspicious. Take a look at the risks before you continue."
+  },
+  "securityTrustRiskyTokenDescriptionNoSymbol": {
+    "message": "This token is flagged as suspicious. Take a look at the risks before you continue."
+  },
+  "securityTrustRiskyTokenTitle": {
+    "message": "Suspicious token"
+  },
+  "securityTrustSellTax": {
+    "message": "Sell tax"
+  },
+  "securityTrustSubtitleKnown": {
+    "message": "No risk signals detected. Always research any asset before trading."
+  },
+  "securityTrustSubtitleMalicious": {
+    "message": "Serious risk signals detected. We recommend avoiding this asset."
+  },
+  "securityTrustSubtitleNoIssues": {
+    "message": "No risk signals detected. Always research any asset before trading."
+  },
+  "securityTrustSubtitleSuspicious": {
+    "message": "Cautionary signals detected. Review the flagged issues carefully before trading this asset."
+  },
+  "securityTrustSubtitleUnavailable": {
+    "message": "Security analysis could not be loaded for this token."
+  },
+  "securityTrustSuspicious": {
+    "message": "Suspicious"
+  },
+  "securityTrustSuspiciousTokenDescription": {
+    "message": "$1 is a suspicious token."
+  },
+  "securityTrustSuspiciousTokenDescriptionNoSymbol": {
+    "message": "This is a suspicious token."
+  },
+  "securityTrustTelegram": {
+    "message": "Telegram"
+  },
+  "securityTrustTitle": {
+    "message": "Security and trust"
+  },
+  "securityTrustTokenAge": {
+    "message": "Token age"
+  },
+  "securityTrustTokenDistribution": {
+    "message": "Token distribution"
+  },
+  "securityTrustTokenInfo": {
+    "message": "Token Info"
+  },
+  "securityTrustTop10Holders": {
+    "message": "Top 10 holders"
+  },
+  "securityTrustTotalSupply": {
+    "message": "Total supply"
+  },
+  "securityTrustTransfer": {
+    "message": "Transfer"
+  },
+  "securityTrustType": {
+    "message": "Type"
+  },
+  "securityTrustVerified": {
+    "message": "Verified"
+  },
+  "securityTrustVerifiedTokenDescription": {
+    "message": "$1 is actively traded and is widely recognized. Verification is not an endorsement by MetaMask."
+  },
+  "securityTrustVerifiedTokenTitle": {
+    "message": "Verified token"
+  },
+  "securityTrustWebsite": {
+    "message": "Website"
+  },
   "seeAllPermissions": {
     "message": "See all permissions",
     "description": "Used for revealing more content (e.g. permission list, etc.)"

--- a/app/_locales/en_GB/messages.json
+++ b/app/_locales/en_GB/messages.json
@@ -8935,6 +8935,300 @@
   "securitySrpLabel": {
     "message": "SECRET RECOVERY PHRASES"
   },
+  "securityTrustBuySellTax": {
+    "message": "Buy/Sell Tax"
+  },
+  "securityTrustBuyTax": {
+    "message": "Buy tax"
+  },
+  "securityTrustContinueAnyway": {
+    "message": "Continue anyway"
+  },
+  "securityTrustCreated": {
+    "message": "Created"
+  },
+  "securityTrustDataUnavailable": {
+    "message": "Security data unavailable"
+  },
+  "securityTrustEtherscan": {
+    "message": "Etherscan"
+  },
+  "securityTrustEvaluationDisclaimer": {
+    "message": "This security review is for evaluation only and does not constitute an endorsement or recommendation to trade."
+  },
+  "securityTrustFeatureAirdropPattern": {
+    "message": "Suspicious airdrop"
+  },
+  "securityTrustFeatureCanBlacklist": {
+    "message": "Can blacklist"
+  },
+  "securityTrustFeatureCanWhitelist": {
+    "message": "Can whitelist"
+  },
+  "securityTrustFeatureConcentratedSupplyDistribution": {
+    "message": "Concentrated supply"
+  },
+  "securityTrustFeatureConfidentialTransfersEnabled": {
+    "message": "Confidential transfers"
+  },
+  "securityTrustFeatureDynamicAnalysis": {
+    "message": "Suspicious behavior"
+  },
+  "securityTrustFeatureExternalFunctions": {
+    "message": "External calls"
+  },
+  "securityTrustFeatureFakeTradeMakerCount": {
+    "message": "Inflated trader count"
+  },
+  "securityTrustFeatureFakeVolume": {
+    "message": "Fake volume"
+  },
+  "securityTrustFeatureHasTradingCooldown": {
+    "message": "Trading cooldown"
+  },
+  "securityTrustFeatureHeavilySniped": {
+    "message": "Heavy bot activity"
+  },
+  "securityTrustFeatureHiddenOwner": {
+    "message": "Hidden owner"
+  },
+  "securityTrustFeatureHiddenSupplyByKeyHolder": {
+    "message": "Undisclosed supply"
+  },
+  "securityTrustFeatureHighBuyFee": {
+    "message": "High buy fee"
+  },
+  "securityTrustFeatureHighReputationToken": {
+    "message": "Established reputation"
+  },
+  "securityTrustFeatureHighSellFee": {
+    "message": "High sell fee"
+  },
+  "securityTrustFeatureHighTradeVolume": {
+    "message": "High trading volume"
+  },
+  "securityTrustFeatureHighTransferFee": {
+    "message": "High transfer fee"
+  },
+  "securityTrustFeatureHoneypot": {
+    "message": "Honeypot risk"
+  },
+  "securityTrustFeatureImpersonator": {
+    "message": "Impersonator"
+  },
+  "securityTrustFeatureImpersonatorHighConfidence": {
+    "message": "Likely impersonator"
+  },
+  "securityTrustFeatureImpersonatorLowConfidence": {
+    "message": "Unconfirmed impersonator"
+  },
+  "securityTrustFeatureImpersonatorMediumConfidence": {
+    "message": "Possible impersonator"
+  },
+  "securityTrustFeatureImpersonatorSensitiveAsset": {
+    "message": "Impersonates a sensitive asset"
+  },
+  "securityTrustFeatureInappropriateContent": {
+    "message": "Inappropriate content"
+  },
+  "securityTrustFeatureInorganicVolume": {
+    "message": "Artificial volume"
+  },
+  "securityTrustFeatureInsufficientLockedLiquidity": {
+    "message": "Low locked liquidity"
+  },
+  "securityTrustFeatureIsMintable": {
+    "message": "Mintable"
+  },
+  "securityTrustFeatureKnownMalicious": {
+    "message": "Known malicious"
+  },
+  "securityTrustFeatureListedOnCentralizedExchange": {
+    "message": "Listed on exchange"
+  },
+  "securityTrustFeatureLowReputationCreator": {
+    "message": "Creator has low reputation"
+  },
+  "securityTrustFeatureMetadata": {
+    "message": "Suspicious metadata"
+  },
+  "securityTrustFeatureModifiableTaxes": {
+    "message": "Modifiable taxes"
+  },
+  "securityTrustFeatureNonTranserable": {
+    "message": "Non-transferable"
+  },
+  "securityTrustFeatureOwnerCanChangeBalance": {
+    "message": "Owner can change balance"
+  },
+  "securityTrustFeaturePostDump": {
+    "message": "Possible price manipulation"
+  },
+  "securityTrustFeatureProxyContract": {
+    "message": "Proxy contract"
+  },
+  "securityTrustFeatureRugpull": {
+    "message": "Rugpull risk"
+  },
+  "securityTrustFeatureSanctionedCreator": {
+    "message": "Sanctioned creator"
+  },
+  "securityTrustFeatureSimilarMaliciousContract": {
+    "message": "Resembles malicious contract"
+  },
+  "securityTrustFeatureSnipeAtMint": {
+    "message": "Bot activity at launch"
+  },
+  "securityTrustFeatureSpamText": {
+    "message": "Spam text"
+  },
+  "securityTrustFeatureStaticCodeSignature": {
+    "message": "Suspicious code"
+  },
+  "securityTrustFeatureTokenBackdoor": {
+    "message": "Token backdoor"
+  },
+  "securityTrustFeatureTransferFromReverts": {
+    "message": "Transfer reversals enabled"
+  },
+  "securityTrustFeatureTransferHookEnabled": {
+    "message": "Transfer hook enabled"
+  },
+  "securityTrustFeatureTransferPauseable": {
+    "message": "Transfers pauseable"
+  },
+  "securityTrustFeatureUnsellableToken": {
+    "message": "Unsellable token"
+  },
+  "securityTrustFeatureUnstableTokenPrice": {
+    "message": "Unstable price"
+  },
+  "securityTrustFeatureVerifiedContract": {
+    "message": "Published contract"
+  },
+  "securityTrustFeatureWashTrading": {
+    "message": "Wash trading"
+  },
+  "securityTrustMalicious": {
+    "message": "Malicious"
+  },
+  "securityTrustMaliciousLabel": {
+    "message": "Malicious"
+  },
+  "securityTrustMaliciousTokenBannerDescription": {
+    "message": "$1 is flagged as malicious. It's likely to steal funds from anyone who interacts with it."
+  },
+  "securityTrustMaliciousTokenBannerDescriptionNoSymbol": {
+    "message": "This token is flagged as malicious. It's likely to steal funds from anyone who interacts with it."
+  },
+  "securityTrustMaliciousTokenSheetDescription": {
+    "message": "Serious risk signals detected on $1. We recommend not trading this token."
+  },
+  "securityTrustMaliciousTokenSheetDescriptionNoSymbol": {
+    "message": "Serious risk signals detected on this token. We recommend not trading this token."
+  },
+  "securityTrustMaliciousTokenTitle": {
+    "message": "Malicious token"
+  },
+  "securityTrustMore": {
+    "message": "more"
+  },
+  "securityTrustNa": {
+    "message": "N/A"
+  },
+  "securityTrustNetwork": {
+    "message": "Network"
+  },
+  "securityTrustNoHiddenFeesDetected": {
+    "message": "No hidden fees detected"
+  },
+  "securityTrustNoIssues": {
+    "message": "No issues"
+  },
+  "securityTrustOfficialLinks": {
+    "message": "Official Links"
+  },
+  "securityTrustOther": {
+    "message": "Other"
+  },
+  "securityTrustRisky": {
+    "message": "Risky"
+  },
+  "securityTrustRiskyTokenDescription": {
+    "message": "$1 is flagged as suspicious. Take a look at the risks before you continue."
+  },
+  "securityTrustRiskyTokenDescriptionNoSymbol": {
+    "message": "This token is flagged as suspicious. Take a look at the risks before you continue."
+  },
+  "securityTrustRiskyTokenTitle": {
+    "message": "Suspicious token"
+  },
+  "securityTrustSellTax": {
+    "message": "Sell tax"
+  },
+  "securityTrustSubtitleKnown": {
+    "message": "No risk signals detected. Always research any asset before trading."
+  },
+  "securityTrustSubtitleMalicious": {
+    "message": "Serious risk signals detected. We recommend avoiding this asset."
+  },
+  "securityTrustSubtitleNoIssues": {
+    "message": "No risk signals detected. Always research any asset before trading."
+  },
+  "securityTrustSubtitleSuspicious": {
+    "message": "Cautionary signals detected. Review the flagged issues carefully before trading this asset."
+  },
+  "securityTrustSubtitleUnavailable": {
+    "message": "Security analysis could not be loaded for this token."
+  },
+  "securityTrustSuspicious": {
+    "message": "Suspicious"
+  },
+  "securityTrustSuspiciousTokenDescription": {
+    "message": "$1 is a suspicious token."
+  },
+  "securityTrustSuspiciousTokenDescriptionNoSymbol": {
+    "message": "This is a suspicious token."
+  },
+  "securityTrustTelegram": {
+    "message": "Telegram"
+  },
+  "securityTrustTitle": {
+    "message": "Security and trust"
+  },
+  "securityTrustTokenAge": {
+    "message": "Token age"
+  },
+  "securityTrustTokenDistribution": {
+    "message": "Token distribution"
+  },
+  "securityTrustTokenInfo": {
+    "message": "Token Info"
+  },
+  "securityTrustTop10Holders": {
+    "message": "Top 10 holders"
+  },
+  "securityTrustTotalSupply": {
+    "message": "Total supply"
+  },
+  "securityTrustTransfer": {
+    "message": "Transfer"
+  },
+  "securityTrustType": {
+    "message": "Type"
+  },
+  "securityTrustVerified": {
+    "message": "Verified"
+  },
+  "securityTrustVerifiedTokenDescription": {
+    "message": "$1 is actively traded and is widely recognized. Verification is not an endorsement by MetaMask."
+  },
+  "securityTrustVerifiedTokenTitle": {
+    "message": "Verified token"
+  },
+  "securityTrustWebsite": {
+    "message": "Website"
+  },
   "seeAllPermissions": {
     "message": "See all permissions",
     "description": "Used for revealing more content (e.g. permission list, etc.)"

--- a/test/unit-global/locale-query-mismatch.test.ts
+++ b/test/unit-global/locale-query-mismatch.test.ts
@@ -223,6 +223,10 @@ const RULE_2_BASELINE: Record<string, number> = {
   // Snap SDK Field props (label, error) are external input data, not i18n-rendered by the component under test.
   // Hardcoded to avoid tying Snap test fixtures to MetaMask locale files.
   'ui/components/app/snaps/snap-ui-renderer/components/address-input.test.ts': 2,
+  // Perps market-row hardcodes 'N/A' for missing metrics — not locale-rendered.
+  'ui/components/app/perps/market-row/market-row.test.tsx': 2,
+  // Account details tab label is hardcoded as "Type" — not locale-rendered.
+  'ui/components/multichain/account-details/account-details-display.test.tsx': 2,
 };
 
 function findRule2Violations(filePath: string, lines: string[]): Violation[] {

--- a/ui/hooks/useTokenSecurityData.test.ts
+++ b/ui/hooks/useTokenSecurityData.test.ts
@@ -1,0 +1,195 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
+import type { TokenSecurityData } from '@metamask/assets-controllers';
+import type { CaipAssetType } from '@metamask/utils';
+import { fetchCachedTokenAssets } from '../pages/bridge/utils/token-security';
+import { useTokenSecurityData } from './useTokenSecurityData';
+
+jest.mock('../pages/bridge/utils/token-security', () => ({
+  fetchCachedTokenAssets: jest.fn(),
+}));
+
+const mockFetchCachedTokenAssets = jest.mocked(fetchCachedTokenAssets);
+
+const mockSecurityData: TokenSecurityData = {
+  resultType: 'Verified',
+  maliciousScore: '0',
+  features: [
+    {
+      featureId: 'VERIFIED_CONTRACT',
+      type: 'Info',
+      description: 'Verified contract',
+    },
+  ],
+  fees: {
+    transfer: 0,
+    transferFeeMaxAmount: null,
+    buy: 0,
+    sell: null,
+  },
+  financialStats: {
+    supply: 1000000,
+    topHolders: [],
+    holdersCount: 100,
+    tradeVolume24h: null,
+    lockedLiquidityPct: null,
+    markets: [],
+  },
+  metadata: {
+    externalLinks: {
+      homepage: null,
+      twitterPage: null,
+      telegramChannelId: null,
+    },
+  },
+  created: '2023-01-01T00:00:00Z',
+};
+
+describe('useTokenSecurityData', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns prefetched data immediately without fetching', () => {
+    const assetId = 'eip155:1/erc20:0x1234' as CaipAssetType;
+
+    const { result } = renderHook(() =>
+      useTokenSecurityData({
+        assetId,
+        prefetchedData: mockSecurityData,
+      }),
+    );
+
+    expect(result.current.securityData).toBe(mockSecurityData);
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(mockFetchCachedTokenAssets).not.toHaveBeenCalled();
+  });
+
+  it('fetches security data when assetId is provided', async () => {
+    const assetId = 'eip155:1/erc20:0x1234' as CaipAssetType;
+    mockFetchCachedTokenAssets.mockResolvedValue([
+      {
+        assetId,
+        name: 'Test Token',
+        symbol: 'TEST',
+        decimals: 18,
+        securityData: mockSecurityData,
+      },
+    ]);
+
+    const { result } = renderHook(() => useTokenSecurityData({ assetId }));
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockFetchCachedTokenAssets).toHaveBeenCalledWith([assetId]);
+    expect(result.current.securityData).toBe(mockSecurityData);
+    expect(result.current.error).toBeNull();
+    expect(result.current.symbol).toBe('TEST');
+    expect(result.current.decimals).toBe(18);
+    expect(result.current.address).toBe('0x1234');
+    expect(result.current.isNative).toBe(false);
+  });
+
+  it('clears stale data when assetId changes', async () => {
+    const firstAssetId = 'eip155:1/erc20:0x1111' as CaipAssetType;
+    const secondAssetId = 'eip155:1/erc20:0x2222' as CaipAssetType;
+    const secondSecurityData: TokenSecurityData = {
+      ...mockSecurityData,
+      resultType: 'Warning',
+    };
+
+    mockFetchCachedTokenAssets.mockImplementation(async (assetIds) => {
+      const assetId = assetIds[0];
+      if (assetId === firstAssetId) {
+        return [
+          {
+            assetId: firstAssetId,
+            name: 'First Token',
+            symbol: 'FIRST',
+            decimals: 18,
+            securityData: mockSecurityData,
+          },
+        ];
+      }
+
+      return [
+        {
+          assetId: secondAssetId,
+          name: 'Second Token',
+          symbol: 'SECOND',
+          decimals: 6,
+          securityData: secondSecurityData,
+        },
+      ];
+    });
+
+    const { result, rerender } = renderHook(
+      ({ assetId }: { assetId: CaipAssetType }) =>
+        useTokenSecurityData({ assetId }),
+      { initialProps: { assetId: firstAssetId } },
+    );
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.securityData).toBe(mockSecurityData);
+    expect(result.current.symbol).toBe('FIRST');
+
+    rerender({ assetId: secondAssetId });
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.securityData).toBeNull();
+    expect(result.current.error).toBeNull();
+    expect(result.current.address).toBe('0x2222');
+    expect(result.current.isNative).toBe(false);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.securityData).toBe(secondSecurityData);
+    expect(result.current.symbol).toBe('SECOND');
+  });
+
+  it('derives native asset metadata from slip44 asset id', async () => {
+    const assetId = 'eip155:1/slip44:60' as CaipAssetType;
+    mockFetchCachedTokenAssets.mockResolvedValue([
+      {
+        assetId,
+        name: 'Ethereum',
+        symbol: 'ETH',
+        decimals: 18,
+        securityData: mockSecurityData,
+      },
+    ]);
+
+    const { result } = renderHook(() => useTokenSecurityData({ assetId }));
+
+    expect(result.current.isNative).toBe(true);
+    expect(result.current.address).toBe('60');
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+  });
+
+  it('sets error when fetch fails', async () => {
+    const assetId = 'eip155:1/erc20:0x1234' as CaipAssetType;
+    mockFetchCachedTokenAssets.mockRejectedValue(new Error('Fetch failed'));
+
+    const { result } = renderHook(() => useTokenSecurityData({ assetId }));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toEqual(new Error('Fetch failed'));
+    expect(result.current.securityData).toBeNull();
+  });
+});

--- a/ui/hooks/useTokenSecurityData.test.ts
+++ b/ui/hooks/useTokenSecurityData.test.ts
@@ -165,8 +165,8 @@ describe('useTokenSecurityData', () => {
       resultType: 'Warning',
     };
 
-    let resolveFirstFetch: (value: unknown) => void;
-    const firstFetchPromise = new Promise((resolve) => {
+    let resolveFirstFetch: ((value: unknown) => void) | undefined;
+    const firstFetchPromise = new Promise<void>((resolve) => {
       resolveFirstFetch = resolve;
     });
 
@@ -212,7 +212,7 @@ describe('useTokenSecurityData', () => {
     expect(result.current.securityData).toBe(secondSecurityData);
     expect(result.current.symbol).toBe('SECOND');
 
-    resolveFirstFetch!(null);
+    resolveFirstFetch?.(null);
 
     await waitFor(() => {
       expect(mockFetchCachedTokenAssets).toHaveBeenCalledTimes(2);

--- a/ui/hooks/useTokenSecurityData.test.ts
+++ b/ui/hooks/useTokenSecurityData.test.ts
@@ -157,6 +157,71 @@ describe('useTokenSecurityData', () => {
     expect(result.current.symbol).toBe('SECOND');
   });
 
+  it('ignores stale fetch responses when assetId changes quickly', async () => {
+    const firstAssetId = 'eip155:1/erc20:0x1111' as CaipAssetType;
+    const secondAssetId = 'eip155:1/erc20:0x2222' as CaipAssetType;
+    const secondSecurityData: TokenSecurityData = {
+      ...mockSecurityData,
+      resultType: 'Warning',
+    };
+
+    let resolveFirstFetch: (value: unknown) => void;
+    const firstFetchPromise = new Promise((resolve) => {
+      resolveFirstFetch = resolve;
+    });
+
+    mockFetchCachedTokenAssets.mockImplementation(async (assetIds) => {
+      const requestedAssetId = assetIds[0];
+
+      if (requestedAssetId === firstAssetId) {
+        await firstFetchPromise;
+        return [
+          {
+            assetId: firstAssetId,
+            name: 'First Token',
+            symbol: 'FIRST',
+            decimals: 18,
+            securityData: mockSecurityData,
+          },
+        ];
+      }
+
+      return [
+        {
+          assetId: secondAssetId,
+          name: 'Second Token',
+          symbol: 'SECOND',
+          decimals: 6,
+          securityData: secondSecurityData,
+        },
+      ];
+    });
+
+    const { result, rerender } = renderHook(
+      ({ assetId }: { assetId: CaipAssetType }) =>
+        useTokenSecurityData({ assetId }),
+      { initialProps: { assetId: firstAssetId } },
+    );
+
+    rerender({ assetId: secondAssetId });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.securityData).toBe(secondSecurityData);
+    expect(result.current.symbol).toBe('SECOND');
+
+    resolveFirstFetch!(null);
+
+    await waitFor(() => {
+      expect(mockFetchCachedTokenAssets).toHaveBeenCalledTimes(2);
+    });
+
+    expect(result.current.securityData).toBe(secondSecurityData);
+    expect(result.current.symbol).toBe('SECOND');
+  });
+
   it('derives native asset metadata from slip44 asset id', async () => {
     const assetId = 'eip155:1/slip44:60' as CaipAssetType;
     mockFetchCachedTokenAssets.mockResolvedValue([

--- a/ui/hooks/useTokenSecurityData.ts
+++ b/ui/hooks/useTokenSecurityData.ts
@@ -65,15 +65,12 @@ export const useTokenSecurityData = ({
   const [error, setError] = useState<Error | null>(null);
   const [assetMetadata, setAssetMetadata] =
     useState<TokenSecurityAssetMetadata>({});
-  const isMountedRef = useRef(true);
+  const activeAssetIdRef = useRef<CaipAssetType | null>(null);
 
-  const fetchData = useCallback(async () => {
-    if (!assetId) {
-      return;
-    }
+  const fetchData = useCallback(async (requestAssetId: CaipAssetType) => {
     try {
-      const assets = await fetchCachedTokenAssets([assetId]);
-      if (!isMountedRef.current) {
+      const assets = await fetchCachedTokenAssets([requestAssetId]);
+      if (requestAssetId !== activeAssetIdRef.current) {
         return;
       }
       const asset = assets?.[0];
@@ -84,27 +81,26 @@ export const useTokenSecurityData = ({
               symbol: asset.symbol,
               name: asset.name,
               decimals: asset.decimals,
-              ...getAssetMetadataFromAssetId(assetId),
+              ...getAssetMetadataFromAssetId(requestAssetId),
             }
-          : getAssetMetadataFromAssetId(assetId),
+          : getAssetMetadataFromAssetId(requestAssetId),
       );
       setError(null);
     } catch (err) {
-      if (!isMountedRef.current) {
+      if (requestAssetId !== activeAssetIdRef.current) {
         return;
       }
       setError(err as Error);
     } finally {
-      if (isMountedRef.current) {
+      if (requestAssetId === activeAssetIdRef.current) {
         setIsLoading(false);
       }
     }
-  }, [assetId]);
+  }, []);
 
   useEffect(() => {
-    isMountedRef.current = true;
-
     if (prefetchedData) {
+      activeAssetIdRef.current = assetId;
       setSecurityData(prefetchedData);
       setError(null);
       setIsLoading(false);
@@ -112,6 +108,7 @@ export const useTokenSecurityData = ({
     }
 
     if (!assetId) {
+      activeAssetIdRef.current = null;
       setSecurityData(null);
       setError(null);
       setAssetMetadata({});
@@ -119,14 +116,15 @@ export const useTokenSecurityData = ({
       return undefined;
     }
 
+    activeAssetIdRef.current = assetId;
     setSecurityData(null);
     setError(null);
     setAssetMetadata(getAssetMetadataFromAssetId(assetId));
     setIsLoading(true);
-    fetchData();
+    fetchData(assetId);
 
     return () => {
-      isMountedRef.current = false;
+      activeAssetIdRef.current = null;
     };
   }, [assetId, prefetchedData, fetchData]);
 

--- a/ui/hooks/useTokenSecurityData.ts
+++ b/ui/hooks/useTokenSecurityData.ts
@@ -1,0 +1,134 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { TokenSecurityData } from '@metamask/assets-controllers';
+import { parseCaipAssetType, type CaipAssetType } from '@metamask/utils';
+import { fetchCachedTokenAssets } from '../pages/bridge/utils/token-security';
+
+type UseTokenSecurityDataOpts = {
+  /** CAIP-19 asset ID. When null, no fetch is attempted. */
+  assetId: CaipAssetType | null;
+  /** Pre-fetched security data — returned immediately if provided. */
+  prefetchedData?: TokenSecurityData;
+};
+
+export type TokenSecurityAssetMetadata = {
+  symbol?: string;
+  name?: string;
+  decimals?: number;
+  address?: string;
+  isNative?: boolean;
+};
+
+type UseTokenSecurityDataResult = {
+  securityData: TokenSecurityData | null;
+  isLoading: boolean;
+  error: Error | null;
+} & TokenSecurityAssetMetadata;
+
+const getAssetMetadataFromAssetId = (
+  assetId: CaipAssetType,
+): TokenSecurityAssetMetadata => {
+  try {
+    const { assetReference, assetNamespace } = parseCaipAssetType(assetId);
+    return {
+      address: assetReference,
+      isNative: assetNamespace === 'slip44',
+    };
+  } catch {
+    return {};
+  }
+};
+
+const isValidTokenSecurityData = (data: unknown): data is TokenSecurityData =>
+  data !== null &&
+  data !== undefined &&
+  typeof data === 'object' &&
+  typeof (data as TokenSecurityData).resultType === 'string' &&
+  Array.isArray((data as TokenSecurityData).features);
+
+// TODO(security-trust): Once home page Security & Trust signals land (separate PR)
+// via TanStack Query, read from the shared query cache first and fall back to REST
+// (`fetchCachedTokenAssets`) when cached data is unavailable.
+export const useTokenSecurityData = ({
+  assetId,
+  prefetchedData: rawPrefetchedData,
+}: UseTokenSecurityDataOpts): UseTokenSecurityDataResult => {
+  const prefetchedData = isValidTokenSecurityData(rawPrefetchedData)
+    ? rawPrefetchedData
+    : undefined;
+
+  const [securityData, setSecurityData] = useState<TokenSecurityData | null>(
+    prefetchedData ?? null,
+  );
+  const [isLoading, setIsLoading] = useState(
+    !prefetchedData && Boolean(assetId),
+  );
+  const [error, setError] = useState<Error | null>(null);
+  const [assetMetadata, setAssetMetadata] =
+    useState<TokenSecurityAssetMetadata>({});
+  const isMountedRef = useRef(true);
+
+  const fetchData = useCallback(async () => {
+    if (!assetId) {
+      return;
+    }
+    try {
+      const assets = await fetchCachedTokenAssets([assetId]);
+      if (!isMountedRef.current) {
+        return;
+      }
+      const asset = assets?.[0];
+      setSecurityData(asset?.securityData ?? null);
+      setAssetMetadata(
+        asset
+          ? {
+              symbol: asset.symbol,
+              name: asset.name,
+              decimals: asset.decimals,
+              ...getAssetMetadataFromAssetId(assetId),
+            }
+          : getAssetMetadataFromAssetId(assetId),
+      );
+      setError(null);
+    } catch (err) {
+      if (!isMountedRef.current) {
+        return;
+      }
+      setError(err as Error);
+    } finally {
+      if (isMountedRef.current) {
+        setIsLoading(false);
+      }
+    }
+  }, [assetId]);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    if (prefetchedData) {
+      setSecurityData(prefetchedData);
+      setError(null);
+      setIsLoading(false);
+      return undefined;
+    }
+
+    if (!assetId) {
+      setSecurityData(null);
+      setError(null);
+      setAssetMetadata({});
+      setIsLoading(false);
+      return undefined;
+    }
+
+    setSecurityData(null);
+    setError(null);
+    setAssetMetadata(getAssetMetadataFromAssetId(assetId));
+    setIsLoading(true);
+    fetchData();
+
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, [assetId, prefetchedData, fetchData]);
+
+  return { securityData, isLoading, error, ...assetMetadata };
+};

--- a/ui/pages/asset/components/asset-page.tsx
+++ b/ui/pages/asset/components/asset-page.tsx
@@ -37,7 +37,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { AssetType } from '../../../../shared/constants/transaction';
 import { ALLOWED_BRIDGE_CHAIN_IDS } from '../../../../shared/constants/bridge';
 import {
-  ALLOWED_DEV_SWAPS_CHAIN_IDS,
+  ALLOWED_PROD_SWAPS_CHAIN_IDS,
 } from '../../../../shared/constants/swaps';
 import { isEvmChainId, toAssetId } from '../../../../shared/lib/asset-utils';
 import { endTrace, TraceName } from '../../../../shared/lib/trace';
@@ -142,7 +142,7 @@ const AssetPage = ({
 
   const isSwapsChain = useMemo(
     () =>
-      (ALLOWED_DEV_SWAPS_CHAIN_IDS as readonly string[]).includes(chainId),
+      (ALLOWED_PROD_SWAPS_CHAIN_IDS as readonly string[]).includes(chainId),
     [chainId],
   );
 

--- a/ui/pages/asset/components/asset-page.tsx
+++ b/ui/pages/asset/components/asset-page.tsx
@@ -36,9 +36,7 @@ import { useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
 import { AssetType } from '../../../../shared/constants/transaction';
 import { ALLOWED_BRIDGE_CHAIN_IDS } from '../../../../shared/constants/bridge';
-import {
-  ALLOWED_PROD_SWAPS_CHAIN_IDS,
-} from '../../../../shared/constants/swaps';
+import { ALLOWED_PROD_SWAPS_CHAIN_IDS } from '../../../../shared/constants/swaps';
 import { isEvmChainId, toAssetId } from '../../../../shared/lib/asset-utils';
 import { endTrace, TraceName } from '../../../../shared/lib/trace';
 import { hexToDecimal } from '../../../../shared/lib/conversion.utils';
@@ -141,8 +139,7 @@ const AssetPage = ({
   const { chainId, type, symbol, name, image } = asset;
 
   const isSwapsChain = useMemo(
-    () =>
-      (ALLOWED_PROD_SWAPS_CHAIN_IDS as readonly string[]).includes(chainId),
+    () => (ALLOWED_PROD_SWAPS_CHAIN_IDS as readonly string[]).includes(chainId),
     [chainId],
   );
 

--- a/ui/pages/asset/components/asset-page.tsx
+++ b/ui/pages/asset/components/asset-page.tsx
@@ -31,13 +31,7 @@ import {
   isCaipChainId,
   parseCaipAssetType,
 } from '@metamask/utils';
-import React, {
-  ReactNode,
-  useCallback,
-  useEffect,
-  useMemo,
-  useState,
-} from 'react';
+import React, { ReactNode, useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
 import { AssetType } from '../../../../shared/constants/transaction';
@@ -109,6 +103,11 @@ import { TronDailyResources } from './tron-daily-resources';
 import { MusdBonusSection } from './musd-bonus-section';
 import { MusdConvertSection } from './musd-convert-section';
 import { MusdPositionSection } from './musd-position-section';
+import {
+  AssetPageSecurityTrustBanner,
+  AssetPageSecurityTrustHeaderBadge,
+  AssetPageSecurityTrustProvider,
+} from './security-trust';
 
 // TODO BIP44 Refactor: BIP-44 has been enabled and is stable, this page needs a significant refactor to remove confusing branching logic
 const AssetPage = ({
@@ -126,57 +125,30 @@ const AssetPage = ({
   // TODO BIP44 Refactor: This selector does not work with BIP44 enabled, pass the information in the asset object
   const nativeAssetType = useSelector(getMultichainNativeAssetType);
   const accountGroupIdAssets = useSelector(getAssetsBySelectedAccountGroup);
-  const caipChainId = useMemo(
-    () =>
-      isCaipChainId(asset.chainId)
-        ? asset.chainId
-        : formatChainIdToCaip(asset.chainId),
-    [asset.chainId],
-  );
-  const selectSelectedAccount = useMemo(
-    () =>
-      (
-        state: Parameters<
-          typeof getInternalAccountBySelectedAccountGroupAndCaip
-        >[0],
-      ) =>
-        getInternalAccountBySelectedAccountGroupAndCaip(state, caipChainId),
-    [caipChainId],
-  );
-  const selectedAccount = useSelector(selectSelectedAccount) as InternalAccount;
+  const caipChainId = isCaipChainId(asset.chainId)
+    ? asset.chainId
+    : formatChainIdToCaip(asset.chainId);
+  const selectedAccount = useSelector((state) =>
+    getInternalAccountBySelectedAccountGroupAndCaip(state, caipChainId),
+  ) as InternalAccount;
 
   useEffect(() => {
     endTrace({ name: TraceName.AssetDetails });
   }, []);
 
   const { chainId, type, symbol, name, image } = asset;
-  const tokenAddress =
-    asset.type === AssetType.token ? asset.address : undefined;
-  const aggregators =
-    asset.type === AssetType.token ? asset.aggregators : undefined;
 
-  const selectIsSwapsChain = useMemo(
-    () => (state: Parameters<typeof getIsSwapsChain>[0]) =>
-      getIsSwapsChain(state, chainId),
-    [chainId],
+  const isSwapsChain = useSelector((state) => getIsSwapsChain(state, chainId));
+  const isBridgeChain = useSelector((state) =>
+    getIsBridgeChain(state, chainId),
   );
-  const isSwapsChain = useSelector(selectIsSwapsChain);
-  const selectIsBridgeChain = useMemo(
-    () => (state: Parameters<typeof getIsBridgeChain>[0]) =>
-      getIsBridgeChain(state, chainId),
-    [chainId],
-  );
-  const isBridgeChain = useSelector(selectIsBridgeChain);
 
-  const isSigningEnabled = useMemo(
-    () =>
-      selectedAccount.methods.includes(EthMethod.SignTransaction) ||
-      selectedAccount.methods.includes(EthMethod.SignUserOperation) ||
-      selectedAccount.methods.includes(SolMethod.SignTransaction) ||
-      selectedAccount.methods.includes(BtcMethod.SignPsbt) ||
-      selectedAccount.type === TrxAccountType.Eoa,
-    [selectedAccount.methods, selectedAccount.type],
-  );
+  const isSigningEnabled =
+    selectedAccount.methods.includes(EthMethod.SignTransaction) ||
+    selectedAccount.methods.includes(EthMethod.SignUserOperation) ||
+    selectedAccount.methods.includes(SolMethod.SignTransaction) ||
+    selectedAccount.methods.includes(BtcMethod.SignPsbt) ||
+    selectedAccount.type === TrxAccountType.Eoa;
 
   const isTestnet = useMultichainSelector(getMultichainIsTestnet);
   const shouldShowFiat = useMultichainSelector(getMultichainShouldShowFiat);
@@ -197,30 +169,27 @@ const AssetPage = ({
     getCompletedMetaMetricsOnboarding,
   );
   const isOptedIn = useSelector(getOptedIn);
-  const isMetaMetricsEnabled = useMemo(
-    () => completedMetaMetricsOnboarding && isOptedIn,
-    [completedMetaMetricsOnboarding, isOptedIn],
-  );
+  const isMetaMetricsEnabled = completedMetaMetricsOnboarding && isOptedIn;
   const isMarketingEnabled = useSelector(getDataCollectionForMarketing);
   const analyticsId = useSelector(getAnalyticsId);
 
   let address =
     (() => {
-      if (tokenAddress) {
-        return isEvm ? toChecksumHexAddress(tokenAddress) : tokenAddress;
+      if (type === AssetType.token) {
+        return isEvm ? toChecksumHexAddress(asset.address) : asset.address;
       }
       return isEvm ? getNativeTokenAddress(chainId) : nativeAssetType;
     })() ?? '';
 
   const shouldShowContractAddress = type === AssetType.token;
-  const contractAddress = useMemo(() => {
-    if (shouldShowContractAddress && tokenAddress) {
+  const contractAddress = (() => {
+    if (shouldShowContractAddress) {
       return isEvm
-        ? toChecksumHexAddress(tokenAddress)
+        ? toChecksumHexAddress(asset.address)
         : parseCaipAssetType(address as CaipAssetType).assetReference;
     }
     return '';
-  }, [shouldShowContractAddress, isEvm, tokenAddress, address]);
+  })();
 
   const { currentPrice } = useCurrentPrice(asset);
 
@@ -265,15 +234,24 @@ const AssetPage = ({
   const caipAssetId = isEvm
     ? toAssetId(address, caipChainId)
     : (decodedAsset as CaipAssetType);
+
+  const securityTrustToken = useMemo(
+    () => ({
+      symbol,
+      name,
+      chainId: String(chainId),
+      address,
+      decimals: asset.decimals,
+      isNative: type === AssetType.native,
+      image,
+    }),
+    [address, asset.decimals, chainId, image, name, symbol, type],
+  );
+
   const networkName = networkConfigurationsByChainId[chainId]?.name;
   const tokenChainImage = getImageForChainId(chainId);
 
-  const selectBip44Asset = useMemo(
-    () => (state: Parameters<typeof getAsset>[0]) =>
-      getAsset(state, address, chainId),
-    [address, chainId],
-  );
-  const bip44Asset = useSelector(selectBip44Asset);
+  const bip44Asset = useSelector((state) => getAsset(state, address, chainId));
   const rwaData =
     assetWithBalance?.rwaData ?? bip44Asset?.rwaData ?? asset.rwaData;
   const updatedAsset: Asset = {
@@ -286,62 +264,48 @@ const AssetPage = ({
     },
   };
 
-  const tokenWithFiatAmount = useMemo(
-    () => ({
-      address: isEvm ? address : assetId,
-      chainId,
-      symbol,
-      image,
-      title: name ?? symbol,
-      tokenFiatAmount: showFiat ? tokenFiatAmount : null,
-      string: balance ? balance.toString() : '',
-      decimals: asset.decimals,
-      aggregators: aggregators ?? [],
-      isNative: type === AssetType.native,
-      balance,
-      secondary: balance ? Number(balance) : 0,
-      accountType: bip44Asset?.accountType,
-      assetId: bip44Asset?.assetId ?? assetId,
-      rwaData,
-    }),
-    [
-      isEvm,
-      address,
-      assetId,
-      chainId,
-      symbol,
-      image,
-      name,
-      showFiat,
-      tokenFiatAmount,
-      balance,
-      asset.decimals,
-      aggregators,
-      type,
-      bip44Asset,
-      rwaData,
-    ],
-  );
+  const tokenWithFiatAmount = {
+    address: isEvm ? address : assetId,
+    chainId,
+    symbol,
+    image,
+    title: name ?? symbol,
+    tokenFiatAmount: showFiat ? tokenFiatAmount : null,
+    string: balance ? balance.toString() : '',
+    decimals: asset.decimals,
+    aggregators:
+      type === AssetType.token && asset.aggregators ? asset.aggregators : [],
+    isNative: type === AssetType.native,
+    balance,
+    secondary: balance ? Number(balance) : 0,
+    accountType: bip44Asset?.accountType,
+    assetId: bip44Asset?.assetId ?? assetId,
+    rwaData,
+  };
   const { safeChains } = useSafeChains();
   const { isStockToken: checkIsStockToken, isTokenTradingOpen } = useRWAToken();
   const isStockToken = checkIsStockToken(updatedAsset);
   const isMarketClosed = isStockToken && !isTokenTradingOpen(updatedAsset);
-  const assetDisplayName = useMemo(
-    () =>
-      name && symbol && name !== symbol
-        ? `${name} (${symbol})`
-        : (name ?? symbol),
-    [name, symbol],
-  );
+  const assetDisplayName =
+    name && symbol && name !== symbol
+      ? `${name} (${symbol})`
+      : (name ?? symbol);
   const assetNameElement = (
-    <Text
-      variant={TextVariant.BodyMd}
-      fontWeight={FontWeight.Medium}
-      color={TextColor.TextAlternative}
-      data-testid="asset-name"
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      gap={2}
     >
-      {assetDisplayName}
-    </Text>
+      <Text
+        variant={TextVariant.BodyMd}
+        fontWeight={FontWeight.Medium}
+        color={TextColor.TextAlternative}
+        data-testid="asset-name"
+      >
+        {assetDisplayName}
+      </Text>
+      <AssetPageSecurityTrustHeaderBadge />
+    </Box>
   );
 
   // Check if we should show Tron resources
@@ -350,14 +314,11 @@ const AssetPage = ({
 
   const isUpdatedAssetNative = isNativeAsset(updatedAsset);
   const tokenAsset = isUpdatedAssetNative ? null : updatedAsset;
-  const isMusdAssetPage = useMemo(
-    () =>
-      type === AssetType.token &&
-      isEvm &&
-      isMusdToken((asset as { address?: Hex }).address) &&
-      isMusdFlowEnabled,
-    [type, isEvm, asset, isMusdFlowEnabled],
-  );
+  const isMusdAssetPage =
+    type === AssetType.token &&
+    isEvm &&
+    isMusdToken((asset as { address?: Hex }).address) &&
+    isMusdFlowEnabled;
 
   const {
     aggregatedFiat: aggregatedMusdFiat,
@@ -365,302 +326,308 @@ const AssetPage = ({
   } = useMusdMerklPosition(isMusdAssetPage);
 
   const [isMarketClosedModalOpen, setIsMarketClosedModalOpen] = useState(false);
-  const handleOpenMarketClosedModal = useCallback(() => {
+  const handleOpenMarketClosedModal = () => {
     setIsMarketClosedModalOpen(true);
-  }, []);
+  };
 
   return (
-    <Box className="asset__content">
-      <Box
-        flexDirection={BoxFlexDirection.Row}
-        justifyContent={BoxJustifyContent.Between}
-        paddingBottom={3}
-        paddingLeft={2}
-        paddingRight={4}
-        className="pt-4 sticky top-0 z-10 bg-background-default"
-      >
-        <Box flexDirection={BoxFlexDirection.Row}>
-          <ButtonIcon
-            color={IconColor.IconDefault}
-            size={ButtonIconSize.Md}
-            ariaLabel={t('back') as string}
-            iconName={IconName.ArrowLeft}
-            onClick={() => transitionBack(() => navigate(-1))}
-            className="asset-page__back-button"
-          />
+    <AssetPageSecurityTrustProvider
+      assetId={caipAssetId as CaipAssetType}
+      token={securityTrustToken}
+    >
+      <Box className="asset__content">
+        <Box
+          flexDirection={BoxFlexDirection.Row}
+          justifyContent={BoxJustifyContent.Between}
+          paddingBottom={3}
+          paddingLeft={2}
+          paddingRight={4}
+          className="pt-4 sticky top-0 z-10 bg-background-default"
+        >
+          <Box flexDirection={BoxFlexDirection.Row}>
+            <ButtonIcon
+              color={IconColor.IconDefault}
+              size={ButtonIconSize.Md}
+              ariaLabel={t('back') as string}
+              iconName={IconName.ArrowLeft}
+              onClick={() => transitionBack(() => navigate(-1))}
+              className="asset-page__back-button"
+            />
+          </Box>
+          {optionsButton}
         </Box>
-        {optionsButton}
-      </Box>
-      <Box paddingLeft={4}>
-        {isStockToken ? (
-          <Box alignItems={BoxAlignItems.Center} gap={2}>
-            {assetNameElement}
-            <StockBadge isMarketClosed={isMarketClosed} />
-          </Box>
-        ) : (
-          assetNameElement
-        )}
-      </Box>
-      <AssetChart
-        chainId={chainId}
-        address={address}
-        currentPrice={currentPrice}
-        currency={currency}
-        asset={tokenWithFiatAmount as TokenFiatDisplayInfo}
-      />
-      <Box marginTop={4} paddingLeft={4} paddingRight={4}>
-        {isUpdatedAssetNative ? (
-          <CoinButtons
-            {...{
-              account: selectedAccount,
-              trackingLocation: 'asset-page',
-              isSigningEnabled,
-              isSwapsChain,
-              isBridgeChain,
-              chainId,
-              disableSendForNonEvm: true,
-              buyAssetId: caipAssetId,
-            }}
-          />
-        ) : null}
-        {tokenAsset ? (
-          <TokenButtons
-            token={tokenAsset}
-            disableSendForNonEvm
-            isMarketClosed={isMarketClosed}
-          />
-        ) : null}
-        {isMarketClosed && tokenAsset ? (
-          <Box marginTop={4}>
-            <MarketClosedActionButton onClick={handleOpenMarketClosedModal} />
-          </Box>
-        ) : null}
-      </Box>
-      <Box flexDirection={BoxFlexDirection.Column} paddingTop={3}>
-        {showTronResources && (
-          <Box>
-            <TronDailyResources
-              account={selectedAccount}
-              chainId={chainId}
-              t={t}
+        <Box paddingLeft={4}>
+          {isStockToken ? (
+            <Box alignItems={BoxAlignItems.Center} gap={2}>
+              {assetNameElement}
+              <StockBadge isMarketClosed={isMarketClosed} />
+            </Box>
+          ) : (
+            assetNameElement
+          )}
+        </Box>
+        <AssetPageSecurityTrustBanner />
+        <AssetChart
+          chainId={chainId}
+          address={address}
+          currentPrice={currentPrice}
+          currency={currency}
+          asset={tokenWithFiatAmount as TokenFiatDisplayInfo}
+        />
+        <Box marginTop={4} paddingLeft={4} paddingRight={4}>
+          {isUpdatedAssetNative ? (
+            <CoinButtons
+              {...{
+                account: selectedAccount,
+                trackingLocation: 'asset-page',
+                isSigningEnabled,
+                isSwapsChain,
+                isBridgeChain,
+                chainId,
+                disableSendForNonEvm: true,
+                buyAssetId: caipAssetId,
+              }}
             />
-            <Box
-              marginTop={2}
-              marginBottom={2}
-              className="asset-page__divider"
+          ) : null}
+          {tokenAsset ? (
+            <TokenButtons
+              token={tokenAsset}
+              disableSendForNonEvm
+              isMarketClosed={isMarketClosed}
             />
-          </Box>
-        )}
-        {isMusdAssetPage ? (
-          <>
-            <MusdPositionSection
-              balanceDisplay={balance ? `${balance} ${t('musdSymbol')}` : '0'}
-              fiatValue={tokenFiatAmount}
-              showFiat={showFiat}
-            />
-            {isMerklClaimingEnabled ? (
-              <>
+          ) : null}
+          {isMarketClosed && tokenAsset ? (
+            <Box marginTop={4}>
+              <MarketClosedActionButton onClick={handleOpenMarketClosedModal} />
+            </Box>
+          ) : null}
+        </Box>
+        <Box flexDirection={BoxFlexDirection.Column} paddingTop={3}>
+          {showTronResources && (
+            <Box>
+              <TronDailyResources
+                account={selectedAccount}
+                chainId={chainId}
+                t={t}
+              />
+              <Box
+                marginTop={2}
+                marginBottom={2}
+                className="asset-page__divider"
+              />
+            </Box>
+          )}
+          {isMusdAssetPage ? (
+            <>
+              <MusdPositionSection
+                balanceDisplay={balance ? `${balance} ${t('musdSymbol')}` : '0'}
+                fiatValue={tokenFiatAmount}
+                showFiat={showFiat}
+              />
+              {isMerklClaimingEnabled ? (
+                <>
+                  <Box
+                    marginTop={5}
+                    marginBottom={5}
+                    className="asset-page__divider"
+                  />
+                  <MusdBonusSection
+                    chainId={chainId as Hex}
+                    tokenAddress={(asset as { address: Hex }).address}
+                    positionFiatValue={showFiat ? aggregatedMusdFiat : null}
+                    showFiat={showFiat}
+                    hasPositiveBalance={hasAnyMusdBalance}
+                  />
+                  <Box
+                    marginTop={5}
+                    marginBottom={5}
+                    className="asset-page__divider"
+                  />
+                </>
+              ) : (
                 <Box
                   marginTop={5}
                   marginBottom={5}
                   className="asset-page__divider"
                 />
-                <MusdBonusSection
-                  chainId={chainId as Hex}
-                  tokenAddress={(asset as { address: Hex }).address}
-                  positionFiatValue={showFiat ? aggregatedMusdFiat : null}
-                  showFiat={showFiat}
-                  hasPositiveBalance={hasAnyMusdBalance}
-                />
-                <Box
-                  marginTop={5}
-                  marginBottom={5}
-                  className="asset-page__divider"
-                />
-              </>
-            ) : (
+              )}
+              <MusdConvertSection />
               <Box
                 marginTop={5}
                 marginBottom={5}
                 className="asset-page__divider"
               />
-            )}
-            <MusdConvertSection />
-            <Box
-              marginTop={5}
-              marginBottom={5}
-              className="asset-page__divider"
-            />
-          </>
-        ) : (
-          <>
-            <Text
-              variant={TextVariant.HeadingSm}
-              className="asset-page__balance-heading"
-            >
-              {t('yourBalance')}
-            </Text>
-            {[AssetType.token, AssetType.native].includes(type) && (
-              <TokenCell
-                key={`${symbol}-${address}`}
-                token={tokenWithFiatAmount as TokenWithFiatAmount}
-                safeChains={safeChains}
-                musd={ASSET_OVERVIEW_TOKEN_CELL_MUSD_OPTIONS}
-              />
-            )}
-          </>
-        )}
-        {/* mUSD Conversion CTA - shows for eligible stablecoins */}
-        {!isNativeAsset(updatedAsset) &&
-          type === AssetType.token &&
-          isEvm &&
-          !isMusdAssetPage &&
-          checkMusdCtaVisibility({
-            address: (asset as { address: Hex }).address,
-            chainId,
-            symbol,
-          }) && (
-            <Box marginTop={2} paddingLeft={4} paddingRight={4}>
-              <MusdAssetCta
-                token={{
-                  address: (asset as { address: Hex }).address,
-                  chainId: chainId as string,
-                  symbol,
-                  balance: String(balance),
-                  fiatBalance: String(tokenFiatAmount),
-                }}
-                variant="card"
-              />
-            </Box>
-          )}
-        <Box marginTop={6} flexDirection={BoxFlexDirection.Column} gap={4}>
-          {[AssetType.token, AssetType.native].includes(type) && (
-            <Box
-              flexDirection={BoxFlexDirection.Column}
-              paddingLeft={4}
-              paddingRight={4}
-            >
+            </>
+          ) : (
+            <>
               <Text
                 variant={TextVariant.HeadingSm}
-                className="asset-page__details-heading"
+                className="asset-page__balance-heading"
               >
-                {t('tokenDetails')}
+                {t('yourBalance')}
               </Text>
-              <Box flexDirection={BoxFlexDirection.Column} gap={2}>
-                {renderRow(
-                  t('network'),
-                  <Box
-                    flexDirection={BoxFlexDirection.Row}
-                    alignItems={BoxAlignItems.Center}
-                    gap={2}
-                    data-testid="asset-network"
-                  >
-                    <AvatarNetwork
-                      src={tokenChainImage}
-                      name={networkName}
-                      size={AvatarNetworkSize.Xs}
-                    />
-                    <Text
-                      variant={TextVariant.BodyMd}
-                      fontWeight={FontWeight.Medium}
+              {[AssetType.token, AssetType.native].includes(type) && (
+                <TokenCell
+                  key={`${symbol}-${address}`}
+                  token={tokenWithFiatAmount as TokenWithFiatAmount}
+                  safeChains={safeChains}
+                  musd={ASSET_OVERVIEW_TOKEN_CELL_MUSD_OPTIONS}
+                />
+              )}
+            </>
+          )}
+          {/* mUSD Conversion CTA - shows for eligible stablecoins */}
+          {!isNativeAsset(updatedAsset) &&
+            type === AssetType.token &&
+            isEvm &&
+            !isMusdAssetPage &&
+            checkMusdCtaVisibility({
+              address: (asset as { address: Hex }).address,
+              chainId,
+              symbol,
+            }) && (
+              <Box marginTop={2} paddingLeft={4} paddingRight={4}>
+                <MusdAssetCta
+                  token={{
+                    address: (asset as { address: Hex }).address,
+                    chainId: chainId as string,
+                    symbol,
+                    balance: String(balance),
+                    fiatBalance: String(tokenFiatAmount),
+                  }}
+                  variant="card"
+                />
+              </Box>
+            )}
+          <Box marginTop={6} flexDirection={BoxFlexDirection.Column} gap={4}>
+            {[AssetType.token, AssetType.native].includes(type) && (
+              <Box
+                flexDirection={BoxFlexDirection.Column}
+                paddingLeft={4}
+                paddingRight={4}
+              >
+                <Text
+                  variant={TextVariant.HeadingSm}
+                  className="asset-page__details-heading"
+                >
+                  {t('tokenDetails')}
+                </Text>
+                <Box flexDirection={BoxFlexDirection.Column} gap={2}>
+                  {renderRow(
+                    t('network'),
+                    <Box
+                      flexDirection={BoxFlexDirection.Row}
+                      alignItems={BoxAlignItems.Center}
+                      gap={2}
+                      data-testid="asset-network"
                     >
-                      {networkName}
-                    </Text>
-                  </Box>,
-                )}
-                {shouldShowContractAddress && (
-                  <Box>
-                    {renderRow(
-                      t('contractAddress'),
-                      <AddressCopyButton address={contractAddress} shorten />,
-                    )}
-                    <Box flexDirection={BoxFlexDirection.Column} gap={2}>
-                      {isMusdAssetPage
-                        ? renderRow(
-                            t('tokenStandard'),
+                      <AvatarNetwork
+                        src={tokenChainImage}
+                        name={networkName}
+                        size={AvatarNetworkSize.Xs}
+                      />
+                      <Text
+                        variant={TextVariant.BodyMd}
+                        fontWeight={FontWeight.Medium}
+                      >
+                        {networkName}
+                      </Text>
+                    </Box>,
+                  )}
+                  {shouldShowContractAddress && (
+                    <Box>
+                      {renderRow(
+                        t('contractAddress'),
+                        <AddressCopyButton address={contractAddress} shorten />,
+                      )}
+                      <Box flexDirection={BoxFlexDirection.Column} gap={2}>
+                        {isMusdAssetPage
+                          ? renderRow(
+                              t('tokenStandard'),
+                              <Text
+                                variant={TextVariant.BodyMd}
+                                fontWeight={FontWeight.Medium}
+                              >
+                                ERC-20
+                              </Text>,
+                            )
+                          : null}
+                        {asset.decimals !== undefined &&
+                          renderRow(
+                            t('tokenDecimal'),
                             <Text
                               variant={TextVariant.BodyMd}
                               fontWeight={FontWeight.Medium}
                             >
-                              ERC-20
+                              {asset.decimals}
                             </Text>,
-                          )
-                        : null}
-                      {asset.decimals !== undefined &&
-                        renderRow(
-                          t('tokenDecimal'),
-                          <Text
-                            variant={TextVariant.BodyMd}
-                            fontWeight={FontWeight.Medium}
-                          >
-                            {asset.decimals}
-                          </Text>,
+                          )}
+                        {asset.aggregators && asset.aggregators.length > 0 && (
+                          <Box>
+                            <Text
+                              variant={TextVariant.BodyMd}
+                              fontWeight={FontWeight.Medium}
+                              color={TextColor.TextAlternative}
+                            >
+                              {t('tokenList')}
+                            </Text>
+                            <Text
+                              variant={TextVariant.BodyMd}
+                              fontWeight={FontWeight.Medium}
+                            >
+                              {asset.aggregators
+                                .map((agg) =>
+                                  agg.replace(/^metamask$/iu, 'MetaMask'),
+                                )
+                                .join(', ')}
+                            </Text>
+                          </Box>
                         )}
-                      {aggregators && aggregators.length > 0 && (
-                        <Box>
-                          <Text
-                            variant={TextVariant.BodyMd}
-                            fontWeight={FontWeight.Medium}
-                            color={TextColor.TextAlternative}
-                          >
-                            {t('tokenList')}
-                          </Text>
-                          <Text
-                            variant={TextVariant.BodyMd}
-                            fontWeight={FontWeight.Medium}
-                          >
-                            {aggregators
-                              .map((agg) =>
-                                agg.replace(/^metamask$/iu, 'MetaMask'),
-                              )
-                              .join(', ')}
-                          </Text>
-                        </Box>
-                      )}
+                      </Box>
                     </Box>
-                  </Box>
-                )}
-                {shouldShowSpendingCaps &&
-                  renderRow(
-                    t('spendingCaps'),
-                    <TextButton size={TextButtonSize.BodyMd} asChild>
-                      <a
-                        className="asset-page__spending-caps"
-                        href={portfolioSpendingCapsUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                      >
-                        {t('editInPortfolio')}
-                      </a>
-                    </TextButton>,
                   )}
+                  {shouldShowSpendingCaps &&
+                    renderRow(
+                      t('spendingCaps'),
+                      <TextButton size={TextButtonSize.BodyMd} asChild>
+                        <a
+                          className="asset-page__spending-caps"
+                          href={portfolioSpendingCapsUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                        >
+                          {t('editInPortfolio')}
+                        </a>
+                      </TextButton>,
+                    )}
+                </Box>
               </Box>
-            </Box>
-          )}
-          <AssetMarketDetails asset={updatedAsset} address={address} />
-          <Box className="asset-page__divider" />
-          <Box marginBottom={4}>
-            <Text
-              variant={TextVariant.HeadingSm}
-              className="asset-page__activity-heading"
-            >
-              {t('yourActivity')}
-            </Text>
-            {caipAssetId && (
-              <ActivityList
-                filter={{
-                  assetId: caipAssetId,
-                }}
-              />
             )}
+            <AssetMarketDetails asset={updatedAsset} address={address} />
+            <Box className="asset-page__divider" />
+            <Box marginBottom={4}>
+              <Text
+                variant={TextVariant.HeadingSm}
+                className="asset-page__activity-heading"
+              >
+                {t('yourActivity')}
+              </Text>
+              {caipAssetId && (
+                <ActivityList
+                  filter={{
+                    assetId: caipAssetId,
+                  }}
+                />
+              )}
+            </Box>
           </Box>
         </Box>
+        <MarketClosedModal
+          isOpen={isMarketClosedModalOpen}
+          onClose={() => setIsMarketClosedModalOpen(false)}
+        />
       </Box>
-      <MarketClosedModal
-        isOpen={isMarketClosedModalOpen}
-        onClose={() => setIsMarketClosedModalOpen(false)}
-      />
-    </Box>
+    </AssetPageSecurityTrustProvider>
   );
 };
 

--- a/ui/pages/asset/components/asset-page.tsx
+++ b/ui/pages/asset/components/asset-page.tsx
@@ -35,6 +35,10 @@ import React, { ReactNode, useEffect, useMemo, useState } from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router-dom';
 import { AssetType } from '../../../../shared/constants/transaction';
+import { ALLOWED_BRIDGE_CHAIN_IDS } from '../../../../shared/constants/bridge';
+import {
+  ALLOWED_DEV_SWAPS_CHAIN_IDS,
+} from '../../../../shared/constants/swaps';
 import { isEvmChainId, toAssetId } from '../../../../shared/lib/asset-utils';
 import { endTrace, TraceName } from '../../../../shared/lib/trace';
 import { hexToDecimal } from '../../../../shared/lib/conversion.utils';
@@ -59,8 +63,6 @@ import { useMultichainSelector } from '../../../hooks/useMultichainSelector';
 import { transitionBack } from '../../../components/ui/transition';
 import {
   getDataCollectionForMarketing,
-  getIsBridgeChain,
-  getIsSwapsChain,
   getAnalyticsId,
   getCompletedMetaMetricsOnboarding,
   getOptedIn,
@@ -138,9 +140,15 @@ const AssetPage = ({
 
   const { chainId, type, symbol, name, image } = asset;
 
-  const isSwapsChain = useSelector((state) => getIsSwapsChain(state, chainId));
-  const isBridgeChain = useSelector((state) =>
-    getIsBridgeChain(state, chainId),
+  const isSwapsChain = useMemo(
+    () =>
+      (ALLOWED_DEV_SWAPS_CHAIN_IDS as readonly string[]).includes(chainId),
+    [chainId],
+  );
+
+  const isBridgeChain = useMemo(
+    () => (ALLOWED_BRIDGE_CHAIN_IDS as readonly string[]).includes(chainId),
+    [chainId],
   );
 
   const isSigningEnabled =

--- a/ui/pages/asset/components/security-trust/asset-page-security-trust.test.tsx
+++ b/ui/pages/asset/components/security-trust/asset-page-security-trust.test.tsx
@@ -1,0 +1,151 @@
+import React from 'react';
+import { configureStore } from '@reduxjs/toolkit';
+import type { TokenSecurityData } from '@metamask/assets-controllers';
+import type { CaipAssetType } from '@metamask/utils';
+import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
+import {
+  AssetPageSecurityTrustBanner,
+  AssetPageSecurityTrustHeaderBadge,
+  AssetPageSecurityTrustProvider,
+} from './asset-page-security-trust';
+
+jest.mock('../../../../hooks/useTokenSecurityData', () => ({
+  useTokenSecurityData: jest.fn(),
+}));
+
+const { useTokenSecurityData } = jest.requireMock(
+  '../../../../hooks/useTokenSecurityData',
+);
+
+const assetId = 'eip155:1/erc20:0xabc' as CaipAssetType;
+
+const token = {
+  symbol: 'AAVE',
+  name: 'Aave',
+  chainId: 'eip155:1',
+  address: '0xabc',
+  decimals: 18,
+  isNative: false,
+};
+
+const mockSecurityData: TokenSecurityData = {
+  resultType: 'Verified',
+  maliciousScore: '0',
+  features: [
+    {
+      featureId: 'VERIFIED_CONTRACT',
+      type: 'Info',
+      description: 'Verified contract',
+    },
+  ],
+  fees: {
+    transfer: 0,
+    transferFeeMaxAmount: null,
+    buy: 0,
+    sell: null,
+  },
+  financialStats: {
+    supply: 1000000,
+    topHolders: [],
+    holdersCount: 100,
+    tradeVolume24h: null,
+    lockedLiquidityPct: null,
+    markets: [],
+  },
+  metadata: {
+    externalLinks: {
+      homepage: null,
+      twitterPage: null,
+      telegramChannelId: null,
+    },
+  },
+  created: '2020-01-01T00:00:00.000Z',
+};
+
+const createStore = (useExternalServices: boolean) =>
+  configureStore({
+    reducer: (state = { metamask: { useExternalServices } }) => state,
+  });
+
+const renderSlots = ({
+  securityData = mockSecurityData,
+  useExternalServices = true,
+  isLoading = false,
+  error = null,
+}: {
+  securityData?: TokenSecurityData | null;
+  useExternalServices?: boolean;
+  isLoading?: boolean;
+  error?: Error | null;
+} = {}) => {
+  useTokenSecurityData.mockReturnValue({
+    securityData,
+    isLoading,
+    error,
+  });
+
+  return renderWithProvider(
+    <AssetPageSecurityTrustProvider assetId={assetId} token={token}>
+      <AssetPageSecurityTrustHeaderBadge />
+      <AssetPageSecurityTrustBanner />
+    </AssetPageSecurityTrustProvider>,
+    createStore(useExternalServices),
+  );
+};
+
+describe('AssetPageSecurityTrust', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders verified header badge for verified tokens', () => {
+    const { getAllByTestId } = renderSlots();
+    expect(getAllByTestId('security-badge-verified').length).toBeGreaterThan(0);
+  });
+
+  it('renders malicious banner when result type is malicious', () => {
+    const { getByTestId } = renderSlots({
+      securityData: { ...mockSecurityData, resultType: 'Malicious' },
+    });
+
+    expect(getByTestId('security-banner-malicious')).toBeInTheDocument();
+  });
+
+  it('renders warning banner when result type is warning', () => {
+    const { getByTestId } = renderSlots({
+      securityData: { ...mockSecurityData, resultType: 'Warning' },
+    });
+
+    expect(getByTestId('security-banner-warning')).toBeInTheDocument();
+  });
+
+  it('renders nothing when feature is disabled', () => {
+    const { queryByTestId } = renderSlots({ useExternalServices: false });
+
+    expect(queryByTestId('security-badge-verified')).not.toBeInTheDocument();
+    expect(queryByTestId('security-banner-malicious')).not.toBeInTheDocument();
+    expect(queryByTestId('security-banner-warning')).not.toBeInTheDocument();
+  });
+
+  it('hides badge and banner while security data is loading', () => {
+    const { queryByTestId } = renderSlots({
+      securityData: null,
+      isLoading: true,
+    });
+
+    expect(queryByTestId('security-badge-verified')).not.toBeInTheDocument();
+    expect(queryByTestId('security-banner-malicious')).not.toBeInTheDocument();
+    expect(queryByTestId('security-banner-warning')).not.toBeInTheDocument();
+  });
+
+  it('hides badge and banner when security data fetch fails', () => {
+    const { queryByTestId } = renderSlots({
+      securityData: null,
+      isLoading: false,
+      error: new Error('Fetch failed'),
+    });
+
+    expect(queryByTestId('security-badge-verified')).not.toBeInTheDocument();
+    expect(queryByTestId('security-banner-malicious')).not.toBeInTheDocument();
+  });
+});

--- a/ui/pages/asset/components/security-trust/asset-page-security-trust.tsx
+++ b/ui/pages/asset/components/security-trust/asset-page-security-trust.tsx
@@ -1,0 +1,180 @@
+import { BannerAlertSeverity, Box } from '@metamask/design-system-react';
+import type { TokenSecurityData } from '@metamask/assets-controllers';
+import type { CaipAssetType } from '@metamask/utils';
+import React, {
+  createContext,
+  useContext,
+  useMemo,
+  type ReactNode,
+} from 'react';
+import { useSelector } from 'react-redux';
+import { useI18nContext } from '../../../../hooks/useI18nContext';
+import { useTokenSecurityData } from '../../../../hooks/useTokenSecurityData';
+import { getUseExternalServices } from '../../../../selectors';
+import {
+  getResultTypeConfig,
+  type ResultTypeConfig,
+} from '../../utils/security-utils';
+import { SecurityBanner } from './security-banner';
+import { SecurityTrustVerifiedBadge } from './security-trust-inline-badge';
+
+export type AssetPageSecurityTrustToken = {
+  symbol: string;
+  name?: string;
+  chainId: string;
+  address?: string;
+  decimals?: number;
+  isNative?: boolean;
+  image?: string;
+};
+
+type AssetPageSecurityTrustProviderProps = {
+  assetId: CaipAssetType | null | undefined;
+  token: AssetPageSecurityTrustToken;
+  children: ReactNode;
+};
+
+type AssetPageSecurityTrustContextValue = {
+  isEnabled: boolean;
+  securityConfig: ResultTypeConfig;
+  securityData: TokenSecurityData | null;
+  isLoading: boolean;
+  showVerifiedBadge: boolean;
+  showSecurityBanner: boolean;
+  securityBannerDescription: string;
+};
+
+const AssetPageSecurityTrustContext =
+  createContext<AssetPageSecurityTrustContextValue | null>(null);
+
+const useAssetPageSecurityTrustContext = () =>
+  useContext(AssetPageSecurityTrustContext);
+
+/**
+ * Provides Security & Trust data and visibility for the Token Details Page.
+ * Wrap TDP content once, then place slot components where needed.
+ *
+ * @param options - Provider options.
+ * @param options.assetId - CAIP-19 asset ID for security data fetch.
+ * @param options.token - Token metadata for display and analytics context.
+ * @param options.children - TDP content to wrap.
+ */
+export const AssetPageSecurityTrustProvider = ({
+  assetId,
+  token,
+  children,
+}: AssetPageSecurityTrustProviderProps) => {
+  const t = useI18nContext();
+  const isEnabled = useSelector(getUseExternalServices);
+  const resolvedAssetId =
+    isEnabled && assetId ? (assetId as CaipAssetType) : null;
+
+  const {
+    securityData,
+    isLoading: isSecurityDataLoading,
+    error: securityDataError,
+  } = useTokenSecurityData({
+    assetId: resolvedAssetId,
+  });
+
+  const securityConfig = getResultTypeConfig(
+    securityData?.resultType,
+    t as (key: string, substitutions?: string[]) => string,
+  );
+
+  const tokenDisplaySymbol = token.symbol || token.name || '';
+  const securityBannerDescription = useMemo(() => {
+    if (securityData?.resultType === 'Malicious') {
+      return tokenDisplaySymbol
+        ? t('securityTrustMaliciousTokenBannerDescription', [
+            tokenDisplaySymbol,
+          ])
+        : t('securityTrustMaliciousTokenBannerDescriptionNoSymbol');
+    }
+
+    return tokenDisplaySymbol
+      ? t('securityTrustSuspiciousTokenDescription', [tokenDisplaySymbol])
+      : t('securityTrustSuspiciousTokenDescriptionNoSymbol');
+  }, [securityData?.resultType, t, tokenDisplaySymbol]);
+
+  const contextValue = useMemo<AssetPageSecurityTrustContextValue>(
+    () => ({
+      isEnabled,
+      securityConfig,
+      securityData,
+      isLoading: isSecurityDataLoading,
+      showVerifiedBadge:
+        isEnabled &&
+        !isSecurityDataLoading &&
+        !securityDataError &&
+        securityData?.resultType === 'Verified',
+      showSecurityBanner:
+        isEnabled &&
+        !isSecurityDataLoading &&
+        !securityDataError &&
+        (securityData?.resultType === 'Malicious' ||
+          securityData?.resultType === 'Warning' ||
+          securityData?.resultType === 'Spam'),
+      securityBannerDescription,
+    }),
+    [
+      isEnabled,
+      isSecurityDataLoading,
+      securityBannerDescription,
+      securityConfig,
+      securityData,
+      securityDataError,
+    ],
+  );
+
+  return (
+    <AssetPageSecurityTrustContext.Provider value={contextValue}>
+      {children}
+    </AssetPageSecurityTrustContext.Provider>
+  );
+};
+
+/** Verified badge shown next to the asset name on TDP. */
+export const AssetPageSecurityTrustHeaderBadge = () => {
+  const context = useAssetPageSecurityTrustContext();
+
+  if (!context?.showVerifiedBadge || !context.securityConfig.badge) {
+    return null;
+  }
+
+  return (
+    <SecurityTrustVerifiedBadge
+      badge={context.securityConfig.badge}
+      testId="security-badge-verified"
+    />
+  );
+};
+
+/** Warning banner shown below the token name row on TDP. */
+export const AssetPageSecurityTrustBanner = () => {
+  const t = useI18nContext();
+  const context = useAssetPageSecurityTrustContext();
+
+  if (!context?.showSecurityBanner || !context.securityData) {
+    return null;
+  }
+
+  const { securityData, securityConfig, securityBannerDescription } = context;
+  const isMalicious = securityData.resultType === 'Malicious';
+
+  return (
+    <Box marginTop={3} marginBottom={3} paddingLeft={4} paddingRight={4}>
+      <SecurityBanner
+        securityConfig={securityConfig}
+        severity={
+          isMalicious ? BannerAlertSeverity.Danger : BannerAlertSeverity.Warning
+        }
+        testId={
+          isMalicious ? 'security-banner-malicious' : 'security-banner-warning'
+        }
+        title={isMalicious ? t('securityTrustMaliciousTokenTitle') : undefined}
+        description={securityBannerDescription}
+      />
+    </Box>
+  );
+};

--- a/ui/pages/asset/components/security-trust/index.ts
+++ b/ui/pages/asset/components/security-trust/index.ts
@@ -1,0 +1,11 @@
+export {
+  AssetPageSecurityTrustProvider,
+  AssetPageSecurityTrustHeaderBadge,
+  AssetPageSecurityTrustBanner,
+} from './asset-page-security-trust';
+export type { AssetPageSecurityTrustToken } from './asset-page-security-trust';
+export { SecurityBanner } from './security-banner';
+export {
+  SecurityTrustInlineBadge,
+  SecurityTrustVerifiedBadge,
+} from './security-trust-inline-badge';

--- a/ui/pages/asset/components/security-trust/security-banner.test.tsx
+++ b/ui/pages/asset/components/security-trust/security-banner.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { BannerAlertSeverity } from '@metamask/design-system-react';
+import { getResultTypeConfig } from '../../utils/security-utils';
+import { SecurityBanner } from './security-banner';
+
+const t = (key: string) => key;
+
+describe('SecurityBanner', () => {
+  it('renders malicious banner', () => {
+    const config = getResultTypeConfig('Malicious', t);
+    const { getByTestId } = render(
+      <SecurityBanner
+        securityConfig={config}
+        severity={BannerAlertSeverity.Danger}
+        testId="security-banner-malicious"
+        title="securityTrustMaliciousTokenTitle"
+        description="Malicious token description"
+      />,
+    );
+
+    expect(getByTestId('security-banner-malicious')).toBeInTheDocument();
+  });
+
+  it('calls onClick when banner is pressed', () => {
+    const config = getResultTypeConfig('Malicious', t);
+    const onClick = jest.fn();
+    const { getByTestId } = render(
+      <SecurityBanner
+        securityConfig={config}
+        severity={BannerAlertSeverity.Danger}
+        testId="security-banner-malicious"
+        title="securityTrustMaliciousTokenTitle"
+        description="Malicious token description"
+        onClick={onClick}
+      />,
+    );
+
+    fireEvent.click(getByTestId('security-banner-malicious'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/pages/asset/components/security-trust/security-banner.tsx
+++ b/ui/pages/asset/components/security-trust/security-banner.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import {
+  BannerAlert,
+  BannerAlertSeverity,
+} from '@metamask/design-system-react';
+import type { ResultTypeConfig } from '../../utils/security-utils';
+
+export type SecurityBannerProps = {
+  securityConfig: ResultTypeConfig;
+  severity: BannerAlertSeverity;
+  testId: string;
+  title?: string;
+  description: string;
+  onClick?: () => void;
+};
+
+export const SecurityBanner = ({
+  securityConfig,
+  severity,
+  testId,
+  title,
+  description,
+  onClick,
+}: SecurityBannerProps) => {
+  const banner = (
+    <BannerAlert
+      data-testid={onClick ? undefined : testId}
+      severity={severity}
+      title={title ?? securityConfig.label}
+      description={description}
+    />
+  );
+
+  if (!onClick) {
+    return banner;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-testid={testId}
+      className="w-full cursor-pointer border-0 bg-transparent p-0 text-left"
+    >
+      {banner}
+    </button>
+  );
+};

--- a/ui/pages/asset/components/security-trust/security-trust-inline-badge.test.tsx
+++ b/ui/pages/asset/components/security-trust/security-trust-inline-badge.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { fireEvent, render } from '@testing-library/react';
+import { getResultTypeConfig } from '../../utils/security-utils';
+import {
+  SecurityTrustInlineBadge,
+  SecurityTrustVerifiedBadge,
+  type SecurityTrustInlineBadgeConfig,
+} from './security-trust-inline-badge';
+
+const t = (key: string) => key;
+
+const getTestBadgeConfig = (
+  resultType: string,
+): SecurityTrustInlineBadgeConfig => {
+  const { badge } = getResultTypeConfig(resultType, t);
+  expect(badge).toBeDefined();
+  if (!badge) {
+    throw new Error(`Expected badge config for result type: ${resultType}`);
+  }
+  return badge;
+};
+
+describe('SecurityTrustInlineBadge', () => {
+  it('renders verified icon without onClick', () => {
+    const badge = getTestBadgeConfig('Verified');
+    const { getByTestId } = render(
+      <SecurityTrustInlineBadge
+        badge={badge}
+        testId="security-badge-verified"
+      />,
+    );
+
+    expect(getByTestId('security-badge-verified')).toBeInTheDocument();
+  });
+
+  it('wraps verified icon in a button when onClick is provided', () => {
+    const badge = getTestBadgeConfig('Verified');
+    const onClick = jest.fn();
+    const { getByTestId } = render(
+      <SecurityTrustInlineBadge
+        badge={badge}
+        testId="security-badge-verified"
+        onClick={onClick}
+      />,
+    );
+
+    fireEvent.click(getByTestId('security-badge-verified'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders labeled warning badge with warning background', () => {
+    const badge = getTestBadgeConfig('Warning');
+    const { getByTestId, getByText } = render(
+      <SecurityTrustInlineBadge
+        badge={badge}
+        testId="security-badge-warning"
+      />,
+    );
+
+    expect(getByTestId('security-badge-warning')).toHaveClass(
+      'bg-warning-muted',
+    );
+    expect(getByText('securityTrustRisky')).toBeInTheDocument();
+  });
+
+  it('renders labeled malicious badge with error background', () => {
+    const badge = getTestBadgeConfig('Malicious');
+    const { getByTestId, getByText } = render(
+      <SecurityTrustInlineBadge
+        badge={badge}
+        testId="security-badge-malicious"
+      />,
+    );
+
+    expect(getByTestId('security-badge-malicious')).toHaveClass(
+      'bg-error-muted',
+    );
+    expect(getByText('securityTrustMalicious')).toBeInTheDocument();
+  });
+
+  it('wraps labeled badge in a button when onClick is provided', () => {
+    const badge = getTestBadgeConfig('Warning');
+    const onClick = jest.fn();
+    const { getByTestId } = render(
+      <SecurityTrustInlineBadge
+        badge={badge}
+        testId="security-badge-warning"
+        onClick={onClick}
+      />,
+    );
+
+    fireEvent.click(getByTestId('security-badge-warning'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('SecurityTrustVerifiedBadge', () => {
+  it('renders verified badge wrapper without onClick', () => {
+    const badge = getTestBadgeConfig('Verified');
+    const { getAllByTestId } = render(
+      <SecurityTrustVerifiedBadge badge={badge} />,
+    );
+
+    expect(getAllByTestId('security-badge-verified').length).toBeGreaterThan(0);
+  });
+
+  it('delegates onClick to inline badge', () => {
+    const badge = getTestBadgeConfig('Verified');
+    const onClick = jest.fn();
+    const { getByTestId } = render(
+      <SecurityTrustVerifiedBadge badge={badge} onClick={onClick} />,
+    );
+
+    fireEvent.click(getByTestId('security-badge-verified'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ui/pages/asset/components/security-trust/security-trust-inline-badge.tsx
+++ b/ui/pages/asset/components/security-trust/security-trust-inline-badge.tsx
@@ -1,0 +1,111 @@
+import React from 'react';
+import {
+  Box,
+  BoxAlignItems,
+  BoxFlexDirection,
+  FontWeight,
+  Icon,
+  IconSize,
+  Text,
+  TextVariant,
+} from '@metamask/design-system-react';
+import type { ResultTypeConfig } from '../../utils/security-utils';
+
+export type SecurityTrustInlineBadgeConfig = NonNullable<
+  ResultTypeConfig['badge']
+>;
+
+type SecurityTrustInlineBadgeProps = {
+  badge: SecurityTrustInlineBadgeConfig;
+  testId?: string;
+  onClick?: () => void;
+};
+
+export const SecurityTrustInlineBadge = ({
+  badge,
+  testId,
+  onClick,
+}: SecurityTrustInlineBadgeProps) => {
+  if (badge.label === null) {
+    const verifiedIcon = (
+      <Icon
+        data-testid={onClick ? undefined : testId}
+        name={badge.icon}
+        size={IconSize.Sm}
+        color={badge.iconColor}
+      />
+    );
+
+    if (onClick) {
+      return (
+        <button
+          type="button"
+          onClick={onClick}
+          data-testid={testId}
+          aria-label={testId ?? 'security-badge'}
+          className="cursor-pointer border-0 bg-transparent p-0 leading-none"
+        >
+          {verifiedIcon}
+        </button>
+      );
+    }
+
+    return verifiedIcon;
+  }
+
+  const tagBackgroundClass =
+    badge.backgroundColor === 'warning-muted'
+      ? 'bg-warning-muted'
+      : 'bg-error-muted';
+
+  const tag = (
+    <Box
+      flexDirection={BoxFlexDirection.Row}
+      alignItems={BoxAlignItems.Center}
+      className={`inline-flex self-start items-center gap-1 rounded-md px-2 py-0.5 ${tagBackgroundClass}`}
+      data-testid={onClick ? undefined : testId}
+    >
+      <Icon name={badge.icon} size={IconSize.Sm} color={badge.iconColor} />
+      <Text
+        variant={TextVariant.BodyXs}
+        color={badge.textColor}
+        fontWeight={FontWeight.Medium}
+      >
+        {badge.label}
+      </Text>
+    </Box>
+  );
+
+  if (!onClick) {
+    return tag;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-testid={testId}
+      className="cursor-pointer border-0 bg-transparent p-0"
+    >
+      {tag}
+    </button>
+  );
+};
+
+export const SecurityTrustVerifiedBadge = ({
+  badge,
+  testId = 'security-badge-verified',
+  onClick,
+}: {
+  badge: SecurityTrustInlineBadgeConfig;
+  testId?: string;
+  onClick?: () => void;
+}) => (
+  <Box
+    flexDirection={BoxFlexDirection.Row}
+    alignItems={BoxAlignItems.Center}
+    data-testid={onClick ? undefined : testId}
+  >
+    <SecurityTrustInlineBadge badge={badge} testId={testId} onClick={onClick} />
+  </Box>
+);

--- a/ui/pages/asset/types/security-trust.ts
+++ b/ui/pages/asset/types/security-trust.ts
@@ -1,0 +1,26 @@
+import type { TokenSecurityData } from '@metamask/assets-controllers';
+
+export type {
+  TokenSecurityData,
+  TokenSecurityFeature,
+  TokenSecurityFees,
+  TokenSecurityFinancialStats,
+  TokenSecurityHolder,
+  TokenSecurityMarket,
+  TokenSecurityMetadata,
+} from '@metamask/assets-controllers';
+
+export type FeatureTag = {
+  label: string;
+};
+
+export type SecurityTrustLocationState = {
+  securityData?: TokenSecurityData | null;
+  symbol?: string;
+  name?: string;
+  decimals?: number;
+  isNative?: boolean;
+  image?: string;
+  chainId?: string;
+  address?: string;
+};

--- a/ui/pages/asset/utils/security-utils.test.ts
+++ b/ui/pages/asset/utils/security-utils.test.ts
@@ -1,0 +1,127 @@
+import { IconColor, IconName, TextColor } from '@metamask/design-system-react';
+import type {
+  TokenSecurityFeature,
+  TokenSecurityFinancialStats,
+} from '../types/security-trust';
+import {
+  formatCompactSupply,
+  formatFeePercent,
+  getFeatureTags,
+  getResultTypeConfig,
+  getTop10HoldingPct,
+  hasNoHiddenFees,
+} from './security-utils';
+
+const t = (key: string, substitutions?: string[]) => {
+  if (substitutions?.length) {
+    return `${key}:${substitutions.join(',')}`;
+  }
+  return key;
+};
+
+describe('security-utils', () => {
+  describe('getResultTypeConfig', () => {
+    it('returns config for Verified result type', () => {
+      const config = getResultTypeConfig('Verified', t);
+
+      expect(config.label).toBe('securityTrustVerified');
+      expect(config.textColor).toBe(TextColor.SuccessDefault);
+      expect(config.icon).toBe(IconName.SecurityTick);
+      expect(config.badge?.icon).toBe(IconName.VerifiedFilled);
+    });
+
+    it('returns config for Malicious result type', () => {
+      const config = getResultTypeConfig('Malicious', t);
+
+      expect(config.label).toBe('securityTrustMaliciousLabel');
+      expect(config.textColor).toBe(TextColor.ErrorDefault);
+      expect(config.iconColor).toBe(IconColor.ErrorDefault);
+    });
+
+    it('returns default config for unknown result type', () => {
+      const config = getResultTypeConfig(undefined, t);
+
+      expect(config.label).toBe('securityTrustDataUnavailable');
+      expect(config.textColor).toBe(TextColor.TextAlternative);
+    });
+  });
+
+  describe('getFeatureTags', () => {
+    const makeFeature = (featureId: string): TokenSecurityFeature =>
+      ({ featureId }) as TokenSecurityFeature;
+
+    it('returns positive tags for Verified result type', () => {
+      const features = [
+        makeFeature('VERIFIED_CONTRACT'),
+        makeFeature('HIGH_REPUTATION_TOKEN'),
+      ];
+
+      const { tags, remainingCount } = getFeatureTags(features, 'Verified', t);
+
+      expect(tags).toHaveLength(2);
+      expect(remainingCount).toBe(0);
+    });
+
+    it('returns warning tags for Warning result type', () => {
+      const features = [makeFeature('HONEYPOT')];
+
+      const { tags } = getFeatureTags(features, 'Warning', t);
+
+      expect(tags).toEqual([{ label: 'securityTrustFeatureHoneypot' }]);
+    });
+  });
+
+  describe('formatFeePercent', () => {
+    it('formats a number as a percentage', () => {
+      expect(formatFeePercent(5)).toBe('5.0%');
+    });
+
+    it('returns N/A for null', () => {
+      expect(formatFeePercent(null)).toBe('N/A');
+    });
+  });
+
+  describe('hasNoHiddenFees', () => {
+    it('returns true when fees are zero or absent', () => {
+      expect(
+        hasNoHiddenFees({
+          transfer: 0,
+          transferFeeMaxAmount: null,
+          buy: 0,
+          sell: null,
+        }),
+      ).toBe(true);
+    });
+
+    it('returns false when any fee is greater than zero', () => {
+      expect(
+        hasNoHiddenFees({
+          transfer: 0,
+          transferFeeMaxAmount: null,
+          buy: 0,
+          sell: 2.5,
+        }),
+      ).toBe(false);
+    });
+
+    it('returns false when fees are missing', () => {
+      expect(hasNoHiddenFees(null)).toBe(false);
+    });
+  });
+
+  describe('getTop10HoldingPct', () => {
+    it('sums holder percentages', () => {
+      const stats = {
+        topHolders: [{ holdingPercentage: 10 }, { holdingPercentage: 15 }],
+      } as TokenSecurityFinancialStats;
+
+      expect(getTop10HoldingPct(stats)).toBe(25);
+    });
+  });
+
+  describe('formatCompactSupply', () => {
+    it('formats millions', () => {
+      expect(formatCompactSupply(5_000_000)).toBe('5.00M');
+    });
+  });
+});

--- a/ui/pages/asset/utils/security-utils.ts
+++ b/ui/pages/asset/utils/security-utils.ts
@@ -1,0 +1,531 @@
+import { IconColor, IconName, TextColor } from '@metamask/design-system-react';
+import type {
+  FeatureTag,
+  TokenSecurityData,
+  TokenSecurityFeature,
+  TokenSecurityFees,
+  TokenSecurityFinancialStats,
+} from '../types/security-trust';
+
+export type SecurityTrustTranslate = (
+  key: string,
+  substitutions?: string[],
+) => string;
+
+export type SecurityAlertSeverity = 'success' | 'warning' | 'danger';
+
+export type ResultTypeConfig = {
+  label: string;
+  textColor: TextColor;
+  subtitle?: string;
+  icon?: IconName;
+  iconColor?: IconColor;
+  alertSeverity?: SecurityAlertSeverity;
+  badge?: {
+    icon: IconName;
+    iconColor: IconColor;
+    alertSeverity?: SecurityAlertSeverity;
+    label: string | null;
+    backgroundColor?: 'warning-muted' | 'error-muted';
+    textColor?: TextColor;
+  } | null;
+  sheetTitle?: string;
+  getSheetDescription?: (tokenSymbol: string | undefined) => string;
+};
+
+export const getResultTypeConfig = (
+  resultType: string | undefined,
+  t: SecurityTrustTranslate,
+): ResultTypeConfig => {
+  switch (resultType) {
+    case 'Verified':
+      return {
+        label: t('securityTrustVerified'),
+        textColor: TextColor.SuccessDefault,
+        subtitle: t('securityTrustSubtitleKnown'),
+        icon: IconName.SecurityTick,
+        iconColor: IconColor.SuccessDefault,
+        alertSeverity: 'success',
+        badge: {
+          icon: IconName.VerifiedFilled,
+          iconColor: IconColor.InfoDefault,
+          label: null,
+          backgroundColor: undefined,
+          textColor: undefined,
+        },
+        sheetTitle: t('securityTrustVerifiedTokenTitle'),
+        getSheetDescription: (symbol) =>
+          t('securityTrustVerifiedTokenDescription', [symbol ?? '']),
+      };
+    case 'Benign':
+      return {
+        label: t('securityTrustNoIssues'),
+        textColor: TextColor.SuccessDefault,
+        subtitle: t('securityTrustSubtitleNoIssues'),
+        icon: IconName.SecurityTick,
+        iconColor: IconColor.SuccessDefault,
+        alertSeverity: 'success',
+        badge: null,
+      };
+    case 'Warning':
+    case 'Spam':
+      return {
+        label: t('securityTrustSuspicious'),
+        textColor: TextColor.WarningDefault,
+        subtitle: t('securityTrustSubtitleSuspicious'),
+        icon: IconName.Warning,
+        iconColor: IconColor.WarningDefault,
+        alertSeverity: 'warning',
+        badge: {
+          icon: IconName.Warning,
+          iconColor: IconColor.WarningDefault,
+          alertSeverity: 'warning',
+          label: t('securityTrustRisky'),
+          backgroundColor: 'warning-muted',
+          textColor: TextColor.WarningDefault,
+        },
+        sheetTitle: t('securityTrustRiskyTokenTitle'),
+        getSheetDescription: (symbol) =>
+          symbol
+            ? t('securityTrustRiskyTokenDescription', [symbol])
+            : t('securityTrustRiskyTokenDescriptionNoSymbol'),
+      };
+    case 'Malicious':
+      return {
+        label: t('securityTrustMaliciousLabel'),
+        textColor: TextColor.ErrorDefault,
+        subtitle: t('securityTrustSubtitleMalicious'),
+        icon: IconName.Error,
+        iconColor: IconColor.ErrorDefault,
+        alertSeverity: 'danger',
+        badge: {
+          icon: IconName.Danger,
+          iconColor: IconColor.ErrorDefault,
+          alertSeverity: 'danger',
+          label: t('securityTrustMalicious'),
+          backgroundColor: 'error-muted',
+          textColor: TextColor.ErrorDefault,
+        },
+        sheetTitle: t('securityTrustMaliciousTokenTitle'),
+        getSheetDescription: (symbol) =>
+          symbol
+            ? t('securityTrustMaliciousTokenSheetDescription', [symbol])
+            : t('securityTrustMaliciousTokenSheetDescriptionNoSymbol'),
+      };
+    default:
+      return {
+        label: t('securityTrustDataUnavailable'),
+        textColor: TextColor.TextAlternative,
+        subtitle: t('securityTrustSubtitleUnavailable'),
+      };
+  }
+};
+
+export type BlockaidFeatureType =
+  | 'Benign'
+  | 'Info'
+  | 'Warning'
+  | 'Spam'
+  | 'Malicious';
+
+type FeatureDefinition = {
+  label: string;
+  type: BlockaidFeatureType;
+};
+
+const getPositiveFeatureLabels = (
+  t: SecurityTrustTranslate,
+): Record<string, FeatureDefinition> => ({
+  HIGH_REPUTATION_TOKEN: {
+    label: t('securityTrustFeatureHighReputationToken'),
+    type: 'Benign',
+  },
+  LISTED_ON_CENTRALIZED_EXCHANGE: {
+    label: t('securityTrustFeatureListedOnCentralizedExchange'),
+    type: 'Benign',
+  },
+  VERIFIED_CONTRACT: {
+    label: t('securityTrustFeatureVerifiedContract'),
+    type: 'Info',
+  },
+  HIGH_TRADE_VOLUME: {
+    label: t('securityTrustFeatureHighTradeVolume'),
+    type: 'Info',
+  },
+});
+
+export const getNegativeFeatureLabels = (
+  t: SecurityTrustTranslate,
+): Record<string, FeatureDefinition> => ({
+  KNOWN_MALICIOUS: {
+    label: t('securityTrustFeatureKnownMalicious'),
+    type: 'Malicious',
+  },
+  METADATA: {
+    label: t('securityTrustFeatureMetadata'),
+    type: 'Malicious',
+  },
+  IMPERSONATOR_SENSITIVE_ASSET: {
+    label: t('securityTrustFeatureImpersonatorSensitiveAsset'),
+    type: 'Malicious',
+  },
+  STATIC_CODE_SIGNATURE: {
+    label: t('securityTrustFeatureStaticCodeSignature'),
+    type: 'Malicious',
+  },
+  RUGPULL: {
+    label: t('securityTrustFeatureRugpull'),
+    type: 'Malicious',
+  },
+  HIGH_TRANSFER_FEE: {
+    label: t('securityTrustFeatureHighTransferFee'),
+    type: 'Malicious',
+  },
+  HIGH_BUY_FEE: {
+    label: t('securityTrustFeatureHighBuyFee'),
+    type: 'Malicious',
+  },
+  HIGH_SELL_FEE: {
+    label: t('securityTrustFeatureHighSellFee'),
+    type: 'Malicious',
+  },
+  UNSELLABLE_TOKEN: {
+    label: t('securityTrustFeatureUnsellableToken'),
+    type: 'Malicious',
+  },
+  SANCTIONED_CREATOR: {
+    label: t('securityTrustFeatureSanctionedCreator'),
+    type: 'Malicious',
+  },
+  SIMILAR_MALICIOUS_CONTRACT: {
+    label: t('securityTrustFeatureSimilarMaliciousContract'),
+    type: 'Malicious',
+  },
+  TOKEN_BACKDOOR: {
+    label: t('securityTrustFeatureTokenBackdoor'),
+    type: 'Malicious',
+  },
+  POST_DUMP: {
+    label: t('securityTrustFeaturePostDump'),
+    type: 'Malicious',
+  },
+  IMPERSONATOR_HIGH_CONFIDENCE: {
+    label: t('securityTrustFeatureImpersonatorHighConfidence'),
+    type: 'Spam',
+  },
+  IMPERSONATOR_MEDIUM_CONFIDENCE: {
+    label: t('securityTrustFeatureImpersonatorMediumConfidence'),
+    type: 'Spam',
+  },
+  AIRDROP_PATTERN: {
+    label: t('securityTrustFeatureAirdropPattern'),
+    type: 'Warning',
+  },
+  IMPERSONATOR: {
+    label: t('securityTrustFeatureImpersonator'),
+    type: 'Warning',
+  },
+  INORGANIC_VOLUME: {
+    label: t('securityTrustFeatureInorganicVolume'),
+    type: 'Warning',
+  },
+  DYNAMIC_ANALYSIS: {
+    label: t('securityTrustFeatureDynamicAnalysis'),
+    type: 'Warning',
+  },
+  UNSTABLE_TOKEN_PRICE: {
+    label: t('securityTrustFeatureUnstableTokenPrice'),
+    type: 'Warning',
+  },
+  INAPPROPRIATE_CONTENT: {
+    label: t('securityTrustFeatureInappropriateContent'),
+    type: 'Warning',
+  },
+  HONEYPOT: {
+    label: t('securityTrustFeatureHoneypot'),
+    type: 'Warning',
+  },
+  SPAM_TEXT: {
+    label: t('securityTrustFeatureSpamText'),
+    type: 'Warning',
+  },
+  INSUFFICIENT_LOCKED_LIQUIDITY: {
+    label: t('securityTrustFeatureInsufficientLockedLiquidity'),
+    type: 'Warning',
+  },
+  CONCENTRATED_SUPPLY_DISTRIBUTION: {
+    label: t('securityTrustFeatureConcentratedSupplyDistribution'),
+    type: 'Warning',
+  },
+  WASH_TRADING: {
+    label: t('securityTrustFeatureWashTrading'),
+    type: 'Warning',
+  },
+  FAKE_VOLUME: {
+    label: t('securityTrustFeatureFakeVolume'),
+    type: 'Warning',
+  },
+  HIDDEN_SUPPLY_BY_KEY_HOLDER: {
+    label: t('securityTrustFeatureHiddenSupplyByKeyHolder'),
+    type: 'Warning',
+  },
+  HEAVILY_SNIPED: {
+    label: t('securityTrustFeatureHeavilySniped'),
+    type: 'Warning',
+  },
+  FAKE_TRADE_MAKER_COUNT: {
+    label: t('securityTrustFeatureFakeTradeMakerCount'),
+    type: 'Warning',
+  },
+  LOW_REPUTATION_CREATOR: {
+    label: t('securityTrustFeatureLowReputationCreator'),
+    type: 'Warning',
+  },
+  SNIPE_AT_MINT: {
+    label: t('securityTrustFeatureSnipeAtMint'),
+    type: 'Warning',
+  },
+  IMPERSONATOR_LOW_CONFIDENCE: {
+    label: t('securityTrustFeatureImpersonatorLowConfidence'),
+    type: 'Warning',
+  },
+  IS_MINTABLE: {
+    label: t('securityTrustFeatureIsMintable'),
+    type: 'Info',
+  },
+  CAN_BLACKLIST: {
+    label: t('securityTrustFeatureCanBlacklist'),
+    type: 'Info',
+  },
+  CAN_WHITELIST: {
+    label: t('securityTrustFeatureCanWhitelist'),
+    type: 'Info',
+  },
+  HAS_TRADING_COOLDOWN: {
+    label: t('securityTrustFeatureHasTradingCooldown'),
+    type: 'Info',
+  },
+  EXTERNAL_FUNCTIONS: {
+    label: t('securityTrustFeatureExternalFunctions'),
+    type: 'Info',
+  },
+  HIDDEN_OWNER: {
+    label: t('securityTrustFeatureHiddenOwner'),
+    type: 'Info',
+  },
+  TRANSFER_PAUSEABLE: {
+    label: t('securityTrustFeatureTransferPauseable'),
+    type: 'Info',
+  },
+  PROXY_CONTRACT: {
+    label: t('securityTrustFeatureProxyContract'),
+    type: 'Info',
+  },
+  MODIFIABLE_TAXES: {
+    label: t('securityTrustFeatureModifiableTaxes'),
+    type: 'Info',
+  },
+  OWNER_CAN_CHANGE_BALANCE: {
+    label: t('securityTrustFeatureOwnerCanChangeBalance'),
+    type: 'Info',
+  },
+  TRANSFER_FROM_REVERTS: {
+    label: t('securityTrustFeatureTransferFromReverts'),
+    type: 'Info',
+  },
+  TRANSFER_HOOK_ENABLED: {
+    label: t('securityTrustFeatureTransferHookEnabled'),
+    type: 'Info',
+  },
+  CONFIDENTIAL_TRANSFERS_ENABLED: {
+    label: t('securityTrustFeatureConfidentialTransfersEnabled'),
+    type: 'Info',
+  },
+  NON_TRANSERABLE: {
+    label: t('securityTrustFeatureNonTranserable'),
+    type: 'Info',
+  },
+});
+
+export type FeatureTagsResult = {
+  tags: FeatureTag[];
+  remainingCount: number;
+};
+
+const FEATURE_TAG_DISPLAY_MAX = 3;
+const POSITIVE_FEATURE_TAG_DISPLAY_MAX = 4;
+
+const collectNegativeFeatureTags = (
+  features: TokenSecurityFeature[],
+  negativeLabels: Record<string, FeatureDefinition>,
+  matchingTypes: BlockaidFeatureType[],
+  showAll: boolean,
+  maxTags: number,
+): { tags: FeatureTag[]; totalMatching: number } => {
+  const tags: FeatureTag[] = [];
+  let totalMatching = 0;
+
+  for (const feature of features) {
+    const def = negativeLabels[feature.featureId];
+    if (def && matchingTypes.includes(def.type)) {
+      totalMatching += 1;
+      if (showAll || tags.length < maxTags) {
+        tags.push({ label: def.label });
+      }
+    }
+  }
+
+  return { tags, totalMatching };
+};
+
+const collectPositiveFeatureTags = (
+  features: TokenSecurityFeature[],
+  t: SecurityTrustTranslate,
+  showAll: boolean,
+): FeatureTag[] => {
+  const positiveLabels = getPositiveFeatureLabels(t);
+  const tags: FeatureTag[] = [];
+
+  for (const feature of features) {
+    const def = positiveLabels[feature.featureId];
+    if (def && (showAll || tags.length < POSITIVE_FEATURE_TAG_DISPLAY_MAX)) {
+      tags.push({ label: def.label });
+    }
+  }
+
+  return tags;
+};
+
+const buildNegativeFeatureTagsResult = (
+  features: TokenSecurityFeature[],
+  matchingTypes: BlockaidFeatureType[],
+  t: SecurityTrustTranslate,
+  showAll: boolean,
+): FeatureTagsResult => {
+  const { tags, totalMatching } = collectNegativeFeatureTags(
+    features,
+    getNegativeFeatureLabels(t),
+    matchingTypes,
+    showAll,
+    FEATURE_TAG_DISPLAY_MAX,
+  );
+
+  return {
+    tags,
+    remainingCount: showAll
+      ? 0
+      : Math.max(0, totalMatching - FEATURE_TAG_DISPLAY_MAX),
+  };
+};
+
+export const getFeatureTags = (
+  features: TokenSecurityFeature[],
+  resultType: TokenSecurityData['resultType'] | undefined,
+  t: SecurityTrustTranslate,
+  showAll = false,
+): FeatureTagsResult => {
+  if (resultType === 'Malicious') {
+    return buildNegativeFeatureTagsResult(features, ['Malicious'], t, showAll);
+  }
+
+  if (resultType === 'Warning' || resultType === 'Spam') {
+    return buildNegativeFeatureTagsResult(
+      features,
+      ['Warning', 'Spam'],
+      t,
+      showAll,
+    );
+  }
+
+  return {
+    tags: collectPositiveFeatureTags(features, t, showAll),
+    remainingCount: 0,
+  };
+};
+
+export const formatFeePercent = (fee: number | null | undefined): string => {
+  if (fee === null || fee === undefined) {
+    return 'N/A';
+  }
+  return `${fee.toFixed(1)}%`;
+};
+
+const hasHiddenFee = (fee: number | null | undefined): boolean =>
+  fee !== null && fee !== undefined && fee > 0;
+
+export const hasNoHiddenFees = (
+  fees: TokenSecurityFees | null | undefined,
+): boolean => {
+  if (!fees) {
+    return false;
+  }
+
+  return (
+    !hasHiddenFee(fees.buy) &&
+    !hasHiddenFee(fees.sell) &&
+    !hasHiddenFee(fees.transfer)
+  );
+};
+
+export const getTop10HoldingPct = (
+  financialStats: TokenSecurityFinancialStats | null | undefined,
+): number | null => {
+  if (!financialStats?.topHolders?.length) {
+    return null;
+  }
+  const sum = financialStats.topHolders.reduce(
+    (acc, h) => acc + (h.holdingPercentage ?? 0),
+    0,
+  );
+  return Math.min(sum, 100);
+};
+
+export const formatCompactSupply = (
+  supply: number | null | undefined,
+  decimals?: number,
+): string => {
+  if (supply === null || supply === undefined) {
+    return 'N/A';
+  }
+  const adjusted =
+    decimals !== null && decimals !== undefined && decimals > 0
+      ? supply / 10 ** decimals
+      : supply;
+  const units: [number, string][] = [
+    [1e15, 'Q'],
+    [1e12, 'T'],
+    [1e9, 'B'],
+    [1e6, 'M'],
+    [1e3, 'K'],
+  ];
+  for (const [threshold, suffix] of units) {
+    if (adjusted >= threshold) {
+      return `${(adjusted / threshold).toFixed(2)}${suffix}`;
+    }
+  }
+  return adjusted.toFixed(0);
+};
+
+export const getSecurityAlertIconProps = (
+  severity: SecurityAlertSeverity | undefined,
+): { name: IconName; color: IconColor } | null => {
+  switch (severity) {
+    case 'success':
+      return {
+        name: IconName.SecurityTick,
+        color: IconColor.SuccessDefault,
+      };
+    case 'warning':
+      return {
+        name: IconName.Warning,
+        color: IconColor.WarningDefault,
+      };
+    case 'danger':
+      return {
+        name: IconName.Danger,
+        color: IconColor.ErrorDefault,
+      };
+    default:
+      return null;
+  }
+};


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

**PR 1 of 3** — stacked split of Security & Trust on the Token Details Page (TDP). Follow-up PRs will add the Security section + detail page (PR2) and info modals + Buy/Swap CTA gating (PR3).

**Reason:** Port mobile Security & Trust UX to extension TDP in reviewable slices. This PR lands the foundation and read-only header signals so reviewers can validate data fetching and result-type display before navigation and modal behavior ship.

**What this PR adds:**
- `useTokenSecurityData` hook — fetches token security data when Basic Functionality (`getUseExternalServices`) is enabled
- Shared `security-utils` — result-type config, feature tags, formatters
- **Verified badge** next to the token name on TDP
- **Warning banner** below the name for `Malicious`, `Warning`, and `Spam` result types
- `AssetPageSecurityTrustProvider` with header badge and banner slots wired in `asset-page.tsx`

**Intentionally deferred to later PRs (not missing — scoped out):**
- Security & Trust entry card section
- Security detail page (`/asset/.../security-trust`)
- Info modal on badge/banner tap (badge and banner are **display-only** in this PR)
- Buy/Swap CTA gating modal

**Key files:**
| Area | Path |
|------|------|
| Data hook | `ui/hooks/useTokenSecurityData.ts` |
| Provider + slots | `ui/pages/asset/components/security-trust/asset-page-security-trust.tsx` |
| Badge / banner | `security-trust-inline-badge.tsx`, `security-banner.tsx` |
| Shared utils | `ui/pages/asset/utils/security-utils.ts` |
| TDP wiring | `ui/pages/asset/components/asset-page.tsx` |

## **Changelog**

CHANGELOG entry: Added Security & Trust verified badge and warning banner to the token details page header

## **Related issues**

Part of Security & Trust TDP work. Related tickets:
- [ASSETS-3677](https://consensyssoftware.atlassian.net/browse/ASSETS-3677)
- [ASSETS-3678](https://consensyssoftware.atlassian.net/browse/ASSETS-3678)
- [ASSETS-3680](https://consensyssoftware.atlassian.net/browse/ASSETS-3680)

Full feature tracking PR: #44761

Fixes:

## **Manual testing steps**

1. Build and load the extension (`yarn start` or test build).
2. Ensure **Basic Functionality** is enabled in Settings (required for security data fetch).
3. Open a **verified** ERC-20 token on Ethereum mainnet (e.g. AAVE, USDC) → Token Details Page.
4. Confirm a **verified checkmark badge** appears next to the token name.
5. Confirm **no warning banner** appears for verified tokens.
6. Open a token known to return a **Malicious**, **Warning**, or **Spam** result type (or mock via devtools/network if needed).
7. Confirm a **warning or danger banner** appears below the token name with appropriate copy.
8. Confirm badge and banner are **not tappable** in this PR (no modal opens — expected until PR3).
9. Disable Basic Functionality → reopen TDP → confirm badge and banner do **not** appear.
10. Switch between tokens and confirm signals update without stale data from the previous asset.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

No Security & Trust badge or banner on TDP header.

### **After**

Verified badge beside token name; malicious/warning/spam banner below name row (screenshots to be added by author).

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[ASSETS-3677]: https://consensyssoftware.atlassian.net/browse/ASSETS-3677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> User-facing security classifications on trading surfaces can affect user decisions; behavior is gated on external services and fails closed on errors, but incorrect or stale API data could mislead users.
> 
> **Overview**
> Adds **Security & Trust** read-only header signals on the Token Details Page (TDP), gated on **Basic Functionality** (`getUseExternalServices`).
> 
> A new `useTokenSecurityData` hook loads `TokenSecurityData` via `fetchCachedTokenAssets`, with prefetch support, stale-response guards when the asset changes, and derived token metadata. Shared `security-utils` maps Blockaid result types and feature IDs to i18n labels, badges, and formatters.
> 
> `AssetPageSecurityTrustProvider` wraps TDP content and drives slot components: a **verified badge** beside the asset name and **warning/danger banners** for Malicious, Warning, and Spam. Loading and fetch errors hide both signals. `asset-page.tsx` is refactored slightly (e.g. swaps/bridge chain checks use allowlists instead of Redux selectors).
> 
> Large `securityTrust*` locale entries were added in `en` and `en_GB`. Unit tests cover the hook, provider, banner, badges, and utils.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 153266eedcdcc0a012f7feb43f436df797ca7714. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->