### PR TITLE
fix(persistence): suppress false-positive Sentry errors on browser shutdown

### DIFF
--- a/shared/lib/stores/persistence-manager.test.ts
+++ b/shared/lib/stores/persistence-manager.test.ts
@@ -466,17 +466,6 @@ describe('PersistenceManager', () => {
       expect(log.error).not.toHaveBeenCalled();
     });
 
-    it('does not capture exception when store.get throws a browser-shutdown error with reportErrors disabled', async () => {
-      const shutdownError = new Error('The browser is shutting down.');
-      mockStoreGet.mockRejectedValueOnce(shutdownError);
-
-      await expect(
-        manager.get({ validateVault: false, reportErrors: false }),
-      ).rejects.toThrow(shutdownError);
-
-      expect(mockedCaptureException).not.toHaveBeenCalled();
-      expect(log.error).not.toHaveBeenCalled();
-    });
 
     it('does not overwrite mostRecentRetrievedState if already initialized', async () => {
       manager.storageKind = 'data';

--- a/shared/lib/stores/persistence-manager.test.ts
+++ b/shared/lib/stores/persistence-manager.test.ts
@@ -451,6 +451,16 @@ describe('PersistenceManager', () => {
       );
     });
 
+    it('does not capture exception or trigger vault recovery when store.get throws a browser-shutdown error', async () => {
+      const shutdownError = new Error('The browser is shutting down.');
+      mockStoreGet.mockRejectedValueOnce(shutdownError);
+
+      const result = await manager.get({ validateVault: true });
+
+      expect(result).toBeUndefined();
+      expect(mockedCaptureException).not.toHaveBeenCalled();
+    });
+
     it('does not overwrite mostRecentRetrievedState if already initialized', async () => {
       manager.storageKind = 'data';
       mockStoreGet.mockResolvedValueOnce({ data: MOCK_DATA });

--- a/shared/lib/stores/persistence-manager.test.ts
+++ b/shared/lib/stores/persistence-manager.test.ts
@@ -459,6 +459,21 @@ describe('PersistenceManager', () => {
 
       expect(result).toBeUndefined();
       expect(mockedCaptureException).not.toHaveBeenCalled();
+      expect(log.error).not.toHaveBeenCalled();
+    });
+
+    it('does not capture exception when store.get throws a browser-shutdown error with reportErrors disabled', async () => {
+      const shutdownError = new Error('The browser is shutting down.');
+      mockStoreGet.mockRejectedValueOnce(shutdownError);
+
+      const result = await manager.get({
+        validateVault: false,
+        reportErrors: false,
+      });
+
+      expect(result).toBeUndefined();
+      expect(mockedCaptureException).not.toHaveBeenCalled();
+      expect(log.error).not.toHaveBeenCalled();
     });
 
     it('does not overwrite mostRecentRetrievedState if already initialized', async () => {

--- a/shared/lib/stores/persistence-manager.test.ts
+++ b/shared/lib/stores/persistence-manager.test.ts
@@ -455,9 +455,13 @@ describe('PersistenceManager', () => {
       const shutdownError = new Error('The browser is shutting down.');
       mockStoreGet.mockRejectedValueOnce(shutdownError);
 
-      const result = await manager.get({ validateVault: true });
+      // Re-throws so callers fail gracefully instead of continuing with
+      // undefined state (which would trigger generateInitialState and could
+      // overwrite persisted data on the next write).
+      await expect(manager.get({ validateVault: true })).rejects.toThrow(
+        shutdownError,
+      );
 
-      expect(result).toBeUndefined();
       expect(mockedCaptureException).not.toHaveBeenCalled();
       expect(log.error).not.toHaveBeenCalled();
     });
@@ -466,12 +470,10 @@ describe('PersistenceManager', () => {
       const shutdownError = new Error('The browser is shutting down.');
       mockStoreGet.mockRejectedValueOnce(shutdownError);
 
-      const result = await manager.get({
-        validateVault: false,
-        reportErrors: false,
-      });
+      await expect(
+        manager.get({ validateVault: false, reportErrors: false }),
+      ).rejects.toThrow(shutdownError);
 
-      expect(result).toBeUndefined();
       expect(mockedCaptureException).not.toHaveBeenCalled();
       expect(log.error).not.toHaveBeenCalled();
     });

--- a/shared/lib/stores/persistence-manager.test.ts
+++ b/shared/lib/stores/persistence-manager.test.ts
@@ -466,7 +466,6 @@ describe('PersistenceManager', () => {
       expect(log.error).not.toHaveBeenCalled();
     });
 
-
     it('does not overwrite mostRecentRetrievedState if already initialized', async () => {
       manager.storageKind = 'data';
       mockStoreGet.mockResolvedValueOnce({ data: MOCK_DATA });

--- a/shared/lib/stores/persistence-manager.ts
+++ b/shared/lib/stores/persistence-manager.ts
@@ -866,16 +866,20 @@ export class PersistenceManager extends EventEmitter<PersistenceManagerEventMap>
 
         // Log and capture the error if one occurred, but don't throw yet
         if (localStoreError) {
+          // "The browser is shutting down." is thrown by chrome.storage.local.get
+          // during browser shutdown. It is expected and not actionable — skip
+          // Sentry reporting and vault recovery to avoid false-positive alerts.
+          if (localStoreError.message === 'The browser is shutting down.') {
+            log.info(
+              'storage.local.get rejected during browser shutdown — expected',
+            );
+            return undefined;
+          }
           log.error(
             'Error retrieving the current state of the local store:',
             localStoreError,
           );
-          // "The browser is shutting down." is thrown by chrome.storage.local.get
-          // during browser shutdown. It is expected and not actionable — skip
-          // Sentry reporting and vault recovery to avoid false-positive alerts.
-          const isBrowserShuttingDown =
-            localStoreError.message === 'The browser is shutting down.';
-          if (reportErrors && !isBrowserShuttingDown) {
+          if (reportErrors) {
             // Custom fingerprint prevents Sentry's deduplication from dropping
             // this event when other persistence errors with the same underlying
             // error message (e.g., "An unexpected error occurred") are reported.
@@ -883,9 +887,6 @@ export class PersistenceManager extends EventEmitter<PersistenceManagerEventMap>
               tags: { 'persistence.error': 'get-failed' },
               fingerprint: ['persistence-error', 'get-failed'],
             });
-          }
-          if (isBrowserShuttingDown) {
-            return undefined;
           }
         }
 

--- a/shared/lib/stores/persistence-manager.ts
+++ b/shared/lib/stores/persistence-manager.ts
@@ -869,11 +869,14 @@ export class PersistenceManager extends EventEmitter<PersistenceManagerEventMap>
           // "The browser is shutting down." is thrown by chrome.storage.local.get
           // during browser shutdown. It is expected and not actionable — skip
           // Sentry reporting and vault recovery to avoid false-positive alerts.
+          // We still re-throw below so callers fail gracefully rather than
+          // silently continuing with undefined state (which could trigger
+          // generateInitialState and overwrite persisted data on the next write).
           if (localStoreError.message === 'The browser is shutting down.') {
             log.info(
               'storage.local.get rejected during browser shutdown — expected',
             );
-            return undefined;
+            throw localStoreError;
           }
           log.error(
             'Error retrieving the current state of the local store:',

--- a/shared/lib/stores/persistence-manager.ts
+++ b/shared/lib/stores/persistence-manager.ts
@@ -870,7 +870,12 @@ export class PersistenceManager extends EventEmitter<PersistenceManagerEventMap>
             'Error retrieving the current state of the local store:',
             localStoreError,
           );
-          if (reportErrors) {
+          // "The browser is shutting down." is thrown by chrome.storage.local.get
+          // during browser shutdown. It is expected and not actionable — skip
+          // Sentry reporting and vault recovery to avoid false-positive alerts.
+          const isBrowserShuttingDown =
+            localStoreError.message === 'The browser is shutting down.';
+          if (reportErrors && !isBrowserShuttingDown) {
             // Custom fingerprint prevents Sentry's deduplication from dropping
             // this event when other persistence errors with the same underlying
             // error message (e.g., "An unexpected error occurred") are reported.
@@ -878,6 +883,9 @@ export class PersistenceManager extends EventEmitter<PersistenceManagerEventMap>
               tags: { 'persistence.error': 'get-failed' },
               fingerprint: ['persistence-error', 'get-failed'],
             });
+          }
+          if (isBrowserShuttingDown) {
+            return undefined;
           }
         }
 


### PR DESCRIPTION
## **Description**

When \`chrome.storage.local.get\` rejects with \`"The browser is shutting down."\`, the persistence manager was:
1. Capturing a Sentry exception tagged \`get-failed\`
2. Triggering vault recovery (\`MISSING_VAULT_ERROR\`) when a backup exists

Both are false positives — storage is inaccessible because Chrome is shutting down, not because the vault is corrupt. @davidmurdoch's investigation of the Chromium source confirmed this error is emitted during normal browser shutdown once all windows/tabs have been destroyed, and accounts for ~4% of \`MISSING_VAULT_ERROR\` errors.

This PR detects that exact error message and:
- Skips Sentry reporting
- Skips vault recovery
- Re-throws the original error so callers abort gracefully (returning \`undefined\` instead would cause \`background.js\` to treat it as an empty store, trigger \`generateInitialState\`, and potentially overwrite the entire persisted state on the next write)

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. No straightforward manual repro — the error only occurs during actual browser shutdown.
2. Unit tests cover the new paths: a \`storage.local.get\` rejection with \`"The browser is shutting down."\` re-throws without triggering Sentry or vault recovery, and does not call \`log.error\`.

## **Screenshots/Recordings**

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow, message-specific branch in persistence read error handling with a unit test; behavior for all other storage errors is unchanged.
> 
> **Overview**
> **Persistence `get()`** now treats Chrome’s `"The browser is shutting down."` rejection from `chrome.storage.local.get` as an expected shutdown case instead of a vault/storage failure.
> 
> For that message only, the manager logs at **info**, skips **Sentry** (`get-failed`) and the **vault recovery** path that would throw `MISSING_VAULT_ERROR` when a backup exists, then **re-throws** the same error so startup does not continue with empty/undefined state (avoiding `generateInitialState` and a possible full overwrite on the next write).
> 
> A unit test asserts shutdown errors re-throw with `validateVault: true` without `captureException` or `log.error`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0de163312e164237a9b105fe6edba6f9d2545da0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->