### PR TITLE
chore: pass Firefox system access via geckodriver and pin 0.36.0

### DIFF
--- a/.github/scripts/pin-geckodriver.sh
+++ b/.github/scripts/pin-geckodriver.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Pin geckodriver 0.36.0 for Firefox Selenium runs.
+#
+# geckodriver 0.37.0 breaks some e2e tests as the dapp can't detect the wallet.
+# We pin the version as a temporary patch until migration to Playwright (in progress).
+# This sets GECKODRIVER_PATH, which `test/e2e/webdriver/firefox.js` reads first;
+# the firefox.js fallback handles local runs. Remove this script (and the
+# firefox.js pin) once a fixed geckodriver release is verified.
+# See: https://github.com/mozilla/geckodriver/releases/tag/v0.37.0
+#
+# Used by:
+# - .github/workflows/run-e2e.yml
+# - .github/workflows/run-benchmarks.yml
+#
+# Expected env (GitHub Actions):
+# - RUNNER_TEMP
+# - GITHUB_ENV
+
+set -euo pipefail
+
+GECKO_VERSION="${GECKO_VERSION:-0.36.0}"
+GECKO_DIR="${RUNNER_TEMP:?RUNNER_TEMP is required}/geckodriver-${GECKO_VERSION}"
+
+mkdir -p "$GECKO_DIR"
+curl -fsSL "https://github.com/mozilla/geckodriver/releases/download/v${GECKO_VERSION}/geckodriver-v${GECKO_VERSION}-linux64.tar.gz" \
+  | tar -xz -C "$GECKO_DIR"
+chmod +x "$GECKO_DIR/geckodriver"
+
+echo "GECKODRIVER_PATH=$GECKO_DIR/geckodriver" >> "${GITHUB_ENV:?GITHUB_ENV is required}"
+"$GECKO_DIR/geckodriver" --version

--- a/.github/workflows/run-benchmarks.yml
+++ b/.github/workflows/run-benchmarks.yml
@@ -67,6 +67,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ inputs.builds-from-run }}
 
+      - name: Pin geckodriver 0.36.0 (Firefox only)
+        if: ${{ matrix.browser == 'firefox' }}
+        run: .github/scripts/pin-geckodriver.sh
+
       - name: Run the benchmark
         run: >-
           ${{ matrix.pageType == 'startupPowerUserHome' && format('yarn test:e2e:benchmark --preset startupPowerUserHome --browserLoads 15 --pageLoads 7 --out test-artifacts/benchmarks/benchmark-{0}-{1}-startupPowerUserHome.json --retries 2', matrix.browser, matrix.buildType) || format('yarn test:e2e:benchmark --preset {2} --out test-artifacts/benchmarks/benchmark-{0}-{1}-{2}.json --retries 2', matrix.browser, matrix.buildType, matrix.pageType) }}

--- a/.github/workflows/run-e2e.yml
+++ b/.github/workflows/run-e2e.yml
@@ -130,23 +130,9 @@ jobs:
           name: ${{ env.JOB_NAME }}
           path: ./previous-test-results/
 
-      # geckodriver 0.37.0 breaks some e2e tests as the dapp can't detect the wallet.
-      # We pin the version as a temporary patch until migration to Playwright (in progress)
-      # This sets GECKODRIVER_PATH, which `test/e2e/webdriver/firefox.js` reads
-      # first; the firefox.js fallback handles local runs. Remove this step (and
-      # the firefox.js pin) once a fixed geckodriver release is verified.
-      # See: https://github.com/mozilla/geckodriver/releases/tag/v0.37.0
       - name: Pin geckodriver 0.36.0 (Firefox only)
         if: ${{ contains(inputs.test-command, 'firefox') }}
-        run: |
-          GECKO_VERSION=0.36.0
-          GECKO_DIR="$RUNNER_TEMP/geckodriver-${GECKO_VERSION}"
-          mkdir -p "$GECKO_DIR"
-          curl -fsSL "https://github.com/mozilla/geckodriver/releases/download/v${GECKO_VERSION}/geckodriver-v${GECKO_VERSION}-linux64.tar.gz" \
-            | tar -xz -C "$GECKO_DIR"
-          chmod +x "$GECKO_DIR/geckodriver"
-          echo "GECKODRIVER_PATH=$GECKO_DIR/geckodriver" >> "$GITHUB_ENV"
-          "$GECKO_DIR/geckodriver" --version
+        run: .github/scripts/pin-geckodriver.sh
 
       - name: Run E2E tests
         timeout-minutes: ${{ inputs.test-timeout-minutes }}

--- a/test/e2e/webdriver/firefox.js
+++ b/test/e2e/webdriver/firefox.js
@@ -23,9 +23,9 @@ const PINNED_GECKODRIVER_VERSION = '0.36.0';
  * Resolve the geckodriver binary to use.
  *
  * Resolution order:
- * 1. `GECKODRIVER_PATH` env var, if set. CI sets this explicitly via the
- *    "Pin geckodriver" step in `.github/workflows/run-e2e.yml` (also usable as
- *    a manual override to test a different driver version).
+ * 1. `GECKODRIVER_PATH` env var, if set. CI sets this via
+ *    `.github/scripts/pin-geckodriver.sh` (also usable as a manual override to
+ *    test a different driver version).
  * 2. The pinned {@link PINNED_GECKODRIVER_VERSION}, resolved (and downloaded +
  *    cached cross-platform) via the `selenium-manager` binary that ships with
  *    `selenium-webdriver`. This is the fallback that fixes local runs without
@@ -145,13 +145,6 @@ class FirefoxDriver {
       path.join(process.cwd(), 'test-artifacts', 'downloads'),
     );
 
-    // Firefox 153 restricts WebDriver navigation to privileged pages (most
-    // `about:` pages, `chrome://`, `resource://`) unless the browser is
-    // launched with system access allowed. `getInternalId` reads the extension
-    // UUID from `about:debugging#addons`, so without this the session cannot
-    // start. See https://bugzilla.mozilla.org/show_bug.cgi?id=1579790
-    options.addArguments('--remote-allow-system-access');
-
     if (isHeadless('SELENIUM')) {
       // TODO: Remove notice and consider non-experimental when results are consistent
       console.warn(
@@ -168,6 +161,15 @@ class FirefoxDriver {
     const service = process.env.FIREFOX_SNAP
       ? new firefox.ServiceBuilder(FF_SNAP_GECKO_PATH)
       : new firefox.ServiceBuilder(resolveGeckodriverPath());
+
+    // Firefox 153 restricts WebDriver navigation to privileged pages (most
+    // `about:` pages, `chrome://`, `resource://`) unless system access is
+    // allowed. `getInternalId` reads the extension UUID from
+    // `about:debugging#addons`, so without this the session cannot start.
+    // Newer geckodriver rejects `--remote-allow-system-access` via Firefox
+    // capabilities; pass `--allow-system-access` to geckodriver instead.
+    // See https://bugzilla.mozilla.org/show_bug.cgi?id=1579790
+    service.addArguments('--allow-system-access');
 
     if (port) {
       service.setPort(port);


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

[#44946](https://github.com/MetaMask/metamask-extension/pull/44946) passed `--remote-allow-system-access` via Firefox capabilities so WebDriver can open `about:debugging#addons` (needed by getInternalId() for moz-extension:// URLs). Newer geckodriver rejects that arg via capabilities.

In this PR we 
- pass `--allow-system-access` to the geckodriver service instead (same privilege, Mozilla-supported path).
- Pin `geckodriver 0.36.0` in benchmarks as well as E2E, via a shared script (`.github/scripts/pin-geckodriver.sh`) used by both `run-e2e.yml`and `run-benchmarks.yml`.

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to test/CI WebDriver configuration and workflow scripts, with no production or user-facing code paths affected.
> 
> **Overview**
> Fixes Firefox WebDriver setup for newer **geckodriver** by stopping use of `--remote-allow-system-access` on Firefox capabilities (rejected by newer drivers) and instead passing **`--allow-system-access`** on the geckodriver service so sessions can still reach `about:debugging#addons` for extension UUID discovery.
> 
> **CI** extracts the inline geckodriver 0.36.0 download into **`.github/scripts/pin-geckodriver.sh`** (sets `GECKODRIVER_PATH`), wires **E2E** to call it, and adds the same pin step to **Firefox benchmark** jobs so they avoid geckodriver 0.37.0 wallet-detection failures. Comments in `firefox.js` now point at the shared script for the env var path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 88c87195116cb937c226685d1936452d0e5c99f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->