### PR TITLE
test: fix flaky test `BTC Account - Activity Receive transaction is rendered with Received label and confirmed status`

### DIFF
--- a/test/e2e/page-objects/flows/bitcoin-send.flow.ts
+++ b/test/e2e/page-objects/flows/bitcoin-send.flow.ts
@@ -1,0 +1,45 @@
+import { DEFAULT_BTC_BALANCE } from '../../constants';
+import { Driver } from '../../webdriver/driver';
+import HomePage from '../pages/home/homepage';
+import TokensTab from '../pages/home/tokens-tab';
+import BitcoinReviewTxPage from '../pages/send/bitcoin-review-tx-page';
+import SendPage from '../pages/send/send-page';
+
+const BITCOIN_CHAIN_ID = 'bip122:000000000019d6689c085ae165831e93';
+
+/**
+ * Broadcasts a Bitcoin send transaction from the homepage through confirmation.
+ *
+ * @param params - An object containing the parameters.
+ * @param params.driver - The webdriver instance.
+ * @param params.recipientAddress - The recipient Bitcoin address.
+ * @param params.amount - The amount of BTC to send.
+ * @param params.expectedBalance - The expected BTC balance shown before sending. Defaults to DEFAULT_BTC_BALANCE.
+ */
+export const broadcastBitcoinSend = async ({
+  driver,
+  recipientAddress,
+  amount,
+  expectedBalance = DEFAULT_BTC_BALANCE,
+}: {
+  driver: Driver;
+  recipientAddress: string;
+  amount: string;
+  expectedBalance?: number;
+}): Promise<void> => {
+  const homePage = new HomePage(driver);
+  const assetList = new TokensTab(driver);
+  await assetList.checkTokenAmountIsDisplayed(`${expectedBalance} BTC`);
+
+  const sendPage = new SendPage(driver);
+  await homePage.startSendFlow();
+  await sendPage.selectToken(BITCOIN_CHAIN_ID, 'BTC');
+  await sendPage.fillRecipient({ recipientAddress });
+  await sendPage.fillAmount(amount);
+  await sendPage.checkContinueButton({ state: 'enabled' });
+  await sendPage.pressContinueButton();
+
+  const reviewPage = new BitcoinReviewTxPage(driver);
+  await reviewPage.checkPageIsLoaded();
+  await reviewPage.clickConfirmButton();
+};

--- a/test/e2e/tests/btc/activity.spec.ts
+++ b/test/e2e/tests/btc/activity.spec.ts
@@ -3,15 +3,13 @@ import { Mockttp } from 'mockttp';
 import { DEFAULT_BTC_ADDRESS, DEFAULT_BTC_BALANCE } from '../../constants';
 import FixtureBuilderV2 from '../../fixtures/fixture-builder-v2';
 import { withFixtures } from '../../helpers';
+import { broadcastBitcoinSend } from '../../page-objects/flows/bitcoin-send.flow';
 import { login } from '../../page-objects/flows/login.flow';
 import { switchToNetworkFromNetworkSelect } from '../../page-objects/flows/network.flow';
 import ActivityTab from '../../page-objects/pages/home/activity-tab';
 import TokensTab from '../../page-objects/pages/home/tokens-tab';
 import HomePage from '../../page-objects/pages/home/homepage';
 import TransactionDetailsPage from '../../page-objects/pages/transaction-details-page';
-import SendPage from '../../page-objects/pages/send/send-page';
-import BitcoinReviewTxPage from '../../page-objects/pages/send/bitcoin-review-tx-page';
-import { Driver } from '../../webdriver/driver';
 import {
   mockExchangeRates,
   mockCurrencyExchangeRates,
@@ -23,7 +21,6 @@ import {
   mockTokensV3Assets,
 } from './mocks';
 import { mockPriceMulti, mockPriceMultiBtcAndSol } from './mocks/min-api';
-import { BTC_CHAIN_ID } from './mocks/bridge';
 
 async function mockBtcActivityMocks(mockServer: Mockttp) {
   return [
@@ -40,34 +37,6 @@ async function mockBtcActivityMocks(mockServer: Mockttp) {
   ];
 }
 
-async function landOnBitcoinHomepage(driver: Driver): Promise<HomePage> {
-  await login(driver);
-  const homePage = new HomePage(driver);
-  await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Bitcoin');
-  await homePage.checkPageIsLoaded();
-  return homePage;
-}
-
-async function broadcastBitcoinSend(
-  driver: Driver,
-  recipient: string,
-  amount: string,
-): Promise<void> {
-  const homePage = await landOnBitcoinHomepage(driver);
-  const assetList = new TokensTab(driver);
-  await assetList.checkTokenAmountIsDisplayed(`${DEFAULT_BTC_BALANCE} BTC`);
-  const sendPage = new SendPage(driver);
-  await homePage.startSendFlow();
-  await sendPage.selectToken(BTC_CHAIN_ID, 'BTC');
-  await sendPage.fillRecipient({ recipientAddress: recipient });
-  await sendPage.fillAmount(amount);
-  await sendPage.checkContinueButton({ state: 'enabled' });
-  await sendPage.pressContinueButton();
-  const reviewPage = new BitcoinReviewTxPage(driver);
-  await reviewPage.checkPageIsLoaded();
-  await reviewPage.clickConfirmButton();
-}
-
 describe('BTC Account - Activity', function (this: Suite) {
   const recipientAddress = 'bc1qsqvczpxkgvp3lw230p7jffuuqnw9pp4j5tawmf';
   const sendAmount = '0.5';
@@ -81,7 +50,10 @@ describe('BTC Account - Activity', function (this: Suite) {
         testSpecificMock: mockBtcActivityMocks,
       },
       async ({ driver }) => {
-        const homePage = await landOnBitcoinHomepage(driver);
+        await login(driver);
+        const homePage = new HomePage(driver);
+        await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Bitcoin');
+        await homePage.checkPageIsLoaded();
         await homePage.goToActivityList();
 
         const activity = new ActivityTab(driver);
@@ -106,9 +78,21 @@ describe('BTC Account - Activity', function (this: Suite) {
         testSpecificMock: mockBtcActivityMocks,
       },
       async ({ driver }) => {
-        await broadcastBitcoinSend(driver, recipientAddress, sendAmount);
+        await login(driver);
+        const homePage = new HomePage(driver);
+        await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Bitcoin');
+        await homePage.checkPageIsLoaded();
+
+        await broadcastBitcoinSend({
+          driver,
+          recipientAddress,
+          amount: sendAmount,
+        });
 
         const activity = new ActivityTab(driver);
+
+        // Bug #43641 - Sometimes we land at Home instead of Activity list, so we manually go to the Activity list before checking for the transaction until that is resolved
+        await homePage.goToActivityList();
         await activity.checkTransactionActivityByText('Sending BTC');
         await activity.checkPendingTxNumberDisplayedInActivity(1);
         await activity.clickOnActivity(1);
@@ -136,7 +120,11 @@ describe('BTC Account - Activity', function (this: Suite) {
         testSpecificMock: mockBtcActivityMocks,
       },
       async ({ driver }) => {
-        const homePage = await landOnBitcoinHomepage(driver);
+        await login(driver);
+        const homePage = new HomePage(driver);
+        await switchToNetworkFromNetworkSelect(driver, 'Popular', 'Bitcoin');
+        await homePage.checkPageIsLoaded();
+
         const assetList = new TokensTab(driver);
         await assetList.selectOnlyNetworkInFilter('Bitcoin');
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

There is a known bug where sometimes after sending a transaction we land into the Tokens page instead of the activity list.

This causes flakiness in the send btc, as when looks for the tx is not there if we are in the tokens page.

See:[ [Bug]: Send - After sending a tx, we land into the Tokens page instead of Activity](https://github.com/MetaMask/metamask-extension/issues/43641)

<img width="780" height="493" alt="image" src="https://github.com/user-attachments/assets/b2be3367-e500-43de-ae06-e85d9e1590c5" />


Now we ensure we are in the activity list, by actively going there after send (if we are there, it's harmless, and if not, we then load the activity list page, which mitigates the issue).
This needs to be solved in the wallet side eventually.

Side: this spec was using helper functions inside the spec file. This has now been moved into a flow file


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit b79457f171a80a4d94cc4690b2eb26b331069179. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->