### PR TITLE
fix: navigate to homepage after users close popup from batch sell

### DIFF
--- a/ui/pages/batch-sell/batch-sell-page.test.tsx
+++ b/ui/pages/batch-sell/batch-sell-page.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import {
+  BATCH_SELL_ROOT_ROUTE,
+  BATCH_SELL_SELECT_ROUTE,
+  DEFAULT_ROUTE,
+} from '../../helpers/constants/routes';
+import { resetBridgeController } from '../../ducks/bridge/actions';
+import { useDispatch } from '../../store/hooks';
+import BatchSellPage from './batch-sell-page';
+
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useSelector: jest.fn(),
+}));
+
+jest.mock('../../store/hooks', () => ({
+  useDispatch: jest.fn(),
+}));
+
+jest.mock('../../ducks/bridge/actions', () => ({
+  resetBridgeController: jest.fn(() => ({
+    type: 'RESET_BRIDGE_CONTROLLER',
+  })),
+}));
+
+// Thin stubs: this suite only cares about BatchSellPage's own behavior
+// (feature-flag gating and the popup-close cleanup), not what each sub-page
+// renders.
+jest.mock('./pages/select/batch-sell-select-page', () => ({
+  BatchSellSelectPage: () => <div data-testid="batch-sell-select-page" />,
+}));
+jest.mock('./pages/review/batch-sell-review-page', () => ({
+  BatchSellReviewPage: () => <div data-testid="batch-sell-review-page" />,
+}));
+jest.mock('./providers/batch-sell-info-modal-provider', () => ({
+  BatchSellInfoModalProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+jest.mock('./providers/batch-sell-selection-provider', () => ({
+  BatchSellSelectionProvider: ({ children }: { children: React.ReactNode }) => (
+    <>{children}</>
+  ),
+}));
+
+const mockDispatch = jest.fn();
+const mockUseSelector = jest.mocked(useSelector);
+const mockUseDispatch = jest.mocked(useDispatch);
+
+const renderBatchSellPage = (pathname: string = BATCH_SELL_SELECT_ROUTE) =>
+  render(
+    <MemoryRouter
+      initialEntries={[pathname]}
+      future={{
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        v7_startTransition: true,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        v7_relativeSplatPath: true,
+      }}
+    >
+      <Routes>
+        <Route
+          path={`${BATCH_SELL_ROOT_ROUTE}/*`}
+          element={<BatchSellPage />}
+        />
+        <Route path={DEFAULT_ROUTE} element={<div data-testid="home" />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+
+describe('BatchSellPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseDispatch.mockReturnValue(mockDispatch as never);
+    // Only selector BatchSellPage itself reads directly is the batch-sell
+    // feature flag; the mocked sub-pages/providers don't read from the store.
+    mockUseSelector.mockReturnValue(true);
+  });
+
+  it('renders the batch sell flow when the feature is enabled', () => {
+    const { getByTestId } = renderBatchSellPage();
+
+    expect(getByTestId('batch-sell-select-page')).toBeInTheDocument();
+  });
+
+  it('redirects home when the batch sell feature flag is disabled', () => {
+    mockUseSelector.mockReturnValue(false);
+
+    const { getByTestId } = renderBatchSellPage();
+
+    expect(getByTestId('home')).toBeInTheDocument();
+  });
+
+  describe('on popup close', () => {
+    it('dispatches resetBridgeController so a stale batch-sell quote does not leak into the next popup session', () => {
+      renderBatchSellPage();
+
+      fireEvent(window, new Event('beforeunload'));
+
+      expect(resetBridgeController).toHaveBeenCalled();
+      expect(mockDispatch).toHaveBeenCalledWith({
+        type: 'RESET_BRIDGE_CONTROLLER',
+      });
+    });
+  });
+});

--- a/ui/pages/batch-sell/batch-sell-page.tsx
+++ b/ui/pages/batch-sell/batch-sell-page.tsx
@@ -10,6 +10,7 @@ import { Content, Header, Page } from '../../components/multichain/pages/page';
 import { useI18nContext } from '../../hooks/useI18nContext';
 import { transitionBack } from '../../components/ui/transition';
 import { useBatchSellNavigation } from '../../hooks/batch-sell/useBatchSellNavigation';
+import { useEventListener } from '../../hooks/useEventListener';
 import { toRelativeRoutePath } from '../routes/utils';
 import {
   BATCH_SELL_REVIEW_ROUTE,
@@ -18,6 +19,8 @@ import {
   DEFAULT_ROUTE,
 } from '../../helpers/constants/routes';
 import { getIsBatchSellEnabled } from '../../selectors/batch-sell/feature-flags';
+import { resetBridgeController } from '../../ducks/bridge/actions';
+import { useDispatch } from '../../store/hooks';
 import { BatchSellSelectPage } from './pages/select/batch-sell-select-page';
 import { BatchSellReviewPage } from './pages/review/batch-sell-review-page';
 import { BatchSellInfoModalProvider } from './providers/batch-sell-info-modal-provider';
@@ -25,10 +28,16 @@ import { BatchSellSelectionProvider } from './providers/batch-sell-selection-pro
 
 const BatchSellPage = () => {
   const t = useI18nContext();
+  const dispatch = useDispatch();
   const { pathname } = useLocation();
   const { navigateToDefaultRoute, navigateToBatchSellSelectPage } =
     useBatchSellNavigation();
   const batchSellEnabled = useSelector(getIsBatchSellEnabled);
+
+  // Reset controller and inputs before unloading the page
+  useEventListener('beforeunload', () => {
+    dispatch(resetBridgeController());
+  });
 
   const handleBack = () => {
     const isOnConfirmPage = pathname === BATCH_SELL_REVIEW_ROUTE;

--- a/ui/pages/routes/confirmation-router.test.tsx
+++ b/ui/pages/routes/confirmation-router.test.tsx
@@ -18,11 +18,20 @@ import {
   DEFAULT_ROUTE,
   PREPARE_SWAP_ROUTE,
 } from '../../helpers/constants/routes';
+import { resetBridgeController } from '../../ducks/bridge/actions';
+import { UPDATE_METAMASK_STATE } from '../../store/actionConstants';
+import type { MetaMaskReduxDispatch } from '../../store/store';
 import { ConfirmationRouter } from './confirmation-router';
 
 jest.mock('../../../shared/lib/environment-type', () => ({
   ...jest.requireActual('../../../shared/lib/environment-type'),
   getEnvironmentType: jest.fn(),
+}));
+
+jest.mock('../../ducks/bridge/actions', () => ({
+  resetBridgeController: jest.fn(() => ({
+    type: 'RESET_BRIDGE_CONTROLLER',
+  })),
 }));
 
 const SWAP_ROUTE = `${CROSS_CHAIN_SWAP_ROUTE}${PREPARE_SWAP_ROUTE}`;
@@ -155,6 +164,53 @@ describe('ConfirmationRouter', () => {
       });
 
       expect(getByTestId('pathname').textContent).toBe(DEFAULT_ROUTE);
+    });
+
+    // The batch-sell page's `beforeunload` listener is the primary way this
+    // state gets cleared, but it isn't reliable when the popup is dismissed
+    // rather than fully unloaded. The router must reset it directly so a
+    // leftover quote can't keep hijacking every future popup navigation.
+    it('resets the bridge controller so the leftover quote does not keep hijacking future navigations', () => {
+      renderConfirmationRouter({
+        pathname: DEFAULT_ROUTE,
+        hasBatchSellQuotes: true,
+      });
+
+      expect(resetBridgeController).toHaveBeenCalled();
+    });
+
+    it('does not reset the bridge controller when there is nothing to redirect for', () => {
+      renderConfirmationRouter({
+        pathname: BATCH_SELL_REVIEW_ROUTE,
+        hasBatchSellQuotes: true,
+      });
+
+      expect(resetBridgeController).not.toHaveBeenCalled();
+    });
+
+    // Simulates the real `resetBridgeController` thunk actually clearing the
+    // quote from state (via the background state sync), rather than being a
+    // pure no-op. Without dispatching a reset, this quote would keep
+    // re-triggering the home redirect on every check and the pending
+    // approval would never be shown.
+    it('still navigates to the pending approval once the leftover quote is cleared', () => {
+      (resetBridgeController as jest.Mock).mockImplementation(
+        () => (dispatch: MetaMaskReduxDispatch) =>
+          dispatch({
+            type: UPDATE_METAMASK_STATE,
+            value: { quotes: [] },
+          }),
+      );
+
+      const { getByTestId } = renderConfirmationRouter({
+        pathname: DEFAULT_ROUTE,
+        hasBatchSellQuotes: true,
+        hasPendingApproval: true,
+      });
+
+      expect(getByTestId('pathname').textContent).toBe(
+        `${CONFIRM_TRANSACTION_ROUTE}/${PENDING_APPROVAL_ID}`,
+      );
     });
 
     it('stays on the batch sell review page', () => {

--- a/ui/pages/routes/confirmation-router.test.tsx
+++ b/ui/pages/routes/confirmation-router.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
+import { FeatureId } from '@metamask/bridge-controller';
 import configureStore from '../../store/store';
 import { renderWithProvider } from '../../../test/lib/render-helpers-navigate';
 import mockState from '../../../test/data/mock-state.json';
@@ -32,14 +33,31 @@ const PathnameDisplay = () => {
   return <div data-testid="pathname">{pathname}</div>;
 };
 
+// A leftover batch-sell quote carries `featureId: 'batch_sell'`, which is what
+// distinguishes it from a real in-progress swap quote.
+const getMockQuotes = ({
+  hasQuotes,
+  hasBatchSellQuotes,
+}: {
+  hasQuotes: boolean;
+  hasBatchSellQuotes: boolean;
+}) => {
+  if (hasBatchSellQuotes) {
+    return [{ featureId: FeatureId.BATCH_SELL }];
+  }
+  return hasQuotes ? [{}] : [];
+};
+
 const renderConfirmationRouter = ({
   pathname,
   hasQuotes = false,
+  hasBatchSellQuotes = false,
   hasPendingApproval = false,
   environmentType = ENVIRONMENT_TYPE_POPUP,
 }: {
   pathname: string;
   hasQuotes?: boolean;
+  hasBatchSellQuotes?: boolean;
   hasPendingApproval?: boolean;
   environmentType?: string;
 }) => {
@@ -54,7 +72,9 @@ const renderConfirmationRouter = ({
         : { pendingApprovals: {}, pendingApprovalCount: 0, approvalFlows: [] }),
       // Batch sell fetches quotes through the bridge controller, so they land in
       // the same state that drives the swap redirect. A single entry is enough.
-      quotes: hasQuotes ? [{}] : [],
+      // A leftover batch-sell quote carries `featureId: 'batch_sell'`, which is
+      // what distinguishes it from a real in-progress swap quote.
+      quotes: getMockQuotes({ hasQuotes, hasBatchSellQuotes }),
     },
   });
 
@@ -118,6 +138,39 @@ describe('ConfirmationRouter', () => {
         pathname: DEFAULT_ROUTE,
         hasQuotes: true,
         environmentType: ENVIRONMENT_TYPE_SIDEPANEL,
+      });
+
+      expect(getByTestId('pathname').textContent).toBe(DEFAULT_ROUTE);
+    });
+  });
+
+  describe('with a leftover batch-sell quote in state', () => {
+    // Reproduces closing the popup mid-review and reopening it: the popup
+    // cold-mounts at the home route, and the batch-sell quote fetched before
+    // closing is still sitting in the (unmocked) BridgeController state.
+    it('redirects home instead of the swap page from a non-exempted route in the popup', () => {
+      const { getByTestId } = renderConfirmationRouter({
+        pathname: DEFAULT_ROUTE,
+        hasBatchSellQuotes: true,
+      });
+
+      expect(getByTestId('pathname').textContent).toBe(DEFAULT_ROUTE);
+    });
+
+    it('stays on the batch sell review page', () => {
+      const { getByTestId } = renderConfirmationRouter({
+        pathname: BATCH_SELL_REVIEW_ROUTE,
+        hasBatchSellQuotes: true,
+      });
+
+      expect(getByTestId('pathname').textContent).toBe(BATCH_SELL_REVIEW_ROUTE);
+    });
+
+    it('does not redirect from a non-exempted route in fullscreen', () => {
+      const { getByTestId } = renderConfirmationRouter({
+        pathname: DEFAULT_ROUTE,
+        hasBatchSellQuotes: true,
+        environmentType: ENVIRONMENT_TYPE_FULLSCREEN,
       });
 
       expect(getByTestId('pathname').textContent).toBe(DEFAULT_ROUTE);

--- a/ui/pages/routes/confirmation-router.tsx
+++ b/ui/pages/routes/confirmation-router.tsx
@@ -37,6 +37,8 @@ import {
   isMerklClaimTransaction,
   isMusdConversionTransaction,
 } from '../../components/app/musd/utils';
+import { resetBridgeController } from '../../ducks/bridge/actions';
+import { useDispatch } from '../../store/hooks';
 
 const EXEMPTED_ROUTES = [
   CROSS_CHAIN_SWAP_ROUTE,
@@ -61,6 +63,7 @@ const SNAP_APPROVAL_TYPES = [
 
 export const ConfirmationRouter = () => {
   const navigate = useNavigate();
+  const dispatch = useDispatch();
   const location = useLocation();
   const { pathname } = location;
   const { closeModals } = useModalState();
@@ -89,6 +92,7 @@ export const ConfirmationRouter = () => {
     if (canRedirect && hasBatchSellQuotes && isPopup) {
       closeModals();
       navigate(DEFAULT_ROUTE, { replace: true });
+      dispatch(resetBridgeController());
     } else if (canRedirect && hasBridgeQuotes && isPopup) {
       closeModals();
       navigate(CROSS_CHAIN_SWAP_ROUTE + PREPARE_SWAP_ROUTE);
@@ -108,6 +112,7 @@ export const ConfirmationRouter = () => {
   }, [
     canRedirect,
     closeModals,
+    dispatch,
     hasApprovalFlows,
     hasBatchSellQuotes,
     hasBridgeQuotes,

--- a/ui/pages/routes/confirmation-router.tsx
+++ b/ui/pages/routes/confirmation-router.tsx
@@ -15,6 +15,7 @@ import {
   SHIELD_PLAN_ROUTE,
   TRANSACTION_SHIELD_ROUTE,
   BATCH_SELL_ROOT_ROUTE,
+  DEFAULT_ROUTE,
 } from '../../helpers/constants/routes';
 import { getConfirmationRoute } from '../confirmations/hooks/useConfirmationNavigation';
 import { getEnvironmentType } from '../../../shared/lib/environment-type';
@@ -27,6 +28,7 @@ import {
 import {
   getTransactions,
   selectHasApprovalFlows,
+  selectHasBatchSellQuotes,
   selectHasBridgeQuotes,
   selectPendingApprovalsForNavigation,
 } from '../../selectors';
@@ -69,6 +71,7 @@ export const ConfirmationRouter = () => {
   const isPopup = envType === ENVIRONMENT_TYPE_POPUP;
 
   const hasBridgeQuotes = useSelector(selectHasBridgeQuotes);
+  const hasBatchSellQuotes = useSelector(selectHasBatchSellQuotes);
   const pendingApprovals = useSelector(selectPendingApprovalsForNavigation);
   const hasApprovalFlows = useSelector(selectHasApprovalFlows);
   const stayOnHomePage = Boolean(location.state?.stayOnHomePage);
@@ -83,7 +86,10 @@ export const ConfirmationRouter = () => {
 
   // Ported from home.component - checkStatusAndNavigate()
   const checkStatusAndNavigate = useCallback(() => {
-    if (canRedirect && hasBridgeQuotes && isPopup) {
+    if (canRedirect && hasBatchSellQuotes && isPopup) {
+      closeModals();
+      navigate(DEFAULT_ROUTE, { replace: true });
+    } else if (canRedirect && hasBridgeQuotes && isPopup) {
       closeModals();
       navigate(CROSS_CHAIN_SWAP_ROUTE + PREPARE_SWAP_ROUTE);
     } else if (pendingApprovals.length || hasApprovalFlows) {
@@ -103,6 +109,7 @@ export const ConfirmationRouter = () => {
     canRedirect,
     closeModals,
     hasApprovalFlows,
+    hasBatchSellQuotes,
     hasBridgeQuotes,
     navigate,
     pendingApprovals,

--- a/ui/selectors/selectors.js
+++ b/ui/selectors/selectors.js
@@ -25,7 +25,10 @@ import {
   getCaip25CaveatFromPermission,
 } from '@metamask/chain-agnostic-permission';
 import { KeyringTypes } from '@metamask/keyring-controller';
-import { selectBridgeFeatureFlags } from '@metamask/bridge-controller';
+import {
+  FeatureId,
+  selectBridgeFeatureFlags,
+} from '@metamask/bridge-controller';
 import {
   KnownCaipNamespace,
   parseCaipAccountId,
@@ -2013,6 +2016,23 @@ export const getIsSwapsChain = createParameterizedSelector(20)(
 
 export function selectHasBridgeQuotes(state) {
   return Boolean(Object.values(state.metamask.quotes || {}).length);
+}
+
+/**
+ * Batch sell fetches quotes through the same BridgeController state as a
+ * regular swap/bridge (`state.metamask.quotes`), so a lingering batch-sell
+ * quote also makes {@link selectHasBridgeQuotes} return `true`. Every quote
+ * fetched for batch sell carries `featureId: FeatureId.BATCH_SELL`, which
+ * lets callers tell the two apart, e.g. so a popup reopened with a stale
+ * batch-sell quote doesn't get redirected to the generic swap page.
+ *
+ * @param state - The Redux state
+ * @returns {boolean} Whether any bridge quote in state came from batch sell
+ */
+export function selectHasBatchSellQuotes(state) {
+  return Object.values(state.metamask.quotes || {}).some(
+    (quote) => quote?.featureId === FeatureId.BATCH_SELL,
+  );
 }
 
 /**

--- a/ui/selectors/selectors.test.js
+++ b/ui/selectors/selectors.test.js
@@ -5260,3 +5260,22 @@ describe('getUnconnectedAccounts', () => {
     );
   });
 });
+
+describe('selectHasBatchSellQuotes', () => {
+  it('returns false when there are no quotes', () => {
+    const state = { metamask: { quotes: [] } };
+    expect(selectors.selectHasBatchSellQuotes(state)).toBe(false);
+  });
+
+  it('returns false when quotes exist but none came from batch sell', () => {
+    const state = {
+      metamask: { quotes: [{ featureId: 'unified_swap_bridge' }] },
+    };
+    expect(selectors.selectHasBatchSellQuotes(state)).toBe(false);
+  });
+
+  it('returns true when a quote came from batch sell', () => {
+    const state = { metamask: { quotes: [{ featureId: 'batch_sell' }] } };
+    expect(selectors.selectHasBatchSellQuotes(state)).toBe(true);
+  });
+});


### PR DESCRIPTION
## **Description**

Closing the extension popup while on the batch-sell review page and then reopening it was redirecting the user to the generic swap page instead of home/dashboard.

**Root cause:** Batch sell fetches its quotes through the same shared `BridgeController` state as a regular swap/bridge (`state.metamask.quotes`). `ConfirmationRouter` only checked whether *any* quote existed (`hasBridgeQuotes`) to decide whether to redirect a reopened popup to the swap page. A batch-sell quote left over from closing the popup mid-review was therefore indistinguishable from an in-progress swap, so the user got bounced to `cross-chain-swap` instead.

**Fix:**
- Added `selectHasBatchSellQuotes`, which reads the `featureId` MetaMask already attaches to every batch-sell quote (`FeatureId.BATCH_SELL`) to tell it apart from a real swap/bridge quote.
- `ConfirmationRouter` now checks `hasBatchSellQuotes` before `hasBridgeQuotes` and, when true, redirects the popup home instead of to the swap page. There's no batch-sell selection state to resume into at that point (it lives in a React context that resets when the popup remounts), so redirecting home rather than reconstructing the review page was the chosen scope for this fix.
- Added a `beforeunload` listener in `BatchSellPage` (mirroring the existing pattern in `usePrefillFromBridgeState` for the swap flow) to proactively reset the shared bridge controller state when a batch-sell popup session ends by being closed, since the review page's own unmount cleanup only runs on in-app navigation, not on the popup closing outright.

## **Changelog**

CHANGELOG entry: Fixed a bug that could send users to the swap page instead of home after closing and reopening the extension while reviewing a batch sell.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4839

## **Manual testing steps**

1. Enable the batch-sell feature flag and open the extension popup.
2. Start a batch sell: select one or more assets to sell and a destination asset, and get to the review page (quotes fetched).
3. Close the popup window (click away/close it, don't navigate back in-app).
4. Reopen the extension popup.
5. Verify you land on the home/dashboard page — not the swap page.
6. Regression check: start a real swap on the swap page, let quotes fetch, close the popup, and reopen it. Verify you're still redirected to the swap page as before (this path shouldn't have changed).

## **Screenshots/Recordings**

<!--
### **Before**
### **After**
-->
Not applicable — this is a navigation/redirect fix with no visual UI changes. Manual testing above covers the behavior change.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes popup navigation and bridge quote reset logic in ConfirmationRouter; swap resume behavior should be unchanged but routing edge cases (approvals, exempt routes) were expanded in tests.
> 
> **Overview**
> Fixes popup reopen after closing mid **batch sell** review: users were sent to the generic swap flow because leftover bridge quotes looked like an in-progress swap.
> 
> Adds **`selectHasBatchSellQuotes`** to detect quotes tagged with `FeatureId.BATCH_SELL` in shared bridge state. **`ConfirmationRouter`** now handles that case first in the popup—navigate **home**, **`resetBridgeController()`**—instead of the swap redirect. **`BatchSellPage`** registers **`beforeunload`** to reset bridge state when the popup closes.
> 
> Tests cover the new selector, router behavior (home vs swap, reset, pending approvals after clear), and batch-sell page cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0b9fedf0120b3b5a47982d63bf8cbaf8f990582. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->