### PR TITLE
test: fix flaky `Add wallet Import wallet using SRP during onboarding`and `MetaMask onboarding  should not prevent network requests to advanced...`

### DIFF
--- a/test/e2e/tests/multichain-accounts/add-wallet.spec.ts
+++ b/test/e2e/tests/multichain-accounts/add-wallet.spec.ts
@@ -66,6 +66,7 @@ describe('Add wallet', function () {
           DEFAULT_LOCAL_NODE_USD_BALANCE,
           '$',
         );
+        await homePage.checkHasAccountSyncingSyncedAtLeastOnce();
 
         // Open account details modal and check displayed account address
         const headerNavbar = new HeaderNavbar(driver);

--- a/test/e2e/tests/privacy/advanced-functionality-privacy.spec.ts
+++ b/test/e2e/tests/privacy/advanced-functionality-privacy.spec.ts
@@ -175,6 +175,7 @@ describe('MetaMask onboarding ', function () {
         const tokensTab = new TokensTab(driver);
         await tokensTab.refreshErc20TokenList();
         await homePage.checkPageIsLoaded();
+        await homePage.checkHasAccountSyncingSyncedAtLeastOnce();
         await homePage.headerNavbar.openAccountMenu();
         await new AccountList(driver).checkPageIsLoaded();
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Sometimes the tests are flaky as we still see Sync in the add account button.

To prevent this we have the checkHasAccountSyncingSyncedAtLeastOnce already used in the identity tests, so we also use it here (in add wallet and onboard cases) where we open the accounts menu right after onboarding

<img width="401" height="493" alt="image" src="https://github.com/user-attachments/assets/9bc26c5e-2467-44a3-b2b6-c78e247c9ad9" />



## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1.  Check ci

## **Screenshots/Recordings**

<!-- If applicable, add screenshots and/or recordings to visualize the before and after of your change. -->

### **Before**

<!-- [screenshots/recordings] -->

### **After**

<!-- [screenshots/recordings] -->

## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2e-only synchronization waits; no production code or security paths changed.
> 
> **Overview**
> Reduces flakiness in two onboarding e2e specs by **waiting for account syncing to complete at least once** before continuing.
> 
> After the home page and balance checks (and token list refresh where applicable), both **Import wallet using SRP during onboarding** (`add-wallet.spec.ts`) and **advanced functionality privacy** (`advanced-functionality-privacy.spec.ts`) now call `homePage.checkHasAccountSyncingSyncedAtLeastOnce()`. That matches the pattern already used in identity/account-syncing tests and avoids racing the account menu or mock request assertions against in-flight sync work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70df8a79421653da42db7340415346cf386ff6be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->