### PR TITLE
feat(perps): wire dedicated aggregated order-book socket per UI connection

### DIFF
--- a/app/scripts/controllers/perps/perps-stream-bridge.test.ts
+++ b/app/scripts/controllers/perps/perps-stream-bridge.test.ts
@@ -73,6 +73,7 @@ type BridgeOverrides = {
   onConnectivityChange?: jest.Mock;
   isConnectionAlive?: () => boolean;
   isTerminalBackendEnabled?: () => boolean;
+  subscribeAggregatedOrderBook?: jest.Mock;
   emit?: jest.Mock;
 };
 
@@ -89,6 +90,9 @@ function createBridge(overrides: BridgeOverrides = {}) {
   const isConnectionAlive = overrides.isConnectionAlive ?? (() => true);
   const isTerminalBackendEnabled =
     overrides.isTerminalBackendEnabled ?? (() => false);
+  const subscribeAggregatedOrderBook =
+    overrides.subscribeAggregatedOrderBook ??
+    jest.fn().mockReturnValue(jest.fn());
 
   const bridge = new PerpsStreamBridge({
     controller,
@@ -99,6 +103,7 @@ function createBridge(overrides: BridgeOverrides = {}) {
     perpsToggleTestnet: controllerApi.perpsToggleTestnet,
     isConnectionAlive,
     isTerminalBackendEnabled,
+    subscribeAggregatedOrderBook,
     emit,
   });
 
@@ -109,6 +114,7 @@ function createBridge(overrides: BridgeOverrides = {}) {
     controllerApi,
     onControllerStateChange,
     onConnectivityChange,
+    subscribeAggregatedOrderBook,
   };
 }
 
@@ -771,6 +777,263 @@ describe('PerpsStreamBridge', () => {
 
       expect(unsub).toHaveBeenCalledTimes(1);
     });
+
+    it('does not subscribe when deactivated before init resolves (deferred-init guard)', async () => {
+      const controller = createMockController();
+      const controllerApi = createMockControllerApi();
+      let resolveInit: () => void = () => undefined;
+      controllerApi.perpsInit.mockReturnValue(
+        new Promise<void>((resolve) => {
+          resolveInit = resolve;
+        }),
+      );
+      const { bridge } = createBridge({
+        controller: controller as unknown as PerpsController,
+        controllerApi,
+      });
+      const api = bridge.bridgeApi();
+
+      // Activation starts but blocks on the still-pending init promise.
+      const activation = (
+        api.perpsActivateOrderBookStream as (p: {
+          symbol: string;
+        }) => Promise<void>
+      )({ symbol: 'ETH' });
+
+      // The panel is closed (deactivated) before init resolves.
+      (api.perpsDeactivateOrderBookStream as () => void)();
+
+      // Init finally resolves; the stale continuation must abort instead of
+      // resurrecting the subscription after teardown.
+      resolveInit();
+      await activation;
+
+      expect(controller.subscribeToOrderBook).not.toHaveBeenCalled();
+    });
+
+    it('still subscribes for a deferred activation that is not deactivated', async () => {
+      const controller = createMockController();
+      const controllerApi = createMockControllerApi();
+      let resolveInit: () => void = () => undefined;
+      controllerApi.perpsInit.mockReturnValue(
+        new Promise<void>((resolve) => {
+          resolveInit = resolve;
+        }),
+      );
+      const { bridge } = createBridge({
+        controller: controller as unknown as PerpsController,
+        controllerApi,
+      });
+      const api = bridge.bridgeApi();
+
+      const activation = (
+        api.perpsActivateOrderBookStream as (p: {
+          symbol: string;
+        }) => Promise<void>
+      )({ symbol: 'ETH' });
+
+      // No deactivation this time — the guard must not suppress a legitimate
+      // activation once init resolves.
+      resolveInit();
+      await activation;
+
+      expect(controller.subscribeToOrderBook).toHaveBeenCalledWith({
+        symbol: 'ETH',
+        callback: expect.any(Function),
+      });
+    });
+  });
+
+  describe('perpsActivateOrderBookAggregatedStream / perpsDeactivateOrderBookAggregatedStream', () => {
+    it('subscribes on the dedicated connection and emits on orderBookAggregated channel', async () => {
+      const controller = createMockController();
+      const subscribeAggregatedOrderBook = jest.fn().mockReturnValue(jest.fn());
+      const { bridge, emit } = createBridge({
+        controller: controller as unknown as PerpsController,
+        subscribeAggregatedOrderBook,
+      });
+      const api = bridge.bridgeApi();
+
+      await (
+        api.perpsActivateOrderBookAggregatedStream as (p: {
+          symbol: string;
+          levels?: number;
+          nSigFigs?: 2 | 3 | 4 | 5;
+          mantissa?: 2 | 5;
+          subscriptionId?: string;
+        }) => Promise<void>
+      )({
+        symbol: 'ETH',
+        levels: 20,
+        nSigFigs: 3,
+        subscriptionId: 'ETH:3::0',
+      });
+
+      // The aggregated stream uses the dedicated connection, never the shared
+      // controller socket.
+      expect(controller.subscribeToOrderBook).not.toHaveBeenCalled();
+      expect(subscribeAggregatedOrderBook).toHaveBeenCalledWith({
+        symbol: 'ETH',
+        levels: 20,
+        nSigFigs: 3,
+        mantissa: undefined,
+        callback: expect.any(Function),
+        onStatusChange: expect.any(Function),
+      });
+      const callback = subscribeAggregatedOrderBook.mock.calls[0][0]
+        .callback as (data: unknown) => void;
+      callback({ bids: [], asks: [] });
+      expect(emit).toHaveBeenCalledWith(
+        'orderBookAggregated',
+        {
+          bids: [],
+          asks: [],
+        },
+        { subscriptionId: 'ETH:3::0' },
+      );
+    });
+
+    it('emits connection status on the orderBookAggregatedStatus channel', async () => {
+      const controller = createMockController();
+      const subscribeAggregatedOrderBook = jest.fn().mockReturnValue(jest.fn());
+      const { bridge, emit } = createBridge({
+        controller: controller as unknown as PerpsController,
+        subscribeAggregatedOrderBook,
+      });
+      const api = bridge.bridgeApi();
+
+      await (
+        api.perpsActivateOrderBookAggregatedStream as (p: {
+          symbol: string;
+          nSigFigs?: 2 | 3 | 4 | 5;
+          subscriptionId?: string;
+        }) => Promise<void>
+      )({ symbol: 'ETH', nSigFigs: 3, subscriptionId: 'ETH:3::0' });
+
+      const { onStatusChange } = subscribeAggregatedOrderBook.mock.calls[0][0];
+      onStatusChange('error');
+      expect(emit).toHaveBeenCalledWith('orderBookAggregatedStatus', 'error', {
+        subscriptionId: 'ETH:3::0',
+      });
+    });
+
+    it('tags emissions with the subscription identity captured at activate time', async () => {
+      const controller = createMockController();
+      const subscribeAggregatedOrderBook = jest.fn().mockReturnValue(jest.fn());
+      const { bridge, emit } = createBridge({
+        controller: controller as unknown as PerpsController,
+        subscribeAggregatedOrderBook,
+      });
+      const api = bridge.bridgeApi();
+
+      await (
+        api.perpsActivateOrderBookAggregatedStream as (p: {
+          symbol: string;
+          nSigFigs?: 2 | 3 | 4 | 5;
+          subscriptionId?: string;
+        }) => Promise<void>
+      )({ symbol: 'BTC', nSigFigs: 4, subscriptionId: 'BTC:4::0' });
+
+      const firstCallback = subscribeAggregatedOrderBook.mock.calls[0][0]
+        .callback as (data: unknown) => void;
+
+      await (
+        api.perpsActivateOrderBookAggregatedStream as (p: {
+          symbol: string;
+          nSigFigs?: 2 | 3 | 4 | 5;
+          subscriptionId?: string;
+        }) => Promise<void>
+      )({ symbol: 'BTC', nSigFigs: 5, subscriptionId: 'BTC:5::0' });
+
+      // Late packet from the first subscription still carries the old identity.
+      firstCallback({ bids: [{ price: '1' }], asks: [] });
+      expect(emit).toHaveBeenCalledWith(
+        'orderBookAggregated',
+        { bids: [{ price: '1' }], asks: [] },
+        { subscriptionId: 'BTC:4::0' },
+      );
+
+      const secondCallback = subscribeAggregatedOrderBook.mock.calls[1][0]
+        .callback as (data: unknown) => void;
+      secondCallback({ bids: [{ price: '2' }], asks: [] });
+      expect(emit).toHaveBeenCalledWith(
+        'orderBookAggregated',
+        { bids: [{ price: '2' }], asks: [] },
+        { subscriptionId: 'BTC:5::0' },
+      );
+    });
+
+    it('runs independently of the raw order book stream', async () => {
+      const controller = createMockController();
+      const rawUnsub = jest.fn();
+      const aggregatedUnsub = jest.fn();
+      controller.subscribeToOrderBook.mockReturnValue(rawUnsub);
+      const subscribeAggregatedOrderBook = jest
+        .fn()
+        .mockReturnValue(aggregatedUnsub);
+      const { bridge } = createBridge({
+        controller: controller as unknown as PerpsController,
+        subscribeAggregatedOrderBook,
+      });
+      const api = bridge.bridgeApi();
+
+      await (
+        api.perpsActivateOrderBookStream as (p: {
+          symbol: string;
+        }) => Promise<void>
+      )({
+        symbol: 'ETH',
+      });
+      await (
+        api.perpsActivateOrderBookAggregatedStream as (p: {
+          symbol: string;
+          nSigFigs?: 2 | 3 | 4 | 5;
+        }) => Promise<void>
+      )({ symbol: 'ETH', nSigFigs: 3 });
+
+      // Raw stream on the shared socket, aggregated on the dedicated connection.
+      expect(controller.subscribeToOrderBook).toHaveBeenCalledTimes(1);
+      expect(subscribeAggregatedOrderBook).toHaveBeenCalledTimes(1);
+      expect(rawUnsub).not.toHaveBeenCalled();
+      expect(aggregatedUnsub).not.toHaveBeenCalled();
+
+      // Tearing down the aggregated stream leaves the raw stream intact.
+      (api.perpsDeactivateOrderBookAggregatedStream as () => void)();
+      expect(aggregatedUnsub).toHaveBeenCalledTimes(1);
+      expect(rawUnsub).not.toHaveBeenCalled();
+    });
+
+    it('does not subscribe when deactivated before init resolves (deferred-init guard)', async () => {
+      const controller = createMockController();
+      const controllerApi = createMockControllerApi();
+      const subscribeAggregatedOrderBook = jest.fn().mockReturnValue(jest.fn());
+      let resolveInit: () => void = () => undefined;
+      controllerApi.perpsInit.mockReturnValue(
+        new Promise<void>((resolve) => {
+          resolveInit = resolve;
+        }),
+      );
+      const { bridge } = createBridge({
+        controller: controller as unknown as PerpsController,
+        controllerApi,
+        subscribeAggregatedOrderBook,
+      });
+      const api = bridge.bridgeApi();
+
+      const activation = (
+        api.perpsActivateOrderBookAggregatedStream as (p: {
+          symbol: string;
+          nSigFigs?: 2 | 3 | 4 | 5;
+        }) => Promise<void>
+      )({ symbol: 'ETH', nSigFigs: 3 });
+
+      (api.perpsDeactivateOrderBookAggregatedStream as () => void)();
+
+      resolveInit();
+      await activation;
+
+      expect(subscribeAggregatedOrderBook).not.toHaveBeenCalled();
+    });
   });
 
   describe('perpsActivateCandleStream / perpsDeactivateCandleStream', () => {
@@ -785,7 +1048,11 @@ describe('PerpsStreamBridge', () => {
         api.perpsActivateCandleStream as (
           p: Record<string, unknown>,
         ) => Promise<void>
-      )({ symbol: 'ETH', interval: '1h', duration: '1d' });
+      )({
+        symbol: 'ETH',
+        interval: '1h',
+        duration: '1d',
+      });
 
       expect(controller.subscribeToCandles).toHaveBeenCalledWith({
         symbol: 'ETH',
@@ -817,13 +1084,19 @@ describe('PerpsStreamBridge', () => {
         api.perpsActivateCandleStream as (
           p: Record<string, unknown>,
         ) => Promise<void>
-      )({ symbol: 'ETH', interval: '1h' });
+      )({
+        symbol: 'ETH',
+        interval: '1h',
+      });
       (
         api.perpsDeactivateCandleStream as (p: {
           symbol: string;
           interval: string;
         }) => void
-      )({ symbol: 'ETH', interval: '1h' });
+      )({
+        symbol: 'ETH',
+        interval: '1h',
+      });
 
       jest.advanceTimersByTime(150);
 
@@ -852,12 +1125,18 @@ describe('PerpsStreamBridge', () => {
         api.perpsActivateCandleStream as (
           p: Record<string, unknown>,
         ) => Promise<void>
-      )({ symbol: 'BTC', interval: '1h' });
+      )({
+        symbol: 'BTC',
+        interval: '1h',
+      });
       await (
         api.perpsActivateCandleStream as (
           p: Record<string, unknown>,
         ) => Promise<void>
-      )({ symbol: 'ETH', interval: '4h' });
+      )({
+        symbol: 'ETH',
+        interval: '4h',
+      });
 
       expect(controller.subscribeToCandles).toHaveBeenCalledTimes(2);
 
@@ -1113,7 +1392,9 @@ describe('PerpsStreamBridge', () => {
         api.perpsActivateStreaming as (
           p: Record<string, unknown>,
         ) => Promise<void>
-      )({ priceSymbols: ['ETH'] });
+      )({
+        priceSymbols: ['ETH'],
+      });
 
       expect(() => bridge.destroy()).not.toThrow();
     });
@@ -1157,7 +1438,9 @@ describe('PerpsStreamBridge', () => {
         api.perpsActivateStreaming as (
           p: Record<string, unknown>,
         ) => Promise<void>
-      )({ priceSymbols: ['ETH'] });
+      )({
+        priceSymbols: ['ETH'],
+      });
 
       expect(() => {
         bridge.destroy();

--- a/app/scripts/controllers/perps/perps-stream-bridge.ts
+++ b/app/scripts/controllers/perps/perps-stream-bridge.ts
@@ -38,6 +38,21 @@ type ConnectivityChangeListener = (
   callback: (state: { connectivityStatus: string }) => void,
 ) => () => void;
 
+/**
+ * Opens the server-aggregated order-book subscription on a dedicated
+ * Hyperliquid WebSocket connection (separate from the controller's shared
+ * socket) and returns an unsubscribe function. Injected so this file never
+ * value-imports the ESM-only Hyperliquid SDK, keeping the bridge Jest-friendly.
+ */
+type SubscribeAggregatedOrderBook = (params: {
+  symbol: string;
+  levels?: number;
+  nSigFigs?: 2 | 3 | 4 | 5;
+  mantissa?: 2 | 5;
+  callback: (data: unknown) => void;
+  onStatusChange?: (status: 'connecting' | 'connected' | 'error') => void;
+}) => () => void;
+
 type PerpsStreamBridgeOptions = {
   controller: PerpsController;
   onControllerStateChange: StateChangeListener;
@@ -47,6 +62,7 @@ type PerpsStreamBridgeOptions = {
   perpsToggleTestnet: (...args: unknown[]) => Promise<unknown>;
   isConnectionAlive: () => boolean;
   isTerminalBackendEnabled: () => boolean;
+  subscribeAggregatedOrderBook: SubscribeAggregatedOrderBook;
   emit: EmitFn;
 };
 
@@ -99,11 +115,27 @@ export class PerpsStreamBridge {
 
   readonly #isTerminalBackendEnabled: () => boolean;
 
+  readonly #subscribeAggregatedOrderBook: SubscribeAggregatedOrderBook;
+
   readonly #emit: EmitFn;
 
   readonly #staticUnsubs: (() => void)[] = [];
 
   readonly #dynamicUnsubs: Record<string, () => void> = {};
+
+  /**
+   * Per-channel activation generation for the deferred dynamic subscriptions
+   * (prices / orderBook / orderBookAggregated). Each `perpsDeactivate*Stream`
+   * bumps its channel's counter, so an activation whose `#initAndActivate()`
+   * only resolves *after* that deactivation ran will see the mismatch and
+   * refuse to subscribe. Without this, opening and quickly closing a panel
+   * during cold init would let the activation continuation resurrect the
+   * subscription after teardown, leaking a hidden stream that survives until
+   * the next (de)activation or bridge destruction. Mirrors the candle path's
+   * `#destroyGeneration` guard, but scoped per channel so an unrelated
+   * channel's teardown never cancels this activation.
+   */
+  readonly #dynamicActivationGeneration: Record<string, number> = {};
 
   readonly #pendingCandleTeardowns = new Map<
     string,
@@ -166,6 +198,7 @@ export class PerpsStreamBridge {
     this.#perpsToggleTestnet = options.perpsToggleTestnet;
     this.#isConnectionAlive = options.isConnectionAlive;
     this.#isTerminalBackendEnabled = options.isTerminalBackendEnabled;
+    this.#subscribeAggregatedOrderBook = options.subscribeAggregatedOrderBook;
     this.#emit = options.emit;
   }
 
@@ -220,22 +253,20 @@ export class PerpsStreamBridge {
           this.#activateStreaming(params);
         }
       },
-      perpsActivatePriceStream: async ({
+      perpsActivatePriceStream: ({
         symbols,
         includeMarketData,
       }: {
         symbols: string[];
         includeMarketData?: boolean;
-      }) => {
-        await this.#initAndActivate();
-        if (this.#isConnectionAlive()) {
-          this.#activatePriceStream(symbols, includeMarketData);
-        }
-      },
+      }) =>
+        this.#activateDynamicWhenReady('prices', () =>
+          this.#activatePriceStream(symbols, includeMarketData),
+        ),
       perpsDeactivatePriceStream: () => {
-        this.#tearDownChannel('prices');
+        this.#deactivateDynamicChannel('prices');
       },
-      perpsActivateOrderBookStream: async ({
+      perpsActivateOrderBookStream: ({
         symbol,
         levels,
         nSigFigs,
@@ -245,14 +276,42 @@ export class PerpsStreamBridge {
         levels?: number;
         nSigFigs?: 2 | 3 | 4 | 5;
         mantissa?: 2 | 5;
-      }) => {
-        await this.#initAndActivate();
-        if (this.#isConnectionAlive()) {
-          this.#activateOrderBookStream({ symbol, levels, nSigFigs, mantissa });
-        }
-      },
+      }) =>
+        this.#activateDynamicWhenReady('orderBook', () =>
+          this.#activateOrderBookStream({ symbol, levels, nSigFigs, mantissa }),
+        ),
       perpsDeactivateOrderBookStream: () => {
-        this.#tearDownChannel('orderBook');
+        this.#deactivateDynamicChannel('orderBook');
+      },
+      perpsActivateOrderBookAggregatedStream: ({
+        symbol,
+        levels,
+        nSigFigs,
+        mantissa,
+        subscriptionId,
+      }: {
+        symbol: string;
+        levels?: number;
+        nSigFigs?: 2 | 3 | 4 | 5;
+        mantissa?: 2 | 5;
+        /**
+         * UI-generated identity for this activate request. Echoed on every
+         * data/status emission so the UI can discard packets from a prior
+         * grouping that arrive during the async deactivate/activate IPC gap.
+         */
+        subscriptionId?: string;
+      }) =>
+        this.#activateDynamicWhenReady('orderBookAggregated', () =>
+          this.#activateOrderBookAggregatedStream({
+            symbol,
+            levels,
+            nSigFigs,
+            mantissa,
+            subscriptionId,
+          }),
+        ),
+      perpsDeactivateOrderBookAggregatedStream: () => {
+        this.#deactivateDynamicChannel('orderBookAggregated');
       },
       perpsActivateCandleStream: async ({
         symbol,
@@ -382,6 +441,55 @@ export class PerpsStreamBridge {
     if (!this.#activated && this.#isConnectionAlive()) {
       this.#activate();
     }
+  }
+
+  /**
+   * Runs a deferred dynamic-channel activation behind a per-channel generation
+   * guard. If a `perpsDeactivate*Stream` for the same channel — or a full
+   * `destroy()` — fires while `#initAndActivate()` is still pending, the
+   * captured generation no longer matches on resume and the subscription is
+   * skipped, so a quick open→close during cold init cannot leak a hidden
+   * subscription created after teardown.
+   *
+   * @param channel - The dynamic channel being (re)activated.
+   * @param activate - Subscribe callback, invoked only if still current.
+   */
+  async #activateDynamicWhenReady(
+    channel: 'prices' | 'orderBook' | 'orderBookAggregated',
+    activate: () => void,
+  ): Promise<void> {
+    const activationGenerationAtStart =
+      this.#dynamicActivationGeneration[channel] ?? 0;
+    const destroyGenerationAtStart = this.#destroyGeneration;
+
+    await this.#initAndActivate();
+
+    if (
+      this.#destroyGeneration !== destroyGenerationAtStart ||
+      (this.#dynamicActivationGeneration[channel] ?? 0) !==
+        activationGenerationAtStart
+    ) {
+      return;
+    }
+
+    if (this.#isConnectionAlive()) {
+      activate();
+    }
+  }
+
+  /**
+   * Tears down a dynamic channel and bumps its activation generation so any
+   * activation that is still awaiting init for this channel aborts on resume
+   * instead of resurrecting the subscription.
+   *
+   * @param channel - The dynamic channel to deactivate.
+   */
+  #deactivateDynamicChannel(
+    channel: 'prices' | 'orderBook' | 'orderBookAggregated',
+  ): void {
+    this.#dynamicActivationGeneration[channel] =
+      (this.#dynamicActivationGeneration[channel] ?? 0) + 1;
+    this.#tearDownChannel(channel);
   }
 
   #activate(): void {
@@ -723,6 +831,55 @@ export class PerpsStreamBridge {
     }
   }
 
+  /**
+   * Activate the server-aggregated order-book subscription (`nSigFigs` /
+   * `mantissa`) for the order-book panel's grouped ladder.
+   *
+   * Unlike the raw `orderBook` channel — which runs on the controller's shared
+   * WebSocket — this runs on a dedicated Hyperliquid connection. The SDK routes
+   * `l2Book` events by `coin` only, so a raw and an aggregated subscription for
+   * the same coin on the same socket cross-contaminate (the coarse ladder and
+   * the precise spread/slippage clobber each other). Isolating the aggregated
+   * subscription on its own socket removes the collision: that socket carries a
+   * single `l2Book` stream and the shared socket is never touched by grouping.
+   *
+   * @param params - Subscription parameters.
+   * @param params.symbol - Market symbol.
+   * @param params.levels - Number of levels per side to request.
+   * @param params.nSigFigs - Server-side aggregation significant figures.
+   * @param params.mantissa - Mantissa refinement when nSigFigs is 5.
+   * @param params.subscriptionId - UI identity echoed on every emission.
+   */
+  #activateOrderBookAggregatedStream(params: {
+    symbol: string;
+    levels?: number;
+    nSigFigs?: 2 | 3 | 4 | 5;
+    mantissa?: 2 | 5;
+    subscriptionId?: string;
+  }): void {
+    const { symbol, subscriptionId, levels, nSigFigs, mantissa } = params;
+    this.#tearDownChannel('orderBookAggregated');
+    if (symbol) {
+      // Capture the UI identity in this subscription's closures so emissions
+      // from a prior grouping keep their old id after the UI has already
+      // switched — the StreamManager then discards the mismatch.
+      const emitExtra =
+        subscriptionId === undefined ? undefined : { subscriptionId };
+      this.#addDynamicSubscription('orderBookAggregated', () =>
+        this.#subscribeAggregatedOrderBook({
+          symbol,
+          levels,
+          nSigFigs,
+          mantissa,
+          callback: (data: unknown) =>
+            this.#emit('orderBookAggregated', data, emitExtra),
+          onStatusChange: (status) =>
+            this.#emit('orderBookAggregatedStatus', status, emitExtra),
+        }),
+      );
+    }
+  }
+
   #activateCandleStream(params: {
     symbol: string;
     interval: CandlePeriod;
@@ -782,7 +939,9 @@ export class PerpsStreamBridge {
     }
   }
 
-  #tearDownChannel(channel: 'prices' | 'orderBook'): void {
+  #tearDownChannel(
+    channel: 'prices' | 'orderBook' | 'orderBookAggregated',
+  ): void {
     const unsub = this.#dynamicUnsubs[channel];
     if (unsub) {
       this.#callAndClearUnsub(unsub);

--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -130,6 +130,7 @@ import { PRODUCT_TYPES } from '@metamask/subscription-controller';
 import { isSnapId } from '@metamask/snaps-utils';
 import { KeyringType } from '@metamask/keyring-api/v2';
 import { KeyringControllerErrorMessage } from '@metamask/keyring-controller';
+import { AggregatedOrderBookConnection } from '@metamask/perps-controller';
 import { KeyringType as KeyringTypes } from '../../shared/constants/keyring';
 import { ExtensionPasskeyErrorCode } from '../../shared/lib/passkey/passkey-error';
 import {
@@ -6842,6 +6843,15 @@ export default class MetamaskController extends EventEmitter {
     );
 
     const perpsController = this.messengerClientsByName.PerpsController;
+    // Dedicated Hyperliquid WebSocket for the order-book panel's aggregated
+    // (`nSigFigs`) subscription, isolated from the controller's shared socket so
+    // the raw and aggregated `l2Book` streams for the same coin cannot
+    // cross-contaminate (the SDK dispatches `l2Book` events by coin only).
+    const aggregatedOrderBookConnection = perpsController
+      ? new AggregatedOrderBookConnection({
+          isTestnet: () => Boolean(perpsController.state?.isTestnet),
+        })
+      : null;
     const perpsStream = perpsController
       ? new PerpsStreamBridge({
           controller: perpsController,
@@ -6871,6 +6881,8 @@ export default class MetamaskController extends EventEmitter {
           perpsDisconnect: this.messengerClientApi.perpsDisconnect,
           perpsToggleTestnet: this.messengerClientApi.perpsToggleTestnet,
           isConnectionAlive: () => !outStream.mmFinished,
+          subscribeAggregatedOrderBook: (params) =>
+            aggregatedOrderBookConnection.subscribe(params),
           isTerminalBackendEnabled: () => {
             const { remoteFeatureFlags } = this.controllerMessenger.call(
               'RemoteFeatureFlagController:getState',
@@ -6966,6 +6978,7 @@ export default class MetamaskController extends EventEmitter {
         patchStore.destroy();
         messengerSubscriptions.clear();
         perpsStream?.destroy();
+        aggregatedOrderBookConnection?.close();
         if (this.activeControllerConnections === 0) {
           // Defer the controller-owned Perps WS teardown so a brief close/reopen
           // within PERPS_DISCONNECT_GRACE_MS reuses the live session instead of

--- a/test/mocks/metamask-perps-controller.js
+++ b/test/mocks/metamask-perps-controller.js
@@ -167,6 +167,24 @@ const mockTradingDefaults = {
 };
 
 /**
+ * Stub for the dedicated aggregated order-book WebSocket. Keeps controller /
+ * bridge unit tests from opening a real Hyperliquid socket.
+ */
+class MockAggregatedOrderBookConnection {
+  constructor(options) {
+    this.options = options;
+  }
+
+  subscribe(_params) {
+    return () => undefined;
+  }
+
+  close() {
+    return undefined;
+  }
+}
+
+/**
  * Simplified max-amount helper for unit tests (matches controller shape; omits
  * position-size rounding details that are covered by controller tests).
  *
@@ -204,4 +222,5 @@ module.exports = {
   isHip3Market: mockIsHip3Market,
   getMarketTypeFilter: mockGetMarketTypeFilter,
   getPerpsDisplaySymbol: mockGetPerpsDisplaySymbol,
+  AggregatedOrderBookConnection: MockAggregatedOrderBookConnection,
 };


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

### Context

The Perps order-book ladder needs a server-aggregated `l2Book` subscription (`nSigFigs` / `mantissa` / fast). PerpsController already keeps a shared Hyperliquid WebSocket for the raw `l2Book` used by spread / mid / slippage. The Hyperliquid SDK dispatches `l2Book` events by coin only, so running raw and aggregated subscriptions for the same coin on one socket cross-contaminates them.

### Problem

Without a dedicated connection per UI stream, aggregated and raw order-book data for the same market can clobber each other on the shared controller socket.

### Solution

In the per-UI-connection setup path of `metamask-controller.js`:

- Construct one `AggregatedOrderBookConnection` per UI outStream (not a controller singleton), with live `isTestnet` reads from `perpsController.state`.
- Inject `subscribeAggregatedOrderBook` into `PerpsStreamBridge`.
- Close the dedicated socket in `outstreamEndHandler` after `perpsStream?.destroy()`.

Also stub `AggregatedOrderBookConnection` in the Jest mock for `@metamask/perps-controller` so unit tests do not open a real socket.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Relates to https://github.com/MetaMask/metamask-extension/pull/44254

## **Manual testing steps**

```gherkin
Feature: Dedicated aggregated order-book socket per UI connection

  Scenario: Order-book panel uses the dedicated aggregated connection
    Given Perps is enabled and the extension UI is connected
    And a market detail / order-book panel is available
    When I open the order-book panel for a market
    Then the aggregated `l2Book` stream is activated via the injected AggregatedOrderBookConnection
    And the raw order book / spread path still uses the controller shared socket

  Scenario: UI disconnect tears down the dedicated socket
    Given an active UI connection with an AggregatedOrderBookConnection
    When the UI outStream ends (popup close / stream teardown)
    Then PerpsStreamBridge is destroyed first
    And aggregatedOrderBookConnection.close() is called afterward
```

## **Screenshots/Recordings**

N/A — background socket wiring only; no UI visual change in this PR.

<!--
### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [x] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes real-time perps streaming and WebSocket lifecycle per UI connection; incorrect teardown or subscription identity could leak sockets or show wrong ladder data, though behavior is heavily covered by new bridge tests.
> 
> **Overview**
> Wires **server-aggregated order book** (`nSigFigs` / `mantissa`) through a **dedicated Hyperliquid WebSocket per UI outStream**, separate from the controller’s shared socket used for the **raw** `l2Book`. That avoids SDK `l2Book` dispatch-by-coin cross-talk between the grouped ladder and spread/slippage paths.
> 
> `PerpsStreamBridge` gains **`perpsActivateOrderBookAggregatedStream` / `perpsDeactivateOrderBookAggregatedStream`**, injecting `subscribeAggregatedOrderBook` and emitting **`orderBookAggregated`** plus **`orderBookAggregatedStatus`** with an optional **`subscriptionId`** so the UI can ignore stale packets after grouping changes.
> 
> Price, raw order book, and aggregated streams now share **`#activateDynamicWhenReady`** / **`#deactivateDynamicChannel`** generation guards so a deactivate (or `destroy`) during pending **`perpsInit`** does not resurrect a hidden subscription after teardown.
> 
> `metamask-controller.js` constructs **`AggregatedOrderBookConnection`** when the stream opens and **`close()`**s it after **`perpsStream.destroy()`**; Jest mocks stub the connection for unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ccd9fe8a8c0a417ff15c0763b3d9735885c2a1e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->