### PR TITLE
feat: added timer for balance loading cp-13.42.0

### DIFF
--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -1,4 +1,10 @@
-import React, { useContext, useCallback, useMemo } from 'react';
+import React, {
+  useContext,
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
 import { useSelector } from 'react-redux';
 import { useNavigate } from 'react-router-dom';
 import classnames from 'clsx';
@@ -75,6 +81,8 @@ export type CoinOverviewProps = {
   isSwapsChain: boolean;
   isSigningEnabled: boolean;
 };
+
+const ZERO_FIAT_BALANCE_DELAY_MS = 1500;
 
 const BalanceOverviewSkeleton = () => (
   <Box
@@ -256,16 +264,51 @@ export const CoinOverview = ({
     hasBalance &&
     aggregateFiatBalanceIsZero;
 
+  const enabledNetworksDelayKey = useMemo(
+    () =>
+      Object.entries(enabledNetworks)
+        .map(([namespace, networks]) => {
+          const enabledChainIds = Object.entries(networks)
+            .filter(([, isEnabled]) => isEnabled)
+            .map(([enabledChainId]) => enabledChainId)
+            .sort()
+            .join(',');
+
+          return `${namespace}:${enabledChainIds}`;
+        })
+        .sort()
+        .join('|'),
+    [enabledNetworks],
+  );
+
+  const [hasZeroFiatBalanceDelayElapsed, setHasZeroFiatBalanceDelayElapsed] =
+    useState(false);
+
+  useEffect(() => {
+    if (!shouldDelayZeroFiatBalance) {
+      setHasZeroFiatBalanceDelayElapsed(false);
+      return undefined;
+    }
+
+    setHasZeroFiatBalanceDelayElapsed(false);
+    const timeoutId = setTimeout(() => {
+      setHasZeroFiatBalanceDelayElapsed(true);
+    }, ZERO_FIAT_BALANCE_DELAY_MS);
+
+    return () => clearTimeout(timeoutId);
+  }, [enabledNetworksDelayKey, shouldDelayZeroFiatBalance]);
+
   const shouldShowBalanceLoadingState = useMemo(
     () =>
       isEvm &&
-      (shouldDelayZeroFiatBalance ||
+      ((shouldDelayZeroFiatBalance && !hasZeroFiatBalanceDelayElapsed) ||
         (shouldCheckBalanceState &&
           !hasBalance &&
           (balanceIsLoading || !balanceIsLoaded))),
     [
       isEvm,
       shouldDelayZeroFiatBalance,
+      hasZeroFiatBalanceDelayElapsed,
       shouldCheckBalanceState,
       hasBalance,
       balanceIsLoading,

--- a/ui/components/app/wallet-overview/coin-overview.tsx
+++ b/ui/components/app/wallet-overview/coin-overview.tsx
@@ -271,12 +271,16 @@ export const CoinOverview = ({
           const enabledChainIds = Object.entries(networks)
             .filter(([, isEnabled]) => isEnabled)
             .map(([enabledChainId]) => enabledChainId)
-            .sort()
+            .sort((firstChainId, secondChainId) =>
+              firstChainId.localeCompare(secondChainId),
+            )
             .join(',');
 
           return `${namespace}:${enabledChainIds}`;
         })
-        .sort()
+        .sort((firstNetwork, secondNetwork) =>
+          firstNetwork.localeCompare(secondNetwork),
+        )
         .join('|'),
     [enabledNetworks],
   );

--- a/ui/components/app/wallet-overview/eth-overview.test.js
+++ b/ui/components/app/wallet-overview/eth-overview.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
-import { fireEvent, waitFor } from '@testing-library/react';
+import { act, fireEvent, waitFor } from '@testing-library/react';
 import { EthAccountType, EthMethod, BtcScope } from '@metamask/keyring-api';
 import { AVAILABLE_MULTICHAIN_NETWORK_CONFIGURATIONS } from '@metamask/multichain-network-controller';
 import { CHAIN_IDS } from '../../../../shared/constants/network';
@@ -243,6 +243,7 @@ describe('EthOverview', () => {
   const ETH_OVERVIEW_BALANCE_SKELETON = 'coin-overview-balance-skeleton';
 
   afterEach(() => {
+    jest.useRealTimers();
     store.clearActions();
     mockOpenBatchSellExperience.mockClear();
   });
@@ -316,7 +317,8 @@ describe('EthOverview', () => {
       ).not.toBeInTheDocument();
     });
 
-    it('should show a balance skeleton when funded account aggregate fiat balance is still zero', async () => {
+    it('should temporarily show a balance skeleton when funded account aggregate fiat balance is still zero', async () => {
+      jest.useFakeTimers();
       const mockedStoreWithStartupZeroBalance = {
         ...mockStore,
         metamask: {
@@ -338,6 +340,17 @@ describe('EthOverview', () => {
       );
 
       expect(queryByTestId(ETH_OVERVIEW_BALANCE_SKELETON)).toBeInTheDocument();
+      expect(
+        queryByTestId(ETH_OVERVIEW_BALANCE_EMPTY_STATE),
+      ).not.toBeInTheDocument();
+
+      act(() => {
+        jest.advanceTimersByTime(1500);
+      });
+
+      expect(
+        queryByTestId(ETH_OVERVIEW_BALANCE_SKELETON),
+      ).not.toBeInTheDocument();
       expect(
         queryByTestId(ETH_OVERVIEW_BALANCE_EMPTY_STATE),
       ).not.toBeInTheDocument();


### PR DESCRIPTION
This PR is to add timeout to the balance loading state

## **Description**

<!--
Write a short description of the changes included in this pull request, also include relevant motivation and context. Have in mind the following questions:
1. What is the reason for the change?
2. What is the improvement/solution?
-->

## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry: null

## **Related issues**

Fixes:

## **Manual testing steps**

1. Go to this page...
2.
3.

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only loading-state timing in wallet overview; no auth, data, or payment logic.
> 
> **Overview**
> **Wallet overview** no longer keeps the balance skeleton up indefinitely when the account has on-chain balance but aggregate fiat is still **$0** (e.g. rates still loading).
> 
> `coin-overview` adds a **1.5s** timer (`ZERO_FIAT_BALANCE_DELAY_MS`): the loading skeleton only applies while `shouldDelayZeroFiatBalance` is true **and** the delay has not elapsed. After the timeout, the normal balance UI is shown instead of staying on the skeleton. The timer **restarts** when enabled networks change (stable key from `enabledNetworks`).
> 
> `eth-overview.test.js` asserts the skeleton disappears after 1500ms (fake timers) and resets real timers in `afterEach`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12dce0832d5c400f6c48b620b86dd6987a5f6e52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->