### PR TITLE
chore: gate trust and security TDP with remote feature flag

### DIFF
--- a/.github/scripts/known-feature-flag-constants.mts
+++ b/.github/scripts/known-feature-flag-constants.mts
@@ -70,6 +70,11 @@ const FILE_SOURCES: Array<{
     file: 'shared/lib/defi-controller-v2/remote-feature-flag.ts',
     exportName: 'DEFI_CONTROLLER_V2_FLAG',
   },
+  {
+    key: 'EXTENSION_TRUST_AND_SECURITY_TDP_FLAG',
+    file: 'shared/lib/assets/security-trust-feature-flags.ts',
+    exportName: 'EXTENSION_TRUST_AND_SECURITY_TDP_FLAG',
+  },
 ];
 
 /**

--- a/shared/lib/assets/security-trust-feature-flags.ts
+++ b/shared/lib/assets/security-trust-feature-flags.ts
@@ -1,0 +1,7 @@
+/**
+ * Client-config / RemoteFeatureFlagController key (camelCase). LaunchDarkly
+ * uses kebab-case `extension-trust-and-security-tdp`, which is converted
+ * before it reaches extension state.
+ */
+export const EXTENSION_TRUST_AND_SECURITY_TDP_FLAG =
+  'extensionTrustAndSecurityTdp';

--- a/test/e2e/feature-flags/feature-flag-registry.ts
+++ b/test/e2e/feature-flags/feature-flag-registry.ts
@@ -2897,6 +2897,17 @@ export const FEATURE_FLAG_REGISTRY: Record<string, FeatureFlagRegistryEntry> = {
     status: FeatureFlagStatus.Active,
   },
 
+  extensionTrustAndSecurityTdp: {
+    name: 'extensionTrustAndSecurityTdp',
+    type: FeatureFlagType.Remote,
+    inProd: false,
+    productionDefault: {
+      enabled: false,
+      minimumVersion: '13.40.0',
+    },
+    status: FeatureFlagStatus.Active,
+  },
+
   stxMigrationBatchStatus: {
     name: 'stxMigrationBatchStatus',
     type: FeatureFlagType.Remote,

--- a/ui/pages/asset/components/security-trust/asset-page-security-trust.test.tsx
+++ b/ui/pages/asset/components/security-trust/asset-page-security-trust.test.tsx
@@ -4,6 +4,7 @@ import { configureStore } from '@reduxjs/toolkit';
 import type { TokenSecurityData } from '@metamask/assets-controllers';
 import type { CaipAssetType } from '@metamask/utils';
 import { renderWithProvider } from '../../../../../test/lib/render-helpers-navigate';
+import { EXTENSION_TRUST_AND_SECURITY_TDP_FLAG } from '../../../../../shared/lib/assets/security-trust-feature-flags';
 import {
   AssetPageSecurityTrustBanner,
   AssetPageSecurityTrustHeaderBadge,
@@ -66,19 +67,41 @@ const mockSecurityData: TokenSecurityData = {
   created: '2020-01-01T00:00:00.000Z',
 };
 
-const createStore = (useExternalServices: boolean) =>
+const enabledSecurityTrustFlag = {
+  enabled: true,
+  minimumVersion: '0.0.0',
+};
+
+const createStore = ({
+  useExternalServices = true,
+  securityTrustTdpFlag = enabledSecurityTrustFlag,
+}: {
+  useExternalServices?: boolean;
+  securityTrustTdpFlag?: boolean | { enabled: boolean; minimumVersion: string };
+} = {}) =>
   configureStore({
-    reducer: (state = { metamask: { useExternalServices } }) => state,
+    reducer: (
+      state = {
+        metamask: {
+          useExternalServices,
+          remoteFeatureFlags: {
+            [EXTENSION_TRUST_AND_SECURITY_TDP_FLAG]: securityTrustTdpFlag,
+          },
+        },
+      },
+    ) => state,
   });
 
 const renderSlots = ({
   securityData = mockSecurityData,
   useExternalServices = true,
+  securityTrustTdpFlag = enabledSecurityTrustFlag,
   isLoading = false,
   error = null,
 }: {
   securityData?: TokenSecurityData | null;
   useExternalServices?: boolean;
+  securityTrustTdpFlag?: boolean | { enabled: boolean; minimumVersion: string };
   isLoading?: boolean;
   error?: Error | null;
 } = {}) => {
@@ -94,7 +117,7 @@ const renderSlots = ({
       <AssetPageSecurityTrustBanner />
       <AssetPageSecurityTrustSection />
     </AssetPageSecurityTrustProvider>,
-    createStore(useExternalServices),
+    createStore({ useExternalServices, securityTrustTdpFlag }),
   );
 };
 
@@ -174,6 +197,16 @@ describe('AssetPageSecurityTrust', () => {
     expect(queryByTestId('security-trust-section')).not.toBeInTheDocument();
   });
 
+  it('renders nothing when security trust TDP flag is disabled', () => {
+    const { queryByTestId } = renderSlots({
+      useExternalServices: true,
+      securityTrustTdpFlag: false,
+    });
+
+    expect(queryByTestId('security-badge-verified')).not.toBeInTheDocument();
+    expect(queryByTestId('security-trust-section')).not.toBeInTheDocument();
+  });
+
   it('hides badge and banner while security data is loading', () => {
     const { queryByTestId } = renderSlots({
       securityData: null,
@@ -208,7 +241,7 @@ describe('AssetPageSecurityTrust', () => {
       <AssetPageSecurityTrustProvider assetId={assetId} token={token}>
         <CtaGateProbe onGate={onGate} />
       </AssetPageSecurityTrustProvider>,
-      createStore(true),
+      createStore({ useExternalServices: true }),
     );
 
     const gate = onGate.mock.calls.at(-1)?.[0];
@@ -231,7 +264,7 @@ describe('AssetPageSecurityTrust', () => {
       <AssetPageSecurityTrustProvider assetId={assetId} token={token}>
         <CtaGateProbe onGate={onGate} />
       </AssetPageSecurityTrustProvider>,
-      createStore(true),
+      createStore({ useExternalServices: true }),
     );
 
     const gate = onGate.mock.calls.at(-1)?.[0];

--- a/ui/pages/asset/components/security-trust/asset-page-security-trust.tsx
+++ b/ui/pages/asset/components/security-trust/asset-page-security-trust.tsx
@@ -13,6 +13,7 @@ import { useSelector } from 'react-redux';
 import { useI18nContext } from '../../../../hooks/useI18nContext';
 import { useTokenSecurityData } from '../../../../hooks/useTokenSecurityData';
 import { getUseExternalServices } from '../../../../selectors';
+import { getIsSecurityTrustTdpEnabled } from '../../../../selectors/multichain/feature-flags';
 import {
   getResultTypeConfig,
   type ResultTypeConfig,
@@ -103,7 +104,9 @@ export const AssetPageSecurityTrustProvider = ({
   children,
 }: AssetPageSecurityTrustProviderProps) => {
   const t = useI18nContext();
-  const isEnabled = useSelector(getUseExternalServices);
+  const useExternalServices = useSelector(getUseExternalServices);
+  const isSecurityTrustTdpEnabled = useSelector(getIsSecurityTrustTdpEnabled);
+  const isEnabled = useExternalServices && isSecurityTrustTdpEnabled;
   const resolvedAssetId =
     isEnabled && assetId ? (assetId as CaipAssetType) : null;
   const [sheetParams, setSheetParams] =

--- a/ui/pages/asset/security-trust/security-trust-page.test.tsx
+++ b/ui/pages/asset/security-trust/security-trust-page.test.tsx
@@ -194,6 +194,12 @@ describe('SecurityTrustPage', () => {
       '/asset/eip155:1/eip155%3A1%2Ferc20%3A0xabc',
       { replace: true },
     );
+    expect(useTokenSecurityData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assetId: null,
+        prefetchedData: undefined,
+      }),
+    );
     expect(
       screen.queryByTestId('security-trust-screen'),
     ).not.toBeInTheDocument();

--- a/ui/pages/asset/security-trust/security-trust-page.test.tsx
+++ b/ui/pages/asset/security-trust/security-trust-page.test.tsx
@@ -5,6 +5,7 @@ import type { TokenSecurityData } from '@metamask/assets-controllers';
 import type { CaipAssetType } from '@metamask/utils';
 import { enLocale as messages } from '../../../../test/lib/i18n-helpers';
 import { MOCK_ACCOUNT_EOA } from '../../../../test/data/mock-accounts';
+import { EXTENSION_TRUST_AND_SECURITY_TDP_FLAG } from '../../../../shared/lib/assets/security-trust-feature-flags';
 import { renderWithProvider } from '../../../../test/lib/render-helpers-navigate';
 import SecurityTrustPage from './security-trust-page';
 
@@ -95,11 +96,23 @@ const locationState = {
   chainId: '0x1',
 };
 
-const createStore = () =>
+const enabledSecurityTrustFlag = {
+  enabled: true,
+  minimumVersion: '0.0.0',
+};
+
+const createStore = ({
+  securityTrustTdpFlag = enabledSecurityTrustFlag,
+  useExternalServices = true,
+}: {
+  securityTrustTdpFlag?: boolean | { enabled: boolean; minimumVersion: string };
+  useExternalServices?: boolean;
+} = {}) =>
   configureStore({
     reducer: (
       state = {
         metamask: {
+          useExternalServices,
           internalAccounts: {
             selectedAccount: MOCK_ACCOUNT_EOA.id,
             accounts: {
@@ -107,6 +120,7 @@ const createStore = () =>
             },
           },
           remoteFeatureFlags: {
+            [EXTENSION_TRUST_AND_SECURITY_TDP_FLAG]: securityTrustTdpFlag,
             solanaAccounts: { enabled: false, minimumVersion: '13.6.0' },
             solanaTestnetsEnabled: false,
             bitcoinTestnetsEnabled: false,
@@ -162,6 +176,27 @@ describe('SecurityTrustPage', () => {
     mockLocationState = locationState;
     globalThis.open = jest.fn();
     document.querySelector('.app')?.scroll(0, 0);
+  });
+
+  it('redirects to asset page when security trust TDP flag is disabled', () => {
+    useTokenSecurityData.mockReturnValue({
+      securityData: baseSecurityData,
+      isLoading: false,
+      error: null,
+    });
+
+    renderWithProvider(
+      <SecurityTrustPage />,
+      createStore({ securityTrustTdpFlag: false }),
+    );
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      '/asset/eip155:1/eip155%3A1%2Ferc20%3A0xabc',
+      { replace: true },
+    );
+    expect(
+      screen.queryByTestId('security-trust-screen'),
+    ).not.toBeInTheDocument();
   });
 
   it('renders loading state when data is loading and unavailable', () => {

--- a/ui/pages/asset/security-trust/security-trust-page.tsx
+++ b/ui/pages/asset/security-trust/security-trust-page.tsx
@@ -15,11 +15,15 @@ import {
   TextColor,
   TextVariant,
 } from '@metamask/design-system-react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { buildAssetRoutePath } from '../../../../shared/lib/asset-route';
 import { ThemeType } from '../../../../shared/constants/preferences';
 import { transitionBack } from '../../../components/ui/transition';
 import { ScrollContainer } from '../../../contexts/scroll-container';
 import { useTheme } from '../../../hooks/useTheme';
+import { getUseExternalServices } from '../../../selectors';
+import { getIsSecurityTrustTdpEnabled } from '../../../selectors/multichain/feature-flags';
 import {
   formatCompactSupply,
   formatFeePercent,
@@ -32,6 +36,7 @@ import type {
   TokenSecurityMetadata,
 } from '../types/security-trust';
 import type { ResultTypeConfig } from '../utils/security-utils';
+import { processAssetParams, resolveAssetRouteLookup } from '../util';
 import { useSecurityTrustPageData } from './useSecurityTrustPageData';
 
 const OTHER_HOLDERS_BAR_BG_LIGHT = 'bg-[rgba(133,139,154,0.77)]';
@@ -445,10 +450,28 @@ const OfficialLinksSection = ({
 const SecurityTrustPage = () => {
   const theme = useTheme();
   const navigate = useNavigate();
+  const params = useParams();
+  const { assetId } = resolveAssetRouteLookup(processAssetParams(params));
+  const useExternalServices = useSelector(getUseExternalServices);
+  const isSecurityTrustTdpEnabled = useSelector(getIsSecurityTrustTdpEnabled);
+  const isFeatureEnabled = useExternalServices && isSecurityTrustTdpEnabled;
   const otherHoldersBarClassName =
     theme === ThemeType.dark
       ? OTHER_HOLDERS_BAR_BG_DARK
       : OTHER_HOLDERS_BAR_BG_LIGHT;
+
+  useEffect(() => {
+    if (isFeatureEnabled) {
+      return;
+    }
+
+    if (assetId) {
+      navigate(buildAssetRoutePath(assetId), { replace: true });
+      return;
+    }
+
+    navigate(-1);
+  }, [assetId, isFeatureEnabled, navigate]);
 
   const {
     t,
@@ -476,6 +499,10 @@ const SecurityTrustPage = () => {
   }, []);
 
   const handleBack = () => transitionBack(() => navigate(-1));
+
+  if (!isFeatureEnabled) {
+    return null;
+  }
 
   const pageContent =
     isLoading && !securityData ? (

--- a/ui/pages/asset/security-trust/useSecurityTrustPageData.test.ts
+++ b/ui/pages/asset/security-trust/useSecurityTrustPageData.test.ts
@@ -8,6 +8,24 @@ import { getAllMultichainNetworkConfigurations } from '../../../selectors/multic
 import { useTokenSecurityData } from '../../../hooks/useTokenSecurityData';
 import { useSecurityTrustPageData } from './useSecurityTrustPageData';
 
+jest.mock('../../../selectors', () => ({
+  getUseExternalServices: jest.fn(),
+}));
+
+jest.mock('../../../selectors/multichain/feature-flags', () => ({
+  getIsSecurityTrustTdpEnabled: jest.fn(),
+}));
+
+const { getUseExternalServices } = jest.requireMock('../../../selectors') as {
+  getUseExternalServices: jest.Mock;
+};
+
+const { getIsSecurityTrustTdpEnabled } = jest.requireMock(
+  '../../../selectors/multichain/feature-flags',
+) as {
+  getIsSecurityTrustTdpEnabled: jest.Mock;
+};
+
 const mockUseSelector = jest.fn();
 
 jest.mock('react-redux', () => ({
@@ -106,6 +124,14 @@ describe('useSecurityTrustPageData', () => {
     });
 
     mockUseSelector.mockImplementation((selector) => {
+      if (selector === getUseExternalServices) {
+        return true;
+      }
+
+      if (selector === getIsSecurityTrustTdpEnabled) {
+        return true;
+      }
+
       if (selector === getAllMultichainNetworkConfigurations) {
         return multichainNetworks;
       }
@@ -174,6 +200,100 @@ describe('useSecurityTrustPageData', () => {
 
     expect(mockUseTokenSecurityData).toHaveBeenCalledWith({
       assetId,
+      prefetchedData: undefined,
+    });
+  });
+
+  it('does not request security data when feature is disabled', () => {
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === getUseExternalServices) {
+        return true;
+      }
+
+      if (selector === getIsSecurityTrustTdpEnabled) {
+        return false;
+      }
+
+      if (selector === getAllMultichainNetworkConfigurations) {
+        return multichainNetworks;
+      }
+
+      if (selector === getNetworkConfigurationsByChainId) {
+        return {
+          '0x1': {
+            chainId: '0x1',
+            name: 'Ethereum Mainnet Hex',
+            defaultBlockExplorerUrlIndex: 0,
+            blockExplorerUrls: ['https://etherscan.io'],
+          },
+        };
+      }
+
+      if (typeof selector === 'function') {
+        return getFungibleAssetForRoute(
+          { metamask: {} },
+          {
+            assetId,
+            chainId: 'eip155:1',
+            decodedAsset: '0xabc',
+          },
+        );
+      }
+
+      return undefined;
+    });
+
+    renderHook(() => useSecurityTrustPageData());
+
+    expect(mockUseTokenSecurityData).toHaveBeenCalledWith({
+      assetId: null,
+      prefetchedData: undefined,
+    });
+  });
+
+  it('does not request security data when external services are disabled', () => {
+    mockUseSelector.mockImplementation((selector) => {
+      if (selector === getUseExternalServices) {
+        return false;
+      }
+
+      if (selector === getIsSecurityTrustTdpEnabled) {
+        return true;
+      }
+
+      if (selector === getAllMultichainNetworkConfigurations) {
+        return multichainNetworks;
+      }
+
+      if (selector === getNetworkConfigurationsByChainId) {
+        return {
+          '0x1': {
+            chainId: '0x1',
+            name: 'Ethereum Mainnet Hex',
+            defaultBlockExplorerUrlIndex: 0,
+            blockExplorerUrls: ['https://etherscan.io'],
+          },
+        };
+      }
+
+      if (typeof selector === 'function') {
+        return getFungibleAssetForRoute(
+          { metamask: {} },
+          {
+            assetId,
+            chainId: 'eip155:1',
+            decodedAsset: '0xabc',
+          },
+        );
+      }
+
+      return undefined;
+    });
+
+    renderHook(() => useSecurityTrustPageData());
+
+    expect(mockUseTokenSecurityData).toHaveBeenCalledWith({
+      assetId: null,
       prefetchedData: undefined,
     });
   });

--- a/ui/pages/asset/security-trust/useSecurityTrustPageData.ts
+++ b/ui/pages/asset/security-trust/useSecurityTrustPageData.ts
@@ -16,7 +16,9 @@ import { isEvmChainId } from '../../../../shared/lib/asset-utils';
 import { convertCaipToHexChainId } from '../../../../shared/lib/network.utils';
 import { useI18nContext } from '../../../hooks/useI18nContext';
 import { useTokenSecurityData } from '../../../hooks/useTokenSecurityData';
+import { getUseExternalServices } from '../../../selectors';
 import { getFungibleAssetForRoute } from '../../../selectors/assets';
+import { getIsSecurityTrustTdpEnabled } from '../../../selectors/multichain/feature-flags';
 import { getAllMultichainNetworkConfigurations } from '../../../selectors/multichain/networks';
 import {
   getFeatureTags,
@@ -60,6 +62,11 @@ export const useSecurityTrustPageData = () => {
   const routeAsset = useSelector((state) =>
     getFungibleAssetForRoute(state, { assetId, chainId, decodedAsset }),
   );
+  const useExternalServices = useSelector(getUseExternalServices);
+  const isSecurityTrustTdpEnabled = useSelector(getIsSecurityTrustTdpEnabled);
+  const isEnabled = useExternalServices && isSecurityTrustTdpEnabled;
+  const resolvedAssetId =
+    isEnabled && assetId ? (assetId as CaipAssetType) : null;
 
   const {
     securityData: fetchedSecurityData,
@@ -69,8 +76,10 @@ export const useSecurityTrustPageData = () => {
     address: fetchedAddress,
     isNative: fetchedIsNative,
   } = useTokenSecurityData({
-    assetId: (assetId ?? null) as CaipAssetType | null,
-    prefetchedData: locationState?.securityData ?? undefined,
+    assetId: resolvedAssetId,
+    prefetchedData: isEnabled
+      ? (locationState?.securityData ?? undefined)
+      : undefined,
   });
 
   const parsedAssetMetadata = useMemo(() => {
@@ -90,7 +99,8 @@ export const useSecurityTrustPageData = () => {
   }, [assetId]);
 
   const securityData =
-    fetchedSecurityData ?? locationState?.securityData ?? null;
+    fetchedSecurityData ??
+    (isEnabled ? (locationState?.securityData ?? null) : null);
   const symbol =
     locationState?.symbol ?? fetchedSymbol ?? routeAsset?.symbol ?? '';
   const decimals =

--- a/ui/selectors/multichain/feature-flags.test.ts
+++ b/ui/selectors/multichain/feature-flags.test.ts
@@ -1,7 +1,9 @@
+import { EXTENSION_TRUST_AND_SECURITY_TDP_FLAG } from '../../../shared/lib/assets/security-trust-feature-flags';
 import {
   getIsBasicFunctionalityConsolidationEnabled,
   getIsBasicFunctionalityToggleEnabled,
   getIsNetworkManagementEnabled,
+  getIsSecurityTrustTdpEnabled,
   getIsTokenManagementFilterEnabled,
 } from './feature-flags';
 
@@ -268,6 +270,57 @@ describe('getIsBasicFunctionalityConsolidationEnabled', () => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         buildState({ extensionBasicFunctionalityToggle: false }, true) as any,
       ),
+    ).toBe(false);
+  });
+});
+
+describe('getIsSecurityTrustTdpEnabled', () => {
+  it('returns true for a version-gated flag whose minimumVersion is satisfied', () => {
+    expect(
+      getIsSecurityTrustTdpEnabled(
+        buildState({
+          [EXTENSION_TRUST_AND_SECURITY_TDP_FLAG]: {
+            enabled: true,
+            minimumVersion: '0.0.0',
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }) as any,
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for a version-gated flag whose minimumVersion is in the future', () => {
+    expect(
+      getIsSecurityTrustTdpEnabled(
+        buildState({
+          [EXTENSION_TRUST_AND_SECURITY_TDP_FLAG]: {
+            enabled: true,
+            minimumVersion: '999.0.0',
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }) as any,
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false when the version-gated flag is explicitly disabled', () => {
+    expect(
+      getIsSecurityTrustTdpEnabled(
+        buildState({
+          [EXTENSION_TRUST_AND_SECURITY_TDP_FLAG]: {
+            enabled: false,
+            minimumVersion: '0.0.0',
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        }) as any,
+      ),
+    ).toBe(false);
+  });
+
+  it('returns false when the flag is missing', () => {
+    expect(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      getIsSecurityTrustTdpEnabled(buildState() as any),
     ).toBe(false);
   });
 });

--- a/ui/selectors/multichain/feature-flags.ts
+++ b/ui/selectors/multichain/feature-flags.ts
@@ -3,6 +3,7 @@
 import { createSelector } from 'reselect';
 import { isMultichainFeatureEnabled } from '../../../shared/lib/multichain-feature-flags';
 import { getBooleanFeatureFlag } from '../../../shared/lib/remote-feature-flag-utils';
+import { EXTENSION_TRUST_AND_SECURITY_TDP_FLAG } from '../../../shared/lib/assets/security-trust-feature-flags';
 import { getRemoteFeatureFlags } from '../../../shared/lib/selectors/remote-feature-flags';
 
 /**
@@ -152,4 +153,20 @@ export const getIsChainlistEnabled = createSelector(
   getRemoteFeatureFlags,
   ({ extensionUxChainlist }) =>
     getBooleanFeatureFlag(extensionUxChainlist, false),
+);
+
+/**
+ * Get the state of the `extensionTrustAndSecurityTdp` remote feature flag.
+ * LD key: `extension-trust-and-security-tdp` (camelCased in extension state).
+ *
+ * @param _state - The MetaMask state object
+ * @returns boolean - True when Security & Trust TDP surfaces should be shown.
+ */
+export const getIsSecurityTrustTdpEnabled = createSelector(
+  getRemoteFeatureFlags,
+  (remoteFeatureFlags) =>
+    getBooleanFeatureFlag(
+      remoteFeatureFlags[EXTENSION_TRUST_AND_SECURITY_TDP_FLAG],
+      false,
+    ),
 );


### PR DESCRIPTION
<!--
Please submit this PR as a draft initially.
Do not mark it as "Ready for review" until the template has been completely filled out, and PR status checks have passed at least once.
-->

## **Description**

Adds remote feature-flag gating for Security & Trust Token Details Page (TDP) surfaces introduced in #44761 (merged to main).

**Flag:** `extensionTrustAndSecurityTdp` (LaunchDarkly key: `extension-trust-and-security-tdp`) https://app.launchdarkly.com/projects/metamask-client-config-api-extension/flags/extension-trust-and-security-tdp/targeting?env=main-exp&env=production&env=test&env=beta-dev&env=main-dev&selected-env=main-dev

**Why:** Security & Trust UI should stay hidden until the flag is enabled in client-config, so we can roll out incrementally without shipping the feature to all users.

**What is gated (when flag is off or Basic Functionality is disabled):**
- Verified header badge, warning banner, and entry section on TDP
- Security data fetch on TDP (`useTokenSecurityData` is not called)
- Security & Trust detail route (redirects back to TDP)

**Gate condition:** `getUseExternalServices && getIsSecurityTrustTdpEnabled`

**Changes:**
- Add `EXTENSION_TRUST_AND_SECURITY_TDP_FLAG` constant and `getIsSecurityTrustTdpEnabled` selector
- Register flag in E2E feature-flag registry (`inProd: false`, `minimumVersion: 13.40.0`) and CI known-constants mapping
- Wire provider `isEnabled` and detail-page redirect to the new selector
- Add unit tests for selector and flag-off behavior

Follow-up to #44761. Supersedes #45000.

## **Changelog**

CHANGELOG entry: null

## **Related issues**

Fixes: https://consensyssoftware.atlassian.net/browse/ASSETS-3801

## **Manual testing steps**

1. Build and load the extension from this branch (`chore/feature-flag-security-trust-tdp-v2`).
2. With the flag **off** (default) and Basic Functionality enabled, open a token TDP (e.g. USDC on Ethereum Mainnet).
3. Verify the verified badge, security banner, and Security & Trust entry section are **not** shown.
4. Attempt to navigate directly to the Security & Trust detail route for that token; verify you are redirected back to TDP.
5. Enable the flag locally via `.manifest-overrides.json` and `MANIFEST_OVERRIDES=.manifest-overrides.json` in `.metamaskrc`:
   ```json
   {
     "_flags": {
       "remoteFeatureFlags": {
         "extensionTrustAndSecurityTdp": { "enabled": true, "minimumVersion": "0.0.0" }
       }
     }
   }
   ```
6. Rebuild, reload the extension, and reopen TDP for a token with security data.
7. Verify badge/banner/section appear as expected when data is available, and the detail route is reachable from the entry card.

<!--
## **Screenshots/Recordings**

### **Before**

### **After**
-->

## **Pre-merge author checklist**

- [x] I've followed [MetaMask Contributor Docs](https://github.com/MetaMask/contributor-docs) and [MetaMask Extension Coding Standards](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/CODING_GUIDELINES.md).
- [x] I've completed the PR template to the best of my ability
- [x] I’ve included tests if applicable
- [x] I’ve documented my code using [JSDoc](https://jsdoc.app/) format if applicable
- [ ] I’ve applied the right labels on the PR (see [labeling guidelines](https://github.com/MetaMask/metamask-extension/blob/main/.github/guidelines/LABELING_GUIDELINES.md)). Not required for external contributors.

## **Pre-merge reviewer checklist**

- [ ] I've manually tested the PR (e.g. pull and build branch, run the app, test code being changed).
- [ ] I confirm that this PR addresses all acceptance criteria described in the ticket it closes and includes the necessary testing evidence such as recordings and or screenshots.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI rollout gating with conservative defaults; no auth or payment paths, and behavior when disabled is to hide UI and skip fetches.
> 
> **Overview**
> Introduces remote flag **`extensionTrustAndSecurityTdp`** (`extension-trust-and-security-tdp` in LaunchDarkly) so Security & Trust on the token details page can roll out behind client-config instead of showing for everyone when Basic Functionality / external services are on.
> 
> A shared constant and **`getIsSecurityTrustTdpEnabled`** selector (version-gated, default off) are wired into the E2E registry and CI known-flag list. **TDP surfaces** (badge, banner, entry section) and **`useSecurityTrustPageData`** only fetch or use security data when **`getUseExternalServices && getIsSecurityTrustTdpEnabled`**. The **Security & Trust detail route** redirects to the asset page (or back) and renders nothing when the gate is off.
> 
> Unit tests cover the selector and flag-off behavior on the provider, detail page, and data hook.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit db5251dd4d5746ebfb4c3e45ce7339271ed1aebf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->