### PR TITLE
fix(pure-black): remove border from page footer cancel buttons

### DIFF
--- a/ui/pages/contacts/components/add-contact-form.tsx
+++ b/ui/pages/contacts/components/add-contact-form.tsx
@@ -404,7 +404,7 @@ export function AddContactForm({ onCancel, onSuccess }: AddContactFormProps) {
           variant={ButtonVariant.Secondary}
           size={ButtonSize.Lg}
           onClick={onCancel}
-          className="flex-1 rounded-xl border border-border-default"
+          className="flex-1 rounded-xl"
           data-testid="page-container-footer-cancel"
         >
           {t('cancel')}

--- a/ui/pages/contacts/components/edit-contact-form.tsx
+++ b/ui/pages/contacts/components/edit-contact-form.tsx
@@ -303,7 +303,7 @@ export function EditContactForm({
           variant={ButtonVariant.Secondary}
           size={ButtonSize.Lg}
           onClick={onCancel}
-          className="flex-1 rounded-xl border border-border-default"
+          className="flex-1 rounded-xl"
           data-testid="page-container-footer-cancel"
         >
           {t('cancel')}

--- a/ui/pages/networks/add-rpc-url-page-form.tsx
+++ b/ui/pages/networks/add-rpc-url-page-form.tsx
@@ -117,7 +117,7 @@ export const AddRpcUrlPageForm = ({
           variant={ButtonVariant.Secondary}
           size={ButtonSize.Lg}
           onClick={onCancel}
-          className="flex-1 rounded-xl border border-border-default"
+          className="flex-1 rounded-xl"
           data-testid="page-container-footer-cancel"
         >
           {t('cancel')}


### PR DESCRIPTION
## **Description**

Removes the extra `border border-border-default` class from cancel buttons with `data-testid="page-container-footer-cancel"` on the add contact, edit contact, and add RPC URL forms. In pure black mode these secondary cancel buttons incorrectly showed a border; they should match the borderless secondary button style.

## **Changelog**

CHANGELOG entry: Fixed cancel buttons in contact and network forms showing an incorrect border in pure black mode

## **Related issues**

Fixes: [TMCU-1170](https://consensyssoftware.atlassian.net/browse/TMCU-1170)

## **Manual testing steps**

1. Enable Pure Black (OLED) mode in Settings → Appearance
2. Go to Settings → Contacts → Add contact — confirm the Cancel button has no border
3. Open an existing contact to edit — confirm the Cancel button has no border
4. Go to Settings → Networks → add/edit a network → Add RPC URL — confirm the Cancel button has no border
5. Repeat in light and dark themes to confirm no regression

## **Screenshots/Recordings**

### **Before**

<img width="394" height="771" alt="Screenshot 2026-07-29 at 8 42 44 PM" src="https://github.com/user-attachments/assets/7b83c36b-f1a8-46b6-b07a-3f0315add66c" />


### **After**

<img width="505" height="770" alt="Screenshot 2026-07-29 at 5 00 23 PM" src="https://github.com/user-attachments/assets/e65c89de-fb1a-44e6-8339-732c3bdc5fd0" />



## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)

[TMCU-1170]: https://consensyssoftware.atlassian.net/browse/TMCU-1170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ