### PR TITLE
test: fix flaky test `Smart Transactions should send transaction using USDC to pay fee`

### DIFF
--- a/test/e2e/page-objects/components/tx-toast-notification.ts
+++ b/test/e2e/page-objects/components/tx-toast-notification.ts
@@ -1,0 +1,30 @@
+import { Driver } from '../../webdriver/driver';
+
+/**
+ * Page object for transaction toast notifications shown after a tx completes.
+ *
+ */
+export class TxToastNotification {
+  protected driver: Driver;
+
+  private readonly closeButton = '[aria-label="Close"]';
+
+  private readonly transactionConfirmedText = {
+    tag: 'p',
+    text: 'Transaction confirmed',
+  };
+
+  constructor(driver: Driver) {
+    this.driver = driver;
+  }
+
+  async checkTxConfirmedToast(): Promise<void> {
+    console.log('Check transaction confirmed toast is displayed');
+    await this.driver.waitForSelector(this.transactionConfirmedText);
+  }
+
+  async closeToastNotification(): Promise<void> {
+    // The toast auto-dismisses after a few seconds, so use clickElementSafe to avoid race conditions.
+    await this.driver.clickElementSafe(this.closeButton, 5_000);
+  }
+}

--- a/test/e2e/page-objects/components/tx-toast-notification.ts
+++ b/test/e2e/page-objects/components/tx-toast-notification.ts
@@ -5,9 +5,9 @@ import { Driver } from '../../webdriver/driver';
  *
  */
 export class TxToastNotification {
-  protected driver: Driver;
-
   private readonly closeButton = '[aria-label="Close"]';
+
+  protected driver: Driver;
 
   private readonly transactionConfirmedText = {
     tag: 'p',

--- a/test/e2e/tests/smart-transactions/smart-transactions.spec.ts
+++ b/test/e2e/tests/smart-transactions/smart-transactions.spec.ts
@@ -12,6 +12,7 @@ import {
   createDappTransaction,
   createInternalTransaction,
 } from '../../page-objects/flows/transaction.flow';
+import { TxToastNotification } from '../../page-objects/components/tx-toast-notification';
 import ActivityTab from '../../page-objects/pages/home/activity-tab';
 import TransactionConfirmation from '../../page-objects/pages/confirmations/transaction-confirmation';
 import HomePage from '../../page-objects/pages/home/homepage';
@@ -117,6 +118,7 @@ describe('Smart Transactions', function () {
         const transactionConfirmation = new TransactionConfirmation(driver);
         const homePage = new HomePage(driver);
         const activityTab = new ActivityTab(driver);
+        const txToastNotification = new TxToastNotification(driver);
 
         await createInternalTransaction({
           driver,
@@ -127,6 +129,9 @@ describe('Smart Transactions', function () {
 
         await transactionConfirmation.selectTokenFee('USDC');
         await transactionConfirmation.clickFooterConfirmButtonAndWaitToDisappear();
+
+        await txToastNotification.checkTxConfirmedToast();
+        await txToastNotification.closeToastNotification();
 
         await homePage.goToActivityList();
         await activityTab.checkCompletedTxNumberDisplayedInActivity(1);

--- a/test/e2e/tests/smart-transactions/smart-transactions.spec.ts
+++ b/test/e2e/tests/smart-transactions/smart-transactions.spec.ts
@@ -130,6 +130,8 @@ describe('Smart Transactions', function () {
         await transactionConfirmation.selectTokenFee('USDC');
         await transactionConfirmation.clickFooterConfirmButtonAndWaitToDisappear();
 
+        // 2 toast notifications appear, one for the gas payment and one for the main transaction.
+        // The 2nd toast obfuscates the Activity tab, so we need to actively close one to be able to click on the Activity tab without error.
         await txToastNotification.checkTxConfirmedToast();
         await txToastNotification.closeToastNotification();
 


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**
Sometimes clicking the Activity tab throws a click intercept error as 2 toast notifications appear and overlay the Activity tab button.
We now close one of the toasts to ensure the Activity tab is ready to be clicked without intercepting toasts
We use the clickElementSafe because the toasts auto-close automatically so we don't want to run into errors now due to trying to click on a toast that is already closed.

<img width="991" height="175" alt="image" src="https://github.com/user-attachments/assets/9ed03148-0865-4d78-8658-ab6419fd13a3" />


## **Changelog**

<!--
If this PR is not End-User-Facing and should not show up in the CHANGELOG, you can choose to either:
1. Write `CHANGELOG entry: null`
2. Label with `no-changelog`

If this PR is End-User-Facing, please write a short User-Facing description in the past tense like:
`CHANGELOG entry: Added a new tab for users to see their NFTs`
`CHANGELOG entry: Fixed a bug that was causing some NFTs to flicker`

(This helps the Release Engineer do their job more quickly and accurately)
-->

CHANGELOG entry:

## **Related issues**

Fixes:

## **Manual testing steps**

1. check ci

## **Screenshots/Recordings**


https://github.com/user-attachments/assets/7c9ec5d2-670f-407d-a61a-c4af10beb2c6



## **Pre-merge author checklist**

- [ ] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [ ] I've completed the PR template to the best of my ability
- [ ] I’ve included tests if applicable
- [ ] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> E2E test and page-object changes only; no production wallet or transaction logic is modified.
> 
> **Overview**
> Fixes flaky **Smart Transactions** e2e coverage when paying fees with USDC by handling overlapping post-confirmation toasts (gas payment + main send).
> 
> Adds a **`TxToastNotification`** page object that waits for the “Transaction confirmed” toast and closes it via **`clickElementSafe`** so auto-dismiss does not race the click. The USDC fee test now dismisses one toast before **`goToActivityList`**, avoiding click-intercept errors on the Activity tab.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f1404ed9aca47237337aa49c3c4993d7d430184. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->