### PR TITLE
feat: migrate Infura IPFS users to dweb.link and block Infura IPFS gateway entry

### DIFF
--- a/app/scripts/migrations/221.test.ts
+++ b/app/scripts/migrations/221.test.ts
@@ -1,0 +1,116 @@
+import { cloneDeep } from 'lodash';
+import { migrate, version } from './221';
+
+const VERSION = version;
+const OLD_VERSION = VERSION - 1;
+
+type VersionedData = {
+  meta: { version: number };
+  data: Record<string, unknown>;
+};
+
+describe(`migration #${VERSION}`, () => {
+  it('bumps the version', async () => {
+    const oldStorage: VersionedData = {
+      meta: { version: OLD_VERSION },
+      data: {},
+    };
+
+    const versionedData = cloneDeep(oldStorage);
+    await migrate(versionedData, new Set<string>());
+
+    expect(versionedData.meta.version).toBe(VERSION);
+  });
+
+  it('migrates Infura IPFS gateway to dweb.link', async () => {
+    const oldStorage: VersionedData = {
+      meta: { version: OLD_VERSION },
+      data: {
+        PreferencesController: {
+          ipfsGateway: 'ipfs.infura.io',
+        },
+      },
+    };
+
+    const versionedData = cloneDeep(oldStorage);
+    const changedControllers = new Set<string>();
+    await migrate(versionedData, changedControllers);
+
+    expect(versionedData.data.PreferencesController).toStrictEqual({
+      ipfsGateway: 'dweb.link',
+    });
+    expect(changedControllers.has('PreferencesController')).toBe(true);
+  });
+
+  it('migrates Infura IPFS URL to dweb.link', async () => {
+    const oldStorage: VersionedData = {
+      meta: { version: OLD_VERSION },
+      data: {
+        PreferencesController: {
+          ipfsGateway: 'https://ipfs.infura.io/ipfs/',
+        },
+      },
+    };
+
+    const versionedData = cloneDeep(oldStorage);
+    const changedControllers = new Set<string>();
+    await migrate(versionedData, changedControllers);
+
+    expect(versionedData.data.PreferencesController).toStrictEqual({
+      ipfsGateway: 'dweb.link',
+    });
+    expect(changedControllers.has('PreferencesController')).toBe(true);
+  });
+
+  it('does not change non-Infura IPFS gateway', async () => {
+    const oldStorage: VersionedData = {
+      meta: { version: OLD_VERSION },
+      data: {
+        PreferencesController: {
+          ipfsGateway: 'custom.example',
+        },
+      },
+    };
+
+    const versionedData = cloneDeep(oldStorage);
+    const changedControllers = new Set<string>();
+    await migrate(versionedData, changedControllers);
+
+    expect(versionedData.data.PreferencesController).toStrictEqual({
+      ipfsGateway: 'custom.example',
+    });
+    expect(changedControllers.has('PreferencesController')).toBe(false);
+  });
+
+  it('does not change state if PreferencesController is missing', async () => {
+    const oldStorage: VersionedData = {
+      meta: { version: OLD_VERSION },
+      data: {},
+    };
+
+    const versionedData = cloneDeep(oldStorage);
+    const changedControllers = new Set<string>();
+    await migrate(versionedData, changedControllers);
+
+    expect(versionedData.data).toStrictEqual({});
+    expect(changedControllers.has('PreferencesController')).toBe(false);
+  });
+
+  it('does not change state if PreferencesController is not an object', async () => {
+    const oldStorage: VersionedData = {
+      meta: { version: OLD_VERSION },
+      data: {
+        PreferencesController: 'invalid',
+      },
+    };
+
+    const versionedData = cloneDeep(oldStorage);
+    const changedControllers = new Set<string>();
+    await migrate(versionedData, changedControllers);
+
+    expect(versionedData.data).toStrictEqual({
+      PreferencesController: 'invalid',
+    });
+    expect(changedControllers.has('PreferencesController')).toBe(false);
+  });
+});

--- a/app/scripts/migrations/221.ts
+++ b/app/scripts/migrations/221.ts
@@ -1,0 +1,44 @@
+import { hasProperty, isObject } from '@metamask/utils';
+import type { Migrate } from './types';
+
+export const version = 221;
+
+const IPFS_DEFAULT_GATEWAY_URL = 'dweb.link';
+const INFURA_IPFS_GATEWAY_HOST = 'ipfs.infura.io';
+
+/**
+ * Migrates users from the deprecated Infura IPFS gateway to the default IPFS gateway.
+ *
+ * @param versionedData - The versioned data object to migrate.
+ * @param changedControllers - A set used to record controllers that were modified.
+ */
+export const migrate = (async (versionedData, changedControllers) => {
+  versionedData.meta.version = version;
+
+  const state = versionedData.data;
+  if (!hasProperty(state, 'PreferencesController')) {
+    return;
+  }
+
+  if (!isObject(state.PreferencesController)) {
+    return;
+  }
+
+  const preferencesControllerState = state.PreferencesController;
+  const { ipfsGateway } = preferencesControllerState;
+
+  if (
+    typeof ipfsGateway === 'string' &&
+    getGatewayHost(ipfsGateway) === INFURA_IPFS_GATEWAY_HOST
+  ) {
+    preferencesControllerState.ipfsGateway = IPFS_DEFAULT_GATEWAY_URL;
+    changedControllers.add('PreferencesController');
+  }
+}) satisfies Migrate;
+
+export default migrate;
+
+function getGatewayHost(ipfsGateway: string): string {
+  const gatewayWithoutProtocol = ipfsGateway.replace(/^https?:\/\//u, '');
+  return gatewayWithoutProtocol.split('/')[0];
+}

--- a/app/scripts/migrations/index.js
+++ b/app/scripts/migrations/index.js
@@ -256,6 +256,7 @@ const migrations = [
   require('./218'),
   require('./219'),
   require('./220'),
+  require('./221'),
 ];
 
 export default migrations;

--- a/shared/constants/network.ts
+++ b/shared/constants/network.ts
@@ -1558,6 +1558,10 @@ export const UNSUPPORTED_RPC_METHODS = new Set([
 
 export const IPFS_DEFAULT_GATEWAY_URL = 'dweb.link';
 export const IPFS_FORBIDDEN_GATEWAY = 'gateway.ipfs.io';
+export const IPFS_FORBIDDEN_GATEWAYS = [
+  IPFS_FORBIDDEN_GATEWAY,
+  'ipfs.infura.io',
+];
 
 export const QUICKNODE_ENDPOINT_URLS_BY_INFURA_NETWORK_NAME = {
   'ethereum-mainnet': () => process.env.QUICKNODE_MAINNET_URL,

--- a/test/e2e/fixtures/default-fixture.json
+++ b/test/e2e/fixtures/default-fixture.json
@@ -179,7 +179,7 @@
       "announcements": {}
     },
     "AppMetadataController": {
-      "currentMigrationVersion": 220,
+      "currentMigrationVersion": 221,
       "firstTimeInfo": {},
       "previousAppVersion": "",
       "previousMigrationVersion": 0

--- a/test/e2e/fixtures/default-fixture.json
+++ b/test/e2e/fixtures/default-fixture.json
@@ -1315,6 +1315,6 @@
   },
   "meta": {
     "storageKind": "split",
-    "version": 220
+    "version": 221
   }
 }

--- a/test/e2e/fixtures/onboarding-fixture.json
+++ b/test/e2e/fixtures/onboarding-fixture.json
@@ -49,7 +49,7 @@
       "announcements": {}
     },
     "AppMetadataController": {
-      "currentMigrationVersion": 220,
+      "currentMigrationVersion": 221,
       "firstTimeInfo": {
         "date": 0,
         "version": "13.17.0"
@@ -2321,6 +2321,6 @@
   },
   "meta": {
     "storageKind": "split",
-    "version": 220
+    "version": 221
   }
 }

--- a/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
+++ b/test/e2e/tests/metrics/state-snapshots/errors-before-init-opt-in-ui-state.json
@@ -378,6 +378,6 @@
   },
   "meta": {
     "storageKind": "split",
-    "version": 220
+    "version": 221
   }
 }

--- a/ui/pages/onboarding-flow/privacy-settings/privacy-settings.test.tsx
+++ b/ui/pages/onboarding-flow/privacy-settings/privacy-settings.test.tsx
@@ -257,6 +257,31 @@ describe('Privacy Settings Onboarding View', () => {
       expect(invalidErrorMsg).toBeInTheDocument();
     });
 
+    it('should error with ipfs.infura.io IPFS input', () => {
+      const { queryByTestId, queryByText } = renderWithProvider(
+        <PrivacySettings />,
+        store,
+      );
+
+      const itemCategoryAssets = queryByTestId('category-item-Assets');
+      fireEvent.click(itemCategoryAssets as HTMLElement);
+
+      const ipfsInput = queryByTestId('ipfs-input');
+      const ipfsEvent = {
+        target: {
+          value: 'ipfs.infura.io',
+        },
+      };
+
+      fireEvent.change(ipfsInput as HTMLElement, ipfsEvent);
+
+      const invalidErrorMsg = queryByText(
+        messages.onboardingAdvancedPrivacyIPFSInvalid.message,
+      );
+
+      expect(invalidErrorMsg).toBeInTheDocument();
+    });
+
     it('should error with improper IPFS input', () => {
       const { queryByTestId, queryByText } = renderWithProvider(
         <PrivacySettings />,

--- a/ui/pages/onboarding-flow/privacy-settings/privacy-settings.tsx
+++ b/ui/pages/onboarding-flow/privacy-settings/privacy-settings.tsx
@@ -65,7 +65,7 @@ import {
 } from '../../../ducks/app/app';
 import {
   CHAIN_ID_TO_NETWORK_IMAGE_URL_MAP,
-  IPFS_FORBIDDEN_GATEWAY,
+  IPFS_FORBIDDEN_GATEWAYS,
   TEST_CHAINS,
 } from '../../../../shared/constants/network';
 import { selectIsBackupAndSyncEnabled } from '../../../selectors/identity/backup-and-sync';
@@ -184,7 +184,7 @@ export default function PrivacySettings() {
     setIPFSURL(url);
     try {
       const { host } = new URL(addUrlProtocolPrefix(url) as string);
-      if (!host || host === IPFS_FORBIDDEN_GATEWAY) {
+      if (!host || IPFS_FORBIDDEN_GATEWAYS.includes(host)) {
         throw new Error();
       }
       setIPFSError(null);

--- a/ui/pages/settings/privacy-tab/ipfs-gateway-item.tsx
+++ b/ui/pages/settings/privacy-tab/ipfs-gateway-item.tsx
@@ -11,7 +11,7 @@ import {
 import type { MetaMaskReduxState } from '../../../store/store';
 import {
   IPFS_DEFAULT_GATEWAY_URL,
-  IPFS_FORBIDDEN_GATEWAY,
+  IPFS_FORBIDDEN_GATEWAYS,
 } from '../../../../shared/constants/network';
 import { addUrlProtocolPrefix } from '../../../../shared/lib/url-utils';
 import { PRIVACY_ITEMS } from '../search-config';
@@ -53,7 +53,7 @@ export const IpfsGatewayItem = () => {
     }
 
     const urlObj = new URL(validUrl);
-    if (urlObj.host === IPFS_FORBIDDEN_GATEWAY) {
+    if (IPFS_FORBIDDEN_GATEWAYS.includes(urlObj.host)) {
       setIpfsGatewayError(t('forbiddenIpfsGateway'));
       return;
     }

--- a/ui/pages/settings/privacy-tab/privacy-tab.test.tsx
+++ b/ui/pages/settings/privacy-tab/privacy-tab.test.tsx
@@ -1,4 +1,4 @@
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
@@ -73,6 +73,18 @@ describe('PrivacyTab', () => {
     ).toBeInTheDocument();
     expect(
       screen.getByTestId('batch-account-balance-requests-toggle'),
+    ).toBeInTheDocument();
+  });
+
+  it('shows an error when the user enters an Infura IPFS gateway', () => {
+    renderWithProvider(<PrivacyTab />, mockStore);
+
+    fireEvent.change(screen.getByDisplayValue('dweb.link'), {
+      target: { value: 'ipfs.infura.io' },
+    });
+
+    expect(
+      screen.getByText(messages.forbiddenIpfsGateway.message),
     ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
This PR migrates users who have the deprecated Infura IPFS gateway configured to dweb.link.

It also prevents users from adding ipfs.infura.io as a custom IPFS gateway in both:

Onboarding advanced privacy settings
Settings → Security & Privacy → IPFS gateway
Existing non-Infura custom IPFS gateways are preserved.

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: deprecated support for infura ipfs

## **Related issues**

Fixes: [issue](https://consensyssoftware.atlassian.net/browse/CEUX-1259)

## **Manual testing steps**

1. Start the extension.
2. Go through onboarding and open advanced privacy settings.
3. In the IPFS gateway field, enter ipfs.infura.io.
4. Verify an error is shown and the gateway cannot be saved.
5. Complete onboarding.
6. Go to Settings → Security & Privacy.
7. Enable the IPFS gateway setting if needed.
8. Enter ipfs.infura.io.
9. Verify an error is shown and the gateway cannot be saved.
10. Enter a valid non-Infura gateway, for example dweb.link.
11. Verify it can be saved successfully.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**


https://github.com/user-attachments/assets/7962771c-feb7-40d3-8814-0167288bf4c9


## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped preference migration and IPFS gateway validation; well-tested and does not touch auth, keys, or transactions.
> 
> **Overview**
> Deprecates the Infura IPFS gateway by **auto-migrating** stored preferences and **blocking** new `ipfs.infura.io` entries in the UI.
> 
> **Migration #221** rewrites `PreferencesController.ipfsGateway` from `ipfs.infura.io` (host-only or full `https://…/ipfs/` URLs) to `dweb.link`, and records `PreferencesController` in `changedControllers` only when that rewrite happens. Other custom gateways are left unchanged.
> 
> **Validation** now treats `ipfs.infura.io` like the existing forbidden `gateway.ipfs.io`: shared `IPFS_FORBIDDEN_GATEWAYS` replaces the single `IPFS_FORBIDDEN_GATEWAY` check in onboarding advanced privacy IPFS input and Settings → Security & Privacy IPFS gateway field (forbidden-gateway error in settings).
> 
> E2E fixtures and migration tests cover version **221** and the Infura → dweb.link behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 66bf74d12565bb15766ebb23cc6d001caac0b3aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->