### PR TITLE
fix(ci): stop the quality gate passing when a gated benchmark never ran

### DIFF
--- a/development/metamaskbot-build-announce/compare-benchmarks.test.ts
+++ b/development/metamaskbot-build-announce/compare-benchmarks.test.ts
@@ -424,7 +424,13 @@ describe('compare-benchmarks', () => {
     });
 
     it('reports no-result benchmarks in an ERROR section of printReport', () => {
-      const benchmarks = [
+      // Annotated rather than inferred: the two entries carry different
+      // benchmark keys, so TS would widen `data` to a union in which each
+      // key is optional-undefined on the other member.
+      const benchmarks: {
+        name: string;
+        data: Record<string, BenchmarkResults>;
+      }[] = [
         {
           name: 'benchmark-chrome-webpack-startupStandardHome',
           data: {

--- a/development/metamaskbot-build-announce/compare-benchmarks.test.ts
+++ b/development/metamaskbot-build-announce/compare-benchmarks.test.ts
@@ -331,7 +331,10 @@ describe('compare-benchmarks', () => {
       expect(result.comparisons).toHaveLength(0);
     });
 
-    it('skips entries from failed benchmark runs (missing p75/p95)', () => {
+    it('fails when a benchmark owning a gated metric produced no results', () => {
+      // `startupStandardHome.uiStartup` is allowlisted, so an artifact with no
+      // percentiles removes a blocking signal — the gate must not pass on
+      // absent evidence.
       const benchmarks = [
         {
           name: 'benchmark-chrome-webpack-startupStandardHome',
@@ -343,9 +346,120 @@ describe('compare-benchmarks', () => {
 
       const result = runComparison(benchmarks, {});
       expect(result.comparisons).toHaveLength(0);
+      expect(result.anyFailed).toBe(true);
+      expect(result.errored).toStrictEqual([
+        {
+          benchmarkName: 'startupStandardHome',
+          file: 'benchmark-chrome-webpack-startupStandardHome',
+          source: 'chrome-webpack',
+          error: 'Browser crashed',
+          gated: true,
+        },
+      ]);
+    });
+
+    it('warns without failing when a benchmark with no gated metric produced no results', () => {
+      // No `startupPowerUserHome.*` entry is allowlisted, so its absence is
+      // reported but cannot block — mirroring `applyGatingPolicy`, where a
+      // non-allowlisted breach degrades to a warning.
+      const benchmarks = [
+        {
+          name: 'benchmark-chrome-webpack-startupPowerUserHome',
+          data: {
+            startupPowerUserHome: {
+              error: 'Error: Retry limit reached',
+            } as never,
+          },
+        },
+      ];
+
+      const result = runComparison(benchmarks, {});
+      expect(result.comparisons).toHaveLength(0);
+      expect(result.anyFailed).toBe(false);
+      expect(result.errored).toStrictEqual([
+        {
+          benchmarkName: 'startupPowerUserHome',
+          file: 'benchmark-chrome-webpack-startupPowerUserHome',
+          source: 'chrome-webpack',
+          error: 'Error: Retry limit reached',
+          gated: false,
+        },
+      ]);
+    });
+
+    it('records a no-result benchmark that carries no error text', () => {
+      const benchmarks = [
+        {
+          name: 'benchmark-chrome-webpack-startupStandardHome',
+          data: {
+            startupStandardHome: {} as never,
+          },
+        },
+      ];
+
+      const result = runComparison(benchmarks, {});
+      expect(result.anyFailed).toBe(true);
+      expect(result.errored[0].error).toBeUndefined();
+    });
+
+    it('does not record a no-result entry that has no threshold config', () => {
+      // An unregistered benchmark has no gated metric to lose, and no
+      // threshold to compare against — unchanged warn-and-skip behaviour.
+      const benchmarks = [
+        {
+          name: 'unknown-benchmark',
+          data: {
+            'unknown-benchmark': { error: 'Browser crashed' } as never,
+          },
+        },
+      ];
+
+      const result = runComparison(benchmarks, {});
+      expect(result.comparisons).toHaveLength(0);
+      expect(result.errored).toHaveLength(0);
+      expect(result.anyFailed).toBe(false);
       expect(console.warn).toHaveBeenCalledWith(
-        expect.stringContaining('missing p75/p95'),
+        expect.stringContaining('No threshold config'),
       );
+    });
+
+    it('reports no-result benchmarks in an ERROR section of printReport', () => {
+      const benchmarks = [
+        {
+          name: 'benchmark-chrome-webpack-startupStandardHome',
+          data: {
+            startupStandardHome: { error: 'Browser crashed' } as never,
+          },
+        },
+        {
+          name: 'benchmark-chrome-webpack-startupPowerUserHome',
+          data: {
+            startupPowerUserHome: {
+              error: 'Error: Retry limit reached',
+            } as never,
+          },
+        },
+      ];
+
+      const result = runComparison(benchmarks, {});
+      const consoleSpy = jest.spyOn(console, 'log').mockImplementation();
+      try {
+        printReport(result);
+        const allCalls = consoleSpy.mock.calls.flat().join('\n');
+        expect(allCalls).toContain(
+          'ERROR  startupStandardHome [chrome-webpack]',
+        );
+        expect(allCalls).toContain('Browser crashed');
+        expect(allCalls).toContain(
+          'ERROR (non-gated)  startupPowerUserHome [chrome-webpack]',
+        );
+        expect(allCalls).toContain('2 no results');
+        expect(allCalls).toContain(
+          'RESULT: FAIL — a benchmark carrying a gated metric produced no results',
+        );
+      } finally {
+        consoleSpy.mockRestore();
+      }
     });
   });
 });
@@ -415,7 +529,7 @@ describe('printReport', () => {
   });
 
   it('prints PASS result when no comparison failed', () => {
-    printReport({ comparisons: [], anyFailed: false });
+    printReport({ comparisons: [], errored: [], anyFailed: false });
 
     expect(consoleSpy).toHaveBeenCalledWith(
       expect.stringContaining('PASS — all benchmarks within constant limits'),
@@ -424,6 +538,7 @@ describe('printReport', () => {
 
   it('prints FAIL result when anyFailed is true', () => {
     printReport({
+      errored: [],
       comparisons: [
         makeComparison({
           benchmarkName: 'standardHome',
@@ -440,6 +555,7 @@ describe('printReport', () => {
 
   it('shows passing comparison in grouped PASS section', () => {
     printReport({
+      errored: [],
       comparisons: [
         makeComparison({
           benchmarkName: 'loadNewAccount',
@@ -458,6 +574,7 @@ describe('printReport', () => {
 
   it('shows failing comparison with source label and FAIL prefix', () => {
     printReport({
+      errored: [],
       comparisons: [
         makeComparison({
           benchmarkName: 'loadNewAccount',
@@ -474,6 +591,7 @@ describe('printReport', () => {
 
   it('groups passing entries without baseline into PASS section', () => {
     printReport({
+      errored: [],
       comparisons: [
         makeComparison({ relativeMetrics: [], absoluteViolations: [] }),
       ],
@@ -489,6 +607,7 @@ describe('printReport', () => {
       './comparison-utils',
     ) as typeof import('./comparison-utils');
     printReport({
+      errored: [],
       comparisons: [
         makeComparison({
           benchmarkName: 'standardHome',
@@ -524,6 +643,7 @@ describe('printReport', () => {
       '../../shared/constants/benchmarks',
     ) as typeof import('../../shared/constants/benchmarks');
     printReport({
+      errored: [],
       comparisons: [
         makeComparison({
           benchmarkName: 'standardHome',
@@ -554,6 +674,7 @@ describe('printReport', () => {
       '../../shared/constants/benchmarks',
     ) as typeof import('../../shared/constants/benchmarks');
     printReport({
+      errored: [],
       comparisons: [
         makeComparison({ benchmarkName: 'A', absoluteFailed: true }),
         makeComparison({
@@ -582,6 +703,7 @@ describe('printReport', () => {
 
   it('groups multiple sources for the same benchmark name in PASS section', () => {
     printReport({
+      errored: [],
       comparisons: [
         makeComparison({
           benchmarkName: 'startupStandardHome',

--- a/development/metamaskbot-build-announce/compare-benchmarks.ts
+++ b/development/metamaskbot-build-announce/compare-benchmarks.ts
@@ -11,9 +11,12 @@
  * --current <path-to-benchmark-json-directory>
  *
  * Exit codes:
- * 0 — no allowlisted (GATED_METRICS) metric exceeded its fail threshold
- * 1 — at least one allowlisted metric exceeded its fail threshold;
- * non-allowlisted breaches are degraded to warnings and do not block
+ * 0 — no allowlisted (GATED_METRICS) metric exceeded its fail threshold, and
+ * every benchmark carrying an allowlisted metric produced results
+ * 1 — at least one allowlisted metric exceeded its fail threshold, or a
+ * benchmark carrying an allowlisted metric produced no results at all;
+ * non-allowlisted breaches and non-allowlisted no-result benchmarks are
+ * degraded to warnings and do not block
  * 2 — usage error or fatal crash
  */
 
@@ -24,6 +27,7 @@ import { parseArgs } from 'util';
 import { THRESHOLD_SEVERITY } from '../../shared/constants/benchmarks';
 import type {
   ThresholdSeverity,
+  ThresholdConfig,
   ComparisonKey,
   BenchmarkResults,
 } from '../../shared/constants/benchmarks';
@@ -46,6 +50,66 @@ type LoadedBenchmark = {
   name: string;
   data: Record<string, BenchmarkResults>;
 };
+
+/**
+ * A benchmark entry that produced no percentiles — the run crashed, timed out,
+ * or exhausted its retries, so the artifact holds an `error` instead of
+ * statistics. Distinct from a threshold breach: there is no measurement to
+ * compare, which means the gate has no signal for whatever that benchmark
+ * covers.
+ */
+export type ErroredBenchmark = {
+  benchmarkName: string;
+  /** Artifact basename, e.g. `benchmark-chrome-webpack-startupPowerUserHome`. */
+  file: string;
+  /** `<browser>-<buildType>`, when derivable from the artifact name. */
+  source?: string;
+  /** Failure text carried in the artifact, when present. */
+  error?: string;
+  /**
+   * Whether this benchmark owns at least one metric in `GATED_METRICS`. Blocks
+   * only when it does — mirroring `applyGatingPolicy`, where a breach of a
+   * non-allowlisted metric is degraded to a warning rather than blocking.
+   */
+  gated: boolean;
+};
+
+export type ComparisonResult = {
+  comparisons: BenchmarkEntryComparison[];
+  errored: ErroredBenchmark[];
+  anyFailed: boolean;
+};
+
+/**
+ * Reads the failure text an errored benchmark artifact carries, if any.
+ *
+ * The benchmark runner writes `{ "<name>": { "error": "..." } }` in place of
+ * statistics, which does not fit `BenchmarkResults` — hence the narrowing.
+ *
+ * @param results - The benchmark entry payload.
+ */
+function readErrorText(results: BenchmarkResults): string | undefined {
+  const { error } = results as unknown as { error?: unknown };
+  return typeof error === 'string' ? error : undefined;
+}
+
+/**
+ * Reports whether a benchmark owns at least one allowlisted metric, i.e.
+ * whether the absence of its results removes a blocking signal.
+ *
+ * @param benchmarkName - Benchmark entry name, e.g. `onboardingNewWallet`.
+ * @param thresholdConfig - That benchmark's threshold config.
+ * @param gatedMetrics - The allowlist, as `<benchmarkName>.<metricId>` keys.
+ */
+function hasGatedMetric(
+  benchmarkName: string,
+  thresholdConfig: ThresholdConfig,
+  gatedMetrics: ReadonlySet<string>,
+): boolean {
+  return Object.keys(thresholdConfig).some((metricId) =>
+    gatedMetrics.has(`${benchmarkName}.${metricId}`),
+  );
+}
 
 /**
  * Loads all benchmark JSON files from a directory.
@@ -85,27 +149,45 @@ async function loadBaseline(): Promise<HistoricalBaselineReference> {
 export function runComparison(
   benchmarks: LoadedBenchmark[],
   baseline: HistoricalBaselineReference,
-): { comparisons: BenchmarkEntryComparison[]; anyFailed: boolean } {
+): ComparisonResult {
   const comparisons: BenchmarkEntryComparison[] = [];
+  const errored: ErroredBenchmark[] = [];
   let anyFailed = false;
 
   for (const { name, data } of benchmarks) {
     const parsed = parseArtifactName(name);
+    const source = parsed ? `${parsed.browser}-${parsed.buildType}` : undefined;
 
     for (const [entryName, results] of Object.entries(data)) {
-      if (!results.p75 || !results.p95) {
-        console.warn(
-          `Skipping "${entryName}" in "${name}": missing p75/p95 (benchmark likely failed).`,
-        );
-        continue;
-      }
-
       const baseThresholdConfig = THRESHOLD_REGISTRY[entryName];
 
       if (!baseThresholdConfig) {
         console.warn(
           `No threshold config for benchmark "${entryName}" in file "${name}". Add an entry to THRESHOLD_REGISTRY in thresholds.ts.`,
         );
+        continue;
+      }
+
+      // No percentiles means the benchmark never produced a measurement.
+      // Treated as a missing signal rather than a skip: if the benchmark owns
+      // an allowlisted metric, the gate can no longer vouch for it, so it
+      // blocks instead of passing on absent evidence.
+      if (!results.p75 || !results.p95) {
+        const gated = hasGatedMetric(
+          entryName,
+          baseThresholdConfig,
+          GATED_METRICS,
+        );
+        errored.push({
+          benchmarkName: entryName,
+          file: name,
+          source,
+          error: readErrorText(results),
+          gated,
+        });
+        if (gated) {
+          anyFailed = true;
+        }
         continue;
       }
 
@@ -131,8 +213,8 @@ export function runComparison(
         results,
       );
 
-      if (parsed) {
-        comparison.source = `${parsed.browser}-${parsed.buildType}`;
+      if (source) {
+        comparison.source = source;
       }
 
       comparisons.push(comparison);
@@ -143,7 +225,7 @@ export function runComparison(
     }
   }
 
-  return { comparisons, anyFailed };
+  return { comparisons, errored, anyFailed };
 }
 
 function violationIcon(severity: ThresholdSeverity): string {
@@ -301,20 +383,26 @@ function formatName(comparison: BenchmarkEntryComparison): string {
   return `${comparison.benchmarkName}${source}`;
 }
 
+function formatErroredName(entry: ErroredBenchmark): string {
+  const source = entry.source ? ` [${entry.source}]` : '';
+  return `${entry.benchmarkName}${source}`;
+}
+
 /**
  * Prints a human-readable report of the comparison results.
  *
- * Output groups entries by severity (FAIL → WARN → PASS) and includes
- * browser/buildType source labels for disambiguation.
+ * Output groups entries by severity (ERROR → FAIL → WARN → PASS) and includes
+ * browser/buildType source labels for disambiguation. ERROR covers benchmarks
+ * that produced no measurement at all, which is reported ahead of threshold
+ * breaches because a missing benchmark leaves the gate blind rather than
+ * merely over budget.
  *
  * @param result - Comparison results.
  * @param result.comparisons
+ * @param result.errored
  * @param result.anyFailed
  */
-export function printReport(result: {
-  comparisons: BenchmarkEntryComparison[];
-  anyFailed: boolean;
-}): void {
+export function printReport(result: ComparisonResult): void {
   console.log('\n═══════════════════════════════════════');
   console.log('  Performance Benchmark Quality Gate');
   console.log('═══════════════════════════════════════');
@@ -342,6 +430,23 @@ export function printReport(result: {
       ) &&
       !w.lines.some((l) => l.hasIssue),
   );
+
+  // Show benchmarks that produced no measurement, blocking ones first.
+  const erroredOrdered = [
+    ...result.errored.filter((e) => e.gated),
+    ...result.errored.filter((e) => !e.gated),
+  ];
+  for (const entry of erroredOrdered) {
+    const label = entry.gated ? 'ERROR' : 'ERROR (non-gated)';
+    console.log(`\n${label}  ${formatErroredName(entry)}`);
+    console.log(`      ⛔ no results — ${entry.error ?? 'benchmark failed'}`);
+    console.log(
+      entry.gated
+        ? `      This benchmark owns a gated metric, so the gate cannot vouch for it.`
+        : `      No gated metric on this benchmark — reported, not blocking.`,
+    );
+    console.log(`      Artifact: ${entry.file}.json`);
+  }
 
   // Show failed entries with details
   for (const { comparison, lines } of failed) {
@@ -380,19 +485,27 @@ export function printReport(result: {
 
   const failCount = failed.length;
   const warnCount = warned.length;
+  const erroredCount = result.errored.length;
+  const blockingErroredCount = result.errored.filter((e) => e.gated).length;
 
   console.log('\n───────────────────────────────────────');
   console.log(
-    `Total: ${result.comparisons.length} benchmarks | ${failCount} failed | ${warnCount} warnings`,
+    `Total: ${result.comparisons.length} benchmarks | ${failCount} failed | ${warnCount} warnings | ${erroredCount} no results`,
   );
 
-  if (result.anyFailed) {
-    console.log(
-      '\nRESULT: FAIL — at least one benchmark exceeds constant fail limit',
-    );
-  } else {
+  if (!result.anyFailed) {
     console.log('\nRESULT: PASS — all benchmarks within constant limits');
+    return;
   }
+
+  const reasons = [];
+  if (failCount > 0) {
+    reasons.push('at least one benchmark exceeds constant fail limit');
+  }
+  if (blockingErroredCount > 0) {
+    reasons.push('a benchmark carrying a gated metric produced no results');
+  }
+  console.log(`\nRESULT: FAIL — ${reasons.join('; ')}`);
 }
 
 async function main(): Promise<void> {


### PR DESCRIPTION
## **Description**

A benchmark artifact with no `p75`/`p95` — the shape the runner writes when a benchmark crashes, times out, or exhausts its retries — was skipped with a `console.warn` and had no effect on the gate's verdict.

- **The hole:** a change that made an onboarding benchmark die outright produced a **green** gate, because the absence of a measurement was indistinguishable from a passing one.
  - `onboardingNewWallet.total` and `startupStandardHome.uiStartup` are in `GATED_METRICS`, so they are supposed to block a PR.
  - If their artifact came back as `{"error": "…"}`, the gate exited `0` and said `RESULT: PASS — all benchmarks within constant limits`.
- **The change:** a no-result benchmark is now a *missing signal* rather than a skip.
  - It **blocks** when the benchmark owns at least one metric in `GATED_METRICS` — the gate can no longer vouch for a metric it never measured.
  - It **degrades to a report-only `ERROR`** otherwise, mirroring `applyGatingPolicy`, where a breach of a non-allowlisted metric is already downgraded to a warning.
  - Entries with no `THRESHOLD_REGISTRY` config keep the existing warn-and-skip behaviour, since they have no gated metric to lose.
- **The reporting:** no-result benchmarks now get their own `ERROR` section ahead of `FAIL`, carrying the artifact's error text and filename, and the `Total:` line gains a `N no results` column. `RESULT: FAIL` names which of the two causes fired.

Surfaced by [`benchmark-chrome-webpack-startupPowerUserHome.json`](https://github.com/MetaMask/metamask-extension/actions/runs/30546745479) reporting `{"error": "Error: Retry limit reached"}` and vanishing into a single buried warn line.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

- Related: #45046 — the same run surfaced that the gate has been red on `main` since Jul 17 for an unrelated reason. This PR does **not** address that; it closes the silent-pass hole the same log revealed.

## **Manual testing steps**

Both fixtures below are a single benchmark artifact directory.

1. Take a passing artifact, e.g. `benchmark-chrome-webpack-startupStandardHome.json` from any recent run.
2. Run `yarn tsx development/metamaskbot-build-announce/compare-benchmarks.ts --current <dir>/` → `PASS`, exit `0`, on both `main` and this branch.
3. Replace the file's contents with `{"startupStandardHome":{"error":"Error: Retry limit reached"}}`.
4. Re-run.
   - On `main`: `PASS`, exit `0`, with the failure reduced to one `Skipping "startupStandardHome" … missing p75/p95` line.
   - On this branch: `FAIL`, exit `1`, with an `ERROR` block naming the benchmark, its error text, and its artifact.

## **Screenshots/Recordings**

N/A — CI script only, no UI change. Console output is in the validation section below.

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only benchmark gating logic with broad test coverage; no runtime, auth, or user-facing behavior changes.
> 
> **Overview**
> Fixes a hole where benchmark artifacts with only an `error` and no `p75`/`p95` were skipped with a warn, so the quality gate could **PASS** even when allowlisted metrics like `startupStandardHome.uiStartup` never ran.
> 
> **`runComparison`** now treats missing percentiles as a **missing signal**: entries are recorded in a new `errored` list (with `gated` derived via `hasGatedMetric` / `GATED_METRICS`). **Gated** no-results set `anyFailed` and block exit `0`; **non-gated** no-results are reported only, matching how non-allowlisted threshold breaches are warnings. Unregistered benchmarks still warn-and-skip with no `errored` row.
> 
> **`printReport`** adds an **ERROR** section (blocking vs `ERROR (non-gated)`), a `no results` count on the total line, and **RESULT: FAIL** text that can cite gated no-results separately from threshold failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fb11ea2a83b76b39267ba7bc9317e2d2be3c691. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->