### PR TITLE
fix(hardware-wallets): bound stuck account-creation spinner with device-read timeout cp-13.42.0

### DIFF
--- a/app/scripts/metamask-controller.js
+++ b/app/scripts/metamask-controller.js
@@ -5651,7 +5651,15 @@ export default class MetamaskController extends EventEmitter {
     hdPath,
     hdPathDescription,
   ) {
-    const { address: unlockedAccount } = await this.#withKeyringForDevice(
+    // `createAccounts` derives the account address from the device, so a
+    // locked or unresponsive device can make this call hang indefinitely.
+    // Unlike the pure-read hardware methods (which run on the lock-free
+    // `deviceRead` path), `createAccounts` mutates vault state and must run
+    // under the controller lock, so it cannot use `deviceRead: true`. Wrap
+    // it in the same UX backstop as `#withKeyringForDevice`'s device-read
+    // branch so a wedged device rejects with an actionable error instead of
+    // leaving the UI spinner (and `showLoadingIndication`) stuck forever.
+    const createOperation = this.#withKeyringForDevice(
       { name: deviceName, hdPath },
       async (keyring) => {
         const { entropySource } = keyring;
@@ -5735,6 +5743,39 @@ export default class MetamaskController extends EventEmitter {
         };
       },
     );
+
+    let timeoutHandle;
+    let timedOut = false;
+    let unlockedAccount;
+    try {
+      ({ address: unlockedAccount } = await Promise.race([
+        createOperation,
+        new Promise((_resolve, reject) => {
+          timeoutHandle = setTimeout(() => {
+            timedOut = true;
+            reject(
+              new Error(
+                `Hardware wallet account creation timed out for device: ${deviceName}. Make sure the device is connected and unlocked, then try again.`,
+              ),
+            );
+          }, HARDWARE_DEVICE_READ_TIMEOUT_MS);
+        }),
+      ]));
+    } finally {
+      clearTimeout(timeoutHandle);
+      if (timedOut) {
+        // The abandoned create operation still holds the controller lock until
+        // the device call settles; observe its rejection so it never surfaces
+        // as an unhandled rejection. Mirrors the device-read path in
+        // `#withKeyringForDevice`.
+        createOperation.catch((error) =>
+          log.warn(
+            `Abandoned hardware wallet account creation failed after timeout for device: ${deviceName}`,
+            error,
+          ),
+        );
+      }
+    }
 
     const accounts = this.accountsController.listAccounts();
 

--- a/app/scripts/metamask-controller.test.js
+++ b/app/scripts/metamask-controller.test.js
@@ -2793,6 +2793,71 @@ describe('MetaMaskController', () => {
             });
           },
         );
+
+        it('times out the abandoned account creation when the device wedges, instead of leaving the UI spinner stuck forever', async () => {
+          // Regression test: a locked/unresponsive device makes
+          // `keyring.createAccounts` hang forever. `createAccounts` mutates
+          // vault state so it cannot run on the lock-free `deviceRead` path,
+          // but the UX backstop must still reject so the UI thunk's
+          // `hideLoadingIndication()` runs and the spinner clears.
+          const withKeyringV2Spy = jest
+            .spyOn(metamaskController.keyringController, 'withKeyringV2')
+            .mockImplementation(async (selector, callback) => {
+              expect(selector).toStrictEqual({ type: KeyringTypeV2.Lattice });
+
+              return await callback({
+                keyring: {
+                  entropySource: 'test-entropy-source',
+                  createAccounts: jest
+                    .fn()
+                    .mockReturnValue(new Promise(() => undefined)),
+                  network: null,
+                },
+              });
+            });
+
+          // Intercept the device-read backstop timer so the test can fire it
+          // deterministically without faking every timer in the app.
+          const originalSetTimeout = global.setTimeout;
+          let fireDeviceReadTimeout;
+          const setTimeoutSpy = jest
+            .spyOn(global, 'setTimeout')
+            .mockImplementation((handler, timeout, ...args) => {
+              if (timeout === HARDWARE_DEVICE_READ_TIMEOUT_MS) {
+                fireDeviceReadTimeout = handler;
+                return 0;
+              }
+              return originalSetTimeout(handler, timeout, ...args);
+            });
+
+          try {
+            const wedgedUnlock = metamaskController.unlockHardwareWalletAccount(
+              accountToUnlock,
+              HardwareDeviceNames.lattice,
+            );
+            // Swallow the timeout rejection asserted below so the wedged
+            // promise never surfaces as an unhandled rejection.
+            wedgedUnlock.catch(() => undefined);
+
+            // Let `unlockHardwareWalletAccount` reach the (hanging) create call.
+            await new Promise((resolve) => {
+              const poll = () =>
+                withKeyringV2Spy.mock.calls.length > 0
+                  ? resolve()
+                  : originalSetTimeout(poll, 5);
+              poll();
+            });
+
+            // The abandoned account creation is bounded by the UX backstop.
+            fireDeviceReadTimeout();
+            await expect(wedgedUnlock).rejects.toThrow(
+              'Hardware wallet account creation timed out',
+            );
+          } finally {
+            withKeyringV2Spy.mockRestore();
+            setTimeoutSpy.mockRestore();
+          }
+        });
       });
     });
 


### PR DESCRIPTION
## **Description**

`unlockHardwareWalletAccount` calls `keyring.createAccounts`, which derives the account address from the hardware device. When the device is locked or unresponsive, that device read can hang indefinitely.

Every other device-reading method (`connectHardware`, `checkHardwareStatus`, `getLedgerPublicKey`, …) runs on the lock-free `deviceRead: true` path in `#withKeyringForDevice`, which wraps the call in a `Promise.race` against `HARDWARE_DEVICE_READ_TIMEOUT_MS` so a wedged device rejects with an actionable error. `unlockHardwareWalletAccount` did not.

`createAccounts` mutates vault state, so it cannot use the lock-free `deviceRead` path (the `restrictKeyringForDeviceRead` facade intentionally omits `createAccounts` along with every other mutating method). It must run under the controller lock — but it still does device I/O that can hang, and there was no timeout backstop. As a result, a hung device during account creation:

1. Never settled `submitRequestToBackground('unlockHardwareWalletAccount', …)`, so the `unlockHardwareWalletAccounts` thunk never reached `hideLoadingIndication()` → `appState.isLoading` stayed `true` → the global `<Loading />` overlay in `ui/pages/routes/routes.component.tsx` spun forever.
2. Held the controller operation mutex across the hang, wedging other locked keyring operations until the browser restarted.

The user-facing symptom: after pressing **Unlock** on the "Select an account" page at `/new-account/connect`, the spinner never resolved and the UX appeared stuck.

**Solution:** wrap the create operation in the same `HARDWARE_DEVICE_READ_TIMEOUT_MS` `Promise.race` backstop used by `#withKeyringForDevice`'s device-read branch. On timeout the call rejects with an actionable error, which propagates back through the thunk so `hideLoadingIndication()` runs, the spinner clears, and the error surfaces to the user. The abandoned create operation's eventual rejection is observed (`.catch`) so it never surfaces as an unhandled rejection — mirroring the existing device-read path.

## **Changelog**

CHANGELOG entry: Fixed a bug where connecting a hardware wallet account could leave the loading spinner stuck forever if the device stopped responding.

## **Related issues**

Fixes: TBD

## **Manual testing steps**

1. Build the extension (`yarn start` or `yarn build:test`).
2. Go to **Add account → Add hardware wallet** (the `/new-account/connect` route) and connect a Ledger or Trezor.
3. On the "Select an account" page, select one or more accounts and press **Unlock**.
4. With the device responsive, confirm the spinner shows briefly and the account imports successfully.
5. Repeat, but leave the device locked / disconnected / unresponsive after pressing **Unlock**.
6. Verify the spinner no longer spins forever — after the timeout it dismisses and an actionable "Hardware wallet account creation timed out" error is shown, and the rest of the wallet remains usable.

## **Screenshots/Recordings**

<!--
### **Before**
### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I've included tests if applicable
- [x] I've documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I've applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

Made with [Cursor](https://cursor.com)