### PR TITLE
fix(ui): fall back to getAssetImageUrl for missing token icons

### DIFF
--- a/ui/hooks/useTokensData.test.ts
+++ b/ui/hooks/useTokensData.test.ts
@@ -1,6 +1,7 @@
 import { waitFor } from '@testing-library/react';
 import { renderHook, act } from '@testing-library/react-hooks';
 import { handleFetch } from '@metamask/controller-utils';
+import { parseCaipAssetType } from '@metamask/utils';
 import {
   useTokensData,
   MAX_BATCH_SIZE,
@@ -11,6 +12,13 @@ jest.mock('@metamask/controller-utils', () => ({
   handleFetch: jest.fn(),
 }));
 
+jest.mock('@metamask/utils', () => ({
+  ...jest.requireActual('@metamask/utils'),
+  parseCaipAssetType: jest.fn(
+    jest.requireActual('@metamask/utils').parseCaipAssetType,
+  ),
+}));
+
 jest.mock('../../shared/lib/asset-utils', () => ({
   getAssetImageUrl: jest.fn(
     (assetId: string, chainId: string) =>
@@ -19,6 +27,7 @@ jest.mock('../../shared/lib/asset-utils', () => ({
 }));
 
 const mockHandleFetch = handleFetch as jest.Mock;
+const mockParseCaipAssetType = parseCaipAssetType as jest.Mock;
 const { getAssetImageUrl: mockGetAssetImageUrl } = jest.requireMock(
   '../../shared/lib/asset-utils',
 ) as { getAssetImageUrl: jest.Mock };
@@ -173,6 +182,31 @@ describe('useTokensData', () => {
       });
 
       expect(result.current[assetId].iconUrl).toBe(apiIconUrl);
+      expect(mockGetAssetImageUrl).not.toHaveBeenCalled();
+    });
+
+    it('keeps the token unchanged when parseCaipAssetType throws', async () => {
+      const address = uniqueAddress();
+      const assetId = buildAssetId(address);
+      const token = buildTokenAsset({
+        assetId,
+        name: 'Broken Icon Token',
+        symbol: 'BIT',
+        iconUrl: '',
+      });
+
+      mockParseCaipAssetType.mockImplementationOnce(() => {
+        throw new Error('Invalid CAIP asset type.');
+      });
+      mockHandleFetch.mockResolvedValue([token]);
+
+      const { result } = renderHook(() => useTokensData([assetId]));
+
+      await waitFor(() => {
+        expect(result.current[assetId]).toBeDefined();
+      });
+
+      expect(result.current[assetId]).toStrictEqual(token);
       expect(mockGetAssetImageUrl).not.toHaveBeenCalled();
     });
   });

--- a/ui/hooks/useTokensData.test.ts
+++ b/ui/hooks/useTokensData.test.ts
@@ -11,7 +11,17 @@ jest.mock('@metamask/controller-utils', () => ({
   handleFetch: jest.fn(),
 }));
 
+jest.mock('../../shared/lib/asset-utils', () => ({
+  getAssetImageUrl: jest.fn(
+    (assetId: string, chainId: string) =>
+      `https://static.cx.metamask.io/api/v2/tokenIcons/assets/${chainId.replaceAll(':', '/')}/${String(assetId).split('/').slice(1).join('/').toLowerCase()}.png`,
+  ),
+}));
+
 const mockHandleFetch = handleFetch as jest.Mock;
+const { getAssetImageUrl: mockGetAssetImageUrl } = jest.requireMock(
+  '../../shared/lib/asset-utils',
+) as { getAssetImageUrl: jest.Mock };
 
 // Each test should use unique addresses so that the module-level token cache
 // (which persists for the lifetime of the test suite) never serves a cached
@@ -118,6 +128,52 @@ describe('useTokensData', () => {
 
       expect(result.current[assetIdA].symbol).toBe('AAA');
       expect(result.current[assetIdB].symbol).toBe('BBB');
+    });
+
+    it('falls back to getAssetImageUrl when the API omits iconUrl', async () => {
+      const address = uniqueAddress();
+      const assetId = buildAssetId(address);
+      const token = buildTokenAsset({
+        assetId,
+        name: 'MetaMask USD',
+        symbol: 'mUSD',
+        iconUrl: '',
+      });
+
+      mockHandleFetch.mockResolvedValue([token]);
+
+      const { result } = renderHook(() => useTokensData([assetId]));
+
+      await waitFor(() => {
+        expect(result.current[assetId]).toBeDefined();
+      });
+
+      const chainId = assetId.split('/')[0];
+      expect(mockGetAssetImageUrl).toHaveBeenCalledWith(assetId, chainId);
+      expect(result.current[assetId].iconUrl).toBe(
+        mockGetAssetImageUrl(assetId, chainId),
+      );
+    });
+
+    it('keeps the API iconUrl when it is present', async () => {
+      const address = uniqueAddress();
+      const assetId = buildAssetId(address);
+      const apiIconUrl = 'https://tokens.api/custom-icon.png';
+      const token = buildTokenAsset({
+        assetId,
+        iconUrl: apiIconUrl,
+      });
+
+      mockHandleFetch.mockResolvedValue([token]);
+
+      const { result } = renderHook(() => useTokensData([assetId]));
+
+      await waitFor(() => {
+        expect(result.current[assetId]).toBeDefined();
+      });
+
+      expect(result.current[assetId].iconUrl).toBe(apiIconUrl);
+      expect(mockGetAssetImageUrl).not.toHaveBeenCalled();
     });
   });
 

--- a/ui/hooks/useTokensData.ts
+++ b/ui/hooks/useTokensData.ts
@@ -43,11 +43,16 @@ function withIconUrlFallback(token: TokenAsset): TokenAsset {
     return token;
   }
 
-  const { chainId } = parseCaipAssetType(token.assetId);
-  return {
-    ...token,
-    iconUrl: getAssetImageUrl(token.assetId, chainId) ?? '',
-  };
+  try {
+    const { chainId } = parseCaipAssetType(token.assetId);
+    return {
+      ...token,
+      iconUrl: getAssetImageUrl(token.assetId, chainId) ?? '',
+    };
+  } catch {
+    // Unexpected malformed CAIP asset id — keep the API token as-is.
+    return token;
+  }
 }
 
 function fetchTokenBatch(assetIds: string[]): Promise<TokenAsset[]> {

--- a/ui/hooks/useTokensData.ts
+++ b/ui/hooks/useTokensData.ts
@@ -4,6 +4,8 @@
 // from Redux state rather than calling the API directly.
 import { useState, useEffect } from 'react';
 import { handleFetch } from '@metamask/controller-utils';
+import type { CaipChainId } from '@metamask/utils';
+import { getAssetImageUrl } from '../../shared/lib/asset-utils';
 
 export type TokenAsset = {
   assetId: string;
@@ -23,6 +25,26 @@ export const MAX_BATCH_SIZE = 25;
 // share a single HTTP request for the same batch of asset IDs.
 const tokenCache: Record<string, TokenAsset> = {};
 const inFlight = new Map<string, Promise<TokenAsset[]>>();
+
+/**
+ * The tokens API omits `iconUrl` for some recognized tokens (e.g. mUSD)
+ * even though the canonical icon exists on the static CDN, so fall back to
+ * {@link getAssetImageUrl} when the API response has no icon.
+ *
+ * @param token - Token metadata returned by the tokens API.
+ * @returns Token with a resolved icon URL when possible.
+ */
+function withIconUrlFallback(token: TokenAsset): TokenAsset {
+  if (token.iconUrl) {
+    return token;
+  }
+
+  const chainId = token.assetId.split('/')[0] as CaipChainId;
+  return {
+    ...token,
+    iconUrl: getAssetImageUrl(token.assetId, chainId) ?? '',
+  };
+}
 
 function fetchTokenBatch(assetIds: string[]): Promise<TokenAsset[]> {
   const normalizedIds = assetIds.map((id) => id.toLowerCase());
@@ -51,10 +73,12 @@ function fetchTokenBatch(assetIds: string[]): Promise<TokenAsset[]> {
       // asset IDs (addresses are lowercased before building the CAIP-19 ID).
       // The API may return EIP-55 checksummed addresses (e.g. 0xABc…) which
       // would otherwise cause every cache lookup and state lookup to miss.
-      data.forEach((t) => {
-        tokenCache[t.assetId.toLowerCase()] = t;
+      // Also fill missing icon URLs from the static token-icons CDN.
+      return data.map((token) => {
+        const normalized = withIconUrlFallback(token);
+        tokenCache[token.assetId.toLowerCase()] = normalized;
+        return normalized;
       });
-      return data;
     } finally {
       inFlight.delete(key);
     }

--- a/ui/hooks/useTokensData.ts
+++ b/ui/hooks/useTokensData.ts
@@ -4,7 +4,7 @@
 // from Redux state rather than calling the API directly.
 import { useState, useEffect } from 'react';
 import { handleFetch } from '@metamask/controller-utils';
-import type { CaipChainId } from '@metamask/utils';
+import { isCaipAssetType, parseCaipAssetType } from '@metamask/utils';
 import { getAssetImageUrl } from '../../shared/lib/asset-utils';
 
 export type TokenAsset = {
@@ -39,7 +39,11 @@ function withIconUrlFallback(token: TokenAsset): TokenAsset {
     return token;
   }
 
-  const chainId = token.assetId.split('/')[0] as CaipChainId;
+  if (!isCaipAssetType(token.assetId)) {
+    return token;
+  }
+
+  const { chainId } = parseCaipAssetType(token.assetId);
   return {
     ...token,
     iconUrl: getAssetImageUrl(token.assetId, chainId) ?? '',


### PR DESCRIPTION
Use the static token-icons CDN when the tokens API omits iconUrl so recognized assets like mUSD still render an icon via useTokensData.

<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: fall back to getAssetImageUrl for missing token icons

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UI metadata enrichment with defensive guards; no auth, payments, or persistence changes.
> 
> **Overview**
> **`useTokensData`** now fills in missing token icons when the v3 tokens API returns an empty `iconUrl`, using the existing static CDN helper **`getAssetImageUrl`** for valid CAIP asset IDs.
> 
> API-provided `iconUrl` values are left unchanged. Malformed or non-CAIP asset IDs skip the fallback (including when **`parseCaipAssetType`** throws). Normalized tokens—including any resolved icon—are what get written to the module-level cache.
> 
> Tests mock **`getAssetImageUrl`** and **`parseCaipAssetType`** and cover fallback, no-op when an icon exists, and error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2895343d7b46cb703685613688d32359fe32dcf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->