### PR TITLE
chore: fix `lint:changed` script

### DIFF
--- a/development/lint-changed.mts
+++ b/development/lint-changed.mts
@@ -134,6 +134,8 @@ function main(): void {
     '--cache',
     '--cache-location',
     path.join('node_modules', '.cache', 'eslint', '.eslint-cache'),
+    '-c',
+    './.eslintrc.js',
   ];
 
   const eslintArgsWithDelimiter = [...eslintArgsBase, '--'];


### PR DESCRIPTION
## **Description**

The `lint:changed` and `lint:changed:fix` scripts were broken by the ESLint v9 update in #44734. ESLint v9 has a different default config filename, and I neglected to update the lint changed script with the CLI flag pointing at our config file.

This has been fixed. This will soon be removed in a future PR when we convert to using the default config filename.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes regression introduced by #44734.

## **Manual testing steps**

* Make some changes to your working tree
* Run `yarn lint:changed` and/or `yarn lint:changed:fix`, and ensure they give the expected result

## **Screenshots/Recordings**

N/A

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only lint script change with no runtime, security, or data impact.
> 
> **Overview**
> **Fixes `yarn lint:changed` and `yarn lint:changed:fix`** after ESLint v9 stopped picking up the repo’s legacy config by default.
> 
> `development/lint-changed.mts` now passes **`-c ./.eslintrc.js`** in the ESLint CLI args (same pattern as `lint:eslint`), so changed-file linting uses the project rules again instead of failing or running with the wrong config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26796bcffdf93e4dc0085503e18cd958b4db64be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->