### PR TITLE
fix: consume stx enabled flag for batch sell from selected chain

### DIFF
--- a/ui/pages/batch-sell/pages/review/batch-sell-review-page.test.tsx
+++ b/ui/pages/batch-sell/pages/review/batch-sell-review-page.test.tsx
@@ -7,11 +7,12 @@ import {
   buildSendAssetConfigEntry,
   buildReceivedAsset,
 } from '../../../../../test/data/batch-sell';
+// eslint-disable-next-line import-x/no-restricted-paths
+import { useRefreshSmartTransactionsLiveness } from '../../../bridge/hooks/useRefreshSmartTransactionsLiveness';
 import { useBatchSellQuotesConfig } from './hooks/useBatchSellQuotesConfig';
 import { useBatchSellQuotesFetching } from './hooks/useBatchSellQuotesFetching';
 import { useBatchSellAggregateValidation } from './hooks/useBatchSellAggregateValidation';
-// eslint-disable-next-line import-x/no-restricted-paths
-import { useRefreshSmartTransactionsLiveness } from '../../../bridge/hooks/useRefreshSmartTransactionsLiveness';
+
 import { BatchSellReviewPage } from './batch-sell-review-page';
 
 // Referenced from inside the `useBatchSellHighRateAlertModal` jest.mock(..)

--- a/ui/pages/batch-sell/pages/review/batch-sell-review-page.test.tsx
+++ b/ui/pages/batch-sell/pages/review/batch-sell-review-page.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 import { useSelector } from 'react-redux';
+import { MultichainNetworks } from '../../../../../shared/constants/multichain/networks';
 import {
   BATCH_SELL_ASSET_IDS,
   buildSendAssetConfigEntry,
@@ -9,6 +10,8 @@ import {
 import { useBatchSellQuotesConfig } from './hooks/useBatchSellQuotesConfig';
 import { useBatchSellQuotesFetching } from './hooks/useBatchSellQuotesFetching';
 import { useBatchSellAggregateValidation } from './hooks/useBatchSellAggregateValidation';
+// eslint-disable-next-line import-x/no-restricted-paths
+import { useRefreshSmartTransactionsLiveness } from '../../../bridge/hooks/useRefreshSmartTransactionsLiveness';
 import { BatchSellReviewPage } from './batch-sell-review-page';
 
 // Referenced from inside the `useBatchSellHighRateAlertModal` jest.mock(..)
@@ -23,6 +26,9 @@ jest.mock('./hooks/useBatchSellTradesFetching', () => ({
   useBatchSellTradesFetching: jest.fn(),
 }));
 jest.mock('./hooks/useBatchSellAggregateValidation');
+jest.mock('../../../bridge/hooks/useRefreshSmartTransactionsLiveness', () => ({
+  useRefreshSmartTransactionsLiveness: jest.fn(),
+}));
 jest.mock('../../hooks/useBatchSellHighRateAlertModal', () => ({
   useBatchSellHighRateAlertModal: () => ({
     openHighAlertModal: mockOpenHighAlertModal,
@@ -175,6 +181,9 @@ const mockUseBatchSellQuotesFetching = jest.mocked(useBatchSellQuotesFetching);
 const mockUseBatchSellAggregateValidation = jest.mocked(
   useBatchSellAggregateValidation,
 );
+const mockUseRefreshSmartTransactionsLiveness = jest.mocked(
+  useRefreshSmartTransactionsLiveness,
+);
 const mockUseSelector = jest.mocked(useSelector);
 
 // ── Default return values ──────────────────────────────────────────────────
@@ -270,6 +279,34 @@ describe('BatchSellReviewPage', () => {
 
       expect(screen.getByTestId('batch-sell-review-page')).toBeInTheDocument();
       expect(screen.queryByTestId('navigate')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('STX liveness refresh', () => {
+    // STX availability is gated on per-chain liveness, which is only fetched
+    // for chains the wallet has visited, so the review page refreshes it for
+    // the batch-sell source chain up front.
+    it('refreshes STX liveness for the selected receive asset chain', () => {
+      renderPage();
+
+      expect(mockUseRefreshSmartTransactionsLiveness).toHaveBeenCalledWith(
+        '0x1',
+      );
+    });
+
+    it('passes undefined for a non-EVM selected receive asset chain', () => {
+      renderPage({
+        quotesConfig: {
+          selectedReceiveAsset: buildReceivedAsset({
+            assetId: BATCH_SELL_ASSET_IDS.USDC,
+            chainId: MultichainNetworks.SOLANA,
+          }),
+        },
+      });
+
+      expect(mockUseRefreshSmartTransactionsLiveness).toHaveBeenCalledWith(
+        undefined,
+      );
     });
   });
 

--- a/ui/pages/batch-sell/pages/review/batch-sell-review-page.tsx
+++ b/ui/pages/batch-sell/pages/review/batch-sell-review-page.tsx
@@ -8,6 +8,9 @@ import {
 } from '../../../../constants/batch-sell';
 import { BATCH_SELL_SELECT_ROUTE } from '../../../../helpers/constants/routes';
 import { getBatchSellTrades } from '../../../../ducks/batch-sell/selectors';
+import { getMaybeHexChainId } from '../../../../ducks/bridge/utils';
+// eslint-disable-next-line import-x/no-restricted-paths
+import { useRefreshSmartTransactionsLiveness } from '../../../bridge/hooks/useRefreshSmartTransactionsLiveness';
 import { useBatchSellHighRateAlertModal } from '../../hooks/useBatchSellHighRateAlertModal';
 import { useBatchSellQuotesConfig } from './hooks/useBatchSellQuotesConfig';
 import { Header } from './components/header';
@@ -63,6 +66,17 @@ export const BatchSellReviewPage = () => {
   );
 
   const batchSellChain = entries[0]?.asset.chainId ?? '';
+
+  const batchSellHexChainId = useMemo(
+    () => getMaybeHexChainId(selectedReceiveAsset.chainId),
+    [selectedReceiveAsset.chainId],
+  );
+
+  // STX availability is gated on per-chain liveness, which is only fetched for
+  // chains the wallet has visited. Refresh it for the batch-sell source chain
+  // so the flag above isn't a false negative when that chain differs from the
+  // globally selected network.
+  useRefreshSmartTransactionsLiveness(batchSellHexChainId);
 
   useBatchSellTradesFetching(
     { data, entries, quotesLastFetchedMs, chain: batchSellChain },

--- a/ui/pages/batch-sell/pages/review/hooks/useBatchSellQuotesFetching.test.ts
+++ b/ui/pages/batch-sell/pages/review/hooks/useBatchSellQuotesFetching.test.ts
@@ -1,12 +1,13 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 import { useSelector } from 'react-redux';
 import type { CaipAssetType } from '@metamask/utils';
+import { MultichainNetworks } from '../../../../../../shared/constants/multichain/networks';
 import {
   resetBridgeController,
   setSelectedQuote,
   updateQuoteRequestParams,
 } from '../../../../../ducks/bridge/actions';
-import { getIsStxEnabled } from '../../../../../ducks/bridge/selectors';
+import { getIsSmartTransaction } from '../../../../../../shared/lib/selectors';
 import { getInternalAccountBySelectedAccountGroupAndCaip } from '../../../../../selectors/multichain-accounts/account-tree';
 import {
   getBatchSellQuotes,
@@ -43,8 +44,8 @@ jest.mock('../../../../../ducks/bridge/actions', () => ({
   })),
 }));
 
-jest.mock('../../../../../ducks/bridge/selectors', () => ({
-  getIsStxEnabled: jest.fn(),
+jest.mock('../../../../../../shared/lib/selectors', () => ({
+  getIsSmartTransaction: jest.fn(),
 }));
 
 jest.mock('../../../../../selectors/multichain-accounts/account-tree', () => ({
@@ -81,7 +82,7 @@ const mockUseSelector = jest.mocked(useSelector);
 const mockGetInternalAccountBySelectedAccountGroupAndCaip = jest.mocked(
   getInternalAccountBySelectedAccountGroupAndCaip,
 );
-const mockGetIsStxEnabled = jest.mocked(getIsStxEnabled);
+const mockGetIsSmartTransaction = jest.mocked(getIsSmartTransaction);
 const mockGetBatchSellQuotes = jest.mocked(getBatchSellQuotes);
 const mockGetBatchSellQuotesValidationErrors = jest.mocked(
   getBatchSellQuotesValidationErrors,
@@ -191,7 +192,7 @@ describe('useBatchSellQuotesFetching', () => {
     mockGetInternalAccountBySelectedAccountGroupAndCaip.mockReturnValue(
       MOCK_ACCOUNT as never,
     );
-    mockGetIsStxEnabled.mockReturnValue(true as never);
+    mockGetIsSmartTransaction.mockReturnValue(true);
     mockGetBatchSellQuotes.mockReturnValue(
       MOCK_CONTROLLER_RESULT_NOT_FETCHED as never,
     );
@@ -300,6 +301,37 @@ describe('useBatchSellQuotesFetching', () => {
           controllerResult: MOCK_CONTROLLER_RESULT_FETCHED,
           receivedAsset,
         }),
+      );
+    });
+  });
+
+  describe('smart transactions flag', () => {
+    // Batch sell never writes its source chain to the bridge slice, so reading
+    // STX availability from the bridge/global network would describe a
+    // different chain than the one being sold on.
+    it('scopes the STX check to the batch-sell source chain', () => {
+      renderDefault({ enabled: true });
+
+      expect(mockGetIsSmartTransaction).toHaveBeenCalledWith({}, '0x1');
+      expect(mockBuildQuoteRequestContext).toHaveBeenCalledWith(
+        expect.objectContaining({ smartTransactionsEnabled: true }),
+      );
+    });
+
+    it('reports STX as disabled on a non-EVM source chain rather than falling back to the global network', () => {
+      renderDefault({
+        enabled: true,
+        config: {
+          sendAssetsConfig,
+          receivedAsset: buildReceivedAsset({
+            chainId: MultichainNetworks.SOLANA,
+          }),
+        },
+      });
+
+      expect(mockGetIsSmartTransaction).not.toHaveBeenCalled();
+      expect(mockBuildQuoteRequestContext).toHaveBeenCalledWith(
+        expect.objectContaining({ smartTransactionsEnabled: false }),
       );
     });
   });

--- a/ui/pages/batch-sell/pages/review/hooks/useBatchSellQuotesFetching.ts
+++ b/ui/pages/batch-sell/pages/review/hooks/useBatchSellQuotesFetching.ts
@@ -8,10 +8,9 @@ import {
   setSelectedQuote,
   updateQuoteRequestParams,
 } from '../../../../../ducks/bridge/actions';
-import {
-  type BridgeAppState,
-  getIsStxEnabled,
-} from '../../../../../ducks/bridge/selectors';
+import { type BridgeAppState } from '../../../../../ducks/bridge/selectors';
+import { getMaybeHexChainId } from '../../../../../ducks/bridge/utils';
+import { getIsSmartTransaction } from '../../../../../../shared/lib/selectors';
 import { getInternalAccountBySelectedAccountGroupAndCaip } from '../../../../../selectors/multichain-accounts/account-tree';
 import {
   BatchSellQuotesConfig,
@@ -58,7 +57,15 @@ export const useBatchSellQuotesFetching = (
     ),
   );
 
-  const smartTransactionsEnabled = useSelector(getIsStxEnabled);
+  const batchSellHexChainId = useMemo(
+    () => getMaybeHexChainId(receivedAsset.chainId),
+    [receivedAsset.chainId],
+  );
+  const smartTransactionsEnabled = useSelector((state: BridgeAppState) =>
+    batchSellHexChainId
+      ? getIsSmartTransaction(state, batchSellHexChainId)
+      : false,
+  );
 
   const entries = useMemo<SendAssetEntry[]>(
     () =>

--- a/ui/pages/batch-sell/pages/review/hooks/useBatchSellSubmitQuotes.test.ts
+++ b/ui/pages/batch-sell/pages/review/hooks/useBatchSellSubmitQuotes.test.ts
@@ -62,7 +62,9 @@ const mockSubmitBatchSellTrade = jest.mocked(submitBatchSellTrade);
 
 const MOCK_ACCOUNT = { address: '0xdeadbeef', type: 'eip155:eoa' };
 
-const MOCK_QUOTE_RESPONSE = { quote: { requestId: 'req-1' } } as never;
+const MOCK_QUOTE_RESPONSE = {
+  quote: { requestId: 'req-1', srcChainId: 1 },
+} as never;
 
 const MOCK_RECEIVED_ASSET_NO_SECURITY: BatchSellAsset = {
   assetId: 'eip155:1/erc20:0xusdc' as never,
@@ -225,6 +227,23 @@ describe('useBatchSellSubmitQuotes', () => {
       expect(mockGetIsSmartTransaction).toHaveBeenCalledWith(
         expect.anything(),
         '0x1',
+      );
+    });
+
+    // `getIsSmartTransaction` falls back to the globally selected network when
+    // given no chain id, which has nothing to do with the chain being sold on.
+    it('reports STX as disabled instead of querying the global network when the source chain has no hex equivalent', async () => {
+      mockGetMaybeHexChainId.mockReturnValue(undefined);
+
+      const { result } = renderDefault();
+
+      await act(async () => {
+        await result.current.submitBatchSellQuotes();
+      });
+
+      expect(mockGetIsSmartTransaction).not.toHaveBeenCalled();
+      expect(mockSubmitBatchSellTrade).toHaveBeenCalledWith(
+        expect.objectContaining({ isStxEnabled: false }),
       );
     });
 

--- a/ui/pages/batch-sell/pages/review/hooks/useBatchSellSubmitQuotes.ts
+++ b/ui/pages/batch-sell/pages/review/hooks/useBatchSellSubmitQuotes.ts
@@ -45,7 +45,9 @@ export default function useBatchSellSubmitQuotes({
   const srcChainId = quoteResponses.find((q) => q)?.quote.srcChainId;
   const srcChainIdHex = getMaybeHexChainId(srcChainId?.toString());
   const isStxEnabled = useSelector((state) =>
-    getIsSmartTransaction(state as BridgeAppState, srcChainIdHex),
+    srcChainIdHex
+      ? getIsSmartTransaction(state as BridgeAppState, srcChainIdHex)
+      : false,
   );
   const fromAccount = useSelector(getFromAccount);
   const [isSubmitting, setIsSubmitting] = useState(false);


### PR DESCRIPTION
## **Description**

The batch-sell review page was reading STX (smart transaction) availability from the globally selected network / bridge slice instead of the actual chain the batch-sell source assets live on. Batch sell never writes its source chain into the bridge slice, so `getIsStxEnabled`/`getIsSmartTransaction` could report STX status for the wrong chain (or fall back to the global network) whenever the batch-sell chain differed from the currently selected network, or produce a false negative for chains not yet visited by the wallet (STX liveness is only fetched per-chain, lazily).

This PR scopes the STX-enabled check to the actual batch-sell chain (source/received asset chain) instead of the globally selected network, and proactively refreshes STX liveness for that chain on the review page so the flag isn't a false negative. Non-EVM chains (e.g. Solana) correctly report STX as disabled instead of querying the global network.

## **Changelog**

CHANGELOG entry: Fixed a bug where smart transactions could be incorrectly enabled or disabled during batch sell based on the globally selected network instead of the chain being sold on.

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/SWAPS-4869

## **Manual testing steps**

1. Select a network (e.g. Ethereum Mainnet) as the globally active network.
2. Switch the globally selected network to a different chain (e.g. Polygon) that has STX disabled/unsupported, while keeping Ethereum Mainnet assets selected for batch sell.
3. Start a batch sell flow selling assets on Ethereum Mainnet and reach the review page.
4. Verify smart transactions are still correctly enabled/disabled based on Ethereum Mainnet (the batch-sell chain), not the globally selected Polygon network.
5. Repeat with a non-EVM chain (e.g. Solana) as the selected receive asset chain and verify smart transactions are reported as disabled rather than falling back to the global network's STX status.
6. Submit the batch sell trade and verify the correct STX flag is passed through to the transaction submission.

## **Screenshots/Recordings**

<!--
## **Screenshots/Recordings**
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [ ] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how STX is decided for quotes and submission in batch sell; incorrect behavior would affect transaction type, but the change tightens chain scoping rather than broadening risky paths.
> 
> **Overview**
> Fixes batch sell using the **globally selected network / bridge slice** for smart transaction (STX) availability even though batch sell never sets that slice to the sell chain—so STX could be wrong when the active network differed from the assets being sold.
> 
> **Quote fetching** now derives a hex chain id from the **selected receive asset** and calls `getIsSmartTransaction(state, chainId)` instead of `getIsStxEnabled`. **Non-EVM** receive chains (e.g. Solana) set STX off without hitting the global-network fallback.
> 
> The **review page** calls `useRefreshSmartTransactionsLiveness` for that same chain so lazy per-chain liveness data is refreshed and STX is less likely to read as disabled on an unvisited chain.
> 
> **Submit** treats a missing hex source chain as `isStxEnabled: false` instead of invoking `getIsSmartTransaction` with no chain (global fallback). Tests cover liveness refresh, chain-scoped STX checks, and non-EVM / missing-hex behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a9cc5ba51762b0b057a351fd2a862ea35bd53895. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->