### PR TITLE
test: fix flaky test `BTC Account - Send with local bitcoind sends BTC using a local Bitcoin regtest node`

### DIFF
--- a/test/e2e/seeder/bitcoin/node.ts
+++ b/test/e2e/seeder/bitcoin/node.ts
@@ -24,6 +24,7 @@ import {
   getAvailablePorts,
   isTcpPortAvailable,
 } from '../ports';
+import { stopProcess } from '../stop-process';
 
 export const BITCOIN_LOCAL_NODE_HOST = '127.0.0.1';
 
@@ -798,52 +799,4 @@ async function resolveNodePorts(
     options.rpcPort ?? (allocatedPorts.shift() as number),
     options.p2pPort ?? (allocatedPorts.shift() as number),
   ];
-}
-
-async function stopProcess(childProcess: ChildProcess): Promise<void> {
-  if (childProcess.exitCode !== null || childProcess.signalCode !== null) {
-    return;
-  }
-
-  const exitPromise = new Promise<void>((resolvePromise) => {
-    childProcess.once('exit', () => resolvePromise());
-  });
-  killProcessTree(childProcess, 'SIGTERM');
-
-  const exitedAfterTerm = await Promise.race([
-    exitPromise,
-    new Promise<boolean>((resolvePromise) => {
-      setTimeout(() => {
-        resolvePromise(false);
-      }, 10_000);
-    }),
-  ]);
-
-  if (exitedAfterTerm !== false) {
-    return;
-  }
-
-  killProcessTree(childProcess, 'SIGKILL');
-  await Promise.race([
-    exitPromise,
-    new Promise<void>((resolvePromise) => setTimeout(resolvePromise, 1_000)),
-  ]);
-}
-
-function killProcessTree(
-  childProcess: ChildProcess,
-  signal: NodeJS.Signals,
-): void {
-  if (process.platform === 'win32') {
-    childProcess.kill(signal);
-    return;
-  }
-
-  if (childProcess.pid) {
-    try {
-      process.kill(-childProcess.pid, signal);
-    } catch {
-      childProcess.kill(signal);
-    }
-  }
 }

--- a/test/e2e/seeder/bitcoin/node.ts
+++ b/test/e2e/seeder/bitcoin/node.ts
@@ -496,11 +496,24 @@ export class BitcoinNode {
     this.#nodeProcess = undefined;
 
     if (nodeProcess) {
+      // Gracefully stop bitcoind so LevelDB locks are released before we
+      // delete the regtest datadir. Without this, teardown can race the
+      // daemon shutdown and fail with ENOTEMPTY on Linux CI runners.
+      try {
+        await this.rpc('stop');
+      } catch {
+        // bitcoind may already be stopped or RPC may be unavailable.
+      }
       await stopProcess(nodeProcess);
     }
 
     if (dataDir) {
-      await rm(dataDir, { force: true, recursive: true });
+      await rm(dataDir, {
+        force: true,
+        maxRetries: 5,
+        recursive: true,
+        retryDelay: 200,
+      });
     }
   }
 

--- a/test/e2e/seeder/bitcoin/node.ts
+++ b/test/e2e/seeder/bitcoin/node.ts
@@ -496,14 +496,6 @@ export class BitcoinNode {
     this.#nodeProcess = undefined;
 
     if (nodeProcess) {
-      // Gracefully stop bitcoind so LevelDB locks are released before we
-      // delete the regtest datadir. Without this, teardown can race the
-      // daemon shutdown and fail with ENOTEMPTY on Linux CI runners.
-      try {
-        await this.rpc('stop');
-      } catch {
-        // bitcoind may already be stopped or RPC may be unavailable.
-      }
       await stopProcess(nodeProcess);
     }
 

--- a/test/e2e/seeder/solana/node.ts
+++ b/test/e2e/seeder/solana/node.ts
@@ -16,6 +16,7 @@ import {
   isTcpPortAvailable,
   isTcpPortRangeAvailable,
 } from '../ports';
+import { stopProcess } from '../stop-process';
 
 export const SOLANA_LOCAL_NODE_HOST = '127.0.0.1';
 export const SOLANA_LOCAL_NODE_RPC_PORT = 8899;
@@ -99,7 +100,12 @@ export class SolanaNode {
     }
 
     if (ledgerDirectory) {
-      await rm(ledgerDirectory, { force: true, recursive: true });
+      await rm(ledgerDirectory, {
+        force: true,
+        maxRetries: 5,
+        recursive: true,
+        retryDelay: 200,
+      });
     }
   }
 
@@ -326,52 +332,4 @@ function dynamicPortRangeOverlapsExcludedPorts(
     }
   }
   return false;
-}
-
-async function stopProcess(childProcess: ChildProcess): Promise<void> {
-  if (childProcess.exitCode !== null || childProcess.signalCode !== null) {
-    return;
-  }
-
-  const exitPromise = new Promise<void>((resolvePromise) => {
-    childProcess.once('exit', () => resolvePromise());
-  });
-  killProcessTree(childProcess, 'SIGTERM');
-
-  const exitedAfterTerm = await Promise.race([
-    exitPromise,
-    new Promise<boolean>((resolvePromise) => {
-      setTimeout(() => {
-        resolvePromise(false);
-      }, 5_000);
-    }),
-  ]);
-
-  if (exitedAfterTerm !== false) {
-    return;
-  }
-
-  killProcessTree(childProcess, 'SIGKILL');
-  await Promise.race([
-    exitPromise,
-    new Promise<void>((resolvePromise) => setTimeout(resolvePromise, 1_000)),
-  ]);
-}
-
-function killProcessTree(
-  childProcess: ChildProcess,
-  signal: NodeJS.Signals,
-): void {
-  if (process.platform === 'win32') {
-    childProcess.kill(signal);
-    return;
-  }
-
-  if (childProcess.pid) {
-    try {
-      process.kill(-childProcess.pid, signal);
-    } catch {
-      childProcess.kill(signal);
-    }
-  }
 }

--- a/test/e2e/seeder/stop-process.ts
+++ b/test/e2e/seeder/stop-process.ts
@@ -1,0 +1,71 @@
+import type { ChildProcess } from 'child_process';
+
+const SIGTERM_TIMEOUT_MS = 10_000;
+const SIGKILL_TIMEOUT_MS = 5_000;
+
+/**
+ * Stops a spawned local node process and waits for it to exit.
+ *
+ * Sends SIGTERM first, then SIGKILL if needed. After SIGKILL, waits for the
+ * `exit` event (up to {@link SIGKILL_TIMEOUT_MS}) and throws if the process is
+ * still alive so teardown does not race directory cleanup.
+ */
+export async function stopProcess(childProcess: ChildProcess): Promise<void> {
+  if (childProcess.exitCode !== null || childProcess.signalCode !== null) {
+    return;
+  }
+
+  const exitPromise = new Promise<void>((resolvePromise) => {
+    childProcess.once('exit', () => resolvePromise());
+  });
+
+  killProcessTree(childProcess, 'SIGTERM');
+
+  const exitedAfterTerm = await Promise.race([
+    exitPromise.then(() => true),
+    new Promise<false>((resolvePromise) => {
+      setTimeout(() => {
+        resolvePromise(false);
+      }, SIGTERM_TIMEOUT_MS);
+    }),
+  ]);
+
+  if (exitedAfterTerm) {
+    return;
+  }
+
+  killProcessTree(childProcess, 'SIGKILL');
+
+  const exitedAfterKill = await Promise.race([
+    exitPromise.then(() => true),
+    new Promise<false>((resolvePromise) => {
+      setTimeout(() => {
+        resolvePromise(false);
+      }, SIGKILL_TIMEOUT_MS);
+    }),
+  ]);
+
+  if (!exitedAfterKill) {
+    throw new Error(
+      `Child process (pid=${childProcess.pid ?? 'unknown'}) did not exit after SIGKILL`,
+    );
+  }
+}
+
+function killProcessTree(
+  childProcess: ChildProcess,
+  signal: NodeJS.Signals,
+): void {
+  if (process.platform === 'win32') {
+    childProcess.kill(signal);
+    return;
+  }
+
+  if (childProcess.pid) {
+    try {
+      process.kill(-childProcess.pid, signal);
+    } catch {
+      childProcess.kill(signal);
+    }
+  }
+}

--- a/test/e2e/seeder/stop-process.ts
+++ b/test/e2e/seeder/stop-process.ts
@@ -9,6 +9,8 @@ const SIGKILL_TIMEOUT_MS = 5_000;
  * Sends SIGTERM first, then SIGKILL if needed. After SIGKILL, waits for the
  * `exit` event (up to {@link SIGKILL_TIMEOUT_MS}) and throws if the process is
  * still alive so teardown does not race directory cleanup.
+ *
+ * @param childProcess - The spawned child process to stop.
  */
 export async function stopProcess(childProcess: ChildProcess): Promise<void> {
   if (childProcess.exitCode !== null || childProcess.signalCode !== null) {

--- a/test/e2e/seeder/tron/node.ts
+++ b/test/e2e/seeder/tron/node.ts
@@ -13,6 +13,7 @@ import {
   getAvailablePorts,
   isTcpPortAvailable,
 } from '../ports';
+import { stopProcess } from '../stop-process';
 import {
   TRON_TEST_ASSETS,
   TronLocalNodeOptions,
@@ -245,7 +246,12 @@ export class TronNode {
       }
 
       if (runtimeDirectory) {
-        await rm(runtimeDirectory, { force: true, recursive: true });
+        await rm(runtimeDirectory, {
+          force: true,
+          maxRetries: 5,
+          recursive: true,
+          retryDelay: 200,
+        });
       }
     } finally {
       this.#resetSeederState();
@@ -945,52 +951,4 @@ export async function resolveJavaTronPrivateNetworkPorts(
   }
 
   return resolvedPorts as JavaTronPrivateNetworkPorts;
-}
-
-async function stopProcess(childProcess: ChildProcess): Promise<void> {
-  if (childProcess.exitCode !== null || childProcess.signalCode !== null) {
-    return;
-  }
-
-  const exitPromise = new Promise<void>((resolvePromise) => {
-    childProcess.once('exit', () => resolvePromise());
-  });
-  killProcessTree(childProcess, 'SIGTERM');
-
-  const exitedAfterTerm = await Promise.race([
-    exitPromise,
-    new Promise<boolean>((resolvePromise) => {
-      setTimeout(() => {
-        resolvePromise(false);
-      }, 5_000);
-    }),
-  ]);
-
-  if (exitedAfterTerm !== false) {
-    return;
-  }
-
-  killProcessTree(childProcess, 'SIGKILL');
-  await Promise.race([
-    exitPromise,
-    new Promise<void>((resolvePromise) => setTimeout(resolvePromise, 1_000)),
-  ]);
-}
-
-function killProcessTree(
-  childProcess: ChildProcess,
-  signal: NodeJS.Signals,
-): void {
-  if (process.platform === 'win32') {
-    childProcess.kill(signal);
-    return;
-  }
-
-  if (childProcess.pid) {
-    try {
-      process.kill(-childProcess.pid, signal);
-    } catch {
-      childProcess.kill(signal);
-    }
-  }
 }

--- a/test/e2e/tests/send/btc-send-local.spec.ts
+++ b/test/e2e/tests/send/btc-send-local.spec.ts
@@ -54,7 +54,7 @@ async function mockBtcSendLocalMocks(
 describe('BTC Account - Send with local bitcoind', function (this: Suite) {
   this.timeout(180_000);
 
-  it('sends BTC using a local Bitcoin regtest node TEST', async function () {
+  it('sends BTC using a local Bitcoin regtest node', async function () {
     // Captured in afterLocalNodesStart (which runs before the network mocks
     // are set up) so the mock builder can proxy calls to the local node.
     // testSpecificMock itself keeps its single-argument contract.

--- a/test/e2e/tests/send/btc-send-local.spec.ts
+++ b/test/e2e/tests/send/btc-send-local.spec.ts
@@ -54,7 +54,7 @@ async function mockBtcSendLocalMocks(
 describe('BTC Account - Send with local bitcoind', function (this: Suite) {
   this.timeout(180_000);
 
-  it('sends BTC using a local Bitcoin regtest node', async function () {
+  it('sends BTC using a local Bitcoin regtest node TEST', async function () {
     // Captured in afterLocalNodesStart (which runs before the network mocks
     // are set up) so the mock builder can proxy calls to the local node.
     // testSpecificMock itself keeps its single-argument contract.


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
There is a flaky test failure on the bitcoin spec, when it's trying to tear down the node. The error is happening in the remove folder/contents action after stopping the node:
`ENOTEMPTY: directory not empty, rmdir '/tmp/bitcoin-regtest-e2e-.../regtest'`

Possibly bitcoind is still shutting down so LevelDB/wallet files are still open or locked in the folder, making it not possible to remove.

Adding a retry flag on the rm action for the 3 nodes, and unifying the stopProcess into 1 shared function

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci. I've triggered the e2e quality gate to run the test a few extra times

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to E2E seeder teardown helpers and do not affect production extension behavior.
> 
> **Overview**
> Addresses flaky E2E failures where **`ENOTEMPTY`** occurred while removing regtest data dirs because **`bitcoind`** (and similar nodes) were still shutting down and holding files open.
> 
> **Process shutdown** is centralized in **`test/e2e/seeder/stop-process.ts`**, replacing duplicated **`stopProcess`** / **`killProcessTree`** logic in the Bitcoin, Solana, and Tron seeders. The shared helper still uses SIGTERM then SIGKILL, but after SIGKILL it waits up to **5s** for **`exit`** and **throws** if the child is still alive so teardown does not race **`rm`**. SIGTERM wait is **10s** everywhere (Solana/Tron previously used **5s**).
> 
> **Directory cleanup** in each seeder’s **`quit()`** now passes **`maxRetries: 5`** and **`retryDelay: 200`** to **`fs/promises.rm`** so transient locks during shutdown are less likely to fail the test run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 720b67c06ef5be93843c0de53f59e9bb6b641fb7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->