### PR TITLE
fix(pure-black): use bg-default for SRP backup onboarding screens

### DIFF
--- a/ui/pages/onboarding-flow/index.scss
+++ b/ui/pages/onboarding-flow/index.scss
@@ -22,11 +22,16 @@
     min-height: 627px;
     height: auto;
     margin-bottom: 32px;
+    background-color: var(--color-background-muted);
 
     @include design-system.screen-sm-min {
       padding-inline: 24px;
       padding-top: 32px;
       padding-bottom: 32px;
+    }
+
+    &--srp {
+      background-color: var(--color-background-default);
     }
 
     &--full {

--- a/ui/pages/onboarding-flow/onboarding-flow.tsx
+++ b/ui/pages/onboarding-flow/onboarding-flow.tsx
@@ -384,7 +384,8 @@ export default function OnboardingFlow() {
 
   const isSrpBackupRoute =
     pathname?.startsWith(ONBOARDING_REVEAL_SRP_ROUTE) ||
-    pathname?.startsWith(ONBOARDING_REVIEW_SRP_ROUTE);
+    pathname?.startsWith(ONBOARDING_REVIEW_SRP_ROUTE) ||
+    pathname?.startsWith(ONBOARDING_CONFIRM_SRP_ROUTE);
 
   const isTransparentContainer =
     pathname === ONBOARDING_WELCOME_ROUTE ||

--- a/ui/pages/onboarding-flow/onboarding-flow.tsx
+++ b/ui/pages/onboarding-flow/onboarding-flow.tsx
@@ -382,6 +382,15 @@ export default function OnboardingFlow() {
     pathname === ONBOARDING_UNLOCK_ROUTE ||
     (isFlask() && pathname === ONBOARDING_EXPERIMENTAL_AREA);
 
+  const isSrpBackupRoute =
+    pathname?.startsWith(ONBOARDING_REVEAL_SRP_ROUTE) ||
+    pathname?.startsWith(ONBOARDING_REVIEW_SRP_ROUTE);
+
+  const isTransparentContainer =
+    pathname === ONBOARDING_WELCOME_ROUTE ||
+    pathname === ONBOARDING_UNLOCK_ROUTE ||
+    isPopup;
+
   const backgroundColorForWelcomePage = useMemo(() => {
     if (isWelcomePage) {
       return theme === ThemeType.light
@@ -419,6 +428,7 @@ export default function OnboardingFlow() {
             'onboarding-flow__container--full': isFullPage,
             'onboarding-flow__container--popup': isPopup,
             'onboarding-flow__container--sidepanel': isSidepanel,
+            'onboarding-flow__container--srp': isSrpBackupRoute,
           },
         )}
         marginTop={
@@ -428,12 +438,7 @@ export default function OnboardingFlow() {
         }
         marginBottom={pathname === ONBOARDING_EXPERIMENTAL_AREA ? 6 : 0}
         style={{
-          backgroundColor:
-            [ONBOARDING_WELCOME_ROUTE, ONBOARDING_UNLOCK_ROUTE].includes(
-              pathname,
-            ) || isPopup
-              ? 'transparent'
-              : 'var(--color-background-muted)',
+          backgroundColor: isTransparentContainer ? 'transparent' : undefined,
         }}
       >
         <ErrorBoundary>

--- a/ui/pages/onboarding-flow/recovery-phrase/__snapshots__/review-recovery-phrase.test.tsx.snap
+++ b/ui/pages/onboarding-flow/recovery-phrase/__snapshots__/review-recovery-phrase.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Review Recovery Phrase Component renders match snapshot when isFromReminder and isFromSettingsSecurity are present in the search params 1`] = `
 <div>
   <div
-    class="flex flex-col gap-6 items-center justify-between recovery-phrase h-full"
+    class="flex flex-col gap-6 items-center justify-between recovery-phrase h-full bg-default"
     data-testid="recovery-phrase"
   >
     <div
@@ -339,7 +339,7 @@ exports[`Review Recovery Phrase Component renders match snapshot when isFromRemi
 exports[`Review Recovery Phrase Component should match snapshot 1`] = `
 <div>
   <div
-    class="flex flex-col gap-6 items-center justify-between recovery-phrase h-full"
+    class="flex flex-col gap-6 items-center justify-between recovery-phrase h-full bg-default"
     data-testid="recovery-phrase"
   >
     <div
@@ -652,7 +652,7 @@ exports[`Review Recovery Phrase Component should match snapshot 1`] = `
 exports[`Review Recovery Phrase Component should match snapshot after reveal recovery button is clicked 1`] = `
 <div>
   <div
-    class="flex flex-col gap-6 items-center justify-between recovery-phrase h-full"
+    class="flex flex-col gap-6 items-center justify-between recovery-phrase h-full bg-default"
     data-testid="recovery-phrase"
   >
     <div

--- a/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/confirm-recovery-phrase.tsx
@@ -202,7 +202,7 @@ export default function ConfirmRecoveryPhrase({ secretRecoveryPhrase = '' }) {
       flexDirection={BoxFlexDirection.Column}
       justifyContent={BoxJustifyContent.Between}
       gap={6}
-      className="recovery-phrase recovery-phrase__confirm h-full"
+      className="recovery-phrase recovery-phrase__confirm h-full bg-default"
       data-testid="confirm-recovery-phrase"
     >
       <Box>

--- a/ui/pages/onboarding-flow/recovery-phrase/reveal-recovery-phrase.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/reveal-recovery-phrase.tsx
@@ -255,7 +255,7 @@ export default function RevealRecoveryPhrase({
       justifyContent={BoxJustifyContent.Between}
       alignItems={BoxAlignItems.Center}
       gap={6}
-      className="reveal-recovery-phrase h-full"
+      className="reveal-recovery-phrase h-full bg-default"
       data-testid="reveal-recovery-phrase"
     >
       <Box className="w-full">

--- a/ui/pages/onboarding-flow/recovery-phrase/review-recovery-phrase.tsx
+++ b/ui/pages/onboarding-flow/recovery-phrase/review-recovery-phrase.tsx
@@ -183,7 +183,7 @@ export default function RecoveryPhrase({
       justifyContent={BoxJustifyContent.Between}
       alignItems={BoxAlignItems.Center}
       gap={6}
-      className="recovery-phrase h-full"
+      className="recovery-phrase h-full bg-default"
       data-testid="recovery-phrase"
     >
       <Box>


### PR DESCRIPTION
## **Description**

Sets the Secret Recovery Phrase backup flow backgrounds to `bg-default` so they use pure black in OLED/pure black mode instead of the muted/gray surface.

Approach:
- Move the default onboarding container background into SCSS (`background-muted`)
- Add an `onboarding-flow__container--srp` modifier that uses `background-default` for reveal, review, and confirm SRP routes (including trailing-slash entry points)
- Keep welcome/unlock/popup containers transparent via inline style
- Add `bg-default` on the reveal, review, and confirm page roots

## **Changelog**

CHANGELOG entry: Fixed Secret Recovery Phrase backup page backgrounds in pure black mode

## **Related issues**

Fixes: [TMCU-1187](https://consensyssoftware.atlassian.net/browse/TMCU-1187)

## **Manual testing steps**

1. Enable Pure Black (OLED) mode in Settings → Appearance
2. Open the Back up Secret Recovery Phrase flow (e.g. from Settings → Security)
3. Confirm the reveal/password prompt page background is pure black (`bg-default`), not muted gray
4. Continue to the Save Secret Recovery Phrase (review) screen and confirm its background is also pure black
5. Continue to the confirm Secret Recovery Phrase screen and confirm it stays pure black (no jump back to muted gray)
6. Confirm welcome and unlock onboarding screens are unchanged (transparent container)
7. Repeat in light and dark themes to confirm no regression

## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/56ee95fd-d2f1-4b2a-8784-71dcc4a9e666



### **After**

https://github.com/user-attachments/assets/42cef4ab-a2b8-4f12-9328-1cbce5e28bd8

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

[TMCU-1187]: https://consensyssoftware.atlassian.net/browse/TMCU-1187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped onboarding appearance and CSS class changes only; no auth, wallet, or data logic.
> 
> **Overview**
> Fixes **Secret Recovery Phrase backup** screens showing a muted gray card background in **Pure Black (OLED)** mode by aligning them with `bg-default` / `background-default`.
> 
> The onboarding shell now sets the default container fill in SCSS (`background-muted`) and applies `onboarding-flow__container--srp` on reveal, review, and confirm SRP routes so those steps use `background-default`. Welcome, unlock, and popup flows still get a transparent container via a simplified inline style. Reveal, review, and confirm page roots also gain `bg-default` so the full step stays consistent. Jest snapshots for review recovery phrase were updated for the new class.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5412908973ac747784a8555647065af4a60d5d4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->